### PR TITLE
pwg_ru: FIX homograph keying (no handoff needed) — verified on dA + vah

### DIFF
--- a/RussianTranslation/HOMOGRAPH_KEYING_FIX_2026-06-30.md
+++ b/RussianTranslation/HOMOGRAPH_KEYING_FIX_2026-06-30.md
@@ -1,0 +1,49 @@
+# Homograph keying — FIXED (supersedes the handoff)
+
+**Date:** 2026-06-30. The homograph multiplication in the bridge preview is **fixed**, verified
+on `dA` and `vah`. This supersedes [`HANDOFF_2026-06-30_homograph_keying.md`](HANDOFF_2026-06-30_homograph_keying.md)
+(no handoff needed) and corrects the "blocked, no discriminator" assessment in the bridge
+follow-up note.
+
+## The insight that unblocked it
+
+The blocker was framed as "the **assembled** side has no homonym discriminator." True — and the
+assembled same-`key1` entries are redundant (identical dict glosses) and segmented differently
+from PWG homonyms, so they can't be matched. **But the homonym never needed to come from the
+assembled side** — the **store** side has a clean homonym: each row's `subcard` key carries it
+(`dA~~h3_..` → `h3`). So instead of attaching `translations[key1]` to every assembled entry
+(the multiplication) and trying to fragile-match the assembled side, the fix attaches the
+translations **once per `key1`** and labels each translation sense with its **store** homonym.
+
+## What changed ([`src/export_interop.py`](src/export_interop.py))
+
+1. `card_glosses(card, translations, emitted)` — translations are emitted **once per `key1`**
+   (an `emitted` set, shared per export). `emitted=None` keeps the legacy behaviour.
+2. Each translation sense is labelled by `store_homonym(row)` → `n="h3-review-2"`, so per-homonym
+   attribution is preserved from the clean store side.
+3. **Unique `xml:id`** per same-`key1` entry (`pwg-dA`, `pwg-dA-2`, …) — also fixes the prior
+   invalid-TEI duplicate-ID collision (all homographs were `xml:id="pwg-dA"`).
+4. Threaded through `export_tei` / `export_ontolex` / `export_reverse_index`.
+
+## Verified on the 2 real cases
+
+Preview export (`--review-status ai_translated`) over a `dA`+`vah` fixture:
+
+| | before (multiplied) | after (fixed) |
+|---|---|---|
+| total `approved_translation` senses | ~1,785 (345×4 + 135×3) | **480** (345 + 135 = the actual store rows) |
+| `xml:id`s | 4× `pwg-dA`, 3× `pwg-vah` (collide) | `pwg-dA`, `pwg-dA-2/3/4`, `pwg-vah`, `pwg-vah-2/3` (unique) |
+| translation senses on `pwg-dA` / siblings | 345 on each of 4 | **345 on `pwg-dA`, 0 on siblings** |
+| homonym labels | none | `h0..h9` (dA), `h0..h2` (vah) on each sense |
+
+`window_selftest` 18/18 (new `test_export_translation_dedup`).
+
+## Production safety + a remaining minor item
+
+- **Unchanged in production:** the default export gate is still `{approved, human_reviewed}`
+  (0 rows until G5 review), so this fix only affects *attribution* of preview/approved rows.
+- **Separate, pre-existing:** the *structural* dict glosses still repeat across the redundant
+  sibling entries (`pwg-dA-2/3/4` carry the same koch glosses). That is a different
+  redundancy (the assembled cards overlap) and is out of scope here — this fix targets the
+  translation multiplication + the duplicate IDs. Collapsing redundant sibling entries is an
+  edition-modelling choice for the renderer stage.

--- a/RussianTranslation/src/export_interop.py
+++ b/RussianTranslation/src/export_interop.py
@@ -7,6 +7,7 @@
   python export_interop.py all --limit 100 --out-dir release/fixture
 """
 import argparse
+import collections
 import json
 import os
 import re
@@ -76,7 +77,14 @@ def statuses(args):
     return {s.strip() for s in raw.split(',') if s.strip()}
 
 
-def card_glosses(card, translations):
+def store_homonym(row):
+    """The store row's homonym ordinal (h0/h1/..) from its sub-card key — the CLEAN homonym
+    label. The assembled side has no homonym key, so attribution is sourced from the store."""
+    sub = row.get('subcard') or ''
+    return sub.split('~~')[1].split('_')[0] if '~~' in sub else 'h?'
+
+
+def card_glosses(card, translations, emitted=None):
     rows = []
     for d in card.get('attested_senses', {}).get('dict') or []:
         if d.get('gloss'):
@@ -87,8 +95,17 @@ def card_glosses(card, translations):
         for r in st.get('renderings') or []:
             if r.get('lemma'):
                 rows.append(('corpus_lexicon', st.get('period') or 'corpus', r.get('lemma')))
-    for i, r in enumerate(translations.get(card.get('key1'), []), 1):
-        rows.append(('approved_translation', 'review-%d' % i, r.get('ru')))
+    # Translations attach ONCE per key1 (homograph fix): the assembled side has no homonym
+    # discriminator and its same-key1 entries are redundant, so attaching translations[key1]
+    # to every entry multiplied them. The store separates homonyms cleanly — each translation
+    # sense is labelled with its store homonym (h0/h1/..). `emitted` (a per-export set) makes
+    # the dedup explicit; pass None for the legacy (multiplying) behaviour.
+    key1 = card.get('key1')
+    if emitted is None or key1 not in emitted:
+        if isinstance(emitted, set):
+            emitted.add(key1)
+        for i, r in enumerate(translations.get(key1, []), 1):
+            rows.append(('approved_translation', '%s-review-%d' % (store_homonym(r), i), r.get('ru')))
     return rows
 
 
@@ -103,12 +120,15 @@ def export_tei(args):
         f.write('<publicationStmt><p>Project release artifact.</p></publicationStmt>')
         f.write('<sourceDesc><p>Generated from assembled_cards.jsonl.</p></sourceDesc></fileDesc></teiHeader>\n')
         f.write('  <text><body>\n')
+        emitted, idn = set(), collections.Counter()
         for card in iter_cards(args.cards, args.limit):
-            cid = 'pwg-%s' % safe_id(card.get('key1'))
+            key1 = card.get('key1')
+            idn[key1] += 1                      # unique xml:id across same-key1 homograph entries
+            cid = 'pwg-%s' % safe_id(key1) + ('' if idn[key1] == 1 else '-%d' % idn[key1])
             f.write('    <entry xml:id="%s">\n' % q(cid))
             f.write('      <form><orth>%s</orth><pron notation="iast">%s</pron></form>\n'
                     % (q(card.get('key1')), q(card.get('iast'))))
-            for source, ref, text in card_glosses(card, translations):
+            for source, ref, text in card_glosses(card, translations, emitted):
                 f.write('      <sense source="%s" n="%s"><def>%s</def></sense>\n'
                         % (q(source), q(ref), q(text)))
             f.write('    </entry>\n')
@@ -124,11 +144,14 @@ def export_ontolex(args):
         f.write('@prefix ontolex: <http://www.w3.org/ns/lemon/ontolex#> .\n')
         f.write('@prefix lexinfo: <http://www.lexinfo.net/ontology/3.0/lexinfo#> .\n')
         f.write('@prefix pwg: <https://example.org/pwg/ru/> .\n\n')
+        emitted, idn = set(), collections.Counter()
         for card in iter_cards(args.cards, args.limit):
-            sid = safe_id(card.get('key1'))
+            key1 = card.get('key1')
+            idn[key1] += 1
+            sid = safe_id(key1) + ('' if idn[key1] == 1 else '_%d' % idn[key1])
             f.write('pwg:%s a ontolex:LexicalEntry ;\n' % sid)
             f.write('  ontolex:canonicalForm [ ontolex:writtenRep "%s"@sa-Latn ] ;\n' % ttl(card.get('key1')))
-            senses = card_glosses(card, translations)
+            senses = card_glosses(card, translations, emitted)
             if senses:
                 refs = ', '.join('pwg:%s_sense_%d' % (sid, i + 1) for i in range(len(senses)))
                 f.write('  ontolex:sense %s .\n' % refs)
@@ -150,9 +173,10 @@ def export_reverse_index(args):
     out = os.path.join(args.out_dir, 'reverse_index.jsonl')
     count = 0
     with open(out, 'w', encoding='utf-8', newline='') as f:
+        emitted = set()
         for card in iter_cards(args.cards, args.limit):
             seen = set()
-            for source, ref, text in card_glosses(card, translations):
+            for source, ref, text in card_glosses(card, translations, emitted):
                 for m in CYR.findall(text or ''):
                     lemma = m.lower().strip('-')
                     if len(lemma) < 2:

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -654,11 +654,30 @@ def test_requeue_transient_vs_defect_state():
         fail('pre-split reports must remain needs_requeue (no silent transient downgrade)')
 
 
+def test_export_translation_dedup():
+    """Homograph fix: translations attach ONCE per key1, labelled by store homonym; a second
+    same-key1 (homograph) entry must NOT repeat them (was the preview multiplication)."""
+    from export_interop import card_glosses
+    translations = {'dA': [{'ru': 'давать', 'subcard': 'dA~~h0_00_pwg00'},
+                           {'ru': 'резать', 'subcard': 'dA~~h3_00_pwg00'}]}
+    card = {'key1': 'dA', 'attested_senses': {}, 'records': []}
+    emitted = set()
+    t1 = [r for r in card_glosses(card, translations, emitted) if r[0] == 'approved_translation']
+    t2 = [r for r in card_glosses(card, translations, emitted) if r[0] == 'approved_translation']
+    if len(t1) != 2:
+        fail('first homograph entry must carry both translations')
+    if t2:
+        fail('a second same-key1 entry must NOT repeat translations (homograph dedup)')
+    if not (t1[0][1].startswith('h0-') and t1[1][1].startswith('h3-')):
+        fail('each translation sense must be labelled by its store homonym')
+
+
 def main():
     tests = [
         test_workflow_payload_nested,
         test_sense_dupe_batch_override,
         test_sense_dupe_cross_level_exempt,
+        test_export_translation_dedup,
         test_requeue_transient_vs_defect_state,
         test_harness_scope_and_tools,
         test_prompt_rule_audit_template,


### PR DESCRIPTION
The homograph multiplication is **fixed**, not handed off. **Supersedes PR #21** (the handoff). See `HOMOGRAPH_KEYING_FIX_2026-06-30.md`.

## Insight
The homonym never needed to come from the **assembled** side (no discriminator; redundant same-`key1` entries). The **store** side has it — each row's `subcard` key (`dA~~h3_..` → `h3`). So `export_interop.py` now: attaches translations **once per `key1`** (an `emitted` set; `None` = legacy), labels each translation sense by its **store** homonym (`n="h3-review-2"`), and mints a **unique `xml:id`** per same-`key1` entry (`pwg-dA`, `pwg-dA-2`, …) — also fixing the prior invalid-TEI duplicate-ID collision.

## Verified on dA + vah (preview)
- `approved_translation` senses: ~1,785 (multiplied) → **480** (= actual store rows).
- xml:ids: collide → unique. Translations on `pwg-dA`: 345; siblings: **0**. Homonym labels `h0..h9` present.
- `window_selftest` 18/18 (+`test_export_translation_dedup`).
- **Production unchanged** (default gate `{approved,human_reviewed}` = 0 rows; fixes attribution only). Pre-existing separate item: structural dict glosses still repeat across redundant siblings (renderer-stage collapse, out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)