### PR TITLE
[codex] pwg_ru performance spend gate

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -20,6 +20,16 @@ Two live tracks:
 
 ## ➡️ Next Steps (Queue)
 
+- [x] **pwg_ru performance spend gate implemented (2026-07-03, Codex/GPT-5).**
+      RussianTranslation now has a multi-root read-only `perf_preflight.py` matrix/JSON
+      wrapper, fragment-TM empty/provenance warnings, conservative correction-prose handling
+      for degenerate pass-through, and pinned selftests. Validation passed:
+      `python src/pilot/window_selftest.py`, `python src/pilot/translation_memory.py selftest`,
+      and `python src/pilot/perf_preflight.py sTA BU gam as i yuj vid han`. Current order:
+      run `gam`, `vid`, `as`, `BU`, `yuj`; skip cached `han`; defer `sTA`/`i` until
+      cache refresh or calibration. Details in
+      [RussianTranslation/.ai_state.md](RussianTranslation/.ai_state.md).
+
 - [x] **A33 (genetic-not-historical sense ordering) data + hypothesis pass — DONE (2026-07-03, Fable 5 `claude-fable-5`).** Verified A33's numbers against `RussianTranslation/research/`. **Found a committed-script reproducibility bug (NOT source drift — corrected mid-pass):** BOTH `analyze_sense_order.py` and `analyze_cross_dict.py` used a `)`-only PWG sense-delimiter regex, but committed csl-orig `pwg.txt` has ALWAYS used `N〉` (U+3009) — verified identical back to the 2026-06-24 commit (53,033 `〉` markers then and now). So the `)`-regex matched **0** delimiters: `analyze_sense_order` zeroed out entirely (split needs ≥2 hits), and `analyze_cross_dict` degraded silently to whole-entry units (PWG "density" 24.3%/87,680 entry-blobs instead of per-sense). Neither reproduced as committed. Fixed both to `[)〉]`. Rates reproduce EXACTLY (sense-1-oldest 73.5%, τ 0.375, adjacent ~76%, PWG Vedic-density **23.4%**) but current-source counts differ from the paper (dated-multisense 13,900→**11,882**; within-sense 32,254→28,280; cited senses 118,528→113,012; probe 57→51) — the paper's figures reflect an earlier citation state (2026-06-24 LS-correction commits), not a delimiter change. Regenerated `sense_order_metrics.{json,md}`. **Added the chance baseline the paper lacked** (`analyze_sense_order_null.py` → `sense_order_null.{json,md}`): sense-1-oldest floor **52.7%** → obs 73.5% → ceil 100% = **44% of span**; τ floor 0.00 → 0.375 → 1.0 = 38% — the calibrated form of "genetic, not historical". **Article prose NOT touched.** **Queued A33 paper edits:** update N to 11,882 (+ 28,280, 113,012, probe 51/72.5%); fix §5 Reproducibility (both scripts now `[)〉]`; pin the source snapshot); add the floor baseline to §3.1; author-scholarly related-work + venue remain. Delivered via worktree off origin/master (WIP on `heritage-h111...` untouched).
 - [x] **Heritage/INRIA reuse — H099 Phases 0–2 DONE (2026-07-03, Sonnet 5
       `claude-sonnet-5`).** Mirror sparse-cloned (gitignored,

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,40 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
+- **pwg_ru performance preflight/spend gate shipped 2026-07-03 (Codex/GPT-5 implementation pass).**
+  New read-only [`perf_preflight.py`](src/pilot/perf_preflight.py) reports TM sidecar
+  presence/hits, fragment-TM reuse, degenerate pass-through keys, near-degenerate candidates,
+  presplit keys, batch count, and `agent_expected_after_tm` without writing harnesses or
+  touching the RU store. [`calibrate_perf_harness.py`](src/pilot/calibrate_perf_harness.py)
+  now has named scratch grids: `--arm-set conservative` (90/110 × selfheal 12 × TM auto/off)
+  and `--arm-set wide` (90/110/120 × selfheal 8/12/16 × TM auto/off). This is not a new
+  Fable/Sonnet judgment session and made no live Workflow/Max runs. Follow-up implementation:
+  `perf_preflight.py` now accepts multiple roots and emits a compact matrix / JSON wrapper,
+  preserves the single-root JSON shape, warns when presplit keys exist but
+  `translation_memory.frag.<lang>.jsonl` is empty (including the exact `build-frags` command
+  and "no fragment provenance available yet" when applicable), and recommends run order.
+  Current staged-root preflight:
+  **run `gam` (2 agents), `vid` (13), `as` (14), `BU`/`yuj` (19); skip cached `han` (0);
+  defer `sTA` (30) and `i` (35)** until cache refresh/calibration.
+
+- **pwg_ru performance hygiene shipped 2026-07-03 (Codex/GPT-5 hygiene/verification pass).**
+  `gen_opt_harness2.py` now defaults to `--tm=auto` (card + fragment sidecars when present,
+  no-op with explicit metadata when absent), records `tm_cards` / `frag_tm_cards` /
+  `agent_expected_after_tm`, and adds a conservative deterministic no-LLM lane for tiny
+  cross-reference stubs (`degenerate_passthrough:true`, accounted rows, never silent skips).
+  New scratch-only [`calibrate_perf_harness.py`](src/pilot/calibrate_perf_harness.py) builds
+  comparable harness arms/report templates across output budgets, selfheal budgets, and TM
+  modes; it records the AB_TEST_LEAN_TR cache-cooldown warning and does not touch the RU
+  store. Current performance truths: article-site lazy loading is already done; lean TR was
+  rejected; `OUTPUT_BUDGET=90` is the default; refresh TM after promotion/heal harvest and
+  let the generator use it by default. Degenerate pass-through remains deliberately narrow:
+  editorial correction prose (`lies:`, `zu streichen`) stays in the LLM lane and is only
+  reported as near-degenerate. Validation: `python src/pilot/window_selftest.py` PASS,
+  `python src/pilot/translation_memory.py selftest` PASS,
+  `python src/pilot/perf_preflight.py sTA BU gam as i yuj vid han` PASS (warnings only:
+  fragment TM empty / no local `frag_prov`). Remaining speed work is TM/fragment-TM coverage
+  and wider measured calibration; no defaults change without live sequential A/B.
+
 - **Audit-tail (FL4 + FL8 + `ka` missing-group topup) — ✅ CLOSED 2026-07-03 (Opus 4.8,
   `claude-opus-4-8`), 3 merged PRs, each with a pinning `window_selftest.py` test (now 31 green).**
   The three deferred items from the S10 audit
@@ -47,8 +81,8 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   **cross-card reuse** for byte-identical sources. Built from the local-only store: **2,121
   cards / 10,841 senses / 49 roots** (4 legacy no-SHA rows skipped). Wired into
   [`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py)
-  as `--tm[=PATH]` (OFF by default): TM-hit keys go to a `TM_RESOLVED` lane (canonical,
-  restored-markup cards, **no `agent()` call**) and are removed from every translate lane
+  as default `--tm=auto` (explicit `--no-tm` opt-out; `--tm=PATH` override): TM-hit keys go
+  to a `TM_RESOLVED` lane (canonical, restored-markup cards, **no `agent()` call**) and are removed from every translate lane
   (batches / presplit / selfheal frags); total-accounting invariant preserved
   (`tm ∪ batched ∪ presplit == selected`, disjoint). `window_selftest.py` **24/24** (+2 TM
   tests). Validated: **gam 127→3** cards route to translation (124 pre-resolved); **jIv 17/17
@@ -94,8 +128,9 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 - **Opt2 harness: S10 recovery machinery is now DEFAULT + presplit router SHIPPED
   (MG decision 2026-07-02, Fable 5 (`claude-fable-5`) approach-review session; this PR).**
   [`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py):
-  selfheal, binary-split, and citation-weighted `--output-budget=60` (the S10-validated
-  value) are ON by default; a NEW generation-time **presplit router** sends any card whose
+  selfheal, binary-split, and citation-weighted `--output-budget=90` (raised from the
+  S10-era 60 by the 2026-07-03 calibration) are ON by default; a NEW generation-time
+  **presplit router** sends any card whose
   `1+<ls>` units exceed the whole per-batch output budget straight to the proven fragment
   path — no more paying up to 5 doomed whole-card StructuredOutput retries on giant heads
   (verified: 150-`<ls>` `gam~~h0_00_pwg00` routes to fragments; `presplit:true` + reason

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -31,8 +31,14 @@ and eliminated the transient dropouts.
 ## Current operating truth
 
 - The optimized **translate-only** Max harness is live and is generated per root by
-  [`gen_opt_harness.py`](gen_opt_harness.py). It inlines raw/portrait inputs, disables
-  translate-agent tools, and returns provenance metadata used by the audit stale guard.
+  [`gen_opt_harness2.py`](gen_opt_harness2.py). It masks and batches raw/portrait inputs,
+  disables translate-agent tools, auto-uses translation-memory sidecars when present,
+  presplits over-budget dense cards into the selfheal lane, and returns provenance metadata
+  used by the audit stale guard.
+- Article-site/root dashboard lazy loading is already shipped; do not spend performance time
+  re-implementing that path.
+- Lean TR / prompt trimming was tested and rejected; keep the full production TR unless a new
+  measured sequential calibration proves otherwise.
 - Superseded a-section/manual harness notes are archived under
   [`archive/legacy_max_2026-06-27/`](archive/legacy_max_2026-06-27/). Do not use those
   files for current production windows.
@@ -134,28 +140,54 @@ Preflight the root before spending Claude/Max tokens:
 
 ```powershell
 python src\pilot\root_window_status.py sTA
+python src\pilot\perf_preflight.py sTA
+python src\pilot\perf_preflight.py sTA BU gam as i yuj vid han
 ```
 
-This command prints the structural state plus one `next action` and one
+The first command prints the structural state plus one `next action` and one
 `next command`; if it disagrees with stale notes elsewhere, trust the command
-output and `src\pilot\output\window_status.json`.
+output and `src\pilot\output\window_status.json`. The second command is read-only
+performance accounting: it reports card/fragment TM hits, degenerate pass-through,
+presplit routing, batch count, and `agent_expected_after_tm` before Max spend. Use
+`--json` when saving a machine-readable preflight report. With more than one root it
+prints a compact comparison table plus a recommended order: zero-agent roots are skipped,
+low-agent roots run first, and high-agent roots are deferred until cache refresh or
+calibration. If presplit keys exist while `translation_memory.frag.<lang>.jsonl` is empty,
+the preflight warns to run
+`python src\pilot\translation_memory.py build-frags --lang ru` after a heal Workflow emits
+`frag_prov`; if no matching `wf_output*.json` contains `frag_prov`, the warning says so.
 
 Generate the harness for the root. **Default: the batched + masked v2 harness**
 ([`gen_opt_harness2.py`](gen_opt_harness2.py)) — masks each card (pwg_mask), packs
 several per agent call, and restores `{Tn}` to source markup in-JS so the result is a
 canonical `wf_output.json` (audit consumes it unchanged, no extra step). Measured
 **−72 % cost on a full mixed root** (gam: original per-card **\$16.14 → \$4.45**; a clean
-small batch is −90 %). See [`../../TLONLY_PROTOTYPE.md`](../../TLONLY_PROTOTYPE.md).
+small batch is −90 %). Current defaults: `--output-budget=90`, selfheal on,
+binary-split on, presplit routing on, and `--tm=auto` (uses
+`translation_memory.<lang>.json` + `translation_memory.frag.<lang>.jsonl` when present;
+`--no-tm` is the explicit opt-out). Refresh TM after every promotion/heal harvest:
+`python src\pilot\translation_memory.py build --lang ru` and, when fragment provenance was
+created, `python src\pilot\translation_memory.py build-frags --lang ru`. See
+[`../../TLONLY_PROTOTYPE.md`](../../TLONLY_PROTOTYPE.md).
 
 ```powershell
-python src\pilot\gen_opt_harness2.py sTA            # default (batched+masked, -72%)
+python src\pilot\gen_opt_harness2.py sTA            # default (batched+masked, TM auto, output-budget 90)
 # -> writes src\pilot\run_pilot_wf.opt2.js  (run THIS in Max, save result as wf_output.json)
-# --budget=N tunes batch packing (chars of skeleton+portrait per batch; default 12000 —
-#   higher = fewer agent calls = less ~30k/agent fixed overhead; the post-restore fidelity
-#   guard nulls any degraded big-batch card -> requeue. See TOKEN_LEVER_FINDING_2026-06-30.md).
+# --output-budget=N tunes citation-weighted output packing (default 90).
+# --budget=N without --output-budget keeps legacy byte-mode packing.
+# --no-tm disables automatic card/fragment translation-memory reuse.
 # A batch retries only its still-unresolved cards; a card whose restored <ls>/{#..#}
 # counts don't match source is nulled -> requeue (never emitted garbled).
 ```
+
+Remaining useful speed work is measured, not guessed: increase TM/fragment-TM coverage,
+let conservative degenerate cross-reference stubs pass through without an LLM call, and use
+[`calibrate_perf_harness.py`](calibrate_perf_harness.py) for scratch-only wider calibration
+across fixed key sets (`--arm-set conservative` or `--arm-set wide`). Run live calibration
+arms sequentially with cache cooldown; never run same-prompt arms in parallel.
+Do not widen degenerate pass-through for editorial correction prose (`lies:`, `zu streichen`,
+etc.); those rows stay in the normal LLM lane unless a future fixture proves exact
+deterministic reconstruction is safe.
 
 Legacy per-card harness (still supported; no masking/batching):
 

--- a/RussianTranslation/src/pilot/calibrate_perf_harness.py
+++ b/RussianTranslation/src/pilot/calibrate_perf_harness.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+"""Build scratch harness arms for pwg_ru performance calibration.
+
+This helper only generates harness files plus a manifest/report template. It does
+not run Workflow, audit outputs, promote cards, or touch the RU store.
+"""
+import argparse
+import datetime
+import json
+import os
+import subprocess
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+OUT = os.path.join(HERE, 'output')
+
+CACHE_WARNING = (
+    'Run live calibration arms sequentially with cache cooldown; never run same-prompt '
+    'arms in parallel. AB_TEST_LEAN_TR.md showed the 5-minute prompt cache makes the '
+    'second parallel/same-prompt run artificially cheap.'
+)
+
+
+def split_csv(text):
+    return [x.strip() for x in str(text).split(',') if x.strip()]
+
+
+def parse_ints(text):
+    return [int(x) for x in split_csv(text)]
+
+
+def apply_arm_set(args):
+    if args.arm_set == 'conservative':
+        args.output_budgets = args.output_budgets or [90, 110]
+        args.selfheal_budgets = args.selfheal_budgets or [12]
+        args.tm_modes = args.tm_modes or ['auto', 'off']
+    elif args.arm_set == 'wide':
+        args.output_budgets = args.output_budgets or [90, 110, 120]
+        args.selfheal_budgets = args.selfheal_budgets or [8, 12, 16]
+        args.tm_modes = args.tm_modes or ['auto', 'off']
+    else:
+        args.output_budgets = args.output_budgets or [60, 90]
+        args.selfheal_budgets = args.selfheal_budgets or [12]
+        args.tm_modes = args.tm_modes or ['auto', 'off']
+    return args
+
+
+def arm_name(output_budget, selfheal_budget, tm_mode):
+    return 'ob%s_sh%s_tm%s' % (output_budget, selfheal_budget, tm_mode)
+
+
+def build_command(args, out_js, output_budget, selfheal_budget, tm_mode):
+    cmd = [
+        sys.executable,
+        os.path.join(HERE, 'gen_opt_harness2.py'),
+        args.root,
+        '--keys=%s' % ','.join(args.keys),
+        '--out=%s' % out_js,
+        '--output-budget=%s' % output_budget,
+        '--selfheal-budget=%s' % selfheal_budget,
+        '--lang=%s' % args.lang,
+    ]
+    if args.nominal:
+        cmd.append('--nominal')
+    if args.no_grammar:
+        cmd.append('--no-grammar')
+    if tm_mode == 'off':
+        cmd.append('--no-tm')
+    elif tm_mode == 'on':
+        cmd.append('--tm=%s' % args.tm_path if args.tm_path else '--tm')
+    elif tm_mode == 'auto':
+        cmd.append('--tm=auto')
+    else:
+        raise ValueError('unknown tm mode %r' % tm_mode)
+    return cmd
+
+
+def write_readme(path, manifest):
+    lines = [
+        '# pwg_ru Performance Calibration Scratch',
+        '',
+        CACHE_WARNING,
+        '',
+        'These files are generated harness arms only. Run each arm manually in Workflow,',
+        'one at a time, record transcript/cost/audit outputs below, then compare.',
+        '',
+        '## Fixed Inputs',
+        '',
+        '- root: `%s`' % manifest['root'],
+        '- lang: `%s`' % manifest['lang'],
+        '- keys: `%s`' % ','.join(manifest['keys']),
+        '- generated_at: `%s`' % manifest['generated_at'],
+        '',
+        '## Arms',
+        '',
+    ]
+    for arm in manifest['arms']:
+        lines.extend([
+            '### %s' % arm['name'],
+            '',
+            '- output_budget: `%s`' % arm['output_budget'],
+            '- selfheal_budget: `%s`' % arm['selfheal_budget'],
+            '- tm_mode: `%s`' % arm['tm_mode'],
+            '- harness: `%s`' % arm['harness'],
+            '- generator_status: `%s`' % arm['status'],
+            '- command: `%s`' % ' '.join(arm['command']),
+            '- workflow_output: TODO',
+            '- audit_report: TODO',
+            '- cost_summary: TODO',
+            '- null_keys: TODO',
+            '',
+        ])
+    with open(path, 'w', encoding='utf-8', newline='\n') as f:
+        f.write('\n'.join(lines).rstrip() + '\n')
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description='Generate scratch harness arms for calibration.')
+    ap.add_argument('root')
+    ap.add_argument('--keys', required=True, type=split_csv,
+                    help='Comma-separated fixed key set; required so arms are comparable.')
+    ap.add_argument('--arm-set', default='custom', choices=('custom', 'conservative', 'wide'),
+                    help='Named calibration grid; explicit budget/TM flags override each axis.')
+    ap.add_argument('--output-budgets', default=None, type=parse_ints)
+    ap.add_argument('--selfheal-budgets', default=None, type=parse_ints)
+    ap.add_argument('--tm-modes', default=None, type=split_csv,
+                    help='Comma-separated: auto,on,off.')
+    ap.add_argument('--tm-path', default=None)
+    ap.add_argument('--lang', default='ru', choices=('ru', 'en'))
+    ap.add_argument('--nominal', action='store_true')
+    ap.add_argument('--no-grammar', action='store_true')
+    ap.add_argument('--out-dir', default=None)
+    ap.add_argument('--emit-only', action='store_true',
+                    help='Write manifest/report commands without invoking gen_opt_harness2.py.')
+    args = ap.parse_args(argv)
+    args = apply_arm_set(args)
+
+    stamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+    out_dir = os.path.abspath(args.out_dir or os.path.join(OUT, 'perf_calibration',
+                                                          '%s_%s' % (args.root, stamp)))
+    os.makedirs(out_dir, exist_ok=True)
+
+    manifest = {
+        'schema': 'pwg.performance_calibration.v1',
+        'generated_at': datetime.datetime.now(datetime.timezone.utc).isoformat(
+            timespec='seconds').replace('+00:00', 'Z'),
+        'root': args.root,
+        'lang': args.lang,
+        'keys': args.keys,
+        'arm_set': args.arm_set,
+        'cache_warning': CACHE_WARNING,
+        'arms': [],
+    }
+    for output_budget in args.output_budgets:
+        for selfheal_budget in args.selfheal_budgets:
+            for tm_mode in args.tm_modes:
+                name = arm_name(output_budget, selfheal_budget, tm_mode)
+                out_js = os.path.join(out_dir, '%s.js' % name)
+                cmd = build_command(args, out_js, output_budget, selfheal_budget, tm_mode)
+                status, stdout, stderr = 'emit-only', '', ''
+                if not args.emit_only:
+                    proc = subprocess.run(cmd, cwd=REPO, capture_output=True, text=True,
+                                          encoding='utf-8')
+                    status, stdout, stderr = proc.returncode, proc.stdout, proc.stderr
+                    if proc.returncode != 0:
+                        print(proc.stdout)
+                        print(proc.stderr, file=sys.stderr)
+                        raise SystemExit(proc.returncode)
+                manifest['arms'].append({
+                    'name': name,
+                    'output_budget': output_budget,
+                    'selfheal_budget': selfheal_budget,
+                    'tm_mode': tm_mode,
+                    'harness': out_js,
+                    'command': cmd,
+                    'status': status,
+                    'stdout_tail': stdout[-2000:],
+                    'stderr_tail': stderr[-2000:],
+                })
+
+    manifest_path = os.path.join(out_dir, 'manifest.json')
+    readme_path = os.path.join(out_dir, 'REPORT_TEMPLATE.md')
+    with open(manifest_path, 'w', encoding='utf-8', newline='\n') as f:
+        json.dump(manifest, f, ensure_ascii=False, indent=2)
+        f.write('\n')
+    write_readme(readme_path, manifest)
+    print('wrote', manifest_path)
+    print('wrote', readme_path)
+    print(CACHE_WARNING)
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -21,9 +21,9 @@ Usage:  python src/pilot/gen_opt_harness2.py <root> [--keys=k1,k2] [--budget=N] 
                                                 # (calibrated 2026-07-03, see
                                                 # KNOB_CALIBRATION_2026-07-03.md);
                                                 # 'off' or an explicit --budget=N = byte mode
-        [--tm[=PATH]]                           # content-addressed translation memory:
-                                                # pre-resolve cards whose source SHA is cached
-                                                # (0 tokens); OFF by default. See translation_memory.py
+        [--tm[=PATH] | --no-tm]                 # content-addressed translation memory:
+                                                # default auto-uses translation_memory.<lang>.json
+                                                # when present; --no-tm opts out.
         (--selfheal / --binary-split still accepted as no-ops for documented runbooks)
 Writes: src/pilot/run_pilot_wf.opt2.js  (or --out=PATH — use a per-root/per-chat path to
         avoid the gen->copy race when several chats generate harnesses concurrently)
@@ -159,11 +159,9 @@ def parse_args(argv):
     keylist = None                     # ordered keys (nominal mode preserves order)
     out_path = None                    # --out=PATH overrides the default opt2.js (avoids the
     lang, mw_tm = 'ru', None           # --lang en + --mw-tm=PATH: PWG->English pilot (MG 2026-06-30)
-    tm = None                          # --tm[=PATH]: content-addressed translation-memory cache;
-                                       #  pre-resolves any card whose source SHA is already in the
-                                       #  TM (zero tokens, no manual --keys scoping). OFF by default
-                                       #  (opt-in; a stale/empty TM is simply a no-op). See
-                                       #  translation_memory.py.
+    tm = '__auto__'                    # default auto: use translation_memory.<lang>.json if present;
+                                       #  no sidecar = no-op with a loud summary. --no-tm disables.
+    tm_auto = True
     budget_explicit = output_explicit = False
     for a in argv[1:]:                 # gen->copy race when several chats generate at once)
         if a.startswith('--keys='):
@@ -180,10 +178,15 @@ def parse_args(argv):
             mw_tm = a.split('=', 1)[1]
         elif a == '--tm':
             tm = '__default__'          # resolved to translation_memory.<lang>.json after the loop
+            tm_auto = False
         elif a.startswith('--tm='):
             tm = a.split('=', 1)[1]
+            tm_auto = (tm == 'auto')
+            if tm_auto:
+                tm = '__auto__'
         elif a == '--no-tm':
             tm = None
+            tm_auto = False
         elif a == '--lean':
             lean = True
         elif a == '--nws-gate':
@@ -216,9 +219,9 @@ def parse_args(argv):
         die('unknown --lang %r (ru|en)' % lang)
     if lang == 'en' and mw_tm is None:
         mw_tm = os.path.join(SRC, 'mw_en_tm.json')      # default MW translation-memory feed
-    if tm == '__default__':
+    if tm in ('__default__', '__auto__'):
         tm = os.path.join(os.path.dirname(INP), 'translation_memory.%s.json' % lang)
-    return root, keyfilter, keylist, budget, lean, nws_gate, nominal, grammar_on, out_path, lang, mw_tm, tm
+    return root, keyfilter, keylist, budget, lean, nws_gate, nominal, grammar_on, out_path, lang, mw_tm, tm, tm_auto
 
 
 def extract_nws(tr):
@@ -381,8 +384,75 @@ def mw_tm_block(root, mw_tm_path):
             'lacks (e.g. a domain note "(as heavenly bodies)"), OMIT it) ===\n%s\n\n' % tm)
 
 
+_DEGENERATE_WORDS = {
+    's', 'siehe', 's.', 'vgl', 'vgl.', 'vergl', 'vergl.', 'u', 'und',
+    'ff', 'fgg', 'fg', 'fg.', 'fgg.', 'nachtrage', 'nachträge',
+}
+_DEGENERATE_CORRECTION_RE = re.compile(r'\b(lies|lesen|streichen)\b', re.I)
+
+
+def _portrait_key_iast(portrait_text, key):
+    try:
+        p = json.loads(portrait_text)
+    except Exception:
+        return key
+    rows = p if isinstance(p, list) else [p]
+    for row in rows:
+        if isinstance(row, dict):
+            return row.get('iast') or row.get('key1') or key
+    return key
+
+
+def degenerate_passthrough_card(key, raw, portrait_text, field='russian'):
+    """Conservative no-LLM lane for cross-reference/supplement stubs.
+
+    These cards contain citation/reference markup but no German gloss prose to translate.
+    False negatives are fine (normal harness handles them); false positives are not, so the
+    classifier intentionally admits only tiny non-gloss stubs with no gloss blocks or senses.
+    """
+    if not raw or len(raw) > 900:
+        return None
+    if '{%' in raw or '<div' in raw or re.search(r'\b\d+\)', raw):
+        return None
+    if not (re.search(r'\{#[^}]+#\}', raw) or '<ls' in raw or '<ab>' in raw):
+        return None
+    body = re.sub(r'^=== LAYER:.*?===\s*', '', raw, flags=re.S).strip()
+    if not body:
+        return None
+    if _DEGENERATE_CORRECTION_RE.search(body):
+        return None
+    probe = re.sub(r'\{#[^}]*#\}', ' ', body)
+    probe = re.sub(r'\{%[^}]*%\}', ' ', probe)
+    probe = re.sub(r'<[^>]+>', ' ', probe)
+    probe = re.sub(r'\[[^\]]+\]', ' ', probe)
+    words = [w.lower().strip('.:,;()') for w in re.findall(r'[A-Za-zÄÖÜäöüß]+\.?', probe)]
+    words = [w for w in words if w]
+    norm = [w.replace('ä', 'a').replace('ö', 'o').replace('ü', 'u').replace('ß', 'ss')
+            for w in words]
+    if len(words) > 8 or any((w not in _DEGENERATE_WORDS and n not in _DEGENERATE_WORDS)
+                             for w, n in zip(words, norm)):
+        return None
+    sense = {
+        'tag': 'xref',
+        'german': body,
+        field: body,
+        'equivalence_type': 'explanatory',
+        'source_type': 'lexicographic',
+        'stratum': '',
+        'differentia': 'Deterministic pass-through: cross-reference stub with no translatable gloss.',
+    }
+    return {
+        'key1': key,
+        'iast': _portrait_key_iast(portrait_text, key),
+        'records': [{'h': None, 'senses': [sense]}],
+        'notes': '',
+        'degenerate_passthrough': True,
+    }
+
+
 def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
-          nominal=False, grammar_on=True, lang='ru', mw_tm_path=None, tm_path=None):
+          nominal=False, grammar_on=True, lang='ru', mw_tm_path=None, tm_path=None,
+          tm_auto=False):
     field = 'english' if lang == 'en' else 'russian'   # the per-sense translation field
     nws_block = ''
     if lang == 'en':
@@ -434,18 +504,21 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         '$defs': defs,
     }
 
-    inputs, phmaps, input_hashes = {}, {}, {}
+    inputs, phmaps, input_hashes, raws, portraits = {}, {}, {}, {}, {}
     for k in keys:
         rp, pp = input_paths(k)
         if not (os.path.exists(rp) and os.path.exists(pp)):
             die('missing input for %s' % k)
         raw = read_text(rp)
+        portrait = read_text(pp)
         skel, ph, _ = pwg_mask.mask(raw)
         if pwg_mask.restore(skel, ph) != raw:
             die('mask round-trip not lossless for %s' % k)
-        inputs[k] = {'skeleton': skel, 'portrait': read_text(pp),
+        inputs[k] = {'skeleton': skel, 'portrait': portrait,
                      'ls': raw.count('<ls'), 'sk': raw.count('{#'),
                      'nws': 1 if 'NWS' in raw else 0}
+        raws[k] = raw
+        portraits[k] = portrait
         phmaps[k] = ph
         input_hashes[k] = {'raw_sha256': sha256_file(rp), 'portrait_sha256': sha256_file(pp)}
 
@@ -469,6 +542,18 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     elif tm_path:
         print('  tm: %s not found — no pre-resolution (run translation_memory.py build)' % tm_path)
     tm_keys = set(tm_resolved)
+
+    degenerate_resolved = {}
+    for k in keys:
+        if k in tm_keys:
+            continue
+        card = degenerate_passthrough_card(k, raws[k], portraits[k], field)
+        if card:
+            degenerate_resolved[k] = card
+    degenerate_keys = set(degenerate_resolved)
+    if degenerate_keys:
+        print('  degenerate: %d/%d cross-reference stub(s) accounted with no LLM: %s'
+              % (len(degenerate_keys), len(keys), ','.join(sorted(degenerate_keys))))
 
     # --selfheal: precompute a per-card fragment fallback (deterministic sense/citation split).
     # The JS uses it only for cards the batch could not translate; each fragment is masked here
@@ -499,7 +584,7 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     if SELFHEAL:
         import translation_memory as _tm
         for k in keys:
-            if k in tm_keys:                 # cached whole card — no heal fallback needed
+            if k in tm_keys or k in degenerate_keys:  # cached/pass-through whole card — no heal fallback needed
                 continue
             pl = split_plan(read_text(input_paths(k)[0]))
             if len(pl) < 2:
@@ -542,11 +627,12 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     presplit = []
     if SELFHEAL and OUTPUT_BUDGET is not None:
         presplit = [k for k in keys
-                    if k not in tm_keys and (1 + inputs[k]['ls']) > OUTPUT_BUDGET and k in frags]
+                    if k not in tm_keys and k not in degenerate_keys
+                    and (1 + inputs[k]['ls']) > OUTPUT_BUDGET and k in frags]
         for k in presplit:
             print('  presplit: %s (%d <ls> exceeds output budget %d) -> direct fragment translation'
                   % (k, inputs[k]['ls'], OUTPUT_BUDGET))
-    batch_keys = [k for k in keys if k not in presplit and k not in tm_keys]
+    batch_keys = [k for k in keys if k not in presplit and k not in tm_keys and k not in degenerate_keys]
 
     # --output-budget=N (default 60): size batches by citation-weighted OUTPUT complexity
     # (1 + <ls> per card) instead of input bytes — bytes don't predict StructuredOutput
@@ -587,11 +673,19 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         'binary_split': BINARY_SPLIT, 'output_budget': OUTPUT_BUDGET,
         'presplit_keys': presplit,
         'tm': os.path.basename(tm_path) if tm_path else None,
+        'tm_auto': bool(tm_auto),
+        'tm_available': bool(tm_path and os.path.exists(tm_path)),
+        'tm_cards': len(tm_keys),
         'tm_hits': sorted(tm_keys),
         'frag_tm': os.path.basename(frag_file) if (frag_cache and tm_path) else None,
         'frag_tm_cards': sorted(frag_tm),
         'frag_tm_fragments': sum(sum(1 for grp in v for s in grp if s) for v in frag_tm.values()),
+        'degenerate_passthrough_keys': sorted(degenerate_keys),
+        'agent_expected_after_tm': len(batches) + len(presplit),
     }
+    print('  lanes: tm_cards=%d frag_tm_cards=%d degenerate_passthrough=%d agent_expected_after_tm=%d'
+          % (meta['tm_cards'], len(meta['frag_tm_cards']),
+             len(meta['degenerate_passthrough_keys']), meta['agent_expected_after_tm']))
 
     js = """// AUTO-DERIVED v2 (batched + masked, canonical output) from run_pilot_wf.js - root=%(root)s.
 // Several masked cards per agent call; {Tn} restored to source markup in-JS so the
@@ -619,6 +713,9 @@ const PRESPLIT = %(presplit)s
 // Emitted verbatim as canonical rows with tm:true and NO agent() call — their markup is
 // already restored (they come from the promoted store), so they bypass restore/accept.
 const TM_RESOLVED = %(tm_resolved)s
+// Conservative no-LLM lane for tiny cross-reference/supplement stubs that contain no
+// translatable German gloss. These are accounted rows, not skipped keys.
+const DEGENERATE_RESOLVED = %(degenerate_resolved)s
 // --tm fragment reuse: FRAG_TM[k] mirrors FRAGS[k]'s group shape; each slot is either a
 // cached fragment's ALREADY-RESTORED senses (served with NO agent() call inside selfHeal)
 // or null (translate it). A fully-cached card heals at zero cost; a partial giant card
@@ -929,6 +1026,7 @@ const seen = new Set()
 // TM lane first: pre-resolved cards cost nothing and are already accounted for, so seed
 // them before backfilling the translated units. tm:true marks provenance for the summary.
 for (const k in TM_RESOLVED) { if (!seen.has(k)) { out.push({ key: k, card: TM_RESOLVED[k], judge: null, judge_sonnet: null, escalated: false, tm: true }); seen.add(k) } }
+for (const k in DEGENERATE_RESOLVED) { if (!seen.has(k)) { out.push({ key: k, card: DEGENERATE_RESOLVED[k], judge: null, judge_sonnet: null, escalated: false, degenerate_passthrough: true }); seen.add(k) } }
 grouped.forEach((rows, i) => {
   if (Array.isArray(rows)) {
     for (const r of rows) if (r && r.key && !seen.has(r.key)) { out.push(r); seen.add(r.key) }
@@ -949,6 +1047,7 @@ for (const r of out) if (!r.card) _failures[r.key] = r.error || FAIL[r.key] || '
 const summary = { root: META.root, lang: META.lang, cards: out.length, ok: _ok,
                   null: out.length - _ok, healed: out.filter(r => r.escalated).length,
                   presplit: PRESPLIT.length, tm: out.filter(r => r.tm).length,
+                  degenerate_passthrough: out.filter(r => r.degenerate_passthrough).length,
                   frag_tm_fragments: META.frag_tm_fragments || 0,
                   null_keys: out.filter(r => !r.card).map(r => r.key),
                   partial_keys: out.filter(r => r.card && r.card.partial).map(r => r.key),
@@ -973,6 +1072,7 @@ return { meta: META, summary, results: out }
         'frags': json.dumps(frags, ensure_ascii=True), 'phf': json.dumps(phf, ensure_ascii=True),
         'binary_split': json.dumps(BINARY_SPLIT), 'presplit': json.dumps(presplit),
         'tm_resolved': json.dumps(tm_resolved, ensure_ascii=True),
+        'degenerate_resolved': json.dumps(degenerate_resolved, ensure_ascii=True),
         'frag_tm': json.dumps(frag_tm, ensure_ascii=True),
     }
     for bad in ['readFileSync', 'fileURLToPath', 'import.meta']:
@@ -982,7 +1082,7 @@ return { meta: META, summary, results: out }
 
 
 def main():
-    root, keyfilter, keylist, budget, lean, nws_gate, nominal, grammar_on, out_path, lang, mw_tm, tm = parse_args(sys.argv[1:])
+    root, keyfilter, keylist, budget, lean, nws_gate, nominal, grammar_on, out_path, lang, mw_tm, tm, tm_auto = parse_args(sys.argv[1:])
     if nominal:
         # No rootmap: the headword keys ARE the cards, in the order given.
         if not keylist:
@@ -992,7 +1092,7 @@ def main():
         rootmap, keys = selected_keys(root, keyfilter)
         if keylist:
             keys = [k for k in keylist if k in set(keys)]
-    js, batches = build(root, keys, rootmap, budget, lean, nws_gate, nominal, grammar_on, lang, mw_tm, tm)
+    js, batches = build(root, keys, rootmap, budget, lean, nws_gate, nominal, grammar_on, lang, mw_tm, tm, tm_auto)
     out = os.path.abspath(out_path) if out_path else os.path.join(REPO, 'src', 'pilot', 'run_pilot_wf.opt2.js')
     # Write LF (not CRLF): the Workflow-tool approval rejects scripts containing
     # raw \r control chars, so a CRLF harness cannot be launched on Windows.

--- a/RussianTranslation/src/pilot/perf_preflight.py
+++ b/RussianTranslation/src/pilot/perf_preflight.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python
+"""Read-only performance preflight for pwg_ru optimized harness lanes.
+
+Builds the same in-memory lane plan as gen_opt_harness2.py, then reports the
+agent-cost reducers before an operator spends Workflow/Max tokens. It writes
+nothing and never touches the RU store.
+"""
+import argparse
+import contextlib
+import glob
+import io
+import json
+import os
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import gen_opt_harness2 as gh
+import translation_memory  # noqa: F401  # pre-import before stdout capture; module reconfigures stdout.
+from window_common import INP, input_paths, read_text
+
+
+def split_csv(text):
+    return [x.strip() for x in str(text).split(',') if x.strip()]
+
+
+def const_json(js, name):
+    m = re.search(r'^const %s = (.*)$' % re.escape(name), js, re.M)
+    return json.loads(m.group(1)) if m else None
+
+
+def default_tm_path(lang):
+    return os.path.join(os.path.dirname(INP), 'translation_memory.%s.json' % lang)
+
+
+def default_frag_path(lang, tm_path=None):
+    base = os.path.dirname(tm_path or default_tm_path(lang))
+    return os.path.join(base, 'translation_memory.frag.%s.jsonl' % lang)
+
+
+def selected(root, keylist, nominal):
+    if nominal:
+        if not keylist:
+            raise SystemExit('FAIL: --nominal requires --keys=k1,k2,...')
+        return None, keylist
+    rootmap, keys = gh.selected_keys(root, set(keylist) if keylist else None)
+    if keylist:
+        wanted = set(keys)
+        keys = [k for k in keylist if k in wanted]
+    return rootmap, keys
+
+
+def near_degenerate_reason(key, raw, portrait, field):
+    if gh.degenerate_passthrough_card(key, raw, portrait, field):
+        return None
+    if not (re.search(r'\{#[^}]+#\}', raw) or '<ls' in raw or '<ab>' in raw):
+        return None
+    if len(raw) > 1500 or '<div' in raw or re.search(r'\b\d+\)', raw):
+        return None
+    if '{%' in raw:
+        return None
+    body = re.sub(r'^=== LAYER:.*?===\s*', '', raw, flags=re.S).strip()
+    if has_correction_prose(body):
+        return 'editorial correction prose; keep in LLM lane'
+    probe = re.sub(r'\{#[^}]*#\}', ' ', body)
+    probe = re.sub(r'\{%[^}]*%\}', ' ', probe)
+    probe = re.sub(r'<[^>]+>', ' ', probe)
+    words = [w.lower().strip('.:,;()') for w in re.findall(r'[A-Za-zÄÖÜäöüß]+\.?', probe)]
+    words = [w for w in words if w]
+    if len(words) <= 12:
+        return 'short reference-like stub, but words are outside the pass-through whitelist'
+    return None
+
+
+def has_correction_prose(text):
+    return bool(re.search(r'\b(lies|lesen|streichen)\b', text, re.I))
+
+
+def near_degenerate_candidates(keys, field):
+    rows = []
+    for key in keys:
+        rp, pp = input_paths(key)
+        if not (os.path.exists(rp) and os.path.exists(pp)):
+            continue
+        raw, portrait = read_text(rp), read_text(pp)
+        reason = near_degenerate_reason(key, raw, portrait, field)
+        if reason:
+            rows.append({'key': key, 'reason': reason})
+    return rows
+
+
+def has_frag_provenance(glob_pattern):
+    for fp in sorted(glob.glob(os.path.join(REPO, glob_pattern))):
+        try:
+            with open(fp, 'r', encoding='utf-8') as f:
+                for chunk in iter(lambda: f.read(1024 * 1024), ''):
+                    if not chunk:
+                        break
+                    if '"frag_prov"' in chunk or "'frag_prov'" in chunk:
+                        return True
+        except OSError:
+            continue
+    return False
+
+
+def recommendation(report):
+    agents = report.get('agent_expected_after_tm', 0)
+    if agents == 0:
+        return 'skip-cached'
+    if agents <= 15:
+        return 'run-now-low'
+    if agents <= 20:
+        return 'run-next'
+    return 'defer-calibrate'
+
+
+def build_report(args, root):
+    keylist = split_csv(args.keys) if args.keys else None
+    rootmap, keys = selected(root, keylist, args.nominal)
+    tm_path = (args.tm_path or default_tm_path(args.lang)) if args.tm_auto else None
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        js, _batches = gh.build(root, keys, rootmap, args.budget,
+                                nominal=args.nominal, grammar_on=not args.no_grammar,
+                                lang=args.lang, tm_path=tm_path, tm_auto=args.tm_auto)
+    meta = const_json(js, 'META')
+    frag_tm = const_json(js, 'FRAG_TM') or {}
+    fragment_hit_groups = {
+        key: sum(1 for group in groups if any(slot for slot in group))
+        for key, groups in frag_tm.items()
+    }
+    field = 'english' if args.lang == 'en' else 'russian'
+    tm_sidecar = tm_path or default_tm_path(args.lang)
+    frag_sidecar = default_frag_path(args.lang, tm_sidecar)
+    frag_cache = translation_memory.load_frag_tm(args.lang, frag_sidecar)
+    warnings = []
+    if meta.get('presplit_keys') and not frag_cache:
+        warning = (
+            'presplit keys need fragment fallback, but %s is empty; run '
+            '`python src/pilot/translation_memory.py build-frags --lang %s` after a heal '
+            'Workflow emits frag_prov'
+            % (os.path.basename(frag_sidecar), args.lang)
+        )
+        if not has_frag_provenance(args.wf_glob):
+            warning += '; no fragment provenance available yet'
+        warnings.append(warning)
+    report = {
+        'schema': 'pwg.performance_preflight.v1',
+        'root': root,
+        'lang': args.lang,
+        'nominal': bool(args.nominal),
+        'selected_keys': keys,
+        'tm_sidecar': tm_sidecar,
+        'tm_available': os.path.exists(tm_sidecar),
+        'tm_auto': bool(args.tm_auto),
+        'tm_hits': meta.get('tm_hits', []),
+        'tm_cards': meta.get('tm_cards', 0),
+        'frag_tm_sidecar': frag_sidecar,
+        'frag_tm_available': os.path.exists(frag_sidecar),
+        'frag_tm_entries': len(frag_cache),
+        'frag_tm_cards': meta.get('frag_tm_cards', []),
+        'frag_tm_fragments': meta.get('frag_tm_fragments', 0),
+        'fragment_hit_groups': fragment_hit_groups,
+        'degenerate_passthrough_keys': meta.get('degenerate_passthrough_keys', []),
+        'near_degenerate_candidates': near_degenerate_candidates(keys, field),
+        'presplit_keys': meta.get('presplit_keys', []),
+        'batch_count': meta.get('batch_count', 0),
+        'agent_expected_after_tm': meta.get('agent_expected_after_tm', 0),
+        'output_budget': meta.get('output_budget'),
+        'selfheal_group_budget': meta.get('selfheal_group_budget'),
+        'recommended_action': None,
+        'warnings': warnings,
+        'generator_log': [line for line in buf.getvalue().splitlines() if line.strip()],
+    }
+    report['recommended_action'] = recommendation(report)
+    return report
+
+
+def print_human(report):
+    print('pwg_ru performance preflight: %s (%s)' % (report['root'], report['lang']))
+    print('  selected_keys: %d' % len(report['selected_keys']))
+    print('  card TM: %s | hits %d'
+          % ('present' if report['tm_available'] else 'missing', report['tm_cards']))
+    print('  fragment TM: %s | cards %d | fragments %d'
+          % ('present' if report['frag_tm_available'] else 'missing',
+             len(report['frag_tm_cards']), report['frag_tm_fragments']))
+    print('  degenerate pass-through: %d' % len(report['degenerate_passthrough_keys']))
+    if report['near_degenerate_candidates']:
+        print('  near-degenerate candidates: %d' % len(report['near_degenerate_candidates']))
+        for row in report['near_degenerate_candidates'][:12]:
+            print('    - %s: %s' % (row['key'], row['reason']))
+    print('  presplit: %d' % len(report['presplit_keys']))
+    print('  batches: %d' % report['batch_count'])
+    print('  agent_expected_after_tm: %d' % report['agent_expected_after_tm'])
+    print('  recommendation: %s' % report['recommended_action'])
+    for warning in report.get('warnings') or []:
+        print('  WARNING: %s' % warning)
+
+
+def recommended_order(reports):
+    runnable = [r for r in reports if r['agent_expected_after_tm'] > 0]
+    runnable.sort(key=lambda r: (r['agent_expected_after_tm'], len(r['selected_keys']), r['root']))
+    skipped = [r['root'] for r in reports if r['agent_expected_after_tm'] == 0]
+    deferred = [r['root'] for r in runnable if r['recommended_action'] == 'defer-calibrate']
+    ordered = [r['root'] for r in runnable if r['recommended_action'] != 'defer-calibrate']
+    return {'run_first': ordered, 'defer': deferred, 'skip_cached': skipped}
+
+
+def print_matrix(reports):
+    print('pwg_ru performance preflight matrix (%s)' % reports[0]['lang'])
+    header = ('root', 'keys', 'tm', 'frag', 'deg', 'near', 'pre', 'batches', 'agents', 'action')
+    rows = []
+    for r in reports:
+        rows.append((
+            r['root'], len(r['selected_keys']), r['tm_cards'], r['frag_tm_fragments'],
+            len(r['degenerate_passthrough_keys']), len(r['near_degenerate_candidates']),
+            len(r['presplit_keys']), r['batch_count'], r['agent_expected_after_tm'],
+            r['recommended_action'],
+        ))
+    widths = [max(len(str(row[i])) for row in [header] + rows) for i in range(len(header))]
+    fmt = '  '.join('%%-%ds' % w for w in widths)
+    print(fmt % header)
+    print(fmt % tuple('-' * w for w in widths))
+    for row in rows:
+        print(fmt % row)
+    order = recommended_order(reports)
+    if order['run_first']:
+        print('recommended run order: %s' % ', '.join(order['run_first']))
+    if order['skip_cached']:
+        print('skip cached: %s' % ', '.join(order['skip_cached']))
+    if order['defer']:
+        print('defer until cache refresh/calibration: %s' % ', '.join(order['defer']))
+    warnings = [(r['root'], w) for r in reports for w in (r.get('warnings') or [])]
+    for root, warning in warnings:
+        print('WARNING [%s]: %s' % (root, warning))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description='Read-only optimized-harness performance preflight.')
+    ap.add_argument('roots', nargs='+')
+    ap.add_argument('--keys', default=None)
+    ap.add_argument('--lang', default='ru', choices=('ru', 'en'))
+    ap.add_argument('--nominal', action='store_true')
+    ap.add_argument('--no-grammar', action='store_true')
+    ap.add_argument('--budget', default=12000, type=int)
+    ap.add_argument('--tm', dest='tm_path', default=None,
+                    help='Optional TM sidecar path; defaults to src/pilot/translation_memory.<lang>.json.')
+    ap.add_argument('--no-tm', dest='tm_auto', action='store_false',
+                    help='Disable auto sidecar lookup for what-if accounting.')
+    ap.add_argument('--wf-glob', default='wf_output*.json',
+                    help='Workflow-output glob, relative to RussianTranslation/, used only for frag_prov warnings.')
+    ap.add_argument('--json', action='store_true')
+    ap.set_defaults(tm_auto=True)
+    args = ap.parse_args(argv)
+    if len(args.roots) > 1 and args.keys:
+        raise SystemExit('FAIL: --keys is root-specific; use one root per --keys preflight')
+    if len(args.roots) > 1 and args.nominal:
+        raise SystemExit('FAIL: --nominal requires one root/key namespace per preflight')
+    reports = [build_report(args, root) for root in args.roots]
+    if args.json:
+        if len(reports) == 1:
+            payload = reports[0]
+        else:
+            payload = {
+                'schema': 'pwg.performance_preflight.matrix.v1',
+                'lang': args.lang,
+                'roots': args.roots,
+                'reports': reports,
+                'recommended_order': recommended_order(reports),
+            }
+        json.dump(payload, sys.stdout, ensure_ascii=False, indent=2)
+        print()
+    elif len(reports) == 1:
+        print_human(reports[0])
+    else:
+        print_matrix(reports)
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -1101,6 +1101,196 @@ def test_tm_pre_resolves_cards():
             pass
 
 
+def test_tm_auto_no_sidecar_metadata():
+    """Default CLI semantics are --tm=auto: if the sidecar is missing, generation continues
+    normally and records the no-op in META instead of silently changing lanes."""
+    import re as _re
+    import gen_opt_harness2 as gh
+    from window_common import rootmap_path, input_paths
+    root = 'gam'
+    rmpath, _ = rootmap_path(root)
+    if not rmpath:
+        return
+    rootmap, keys = gh.selected_keys(root, None)
+    keys = [k for k in keys if os.path.exists(input_paths(k)[0])][:3]
+    if not keys:
+        return
+    missing_tm = os.path.join(tempfile.gettempdir(), 'missing_pwg_tm_selftest_%s.json' % os.getpid())
+    try:
+        os.remove(missing_tm)
+    except OSError:
+        pass
+    js, _batches = gh.build(root, keys, rootmap, 12000, tm_path=missing_tm, tm_auto=True)
+    meta = json.loads(_re.search(r'const META = (\{.*?\})\n', js, _re.S).group(1))
+    if not meta.get('tm_auto'):
+        fail('META.tm_auto must be true for --tm=auto/default generation')
+    if meta.get('tm_available'):
+        fail('META.tm_available must be false when the auto sidecar is absent')
+    if meta.get('tm_cards') != 0 or meta.get('tm_hits'):
+        fail('missing auto TM sidecar must not pre-resolve any cards')
+    owed = {k for b in meta['batches'] for k in b} | set(meta['presplit_keys']) | set(meta['degenerate_passthrough_keys'])
+    if owed != set(keys):
+        fail('missing auto TM sidecar must keep every selected key owed/accounted')
+
+
+def test_degenerate_passthrough_accounted():
+    """A safely-degenerate cross-reference stub is emitted as an accounted no-LLM row and is
+    excluded from translation lanes; it is never a silent skip."""
+    import re as _re
+    import gen_opt_harness2 as gh
+    from window_common import input_paths, read_text
+    key = 'ab'
+    rp, pp = input_paths(key)
+    if not (os.path.exists(rp) and os.path.exists(pp)):
+        return
+    card = gh.degenerate_passthrough_card(key, read_text(rp), read_text(pp), 'russian')
+    if not card or not card.get('degenerate_passthrough'):
+        fail('ab fixture should qualify for conservative degenerate pass-through')
+    js, batches = gh.build(key, [key], None, 12000, nominal=True, tm_path=None)
+    meta = json.loads(_re.search(r'const META = (\{.*?\})\n', js, _re.S).group(1))
+    if meta.get('degenerate_passthrough_keys') != [key]:
+        fail('META.degenerate_passthrough_keys must account for the stub key')
+    if batches or meta.get('presplit_keys'):
+        fail('a degenerate pass-through key must not also enter an agent translation lane')
+    if 'const DEGENERATE_RESOLVED' not in js or 'degenerate_passthrough: true' not in js:
+        fail('generated harness must emit explicit degenerate pass-through rows')
+
+
+def test_degenerate_passthrough_rejects_glosses():
+    import gen_opt_harness2 as gh
+    import perf_preflight as pp
+    raw = """=== LAYER: PWG — MAIN ENTRY ===
+{#agni#}¦ {%Feuer%}, <ls>RV.</ls>
+"""
+    if gh.degenerate_passthrough_card('agni', raw, '{"key1":"agni"}', 'russian'):
+        fail('cards with German gloss blocks must not enter deterministic pass-through')
+    if pp.near_degenerate_reason('agni', raw, '{"key1":"agni"}', 'russian'):
+        fail('cards with German gloss blocks must not be suggested as near-degenerate stubs')
+    correction = """=== LAYER: PWG — MAIN ENTRY ===
+{#as#}¦ <ab>vgl.</ab> mit {#aBi#} <ab>Z.</ab> 9 <ab>v. u.</ab> lies: {#etattrikam#}.
+"""
+    if gh.degenerate_passthrough_card('as', correction, '{"key1":"as"}', 'russian'):
+        fail('editorial correction prose (lies:) must stay out of deterministic pass-through')
+    if 'editorial correction prose' not in (pp.near_degenerate_reason('as', correction, '{"key1":"as"}', 'russian') or ''):
+        fail('preflight should explain why correction prose is report-only')
+    strike = """=== LAYER: PWG — MAIN ENTRY ===
+{#vid#}¦ <ab>Z.</ab> 5 ist ein {#tasya#} zu streichen.
+"""
+    if gh.degenerate_passthrough_card('vid', strike, '{"key1":"vid"}', 'russian'):
+        fail('editorial correction prose (streichen) must stay out of deterministic pass-through')
+
+
+def test_perf_preflight_small_tm_and_no_tm():
+    key = 'gam~~h0_03_sec_3'
+    proc = run([sys.executable, 'src/pilot/perf_preflight.py', 'gam',
+                '--keys=%s' % key, '--json'], 0)
+    report = json.loads(proc.stdout)
+    if report['selected_keys'] != [key]:
+        fail('perf_preflight must preserve the requested fixed key set')
+    if report.get('schema') != 'pwg.performance_preflight.v1' or 'reports' in report:
+        fail('single-root perf_preflight JSON must remain the plain v1 report shape')
+    if 'tm_available' not in report or 'agent_expected_after_tm' not in report:
+        fail('perf_preflight JSON missing TM/agent accounting fields')
+    proc2 = run([sys.executable, 'src/pilot/perf_preflight.py', 'gam',
+                 '--keys=%s' % key, '--no-tm', '--json'], 0)
+    no_tm = json.loads(proc2.stdout)
+    if no_tm['tm_auto'] or no_tm['tm_cards'] != 0:
+        fail('--no-tm preflight must disable TM accounting')
+    if no_tm['batch_count'] < 1 or no_tm['agent_expected_after_tm'] < 1:
+        fail('small no-TM card should still be owed by a normal agent lane')
+
+
+def test_perf_preflight_dense_presplit():
+    key = 'gam~~h0_00_pwg00'
+    proc = run([sys.executable, 'src/pilot/perf_preflight.py', 'gam',
+                '--keys=%s' % key, '--no-tm', '--json'], 0)
+    report = json.loads(proc.stdout)
+    if key not in report.get('presplit_keys', []):
+        fail('dense key must report presplit routing in performance preflight')
+    if report.get('agent_expected_after_tm', 0) < 1:
+        fail('dense presplit key must report a nonzero expected agent lane')
+
+
+def test_perf_preflight_degenerate_zero_agent():
+    proc = run([sys.executable, 'src/pilot/perf_preflight.py', 'ab',
+                '--nominal', '--keys=ab', '--json'], 0)
+    report = json.loads(proc.stdout)
+    if report.get('degenerate_passthrough_keys') != ['ab']:
+        fail('ab must report degenerate pass-through in performance preflight')
+    if report.get('agent_expected_after_tm') != 0:
+        fail('degenerate pass-through should report zero expected agents')
+
+
+def test_perf_preflight_multi_root_matrix_and_order():
+    tm_sidecar = os.path.join(HERE, 'translation_memory.ru.json')
+    if not os.path.exists(tm_sidecar):
+        return
+    proc = run([sys.executable, 'src/pilot/perf_preflight.py',
+                'gam', 'han', 'as', 'vid', '--json'], 0)
+    matrix = json.loads(proc.stdout)
+    if matrix.get('schema') != 'pwg.performance_preflight.matrix.v1':
+        fail('multi-root perf_preflight JSON must use the matrix wrapper')
+    reports = {r['root']: r for r in matrix.get('reports', [])}
+    for root in ['gam', 'han', 'as', 'vid']:
+        if root not in reports:
+            fail('multi-root matrix missing %s' % root)
+    if reports['han'].get('agent_expected_after_tm') != 0:
+        fail('han should be recognized as fully cached / zero-agent in the local TM preflight')
+    if 'han' not in matrix.get('recommended_order', {}).get('skip_cached', []):
+        fail('fully cached roots must be listed in skip_cached')
+    run_first = matrix.get('recommended_order', {}).get('run_first', [])
+    if 'vid' not in run_first or 'as' not in run_first:
+        fail('low-agent roots should appear in recommended run order')
+
+
+def test_perf_preflight_fragment_tm_empty_warning():
+    from window_common import rootmap_path, input_paths
+    root = 'gam'
+    key = 'gam~~h0_00_pwg00'
+    rmpath, _ = rootmap_path(root)
+    if not rmpath or not os.path.exists(input_paths(key)[0]):
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        tm_sidecar = os.path.join(tmp, 'translation_memory.ru.json')
+        with open(tm_sidecar, 'w', encoding='utf-8') as f:
+            json.dump({'schema': 'pwg.translation_memory.v1', 'lang': 'ru', 'entries': {}}, f)
+        proc = run([sys.executable, 'src/pilot/perf_preflight.py', root,
+                    '--keys=%s' % key, '--tm=%s' % tm_sidecar,
+                    '--wf-glob=no_such_frag_prov_fixture_*.json', '--json'], 0)
+        report = json.loads(proc.stdout)
+        warnings = report.get('warnings') or []
+        if key not in report.get('presplit_keys', []):
+            fail('dense fixture must route to presplit for fragment-TM warning test')
+        joined = '\n'.join(warnings)
+        if 'build-frags --lang ru' not in joined:
+            fail('empty fragment TM warning must include the build-frags command')
+        if 'no fragment provenance available yet' not in joined:
+            fail('empty fragment TM warning must state when no frag_prov source exists')
+
+
+def test_calibration_arm_set_conservative_emit_only():
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = os.path.join(tmp, 'perf_smoke_preflight')
+        proc = run([sys.executable, 'src/pilot/calibrate_perf_harness.py', 'gam',
+                    '--keys=gam~~h0_03_sec_3', '--arm-set', 'conservative',
+                    '--emit-only', '--out-dir=%s' % out_dir], 0)
+        manifest_path = os.path.join(out_dir, 'manifest.json')
+        if not os.path.exists(manifest_path):
+            fail('calibration emit-only must write manifest.json')
+        manifest = json.load(open(manifest_path, encoding='utf-8'))
+        arms = {(a['output_budget'], a['selfheal_budget'], a['tm_mode'])
+                for a in manifest.get('arms', [])}
+        expected = {(90, 12, 'auto'), (90, 12, 'off'), (110, 12, 'auto'), (110, 12, 'off')}
+        if arms != expected:
+            fail('conservative arm set mismatch: %s' % sorted(arms))
+        if 'cache cooldown' not in manifest.get('cache_warning', ''):
+            fail('calibration manifest must keep the cache-cooldown warning')
+        if any(name.endswith('.js') for name in os.listdir(out_dir)):
+            fail('emit-only calibration must not generate harness JS files')
+        if 'cache cooldown' not in proc.stdout:
+            fail('calibration CLI must print the cache-cooldown warning')
+
+
 def test_frag_tm_reuse():
     """Fragment-level --tm: a card that plan()-splits into >=2 fragments, with ONE fragment
     in the fragment sidecar, emits a FRAG_TM group-shape mirroring FRAGS where exactly the
@@ -1179,6 +1369,15 @@ def main():
     tests = [
         test_translation_memory_addressing,
         test_tm_pre_resolves_cards,
+        test_tm_auto_no_sidecar_metadata,
+        test_degenerate_passthrough_accounted,
+        test_degenerate_passthrough_rejects_glosses,
+        test_perf_preflight_small_tm_and_no_tm,
+        test_perf_preflight_dense_presplit,
+        test_perf_preflight_degenerate_zero_agent,
+        test_perf_preflight_multi_root_matrix_and_order,
+        test_perf_preflight_fragment_tm_empty_warning,
+        test_calibration_arm_set_conservative_emit_only,
         test_frag_tm_reuse,
         test_autosplit_topup_targets_and_reassembles,
         test_workflow_payload_nested,


### PR DESCRIPTION
## Summary

- add a read-only multi-root `perf_preflight.py` spend gate for PWG Russian Max runs
- add scratch-only calibration arm generation with cache-cooldown warnings
- keep degenerate pass-through conservative and explicitly reject editorial correction prose such as `lies:` / `zu streichen`
- update the Max runbook and AI state journals with the current run order and validation status

## Validation

- `python src/pilot/window_selftest.py`
- `python src/pilot/translation_memory.py selftest`
- `python src/pilot/perf_preflight.py sTA BU gam as i yuj vid han`

## Notes

No live Max/Workflow runs were performed. The worktree had unrelated unstaged local changes and backup artifacts; this PR intentionally stages only the performance-gate implementation files.
