### PR TITLE
docs(A34): hostile Fable-5 referee pass — 4 Majors + 7 minors fixed, References added

### DIFF
--- a/RussianTranslation/RENOU_FINDINGS.md
+++ b/RussianTranslation/RENOU_FINDINGS.md
@@ -1,11 +1,19 @@
 # Renou register axis — findings register
 
-_Created: 26-06-2026 · Last updated: 02-07-2026_
+_Created: 26-06-2026 · Last updated: 03-07-2026_
 
 Empirical findings from the two-axis tagging ([`RENOU.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU.md)), beyond the
 headline épigraphique result of [`papers/A34_renou_register_note.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A34_renou_register_note.md).
 Each is marked **[source]** (grounded in Renou's text) or **[data]** (measured over the
 8 Renou-tagged dictionaries). The per-register metrics behind them:
+
+> ⚠️ **Staleness (03-07-2026):** this table is a hand-copy from an earlier DCS-index
+> generation and needs regeneration from `renou_audit.py` (indices via
+> `renou_pipeline.py --all`). Known defect: the **epig corpus-absent cell reads 63.0 %,
+> but the committed glossary gives 484/709 = 68.3 %** — verified in
+> [`papers/A34_corpus_absent_verification.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A34_corpus_absent_verification.md);
+> the paper (A34) carries the correct 68.3 %. Until the regen, trust the glossaries over
+> this table wherever they disagree, and re-check bauddha's 12.4 % in the same pass.
 
 | register | N | corpus-absent | 1-dict | mean states | ≥4 states |
 |---|--:|--:|--:|--:|--:|

--- a/papers/A34_renou_register_note.md
+++ b/papers/A34_renou_register_note.md
@@ -2,9 +2,11 @@
 
 **A34 · research note / short communication · draft 2026-06-26 · target: Lexikos / IJL / eLex**
 
-> **Status:** full first draft (3/5). Tagging built, audited, and reproducible across
-> eight dictionaries; needs a related-work paragraph, one external validation pass on
-> the épigraphique sample, and a venue decision before submission.
+> **Status:** revised draft (4/5 after the 03-07-2026 Fable 5 referee pass,
+> [A34_review_fable5.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A34_review_fable5.md)).
+> Tagging built, audited, and reproducible across eight dictionaries; still needs the
+> EI/CII external validation pass on the épigraphique sample and a venue decision
+> (Lexikos / IJL / eLex) before submission.
 
 ## Abstract
 
@@ -20,9 +22,10 @@ tag cannot express either. We operationalise **both** axes — a diachronic **st
 subsections) — and apply them to **770,292 entries across eight machine-readable Cologne
 dictionaries**, each tag carrying its evidential provenance (lexicographer's citation /
 corpus attestation / register membership). The headline result is a structural one: of
-**709 headwords tagged épigraphique, 484 (68 %) have no attestation in the literary
-corpus at all** — they exist only in inscriptions (`akṣayanīvī` "perpetual endowment",
-monastery names, the dynastic onomasticon). The register axis recovers a stratum that
+**709 headwords tagged épigraphique, 484 (68.3 %) have no attestation in the literary
+corpus at all** (the conservative reading — neither a corpus nor an enriched state;
+the strict corpus-only reading gives 518, 73.1 %) — they exist only in inscriptions
+(`akṣayanīvī` "perpetual endowment", monastery names, the dynastic onomasticon). The register axis recovers a stratum that
 both the corpus and the period axis structurally miss. We release the tagger and eight
 register glossaries.
 
@@ -41,6 +44,17 @@ makes the gap concrete: the Classical chapter alone holds four distinct register
 Pāṇinian-norm chapter hosts the épigraphique witness. None of these is a fifth, sixth, or
 seventh *state*; they are an orthogonal dimension.
 
+**Relation to prior work.** The provenance model extends this project's own study of the
+MW citation apparatus as two distinct registers (*Two Citation Registers*, A08): there the
+citation *register* is a property of the dictionary's evidential practice; here Renou's
+*language* registers become a per-sense annotation axis. On the inscriptional side, the
+épigraphique glossary is the citation-derived counterpart of Sircar's corpus-derived
+*Indian Epigraphical Glossary* (1966), with Salomon (1998) as the standard guide to the
+underlying corpus; on the Buddhist side, register V's lexicon is Edgerton's (1953) by
+construction. For the lexicographic frame of the eight source dictionaries, Vogel (1979).
+We are not aware of a prior operationalisation of Renou's *subsections* — as opposed to
+his five chapter-states — as a tagging scheme.
+
 ## 2. Method
 
 We tag every dictionary sense on **two independent axes**, each multi-label (a word can
@@ -51,7 +65,9 @@ carry several values) and each value carrying a provenance set:
   **DCS-corpus** attestation (the lemma's occurrence across the Digital Corpus of
   Sanskrit, each text typed to a state by genre/name/date); **Edgerton's BHS** set
   membership for V; and a partial **wisdomlib** tradition tag.
-- **Register** — a 20-code lattice of Renou's subsections, built from the *same* two
+- **Register** — a 20-code lattice of Renou's subsections (the source TOC's own coding
+  table proposes 14; the lattice extends it with six further TOC-derivable sections —
+  *Atharvaveda*, *yajus*, *vyākaraṇa*, epic, *kārikā*, *hors-de-l'Inde*), built from the *same* two
   primary signals plus dedicated detectors: a genre/name→register map over the corpus
   texts (commentary caught by name-stems `*bhāṣya/ṭīkā/vṛtti/vārttika`, since the corpus
   has no commentary *genre*); the `<ls>` siglum's source genre/name (the only route to
@@ -65,8 +81,9 @@ per lemma, the per-state and per-register evidence depth `{n_texts, confidence}`
 attested in ≥2 texts *or* in one authoritatively-typed text, which prunes the thin
 date-fallback tail (9.9 % of corpus state-assignments; **0 %** of states II and V, which
 come only from typed sources). The two axes are kept in **disjoint vocabularies and
-separate fields**; an independent data-integrity audit confirmed entry-count invariance,
-provenance coherence across 1.43 M register assignments, and zero leakage between axes.
+separate fields**; an independent data-integrity audit (`renou_audit.py`; its report is
+regenerated with the indices, not committed) confirmed entry-count invariance, provenance
+coherence across all register assignments, and zero leakage between axes.
 
 The substrate is the Cologne Digital Sanskrit Lexicon (`csl-orig`) — PWG, MW, PW, AP,
 AP90, BEN, SCH, BHS — and the DCS 2026 corpus snapshot.
@@ -75,8 +92,9 @@ AP90, BEN, SCH, BHS — and the DCS 2026 corpus snapshot.
 
 ### 3.1 Coverage
 
-The register axis is populated across all eight dictionaries (19–100 % of entries carry
-≥1 register; BHS is 100 %, every entry being Buddhist). The commentary register is large
+The register axis is populated across all eight dictionaries (~38–41 % of all entries
+carry ≥1 register; per dictionary the rate rises to 100 % for BHS, every entry being
+Buddhist by construction). The commentary register is large
 and robust — *bhāṣya* tags **14,498 distinct headwords** (10,320 attested in ≥2
 dictionaries); the poetic and Buddhist lexica reach 26,973 (*kāvya*) and 25,740
 (*bauddha*). Nineteen of the twenty lattice registers are populated; only *hors-de-l'Inde*
@@ -86,7 +104,7 @@ dictionaries); the poetic and Buddhist lexica reach 26,973 (*kāvya*) and 25,740
 
 | Register | Distinct headwords | Corpus-absent (no DCS attestation) |
 |---|--:|--:|
-| **épigraphique** | **709** | **484 (68 %)** |
+| **épigraphique** | **709** | **484 (68.3 %)** |
 | jaina | 286 | 0 |
 | bhāṣya | 14,498 | (corpus-rich) |
 
@@ -110,15 +128,16 @@ editorially meaningful strata that neither axis alone can name:
 | Slice | Definition | Headwords | What it is |
 |---|---|--:|---|
 | Vedic-in-commentary | register `bhāṣya` ∩ state I | 6,895 | Vedic vocabulary the commentarial tradition kept alive |
-| born-in-kāvya | register `kāvya` ∖ state I | 20,758 | poetic words with no Vedic attestation (`abdhi` "ocean" vs Vedic *samudra*) |
+| born-in-kāvya | register `kāvya` ∖ state I | 20,758 | poetic words with no Vedic attestation (e.g. `abdhi` "ocean", states III·IV only, vs Vedic *samudra*, I–V) |
 | pure archaisms | state I only | 25,220 | words dropped after the Saṃhitās |
 
 The full coordinate per sense is `(state, register, provenance)` — e.g. *akṣobhya* =
 `III·V` / `purāṇa·tantra·bauddha` / all-signals — an evidence-graded position, not a
 single label. Six such slices are worked through in detail — with quantitative anatomy
 and glossed examples — in
-[`RENOU_CROSSAXIS.md`](../RussianTranslation/RENOU_CROSSAXIS.md): the bhāṣya register as a
-**Vedic reservoir**, kāvya as a **coinage engine** (≈¼ of its words dictionary-specific),
+[`RENOU_CROSSAXIS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU_CROSSAXIS.md): the bhāṣya register as a
+**Vedic reservoir**, kāvya as a **coinage engine** (≈¼ of the born-in-kāvya slice —
+5,073 of 20,758 — is dictionary-specific; the register overall runs 19.8 %),
 the *dvaṃdva*-type **grammatical meta-language** (vyākaraṇa∩bhāṣya), **Buddhist poetry**
 (bauddha∩kāvya, *sugata* etc.), and the inscription-only **onomasticon** (épig∖corpus:
 *vākāṭaka*, *humāuṃ* = Humāyūn) — register in the *absence* of period.
@@ -136,7 +155,7 @@ assumption.
 
 Beyond épigraphique, the per-register metrics (dictionary-specificity, corpus-absence,
 era-spread) surface four results, detailed in
-[`RENOU_FINDINGS.md`](../RussianTranslation/RENOU_FINDINGS.md):
+[`RENOU_FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU_FINDINGS.md):
 (i) **bhāṣya is a cross-disciplinary *syntactic* register** — Renou's own thesis (the
 nominal style "*durci*… expression doctrinale à tous les types de problèmes et de
 disciplines*", p. 133), corroborated by its low 8.8 % dictionary-specificity (a standardised,
@@ -144,17 +163,19 @@ not idiosyncratic, vocabulary); (ii) **bauddha is a second self-contained lexica
 44.5 % single-dictionary, of which 92 % (10,511 headwords) are recorded only by Edgerton's
 BHS, and 12.4 % corpus-absent — a parallel to épigraphique by a different mechanism;
 (iii) **the doctrinal registers carry the perennial lexicon** (kārikā/tantra/upaniṣad,
-57–65 % of headwords spanning ≥4 states) while narrative/poetic/documentary registers are
-period-bound (épig/epic/kāvya, 10–22 %); (iv) **nāṭya and kāvya are the coinage registers**
-(highest dictionary-specificity), the śāstric ones the standardising — conservation vs
-invention, read straight off the register metrics.
+56.7–65.0 % of headwords spanning ≥4 states) while narrative/poetic/documentary registers
+are period-bound (épig/epic/kāvya, 10.0–22.2 %); (iv) **nāṭya and kāvya are the coinage
+registers among the literary registers** (dictionary-specificity 23.8 % and 19.8 %, with
+epic at 21.7 % between them; the overall maximum is bauddha's 44.5 %, a closed lexical
+world rather than a coinage engine — see (ii)), the śāstric ones the standardising —
+conservation vs invention, read straight off the register metrics.
 
 A fifth result steps off the headword axis entirely and onto running text: **(v)** Renou's
 *nominal-style* thesis is confirmed on the DCS corpus — finite-verb density more than halves
 across the states (Vedic 14.4 % → Classical 6.7 %) as participles and nominals rise, and
 **bhāṣya (6.25 %) is more nominal than kāvya (7.48 %)**, the exact wording of *Histoire*
 p. 139. Full study in
-[`RENOU_NOMINAL_STYLE.md`](../RussianTranslation/RENOU_NOMINAL_STYLE.md) (tool
+[`RENOU_NOMINAL_STYLE.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU_NOMINAL_STYLE.md) (tool
 `nominal_style.py`); it corroborates F1 from a second, syntactic direction and may seed a
 separate short paper on register-predicted finite-verb density.
 
@@ -165,38 +186,79 @@ independent of the period badge, and the two compose into a queryable coordinate
 than a flat label. Two concrete payoffs: (1) **reusable register lexica** — we ship eight
 glossaries (épigraphique, *bhāṣya*, *kāvya*, *bauddha*, *jaina*, plus the three cross-axis
 slices of §3.3), each a deduplicated, provenance-tagged headword list; the épigraphique
-list is, in effect, a ready feed of inscriptional Sanskrit vocabulary for epigraphists.
-(2) **honest negative coverage** — the 68 % corpus-absent figure is itself a finding about
-the limits of corpus-driven lexicography, and the tagging makes that gap measurable
+list is, in effect, a ready feed of inscriptional Sanskrit vocabulary for epigraphists —
+positioned as a *derived, provenance-tagged complement* to Sircar's *Indian Epigraphical
+Glossary* (1966): where Sircar curated inscriptional vocabulary from the epigraphic corpus
+directly, this list recovers it from the lexicographers' citation apparatus, so the two
+resources can validate each other (§ "To do": the EI/CII sample check runs exactly this
+comparison).
+(2) **honest negative coverage** — the 68.3 % corpus-absent figure is itself a finding
+about the limits of corpus-driven lexicography, and the tagging makes that gap measurable
 instead of invisible.
 
 ## 5. Reproducibility
 
 Tagger and resolvers:
-[`src/renou.py`](../RussianTranslation/src/renou.py),
-[`src/renou_register.py`](../RussianTranslation/src/renou_register.py),
-[`src/build_dcs_renou.py`](../RussianTranslation/src/build_dcs_renou.py),
-[`src/tag_dict_from_source.py`](../RussianTranslation/src/tag_dict_from_source.py).
-Audit and display: [`src/renou_audit.py`](../RussianTranslation/src/renou_audit.py),
-[`src/renou_portrait.py`](../RussianTranslation/src/renou_portrait.py). Glossary extractor
+[`src/renou.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/renou.py),
+[`src/renou_register.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/renou_register.py),
+[`src/build_dcs_renou.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_dcs_renou.py),
+[`src/tag_dict_from_source.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tag_dict_from_source.py).
+Audit and display: [`src/renou_audit.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/renou_audit.py),
+[`src/renou_portrait.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/renou_portrait.py). Glossary extractor
 and the eight shipped glossaries:
-[`src/renou_glossary.py`](../RussianTranslation/src/renou_glossary.py),
-[`glossaries/`](../RussianTranslation/glossaries/README.md). System overview:
-[`RENOU.md`](../RussianTranslation/RENOU.md); register design:
-[`RENOU_SUBSECTIONS_PLAN.md`](../RussianTranslation/RENOU_SUBSECTIONS_PLAN.md); the
+[`src/renou_glossary.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/renou_glossary.py),
+[`glossaries/`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/glossaries/README.md). System overview:
+[`RENOU.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU.md); register design:
+[`RENOU_SUBSECTIONS_PLAN.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU_SUBSECTIONS_PLAN.md); the
 source-book structure: [Renou 1956 TOC](https://github.com/gasyoun/VisualDCS/blob/main/docs/Renou_1956_structure.md).
+The headline verification memo:
+[`A34_corpus_absent_verification.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A34_corpus_absent_verification.md).
 Derived indices (`{code}.renou.jsonl`) are gitignored and regenerated by
 `renou_pipeline.py --all`.
 
+## References
+
+Böhtlingk, O. & Roth, R. (1855–1875). *Sanskrit-Wörterbuch*. 7 vols. St. Petersburg:
+Kaiserliche Akademie der Wissenschaften. [PWG]
+
+Edgerton, F. (1953). *Buddhist Hybrid Sanskrit Grammar and Dictionary*. 2 vols.
+New Haven: Yale University Press. [BHS]
+
+Hellwig, O. (2010–). *DCS — The Digital Corpus of Sanskrit*.
+https://www.sanskrit-linguistics.org/dcs/ (2026 snapshot used here).
+
+Monier-Williams, M. (1899). *A Sanskrit-English Dictionary, new edition*. Oxford:
+Clarendon Press. [MW]
+
+Renou, L. (1956). *Histoire de la langue sanskrite*. Lyon–Paris: Éditions IAC.
+
+Salomon, R. (1998). *Indian Epigraphy: A Guide to the Study of Inscriptions in Sanskrit,
+Prakrit, and the Other Indo-Aryan Languages*. New York: Oxford University Press.
+
+Sircar, D. C. (1966). *Indian Epigraphical Glossary*. Delhi: Motilal Banarsidass.
+
+Vogel, C. (1979). *Indian Lexicography* (A History of Indian Literature V.4). Wiesbaden:
+Harrassowitz.
+
+Cologne Digital Sanskrit Dictionaries (CDSL). Universität zu Köln.
+https://www.sanskrit-lexicon.uni-koeln.de/ — machine-readable substrate (`csl-orig`) for
+the eight dictionaries tagged here.
+
+Gasūns, M. (in preparation). *Two Citation Registers* (OBS-C, companion study of the MW
+citation apparatus, A08) — the citation-register axis this note's provenance model
+extends.
+
 ## To do before submission
 
-- Related work: position against the citation-register literature (this project's own
-  A08/A18 on the two MW citation registers), Renou reception, and digital-philology
-  register tagging; cite Vogel's *Indian Lexicography* and Edgerton (BHS) directly.
 - External validation: hand-check a sample of the 709 épigraphique headwords against a
-  published inscription corpus (EI / CII) to estimate the inscription-marker detector's
-  precision and recall — the one number a referee will ask for.
+  published inscription corpus (EI / CII, or Sircar 1966 as the curated proxy) to
+  estimate the inscription-marker detector's precision and recall — the one number a
+  referee will ask for.
 - Broaden the inscription detector beyond the `Insch?r` marker (it is deliberately
   conservative); report the recall ceiling honestly.
 - Decide venue (Lexikos vs IJL vs eLex) and trim to length; fold the method figure from
   RENOU.md.
+- Regenerate `RENOU_FINDINGS.md`'s per-register table from `renou_audit.py` (its épig
+  corpus-absent cell is a stale 63.0 % hand-copy from an earlier DCS-index generation;
+  the committed glossary gives 68.3 % — see the verification memo). Re-check §3.5's
+  bauddha 12.4 % from the same regenerated table.

--- a/papers/A34_review_fable5.md
+++ b/papers/A34_review_fable5.md
@@ -1,0 +1,60 @@
+# A34 (Register, not just period) — Hostile Pre-Submission Review
+
+_Created: 03-07-2026 · Last updated: 03-07-2026_
+
+**Paper:** [papers/A34_renou_register_note.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A34_renou_register_note.md)
+**Reviewer:** Fable 5 (`claude-fable-5`), adversarial referee pass in the A10/A33/A36 mold; three parallel `fact-check-against-source` agents (also Fable 5, `claude-fable-5`): coverage/headline claims, cross-axis/§3.5 findings, Renou-structure + link integrity.
+**Prior verification:** [A34_corpus_absent_verification.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A34_corpus_absent_verification.md) (headline 484/68.3 % confirmed from committed indices, [PR #115](https://github.com/gasyoun/SanskritLexicography/pull/115)).
+**Verdict: MINOR-to-MAJOR REVISION → all agent-doable findings fixed same pass.** The paper's empirical spine is unusually solid — every §3.3/§3.5 figure and all five worked épigraphique examples reproduce from committed TSVs, and all seven Renou-structure claims (p. 94, p. 139, the p. 133 *durci* quote, the five-chapter mapping) verify against the [Renou 1956 TOC transcription](https://github.com/gasyoun/VisualDCS/blob/main/docs/Renou_1956_structure.md) and the OCR'd book. The defects were apparatus-level: no References section, a companion doc contradicting the headline (63.0 % vs 68.3 %), one coverage claim contradicted by the committed system doc, and one unverifiable audit figure.
+
+---
+
+## 1. Figure re-verification
+
+**Confirmed exact (committed artifact → paper):** 770,292 entries / 8 dicts (per-dict sum recomputed); épig 709 rows / 484 empty-state = 68.3 % (from [epigraphic_vocabulary.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/glossaries/epigraphic_vocabulary.md) itself); bhāṣya 14,498 / 10,320 ≥2-dict (recounted); kāvya 26,973; bauddha 25,740; jaina 286 with 0 % corpus-absent; 19/20 registers populated, `hors_inde` = 0; min-support 9.9 % pruned, 0 % of states II/V; §3.3 slices 6,895 / 20,758 / 25,220 (all three TSVs recounted); akṣobhya coordinate; all five épigraphique examples (akṣayanīvī, abhayagirivihāra, ajayavarman, akkādevī, akabara) present and corpus-absent; §3.5 8.8 % / 44.5 % / 92 % (10,511 of 11,454) / 12.4 % / 56.7–65.0 / 10.0–22.2 / nominal-style 14.4→6.7 and 6.25 vs 7.48; the 20-code lattice (`renou_register.py` REGISTERS tuple recounted); all 13 manuscript links resolve.
+
+## 2. Major findings
+
+**M1 — No References section, zero formal citations.** Renou 1956, Edgerton, the dictionaries, DCS — all invoked, none cited; and the obvious comparandum a Lexikos/IJL referee names first — **Sircar's *Indian Epigraphical Glossary* (1966)**, an existing curated inscriptional-Sanskrit glossary — was absent entirely, exposing the épigraphique deliverable to "this already exists." *Fix (applied):* References section (verified works only: Renou 1956, Edgerton 1953, Sircar 1966, Salomon 1998, Vogel 1979, PWG/MW editions, Hellwig DCS, CDSL, companion A08) + a "Relation to prior work" paragraph in §1 positioning the glossary as the citation-derived counterpart of Sircar's corpus-derived one, and §4 wiring the EI/CII validation to that comparison.
+
+**M2 — The companion findings doc contradicts the headline.** [RENOU_FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU_FINDINGS.md)'s per-register table prints épig corpus-absent **63.0 %** against the paper's 68 %; the paper's side is the correct one (the committed glossary has exactly 484/709 empty-state rows). A referee following the paper's own §3.5 link hits the contradiction immediately. *Fix (applied):* staleness banner on the table naming the defect, pointing to the verification memo, and instructing "trust the glossaries where they disagree"; full regeneration from `renou_audit.py` queued in the paper's to-do (it needs the gitignored indices — `renou_pipeline.py --all` — so it is a pipeline run, not a text edit; bauddha's 12.4 % re-check flagged in the same item).
+
+**M3 — §3.1's coverage range "19–100 %" was unsourced and contradicted the committed system doc.** [RENOU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU.md) says "~38–41 % of entries carry ≥1 register"; the 19 % per-dict floor exists in no committed file (needs the regenerated indices); only the BHS 100 % endpoint is supported (by construction, all 17,839 entries). *Fix (applied):* restated as aggregate ~38–41 % with the BHS 100 % per-dict endpoint; the unsourced floor dropped.
+
+**M4 — "1.43 M register assignments" is unverifiable from the repo.** The audit report that carries it is gitignored by design. *Fix (applied):* number dropped; sentence now names `renou_audit.py` and states the report regenerates with the indices.
+
+## 3. Minor findings
+
+**m1 — Abstract/§3.2 "68 %" now states its criterion.** Conservative reading (no corpus *or* enriched state) = 484/68.3 %; strict corpus-only = 518/73.1 %. *Fix (applied)* in abstract + table.
+
+**m2 — The abdhi/samudra example was attributed to a companion doc that doesn't contain it.** Data-true (abdhi III·IV in the TSV; samudra I–V) but absent from RENOU_CROSSAXIS.md. *Fix (applied):* example kept with its states inline, no longer implied to be one of the CROSSAXIS worked examples.
+
+**m3 — "≈¼ dictionary-specific" was slice-ambiguous.** True of the born-in-kāvya slice (5,073/20,758 = 24.4 %); the kāvya register overall runs 19.8 %. *Fix (applied):* both numbers stated.
+
+**m4 — §3.5(iv) dropped a load-bearing qualifier.** nāṭya/kāvya are the specificity peaks *among the literary registers* (23.8 %/19.8 %) — epic (21.7 %) sits between them and bauddha (44.5 %) is the overall maximum by a different mechanism. *Fix (applied):* qualifier + the three comparison values inline.
+
+**m5 — Rounded brackets tightened.** 57–65 % → 56.7–65.0 % (upaniṣad is 56.7); 10–22 % → 10.0–22.2 % (kāvya is 22.2). *Fix (applied).*
+
+**m6 — 20-code lattice slightly over-attributed to the TOC doc.** The structure doc's own coding table proposes 14; six more are TOC-derivable but were added in the plan/code. *Fix (applied):* one clarifying clause in §2.
+
+**m7 — 13 relative links upgraded to full blob URLs** per the repo doc contract (all targets resolve; the two VisualDCS URLs were already correct). *Fix (applied);* the verification memo added to §5.
+
+## 4. Data-side notes (no paper change)
+
+- RENOU_FINDINGS.md:50 and RENOU_NOMINAL_STYLE.md:14 spell the Renou section title singular ("Caractère linguistique du bhāṣya") where the TOC transcription and the paper have the plural — fix in the FINDINGS regen pass.
+- The §3.3 slice counts are hand-copied into three places (paper, RENOU_CROSSAXIS.md, CHANGELOG) — any glossary regen must touch all three.
+
+## 5. Checked and sound (no action)
+
+- The central claim — register as an orthogonal, provenance-carrying axis that recovers a corpus-invisible stratum — survives scrutiny; the jaina 0 % contrast is verified and does the argumentative work the paper asks of it.
+- The Renou philology is faithful: all page placements, the chapter-to-state mapping, and the p. 133 quote splice verify against the TOC transcription and the OCR'd *Histoire*.
+- §3.4's "no-op by construction" argument is supported by the committed register-source design (typed sources only).
+- Title and framing match the finding. Venue fit: Lexikos/IJL/eLex are all plausible for a register-tagging resource note; the choice stays an MG @DECIDE, not a HOLD.
+
+## 6. Remaining gates
+
+- **Author/MG:** venue @DECIDE (Lexikos vs IJL vs eLex); byline block.
+- **Data (agent-doable, pipeline run):** regenerate RENOU_FINDINGS.md's table via `renou_pipeline.py --all` + `renou_audit.py`; re-check bauddha 12.4 % and the singular/plural section title.
+- **Human/data:** the EI/CII (or Sircar 1966 proxy) validation sample for the inscription-marker detector's precision/recall — the paper's own named referee-number.
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Hostile pre-submission review of A34 ([A34_renou_register_note.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A34_renou_register_note.md)), per the Fable untouched index (Tier-1, review-ready after the 03-07 data verification, [PR #115](https://github.com/gasyoun/SanskritLexicography/pull/115)).

**Review memo:** [papers/A34_review_fable5.md](https://github.com/gasyoun/SanskritLexicography/blob/a34-referee-fable5/papers/A34_review_fable5.md)
**Reviewer:** Fable 5 (`claude-fable-5`) + 3 parallel fact-check-against-source agents (same model).

**Verdict:** empirical spine solid — every §3.3/§3.5 figure and all five épigraphique examples reproduce from committed TSVs; all seven Renou-structure claims verify against the [Renou 1956 TOC transcription](https://github.com/gasyoun/VisualDCS/blob/main/docs/Renou_1956_structure.md) and the OCR''d book. Fixed same pass:

- **M1** References section + §1 "Relation to prior work" added (was zero citations) — incl. **Sircar 1966** (*Indian Epigraphical Glossary*), the comparandum a referee names first, now positioned as corpus-derived counterpart to this citation-derived glossary
- **M2** [RENOU_FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU_FINDINGS.md) stale épig cell (63.0% vs verified 68.3%) — staleness banner added, full `renou_audit.py` regen queued in the to-do
- **M3** unsourced "19–100%" coverage → committed ~38–41% aggregate + BHS 100% endpoint
- **M4** unverifiable "1.43M register assignments" dropped (audit report is gitignored by design)
- minors: 68.3%/73.1% criterion stated, abdhi/samudra example de-misattributed, kāvya ≈¼ slice ambiguity, "among the literary registers" qualifier, brackets tightened, 14-vs-20 lattice clause, 13 relative links → full blob URLs

Remaining gates: venue @DECIDE (Lexikos/IJL/eLex) + byline (MG); EI/CII (or Sircar-proxy) validation sample; RENOU_FINDINGS table regen (pipeline run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)