### PR TITLE
FL2: give the EN audit gate teeth — nulls/crash fail --strict, strict-by-default in save

### DIFF
--- a/RussianTranslation/save_and_audit.py
+++ b/RussianTranslation/save_and_audit.py
@@ -85,10 +85,16 @@ def main():
     if "--no-audit" in flags:
         return
     # The RU gate (audit_window.py) is .merged.md/RU-specific; the EN track has its own
-    # report-only sibling that audits the wf_output.en.*.json per-sense english fields.
+    # sibling that audits the wf_output.en.*.json per-sense english fields.
     if tag == "en":
+        # Strict-by-default in the save path (FL2): a null/hard/crashed gate must fail the
+        # save rather than slide through as report-only. A machine-readable report is always
+        # written. Pass --lenient to save an EN window without gating.
         audit = os.path.join(HERE, "src", "pilot", "audit_window_en.py")
-        cmd = [sys.executable, audit, out_path]
+        report_path = os.path.join(HERE, "src", "pilot", "output", f"audit_en.{root}.report.json")
+        cmd = [sys.executable, audit, out_path, "--report", report_path]
+        if "--lenient" not in flags:
+            cmd.append("--strict")
     else:
         audit = os.path.join(HERE, "src", "pilot", "audit_window.py")
         cmd = [sys.executable, audit, out_path, "--root", root]

--- a/RussianTranslation/src/pilot/audit_window_en.py
+++ b/RussianTranslation/src/pilot/audit_window_en.py
@@ -31,7 +31,9 @@ Gates (per non-null card -> record -> sense, comparing `german` vs `english`):
                (soft cross-check against Monier-Williams, the gold MG chose)
 
 Report-only by default (exit 0). `--strict` exits non-zero if any HARD gate
-(LS/SAN/AB/MISSING-EN/DUP) fires; the soft semantic flags never fail the gate.
+(LS/SAN/AB/MISSING-EN/DUP) fires, if any card came back null (missing EN), or if the
+sense-dupe subgate crashed (a crash is NOT a clean pass); the soft semantic flags never
+fail the gate. Failure reasons are printed and written to `--report`.
 
   python src/pilot/audit_window_en.py wf_output.en.pat.json
   python src/pilot/audit_window_en.py wf_output.en.*.json --strict
@@ -247,7 +249,8 @@ def main():
     ap.add_argument('wf_output', nargs='+',
                     help='one or more wf_output.en.<root>.json files (globs allowed)')
     ap.add_argument('--strict', action='store_true',
-                    help='exit non-zero if any HARD gate (LS/SAN/AB/MISSING-EN/DUP) fires')
+                    help='exit non-zero on any HARD gate (LS/SAN/AB/MISSING-EN/DUP), '
+                         'any null card, or a crashed sense-dupe subgate')
     ap.add_argument('--mw-tm', default=DEFAULT_MW_TM,
                     help='MW translation-memory JSON for the soft cross-check (default: src/mw_en_tm.json)')
     ap.add_argument('--no-mw', action='store_true', help='skip the MW divergence cross-check')
@@ -273,6 +276,8 @@ def main():
     flag_counts = {}
     per_file = []
     hard_keys = set()
+    null_keys = []            # keys that came back with no card (missing EN translation)
+    crashed_files = []        # files where the sense-dupe subgate could not run -> NOT clean
     for path in paths:
         if not os.path.exists(path):
             print('(skip: %s not found)' % path, file=sys.stderr)
@@ -285,6 +290,7 @@ def main():
             row = audit_card(res, tm, do_mw)
             if row['null']:
                 totals['null'] += 1
+                null_keys.append(row.get('key') or '?')
                 continue
             totals['cards'] += 1
             for loc, fl in row['flags']:
@@ -299,7 +305,11 @@ def main():
         # language), so the existing RU tool runs unchanged on the EN wf_output. Called
         # in-process (see run_sense_dupes) to avoid a subprocess spawn per file.
         sd = run_sense_dupes(sense_dupes_mod, path)
-        if sd['returncode']:
+        if sd['returncode'] is None:
+            # A crash / unavailable subgate is NOT a clean pass — record it so --strict fails
+            # instead of a green light on an un-run gate (FL2: "crash != clean").
+            crashed_files.append(os.path.basename(path))
+        elif sd['returncode']:
             flag_counts['SENSE-DUPE'] = flag_counts.get('SENSE-DUPE', 0) + 1
 
         per_file.append({'file': os.path.basename(path), 'flags': file_flags, 'sense_dupe': sd})
@@ -321,15 +331,36 @@ def main():
         print('  no flags')
     hard_total = sum(v for k, v in flag_counts.items() if is_hard(k))
     print('hard flags   : %d  (cards: %d)' % (hard_total, len(hard_keys)))
+    if null_keys:
+        print('null cards   : %d (missing EN — %s%s)' % (
+            len(null_keys), ', '.join(null_keys[:8]), ', ...' if len(null_keys) > 8 else ''))
+    if crashed_files:
+        print('crashed gates: sense-dupe could not run on %s' % ', '.join(crashed_files))
+
+    # --strict must fail on a HARD gate, a null card (missing translation), OR a crashed
+    # subgate — each is a reason the window is not verified clean. Report the reasons.
+    strict_reasons = []
+    if hard_total:
+        strict_reasons.append('%d hard flag(s)' % hard_total)
+    if null_keys:
+        strict_reasons.append('%d null card(s)' % len(null_keys))
+    if crashed_files:
+        strict_reasons.append('%d crashed sense-dupe gate(s)' % len(crashed_files))
 
     if args.report:
+        os.makedirs(os.path.dirname(os.path.abspath(args.report)), exist_ok=True)
         rep = {'totals': totals, 'flag_counts': flag_counts,
-               'hard_keys': sorted(hard_keys), 'files': per_file}
+               'hard_keys': sorted(hard_keys), 'null_keys': null_keys,
+               'crashed_files': crashed_files, 'strict_reasons': strict_reasons,
+               'files': per_file}
         with open(args.report, 'w', encoding='utf-8') as f:
             json.dump(rep, f, ensure_ascii=False, indent=1)
         print('report json  : %s' % args.report)
 
-    sys.exit(1 if (args.strict and hard_total) else 0)
+    if args.strict and strict_reasons:
+        print('STRICT FAIL   : %s' % '; '.join(strict_reasons))
+        sys.exit(1)
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -730,6 +730,36 @@ def test_export_translation_dedup():
         fail('each translation sense must be labelled by its store homonym')
 
 
+def test_en_gate_strict_has_teeth():
+    """FL2: the EN gate's --strict must FAIL on a null card (missing EN) and write a report;
+    report-only (no --strict) must still exit 0. A null card used to slide through clean."""
+    fixture = {'meta': {'root': 'zz'}, 'results': [
+        {'key': 'zz~~h0_00_pwg00', 'card': {'iast': 'zz', 'records': [
+            {'h': '1', 'senses': [{'tag': '1', 'german': '{%Wasser%}', 'english': 'water'}]}]}},
+        {'key': 'zz~~h0_01_pwg01', 'card': None},
+    ]}
+    with tempfile.NamedTemporaryFile('w', encoding='utf-8', suffix='.json', delete=False) as f:
+        wf_path = f.name
+        json.dump(fixture, f, ensure_ascii=False)
+    report_path = wf_path + '.report.json'
+    en_audit = os.path.join(HERE, 'audit_window_en.py')
+    try:
+        # report-only: exit 0 even with a null card
+        run([sys.executable, en_audit, wf_path, '--no-mw'], expect=0)
+        # strict: null card must fail, and the report must record it
+        run([sys.executable, en_audit, wf_path, '--no-mw', '--strict', '--report', report_path],
+            expect=1)
+        rep = json.load(open(report_path, encoding='utf-8'))
+        if 'zz~~h0_01_pwg01' not in (rep.get('null_keys') or []):
+            fail('EN gate report did not record the null key')
+        if not rep.get('strict_reasons'):
+            fail('EN gate report did not record a strict failure reason')
+    finally:
+        os.remove(wf_path)
+        if os.path.exists(report_path):
+            os.remove(report_path)
+
+
 def main():
     tests = [
         test_workflow_payload_nested,
@@ -749,6 +779,7 @@ def main():
         test_report_only_risks_never_requeue,
         test_attested_text_signal_redesign,
         test_nws_fp_suppressed,
+        test_en_gate_strict_has_teeth,
         test_stale_refusal_preserves_requeue,
         test_release_manifest_hash_validation,
     ]


### PR DESCRIPTION
Fixes flag **FL2** from the S10 audit ([`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) §3). Model: **Opus 4.8 (`claude-opus-4-8`)**.

## Problem — the EN gate had no teeth
- `audit_window_en.py --strict` exited non-zero only on **hard flags**; a **null card** (missing EN translation) and a **crashed sense-dupe subgate** (`run_sense_dupes` returns `returncode: None`, which is falsy) both counted as a **clean pass**.
- [`save_and_audit.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/save_and_audit.py) invoked the EN gate **non-strict with no `--report`**, so the save path never gated and left no machine-readable trail.

## Fix
- `--strict` now fails on any **HARD gate**, any **null card**, **or** a **crashed subgate** — a crash is not a clean pass. Each reason is printed (`STRICT FAIL: …`) and written to `--report` as `null_keys` / `crashed_files` / `strict_reasons`.
- `save_and_audit.py` runs the EN gate **strict-by-default** and **always writes a report** (`src/pilot/output/audit_en.<root>.report.json`); pass `--lenient` to save an EN window without gating.
- The report's parent dir is created before writing.

## Before / after (synthetic wf_output.en: 1 clean card + 1 null card)
| | `--strict` exit | report-only exit |
|---|---:|---:|
| origin/master | **0** (null slid through) | 0 |
| this PR | **1** (`STRICT FAIL: 1 null card(s)`, null key recorded) | 0 |

## Tests
`window_selftest.py` **18/18 green** (real runtime data), new `test_en_gate_strict_has_teeth` pins: report-only exits 0 on a null; `--strict` exits 1 and records the null key + reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)