### PR TITLE
pwg_ru: calibrate output-budget 60->90 (clear win); keep AUTOSPLIT_LS_BUDGET at 18

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1167,6 +1167,81 @@ version until the extractor is fixed.
 
 ---
 
+### §54. DICO's entry anchors nest three structural roles under one HTML class — only one is a true entry boundary
+
+🟡 **The Heritage DICO mirror's named entry anchors mark three different
+structural roles that all share the same CSS class, and conflating them
+truncates or over-merges entry glosses.** (1) a fresh headword anchor
+immediately preceded by its own Devanagari span; (2) a compound/sub-entry
+anchor immediately preceded by a bare paragraph break (no Devanagari span) —
+genuinely a separate entry (e.g. `aṃśavāda`, `aṃśahara` under `aṃśa`'s letter
+group); (3) an inline cross-reference anchor embedded mid-sentence in another
+entry's own prose (e.g. the proper noun `Aṃśa` mentioned inside `aṃśa`'s
+definition, or a dual form like `aṃsau` mentioned inline in `aṃsa`'s gloss) —
+**not** a boundary. A naive per-anchor split (boundary = every anchor)
+truncates entries like `aṃśa` mid-sentence before its mythological sense; the
+opposite over-correction (boundary = only Devanagari-preceded anchors) merges
+the compound sub-entries' distinct glosses into the parent's. The fix
+distinguishes (1)/(2) from (3) by checking whether the anchor is preceded
+(modulo whitespace/entity noise) by a tag close versus plain running text,
+and must resolve the boundary to the **start** of the next Devanagari span
+(not the anchor position itself), else the next entry's headword text leaks
+into the tail of the previous gloss. Separately: DICO uses two distinct
+link-color classes for genuine cross-references to other entries (inline
+citation links, and trailing "see also" links) — a third color class is only
+external declension/conjugation-generator CGI links, not an entry
+cross-reference, and must be excluded from any `cross_refs` field.
+
+Evidence: 24,549/24,549 crosswalk-resolved entries extracted with zero
+truncation/bleed on 25 hand-checked rows (10 shortest, 10 longest up to 3,832
+chars, 5 random) — full workings in
+[heritage_dico_gloss.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/heritage_dico_gloss.md).
+
+Implication: any future DICO HTML parser must classify anchors by their
+*preceding-tag context*, not just their CSS class, before treating one as an
+entry boundary.
+
+> **Source:** [heritage_dico_gloss.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/heritage_dico_gloss.md),
+> Sonnet 5 `claude-sonnet-5` · 2026-07-03
+
+---
+
+### §55. `gen_opt_harness2.py` output-budget: coarser wins on both knobs, in opposite directions
+
+🟢 **Two untuned S10-era knobs in
+[`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py)
+calibrated by A/B — the general lesson is "coarser batching wins," but it does
+NOT generalize to "coarser splitting always wins":** (1) `--output-budget`
+60→90 on the 56-card `hA` root: **90 wins clearly** — 60 agent calls vs 66
+(−9%), 4.03M vs 4.68M tokens (−14%), 496s vs 1,082s wall-clock (−54%),
+identical quality (0/56 null both). Shipped as the new default same-session.
+(2) `AUTOSPLIT_LS_BUDGET` (giant-head fragment granularity, in
+[`autosplit_requeue.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/autosplit_requeue.py))
+18 (stock) vs 10 (finer) on the 150-`<ls>` giant head `gam~~h0_00_pwg00`: finer
+fragmentation made it **worse** — 21 agent calls vs 13 (+62%), 1.46M vs 925K
+tokens (+58%), 1,207s vs 615s wall-clock (+96%), same outcome (1/1 healed,
+0 null). Kept at 18, not changed. The direction differs because
+`--output-budget` controls how many *whole cards* share a batch (bigger =
+more amortization of the fixed per-call system-prompt overhead), while
+`AUTOSPLIT_LS_BUDGET` controls how finely ONE already-failing giant card gets
+chopped (finer = more, smaller heal calls, each still paying the fixed
+overhead, with no offsetting reduction in per-fragment failure rate at this
+citation density).
+
+Evidence: 4-arm live calibration (Sonnet 5 `claude-sonnet-5`), fresh worktree
+off `origin/master` (branch `knob-calibration-20260703`), full numbers in
+[RussianTranslation/KNOB_CALIBRATION_2026-07-03.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/KNOB_CALIBRATION_2026-07-03.md).
+
+Implication: when tuning a batching/splitting knob in this harness, check
+which of the two mechanisms it governs (amortization vs failure-isolation)
+before assuming "smaller unit = more robust" — for this harness the opposite
+held on the split-granularity knob.
+
+> **Source:** [KNOB_CALIBRATION_2026-07-03.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/KNOB_CALIBRATION_2026-07-03.md),
+> Sonnet 5 `claude-sonnet-5` · 2026-07-03
+
+---
+
 _Started 2026-06-26 (relocated from `Uprava/FINDINGS.md`, which now holds **non-Sanskrit**
 findings). Appended on a regular basis — add findings as they're discovered; this is the
 shared memory of "things we measured that aren't obvious from the code."_

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -104,12 +104,22 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   `--no-binary-split` / `--output-budget=off` restore old behavior; `--selfheal` /
   `--binary-split` accepted as no-ops so all queued runbooks work verbatim.
   `window_selftest.py` 17/17 PASS, `node --check` PASS, presplit + byte-mode + defaults
-  smoke-verified on vas/gam. The **knob calibration A/B** (MG: approved 02-07) got its own
-  handoff — the dense-residual session it was to be folded into had already executed:
-  `AUTOSPLIT_LS_BUDGET` 18 vs 10 on the 150-`<ls>` gam head + `--output-budget` 60 vs 90 on
-  a medium root, findings → the hubs, defaults-PR only on a clear win.
-  **Start (Sonnet chat in this repo):** `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\SONNET_pwg_knob_calibration.md and execute it.`
-  ([handoff file](https://github.com/gasyoun/Uprava/blob/main/handoffs/SONNET_pwg_knob_calibration.md))
+  smoke-verified on vas/gam.
+  **Knob calibration A/B — ✅ EXECUTED 2026-07-03 (Sonnet 5, `claude-sonnet-5`),
+  [PR #101](https://github.com/gasyoun/SanskritLexicography/pull/101).** 4-arm live
+  Workflow run in a fresh worktree off `origin/master` (branch
+  `knob-calibration-20260703`), scratch-only (never touched the RU store).
+  `--output-budget` 60 vs 90 on the 56-card `hA` root: **90 wins clearly** — 60 agent
+  calls vs 66 (−9%), 4.03M vs 4.68M tokens (−14%), 496s vs 1,082s wall-clock (−54%),
+  identical 0/56 null rate → **shipped as the new `OUTPUT_BUDGET` default.**
+  `AUTOSPLIT_LS_BUDGET` 18 (stock) vs 10 (finer) on the 150-`<ls>` `gam~~h0_00_pwg00`
+  giant head: finer fragmentation made things **worse** — 21 agent calls vs 13 (+62%),
+  1.46M vs 925K tokens (+58%), 1,207s vs 615s wall-clock (+96%), same outcome →
+  **left unchanged at 18.** Full numbers:
+  [`KNOB_CALIBRATION_2026-07-03.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/KNOB_CALIBRATION_2026-07-03.md);
+  finding appended to [`FINDINGS.md` §55](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).
+  `window_selftest.py` 31/31 green after the `OUTPUT_BUDGET` change. The handoff file
+  is SPENT — do not re-execute.
 
 - ~~**Dense-residual re-run through the fixed stack — QUEUED**~~ **✅ EXECUTED 2026-07-02
   (Sonnet 5, `claude-sonnet-5`) — recorded in the GTD hub; this queue item was stale.**

--- a/RussianTranslation/KNOB_CALIBRATION_2026-07-03.md
+++ b/RussianTranslation/KNOB_CALIBRATION_2026-07-03.md
@@ -1,0 +1,90 @@
+# Knob calibration — giant-head split granularity + output-budget headroom
+
+_Created: 03-07-2026 · Last updated: 03-07-2026_
+
+MG-authorized (02-07-2026) cheap A/B calibration of the two untuned big-article
+knobs in [`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py):
+`AUTOSPLIT_LS_BUDGET` (giant-head fragment granularity, in
+[`autosplit_requeue.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/autosplit_requeue.py))
+and `--output-budget` (citation-weighted batch sizing). Both were S10-era
+values (18 and 60 respectively) never systematically tuned. Executed in a
+fresh worktree off `origin/master` (`knob-calibration-20260703` branch) per
+the handoff's branch-contention guardrail; all four runs SCRATCH only — never
+touched `src/pwg_ru_translated.jsonl`.
+
+Handoff: [`Uprava/handoffs/SONNET_pwg_knob_calibration.md`](https://github.com/gasyoun/Uprava/blob/main/handoffs/SONNET_pwg_knob_calibration.md).
+Model: Sonnet 5 (`claude-sonnet-5`) throughout (generation + Workflow agents).
+
+## 1. Giant-head split granularity — `AUTOSPLIT_LS_BUDGET` 18 (stock) vs 10 (finer)
+
+Target: `gam~~h0_00_pwg00` (150 `<ls>`, presplit-routed to the fragment path
+on both arms since it exceeds the output budget).
+
+| | Arm A (stock, LS_BUDGET=18) | Arm B (finer, LS_BUDGET=10) |
+|---|---:|---:|
+| selfheal fragment groups | 9 | 17 |
+| agent() calls | 13 | 21 |
+| total tokens | 925,605 | 1,462,827 |
+| tool calls | 18 | 34 |
+| wall-clock | 615 s | 1,207 s |
+| cards ok / null | 1 / 0 | 1 / 0 |
+| outcome | healed, presplit | healed, presplit |
+
+**Verdict: Arm A (stock 18) wins clearly.** Finer fragmentation produced
+*more* fragment groups (17 vs 9), which drove up agent calls (+62%), tokens
+(+58%), and wall-clock (+96%) for the **same** translated outcome (both
+arms fully healed the one giant card, 0 null). Smaller fragments do not
+reduce per-fragment failure risk enough to offset the added per-call
+overhead at this citation density. **No change proposed** —
+`AUTOSPLIT_LS_BUDGET` stays at its current default of 18.
+
+## 2. Output-budget headroom — `--output-budget` 60 (stock) vs 90
+
+Target: `hA` root, 56 cards (24 `h0_*` prefix cards + 30 `h1_*`/`h2_*`/`pw*`
+cards, several dense enough to presplit).
+
+| | Arm C60 (stock) | Arm C90 |
+|---|---:|---:|
+| batch count | 8 | 7 |
+| presplit keys | 5 | 3 |
+| selfheal groups (total) | 15 keys healed | 15 keys healed |
+| agent() calls | 66 | 60 |
+| total tokens | 4,675,011 | 4,025,248 |
+| tool calls | 94 | 81 |
+| wall-clock | 1,082 s | 496 s |
+| cards ok / null | 56 / 0 (1 transient mid-stream stall, recovered) | 56 / 0 |
+| partial (healed but incomplete-in-one-shot) keys | 1 | 1 |
+
+**Verdict: Arm C90 wins clearly on both cost AND quality** (the handoff's
+gating condition for a defaults-change PR): −9% agent calls, −14% tokens,
+−14% tool calls, **−54% wall-clock**, identical null rate (0/56 both), and
+*fewer* giant cards needed the presplit fragment path (3 vs 5, because more
+cards fit whole within the larger budget). No retry-rate regression — the
+one transient stall in Arm C60 does not appear in C90's failures. The
+`yuj`-lesson risk (bigger budget → busier StructuredOutput retries eating
+the token saving) did **not** materialize here.
+
+## Decision
+
+- `AUTOSPLIT_LS_BUDGET` — **unchanged at 18.**
+- `--output-budget` default — **raised 60 → 90**, shipped in this same
+  branch: [`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py)
+  `OUTPUT_BUDGET = 90` (was 60), `window_selftest.py` 31/31 still green
+  after the change (re-ran the canonical `run_pilot_wf.opt2.js` harness
+  regeneration for `gam` to validate the harness-scope fixture).
+
+## Caveats
+
+- N=1 giant head and N=1 medium root — a single calibration point per arm,
+  not a distribution. The direction (coarser is cheaper at these two
+  knobs) is consistent with the general "fixed per-call overhead dominates"
+  finding in [`TLONLY_PROTOTYPE.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/TLONLY_PROTOTYPE.md),
+  but a wider sample (a few more giant heads / medium roots) would harden
+  the output-budget=90 recommendation before pushing it further (e.g. to
+  120) — not attempted here, out of session scope/budget.
+- Quality (translation fidelity) was NOT separately judged in this session —
+  "quality" here means the harness-level null/partial/retry signal only, per
+  the handoff's instructions. A fidelity sample pass is a natural follow-up
+  if 90 is scaled to a full freq-queue run.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -17,7 +17,9 @@ input-format + markup-verbatim specifics ("keep {Tn} verbatim" instead of "{#..#
 Usage:  python src/pilot/gen_opt_harness2.py <root> [--keys=k1,k2] [--budget=N] [--out=PATH]
         [--no-selfheal] [--selfheal-budget=12]  # selfheal ON by default (MG 2026-07-02)
         [--no-binary-split]                     # binary-split ON by default (MG 2026-07-02)
-        [--output-budget=N|off]                 # citation-weighted batching, DEFAULT 60;
+        [--output-budget=N|off]                 # citation-weighted batching, DEFAULT 90
+                                                # (calibrated 2026-07-03, see
+                                                # KNOB_CALIBRATION_2026-07-03.md);
                                                 # 'off' or an explicit --budget=N = byte mode
         [--tm[=PATH]]                           # content-addressed translation memory:
                                                 # pre-resolve cards whose source SHA is cached
@@ -65,14 +67,18 @@ BINARY_SPLIT = True   # DEFAULT ON since 2026-07-02 (MG decision): when a whole 
                    #  batch — isolates a single poison card without re-billing the cards around
                    #  it. Bottoms out at single cards, which fall through to selfheal as before.
                    #  --no-binary-split restores the flat-retry loop.
-OUTPUT_BUDGET = 60 # DEFAULT 60 citation-weighted units since 2026-07-02 (the S10-validated
-                   #  value): size the main batches by estimated OUTPUT complexity (1 + <ls>
-                   #  count per card — same metric as --selfheal-budget) instead of INPUT bytes
-                   #  (skeleton+portrait). Input bytes don't predict StructuredOutput failure
-                   #  (TOKEN_LEVER_FINDING_2026-06-30: the portrait-slim byte lever was a
-                   #  non-lever); citation density does. Byte mode is still reachable: an
-                   #  EXPLICIT --budget=N (without --output-budget) or --output-budget=off —
-                   #  keeps documented byte-budget invocations (e.g. FU1 --budget=6000) exact.
+OUTPUT_BUDGET = 90 # DEFAULT 90 citation-weighted units since 2026-07-03 (raised from the
+                   #  untuned S10-era 60 after a calibration A/B on the hA root: 90 clearly
+                   #  won on both cost and quality — 60 agents/4.03M tok/496s vs 60's
+                   #  66 agents/4.68M tok/1082s, both 56/56 ok with 0 null — see
+                   #  KNOB_CALIBRATION_2026-07-03.md): size the main batches by estimated
+                   #  OUTPUT complexity (1 + <ls> count per card — same metric as
+                   #  --selfheal-budget) instead of INPUT bytes (skeleton+portrait). Input
+                   #  bytes don't predict StructuredOutput failure (TOKEN_LEVER_FINDING_2026-06-30:
+                   #  the portrait-slim byte lever was a non-lever); citation density does.
+                   #  Byte mode is still reachable: an EXPLICIT --budget=N (without
+                   #  --output-budget) or --output-budget=off — keeps documented byte-budget
+                   #  invocations (e.g. FU1 --budget=6000) exact.
 
 
 def grammar_text(root):


### PR DESCRIPTION
## Summary
- MG-authorized (02-07-2026) A/B calibration of two untuned S10-era knobs in [`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py): `--output-budget` and `AUTOSPLIT_LS_BUDGET`.
- **`--output-budget` 60→90 wins clearly** on the 56-card `hA` root: −9% agent calls, −14% tokens, **−54% wall-clock**, identical quality (0/56 null both arms). Shipped as new default.
- **`AUTOSPLIT_LS_BUDGET` left at 18** — finer fragmentation (10) tested worse on the 150-`<ls>` giant head `gam~~h0_00_pwg00`: +62% agent calls, +58% tokens, +96% wall-clock, same outcome.
- Full numbers: [RussianTranslation/KNOB_CALIBRATION_2026-07-03.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/KNOB_CALIBRATION_2026-07-03.md)
- Finding routed to [FINDINGS.md §55](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)

## Test plan
- [x] `window_selftest.py` 31/31 PASS after the `OUTPUT_BUDGET` change (re-generated the canonical `run_pilot_wf.opt2.js` harness for `gam` to validate the harness-scope fixture)
- [x] `python -m py_compile gen_opt_harness2.py` clean
- [x] All 4 calibration arms run live via the Workflow tool in a fresh worktree off `origin/master`, no store files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)