### PR TITLE
ai-wip: S10 close-out — journal tidy + executable handoff pointers

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -20,6 +20,8 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   nulls, the 77 EN residuals, and `ka`'s 2 missing groups (now targetable via the
   `missing_fragments` ids). Then `promote_final_cards.py --merge` + re-run `promote_en.py`
   (the S7 leftover — EN layer currently on DA only).
+  **Start (Sonnet chat in this repo):** `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\SONNET_pwg_dense_residual_rerun.md and execute it.`
+  ([handoff file](https://github.com/gasyoun/Uprava/blob/main/handoffs/SONNET_pwg_dense_residual_rerun.md))
 
 - **Audit-churn fix — QUEUED (Opus/Fable-tier judgment, from S10 2026-07-02).**
   `prompt_rule_audit.has_text_signal()` false positive (`suspicious_attested_without_text_signal`,
@@ -29,6 +31,8 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   the `whitney_grammar.grammar_for` homonym fallback (`… or recs` returns ALL homonyms on a
   miss). Full flag list FL1–FL8:
   [`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) §3.
+  **Start (Opus 4.8+ chat in this repo):** `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\OPUS_pwg_audit_churn_fix.md and execute it.`
+  ([handoff file](https://github.com/gasyoun/Uprava/blob/main/handoffs/OPUS_pwg_audit_churn_fix.md))
 
 - **Renou hypothesis programme (H1–H7) — STEP 1 DONE 2026-07-02 (Sonnet 5,
   `claude-sonnet-5`), awaiting MG's Step-0 votes.**
@@ -529,31 +533,6 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- **S10 architecture audit + big-card failure closure — RUN 2026-07-02, Fable 5
-  (`claude-fable-5`).** Full findings:
-  [`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md).
-  Verdict: "fails too often" = ten distinct failure modes, PR #35/#37/#38/#40 cover one;
-  systemic root defect = every failure collapsed to an undifferentiated `card:null` with
-  the cause discarded. **PARTIALLY CLOSED** by 5 PRs (all mock/selftest-validated):
-  [#63](https://github.com/gasyoun/SanskritLexicography/pull/63) harness total-accounting
-  invariant + failure ledger + key1-matched acceptance + heal-side fidelity + partial
-  credit in healGroup; [#64](https://github.com/gasyoun/SanskritLexicography/pull/64)
-  autosplit accounted nulls + persisted fail-trail + per-root manifest (race);
-  [#65](https://github.com/gasyoun/SanskritLexicography/pull/65) promote: EN-shadow fix +
-  partial markers + model_version provenance;
-  [#66](https://github.com/gasyoun/SanskritLexicography/pull/66) audit: partials +
-  reason histogram + fidelity-nulls→defect lane;
-  [#67](https://github.com/gasyoun/SanskritLexicography/pull/67) dead code + stale
-  operator pointers + this doc. **Live validation PASSED 4/4**: the 4 store-missing `vas`
-  keys re-run through the #63 harness via the Workflow tool (15 agent calls / ~988k tok;
-  generation = Sonnet 5 (`claude-sonnet-5`) — ⚠ the `sonnet` alias now resolves to
-  Sonnet 5, not 4.6); one junk `"test"` response rejected by key1-matching, one
-  StructuredOutput-cap hard throw absorbed into selfheal, `zz_pw01` healed complete
-  across 9 groups. Merge-saved (`wf_output.sc.vas.json` 7→11 non-null) + merge-promoted
-  (store 10,614→10,771 rows, `--gen-model-version claude-sonnet-5`, backup
-  `pwg_ru_translated.jsonl.SAFE_s10_20260702.keep`). Remaining open work is queued above
-  (dense-residual re-run; audit-churn fix).
-
 - **Nominal grammar layer SHIPPED 2026-06-29** ([`HANDOFF_2026-06-29_nominal_grammar_layer.md`](HANDOFF_2026-06-29_nominal_grammar_layer.md)).
   All 5 build steps complete:
   (0) vidyut subanta confirmed (`Pratipadika.basic('deva')` → `['devaH']`);
@@ -743,6 +722,32 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   ([SamudraManthanam #16](https://github.com/gasyoun/SamudraManthanam/issues/16)).
 
 ## ✅ Completed (Recent only)
+
+- **S10 architecture audit + big-card failure closure — ✅ DONE 2026-07-02, Fable 5
+  (`claude-fable-5`).** Full findings:
+  [`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md).
+  Verdict: "fails too often" = ten distinct failure modes, PR #35/#37/#38/#40 cover one;
+  systemic root defect = every failure collapsed to an undifferentiated `card:null` with
+  the cause discarded. **PARTIALLY CLOSED** by 5 PRs (all mock/selftest-validated):
+  [#63](https://github.com/gasyoun/SanskritLexicography/pull/63) harness total-accounting
+  invariant + failure ledger + key1-matched acceptance + heal-side fidelity + partial
+  credit in healGroup; [#64](https://github.com/gasyoun/SanskritLexicography/pull/64)
+  autosplit accounted nulls + persisted fail-trail + per-root manifest (race);
+  [#65](https://github.com/gasyoun/SanskritLexicography/pull/65) promote: EN-shadow fix +
+  partial markers + model_version provenance;
+  [#66](https://github.com/gasyoun/SanskritLexicography/pull/66) audit: partials +
+  reason histogram + fidelity-nulls→defect lane;
+  [#67](https://github.com/gasyoun/SanskritLexicography/pull/67) dead code + stale
+  operator pointers + this doc. **Live validation PASSED 4/4**: the 4 store-missing `vas`
+  keys re-run through the #63 harness via the Workflow tool (15 agent calls / ~988k tok;
+  generation = Sonnet 5 (`claude-sonnet-5`) — ⚠ the `sonnet` alias now resolves to
+  Sonnet 5, not 4.6); one junk `"test"` response rejected by key1-matching, one
+  StructuredOutput-cap hard throw absorbed into selfheal, `zz_pw01` healed complete
+  across 9 groups. Merge-saved (`wf_output.sc.vas.json` 7→11 non-null) + merge-promoted
+  (store 10,614→10,771 rows, `--gen-model-version claude-sonnet-5`, backup
+  `pwg_ru_translated.jsonl.SAFE_s10_20260702.keep`). Remaining open work is queued above
+  (dense-residual re-run; audit-churn fix).
+
 
 - **pwg selfheal/binary-split/output-budget/partial-credit fixes — 4 PRs merged, live-validated
   (2026-07-02, Sonnet 5 `claude-sonnet-5`).**


### PR DESCRIPTION
Session-end tidy for the S10 architecture audit (follows [#63](https://github.com/gasyoun/SanskritLexicography/pull/63)–[#67](https://github.com/gasyoun/SanskritLexicography/pull/67)): the S10 entry moves WIP → ✅ Completed in [RussianTranslation/.ai_state.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md), and both queued follow-up sessions now carry their one-line executable start commands, pointing at [SONNET_pwg_dense_residual_rerun.md](https://github.com/gasyoun/Uprava/blob/main/handoffs/SONNET_pwg_dense_residual_rerun.md) and [OPUS_pwg_audit_churn_fix.md](https://github.com/gasyoun/Uprava/blob/main/handoffs/OPUS_pwg_audit_churn_fix.md).

Session: Fable 5 (`claude-fable-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)