### PR TITLE
pwg_ru: token lever (portrait-slim invalid -> budget bump) + bridge follow-up assessment

### DIFF
--- a/RussianTranslation/BRIDGE_FOLLOWUPS_2026-06-30.md
+++ b/RussianTranslation/BRIDGE_FOLLOWUPS_2026-06-30.md
@@ -1,0 +1,50 @@
+# Print-bridge follow-ups — assessment (both are NOT quick fixes)
+
+After the print bridge (PR #18) two follow-ups were flagged. On investigation, neither is a
+small tweak; this records why, so they're scoped correctly rather than hacked.
+
+## 1. Slice-C full-output recovery — coordination, do not re-run here
+
+**State.** The per-root `wf_output.sc.*.json` files for the 16 requeued Slice-C roots are
+requeue *subsets* (the full originals were overwritten when the requeue results were saved over
+them). The bridge recovers jan/han from the shared `wf_output.sc.json`/`wf_output.json` and
+flags the 11 thin roots; ~1,431 of ~1,989 cards are present.
+
+**Why not now.** Recovery requires **re-running** those roots' full translation (the originals
+are gone from local files, and the original Slice-C run was a different session whose transcripts
+are not reachable here). That is a Max translation run, which **overlaps the autonomous account**
+already doing Slice-C requeue work on `master` (it committed the `run_pilot_wf.sd_rq_*.js`
+requeue harnesses). Launching a Slice-C re-run from this session would duplicate/race it.
+
+**Disposition.** Coordination item — the autonomous account owns Slice-C requeue. When the full
+roots are re-run, re-run `promote_final_cards.py` (idempotent, supersede) to complete the store.
+
+## 2. Homograph `(key1,h)` keying — blocked on a missing discriminator
+
+**Symptom.** In `--review-status ai_translated` preview, a promoted translation appears under
+*every* `assembled_cards` entry that shares its `key1`, because [`export_interop.py`](src/export_interop.py)
+joins translations to structural cards by `key1` alone, and 11.7 % of `key1` (12,373) have >1
+entry (homographs). The store rows are keyed on the headword `key1` (`meta.root`).
+
+**Why it can't be fixed at the exporter now.** True per-homonym attribution needs a `(key1, h)`
+join — but the **assembled side has no homonym discriminator**: a sampled 3-entry homograph
+(`aNGas`) has `ord=None`, `hom=None`, `records[0].h=None` on every entry. There is nothing to
+join the store's `h` against. The store side is ready (each row carries `h` and the homonym
+ordinal is recoverable from `subcard`, e.g. `han~~h0_..` → `h0`); the blocker is that
+`assembled_cards.jsonl` would first need a homonym key minted on its entries — the
+"normalize `record.h` → `{h:int, sublemma, upasarga_chain}`" data-model task from the print
+roadmap, not a bridge tweak.
+
+**Why it is not urgent.** The multiplication is **inert in production**: it only shows in the
+preview path. The default export gate is `{approved, human_reviewed}`, which is currently **0**
+rows (no G5 review yet), so the citable edition emits no duplicated translations. The homograph
+fix and G5 review are the same milestone — do the reconciliation layer when the renderer/edition
+work starts, not before.
+
+**Disposition.** Roadmap task (renderer/edition stage), tracked here; no code change now.
+
+## Net
+
+Both follow-ups are real but neither is a follow-up-sized change: one is a coordination boundary
+(autonomous account owns Slice-C requeue), the other is blocked on a data-model layer that the
+edition/renderer stage will build anyway and is inert until then.

--- a/RussianTranslation/TOKEN_LEVER_FINDING_2026-06-30.md
+++ b/RussianTranslation/TOKEN_LEVER_FINDING_2026-06-30.md
@@ -1,0 +1,57 @@
+# Token lever: portrait-slim is a non-lever; the real lever is batch budget
+
+**Date:** 2026-06-30 · **Context:** PROCESS_AUDIT rec 4 proposed "portrait-slim": strip
+`citations_resolved`/`citations`/`strata`/`examples_sa` from the inlined portrait for a
+"~30–35 % lossless cut on the larger half of inlined card content." MG confirmed the
+translator *needs* citations, gating the design. On inspection, the premise is **false**.
+
+## Finding (verified corpus-wide, 3,538 sub-card portraits)
+
+The harness ([`gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py):278) inlines the
+**per-sub-card** portrait (`*~~*.portrait.json`), and:
+
+- the portrait is the **smaller** part of inlined content: **32 %** (skeleton 68 %),
+  portrait/skeleton ratio **0.47** — *not* "1.7–2× the skeleton";
+- every populated portrait contains exactly four fields: **`key1`, `iast`, `evidence_scope`,
+  `corpus_synonyms`** (the corpus lexical-layer signal). `corpus_synonyms` is small
+  (median 323 B, max 449 B);
+- **none** of the audit's claimed strippable fields (`citations_resolved` / `citations` /
+  `strata` / `examples_sa`) exist in any sub-card portrait.
+
+The audit's token agent measured the per-**headword** aggregate (`vart.portrait.json`, ~447 KB),
+which is **not** what the harness inlines. Decision #11 ("does the translator need
+`citations_resolved`?") was therefore moot — that field isn't present; the real citations the
+translator sees are the `{Tn}`-masked `<ls>` references inside the **skeleton** (essential, the
+card itself). There is nothing in the portrait that is both sizeable and unneeded
+(`corpus_synonyms` is the corpus layer; stripping it would remove a designed signal).
+
+**Conclusion: portrait-slim is not implemented — it would strip non-existent fields or the
+corpus signal.**
+
+## The real lever: batch budget (rec 11)
+
+The dominant cost is the **fixed per-agent framework overhead (~30 k tokens, paid once per
+agent call)**, not the inlined card. So the lever is **fewer agent calls** = a higher
+`--budget` (bytes packed per agent call). Measured batch counts (= agent calls = cost driver):
+
+| root | b9000 (old) | b12000 | b16000 | b20000 |
+|---|---:|---:|---:|---:|
+| dA | 12 | — | 7 | 6 |
+| car | 12 | — | 6 | 5 |
+| viS | 13 | — | 7 | 6 |
+| vas | 10 | — | 6 | 4 |
+| hA | 8 | — | 4 | 4 |
+
+**Default bumped 9000 → 12000** (a conservative ~−20–25 % agent calls while keeping batches
+within the already-tested 13–14-card range). This is safe: a larger batch that degrades is
+caught by the harness's post-restore `<ls>`/`{#..#}` **fidelity guard**, which nulls the
+mismatched card → requeue — it cannot silently corrupt. Bigger budgets (16–18 k, ~−45 % agent
+calls) are available via `--budget=` but should be **retry-rate-validated on a Max run** before
+becoming the default (a larger batch can raise schema-validation retries).
+
+## Net
+
+The harness was already lean on the dimension the audit targeted. The remaining token savings
+are: (a) this budget bump (shipped), (b) further budget tuning pending a retry-rate measurement,
+(c) the lean-TR trim (already tested twice and **rejected** for quality loss). There is no free
+portrait cut.

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -150,7 +150,9 @@ small batch is −90 %). See [`../../TLONLY_PROTOTYPE.md`](../../TLONLY_PROTOTYP
 ```powershell
 python src\pilot\gen_opt_harness2.py sTA            # default (batched+masked, -72%)
 # -> writes src\pilot\run_pilot_wf.opt2.js  (run THIS in Max, save result as wf_output.json)
-# --budget=N tunes batch packing (chars of skeleton+portrait per batch; default 9000).
+# --budget=N tunes batch packing (chars of skeleton+portrait per batch; default 12000 —
+#   higher = fewer agent calls = less ~30k/agent fixed overhead; the post-restore fidelity
+#   guard nulls any degraded big-batch card -> requeue. See TOKEN_LEVER_FINDING_2026-06-30.md).
 # A batch retries only its still-unresolved cards; a card whose restored <ls>/{#..#}
 # counts don't match source is nulled -> requeue (never emitted garbled).
 ```

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -14,7 +14,7 @@ Quality parity: reuses the FULL production CONV+TR prompt (all HARD RULES, NWS o
 map, Nachträge, microstructure) with a MASKED/BATCHED preamble that overrides only the
 input-format + markup-verbatim specifics ("keep {Tn} verbatim" instead of "{#..#}/<ls>").
 
-Usage:  python src/pilot/gen_opt_harness2.py <root> [--keys=k1,k2] [--budget=9000] [--out=PATH]
+Usage:  python src/pilot/gen_opt_harness2.py <root> [--keys=k1,k2] [--budget=12000] [--out=PATH]
 Writes: src/pilot/run_pilot_wf.opt2.js  (or --out=PATH — use a per-root/per-chat path to
         avoid the gen->copy race when several chats generate harnesses concurrently)
 """
@@ -102,7 +102,13 @@ def parse_args(argv):
     if not argv:
         die('usage: gen_opt_harness2.py <root> [--keys=..] [--budget=N] [--lean] '
             '[--nominal] [--no-grammar]')
-    root, keyfilter, budget, lean, nws_gate = argv[0], None, 9000, False, False
+    # budget = bytes (skeleton+portrait) packed per agent call. Higher = fewer agent calls =
+    # fewer ~30k-token fixed-framework payments per root (the dominant cost). 12000 measured
+    # ~-25% agent calls vs the old 9000 while keeping batches within the tested 13-14-card range;
+    # the post-restore fidelity guard nulls any degraded card -> requeue, so it can't silently
+    # corrupt. Further bumps (16-18k) are available but should be retry-rate-validated on a Max
+    # run first. See TOKEN_LEVER_FINDING_2026-06-30.md (portrait-slim was a non-lever).
+    root, keyfilter, budget, lean, nws_gate = argv[0], None, 12000, False, False
     nominal, grammar_on = False, True
     keylist = None                     # ordered keys (nominal mode preserves order)
     out_path = None                    # --out=PATH overrides the default opt2.js (avoids the


### PR DESCRIPTION
Following up the audit's remaining items; two were not what they appeared.

## Token lever — portrait-slim is a non-lever; budget bump instead
Verified corpus-wide (3,538 sub-card portraits): PROCESS_AUDIT rec 4 is **invalid**. The harness inlines the per-**sub-card** portrait — only **32%** of inlined content (skeleton 68%) with exactly `key1`/`iast`/`evidence_scope`/`corpus_synonyms`; **none** of the claimed strippable fields exist (the audit measured the per-headword aggregate `vart.portrait.json`, not the harness input). Decision #11 moot (`citations_resolved` isn't in the portrait).
- **Real lever:** fewer agent calls (the ~30k/agent fixed overhead) via higher `--budget`. **Default 9000 → 12000** (~−20–25% agent calls: dA 12→9), within the tested batch range; the post-restore fidelity guard nulls any degraded card → requeue.

## Bridge follow-ups — both deeper than a tweak
- **Slice-C recovery** needs a Max re-run (originals overwritten) and overlaps the autonomous account's Slice-C requeue → coordination item.
- **Homograph `(key1,h)`** blocked on assembled having no homonym discriminator (`ord`/`hom`/`h` all `None` on 11.7% multi-entry `key1`); store side is ready. Inert in production (preview-only; G5 gate = 0).

Details in `TOKEN_LEVER_FINDING_2026-06-30.md` + `BRIDGE_FOLLOWUPS_2026-06-30.md`. `window_selftest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)