### PR TITLE
docs: close out audit-churn FL1/FL2/FL3/FL5 (flag table + .ai_state)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -43,16 +43,24 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   NOT fixed — folded into the audit-churn session (needs missing-fragment persistence).
   The handoff file carries a SPENT banner — do not re-execute.
 
-- **Audit-churn fix — QUEUED (Opus/Fable-tier judgment, from S10 2026-07-02).**
-  `prompt_rule_audit.has_text_signal()` false positive (`suspicious_attested_without_text_signal`,
-  66 % of round-2 risks; 2,152 key-requeues on 06-29 alone — requeues NO model output can
-  clear; OPEN since 06-29) + give `audit_window_en.py` teeth (nulls never fail `--strict`;
-  `save_and_audit.py` invokes it non-strict) + wire `ru_coverage.py` into the save path +
-  the `whitney_grammar.grammar_for` homonym fallback (`… or recs` returns ALL homonyms on a
-  miss). Full flag list FL1–FL8:
-  [`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) §3.
-  **Start (Opus 4.8+ chat in this repo):** `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\OPUS_pwg_audit_churn_fix.md and execute it.`
-  ([handoff file](https://github.com/gasyoun/Uprava/blob/main/handoffs/OPUS_pwg_audit_churn_fix.md))
+- ~~**Audit-churn fix — QUEUED (Opus/Fable-tier judgment, from S10 2026-07-02).**~~
+  **✅ EXECUTED 2026-07-02 (Opus 4.8, `claude-opus-4-8`) — FL1/FL2/FL3/FL5 all fixed +
+  merged, each its own PR with a pinning `window_selftest.py` test (now 20 tests, green).**
+  FL5 [#79](https://github.com/gasyoun/SanskritLexicography/pull/79): `has_text_signal`
+  redesign — the flag now fires only on a sense that makes a `{%..%}` meaning claim and lacks
+  any citation/stratum/NWS-owner/**lexicographic** signal (37→6 fires on 39 Slice-C files);
+  report-only enforced by a `REPORT_ONLY_RISKS`×`HIGH_CONFIDENCE_RISKS` disjointness invariant;
+  reasoning in [`AUDIT_CHURN_FL5.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/AUDIT_CHURN_FL5.md).
+  FL2 [#80](https://github.com/gasyoun/SanskritLexicography/pull/80): EN gate `--strict` now
+  fails on nulls/crash; strict-by-default + report in `save_and_audit.py`. FL3
+  [#81](https://github.com/gasyoun/SanskritLexicography/pull/81): `ru_coverage.py` wired into
+  the RU save path (advisory); corrupt EN denom → FAIL, missing denom → loud `UNVERIFIABLE`
+  (no more silent gam-6/127 exemption). FL1
+  [#82](https://github.com/gasyoun/SanskritLexicography/pull/82): `grammar_for` returns
+  empty + warns on an absent homonym instead of ALL homonyms. **FL4 + FL8 remain open**
+  (EN-track `en_residual_keys`/`en_split_triage` partial-as-done; singleton-status-file
+  clobber) — see [`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) §3.
+  The handoff file carries a SPENT banner — do not re-execute.
 
 - **S7 quality follow-through — QUEUED as its own handoff (MG decision 2026-07-02;
   runs AFTER the churn-fix — the re-run leg of the locked order is already ✅).** The two S7 judge

--- a/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md
+++ b/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md
@@ -2,6 +2,14 @@
 
 _Created: 02-07-2026 · Last updated: 02-07-2026_
 
+> **Update 02-07-2026 — audit-churn session closed.** The §3 flags FL1/FL2/FL3/FL5 named
+> for a follow-up "audit-churn (Opus/Fable-tier judgment)" session in §6 are now FIXED and
+> merged: [#82](https://github.com/gasyoun/SanskritLexicography/pull/82) (FL1),
+> [#80](https://github.com/gasyoun/SanskritLexicography/pull/80) (FL2),
+> [#81](https://github.com/gasyoun/SanskritLexicography/pull/81) (FL3),
+> [#79](https://github.com/gasyoun/SanskritLexicography/pull/79) (FL5). FL4/FL8 remain open
+> (EN-track / small PRs). Session model: Opus 4.8 (`claude-opus-4-8`).
+
 **Mission:** M.G. reported the pwg pipeline "failed too often" over the last week — big/dense
 cards not translated even after many retries. A same-day Sonnet 5 (`claude-sonnet-5`) session
 fixed 4 layered bugs ([PR #35](https://github.com/gasyoun/SanskritLexicography/pull/35),
@@ -120,11 +128,11 @@ mission forbids touching translation-quality logic — or its own scoped change)
 
 | # | Site | Issue | Suggested owner/session |
 |---|---|---|---|
-| FL1 | [`whitney_grammar.py:154-160`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/whitney_grammar.py) | `grammar_for(slp1, homonym)` falls back `… or recs`: a nonexistent homonym silently returns ALL homonyms — wrong-root grammar attached; collides with the siD homonym-safety finding | small dedicated PR; touches evidence injection, so validate on a homonym root |
-| FL2 | [`audit_window_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window_en.py) | the EN gate has no teeth: nulls never fail `--strict`; `save_and_audit.py` invokes it non-strict with no `--report`; a crashing sense-dupe subgate counts as clean (`returncode None` is falsy) | EN-track session (pairs with the EN residual re-run) |
-| FL3 | [`ru_coverage.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/ru_coverage.py) | the anti-silent-partial gate is wired to NOTHING (hand-run only), and a corrupt/missing EN denominator silently exempts a root from the very check built after the gam-6/127 incident | wire into `save_and_audit.py` or CI |
-| FL4 | `en_residual_keys.py:27-34` + `en_split_triage.py:66-68` | "done" = ≥1 English sense (a 1/40 card counts as done); a null card with a missing input vanishes from triage entirely | EN-track session |
-| FL5 | [`prompt_rule_audit.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/prompt_rule_audit.py) `has_text_signal()` | Mode-6 false positive (`suspicious_attested_without_text_signal`, 66% of round-2 risks) — requeues that NO model output can clear; 2,152 key-requeues on 06-29 alone | own session; semantic-risk heuristic, needs care |
+| FL1 | [`whitney_grammar.py:154-160`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/whitney_grammar.py) | `grammar_for(slp1, homonym)` falls back `… or recs`: a nonexistent homonym silently returns ALL homonyms — wrong-root grammar attached; collides with the siD homonym-safety finding | **✅ FIXED — [#82](https://github.com/gasyoun/SanskritLexicography/pull/82)** (empty + warning; validated on `vas`) |
+| FL2 | [`audit_window_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window_en.py) | the EN gate has no teeth: nulls never fail `--strict`; `save_and_audit.py` invokes it non-strict with no `--report`; a crashing sense-dupe subgate counts as clean (`returncode None` is falsy) | **✅ FIXED — [#80](https://github.com/gasyoun/SanskritLexicography/pull/80)** (nulls/crash fail `--strict`; strict-by-default in save; report always written) |
+| FL3 | [`ru_coverage.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/ru_coverage.py) | the anti-silent-partial gate is wired to NOTHING (hand-run only), and a corrupt/missing EN denominator silently exempts a root from the very check built after the gam-6/127 incident | **✅ FIXED — [#81](https://github.com/gasyoun/SanskritLexicography/pull/81)** (wired into `save_and_audit.py`; corrupt denom fails, missing denom loud `UNVERIFIABLE`) |
+| FL4 | `en_residual_keys.py:27-34` + `en_split_triage.py:66-68` | "done" = ≥1 English sense (a 1/40 card counts as done); a null card with a missing input vanishes from triage entirely | EN-track session (still open) |
+| FL5 | [`prompt_rule_audit.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/prompt_rule_audit.py) `has_text_signal()` | Mode-6 false positive (`suspicious_attested_without_text_signal`, 66% of round-2 risks) — requeues that NO model output can clear; 2,152 key-requeues on 06-29 alone | **✅ FIXED — [#79](https://github.com/gasyoun/SanskritLexicography/pull/79)** (meaning-claim + lexicographic-signal redesign, 37→6 fires; report-only by construction; reasoning in [`AUDIT_CHURN_FL5.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/AUDIT_CHURN_FL5.md)) |
 | FL6 | [`pwg_mask.py:43-58`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_mask.py) | a truncated final record (missing `<L END>`) is buffered and never yielded — last record silently disappears from every consumer | small PR, low urgency (source file is stable) |
 | FL7 | `corpus_gate.py` evidence loaders | absent evidence jsonl → authority silently removed (degrades safely to LLM-verdict, but "sources not built" and "word uncovered" are indistinguishable); DB errors leave `corpus_examples: []` unmarked | note-only; safe direction |
 | FL8 | singleton status files (`window_status.json`, `audit_window.report.json`) | ANY audit run — including test fixtures — clobbers them; "current status" cannot be trusted without the event log (observed: current status reports a temp-file fixture) | small PR: per-run-id reports or a fixture guard |


### PR DESCRIPTION
Documentation close-out for the audit-churn session. Marks the S10 audit ([`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md)) §3 flags **FL1/FL2/FL3/FL5** as FIXED with PR links ([#82](https://github.com/gasyoun/SanskritLexicography/pull/82), [#80](https://github.com/gasyoun/SanskritLexicography/pull/80), [#81](https://github.com/gasyoun/SanskritLexicography/pull/81), [#79](https://github.com/gasyoun/SanskritLexicography/pull/79)), adds a closeout banner, and records the executed session in [`RussianTranslation/.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md). FL4/FL8 remain open. Model: **Opus 4.8 (`claude-opus-4-8`)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)