### PR TITLE
docs(pwg): state sync — re-run EXECUTED, calibration handoff re-homed

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -25,20 +25,23 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   `--no-binary-split` / `--output-budget=off` restore old behavior; `--selfheal` /
   `--binary-split` accepted as no-ops so all queued runbooks work verbatim.
   `window_selftest.py` 17/17 PASS, `node --check` PASS, presplit + byte-mode + defaults
-  smoke-verified on vas/gam. The queued dense-residual handoff now also carries the
-  **knob calibration step** (MG: fold in): A/B `--output-budget` 60 vs ~90 and
-  `HEAD_CIT_BATCH_BUDGET` 8–10 vs 18 on one giant head, findings → the hubs.
+  smoke-verified on vas/gam. The **knob calibration A/B** (MG: approved 02-07) got its own
+  handoff — the dense-residual session it was to be folded into had already executed:
+  `AUTOSPLIT_LS_BUDGET` 18 vs 10 on the 150-`<ls>` gam head + `--output-budget` 60 vs 90 on
+  a medium root, findings → the hubs, defaults-PR only on a clear win.
+  **Start (Sonnet chat in this repo):** `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\SONNET_pwg_knob_calibration.md and execute it.`
+  ([handoff file](https://github.com/gasyoun/Uprava/blob/main/handoffs/SONNET_pwg_knob_calibration.md))
 
-- **Dense-residual re-run through the fixed stack — QUEUED (Sonnet-tier, mechanical,
-  from S10 2026-07-02).** After S10's PRs [#63](https://github.com/gasyoun/SanskritLexicography/pull/63)–[#67](https://github.com/gasyoun/SanskritLexicography/pull/67)
-  merge: re-run with `--selfheal --binary-split --output-budget=60`, ≤3-wide — the
-  remaining store-missing RU keys (`gam~~h0_zz_pw00`, `gam~~h3_04_upa`, `gam~~h3_06_vini`,
-  `gam~~h3_08_sam`; the 4 vas siblings were live-run in S10 itself — see WIP), `en.DA`'s 7
-  nulls, the 77 EN residuals, and `ka`'s 2 missing groups (now targetable via the
-  `missing_fragments` ids). Then `promote_final_cards.py --merge` + re-run `promote_en.py`
-  (the S7 leftover — EN layer currently on DA only).
-  **Start (Sonnet chat in this repo):** `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\SONNET_pwg_dense_residual_rerun.md and execute it.`
-  ([handoff file](https://github.com/gasyoun/Uprava/blob/main/handoffs/SONNET_pwg_dense_residual_rerun.md))
+- ~~**Dense-residual re-run through the fixed stack — QUEUED**~~ **✅ EXECUTED 2026-07-02
+  (Sonnet 5, `claude-sonnet-5`) — recorded in the GTD hub; this queue item was stale.**
+  Outcome per [`Uprava/GTD_NEXT_ACTIONS.md`](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md)
+  Agent-Ready: 4 gam RU keys + `en.DA`'s 7 nulls + the 2 real remaining EN residuals
+  (jYA, yat — the historical "77" was already drained) all **ok**; EN overlay re-run
+  (`promote_en.py` + `annotate_dcs_freq.py`; store 8,574/10,856 rows carry `en` — closes
+  the S7 leftover). 2 new hard flags logged, not retried (`LS-LOSS` on
+  `_d_a~~h0_56_pra_ri`, `SAN-LOSS` on `yat~~h0_zz_pw/r0/s1`). `ka`'s 2 missing heal groups
+  NOT fixed — folded into the audit-churn session (needs missing-fragment persistence).
+  The handoff file carries a SPENT banner — do not re-execute.
 
 - **Audit-churn fix — QUEUED (Opus/Fable-tier judgment, from S10 2026-07-02).**
   `prompt_rule_audit.has_text_signal()` false positive (`suspicious_attested_without_text_signal`,
@@ -52,7 +55,7 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   ([handoff file](https://github.com/gasyoun/Uprava/blob/main/handoffs/OPUS_pwg_audit_churn_fix.md))
 
 - **S7 quality follow-through — QUEUED as its own handoff (MG decision 2026-07-02;
-  runs AFTER re-run → churn-fix, per the locked order).** The two S7 judge
+  runs AFTER the churn-fix — the re-run leg of the locked order is already ✅).** The two S7 judge
   recommendations that neither queued session owns: (a) deterministic `{%..%}`
   pair-count soft flag in the audit (dropped German-echo markers = the dominant
   residual: RU 17/50 cards, EN 32/68 rows, systematic on the EN path); (b) prompt


### PR DESCRIPTION
Follow-up to [PR #70](https://github.com/gasyoun/SanskritLexicography/pull/70). The dense-residual re-run executed on 02-07 (Sonnet 5 `claude-sonnet-5`) but recorded its outcome only in the [Uprava GTD hub](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md) — the [.ai_state.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md) queue item was stale and could have triggered a duplicate re-run. This PR:

- flips the dense-residual queue item to ✅ EXECUTED with the GTD-recorded outcome (2 new hard flags; `ka` folded into the audit-churn session)
- re-homes the knob-calibration A/B to [SONNET_pwg_knob_calibration.md](https://github.com/gasyoun/Uprava/blob/main/handoffs/SONNET_pwg_knob_calibration.md) (its intended host session had already run)
- updates the S7-quality item's sequencing (now: after churn-fix only)

Model: Fable 5 (`claude-fable-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)