### PR TITLE
Slice-C recovery (partial): DA recovered free; pat/gA/vad re-run

### DIFF
--- a/RussianTranslation/HANDOFF_2026-06-30_slicec_recovery.md
+++ b/RussianTranslation/HANDOFF_2026-06-30_slicec_recovery.md
@@ -1,5 +1,22 @@
 # Handoff — recover the full Slice-C translated output
 
+> **UPDATE 2026-06-30 (recovery session, branch `recover/slicec-top3-pat-ga-vad`):**
+> Two material corrections to the plan below, plus progress:
+> - **DA needs NO re-run.** The full dhā output survives on disk in
+>   [`wf_output_da_a.json`](wf_output_da_a.json) + [`wf_output_da_b.json`](wf_output_da_b.json)
+>   (72+73=145 cards; the bridge globs `wf_output*.json` and promoted **138/145**). The
+>   table's "DA 0/145 — biggest loss" is stale. Only ~7 DA cards are marginal.
+> - **True remaining deficit ≈ 514 cards / 15 roots** (not 630/16), because DA drops out.
+> - **`jan`/`han` salvaged** to stable names `wf_output.sc.jan_full.json` / `wf_output.sc.han.json`.
+> - **The §Guardrail fix is already implemented** in [`save_and_audit.py`](save_and_audit.py)
+>   (overwrite-refusal + `--merge`). Do not re-add it.
+> - **DONE this session (Max re-run, ≤3-wide): `pat` (73), `gA` (65), `vad` (47).** Saved as
+>   full per-root files; bridge coverage 1431→1603 non-null cards / 7218 sense rows; pat/gA/vad
+>   off the thin-warning list. Residual requeues left for an optional quality pass:
+>   transient nulls pat 5 / gA 2; defect (semantic-risk, G5 territory) pat 14 / gA 6 / vad 8.
+> - **STILL TO DO (12 roots, ~390 cards):** Sam(36), vraj(34), Buj(33), Bid(32), pA(32),
+>   Cid(27), yat(25), naS(25), yaj(25), rakz(23), hi(19), mad(17) — same loop as below.
+
 **For:** a fresh agent session (or the autonomous account). **Goal:** restore the ~630
 Slice-C cards missing from local files so the print bridge ([`src/promote_final_cards.py`](src/promote_final_cards.py))
 promotes the **full** Slice C, not a partial set. This is a **Max re-run** task (the originals


### PR DESCRIPTION
Acts on [`RussianTranslation/HANDOFF_2026-06-30_slicec_recovery.md`](https://github.com/gasyoun/SanskritLexicography/blob/recover/slicec-top3-pat-ga-vad/RussianTranslation/HANDOFF_2026-06-30_slicec_recovery.md). The translated outputs are gitignored regenerable artifacts, so this PR is the **documentation + plan correction**; the data lives in the per-root `wf_output.sc.*.json` files and the promoted store.

## Two material corrections to the original handoff plan
- **DA (dhā) needs NO re-run.** The full output survives on disk in `wf_output_da_a.json` + `wf_output_da_b.json` (72+73 = 145 cards). The bridge globs `wf_output*.json` and promotes any non-null `card` (it does **not** gate on `judge`), so DA was already recoverable — the bridge promoted **138/145**. The handoff's "DA 0/145 — biggest loss" was stale.
- **True remaining deficit ≈ 514 cards / 15 roots**, not 630/16 (DA drops out).

## Done this session (Max re-run, ≤3-wide on this branch)

| root | cards | non-null | transient nulls | defect (G5 territory) |
|---|---:|---:|---:|---:|
| pat | 73 | 68 | 5 | 14 |
| gA | 65 | 63 | 2 | 6 |
| vad | 47 | 47 | 0 | 8 |

- Bridge coverage **1431 → 1603 non-null cards / 7218 sense rows**, written `review_status=ai_translated` (G5 approval gate intact; prior store backed up). pat/gA/vad are off the thin-warning list.
- `jan`/`han` salvaged to stable per-root names before any shared-file overwrite.
- The handoff's recommended overwrite-guard is **already implemented** in [`save_and_audit.py`](https://github.com/gasyoun/SanskritLexicography/blob/recover/slicec-top3-pat-ga-vad/RussianTranslation/save_and_audit.py) (refuse thinner overwrite + `--merge`); not re-added.

## Still to do (12 roots, ~390 cards) — separate Max sessions
Sam(36), vraj(34), Buj(33), Bid(32), pA(32), Cid(27), yat(25), naS(25), yaj(25), rakz(23), hi(19), mad(17). Optional quality pass: residual transient/defect requeues on pat/gA/vad. Resume point recorded in `Uprava/GTD_NEXT_ACTIONS.md`.

## Coordination
A second (autonomous) account works pwg_ru Slice-D on `master`; this Slice-C work is distinct. Done on a branch; only the handoff doc is a tracked change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
