### PR TITLE
FL3: wire ru_coverage into save path; stop silent exemption on missing denominator

### DIFF
--- a/RussianTranslation/save_and_audit.py
+++ b/RussianTranslation/save_and_audit.py
@@ -102,6 +102,18 @@ def main():
         print(f"({os.path.basename(audit)} not found — saved only)")
         return
     p = subprocess.run(cmd, text=True, encoding="utf-8")
+
+    # RU path: also run the anti-silent-partial coverage gate for this root (FL3). Advisory
+    # (--warn-only) because it reads the promoted store (pwg_ru_translated.jsonl), which this
+    # save has not updated yet — so it reflects the root's CURRENT store completeness and
+    # surfaces a known-partial or unverifiable root (the gam 6/127 blind spot) without failing
+    # the save. A corrupt/missing EN denominator is reported loudly, never silently exempted.
+    if tag != "en":
+        cov = os.path.join(HERE, "src", "pilot", "ru_coverage.py")
+        if os.path.exists(cov):
+            print("\n=== RU coverage (advisory, current store) ===")
+            subprocess.run([sys.executable, cov, "--root", root, "--warn-only"],
+                           text=True, encoding="utf-8")
     sys.exit(p.returncode)
 
 

--- a/RussianTranslation/src/pilot/ru_coverage.py
+++ b/RussianTranslation/src/pilot/ru_coverage.py
@@ -45,26 +45,42 @@ def ru_by_root():
 
 
 def intended_by_root():
-    """root -> set(sub-card keys) from each EN store's meta.selected_keys (the rootmap set)."""
+    """root -> set(sub-card keys) from each EN store's meta.selected_keys (the rootmap set).
+
+    Returns (intended, corrupt): `corrupt` is [(root, error)] for EN files that exist but do
+    not parse. A corrupt denominator MUST NOT silently drop the root (that is the exact blind
+    spot that hid gam 6/127) — the caller surfaces it loudly and fails."""
     out = {}
+    corrupt = []
     for fp in glob.glob(os.path.join(REPO, 'wf_output.en.*.json')):
         root = os.path.basename(fp).replace('wf_output.en.', '').replace('.json', '')
         try:
             d = json.load(open(fp, encoding='utf-8'))
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError) as e:
+            corrupt.append((root, str(e)))
             continue
         out[root] = set(d.get('meta', {}).get('selected_keys') or [])
-    return out
+    return out, corrupt
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--min', type=float, default=90.0, help='fail if any root RU%% below this')
     ap.add_argument('--keys', metavar='ROOT', help='print the missing RU sub-card keys for ROOT')
+    ap.add_argument('--root', metavar='ROOT', help='restrict the coverage report to one root')
+    ap.add_argument('--warn-only', action='store_true',
+                    help='advisory mode: print coverage but always exit 0 (used by save_and_audit)')
+    ap.add_argument('--strict-denominator', action='store_true',
+                    help='also fail when a root has RU cards but no EN denominator to verify against')
     args = ap.parse_args()
 
     ru = ru_by_root()
-    intended = intended_by_root()
+    intended, corrupt_en = intended_by_root()
+
+    if args.root:
+        ru = {k: v for k, v in ru.items() if k == args.root}
+        intended = {k: v for k, v in intended.items() if k == args.root}
+        corrupt_en = [c for c in corrupt_en if c[0] == args.root]
 
     if args.keys:
         root = args.keys
@@ -76,15 +92,22 @@ def main():
     print('%-8s %6s %6s %6s  %s' % ('root', 'RU', 'intend', 'RU%', 'flag'))
     worst = 100.0
     partial = []
+    unverifiable = []      # RU cards present but NO EN denominator to check against
     for root in roots:
         have = ru.get(root, set())
         want = intended.get(root, set())
-        denom = len(want) if want else len(have)
-        pct = 100.0 * len(have & (want or have)) / denom if denom else 0.0
-        # if no EN store to define 'want', report RU subcard count only (unknown denom)
+        # No EN denominator. A root with RU cards here is UNVERIFIABLE, not exempt — surface
+        # it loudly (this is exactly how gam 6/127 stayed invisible). A root with no RU cards
+        # AND no denominator is simply not started; report it plainly.
         if not want:
-            print('%-8s %6d %6s %6s  %s' % (root, len(have), '?', '?', '(no EN denom)'))
+            if have:
+                unverifiable.append((root, len(have)))
+                print('%-8s %6d %6s %6s  %s' % (root, len(have), '?', '?',
+                                                'UNVERIFIABLE (no EN denom)'))
+            else:
+                print('%-8s %6d %6s %6s  %s' % (root, 0, '?', '?', '(not started)'))
             continue
+        pct = 100.0 * len(have & want) / len(want)
         flag = '' if pct >= args.min else 'LOW'
         if pct < 100:
             partial.append((root, pct, len(have), len(want)))
@@ -95,11 +118,40 @@ def main():
     for root, pct, h, w in sorted(partial, key=lambda x: x[1]):
         print('  %-8s %5.0f%%  (%d/%d)  catch-up: python src/pilot/ru_coverage.py --keys %s'
               % (root, pct, h, w, root))
+
+    # Loud, non-silent surfacing of the two ways the denominator can be absent.
+    if corrupt_en:
+        print('\n⚠ CORRUPT EN denominator file(s) — cannot verify these root(s):')
+        for root, err in corrupt_en:
+            print('  wf_output.en.%s.json  %s' % (root, err))
+    if unverifiable:
+        print('\n⚠ UNVERIFIABLE: %d root(s) have RU cards but NO EN denominator — coverage'
+              % len(unverifiable))
+        print('  cannot be computed (the exact blind spot that hid gam 6/127). Build the EN')
+        print('  denominator (wf_output.en.<root>.json) before trusting these as complete:')
+        for root, n in unverifiable:
+            print('    %-8s %d RU cards, denominator unknown' % (root, n))
+
     below = [p for p in partial if p[1] < args.min]
+    # A corrupt denominator is a hard data defect the gate exists to catch -> always fail.
+    # A partial root below --min -> fail. Missing (but not corrupt) denominators fail only
+    # under --strict-denominator, since the EN track legitimately lags the RU track.
+    fail_reasons = []
     if below:
-        print('\nFAIL: %d root(s) below %.0f%% RU coverage' % (len(below), args.min))
+        fail_reasons.append('%d root(s) below %.0f%% RU coverage' % (len(below), args.min))
+    if corrupt_en:
+        fail_reasons.append('%d corrupt EN denominator file(s)' % len(corrupt_en))
+    if args.strict_denominator and unverifiable:
+        fail_reasons.append('%d unverifiable root(s) (no EN denominator)' % len(unverifiable))
+
+    if fail_reasons and not args.warn_only:
+        print('\nFAIL: %s' % '; '.join(fail_reasons))
         sys.exit(1)
-    print('\nOK: all roots >= %.0f%% RU coverage' % args.min)
+    if fail_reasons:
+        print('\nWARN (advisory): %s' % '; '.join(fail_reasons))
+    else:
+        print('\nOK: all roots >= %.0f%% RU coverage%s' % (
+            args.min, '' if not unverifiable else ' (some roots unverifiable — see above)'))
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -760,6 +760,47 @@ def test_en_gate_strict_has_teeth():
             os.remove(report_path)
 
 
+def test_ru_coverage_denominator_not_silently_exempt():
+    """FL3: a corrupt EN denominator must FAIL the coverage gate (not be silently skipped),
+    and a RU root with no denominator must be surfaced as UNVERIFIABLE (the gam 6/127 blind
+    spot), never exempted."""
+    import io
+    import contextlib
+    import ru_coverage
+    with tempfile.TemporaryDirectory() as tmp:
+        with open(os.path.join(tmp, 'wf_output.en.aa.json'), 'w', encoding='utf-8') as f:
+            f.write(json.dumps({'meta': {'selected_keys': ['aa~~h0_00_pwg00']}}))
+        with open(os.path.join(tmp, 'wf_output.en.bb.json'), 'w', encoding='utf-8') as f:
+            f.write('{ broken json')
+        store = os.path.join(tmp, 'store.jsonl')
+        with open(store, 'w', encoding='utf-8') as f:
+            f.write(json.dumps({'key1': 'aa', 'subcard': 'aa~~h0_00_pwg00'}) + '\n')
+            f.write(json.dumps({'key1': 'cc', 'subcard': 'cc~~h0_00_pwg00'}) + '\n')
+        old_repo, old_store, old_argv = ru_coverage.REPO, ru_coverage.RU_STORE, sys.argv
+        ru_coverage.REPO, ru_coverage.RU_STORE = tmp, store
+        try:
+            intended, corrupt = ru_coverage.intended_by_root()
+            if not any(r == 'bb' for r, _ in corrupt):
+                fail('corrupt EN denominator not detected')
+            if 'aa' not in intended:
+                fail('valid EN denominator dropped')
+            sys.argv = ['ru_coverage']
+            buf = io.StringIO()
+            rc = 0
+            try:
+                with contextlib.redirect_stdout(buf):
+                    ru_coverage.main()
+            except SystemExit as e:
+                rc = e.code if isinstance(e.code, int) else 1
+            out = buf.getvalue()
+            if rc != 1:
+                fail('ru_coverage did not FAIL on a corrupt EN denominator (silent exemption)')
+            if 'UNVERIFIABLE' not in out:
+                fail('a RU root with no EN denominator was not surfaced as UNVERIFIABLE')
+        finally:
+            ru_coverage.REPO, ru_coverage.RU_STORE, sys.argv = old_repo, old_store, old_argv
+
+
 def main():
     tests = [
         test_workflow_payload_nested,
@@ -780,6 +821,7 @@ def main():
         test_attested_text_signal_redesign,
         test_nws_fp_suppressed,
         test_en_gate_strict_has_teeth,
+        test_ru_coverage_denominator_not_silently_exempt,
         test_stale_refusal_preserves_requeue,
         test_release_manifest_hash_validation,
     ]


### PR DESCRIPTION
Fixes flag **FL3** from the S10 audit ([`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) §3). Model: **Opus 4.8 (`claude-opus-4-8`)**.

## Problem
[`ru_coverage.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/ru_coverage.py) — the anti-silent-partial gate built *after* gam sat at **6/127** sub-cards invisibly — was **wired to nothing** (hand-run only) and could be disabled by the exact failure it guards:
- a **corrupt** `wf_output.en.<root>.json` denominator hit `except: continue`, silently dropping the root;
- a RU root with **no** EN denominator printed `(no EN denom)` and `continue`d — never counted, so it could never fail.

Both paths meant the gate exited **0** on precisely the blind spot it exists to catch.

## Fix
- **Corrupt** EN denominator → loud `⚠ CORRUPT EN denominator file(s)` report **+ hard FAIL**.
- RU root with cards but **no** EN denominator → loud `⚠ UNVERIFIABLE (no EN denom)` surfacing; `--strict-denominator` can fail on it.
- New `--root` filter and `--warn-only` advisory mode.
- [`save_and_audit.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/save_and_audit.py) RU path now runs `ru_coverage --root <root> --warn-only` after the audit — every RU save surfaces that root's current-store completeness. (Advisory because the store is updated at *promotion*, not save.)

## Before / after (temp scenario: valid `aa`, corrupt `bb`, RU-only `cc`)
| | exit | corrupt denom | RU-only root |
|---|---:|---|---|
| origin/master | **0** | silently dropped | silently `(no EN denom)` |
| this PR | **1** | `⚠ CORRUPT … FAIL` | `⚠ UNVERIFIABLE` |

## Tests
`window_selftest.py` **18/18 green**, new `test_ru_coverage_denominator_not_silently_exempt` pins: corrupt denominator detected + gate FAILs; RU-only root surfaced as UNVERIFIABLE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)