### PR TITLE
Sa→Ru glossary: surface · lemma · root (from corpus_lexicon)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -552,6 +552,21 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ✅ Completed (Recent only)
 
+- **Sa→Ru glossary (surface · lemma · root) BUILT from `corpus_lexicon.jsonl` (2026-07-01).**
+  Full inventory of how every Sanskrit word is rendered into Russian, 3 granularities, from
+  the 1,091,528-token aligned corpus. Answers "how is √gam translated" → root rollup: 678
+  forms / 44 lemmas / 7,116 occ, ranked (пришёл 196, отправился 177, ушёл 141…). Pipeline in
+  [`glossary/README.md`](glossary/README.md): DCS `dcs_full.sqlite` form→lemma join (IAST→SLP1
+  via sanscript; root = longest DCS-root suffix, sidesteps preverb sandhi) → **vidyut.kosha**
+  fallback → morpheme-marker tier (`A+gam`=ā+√gam) → provenance-tagged rollups. Coverage
+  **87.1% of tokens**; 190,838 forms → 40,370 lemmas → 2,021 roots; 78,842 unresolved with a
+  documented failure typology. Scripts:
+  [`src/build_dcs_maps.py`](src/build_dcs_maps.py),
+  [`src/build_surface_glossary.py`](src/build_surface_glossary.py),
+  [`src/build_vidyut_fallback.py`](src/build_vidyut_fallback.py),
+  [`src/build_rollup_glossaries.py`](src/build_rollup_glossaries.py). Bulk data git-ignored
+  (regenerable); committed = scripts + README + `SAMPLE_root_glossary.md`. PR #30.
+
 - **PWG→EN follow-ups FU2 + FU3 SHIPPED (2026-06-30)** — from
   [`HANDOFF_2026-06-30_pwg_en_followups.md`](HANDOFF_2026-06-30_pwg_en_followups.md). FU1
   (the freq-ordered bulk EN run, real Max-quota spend) remains open, pending MG scope.

--- a/RussianTranslation/.gitignore
+++ b/RussianTranslation/.gitignore
@@ -72,3 +72,9 @@ src/pwg_ru_translated.jsonl.prefreq.bak
 src/dcs_freq_dims.json
 src/mw_en_tm.json
 src/pilot/run_pilot_wf.en_*.js
+
+# Sa→Ru glossary — generated data (regenerate via src/build_*.py; see glossary/README.md).
+# Tracked: glossary/README.md, glossary/SAMPLE_root_glossary.md, and the src/ scripts.
+glossary/*.jsonl
+glossary/*.tsv
+glossary/md/

--- a/RussianTranslation/glossary/README.md
+++ b/RussianTranslation/glossary/README.md
@@ -1,0 +1,126 @@
+# Sanskrit → Russian glossary (surface · lemma · root)
+
+<p align="right"><sub>Created: 01-07-2026 · Last updated: 01-07-2026</sub></p>
+
+A full inventory of **how every Sanskrit word is rendered into Russian** in the aligned
+corpus, at three granularities:
+
+| Layer | Question it answers | Key |
+|---|---|---|
+| **surface form** | how is the *attested form* `gamemahi` translated? | corpus SLP1 form |
+| **lemma / stem** | how is the *stem* `mahāratha` / verb-lemma `saṃgam` translated? | DCS / Vidyut lemma |
+| **root** | how is *√gam* translated across **all** its forms and prefixed verbs? | verb root (dhātu) |
+
+Built from [`RussianTranslation/src/corpus_lexicon.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/corpus_lexicon.jsonl)
+— **1,091,528** word-aligned Saṃskṛta→Russian tokens (SLP1), the alignment asset described in
+[`RENOU.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU.md).
+Scope: **everything, all n ≥ 1** — hapax kept, `kind=translation` **and** `kind=commentary`
+kept (each entry records the split).
+
+## The `gam` example, answered
+
+`root_glossary` for **√gam** aggregates **678 surface forms** across **44 verb lemmas**
+(`gam, āgam, saṃāgam, abhigam, adhigam, upagam, anugam, …`), **7,116 occurrences**, ranked:
+
+> пришёл (195) · отправился (176) · ушёл (140) · пришли (100) · достигает (99) · явился (92)
+> · ступай (79) · пошёл (77) · отправились (77) · идёт (73) · удалился (73) · направился (64) …
+
+The four `gamemahi` lines you started from are one surface entry inside this rollup.
+
+## Files
+
+Regenerable data (git-ignored, like `corpus_lexicon.jsonl`); the scripts + this README are tracked.
+
+| File | What |
+|---|---|
+| `surface_glossary.jsonl` / `.tsv` | **Layer 1** — 190,838 forms → Ru with counts, registers, works, kinds |
+| `md/surface/<X>.md` | human-readable surface glossary, one file per initial SLP1 letter |
+| `lemma_glossary.jsonl` / `.tsv` + `md/lemma/` | **Layer 2** — 40,370 lemmas → Ru (nouns' stem, verbs' lemma) |
+| `root_glossary.jsonl` / `.tsv` + `md/root/` | **Layer 3** — 2,021 verb roots → Ru (aggregated over lemmas & forms) |
+| `dcs_form2lemma.tsv` | DCS map: 408,660 `form → lemma` pairs (SLP1) |
+| `dcs_lemma2root.tsv` | DCS map: `verb-lemma → root` (via DCS root inventory, longest-suffix) |
+| `vidyut_form2lemma.tsv` | Vidyut fallback: 28,567 DCS-missed forms → lemma/pos |
+| `surface_dcs_misses.tsv` | forms DCS could not lemmatize (stable **input to the Vidyut pass**) |
+| `surface_unresolved.tsv` | forms **no tier** resolved (DCS+Vidyut+marker) — the typology input |
+| `ambiguity_homographs.tsv` | forms whose top DCS lemmas span different POS / are close in count |
+
+Every rollup record carries a `source` field (`dcs` vs `vidyut`) so provenance is auditable.
+
+## Method
+
+The corpus stores **only surface forms** — no lemma. Roots/lemmas are attached by a
+*context-free* join (robust for an aggregate glossary; a per-passage alignment would fight
+270 texts' mismatched ref schemes):
+
+1. **DCS morphology (primary).** [VisualDCS `dcs_full.sqlite`](https://github.com/gasyoun/VisualDCS/tree/main/src/DCS-data-2026)
+   — 5.69M annotated tokens (IAST). Grouped to a `form → lemma` map, transcoded IAST→SLP1
+   (`indic_transliteration.sanscript`). Root for a prefixed verb lemma = the **longest member
+   of DCS's own simple-root inventory** that is a suffix of the lemma (`saṃgam` → `gam`),
+   which sidesteps preverb sandhi (`uddhṛ` ← preverb `ut`, not `ud`).
+2. **Vidyut kosha (fallback).** Forms DCS misses are lemmatized by the Pāṇinian FST
+   (`vidyut.kosha`, v0.4.0). Tinanta → dhātu (root); Subanta → stem.
+3. **Morpheme-marker recovery.** Forms both lexica miss but that carry a corpus boundary
+   mark (`A+gam` = ā+√gam) are split on `[+-]`: the joined string is retried as a form, else
+   the rightmost element is taken when it is a known root/lemma (`source='marker'`).
+4. **Unresolved** forms are kept in Layer 1 and characterised below.
+
+Join keys strip a leading avagraha/apostrophe on both sides (`'gacchat` == `gacchat`).
+Homographs: a form's Ru distribution is attributed to its **highest-count** lemma; alternates
+are logged in `ambiguity_homographs.tsv`, never double-counted.
+
+### Coverage (of 190,838 distinct forms / 1,091,528 tokens)
+
+| Stage | forms resolved | token coverage |
+|---|--:|--:|
+| DCS only | 80,949 (42.4 %) | 79.1 % |
+| + Vidyut fallback | 109,516 (57.4 %) | 86.6 % |
+| + morpheme-marker recovery | 111,996 (58.7 %) | **87.1 %** |
+| unresolved | 78,842 (41.3 %) | 12.9 % |
+
+Distinct-form hit rate is far below token coverage because the misses are the **rare long
+tail** — DCS/Vidyut resolve nearly every common form.
+
+## Failure typology (78,842 unresolved forms · 140,667 tokens)
+
+| Type | forms | tokens | Example | Why it misses |
+|---|--:|--:|---|---|
+| unrecognized simplex | 48,646 | 91,548 | `maratejasi`, `ABArizam` | rare inflection / sandhi-altered stem absent from both lexica |
+| long compound (≥14 chars) | 20,823 | 25,482 | `ADArmikajanAvfta`, `ADUtadvajapawam` | samāsa the FST won't split without a *chedaka* |
+| ends in a known root | 4,695 | 10,267 | `ABAz`, `ABijIvanam` | derived stem, but not a bare lemma either lexicon lists |
+| proper name | 3,094 | 8,945 | `ABIrya` (Абхиры), `ABar` | names/vocatives outside the lexica (Ru gloss capitalised) |
+| morpheme-marker residual | 1,389 | 2,312 | `A-brahma-BuvanAt` | has `+`/`-` marks but rightmost element is itself inflected, not a bare root |
+| short form / particle | 195 | 2,113 | `ABf`, `Ahf` | too short / clitic |
+
+**Join-side edge cases** (handled, not part of the 78,842):
+
+- **Homographs** — 9,521 forms carry ≥2 DCS lemmas of differing POS/near-equal count
+  (`ambiguity_homographs.tsv`). Attributed to the dominant lemma.
+- **Morpheme markers** — corpus forms embedding `+`/`-` marks (`A+gam` = ā+√gam) are now
+  recovered (tier 3, `source='marker'`, 2,480 forms); only 1,389 whose rightmost element is
+  itself inflected remain unresolved.
+- **Avagraha / apostrophe** — leading `'`/`’` normalised away before the join.
+- **Compound-split spacing** — a few corpus forms keep a space (`vācas pati`); these key on the
+  spaced string.
+- **Nominal roots** — Layer 3 (root) is **verbal only**; a noun stem has no verbal root in this
+  pipeline, so nominal lemmas appear at Layer 2 but not Layer 3 by design.
+
+## Regenerate
+
+From [`RussianTranslation/src/`](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation/src):
+
+```sh
+python build_dcs_maps.py            # DCS form→lemma + lemma→root maps   (needs VisualDCS dcs_full.sqlite)
+python build_surface_glossary.py    # Layer 1
+python build_rollup_glossaries.py   # 1st pass: emits surface_dcs_misses.tsv (Vidyut input)
+python build_vidyut_fallback.py <kosha_dir>   # lemmatize the DCS misses (needs vidyut.download_data())
+python build_rollup_glossaries.py   # 2nd pass: folds in Vidyut + marker tier -> Layers 2 & 3
+```
+
+Two-pass bootstrap: the rollup emits the DCS-miss list the Vidyut stage consumes, so run it
+once before Vidyut and once after. `surface_dcs_misses.tsv` is deterministic (snapshotted
+before the Vidyut supplement), so the second pass does not disturb the Vidyut input.
+
+Vidyut data: `python -c "import vidyut; vidyut.download_data('vidyut_data')"` then pass
+`vidyut_data/kosha` to the fallback. Transcoding uses `indic_transliteration`; both are pip-installable.
+
+<p align="right"><sub>Dr. Mārcis Gasūns</sub></p>

--- a/RussianTranslation/glossary/SAMPLE_root_glossary.md
+++ b/RussianTranslation/glossary/SAMPLE_root_glossary.md
@@ -1,0 +1,217 @@
+# Sample — root → Russian (showcase)
+
+<p align="right"><sub>Created: 01-07-2026 · Last updated: 01-07-2026</sub></p>
+
+Excerpt of the full `root_glossary` (regenerable; see [README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/glossary/README.md)). Each root aggregates every attested form and prefixed verb-lemma across the 1.09M-token Sa→Ru corpus.
+
+## √gam  (IAST √gam) — n=7116, 678 forms, 44 lemmas
+
+Lemmas rolled up: `gam, Agam, samAgam, aBigam, aDigam, upagam, anugam, upAgam, aByAgam, nirgam, saMgam, avagam` …
+
+- пришел · n=196
+- отправился · n=177
+- ушел · n=141
+- пришли · n=100
+- достигает · n=99
+- явился · n=92
+- ступай · n=79
+- пошел · n=77
+- отправились · n=77
+- идет · n=73
+- удалился · n=73
+- направился · n=66
+- придя · n=58
+- Ступай · n=48
+- иди · n=47
+- придет · n=46
+- вернулся · n=43
+- идут · n=43
+- пришла · n=41
+- пойду · n=37
+- идти · n=37
+- приходит · n=36
+- пошли · n=34
+- пойдем · n=34
+- собрались · n=34
+
+## √kf  (IAST √kṛ) — n=9432, 817 forms, 118 lemmas
+
+Lemmas rolled up: `kf, vikf, puraskf, avakf, prakf, satkf, namaskf, Akf, saMskf, prAduzkf, aDikf, parizkf` …
+
+- сделал · n=261
+- совершил · n=165
+- сделав · n=159
+- делает · n=115
+- сделали · n=113
+- сделай · n=113
+- сделать · n=103
+- совершив · n=97
+- делать · n=89
+- сделаю · n=88
+- сделано · n=82
+- совершает · n=71
+- Сделай · n=63
+- создали · n=55
+- создал · n=52
+- сделает · n=52
+- совершили · n=43
+- осыпал · n=42
+- совершая · n=39
+- исполню · n=39
+- делаю · n=37
+- делай · n=36
+- действует · n=36
+- делают · n=34
+- делали · n=33
+
+## √BU  (IAST √bhū) — n=6906, 381 forms, 46 lemmas
+
+Lemmas rolled up: `BU, samBU, aBiBU, praBU, anuBU, pariBU, prAdurBU, ABU, ekIBU, parABU, udBU, samudBU` …
+
+- будет · n=512
+- был · n=267
+- будь · n=259
+- стал · n=246
+- становится · n=225
+- бывает · n=168
+- на земле · n=134
+- став · n=108
+- было · n=103
+- есть · n=90
+- была · n=89
+- были · n=71
+- стали · n=69
+- ты · n=65
+- будучи · n=64
+- будешь · n=62
+- станет · n=59
+- стала · n=59
+- быть · n=58
+- будут · n=58
+- Будь · n=58
+- стало · n=57
+- на землю · n=53
+- земля · n=48
+- становятся · n=37
+
+## √sTA  (IAST √sthā) — n=4011, 394 forms, 26 lemmas
+
+Lemmas rolled up: `sTA, AsTA, avasTA, upasTA, prasTA, vyavasTA, samupasTA, saMsTA, samAsTA, samavasTA, samprasTA, paryavasTA` …
+
+- пребывает · n=123
+- стоит · n=90
+- стоя · n=82
+- стоят · n=59
+- пребывая · n=56
+- стоял · n=54
+- находится · n=50
+- стояли · n=44
+- стоящего · n=40
+- стой · n=36
+- находясь · n=32
+- пребывающий · n=31
+- стоять · n=30
+- пребывают · n=29
+- пребывающего · n=27
+- отправился · n=25
+- взойдя · n=24
+- стоящий · n=23
+- стоящих · n=23
+- приняв · n=22
+- остановился · n=22
+- взошел · n=21
+- находятся · n=21
+- пребываю · n=21
+- встал · n=19
+
+## √han  (IAST √han) — n=4994, 447 forms, 28 lemmas
+
+Lemmas rolled up: `han, nihan, aBihan, Ahan, vinihan, upahan, pratihan, saMhan, vihan, samAhan, apahan, vyAhan` …
+
+- убит · n=323
+- убив · n=226
+- убил · n=214
+- убиты · n=141
+- убить · n=111
+- убивает · n=100
+- убью · n=97
+- убитый · n=94
+- убей · n=82
+- поразил · n=71
+- убивать · n=65
+- убьет · n=59
+- ударил · n=55
+- сражен · n=55
+- день · n=51
+- убитым · n=50
+- убивая · n=49
+- убитых · n=49
+- сразил · n=44
+- Убив · n=42
+- убитого · n=42
+- сраженный · n=37
+- Убей · n=37
+- убивают · n=35
+- убили · n=33
+
+## √vac  (IAST √vac) — n=5315, 218 forms, 15 lemmas
+
+Lemmas rolled up: `vac, pravac, prativac, aBivac, sampravac, upavac, anuvac, nirvac, vivac, nivac, aDivac, ativac` …
+
+- сказал · n=1061
+- сказав · n=327
+- сказано · n=264
+- сказала · n=149
+- ответил · n=134
+- называется · n=130
+- сказали · n=88
+- скажу · n=82
+- отвечал · n=79
+- расскажу · n=71
+- обратился · n=70
+- молвил · n=64
+- сказать · n=54
+- зовется · n=52
+- говорил · n=51
+- именуется · n=50
+- считается · n=49
+- поведаю · n=46
+- говорить · n=42
+- поведал · n=42
+- промолвил · n=35
+- произнес · n=35
+- скажет · n=34
+- говорится · n=33
+- сказанное · n=30
+
+## √dA  (IAST √dā) — n=2647, 321 forms, 24 lemmas
+
+Lemmas rolled up: `dA, AdA, pradA, upAdA, samAdA, paridA, sampradA, upadA, parAdA, saMdA, pratidA, vyAdA` …
+
+- взяв · n=169
+- взял · n=72
+- дает · n=66
+- дам · n=66
+- дал · n=55
+- отдал · n=44
+- дай · n=40
+- отдам · n=33
+- дали · n=28
+- дать · n=25
+- дав · n=21
+- дарую · n=20
+- отдать · n=19
+- отдает · n=19
+- даю · n=19
+- дан · n=19
+- передал · n=18
+- даст · n=18
+- дается · n=18
+- дано · n=18
+- отдай · n=17
+- раздав · n=17
+- дают · n=16
+- даровал · n=15
+- вручаю · n=15
+
+<p align="right"><sub>Dr. Mārcis Gasūns</sub></p>

--- a/RussianTranslation/src/build_dcs_maps.py
+++ b/RussianTranslation/src/build_dcs_maps.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+"""build_dcs_maps.py — context-free DCS form->lemma and lemma->root maps (SLP1-keyed).
+
+The corpus (corpus_lexicon.jsonl) stores only surface SLP1 forms with no lemma. To roll
+a Sa->Ru glossary up from surface forms to lemmas and roots we need a lemmatizer. DCS
+(VisualDCS dcs_full.sqlite, 5.69M annotated tokens, IAST) is the join backbone.
+
+Because the glossary AGGREGATES over occurrences, we build a *context-free* map rather
+than a per-passage alignment (which would fight 270 texts' mismatched ref schemes):
+
+  dcs_form2lemma.tsv : form_slp1 \\t lemma_slp1 \\t upos \\t count     (all attested pairs)
+  dcs_lemma2root.tsv : lemma_slp1 \\t root_slp1 \\t how                 (verb lemmas only)
+
+Root derivation avoids preverb sandhi (uddhf<-ut, saMgam<-sam): we build DCS's own root
+inventory R = simple verb lemmas (empty `preverbs`, verbal grammar) and pick the LONGEST
+member of R that is a suffix of the prefixed lemma. Grounded in DCS, not blind stripping.
+
+  python build_dcs_maps.py  [path/to/dcs_full.sqlite]
+"""
+import os, sys, sqlite3, collections
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+from indic_transliteration import sanscript
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_DB = os.path.normpath(os.path.join(
+    HERE, '..', '..', '..', 'VisualDCS', 'src', 'DCS-data-2026', 'dcs_full.sqlite'))
+OUT_DIR = os.path.normpath(os.path.join(HERE, '..', 'glossary'))
+os.makedirs(OUT_DIR, exist_ok=True)
+
+_tc = {}
+def to_slp1(s):
+    """IAST -> SLP1 with a memo cache; returns '' on empty/None."""
+    if not s:
+        return ''
+    v = _tc.get(s)
+    if v is None:
+        try:
+            v = sanscript.transliterate(s, sanscript.IAST, sanscript.SLP1)
+        except Exception:
+            v = ''
+        _tc[s] = v
+    return v
+
+def is_verbal(grammar):
+    """DCS grammar string marks a verb by pada codes like '1.P.', '6.Ā.'."""
+    return bool(grammar) and ('P.' in grammar or 'Ā.' in grammar)
+
+def main():
+    db = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DB
+    con = sqlite3.connect(db)
+
+    # ---- form -> lemma (distinct pairs with occurrence counts) ----
+    print('[1/3] grouping token (form,lemma,upos)...', file=sys.stderr)
+    f2l_path = os.path.join(OUT_DIR, 'dcs_form2lemma.tsv')
+    npairs = 0
+    with open(f2l_path, 'w', encoding='utf-8', newline='\n') as out:
+        out.write('form_slp1\tlemma_slp1\tupos\tcount\n')
+        q = ("select form, lemma, upos, count(*) c from token "
+             "where form is not null and lemma is not null "
+             "group by form, lemma, upos")
+        for form, lemma, upos, c in con.execute(q):
+            fs, ls = to_slp1(form), to_slp1(lemma)
+            if not fs or not ls:
+                continue
+            out.write(f'{fs}\t{ls}\t{upos or ""}\t{c}\n')
+            npairs += 1
+    print(f'      wrote {npairs} form->lemma pairs -> {f2l_path}', file=sys.stderr)
+
+    # ---- root inventory + lemma -> root ----
+    print('[2/3] building root inventory from lemma table...', file=sys.stderr)
+    # verbal lemmas: (lemma_slp1, has_preverb, grammar_verbal)
+    verb_lemmas = {}   # lemma_slp1 -> has_preverb(bool)
+    roots = set()      # simple verb lemmas = root inventory
+    for lemma, grammar, preverbs in con.execute(
+            'select lemma, grammar, preverbs from lemma'):
+        if not is_verbal(grammar):
+            continue
+        ls = to_slp1(lemma)
+        if not ls:
+            continue
+        has_pre = bool(preverbs and preverbs.strip())
+        verb_lemmas[ls] = has_pre
+        if not has_pre:
+            roots.add(ls)
+
+    # roots sorted by length desc for longest-suffix match
+    roots_by_len = sorted(roots, key=len, reverse=True)
+    print(f'      {len(verb_lemmas)} verb lemmas; {len(roots)} simple roots',
+          file=sys.stderr)
+
+    print('[3/3] deriving lemma -> root (longest root-suffix)...', file=sys.stderr)
+    l2r_path = os.path.join(OUT_DIR, 'dcs_lemma2root.tsv')
+    counts = collections.Counter()
+    with open(l2r_path, 'w', encoding='utf-8', newline='\n') as out:
+        out.write('lemma_slp1\troot_slp1\thow\n')
+        for ls, has_pre in sorted(verb_lemmas.items()):
+            if not has_pre:
+                out.write(f'{ls}\t{ls}\tself\n')          # lemma IS a root
+                counts['self'] += 1
+                continue
+            root = ''
+            for r in roots_by_len:
+                if r != ls and ls.endswith(r) and len(r) >= 2:
+                    root = r
+                    break
+            if root:
+                out.write(f'{ls}\t{root}\tsuffix\n')
+                counts['suffix'] += 1
+            else:
+                out.write(f'{ls}\t{ls}\tunresolved\n')     # keep lemma as its own root
+                counts['unresolved'] += 1
+    print(f'      lemma->root: {dict(counts)} -> {l2r_path}', file=sys.stderr)
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/build_rollup_glossaries.py
+++ b/RussianTranslation/src/build_rollup_glossaries.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python
+"""build_rollup_glossaries.py — Stage D: lemma-level and root-level Sa->Ru glossaries.
+
+Joins the surface glossary (Stage A) to the DCS form->lemma / lemma->root maps (Stage B)
+to answer "how is <lemma> / <root> translated into Russian" across ALL its attested forms.
+
+  lemma_glossary.*   every DCS lemma (noun stem / verb lemma) -> aggregated Ru renderings,
+                     the surface forms feeding it, works/registers, upos.  (the stem/lemma layer)
+  root_glossary.*    verb roots only (lemma->root via DCS root inventory) -> aggregated Ru.
+                     nominal lemmas have no verbal root here (documented in typology).
+  surface_dcs_misses.tsv   surface forms with NO DCS lemma -> feeds Stage C (Vidyut).
+  ambiguity_homographs.tsv forms whose top DCS lemmas span different upos / are close in count.
+
+Join key normalization: leading avagraha/apostrophe stripped on both sides ('gacCat==gacCat)
+so elided-initial DCS forms match un-elided corpus forms. Homographs: the surface form's Ru
+distribution is attributed to its HIGHEST-COUNT DCS lemma (primary); alternates are recorded
+in the ambiguity report, not double-counted.
+
+  python build_rollup_glossaries.py
+"""
+import os, re, sys, json, collections
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+G = os.path.normpath(os.path.join(HERE, '..', 'glossary'))
+MD_LEMMA = os.path.join(G, 'md', 'lemma')
+MD_ROOT = os.path.join(G, 'md', 'root')
+os.makedirs(MD_LEMMA, exist_ok=True)
+os.makedirs(MD_ROOT, exist_ok=True)
+
+_ava = re.compile(r"^['’‘]+")
+def norm(k):
+    return _ava.sub('', k or '')
+
+_reg = re.compile(r'^\d+_')
+def register(work):
+    return _reg.sub('', work or '')
+
+def bucket(s):
+    if not s:
+        return '_'
+    return s[0] if re.match(r'[A-Za-z]', s[0]) else '_other'
+
+
+def load_maps():
+    """form_norm -> [(lemma,upos,count,source)...] sorted desc; lemma -> root.
+
+    DCS is primary; vidyut (Stage C) supplements ONLY forms DCS missed, tagged source.
+    """
+    f2l = collections.defaultdict(list)
+    with open(os.path.join(G, 'dcs_form2lemma.tsv'), encoding='utf-8') as f:
+        next(f)
+        for line in f:
+            p = line.rstrip('\n').split('\t')
+            if len(p) < 4:
+                continue
+            form, lemma, upos, cnt = p[0], p[1], p[2], int(p[3])
+            f2l[norm(form)].append((lemma, upos, cnt, 'dcs'))
+    for k in f2l:
+        f2l[k].sort(key=lambda x: -x[2])
+    l2r = {}
+    with open(os.path.join(G, 'dcs_lemma2root.tsv'), encoding='utf-8') as f:
+        next(f)
+        for line in f:
+            p = line.rstrip('\n').split('\t')
+            if len(p) >= 2:
+                l2r[p[0]] = p[1]
+    dcs_keys = frozenset(f2l)          # snapshot BEFORE vidyut -> stable DCS-miss detection
+    # vidyut fallback: add only for form keys DCS did not resolve
+    vpath = os.path.join(G, 'vidyut_form2lemma.tsv')
+    if os.path.exists(vpath):
+        added = 0
+        with open(vpath, encoding='utf-8') as f:
+            next(f)
+            for line in f:
+                p = line.rstrip('\n').split('\t')
+                if len(p) < 3:
+                    continue
+                form, lemma, pos = p[0], p[1], p[2]
+                nk = norm(form)
+                if nk in f2l:
+                    continue
+                f2l[nk].append((lemma, pos, 1, 'vidyut'))
+                if pos == 'verb':          # vidyut dhatu lemma IS its own root
+                    l2r.setdefault(lemma, lemma)
+                added += 1
+        print(f'    vidyut supplement: +{added} forms', file=sys.stderr)
+    roots_set = set(l2r.values())
+    lemmas_set = {lem for cands in f2l.values() for (lem, _, _, _) in cands}
+    return f2l, l2r, roots_set, lemmas_set, dcs_keys
+
+
+_mark = re.compile(r'[+\-]')
+def marker_recover(slp1, f2l, l2r, roots_set, lemmas_set):
+    """Corpus forms carry morpheme marks (A+gam = ā+√gam). Recover a lemma from the
+    marked structure: (1) the joined string may already be a known form; (2) the rightmost
+    element is often a bare root or lemma. Returns (lemma, upos, root_or_None) or None."""
+    if '+' not in slp1 and '-' not in slp1:
+        return None
+    parts = [p for p in _mark.split(slp1) if p]
+    if not parts:
+        return None
+    joined = norm(''.join(parts))
+    cands = f2l.get(joined)
+    if cands:                                   # e.g. A+gam -> Agam is a known form
+        lemma, upos, _, _ = cands[0]
+        return lemma, upos, l2r.get(lemma)
+    right = norm(parts[-1])
+    if right in roots_set:                      # rightmost is a bare verb root
+        return right, 'verb', right
+    if right in lemmas_set:                      # rightmost is a known lemma (stem)
+        return right, 'noun', l2r.get(right)
+    return None
+
+
+def new_acc():
+    return {'ru': collections.Counter(), 'forms': collections.Counter(),
+            'works': collections.Counter(), 'upos': collections.Counter(),
+            'lemmas': collections.Counter(), 'src': collections.Counter()}
+
+
+def emit(table, path_base, md_dir, key_name, title, extra_lemmas=False):
+    """Write .jsonl + .tsv + per-letter .md for a lemma/root accumulator table."""
+    jf = open(path_base + '.jsonl', 'w', encoding='utf-8', newline='\n')
+    tf = open(path_base + '.tsv', 'w', encoding='utf-8', newline='\n')
+    tf.write(f'{key_name}\tru\tn\tn_total\tn_forms\tupos\n')
+    buckets = collections.defaultdict(list)
+    for key in sorted(table):
+        a = table[key]
+        total = sum(a['ru'].values())
+        regs = collections.Counter()
+        for w, c in a['works'].items():
+            regs[register(w)] += c
+        rec = {key_name: key, 'n': total,
+               'upos': dict(a['upos'].most_common()),
+               'source': dict(a['src'].most_common()),
+               'n_forms': len(a['forms']),
+               'forms': dict(a['forms'].most_common(50)),
+               'registers': dict(regs.most_common()),
+               'translations': [{'ru': ru, 'n': c} for ru, c in a['ru'].most_common()]}
+        if extra_lemmas:
+            rec['lemmas'] = dict(a['lemmas'].most_common())
+        jf.write(json.dumps(rec, ensure_ascii=False) + '\n')
+        upos = ','.join(u for u, _ in a['upos'].most_common())
+        for ru, c in a['ru'].most_common():
+            tf.write(f'{key}\t{ru}\t{c}\t{total}\t{len(a["forms"])}\t{upos}\n')
+        buckets[bucket(key)].append((key, rec))
+    jf.close(); tf.close()
+    for letter, items in sorted(buckets.items()):
+        with open(os.path.join(md_dir, f'{letter}.md'), 'w',
+                  encoding='utf-8', newline='\n') as mf:
+            mf.write(f'# {title} — `{letter}`\n\n{len(items)} entries.\n\n')
+            for key, rec in items:
+                head = f"### `{key}`  (n={rec['n']}, {rec['n_forms']} forms)"
+                if rec['upos']:
+                    head += '  ·  ' + '/'.join(rec['upos'])
+                mf.write(head + '\n\n')
+                for t in rec['translations'][:60]:
+                    mf.write(f"- {t['ru']}  · n={t['n']}\n")
+                mf.write('\n')
+    return len(buckets)
+
+
+def main():
+    print('[D] loading DCS maps...', file=sys.stderr)
+    f2l, l2r, roots_set, lemmas_set, dcs_keys = load_maps()
+    print(f'    {len(f2l)} normalized DCS form keys, {len(l2r)} lemma->root', file=sys.stderr)
+
+    lemma_tab = collections.defaultdict(new_acc)
+    root_tab = collections.defaultdict(new_acc)
+    # DCS-miss list = stable input to the Vidyut stage (independent of whether it has run)
+    dcs_misses = open(os.path.join(G, 'surface_dcs_misses.tsv'), 'w',
+                      encoding='utf-8', newline='\n')
+    dcs_misses.write('form_slp1\tsa\tn\ttop_ru\n')
+    # unresolved = forms no tier could lemmatize (DCS + Vidyut + marker) -> typology input
+    unresolved = open(os.path.join(G, 'surface_unresolved.tsv'), 'w',
+                      encoding='utf-8', newline='\n')
+    unresolved.write('form_slp1\tsa\tn\ttop_ru\n')
+    amb = open(os.path.join(G, 'ambiguity_homographs.tsv'), 'w',
+               encoding='utf-8', newline='\n')
+    amb.write('form_slp1\tprimary_lemma\tprimary_upos\tprimary_n\talt_lemma\talt_upos\talt_n\n')
+
+    n_forms = n_hit = n_miss = n_amb = n_mark = 0
+    with open(os.path.join(G, 'surface_glossary.jsonl'), encoding='utf-8') as f:
+        for line in f:
+            d = json.loads(line)
+            slp1 = d['slp1']
+            nk = norm(slp1)
+            top_ru = d['translations'][0]['ru'] if d['translations'] else ''
+            if nk not in dcs_keys:                       # DCS could not lemmatize it
+                dcs_misses.write(f"{slp1}\t{d['sa']}\t{d['n']}\t{top_ru}\n")
+            cands = f2l.get(nk)
+            if not cands:
+                # tier 3: recover from corpus morpheme markers (A+gam = a+gam)
+                rec = marker_recover(slp1, f2l, l2r, roots_set, lemmas_set)
+                if rec:
+                    lem, upos, root = rec
+                    if root:
+                        l2r.setdefault(lem, root)
+                    cands = [(lem, upos, 1, 'marker')]
+                    n_mark += 1
+                else:
+                    unresolved.write(f"{slp1}\t{d['sa']}\t{d['n']}\t{top_ru}\n")
+                    n_miss += 1
+                    continue
+            n_hit += 1
+            lemma, upos, lcnt, source = cands[0]
+            # ambiguity: a second candidate of a DIFFERENT upos or within 50% count
+            if len(cands) > 1:
+                l2, u2, c2, _ = cands[1]
+                if u2 != upos or c2 >= 0.5 * lcnt:
+                    amb.write(f'{slp1}\t{lemma}\t{upos}\t{lcnt}\t{l2}\t{u2}\t{c2}\n')
+                    n_amb += 1
+            # per-form Ru distribution and works
+            ru_counts = {t['ru']: t['n'] for t in d['translations']}
+            works = collections.Counter()
+            for t in d['translations']:
+                for w, c in t.get('works', {}).items():
+                    works[w] += c
+            # attribute to primary lemma
+            la = lemma_tab[lemma]
+            for ru, c in ru_counts.items():
+                la['ru'][ru] += c
+            la['forms'][slp1] += d['n']
+            la['works'].update(works)
+            la['upos'][upos] += d['n']
+            la['src'][source] += d['n']
+            # roll up to root (verbal lemmas only)
+            root = l2r.get(lemma)
+            if root:
+                ra = root_tab[root]
+                for ru, c in ru_counts.items():
+                    ra['ru'][ru] += c
+                ra['forms'][slp1] += d['n']
+                ra['works'].update(works)
+                ra['upos'][upos] += d['n']
+                ra['lemmas'][lemma] += d['n']
+                ra['src'][source] += d['n']
+            n_forms += 1
+    dcs_misses.close(); unresolved.close(); amb.close()
+    print(f'[D] surface forms: hit={n_hit} (marker-recovered={n_mark}) miss={n_miss} '
+          f'(hit%={100*n_hit/(n_hit+n_miss):.1f}); homograph-flagged={n_amb}',
+          file=sys.stderr)
+    print(f'[D] {len(lemma_tab)} lemmas, {len(root_tab)} roots', file=sys.stderr)
+
+    nb = emit(lemma_tab, os.path.join(G, 'lemma_glossary'), MD_LEMMA,
+              'lemma_slp1', 'Lemma glossary (Sa→Ru)')
+    print(f'[D] lemma_glossary written ({nb} md letters)', file=sys.stderr)
+    nb = emit(root_tab, os.path.join(G, 'root_glossary'), MD_ROOT,
+              'root_slp1', 'Root glossary (Sa→Ru)', extra_lemmas=True)
+    print(f'[D] root_glossary written ({nb} md letters)', file=sys.stderr)
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/build_surface_glossary.py
+++ b/RussianTranslation/src/build_surface_glossary.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+"""build_surface_glossary.py — Stage A: surface-form -> Russian glossary.
+
+Direct group-by on corpus_lexicon.jsonl (1.09M word-aligned Sa->Ru tokens). No lemmatizer
+needed: every attested SLP1 surface form -> all its Russian renderings with counts and
+provenance. This is the "all forms / all words" layer; the lemma & root rollups (Stage D)
+consume it.
+
+Scope (per MG): EVERYTHING, all n>=1 — hapax kept, both kind=translation and kind=commentary
+kept (a `kinds` field records the split so downstream can filter).
+
+Outputs (in ../glossary/):
+  surface_glossary.jsonl   nested: one record per form, translations[] sorted by n desc
+  surface_glossary.tsv     flat:   one row per (form, ru) pair — queryable master
+  md/surface/<X>.md        human-readable, one file per initial SLP1 letter
+
+Per (form, ru) we keep a work-count map and a capped sample of `work:passage` sources
+(SRC_CAP) with a total; the raw corpus remains the exhaustive provenance.
+
+  python build_surface_glossary.py [corpus_lexicon.jsonl]
+"""
+import os, re, sys, json, collections
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUT_DIR = os.path.normpath(os.path.join(HERE, '..', 'glossary'))
+MD_DIR = os.path.join(OUT_DIR, 'md', 'surface')
+os.makedirs(MD_DIR, exist_ok=True)
+
+SRC_CAP = 25                      # sample sources kept per (form, ru)
+_reg = re.compile(r'^\d+_')
+def register(work):
+    return _reg.sub('', work or '')
+
+def letter_bucket(slp1):
+    """First SLP1 char, folded to a filesystem-safe bucket name."""
+    if not slp1:
+        return '_'
+    ch = slp1[0]
+    return ch if re.match(r'[A-Za-z]', ch) else '_other'
+
+def main():
+    corpus = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, 'corpus_lexicon.jsonl')
+
+    # form -> aggregate
+    forms = {}   # slp1 -> {sa:Counter, ru:Counter, kinds:Counter, periods:Counter,
+                 #          genres:Counter, works:Counter, tr:{ru->{works:Counter,src:list,total:int}}}
+    n = 0
+    with open(corpus, encoding='utf-8') as f:
+        for line in f:
+            if not line.strip():
+                continue
+            d = json.loads(line)
+            slp1 = d.get('slp1') or ''
+            ru = (d.get('ru') or '').strip()
+            if not slp1 or not ru:
+                continue
+            e = forms.get(slp1)
+            if e is None:
+                e = forms[slp1] = {
+                    'sa': collections.Counter(), 'ru': collections.Counter(),
+                    'kinds': collections.Counter(), 'periods': collections.Counter(),
+                    'genres': collections.Counter(), 'works': collections.Counter(),
+                    'tr': {}}
+            e['sa'][d.get('sa') or slp1] += 1
+            e['ru'][ru] += 1
+            e['kinds'][d.get('kind') or ''] += 1
+            e['periods'][d.get('period') or ''] += 1
+            e['genres'][d.get('genre') or ''] += 1
+            work = d.get('work') or ''
+            e['works'][work] += 1
+            t = e['tr'].get(ru)
+            if t is None:
+                t = e['tr'][ru] = {'works': collections.Counter(), 'src': [], 'total': 0}
+            t['works'][work] += 1
+            t['total'] += 1
+            if len(t['src']) < SRC_CAP:
+                t['src'].append(f"{work}:{d.get('passage','')}")
+            n += 1
+            if n % 200000 == 0:
+                print(f'  ...{n} tokens, {len(forms)} forms', file=sys.stderr)
+    print(f'[A] {n} tokens -> {len(forms)} distinct surface forms', file=sys.stderr)
+
+    # ---- emit JSONL + TSV ----
+    jpath = os.path.join(OUT_DIR, 'surface_glossary.jsonl')
+    tpath = os.path.join(OUT_DIR, 'surface_glossary.tsv')
+    buckets = collections.defaultdict(list)   # letter -> list of (slp1, record)
+    with open(jpath, 'w', encoding='utf-8', newline='\n') as jf, \
+         open(tpath, 'w', encoding='utf-8', newline='\n') as tf:
+        tf.write('form_slp1\tsa\tru\tn\tn_form_total\tworks\n')
+        for slp1 in sorted(forms):
+            e = forms[slp1]
+            sa = e['sa'].most_common(1)[0][0]
+            total = sum(e['ru'].values())
+            translations = []
+            for ru, cnt in e['ru'].most_common():
+                t = e['tr'][ru]
+                translations.append({
+                    'ru': ru, 'n': cnt,
+                    'works': dict(t['works'].most_common()),
+                    'src_sample': t['src'], 'src_total': t['total']})
+                tf.write(f"{slp1}\t{sa}\t{ru}\t{cnt}\t{total}\t"
+                         f"{'|'.join(f'{w}:{c}' for w,c in t['works'].most_common())}\n")
+            rec = {
+                'slp1': slp1, 'sa': sa, 'n': total,
+                'kinds': dict(e['kinds']),
+                'periods': dict(e['periods'].most_common()),
+                'genres': dict(e['genres'].most_common()),
+                'registers': dict(collections.Counter(
+                    {register(w): c for w, c in e['works'].items()}).most_common()),
+                'translations': translations}
+            jf.write(json.dumps(rec, ensure_ascii=False) + '\n')
+            buckets[letter_bucket(slp1)].append((slp1, rec))
+    print(f'[A] wrote {jpath} and {tpath}', file=sys.stderr)
+
+    # ---- per-letter Markdown ----
+    for letter, items in sorted(buckets.items()):
+        mp = os.path.join(MD_DIR, f'{letter}.md')
+        with open(mp, 'w', encoding='utf-8', newline='\n') as mf:
+            mf.write(f'# Surface glossary — SLP1 `{letter}`\n\n')
+            mf.write(f'{len(items)} forms. Format: `form` (sa) — total n → '
+                     'ru (n) · registers.\n\n')
+            for slp1, rec in items:
+                mf.write(f"### `{slp1}` — {rec['sa']}  (n={rec['n']})\n\n")
+                for t in rec['translations']:
+                    regs = ', '.join(register(w) for w in t['works'])
+                    mf.write(f"- {t['ru']}  · n={t['n']}  · {regs}\n")
+                mf.write('\n')
+    print(f'[A] wrote {len(buckets)} Markdown letter files -> {MD_DIR}', file=sys.stderr)
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/build_vidyut_fallback.py
+++ b/RussianTranslation/src/build_vidyut_fallback.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+"""build_vidyut_fallback.py — Stage C: lemmatize DCS-missed forms with vidyut.kosha.
+
+DCS (Stage B) resolves ~79% of tokens but only 42% of distinct forms; the long tail of
+rare / sandhi-variant / compound forms misses. vidyut's kosha (Paninian FST lexicon) is the
+fallback: it lemmatizes an inflected pada to its stem (Subanta) or root/dhatu (Tinanta).
+
+Reads   ../glossary/surface_dcs_misses.tsv   (form_slp1, sa, n, top_ru)
+Writes  ../glossary/vidyut_form2lemma.tsv     (form_slp1, lemma_slp1, pos, n_entries)
+        pos in {verb, noun, ind}; verb lemma is already the dhatu (= its own root).
+
+Primary lemma per form = the one carried by the most kosha entries (ties -> shortest, to
+prefer the root over a longer derived stem). Forms kosha also misses stay unresolved and are
+reported in the typology (Stage E).
+
+  python build_vidyut_fallback.py [path/to/vidyut_data/kosha]
+"""
+import os, sys, collections
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+from vidyut.kosha import Kosha
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+G = os.path.normpath(os.path.join(HERE, '..', 'glossary'))
+DEFAULT_KOSHA = os.path.normpath(os.path.join(
+    HERE, '..', '..', '..', '..', 'AppData', 'Local', 'Temp', 'claude',
+    'C--Users-user-Documents-GitHub',
+    'c939e6f9-2b2a-45d0-864d-09d57e9a0e34', 'scratchpad', 'vidyut_data', 'kosha'))
+
+def pos_of(entry):
+    t = type(entry).__name__
+    if 'Tinanta' in t:
+        return 'verb'
+    if getattr(entry, 'is_avyaya', False):
+        return 'ind'
+    return 'noun'
+
+def main():
+    kpath = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_KOSHA
+    if not os.path.isdir(kpath):
+        sys.exit(f'kosha data not found: {kpath}')
+    k = Kosha(kpath)
+
+    inp = os.path.join(G, 'surface_dcs_misses.tsv')
+    outp = os.path.join(G, 'vidyut_form2lemma.tsv')
+    n = hit = 0
+    stats = collections.Counter()
+    with open(inp, encoding='utf-8') as f, \
+         open(outp, 'w', encoding='utf-8', newline='\n') as out:
+        next(f)
+        out.write('form_slp1\tlemma_slp1\tpos\tn_entries\n')
+        for line in f:
+            p = line.rstrip('\n').split('\t')
+            if not p or not p[0]:
+                continue
+            form = p[0]
+            n += 1
+            try:
+                ents = k.get(form)
+            except Exception:
+                ents = []
+            if not ents:
+                stats['unresolved'] += 1
+                continue
+            # tally (lemma, pos) across entries
+            lp = collections.Counter()
+            for e in ents:
+                lem = getattr(e, 'lemma', None)
+                if lem:
+                    lp[(lem, pos_of(e))] += 1
+            if not lp:
+                stats['unresolved'] += 1
+                continue
+            # primary: most entries, then shortest lemma
+            (lemma, pos), cnt = max(lp.items(), key=lambda kv: (kv[1], -len(kv[0][0])))
+            out.write(f'{form}\t{lemma}\t{pos}\t{cnt}\n')
+            hit += 1
+            stats[pos] += 1
+            if len(lp) > 1:
+                stats['ambiguous'] += 1
+            if n % 20000 == 0:
+                print(f'  ...{n} misses, {hit} recovered', file=sys.stderr)
+    print(f'[C] {n} missed forms -> vidyut recovered {hit} '
+          f'({100*hit/n:.1f}%); {stats["unresolved"]} still unresolved', file=sys.stderr)
+    print(f'[C] pos: verb={stats["verb"]} noun={stats["noun"]} ind={stats["ind"]}; '
+          f'ambiguous={stats["ambiguous"]}', file=sys.stderr)
+    print(f'[C] -> {outp}', file=sys.stderr)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What

A full inventory of **how every Sanskrit word is rendered into Russian** in the aligned corpus, at three granularities, built from [`RussianTranslation/src/corpus_lexicon.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/corpus_lexicon.jsonl) (1,091,528 word-aligned Sa→Ru tokens).

| Layer | Entries | Answers |
|---|--:|---|
| surface form → Ru | 190,838 | how is `gamemahi` translated |
| lemma / stem → Ru | 40,370 | how is stem `mahāratha` / verb-lemma `saṃgam` translated |
| root → Ru | 2,021 | **how is √gam translated across all its forms & prefixed verbs** |

**√gam:** 678 forms / 44 lemmas / 7,116 occ → пришёл (196) · отправился (177) · ушёл (141) · достигает (99) · явился (92) · ступай (79)…

## Method

Context-free join (robust for an aggregate glossary; a per-passage alignment would fight 270 texts' mismatched ref schemes). Full write-up + failure typology in [`glossary/README.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/glossary/README.md).

1. **DCS morphology (primary)** — join to [VisualDCS `dcs_full.sqlite`](https://github.com/gasyoun/VisualDCS/tree/main/src/DCS-data-2026) (5.69M tokens), IAST→SLP1 via `indic_transliteration.sanscript`. Root = longest DCS-root suffix of a prefixed lemma (sidesteps preverb sandhi `uddhṛ`←`ut`).
2. **Vidyut kosha (fallback)** — `vidyut.kosha` lemmatizes DCS-missed forms.
3. **Morpheme-marker tier** — corpus forms with `+`/`-` marks (`A+gam` = ā+√gam) split to their root.

Every rollup row carries `source: dcs|vidyut|marker`. **Token coverage 87.1%** (DCS 79.1% + Vidyut + marker); 78,842 unresolved with a documented typology.

## Files

- New scripts: [`build_dcs_maps.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_dcs_maps.py), [`build_surface_glossary.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_surface_glossary.py), [`build_vidyut_fallback.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_vidyut_fallback.py), [`build_rollup_glossaries.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_rollup_glossaries.py)
- Docs: [`glossary/README.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/glossary/README.md), [`glossary/SAMPLE_root_glossary.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/glossary/SAMPLE_root_glossary.md)
- Bulk glossary data (≈230 MB) is **git-ignored and regenerable**, matching how `corpus_lexicon.jsonl` itself is handled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)