### PR TITLE
fix(pwg-audit): FL8 — fixture guard so self-test/temp audits can't clobber live status

### DIFF
--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -13,6 +13,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 
 sys.stdout.reconfigure(encoding='utf-8')
@@ -40,6 +41,18 @@ from window_reports import (
     build_production_metrics,
     write_reports,
 )
+
+def _under_tempdir(path):
+    """True if `path` lives under the OS temp dir — i.e. a self-test/fixture wf_output rather
+    than a real repo run. Used to auto-guard the live singleton status files (FL8): a fixture
+    audit must never overwrite window_status.json / audit_window.report.json. commonpath raises
+    ValueError across Windows drives (temp on a different drive than the wf) -> treat as real."""
+    try:
+        tmp = os.path.realpath(tempfile.gettempdir())
+        return os.path.commonpath([tmp, os.path.realpath(path)]) == tmp
+    except (ValueError, OSError):
+        return False
+
 
 COLLECT = os.path.join(SRC, '_pilot_collect.py')
 BATCH_FILE = os.path.join(OUT, '_realtest_batch.json')
@@ -245,6 +258,10 @@ def main():
     ap.add_argument('--write-requeue', action='store_true')
     ap.add_argument('--allow-stale', action='store_true',
                     help='forensic mode: continue even if workflow/rootmap/input provenance is stale')
+    ap.add_argument('--ephemeral', action='store_true',
+                    help='fixture/self-test mode: write status+report to a throwaway scratch dir, '
+                         'never touching the live singleton window_status.json / '
+                         'audit_window.report.json (auto-enabled for a wf_output under the OS temp dir)')
     ap.add_argument('--judge-sample-rate', type=float, default=0.10,
                     help='deterministic clean-key semantic judge sample rate (default: 0.10)')
     ap.add_argument('--judge-sample-min', type=int, default=5,
@@ -274,6 +291,10 @@ def main():
     wf = os.path.abspath(args.wf_output)
     if not os.path.exists(wf):
         sys.exit('no workflow output %r' % args.wf_output)
+    # FL8 fixture guard: a self-test / temp-file audit writes its status+report to a scratch
+    # dir so it can never clobber the live singletons; a real repo run writes OUT as before.
+    ephemeral = args.ephemeral or _under_tempdir(wf)
+    report_out_dir = tempfile.mkdtemp(prefix='pwg_audit_ephemeral_') if ephemeral else None
 
     _payload, wf_meta, results, keys, null_cards = workflow_payload(wf)
     emit_audit_event(
@@ -302,7 +323,7 @@ def main():
                   'judge_sample_seed': args.judge_sample_seed,
                   'production_metrics': build_production_metrics(args)}
         json_path, md_path, rq_path, js_path, status_json, status_md = write_reports(
-            report, args.write_requeue, write_requeue_file=False)
+            report, args.write_requeue, write_requeue_file=False, out_dir=report_out_dir)
         emit_audit_event(
             'stale_refusal', level='error', root=args.root, state='stale_artifact',
             summary='stale artifact refused before collect/gates/glue (%d issue%s)' %
@@ -462,7 +483,8 @@ def main():
     report['judge_sample'] = build_judge_sample(
         report, args.judge_sample_rate, args.judge_sample_min, args.judge_sample_seed)
     report['production_metrics'] = build_production_metrics(args)
-    json_path, md_path, rq_path, js_path, status_json, status_md = write_reports(report, args.write_requeue)
+    json_path, md_path, rq_path, js_path, status_json, status_md = write_reports(
+        report, args.write_requeue, out_dir=report_out_dir)
     state = audit_state(report)
     emit_audit_event(
         'requeue_summary',

--- a/RussianTranslation/src/pilot/window_reports.py
+++ b/RussianTranslation/src/pilot/window_reports.py
@@ -122,8 +122,9 @@ def next_action_for(state, report, pending):
     return 'Window is mechanically clean; advance to the next frequency root.'
 
 
-def append_ledger(status):
-    os.makedirs(OUT, exist_ok=True)
+def append_ledger(status, out_dir=None):
+    out_dir = out_dir or OUT
+    os.makedirs(out_dir, exist_ok=True)
     compact = {
         'recorded_at': status.get('recorded_at'),
         'root': status.get('root'),
@@ -144,11 +145,12 @@ def append_ledger(status):
         'crashed': status.get('crashed'),
         'rootmap_sha256': status.get('rootmap_sha256'),
     }
-    with open(LEDGER, 'a', encoding='utf-8') as f:
+    with open(os.path.join(out_dir, os.path.basename(LEDGER)), 'a', encoding='utf-8') as f:
         f.write(json.dumps(compact, ensure_ascii=False) + '\n')
 
 
-def write_window_status(report):
+def write_window_status(report, out_dir=None):
+    out_dir = out_dir or OUT
     root = report.get('root')
     rootmap = rootmap_for(root) if root else None
     subkeys = []
@@ -221,8 +223,9 @@ def write_window_status(report):
                  'nested_exists': glue.get('nested_exists'),
                  'seconds': glue.get('seconds')},
     }
-    json_path = os.path.join(OUT, 'window_status.json')
-    md_path = os.path.join(OUT, 'window_status.md')
+    os.makedirs(out_dir, exist_ok=True)
+    json_path = os.path.join(out_dir, 'window_status.json')
+    md_path = os.path.join(out_dir, 'window_status.md')
     with open(json_path, 'w', encoding='utf-8') as f:
         json.dump(status, f, ensure_ascii=False, indent=1)
     lines = [
@@ -289,7 +292,7 @@ def write_window_status(report):
     lines += (judge_sample.get('keys') or ['(none)'])
     with open(md_path, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines) + '\n')
-    append_ledger(status)
+    append_ledger(status, out_dir)
     return json_path, md_path
 
 
@@ -320,18 +323,23 @@ def audit_state(report):
     return 'clean'
 
 
-def write_reports(report, write_requeue, write_requeue_file=True):
-    os.makedirs(OUT, exist_ok=True)
+def write_reports(report, write_requeue, write_requeue_file=True, out_dir=None):
+    # out_dir defaults to the live OUT dir. An ephemeral/fixture audit (see audit_window.py
+    # --ephemeral) passes a throwaway scratch dir so a self-test or temp-file run can NEVER
+    # clobber the live singleton window_status.json / audit_window.report.json — the "current
+    # status" once reported a temp-file fixture precisely because these names were fixed (FL8).
+    out_dir = out_dir or OUT
+    os.makedirs(out_dir, exist_ok=True)
     if 'judge_sample' not in report:
         report['judge_sample'] = build_judge_sample(
             report,
             report.get('judge_sample_rate', 0.10),
             report.get('judge_sample_min', 5),
             report.get('judge_sample_seed'))
-    json_path = os.path.join(OUT, 'audit_window.report.json')
-    md_path = os.path.join(OUT, 'audit_window.report.md')
-    requeue_path = os.path.join(OUT, 'requeue.keys.txt')
-    judge_sample_path = JUDGE_SAMPLE_FILE
+    json_path = os.path.join(out_dir, 'audit_window.report.json')
+    md_path = os.path.join(out_dir, 'audit_window.report.md')
+    requeue_path = os.path.join(out_dir, 'requeue.keys.txt')
+    judge_sample_path = os.path.join(out_dir, os.path.basename(JUDGE_SAMPLE_FILE))
     requeue_written = bool(write_requeue and write_requeue_file)
     report['requeue_file_written'] = requeue_written
     report.setdefault('requeue_file_preserved', bool(write_requeue and not write_requeue_file))
@@ -424,9 +432,9 @@ def write_reports(report, write_requeue, write_requeue_file=True):
                              ('requeue.defect.keys.txt', report.get('requeue_defect'))):
             if keys_ is None:
                 continue
-            with open(os.path.join(OUT, fname), 'w', encoding='utf-8') as f:
+            with open(os.path.join(out_dir, fname), 'w', encoding='utf-8') as f:
                 f.write('\n'.join(keys_) + ('\n' if keys_ else ''))
-    status_json, status_md = write_window_status(report)
+    status_json, status_md = write_window_status(report, out_dir)
     return (json_path, md_path,
             requeue_path if write_requeue and write_requeue_file else None,
             judge_sample_path, status_json, status_md)

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -654,6 +654,40 @@ def test_stale_refusal_preserves_requeue():
                 f.write(old)
 
 
+def test_fixture_audit_does_not_clobber_live_status():
+    """FL8: a fixture/self-test audit run must NEVER overwrite the live singleton status files
+    (window_status.json / audit_window.report.json). A temp-file wf auto-enables the guard, and
+    --ephemeral forces it; either way the live OUT singletons are byte-identical afterward."""
+    live = [os.path.join(OUT, 'window_status.json'),
+            os.path.join(OUT, 'audit_window.report.json'),
+            os.path.join(OUT, 'window_ledger.jsonl')]
+
+    def snap(p):
+        return open(p, 'rb').read() if os.path.exists(p) else None
+
+    before = {p: snap(p) for p in live}
+    fixture = {'meta': {'root': 'zzfixture'}, 'results': [
+        {'key': 'zzfixture~~h0_00_pwg00', 'card': {'iast': 'zz', 'records': [
+            {'h': '1', 'senses': [{'tag': '1', 'german': '{%Wasser%}', 'russian': 'вода',
+             'equivalence_type': 'equivalent', 'source_type': 'attested',
+             'stratum': '', 'differentia': ''}]}]}}]}
+    with tempfile.NamedTemporaryFile('w', encoding='utf-8', suffix='.json', delete=False) as f:
+        wf_path = f.name
+        json.dump(fixture, f, ensure_ascii=False)
+    try:
+        # No expect() — a fixture may audit clean/blocked/stale; the guarantee under test is
+        # only that the live singletons are not touched, whatever the exit code.
+        subprocess.run([sys.executable, os.path.join(SRC, 'pilot', 'audit_window.py'),
+                        wf_path, '--ephemeral'],
+                       cwd=ROOT, capture_output=True, text=True, encoding='utf-8')
+        after = {p: snap(p) for p in live}
+        for p in live:
+            if before[p] != after[p]:
+                fail('ephemeral audit clobbered the live status file %s' % os.path.basename(p))
+    finally:
+        os.remove(wf_path)
+
+
 def test_release_manifest_hash_validation():
     with tempfile.TemporaryDirectory() as tmp:
         edition = os.path.join(tmp, 'edition_selftest')
@@ -1035,6 +1069,7 @@ def main():
         test_ru_coverage_denominator_not_silently_exempt,
         test_whitney_homonym_safety,
         test_stale_refusal_preserves_requeue,
+        test_fixture_audit_does_not_clobber_live_status,
         test_release_manifest_hash_validation,
     ]
     for test in tests:


### PR DESCRIPTION
## FL8 — singleton status files clobbered by any run

`audit_window`'s [`window_status.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/output/window_status.json) and `audit_window.report.json` are fixed singleton names, overwritten by **any** audit run — including test fixtures. So "current status" could not be trusted without the event ledger (observed: current status once reported a temp-file fixture). Flagged FL8 in [`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) §3.

## Fix

- Thread an `out_dir` (default = live `OUT`) through `write_reports` / `write_window_status` / `append_ledger` in [`window_reports.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_reports.py).
- [`audit_window.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window.py) writes status+report to a throwaway scratch dir whenever the run is **ephemeral**: explicit `--ephemeral`, or auto-detected when the `wf_output` lives under the OS temp dir (every `NamedTemporaryFile` self-test). Real repo runs write `OUT` exactly as before.

The auto-detect makes the guard robust without every fixture having to remember a flag — the observed failure mode (a temp-file fixture becoming "current status") is now impossible by construction.

## Test

`test_fixture_audit_does_not_clobber_live_status` ([`window_selftest.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_selftest.py), now **28 green**) runs `audit_window` on a temp wf and asserts the live `window_status.json` / `audit_window.report.json` / `window_ledger.jsonl` are byte-identical afterward.

Model: Opus 4.8 (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)