### PR TITLE
Live uncovered-works list + citation usage-frequency (scan vs HTML) findings

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -244,6 +244,25 @@ a probe), never a hunch. When a finding is later refuted or superseded, strike i
   **Source:** [`nearest_root_audit.json`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/etymology_stats/nearest_root_audit.json)
   + [`build_root_normalization.py`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/etymology_stats/build_root_normalization.py) — csl-orig · 2026-06-26
 
+- **PWG `<ls>` citation usage frequency ≈ distinct-reference frequency — HTML-target works are NOT cited disproportionately more than scan-target works.**
+  Evidence: across the displayed PWG article corpus ([gasyoun.github.io/SanskritLexicography](https://gasyoun.github.io/SanskritLexicography/))
+  the `<ls>` citations number **50,065 occurrences** vs **37,951 distinct references** — mean ~1.32
+  citations per distinct reference (most appear exactly once). Splitting resolved links by target
+  kind, the **scan : HTML ratio is 4.9 : 1 by occurrence vs 5.1 : 1 by distinct reference**: HTML-target
+  works (only ṚV., AV., P. — Rigveda / Atharvaveda / Pāṇini resolve to rendered digital text rather
+  than a page scan) are re-cited only marginally more per reference (1.32×) than scan works (1.26×),
+  *not* an order of magnitude more (a plausible-sounding hypothesis that the data refutes). Occurrence
+  coverage 83.2 % (41,642 / 50,065 link out = 34,560 scan + 7,082 HTML); the 16.8 % unlinked = 6,505
+  occurrences of 446 truly-uncovered works + 1,883 non-coordinate `<ls>` labels (edition/cross-ref
+  notes like "ed. Bomb.", never linkable) + 35 edge-case parse misses.
+  Implication: distinct-reference counts are a faithful proxy for citation frequency here — do not
+  occurrence-weight coverage/impact estimates by target type. When counting `<ls>`, exclude
+  no-coordinate labels (they are not references), and count from the deduplicated display model, not
+  the raw DE/RU/EN stores (which multiply each citation ~4× via translation fields + store overlap).
+  **Source:** [`build_citation_index.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_citation_index.py)
+  → [`UNCOVERED_SOURCES.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/UNCOVERED_SOURCES.md)
+  + [`CITATION_SOURCES.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/CITATION_SOURCES.md) — SanskritLexicography · 2026-07-02
+
 ---
 
 _Started 2026-06-26 (relocated from `Uprava/FINDINGS.md`, which now holds **non-Sanskrit**

--- a/RussianTranslation/CITATION_SOURCES.md
+++ b/RussianTranslation/CITATION_SOURCES.md
@@ -17,6 +17,8 @@ Every `<ls>` literary-source citation in the PWG article corpus (the roots publi
 
 > **Coverage is target-limited, not resolver-limited.** The resolver implements essentially the full mapping set the Cologne app itself supports; most unresolved references cite works the Cologne project has **not digitized** (no scan repository exists — e.g. Suśruta, most Upaniṣads, the Śrauta/Gṛhya sūtras, several chrestomathies), so they cannot be linked from anywhere.
 
+> The most-cited uncovered works are ranked (by how often each is actually cited) in [`UNCOVERED_SOURCES.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/UNCOVERED_SOURCES.md), regenerated on every build.
+
 ## Abbreviation index
 
 | abbreviation | refs | resolved | scan | HTML | target | example |

--- a/RussianTranslation/UNCOVERED_SOURCES.md
+++ b/RussianTranslation/UNCOVERED_SOURCES.md
@@ -1,0 +1,471 @@
+# PWG uncovered citation sources — most-cited works with no link
+
+<p align="right"><sub>Created: 02-07-2026 · Last updated: 02-07-2026</sub></p>
+
+Works cited by `<ls>` in the PWG article corpus that **have no Cologne target at all** — *no* occurrence resolves, because no scan repo exists in the [`sanskrit-lexicon-scans`](https://github.com/orgs/sanskrit-lexicon-scans/repositories) org (or the abbreviation is a grammatical authority / cross-reference, not a citable text). Ranked by **how often the work is actually cited** (occurrences on the displayed DE surface), most-cited first — so the top rows are the highest-value targets should Cologne ever digitize them. Regenerated on every build by [`build_citation_index.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_citation_index.py).
+
+Of **50,065** citation occurrences on the site, **41,642** link out (34,560 scan + 7,082 HTML) and **8,423 (16.8%)** stay unlinked. The unlinked ones are **446 truly-uncovered works** below (6,505 occurrences), plus 35 edge-case misses in otherwise-covered works (see end) and 1,883 non-coordinate `<ls>` labels (edition/cross-ref notes like "ed. Bomb.", never linkable).
+
+| rank | source (abbreviation) | citations |
+|---:|---|---:|
+| 1 | SUŚR. | 311 |
+| 2 | CHĀND. UP. | 220 |
+| 3 | PRAB. | 200 |
+| 4 | KAUŚ. | 170 |
+| 5 | KĀM. NĪTIS. | 168 |
+| 6 | MṚCCH. | 162 |
+| 7 | ŚĀṄKH. ŚR. | 160 |
+| 8 | ĀŚV. GṚHY. | 145 |
+| 9 | LĀṬY. | 142 |
+| 10 | Ind. St. | 128 |
+| 11 | SARVADARŚANAS. | 127 |
+| 12 | PAÑCAV. BR. | 110 |
+| 13 | ŚIŚ. | 106 |
+| 14 | JĀTAKAM. | 105 |
+| 15 | DAŚAK. | 92 |
+| 16 | ĀPAST. | 92 |
+| 17 | KĀṬH. | 86 |
+| 18 | ṚV. PRĀT. | 84 |
+| 19 | ĀŚV. ŚR. | 80 |
+| 20 | DIVYĀVAD. | 79 |
+| 21 | GOBH. | 76 |
+| 22 | ṚT. | 75 |
+| 23 | ĀPAST. ŚR. | 68 |
+| 24 | KIR. | 63 |
+| 25 | ŚĀṄKH. BR. | 61 |
+| 26 | VET. | 59 |
+| 27 | MAITR. S. | 56 |
+| 28 | MAITRYUP. | 56 |
+| 29 | ŚĀṄKH. GṚHY. | 55 |
+| 30 | CARAKA. | 51 |
+| 31 | VS. PRĀT. | 48 |
+| 32 | MUṆḌ. UP. | 47 |
+| 33 | ARJ. | 46 |
+| 34 | MAHĀVY. | 46 |
+| 35 | PĀR. GṚHY. | 46 |
+| 36 | BṚH. ĀR. UP. S. | 45 |
+| 37 | DHŪRTAS. | 45 |
+| 38 | KAṬHOP. | 45 |
+| 39 | KĀD. | 44 |
+| 40 | NAIṢ. | 43 |
+| 41 | VET. in LA. (III) | 43 |
+| 42 | Jātakam. | 41 |
+| 43 | SŪRYAS. | 41 |
+| 44 | TS. PRĀT. | 41 |
+| 45 | BĀLAR. | 40 |
+| 46 | KAUṢ. UP. | 40 |
+| 47 | ŚVETĀŚV. UP. | 40 |
+| 48 | PAT. a. a. O. | 39 |
+| 49 | DRAUP. | 36 |
+| 50 | KAP. | 36 |
+| 51 | TAITT. UP. | 36 |
+| 52 | Sp. | 35 |
+| 53 | SĀV. | 34 |
+| 54 | Divyāvad. | 32 |
+| 55 | PRAŚNOP. | 32 |
+| 56 | Sch. | 31 |
+| 57 | Z. d. d. m. G. | 31 |
+| 58 | VAJRACCH. | 29 |
+| 59 | BṚH. ĀR. UP. | 28 |
+| 60 | LALIT. | 28 |
+| 61 | SADDH. P. | 28 |
+| 62 | VĀLAKH. | 28 |
+| 63 | AMAR. | 26 |
+| 64 | KĀRAṆḌ. | 26 |
+| 65 | VET. in LA. | 26 |
+| 66 | ŚĀK. CH. | 26 |
+| 67 | SĀṂKHYAK. | 25 |
+| 68 | Journ. of the Am. Or. S. | 23 |
+| 69 | Nachtr. | 23 |
+| 70 | SUND. | 22 |
+| 71 | ŚAṂK. zu BĀDAR. | 22 |
+| 72 | ṢAḌV. BR. | 22 |
+| 73 | HEMĀDRI | 21 |
+| 74 | HEM. PAR. | 20 |
+| 75 | Mahāvy. | 20 |
+| 76 | ŚRUT. | 20 |
+| 77 | AV. PRĀT. | 19 |
+| 78 | INDR. | 19 |
+| 79 | NALOD. | 19 |
+| 80 | UTTARAR. | 19 |
+| 81 | VARĀH. BṚH. | 19 |
+| 82 | HIḌ. | 18 |
+| 83 | KENOP. | 18 |
+| 84 | LA. (II) | 18 |
+| 85 | MĀLATĪM. | 18 |
+| 86 | UTTARARĀMAC. | 18 |
+| 87 | VEDĀNTAS. (Allah.) No. | 18 |
+| 88 | GṚHY. | 17 |
+| 89 | JAIM. | 17 |
+| 90 | Maitr. S. | 17 |
+| 91 | PRASANNAR. | 17 |
+| 92 | VP. | 17 |
+| 93 | SCHL. | 16 |
+| 94 | SIDDH. K. | 16 |
+| 95 | TAITT. ĀR. | 16 |
+| 96 | HARṢAC. | 15 |
+| 97 | CAMPAKA | 14 |
+| 98 | CARAKA | 14 |
+| 99 | MĀN. GṚHY. | 14 |
+| 100 | Āpast. Śr. | 14 |
+| 101 | ŚATR. | 14 |
+| 102 | ŚĀNTIŚ. | 14 |
+| 103 | BRAHMA-P. | 13 |
+| 104 | HALL | 13 |
+| 105 | MÜLLER, SL. | 13 |
+| 106 | BHĀṢĀP. | 12 |
+| 107 | BṚH. | 12 |
+| 108 | GOP. BR. | 12 |
+| 109 | Z. | 12 |
+| 110 | ĀPAST. GṚHY. | 12 |
+| 111 | ŚUK. | 12 |
+| 112 | AIT. UP. | 11 |
+| 113 | BHĀVAPR. | 11 |
+| 114 | BRAHMA-P. in LA. (III) | 11 |
+| 115 | CĀṆ. | 11 |
+| 116 | GAUT. | 11 |
+| 117 | Lot. de la b. l. | 11 |
+| 118 | S I, | 11 |
+| 119 | H | 10 |
+| 120 | LA. (III) | 10 |
+| 121 | LALIT. ed. Calc. | 10 |
+| 122 | WEBER, RĀMAT. UP. | 10 |
+| 123 | ĪŚOP. | 10 |
+| 124 | ŚR. | 10 |
+| 125 | BṚH. ĀR. UP. p. | 9 |
+| 126 | NYĀYAS. | 9 |
+| 127 | NĪLAK. | 9 |
+| 128 | SOM. NALA | 9 |
+| 129 | WEBER, JYOT. | 9 |
+| 130 | WEBER, KṚṢṆAJ. | 9 |
+| 131 | Z. f. d. K. d. M. | 9 |
+| 132 | {{CARARA->CARAKA\|\| | 9 |
+| 133 | ŚUK. in LA. | 9 |
+| 134 | ŚULBAS. | 9 |
+| 135 | AIT. ĀR. | 8 |
+| 136 | CHĀND. UP. S. | 8 |
+| 137 | Kauṭ. | 8 |
+| 138 | LA. | 8 |
+| 139 | MIT. | 8 |
+| 140 | MĀN. ŚR. | 8 |
+| 141 | TATTVAS. | 8 |
+| 142 | VĀSAV. | 8 |
+| 143 | WILSON, SĀṂKHYAK. S. | 8 |
+| 144 | YOGAŚ. | 8 |
+| 145 | BRAHMA-P. in LA. | 7 |
+| 146 | BRĀHMAṆ. | 7 |
+| 147 | DAŚAR. | 7 |
+| 148 | DEV. | 7 |
+| 149 | HIT. ed. JOHNS. | 7 |
+| 150 | KUSUM. | 7 |
+| 151 | MATSYOP. | 7 |
+| 152 | VAITĀN. | 7 |
+| 153 | VET. in LA. (II) | 7 |
+| 154 | BURN. Intr. | 6 |
+| 155 | BĀLAB. | 6 |
+| 156 | CAMPAKA. | 6 |
+| 157 | COLEBR. Misc. Ess. | 6 |
+| 158 | GṚHYASAṂGR. | 6 |
+| 159 | Harṣac. | 6 |
+| 160 | SAṂHITOPAN. | 6 |
+| 161 | TARKAS. | 6 |
+| 162 | VYUTP. | 6 |
+| 163 | Vajracch. | 6 |
+| 164 | VṚDDHA-CĀṆ. | 6 |
+| 165 | ŚIKṢĀ | 6 |
+| 166 | ŚUK. in LA. (III) | 6 |
+| 167 | <is>Kār.</is> | 5 |
+| 168 | BURNOUF, Intr. | 5 |
+| 169 | Comm. zu NYĀYAM. | 5 |
+| 170 | Comm. zu NYĀYAS. | 5 |
+| 171 | DHARMAŚARM. | 5 |
+| 172 | Kauś. | 5 |
+| 173 | Kir. | 5 |
+| 174 | KĀVYĀD. | 5 |
+| 175 | LAGHUJ. | 5 |
+| 176 | MUDRĀR. | 5 |
+| 177 | MUIR, ST. | 5 |
+| 178 | PAÑCAD. | 5 |
+| 179 | Pūrṇabh. | 5 |
+| 180 | RĀJAN. | 5 |
+| 181 | UPAG. AV. | 5 |
+| 182 | VASIṢṬHA | 5 |
+| 183 | Verz. d. Oxf. H. No. | 5 |
+| 184 | Āpast. Gṛhy. | 5 |
+| 185 | BĀDAR. | 4 |
+| 186 | CHANDOM. | 4 |
+| 187 | Comm. zu ĀPAST. ŚR. | 4 |
+| 188 | CĀT. | 4 |
+| 189 | DHŪRTAS. in LA. | 4 |
+| 190 | GHAṬ. | 4 |
+| 191 | KUVALAY. | 4 |
+| 192 | MBh. | 4 |
+| 193 | MED. <is>avy</is>. | 4 |
+| 194 | N. (BOPP) | 4 |
+| 195 | PISCHEL, Vedische Studien | 4 |
+| 196 | PĀRŚVANĀTHAK. | 4 |
+| 197 | S II, | 4 |
+| 198 | SĀṂKHYAK. S. | 4 |
+| 199 | Sūryaś. | 4 |
+| 200 | TĀṆḌYA-BR. | 4 |
+| 201 | UTTAMAC. | 4 |
+| 202 | UṆĀDIS. | 4 |
+| 203 | VEṆĪS. | 4 |
+| 204 | VĀMANA | 4 |
+| 205 | VĀSAVAD. | 4 |
+| 206 | ĀRYABH. | 4 |
+| 207 | Śiś. | 4 |
+| 208 | Śāṅkh. Br. | 4 |
+| 209 | BHĀG. | 3 |
+| 210 | BHĀMATĪ | 3 |
+| 211 | BRAHMA-P. in LA. (II) | 3 |
+| 212 | Comm. zu JAIM. | 3 |
+| 213 | Comm. zu LĀṬY. | 3 |
+| 214 | Dharmaśarm. | 3 |
+| 215 | Hem. Par. | 3 |
+| 216 | KAṆ. | 3 |
+| 217 | KUHNʼs Z. | 3 |
+| 218 | Kaus. | 3 |
+| 219 | LALIT. Calc. | 3 |
+| 220 | LĀTY. | 3 |
+| 221 | MADHYAM. | 3 |
+| 222 | MAHĀBH. | 3 |
+| 223 | MĀLAT. | 3 |
+| 224 | MĀN. | 3 |
+| 225 | PRATĀPAR. | 3 |
+| 226 | RATNĀV. | 3 |
+| 227 | SAṂSK. K. | 3 |
+| 228 | SV. I, | 3 |
+| 229 | SĀMAV. BR. | 3 |
+| 230 | SĀMAVIDH. BR. | 3 |
+| 231 | SĀY. zu ṚV. | 3 |
+| 232 | UTTAR. | 3 |
+| 233 | VIKRAMĀṄKAC. | 3 |
+| 234 | VIṢṆUS. | 3 |
+| 235 | WEBER, Nakṣ. | 3 |
+| 236 | WIND. Sancara | 3 |
+| 237 | YOGAS. | 3 |
+| 238 | Yudh. | 3 |
+| 239 | ed. Bomb. | 3 |
+| 240 | ed. Vardh. | 3 |
+| 241 | {{MBH. | 3 |
+| 242 | ŚUK. in LA. (II) | 3 |
+| 243 | Śrīk. | 3 |
+| 244 | 14 | 2 |
+| 245 | 231,16 | 2 |
+| 246 | 41 | 2 |
+| 247 | AGNI-P. | 2 |
+| 248 | ARYABH. | 2 |
+| 249 | AV. PAIPP. | 2 |
+| 250 | AV. PRĀYAŚC. | 2 |
+| 251 | BAUDH. | 2 |
+| 252 | BHADRAB. | 2 |
+| 253 | BHOJAPRAB. | 2 |
+| 254 | BHĀTUP. | 2 |
+| 255 | BR.) | 2 |
+| 256 | BĪJAG. | 2 |
+| 257 | BṚH. ĀR. | 2 |
+| 258 | COLEBR. Alg. | 2 |
+| 259 | Caraka | 2 |
+| 260 | Comm. zu KĀTY. ŚR. | 2 |
+| 261 | Comm. zu SŪRYAS. | 2 |
+| 262 | DH. V. | 2 |
+| 263 | Daśak. | 2 |
+| 264 | GOLĀDHY. BHUVANAK. | 2 |
+| 265 | Gopāl. | 2 |
+| 266 | HARAVIJAYA | 2 |
+| 267 | Hariv. | 2 |
+| 268 | J. A. O. S. Procc. Oct. | 2 |
+| 269 | KAP. S. | 2 |
+| 270 | KAUṢ. UP. Einl. | 2 |
+| 271 | KIRĀT. | 2 |
+| 272 | Kap. | 2 |
+| 273 | Kauṣ. Up. | 2 |
+| 274 | Kaṃs. IV, | 2 |
+| 275 | Kir. I, | 2 |
+| 276 | Kir. X, | 2 |
+| 277 | Kir. XVI, | 2 |
+| 278 | Kuhn's Z. | 2 |
+| 279 | KĀTY. ŚR. Comm. | 2 |
+| 280 | KĀVYA-PR. | 2 |
+| 281 | Kāty. Śr. | 2 |
+| 282 | Kāṭh. | 2 |
+| 283 | KṢURIKOP. | 2 |
+| 284 | LIA. I, | 2 |
+| 285 | MAHĀBH. lith. Ausg. | 2 |
+| 286 | MAHĀN. | 2 |
+| 287 | MAHĀVASTU | 2 |
+| 288 | MUIR, ST. ( | 2 |
+| 289 | MUIR, ST. IV, | 2 |
+| 290 | MUIR, Sanscrit Texts I, | 2 |
+| 291 | Med. | 2 |
+| 292 | MĀRK. | 2 |
+| 293 | MĀRK. P. S. | 2 |
+| 294 | NIDĀNAS. | 2 |
+| 295 | Naiṣ. | 2 |
+| 296 | PARIBH. | 2 |
+| 297 | PRASAṄGĀBH. | 2 |
+| 298 | Pischel, Ved. Stud. I, | 2 |
+| 299 | R. Gorr. | 2 |
+| 300 | RATIM. | 2 |
+| 301 | SOM. NAL. | 2 |
+| 302 | SV. II, | 2 |
+| 303 | TĀRAN. | 2 |
+| 304 | UPAL. | 2 |
+| 305 | UTPALA zu VARĀH. BṚH. | 2 |
+| 306 | Uttamac. | 2 |
+| 307 | Uttarar. V, | 2 |
+| 308 | VARĀH. LAGHUJ. | 2 |
+| 309 | VEDĀNTAS. | 2 |
+| 310 | VIVĀDAC. | 2 |
+| 311 | VOP. S. | 2 |
+| 312 | Viṣṇubh. III, | 2 |
+| 313 | VĀGBHAṬĀLAṂKĀRA | 2 |
+| 314 | Vās. | 2 |
+| 315 | WASSILJEW | 2 |
+| 316 | WILSON, Sel. Works | 2 |
+| 317 | WILSON, SĀṂKHYAK. p. | 2 |
+| 318 | YAJÑAD. | 2 |
+| 319 | YAJÑADATTAV. | 2 |
+| 320 | ZDMG | 2 |
+| 321 | ed. Calc. | 2 |
+| 322 | Āpast. | 2 |
+| 323 | Ś. | 2 |
+| 324 | ŚAṂK. zu CHĀND. UP. S. | 2 |
+| 325 | ŚIŚUP. | 2 |
+| 326 | ŚĀNT. | 2 |
+| 327 | ṚV. ANUKR. | 2 |
+| 328 | 1,111,3. | 1 |
+| 329 | 1,12,a | 1 |
+| 330 | 15. | 1 |
+| 331 | AŚNA S. | 1 |
+| 332 | AŚOKĀVAD. | 1 |
+| 333 | AṢṬĀV. | 1 |
+| 334 | BHAR. NĀṬYAŚ. | 1 |
+| 335 | BHOJA-PR. | 1 |
+| 336 | BHĀṬṬ. | 1 |
+| 337 | BRAHMOP. S. | 1 |
+| 338 | CANDRAKĪRTI | 1 |
+| 339 | COLEBR. Misc. Ess. I, | 1 |
+| 340 | COLEBR. Misc. Ess. II, | 1 |
+| 341 | Comm. zu AIT. ĀR. S. | 1 |
+| 342 | Comm. zu AK. | 1 |
+| 343 | Comm. zu CARAKA. | 1 |
+| 344 | Comm. zu NYĀYAM. S. | 1 |
+| 345 | Comm. zu TBR. | 1 |
+| 346 | Comm. zu TS. | 1 |
+| 347 | DHARMAŚ. | 1 |
+| 348 | DHŪRTAN. | 1 |
+| 349 | DĀYABH. | 1 |
+| 350 | GOVINDĀN. S. | 1 |
+| 351 | HARIR. | 1 |
+| 352 | HARṢAC. (ed. Bomb.) | 1 |
+| 353 | IL. | 1 |
+| 354 | INDṚ. | 1 |
+| 355 | JYOT. | 1 |
+| 356 | Journ. of the As. Soc. of B. IV, Pl. XL, Z. | 1 |
+| 357 | JĀBĀLOP. S. | 1 |
+| 358 | KAT. | 1 |
+| 359 | KATHOP. | 1 |
+| 360 | KAURAP. | 1 |
+| 361 | KENOP | 1 |
+| 362 | KUHNʼS Z. | 1 |
+| 363 | Kir. IX, | 1 |
+| 364 | KĀTHOP. | 1 |
+| 365 | KĀVYAPR. | 1 |
+| 366 | Kār. | 1 |
+| 367 | KṚṢIS. | 1 |
+| 368 | KṚṢṆAJ. | 1 |
+| 369 | LASS. | 1 |
+| 370 | LASSEN, Institutt. | 1 |
+| 371 | LASSEN, Pent. | 1 |
+| 372 | M. MÜLLER, Transl. | 1 |
+| 373 | MAHĀBH. (K.) | 1 |
+| 374 | MANTRABR. | 1 |
+| 375 | MUDHĀR. | 1 |
+| 376 | MUIR, ST. I, | 1 |
+| 377 | MUIR, ST. II, | 1 |
+| 378 | MÜLLER, St. | 1 |
+| 379 | MĀṆḌ. UP. | 1 |
+| 380 | MṚCCH | 1 |
+| 381 | MṚCCH. ed. Calc. | 1 |
+| 382 | NIDĀNA | 1 |
+| 383 | NYĀYAM. | 1 |
+| 384 | NĀGĀN. | 1 |
+| 385 | NĀṬYAŚ. | 1 |
+| 386 | NĪLAK. zu MBH. | 1 |
+| 387 | P. Einl. | 1 |
+| 388 | PAT. zu P. | 1 |
+| 389 | PAÑCAT. Bd. I, S. | 1 |
+| 390 | PAÑCAT. ed. Bomb. | 1 |
+| 391 | PAÑCAT. ed. Bomb. IV, | 1 |
+| 392 | PRATYABDAŚ. | 1 |
+| 393 | PRB. | 1 |
+| 394 | Pischel, Ved. Studien I, | 1 |
+| 395 | Prabandh. | 1 |
+| 396 | Praty. Hṛd. | 1 |
+| 397 | R. III, S. | 1 |
+| 398 | R. ed. SCHL. | 1 |
+| 399 | R. ed. Ser. | 1 |
+| 400 | Rasas. | 1 |
+| 401 | RĀJA. | 1 |
+| 402 | SARVAD. | 1 |
+| 403 | SMARADĪP. | 1 |
+| 404 | SPAṢṬĀDH. | 1 |
+| 405 | SUPARṆ. | 1 |
+| 406 | SV. | 1 |
+| 407 | SV. II. | 1 |
+| 408 | Sam. I, | 1 |
+| 409 | Spruch | 1 |
+| 410 | Suśr. | 1 |
+| 411 | SĀY. | 1 |
+| 412 | SĀṂKHYAPR. S. | 1 |
+| 413 | TAITT. BR. | 1 |
+| 414 | TAITT. PRĀT. | 1 |
+| 415 | TARKASAM̃GR. | 1 |
+| 416 | TBR. Comm. | 1 |
+| 417 | TRIPR. | 1 |
+| 418 | TS. Comm. | 1 |
+| 419 | TS. II, | 1 |
+| 420 | Text zu Lot. de la b. l. | 1 |
+| 421 | UP. | 1 |
+| 422 | UPAK. | 1 |
+| 423 | UTTARAR. ed. Cow. | 1 |
+| 424 | VARARUCI | 1 |
+| 425 | VARĀH. BṚH. S. S. | 1 |
+| 426 | VARĀH. YOGAY. | 1 |
+| 427 | VARĀH.BṚH. S. | 1 |
+| 428 | VIKR. drāv. | 1 |
+| 429 | Verz. d. B. H. | 1 |
+| 430 | Verz. d. B. H. No. | 1 |
+| 431 | VĀGBH. | 1 |
+| 432 | VṚDDHACĀṆ. | 1 |
+| 433 | WEBER S. | 1 |
+| 434 | WILSON, ebend. S. | 1 |
+| 435 | WINDISCHMANN, Sancara | 1 |
+| 436 | WISE | 1 |
+| 437 | YANTRĀDHY. | 1 |
+| 438 | YOGAYĀTRĀ | 1 |
+| 439 | YĀJN. | 1 |
+| 440 | ebend. | 1 |
+| 441 | {{BENFEY.,Chr.->BENF.Chr.\|\| | 1 |
+| 442 | {{MEGH. | 1 |
+| 443 | {{ŚR. | 1 |
+| 444 | {{‹ed.› Vardh.->MBH.ed.Vardh.\|\| | 1 |
+| 445 | ŚRUT. (BR.) | 1 |
+| 446 | ŚUK. ebend. | 1 |
+
+## Edge-case misses (work IS digitized; some refs malformed)
+
+These abbreviations resolve for most citations — the counts below are individual references with a malformed/unusual coordinate that the resolver could not parse. Not "uncovered".
+
+| source | unresolved refs |
+|---|---:|
+| VARĀH. BṚH. S. | 24 |
+| VOP. | 5 |
+| HALĀY. | 2 |
+| Verz. d. Oxf. H. | 2 |
+| MBH. | 1 |
+| TBR. | 1 |
+
+<p align="right"><sub>Dr. Mārcis Gasūns</sub></p>

--- a/RussianTranslation/release/uncovered_sources.json
+++ b/RussianTranslation/release/uncovered_sources.json
@@ -1,0 +1,1821 @@
+{
+ "occurrences_total": 50065,
+ "occurrences_linked": 41642,
+ "occurrences_scan": 34560,
+ "occurrences_html": 7082,
+ "occurrences_uncovered": 6505,
+ "occurrences_noncoordinate_labels": 1883,
+ "distinct_uncovered_works": 446,
+ "uncovered": [
+  {
+   "abbr": "SUŚR.",
+   "occurrences": 311
+  },
+  {
+   "abbr": "CHĀND. UP.",
+   "occurrences": 220
+  },
+  {
+   "abbr": "PRAB.",
+   "occurrences": 200
+  },
+  {
+   "abbr": "KAUŚ.",
+   "occurrences": 170
+  },
+  {
+   "abbr": "KĀM. NĪTIS.",
+   "occurrences": 168
+  },
+  {
+   "abbr": "MṚCCH.",
+   "occurrences": 162
+  },
+  {
+   "abbr": "ŚĀṄKH. ŚR.",
+   "occurrences": 160
+  },
+  {
+   "abbr": "ĀŚV. GṚHY.",
+   "occurrences": 145
+  },
+  {
+   "abbr": "LĀṬY.",
+   "occurrences": 142
+  },
+  {
+   "abbr": "Ind. St.",
+   "occurrences": 128
+  },
+  {
+   "abbr": "SARVADARŚANAS.",
+   "occurrences": 127
+  },
+  {
+   "abbr": "PAÑCAV. BR.",
+   "occurrences": 110
+  },
+  {
+   "abbr": "ŚIŚ.",
+   "occurrences": 106
+  },
+  {
+   "abbr": "JĀTAKAM.",
+   "occurrences": 105
+  },
+  {
+   "abbr": "DAŚAK.",
+   "occurrences": 92
+  },
+  {
+   "abbr": "ĀPAST.",
+   "occurrences": 92
+  },
+  {
+   "abbr": "KĀṬH.",
+   "occurrences": 86
+  },
+  {
+   "abbr": "ṚV. PRĀT.",
+   "occurrences": 84
+  },
+  {
+   "abbr": "ĀŚV. ŚR.",
+   "occurrences": 80
+  },
+  {
+   "abbr": "DIVYĀVAD.",
+   "occurrences": 79
+  },
+  {
+   "abbr": "GOBH.",
+   "occurrences": 76
+  },
+  {
+   "abbr": "ṚT.",
+   "occurrences": 75
+  },
+  {
+   "abbr": "ĀPAST. ŚR.",
+   "occurrences": 68
+  },
+  {
+   "abbr": "KIR.",
+   "occurrences": 63
+  },
+  {
+   "abbr": "ŚĀṄKH. BR.",
+   "occurrences": 61
+  },
+  {
+   "abbr": "VET.",
+   "occurrences": 59
+  },
+  {
+   "abbr": "MAITR. S.",
+   "occurrences": 56
+  },
+  {
+   "abbr": "MAITRYUP.",
+   "occurrences": 56
+  },
+  {
+   "abbr": "ŚĀṄKH. GṚHY.",
+   "occurrences": 55
+  },
+  {
+   "abbr": "CARAKA.",
+   "occurrences": 51
+  },
+  {
+   "abbr": "VS. PRĀT.",
+   "occurrences": 48
+  },
+  {
+   "abbr": "MUṆḌ. UP.",
+   "occurrences": 47
+  },
+  {
+   "abbr": "ARJ.",
+   "occurrences": 46
+  },
+  {
+   "abbr": "MAHĀVY.",
+   "occurrences": 46
+  },
+  {
+   "abbr": "PĀR. GṚHY.",
+   "occurrences": 46
+  },
+  {
+   "abbr": "BṚH. ĀR. UP. S.",
+   "occurrences": 45
+  },
+  {
+   "abbr": "DHŪRTAS.",
+   "occurrences": 45
+  },
+  {
+   "abbr": "KAṬHOP.",
+   "occurrences": 45
+  },
+  {
+   "abbr": "KĀD.",
+   "occurrences": 44
+  },
+  {
+   "abbr": "NAIṢ.",
+   "occurrences": 43
+  },
+  {
+   "abbr": "VET. in LA. (III)",
+   "occurrences": 43
+  },
+  {
+   "abbr": "Jātakam.",
+   "occurrences": 41
+  },
+  {
+   "abbr": "SŪRYAS.",
+   "occurrences": 41
+  },
+  {
+   "abbr": "TS. PRĀT.",
+   "occurrences": 41
+  },
+  {
+   "abbr": "BĀLAR.",
+   "occurrences": 40
+  },
+  {
+   "abbr": "KAUṢ. UP.",
+   "occurrences": 40
+  },
+  {
+   "abbr": "ŚVETĀŚV. UP.",
+   "occurrences": 40
+  },
+  {
+   "abbr": "PAT. a. a. O.",
+   "occurrences": 39
+  },
+  {
+   "abbr": "DRAUP.",
+   "occurrences": 36
+  },
+  {
+   "abbr": "KAP.",
+   "occurrences": 36
+  },
+  {
+   "abbr": "TAITT. UP.",
+   "occurrences": 36
+  },
+  {
+   "abbr": "Sp.",
+   "occurrences": 35
+  },
+  {
+   "abbr": "SĀV.",
+   "occurrences": 34
+  },
+  {
+   "abbr": "Divyāvad.",
+   "occurrences": 32
+  },
+  {
+   "abbr": "PRAŚNOP.",
+   "occurrences": 32
+  },
+  {
+   "abbr": "Sch.",
+   "occurrences": 31
+  },
+  {
+   "abbr": "Z. d. d. m. G.",
+   "occurrences": 31
+  },
+  {
+   "abbr": "VAJRACCH.",
+   "occurrences": 29
+  },
+  {
+   "abbr": "BṚH. ĀR. UP.",
+   "occurrences": 28
+  },
+  {
+   "abbr": "LALIT.",
+   "occurrences": 28
+  },
+  {
+   "abbr": "SADDH. P.",
+   "occurrences": 28
+  },
+  {
+   "abbr": "VĀLAKH.",
+   "occurrences": 28
+  },
+  {
+   "abbr": "AMAR.",
+   "occurrences": 26
+  },
+  {
+   "abbr": "KĀRAṆḌ.",
+   "occurrences": 26
+  },
+  {
+   "abbr": "VET. in LA.",
+   "occurrences": 26
+  },
+  {
+   "abbr": "ŚĀK. CH.",
+   "occurrences": 26
+  },
+  {
+   "abbr": "SĀṂKHYAK.",
+   "occurrences": 25
+  },
+  {
+   "abbr": "Journ. of the Am. Or. S.",
+   "occurrences": 23
+  },
+  {
+   "abbr": "Nachtr.",
+   "occurrences": 23
+  },
+  {
+   "abbr": "SUND.",
+   "occurrences": 22
+  },
+  {
+   "abbr": "ŚAṂK. zu BĀDAR.",
+   "occurrences": 22
+  },
+  {
+   "abbr": "ṢAḌV. BR.",
+   "occurrences": 22
+  },
+  {
+   "abbr": "HEMĀDRI",
+   "occurrences": 21
+  },
+  {
+   "abbr": "HEM. PAR.",
+   "occurrences": 20
+  },
+  {
+   "abbr": "Mahāvy.",
+   "occurrences": 20
+  },
+  {
+   "abbr": "ŚRUT.",
+   "occurrences": 20
+  },
+  {
+   "abbr": "AV. PRĀT.",
+   "occurrences": 19
+  },
+  {
+   "abbr": "INDR.",
+   "occurrences": 19
+  },
+  {
+   "abbr": "NALOD.",
+   "occurrences": 19
+  },
+  {
+   "abbr": "UTTARAR.",
+   "occurrences": 19
+  },
+  {
+   "abbr": "VARĀH. BṚH.",
+   "occurrences": 19
+  },
+  {
+   "abbr": "HIḌ.",
+   "occurrences": 18
+  },
+  {
+   "abbr": "KENOP.",
+   "occurrences": 18
+  },
+  {
+   "abbr": "LA. (II)",
+   "occurrences": 18
+  },
+  {
+   "abbr": "MĀLATĪM.",
+   "occurrences": 18
+  },
+  {
+   "abbr": "UTTARARĀMAC.",
+   "occurrences": 18
+  },
+  {
+   "abbr": "VEDĀNTAS. (Allah.) No.",
+   "occurrences": 18
+  },
+  {
+   "abbr": "GṚHY.",
+   "occurrences": 17
+  },
+  {
+   "abbr": "JAIM.",
+   "occurrences": 17
+  },
+  {
+   "abbr": "Maitr. S.",
+   "occurrences": 17
+  },
+  {
+   "abbr": "PRASANNAR.",
+   "occurrences": 17
+  },
+  {
+   "abbr": "VP.",
+   "occurrences": 17
+  },
+  {
+   "abbr": "SCHL.",
+   "occurrences": 16
+  },
+  {
+   "abbr": "SIDDH. K.",
+   "occurrences": 16
+  },
+  {
+   "abbr": "TAITT. ĀR.",
+   "occurrences": 16
+  },
+  {
+   "abbr": "HARṢAC.",
+   "occurrences": 15
+  },
+  {
+   "abbr": "CAMPAKA",
+   "occurrences": 14
+  },
+  {
+   "abbr": "CARAKA",
+   "occurrences": 14
+  },
+  {
+   "abbr": "MĀN. GṚHY.",
+   "occurrences": 14
+  },
+  {
+   "abbr": "Āpast. Śr.",
+   "occurrences": 14
+  },
+  {
+   "abbr": "ŚATR.",
+   "occurrences": 14
+  },
+  {
+   "abbr": "ŚĀNTIŚ.",
+   "occurrences": 14
+  },
+  {
+   "abbr": "BRAHMA-P.",
+   "occurrences": 13
+  },
+  {
+   "abbr": "HALL",
+   "occurrences": 13
+  },
+  {
+   "abbr": "MÜLLER, SL.",
+   "occurrences": 13
+  },
+  {
+   "abbr": "BHĀṢĀP.",
+   "occurrences": 12
+  },
+  {
+   "abbr": "BṚH.",
+   "occurrences": 12
+  },
+  {
+   "abbr": "GOP. BR.",
+   "occurrences": 12
+  },
+  {
+   "abbr": "Z.",
+   "occurrences": 12
+  },
+  {
+   "abbr": "ĀPAST. GṚHY.",
+   "occurrences": 12
+  },
+  {
+   "abbr": "ŚUK.",
+   "occurrences": 12
+  },
+  {
+   "abbr": "AIT. UP.",
+   "occurrences": 11
+  },
+  {
+   "abbr": "BHĀVAPR.",
+   "occurrences": 11
+  },
+  {
+   "abbr": "BRAHMA-P. in LA. (III)",
+   "occurrences": 11
+  },
+  {
+   "abbr": "CĀṆ.",
+   "occurrences": 11
+  },
+  {
+   "abbr": "GAUT.",
+   "occurrences": 11
+  },
+  {
+   "abbr": "Lot. de la b. l.",
+   "occurrences": 11
+  },
+  {
+   "abbr": "S I,",
+   "occurrences": 11
+  },
+  {
+   "abbr": "H",
+   "occurrences": 10
+  },
+  {
+   "abbr": "LA. (III)",
+   "occurrences": 10
+  },
+  {
+   "abbr": "LALIT. ed. Calc.",
+   "occurrences": 10
+  },
+  {
+   "abbr": "WEBER, RĀMAT. UP.",
+   "occurrences": 10
+  },
+  {
+   "abbr": "ĪŚOP.",
+   "occurrences": 10
+  },
+  {
+   "abbr": "ŚR.",
+   "occurrences": 10
+  },
+  {
+   "abbr": "BṚH. ĀR. UP. p.",
+   "occurrences": 9
+  },
+  {
+   "abbr": "NYĀYAS.",
+   "occurrences": 9
+  },
+  {
+   "abbr": "NĪLAK.",
+   "occurrences": 9
+  },
+  {
+   "abbr": "SOM. NALA",
+   "occurrences": 9
+  },
+  {
+   "abbr": "WEBER, JYOT.",
+   "occurrences": 9
+  },
+  {
+   "abbr": "WEBER, KṚṢṆAJ.",
+   "occurrences": 9
+  },
+  {
+   "abbr": "Z. f. d. K. d. M.",
+   "occurrences": 9
+  },
+  {
+   "abbr": "{{CARARA->CARAKA||",
+   "occurrences": 9
+  },
+  {
+   "abbr": "ŚUK. in LA.",
+   "occurrences": 9
+  },
+  {
+   "abbr": "ŚULBAS.",
+   "occurrences": 9
+  },
+  {
+   "abbr": "AIT. ĀR.",
+   "occurrences": 8
+  },
+  {
+   "abbr": "CHĀND. UP. S.",
+   "occurrences": 8
+  },
+  {
+   "abbr": "Kauṭ.",
+   "occurrences": 8
+  },
+  {
+   "abbr": "LA.",
+   "occurrences": 8
+  },
+  {
+   "abbr": "MIT.",
+   "occurrences": 8
+  },
+  {
+   "abbr": "MĀN. ŚR.",
+   "occurrences": 8
+  },
+  {
+   "abbr": "TATTVAS.",
+   "occurrences": 8
+  },
+  {
+   "abbr": "VĀSAV.",
+   "occurrences": 8
+  },
+  {
+   "abbr": "WILSON, SĀṂKHYAK. S.",
+   "occurrences": 8
+  },
+  {
+   "abbr": "YOGAŚ.",
+   "occurrences": 8
+  },
+  {
+   "abbr": "BRAHMA-P. in LA.",
+   "occurrences": 7
+  },
+  {
+   "abbr": "BRĀHMAṆ.",
+   "occurrences": 7
+  },
+  {
+   "abbr": "DAŚAR.",
+   "occurrences": 7
+  },
+  {
+   "abbr": "DEV.",
+   "occurrences": 7
+  },
+  {
+   "abbr": "HIT. ed. JOHNS.",
+   "occurrences": 7
+  },
+  {
+   "abbr": "KUSUM.",
+   "occurrences": 7
+  },
+  {
+   "abbr": "MATSYOP.",
+   "occurrences": 7
+  },
+  {
+   "abbr": "VAITĀN.",
+   "occurrences": 7
+  },
+  {
+   "abbr": "VET. in LA. (II)",
+   "occurrences": 7
+  },
+  {
+   "abbr": "BURN. Intr.",
+   "occurrences": 6
+  },
+  {
+   "abbr": "BĀLAB.",
+   "occurrences": 6
+  },
+  {
+   "abbr": "CAMPAKA.",
+   "occurrences": 6
+  },
+  {
+   "abbr": "COLEBR. Misc. Ess.",
+   "occurrences": 6
+  },
+  {
+   "abbr": "GṚHYASAṂGR.",
+   "occurrences": 6
+  },
+  {
+   "abbr": "Harṣac.",
+   "occurrences": 6
+  },
+  {
+   "abbr": "SAṂHITOPAN.",
+   "occurrences": 6
+  },
+  {
+   "abbr": "TARKAS.",
+   "occurrences": 6
+  },
+  {
+   "abbr": "VYUTP.",
+   "occurrences": 6
+  },
+  {
+   "abbr": "Vajracch.",
+   "occurrences": 6
+  },
+  {
+   "abbr": "VṚDDHA-CĀṆ.",
+   "occurrences": 6
+  },
+  {
+   "abbr": "ŚIKṢĀ",
+   "occurrences": 6
+  },
+  {
+   "abbr": "ŚUK. in LA. (III)",
+   "occurrences": 6
+  },
+  {
+   "abbr": "<is>Kār.</is>",
+   "occurrences": 5
+  },
+  {
+   "abbr": "BURNOUF, Intr.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "Comm. zu NYĀYAM.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "Comm. zu NYĀYAS.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "DHARMAŚARM.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "Kauś.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "Kir.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "KĀVYĀD.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "LAGHUJ.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "MUDRĀR.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "MUIR, ST.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "PAÑCAD.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "Pūrṇabh.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "RĀJAN.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "UPAG. AV.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "VASIṢṬHA",
+   "occurrences": 5
+  },
+  {
+   "abbr": "Verz. d. Oxf. H. No.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "Āpast. Gṛhy.",
+   "occurrences": 5
+  },
+  {
+   "abbr": "BĀDAR.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "CHANDOM.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "Comm. zu ĀPAST. ŚR.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "CĀT.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "DHŪRTAS. in LA.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "GHAṬ.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "KUVALAY.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "MBh.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "MED. <is>avy</is>.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "N. (BOPP)",
+   "occurrences": 4
+  },
+  {
+   "abbr": "PISCHEL, Vedische Studien",
+   "occurrences": 4
+  },
+  {
+   "abbr": "PĀRŚVANĀTHAK.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "S II,",
+   "occurrences": 4
+  },
+  {
+   "abbr": "SĀṂKHYAK. S.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "Sūryaś.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "TĀṆḌYA-BR.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "UTTAMAC.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "UṆĀDIS.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "VEṆĪS.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "VĀMANA",
+   "occurrences": 4
+  },
+  {
+   "abbr": "VĀSAVAD.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "ĀRYABH.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "Śiś.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "Śāṅkh. Br.",
+   "occurrences": 4
+  },
+  {
+   "abbr": "BHĀG.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "BHĀMATĪ",
+   "occurrences": 3
+  },
+  {
+   "abbr": "BRAHMA-P. in LA. (II)",
+   "occurrences": 3
+  },
+  {
+   "abbr": "Comm. zu JAIM.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "Comm. zu LĀṬY.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "Dharmaśarm.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "Hem. Par.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "KAṆ.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "KUHNʼs Z.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "Kaus.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "LALIT. Calc.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "LĀTY.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "MADHYAM.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "MAHĀBH.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "MĀLAT.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "MĀN.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "PRATĀPAR.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "RATNĀV.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "SAṂSK. K.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "SV. I,",
+   "occurrences": 3
+  },
+  {
+   "abbr": "SĀMAV. BR.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "SĀMAVIDH. BR.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "SĀY. zu ṚV.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "UTTAR.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "VIKRAMĀṄKAC.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "VIṢṆUS.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "WEBER, Nakṣ.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "WIND. Sancara",
+   "occurrences": 3
+  },
+  {
+   "abbr": "YOGAS.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "Yudh.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "ed. Bomb.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "ed. Vardh.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "{{MBH.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "ŚUK. in LA. (II)",
+   "occurrences": 3
+  },
+  {
+   "abbr": "Śrīk.",
+   "occurrences": 3
+  },
+  {
+   "abbr": "14",
+   "occurrences": 2
+  },
+  {
+   "abbr": "231,16",
+   "occurrences": 2
+  },
+  {
+   "abbr": "41",
+   "occurrences": 2
+  },
+  {
+   "abbr": "AGNI-P.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "ARYABH.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "AV. PAIPP.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "AV. PRĀYAŚC.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "BAUDH.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "BHADRAB.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "BHOJAPRAB.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "BHĀTUP.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "BR.)",
+   "occurrences": 2
+  },
+  {
+   "abbr": "BĪJAG.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "BṚH. ĀR.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "COLEBR. Alg.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Caraka",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Comm. zu KĀTY. ŚR.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Comm. zu SŪRYAS.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "DH. V.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Daśak.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "GOLĀDHY. BHUVANAK.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Gopāl.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "HARAVIJAYA",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Hariv.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "J. A. O. S. Procc. Oct.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "KAP. S.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "KAUṢ. UP. Einl.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "KIRĀT.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Kap.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Kauṣ. Up.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Kaṃs. IV,",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Kir. I,",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Kir. X,",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Kir. XVI,",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Kuhn's Z.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "KĀTY. ŚR. Comm.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "KĀVYA-PR.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Kāty. Śr.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Kāṭh.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "KṢURIKOP.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "LIA. I,",
+   "occurrences": 2
+  },
+  {
+   "abbr": "MAHĀBH. lith. Ausg.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "MAHĀN.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "MAHĀVASTU",
+   "occurrences": 2
+  },
+  {
+   "abbr": "MUIR, ST. (",
+   "occurrences": 2
+  },
+  {
+   "abbr": "MUIR, ST. IV,",
+   "occurrences": 2
+  },
+  {
+   "abbr": "MUIR, Sanscrit Texts I,",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Med.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "MĀRK.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "MĀRK. P. S.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "NIDĀNAS.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Naiṣ.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "PARIBH.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "PRASAṄGĀBH.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Pischel, Ved. Stud. I,",
+   "occurrences": 2
+  },
+  {
+   "abbr": "R. Gorr.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "RATIM.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "SOM. NAL.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "SV. II,",
+   "occurrences": 2
+  },
+  {
+   "abbr": "TĀRAN.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "UPAL.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "UTPALA zu VARĀH. BṚH.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Uttamac.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Uttarar. V,",
+   "occurrences": 2
+  },
+  {
+   "abbr": "VARĀH. LAGHUJ.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "VEDĀNTAS.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "VIVĀDAC.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "VOP. S.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Viṣṇubh. III,",
+   "occurrences": 2
+  },
+  {
+   "abbr": "VĀGBHAṬĀLAṂKĀRA",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Vās.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "WASSILJEW",
+   "occurrences": 2
+  },
+  {
+   "abbr": "WILSON, Sel. Works",
+   "occurrences": 2
+  },
+  {
+   "abbr": "WILSON, SĀṂKHYAK. p.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "YAJÑAD.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "YAJÑADATTAV.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "ZDMG",
+   "occurrences": 2
+  },
+  {
+   "abbr": "ed. Calc.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Āpast.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "Ś.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "ŚAṂK. zu CHĀND. UP. S.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "ŚIŚUP.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "ŚĀNT.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "ṚV. ANUKR.",
+   "occurrences": 2
+  },
+  {
+   "abbr": "1,111,3.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "1,12,a",
+   "occurrences": 1
+  },
+  {
+   "abbr": "15.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "AŚNA S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "AŚOKĀVAD.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "AṢṬĀV.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "BHAR. NĀṬYAŚ.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "BHOJA-PR.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "BHĀṬṬ.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "BRAHMOP. S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "CANDRAKĪRTI",
+   "occurrences": 1
+  },
+  {
+   "abbr": "COLEBR. Misc. Ess. I,",
+   "occurrences": 1
+  },
+  {
+   "abbr": "COLEBR. Misc. Ess. II,",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Comm. zu AIT. ĀR. S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Comm. zu AK.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Comm. zu CARAKA.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Comm. zu NYĀYAM. S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Comm. zu TBR.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Comm. zu TS.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "DHARMAŚ.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "DHŪRTAN.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "DĀYABH.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "GOVINDĀN. S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "HARIR.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "HARṢAC. (ed. Bomb.)",
+   "occurrences": 1
+  },
+  {
+   "abbr": "IL.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "INDṚ.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "JYOT.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Journ. of the As. Soc. of B. IV, Pl. XL, Z.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "JĀBĀLOP. S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "KAT.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "KATHOP.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "KAURAP.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "KENOP",
+   "occurrences": 1
+  },
+  {
+   "abbr": "KUHNʼS Z.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Kir. IX,",
+   "occurrences": 1
+  },
+  {
+   "abbr": "KĀTHOP.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "KĀVYAPR.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Kār.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "KṚṢIS.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "KṚṢṆAJ.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "LASS.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "LASSEN, Institutt.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "LASSEN, Pent.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "M. MÜLLER, Transl.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "MAHĀBH. (K.)",
+   "occurrences": 1
+  },
+  {
+   "abbr": "MANTRABR.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "MUDHĀR.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "MUIR, ST. I,",
+   "occurrences": 1
+  },
+  {
+   "abbr": "MUIR, ST. II,",
+   "occurrences": 1
+  },
+  {
+   "abbr": "MÜLLER, St.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "MĀṆḌ. UP.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "MṚCCH",
+   "occurrences": 1
+  },
+  {
+   "abbr": "MṚCCH. ed. Calc.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "NIDĀNA",
+   "occurrences": 1
+  },
+  {
+   "abbr": "NYĀYAM.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "NĀGĀN.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "NĀṬYAŚ.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "NĪLAK. zu MBH.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "P. Einl.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "PAT. zu P.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "PAÑCAT. Bd. I, S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "PAÑCAT. ed. Bomb.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "PAÑCAT. ed. Bomb. IV,",
+   "occurrences": 1
+  },
+  {
+   "abbr": "PRATYABDAŚ.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "PRB.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Pischel, Ved. Studien I,",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Prabandh.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Praty. Hṛd.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "R. III, S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "R. ed. SCHL.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "R. ed. Ser.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Rasas.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "RĀJA.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "SARVAD.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "SMARADĪP.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "SPAṢṬĀDH.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "SUPARṆ.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "SV.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "SV. II.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Sam. I,",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Spruch",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Suśr.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "SĀY.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "SĀṂKHYAPR. S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "TAITT. BR.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "TAITT. PRĀT.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "TARKASAM̃GR.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "TBR. Comm.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "TRIPR.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "TS. Comm.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "TS. II,",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Text zu Lot. de la b. l.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "UP.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "UPAK.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "UTTARAR. ed. Cow.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "VARARUCI",
+   "occurrences": 1
+  },
+  {
+   "abbr": "VARĀH. BṚH. S. S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "VARĀH. YOGAY.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "VARĀH.BṚH. S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "VIKR. drāv.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Verz. d. B. H.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "Verz. d. B. H. No.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "VĀGBH.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "VṚDDHACĀṆ.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "WEBER S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "WILSON, ebend. S.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "WINDISCHMANN, Sancara",
+   "occurrences": 1
+  },
+  {
+   "abbr": "WISE",
+   "occurrences": 1
+  },
+  {
+   "abbr": "YANTRĀDHY.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "YOGAYĀTRĀ",
+   "occurrences": 1
+  },
+  {
+   "abbr": "YĀJN.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "ebend.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "{{BENFEY.,Chr.->BENF.Chr.||",
+   "occurrences": 1
+  },
+  {
+   "abbr": "{{MEGH.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "{{ŚR.",
+   "occurrences": 1
+  },
+  {
+   "abbr": "{{‹ed.› Vardh.->MBH.ed.Vardh.||",
+   "occurrences": 1
+  },
+  {
+   "abbr": "ŚRUT. (BR.)",
+   "occurrences": 1
+  },
+  {
+   "abbr": "ŚUK. ebend.",
+   "occurrences": 1
+  }
+ ],
+ "edge_case_misses": [
+  {
+   "abbr": "VARĀH. BṚH. S.",
+   "unresolved": 24
+  },
+  {
+   "abbr": "VOP.",
+   "unresolved": 5
+  },
+  {
+   "abbr": "HALĀY.",
+   "unresolved": 2
+  },
+  {
+   "abbr": "Verz. d. Oxf. H.",
+   "unresolved": 2
+  },
+  {
+   "abbr": "MBH.",
+   "unresolved": 1
+  },
+  {
+   "abbr": "TBR.",
+   "unresolved": 1
+  }
+ ]
+}

--- a/RussianTranslation/src/build_citation_index.py
+++ b/RussianTranslation/src/build_citation_index.py
@@ -19,7 +19,7 @@ import json
 import os
 import re
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
 
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
@@ -32,6 +32,8 @@ REPO = os.path.dirname(HERE)                       # RussianTranslation/
 RU_STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
 OUT_MD = os.path.join(REPO, 'CITATION_SOURCES.md')
 OUT_JSON = os.path.join(REPO, 'release', 'citation_sources.json')
+OUT_UNCOVERED = os.path.join(REPO, 'UNCOVERED_SOURCES.md')
+OUT_UNCOVERED_JSON = os.path.join(REPO, 'release', 'uncovered_sources.json')
 
 _LS = re.compile(r'<ls\b([^>]*)>(.*?)</ls>', re.S)
 _N_ATTR = re.compile(r'\bn\s*=\s*"([^"]*)"')
@@ -194,6 +196,11 @@ def emit(groups, total, resolved, counts):
              'Upaniṣads, the Śrauta/Gṛhya sūtras, several chrestomathies), so they '
              'cannot be linked from anywhere.')
     L.append('')
+    L.append('> The most-cited uncovered works are ranked (by how often each is '
+             'actually cited) in [`UNCOVERED_SOURCES.md`]'
+             '(https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/UNCOVERED_SOURCES.md), '
+             'regenerated on every build.')
+    L.append('')
     L.append('## Abbreviation index')
     L.append('')
     L.append('| abbreviation | refs | resolved | scan | HTML | target | example |')
@@ -227,13 +234,148 @@ def emit(groups, total, resolved, counts):
         f.write('\n'.join(L) + '\n')
 
 
+# ---------------------------------------------------------------------------
+# Occurrence analysis (how OFTEN each source is cited, vs how many DISTINCT refs)
+# ---------------------------------------------------------------------------
+# The distinct-ref counts above measure the *reference set*. To measure how
+# often a source is actually cited we count every <ls> as it appears in the
+# displayed corpus. That corpus is the build_article_site union model (RU∪EN
+# deduplicated per sense) — counting the raw stores instead would multiply by
+# the DE/RU/EN fields and the store overlap. We read the raw DE source per
+# displayed sense (de_raw), which keeps the <ls n="..."> attribute, so a bare
+# continuation inherits its parent work and grouping uses the true prefix.
+
+
+def occurrence_stats():
+    """Count every <ls> as it appears on the displayed DE surface (occurrences).
+
+    Returns (occ_scan, occ_html, per, total) where per[abbr] = {'res','unres'}
+    occurrence counts. An abbreviation with res==0 is *truly uncovered* (no
+    occurrence resolves anywhere → no Cologne target); res>0 with unres>0 is a
+    resolution edge-case (the work is digitized, a few refs are malformed)."""
+    sys.path.insert(0, os.path.join(HERE, 'pilot'))
+    import build_article_site as bas
+    model = bas.build_model()
+    occ_scan = occ_html = total = labels = 0
+    per = defaultdict(lambda: {'res': 0, 'unres': 0})
+    for r in model:
+        for sc in r['subcards']:
+            for s in sc['senses']:
+                for m in _LS.finditer(s.get('de_raw') or ''):
+                    total += 1
+                    nm = _N_ATTR.search(m.group(1) or '')
+                    n_attr = nm.group(1) if nm else None
+                    vis = (m.group(2) or '').strip()
+                    try:
+                        url = lsr.generate_href('pwg', n_attr, vis)
+                    except Exception:
+                        url = None
+                    t = lsr.link_type(url)
+                    if t == 'scan':
+                        occ_scan += 1
+                        per[abbr_of(n_attr, vis)]['res'] += 1
+                    elif t == 'html':
+                        occ_html += 1
+                        per[abbr_of(n_attr, vis)]['res'] += 1
+                    elif not re.search(r'[0-9]', (n_attr or '') + vis):
+                        # <ls> with no coordinate = an edition/cross-ref LABEL
+                        # ("ed. Bomb.", "ebend."), never a linkable reference.
+                        labels += 1
+                    else:
+                        per[abbr_of(n_attr, vis)]['unres'] += 1
+    return occ_scan, occ_html, per, total, labels
+
+
+def emit_uncovered(per, occ_scan, occ_html, occ_total, labels):
+    """Live list of the most-cited sources with NO link, most frequent first.
+
+    `per[abbr] = {'res','unres'}`. Truly-uncovered = res==0 (no target exists);
+    edge-cases (res>0, unres>0) are listed separately — the work is digitized,
+    only some refs are malformed."""
+    uncovered = {k: v['unres'] for k, v in per.items() if v['res'] == 0 and v['unres'] > 0}
+    edge = {k: v['unres'] for k, v in per.items() if v['res'] > 0 and v['unres'] > 0}
+    rows = sorted(uncovered.items(), key=lambda kv: (-kv[1], kv[0]))
+    un_total = sum(uncovered.values())
+    occ_resolved = occ_scan + occ_html
+    data = {
+        'occurrences_total': occ_total,
+        'occurrences_linked': occ_resolved,
+        'occurrences_scan': occ_scan, 'occurrences_html': occ_html,
+        'occurrences_uncovered': un_total,
+        'occurrences_noncoordinate_labels': labels,
+        'distinct_uncovered_works': len(uncovered),
+        'uncovered': [{'abbr': k, 'occurrences': n} for k, n in rows],
+        'edge_case_misses': [{'abbr': k, 'unresolved': n}
+                             for k, n in sorted(edge.items(), key=lambda kv: -kv[1])],
+    }
+    with open(OUT_UNCOVERED_JSON, 'w', encoding='utf-8', newline='\n') as f:
+        json.dump(data, f, ensure_ascii=False, indent=1)
+
+    L = []
+    L.append('# PWG uncovered citation sources — most-cited works with no link')
+    L.append('')
+    L.append('<p align="right"><sub>Created: 02-07-2026 · Last updated: 02-07-2026</sub></p>')
+    L.append('')
+    L.append('Works cited by `<ls>` in the PWG article corpus that **have no Cologne '
+             'target at all** — *no* occurrence resolves, because no scan repo exists '
+             'in the [`sanskrit-lexicon-scans`](https://github.com/orgs/sanskrit-lexicon-scans/repositories) '
+             'org (or the abbreviation is a grammatical authority / cross-reference, '
+             'not a citable text). Ranked by **how often the work is actually cited** '
+             '(occurrences on the displayed DE surface), most-cited first — so the top '
+             'rows are the highest-value targets should Cologne ever digitize them. '
+             'Regenerated on every build by [`build_citation_index.py`]'
+             '(https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_citation_index.py).')
+    L.append('')
+    L.append('Of **%s** citation occurrences on the site, **%s** link out '
+             '(%s scan + %s HTML) and **%s (%.1f%%)** stay unlinked. The unlinked '
+             'ones are **%d truly-uncovered works** below (%s occurrences), plus %d '
+             'edge-case misses in otherwise-covered works (see end) and %s '
+             'non-coordinate `<ls>` labels (edition/cross-ref notes like '
+             '"ed. Bomb.", never linkable).'
+             % (f'{occ_total:,}', f'{occ_resolved:,}', f'{occ_scan:,}', f'{occ_html:,}',
+                f'{occ_total - occ_resolved:,}', 100 * (occ_total - occ_resolved) / occ_total if occ_total else 0,
+                len(uncovered), f'{un_total:,}', sum(edge.values()), f'{labels:,}'))
+    L.append('')
+    L.append('| rank | source (abbreviation) | citations |')
+    L.append('|---:|---|---:|')
+    for i, (k, n) in enumerate(rows, 1):
+        L.append('| %d | %s | %d |' % (i, k.replace('|', '\\|'), n))
+    L.append('')
+    if edge:
+        L.append('## Edge-case misses (work IS digitized; some refs malformed)')
+        L.append('')
+        L.append('These abbreviations resolve for most citations — the counts below '
+                 'are individual references with a malformed/unusual coordinate that '
+                 'the resolver could not parse. Not "uncovered".')
+        L.append('')
+        L.append('| source | unresolved refs |')
+        L.append('|---|---:|')
+        for k, n in sorted(edge.items(), key=lambda kv: -kv[1]):
+            L.append('| %s | %d |' % (k.replace('|', '\\|'), n))
+        L.append('')
+    L.append('<p align="right"><sub>Dr. Mārcis Gasūns</sub></p>')
+    with open(OUT_UNCOVERED, 'w', encoding='utf-8', newline='\n') as f:
+        f.write('\n'.join(L) + '\n')
+
+
 def main():
     groups, total, resolved, counts = build()
     emit(groups, total, resolved, counts)
+    occ_scan, occ_html, per, occ_total, labels = occurrence_stats()
+    emit_uncovered(per, occ_scan, occ_html, occ_total, labels)
+    occ_resolved = occ_scan + occ_html
     print('citation index: %d distinct refs, %d resolved (%.1f%%), %d abbreviations'
           % (total, resolved, 100 * resolved / total if total else 0, len(groups)))
     print('  -> %s' % OUT_MD)
     print('  -> %s' % OUT_JSON)
+    print('occurrences (displayed DE surface): %d total, %d linked '
+          '(scan %d / HTML %d), %d unlinked'
+          % (occ_total, occ_resolved, occ_scan, occ_html, occ_total - occ_resolved))
+    if occ_resolved:
+        print('  scan:HTML by occurrence = %.1f : 1  (by distinct ref = %.1f : 1)'
+              % (occ_scan / occ_html if occ_html else 0,
+                 counts['scan'] / counts['html'] if counts['html'] else 0))
+    print('  -> %s' % OUT_UNCOVERED)
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pilot/build_article_site.py
+++ b/RussianTranslation/src/pilot/build_article_site.py
@@ -239,6 +239,7 @@ def load_en_full(root):
 def make_sense(tag, de, ru, en, dcs, src):
     return {
         'tag': str(tag), 'has_ru': bool(ru), 'has_en': bool(en),
+        'de_raw': de or '',   # raw DE source (keeps <ls n=..>); not emitted, used for citation analysis
         'de_html': _render(de, 'html'), 'ru_html': _render(ru, 'html'), 'en_html': _render(en, 'html'),
         'de_md': _render(de, 'md'), 'ru_md': _render(ru, 'md'), 'en_md': _render(en, 'md'),
         'dcs': dcs_count(dcs), 'src': src or '',


### PR DESCRIPTION
Two follow-up requests.

## 1. Live list of the most-cited *uncovered* works
New [`UNCOVERED_SOURCES.md`](https://github.com/gasyoun/SanskritLexicography/blob/feat/uncovered-sources-freq/RussianTranslation/UNCOVERED_SOURCES.md) — the works cited by `<ls>` in the PWG corpus that have **no Cologne target at all** (no scan repo exists), ranked by **how often each is actually cited**, most-cited first. Regenerated on every build.

Top rows: **SUŚR. 311, CHĀND. UP. 220, PRAB. 200, KAUŚ. 170, KĀM. NĪTIS. 168, MṚCCH. 162, ŚĀṄKH. ŚR. 160 …** — 446 works, 6,505 occurrences. These are the highest-value digitization targets.

The list deliberately excludes two categories that would otherwise pollute it:
- **Resolution edge-cases** (the work *is* digitized; a few refs are malformed) — GORR., VARĀH. BṚH. S., etc. — listed separately at the end.
- **Non-coordinate `<ls>` labels** (edition/cross-ref notes like `<ls>ed. Bomb.</ls>` with no locus) — 1,883 occurrences, never linkable, counted but not ranked as works.

## 2. Usage frequency — scan vs HTML (finding)
You asked whether the 5,352 HTML refs might be quoted ~10× more than the 27,434 scan refs. **They aren't.** Measured by occurrences (documented in [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/feat/uncovered-sources-freq/FINDINGS.md)):

| | scan | HTML | ratio |
|---|---:|---:|---:|
| distinct references | 27,434 | 5,352 | 5.1 : 1 |
| **occurrences** | **34,560** | **7,082** | **4.9 : 1** |

50,065 total occurrences vs 37,951 distinct refs → ~1.32 citations per reference (most appear once). HTML works (ṚV./AV./P.) are re-cited only **1.32×** per ref vs scan's **1.26×** — marginally more, not an order of magnitude. So distinct-reference counts are a faithful proxy for citation frequency; no target-type weighting needed.

## Mechanics
Occurrence counting reads the raw DE per displayed sense (a new **non-emitted** `de_raw` field on `make_sense`) from the `build_article_site` union model — counting the raw stores directly would multiply each citation ~4× (DE/RU/EN fields + RU/EN store overlap). **Site output is unchanged** (`de_raw` isn't emitted), so no `gh-pages` refresh is needed.

Model: Opus 4.8 (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)