### PR TITLE
fix(pwg-en): FL4 — EN triage coverage-complete + keep missing-input nulls visible

### DIFF
--- a/RussianTranslation/src/pilot/en_residual_keys.py
+++ b/RussianTranslation/src/pilot/en_residual_keys.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python
-"""Print the residual (no-English) selected_keys for a root's EN store.
+"""Print the residual (not-fully-English) selected_keys for a root's EN store.
 
   python src/pilot/en_residual_keys.py <root>
 
-A key is "done" iff its card has >=1 record with >=1 sense carrying a non-empty
-`english`. Prints comma-joined missing keys (LF, no trailing CR) to stdout so a
+A key is "done" iff EVERY translation slot in its card carries a non-empty
+`english` — coverage-complete, not merely ">=1 English sense". The old ">=1"
+rule counted a 1/40-sense card as done and hid 39 untranslated senses (FL4;
+same class as ru_coverage's per-root denominator idea, applied within a card).
+The denominator is the card's own senses that carry a German source side (each
+is a slot that must be translated); the numerator is those that also carry
+English. Prints comma-joined missing keys (LF, no trailing CR) to stdout so a
 requeue can `--keys="$(python ... <root>)"`. Empty output => root at 100%.
 """
 import json
@@ -18,19 +23,35 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(HERE))
 
 
+def en_coverage(card):
+    """(english_slots, total_slots) for a card. A slot = a sense carrying a German source
+    side (what must be translated) OR an English side already. A card with no records/senses
+    (or a null card) has 0 slots."""
+    if not card or not card.get("records"):
+        return 0, 0
+    total = eng = 0
+    for r in card["records"]:
+        for s in r.get("senses", []):
+            if s.get("german") or s.get("english"):
+                total += 1
+                if s.get("english"):
+                    eng += 1
+    return eng, total
+
+
+def card_done(card):
+    """Coverage-complete: at least one slot and every slot has English. A null card, an
+    empty card, or a partially-translated card (e.g. 1/40) is NOT done."""
+    eng, total = en_coverage(card)
+    return total > 0 and eng == total
+
+
 def missing(root):
     path = os.path.join(REPO, f"wf_output.en.{root}.json")
     if not os.path.exists(path):
         sys.exit(f"no store: {path}")
     d = json.load(open(path, encoding="utf-8"))
-    have = set()
-    for e in d["results"]:
-        c = e.get("card")
-        if c and c.get("records") and any(
-            any(s.get("english") for s in r.get("senses", []))
-            for r in c["records"]
-        ):
-            have.add(e["key"])
+    have = {e["key"] for e in d["results"] if card_done(e.get("card"))}
     return [k for k in d["meta"]["selected_keys"] if k not in have]
 
 

--- a/RussianTranslation/src/pilot/en_split_triage.py
+++ b/RussianTranslation/src/pilot/en_split_triage.py
@@ -54,7 +54,12 @@ def has_en(card):
 
 
 def scan():
-    """Return list of (root, key, features, passed) for every card in every EN store."""
+    """Return list of (root, key, features, passed) for every card in every EN store.
+
+    A residual key whose source input file is missing is NOT dropped (FL4): it is kept with
+    a `missing_input` feature marker so it stays visible in triage. Silently skipping it hid
+    a null card whose input we could not find — exactly the kind of card that needs a human's
+    eye. Missing-input rows are excluded from boundary learning (no size features to learn)."""
     rows = []
     for fp in sorted(glob.glob(os.path.join(REPO, 'wf_output.en.*.json'))):
         root = os.path.basename(fp).replace('wf_output.en.', '').replace('.json', '')
@@ -62,9 +67,16 @@ def scan():
         passed = {}
         for e in d['results']:
             passed[e['key']] = has_en(e.get('card'))
-        for key in d['meta']['selected_keys']:
+        # A heal/autosplit-merge store (e.g. wf_output.en.man_heal.json) carries no
+        # selected_keys — fall back to its result keys so its cards still appear in triage
+        # rather than crashing the whole run (FL4: nothing should vanish from triage).
+        selected = (d.get('meta') or {}).get('selected_keys')
+        if selected is None:
+            selected = [e['key'] for e in d['results']]
+        for key in selected:
             rp, _ = input_paths(key)
             if not os.path.exists(rp):
+                rows.append((root, key, {'missing_input': True}, passed.get(key, False)))
                 continue
             raw = open(rp, encoding='utf-8').read()
             rows.append((root, key, feats(raw), passed.get(key, False)))
@@ -75,6 +87,7 @@ def learn_boundary(rows):
     """Pick, per feature, the value that best separates pass/fail (max Youden's J),
     plus the 'clean' threshold = the smallest fail value above ALL pass values (a
     high-precision SPLIT cut: nothing above it ever passed)."""
+    rows = [r for r in rows if not r[2].get('missing_input')]   # no size features to learn from
     out = {}
     for key in ('ls', 'est_out_tok', 'raw', 'spans'):
         passv = sorted(f[key] for _, _, f, p in rows if p)
@@ -120,11 +133,16 @@ def main():
         return False
 
     resid = [(r, k, f) for r, k, f, p in rows if not p]
+    # Missing-input residuals have no size features — keep them VISIBLE in their own section
+    # (FL4) rather than dropping them, but exclude them from size classification/sorting.
+    missing_input = [(r, k) for r, k, f in resid if f.get('missing_input')]
+    sized = [(r, k, f) for r, k, f in resid if not f.get('missing_input')]
     split, retry = [], []
-    for r, k, f in resid:
+    for r, k, f in sized:
         (split if needs_split(f) else retry).append((r, k, f))
 
-    print('=== EN residual triage (no LLM) — %d null card(s) ===' % len(resid))
+    print('=== EN residual triage (no LLM) — %d null card(s) (%d missing-input) ==='
+          % (len(resid), len(missing_input)))
     if ls_cut is None and tok_cut is None:
         print('FINDING: NO clean size wall exists — some cards that PASSED are larger on')
         print('every feature than the ones that failed (the 5 largest <ls> cards all passed).')
@@ -139,9 +157,14 @@ def main():
         for r, k, f in sorted(split, key=lambda x: -x[2]['ls']):
             print('  %-26s ls=%-4d sk=%-4d raw=%-6d ~out=%d' % (k, f['ls'], f['sk'], f['raw'], f['est_out_tok']))
     label = 'RETRY priority (ranked by risk; recover cheaply, escalate only if persistent)'
-    print('--- %s (%d) ---' % (label, len(retry) + len(split)))
-    for r, k, f in sorted(resid, key=lambda x: -x[2]['est_out_tok']):
+    print('--- %s (%d) ---' % (label, len(sized)))
+    for r, k, f in sorted(sized, key=lambda x: -x[2]['est_out_tok']):
         print('  %-26s ls=%-4d sk=%-4d raw=%-6d ~out=%d' % (k, f['ls'], f['sk'], f['raw'], f['est_out_tok']))
+    if missing_input:
+        print('--- MISSING INPUT (%d) — null card, source file absent; needs manual attention '
+              '(NOT silently dropped) ---' % len(missing_input))
+        for r, k in sorted(missing_input):
+            print('  %-26s (root %s) — no input file at src/pilot/input/' % (k, r))
 
     if args.all:
         print('\n=== learned boundary per feature (from %d cards) ===' % len(rows))

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -860,6 +860,60 @@ def test_ru_coverage_denominator_not_silently_exempt():
             ru_coverage.REPO, ru_coverage.RU_STORE, sys.argv = old_repo, old_store, old_argv
 
 
+def test_en_residual_coverage_complete():
+    """FL4: en_residual_keys 'done' means coverage-complete, not '>=1 English sense'. A card
+    with 1 of 2 senses translated is a residual (its 1 untranslated sense must not be hidden);
+    a fully-translated card is done; a null/empty card is never done."""
+    from en_residual_keys import card_done, en_coverage
+    partial = {'records': [{'senses': [{'german': 'a', 'english': 'x'}, {'german': 'b'}]}]}
+    if en_coverage(partial) != (1, 2):
+        fail('en_coverage miscounted the partial card')
+    if card_done(partial):
+        fail('a 1/2-sense card must NOT count as done (the FL4 1/40 bug)')
+    full = {'records': [{'senses': [{'german': 'a', 'english': 'x'},
+                                    {'german': 'b', 'english': 'y'}]}]}
+    if not card_done(full):
+        fail('a fully-translated card must count as done')
+    if card_done(None) or card_done({'records': []}):
+        fail('a null/empty card must never count as done')
+
+
+def test_en_split_triage_keeps_missing_input():
+    """FL4: a residual (null) card whose source input file is absent must stay VISIBLE in
+    triage with a missing_input marker, not be silently skipped."""
+    import en_split_triage as est
+    with tempfile.TemporaryDirectory() as tmp:
+        wf = {'meta': {'selected_keys': ['aa~~h0_00', 'bb~~h0_00']},
+              'results': [
+                  {'key': 'aa~~h0_00', 'card': {'records': [
+                      {'senses': [{'german': 'g', 'english': 'e'}]}]}},
+                  {'key': 'bb~~h0_00', 'card': None}]}
+        with open(os.path.join(tmp, 'wf_output.en.zz.json'), 'w', encoding='utf-8') as f:
+            json.dump(wf, f, ensure_ascii=False)
+        aa_raw = os.path.join(tmp, 'aa.raw.txt')
+        with open(aa_raw, 'w', encoding='utf-8') as f:
+            f.write('<ls>x</ls> Wasser')
+
+        def fake_paths(key):
+            if key == 'aa~~h0_00':
+                return aa_raw, aa_raw + '.portrait'
+            return os.path.join(tmp, 'nope_%s.txt' % key), ''
+
+        old_repo, old_ip = est.REPO, est.input_paths
+        est.REPO, est.input_paths = tmp, fake_paths
+        try:
+            rows = est.scan()
+        finally:
+            est.REPO, est.input_paths = old_repo, old_ip
+    by = {k: f for _r, k, f, _p in rows}
+    if 'bb~~h0_00' not in by:
+        fail('missing-input null card was dropped from triage (FL4)')
+    if not by['bb~~h0_00'].get('missing_input'):
+        fail('missing-input residual not marked missing_input')
+    if by['aa~~h0_00'].get('missing_input'):
+        fail('a present-input card wrongly marked missing_input')
+
+
 def test_whitney_homonym_safety():
     """FL1: requesting a Whitney homonym a root lacks must return EMPTY, never fall back to
     ALL homonyms — attaching a different homonym's grammar is a silent wrong-root error."""
@@ -1033,6 +1087,8 @@ def main():
         test_markup_loss_soft_flag_ru,
         test_markup_loss_soft_flag_en,
         test_ru_coverage_denominator_not_silently_exempt,
+        test_en_residual_coverage_complete,
+        test_en_split_triage_keeps_missing_input,
         test_whitney_homonym_safety,
         test_stale_refusal_preserves_requeue,
         test_release_manifest_hash_validation,


### PR DESCRIPTION
## FL4 — EN triage counted partial as done

Two ways the EN residual tracker lied about completeness (flagged FL4 in [`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) §3):

1. [`en_residual_keys.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/en_residual_keys.py) treated **≥1 English sense** as done — a 1-of-40-sense card counted complete and hid 39 untranslated senses. "Done" is now **coverage-complete**: every translation slot (a sense with a German source side) must carry English — the same denominator idea as [`ru_coverage.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/ru_coverage.py), applied within a card. Exposed as `card_done()` / `en_coverage()`.

2. [`en_split_triage.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/en_split_triage.py) dropped a residual key whose source input file was missing (`if not os.path.exists(rp): continue`), so a null card we couldn't locate vanished from triage. Missing-input residuals are now kept with a `missing_input` marker and surfaced in their own **MISSING INPUT** section (excluded from size-boundary learning — no features to learn from).

Also hardened `scan()` to fall back to result keys when a heal/autosplit-merge store (`wf_output.en.man_heal.json`) carries no `selected_keys` — previously the whole triage crashed with `KeyError` before showing anything (verified pre-existing on master).

## Tests

`test_en_residual_coverage_complete` and `test_en_split_triage_keeps_missing_input` ([`window_selftest.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_selftest.py), now **29 green**). Both real scripts also re-run clean against the on-disk EN stores.

Model: Opus 4.8 (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)