### PR TITLE
fix(pwg-promote): exclude EN wf files, mark partial cards, record model version

### DIFF
--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -40,6 +40,11 @@ ROOT = os.path.dirname(HERE)                       # the RussianTranslation repo
 DEFAULT_STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
 DEFAULT_GLOB = 'wf_output*.json'
 MODEL = 'sonnet'                                    # the harness pins model:'sonnet' (gen_opt_harness2)
+# Tier + VERSION must both be recorded (models change — a bare 'sonnet' is ambiguous later;
+# same convention as promote_en.py). The wf_output meta does not carry the resolved version,
+# so it is recorded here; override per run with --gen-model-version if the alias mapping
+# changed for the run being promoted.
+GEN_MODEL_VERSION = 'claude-sonnet-4-6'             # alias 'sonnet' -> Sonnet 4.6 (RU runs)
 
 
 def load_wf(path):
@@ -54,8 +59,14 @@ def load_wf(path):
 
 
 def collect_cards(paths):
-    """sub-card key -> {card, meta, wf_file}. Non-null wins; both-non-null keeps first + logs."""
-    best, conflicts, null_keys = {}, [], set()
+    """sub-card key -> {card, meta, wf_file}. Non-null wins; both-non-null keeps first + logs.
+
+    EN wf files are EXCLUDED: this is the RU bridge (rows_for reads sense['russian']), but
+    DEFAULT_GLOB 'wf_output*.json' also matches wf_output.en.* — and those sort BEFORE the
+    RU files, so first-seen-wins used to let an EN card shadow the RU card for the same
+    sub-key, yielding ZERO rows for it (no 'russian' field) in a full rebuild. EN attachment
+    is promote_en.py's job."""
+    best, conflicts, null_keys, en_skipped = {}, [], set(), 0
     for path in paths:
         try:
             res = load_wf(path)
@@ -63,6 +74,9 @@ def collect_cards(paths):
             print('  skip (unreadable): %s (%s)' % (os.path.basename(path), e))
             continue
         meta = res.get('meta') or {}
+        if meta.get('lang') == 'en' or os.path.basename(path).startswith('wf_output.en.'):
+            en_skipped += 1
+            continue
         for r in res.get('results') or []:
             key = r.get('key')
             card = r.get('card')
@@ -74,16 +88,26 @@ def collect_cards(paths):
             if key in best:
                 conflicts.append(key)
                 continue                            # keep first-seen non-null
-            best[key] = {'card': card, 'meta': meta, 'wf_file': os.path.basename(path)}
+            entry = {'card': card, 'meta': meta, 'wf_file': os.path.basename(path)}
+            # carry result-ROW level partial/drift markers (autosplit merge puts them on the
+            # row, the selfheal inline path on the card) so provenance can record them
+            for m in ('partial', 'missing_senses', 'total_senses', 'fidelity_drift'):
+                if r.get(m):
+                    entry[m] = r[m]
+            best[key] = entry
+    if en_skipped:
+        print('  skipped %d EN wf file(s) (promote_en.py attaches those)' % en_skipped)
     null_keys -= set(best)                          # a key non-null somewhere isn't a null
     return best, conflicts, sorted(null_keys)
 
 
-def provenance(entry, subkey):
+def provenance(entry, subkey, model_version=GEN_MODEL_VERSION):
     meta = entry['meta']
     hashes = (meta.get('input_hashes') or {}).get(subkey) or {}
-    return {
+    card = entry.get('card') or {}
+    prov = {
         'model': MODEL,
+        'model_version': model_version,
         'generator': meta.get('generator'),
         'schema_version': meta.get('schema_version'),
         'root': meta.get('root'),
@@ -95,12 +119,28 @@ def provenance(entry, subkey):
         'wf_file': entry['wf_file'],
         'promoted_by': 'promote_final_cards.py',
     }
+    # A partial card is USABLE but INCOMPLETE — record that on every row it yields, or a
+    # store consumer cannot distinguish it from a complete card (audit_coverage only flags
+    # below 80% of source senses, so a 39/41-group partial reads as 'complete' everywhere
+    # downstream without this marker).
+    partial = card.get('partial') or entry.get('partial')
+    if partial:
+        prov['partial_card'] = True
+        for m in ('missing_fragments', 'missing_groups', 'total_groups'):
+            if card.get(m) is not None:
+                prov[m] = card[m]
+        for m in ('missing_senses', 'total_senses'):
+            if entry.get(m) is not None:
+                prov[m] = entry[m]
+    if entry.get('fidelity_drift'):
+        prov['fidelity_drift'] = True
+    return prov
 
 
-def rows_for(subkey, entry, review_status):
+def rows_for(subkey, entry, review_status, model_version=GEN_MODEL_VERSION):
     card = entry['card']
     key1 = entry['meta'].get('root')               # the join key into assembled_cards.jsonl
-    prov = provenance(entry, subkey)
+    prov = provenance(entry, subkey, model_version)
     for rec in card.get('records') or []:
         for sense in rec.get('senses') or []:
             ru = sense.get('russian')
@@ -143,7 +183,16 @@ def selftest():
     assert r['review_status'] == 'ai_translated', 'must not auto-approve (G5 gate)'
     p = r['provenance']
     assert p['model'] == 'sonnet' and p['rootmap_sha256'] == 'abc'
+    assert p['model_version'] == GEN_MODEL_VERSION, 'model VERSION recorded, not just the tier alias'
     assert p['input_raw_sha256'] == 'r1' and p['generated_at'], 'provenance must be complete'
+    assert 'partial_card' not in p, 'complete card carries no partial marker'
+    # a partial (selfheal) card must be marked on every row it yields
+    pentry = dict(entry)
+    pentry['card'] = dict(entry['card'], partial=True, missing_fragments=['g2:f1'],
+                          missing_groups=1, total_groups=3)
+    pr = list(rows_for('p_a~~h5_00_pwg00', pentry, 'ai_translated'))[0]['provenance']
+    assert pr['partial_card'] is True and pr['missing_fragments'] == ['g2:f1'], \
+        'partial cards must be distinguishable in the store'
     # collect_cards: a non-null card wins over a null for the same sub-card key.
     d = tempfile.mkdtemp()
     nullf = os.path.join(d, 'wf_output.sc.x.json')
@@ -155,6 +204,18 @@ def selftest():
     best, _conf, nulls = collect_cards([nullf, fullf])
     assert 'p_a~~h5_00_pwg00' in best, 'non-null must win over null for the same key'
     assert nulls == [], 'a key non-null in any file is not a null'
+    # EN wf files must NOT shadow RU cards: 'wf_output.en.*' sorts before 'wf_output.sc.*',
+    # and its cards carry 'english' not 'russian' -> zero rows -> silent RU loss on rebuild.
+    enf = os.path.join(d, 'wf_output.en.x.json')
+    en_meta = dict(meta, lang='en')
+    en_card = {'key1': 'p_a~~h5_00_pwg00', 'records': [
+        {'h': 'pā', 'senses': [{'tag': '1', 'english': 'to drink', 'german': 'trinken'}]}]}
+    with open(enf, 'w', encoding='utf-8') as f:
+        json.dump({'meta': en_meta, 'results': [{'key': 'p_a~~h5_00_pwg00', 'card': en_card}]}, f)
+    best, _conf, _nulls = collect_cards(sorted([enf, fullf, nullf]))
+    got = best['p_a~~h5_00_pwg00']
+    assert got['meta'].get('lang') != 'en', 'EN wf file must be excluded from the RU bridge'
+    assert list(rows_for('p_a~~h5_00_pwg00', got, 'ai_translated')), 'RU rows survive the EN sibling'
     print('promote_final_cards selftest OK')
 
 
@@ -165,6 +226,10 @@ def main():
     ap.add_argument('--glob', default=DEFAULT_GLOB, help='wf_output glob, relative to repo root')
     ap.add_argument('--store', default=DEFAULT_STORE)
     ap.add_argument('--review-status', default='ai_translated')
+    ap.add_argument('--gen-model-version', default=GEN_MODEL_VERSION,
+                    help='resolved model version recorded in provenance.model_version '
+                         '(default %(default)s — what the harness\'s model:\'sonnet\' alias '
+                         'resolved to; override if the alias mapping changed for this run)')
     ap.add_argument('--dry-run', action='store_true')
     ap.add_argument('--no-backup', action='store_true')
     ap.add_argument('--force', action='store_true',
@@ -186,7 +251,7 @@ def main():
     rows, per_root = [], {}
     for subkey, entry in sorted(best.items()):
         n = 0
-        for row in rows_for(subkey, entry, args.review_status):
+        for row in rows_for(subkey, entry, args.review_status, args.gen_model_version):
             rows.append(row)
             n += 1
         root = entry['meta'].get('root')


### PR DESCRIPTION
## S10 architecture audit — PR 3/4 (store-promotion integrity)

Companion to [#63](https://github.com/gasyoun/SanskritLexicography/pull/63) / [#64](https://github.com/gasyoun/SanskritLexicography/pull/64). Fixes in [`promote_final_cards.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_final_cards.py):

1. **EN wf files no longer shadow RU cards.** `DEFAULT_GLOB 'wf_output*.json'` matches `wf_output.en.*` too; those sort **before** the RU files, and `collect_cards` keeps the first-seen non-null card per sub-key — so on any full (non-`--merge`) rebuild, a sub-key present in both tracks kept the EN card, whose senses have no `russian` field → **zero rows promoted, silent RU loss**. EN files are now excluded (that lane belongs to [`promote_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_en.py)).
2. **Partial cards are distinguishable in the store.** selfheal partials (`partial`/`missing_fragments` from #63) and autosplit row-level markers (`missing_senses` from #64, `fidelity_drift`) are carried into row provenance. Previously a 39/41-group partial like `ka` promoted as if complete — `audit_coverage.py` only flags below 80% of source senses, so nothing downstream could tell.
3. **`provenance.model_version`** records what the `model:'sonnet'` alias resolved to (`--gen-model-version` to override), matching `promote_en.py`'s convention — a bare tier alias is ambiguous once models rotate.

## Validation
Extended `--selftest`: EN-shadow scenario (EN file sorted first must not displace RU rows), partial-marker propagation, model_version presence, plus all pre-existing assertions. Passes.

Session: Fable 5 (`claude-fable-5`); validation is deterministic (no model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)