### PR TITLE
pwg_ru: Slice-C recovery handoff + save_and_audit overwrite guard

### DIFF
--- a/RussianTranslation/HANDOFF_2026-06-30_slicec_recovery.md
+++ b/RussianTranslation/HANDOFF_2026-06-30_slicec_recovery.md
@@ -1,0 +1,99 @@
+# Handoff — recover the full Slice-C translated output
+
+**For:** a fresh agent session (or the autonomous account). **Goal:** restore the ~630
+Slice-C cards missing from local files so the print bridge ([`src/promote_final_cards.py`](src/promote_final_cards.py))
+promotes the **full** Slice C, not a partial set. This is a **Max re-run** task (the originals
+are unrecoverable otherwise — see below) and must be **coordinated** (a second account also
+works pwg_ru on `master`).
+
+## Why the gap exists
+
+During the Slice-C null-requeue pass, the small requeue results were saved **over** the full
+per-root `wf_output.sc.<root>.json` files (`save_and_audit.py` overwrites). So the per-root files
+for the 16 requeued roots now hold only the **requeue subset**, not the full original. Separately,
+**`wf_output.sc.DA.json` was never written at all** — DA's full output (145 cards) lived only in
+the shared `wf_output.sc.json`, which was later overwritten by other roots. The original Slice-C
+run was a different session whose transcripts are not reachable here, so **re-running is the only
+local recovery path**. The rootmaps + masked inputs under `src/pilot/input/` still exist, so a
+re-run reproduces equivalent output.
+
+## What is still salvageable WITHOUT a re-run (do this first, it's volatile)
+
+The two shared files still hold one root each — preserve them before anything overwrites them:
+
+```powershell
+cd RussianTranslation
+# jan (33/38) currently survives in the shared wf_output.sc.json; han (78) in wf_output.json
+copy wf_output.sc.json  wf_output.sc.jan.json    # rescue jan
+copy wf_output.json     wf_output.sc.han.json    # rescue han (Stage C, also promotable)
+```
+
+(The bridge already globs `wf_output*.json` and recovers these, but copying to stable per-root
+names protects them from the next shared-file overwrite.)
+
+## Roots needing a full re-run (16 — have / full sub-cards)
+
+| root | have | full | missing | note |
+|---|---:|---:|---:|---|
+| **DA** | 0 | 145 | 145 | never saved per-root (biggest loss; dhā) |
+| gA | 5 | 65 | 60 | |
+| pat | 1 | 73 | 72 | |
+| vad | 2 | 47 | 45 | |
+| Sam | 5 | 38 | 33 | |
+| Bid | 3 | 35 | 32 | |
+| Buj | 7 | 39 | 32 | |
+| vraj | 2 | 34 | 32 | |
+| pA | 3 | 34 | 31 | |
+| Cid | 5 | 32 | 27 | |
+| naS | 1 | 26 | 25 | |
+| yat | 4 | 28 | 24 | |
+| yaj | 1 | 25 | 24 | |
+| rakz | 1 | 23 | 22 | |
+| hi | 1 | 20 | 19 | |
+| mad | 5 | 21 | 16 | |
+
+≈ **630 cards** total. (The other 10 Slice-C roots — DA-excepted yA, nI, man, banD, su, iz, paS,
+brU, jIv — have full per-root files; leave them.)
+
+## Recovery procedure (per root)
+
+Follow the canonical loop ([`src/pilot/RUN_FREQ_MAX.md`](src/pilot/RUN_FREQ_MAX.md)), **≤3-wide
+concurrency** (Slice D's 18× fan-out caused the 117-null collapse; single/low-width = 0 nulls):
+
+```powershell
+cd RussianTranslation
+# 1. generate the FULL harness for the root (no --keys — the whole root), per-root output file
+python src/pilot/gen_opt_harness2.py DA --out=src/pilot/run_pilot_wf.sc_rec_DA.js
+# 2. run run_pilot_wf.sc_rec_DA.js via the in-chat Workflow tool (≤3 roots at once)
+# 3. save + audit (tag 'sc'):
+python save_and_audit.py DA <task-output-file> sc
+# 4. repeat for the 16 roots, then re-run the bridge (idempotent, supersede):
+python src/promote_final_cards.py
+```
+
+The bridge's coverage report will show the thin-root warning shrink as roots are recovered;
+done when no Slice-C root is flagged thin.
+
+## Guardrail — prevent this from recurring (recommended small fix)
+
+The root cause is that a requeue save overwrote a fuller file. Add a guard to
+`save_and_audit.py`: **refuse to overwrite an existing `wf_output.<tag>.<root>.json` with a file
+that has FEWER non-null cards, unless `--force`** (and for requeue, MERGE the new non-null cards
+into the existing file instead of replacing). This stops the requeue-overwrite class entirely.
+
+## Coordination
+
+- A second (autonomous) account works pwg_ru on `master`; its committed harnesses are
+  `run_pilot_wf.sd_rq_*.js` = **Slice-D** requeue — so Slice-C recovery is *distinct*, not a
+  direct overlap. Still: announce on the branch/PR, do not double-run a root, and do this on a
+  branch (the store `pwg_ru_translated.jsonl` is a gitignored, regenerable artifact).
+- This is a real Max-quota spend (~630 cards across 16 roots). If quota is tight, prioritise the
+  high-card roots (DA 145, pat 72, gA 60) first.
+
+## Pointers
+
+- bridge + coverage report: [`src/promote_final_cards.py`](src/promote_final_cards.py)
+- loop + concurrency doctrine: [`src/pilot/RUN_FREQ_MAX.md`](src/pilot/RUN_FREQ_MAX.md)
+- harness gen: [`src/pilot/gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py) (default budget 12000 if PR #20 merged, else 9000)
+- save: [`save_and_audit.py`](save_and_audit.py) (note the overwrite hazard above)
+- context: [`BRIDGE_FOLLOWUPS_2026-06-30.md`](BRIDGE_FOLLOWUPS_2026-06-30.md), PR #18 (bridge)

--- a/RussianTranslation/save_and_audit.py
+++ b/RussianTranslation/save_and_audit.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python
 r"""Save a Workflow task-output JSON to wf_output.<tag>.<root>.json, then audit it.
 
-  python save_and_audit.py <root> <task_output_file> [tag] [--no-audit]
+  python save_and_audit.py <root> <task_output_file> [tag] [--no-audit] [--merge] [--force]
 
 tag defaults to 'sc' (Slice C); pass 'sd' etc. for other slices — the tag used to
 be hard-coded to 'sc', which silently misfiled every non-sc slice. With audit on
 (the default) it shells to src/pilot/audit_window.py and prints the gate summary,
 so the script name is honest; pass --no-audit to save only (the bulk-save case).
+
+OVERWRITE GUARD: a requeue save once clobbered a fuller per-root file with its small
+subset (the Slice-C recovery gap, HANDOFF_2026-06-30_slicec_recovery.md). So saving a
+file with FEWER non-null cards than the existing one is REFUSED unless --force. For a
+requeue, use --merge: new non-null cards fill the existing file by result key (the full
+set is preserved, nulls are filled).
 """
 import json
 import os
@@ -36,6 +42,29 @@ def main():
         result = wrapper
 
     out_path = os.path.join(HERE, f"wf_output.{tag}.{root}.json")
+
+    def nn(res):                                  # non-null card count
+        return sum(1 for r in (res.get("results") or []) if r.get("card"))
+
+    new_nn = nn(result)
+    if os.path.exists(out_path):
+        try:
+            existing = json.load(open(out_path, encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            existing = None
+        old_nn = nn(existing) if isinstance(existing, dict) else 0
+        if isinstance(existing, dict) and "--merge" in flags:
+            by_key = {r.get("key"): r for r in (existing.get("results") or [])}
+            for r in result.get("results") or []:
+                if r.get("card") or r.get("key") not in by_key:
+                    by_key[r.get("key")] = r        # new non-null fills; new keys append
+            existing["results"] = list(by_key.values())
+            result = existing                        # keep the full-set meta; write merged
+            print(f"Merged into {os.path.basename(out_path)}: {old_nn} -> {nn(result)} non-null")
+        elif old_nn > new_nn and "--force" not in flags:
+            sys.exit(f"REFUSED: {os.path.basename(out_path)} has {old_nn} non-null cards; new has "
+                     f"only {new_nn}. Use --merge to fill nulls, or --force to overwrite.")
+
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(result, f, ensure_ascii=False)
 


### PR DESCRIPTION
Handoff to recover the full Slice-C output (the bridge currently promotes ~1,431 of ~1,989 cards) + the guardrail that prevents the data-loss from recurring. See `HANDOFF_2026-06-30_slicec_recovery.md`.

## The gap (~630 cards / 16 roots)
The Slice-C null-requeue pass saved small requeue subsets **over** the full per-root `wf_output.sc.<root>.json` files; **`DA` (145 cards) was never saved per-root** (only the later-overwritten shared file). Originals are unrecoverable except by a Max re-run. The handoff lists the 16 roots with have/full counts (DA 145, pat 72, gA 60, …), rescues `jan`(33)/`han`(78) from the volatile shared files, and specs the per-root recovery loop at ≤3-wide concurrency. The autonomous account's `sd_rq_*` harnesses are Slice-**D** requeue (distinct, not a direct overlap) — coordinate anyway.

## Guardrail — `save_and_audit.py`
- **Refuses** to overwrite with fewer non-null cards (unless `--force`) — the exact requeue-clobber that caused the gap.
- **`--merge`** fills the existing file's nulls by result key (correct requeue behavior). Tested: refuse / merge (5→5) / force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)