### PR TITLE
FL1: whitney_grammar homonym-safety — no wrong-homonym fallback

### DIFF
--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -801,6 +801,23 @@ def test_ru_coverage_denominator_not_silently_exempt():
             ru_coverage.REPO, ru_coverage.RU_STORE, sys.argv = old_repo, old_store, old_argv
 
 
+def test_whitney_homonym_safety():
+    """FL1: requesting a Whitney homonym a root lacks must return EMPTY, never fall back to
+    ALL homonyms — attaching a different homonym's grammar is a silent wrong-root error."""
+    from whitney_grammar import grammar_for
+    all_vas = grammar_for('vas')
+    if len(all_vas) < 2:
+        return  # whitney_grammar.json unbuilt in this env — nothing to assert
+    first = all_vas[0]['homonym']
+    exact = grammar_for('vas', first)
+    if len(exact) != 1 or exact[0]['homonym'] != first:
+        fail('an exact homonym request must return only that homonym')
+    if grammar_for('vas', '999') != []:
+        fail('a nonexistent homonym must return empty, not fall back to all homonyms')
+    if grammar_for('zzqqx_no_such_root', '1') != []:
+        fail('an unknown root must return empty')
+
+
 def main():
     tests = [
         test_workflow_payload_nested,
@@ -822,6 +839,7 @@ def main():
         test_nws_fp_suppressed,
         test_en_gate_strict_has_teeth,
         test_ru_coverage_denominator_not_silently_exempt,
+        test_whitney_homonym_safety,
         test_stale_refusal_preserves_requeue,
         test_release_manifest_hash_validation,
     ]

--- a/RussianTranslation/src/whitney_grammar.py
+++ b/RussianTranslation/src/whitney_grammar.py
@@ -152,11 +152,23 @@ def _load():
 
 
 def grammar_for(slp1, homonym=None):
-    """Return the grammar block(s) for an SLP1 root. With homonym, the single match
-    (Whitney homonym index); without, all homonyms (caller disambiguates)."""
+    """Return the grammar block(s) for an SLP1 root. With homonym, ONLY the matching Whitney
+    homonym; without, all homonyms (caller disambiguates).
+
+    Homonym-safety contract: when a specific homonym is requested but this root's Whitney
+    records don't carry it, return an EMPTY list and warn — NEVER fall back to all homonyms.
+    Attaching another homonym's grammar (a different verb, different class/PPP) is a silent
+    wrong-root error, worse than showing no grammar (collides with the siD homonym-safety
+    finding). Roots absent from Whitney entirely return empty silently (no spurious warning)."""
     recs = _load().get(slp1, [])
     if homonym is not None:
-        recs = [r for r in recs if r.get('homonym') == str(homonym)] or recs
+        match = [r for r in recs if r.get('homonym') == str(homonym)]
+        if not match and recs:
+            have = ', '.join(sorted(r.get('homonym') or '?' for r in recs))
+            print('whitney_grammar: root %r has no Whitney homonym %r (has: %s) — returning '
+                  'no grammar rather than a wrong-homonym block' % (slp1, str(homonym), have),
+                  file=sys.stderr)
+        return match
     return recs
 
 


### PR DESCRIPTION
Fixes flag **FL1** from the S10 audit ([`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) §3). Model: **Opus 4.8 (`claude-opus-4-8`)**.

## Problem
[`whitney_grammar.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/whitney_grammar.py) `grammar_for(slp1, homonym)` did:
```python
recs = [r for r in recs if r.get('homonym') == str(homonym)] or recs
```
The `or recs` means: when the requested homonym **doesn't exist**, it returns **all** homonyms — silently attaching a *different* verb's grammar (different class, different PPP) to the card. That is a silent wrong-root error and collides with the siD homonym-safety finding.

## Fix — homonym-safety contract
When a specific homonym is requested but the root's Whitney records don't carry it, return an **empty list and warn** — never fall back to all homonyms. Showing no grammar is strictly safer than showing the wrong one. Roots absent from Whitney entirely still return empty **silently** (no spurious warning). `homonym=None` is unchanged (returns all homonyms for the caller to disambiguate).

## Validation on `vas` (3 Whitney homonyms: 1, 2, 3)
| call | before | after |
|---|---|---|
| `grammar_for('vas', '2')` | only homonym 2 | only homonym 2 ✓ |
| `grammar_for('vas')` | all 3 | all 3 ✓ |
| `grammar_for('vas', '999')` | **all 3 (wrong!)** | **`[]` + warning** ✓ |
| `grammar_for('unknown', '1')` | `[]` | `[]` (silent) ✓ |

## Tests
`window_selftest.py` **18/18 green**, new `test_whitney_homonym_safety`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)