### PR TITLE
pwg_en: FU1 Phase-0 scaffolding — Opus EN judge, en_provenance, gold sample

### DIFF
--- a/RussianTranslation/FU1_PLAN.md
+++ b/RussianTranslation/FU1_PLAN.md
@@ -12,7 +12,7 @@ is [`HANDOFF_2026-06-30_pwg_en_fu1_run.md`](HANDOFF_2026-06-30_pwg_en_fu1_run.md
 | # | Decision | Choice | Consequence |
 |---|---|---|---|
 | 1 | Architecture | **Bilingual for new roots, EN-only for already-RU'd** | FU1's scope is exactly the already-RU'd roots → **this tranche is EN-only + `promote_en.py` merge**. The bilingual single-pass (RU+EN in one workflow call, identical segmentation, one metadata set) is the standing policy for *future* freq roots beyond current RU coverage — adopt it the moment RU and EN extend together. |
-| 2 | Model tier | **Sonnet generate + Opus judge** | Generate with `gen_opt_harness2.py --lang en` (pins `model:'sonnet'`); add an Opus judge pass. Report the tier at every step (per [[feedback_state_model_tier]]). |
+| 2 | Model tier | **Sonnet generate + Opus judge** | Generate with `gen_opt_harness2.py --lang=en` (pins `model:'sonnet'`); add an Opus judge pass. Report the tier at every step (per [[feedback_state_model_tier]]). |
 | 3 | Scope | **Match current RU coverage** | EN for the roots already in the store, no new RU work. Worklist below. |
 | 4 | Validation | **Audit + Opus judge + human gold sample** | FU2 deterministic gate on all + Opus judge on all + a human-validated stratified gold sample with documented inter-annotator agreement (Cohen κ) and error rate. The citable-resource bar. |
 | 5 | Provenance | **Full per-sense** | Each EN sense records model tier, Opus judge verdict + score, `generated_at`, harness SHA, and whether an MW reference was used. |
@@ -54,7 +54,7 @@ the same FAIL until the RU-side h1 dedup lands.
 ```sh
 git rev-parse --abbrev-ref HEAD          # MUST be recover/slicec-top3-pat-ga-vad, not master
 python src/pilot/root_window_status.py <root>            # confirm rootmap + masked inputs exist
-python src/pilot/gen_opt_harness2.py <root> --lang en --out=src/pilot/run_pilot_wf.en_<root>.js
+python src/pilot/gen_opt_harness2.py <root> --lang=en --out=src/pilot/run_pilot_wf.en_<root>.js  # NB: --lang=en (with '='); space form silently falls back to RU
 # → run via in-chat Workflow tool, ≤3-wide
 python save_and_audit.py <root> <task-output-file> en    # runs audit_window_en.py (FU2), no --no-audit
 ```

--- a/RussianTranslation/HANDOFF_2026-06-30_pwg_en_fu1_run.md
+++ b/RussianTranslation/HANDOFF_2026-06-30_pwg_en_fu1_run.md
@@ -65,7 +65,9 @@ Per root (no deviation):
 git rev-parse --abbrev-ref HEAD                          # your FU1 branch, NOT master
 python src/pilot/root_window_status.py <root>            # rootmap + masked inputs must exist;
                                                          # if missing: python src/_pilot_gen_merged.py --manifest freq --root-split --limit N
-python src/pilot/gen_opt_harness2.py <root> --lang en --out=src/pilot/run_pilot_wf.en_<root>.js
+python src/pilot/gen_opt_harness2.py <root> --lang=en --out=src/pilot/run_pilot_wf.en_<root>.js
+# NB: the parser needs --lang=en (with '='); the space form `--lang en` is silently ignored
+# and falls back to RU. Confirm the harness: grep -c '"english"' must be 1, '"russian"' 0.
 # → run run_pilot_wf.en_<root>.js via the in-chat Workflow tool, ≤3-wide
 python save_and_audit.py <root> <task-output-file> en    # runs audit_window_en.py (FU2); fix HARD flags, re-run nulls
 ```
@@ -96,7 +98,7 @@ python src/annotate_dcs_freq.py     # re-attach dcs_freq (language-agnostic, ide
 
 - Plan + decisions: [`FU1_PLAN.md`](FU1_PLAN.md) · parent handoff:
   [`HANDOFF_2026-06-30_pwg_en_followups.md`](HANDOFF_2026-06-30_pwg_en_followups.md)
-- EN harness: [`src/pilot/gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py) (`--lang en`) ·
+- EN harness: [`src/pilot/gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py) (`--lang=en`) ·
   prompt [`src/pilot/tr_en.txt`](src/pilot/tr_en.txt) · MW TM [`src/mw_en_tm.py`](src/mw_en_tm.py)
 - EN audit gate: [`src/pilot/audit_window_en.py`](src/pilot/audit_window_en.py) ·
   merge: [`src/promote_en.py`](src/promote_en.py) · save: [`save_and_audit.py`](save_and_audit.py)

--- a/RussianTranslation/src/fidelity_sample_en.py
+++ b/RussianTranslation/src/fidelity_sample_en.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+r"""fidelity_sample_en.py — deterministic stratified sample of EN cards for the Opus EN judge.
+
+The EN analog of fidelity_sample.py. The DE->RU sampler reads the RU store senses (ru); this one
+reads the per-root EN workflow outputs (wf_output.en.<root>.json) and samples senses carrying an
+`english` rendering so an Opus judge can rate a representative DE->EN slice and we can publish
+precision + a 95% Wilson CI (via the SAME fidelity_aggregate.py — verdict schema is unchanged).
+
+  python src/fidelity_sample_en.py [--n 100] [--seed 42] [--glob 'wf_output.en.*.json']
+  -> writes src/pilot/output/fidelity_sample_en.jsonl  (key, iast, stratum, slice, senses[de,en,tag])
+
+Stratum per card = the most common non-empty sense.stratum (else 'unspecified'). The sample is
+proportional to stratum sizes with a floor of min(5, available) per stratum, deterministic for a
+given (seed, glob) — identical policy to fidelity_sample.py so the two samples are comparable.
+"""
+import argparse
+import collections
+import glob
+import json
+import os
+import random
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+OUT = os.path.join(HERE, 'pilot', 'output')
+
+
+def load_wf(path):
+    with open(path, encoding='utf-8') as f:
+        wrapper = json.load(f)
+    result = wrapper.get('result')
+    if isinstance(result, str):
+        result = json.loads(result)
+    return result if result is not None else wrapper
+
+
+def collect_cards(paths):
+    """sub-card key -> {card, meta, wf_file}; first non-empty wins (mirrors promote/RU sampler)."""
+    best = {}
+    for path in paths:
+        try:
+            res = load_wf(path)
+        except (OSError, json.JSONDecodeError):
+            continue
+        meta = res.get('meta') or {}
+        for r in res.get('results') or []:
+            key, card = r.get('key'), r.get('card')
+            if key and card and key not in best:
+                best[key] = {'card': card, 'meta': meta, 'wf_file': os.path.basename(path)}
+    return best
+
+
+def card_stratum(card):
+    strata = [s.get('stratum') for rec in card.get('records') or []
+              for s in rec.get('senses') or [] if s.get('stratum')]
+    if not strata:
+        return 'unspecified'
+    return collections.Counter(strata).most_common(1)[0][0]
+
+
+def card_senses(card):
+    out = []
+    for rec in card.get('records') or []:
+        for s in rec.get('senses') or []:
+            if s.get('english'):
+                out.append({'tag': s.get('tag'), 'de': s.get('german'),
+                            'en': s.get('english'), 'stratum': s.get('stratum'),
+                            'source_type': s.get('source_type')})
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--n', type=int, default=100)
+    ap.add_argument('--seed', type=int, default=42)
+    ap.add_argument('--glob', default='wf_output.en.*.json')
+    ap.add_argument('--out', default=os.path.join(OUT, 'fidelity_sample_en.jsonl'))
+    args = ap.parse_args()
+
+    paths = sorted(glob.glob(os.path.join(ROOT, args.glob)))
+    best = collect_cards(paths)
+    cards = []
+    for subkey, entry in best.items():
+        card = entry['card']
+        senses = card_senses(card)
+        if not senses:
+            continue
+        cards.append({
+            'key': subkey,
+            'iast': card.get('iast'),
+            'root': entry['meta'].get('root'),
+            'slice': 'sc' if '.sc.' in entry['wf_file'] else ('sd' if '.sd.' in entry['wf_file'] else 'other'),
+            'wf_file': entry['wf_file'],
+            'stratum': card_stratum(card),
+            'senses': senses,
+        })
+
+    by_stratum = collections.defaultdict(list)
+    for c in cards:
+        by_stratum[c['stratum']].append(c)
+    rng = random.Random(args.seed)
+    total = len(cards)
+    picked = []
+    for stratum, group in sorted(by_stratum.items()):
+        group = sorted(group, key=lambda c: c['key'])
+        rng.shuffle(group)
+        want = max(min(5, len(group)), round(args.n * len(group) / total)) if total else 0
+        picked.extend(group[:min(want, len(group))])
+    rng.shuffle(picked)
+    picked = picked[:args.n] if len(picked) > args.n else picked
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, 'w', encoding='utf-8') as f:
+        for c in picked:
+            f.write(json.dumps(c, ensure_ascii=False) + '\n')
+
+    dist = collections.Counter(c['stratum'] for c in picked)
+    print('population cards: %d | sampled: %d (seed %d)' % (total, len(picked), args.seed))
+    print('sample by stratum: %s' % dict(sorted(dist.items())))
+    print('wrote %s' % args.out)
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/gold_sample_en.py
+++ b/RussianTranslation/src/gold_sample_en.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+r"""gold_sample_en.py — stratified human-gold sample of the tri-lingual store's EN layer.
+
+FU1 locked decision 4: the citable bar is FU2 audit + Opus judge + a HUMAN-validated gold sample
+with documented inter-annotator agreement (Cohen kappa) and error rate. This draws that sample.
+
+Population = store rows that carry `en`. Strata = DCS freq band x source_type x stratum, fixed
+seed, proportional with a per-cell floor (deterministic). Emits:
+
+  1. a gitignored WORKING sample (gold_sample_en.jsonl) — id + headword + de + en + the strata, plus
+     `period`/`kind` ALIASES (period = "band<N>", kind = source_type) so the existing kappa/precision
+     scorer gold_agreement.py consumes the ingested labels UNCHANGED (it breaks down by period+kind).
+  2. a BLANK reviewer sheet (gold/reviewer_sheet_en.csv) showing ONLY headword + de + en + a
+     human_label column. Monier-Williams is DELIBERATELY ABSENT — ground truth is faithful-to-German
+     (decision 6); showing MW would anchor the annotator to a different dictionary.
+  3. a METHODS note (gold/METHODS_en.md) for the citable layer.
+
+Reviewer labels (gold_agreement.py vocabulary): correct | lemma-variant | proper-name | partial |
+wrong-sense | hallucinated. GOOD = {correct, lemma-variant, proper-name}; ERR = {wrong-sense,
+hallucinated}. Two annotators -> gold_agreement.py reports precision + Cohen kappa.
+
+  python src/gold_sample_en.py --n 300 [--seed 42]
+  python src/gold_sample_en.py --dry-run        # report composition, write nothing
+  python src/gold_sample_en.py --selftest
+Downstream: python src/gold_packet.py gold/reviewer_sheet_en.csv   # split into reviewer packets
+            python src/gold_agreement.py gold/human_gold_labels_en.jsonl
+"""
+import argparse
+import collections
+import csv
+import json
+import os
+import random
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+DEFAULT_STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+GOLD = os.path.join(ROOT, 'gold')
+SAMPLE = os.path.join(HERE, 'gold_sample_en.jsonl')
+SHEET = os.path.join(GOLD, 'reviewer_sheet_en.csv')
+METHODS = os.path.join(GOLD, 'METHODS_en.md')
+LABELS = ['correct', 'lemma-variant', 'proper-name', 'partial', 'wrong-sense', 'hallucinated']
+SHEET_FIELDS = ['id', 'headword', 'de', 'en', 'human_label', 'notes']
+
+
+def band_label(row):
+    f = row.get('dcs_freq') or {}
+    b = f.get('band')
+    return 'band%s' % b if b is not None else 'band_na'
+
+
+def cell_of(row):
+    return (band_label(row), row.get('source_type') or 'na', row.get('stratum') or 'unspecified')
+
+
+def stratified(rows, n, seed):
+    cells = collections.defaultdict(list)
+    for r in rows:
+        cells[cell_of(r)].append(r)
+    rng = random.Random(seed)
+    total = len(rows)
+    picked = []
+    for cell, group in sorted(cells.items()):
+        group = sorted(group, key=lambda r: (r.get('subcard') or '', r.get('sense_tag') or ''))
+        rng.shuffle(group)
+        want = max(min(3, len(group)), round(n * len(group) / total)) if total else 0
+        picked.extend(group[:min(want, len(group))])
+    rng.shuffle(picked)
+    return picked[:n] if len(picked) > n else picked
+
+
+def to_record(i, r):
+    band, src, stratum = cell_of(r)
+    return {
+        'id': i,
+        'headword': r.get('iast'),
+        'key1': r.get('key1'), 'subcard': r.get('subcard'), 'sense_tag': r.get('sense_tag'),
+        'de': r.get('de'), 'en': r.get('en'),
+        'freq_band': band, 'source_type': src, 'stratum': stratum,
+        'period': band, 'kind': src,           # ALIASES for gold_agreement.py breakdowns
+    }
+
+
+def write_outputs(picked):
+    os.makedirs(GOLD, exist_ok=True)
+    recs = [to_record(i, r) for i, r in enumerate(picked)]
+    with open(SAMPLE, 'w', encoding='utf-8') as f:
+        for rec in recs:
+            f.write(json.dumps(rec, ensure_ascii=False) + '\n')
+    with open(SHEET, 'w', encoding='utf-8-sig', newline='') as f:
+        w = csv.DictWriter(f, fieldnames=SHEET_FIELDS, extrasaction='ignore')
+        w.writeheader()
+        for rec in recs:
+            w.writerow({'id': rec['id'], 'headword': rec['headword'],
+                        'de': rec['de'], 'en': rec['en'], 'human_label': '', 'notes': ''})
+    comp = collections.Counter((rec['freq_band'], rec['source_type']) for rec in recs)
+    methods = [
+        '# EN gold sample — METHODS', '',
+        'Ground truth: **faithful to the PWG German** sense (FU1 decision 6). Monier-Williams is a',
+        'cross-check only and is **withheld from the reviewer sheet** to avoid anchoring.', '',
+        '- Population: tri-lingual store rows carrying `en` (%d sampled).' % len(recs),
+        '- Strata: DCS freq band x source_type x stratum, fixed seed, proportional with a per-cell floor.',
+        '- Reviewer sheet shows headword + German (de) + English (en) only; label vocabulary: '
+        + ', '.join('`%s`' % l for l in LABELS) + '.',
+        '- GOOD = {correct, lemma-variant, proper-name}; ERR = {wrong-sense, hallucinated}.',
+        '- Two annotators -> `gold_agreement.py` reports precision (Wilson 95%% CI) + Cohen kappa.',
+        '  The working sample aliases `period`=freq-band and `kind`=source_type so that scorer is',
+        '  reused unchanged.', '',
+        '## Sample composition (freq_band x source_type)', '',
+        '| freq_band | source_type | n |', '|---|---|---:|',
+    ]
+    for (band, src), c in sorted(comp.items()):
+        methods.append('| %s | %s | %d |' % (band, src, c))
+    open(METHODS, 'w', encoding='utf-8').write('\n'.join(methods) + '\n')
+    return recs, comp
+
+
+def selftest():
+    rows = []
+    for i in range(60):
+        rows.append({'iast': 'hw%d' % i, 'key1': 'k%d' % i, 'subcard': 's%d' % i,
+                     'sense_tag': '1', 'de': 'deutsch %d' % i, 'en': 'english %d' % i,
+                     'source_type': 'attested' if i % 2 else 'lexicographic',
+                     'stratum': 'Vedic' if i % 3 else 'Classical',
+                     'dcs_freq': {'band': i % 6}})
+    picked = stratified(rows, 20, 42)
+    assert 0 < len(picked) <= 20, 'sample is non-empty and never exceeds n'
+    assert [r['key1'] for r in stratified(rows, 20, 42)] == [r['key1'] for r in picked], \
+        'deterministic for a fixed seed'
+    rec = to_record(0, picked[0])
+    assert set(SHEET_FIELDS) - {'human_label', 'notes'} <= set(['id'] + list(rec)), 'sheet cols present'
+    assert 'mw' not in rec and 'monier' not in str(rec).lower(), 'MW must be absent from the sample'
+    assert rec['period'] == rec['freq_band'] and rec['kind'] == rec['source_type'], 'aliases set'
+    print('gold_sample_en selftest OK (%d rows, deterministic, MW-free, aliased)' % len(picked))
+
+
+def main():
+    if '--selftest' in sys.argv[1:]:
+        return selftest()
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--n', type=int, default=300)
+    ap.add_argument('--seed', type=int, default=42)
+    ap.add_argument('--store', default=DEFAULT_STORE)
+    ap.add_argument('--dry-run', action='store_true')
+    args = ap.parse_args()
+
+    if not os.path.exists(args.store):
+        sys.exit('no store at %s' % args.store)
+    rows = [json.loads(l) for l in open(args.store, encoding='utf-8') if l.strip()]
+    en_rows = [r for r in rows if r.get('en')]
+    if not en_rows:
+        sys.exit('no rows carry `en` yet — run promote_en.py first')
+    picked = stratified(en_rows, args.n, args.seed)
+    comp = collections.Counter((band_label(r), r.get('source_type') or 'na') for r in picked)
+    print('population (rows with en): %d | sampled: %d (seed %d, target %d)'
+          % (len(en_rows), len(picked), args.seed, args.n))
+    for cell, c in sorted(comp.items()):
+        print('  %-10s %-14s : %d' % (cell[0], cell[1], c))
+    if args.dry_run:
+        print('\n(dry run — nothing written)')
+        return
+    recs, _ = write_outputs(picked)
+    print('\nwrote working sample  -> %s (%d rows)' % (os.path.relpath(SAMPLE, ROOT), len(recs)))
+    print('wrote reviewer sheet  -> %s (MW hidden)' % os.path.relpath(SHEET, ROOT))
+    print('wrote METHODS note    -> %s' % os.path.relpath(METHODS, ROOT))
+    print('NEXT: src/gold_packet.py %s  (split into reviewer packets)' % os.path.relpath(SHEET, ROOT))
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/gen_fidelity_judge_en.py
+++ b/RussianTranslation/src/pilot/gen_fidelity_judge_en.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+r"""gen_fidelity_judge_en.py — emit a self-contained Opus EN-fidelity-judge workflow.
+
+The EN analog of gen_fidelity_judge.py. Inlines the EN stratified sample into a Workflow JS so the
+script is self-contained (workflow scripts have no filesystem access). Each agent judges a batch of
+cards' DE->EN faithfulness and returns the SAME {key, ok, severity, issues, note} verdict schema as
+the RU judge (judge_ab_score: BAD = ok=false || severity>=3), so fidelity_aggregate.py consumes the
+verdicts unchanged.
+
+Ground truth (FU1 locked decision 6): faithful to the PWG **German** sense. Monier-Williams is a
+cross-check only, never the standard. Markup/sigla preservation and PWG sense-order integrity are
+HARD sub-checks; divergence from MW is a SOFT note, never a fail.
+
+  python src/fidelity_sample_en.py --n 100             # writes the EN sample
+  python src/pilot/gen_fidelity_judge_en.py [--batch 6]  # writes src/pilot/run_fidelity_judge_en.js
+  # run run_fidelity_judge_en.js via the Workflow tool (Opus), save result.verdicts; then:
+  python src/pilot/fidelity_aggregate.py <verdicts.json> --sample src/pilot/output/fidelity_sample_en.jsonl
+"""
+import argparse
+import json
+import os
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUT = os.path.join(HERE, 'output')
+SAMPLE = os.path.join(OUT, 'fidelity_sample_en.jsonl')
+HARNESS = os.path.join(HERE, 'run_fidelity_judge_en.js')
+CAP = 600  # cap de/en per sense for judging (gloss meaning is up front; citations are markup)
+
+RUBRIC = (
+    "You are a proofreader for an English rendering of the Boehtlingk-Roth Sanskrit-German "
+    "dictionary (PWG, Petersburger Woerterbuch). For each card you get a headword (iast) and its "
+    "senses; each sense has the German source gloss (de) and a proposed English rendering (en). "
+    "Judge whether the English FAITHFULLY renders the German sense.\n\n"
+    "GROUND TRUTH: the German source. Monier-Williams or any other dictionary is NOT the standard "
+    "here — do NOT flag a rendering merely because it differs from how MW would word it.\n\n"
+    "BAD criteria (set ok=false or severity>=3):\n"
+    "1. semantic — the English distorts, inverts, or loses the meaning of the German gloss.\n"
+    "2. anchors (HARD) — Sanskrit {#..#}, citations <ls>, abbreviations <ab>, sub-glosses "
+    "{%..%} were dropped, garbled, or altered.\n"
+    "3. order (HARD) — PWG sense order was changed/re-sorted (senses must stay in source order).\n"
+    "4. hallucination — the English adds a meaning not present in the German.\n"
+    "5. truncation — the English omits sense content (allowance: de/en are capped at CAPCHARS "
+    "chars for judging — do NOT penalize a cut at the very end).\n"
+    "6. fluency — ungrammatical or non-idiomatic English, or a German calque left untranslated.\n\n"
+    "NOT an error (do NOT mark BAD):\n"
+    "- preserved German abbreviations (Bed., Schol., vgl., ebend., u. s. w.) — a PWG convention;\n"
+    "- preserved Latin euphemisms (inire feminam, legere, seminis profectui) left verbatim;\n"
+    "- preserved French/scientific terms and a {%German%} echo kept beside the English;\n"
+    "- wording that simply differs from Monier-Williams (cross-check only — a SOFT note at most).\n\n"
+    "severity: 0-1 clean, 2 nitpick, 3 real defect, 4-5 gross. Return ONE verdict PER CARD (by its "
+    "key): {key, ok(bool), severity(0-5), issues([str]), note(one phrase)}."
+).replace('CAPCHARS', str(CAP))
+
+VERDICTS_SCHEMA = {
+    "type": "object", "additionalProperties": False, "required": ["verdicts"],
+    "properties": {"verdicts": {"type": "array", "items": {
+        "type": "object", "additionalProperties": False,
+        "required": ["key", "ok", "severity", "issues", "note"],
+        "properties": {
+            "key": {"type": "string"},
+            "ok": {"type": "boolean"},
+            "severity": {"type": "integer", "minimum": 0, "maximum": 5},
+            "issues": {"type": "array", "items": {"type": "string"}},
+            "note": {"type": "string"},
+        }}}},
+}
+
+TEMPLATE = """// AUTO-DERIVED EN-fidelity-judge workflow (gen_fidelity_judge_en.py). Opus judges DE->EN faithfulness.
+export const meta = {
+  name: 'pwgen-fidelity-judge',
+  description: 'Opus DE->EN fidelity judge over a stratified pwg_en sample (faithful-to-German)',
+  phases: [{ title: 'Judge' }],
+}
+const BATCHES = %(batches)s
+const RUBRIC = %(rubric)s
+const SCHEMA = %(schema)s
+phase('Judge')
+const results = await parallel(BATCHES.map((batch, i) => () =>
+  agent(RUBRIC + '\\n\\nCARDS (JSON):\\n' + JSON.stringify(batch),
+        { label: 'judge-en-' + i, phase: 'Judge', schema: SCHEMA, model: 'opus' })))
+const verdicts = results.filter(Boolean).flatMap(r => (r && r.verdicts) || [])
+return { verdicts, judged: verdicts.length, batch_count: BATCHES.length }
+"""
+
+
+def trim(card):
+    senses = []
+    for s in (card.get('senses') or [])[:8]:
+        senses.append({'tag': s.get('tag'),
+                       'de': (s.get('de') or '')[:CAP],
+                       'en': (s.get('en') or '')[:CAP]})
+    return {'key': card['key'], 'iast': card.get('iast'), 'stratum': card.get('stratum'),
+            'senses': senses}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--batch', type=int, default=6)
+    ap.add_argument('--sample', default=SAMPLE)
+    ap.add_argument('--out', default=HARNESS)
+    args = ap.parse_args()
+    cards = [trim(json.loads(l)) for l in open(args.sample, encoding='utf-8') if l.strip()]
+    batches = [cards[i:i + args.batch] for i in range(0, len(cards), args.batch)]
+    js = TEMPLATE % {
+        'batches': json.dumps(batches, ensure_ascii=False),
+        'rubric': json.dumps(RUBRIC, ensure_ascii=False),
+        'schema': json.dumps(VERDICTS_SCHEMA),
+    }
+    with open(args.out, 'w', encoding='utf-8') as f:
+        f.write(js)
+    print('wrote %s | %d cards in %d batches of <=%d' % (args.out, len(cards), len(batches), args.batch))
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/promote_en.py
+++ b/RussianTranslation/src/promote_en.py
@@ -4,8 +4,18 @@ r"""promote_en.py — attach EN translations onto the RU store, making it tri-li
 The RU bridge (promote_final_cards.py) writes one store row per sense from the RU wf_output
 files: each row carries `de` (German source) + `ru` (Russian) + provenance. The EN track lives
 separately in per-root wf_output.en.<root>.json (per-sense `english`). This script JOINS them:
-for every store row it finds the matching EN sense and attaches an `en` field, leaving the row
-otherwise untouched. The result is a single store carrying de + ru + en per sense.
+for every store row it finds the matching EN sense and attaches an `en` field plus an
+`en_provenance` block, leaving the row otherwise untouched. The result is a single store carrying
+de + ru + en per sense.
+
+en_provenance (FU1 locked decision 5 — full per-sense provenance) records, alongside the plain-
+string `en`:
+  {model:'sonnet',                         # generation tier (gen_opt_harness2 pins model:'sonnet')
+   judge: {model:'opus', ok, severity, verdict, note} | null,   # filled by --judge, else null
+   generated_at, rootmap_sha256,           # from the EN wf_output meta (reproducibility anchors)
+   input_sha256,                           # the sub-card's masked-input raw_sha256 (meta.input_hashes)
+   mw_used: null}                          # MW-TM usage is not recorded per-sense in wf_output
+`en` stays a plain string so export_interop.py is unaffected; en_provenance is a sibling field.
 
 Join key — why not (subkey, sense_tag) or position:
   RU and EN are INDEPENDENT generation runs over the same masked PWG skeleton, so they do NOT
@@ -19,9 +29,10 @@ Join key — why not (subkey, sense_tag) or position:
 review_status is NOT changed (stays 'ai_translated' — the G5 gate). Run annotate_dcs_freq.py
 AFTER this (it is language-agnostic and idempotent) to (re)attach the dcs_freq block.
 
-  python src/promote_en.py                      # attach EN -> src/pwg_ru_translated.jsonl
+  python src/promote_en.py                      # attach EN + en_provenance -> store
   python src/promote_en.py --dry-run            # report coverage, write nothing
   python src/promote_en.py --glob 'wf_output.en.pat.json'   # a subset
+  python src/promote_en.py --judge verdicts.json            # fold Opus judge verdict into provenance
   python src/promote_en.py --selftest
 """
 import argparse
@@ -64,14 +75,22 @@ def load_wf(path):
 
 
 def en_index(paths):
-    """sub-card key -> list of (norm_de, english) for every non-empty EN sense, in card order."""
+    """Returns (idx, prov):
+      idx[sub]  = list of (norm_de, english) for every non-empty EN sense, in card order.
+      prov[sub] = base provenance dict for that sub-card (model, generated_at, rootmap_sha256,
+                  input_sha256, mw_used) — judge is folded in later by attach()."""
     idx = defaultdict(list)
+    prov = {}
     for path in paths:
         try:
             res = load_wf(path)
         except (OSError, json.JSONDecodeError) as e:
             print('  skip (unreadable): %s (%s)' % (os.path.basename(path), e))
             continue
+        meta = res.get('meta') or {}
+        generated_at = meta.get('generated_at')
+        rootmap_sha256 = meta.get('rootmap_sha256')
+        input_hashes = meta.get('input_hashes') or {}
         for r in res.get('results') or []:
             sub, card = r.get('key'), r.get('card')
             if not sub or not card:
@@ -81,7 +100,39 @@ def en_index(paths):
                     e = s.get('english')
                     if e and e.strip():
                         idx[sub].append((norm_de(s.get('german')), e))
-    return idx
+            if sub in idx and sub not in prov:
+                ih = input_hashes.get(sub) or {}
+                prov[sub] = {
+                    'model': 'sonnet',
+                    'judge': None,
+                    'generated_at': generated_at,
+                    'rootmap_sha256': rootmap_sha256,
+                    'input_sha256': ih.get('raw_sha256'),
+                    'mw_used': None,
+                }
+    return idx, prov
+
+
+def load_judge(path):
+    """Opus judge verdicts (JSON {verdicts:[...]}/array/JSONL) -> sub-card key -> judge block."""
+    txt = open(path, encoding='utf-8').read().strip()
+    try:
+        obj = json.loads(txt)
+        if isinstance(obj, dict):
+            obj = obj.get('verdicts') or obj.get('results') or []
+    except json.JSONDecodeError:
+        obj = [json.loads(l) for l in txt.splitlines() if l.strip()]
+    out = {}
+    for v in obj:
+        key = v.get('key') or v.get('key1')
+        if not key:
+            continue
+        ok = v.get('ok', True)
+        sev = int(v.get('severity', 0))
+        out[key] = {'model': 'opus', 'ok': ok, 'severity': sev,
+                    'verdict': 'ok' if (ok and sev < 3) else 'bad',
+                    'note': v.get('note', '')}
+    return out
 
 
 def match_en(de_key, candidates, threshold):
@@ -106,11 +157,14 @@ def match_en(de_key, candidates, threshold):
     return scored[0][1], 'fuzzy'
 
 
-def attach(rows, idx, threshold):
+def attach(rows, idx, threshold, prov=None, judge=None):
+    prov = prov or {}
+    judge = judge or {}
     stats = defaultdict(int)
     for r in rows:
         sub = r.get('subcard')
         r.pop('en', None)                         # idempotent re-run
+        r.pop('en_provenance', None)
         if sub not in idx:
             stats['no-en-file'] += 1
             continue
@@ -118,6 +172,11 @@ def attach(rows, idx, threshold):
         stats[how] += 1
         if en is not None:
             r['en'] = en
+            block = dict(prov.get(sub) or {'model': 'sonnet', 'judge': None})
+            if sub in judge:
+                block['judge'] = judge[sub]
+                stats['judged'] += 1
+            r['en_provenance'] = block
             stats['attached'] += 1
     return stats
 
@@ -134,13 +193,25 @@ def selftest():
         (norm_de('trinken'), 'to drink'),
         (norm_de('<ab>Caus.</ab> schützen'), 'to protect'),
     ]}
-    stats = attach(rows, idx, 0.92)
+    prov = {'p_a~~h0': {'model': 'sonnet', 'judge': None, 'generated_at': '2026-06-30T00:00:00Z',
+                        'rootmap_sha256': 'deadbeef', 'input_sha256': 'cafe', 'mw_used': None}}
+    judge = {'p_a~~h0': {'model': 'opus', 'ok': True, 'severity': 1, 'verdict': 'ok', 'note': 'fine'}}
+    stats = attach(rows, idx, 0.92, prov=prov, judge=judge)
     assert rows[0].get('en') == 'to drink', 'exact German match'
     assert rows[1].get('en') == 'to protect', 'fuzzy German match across comma diff'
     assert 'en' not in rows[2], 'unmatched sense must be left absent, not fabricated'
     assert 'en' not in rows[3], 'row whose sub-card has no EN file stays EN-absent'
     assert rows[0]['ru'] == 'пить' and rows[0]['de'] == 'trinken', 'ru/de untouched'
     assert stats['attached'] == 2
+    # provenance attached, en stays a plain string, judge folded in
+    assert isinstance(rows[0].get('en'), str), 'en stays a plain string (export_interop unaffected)'
+    p0 = rows[0].get('en_provenance')
+    assert p0 and p0['model'] == 'sonnet' and p0['input_sha256'] == 'cafe', 'en_provenance attached'
+    assert p0['judge'] and p0['judge']['model'] == 'opus' and p0['judge']['verdict'] == 'ok', 'judge folded'
+    assert 'en_provenance' not in rows[2], 'no provenance on unmatched rows'
+    # idempotent re-run without judge clears the stale judge block
+    attach(rows, idx, 0.92, prov=prov)
+    assert rows[0]['en_provenance']['judge'] is None, 're-run without --judge resets judge to null'
     print('promote_en selftest OK')
 
 
@@ -152,6 +223,8 @@ def main():
     ap.add_argument('--store', default=DEFAULT_STORE)
     ap.add_argument('--threshold', type=float, default=0.92,
                     help='minimum difflib ratio for a fuzzy German match (default 0.92)')
+    ap.add_argument('--judge', default=None,
+                    help='Opus EN-judge verdicts (JSON/JSONL) to fold into en_provenance.judge')
     ap.add_argument('--dry-run', action='store_true')
     ap.add_argument('--no-backup', action='store_true')
     args = ap.parse_args()
@@ -165,9 +238,12 @@ def main():
     print('ingesting %d EN wf_output file(s)' % len(paths))
 
     rows = [json.loads(l) for l in open(args.store, encoding='utf-8') if l.strip()]
-    idx = en_index(paths)
+    idx, prov = en_index(paths)
+    judge = load_judge(args.judge) if args.judge else None
+    if args.judge:
+        print('judge verdicts: %d (from %s)' % (len(judge), os.path.basename(args.judge)))
     en_senses = sum(len(v) for v in idx.values())
-    stats = attach(rows, idx, args.threshold)
+    stats = attach(rows, idx, args.threshold, prov=prov, judge=judge)
 
     eligible = len(rows) - stats['no-en-file']
     print('\n=== EN MERGE COVERAGE ===')
@@ -176,6 +252,8 @@ def main():
     print('rows with EN sub-card   : %d' % eligible)
     print('  en attached           : %d (exact %d, exact-ambig %d, fuzzy %d)' % (
         stats['attached'], stats['exact'], stats['exact-ambiguous'], stats['fuzzy']))
+    if args.judge:
+        print('  with opus judge block : %d' % stats['judged'])
     print('  unmatched (left absent): %d (below-threshold %d, fuzzy-ambig %d, no-en-sense %d, no-de-key %d)' % (
         stats['below-threshold'] + stats['fuzzy-ambiguous'] + stats['no-en-sense'] + stats['no-de-key'],
         stats['below-threshold'], stats['fuzzy-ambiguous'], stats['no-en-sense'], stats['no-de-key']))


### PR DESCRIPTION
Phase 0 of the [FU1 bulk EN run](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/HANDOFF_2026-06-30_pwg_en_fu1_run.md) — **no Max quota**, the three EN-track tools the runbook requires *before* generation, each adapted from the existing RU pipeline (not reinvented).

## What's here

| Tool | Adapted from | EN change |
|---|---|---|
| [`src/fidelity_sample_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/feat/pwg-en-fu1-phase0/RussianTranslation/src/fidelity_sample_en.py) | `fidelity_sample.py` | stratified DE→EN sample (samples `english`, not `russian`) |
| [`src/pilot/gen_fidelity_judge_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/feat/pwg-en-fu1-phase0/RussianTranslation/src/pilot/gen_fidelity_judge_en.py) | `gen_fidelity_judge.py` | Opus DE→EN **faithful-to-German** judge (`model:'opus'`); markup/sigla + PWG sense-order = HARD checks, MW divergence = SOFT. Same `{key,ok,severity,issues,note}` schema → `fidelity_aggregate.py` reused unchanged |
| [`src/gold_sample_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/feat/pwg-en-fu1-phase0/RussianTranslation/src/gold_sample_en.py) | `gold_sample.py`/`gold_packet.py`/`gold_agreement.py` | human gold sampler over the EN layer (freq-band × source_type × stratum); blank reviewer sheet with **MW hidden**; `period`/`kind` aliases so `gold_packet.py` + `gold_agreement.py` (Cohen κ) reuse unchanged; emits a METHODS note |
| [`src/promote_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/feat/pwg-en-fu1-phase0/RussianTranslation/src/promote_en.py) | extended | attaches `en_provenance {model:'sonnet', judge, generated_at, rootmap_sha256, input_sha256, mw_used}` alongside `en`; `en` stays a plain string; `--judge` folds Opus verdicts in; idempotent |

Implements FU1 locked decisions **2**, **4**, **5**, **6**.

## Validation
- All four parse; `promote_en --selftest` and `gold_sample_en --selftest` pass.
- `run_fidelity_judge_en.js` passes `node --check`.
- Dry-runs over the 16 existing EN roots: `promote_en` attaches **2,417** rows idempotently; gold sampler draws **300** stratified rows.

## Note
Rebased onto `master` (which now includes PR #26's plan, runbook, and the in-process sense-dupe perf fix in `audit_window_en.py`). This PR now **stands alone** — exactly the four Phase-0 code files + two doc fixes, no #26 duplication.

Includes a docs fix: `gen_opt_harness2.py` needs `--lang=en` (with `=`); the previously documented `--lang en` space form is silently ignored and falls back to RU. Caught during the FU1 cost-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
