### PR TITLE
docs: pwg dense-residual rerun COMPLETE — gam keys, en.DA nulls, EN residuals

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -25,20 +25,55 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   `--no-binary-split` / `--output-budget=off` restore old behavior; `--selfheal` /
   `--binary-split` accepted as no-ops so all queued runbooks work verbatim.
   `window_selftest.py` 17/17 PASS, `node --check` PASS, presplit + byte-mode + defaults
-  smoke-verified on vas/gam. The queued dense-residual handoff now also carries the
-  **knob calibration step** (MG: fold in): A/B `--output-budget` 60 vs ~90 and
-  `HEAD_CIT_BATCH_BUDGET` 8–10 vs 18 on one giant head, findings → the hubs.
+  smoke-verified on vas/gam. ⚠️ **Still open** (added to this PR after the dense-residual
+  rerun below had already started, so NOT done as part of it): **knob calibration** —
+  A/B `--output-budget` 60 vs ~90 and `HEAD_CIT_BATCH_BUDGET` 8–10 vs 18 on one giant head,
+  findings → the hubs.
 
-- **Dense-residual re-run through the fixed stack — QUEUED (Sonnet-tier, mechanical,
-  from S10 2026-07-02).** After S10's PRs [#63](https://github.com/gasyoun/SanskritLexicography/pull/63)–[#67](https://github.com/gasyoun/SanskritLexicography/pull/67)
-  merge: re-run with `--selfheal --binary-split --output-budget=60`, ≤3-wide — the
-  remaining store-missing RU keys (`gam~~h0_zz_pw00`, `gam~~h3_04_upa`, `gam~~h3_06_vini`,
-  `gam~~h3_08_sam`; the 4 vas siblings were live-run in S10 itself — see WIP), `en.DA`'s 7
-  nulls, the 77 EN residuals, and `ka`'s 2 missing groups (now targetable via the
-  `missing_fragments` ids). Then `promote_final_cards.py --merge` + re-run `promote_en.py`
-  (the S7 leftover — EN layer currently on DA only).
-  **Start (Sonnet chat in this repo):** `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\SONNET_pwg_dense_residual_rerun.md and execute it.`
-  ([handoff file](https://github.com/gasyoun/Uprava/blob/main/handoffs/SONNET_pwg_dense_residual_rerun.md))
+- **Dense-residual re-run through the fixed stack — COMPLETE (2026-07-02, Sonnet 5
+  `claude-sonnet-5`).** Ran [`Uprava/handoffs/SONNET_pwg_dense_residual_rerun.md`](https://github.com/gasyoun/Uprava/blob/main/handoffs/SONNET_pwg_dense_residual_rerun.md).
+  Per-key outcomes:
+  - **4 store-missing gam RU keys** (`gam~~h0_zz_pw00`, `gam~~h3_04_upa`, `gam~~h3_06_vini`,
+    `gam~~h3_08_sam`): all 4 **ok** (1 self-healed) → `save_and_audit.py --merge` →
+    `promote_final_cards.py --merge --gen-model-version claude-sonnet-5`; confirmed present
+    in `src/pwg_ru_translated.jsonl` (10,771→10,856 rows).
+  - **en.DA's 7 null cards**: all 7 **ok**, 0 null. ⚠️ **Finding**: `DA` and `dA` are two
+    genuinely **different roots** (safe_names `_d_a` vs `d_a`) — not a case collision as
+    initially suspected; `wf_output.en.DA.json` merged 138→145 cards, matching the known
+    RU `DA` total exactly. 1 **hard flag**: `LS-LOSS` (citation loss) on
+    `_d_a~~h0_56_pra_ri` — logged, not retried (hard-flag-on-non-null-card guidance).
+  - **77 EN residuals**: `en_residual_keys.py` across all 43 EN root stores found only
+    **2** actionable residuals remaining today — the historical "77" (FU1 Phase-1 note) had
+    already been drained by prior sessions. `jYA` (`j_y_a~~h1_00_pwg00`) and `yat`
+    (`yat~~h0_zz_pw`), both **ok** (yat self-healed). 1 new **hard flag**: `SAN-LOSS`
+    (Sanskrit-span loss) on `yat~~h0_zz_pw/r0/s1` — logged, not retried.
+  - **`ka`'s 2 missing heal groups — NOT fixed, deferred.** The handoff's assumption (a
+    retrievable `missing_fragments` id list on the stored `ka` card) does not hold:
+    `HANDOFF_2026-07-02_pwg_selfheal_fixes.md` gap 3 explicitly says `selfHeal`'s inline
+    path never persisted which of `ka`'s 41 groups failed, and no `autosplit_missing_*`
+    sidecar exists for `ka`. `autosplit_requeue.py test ka ka` only offers a fresh
+    **whole-card** 81-fragment split — a de facto full re-run, which this item explicitly
+    ruled out. Deferred to the audit-churn session per this handoff's own guardrail
+    (don't invent a new persistence mechanism ad hoc) — see
+    [OPUS_pwg_audit_churn_fix.md](https://github.com/gasyoun/Uprava/blob/main/handoffs/OPUS_pwg_audit_churn_fix.md).
+    `ka` stays usable at 39/41 groups (~220 senses), incomplete but not wrong.
+  - **EN overlay re-run**: `promote_en.py --gen-model-version claude-sonnet-5` (47 files,
+    after removing 4 scratch pseudo-root `.rerun.json` files I'd left matching the
+    `wf_output.en.*.json` glob — cleanup note for future sessions: extract workflow
+    results to a scratch dir outside the repo, not `wf_output.en.<root>.rerun.json`) +
+    `annotate_dcs_freq.py`. Store: 10,856 rows, 8,574 now carry `en` (up from DA-only),
+    88.6% DCS-compound-matched.
+  - **Verification**: `ru_coverage.py` — 5 roots remain below 90% RU coverage (`d_a` 0%,
+    `As` 80%, `Ap` 87%, 2 cosmetic denominator artifacts) — pre-existing broader backlog,
+    outside this handoff's 5 named groups (all closed).
+  - SAFE backups before every promotion: `pwg_ru_translated.jsonl.SAFE_pre_dense_residual_20260702.keep`,
+    `pwg_ru_translated.jsonl.SAFE_pre_en_overlay_20260702.keep` (plus pre-existing `SAFE_s10_20260702.keep`).
+  - ⚠️ **Noted, not touched**: `src/pilot/gen_opt_harness2.py` carries an uncommitted
+    working-tree diff (SELFHEAL/BINARY_SPLIT/OUTPUT_BUDGET flipped to default-on) that
+    predates this session — out of scope per the "no code changes expected" guardrail;
+    flagging so it isn't lost/accidentally discarded by a future session. (Superseded —
+    this diff is now committed upstream as PR #70, folded into the harness-defaults note
+    above.)
 
 - **Audit-churn fix — QUEUED (Opus/Fable-tier judgment, from S10 2026-07-02).**
   `prompt_rule_audit.has_text_signal()` false positive (`suspicious_attested_without_text_signal`,


### PR DESCRIPTION
## Summary
- Ran [SONNET_pwg_dense_residual_rerun.md](https://github.com/gasyoun/Uprava/blob/main/handoffs/SONNET_pwg_dense_residual_rerun.md) end-to-end (Sonnet 5, `claude-sonnet-5`)
- 4 store-missing gam RU keys: all recovered, merged into `pwg_ru_translated.jsonl` (10,771→10,856 rows)
- en.DA's 7 null cards: all recovered (0 null); confirmed `DA`/`dA` are genuinely different roots, not a case collision
- 77 EN residuals: only 2 real actionable residuals remained today (jYA, yat) — both recovered
- EN overlay re-run: `promote_en.py` + `annotate_dcs_freq.py` (8,574/10,856 rows now carry `en`)
- `ka`'s 2 missing heal groups: investigated, found no retrievable missing-fragment mechanism exists — deferred to the audit-churn handoff rather than inventing one ad hoc
- 2 new hard flags logged (`LS-LOSS`, `SAN-LOSS`) for future review, not blindly retried

Docs-only PR — `RussianTranslation/.ai_state.md` updated with full per-key outcomes. No code changes.

## Test plan
- [x] `ru_coverage.py` clean run, no regressions vs pre-existing backlog
- [x] All 4 gam RU keys + 7 en.DA keys + 2 EN residual keys confirmed present in their stores
- [x] SAFE backups taken before every store promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)