### PR TITLE
Coverage: empty-data guard + unattended PWG refresh script

### DIFF
--- a/RussianTranslation/CITATION_COVERAGE.md
+++ b/RussianTranslation/CITATION_COVERAGE.md
@@ -24,4 +24,10 @@ With PWG checked out as a sibling repo, the generator writes the reports into
 python src/build_citation_index.py
 ```
 
+For an unattended refresh that regenerates **and** opens an auto-merge PR to PWG,
+run [`refresh_pwg_coverage.sh`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/refresh_pwg_coverage.sh)
+(from cron / Task Scheduler on the machine that holds the data). The generator
+aborts if the data is missing, so a bad run can never overwrite the reports with
+empty output.
+
 _Dr. Mārcis Gasūns_

--- a/RussianTranslation/refresh_pwg_coverage.sh
+++ b/RussianTranslation/refresh_pwg_coverage.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Regenerate the PWG <ls> citation-coverage reports and open an auto-merge PR to
+# sanskrit-lexicon/PWG. Run on the machine that HAS the (git-ignored) translation
+# data (pwg_ru_translated.jsonl + wf_output.en.*.json) — e.g. from cron or
+# Windows Task Scheduler. Safe by construction:
+#   * the generator aborts if the data is missing (never writes empty reports);
+#   * it works in a throwaway PWG worktree, so it never disturbs your PWG checkout;
+#   * no-op (no PR) when the reports are unchanged.
+#
+# Requires: python (with mako/deps for build_article_site), gh (authenticated),
+# and PWG checked out as a sibling of SanskritLexicography.
+set -euo pipefail
+
+SL="$(cd "$(dirname "$0")/.." && pwd)"        # SanskritLexicography repo root
+PWG="$(cd "$SL/../PWG" && pwd)"               # sibling PWG repo
+WT="$SL/../_wt_pwg_refresh"                    # throwaway worktree
+BR="chore/refresh-pwg-ru-coverage"
+
+git -C "$PWG" fetch origin main -q
+git -C "$PWG" worktree remove --force "$WT" 2>/dev/null || true
+rm -rf "$WT"
+git -C "$PWG" worktree add -q --detach "$WT" origin/main
+
+# Generate straight into the worktree (generator exits non-zero if data missing).
+python "$SL/RussianTranslation/src/build_citation_index.py" \
+    --out-dir "$WT/pwg_ls/pwg_ru_coverage"
+
+cd "$WT"
+if git diff --quiet -- pwg_ls/pwg_ru_coverage; then
+    echo "coverage unchanged — nothing to publish"
+    cd "$SL"; git -C "$PWG" worktree remove --force "$WT"
+    exit 0
+fi
+
+git checkout -B "$BR"
+git add pwg_ls/pwg_ru_coverage
+git commit -m "pwg_ru_coverage: scheduled refresh $(date +%F)"
+git push -u origin "$BR" --force-with-lease
+gh pr create --repo sanskrit-lexicon/PWG --base main --head "$BR" \
+    --title "pwg_ru_coverage: scheduled refresh" \
+    --body "Automated regeneration of the PWG citation-coverage reports (pwg_ls/pwg_ru_coverage) from the RussianTranslation pipeline." \
+    2>/dev/null || echo "PR already open"
+gh pr merge "$BR" --repo sanskrit-lexicon/PWG --auto --squash 2>/dev/null || true
+
+cd "$SL"; git -C "$PWG" worktree remove --force "$WT"
+echo "refresh done — PR opened/updated with auto-merge"

--- a/RussianTranslation/src/build_citation_index.py
+++ b/RussianTranslation/src/build_citation_index.py
@@ -536,8 +536,13 @@ def main():
     args = ap.parse_args()
     if args.out_dir:
         set_outdir(os.path.abspath(args.out_dir))
-    os.makedirs(OUTDIR, exist_ok=True)
     groups, total, resolved, counts = build()
+    # Safety guard for unattended/scheduled runs: never overwrite the published
+    # reports with empty output when the (git-ignored) input data is missing.
+    if total == 0:
+        sys.exit('ERROR: 0 citations found — input data (pwg_ru_translated.jsonl / '
+                 'wf_output.en.*.json) missing; refusing to write empty reports.')
+    os.makedirs(OUTDIR, exist_ok=True)
     emit(groups, total, resolved, counts)
     occ_scan, occ_html, per, occ_total, labels = occurrence_stats()
     emit_uncovered(per, occ_scan, occ_html, occ_total, labels)


### PR DESCRIPTION
Foundation for scheduled auto-refresh of the PWG coverage reports:

- **Guard:** `build_citation_index.py` now aborts (non-zero, writes nothing) when 0 citations are found — so a scheduled run with the git-ignored data absent can never overwrite the published PWG reports with empty output.
- **[`refresh_pwg_coverage.sh`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/refresh_pwg_coverage.sh):** regenerates into a throwaway PWG worktree and opens an auto-merge PR to sanskrit-lexicon/PWG; no-op when unchanged; never disturbs your PWG checkout. Drive it from cron / Task Scheduler on the machine that holds the translation data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)