### PR TITLE
docs: S7 handoff hygiene — full blob URLs in .ai_state entry

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -22,8 +22,8 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   gates Phase 2 + future tranches: **proceed, tighten prompts** ("translate-don't-annotate" +
   MW-TM guard in `tr_en.txt`), add `{%..%}`-pair-count soft flag to the audits. ⚠️ State finding:
   store `en` layer superseded — only DA carries `en` (700 rows); **re-run `promote_en.py` before
-  any Phase-2 sampling**. Memo (binding sampling plan §): [`FABLE_JUDGE_S7_2026-07-02.md`](FABLE_JUDGE_S7_2026-07-02.md);
-  evidence: [`fable_s7_verdicts_2026-07-02.json`](fable_s7_verdicts_2026-07-02.json).
+  any Phase-2 sampling**. Memo (binding sampling plan §): [`FABLE_JUDGE_S7_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/FABLE_JUDGE_S7_2026-07-02.md);
+  evidence: [`fable_s7_verdicts_2026-07-02.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/fable_s7_verdicts_2026-07-02.json).
 
 - **PWG→EN FU1 — Phase 1 GENERATION + REQUEUE COMPLETE on Sonnet 5 (2026-07-01).** All 30
   worklist roots translated with **generation = Sonnet 5 (`claude-sonnet-5`)** (pinned


### PR DESCRIPTION
Follow-up to [PR #56](https://github.com/gasyoun/SanskritLexicography/pull/56): the S7 judge queue entry in [RussianTranslation/.ai_state.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md) used relative links for the memo + evidence JSON — upgraded to full blob URLs per the standing handoff-link rule. No content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)