### PR TITLE
docs(pwg): record S7 quality follow-through (PR #89) in .ai_state

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -784,6 +784,29 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ✅ Completed (Recent only)
 
+- **S7 quality follow-through — ✅ DONE 2026-07-02, Opus 4.8 (`claude-opus-4-8`); A/B
+  generation Sonnet 5 (`claude-sonnet-5`). [PR #89](https://github.com/gasyoun/SanskritLexicography/pull/89)
+  (merged).** The three [`FABLE_JUDGE_S7_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/FABLE_JUDGE_S7_2026-07-02.md)
+  recommendations delivered (handoff [`OPUS_pwg_s7_quality_gate.md`](https://github.com/gasyoun/Uprava/blob/main/handoffs/OPUS_pwg_s7_quality_gate.md)):
+  (1) **"translate, don't annotate"** HARD RULE added to BOTH the RU template
+  ([`run_pilot_wf.js`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/run_pilot_wf.js)
+  `TR` rule 6) and the EN prompt ([`tr_en.txt`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/tr_en.txt)
+  rule 4) — render exactly what the German says, never add glosses/qualifiers/attributions;
+  (2) **MW-TM guard** — [`gen_opt_harness2.mw_tm_block`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py)
+  injected block + `tr_en.txt` MW REFERENCE now state MW is a terminology cross-check only
+  (no phrase copied unless the German licenses it); (3) the **`{%..%}`-pair-count soft gate**
+  the memo asked for **already shipped** in [PR #78](https://github.com/gasyoun/SanskritLexicography/pull/78)
+  (RU `markup_wrapper_dropped` + EN `MARKUP-LOSS`, both soft/report-only) — this session
+  pinned both with `window_selftest.py` fixtures (`test_markup_loss_soft_flag_ru/_en`; suite
+  **26/26 green**). **A/B** (yaj, 7 cards incl. the 208-`<ls>` dense head, old vs new prompt,
+  Sonnet 5, ≤3-wide, scratch-only — RU store untouched): on the 6 identical non-partial cards
+  marker retention **2/13 → 13/13** (drop **85 % → 0 %**); addition-class high-conf risks
+  **3 → 0**; coverage **7/7 ok** both arms (no regression). n small + stochastic = indicative
+  not conclusive; direction unambiguous, nothing regressed. ⚠ concurrent session was editing
+  `gen_opt_harness2.py`/`translation_memory.py`/`window_selftest.py` (sense-level-TM increment)
+  in the working tree during this session — PR #89 is off `origin/master`, edits localized, any
+  merge conflict is trivial (keep both).
+
 - **S10 architecture audit + big-card failure closure — ✅ DONE 2026-07-02, Fable 5
   (`claude-fable-5`).** Full findings:
   [`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md).


### PR DESCRIPTION
Document-first ✅ Completed entry for [#89](https://github.com/gasyoun/SanskritLexicography/pull/89) (S7 quality follow-through). Append-only; a concurrent sense-level-TM session is also editing `.ai_state.md`, so a merge conflict (if any) is trivial — keep both entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)