### PR TITLE
FL5: kill unclearable audit-churn — text-signal redesign, report-only by construction

### DIFF
--- a/RussianTranslation/AUDIT_CHURN_FL5.md
+++ b/RussianTranslation/AUDIT_CHURN_FL5.md
@@ -1,0 +1,75 @@
+# FL5 — what "text signal" means for an attested sense, and why the churn happened
+
+_Created: 02-07-2026 · Last updated: 02-07-2026_
+
+Companion to the S10 audit
+[`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md)
+§3 (flag **FL5**) and the run-log finding
+[`RUN_LOG.md` F-gate-nws-fp](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_LOG.md).
+Model: Opus 4.8 (`claude-opus-4-8`).
+
+## The symptom
+
+`suspicious_attested_without_text_signal` was **66 % of round-2 semantic risks** and drove
+**2,152 key-requeues on 2026-06-29 alone** — requeues that **no re-translation can clear**
+(`pw01` scored *worse* on a clean re-run, 810→1430, purely from emit-noise). It was the
+single largest audit-side failure generator last week — more churn than every real
+translation failure combined.
+
+## Why the flag fired falsely
+
+The check in
+[`prompt_rule_audit.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/prompt_rule_audit.py)
+fires when a sense is `source_type=attested` but `has_text_signal()` finds no grounding.
+Originally "text signal" meant **only** a literary citation (`<ls>`, ṚV, MBH, Manu, …) or a
+non-empty `stratum`. Two whole classes of legitimate attested sense carry neither:
+
+1. **Owner-cited NWS senses** (`[NWS: Graßmann 1873 (1996) : 81]`, `MW : 47`) — grounding
+   lives in `equivalence_type`, which the citation scan skipped. *(Fixed in S10 — owner
+   citations + a card-level signal now suppress the per-sense flag.)*
+2. **Senses that assert no meaning at all** — pure cross-references
+   (`{#paryanu#} <ab>s.</ab> {#paryanubanDa#}` = "paryanu, see paryanubandha"),
+   editorial errata (`<ab>Z.</ab> 3 lies … <info n="rev"/>` = "line 3 read X instead of Y"),
+   and structural headers (desiderative / preverb headers). These have **nothing to cite** —
+   there is no attested *meaning* in a redirect — so "no text signal" is expected, not
+   suspicious. A redirect can never acquire a citation, so the requeue loop was unwinnable
+   by construction.
+
+## The redesign (this PR)
+
+**A "text signal" for an attested sense is now any of:** a literary citation, a non-empty
+`stratum`, an NWS owner citation, **or a lexicographic citation** (Amara / Pāṇini / Medinī /
+kośa …). A lexicographic attribution *is* textual grounding for an attested meaning, so it
+counts. The card-level suppressor was widened the same way.
+
+**And the flag only fires on a sense that makes a translatable meaning claim** — operationally,
+a sense that carries a `{%…%}` gloss span, the pipeline's own marker for "this German is a
+gloss to render." A sense with no gloss span asserts no meaning and is therefore exempt.
+
+The flag stays **report-only**: it is a review hint, never a requeue trigger. This is now
+enforced structurally — `suspicious_attested_without_text_signal` sits in a new
+`REPORT_ONLY_RISKS` set with a module-load invariant that it can never intersect
+`HIGH_CONFIDENCE_RISKS` (the only set the requeue list is built from). If a future edit
+promotes it to high-confidence, the import fails loudly instead of silently re-arming the
+churn loop.
+
+## Validation against known-good cards
+
+Measured across the **39 Slice-C `wf_output.sc.*.json`** files (1,128 cards, 5,857 attested
+senses):
+
+| | fires | nature of the fires |
+|---|---:|---|
+| before this PR (post-S10 card-level fix) | **37** | 21 pure cross-references + 16 errata / connective-only fragments — all noise |
+| after this PR | **6** | every one a genuine `{%…%}` meaning gloss marked attested with **no** citation — the real review target |
+
+The requeue set is provably unchanged. Same-base before/after on
+[`wf_output.sc.pat.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/wf_output.sc.pat.json):
+suspicious fires **7 → 3**, review-queue keys **26 → 24**, requeue set **byte-identical**
+(12 keys). On `wf_output.sc.vas.json` (already clean of this flag) everything is identical.
+
+`src/pilot/window_selftest.py` gains `test_report_only_risks_never_requeue` and
+`test_attested_text_signal_redesign` (cross-ref / erratum never fire; lexicographic citation
+counts; a genuine uncited meaning gloss still surfaces). Full suite green (19/19).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/prompt_rule_audit.py
+++ b/RussianTranslation/src/pilot/prompt_rule_audit.py
@@ -147,6 +147,24 @@ HIGH_CONFIDENCE_RISKS = {
     'foreign_gloss_translated',
 }
 
+# Review-only hints: heuristic semantic flags that surface a card for a HUMAN to eyeball
+# but must NEVER drive a mechanical requeue. Rationale (F-gate-nws-fp, 2026-06-29): the
+# source_type-vs-signal checks are soft cross-checks on a model self-label; a re-translation
+# cannot deterministically clear them, so requeueing on them burns quota on an unclearable
+# loop (2,152 key-requeues on 06-29 alone). The requeue set is built from HIGH_CONFIDENCE_RISKS
+# only (see audit_cards.requeue_keys), so membership here is enforced to stay disjoint from it
+# at module load: if a future edit promotes one of these to high-confidence, this invariant
+# fails loudly instead of silently re-arming the churn loop.
+REPORT_ONLY_RISKS = frozenset({
+    'suspicious_attested_without_text_signal',
+    'suspicious_lexicographic_with_text_signal',
+    'possible_sense_compression',
+    'missing_apresjan_discrimination',
+})
+assert not (REPORT_ONLY_RISKS & HIGH_CONFIDENCE_RISKS), (
+    'REPORT_ONLY_RISKS must never drive a requeue: %s'
+    % ', '.join(sorted(REPORT_ONLY_RISKS & HIGH_CONFIDENCE_RISKS)))
+
 LIVE_MANUAL_COVERAGE = [
     'Apresjan',
     'Hartmann',
@@ -363,6 +381,23 @@ def has_lexicographic_signal(sense):
     return bool(LEXICOGRAPHIC_CITATION.search(citation_blob(sense)))
 
 
+# A translatable meaning claim is marked in the source by a {%...%} gloss span — the
+# pipeline's own convention for "this German is a gloss to render into Russian" (see
+# RETAINED_SPAN / pwg_mask). A sense with NO gloss span asserts no meaning: it is a pure
+# cross-reference ({#x#} <ab>s.</ab> {#y#}), an editorial erratum (<ab>Z.</ab> N lies ...,
+# <info n="rev"/>), or a structural header (desid-/preverb header). Such a sense CANNOT be
+# "attested without text signal" — there is no attested meaning to cite — so the
+# suspicious_attested_without_text_signal hint is gated on this. Measured on the 39 Slice-C
+# known-good wf_output files this cut the flag from 37 fires (all cross-ref/erratum noise)
+# to 6, each a genuine meaning gloss lacking a citation (see AUDIT_CHURN_FL5 memo).
+GLOSS_SPAN = re.compile(r'\{%.*?%\}', re.S)
+
+
+def makes_meaning_claim(sense):
+    """True if the sense carries a {%...%} gloss span, i.e. asserts a translatable meaning."""
+    return bool(GLOSS_SPAN.search(sense.get('german') or ''))
+
+
 def formula_missing(german, russian):
     joined = norm_text(german)
     ru = norm_text(russian)
@@ -511,7 +546,8 @@ def semantic_risks(card_like):
     all_card_senses = [s for rec in (card.get('records') or [])
                        for s in (rec.get('senses') or []) if isinstance(s, dict)]
     card_has_text_signal = any(
-        s.get('source_type') == 'attested' and has_text_signal(s)
+        s.get('source_type') == 'attested'
+        and (has_text_signal(s) or has_lexicographic_signal(s))
         for s in all_card_senses
     )
     for record in card.get('records') or []:
@@ -564,9 +600,18 @@ def semantic_risks(card_like):
                          'fixed śāstric formula appears without expected Russian rendering',
                          tag=tag)
             source_type = sense.get('source_type')
-            if source_type == 'attested' and not has_text_signal(sense) and not card_has_text_signal:
+            # Fire only on a sense that actually asserts a meaning (has a {%...%} gloss span)
+            # yet shows no grounding — literary citation, stratum, NWS owner citation, or a
+            # lexicographic attribution (Amara/Pāṇini/…), any of which counts as a text signal
+            # for an attested meaning. Cross-references / errata / headers make no meaning
+            # claim, so their lack of a citation is expected, not suspicious. REPORT-ONLY: this
+            # is a review hint, never a requeue trigger (see REPORT_ONLY_RISKS).
+            if (source_type == 'attested' and makes_meaning_claim(sense)
+                    and not has_text_signal(sense) and not has_lexicographic_signal(sense)
+                    and not card_has_text_signal):
                 add_risk(risks, 'suspicious_attested_without_text_signal',
-                         'source_type=attested but no text citation or stratum signal found',
+                         'attested meaning gloss without any citation/stratum/lexicographic/'
+                         'owner signal — REVIEW ONLY, not a requeue',
                          tag=tag)
             if source_type == 'lexicographic' and has_text_signal(sense) and not has_lexicographic_signal(sense):
                 add_risk(risks, 'suspicious_lexicographic_with_text_signal',

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -236,7 +236,7 @@ def test_semantic_risk_checker():
                     'differentia': '',
                 }, {
                     'tag': '3',
-                    'german': 'Schein',
+                    'german': '{%Schein%}',
                     'russian': 'agni der',
                     'equivalence_type': 'equivalent',
                     'source_type': 'attested',
@@ -474,6 +474,9 @@ def test_semantic_review_prioritizer():
 
 
 def test_noisy_source_type_not_requeue():
+    # A sense that DOES assert a meaning ({%..%} gloss span) but is marked attested with no
+    # citation/stratum/lexicographic signal is the genuine review target — it must produce
+    # the hint yet never enter the requeue set (REPORT_ONLY_RISKS, F-gate-nws-fp).
     noisy = {
         'key': 'noisy',
         'card': {
@@ -484,7 +487,7 @@ def test_noisy_source_type_not_requeue():
                 'grammar': 'm.',
                 'senses': [{
                     'tag': '1',
-                    'german': 'Glanz',
+                    'german': '{%Glanz%}',
                     'russian': 'блеск',
                     'equivalence_type': 'equivalent',
                     'source_type': 'attested',
@@ -506,6 +509,61 @@ def test_noisy_source_type_not_requeue():
             fail('source-type review hint became high-confidence/requeue')
     finally:
         os.remove(path)
+
+
+def test_report_only_risks_never_requeue():
+    """The report-only semantic hints must be structurally barred from the requeue set:
+    disjoint from HIGH_CONFIDENCE_RISKS (the only thing requeue_keys is built from)."""
+    from prompt_rule_audit import HIGH_CONFIDENCE_RISKS, REPORT_ONLY_RISKS
+    overlap = REPORT_ONLY_RISKS & HIGH_CONFIDENCE_RISKS
+    if overlap:
+        fail('REPORT_ONLY_RISKS leaked into the requeue-driving set: %s'
+             % ', '.join(sorted(overlap)))
+    if 'suspicious_attested_without_text_signal' not in REPORT_ONLY_RISKS:
+        fail('suspicious_attested_without_text_signal must be report-only')
+
+
+def test_attested_text_signal_redesign():
+    """FL5 redesign of suspicious_attested_without_text_signal:
+    - a pure cross-reference / erratum sense (no {%..%} gloss span) never fires, even with
+      no card-level signal (it asserts no meaning to attest);
+    - a lexicographic citation counts as a text signal for an attested meaning;
+    - a real meaning gloss ({%..%}) marked attested with zero signal still fires (kept)."""
+    def ids_for(sense):
+        card = {'key': 'x', 'card': {'key1': 'x', 'iast': 'x', 'records': [
+            {'h': '1', 'grammar': 'verb', 'senses': [sense]}]}}
+        return {r['id'] for r in semantic_risks(card)}
+
+    FLAG = 'suspicious_attested_without_text_signal'
+
+    # 1) Cross-reference sense: {#paryanu#} <ab>s.</ab> {#paryanubanDa#} — no gloss span.
+    crossref = {'tag': '1', 'german': '<div n="p">— {#paryanu#} <ab>s.</ab> {#paryanubanDa#} .',
+                'russian': '<div n="p">— {#paryanu#} <ab>s.</ab> {#paryanubanDa#} .',
+                'equivalence_type': 'explanatory', 'source_type': 'attested',
+                'stratum': '', 'differentia': ''}
+    if FLAG in ids_for(crossref):
+        fail('cross-reference sense (no meaning claim) wrongly flagged as attested-without-signal')
+
+    # 2) Erratum sense: <ab>Z.</ab> 3 lies ... — no gloss span, editorial correction.
+    erratum = {'tag': 'corr', 'german': '<hom>1.</hom> {#nI#}¦ <ab>Z.</ab> 19. Lies: 3 <ab>st.</ab> 8.<info n="rev"/>',
+               'russian': 'читай: 3 вместо 8', 'equivalence_type': 'explanatory',
+               'source_type': 'attested', 'stratum': '', 'differentia': ''}
+    if FLAG in ids_for(erratum):
+        fail('erratum sense (no meaning claim) wrongly flagged as attested-without-signal')
+
+    # 3) Lexicographic citation grounds an attested meaning gloss -> no flag.
+    lexcite = {'tag': '1', 'german': 'Amarakośa: {%Stern%}', 'russian': 'звезда',
+               'equivalence_type': 'equivalent', 'source_type': 'attested',
+               'stratum': '', 'differentia': ''}
+    if FLAG in ids_for(lexcite):
+        fail('attested meaning with a lexicographic citation wrongly flagged')
+
+    # 4) Genuine target survives: a {%..%} meaning gloss, attested, with no signal at all.
+    genuine = {'tag': '1', 'german': '<lex>adj.</lex> {%sich rasch bewegend, eilend%}',
+               'russian': '<lex>adj.</lex> {%быстро движущийся%}', 'equivalence_type': 'equivalent',
+               'source_type': 'attested', 'stratum': '', 'differentia': ''}
+    if FLAG not in ids_for(genuine):
+        fail('a genuine attested meaning gloss without any signal must still surface the hint')
 
 
 def test_nws_fp_suppressed():
@@ -688,6 +746,8 @@ def main():
         test_german_connective_fix,
         test_semantic_review_prioritizer,
         test_noisy_source_type_not_requeue,
+        test_report_only_risks_never_requeue,
+        test_attested_text_signal_redesign,
         test_nws_fp_suppressed,
         test_stale_refusal_preserves_requeue,
         test_release_manifest_hash_validation,


### PR DESCRIPTION
Closes the biggest **audit-side** failure generator from the S10 architecture audit ([`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) §3, flag **FL5**). Model: **Opus 4.8 (`claude-opus-4-8`)**.

## Problem
`suspicious_attested_without_text_signal` was **66 % of round-2 semantic risks** and drove **2,152 key-requeues on 2026-06-29** that *no re-translation can clear* — a redirect / erratum has no meaning to cite, so the requeue loop was unwinnable by construction (`pw01` scored *worse* on a clean re-run, 810→1430, purely from emit-noise).

## What "text signal" should measure (the semantics call)
A **text signal** for an attested sense is now any of: a literary citation, a non-empty `stratum`, an NWS owner citation, **or a lexicographic citation** (Amara / Pāṇini / Medinī / kośa) — a lexicographic attribution *is* textual grounding for an attested meaning.

And the flag now fires **only on a sense that makes a translatable meaning claim** (a `{%…%}` gloss span — the pipeline's own meaning marker). Pure cross-references (`{#paryanu#} <ab>s.</ab> {#paryanubanDa#}`), editorial errata (`<ab>Z.</ab> 3 lies … <info n="rev"/>`), and structural headers assert no meaning, so their lack of a citation is expected, not suspicious.

Full reasoning: [`RussianTranslation/AUDIT_CHURN_FL5.md`](https://github.com/gasyoun/SanskritLexicography/blob/fix/fl5-text-signal-report-only/RussianTranslation/AUDIT_CHURN_FL5.md).

## Report-only, guaranteed structurally
New `REPORT_ONLY_RISKS` set + a **module-load invariant** that it can never intersect `HIGH_CONFIDENCE_RISKS` (the only set the requeue list is built from). If a future edit promotes the flag to high-confidence, the import fails loudly instead of silently re-arming the churn loop.

## Validation on known-good cards (39 Slice-C files, 1,128 cards, 5,857 attested senses)
| | fires | nature |
|---|---:|---|
| before (post-S10 card-level fix) | **37** | 21 cross-refs + 16 errata/connective-only — all noise |
| after | **6** | each a genuine `{%…%}` meaning gloss marked attested with no citation |

**Requeue set provably unchanged.** Same-base before/after on `wf_output.sc.pat.json`: suspicious fires **7 → 3**, review-queue keys **26 → 24**, requeue set **byte-identical** (12 keys). `wf_output.sc.vas.json` fully identical.

## Tests
`window_selftest.py` **19/19 green** (real runtime data), with two new pinning tests: `test_report_only_risks_never_requeue` and `test_attested_text_signal_redesign` (cross-ref/erratum never fire; lexicographic citation counts; a genuine uncited meaning gloss still surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)