### PR TITLE
docs: DharmaMitra 5-persona audience framework in learner-layer Q4 plan

### DIFF
--- a/ROADMAP_2026_2027.md
+++ b/ROADMAP_2026_2027.md
@@ -96,7 +96,7 @@ What is genuinely new versus existing DH lexicography (ELEXIS, Lexonomy, TEI Lex
 
 ### Q4 2026 (Oct–Dec) — *Sense inheritance + learner's layer v1*
 1. **P2 written and submitted** (R2 data is restored and reproducible; checkpoint rows now adjudicated by the pool).
-2. **Learner's reading layer v1** in csl-atlas: DCS frequency bands (VisualDCS adapter contract: `dcs_lemma_summary.json`) joined to lemma-lookup + dossier; per-lemma card = frequency band, best-attested senses (survival-ranked from P2 data), Whitney root + gaṇa, paradigm-browser link. Ship as a public page.
+2. **Learner's reading layer v1** in csl-atlas: DCS frequency bands (VisualDCS adapter contract: `dcs_lemma_summary.json`) joined to lemma-lookup + dossier; per-lemma card = frequency band, best-attested senses (survival-ranked from P2 data), Whitney root + gaṇa, paradigm-browser link. Ship as a public page. *Audience personas (adopted 02-07-2026 from the DharmaMitra workshop intake form — [analysis](https://github.com/gasyoun/VisualDCS/blob/main/non-derived/Pre-Workshop_Questionnaire_ANALYSIS.md)): professional/published translator · academic/researcher · student · practitioner translating for practice · hobbyist/independent learner — the practitioner and hobbyist segments are first-class users of this layer, not an afterthought; actual segment sizes pending DharmaMitra's aggregated form results (MG asks at the workshop, GTD @DO).*
 3. **TEI Lex-0 pilot (G2)** in csl-standards: MW sample + SKD sample exported and schema-validated; documents what the indigenous apparatus needs that Lex-0 lacks (itself publishable as a note).
 4. **Book proposal drafted** (synopsis + P1/P2 as sample chapters).
 


### PR DESCRIPTION
Adopts the translator-persona framework from the DharmaMitra workshop intake form into [ROADMAP_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_2026_2027.md) Q4 2026 item 2 (learner's reading layer v1), per MG decision 02-07-2026: professional translator / academic / student / practitioner / hobbyist — practitioner + hobbyist are first-class users of the layer. Actual segment sizes pending DharmaMitra's aggregated questionnaire results (MG asks at the workshop — GTD @DO in [Uprava/GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md)).

Background: [Pre-Workshop_Questionnaire_ANALYSIS.md](https://github.com/gasyoun/VisualDCS/blob/main/non-derived/Pre-Workshop_Questionnaire_ANALYSIS.md) + [Uprava FINDINGS SS14](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md).

Model: Fable 5 (`claude-fable-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)