### PR TITLE
ai-wip: journal the A33 H123 referee pass + N-resync (PRs #109/#110)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -744,6 +744,23 @@ Two live tracks:
 
 ## ✅ Completed (Recent only)
 
+- **A33 referee + polish pass — DONE (2026-07-03, Fable 5 `claude-fable-5`, H123/S14 + follow-up).**
+  Hostile pre-submission review [papers/A33_review_fable5.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A33_review_fable5.md)
+  ([PR #109](https://github.com/gasyoun/SanskritLexicography/pull/109) merged): References
+  section ADDED (the note had none — incl. **Renou 1956** for the language-state periodisation
+  the dating map rides on), related-work § written from verified literature (the FABLE-index
+  "Zaïane 2008 / Cysouw 2013 / Pereltsvaig 2019" suggestions were UNVERIFIABLE and deliberately
+  not cited — flagged for the author), A33↔A02↔A06 anti-salami companion note, full-URL links.
+  **Second pass** ([PR #110](https://github.com/gasyoun/SanskritLexicography/pull/110) merged)
+  applied the paper edits queued by the parallel PR #103 data pass: PWG figures re-synced to the
+  reproducible current-source run (N 13,900→11,882; cited senses 118,528→113,012; strict-chrono
+  26.2→25.4 %; adjacent 76.3→76.8 % — rates 73.5 %/τ 0.375/density 23.4 % identical), the
+  **chance-floor calibration** added to abstract + §3.1 (sense-1-oldest floor 52.7 %, τ floor ≈0;
+  observed covers 44 %/38 % of the floor→ceiling span), §5 reproducibility note (`[)〉]` delimiter
+  fix + snapshot pin + null-baseline links), MW column flagged as the 2026-06-24 run pending a
+  same-snapshot re-run. **A33 → 4/5.** Remaining: venue `@DECIDE` (Lexikos/IJL/eLex — GTD row),
+  AP90 Vedic-siglum hand-check, MW same-snapshot re-run, optional GRA/PW controls.
+
 - **WhitneyRoots accent-axis validation run — DONE (2026-07-03, Sonnet 5
   `claude-sonnet-5`).** Executed
   [SONNET_WhitneyRoots_accent_validation.md](https://github.com/gasyoun/Uprava/blob/main/handoffs/SONNET_WhitneyRoots_accent_validation.md)


### PR DESCRIPTION
Adds the missing .ai_state.md Completed entry for today's A33 referee pass ([#109](https://github.com/gasyoun/SanskritLexicography/pull/109)) and the current-source N-resync + chance-floor pass ([#110](https://github.com/gasyoun/SanskritLexicography/pull/110)). Model: Fable 5 (`claude-fable-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)