### PR TITLE
feat(pwg-tm): fragment-level translation-memory reuse (sub-card sense/fragment)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -30,9 +30,41 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   served from TM live via the Workflow runtime at 0 agents / 0 tokens / 70 ms**. Build/refresh
   the TM after any promotion: `python src/pilot/translation_memory.py build --lang ru`. TM json
   is gitignored (derived from the local-only store, regenerable).
-  **NEXT INCREMENT (sub-card sense/fragment reuse) — its own handoff:**
-  `Read C:\Users\user\Documents\GitHub\SanskritLexicography\RussianTranslation\HANDOFF_2026-07-02_pwg_tm_sense_level.md and execute it.`
-  ([handoff file](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/HANDOFF_2026-07-02_pwg_tm_sense_level.md))
+  **NEXT INCREMENT (sub-card sense/fragment reuse) — ✅ SHIPPED 2026-07-02 (Opus 4.8
+  `claude-opus-4-8`); see the fragment-TM bullet below. The
+  [HANDOFF_2026-07-02_pwg_tm_sense_level.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/HANDOFF_2026-07-02_pwg_tm_sense_level.md)
+  it pointed at is SPENT — do not re-execute.**
+
+- **Fragment-level TM (sub-card sense/fragment reuse) SHIPPED + wired + LIVE-VALIDATED
+  (2026-07-02, Opus 4.8 `claude-opus-4-8`; branch `feat/pwg-tm-fragment-reuse`, PR pending).**
+  The higher-value increment on top of the card-level TM: reuse ONE fragment inside a
+  still-failing giant flat headword (kAla/ka/SrI) and the same meaning shared byte-for-byte
+  across a root and its derived noun. **Approach (a) — capture ground truth at heal time,
+  NOT re-align the store.** New in
+  [`translation_memory.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/translation_memory.py):
+  `frag_address(lang, frag_source)` = `sha256(lang + NUL 'frag' NUL + plan()-chunk)` — the
+  chunk is the EXACT deterministic `autosplit_requeue.plan()` fragment **including** the
+  header it attaches to fragment 0 (real translated source on both sides; the handoff's
+  "strip the header" step was an artifact of the discarded store-`de` alignment and would
+  have broken the round-trip — DEVIATED, documented in the module). `build_frags` harvests
+  the harness's new per-fragment `frag_prov` channel from `wf_output` into an append-only,
+  fsha-deduped sidecar `translation_memory.frag.<lang>.jsonl` (gitignored, regenerable);
+  `load_frag_tm` reads it. Wired into
+  [`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py)
+  under the SAME `--tm` switch: `build()` addresses each precomputed fragment and emits a
+  `FRAG_TM[k]` map (mirrors `FRAGS[k]` group shape); JS `selfHeal` serves cached fragments
+  with **NO `agent()` call** and heals only the uncached, emitting `frag_prov` for the
+  freshly-resolved — so a partial giant card re-runs only its missing fragments, a
+  fully-cached card heals at zero cost. Every fidelity guard preserved (per-fragment {Tn}
+  multiset + whole-card `<ls>/{#` reassembly). `window_selftest.py` **25/25**
+  (+`test_frag_tm_reuse`); `node --check` clean on empty + populated FRAG_TM. **Live proof
+  (`gam~~h0_02_sec_2`, 7 fragments / 23 senses, store untouched — harvested from wf_output,
+  no promotion):** run-1 cold = **5 agents / 312,393 tokens / 117 s**; harvest `build-frags`;
+  run-2 `--tm` = **0 agents / 0 tokens / 31 ms**, card returned complete and **byte-identical**
+  to run-1 (23/23 senses, `<ls>` 60==60). Refresh the sidecar after every heal run:
+  `python src/pilot/translation_memory.py build-frags --lang ru` (stale = misses, never wrong
+  reuse). The card-level TM shadows a whole-card hit first, so fragment reuse lands exactly
+  where it's needed: cards never promoted whole (partial giants) + cross-card shared fragments.
 
 - **Opt2 harness: S10 recovery machinery is now DEFAULT + presplit router SHIPPED
   (MG decision 2026-07-02, Fable 5 (`claude-fable-5`) approach-review session; this PR).**

--- a/RussianTranslation/.gitignore
+++ b/RussianTranslation/.gitignore
@@ -36,7 +36,10 @@ src/pilot/run_pilot_wf.sc_y*.js
 
 # Translation-memory cache — DERIVED from the local-only store (pwg_ru_translated.jsonl) by
 # translation_memory.py; regenerable, never a deliverable (like the store it comes from).
+# The card cache is *.json; the fragment sidecar (harvested from wf_output frag_prov) is
+# translation_memory.frag.<lang>.jsonl — both regenerable, neither a deliverable.
 src/pilot/translation_memory.*.json
+src/pilot/translation_memory.frag.*.jsonl
 
 # Max workflow run output and A/B transcript artifacts (not deliverables)
 wf_output.json

--- a/RussianTranslation/HANDOFF_2026-07-02_pwg_tm_sense_level.md
+++ b/RussianTranslation/HANDOFF_2026-07-02_pwg_tm_sense_level.md
@@ -2,6 +2,15 @@
 
 _Created: 02-07-2026 · Last updated: 02-07-2026_
 
+> ✅ **SPENT — do NOT re-execute (executed 2026-07-02, Opus 4.8 `claude-opus-4-8`).**
+> Fragment-level TM shipped on branch `feat/pwg-tm-fragment-reuse`: `frag_address` +
+> `build_frags`/`load_frag_tm` in `translation_memory.py`, `frag_prov` channel + `FRAG_TM`
+> reuse in `gen_opt_harness2.py`, `window_selftest.py` 25/25, live-proven
+> (`gam~~h0_02_sec_2`: 5 agents/312k tok → **0 agents/0 tok**, card byte-identical). One
+> deliberate deviation from §Suggested-approach step 2: the `plan()` header is NOT stripped —
+> with approach (a) it is real translated source of fragment 0 on both sides, so stripping it
+> would break the address round-trip. Details in `.ai_state.md` (fragment-TM bullet).
+
 **How M.G. runs me:** open a NEW chat with working dir
 `C:\Users\user\Documents\GitHub\SanskritLexicography`, pick **Opus 4.8** (`claude-opus-4-8`) or
 Sonnet 5 in the model picker, and type exactly:

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -469,10 +469,28 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     # SELFHEAL_GROUP_BUDGET-sized batches, so the JS heal issues one agent() call per GROUP
     # instead of per fragment (a 13-fragment card was costing 13 calls / ~2.2M tok; grouping
     # amortizes the ~30k fixed system-prompt overhead across several fragments per call).
-    frags, phf = {}, {}
+    # --tm fragment reuse: alongside the whole-card cache above, load the per-fragment
+    # sidecar. Each deterministic plan() fragment is content-addressed (its exact chunk
+    # text, header included — see translation_memory.frag_address); a cached fragment is
+    # served WITHOUT an agent() call inside selfHeal, so a partially-failed giant card
+    # re-runs only its still-missing fragments (and a fragment shared byte-for-byte across
+    # a root and its derived noun is reused). Enabled by the same --tm switch; a missing
+    # sidecar is simply a no-op (all fragments translate as before).
+    frag_cache, frag_file = {}, None
+    if tm_path:
+        import translation_memory as _tm
+        frag_file = os.path.join(os.path.dirname(tm_path),
+                                 os.path.basename(_tm.frag_tm_path(lang)))
+        frag_cache = _tm.load_frag_tm(lang, frag_file)
+        if frag_cache:
+            print('  frag-tm: %d cached fragment(s) available from %s'
+                  % (len(frag_cache), os.path.basename(frag_file)))
+
+    frags, phf, frag_tm = {}, {}, {}
     if SELFHEAL:
+        import translation_memory as _tm
         for k in keys:
-            if k in tm_keys:                 # cached — no heal fallback needed
+            if k in tm_keys:                 # cached whole card — no heal fallback needed
                 continue
             pl = split_plan(read_text(input_paths(k)[0]))
             if len(pl) < 2:
@@ -487,13 +505,23 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
                     # so a batch failure on it is unrecoverable in-harness
                     print('  selfheal: %s fallback DROPPED (fragment mask round-trip lossy)' % k)
                     break
-                fl.append({'skeleton': fsk, 'ls': t.count('<ls'), 'sk': t.count('{#'), 'ph': fph})
+                fsha = _tm.frag_address(lang, t)
+                cached = frag_cache.get(fsha)
+                fl.append({'skeleton': fsk, 'ls': t.count('<ls'), 'sk': t.count('{#'),
+                           'ph': fph, 'fsha': fsha,
+                           'tm': cached.get('senses') if cached else None})
             if not fl:
                 continue
             groups = _group_by_budget(fl, lambda it: 1 + it['ls'], SELFHEAL_GROUP_BUDGET)
-            frags[k] = [[{'skeleton': it['skeleton'], 'ls': it['ls'], 'sk': it['sk']} for it in g]
-                        for g in groups]
+            frags[k] = [[{'skeleton': it['skeleton'], 'ls': it['ls'], 'sk': it['sk'],
+                          'fsha': it['fsha']} for it in g] for g in groups]
             phf[k] = [[it['ph'] for it in g] for g in groups]
+            # FRAG_TM[k]: same group shape, each slot = cached restored senses or null.
+            # Only emitted when this card has at least one cached fragment (keeps the JS lean
+            # and lets the summary count reuse). A fully-cached card heals at ZERO agent calls.
+            gview = [[it['tm'] for it in g] for g in groups]
+            if any(slot for grp in gview for slot in grp):
+                frag_tm[k] = gview
 
     # Pre-split router (MG decision 2026-07-02): a card whose citation-weighted output
     # complexity (1 + <ls>) alone exceeds the WHOLE per-batch output budget is near-certain
@@ -551,6 +579,9 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         'presplit_keys': presplit,
         'tm': os.path.basename(tm_path) if tm_path else None,
         'tm_hits': sorted(tm_keys),
+        'frag_tm': os.path.basename(frag_file) if (frag_cache and tm_path) else None,
+        'frag_tm_cards': sorted(frag_tm),
+        'frag_tm_fragments': sum(sum(1 for grp in v for s in grp if s) for v in frag_tm.values()),
     }
 
     js = """// AUTO-DERIVED v2 (batched + masked, canonical output) from run_pilot_wf.js - root=%(root)s.
@@ -579,6 +610,11 @@ const PRESPLIT = %(presplit)s
 // Emitted verbatim as canonical rows with tm:true and NO agent() call — their markup is
 // already restored (they come from the promoted store), so they bypass restore/accept.
 const TM_RESOLVED = %(tm_resolved)s
+// --tm fragment reuse: FRAG_TM[k] mirrors FRAGS[k]'s group shape; each slot is either a
+// cached fragment's ALREADY-RESTORED senses (served with NO agent() call inside selfHeal)
+// or null (translate it). A fully-cached card heals at zero cost; a partial giant card
+// re-runs only its still-missing fragments. Empty ({}) unless --tm found a fragment sidecar.
+const FRAG_TM = %(frag_tm)s
 const META = %(meta)s
 
 const restore = (t, ph) => (t || '').replace(/\\{T(\\d+)\\}/g, (m, n) => (ph[+n - 1] !== undefined ? ph[+n - 1] : m))
@@ -698,38 +734,57 @@ async function healGroup(k, idxs, grp, label) {
 // follow-up can requeue JUST the failed pieces instead of re-running the whole card.
 async function selfHeal(k) {
   const groups = FRAGS[k]; if (!groups || !groups.length) { noteFail(k, 'no-selfheal-fallback (card did not split or a fragment mask was lossy)'); return null }
+  const ftm = FRAG_TM[k] || []            // --tm: per-group cached-senses-or-null, mirrors FRAGS[k]
   const senses = []
   const missingFragments = []   // 'g<gi+1>:f<fi>' identifiers — persisted on the card so a
                                 // targeted requeue of JUST the failed fragments is possible
                                 // from wf_output alone (the inline path previously recorded
                                 // only a count, making a follow-up a full re-run)
+  const fragProv = []           // {fsha, senses} per FRESHLY-resolved fragment — harvested by
+                                // translation_memory.py build-frags into the fragment TM so the
+                                // next run reuses it (ground truth captured at the moment of success)
   for (let gi = 0; gi < groups.length; gi++) {
     const grp = groups[gi]
     const gph = (PHF[k] || [])[gi] || []
+    const gtm = ftm[gi] || []
+    // Fragments already in the TM are served directly (no agent() call); heal only the rest.
+    // A fully-cached group issues zero calls; a partial giant card re-runs only what's missing.
+    const uncached = []
+    for (let i = 0; i < grp.length; i++) { if (!gtm[i]) uncached.push(i) }
     // A hard agent() failure inside healGroup (thrown, not returned — see translateBatch's
     // comment) must be caught HERE, per group: uncaught, it unwinds out of this whole loop and
     // discards every earlier group's already-accumulated senses along with it (observed live —
     // 45 agent calls ran, several groups plausibly succeeded, yet the card still came back with
     // ZERO senses because one later group's hard failure wiped the local `senses` array before
     // selfHeal could return anything).
-    let r = null
-    try { r = await healGroup(k, grp.map((_, i) => i), grp, 'heal:' + k + '#g' + (gi + 1)) }
-    catch (e) { r = null; noteFail(k, 'heal-group-hard-failure g' + (gi + 1) + ': ' + (e && e.message || e)) }
-    if (!r) { for (let i = 0; i < grp.length; i++) missingFragments.push('g' + (gi + 1) + ':f' + i); continue }
+    let r = { resolved: {}, missing: [] }
+    if (uncached.length) {
+      try { r = await healGroup(k, uncached, grp, 'heal:' + k + '#g' + (gi + 1)) }
+      catch (e) { r = { resolved: {}, missing: uncached }; noteFail(k, 'heal-group-hard-failure g' + (gi + 1) + ': ' + (e && e.message || e)) }
+    }
     for (const fi of (r.missing || [])) missingFragments.push('g' + (gi + 1) + ':f' + fi)
     for (let i = 0; i < grp.length; i++) {
+      if (gtm[i]) {
+        // cached senses are ALREADY restored to source markup (validated at their harvest run);
+        // slot them in at their document position — do NOT re-restore (no {Tn} remain).
+        for (const s of gtm[i]) senses.push(s)
+        continue
+      }
       const card = r.resolved[i]
-      if (!card) continue
+      if (!card) continue   // an uncached fragment that never resolved — already in missingFragments
       const ph = gph[i] || []
+      const fsenses = []
       for (const rec of (card.records || [])) for (const s of (rec.senses || [])) {
         if (s.german !== undefined) s.german = restore(s.german, ph)
         if (s.%(field)s !== undefined) s.%(field)s = restore(s.%(field)s, ph)
-        senses.push(s)
+        senses.push(s); fsenses.push(s)
       }
+      if (grp[i].fsha && fsenses.length) fragProv.push({ fsha: grp[i].fsha, senses: fsenses })
     }
   }
   if (!senses.length) { if (!FAIL[k]) noteFail(k, 'selfheal-nothing-resolved'); return null }
   const stitched = { key1: k, records: [{ senses }] }
+  if (fragProv.length) stitched.frag_prov = fragProv
   if (!missingFragments.length) {
     // fidelity check only meaningful on a COMPLETE heal — a partial result legitimately has
     // fewer citations than the source. Per-fragment token checks already gated each piece;
@@ -885,6 +940,7 @@ for (const r of out) if (!r.card) _failures[r.key] = r.error || FAIL[r.key] || '
 const summary = { root: META.root, lang: META.lang, cards: out.length, ok: _ok,
                   null: out.length - _ok, healed: out.filter(r => r.escalated).length,
                   presplit: PRESPLIT.length, tm: out.filter(r => r.tm).length,
+                  frag_tm_fragments: META.frag_tm_fragments || 0,
                   null_keys: out.filter(r => !r.card).map(r => r.key),
                   partial_keys: out.filter(r => r.card && r.card.partial).map(r => r.key),
                   failures: _failures }
@@ -908,6 +964,7 @@ return { meta: META, summary, results: out }
         'frags': json.dumps(frags, ensure_ascii=True), 'phf': json.dumps(phf, ensure_ascii=True),
         'binary_split': json.dumps(BINARY_SPLIT), 'presplit': json.dumps(presplit),
         'tm_resolved': json.dumps(tm_resolved, ensure_ascii=True),
+        'frag_tm': json.dumps(frag_tm, ensure_ascii=True),
     }
     for bad in ['readFileSync', 'fileURLToPath', 'import.meta']:
         if bad in js:

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -26,30 +26,39 @@ sub-cards with byte-identical source (a duplicated sub-entry) reuse one translat
 Version safety is intrinsic: if a card's source changes, its SHA changes, the address
 misses, and the card is re-translated — a stale translation can never be reused.
 
-GRANULARITY (and the next increment)
-------------------------------------
-This TM is CARD-level (one address per sub-card). That is the coarsest unit whose source
-string is byte-identical at both harvest and generation time (the raw `.raw.txt` on disk),
-so content-addressing is exact with no normalization guesswork. Sub-CARD (sense/fragment)
-reuse — reusing an already-translated sense inside a still-failing giant flat headword like
-kAla/ka/SrI, or the same meaning across a root and its derived noun — is the higher-value
-next increment, but the store's per-sense `de` does NOT align byte-for-byte with the
-harness's `autosplit_requeue.plan()` fragments (headers + citation-batching → ~3/7 exact on
-a sample), so it needs a fragment-provenance channel this first version deliberately does
-not fake. See the handoff for the plan.
+GRANULARITY (two levels)
+------------------------
+CARD level (`build` / `load_tm` / `frag_address`-less path): one address per sub-card, keyed
+on the whole masked source. The coarsest unit whose source string is byte-identical at both
+harvest and generation (the raw `.raw.txt`), so content-addressing is exact with no guesswork.
+
+FRAGMENT level (`build_frags` / `load_frag_tm` / `frag_address`, added 2026-07-02): one address
+per deterministic `autosplit_requeue.plan()` fragment, so a partially-failed giant flat headword
+(kAla/ka/SrI) re-runs only its still-missing fragments and the same meaning shared byte-for-byte
+across a root and its derived noun is reused. This does NOT try to align the store's per-sense
+`de` to plan() fragments (the discarded approach — headers + citation-batching gave ~3/7 exact);
+instead the harness's selfHeal records fragment→senses ground truth (`frag_prov`) at the instant
+of a successful heal, and `build_frags` harvests it. See the fragment-TM section below.
 
 USAGE
 -----
-  python src/pilot/translation_memory.py build   [--lang ru|en] [--store PATH] [--out PATH]
-  python src/pilot/translation_memory.py stats    [--lang ru|en] [--tm PATH]
+  python src/pilot/translation_memory.py build        [--lang ru|en] [--store PATH] [--out PATH]
+  python src/pilot/translation_memory.py stats        [--lang ru|en] [--tm PATH]
   python src/pilot/translation_memory.py lookup <input_raw_sha256> [--lang ru|en] [--tm PATH]
+  python src/pilot/translation_memory.py build-frags  [--lang ru|en] [--glob 'wf_output*.json'] [--out PATH]
+  python src/pilot/translation_memory.py frag-stats   [--lang ru|en] [--out PATH]
   python src/pilot/translation_memory.py selftest
 
-The TM file (default src/pilot/translation_memory.<lang>.json) is DERIVED from the
-local-only, gitignored store and is itself gitignored + regenerable — never a deliverable.
+The card TM file (default src/pilot/translation_memory.<lang>.json) is DERIVED from the
+local-only, gitignored store; the fragment sidecar (translation_memory.frag.<lang>.jsonl) is
+harvested from wf_output cards' `frag_prov`. Both are gitignored + regenerable — never a
+deliverable. Refresh both after every promotion (card TM) / heal run (fragment TM), or they
+go stale (stale = misses, never wrong reuse — you only lose the savings).
 """
 import argparse
 import datetime
+import glob as _glob
+import hashlib
 import json
 import os
 import sys
@@ -185,6 +194,115 @@ def lookup(lang, raw_sha256, tm=None):
     return load_tm(lang, tm).get('%s:%s' % (lang, raw_sha256))
 
 
+# ------------------------------------------------------------------- fragment-level TM
+# SUB-CARD reuse. The card-level TM above reuses a whole sub-card only when its ENTIRE
+# masked source is byte-identical to a cached one. The fragment TM reuses ONE fragment
+# inside a still-failing giant card (kAla/ka/SrI: one card, 40+ heal groups) and the same
+# meaning across a root and its derived noun — the higher-value increment.
+#
+# ADDRESS. A fragment is keyed by the SHA-256 of the EXACT deterministic `plan()` chunk
+# text that was translated — INCLUDING the header that `autosplit_requeue.plan()` attaches
+# to fragment 0 (a verb's conjugation-table header is genuine translated source, not
+# scaffolding). Both sides compute the SAME chunk: `split_plan(read_text(raw))` is
+# deterministic, so harvest and generation see byte-identical fragment text -> identical
+# address. (The earlier "3/7 exact" mismatch was an artifact of comparing to the store's
+# per-sense `de`, which carries no header; we never do that here — we capture fragment ->
+# senses at the moment of a successful heal, so there is no alignment guesswork and nothing
+# to strip.) Version safety is intrinsic, exactly as for the card TM: a changed source ->
+# a different chunk -> a different address -> a miss -> re-translation; a stale fragment can
+# never be reused. LS_BUDGET is part of the chunking, so a changed AUTOSPLIT_LS_BUDGET
+# re-chunks -> new addresses -> misses (correct: different chunking is a different fragment).
+#
+# GROUND TRUTH. The sidecar is harvested from wf_output cards' `frag_prov` channel, which
+# `gen_opt_harness2`'s selfHeal emits per FRESHLY-resolved fragment ({fsha, restored
+# senses}) — recorded at the instant of success, after the per-fragment {Tn}-multiset
+# fidelity guard passed. The sidecar is DERIVED (gitignored + regenerable), never a
+# deliverable, and append-only+deduped by fsha (first-seen wins).
+FRAG_SEP = '\x00frag\x00'
+
+
+def frag_address(lang, frag_source):
+    """The content address of one plan() fragment: sha256(lang + NUL 'frag' NUL + source).
+
+    The single source of truth for the address formula — imported by gen_opt_harness2 so
+    the SHA embedded in the harness (and echoed into frag_prov at harvest) is computed the
+    exact same way it is recomputed at injection time."""
+    return hashlib.sha256((lang + FRAG_SEP + frag_source).encode('utf-8')).hexdigest()
+
+
+def frag_tm_path(lang, out=None):
+    return out or os.path.join(HERE, 'translation_memory.frag.%s.jsonl' % lang)
+
+
+def load_frag_tm(lang, path=None):
+    """Return { fsha: {'senses': [...], 'src_key', 'root', ...} } for the fragment sidecar,
+    or {} if none exists. First-seen fsha wins (append-only dedupe)."""
+    p = frag_tm_path(lang, path)
+    out = {}
+    if not os.path.exists(p):
+        return out
+    with open(p, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            fsha = row.get('fsha')
+            if fsha and fsha not in out and row.get('senses'):
+                out[fsha] = row
+    return out
+
+
+def build_frags(glob_pattern, lang, out=None):
+    """Harvest per-fragment ground truth from wf_output cards' `frag_prov` channel into the
+    append-only fragment sidecar. Idempotent: a fragment already present (by fsha) is never
+    duplicated. Returns (path, added, total)."""
+    path = frag_tm_path(lang, out)
+    seen = set(load_frag_tm(lang, path))
+    files = sorted(_glob.glob(os.path.join(REPO, glob_pattern)))
+    new_rows, added = [], 0
+    for fp in files:
+        try:
+            with open(fp, encoding='utf-8') as f:
+                wrapper = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        res = wrapper.get('result')
+        if isinstance(res, str):
+            res = json.loads(res)
+        if res is None:
+            res = wrapper
+        meta = res.get('meta') or {}
+        if (meta.get('lang') or 'ru') != lang:
+            continue
+        root = meta.get('root')
+        for r in res.get('results') or []:
+            card = (r or {}).get('card')
+            if not card:
+                continue
+            for fpv in card.get('frag_prov') or []:
+                fsha, senses = fpv.get('fsha'), fpv.get('senses')
+                if not fsha or not senses or fsha in seen:
+                    continue
+                seen.add(fsha)
+                added += 1
+                new_rows.append({
+                    'schema': 'pwg.translation_memory.frag.v1', 'lang': lang, 'fsha': fsha,
+                    'src_key': r.get('key'), 'root': root, 'n_senses': len(senses),
+                    'senses': senses, 'wf_file': os.path.basename(fp),
+                    'harvested_at': datetime.datetime.now(datetime.timezone.utc).isoformat(
+                        timespec='seconds').replace('+00:00', 'Z'),
+                })
+    if new_rows:
+        with open(path, 'a', encoding='utf-8') as f:
+            for row in new_rows:
+                f.write(json.dumps(row, ensure_ascii=False) + '\n')
+    return path, added, len(seen)
+
+
 # --------------------------------------------------------------------------- selftest
 def selftest():
     import tempfile
@@ -230,6 +348,7 @@ def selftest():
         assert n == 1, n
         assert lookup('ru', 'AAA', tm=out)['src_key'] == 'x~~h0_1'
         assert lookup('ru', 'ZZZ', tm=out) is None
+        _frag_selftest()
         print('translation_memory selftest OK')
     finally:
         for p in (store, out):
@@ -239,12 +358,55 @@ def selftest():
                 pass
 
 
+def _frag_selftest():
+    import tempfile
+    # 1) Address is deterministic, lang-separated, and header-sensitive (no stripping).
+    src = '=== header ===\n1) foo <ls>ṚV.</ls>'
+    assert frag_address('ru', src) == frag_address('ru', src), 'address not deterministic'
+    assert frag_address('ru', src) != frag_address('en', src), 'lang must separate the address'
+    assert frag_address('ru', src) != frag_address('ru', src.split('\n', 1)[1]), \
+        'header is part of the fragment source — the address must change if it is stripped'
+    # 2) build_frags harvests frag_prov from wf_output, dedups by fsha, is idempotent.
+    d = tempfile.mkdtemp()
+    fsha = frag_address('ru', src)
+    senses = [{'tag': '1', 'german': 'foo <ls>ṚV.</ls>', 'russian': 'фу', 'source_type': 'attested'}]
+    wf = {'meta': {'lang': 'ru', 'root': 'zz'}, 'results': [
+        {'key': 'zz~~h0_00_pwg00', 'card': {'key1': 'zz', 'records': [{'senses': senses}],
+                                            'frag_prov': [{'fsha': fsha, 'senses': senses}]}},
+        {'key': 'zz~~h0_01', 'card': None},                       # null card: no frag_prov
+    ]}
+    en_wf = {'meta': {'lang': 'en', 'root': 'zz'}, 'results': [
+        {'key': 'zz~~h9', 'card': {'frag_prov': [{'fsha': 'EN', 'senses': senses}]}}]}
+    old_repo = globals()['REPO']
+    try:
+        globals()['REPO'] = d                                    # build_frags globs under REPO
+        with open(os.path.join(d, 'wf_output.sc.zz.json'), 'w', encoding='utf-8') as f:
+            json.dump(wf, f, ensure_ascii=False)
+        with open(os.path.join(d, 'wf_output.en.zz.json'), 'w', encoding='utf-8') as f:
+            json.dump(en_wf, f, ensure_ascii=False)
+        sidecar = os.path.join(d, 'frag.ru.jsonl')
+        _p, added, total = build_frags('wf_output*.json', 'ru', out=sidecar)
+        assert added == 1 and total == 1, (added, total)          # EN wf must not leak into RU
+        cache = load_frag_tm('ru', sidecar)
+        assert set(cache) == {fsha}, cache
+        assert cache[fsha]['senses'][0]['russian'] == 'фу', cache
+        # idempotent re-harvest adds nothing
+        _p, added2, total2 = build_frags('wf_output*.json', 'ru', out=sidecar)
+        assert added2 == 0 and total2 == 1, (added2, total2)
+    finally:
+        globals()['REPO'] = old_repo
+        import shutil
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def main():
     ap = argparse.ArgumentParser()
     sub = ap.add_subparsers(dest='cmd', required=True)
     b = sub.add_parser('build'); b.add_argument('--lang', default='ru'); b.add_argument('--store', default=DEFAULT_STORE); b.add_argument('--out', default=None)
     s = sub.add_parser('stats'); s.add_argument('--lang', default='ru'); s.add_argument('--tm', default=None)
     lk = sub.add_parser('lookup'); lk.add_argument('sha'); lk.add_argument('--lang', default='ru'); lk.add_argument('--tm', default=None)
+    bf = sub.add_parser('build-frags'); bf.add_argument('--lang', default='ru'); bf.add_argument('--glob', default='wf_output*.json'); bf.add_argument('--out', default=None)
+    fs = sub.add_parser('frag-stats'); fs.add_argument('--lang', default='ru'); fs.add_argument('--out', default=None)
     sub.add_parser('selftest')
     args = ap.parse_args()
 
@@ -269,6 +431,16 @@ def main():
     elif args.cmd == 'lookup':
         e = lookup(args.lang, args.sha, args.tm)
         print(json.dumps(e, ensure_ascii=False, indent=2) if e else '(miss)')
+    elif args.cmd == 'build-frags':
+        path, added, total = build_frags(args.glob, args.lang, out=args.out)
+        print('wrote %s (+%d new fragment(s), %d total, lang=%s)' % (path, added, total, args.lang))
+    elif args.cmd == 'frag-stats':
+        cache = load_frag_tm(args.lang, args.out)
+        senses = sum(len(e.get('senses') or []) for e in cache.values())
+        roots = Counter(e.get('root') for e in cache.values())
+        print('frag TM lang=%s: %d fragments, %d senses, %d roots' % (args.lang, len(cache), senses, len(roots)))
+        for root, c in roots.most_common(12):
+            print('  %-10s %d fragments' % (root, c))
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -874,10 +874,85 @@ def test_tm_pre_resolves_cards():
             pass
 
 
+def test_frag_tm_reuse():
+    """Fragment-level --tm: a card that plan()-splits into >=2 fragments, with ONE fragment
+    in the fragment sidecar, emits a FRAG_TM group-shape mirroring FRAGS where exactly the
+    cached fragment slot is filled (served at runtime with NO agent call) and the rest are
+    null. The card itself stays in a translate lane (reuse is inside selfHeal, not card
+    removal), so the whole-card accounting invariant is untouched."""
+    import re as _re
+    import gen_opt_harness2 as gh
+    import translation_memory as tm
+    from autosplit_requeue import plan as split_plan
+    from window_common import rootmap_path, input_paths, read_text
+    root = 'gam'
+    rmpath, _ = rootmap_path(root)
+    if not rmpath:
+        return  # inputs not present in this checkout — nothing to assert
+    rootmap, keys = gh.selected_keys(root, None)
+    keys = [k for k in keys if os.path.exists(input_paths(k)[0])]
+    # pick the first card that actually splits into >=2 deterministic fragments
+    target, plan0 = None, None
+    for k in keys:
+        pl = split_plan(read_text(input_paths(k)[0]))
+        if len(pl) >= 2:
+            target, plan0 = k, pl
+            break
+    if not target:
+        return
+    d = tempfile.mkdtemp()
+    try:
+        # card-level TM: empty (so `target` is NOT a whole-card hit); fragment sidecar caches
+        # exactly plan0[0]. The sidecar MUST sit next to the card TM under the exact basename.
+        tmfile = os.path.join(d, 'translation_memory.ru.json')
+        with open(tmfile, 'w', encoding='utf-8') as f:
+            json.dump({'schema': 'pwg.translation_memory.v1', 'lang': 'ru', 'entries': {}}, f)
+        fsha0 = tm.frag_address('ru', plan0[0][2])
+        senses0 = [{'tag': '1', 'german': plan0[0][2][:20], 'russian': 'кэш',
+                    'equivalence_type': 'equivalent', 'source_type': 'attested',
+                    'stratum': '', 'differentia': ''}]
+        with open(os.path.join(d, 'translation_memory.frag.ru.jsonl'), 'w', encoding='utf-8') as f:
+            f.write(json.dumps({'schema': 'pwg.translation_memory.frag.v1', 'lang': 'ru',
+                                'fsha': fsha0, 'src_key': target, 'senses': senses0},
+                               ensure_ascii=False) + '\n')
+        js, _batches = gh.build(root, [target], rootmap, 12000, tm_path=tmfile)
+
+        def const(name):
+            return json.loads(_re.search(r'^const %s = (.*)$' % name, js, _re.M).group(1))
+        meta = const('META')
+        frags, frag_tm = const('FRAGS'), const('FRAG_TM')
+        if target not in frag_tm:
+            fail('the card with a cached fragment must appear in FRAG_TM')
+        if target not in meta.get('frag_tm_cards', []):
+            fail('meta.frag_tm_cards must list the reusing card')
+        if meta.get('frag_tm_fragments') != 1:
+            fail('exactly one fragment should be cached, got %r' % meta.get('frag_tm_fragments'))
+        # shape mirrors FRAGS exactly
+        gv, fv = frags[target], frag_tm[target]
+        if [len(g) for g in gv] != [len(g) for g in fv]:
+            fail('FRAG_TM group shape must mirror FRAGS')
+        filled = [(gi, fi) for gi, g in enumerate(fv) for fi, slot in enumerate(g) if slot]
+        if filled != [(0, 0)]:
+            fail('only the first fragment (the cached one) must be filled, got %s' % filled)
+        # the filled slot carries the cached senses; its FRAGS sibling carries the matching fsha
+        if fv[0][0][0]['russian'] != 'кэш':
+            fail('cached fragment slot must carry the sidecar senses')
+        if gv[0][0].get('fsha') != fsha0:
+            fail('FRAGS fragment must carry the content address used for the cache lookup')
+        # whole-card accounting: reuse happens INSIDE selfHeal, so the card is still owed by a
+        # translate lane (batch or presplit), never silently dropped.
+        batched = {k for b in meta['batches'] for k in b}
+        if target not in (batched | set(meta['presplit_keys'])):
+            fail('a fragment-reusing card must still be owed by a translate lane')
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def main():
     tests = [
         test_translation_memory_addressing,
         test_tm_pre_resolves_cards,
+        test_frag_tm_reuse,
         test_workflow_payload_nested,
         test_sense_dupe_batch_override,
         test_sense_dupe_cross_level_exempt,


### PR DESCRIPTION
The next TM increment after the card-level cache ([PR #87](https://github.com/gasyoun/SanskritLexicography/pull/87)): reuse ONE deterministic `plan()` fragment inside a still-failing giant flat headword (kAla/ka/śrī), and the same meaning shared byte-for-byte across a root and its derived noun. Executes [`HANDOFF_2026-07-02_pwg_tm_sense_level.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/HANDOFF_2026-07-02_pwg_tm_sense_level.md) (now SPENT). Model: Opus 4.8 (`claude-opus-4-8`).

## Approach (a) — ground truth at heal time, no store re-alignment
The store's per-sense `de` does not align byte-for-byte with `plan()` fragments (headers + citation-batching), so instead of guessing, the harness records fragment→senses **at the instant of a successful heal**.

- [`translation_memory.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/translation_memory.py): `frag_address(lang, src)` = `sha256(lang + NUL 'frag' NUL + plan()-chunk)`; `build_frags` harvests the harness's new `frag_prov` channel from `wf_output` into an append-only, fsha-deduped sidecar `translation_memory.frag.<lang>.jsonl` (gitignored, regenerable); `load_frag_tm`; `build-frags`/`frag-stats` CLI.
- [`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py): under the **same `--tm` switch**, `build()` addresses each precomputed fragment and emits `FRAG_TM[k]` (mirrors `FRAGS[k]` group shape); JS `selfHeal` serves cached fragments with **no `agent()` call** and heals only the uncached, emitting `frag_prov` for the freshly-resolved. A partial giant card re-runs only its missing fragments; a fully-cached card heals at zero cost. Every fidelity guard preserved (per-fragment `{Tn}` multiset + whole-card `<ls>/{#` reassembly). Backward compatible — empty `FRAG_TM` == prior behavior.

## Deliberate deviation from the handoff (step 2)
The `plan()` header attached to fragment 0 is **not** stripped. With approach (a) it is genuine translated source on both harvest and inject sides, so stripping would break the address round-trip; the handoff's "3/7 exact" was an artifact of the discarded store-`de` alignment. Documented in the module + handoff SPENT banner.

## Validation
- `window_selftest.py` **25/25** (+`test_frag_tm_reuse`); `node --check` clean on empty + populated `FRAG_TM`.
- **Live proof** (`gam~~h0_02_sec_2`, 7 fragments / 23 senses, **store untouched** — harvested from `wf_output`, no promotion): run-1 cold = **5 agents / 312,393 tokens / 117 s** → `build-frags` → run-2 `--tm` = **0 agents / 0 tokens / 31 ms**, card returned complete and **byte-identical** to run-1 (23/23 senses, `<ls>` 60==60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)