### PR TITLE
pwg: partial-credit healing for giant flat headwords (kAla/ka/SrI-scale)

### DIFF
--- a/RussianTranslation/src/pilot/autosplit_requeue.py
+++ b/RussianTranslation/src/pilot/autosplit_requeue.py
@@ -161,14 +161,22 @@ def cmd_merge(root, lang, task_file):
     tree = defaultdict(lambda: defaultdict(dict))
     for fk, info in man.items():
         tree[info['orig']][info['s']][info['p']] = fk
-    results, skipped = [], []
+    results, skipped, partial, missing_frags = [], [], [], {}
     for orig, senses_map in tree.items():
-        frs = [fk for s in senses_map.values() for fk in s.values()]
-        if any(got.get(fk) is None for fk in frs):        # completeness guard
-            skipped.append(orig); continue
-        senses, iast, h = [], None, None
+        # Completeness guard is per SENSE, not per whole card — a giant flat headword (no
+        # rootmap, e.g. large nominal stems like kAla/ka/SrI) can split into 100+ fragments,
+        # where requiring ALL of them to succeed before keeping ANY drives joint success
+        # probability toward zero even at a high per-fragment success rate (0.9^100 << 1%).
+        # Skip only the senses whose fragments are still missing; keep the rest as partial
+        # credit, and persist the missing fragment keys for a targeted follow-up requeue
+        # (not a from-scratch re-run of the whole card).
+        senses, iast, h, missing_si = [], None, None, []
         for si in sorted(senses_map):
             parts = senses_map[si]
+            frs = [parts[pi] for pi in sorted(parts)]
+            if any(got.get(fk) is None for fk in frs):
+                missing_si.append(si)
+                continue
             g_txt, t_txt, tag, extra = [], [], None, {}
             for pi in sorted(parts):
                 card = got[parts[pi]]
@@ -186,20 +194,34 @@ def cmd_merge(root, lang, task_file):
                       field: '\n'.join(x for x in t_txt if x)}
             merged.update({kk: vv for kk, vv in extra.items() if vv is not None})
             senses.append(merged)
-        # post-stitch fidelity: reassembled counts vs the source card
+        if not senses:
+            skipped.append(orig); continue     # nothing at all resolved -> truly skip
+        if missing_si:
+            partial.append(orig)
+            missing_frags[orig] = [fk for si in missing_si for fk in senses_map[si].values()]
+        # post-stitch fidelity: reassembled counts vs the source card. Only meaningful on a
+        # COMPLETE card — a partial merge legitimately has fewer <ls> than the source.
         src = read_text(input_paths(orig)[0])
         got_ls = sum(s['german'].count('<ls') for s in senses)
-        if got_ls != src.count('<ls'):
+        if not missing_si and got_ls != src.count('<ls'):
             print('  ! %s fidelity drift: <ls> %d vs source %d' % (orig, got_ls, src.count('<ls')))
         results.append({'key': orig, 'card': {'key1': orig, 'iast': iast,
-                                              'records': [{'h': h, 'senses': senses}]}})
+                                              'records': [{'h': h, 'senses': senses}]},
+                         'partial': bool(missing_si),
+                         'missing_senses': len(missing_si), 'total_senses': len(senses_map)})
     tag = 'en' if lang == 'en' else 'sc'
     out = os.path.join(REPO, 'wf_output.%s.%s.autosplit.json' % (tag, root))
     meta = {'root': root, 'safe_root': safe_name(root), 'lang': lang,
             'generator': 'autosplit_requeue', 'schema_version': 'pwg_ru.workflow_meta.v1'}
     json.dump({'meta': meta, 'results': results}, open(out, 'w', encoding='utf-8'), ensure_ascii=False)
-    print('stitched %d complete card(s); skipped %d incomplete %s -> %s'
-          % (len(results), len(skipped), skipped or '', out))
+    print('stitched %d card(s) (%d fully complete, %d partial); skipped %d fully-empty %s -> %s'
+          % (len(results), len(results) - len(partial), len(partial), len(skipped), skipped or '', out))
+    if partial:
+        mf = os.path.join(HERE, 'output', 'autosplit_missing_%s_%s.json' % (lang, safe_name(root)))
+        os.makedirs(os.path.dirname(mf), exist_ok=True)
+        json.dump(missing_frags, open(mf, 'w', encoding='utf-8'), ensure_ascii=False, indent=1)
+        print('  partial cards: %s -- missing fragment keys written to %s for a follow-up requeue'
+              % (partial, mf))
     print("then: python src/promote_final_cards.py --glob 'wf_output.%s.%s.autosplit.json' --merge"
           % (tag, root))
 

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -553,16 +553,31 @@ async function healGroup(k, idxs, grp, label) {
 // precomputed in FRAGS) into fragments, GROUPED into budget-sized batches (fragment-grouping
 // tier), then each group is translated in ONE agent() call (several fragments per call, same
 // multi-card-per-prompt pattern as translateBatch) and the fragments' senses are stitched into
-// one card. Returns the stitched card ONLY if every fragment came back and the whole-card
-// <ls>/{#..#} fidelity holds — never a lossy partial.
+// one card. Groups that never resolve (even solo, after healGroup's own bisection) are SKIPPED,
+// not fatal to the whole card — a giant flat headword with no rootmap (e.g. large nominal
+// stems like kAla/ka/SrI) can need 40+ groups, where requiring every one to succeed drives
+// joint success probability toward zero even at a high per-group success rate. A partial
+// result (missing_groups > 0) is still returned so downstream sense-coverage gates
+// (audit_coverage.py / ru_coverage.py) can measure and flag exactly what's missing — the same
+// philosophy the pipeline already uses for partial per-root RU coverage, just applied within
+// one oversized card. Only returns null if NOTHING resolved at all.
 async function selfHeal(k) {
   const groups = FRAGS[k]; if (!groups || !groups.length) return null
   const senses = []
+  let missingGroups = 0
   for (let gi = 0; gi < groups.length; gi++) {
     const grp = groups[gi]
     const gph = (PHF[k] || [])[gi] || []
-    const resolved = await healGroup(k, grp.map((_, i) => i), grp, 'heal:' + k + '#g' + (gi + 1))
-    if (!resolved) return null   // a fragment never resolved even solo -> abandon the heal, never a lossy partial
+    // A hard agent() failure inside healGroup (thrown, not returned — see translateBatch's
+    // comment) must be caught HERE, per group: uncaught, it unwinds out of this whole loop and
+    // discards every earlier group's already-accumulated senses along with it (observed live —
+    // 45 agent calls ran, several groups plausibly succeeded, yet the card still came back with
+    // ZERO senses because one later group's hard failure wiped the local `senses` array before
+    // selfHeal could return anything).
+    let resolved = null
+    try { resolved = await healGroup(k, grp.map((_, i) => i), grp, 'heal:' + k + '#g' + (gi + 1)) }
+    catch (e) { resolved = null }
+    if (!resolved) { missingGroups++; continue }
     for (let i = 0; i < grp.length; i++) {
       const card = resolved[i]
       const ph = gph[i] || []
@@ -573,8 +588,17 @@ async function selfHeal(k) {
       }
     }
   }
+  if (!senses.length) return null   // nothing at all resolved
   const stitched = { key1: k, records: [{ senses }] }
-  if (countOf(stitched, /<ls\\b/g) !== INPUTS[k].ls || countOf(stitched, /\\{#/g) !== INPUTS[k].sk) return null
+  if (!missingGroups) {
+    // fidelity check only meaningful on a COMPLETE heal — a partial result legitimately has
+    // fewer citations than the source
+    if (countOf(stitched, /<ls\\b/g) !== INPUTS[k].ls || countOf(stitched, /\\{#/g) !== INPUTS[k].sk) return null
+  } else {
+    stitched.partial = true
+    stitched.missing_groups = missingGroups
+    stitched.total_groups = groups.length
+  }
   return stitched
 }
 
@@ -613,21 +637,27 @@ async function resolveGroup(pending, label) {
 }
 async function translateBatch(batch, bi) {
   // A hard agent() failure (e.g. StructuredOutput retry cap exceeded, not just a malformed
-  // response our own retry/heal loops already catch) throws instead of returning — left
-  // unguarded, that rejects this whole batch's promise; parallel() then swaps the entire
-  // batch's slot for `null`, and the summary's `out.filter(r => r.card)` crashes on it
-  // (observed live: one flaky fragment call took down an otherwise-healthy 14-fragment run).
-  // Treat it exactly like an unresolved card — requeue-able, not fatal.
+  // response our own retry/heal loops already catch) throws instead of returning. Guard
+  // resolveGroup AND selfHeal INDEPENDENTLY — a caller that wraps both in one try/catch
+  // (as an earlier version of this fix did) swallows a whole-batch failure before --selfheal
+  // ever runs, which defeats the fallback for exactly the cards that need it most (observed
+  // live: a huge single-card nominal batch hard-failed the main attempt and the heal path,
+  // with its precomputed fragment groups, never even got a chance to run). Both paths degrade
+  // to "unresolved" on a hard failure — requeue-able, not fatal, and selfHeal still gets tried.
+  let resolved = {}, pending = batch.slice()
   try {
-    const { resolved, pending } = await resolveGroup(batch, 'b' + bi)
-    // self-healing tier: split-translate-stitch the cards the batch gave up on (no-op unless
-    // --selfheal populated FRAGS). Runs only for the few still-failing cards.
-    const healed = {}
-    for (const k of pending) { const c = await selfHeal(k); if (c) { resolved[k] = c; healed[k] = 1 } }
-    return batch.map(k => ({ key: k, card: resolved[k] || null, judge: null, judge_sonnet: null, escalated: !!healed[k] }))
-  } catch (e) {
-    return batch.map(k => ({ key: k, card: null, judge: null, judge_sonnet: null, escalated: false, error: String(e && e.message || e) }))
+    const r = await resolveGroup(batch, 'b' + bi)
+    resolved = r.resolved; pending = r.pending
+  } catch (e) { /* fall through to --selfheal below with the full batch still pending */ }
+  // self-healing tier: split-translate-stitch the cards the batch gave up on (no-op unless
+  // --selfheal populated FRAGS). Runs only for the few still-failing cards.
+  const healed = {}
+  for (const k of pending) {
+    let c = null
+    try { c = await selfHeal(k) } catch (e) { c = null }
+    if (c) { resolved[k] = c; healed[k] = 1 }
   }
+  return batch.map(k => ({ key: k, card: resolved[k] || null, judge: null, judge_sonnet: null, escalated: !!healed[k] }))
 }
 const grouped = await parallel(BATCHES.map((b, i) => () => translateBatch(b, i)))
 const out = grouped.flat()


### PR DESCRIPTION
## Summary
Investigated why the 3 biggest non-root nominal headwords (`kAla`/`ka`/`SrI` — no rootmap, a single flat card each) fail `--selfheal` even at scale. `kAla` splits into 43 heal groups (149 raw fragments); the all-or-nothing "every group must succeed before stitching anything" design has vanishing joint success probability at this scale (0.9^43 < 1.5%, optimistically).

Found and fixed 3 layered issues via live investigation (3 escalating `kAla` runs, ~4.5M tokens):

1. **`selfHeal()` now returns partial results.** A group that never resolves (even solo, after `healGroup`'s own bisection) is skipped, not fatal to the whole card. Returns `partial`/`missing_groups` markers so downstream sense-coverage gates (`audit_coverage.py`/`ru_coverage.py`) can measure and flag exactly what's missing — same philosophy the pipeline already applies to partial per-root RU coverage, now applied within one oversized card.
2. **Found mid-investigation:** `selfHeal`'s per-group loop had no `try/catch` around `healGroup()` — a hard `agent()` failure in even ONE group unwound the whole loop and discarded every earlier group's already-accumulated senses. Live-observed: 45 agent calls ran, several groups plausibly succeeded, yet the card came back with **zero** senses. Fixed with a per-group `try/catch`.
3. **Corrected `translateBatch()`'s crash-guard from [PR #38](https://github.com/gasyoun/SanskritLexicography/pull/38):** it wrapped `resolveGroup` AND `selfHeal` in ONE `try/catch`, so a hard failure on the main whole-card attempt swallowed the exception before `selfHeal` (with its precomputed fragment groups) ever ran — defeating the fallback for exactly the cards that need it most. Guarding both independently fixes this.
4. **`autosplit_requeue.cmd_merge()`** gets the same per-sense partial-credit fix (was per-whole-card) — same structural problem at the separate lower-level gen/merge tool used to debug `pwg00`. Missing fragment keys now persist to `autosplit_missing_<lang>_<root>.json` for a targeted follow-up requeue instead of re-running the whole card.

## Validation
- [x] `ast.parse` on both files
- [x] `node --check` on generated harnesses
- [x] Manual trace of every `agent()`-touching call site confirming no remaining silent-data-loss path (documented one minor, non-data-loss efficiency gap in `resolveGroup`'s own `Promise.all` bisection — a hard failure in one bisected half discards the sibling half's success for *that* bisection call, but safely falls through to the next tier rather than losing already-stored data)
- [ ] **Not live-validated end-to-end** — the diagnosis was live-tested (confirming each successive bug before fixing it) but the final combined fix was validated locally only, given the cost of further iteration (~4.5M tokens already spent). A future run should confirm `kAla`/`ka`/`SrI` close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)