### PR TITLE
PWG translation-memory (TM) sidecar + gen_opt_harness2 --tm (zero-token card reuse)

### DIFF
--- a/RussianTranslation/.gitignore
+++ b/RussianTranslation/.gitignore
@@ -34,6 +34,10 @@ src/pilot/run_pilot_wf.sc_y*.js
 # `python src/pilot/build_article_site.py`; publish by copying article_site/ onto gh-pages.
 # (No longer ignored — MG asked for it public, 2026-07-01.)
 
+# Translation-memory cache — DERIVED from the local-only store (pwg_ru_translated.jsonl) by
+# translation_memory.py; regenerable, never a deliverable (like the store it comes from).
+src/pilot/translation_memory.*.json
+
 # Max workflow run output and A/B transcript artifacts (not deliverables)
 wf_output.json
 wf_output.*.json

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -19,6 +19,9 @@ Usage:  python src/pilot/gen_opt_harness2.py <root> [--keys=k1,k2] [--budget=N] 
         [--no-binary-split]                     # binary-split ON by default (MG 2026-07-02)
         [--output-budget=N|off]                 # citation-weighted batching, DEFAULT 60;
                                                 # 'off' or an explicit --budget=N = byte mode
+        [--tm[=PATH]]                           # content-addressed translation memory:
+                                                # pre-resolve cards whose source SHA is cached
+                                                # (0 tokens); OFF by default. See translation_memory.py
         (--selfheal / --binary-split still accepted as no-ops for documented runbooks)
 Writes: src/pilot/run_pilot_wf.opt2.js  (or --out=PATH — use a per-root/per-chat path to
         avoid the gen->copy race when several chats generate harnesses concurrently)
@@ -150,6 +153,11 @@ def parse_args(argv):
     keylist = None                     # ordered keys (nominal mode preserves order)
     out_path = None                    # --out=PATH overrides the default opt2.js (avoids the
     lang, mw_tm = 'ru', None           # --lang en + --mw-tm=PATH: PWG->English pilot (MG 2026-06-30)
+    tm = None                          # --tm[=PATH]: content-addressed translation-memory cache;
+                                       #  pre-resolves any card whose source SHA is already in the
+                                       #  TM (zero tokens, no manual --keys scoping). OFF by default
+                                       #  (opt-in; a stale/empty TM is simply a no-op). See
+                                       #  translation_memory.py.
     budget_explicit = output_explicit = False
     for a in argv[1:]:                 # gen->copy race when several chats generate at once)
         if a.startswith('--keys='):
@@ -164,6 +172,12 @@ def parse_args(argv):
             lang = a.split('=', 1)[1].strip().lower()
         elif a.startswith('--mw-tm='):
             mw_tm = a.split('=', 1)[1]
+        elif a == '--tm':
+            tm = '__default__'          # resolved to translation_memory.<lang>.json after the loop
+        elif a.startswith('--tm='):
+            tm = a.split('=', 1)[1]
+        elif a == '--no-tm':
+            tm = None
         elif a == '--lean':
             lean = True
         elif a == '--nws-gate':
@@ -196,7 +210,9 @@ def parse_args(argv):
         die('unknown --lang %r (ru|en)' % lang)
     if lang == 'en' and mw_tm is None:
         mw_tm = os.path.join(SRC, 'mw_en_tm.json')      # default MW translation-memory feed
-    return root, keyfilter, keylist, budget, lean, nws_gate, nominal, grammar_on, out_path, lang, mw_tm
+    if tm == '__default__':
+        tm = os.path.join(os.path.dirname(INP), 'translation_memory.%s.json' % lang)
+    return root, keyfilter, keylist, budget, lean, nws_gate, nominal, grammar_on, out_path, lang, mw_tm, tm
 
 
 def extract_nws(tr):
@@ -357,7 +373,7 @@ def mw_tm_block(root, mw_tm_path):
 
 
 def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
-          nominal=False, grammar_on=True, lang='ru', mw_tm_path=None):
+          nominal=False, grammar_on=True, lang='ru', mw_tm_path=None, tm_path=None):
     field = 'english' if lang == 'en' else 'russian'   # the per-sense translation field
     nws_block = ''
     if lang == 'en':
@@ -424,6 +440,27 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         phmaps[k] = ph
         input_hashes[k] = {'raw_sha256': sha256_file(rp), 'portrait_sha256': sha256_file(pp)}
 
+    # --tm: content-addressed pre-resolution. A card whose masked-input SHA is already in the
+    # translation memory is served from cache (ZERO agent() calls) instead of re-translated —
+    # no manual --keys scoping needed. Keyed on input_raw_sha256 (recorded per store row,
+    # recomputed here), so it survives sub-card key renames and can NEVER reuse a stale
+    # translation (changed source -> different SHA -> cache miss -> re-translate). TM-hit keys
+    # are removed from every translate lane below (batches / presplit / selfheal frags).
+    tm_resolved = {}
+    if tm_path and os.path.exists(tm_path):
+        import translation_memory as _tm
+        cache = _tm.load_tm(lang, tm_path)
+        for k in keys:
+            hit = cache.get('%s:%s' % (lang, input_hashes[k]['raw_sha256']))
+            if hit:
+                tm_resolved[k] = hit['card']
+        print('  tm: %d/%d cards pre-resolved from %s (0 tokens)%s'
+              % (len(tm_resolved), len(keys), os.path.basename(tm_path),
+                 '' if tm_resolved else ' — no source-SHA matches (all cards will translate)'))
+    elif tm_path:
+        print('  tm: %s not found — no pre-resolution (run translation_memory.py build)' % tm_path)
+    tm_keys = set(tm_resolved)
+
     # --selfheal: precompute a per-card fragment fallback (deterministic sense/citation split).
     # The JS uses it only for cards the batch could not translate; each fragment is masked here
     # so the in-harness path reuses the same {Tn} restore. Only cards that actually split (>=2
@@ -435,6 +472,8 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     frags, phf = {}, {}
     if SELFHEAL:
         for k in keys:
+            if k in tm_keys:                 # cached — no heal fallback needed
+                continue
             pl = split_plan(read_text(input_paths(k)[0]))
             if len(pl) < 2:
                 print('  selfheal: %s has no fallback (card does not split — <2 fragments)' % k)
@@ -465,11 +504,12 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     # a usable fragment fallback are routed; unsplittable ones keep the old solo-batch try.
     presplit = []
     if SELFHEAL and OUTPUT_BUDGET is not None:
-        presplit = [k for k in keys if (1 + inputs[k]['ls']) > OUTPUT_BUDGET and k in frags]
+        presplit = [k for k in keys
+                    if k not in tm_keys and (1 + inputs[k]['ls']) > OUTPUT_BUDGET and k in frags]
         for k in presplit:
             print('  presplit: %s (%d <ls> exceeds output budget %d) -> direct fragment translation'
                   % (k, inputs[k]['ls'], OUTPUT_BUDGET))
-    batch_keys = [k for k in keys if k not in presplit]
+    batch_keys = [k for k in keys if k not in presplit and k not in tm_keys]
 
     # --output-budget=N (default 60): size batches by citation-weighted OUTPUT complexity
     # (1 + <ls> per card) instead of input bytes — bytes don't predict StructuredOutput
@@ -509,6 +549,8 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         'selfheal_cards': {k: len(v) for k, v in frags.items()} if SELFHEAL else {},
         'binary_split': BINARY_SPLIT, 'output_budget': OUTPUT_BUDGET,
         'presplit_keys': presplit,
+        'tm': os.path.basename(tm_path) if tm_path else None,
+        'tm_hits': sorted(tm_keys),
     }
 
     js = """// AUTO-DERIVED v2 (batched + masked, canonical output) from run_pilot_wf.js - root=%(root)s.
@@ -533,6 +575,10 @@ const FRAGS = %(frags)s
 const PHF = %(phf)s
 const BINARY_SPLIT = %(binary_split)s
 const PRESPLIT = %(presplit)s
+// --tm: cards pre-resolved from the content-addressed translation memory (source-SHA hit).
+// Emitted verbatim as canonical rows with tm:true and NO agent() call — their markup is
+// already restored (they come from the promoted store), so they bypass restore/accept.
+const TM_RESOLVED = %(tm_resolved)s
 const META = %(meta)s
 
 const restore = (t, ph) => (t || '').replace(/\\{T(\\d+)\\}/g, (m, n) => (ph[+n - 1] !== undefined ? ph[+n - 1] : m))
@@ -816,6 +862,9 @@ const grouped = await parallel(UNITS.map(u => u.run))
 // backfill any key that STILL isn't present (belt over suspenders).
 const out = []
 const seen = new Set()
+// TM lane first: pre-resolved cards cost nothing and are already accounted for, so seed
+// them before backfilling the translated units. tm:true marks provenance for the summary.
+for (const k in TM_RESOLVED) { if (!seen.has(k)) { out.push({ key: k, card: TM_RESOLVED[k], judge: null, judge_sonnet: null, escalated: false, tm: true }); seen.add(k) } }
 grouped.forEach((rows, i) => {
   if (Array.isArray(rows)) {
     for (const r of rows) if (r && r.key && !seen.has(r.key)) { out.push(r); seen.add(r.key) }
@@ -835,7 +884,7 @@ const _failures = {}
 for (const r of out) if (!r.card) _failures[r.key] = r.error || FAIL[r.key] || 'unknown'
 const summary = { root: META.root, lang: META.lang, cards: out.length, ok: _ok,
                   null: out.length - _ok, healed: out.filter(r => r.escalated).length,
-                  presplit: PRESPLIT.length,
+                  presplit: PRESPLIT.length, tm: out.filter(r => r.tm).length,
                   null_keys: out.filter(r => !r.card).map(r => r.key),
                   partial_keys: out.filter(r => r.card && r.card.partial).map(r => r.key),
                   failures: _failures }
@@ -858,6 +907,7 @@ return { meta: META, summary, results: out }
         'phmaps': json.dumps(phmaps, ensure_ascii=True), 'meta': json.dumps(meta, ensure_ascii=True),
         'frags': json.dumps(frags, ensure_ascii=True), 'phf': json.dumps(phf, ensure_ascii=True),
         'binary_split': json.dumps(BINARY_SPLIT), 'presplit': json.dumps(presplit),
+        'tm_resolved': json.dumps(tm_resolved, ensure_ascii=True),
     }
     for bad in ['readFileSync', 'fileURLToPath', 'import.meta']:
         if bad in js:
@@ -866,7 +916,7 @@ return { meta: META, summary, results: out }
 
 
 def main():
-    root, keyfilter, keylist, budget, lean, nws_gate, nominal, grammar_on, out_path, lang, mw_tm = parse_args(sys.argv[1:])
+    root, keyfilter, keylist, budget, lean, nws_gate, nominal, grammar_on, out_path, lang, mw_tm, tm = parse_args(sys.argv[1:])
     if nominal:
         # No rootmap: the headword keys ARE the cards, in the order given.
         if not keylist:
@@ -876,7 +926,7 @@ def main():
         rootmap, keys = selected_keys(root, keyfilter)
         if keylist:
             keys = [k for k in keylist if k in set(keys)]
-    js, batches = build(root, keys, rootmap, budget, lean, nws_gate, nominal, grammar_on, lang, mw_tm)
+    js, batches = build(root, keys, rootmap, budget, lean, nws_gate, nominal, grammar_on, lang, mw_tm, tm)
     out = os.path.abspath(out_path) if out_path else os.path.join(REPO, 'src', 'pilot', 'run_pilot_wf.opt2.js')
     # Write LF (not CRLF): the Workflow-tool approval rejects scripts containing
     # raw \r control chars, so a CRLF harness cannot be launched on Windows.

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python
+r"""Content-addressed translation memory (TM) sidecar for the PWG bulk translation harness.
+
+WHY THIS EXISTS
+---------------
+`resumeFromRunId` REPLAYS a Workflow verbatim (it re-serves the cached failure, it does
+NOT re-roll a stochastic StructuredOutput failure), and a FRESH Workflow run re-translates
+the whole card from scratch — discarding every fragment that already succeeded in a prior
+run. So neither path reuses a prior run's *good* work (brU's first failure burned ~860k
+tokens re-doing 12 of 13 already-good fragments). Card-level `--merge` in
+`save_and_audit`/`promote_final_cards` preserves an already-promoted card in the STORE, but
+only if the operator scopes `--keys` to the missing ones by hand, and it is keyed on the
+sub-card KEY (a rootmap reshape that renames a key defeats it).
+
+This TM closes that gap. It is a **content-addressed** cache: a card is keyed by
+`f"{lang}:{input_raw_sha256}"` — the SHA-256 of its exact masked-input source. Both sides
+compute the same address:
+  * harvest  : from each store row's recorded `provenance.input_raw_sha256`;
+  * generate : `gen_opt_harness2.py --tm` computes `sha256_file(<key>.raw.txt)`.
+So `gen_opt_harness2.py --tm` pre-resolves any card whose source is byte-identical to one
+already translated — ZERO tokens, automatically, WITHOUT hand-scoping `--keys`, and
+surviving key renames (the address is the source content, not the key). Two different
+sub-cards with byte-identical source (a duplicated sub-entry) reuse one translation
+(cross-card reuse).
+
+Version safety is intrinsic: if a card's source changes, its SHA changes, the address
+misses, and the card is re-translated — a stale translation can never be reused.
+
+GRANULARITY (and the next increment)
+------------------------------------
+This TM is CARD-level (one address per sub-card). That is the coarsest unit whose source
+string is byte-identical at both harvest and generation time (the raw `.raw.txt` on disk),
+so content-addressing is exact with no normalization guesswork. Sub-CARD (sense/fragment)
+reuse — reusing an already-translated sense inside a still-failing giant flat headword like
+kAla/ka/SrI, or the same meaning across a root and its derived noun — is the higher-value
+next increment, but the store's per-sense `de` does NOT align byte-for-byte with the
+harness's `autosplit_requeue.plan()` fragments (headers + citation-batching → ~3/7 exact on
+a sample), so it needs a fragment-provenance channel this first version deliberately does
+not fake. See the handoff for the plan.
+
+USAGE
+-----
+  python src/pilot/translation_memory.py build   [--lang ru|en] [--store PATH] [--out PATH]
+  python src/pilot/translation_memory.py stats    [--lang ru|en] [--tm PATH]
+  python src/pilot/translation_memory.py lookup <input_raw_sha256> [--lang ru|en] [--tm PATH]
+  python src/pilot/translation_memory.py selftest
+
+The TM file (default src/pilot/translation_memory.<lang>.json) is DERIVED from the
+local-only, gitignored store and is itself gitignored + regenerable — never a deliverable.
+"""
+import argparse
+import datetime
+import json
+import os
+import sys
+from collections import defaultdict, Counter
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = os.path.dirname(HERE)
+REPO = os.path.dirname(SRC)
+
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+DEFAULT_STORE = os.path.join(SRC, 'pwg_ru_translated.jsonl')
+FIELD = {'ru': 'ru', 'en': 'en'}                    # store column holding the translation
+
+
+def tm_path(lang, out=None):
+    return out or os.path.join(HERE, 'translation_memory.%s.json' % lang)
+
+
+def _iter_store(store_path):
+    with open(store_path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def reconstruct_cards(store_path, lang):
+    """Group store sense-rows back into per-sub-card card objects, addressed by source SHA.
+
+    Returns { address: entry } where address == f"{lang}:{input_raw_sha256}" and entry is
+    { 'card': <card obj shaped like a wf_output card>, 'src_key', 'raw_sha256', 'model',
+      'model_version', 'root', 'n_senses' }.
+
+    A sub-card is included only if EVERY one of its senses (a) has a non-empty translation in
+    the requested `lang` and (b) shares one recorded `input_raw_sha256` — a card whose rows
+    disagree on the source hash is ambiguous (mid-reshape) and is skipped, not guessed.
+    Rows without a recorded `input_raw_sha256` cannot be content-addressed and are skipped.
+    """
+    field = FIELD[lang]
+    by_sub = defaultdict(list)
+    for row in _iter_store(store_path):
+        sub = row.get('subcard')
+        if sub:
+            by_sub[sub].append(row)
+
+    entries, skipped = {}, Counter()
+    for sub, rows in by_sub.items():
+        shas = {(r.get('provenance') or {}).get('input_raw_sha256') for r in rows}
+        shas.discard(None)
+        if not shas:
+            skipped['no-raw-sha'] += 1
+            continue
+        if len(shas) > 1:
+            skipped['sha-disagreement'] += 1
+            continue
+        raw_sha = next(iter(shas))
+        if any(not (r.get(field) or '').strip() for r in rows):
+            skipped['incomplete-%s' % lang] += 1
+            continue
+        # Rebuild records grouped by homonym head `h`, senses in stored order.
+        recs = defaultdict(list)
+        rec_order = []
+        for r in rows:
+            h = r.get('h')
+            if h not in recs:
+                rec_order.append(h)
+            recs[h].append({
+                'tag': r.get('sense_tag'),
+                'german': r.get('de'),
+                field if lang == 'en' else 'russian': r.get(field),
+                'equivalence_type': r.get('equivalence_type'),
+                'source_type': r.get('source_type'),
+                'stratum': r.get('stratum'),
+                'differentia': r.get('differentia'),
+            })
+        card = {
+            'key1': sub,
+            'iast': rows[0].get('iast'),
+            'records': [{'h': h, 'senses': recs[h]} for h in rec_order],
+        }
+        prov0 = rows[0].get('provenance') or {}
+        entries['%s:%s' % (lang, raw_sha)] = {
+            'card': card,
+            'src_key': sub,
+            'raw_sha256': raw_sha,
+            'model': prov0.get('model'),
+            'model_version': prov0.get('model_version'),
+            'root': prov0.get('root'),
+            'n_senses': len(rows),
+        }
+    return entries, skipped
+
+
+def build(store_path, lang, out=None):
+    entries, skipped = reconstruct_cards(store_path, lang)
+    payload = {
+        'schema': 'pwg.translation_memory.v1',
+        'lang': lang,
+        'address': 'sha256(input raw) == provenance.input_raw_sha256',
+        'built_at': datetime.datetime.now(datetime.timezone.utc).isoformat(
+            timespec='seconds').replace('+00:00', 'Z'),
+        'store': os.path.basename(store_path),
+        'count': len(entries),
+        'entries': entries,
+    }
+    path = tm_path(lang, out)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(payload, f, ensure_ascii=False)
+    return path, len(entries), skipped
+
+
+def load_tm(lang, tm=None):
+    """Return the {address: entry} map for a built TM, or {} if none exists."""
+    path = tm_path(lang, tm)
+    if not os.path.exists(path):
+        return {}
+    with open(path, encoding='utf-8') as f:
+        return (json.load(f) or {}).get('entries') or {}
+
+
+def lookup(lang, raw_sha256, tm=None):
+    return load_tm(lang, tm).get('%s:%s' % (lang, raw_sha256))
+
+
+# --------------------------------------------------------------------------- selftest
+def selftest():
+    import tempfile
+    # Two sub-cards; the second row-set disagrees on the source sha (must be skipped),
+    # the third is missing a translation (must be skipped), the fourth has no sha (skipped).
+    rows = [
+        {'subcard': 'x~~h0_1', 'key1': 'x', 'iast': 'xa', 'h': 'xa', 'sense_tag': '1',
+         'ru': 'один', 'de': 'eins', 'equivalence_type': 'equivalent', 'source_type': 'attested',
+         'stratum': '', 'differentia': '',
+         'provenance': {'input_raw_sha256': 'AAA', 'model': 'sonnet', 'model_version': 'claude-sonnet-5', 'root': 'x'}},
+        {'subcard': 'x~~h0_1', 'key1': 'x', 'iast': 'xa', 'h': 'xa', 'sense_tag': '2',
+         'ru': 'два', 'de': 'zwei', 'equivalence_type': 'equivalent', 'source_type': 'attested',
+         'stratum': '', 'differentia': '',
+         'provenance': {'input_raw_sha256': 'AAA', 'model': 'sonnet', 'model_version': 'claude-sonnet-5', 'root': 'x'}},
+        {'subcard': 'y~~h0_1', 'key1': 'y', 'iast': 'ya', 'h': 'ya', 'sense_tag': '1',
+         'ru': 'три', 'de': 'drei', 'provenance': {'input_raw_sha256': 'BBB'}},
+        {'subcard': 'y~~h0_1', 'key1': 'y', 'iast': 'ya', 'h': 'ya', 'sense_tag': '2',
+         'ru': 'четыре', 'de': 'vier', 'provenance': {'input_raw_sha256': 'CCC'}},   # sha disagreement
+        {'subcard': 'z~~h0_1', 'key1': 'z', 'iast': 'za', 'h': 'za', 'sense_tag': '1',
+         'ru': '', 'de': 'fuenf', 'provenance': {'input_raw_sha256': 'DDD'}},         # missing ru
+        {'subcard': 'w~~h0_1', 'key1': 'w', 'iast': 'wa', 'h': 'wa', 'sense_tag': '1',
+         'ru': 'шесть', 'de': 'sechs', 'provenance': {}},                             # no sha
+    ]
+    fd, store = tempfile.mkstemp(suffix='.jsonl'); os.close(fd)
+    fd, out = tempfile.mkstemp(suffix='.json'); os.close(fd)
+    try:
+        with open(store, 'w', encoding='utf-8') as f:
+            for r in rows:
+                f.write(json.dumps(r, ensure_ascii=False) + '\n')
+        entries, skipped = reconstruct_cards(store, 'ru')
+        assert set(entries) == {'ru:AAA'}, entries
+        e = entries['ru:AAA']
+        assert e['n_senses'] == 2, e
+        assert e['card']['key1'] == 'x~~h0_1', e['card']
+        senses = e['card']['records'][0]['senses']
+        assert [s['tag'] for s in senses] == ['1', '2'], senses
+        assert senses[0]['russian'] == 'один' and senses[0]['german'] == 'eins', senses
+        assert skipped['sha-disagreement'] == 1, skipped
+        assert skipped['incomplete-ru'] == 1, skipped
+        assert skipped['no-raw-sha'] == 1, skipped
+        # build + load + lookup round-trip
+        path, n, _ = build(store, 'ru', out=out)
+        assert n == 1, n
+        assert lookup('ru', 'AAA', tm=out)['src_key'] == 'x~~h0_1'
+        assert lookup('ru', 'ZZZ', tm=out) is None
+        print('translation_memory selftest OK')
+    finally:
+        for p in (store, out):
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest='cmd', required=True)
+    b = sub.add_parser('build'); b.add_argument('--lang', default='ru'); b.add_argument('--store', default=DEFAULT_STORE); b.add_argument('--out', default=None)
+    s = sub.add_parser('stats'); s.add_argument('--lang', default='ru'); s.add_argument('--tm', default=None)
+    lk = sub.add_parser('lookup'); lk.add_argument('sha'); lk.add_argument('--lang', default='ru'); lk.add_argument('--tm', default=None)
+    sub.add_parser('selftest')
+    args = ap.parse_args()
+
+    if args.cmd == 'selftest':
+        return selftest()
+    if args.lang not in FIELD:
+        sys.exit('unknown --lang %r (ru|en)' % args.lang)
+    if args.cmd == 'build':
+        if not os.path.exists(args.store):
+            sys.exit('store not found: %s' % args.store)
+        path, n, skipped = build(args.store, args.lang, out=args.out)
+        print('wrote %s (%d content-addressed cards, lang=%s)' % (path, n, args.lang))
+        if skipped:
+            print('  skipped sub-cards:', dict(skipped))
+    elif args.cmd == 'stats':
+        entries = load_tm(args.lang, args.tm)
+        senses = sum(e.get('n_senses', 0) for e in entries.values())
+        roots = Counter(e.get('root') for e in entries.values())
+        print('TM lang=%s: %d cards, %d senses, %d roots' % (args.lang, len(entries), senses, len(roots)))
+        for root, c in roots.most_common(12):
+            print('  %-10s %d cards' % (root, c))
+    elif args.cmd == 'lookup':
+        e = lookup(args.lang, args.sha, args.tm)
+        print(json.dumps(e, ensure_ascii=False, indent=2) if e else '(miss)')
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -818,8 +818,66 @@ def test_whitney_homonym_safety():
         fail('an unknown root must return empty')
 
 
+def test_translation_memory_addressing():
+    """TM sidecar: content-addressing rules — only sub-cards with one agreed source SHA and a
+    complete translation are cached; SHA-disagreement / missing-translation / no-SHA are
+    skipped (never guessed), and reconstruction rebuilds the wf-card sense shape."""
+    import translation_memory as tm
+    tm.selftest()   # raises AssertionError on any rule violation
+
+
+def test_tm_pre_resolves_cards():
+    """--tm plumbing end-to-end: a card whose source SHA is in the TM is pre-resolved (emitted
+    in TM_RESOLVED, excluded from every translate lane), and the total-accounting invariant
+    (tm ∪ batched ∪ presplit == selected, disjoint) holds. Uses a real root's on-disk inputs."""
+    import gen_opt_harness2 as gh
+    from window_common import rootmap_path, input_paths, sha256_file
+    root = 'gam'
+    rmpath, _ = rootmap_path(root)
+    if not rmpath:
+        return  # inputs not present in this checkout — nothing to assert
+    rootmap, keys = gh.selected_keys(root, None)
+    keys = [k for k in keys if os.path.exists(input_paths(k)[0])][:6]
+    if len(keys) < 3:
+        return
+    cached = keys[:2]
+    fd, tmfile = tempfile.mkstemp(suffix='.json'); os.close(fd)
+    try:
+        entries = {}
+        for k in cached:
+            sha = sha256_file(input_paths(k)[0])
+            entries['ru:%s' % sha] = {'card': {'key1': k, 'iast': None,
+                'records': [{'h': None, 'senses': [{'tag': '1', 'german': 'g', 'russian': 'р',
+                    'equivalence_type': 'equivalent', 'source_type': 'attested',
+                    'stratum': '', 'differentia': ''}]}]}, 'src_key': k}
+        with open(tmfile, 'w', encoding='utf-8') as f:
+            json.dump({'schema': 'pwg.translation_memory.v1', 'lang': 'ru',
+                       'entries': entries}, f, ensure_ascii=False)
+        js, batches = gh.build(root, keys, rootmap, 12000, tm_path=tmfile)
+        import re as _re
+        meta = json.loads(_re.search(r'const META = (\{.*?\})\n', js, _re.S).group(1))
+        tm_hits = set(meta['tm_hits'])
+        if tm_hits != set(cached):
+            fail('TM should pre-resolve exactly the cached keys, got %s' % sorted(tm_hits))
+        batched = {k for b in meta['batches'] for k in b}
+        if tm_hits & batched:
+            fail('a TM-resolved card must not also be in a translate batch')
+        if tm_hits & set(meta['presplit_keys']):
+            fail('a TM-resolved card must not also be in the presplit lane')
+        union = tm_hits | batched | set(meta['presplit_keys'])
+        if union != set(keys):
+            fail('accounting: tm ∪ batched ∪ presplit must equal selected keys')
+    finally:
+        try:
+            os.remove(tmfile)
+        except OSError:
+            pass
+
+
 def main():
     tests = [
+        test_translation_memory_addressing,
+        test_tm_pre_resolves_cards,
         test_workflow_payload_nested,
         test_sense_dupe_batch_override,
         test_sense_dupe_cross_level_exempt,


### PR DESCRIPTION
## What

A **content-addressed translation-memory (TM) sidecar** that pre-resolves any card whose masked-input source is already translated — **zero tokens, no manual `--keys` scoping** — and its wiring into the production harness as `gen_opt_harness2.py --tm`.

Closes the reuse gap that both Workflow paths leave open:
- `resumeFromRunId` *replays a run verbatim* (re-serves the cached failure), it does not re-roll a stochastic failure;
- a **fresh** run *re-translates the whole card from scratch*, discarding every fragment that already succeeded (brÅ«'s first failure burned ~860k tokens re-doing 12 of 13 good fragments).

## How

- **`RussianTranslation/src/pilot/translation_memory.py`** (new): harvests the local-only store into a cache keyed on `f"{lang}:{input_raw_sha256}"`. The address is computed **identically** at harvest (each store row's `provenance.input_raw_sha256`) and at generation (`sha256_file` of the `.raw.txt`), so it is exact with no normalization guesswork, **version-safe** (changed source â†' new SHA â†' miss â†' re-translate; a stale translation can never be reused), and gives **cross-card reuse** for byte-identical sources. Built from the current store: **2,121 cards / 10,841 senses / 49 roots** (4 legacy no-SHA rows skipped).
- **`gen_opt_harness2.py --tm[=PATH]`**: TM-hit keys are emitted in a `TM_RESOLVED` lane (canonical, restored-markup cards; **no `agent()` call**) and removed from every translate lane (batches / presplit / selfheal fragments). The total-accounting invariant is preserved: `tm âˆª batched âˆª presplit == selected`, disjoint. **OFF by default** (opt-in; an empty/stale TM is a silent no-op).
- Granularity is **card-level** (the coarsest unit whose source string is byte-identical at both harvest and generation). Sub-card sense/fragment reuse is the documented next increment (the store's per-sense `de` does not align byte-for-byte with `autosplit_requeue.plan()` fragments).
- TM json is **gitignored** (derived from the local-only store, regenerable).

## Validation

- `window_selftest.py` **+2 pinning tests** (addressing rules; end-to-end lane exclusion) â€" suite **24/24 green**.
- **Offline:** `gam` â€" **127 â†' 3 cards** route to translation (124 pre-resolved).
- **Live (Workflow runtime):** `jIv` â€" **17/17 served from TM at 0 agents / 0 tokens / 70 ms**; returned cards carry full restored markup (`<ls>`, `{#..#}`, German + Russian), promote-ready and idempotent under `--merge`.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)