### PR TITLE
docs(pwg): audit-tail closeout — FL4/FL8/ka topup marked fixed

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,31 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
+- **Audit-tail (FL4 + FL8 + `ka` missing-group topup) — ✅ CLOSED 2026-07-03 (Opus 4.8,
+  `claude-opus-4-8`), 3 merged PRs, each with a pinning `window_selftest.py` test (now 31 green).**
+  The three deferred items from the S10 audit
+  ([`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) §3):
+  - **FL8** [#92](https://github.com/gasyoun/SanskritLexicography/pull/92): audit fixture guard —
+    [`audit_window.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window.py)
+    writes status+report to a scratch dir whenever the run is ephemeral (explicit `--ephemeral`,
+    or auto when the wf lives under the OS temp dir), so a self-test/fixture can no longer clobber
+    the live `window_status.json`/`audit_window.report.json`.
+  - **FL4** [#93](https://github.com/gasyoun/SanskritLexicography/pull/93):
+    [`en_residual_keys.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/en_residual_keys.py)
+    "done" now = coverage-complete (every German-bearing sense carries English, not ≥1); a 1/40
+    card is a residual. [`en_split_triage.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/en_split_triage.py)
+    keeps missing-input nulls visible (own section) and no longer crashes on a heal-merge store
+    lacking `selected_keys`.
+  - **Item 1 — `ka`'s 2 missing heal groups** [#94](https://github.com/gasyoun/SanskritLexicography/pull/94):
+    new [`autosplit_requeue.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/autosplit_requeue.py)
+    `topup` / `topup-merge` consume a partial card's `missing_fragments` (+`frag_prov`) to
+    re-translate ONLY the failed fragment groups and stitch a complete card — no full re-split.
+    **Validated on `ka`:** a 2-group-missing partial targets 10 of 81 fragments (reuses 71) and
+    `topup-merge` reassembles a complete 63-sense card. Cards translated before `frag_prov`
+    existed are skipped with a warning (use full `gen`).
+  The [`OPUS_pwg_audit_tail.md`](https://github.com/gasyoun/Uprava/blob/main/handoffs/OPUS_pwg_audit_tail.md)
+  handoff is SPENT — do not re-execute.
+
 - **Translation-memory (TM) sidecar SHIPPED + wired + live-validated (2026-07-02, Opus 4.8
   `claude-opus-4-8`; [PR #87](https://github.com/gasyoun/SanskritLexicography/pull/87)
   merged).** New [`src/pilot/translation_memory.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/translation_memory.py):
@@ -94,7 +119,8 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   (`promote_en.py` + `annotate_dcs_freq.py`; store 8,574/10,856 rows carry `en` — closes
   the S7 leftover). 2 new hard flags logged, not retried (`LS-LOSS` on
   `_d_a~~h0_56_pra_ri`, `SAN-LOSS` on `yat~~h0_zz_pw/r0/s1`). `ka`'s 2 missing heal groups
-  NOT fixed — folded into the audit-churn session (needs missing-fragment persistence).
+  now have a targeted-requeue mechanism — ✅ **[#94](https://github.com/gasyoun/SanskritLexicography/pull/94)
+  `autosplit_requeue.py topup`** (see the audit-tail bullet at the top of this queue).
   The handoff file carries a SPENT banner — do not re-execute.
 
 - ~~**Audit-churn fix — QUEUED (Opus/Fable-tier judgment, from S10 2026-07-02).**~~
@@ -111,9 +137,9 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   the RU save path (advisory); corrupt EN denom → FAIL, missing denom → loud `UNVERIFIABLE`
   (no more silent gam-6/127 exemption). FL1
   [#82](https://github.com/gasyoun/SanskritLexicography/pull/82): `grammar_for` returns
-  empty + warns on an absent homonym instead of ALL homonyms. **FL4 + FL8 remain open**
-  (EN-track `en_residual_keys`/`en_split_triage` partial-as-done; singleton-status-file
-  clobber) — see [`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) §3.
+  empty + warns on an absent homonym instead of ALL homonyms. **FL4 + FL8 + the `ka`
+  missing-group topup are now ✅ CLOSED 2026-07-03** (see the audit-tail bullet at the top of
+  this queue; PRs [#92](https://github.com/gasyoun/SanskritLexicography/pull/92)/[#93](https://github.com/gasyoun/SanskritLexicography/pull/93)/[#94](https://github.com/gasyoun/SanskritLexicography/pull/94)).
   The handoff file carries a SPENT banner — do not re-execute.
 
 - **S7 quality follow-through — QUEUED as its own handoff (MG decision 2026-07-02;

--- a/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md
+++ b/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md
@@ -1,14 +1,22 @@
 # Architecture audit — pwg translation pipeline (Fable window S10)
 
-_Created: 02-07-2026 · Last updated: 02-07-2026_
+_Created: 02-07-2026 · Last updated: 03-07-2026_
 
 > **Update 02-07-2026 — audit-churn session closed.** The §3 flags FL1/FL2/FL3/FL5 named
 > for a follow-up "audit-churn (Opus/Fable-tier judgment)" session in §6 are now FIXED and
 > merged: [#82](https://github.com/gasyoun/SanskritLexicography/pull/82) (FL1),
 > [#80](https://github.com/gasyoun/SanskritLexicography/pull/80) (FL2),
 > [#81](https://github.com/gasyoun/SanskritLexicography/pull/81) (FL3),
-> [#79](https://github.com/gasyoun/SanskritLexicography/pull/79) (FL5). FL4/FL8 remain open
-> (EN-track / small PRs). Session model: Opus 4.8 (`claude-opus-4-8`).
+> [#79](https://github.com/gasyoun/SanskritLexicography/pull/79) (FL5). Session model: Opus 4.8 (`claude-opus-4-8`).
+>
+> **Update 03-07-2026 — audit-tail session closed.** The three deferred items are now FIXED and
+> merged, each with a pinning `window_selftest.py` test (now 31 green): FL8
+> [#92](https://github.com/gasyoun/SanskritLexicography/pull/92) (fixture status-file guard),
+> FL4 [#93](https://github.com/gasyoun/SanskritLexicography/pull/93) (EN triage coverage-complete
+> + missing-input visibility), and item-1 `ka` missing-group topup
+> [#94](https://github.com/gasyoun/SanskritLexicography/pull/94) (`autosplit_requeue.py topup`
+> consumes `missing_fragments`; validated on `ka` — 10 of 81 fragments targeted, complete
+> 63-sense card reassembled). Session model: Opus 4.8 (`claude-opus-4-8`).
 
 **Mission:** M.G. reported the pwg pipeline "failed too often" over the last week — big/dense
 cards not translated even after many retries. A same-day Sonnet 5 (`claude-sonnet-5`) session
@@ -131,11 +139,11 @@ mission forbids touching translation-quality logic — or its own scoped change)
 | FL1 | [`whitney_grammar.py:154-160`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/whitney_grammar.py) | `grammar_for(slp1, homonym)` falls back `… or recs`: a nonexistent homonym silently returns ALL homonyms — wrong-root grammar attached; collides with the siD homonym-safety finding | **✅ FIXED — [#82](https://github.com/gasyoun/SanskritLexicography/pull/82)** (empty + warning; validated on `vas`) |
 | FL2 | [`audit_window_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window_en.py) | the EN gate has no teeth: nulls never fail `--strict`; `save_and_audit.py` invokes it non-strict with no `--report`; a crashing sense-dupe subgate counts as clean (`returncode None` is falsy) | **✅ FIXED — [#80](https://github.com/gasyoun/SanskritLexicography/pull/80)** (nulls/crash fail `--strict`; strict-by-default in save; report always written) |
 | FL3 | [`ru_coverage.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/ru_coverage.py) | the anti-silent-partial gate is wired to NOTHING (hand-run only), and a corrupt/missing EN denominator silently exempts a root from the very check built after the gam-6/127 incident | **✅ FIXED — [#81](https://github.com/gasyoun/SanskritLexicography/pull/81)** (wired into `save_and_audit.py`; corrupt denom fails, missing denom loud `UNVERIFIABLE`) |
-| FL4 | `en_residual_keys.py:27-34` + `en_split_triage.py:66-68` | "done" = ≥1 English sense (a 1/40 card counts as done); a null card with a missing input vanishes from triage entirely | EN-track session (still open) |
+| FL4 | `en_residual_keys.py:27-34` + `en_split_triage.py:66-68` | "done" = ≥1 English sense (a 1/40 card counts as done); a null card with a missing input vanishes from triage entirely | **✅ FIXED — [#93](https://github.com/gasyoun/SanskritLexicography/pull/93)** ("done" = coverage-complete; missing-input nulls kept visible; heal-merge store w/o `selected_keys` no longer crashes scan) |
 | FL5 | [`prompt_rule_audit.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/prompt_rule_audit.py) `has_text_signal()` | Mode-6 false positive (`suspicious_attested_without_text_signal`, 66% of round-2 risks) — requeues that NO model output can clear; 2,152 key-requeues on 06-29 alone | **✅ FIXED — [#79](https://github.com/gasyoun/SanskritLexicography/pull/79)** (meaning-claim + lexicographic-signal redesign, 37→6 fires; report-only by construction; reasoning in [`AUDIT_CHURN_FL5.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/AUDIT_CHURN_FL5.md)) |
 | FL6 | [`pwg_mask.py:43-58`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_mask.py) | a truncated final record (missing `<L END>`) is buffered and never yielded — last record silently disappears from every consumer | small PR, low urgency (source file is stable) |
 | FL7 | `corpus_gate.py` evidence loaders | absent evidence jsonl → authority silently removed (degrades safely to LLM-verdict, but "sources not built" and "word uncovered" are indistinguishable); DB errors leave `corpus_examples: []` unmarked | note-only; safe direction |
-| FL8 | singleton status files (`window_status.json`, `audit_window.report.json`) | ANY audit run — including test fixtures — clobbers them; "current status" cannot be trusted without the event log (observed: current status reports a temp-file fixture) | small PR: per-run-id reports or a fixture guard |
+| FL8 | singleton status files (`window_status.json`, `audit_window.report.json`) | ANY audit run — including test fixtures — clobbers them; "current status" cannot be trusted without the event log (observed: current status reports a temp-file fixture) | **✅ FIXED — [#92](https://github.com/gasyoun/SanskritLexicography/pull/92)** (`--ephemeral` + auto-detect for wf under the OS temp dir → status/report written to a scratch dir; live singletons untouched) |
 
 ---
 
@@ -196,7 +204,8 @@ specific follow-ups (in priority order):
    (`vas~~h0_zz_pw00`, `vas~~h0_zz_pw01`, `vas~~h2_11_prati`, `vas~~h4_18_ni`,
    `gam~~h0_zz_pw00`, `gam~~h3_04_upa`, `gam~~h3_06_vini`, `gam~~h3_08_sam` — 4 vas keys
    live-run this session, see below), `en.DA`'s 7 nulls, the 77 EN residuals, and `ka`'s 2
-   missing groups (now targetable via `missing_fragments`). ≤3-wide, per Mode 2.
+   missing groups (now consumable via `autosplit_requeue.py topup` —
+   [#94](https://github.com/gasyoun/SanskritLexicography/pull/94)). ≤3-wide, per Mode 2.
 2. **Audit-churn session (Opus/Fable-tier judgment).** Fix FL5 (`has_text_signal`) — it
    burned more requeues last week than every real failure combined — plus FL2/FL3 gate
    wiring.


### PR DESCRIPTION
Records the audit-tail session outcome now that all three deferred S10-audit items are merged:

- **FL8** — [#92](https://github.com/gasyoun/SanskritLexicography/pull/92)
- **FL4** — [#93](https://github.com/gasyoun/SanskritLexicography/pull/93)
- **Item 1 (`ka` missing-group topup)** — [#94](https://github.com/gasyoun/SanskritLexicography/pull/94)

Updates [`ARCHITECTURE_AUDIT_2026-07-02.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) §3 FL4/FL8 rows + banner + §6, and [`RussianTranslation/.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md) (top-of-queue closeout bullet; stale "remain open" / "NOT fixed" mentions repointed to the merged PRs). `window_selftest.py` is now 31 green.

Model: Opus 4.8 (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)