### PR TITLE
pwg_ru: Fable S7 gold-sample judge — PROCEED (RU 96% / EN 98.5% clean)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,19 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
+- **PWG gold-sample judge — VERDICT: PROCEED (Fable window S7, 2026-07-02).** Fable 5
+  (`claude-fable-5`) adjudicated an independent 50-card seed-7 Slice C+D RU sample (96.0 %
+  faithful+acceptable, unfaithful 4.0 % CI [1.1, 13.5]) + 68 EN sense rows covering ALL 16 pilot
+  roots (98.5 % clean, 1 unfaithful). **All 3 unfaithful = unsourced ADDITION** (interpretive
+  gloss ×1, invented attribution «и другими» ×1, MW-TM leak "(of a heavenly body)" ×1 — the only
+  confirmed MW contamination). Dominant residual = dropped `{%..%}` markers (RU 17/50 cards, EN
+  32/68 rows, systematic on EN path) — deterministic gate recommended, non-blocking. Verdict
+  gates Phase 2 + future tranches: **proceed, tighten prompts** ("translate-don't-annotate" +
+  MW-TM guard in `tr_en.txt`), add `{%..%}`-pair-count soft flag to the audits. ⚠️ State finding:
+  store `en` layer superseded — only DA carries `en` (700 rows); **re-run `promote_en.py` before
+  any Phase-2 sampling**. Memo (binding sampling plan §): [`FABLE_JUDGE_S7_2026-07-02.md`](FABLE_JUDGE_S7_2026-07-02.md);
+  evidence: [`fable_s7_verdicts_2026-07-02.json`](fable_s7_verdicts_2026-07-02.json).
+
 - **PWG→EN FU1 — Phase 1 GENERATION + REQUEUE COMPLETE on Sonnet 5 (2026-07-01).** All 30
   worklist roots translated with **generation = Sonnet 5 (`claude-sonnet-5`)** (pinned
   explicitly on the `--lang=en` path — the bare `model:'sonnet'` alias previously resolved to

--- a/RussianTranslation/FABLE_JUDGE_S7_2026-07-02.md
+++ b/RussianTranslation/FABLE_JUDGE_S7_2026-07-02.md
@@ -1,0 +1,112 @@
+# PWG gold-sample fidelity judgment — Fable window S7 (quality bar for the bulk EN run)
+
+_Created: 02-07-2026 · Last updated: 02-07-2026_
+
+**Session:** Fable window S7 · **Judge:** Fable 5 (`claude-fable-5`) · **Ground truth:** faithful
+to the PWG German source ([FU1 locked decision 6](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/FU1_PLAN.md)
+— Monier-Williams is a cross-check, never the standard). This memo is the FU1 judge-tier output
+that sets the quality bar for the PWG→EN bulk tranche and for Phase 2 (merge → judge → human gold).
+
+## Headline
+
+| sample | unit | n | faithful | acceptable-loss | unfaithful | clean rate (F+AL) | unfaithful 95 % CI (Wilson) |
+|---|---|---:|---:|---:|---:|---:|---|
+| RU, Slice C+D promoted | card | 50 | 28 | 20 | **2** | **96.0 %** | 4.0 % [1.1 %, 13.5 %] |
+| EN, all 16 pilot roots | sense row | 68 | 33 | 34 | **1** | **98.5 %** | 1.5 % [0.3 %, 7.9 %] |
+| combined | — | 118 | 61 | 54 | **3** | **97.5 %** | 2.5 % [0.9 %, 7.2 %] |
+
+Zero omissions of sense content, zero register drift, zero semantic term mistranslations at the
+gloss level. **All three unfaithful verdicts are the same failure class: unsourced ADDITION** —
+the pipeline occasionally annotates instead of translating.
+
+### The three unfaithful cases (full)
+
+1. `yaj~~h0_04_ati` (RU, *addition*): German has one gloss {%mit dem Opfer übergehen%}; the
+   Russian renders it correctly, then **adds a second interpretive gloss** «пропустить
+   (кого-либо) при раздаче жертвенного» that the German does not contain.
+2. `vah~~h0_01_sec_1` s7 (RU, *addition*): German attributes the derivation to Benfey alone
+   («wird von BENFEY … zurückgeführt»); Russian says «возводится BENFEY **и другими**» —
+   an invented scholarly attribution.
+3. `g_a~~h0_14_a_byastam` (EN, *addition + mw-tm-contamination*): German {%untergehen vor, bei,
+   während einer Handlung%}; English adds **"(of a heavenly body)"** — a parenthetical in
+   Monier-Williams' characteristic style ("to go down, set (as heavenly bodies)") with no German
+   counterpart. The single confirmed MW-translation-memory leak in the sample.
+
+### Failure classes (all severities)
+
+| class | RU (50 cards) | EN (68 rows) | reading |
+|---|---:|---:|---|
+| markup-loss | 17 | 32 | dropped `{%..%}` gloss markers / `<div>` wrappers, meaning intact — the dominant residual, **systematic on the EN path** (~47 % of rows) |
+| addition | 5 | 3 | 3 of these are the unfaithful cases above; the rest are harmless header/gloss doubling |
+| grammar | 2 | 0 | trivial Russian agreement slips |
+| omission | 1 | 0 | a German editorial note retained **verbatim untranslated** (`v_a~~h1_18_sam`) — coverage gap, nothing lost |
+| term-mistranslation | 0 | 1 | minor: "zu verbinden" → "to be read with" (should be "construed together") |
+| register-drift | 0 | 0 | — |
+| mw-tm-contamination | — | 1 | case 3 above |
+
+## Verdict: **PROCEED**, with two prompt tightenings and one gate
+
+The generation quality is at the bar the FU1 plan assumed (this Fable-tier pass independently
+corroborates the [2026-06-30 Opus 4.8 interim](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/FIDELITY_JUDGE_2026-06-30.md):
+98 % clean, defects markup/grammar not meaning). Note honestly: FU1 Phase-1 EN **generation already
+ran** (2026-07-01, Sonnet 5, 94.9 % coverage), so this verdict operationally gates **Phase 2**
+(promote_en → dcs_freq → judge inlining → human gold → G5) and **every future tranche** under the
+standing bilingual policy. No re-generation and no re-judging with a changed rubric is required.
+
+**Tighten before the next generation tranche (prompt-level, both languages):**
+
+1. **"Translate, don't annotate."** Add to [`src/pilot/tr_en.txt`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/tr_en.txt)
+   and the RU counterpart: never add parenthetical domain clarifications, extra glosses, or
+   attributions ("and others") beyond what the German states. All 3 unfaithful cases die here.
+2. **Explicit MW-TM guard (EN path):** the MW reference may inform *wording* of a sense the
+   German attests, never *add content*; if MW has detail the German lacks, omit it.
+
+**Gate to add (deterministic, no quota):** extend the audit (`audit_window.py` /
+[`audit_window_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window_en.py))
+with a `{%..%}`-pair-count soft flag (DE vs target) — markup-loss is ~⅓ of RU cards and ~half of
+EN rows; it is mechanically detectable and mechanically fixable, and should stop riding on judge
+samples. The untranslated-editorial-note case belongs to the existing `fix_german_connectives`
+family.
+
+## Sampling plan the bulk run must carry (binding for Phase 2)
+
+1. **Re-run `promote_en.py` first** — state finding: the current store
+   ([`src/pwg_ru_translated.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_ru_translated.jsonl))
+   carries `en` **only on DA (700 rows)**; the earlier pilot EN merge was superseded by a later
+   `promote_final_cards.py` rebuild. Phase-2 sampling over the store is meaningless until the EN
+   layer is re-merged (join is idempotent, on German text).
+2. **Human gold:** [`src/gold_sample_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/gold_sample_en.py)
+   `--n 300` (fixed seed) over the re-merged store — strata = DCS band × source_type × stratum,
+   MW hidden; two annotators; κ + error rate via `gold_agreement.py`. Unchanged from the locked plan.
+3. **LLM judge, full coverage:** per-sense verdicts inlined via `promote_en.py --judge`
+   (judge tier ≥ Opus 4.8 (`claude-opus-4-8`); Fable-class for adjudicating disagreements).
+4. **Acceptance gate:** unfaithful ≤ 2 % point estimate with Wilson upper bound ≤ 8 % at n ≥ 300;
+   **zero unremediated `mw-tm-contamination`** instances (each found instance is hand-patched);
+   markup-loss tracked but non-blocking (deterministic fix per the gate above).
+5. **Every future generation tranche** carries a 50-card stratified per-tranche judge sample
+   (rotate the seed; rubric = this memo's; unit = card for RU, sense row for EN).
+
+## Method & provenance (per step, tier + version)
+
+| step | tool / actor | model |
+|---|---|---|
+| RU sample draw (50 cards, seed 7, population 1,882 Slice C+D cards — independent of the 2026-06-30 seed-42 draw) | [`src/fidelity_sample.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/fidelity_sample.py) `--glob "wf_output.s[cd].*.json"` | deterministic, no model |
+| EN judge set (60-row seed-42 stratified draw + 8-row seed-7 naS/yaj supplement → 68 rows, all 16 pilot roots) | `src/gold_sample_en.jsonl` + `wf_output.en.{naS,yaj}.json` | deterministic, no model |
+| Batch adjudication (5 RU + 2 EN batches, ≤3-wide) | Agent subagents, session-model inheritance | **Fable 5 (`claude-fable-5`)**, ~455 k subagent tokens |
+| Adversarial verification of every unfaithful verdict, spot-check of 11 cards/rows, 4 documented overrides, batch-strictness reconciliation | main session | **Fable 5 (`claude-fable-5`)** |
+| Source-integrity check (store DE vs csl-orig) | `su~~h1_05_ud` vs [`pwg.txt` l. 532606](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/pwg/pwg.txt) | PASS (only the known citation-period normalization differs) |
+| Generation under judgment | RU Slice C+D: Sonnet 4.6 (`claude-sonnet-4-6`, alias `model:'sonnet'` at run time); EN pilot roots: Sonnet 4.6 (`claude-sonnet-4-6`) | — |
+
+Judge-consistency notes: (a) the batch-2 EN subagent scored dropped `{%..%}` markers leniently;
+I re-applied the strict batch-1 convention to 3 rows (63, 65, 67 — faithful → acceptable-loss),
+so cross-batch class rates are conservative; (b) 1 RU agent verdict was downgraded
+(`v_a~~h1_18_sam`: unfaithful → acceptable-loss — the German note is retained verbatim, not lost),
+2 were confirmed on my own reading of the German; the EN unfaithful was confirmed against the
+German gloss. All overrides are recorded in the evidence file. Senses were capped at 700 chars
+for judging; nothing at/after a cap was penalized.
+
+Evidence: [`fable_s7_verdicts_2026-07-02.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/fable_s7_verdicts_2026-07-02.json)
+(all 118 verdicts + manifest + overrides). Samples regenerable deterministically (gitignored):
+`src/pilot/output/fidelity_sample.s7.jsonl`, `src/pilot/output/en_judge_set.s7.jsonl`.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/fable_s7_verdicts_2026-07-02.json
+++ b/RussianTranslation/fable_s7_verdicts_2026-07-02.json
@@ -1,0 +1,980 @@
+{
+ "session": "FABLE_S7 gold-sample judge",
+ "date": "2026-07-02",
+ "judge_model": "Fable 5 (claude-fable-5), main session + 7 inherited-model subagent batches (<=3-wide)",
+ "ru_sample": {
+  "sampler": "src/fidelity_sample.py --n 50 --seed 7 --glob wf_output.s[cd].*.json",
+  "population_cards": 1882,
+  "n": 50,
+  "unit": "card",
+  "verdicts": {
+   "faithful": 28,
+   "acceptable-loss": 20,
+   "unfaithful": 2
+  },
+  "classes": {
+   "markup-loss": 17,
+   "grammar": 2,
+   "addition": 5,
+   "omission": 1
+  }
+ },
+ "en_sample": {
+  "source": "src/gold_sample_en.jsonl (60 rows, seed-42 stratified draw over store en layer) + 8-row seed-7 supplement for naS/yaj from wf_output.en.*.json",
+  "n": 68,
+  "unit": "sense row",
+  "roots": [
+   "Bid",
+   "Buj",
+   "Cid",
+   "DA",
+   "Sam",
+   "gA",
+   "hi",
+   "mad",
+   "naS",
+   "pA",
+   "pat",
+   "rakz",
+   "vad",
+   "vraj",
+   "yaj",
+   "yat"
+  ],
+  "verdicts": {
+   "acceptable-loss": 34,
+   "faithful": 33,
+   "unfaithful": 1
+  },
+  "classes": {
+   "markup-loss": 32,
+   "addition": 3,
+   "mw-tm-contamination": 1,
+   "term-mistranslation": 1
+  }
+ },
+ "overrides": [
+  {
+   "key": "v_a~~h1_18_sam",
+   "agent": "unfaithful",
+   "final": "acceptable-loss",
+   "reason": "German editorial note retained verbatim untranslated - coverage gap, not loss"
+  },
+  {
+   "id": 63,
+   "agent": "faithful",
+   "final": "acceptable-loss",
+   "reason": "batch-1 markup-loss convention"
+  },
+  {
+   "id": 65,
+   "agent": "faithful",
+   "final": "acceptable-loss",
+   "reason": "batch-1 markup-loss convention"
+  },
+  {
+   "id": 67,
+   "agent": "faithful",
+   "final": "acceptable-loss",
+   "reason": "batch-1 markup-loss convention"
+  }
+ ],
+ "ru_verdicts": [
+  {
+   "key": "_cid~~h0_21_prati",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Glosses and (acc.) marker reordered but semantically exact; markup intact."
+  },
+  {
+   "key": "muc~~h0_28_vi_1",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "sense 0: {%..%} markers dropped around 'отцеплять, распрягать' and 'освобождать кого-либо'; meaning intact."
+  },
+  {
+   "key": "su~~h1_05_ud",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'aufwärts gehen heissen' = 'велеть идти вверх' exact."
+  },
+  {
+   "key": "vraj~~h0_15_ud",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Exact rendering; citations byte-identical."
+  },
+  {
+   "key": "ban_d~~h0_00_pwg01",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "grammar",
+    "addition",
+    "markup-loss"
+   ],
+   "note": "sense 1: 'stockend'→'прерывисто' (adverb, slight shift); added 'в сравнении с' glue; <div n=\"1\"> dropped."
+  },
+  {
+   "key": "na_s~~h0_01_sec_1",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "All five caus. glosses rendered exactly; accented SLP1 preserved."
+  },
+  {
+   "key": "pat~~h0_22_ni_1",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "senses 0-2: {%..%} markers dropped around glosses; meanings faithful."
+  },
+  {
+   "key": "_ap~~h0_21_anusam",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'dazu vollenden, nachher zu Stande bringen' rendered exactly."
+  },
+  {
+   "key": "vraj~~h0_09__a",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Both senses exact incl. 'das wieder abgeht' = 'которая выходит обратно'."
+  },
+  {
+   "key": "_buj~~h2_01_sec_1",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Caus. construction note (double acc. / acc.+instr.) rendered exactly."
+  },
+  {
+   "key": "vas~~h13_00_pwg00",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Sense 0 ni: doublet 'разбил стан / расположился станом' for 'Sitz aufgeschlagen' is harmless; all glosses rendered."
+  },
+  {
+   "key": "vi_s~~h0_34_vini",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "All 15 senses match German semantics; citations and SLP1 intact."
+  },
+  {
+   "key": "_bid~~h0_01_sec_1",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Glosses accurate incl. caus-3 'entzweien/irre machen'; cap at sense 2 not penalized."
+  },
+  {
+   "key": "m_a~~h2_01_sec_1",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Causative triple gloss and 'massen aus'/'bauen lassen' rendered correctly; cap respected."
+  },
+  {
+   "key": "muc~~h0_28_vi_0",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Sense 0: {%..%} markers dropped around 'отцеплять, отвязывать, освобождать' etc.; meaning intact."
+  },
+  {
+   "key": "yaj~~h0_06_apa",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'mit einem Opfer vertreiben, wegopfern' faithfully rendered; citation intact."
+  },
+  {
+   "key": "h_a~~h1_00_pwg01",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "12 senses semantically faithful; sense 4 slight ellipsis of 'soll...sein' covered by 'Согласно'."
+  },
+  {
+   "key": "pat~~h0_zz_sch",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Sense 6 drops [Page243.2] marker; sense 2 drops '-x-' artifact; meanings intact."
+  },
+  {
+   "key": "pat~~h0_zz_pwkvn",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "All three senses match; abbreviations, <ls> refs and cross-references '5.' preserved."
+  },
+  {
+   "key": "man~~h0_16_a_bipra",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Sense 0: {%..%} dropped around 'считать чем-л., принимать за'; meaning of 'halten für' intact."
+  },
+  {
+   "key": "br_u~~h0_zz_pw",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "{%..%} gloss markers dropped throughout (senses 1-47); meanings faithful; harmless doublet renderings (sense 6, 7); spacing slip sense 8."
+  },
+  {
+   "key": "pa_s~~h0_zz_pw01",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Sigla-only entry, byte-identical; nothing to translate."
+  },
+  {
+   "key": "car~~h0_45_vi_1",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Glosses and markers preserved; capped tails not penalized; semantics match."
+  },
+  {
+   "key": "pat~~h0_08_sama_bi",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Sense 0: {%losstürzen auf%} markers dropped; meaning intact."
+  },
+  {
+   "key": "_sam~~h1_17_prati",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Sense 0: {%erloschen seiend%} markers dropped; 'угасший' correct."
+  },
+  {
+   "key": "la_b~~h0_02_sec_2",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "All 6 desiderative glosses rendered; markers and citations preserved; cap respected."
+  },
+  {
+   "key": "m_a~~h2_12_pra_ri",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Forms-only entry, byte-identical; nothing to translate."
+  },
+  {
+   "key": "v_a~~h1_18_sam",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "omission"
+   ],
+   "note": "FABLE OVERRIDE (agent said unfaithful): German editorial note '(wo mit der ed. Bomb. ...)' retained VERBATIM untranslated — coverage gap, nothing lost or misrendered."
+  },
+  {
+   "key": "pa_s~~h0_00_pwg00",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Sense 0: {%..%} markers dropped on both gloss runs; renderings semantically sound."
+  },
+  {
+   "key": "man~~h0_00_pwg02",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Markers, citations, and Sanskrit preserved; all glosses semantically accurate across senses 0-6."
+  },
+  {
+   "key": "rakz~~h0_00_pwg00",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "s0: all 8 glosses + servare rendered; {%..%} markers dropped with meaning intact"
+  },
+  {
+   "key": "vac~~h0_19_paripra",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "s0: meaning fully preserved; {%..%} gloss markers dropped"
+  },
+  {
+   "key": "d_a~~h0_32_pra",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss",
+    "addition"
+   ],
+   "note": "s0: {%..%} markers dropped; extra gloss 'жертвовать' doubles darbringen but stays in its semantic range"
+  },
+  {
+   "key": "_bid~~h0_21_vi",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "all 9 senses semantically exact; markers, citations, section numbers intact"
+  },
+  {
+   "key": "iz~~h1_05_a_bipra",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "auffordern/befehlen rendered accurately; markup and citations intact"
+  },
+  {
+   "key": "j_y_a~~h0_35_a_bisam",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "both glosses match German semantics; markup preserved"
+  },
+  {
+   "key": "yaj~~h0_04_ati",
+   "verdict": "unfaithful",
+   "classes": [
+    "addition"
+   ],
+   "note": "FABLE CONFIRMED: RU adds second unsourced interpretive gloss 'пропустить (кого-либо) при раздаче жертвенного'; German has only 'mit dem Opfer übergehen'"
+  },
+  {
+   "key": "vah~~h0_01_sec_1",
+   "verdict": "unfaithful",
+   "classes": [
+    "addition"
+   ],
+   "note": "FABLE CONFIRMED: s7 'и другими' invents attribution — German credits BENFEY alone; rest faithful"
+  },
+  {
+   "key": "car~~h0_zz_pw02",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "grammar",
+    "addition"
+   ],
+   "note": "s24: dative garbled ('тот, кто Sumantra передал слова'); s33: explanatory '(совокупляться)' added"
+  },
+  {
+   "key": "y_a~~h0_73_upasam",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "vereint kommen zu rendered exactly; markup intact"
+  },
+  {
+   "key": "rakz~~h0_06_a_bi",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "s0: {%..%} markers dropped around gloss; meaning intact, citations byte-identical"
+  },
+  {
+   "key": "vi_s~~h0_23_pratyupa",
+   "verdict": "acceptable-loss",
+   "classes": [],
+   "note": "s0: content reordered/consolidated ahead of citations; all glosses present incl. capped 'entgegentreten' part; meaning intact"
+  },
+  {
+   "key": "_sam~~h3_05_upani",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "only sigla and Sanskrit; nothing translatable lost"
+  },
+  {
+   "key": "gam~~h0_63_sam_0",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "all 6 senses + caus. render German accurately; markers and citations preserved"
+  },
+  {
+   "key": "vi_s~~h0_18_an_upa",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "glosses and birthing-posture note rendered exactly"
+  },
+  {
+   "key": "vad~~h0_10_apa",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "s1-s3,s5,s6: {%..%} markers dropped; s1 'oder' left German; meaning intact throughout"
+  },
+  {
+   "key": "vac~~h0_14_nis",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "s0-s1: {%..%} markers dropped; 'wegsprechen'='отговаривать/изгонять словами' semantically sound"
+  },
+  {
+   "key": "na_s~~h0_00_pwg00",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "grammar-form apparatus and glosses preserved with markers; capped tail excluded"
+  },
+  {
+   "key": "v_a~~h4_00_pwg00",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "s0: {%..%} markers and ¦ headword divider dropped; glosses complete and accurate"
+  },
+  {
+   "key": "d_a~~h2_04_nirava",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "both gloss pairs rendered accurately incl. share-apportioning sense; markers preserved"
+  }
+ ],
+ "en_verdicts": [
+  {
+   "id": 0,
+   "root": "vad",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'erschallen lassen' = 'to cause to resound' exact; {%..%} markers dropped, meaning intact."
+  },
+  {
+   "id": 1,
+   "root": "gA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'besingen' = 'to celebrate in song' faithful; gloss markers dropped; citations byte-identical."
+  },
+  {
+   "id": 2,
+   "root": "Sam",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Both German glosses rendered exactly; {%..%} markers dropped."
+  },
+  {
+   "id": 3,
+   "root": "Sam",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "All four glosses (Heil/Wohl/Glück/Segen) rendered; markers dropped; case abbreviations kept."
+  },
+  {
+   "id": 4,
+   "root": "Buj",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Glosses faithful; markers dropped. EN adds caus./act. header beyond visible DE, consistent with tag caus.1."
+  },
+  {
+   "id": 5,
+   "root": "DA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'erwiedern, antworten' = 'to reply, to answer'; markers dropped only."
+  },
+  {
+   "id": 6,
+   "root": "pat",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'niederfliegen zu' = 'to fly down to' exact; markers dropped."
+  },
+  {
+   "id": 7,
+   "root": "yat",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'an's Herz legen' rendered correctly with gen./acc. roles preserved; leading div and markers dropped."
+  },
+  {
+   "id": 8,
+   "root": "pA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "All three glosses rendered; leading div and markers dropped."
+  },
+  {
+   "id": 9,
+   "root": "Sam",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "All four glosses rendered faithfully incl. 'v. a.' siglum; markers dropped."
+  },
+  {
+   "id": 10,
+   "root": "vad",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'to be mutually inconsistent' doubles the single German gloss but same sense; markers dropped."
+  },
+  {
+   "id": 11,
+   "root": "vraj",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Gloss and 'wohl hierher'='probably here' faithful; markers dropped."
+  },
+  {
+   "id": 12,
+   "root": "mad",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'schlafen' and editorial remark rendered literally; ls preserved; markers dropped."
+  },
+  {
+   "id": 13,
+   "root": "DA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Three glosses faithful; EN adds upasam header line, consistent with subcard; markers dropped."
+  },
+  {
+   "id": 14,
+   "root": "gA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Two German verbs -> three English near-synonyms, same sense; markers dropped; Vedic accents intact."
+  },
+  {
+   "id": 15,
+   "root": "hi",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'dahinfahren' rendered as doublet 'travel away, go forth', same sense; markers dropped."
+  },
+  {
+   "id": 16,
+   "root": "pat",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'zubringen (die Zeit)' = 'to spend (time)' exact; markers dropped."
+  },
+  {
+   "id": 17,
+   "root": "rakz",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "DE already English, retained verbatim; added NWS citation prefix plausibly from unmasked source."
+  },
+  {
+   "id": 18,
+   "root": "pA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "All seven German verbs matched one-to-one; markers dropped; citations intact."
+  },
+  {
+   "id": 19,
+   "root": "Bid",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "{%..%} markers preserved; 'geborsten' = 'burst, cracked' within sense; citation intact."
+  },
+  {
+   "id": 20,
+   "root": "DA",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Cross-reference sigla retained verbatim as required."
+  },
+  {
+   "id": 21,
+   "root": "mad",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Glosses and lexicographer list faithful; 'insbes. especially' doubles siglum harmlessly; markers dropped."
+  },
+  {
+   "id": 22,
+   "root": "DA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'beseitigt' rendered as doublet 'removed, set aside', same sense; markers dropped."
+  },
+  {
+   "id": 23,
+   "root": "pA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'getränkt, erfüllt von' = 'steeped in, filled with' faithful; markers dropped."
+  },
+  {
+   "id": 24,
+   "root": "gA",
+   "verdict": "unfaithful",
+   "classes": [
+    "addition",
+    "mw-tm-contamination",
+    "markup-loss"
+   ],
+   "note": "FABLE CONFIRMED: '(of a heavenly body)' added — not in German 'untergehen vor, bei, während einer Handlung'; MW-style parenthetical for astam-gA."
+  },
+  {
+   "id": 25,
+   "root": "DA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'bei Seite setzen' = 'to set aside' exact; markers dropped."
+  },
+  {
+   "id": 26,
+   "root": "Cid",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Both glosses rendered exactly; sigla bracket retained; punctuation normalization only."
+  },
+  {
+   "id": 27,
+   "root": "pat",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'to outfly, to overtake in flight' both render 'im Fliegen überholen'; same sense; markers dropped."
+  },
+  {
+   "id": 28,
+   "root": "pat",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Equation row retained byte-identical; nothing to translate."
+  },
+  {
+   "id": 29,
+   "root": "gA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Four glosses matched; 'refers to' completes text after cap — not penalized; markers dropped."
+  },
+  {
+   "id": 30,
+   "root": "vad",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Vgl./fgg. sigla and Sanskrit retained verbatim as required."
+  },
+  {
+   "id": 31,
+   "root": "DA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "Both glosses faithful with 'after someone' distributed; [Page3-0907] artifact harmless; markers dropped."
+  },
+  {
+   "id": 32,
+   "root": "Bid",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'verrathen' = 'to betray' exact; markers dropped; citations intact."
+  },
+  {
+   "id": 33,
+   "root": "pat",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "'über etwas hinauskommen' = 'to go beyond something' faithful; {%vyati%} markers dropped."
+  },
+  {
+   "id": 34,
+   "root": "DA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "addition"
+   ],
+   "note": "EN prepends div header '— {#saMni#}' absent from DE; glosses (steht bevor=is imminent, lies=read) faithful."
+  },
+  {
+   "id": 35,
+   "root": "DA",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "entgegenarbeiten doubled as 'work against, counteract' — harmless; question rendered exactly."
+  },
+  {
+   "id": 36,
+   "root": "pat",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'dazu eintreten' and 'gelegentlich zur Erwähnung kommen' both rendered accurately; citations intact."
+  },
+  {
+   "id": 37,
+   "root": "mad",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Identical skeleton row, nothing to translate."
+  },
+  {
+   "id": 38,
+   "root": "gA",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "zurückkehren = to return; Sanskrit and citation byte-identical."
+  },
+  {
+   "id": 39,
+   "root": "yat",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "EN drops leading <div n=\"2\"> wrapper; all glosses and citations otherwise byte-identical."
+  },
+  {
+   "id": 40,
+   "root": "pat",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'gerathen in' = fall/get into; faithful."
+  },
+  {
+   "id": 41,
+   "root": "Buj",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'vorweg essen' = eat in advance/first; acc. note preserved."
+  },
+  {
+   "id": 42,
+   "root": "DA",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "All three insert-glosses and immersion gloss rendered; accented Sanskrit preserved; cap-tail ignored."
+  },
+  {
+   "id": 43,
+   "root": "vraj",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "herbeikommen/hinschreiten, herankommend, kommen in, sich begeben zu all rendered correctly."
+  },
+  {
+   "id": 44,
+   "root": "vraj",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Opposite-direction gloss exact."
+  },
+  {
+   "id": 45,
+   "root": "DA",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'ganz zudecken' = cover completely."
+  },
+  {
+   "id": 46,
+   "root": "DA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "addition"
+   ],
+   "note": "EN prepends '— {#anusam#}' div header absent from DE; desid. glosses themselves faithful."
+  },
+  {
+   "id": 47,
+   "root": "DA",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "zurechtmachen/herbeischaffen = prepare/procure."
+  },
+  {
+   "id": 48,
+   "root": "gA",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Liturgical-singing note and Udgatar etymology rendered accurately; citations intact."
+  },
+  {
+   "id": 49,
+   "root": "pA",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "term-mistranslation"
+   ],
+   "note": "'zu verbinden' means 'to be construed together (as one compound)', not 'to be read with'; minor shift."
+  },
+  {
+   "id": 50,
+   "root": "Buj",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "EN adds homonym number '4.' (masked-context carve-out); 'das Haben, die Habe' = possession, property."
+  },
+  {
+   "id": 51,
+   "root": "DA",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'wieder' repositioned to second gloss but meaning intact; cross-reference preserved."
+  },
+  {
+   "id": 52,
+   "root": "DA",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'etwa sich festsetzen' = perhaps to establish oneself/settle; sigla retained."
+  },
+  {
+   "id": 53,
+   "root": "mad",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'wohl fehlerhaft für' = probably erroneous for."
+  },
+  {
+   "id": 54,
+   "root": "rakz",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'in Acht nehmen' / 'nicht antasten' rendered adequately; v. a. siglum retained."
+  },
+  {
+   "id": 55,
+   "root": "yat",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Source already English (BHSD); NWS header prefix is pipeline formatting; content identical."
+  },
+  {
+   "id": 56,
+   "root": "vad",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'sich unterhalten' = to converse; ebend. retained per carve-out."
+  },
+  {
+   "id": 57,
+   "root": "mad",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Pure cross-reference, byte-identical."
+  },
+  {
+   "id": 58,
+   "root": "gA",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "'gehen, wandeln' = go, walk; case note on des Weges preserved."
+  },
+  {
+   "id": 59,
+   "root": "yat",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Cross-reference byte-identical; Vgl./fgg. retained correctly."
+  },
+  {
+   "id": 60,
+   "root": "naS",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Minimal connective translation only."
+  },
+  {
+   "id": 61,
+   "root": "naS",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Headword skeleton, byte-identical."
+  },
+  {
+   "id": 62,
+   "root": "naS",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "{#..#} German kept byte-identical as required; '+ ud: hinaufreichen' = reach up to (+ Acc.)."
+  },
+  {
+   "id": 63,
+   "root": "naS",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "FABLE RECONCILED (agent said faithful): 'verloren gehen lassen' = 'cause to be lost' exact, but {%..%} markers dropped — batch-1 convention applied."
+  },
+  {
+   "id": 64,
+   "root": "yaj",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "{#..#} preserved; all seven a-senses rendered; 'herbeischaffen' as 'bring near by sacrifice' defensible for both 5) and 7)."
+  },
+  {
+   "id": 65,
+   "root": "yaj",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "FABLE RECONCILED (agent said faithful): all content rendered, 'eropfert/durch Verehrung gewonnen' pairings swapped but same content; {%..%} markers dropped — batch-1 convention."
+  },
+  {
+   "id": 66,
+   "root": "yaj",
+   "verdict": "faithful",
+   "classes": [],
+   "note": "Etymology skeleton; only connective glue translated; Sanskrit and citations byte-identical."
+  },
+  {
+   "id": 67,
+   "root": "yaj",
+   "verdict": "acceptable-loss",
+   "classes": [
+    "markup-loss"
+   ],
+   "note": "FABLE RECONCILED (agent said faithful): 'vertreiben, wegopfern' merged into 'drive away or expel by means of a sacrifice' — meaning covered; {%..%} markers dropped."
+  }
+ ]
+}


### PR DESCRIPTION
## Fable window S7 — FU1 gold-sample judge (quality bar for the bulk EN run)

**Judge:** Fable 5 (`claude-fable-5`), per-step provenance in the memo. **Ground truth:** faithful to the PWG German ([FU1 locked decision 6](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/FU1_PLAN.md)).

| sample | n | clean (F+AL) | unfaithful | CI (Wilson) |
|---|---:|---:|---:|---|
| RU Slice C+D promoted (seed-7, independent of the 2026-06-30 seed-42 Opus pass) | 50 cards | **96.0 %** | 2 | 4.0 % [1.1, 13.5] |
| EN, all 16 pilot roots | 68 sense rows | **98.5 %** | 1 | 1.5 % [0.3, 7.9] |

**Verdict: PROCEED** — Phase 2 (promote_en → judge inlining → human gold → G5) and future tranches are green-lit, with two prompt tightenings ("translate, don''t annotate" + an MW-TM guard) and a deterministic `{%..%}`-pair-count audit flag. All 3 unfaithful verdicts are the same class: **unsourced addition**, incl. the single confirmed MW-TM contamination ("(of a heavenly body)" on astaṃ-gā).

⚠️ State finding: the store''s `en` layer was superseded (only DA carries `en`) — **re-run `promote_en.py` before any Phase-2 sampling**.

Deliverables:
- [RussianTranslation/FABLE_JUDGE_S7_2026-07-02.md](https://github.com/gasyoun/SanskritLexicography/blob/judge/fable-s7-gold/RussianTranslation/FABLE_JUDGE_S7_2026-07-02.md) — quality-bar memo incl. the binding Phase-2 sampling plan
- [RussianTranslation/fable_s7_verdicts_2026-07-02.json](https://github.com/gasyoun/SanskritLexicography/blob/judge/fable-s7-gold/RussianTranslation/fable_s7_verdicts_2026-07-02.json) — all 118 verdicts + manifest + 4 documented overrides
- [RussianTranslation/.ai_state.md](https://github.com/gasyoun/SanskritLexicography/blob/judge/fable-s7-gold/RussianTranslation/.ai_state.md) — queue entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)