### PR TITLE
pwg_ru print bridge: promote_final_cards.py — translations reach the citable edition

### DIFF
--- a/RussianTranslation/src/export_interop.py
+++ b/RussianTranslation/src/export_interop.py
@@ -48,7 +48,14 @@ def iter_cards(path, limit=None):
                 break
 
 
-def approved_store(path):
+APPROVED_STATUSES = {'approved', 'human_reviewed'}
+
+
+def approved_store(path, statuses=APPROVED_STATUSES):
+    """key1 -> [rows] from the translated store, keeping only rows whose review_status is in
+    `statuses` (default the G5-approved set, so unreviewed ai_translated rows stay OUT of the
+    citable edition). Pass a wider set (e.g. via --review-status ai_translated) only to preview
+    the bridge — never for a published release."""
     out = {}
     if not path or not os.path.exists(path):
         return out
@@ -57,9 +64,16 @@ def approved_store(path):
             if not line.strip():
                 continue
             r = json.loads(line)
-            if r.get('review_status') in {'approved', 'human_reviewed'} and r.get('ru'):
+            if r.get('review_status') in statuses and r.get('ru'):
                 out.setdefault(r.get('key1'), []).append(r)
     return out
+
+
+def statuses(args):
+    raw = getattr(args, 'review_status', None)
+    if not raw:
+        return APPROVED_STATUSES
+    return {s.strip() for s in raw.split(',') if s.strip()}
 
 
 def card_glosses(card, translations):
@@ -80,7 +94,7 @@ def card_glosses(card, translations):
 
 def export_tei(args):
     os.makedirs(args.out_dir, exist_ok=True)
-    translations = approved_store(args.store)
+    translations = approved_store(args.store, statuses(args))
     out = os.path.join(args.out_dir, 'tei_lex0.xml')
     with open(out, 'w', encoding='utf-8', newline='') as f:
         f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
@@ -104,7 +118,7 @@ def export_tei(args):
 
 def export_ontolex(args):
     os.makedirs(args.out_dir, exist_ok=True)
-    translations = approved_store(args.store)
+    translations = approved_store(args.store, statuses(args))
     out = os.path.join(args.out_dir, 'ontolex.ttl')
     with open(out, 'w', encoding='utf-8', newline='') as f:
         f.write('@prefix ontolex: <http://www.w3.org/ns/lemon/ontolex#> .\n')
@@ -132,7 +146,7 @@ def export_ontolex(args):
 
 def export_reverse_index(args):
     os.makedirs(args.out_dir, exist_ok=True)
-    translations = approved_store(args.store)
+    translations = approved_store(args.store, statuses(args))
     out = os.path.join(args.out_dir, 'reverse_index.jsonl')
     count = 0
     with open(out, 'w', encoding='utf-8', newline='') as f:
@@ -161,6 +175,8 @@ def main():
     ap.add_argument('--store', default=DEFAULT_STORE)
     ap.add_argument('--out-dir', default=DEFAULT_RELEASE)
     ap.add_argument('--limit', type=int, default=None)
+    ap.add_argument('--review-status', default=None,
+                    help='comma list of review_status values to include; default = approved,human_reviewed (G5 gate). Use ai_translated only to PREVIEW the bridge.')
     args = ap.parse_args()
     if args.mode in ('tei', 'all'):
         export_tei(args)

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+r"""Promote translated workflow cards into the canonical translated store (the print bridge).
+
+The keystone convergence step. Until now the translated wf_output.*.json cards were STRANDED:
+export_interop.py builds the citable TEI/OntoLex edition from src/assembled_cards.jsonl and the
+translated store src/pwg_ru_translated.jsonl, but NOTHING wrote the harness translations into that
+store. This script does: it ingests every wf_output*.json, extracts each non-null card's senses,
+stamps per-card provenance, and writes one store row per sense keyed by the HEADWORD key1 (the
+join key export_interop uses — wf cards key on the sub-card key `root~~h0_..`, but meta.root is the
+plain SLP1 headword that matches assembled_cards.jsonl).
+
+Rows are written with review_status='ai_translated' — NOT 'approved'. export_interop's
+approved_store() gate only exports {approved, human_reviewed}, so promoted translations reach the
+store (and unblock G5 review counting) WITHOUT silently publishing unreviewed AI as a citable
+edition. G5 human review flips a row to 'approved', and only then does it export.
+
+Supersede mode (default): the new store replaces the old run_batch store (which is entirely
+'legacy_needs_review' and therefore exported zero rows anyway). The prior file is backed up to
+<store>.legacy.bak unless --no-backup.
+
+  python src/promote_final_cards.py                 # promote -> src/pwg_ru_translated.jsonl
+  python src/promote_final_cards.py --dry-run        # report coverage, write nothing
+  python src/promote_final_cards.py --glob 'wf_output.sd.*.json'   # a subset
+
+Coverage is reported honestly: per-root card counts plus a WARNING for roots whose per-root file
+is a requeue subset (the full Slice-C originals were overwritten; re-run or recover them, then
+re-run this script — it is idempotent and supersede-safe).
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)                       # the RussianTranslation repo root
+DEFAULT_STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+DEFAULT_GLOB = 'wf_output*.json'
+MODEL = 'sonnet'                                    # the harness pins model:'sonnet' (gen_opt_harness2)
+
+
+def load_wf(path):
+    with open(path, encoding='utf-8') as f:
+        wrapper = json.load(f)
+    result = wrapper.get('result')
+    if isinstance(result, str):
+        result = json.loads(result)
+    if result is None:
+        result = wrapper
+    return result
+
+
+def collect_cards(paths):
+    """sub-card key -> {card, meta, wf_file}. Non-null wins; both-non-null keeps first + logs."""
+    best, conflicts, null_keys = {}, [], set()
+    for path in paths:
+        try:
+            res = load_wf(path)
+        except (OSError, json.JSONDecodeError) as e:
+            print('  skip (unreadable): %s (%s)' % (os.path.basename(path), e))
+            continue
+        meta = res.get('meta') or {}
+        for r in res.get('results') or []:
+            key = r.get('key')
+            card = r.get('card')
+            if not key:
+                continue
+            if not card:
+                null_keys.add(key)
+                continue
+            if key in best:
+                conflicts.append(key)
+                continue                            # keep first-seen non-null
+            best[key] = {'card': card, 'meta': meta, 'wf_file': os.path.basename(path)}
+    null_keys -= set(best)                          # a key non-null somewhere isn't a null
+    return best, conflicts, sorted(null_keys)
+
+
+def provenance(entry, subkey):
+    meta = entry['meta']
+    hashes = (meta.get('input_hashes') or {}).get(subkey) or {}
+    return {
+        'model': MODEL,
+        'generator': meta.get('generator'),
+        'schema_version': meta.get('schema_version'),
+        'root': meta.get('root'),
+        'safe_root': meta.get('safe_root'),
+        'rootmap_sha256': meta.get('rootmap_sha256'),
+        'input_raw_sha256': hashes.get('raw_sha256'),
+        'input_portrait_sha256': hashes.get('portrait_sha256'),
+        'generated_at': meta.get('generated_at'),
+        'wf_file': entry['wf_file'],
+        'promoted_by': 'promote_final_cards.py',
+    }
+
+
+def rows_for(subkey, entry, review_status):
+    card = entry['card']
+    key1 = entry['meta'].get('root')               # the join key into assembled_cards.jsonl
+    prov = provenance(entry, subkey)
+    for rec in card.get('records') or []:
+        for sense in rec.get('senses') or []:
+            ru = sense.get('russian')
+            if not ru:
+                continue
+            yield {
+                'key1': key1,
+                'subcard': subkey,
+                'iast': card.get('iast'),
+                'h': rec.get('h'),
+                'sense_tag': sense.get('tag'),
+                'ru': ru,
+                'de': sense.get('german'),
+                'equivalence_type': sense.get('equivalence_type'),
+                'source_type': sense.get('source_type'),
+                'stratum': sense.get('stratum'),
+                'differentia': sense.get('differentia'),
+                'review_status': review_status,
+                'reviewer': None,
+                'provenance': prov,
+            }
+
+
+def selftest():
+    import tempfile
+    meta = {'root': 'pA', 'safe_root': 'p_a', 'generator': 'gen_opt_harness2.batched-masked',
+            'schema_version': 'v1', 'rootmap_sha256': 'abc', 'generated_at': '2026-06-29T00:00:00Z',
+            'input_hashes': {'p_a~~h5_00_pwg00': {'raw_sha256': 'r1', 'portrait_sha256': 'p1'}}}
+    entry = {'card': {'key1': 'p_a~~h5_00_pwg00', 'iast': 'pā', 'records': [
+        {'h': 'pā', 'senses': [
+            {'tag': '1', 'russian': 'пить', 'german': 'trinken', 'equivalence_type': 'equivalent',
+             'source_type': 'attested', 'stratum': 'Vedic', 'differentia': ''},
+            {'tag': '2', 'russian': '', 'german': 'x'},          # no russian -> skipped
+        ]}]}, 'meta': meta, 'wf_file': 'wf_output.sc.pA.json'}
+    rows = list(rows_for('p_a~~h5_00_pwg00', entry, 'ai_translated'))
+    assert len(rows) == 1, 'a sense without russian must be skipped'
+    r = rows[0]
+    assert r['key1'] == 'pA', 'key1 must be the HEADWORD meta.root, not the sub-card key'
+    assert r['subcard'] == 'p_a~~h5_00_pwg00' and r['ru'] == 'пить' and r['de'] == 'trinken'
+    assert r['review_status'] == 'ai_translated', 'must not auto-approve (G5 gate)'
+    p = r['provenance']
+    assert p['model'] == 'sonnet' and p['rootmap_sha256'] == 'abc'
+    assert p['input_raw_sha256'] == 'r1' and p['generated_at'], 'provenance must be complete'
+    # collect_cards: a non-null card wins over a null for the same sub-card key.
+    d = tempfile.mkdtemp()
+    nullf = os.path.join(d, 'wf_output.sc.x.json')
+    fullf = os.path.join(d, 'wf_output.x.json')
+    with open(nullf, 'w', encoding='utf-8') as f:
+        json.dump({'meta': meta, 'results': [{'key': 'p_a~~h5_00_pwg00', 'card': None}]}, f)
+    with open(fullf, 'w', encoding='utf-8') as f:
+        json.dump({'meta': meta, 'results': [{'key': 'p_a~~h5_00_pwg00', 'card': entry['card']}]}, f)
+    best, _conf, nulls = collect_cards([nullf, fullf])
+    assert 'p_a~~h5_00_pwg00' in best, 'non-null must win over null for the same key'
+    assert nulls == [], 'a key non-null in any file is not a null'
+    print('promote_final_cards selftest OK')
+
+
+def main():
+    if '--selftest' in sys.argv[1:]:
+        return selftest()
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--glob', default=DEFAULT_GLOB, help='wf_output glob, relative to repo root')
+    ap.add_argument('--store', default=DEFAULT_STORE)
+    ap.add_argument('--review-status', default='ai_translated')
+    ap.add_argument('--dry-run', action='store_true')
+    ap.add_argument('--no-backup', action='store_true')
+    args = ap.parse_args()
+
+    paths = sorted(glob.glob(os.path.join(ROOT, args.glob)))
+    if not paths:
+        sys.exit('no wf_output files matched %s under %s' % (args.glob, ROOT))
+    print('ingesting %d wf_output file(s)' % len(paths))
+    best, conflicts, null_keys = collect_cards(paths)
+
+    rows, per_root = [], {}
+    for subkey, entry in sorted(best.items()):
+        n = 0
+        for row in rows_for(subkey, entry, args.review_status):
+            rows.append(row)
+            n += 1
+        root = entry['meta'].get('root')
+        per_root.setdefault(root, {'cards': 0, 'rows': 0})
+        per_root[root]['cards'] += 1
+        per_root[root]['rows'] += n
+
+    # Coverage report — honest about partial (requeue-subset) roots.
+    print('\n=== PROMOTION COVERAGE ===')
+    print('non-null cards promoted : %d' % len(best))
+    print('sense rows              : %d' % len(rows))
+    print('distinct headwords      : %d' % len(per_root))
+    print('null sub-cards skipped  : %d' % len(null_keys))
+    if conflicts:
+        print('duplicate non-null keys : %d (kept first-seen)' % len(conflicts))
+    thin = sorted(r for r, v in per_root.items() if v['cards'] <= 5)
+    if thin:
+        print('\n⚠ roots with <=5 promoted cards (likely a requeue-subset / partial file — the full')
+        print('  output was overwritten; re-run that root and re-run this script to complete it):')
+        print('  ' + ', '.join('%s(%d)' % (r, per_root[r]['cards']) for r in thin))
+
+    if args.dry_run:
+        print('\n(dry run — no store written)')
+        return
+
+    if os.path.exists(args.store) and not args.no_backup:
+        bak = args.store + '.legacy.bak'
+        os.replace(args.store, bak)
+        print('\nbacked up prior store -> %s' % os.path.basename(bak))
+    with open(args.store, 'w', encoding='utf-8') as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + '\n')
+    print('wrote canonical translated store -> %s (%d rows, review_status=%s)'
+          % (args.store, len(rows), args.review_status))
+    print('NOTE: rows are %s, NOT approved — export_interop keeps them out of the citable'
+          % args.review_status)
+    print('      edition until G5 human review flips review_status to approved.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The keystone from [`PROCESS_AUDIT_2026-06-29.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PROCESS_AUDIT_2026-06-29.md) rec 22. Until now the translated `wf_output.*.json` cards were **stranded**: [`export_interop.py`](https://github.com/gasyoun/SanskritLexicography/blob/pwg-ru-print-bridge/RussianTranslation/src/export_interop.py) builds the citable TEI/OntoLex edition from `assembled_cards.jsonl` + the translated store, but **nothing wrote the harness translations into that store** — so the entire PWG→Russian deliverable had zero path into the DOI-registered artifact.

## What this adds
- **[`promote_final_cards.py`](https://github.com/gasyoun/SanskritLexicography/blob/pwg-ru-print-bridge/RussianTranslation/src/promote_final_cards.py)** — ingest every `wf_output*.json` → extract each non-null card's senses → stamp per-card **provenance** (`model`, `generator`, `rootmap_sha256`, input raw/portrait hashes, `generated_at`) → write one store row per sense, keyed on the **headword** `key1` (`meta.root`, the join key into `assembled_cards.jsonl`; wf cards key on the sub-card `root~~h0_..`).
- **`review_status='ai_translated'`, NOT approved.** The translations reach the store and unblock G5 review counting **without** publishing unreviewed AI as a citable edition. The exporter's `approved_store()` gate still only exports `{approved, human_reviewed}`; G5 human review flips a row to `approved`, and only then does it export.
- **Supersede mode** — the old run_batch store was 100% `legacy_needs_review` (exported zero rows), so superseding drops no approved content; the prior file is backed up to `.legacy.bak`.
- **`export_interop.py --review-status`** — preview the bridge (`--review-status ai_translated`) without weakening the published gate (default stays `approved,human_reviewed`).

## Verification
- `1,431` non-null cards → **`6,619`** store rows, **100% provenance-complete**.
- Preview export surfaces them as TEI `approved_translation` senses; **default approved-only export = `0`** (G5 gate holds — no leak).
- `python src/promote_final_cards.py --selftest` OK; `window_selftest` 16/16.

## Honest caveats (follow-ups, not blockers)
- **Slice-C coverage gap:** the per-root `wf_output.sc.*.json` files for the 16 requeued roots are requeue *subsets* (their full originals were overwritten); the bridge recovers jan/han from the shared files and **flags the 11 thin roots** in its coverage report. Re-run those roots and re-run the bridge (idempotent) to complete.
- **Homograph collision:** the exporter attaches translations to every entry sharing a `key1` (the `safe_id(key1)` / `(key1,h)`-keying gap already noted in the print roadmap), so preview sense counts multiply across homonyms. A renderer-side fix, not a bridge bug.

The translated store (`pwg_ru_translated.jsonl`) is a generated artifact (gitignored, regenerable); the committed deliverable is the script + the exporter flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)