### PR TITLE
Plain Markdown headers/bylines (drop <p align=right> HTML from .md)

### DIFF
--- a/RussianTranslation/HANDOFF_2026-07-01_pwg_efficiency_selfheal.md
+++ b/RussianTranslation/HANDOFF_2026-07-01_pwg_efficiency_selfheal.md
@@ -1,6 +1,6 @@
 # Handoff — PWG dashboard, RU catch-up, and the self-healing translation harness
 
-<p align="right"><sub>Created: 01-07-2026 · Last updated: 01-07-2026</sub></p>
+_Created: 01-07-2026 · Last updated: 01-07-2026_
 
 **For:** a fresh chat. **Branch:** `feat/pwg-en-fu1-phase0` (off `master`).
 **Orchestration:** Opus 4.8 (`claude-opus-4-8`). **Generation:** EN = Sonnet 5
@@ -91,4 +91,4 @@ Full journal: [`.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/b
 (Dev Notes carry the tier ladder + undone tiers). Prior handoff:
 [`HANDOFF_2026-07-01_pwg_en_fu1_finalize.md`](https://github.com/gasyoun/SanskritLexicography/blob/feat/pwg-en-fu1-phase0/RussianTranslation/HANDOFF_2026-07-01_pwg_en_fu1_finalize.md).
 
-<p align="right"><sub>Dr. Mārcis Gasūns</sub></p>
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/HANDOFF_2026-07-02_pwg_selfheal_fixes.md
+++ b/RussianTranslation/HANDOFF_2026-07-02_pwg_selfheal_fixes.md
@@ -1,6 +1,6 @@
 # Handoff — pwg selfheal/binary-split/output-budget/partial-credit fixes, live-validated
 
-<p align="right"><sub>Created: 02-07-2026 · Last updated: 02-07-2026</sub></p>
+_Created: 02-07-2026 · Last updated: 02-07-2026_
 
 **For:** a fresh chat. **Branch:** work off `master` directly — `feat/pwg-en-fu1-phase0` was
 merged and deleted mid-session (2026-07-01); it no longer exists.
@@ -119,4 +119,4 @@ python src/pilot/build_article_site.py
 Full journal: [`.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md).
 Prior handoff: [`HANDOFF_2026-07-01_pwg_efficiency_selfheal.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/HANDOFF_2026-07-01_pwg_efficiency_selfheal.md).
 
-<p align="right"><sub>Dr. Mārcis Gasūns</sub></p>
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/RENOU.md
+++ b/RussianTranslation/RENOU.md
@@ -1,6 +1,6 @@
 # Renou language-state tagging
 
-<p align="right"><sub>Created: 24-06-2026 · Last updated: 01-07-2026</sub></p>
+_Created: 24-06-2026 · Last updated: 01-07-2026_
 
 Every dictionary headword/sense is classified into one of **Louis Renou's five
 states of Sanskrit** (*Histoire de la langue sanskrite*, 1956 — the five chapters;
@@ -416,4 +416,4 @@ layer in [`CORPUS_PROVENANCE.md`](CORPUS_PROVENANCE.md#renou-register-layer-atte
 per-*sense* register beats per-*headword* register, and it composes with the state axis the
 same way — independent, provenance-graded, and only as informative as the evidence actually is.
 
-<p align="right"><sub>Dr. Mārcis Gasūns</sub></p>
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/glossary/README.md
+++ b/RussianTranslation/glossary/README.md
@@ -1,6 +1,6 @@
 # Sanskrit → Russian glossary (surface · lemma · root)
 
-<p align="right"><sub>Created: 01-07-2026 · Last updated: 01-07-2026</sub></p>
+_Created: 01-07-2026 · Last updated: 01-07-2026_
 
 **🔎 Live searchable glossary + all data:** **[gasyoun/SanskritRussian](https://github.com/gasyoun/SanskritRussian)**
 → <https://gasyoun.github.io/SanskritRussian/> — type an SLP1 root/word (`gam`, `BU`) or a
@@ -139,4 +139,4 @@ before the Vidyut supplement), so the second pass does not disturb the Vidyut in
 Vidyut data: `python -c "import vidyut; vidyut.download_data('vidyut_data')"` then pass
 `vidyut_data/kosha` to the fallback. Transcoding uses `indic_transliteration`; both are pip-installable.
 
-<p align="right"><sub>Dr. Mārcis Gasūns</sub></p>
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/glossary/SAMPLE_root_glossary.md
+++ b/RussianTranslation/glossary/SAMPLE_root_glossary.md
@@ -1,6 +1,6 @@
 # Sample — root → Russian (showcase)
 
-<p align="right"><sub>Created: 01-07-2026 · Last updated: 01-07-2026</sub></p>
+_Created: 01-07-2026 · Last updated: 01-07-2026_
 
 Excerpt of the full `root_glossary` (regenerable; see [README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/glossary/README.md)). Each root aggregates every attested form and prefixed verb-lemma across the 1.09M-token Sa→Ru corpus.
 
@@ -214,4 +214,4 @@ Lemmas rolled up: `dA, AdA, pradA, upAdA, samAdA, paridA, sampradA, upadA, parAd
 - даровал · n=15
 - вручаю · n=15
 
-<p align="right"><sub>Dr. Mārcis Gasūns</sub></p>
+_Dr. Mārcis Gasūns_

--- a/SAMSAADHANII_INDEX.md
+++ b/SAMSAADHANII_INDEX.md
@@ -1,6 +1,6 @@
 # SAMSAADHANII_INDEX.md — what Amba Kulkarni's SCL toolchain teaches our repos
 
-<p align="right"><sub>Created: 02-07-2026 · Last updated: 02-07-2026</sub></p>
+_Created: 02-07-2026 · Last updated: 02-07-2026_
 
 **Prior-art index (external).** [Amba Kulkarni](https://sanskrit.uohyd.ac.in/faculty/amba/)
 (Prof. & Head, Dept. of Sanskrit Studies, University of Hyderabad) leads
@@ -86,4 +86,4 @@ copying source.
 - **License gate:** live-service call or data cross-check = fine; copying GPL source
   into our repos = ask first.
 
-<p align="right"><sub>Dr. Mārcis Gasūns</sub></p>
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
HTML belongs in `.html`; Markdown files use Markdown. Converts the authored-doc dated-header + byline block `<p align="right"><sub>X</sub></p>` → `_X_` across 6 docs (RENOU.md, glossary READMEs, HANDOFFs, SAMSAADHANII_INDEX.md). Right-alignment is intentionally dropped. Matches the updated global authoring convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)