### PR TITLE
pwg: fix header-budgeting bug that made brū's pwg00 the last holdout

### DIFF
--- a/RussianTranslation/src/pilot/autosplit_requeue.py
+++ b/RussianTranslation/src/pilot/autosplit_requeue.py
@@ -77,7 +77,11 @@ def _cit_parts(block, ls_budget):
 
 def plan(raw, ls_budget=LS_BUDGET):
     """[(sense_ord, part_ord, text)]. Tier 0 = whole; tier 1 = per (sub)sense; tier 2 =
-    citation batches within an oversized (sub)sense. Header attaches to (0,0) only."""
+    citation batches within an oversized (sub)sense. Header attaches to (0,0) only —
+    but the header ITSELF is budgeted together with that first block, not glued on
+    unconditionally (a verb's conjugation-table header can carry all of a card's citation
+    density with almost no glossable text of its own, e.g. brU pwg00's header alone had 28
+    <ls>/26 {#..#} vs 0 <ls> in the actual first sense — see PROCESS_AUDIT dev note #7)."""
     b = _blocks(raw)
     if not b:
         # <2 detectable (sub)senses. If it is nonetheless citation-dense, it is a SINGLE giant
@@ -89,10 +93,13 @@ def plan(raw, ls_budget=LS_BUDGET):
     header, blocks = b
     out = []
     for si, blk in enumerate(blocks):
-        parts = _cit_parts(blk, ls_budget) if blk.count('<ls') > ls_budget else [blk]
+        if si == 0 and header:
+            combined = header + '\n' + blk
+            parts = _cit_parts(combined, ls_budget) if combined.count('<ls') > ls_budget else [combined]
+        else:
+            parts = _cit_parts(blk, ls_budget) if blk.count('<ls') > ls_budget else [blk]
         for pi, p in enumerate(parts):
-            t = (header + '\n' + p) if (si == 0 and pi == 0 and header) else p
-            out.append((si, pi, t))
+            out.append((si, pi, p))
     return out
 
 

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -612,12 +612,22 @@ async function resolveGroup(pending, label) {
   return { resolved, pending: cur }
 }
 async function translateBatch(batch, bi) {
-  const { resolved, pending } = await resolveGroup(batch, 'b' + bi)
-  // self-healing tier: split-translate-stitch the cards the batch gave up on (no-op unless
-  // --selfheal populated FRAGS). Runs only for the few still-failing cards.
-  const healed = {}
-  for (const k of pending) { const c = await selfHeal(k); if (c) { resolved[k] = c; healed[k] = 1 } }
-  return batch.map(k => ({ key: k, card: resolved[k] || null, judge: null, judge_sonnet: null, escalated: !!healed[k] }))
+  // A hard agent() failure (e.g. StructuredOutput retry cap exceeded, not just a malformed
+  // response our own retry/heal loops already catch) throws instead of returning — left
+  // unguarded, that rejects this whole batch's promise; parallel() then swaps the entire
+  // batch's slot for `null`, and the summary's `out.filter(r => r.card)` crashes on it
+  // (observed live: one flaky fragment call took down an otherwise-healthy 14-fragment run).
+  // Treat it exactly like an unresolved card — requeue-able, not fatal.
+  try {
+    const { resolved, pending } = await resolveGroup(batch, 'b' + bi)
+    // self-healing tier: split-translate-stitch the cards the batch gave up on (no-op unless
+    // --selfheal populated FRAGS). Runs only for the few still-failing cards.
+    const healed = {}
+    for (const k of pending) { const c = await selfHeal(k); if (c) { resolved[k] = c; healed[k] = 1 } }
+    return batch.map(k => ({ key: k, card: resolved[k] || null, judge: null, judge_sonnet: null, escalated: !!healed[k] }))
+  } catch (e) {
+    return batch.map(k => ({ key: k, card: null, judge: null, judge_sonnet: null, escalated: false, error: String(e && e.message || e) }))
+  }
 }
 const grouped = await parallel(BATCHES.map((b, i) => () => translateBatch(b, i)))
 const out = grouped.flat()


### PR DESCRIPTION
## Summary
Root-caused the `brū` `pwg00` holdout that survived every prior `--selfheal` live-validation run this session ([PR #35](https://github.com/gasyoun/SanskritLexicography/pull/35), [PR #37](https://github.com/gasyoun/SanskritLexicography/pull/37)):

- `autosplit_requeue.plan()` unconditionally glues the pre-sense-1 "header" (a verb's conjugation/paradigm table) onto the first sense's first fragment, **without ever counting the header's own `<ls>`/`{#..#}` density against `LS_BUDGET`**. For `pwg00`, the header alone carried 28 `<ls>` / 26 `{#..#}` while the actual first sense had 0 `<ls>` — so the "budgeted" first fragment was actually the densest in the card.
- Isolated per-fragment `agent()` calls (13 separate solo calls) confirmed 12/13 fragments translate fine alone; only the oversized header+sense-1 fragment failed consistently.

**Fix:** budget the header together with the first (sub)sense block instead of gluing it on unconditionally. `pwg00`: 13 fragments (one 28-`<ls>` giant) → 14 fragments, all ≤18 `<ls>`. Verified all fragments still round-trip losslessly through `pwg_mask`; sibling `brū` subcards without an oversized header are unaffected (identical fragment counts).

**Also hardens `translateBatch()`** against a hard `agent()` failure (StructuredOutput retry cap exceeded — not a malformed response our retry/heal loops already catch): this previously rejected the whole batch's promise, `parallel()` swapped it for `null`, and the summary's `out.filter(r => r.card)` crashed the entire workflow on one flaky call (observed live mid-investigation). Now caught and degraded to null cards for that batch, matching the existing "never a lossy partial, just requeue" contract.

## Live validation
| | before | after |
|---|---|---|
| brū full root (23 cards) | 22/23 (only pwg00 null) | **23/23, 0 nulls** |

This is the first clean `brū` run across 4 live validation attempts this session.

## Test plan
- [x] `ast.parse` on both files
- [x] `node --check` on generated harnesses
- [x] `autosplit_requeue.py test` — verified fragment round-trips before/after the fix, on `pwg00` and 4 sibling subcards (no regression)
- [x] Isolated 13-call debug run confirmed only the oversized fragment failed
- [x] Live Workflow run on the fixed 14-fragment split (crash-guard caught a transient failure without dying)
- [x] Full-root live re-run: 23/23 resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)