### PR TITLE
pwg_ru speed/token: requeue routing + concurrency doctrine + prompt_rule regression fix

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -30,10 +30,23 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   path canonicalized opt.js→opt2.js across window_common/root_window_status/
   window_provenance/window_selftest/prompt_rule_audit (`OPT_HARNESS` constant);
   (5) `gen_opt_harness2.py --out=PATH` flag kills the gen→copy race; (6) AGENTS.md
-  runbook → opt2 canonical. **NEXT (queued)**: speed/token (throttled single driver
-  2–3 wide + portrait-slim −30% + null/defect split in audit_window); the print
-  bridge (`promote_final_cards.py` + per-card provenance + repoint export_interop,
-  supersede mode); siD source investigation; Opus-judge interim over a stratified sample.
+  runbook → opt2 canonical.
+
+- **Speed/token #1 SHIPPED (2026-06-29, session 3).** (a) **Transient-vs-defect requeue
+  split** (rec 3/10): `audit_window.py` now writes `requeue.transient.keys.txt` (null cards
+  = rate-limit dropout, cheap re-run) vs `requeue.defect.keys.txt` (gate flagged real content
+  = rework); new `transient_only` window state (backward-compat guarded so pre-split reports
+  stay `needs_requeue`); summary prints the split; `requeue_from_audit.py --transient|--defect`
+  routes the cheap re-run. Verified live: Ap 20 requeue = 12 transient + 8 defect; mA 0+13.
+  (b) **Concurrency doctrine** in RUN_FREQ_MAX.md: ≤3-wide, never N parallel chats (Slice D
+  18× → 117 nulls; single-root = 0). window_selftest **16/16 PASS** (+`test_requeue_transient_vs_defect_state`).
+  ⚠️ Caught+reverted a self-inflicted regression: pointing `prompt_rule_audit.DEFAULT_HARNESS`
+  at opt2 made the masked harness's 4 absent SOFT judge-7 rules hard-fail prompt_semantic →
+  every root `blocked` (that file was NOT in the audit's fix list; its rule-check is the
+  template build-contract). **NEXT (queued)**: portrait-slim (rec 4, opt-in flag + cold A/B;
+  gated on MG decision #11 — does the translator ever need `citations_resolved`?); the print
+  bridge (`promote_final_cards.py` + per-card provenance + repoint export_interop, supersede);
+  siD source investigation; Opus-judge interim over a stratified sample.
 
 - **Track A — SLICE D COMPLETE + AUDITED (2026-06-29).** 18 next-freq roots translated
   in parallel on the `gen_opt_harness2` batched+masked 3-layer harness. TAG=`sd`.

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -253,14 +253,25 @@ rewrite prompts, requeue cards, or replace human judgment.
 `judge_sample.keys.txt` is the semantic review spend queue: all Python-gate failures plus a
 deterministic 10 % sample of clean translated keys. It is NOT the mechanical requeue list.
 
+## Concurrency — run a throttled driver, not N parallel chats
+
+**Do not launch more than ~3 root harnesses as separate Workflows at once.** Each generated
+harness internally fans out to ~8–14 agents, so N concurrent root-harnesses peak at N×~12
+Sonnet agents on a single Max session. Slice D launched 18 at once → ~140–250 peak agents →
+~80+ `Server is temporarily limiting requests` 429s → 117 transient null cards; single-root
+runs measured **zero** transient failures. Run roots sequentially or ≤3-wide from one driver;
+a clean sequential sweep is faster end-to-end than a collapsed wide run plus its recovery pass.
+
 ## Flaky API / Internet Policy
 
 - There is no Claude API client in this repo for production PWG translation. Claude work runs
   through the Max Workflow surface, so the local scripts must make interruptions resumable
   instead of trying to hide network loss.
 - The generated optimized harness retries each card once. A still-null card is recorded by
-  `audit_window.py` and lands in `requeue.keys.txt`; rerun only those cards with
-  `requeue_from_audit.py`.
+  `audit_window.py`. The requeue list is **split** so a cheap re-run never triggers expensive
+  rework: `requeue.transient.keys.txt` (null cards = rate-limit/dropout) vs
+  `requeue.defect.keys.txt` (a gate flagged real content). A window whose only requeue is
+  transient nulls reports state `transient_only` — re-run just those at low concurrency.
 - The stale-provenance check is mandatory after any interrupted run. It prevents old
   `wf_output.json` files from being audited against newly regenerated rootmaps or inputs.
 - DeepSeek corpus-lexicon API calls are append-only/resumable in `build_corpus_lexicon.py`.
@@ -268,13 +279,15 @@ deterministic 10 % sample of clean translated keys. It is NOT the mechanical req
   `DEEPSEEK_BACKOFF_BASE` to tune retry behavior; failed API batches are logged locally and
   can be retried later with `--retry-failed`.
 
-If `requeue.keys.txt` is non-empty, generate the rerun harness directly from it:
+If `requeue.keys.txt` is non-empty, generate the rerun harness directly from it (pass
+`--transient` for the cheap null-only re-run, `--defect` for the rework-only set):
 
 ```powershell
-python src\pilot\requeue_from_audit.py sTA
+python src\pilot\requeue_from_audit.py sTA --transient   # null cards only (state transient_only)
+python src\pilot\requeue_from_audit.py sTA               # all requeue keys
 ```
 
-Run the regenerated `run_pilot_wf.opt.js`, save its JSON as the next `wf_output.json`, and rerun
+Run the regenerated `run_pilot_wf.opt2.js`, save its JSON as the next `wf_output.json`, and rerun
 `audit_window.py`.
 
 If `requeue.keys.txt` is empty and `judge_sample.keys.txt` is non-empty, send only those keys to

--- a/RussianTranslation/src/pilot/prompt_rule_audit.py
+++ b/RussianTranslation/src/pilot/prompt_rule_audit.py
@@ -25,7 +25,11 @@ ROOT = os.path.dirname(SRC)
 OUT = os.path.join(HERE, 'output')
 
 DEFAULT_TEMPLATE = os.path.join(HERE, 'run_pilot_wf.js')
-DEFAULT_HARNESS = os.path.join(HERE, 'run_pilot_wf.opt2.js')
+# The missing-required-rule check is the BUILD-TIME contract on the canonical template;
+# it must not point at a generated harness. The masked opt2 harness legitimately omits the
+# SOFT judge-7 guidance rules (samasa/correlatives/sastric-formula/anti-circular), so rule-
+# checking it would hard-fail the prompt_semantic gate on every root (false positive).
+DEFAULT_HARNESS = os.path.join(HERE, 'run_pilot_wf.opt.js')
 
 if HERE not in sys.path:
     sys.path.insert(0, HERE)

--- a/RussianTranslation/src/pilot/requeue_from_audit.py
+++ b/RussianTranslation/src/pilot/requeue_from_audit.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
-"""Build an optimized rerun harness from the latest audit_window requeue file.
+"""Build an optimized (gen_opt_harness2) rerun harness from the latest audit_window requeue.
 
-  python src/pilot/requeue_from_audit.py sTA
+  python src/pilot/requeue_from_audit.py sTA               # all requeue keys (requeue.keys.txt)
+  python src/pilot/requeue_from_audit.py sTA --transient   # only null cards (cheap re-run)
+  python src/pilot/requeue_from_audit.py sTA --defect      # only real content failures (rework)
 """
 import json
 import os
@@ -29,26 +31,37 @@ def rootmap_path(root):
     return None
 
 
-def read_requeue():
-    if not os.path.exists(REQUEUE):
-        sys.exit('no %s — run audit_window.py --write-requeue first' % REQUEUE)
-    keys = [ln.strip() for ln in open(REQUEUE, encoding='utf-8') if ln.strip()]
+def requeue_file(which):
+    return os.path.join(OUT, {
+        'transient': 'requeue.transient.keys.txt',   # null cards only — cheap re-run
+        'defect': 'requeue.defect.keys.txt',         # real content failures — rework
+    }.get(which, 'requeue.keys.txt'))
+
+
+def read_requeue(path):
+    if not os.path.exists(path):
+        sys.exit('no %s — run audit_window.py --write-requeue first' % path)
+    keys = [ln.strip() for ln in open(path, encoding='utf-8') if ln.strip()]
     if not keys:
-        sys.exit('empty requeue file: %s' % REQUEUE)
+        sys.exit('empty requeue file: %s' % path)
     return keys
 
 
 def main():
-    root = sys.argv[1] if len(sys.argv) > 1 else ''
+    argv = sys.argv[1:]
+    which = ('transient' if '--transient' in argv else
+             'defect' if '--defect' in argv else 'all')
+    positional = [a for a in argv if not a.startswith('--')]
+    root = positional[0] if positional else ''
     if not root:
-        sys.exit('usage: python src/pilot/requeue_from_audit.py <root>')
+        sys.exit('usage: python src/pilot/requeue_from_audit.py <root> [--transient|--defect]')
     rp = rootmap_path(root)
     if not rp:
         sys.exit('no rootmap for %r under %s' % (root, INP))
     rm = json.load(open(rp, encoding='utf-8'))
     declared = {s['subkey'] for s in rm.get('sub_cards', [])}
     suffixes = {k.split('~~')[-1]: k for k in declared}
-    keys = read_requeue()
+    keys = read_requeue(requeue_file(which))
     resolved, invalid = [], []
     for k in keys:
         full = k if k in declared else suffixes.get(k)
@@ -75,6 +88,7 @@ def main():
 
     harness = os.path.join(HERE, 'run_pilot_wf.opt2.js')
     print('requeue root      : %s' % root)
+    print('requeue source    : %s' % which)
     print('requeue keys      : %d' % len(resolved))
     print('generated harness : %s' % harness)
     print('keys:')


### PR DESCRIPTION
Complementary layer on top of the transient/defect requeue split that already
landed on `master` (commit `1c0892c`). This PR adds the parts that commit did
**not** cover, so the two streams compose rather than collide.

## What this adds
- **Requeue routing** — [`requeue_from_audit.py`](https://github.com/gasyoun/SanskritLexicography/blob/pwg-ru-speed-token-routing/RussianTranslation/src/pilot/requeue_from_audit.py) gains `--transient` / `--defect` to select the split files (`requeue.transient.keys.txt` = null cards, cheap re-run; `requeue.defect.keys.txt` = real content failures, rework). Without this the split files exist but nothing consumes them differently.
- **Concurrency doctrine** — [`RUN_FREQ_MAX.md`](https://github.com/gasyoun/SanskritLexicography/blob/pwg-ru-speed-token-routing/RussianTranslation/src/pilot/RUN_FREQ_MAX.md): run ≤3-wide from one driver, never N parallel chats. Slice D launched 18× → ~140–250 peak agents → ~80+ `Server is temporarily limiting requests` 429s → 117 transient null cards; single-root runs measured **zero** transient failures.
- **prompt_rule_audit regression fix** — reverts an earlier opt2 repoint of `DEFAULT_HARNESS`. The missing-required-rule check is the build-time contract on the canonical **template**; pointing it at the masked opt2 harness made its 4 absent **soft** judge-7 rules (samāsa / correlatives / śāstric-formula / anti-circular) hard-fail the `prompt_semantic` gate → every root reported `blocked`.

## Verification
- `python src/pilot/window_selftest.py` → **16/16 PASS** (incl. `test_requeue_transient_vs_defect_state`, `test_sense_dupe_batch_override`).
- Live: `audit_window.py wf_output.sd.Ap.json` → 20 requeue = 12 transient + 8 defect, state `needs_requeue` (no longer `blocked`).

Context: full retrospective in [`PROCESS_AUDIT_2026-06-29.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PROCESS_AUDIT_2026-06-29.md) (recs 3/10 = the split; this PR is the routing/doctrine/regression-fix around it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)