### PR TITLE
fix(pwg-ru): 3 audit-gate false positives + CARDS_SCHEMA defs pruning + gam 127/127

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1310,6 +1310,32 @@ pages; and the 8 missing roots (esp. `yam`) are a samskrtam.ru data gap for MG.
 
 ---
 
+### §58. PWG-RU promoted store has input-level provenance, but old RU rows lacked exact model versions
+
+🟡 **The PWG→Russian final workflow card schema does not itself require model
+provenance, but the promoted store does carry the operational breadcrumb needed
+for reuse and repair.** Each promoted sense row in local
+`RussianTranslation/src/pwg_ru_translated.jsonl` has `provenance` fields for
+model alias, generator, root/rootmap hash, raw and portrait SHA-256, generation
+time, workflow file, and promotion script. That is enough for the
+content-addressed translation memory to reuse unchanged inputs without
+re-running Sonnet. The defect was version specificity: a live audit on
+2026-07-03 measured **10,856 store rows; 10,446 RU rows with `model='sonnet'`
+but no exact `model_version`; 410 RU rows already exact-versioned as
+`claude-sonnet-5`; 8,574 EN provenance rows exact-versioned; 15 rows missing
+input hashes; 80 partial-card rows.**
+
+Implication: do not rerun all old cards just because model technology changed.
+First run the deterministic provenance/gap audit, reuse byte-identical cards by
+`provenance.input_raw_sha256`, and only retranslate changed or failed inputs.
+Legacy `sonnet` aliases whose exact version cannot be proven should be marked
+unresolved, not date-mapped or guessed.
+
+> **Source:** `RussianTranslation/src/audit_translation_provenance.py` live store audit
+> and conservative backfill, Codex/GPT-5 · 2026-07-03
+
+---
+
 _Started 2026-06-26 (relocated from `Uprava/FINDINGS.md`, which now holds **non-Sanskrit**
 findings). Appended on a regular basis — add findings as they're discovered; this is the
 shared memory of "things we measured that aren't obvious from the code."_

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,144 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
+- **H130 gam Max run — Workflow-tool schema bug FOUND + FIXED, gam translated + mechanically
+  audited 2026-07-03 (Sonnet 5, `claude-sonnet-5`).** Executing
+  [`H130_SanskritLexicography_pwg_ru_gam_max_run.md`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H130_SanskritLexicography_pwg_ru_gam_max_run.md)
+  hit a hard blocker before any translation happened: **100% of the harness's `agent()`
+  calls (61/61) were rejected pre-execution** by the CLI Workflow tool's safety classifier
+  with `output schema too large to classify safely` (0 tokens spent — rejected before any
+  model call). Three isolated single-agent tests pinned the exact cause: a toy 1-`$def`
+  schema succeeded; the real `CARDS_SCHEMA` (5 `$defs`: card/record/sense/judge/judge_issue,
+  ~4.7 KB) failed even with a trivial one-line prompt; the SAME schema with the unused
+  `judge`/`judge_issue` `$defs` pruned out succeeded instantly. Root cause in
+  [`gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py) `build()`: it read the **entire**
+  `$defs` block from the shared
+  [`schemas/pwg_ru_final_card.schema.json`](schemas/pwg_ru_final_card.schema.json) (which
+  also carries the judge-report `$defs` for a different pipeline step) instead of only the
+  subset reachable from `card` — dead weight that pushed every StructuredOutput call over
+  the classifier's threshold. **Fix shipped** (branch `codex/pwg-gam-gate-fixes-v2` — the
+  original `codex/pwg-performance-spend-gate` branch it was developed on hit a merge
+  conflict against `master` after PR #116 landed a parallel perf-gate change; re-applied
+  source-only via `/branch-contention-recover`, see the closing bullet below): new
+  `_ref_names`/`_reachable_defs` helpers walk
+  `$ref` pointers from `'card'` and filter `$defs` to the reachable subset before building
+  `CARDS_SCHEMA`; `window_selftest.py` 40+/40+ green after the change. **This unblocks every
+  root's production run through the CLI Workflow tool, not just gam** — committed and merged
+  (see PR link in the closing bullet below). Finding + fix detail cross-posted to
+  [`Uprava/FINDINGS.md`](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md).
+  **gam outcome after the fix:** the 4 real (non-TM) keys — `gam~~h0_01_sec_1_0` (presplit,
+  13 fragment groups + binary-split retries), `gam~~h2_36_upasam`, `gam~~h3_05_ni`,
+  `gam~~h3_07_vinis` — all translated clean (16 agents, ~759 K tokens, ~13 min wall-clock,
+  0 failures). Merged in Python with the 123 TM-resolved cards (order-preserving —
+  `window_provenance.stale_check` compares key **lists**, not sets, so the merge must
+  follow `meta.selected_keys` positional order, not TM-first) into a canonical
+  `wf_output.json` (127/127 accounted, 0 null). `audit_window.py --root gam --write-requeue`:
+  **109/127 clean, 18 requeue** (`coverage` 13, `prompt_semantic` 6, 1 key in both);
+  `nws`/`sense_dupes`/`translation` gates all PASS; 0 transient nulls. The 18 requeue keys
+  are the **same known residual class** documented since the original 2026-06-29 gam run
+  (dense `pw00`/`pw03`/`pw04`/`pwkvn`/`sch` head-layer coverage gaps + `untranslated_braced_
+  german_gloss`/`likely_circular_gloss` prompt-semantic flags on `ava`/`ni`/`upa`/`anu`/
+  `a_di`/`sam_a`/`sam_0` cards) — not new defects introduced by this run.
+  **⚠️ TM-staleness-on-requeue trap discovered + fixed (same session).**
+  `requeue_from_audit.py gam`'s default harness generation resolved **18/18 of the flagged
+  keys straight from `translation_memory.ru.json`** (`agent_expected_after_tm: 0`) — i.e. it
+  would have silently re-served the EXACT SAME already-audit-flagged content, since the
+  content-addressed TM keys on input SHA, not on whether the cached translation actually
+  passed the gates. Confirmed concretely: the TM entry for `gam~~h0_zz_pw03` has exactly
+  **47 senses**, matching the audit's `COVERAGE-LOW(47/59)` flag byte-for-byte. Generated a
+  targeted `--no-tm` harness instead (`gen_opt_harness2.py gam --keys=<18> --no-tm`) to force
+  real re-translation. See [`Uprava/FINDINGS.md`](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)
+  for the generalized finding — **any requeue-for-audit-failure harness must pass `--no-tm`**,
+  since `gen_opt_harness2.py`'s TM lookup has no concept of "this cached translation already
+  failed the gates".
+  **Two requeue rounds run (both `--no-tm`, order-preserving Python merge into `wf_output.json`
+  each time — `window_provenance.stale_check` compares key lists positionally, not sets):**
+  round 1 (18 keys, 16 agents, ~759K tokens, ~21 min) → **109→119/127 clean, 18→8 requeue**
+  (`h2_10_ava`/`h2_24_upa`/`h0_zz_pw01`-adjacent keys cleared); round 2 (the remaining 8 keys,
+  14 agents, ~757K tokens, ~18 min) → **119→121/127 clean, 8→6 requeue**. **Diminishing
+  returns confirmed — the SAME 6 keys failed BOTH fresh-translation attempts**:
+  `gam~~h0_02_sec_2`, `gam~~h0_38_sam_a`, `gam~~h0_zz_sch` (prompt_semantic, high-confidence
+  `missing_required_sense_field`-adjacent flags) and `gam~~h0_20_ava` (`COVERAGE-LOW(6/8)`),
+  `gam~~h0_63_sam_0` (`COVERAGE-OVER(13/8)`, also the presplit giant, `partial:true` was even
+  set on a *different* key `gam~~h0_45_upa` from round 1's presplit lane), `gam~~h0_zz_pw04`
+  (`COVERAGE-OVER(8/5)`) — assessed at the time as "a genuine sense-segmentation disagreement
+  between the model and the deterministic `<ls>`/sense counter... not random noise." **This
+  assessment was WRONG for most of these 6 keys — a second session (same day) continued past
+  this point, root-caused 3 real gate bugs, fixed them, and got gam to 127/127 clean.**
+
+  **✅ CLOSED 2026-07-03, same day (Sonnet 5, `claude-sonnet-5`).** Concurrency note first: a
+  second session picked this handoff up mid-flight and, before realizing another session
+  (this one) was already running requeue round 2 live, briefly overwrote the shared
+  `wf_output.json` with an incomplete duplicate. Fully recovered with no data loss by
+  reconstructing the merge from both sessions' scratchpad artifacts (TM-resolved cards +
+  original translate run + both requeue rounds) — logged here as a caution: **two chats can
+  race on the same non-git-tracked `wf_output.json` with no lock**, and a session resuming a
+  requeue handoff should re-check `window_status.md`'s timestamp against wall-clock before
+  assuming a stale state is safe to overwrite.
+
+  **Root-caused, fixed, and selftest-pinned 3 real gate bugs** (not translation defects):
+  1. **`audit_coverage.py` multi-layer over-count** — `raw_markers()` used
+     `t.split('===', 2)` (only 2 splits), so any sub-card bundling >1 `=== LAYER: ... ===`
+     block (PW/SCH/PWKVN addenda cards, e.g. `gam~~h0_zz_pw04`: 3 layers) had its `<div n="p">`
+     cross-reference continuations from layers 2+ counted as if they were numbered senses.
+     `<div n="p">` is a **structural** prefix/secondary-conjugation divider elsewhere in this
+     codebase ([`root_units.py`](src/root_units.py), [`scale_preflight.py`](src/scale_preflight.py)'s
+     `_DIVP`, [`verify_root_glue.py`](src/verify_root_glue.py)), never a sense boundary — fixed
+     by splitting into per-LAYER bodies and counting only the `〉` glyph / numbered `<div n="N">`
+     per layer, floored at 1 (a pure-cross-reference layer is still one translatable unit).
+     Also added a presplit/fragment-card carve-out: those cards produce one JSON row per
+     fragment chunk by construction (not per raw sense), so their row count was tripping
+     `COVERAGE-OVER` as a false positive (`gam~~h0_63_sam_0`: `27/8`) — now skips the
+     threshold check and labels them explicitly instead.
+  2. **`prompt_rule_audit.py` German/Latin misclassification, three distinct instances:**
+     (a) `LATIN_BINOMIAL` (meant for species names like "Homo sapiens") lacked the
+     `and not GERMAN_GLOSS_WORDS.search(...)` guard its sibling checks (`LATIN_WORDS`/
+     `FRENCH_WORDS`/`ENGLISH_GLOSS_WORDS`) all have — German capitalizes every noun, so an
+     ordinary "Jmd zusammenkommen" (Jmd = common B&R abbreviation for "jemand") matched the
+     Capitalized-word+lowercase-word shape unconditionally; (b) `FRENCH_WORDS`' short-word
+     entry `\bdu\b` collided with the German pronoun "du" in colloquial questions ("wie
+     kommst du darauf?"), and `GERMAN_GLOSS_WORDS` had no short pronouns/interrogatives to
+     break the tie — added `Jmd/jmdm/jmdn/du/wie/woraus/dieses`; (c) `LATIN_WORDS` didn't
+     recognize `sequi, obsequi` (Latin, B&R's own untranslated-euphemism convention) — added.
+  3. **`braced_gloss_risks`'s "leaked" check scanned the WHOLE Russian text including
+     verbatim `{#Sanskrit#}` citation spans** — a 3-letter gloss like `{%mit%}` (correctly
+     translated to `{%с%}`) coincidentally matched as a substring of an unrelated SLP1
+     citation token (`miTunO` → lowercased `mituno` contains "mit"). Fixed by scrubbing
+     `{#...#}` spans (new `SANSKRIT_SPAN` regex) before the substring search.
+  All 3 fixes are pinned by new `window_selftest.py` cases
+  (`test_coverage_gate_multi_layer_and_presplit` + 3 assertions added to
+  `test_braced_gloss_audit`); full suite green after each fix.
+
+  **After the fixes:** re-audited gam from the SAME merged `wf_output.json` (no re-translation
+  needed) → **121→126/127 clean, 6→1 requeue.** Ran one more `--no-tm` requeue round on the
+  last 2 non-gate-bug residuals (`h0_63_sam_0` fragment-drop, `h0_zz_sch` untranslated "die")
+  — `h0_63_sam_0` got WORSE across attempts (2→3→7 missing self-heal fragments on 3
+  independent tries, confirming it's a genuine API-reliability gap on this 115-`<ls>`/9-group
+  presplit card, not a code bug); **recovered by using the OTHER session's original round-2
+  attempt for this one key, which was actually complete (0 partial)** — a reminder that
+  "latest requeue wins" is the wrong default when a retry can regress a complete card.
+  `h0_zz_sch`'s hedge word (Schmidt 1928's own `"die"?`, question-marked as an uncertain
+  reading) survived 2 independent fresh-translation attempts unchanged — genuinely ambiguous,
+  not a miss. **Manually resolved** using an independent third attempt's own rendering
+  (`«которая»?`, preserving the same hedge) rather than inventing one. **Final: 127/127
+  clean, 0 requeue.** Promoted: `promote_final_cards.py --gen-model-version claude-sonnet-5`
+  (2122 non-null cards / 10432 senses across the full store, not just gam),
+  `audit_translation_provenance.py` clean (0 unresolved, 0 missing SHA), card TM + fragment TM
+  both rebuilt (`translation_memory.ru.json` 2122 cards, `translation_memory.frag.ru.jsonl`
+  +40 new fragments).
+
+  **⚠️ Open question for MG / a follow-up session:** the 3 gate-bug fixes above were verified
+  narrowly (the specific evidenced instances + a hand-built pinning fixture) but **not
+  re-run across the full historical corpus** — other already-promoted roots may carry the
+  SAME false-positive residuals (multi-layer PW/SCH addenda cards, short-gloss/Sanskrit-
+  substring collisions) that were previously accepted as "documented residuals" but are
+  actually gate bugs now fixed. Worth a `python src/audit_coverage.py` + `prompt_rule_audit`
+  sweep over all promoted roots to see how many historical residuals silently clear.
+  **Next preflight-recommended root: `vid` (13 agents expected), then `as`, `BU`/`yuj`.**
+  The [`H130_SanskritLexicography_pwg_ru_gam_max_run.md`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H130_SanskritLexicography_pwg_ru_gam_max_run.md)
+  handoff is now SPENT (gam is done) — do not re-execute it; a fresh `H###` handoff for
+  `vid` is still needed (not yet minted as of this session).
+
 - **pwg_ru performance preflight/spend gate shipped 2026-07-03 (Codex/GPT-5 implementation pass).**
   New read-only [`perf_preflight.py`](src/pilot/perf_preflight.py) reports TM sidecar
   presence/hits, fragment-TM reuse, degenerate pass-through keys, near-degenerate candidates,
@@ -27,6 +165,9 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   Current staged-root preflight:
   **run `gam` (2 agents), `vid` (13), `as` (14), `BU`/`yuj` (19); skip cached `han` (0);
   defer `sTA` (30) and `i` (35)** until cache refresh/calibration.
+  **Executable next handoff:** open a Sonnet 5 (`claude-sonnet-5`) chat in
+  `C:\Users\user\Documents\GitHub\SanskritLexicography\RussianTranslation` and run:
+  `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H130_SanskritLexicography_pwg_ru_gam_max_run.md and execute it.`
 
 - **pwg_ru performance hygiene shipped 2026-07-03 (Codex/GPT-5 hygiene/verification pass).**
   `gen_opt_harness2.py` now defaults to `--tm=auto` (card + fragment sidecars when present,
@@ -886,6 +1027,21 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   ([SamudraManthanam #16](https://github.com/gasyoun/SamudraManthanam/issues/16)).
 
 ## ✅ Completed (Recent only)
+
+- **Translation provenance audit/backfill shipped (2026-07-03, Codex/GPT-5).**
+  Added [`src/audit_translation_provenance.py`](src/audit_translation_provenance.py)
+  and hardened [`src/promote_final_cards.py`](src/promote_final_cards.py) so future
+  RU promotions require `--gen-model-version <exact-model-id>` instead of relying on
+  a stale implicit `sonnet` mapping. Baseline audit of the live local store:
+  **10,856 rows; 10,446 RU rows missing exact `model_version`; 410 RU rows already
+  exact-versioned (`claude-sonnet-5`); 8,574 EN provenance rows exact-versioned;
+  15 rows missing input hashes; 80 partial-card rows.** Applied conservative
+  backfill to local `src/pwg_ru_translated.jsonl`: legacy ambiguous RU rows now
+  carry `model_version_unresolved` + `model_version_note`; no translation text,
+  review status, hashes, or `wf_file` values changed. Next operator action: when
+  promoting any new RU window, pass the exact generation model explicitly, then run
+  `python src/audit_translation_provenance.py` and refresh TM with
+  `python src/pilot/translation_memory.py build --lang ru`.
 
 - **S7 quality follow-through — ✅ DONE 2026-07-02, Opus 4.8 (`claude-opus-4-8`); A/B
   generation Sonnet 5 (`claude-sonnet-5`). [PR #89](https://github.com/gasyoun/SanskritLexicography/pull/89)

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -8,6 +8,22 @@ See also: [METHODOLOGY_REVIEW.md](METHODOLOGY_REVIEW.md) (where we want to go),
 [failures/FAILURE_GALLERY.md](failures/FAILURE_GALLERY.md) (what went wrong and
 how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
+## 2026-07-03
+
+### Translation provenance audit/backfill
+- Added `src/audit_translation_provenance.py` to report RU/EN provenance counts,
+  input-hash gaps, partial-card rows, and workflow/date/model groups for
+  `src/pwg_ru_translated.jsonl`. In `--write` mode it conservatively marks
+  ambiguous legacy `sonnet` rows as unresolved without inventing an exact model
+  version.
+- Hardened `src/promote_final_cards.py`: future RU promotions must pass
+  `--gen-model-version <exact-model-id>` when workflow metadata lacks an exact
+  version. The stale implicit default is gone.
+- Live store finding: 10,856 rows; 10,446 older RU rows had no exact
+  `model_version`, 410 RU rows already had `claude-sonnet-5`, and 8,574 EN
+  provenance rows were already exact-versioned. The older RU rows were marked
+  unresolved locally; no translation text or review status changed.
+
 ## 2026-07-02
 
 ### Renou H4 citation bias + Step-0 pilot review sheet — step 1 executed

--- a/RussianTranslation/FU1_PLAN.md
+++ b/RussianTranslation/FU1_PLAN.md
@@ -6,8 +6,8 @@ Resume spec for the PWG→English **bulk** follow-up (FU1) after FU2 (audit gate
 (tri-lingual merge) shipped. **Real Max-quota spend** — run in a Max/Workflow session at
 **≤3-wide concurrency**. All six design decisions below are MG-locked (2026-06-30); do not
 re-litigate. This file is the *decision/rationale* record; the step-by-step **execution runbook**
-is [`HANDOFF_2026-06-30_pwg_en_fu1_run.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/HANDOFF_2026-06-30_pwg_en_fu1_run.md). Parent:
-[`HANDOFF_2026-06-30_pwg_en_followups.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/HANDOFF_2026-06-30_pwg_en_followups.md).
+is [`HANDOFF_2026-06-30_pwg_en_fu1_run.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/archive/HANDOFF_2026-06-30_pwg_en_fu1_run.md). Parent:
+[`HANDOFF_2026-06-30_pwg_en_followups.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/archive/HANDOFF_2026-06-30_pwg_en_followups.md).
 
 ## Locked decisions
 

--- a/RussianTranslation/HANDOFF_2026-07-02_pwg_tm_sense_level.md
+++ b/RussianTranslation/HANDOFF_2026-07-02_pwg_tm_sense_level.md
@@ -109,6 +109,6 @@ alignment first; everything else is downstream.
 - Session closed with `/handoff`; this handoff's GTD row flipped.
 
 Full journal: [`.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md).
-Prior handoff: [`HANDOFF_2026-07-02_pwg_selfheal_fixes.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/HANDOFF_2026-07-02_pwg_selfheal_fixes.md).
+Prior handoff: [`HANDOFF_2026-07-02_pwg_selfheal_fixes.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/archive/HANDOFF_2026-07-02_pwg_selfheal_fixes.md).
 
 _Dr. Mārcis Gasūns_

--- a/RussianTranslation/KNOB_CALIBRATION_2026-07-03.md
+++ b/RussianTranslation/KNOB_CALIBRATION_2026-07-03.md
@@ -86,5 +86,12 @@ the token saving) did **not** materialize here.
   "quality" here means the harness-level null/partial/retry signal only, per
   the handoff's instructions. A fidelity sample pass is a natural follow-up
   if 90 is scaled to a full freq-queue run.
+- Follow-up calibrations should use
+  [`calibrate_perf_harness.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/calibrate_perf_harness.py)
+  to generate scratch harness arms/manifests from a fixed key set, after checking
+  the same keys with
+  [`perf_preflight.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/perf_preflight.py).
+  Keep the AB_TEST_LEAN_TR lesson: run live arms sequentially with cache cooldown;
+  never run same-prompt arms in parallel.
 
 _Dr. Mārcis Gasūns_

--- a/RussianTranslation/PIPELINE_ARCHITECTURE.md
+++ b/RussianTranslation/PIPELINE_ARCHITECTURE.md
@@ -66,6 +66,12 @@ Current source of truth:
 - The corpus word-alignment lexicon exists; bulk throughput is no longer
   blocked on that asset. Print readiness remains downstream of human/gold
   gates G5/G6/G7/G10.
+- Provenance lives in the promoted store, not necessarily in standalone final
+  workflow cards. `src/promote_final_cards.py` writes one row per sense with
+  model alias, exact `model_version`, root/rootmap/input hashes, generation
+  time, and `wf_file`; future RU promotions must pass `--gen-model-version
+  <exact-model-id>`. Legacy rows whose `sonnet` alias cannot be resolved are
+  marked with `model_version_unresolved`, not guessed.
 
 ---
 

--- a/RussianTranslation/TOKEN_OPTIMIZATION_2026-06-27.md
+++ b/RussianTranslation/TOKEN_OPTIMIZATION_2026-06-27.md
@@ -12,6 +12,26 @@ ranked optimizations, the decision taken, and the failures hit along the way.
 
 ---
 
+## Current status addendum (2026-07-03)
+
+The speed notes below are historical context; the current production path is
+`src/pilot/gen_opt_harness2.py` with batched+masked inputs, guarded retry/heal,
+presplit routing, `OUTPUT_BUDGET=90`, and translation memory auto-enabled when
+sidecars exist (`--tm=auto`, `--no-tm` to opt out). Article-site/dashboard lazy
+loading is already done. Lean TR / rule-3 compression was tested in
+`AB_TEST_LEAN_TR.md` and rejected for quality; do not revive it as an operator
+shortcut.
+
+Remaining speed work should be measured: refresh and widen card/fragment TM
+coverage after promotions/heal harvests, let conservative degenerate
+cross-reference stubs pass through without LLM calls, and use
+`src/pilot/perf_preflight.py` before Max spend to see remaining agent lanes. Use
+`src/pilot/calibrate_perf_harness.py --arm-set conservative` or `--arm-set wide`
+for scratch-only wider calibration. Live calibration arms must be run sequentially
+with cache cooldown, never in parallel same-prompt arms.
+
+---
+
 ## The question
 
 > "10M tokens for one root is too much even in Sonnet mode. What optimisation of

--- a/RussianTranslation/mw_ru_prompts/2_qa_sudya_opus.txt
+++ b/RussianTranslation/mw_ru_prompts/2_qa_sudya_opus.txt
@@ -164,27 +164,27 @@ body_en: <body><s>vy-avasTA—ratna-mAlA</s>   <lex>f.</lex> <ab>N.</ab> of <ab>
 body_ru: <body><s>vy-avasTA—ratna-mAlA</s> <lex>f.</lex> <ab>N.</ab> <ab>ch.</ab><info lex="f" /></body>
 comment: <ab>N.</ab> <ab>ch.</ab> без 'of' — валидная конвенция, читается как «название главы».
 
---- term-mistranslation (verdict=BAD, sev=5, issues=[term-mistranslation,markup-loss]) ---
+--- term-mistranslation (verdict=BAD, sev=5, issues=[term-mistranslation]) ---
 body_en: <body><s>dIpa—SiKA</s>   <lex>f.</lex> the flame of a <ab n="lamp">l°</ab>-foe, <ls>Kathās. xviii, 77</ls><info lex="f" /></body>
 body_ru: <body><s>dIpa—SiKA</s>   <lex>f.</lex> пламя врага <ab n="lamp">l°</ab>, <ls>Kathās. xviii, 77</ls><info lex="f" /></body>
 comment: 'l°' = lamp, перевод должен быть 'пламя лампы', не 'пламя врага'
 
---- anglicism_iz (verdict=BAD, sev=4, issues=[term-mistranslation,grammar]) ---
+--- anglicism_iz (verdict=BAD, sev=4, issues=[grammar]) ---
 body_en: <body><s>pUtanA—mokzaRa-prastAva</s>   <lex>m.</lex> <ab>N.</ab> of <ab>ch.</ab> of <ls>BrahmaP.</ls><info lex="m" /></body>
 body_ru: <body><s>pUtanA—mokzaRa-prastAva</s>   <lex>m.</lex> <ab>N.</ab> из <ab>ch.</ab> из <ls>BrahmaP.</ls><info lex="m" /></body>
 comment: Калька «<ab>X.</ab> из <ab>Y.</ab>» — 'N. of ch. of' это 'название главы в', не 'из ... из'
 
---- term-mistranslation (verdict=BAD, sev=4, issues=[term-mistranslation]) ---
+--- addition (verdict=BAD, sev=4, issues=[addition]) ---
 body_en: <body><s>BArgavo<srs />papurARa</s>   <lex>n.</lex> <ab>N.</ab> of an <s1 slp1="upapurARa">Upapurāṇa</s1>.<info lex="n" /></body>
 body_ru: <body><s>BArgavo<srs />papurARa</s>   <lex>n.</lex> <ab>N.</ab> названия Упапураны.<info lex="n" /></body>
 comment: Лишнее слово «названия» рядом с <ab>N.</ab> создаёт семантический дубль «название названия».
 
---- markup-loss (verdict=BAD, sev=4, issues=[term-mistranslation,markup-loss]) ---
+--- omission (verdict=BAD, sev=4, issues=[omission,term-mistranslation]) ---
 body_en: <body>   a <bot>Barleria</bot> with <ab n="yellow">y°</ab> flowers, <ls>L.</ls><info lex="inh" /></body>
 body_ru: <body>с цветками Барлерии, <ab n="yellow">y°</ab>, <ls>L.</ls><info lex="inh" /></body>
 comment: Утрачено значение 'Barleria с жёлтыми цветами'; 'y°' — сокращение yellow
 
---- addition (verdict=BAD, sev=4, issues=[addition,term-mistranslation]) ---
+--- term-mistranslation (verdict=BAD, sev=4, issues=[term-mistranslation]) ---
 body_en: <body>   a distiller of spirituous liquor<info lex="inh" /></body>
 body_ru: <body>житель, занимающийся перегонкой спиртных напитков<info lex="inh" /></body>
 comment: «житель» — выдумка; нужно «винокур/перегонщик спиртных напитков»

--- a/RussianTranslation/mw_ru_prompts/2_qa_sudya_yandexgpt.txt
+++ b/RussianTranslation/mw_ru_prompts/2_qa_sudya_yandexgpt.txt
@@ -159,27 +159,27 @@ body_en: <body><s>vy-avasTA—ratna-mAlA</s>   <lex>f.</lex> <ab>N.</ab> of <ab>
 body_ru: <body><s>vy-avasTA—ratna-mAlA</s> <lex>f.</lex> <ab>N.</ab> <ab>ch.</ab><info lex="f" /></body>
 comment: <ab>N.</ab> <ab>ch.</ab> без 'of' — валидная конвенция, читается как «название главы».
 
---- term-mistranslation (verdict=BAD, sev=5, issues=[term-mistranslation,markup-loss]) ---
+--- term-mistranslation (verdict=BAD, sev=5, issues=[term-mistranslation]) ---
 body_en: <body><s>dIpa—SiKA</s>   <lex>f.</lex> the flame of a <ab n="lamp">l°</ab>-foe, <ls>Kathās. xviii, 77</ls><info lex="f" /></body>
 body_ru: <body><s>dIpa—SiKA</s>   <lex>f.</lex> пламя врага <ab n="lamp">l°</ab>, <ls>Kathās. xviii, 77</ls><info lex="f" /></body>
 comment: 'l°' = lamp, перевод должен быть 'пламя лампы', не 'пламя врага'
 
---- anglicism_iz (verdict=BAD, sev=4, issues=[term-mistranslation,grammar]) ---
+--- anglicism_iz (verdict=BAD, sev=4, issues=[grammar]) ---
 body_en: <body><s>pUtanA—mokzaRa-prastAva</s>   <lex>m.</lex> <ab>N.</ab> of <ab>ch.</ab> of <ls>BrahmaP.</ls><info lex="m" /></body>
 body_ru: <body><s>pUtanA—mokzaRa-prastAva</s>   <lex>m.</lex> <ab>N.</ab> из <ab>ch.</ab> из <ls>BrahmaP.</ls><info lex="m" /></body>
 comment: Калька «<ab>X.</ab> из <ab>Y.</ab>» — 'N. of ch. of' это 'название главы в', не 'из ... из'
 
---- term-mistranslation (verdict=BAD, sev=4, issues=[term-mistranslation]) ---
+--- addition (verdict=BAD, sev=4, issues=[addition]) ---
 body_en: <body><s>BArgavo<srs />papurARa</s>   <lex>n.</lex> <ab>N.</ab> of an <s1 slp1="upapurARa">Upapurāṇa</s1>.<info lex="n" /></body>
 body_ru: <body><s>BArgavo<srs />papurARa</s>   <lex>n.</lex> <ab>N.</ab> названия Упапураны.<info lex="n" /></body>
 comment: Лишнее слово «названия» рядом с <ab>N.</ab> создаёт семантический дубль «название названия».
 
---- markup-loss (verdict=BAD, sev=4, issues=[term-mistranslation,markup-loss]) ---
+--- omission (verdict=BAD, sev=4, issues=[omission,term-mistranslation]) ---
 body_en: <body>   a <bot>Barleria</bot> with <ab n="yellow">y°</ab> flowers, <ls>L.</ls><info lex="inh" /></body>
 body_ru: <body>с цветками Барлерии, <ab n="yellow">y°</ab>, <ls>L.</ls><info lex="inh" /></body>
 comment: Утрачено значение 'Barleria с жёлтыми цветами'; 'y°' — сокращение yellow
 
---- addition (verdict=BAD, sev=4, issues=[addition,term-mistranslation]) ---
+--- term-mistranslation (verdict=BAD, sev=4, issues=[term-mistranslation]) ---
 body_en: <body>   a distiller of spirituous liquor<info lex="inh" /></body>
 body_ru: <body>житель, занимающийся перегонкой спиртных напитков<info lex="inh" /></body>
 comment: «житель» — выдумка; нужно «винокур/перегонщик спиртных напитков»

--- a/RussianTranslation/src/audit_coverage.py
+++ b/RussianTranslation/src/audit_coverage.py
@@ -29,6 +29,8 @@ IN = os.path.join(HERE, 'pilot', 'input')
 
 LOW, OVER = 0.80, 1.50
 DIVN = re.compile(r'<div n=')
+NUMBERED_DIVN = re.compile(r'<div n="(\d+)">')
+LAYER_RE = re.compile(r'=== LAYER:.*?===\n', re.S)
 
 
 def find_results(o):
@@ -47,13 +49,44 @@ def find_results(o):
     return None
 
 
+def layer_bodies(t):
+    """Split a raw.txt into its independent '=== LAYER: ... ===' blocks. Most sub-cards carry
+    exactly one layer; PW/SCH/PWKVN addenda cards bundle several independent revision entries
+    into one sub-card file (e.g. gam~~h0_zz_pw04: 3 layers). Falls back to the whole text as a
+    single block if no header is found."""
+    parts = [b for b in LAYER_RE.split(t) if b.strip()]
+    return parts or [t]
+
+
+def layer_sense_count(body):
+    """One layer's raw sense-marker count, counting only real sense boundaries.
+
+    <div n="p"> is a STRUCTURAL prefix/secondary-conjugation divider elsewhere in this
+    codebase (root_units.py, scale_preflight.py's _DIVP, verify_root_glue.py), never a sense
+    number -- only the 'N〉' glyph and numbered <div n="N"> mark an actual new sense (a long
+    citation list can reopen the same numeral across several continuation paragraphs, so
+    distinct labels are counted, not raw occurrences). A layer with neither (pure
+    cross-reference addenda, e.g. '-- Mit X, see II.5') still contributes its own
+    translatable unit, floored at 1 rather than silently counting as zero senses."""
+    nums = set(re.findall(r'(\d+)〉', body)) | set(NUMBERED_DIVN.findall(body))
+    return len(nums) or 1
+
+
 def raw_markers(stem):
     p = os.path.join(IN, stem + '.raw.txt')
     if not os.path.exists(p):
         return None
     t = open(p, encoding='utf-8').read()
-    body = t.split('===', 2)[-1]
-    return max(body.count('〉'), len(DIVN.findall(body)))
+    bodies = layer_bodies(t)
+    if len(bodies) == 1:
+        # Preserve the original single-layer heuristic verbatim (raw '<div n=' occurrence
+        # count, including 'p' divs) to avoid changing behavior for the vast majority of
+        # ordinary sub-cards; only multi-layer addenda cards get the layer-aware count below.
+        # A genuine 0 here (no markers at all) must stay 0, not None -- the caller treats
+        # None as NO-RAW/fail and 0 as the legitimate 'not sense-divided' case.
+        body = bodies[0]
+        return max(body.count('〉'), len(DIVN.findall(body)))
+    return sum(layer_sense_count(b) for b in bodies)
 
 
 def main():
@@ -74,6 +107,16 @@ def main():
             print('%-28s %-8s %-8d %s' % (k, 'n/a', cs, flag))
             if rm is None:
                 fails.append(k)
+            continue
+        if res.get('presplit'):
+            # Presplit/fragment-reassembled cards (a huge head split into per-fragment
+            # translation units, e.g. gam~~h0_63_sam_0) produce one JSON sense row per
+            # fragment chunk by construction, not one per raw numbered sense -- that row
+            # count is not comparable to the coarse raw <div>/glyph count and was tripping
+            # COVERAGE-OVER as a false positive. A dropped/missing fragment is already caught
+            # by audit_window.py's partial-card check, so skip the LOW/OVER thresholds here
+            # rather than duplicate that signal with a confusing mismatch.
+            print('%-28s %-8d %-8d %s' % (k, rm, cs, 'ok (presplit — granular fragment rows)'))
             continue
         # absolute-difference guard: a ±1 sense gap on a tiny card is sub-sense splitting /
         # merging, not a real drop/fabrication — require a meaningful absolute gap too.

--- a/RussianTranslation/src/audit_translation_provenance.py
+++ b/RussianTranslation/src/audit_translation_provenance.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+"""Audit and conservatively mark PWG-RU translation provenance.
+
+The translated store is one JSON object per sense.  Exact model IDs belong in
+`provenance.model_version`; ambiguous legacy aliases stay unresolved and get an
+explicit note so later tools do not confuse a guess with a version.
+"""
+import argparse
+import collections
+import json
+import os
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+UNRESOLVED_FIELD = 'model_version_unresolved'
+UNRESOLVED_NOTE_FIELD = 'model_version_note'
+
+
+def iter_rows(path):
+    with open(path, encoding='utf-8') as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            yield lineno, json.loads(line)
+
+
+def unresolved_note(prov):
+    alias = prov.get('model') or 'unknown'
+    date = prov.get('generated_at') or 'unknown-date'
+    wf_file = prov.get('wf_file') or 'unknown-wf'
+    return "version unresolved - alias %r at %s (wf_file=%s)" % (alias, date, wf_file)
+
+
+def audit(path):
+    stats = collections.Counter()
+    by_model = collections.Counter()
+    by_wf = collections.Counter()
+    missing_examples = []
+    unresolved_examples = []
+    rows = []
+    for lineno, row in iter_rows(path):
+        stats['rows'] += 1
+        prov = row.get('provenance') or {}
+        en_prov = row.get('en_provenance') or {}
+        model_key = (prov.get('model'), prov.get('model_version'))
+        by_model[model_key] += 1
+        if en_prov:
+            stats['en_provenance_rows'] += 1
+            if en_prov.get('model_version'):
+                stats['en_versioned_rows'] += 1
+        if prov.get('model_version'):
+            stats['ru_versioned_rows'] += 1
+        else:
+            stats['ru_missing_model_version'] += 1
+            if len(missing_examples) < 5:
+                missing_examples.append((lineno, row.get('key1'), row.get('subcard'),
+                                         prov.get('model'), prov.get('generated_at'),
+                                         prov.get('wf_file')))
+        if prov.get(UNRESOLVED_FIELD):
+            stats['ru_unresolved_marked_rows'] += 1
+            if len(unresolved_examples) < 5:
+                unresolved_examples.append((lineno, row.get('key1'), row.get('subcard'),
+                                            prov.get(UNRESOLVED_NOTE_FIELD)))
+        if not prov.get('input_raw_sha256'):
+            stats['missing_input_raw_sha256'] += 1
+        if not prov.get('input_portrait_sha256'):
+            stats['missing_input_portrait_sha256'] += 1
+        if prov.get('partial_card'):
+            stats['partial_card_rows'] += 1
+        by_wf[(prov.get('wf_file'), prov.get('generated_at'), prov.get('model'),
+               prov.get('model_version'))] += 1
+        rows.append(row)
+    return {
+        'stats': stats,
+        'by_model': by_model,
+        'by_wf': by_wf,
+        'missing_examples': missing_examples,
+        'unresolved_examples': unresolved_examples,
+        'rows': rows,
+    }
+
+
+def mark_unresolved(rows):
+    changed = 0
+    for row in rows:
+        prov = row.get('provenance')
+        if not isinstance(prov, dict):
+            continue
+        if prov.get('model_version'):
+            continue
+        if prov.get(UNRESOLVED_FIELD) and prov.get(UNRESOLVED_NOTE_FIELD):
+            continue
+        prov[UNRESOLVED_FIELD] = True
+        prov[UNRESOLVED_NOTE_FIELD] = unresolved_note(prov)
+        changed += 1
+    return changed
+
+
+def write_rows(path, rows):
+    tmp = path + '.tmp'
+    with open(tmp, 'w', encoding='utf-8', newline='\n') as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + '\n')
+    os.replace(tmp, path)
+
+
+def print_report(result):
+    stats = result['stats']
+    print('=== TRANSLATION PROVENANCE AUDIT ===')
+    print('store rows                         : %d' % stats['rows'])
+    print('RU rows with exact model_version   : %d' % stats['ru_versioned_rows'])
+    print('RU rows missing model_version      : %d' % stats['ru_missing_model_version'])
+    print('RU unresolved rows already marked  : %d' % stats['ru_unresolved_marked_rows'])
+    print('rows missing input_raw_sha256      : %d' % stats['missing_input_raw_sha256'])
+    print('rows missing input_portrait_sha256 : %d' % stats['missing_input_portrait_sha256'])
+    print('partial-card rows                  : %d' % stats['partial_card_rows'])
+    print('EN provenance rows                 : %d' % stats['en_provenance_rows'])
+    print('EN rows with exact model_version   : %d' % stats['en_versioned_rows'])
+    print()
+    print('Top RU model/version groups:')
+    for (model, version), n in result['by_model'].most_common(12):
+        print('  %6d  model=%r model_version=%r' % (n, model, version))
+    print()
+    print('Top workflow/date/model groups:')
+    for (wf_file, generated_at, model, version), n in result['by_wf'].most_common(12):
+        print('  %6d  %s  %s  model=%r version=%r' %
+              (n, generated_at or 'unknown-date', wf_file or 'unknown-wf', model, version))
+    if result['missing_examples']:
+        print()
+        print('First missing-version examples:')
+        for ex in result['missing_examples']:
+            print('  line=%s key1=%s subcard=%s model=%s generated_at=%s wf_file=%s' % ex)
+    if result['unresolved_examples']:
+        print()
+        print('First unresolved-note examples:')
+        for ex in result['unresolved_examples']:
+            print('  line=%s key1=%s subcard=%s note=%s' % ex)
+
+
+def selftest():
+    import tempfile
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, 'store.jsonl')
+    rows = [
+        {'key1': 'a', 'subcard': 'a~~1', 'ru': 'x', 'de': 'y',
+         'provenance': {'model': 'sonnet', 'input_raw_sha256': 'raw',
+                        'input_portrait_sha256': 'portrait', 'generated_at': '2026-06-29T00:00:00Z',
+                        'wf_file': 'wf_output.sc.a.json'}},
+        {'key1': 'b', 'subcard': 'b~~1', 'ru': 'x', 'de': 'y',
+         'provenance': {'model': 'sonnet', 'model_version': 'claude-sonnet-5',
+                        'input_raw_sha256': 'raw2', 'input_portrait_sha256': 'portrait2'}},
+    ]
+    write_rows(path, rows)
+    result = audit(path)
+    assert result['stats']['rows'] == 2
+    assert result['stats']['ru_missing_model_version'] == 1
+    changed = mark_unresolved(result['rows'])
+    assert changed == 1
+    write_rows(path, result['rows'])
+    reread = audit(path)
+    assert reread['stats']['ru_versioned_rows'] == 1
+    assert reread['stats']['ru_missing_model_version'] == 1
+    assert reread['stats']['ru_unresolved_marked_rows'] == 1
+    first = reread['rows'][0]['provenance']
+    assert first[UNRESOLVED_FIELD] is True
+    assert 'claude-sonnet' not in first.get(UNRESOLVED_NOTE_FIELD, '')
+    assert 'model_version' not in first
+    print('audit_translation_provenance selftest OK')
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--store', default=DEFAULT_STORE)
+    ap.add_argument('--write', action='store_true',
+                    help='mark legacy rows whose model alias cannot be resolved; no guessing')
+    ap.add_argument('--selftest', action='store_true')
+    args = ap.parse_args()
+    if args.selftest:
+        return selftest()
+    if not os.path.exists(args.store):
+        sys.exit('no store %r' % args.store)
+    result = audit(args.store)
+    print_report(result)
+    if args.write:
+        changed = mark_unresolved(result['rows'])
+        write_rows(args.store, result['rows'])
+        print()
+        print('wrote %s; marked %d legacy row(s) unresolved' % (args.store, changed))
+    else:
+        print()
+        print('(report only; pass --write to mark unresolved legacy rows)')
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -369,6 +369,42 @@ def _rename_sense_field(schema, old, new):
     return s
 
 
+def _ref_names(node):
+    """$ref targets ('#/$defs/name' -> 'name') found anywhere under `node`."""
+    names = []
+    if isinstance(node, dict):
+        ref = node.get('$ref')
+        if isinstance(ref, str) and ref.startswith('#/$defs/'):
+            names.append(ref[len('#/$defs/'):])
+        for v in node.values():
+            names.extend(_ref_names(v))
+    elif isinstance(node, list):
+        for v in node:
+            names.extend(_ref_names(v))
+    return names
+
+
+def _reachable_defs(defs, start):
+    """Subset of `defs` transitively reachable via $ref from `start`.
+
+    pwg_ru_final_card.schema.json is shared with the judge step, so its $defs
+    also carry judge/judge_issue. The translate-only CARDS_SCHEMA never
+    references them (its root is 'card', not the judge-report wrapper) — left
+    in, they were dead weight that pushed the per-call StructuredOutput schema
+    over the Workflow tool's safety-classifier size threshold, blocking every
+    agent() call before any model invocation (0 tokens spent, confirmed via
+    isolated schema-only tests 2026-07-03).
+    """
+    seen, stack = set(), [start]
+    while stack:
+        name = stack.pop()
+        if name in seen or name not in defs:
+            continue
+        seen.add(name)
+        stack.extend(_ref_names(defs[name]))
+    return {k: v for k, v in defs.items() if k in seen}
+
+
 def mw_tm_block(root, mw_tm_path):
     """The MW English translation-memory block injected once per root (en pilot). '' if none."""
     if not mw_tm_path or not os.path.exists(mw_tm_path):
@@ -496,7 +532,7 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     # cards; they are re-derivable downstream). validate_final_card_schema.py was
     # relaxed to match, so RU cards with a missing annotator field still validate.
     schema['$defs']['sense']['required'] = ['tag', 'german', field]
-    defs = schema['$defs']
+    defs = _reachable_defs(schema['$defs'], 'card')
     card_ref = {'$ref': '#/$defs/card'}
     batch_schema = {
         'type': 'object', 'additionalProperties': False, 'required': ['cards'],

--- a/RussianTranslation/src/pilot/prompt_rule_audit.py
+++ b/RussianTranslation/src/pilot/prompt_rule_audit.py
@@ -64,7 +64,14 @@ GERMAN_GLOSS_WORDS = re.compile(
     r'eines|einem|einen|auch|wohl|vielleicht|beim|Name|Art|Theil|Teil|'
     r'Bedeutung|Schulter|Strahl|Sonne|Wasser|Gewässer|Gabe|Geschenk|Glanz|'
     r'Schimmer|Pracht|Feuer|Brand|Schein|Ort|Zeit|Grund|Handeln|Zeug|'
-    r'Pflanze|Gefäss|Gefäß|Handhaben|Henkeln|Schulden)\b',
+    r'Pflanze|Gefäss|Gefäß|Handhaben|Henkeln|Schulden|'
+    # Jmd/jmdm/jmdn = "jemand(en)/jemandem" (someone), a near-ubiquitous B&R
+    # abbreviation; du/wie/woraus/dieses = common short German pronouns/
+    # interrogatives that otherwise collide with FRENCH_WORDS ("du") or leave
+    # colloquial questions ("wie kommst du darauf?") with no recognized German
+    # marker at all, mis-tripping foreign_gloss_translated (gam~~h0_20_ava,
+    # gam~~h0_38_sam_a).
+    r'Jmd|jmdm|jmdn|du|wie|woraus|dieses)\b',
     re.I)
 TEXT_CITATION = re.compile(
     r'(?:<ls\b|ṚV|RV|Atharv|AV\.|MBH|Mahābh|Rām|R\.|M\.|BhP|ŚBr|TS\.|VS\.|'
@@ -85,7 +92,7 @@ LEXICOGRAPHIC_CITATION = re.compile(
 LATIN_WORDS = re.compile(
     r'\b(?:inire|feminam?|legere|inveteratus|convenire|coitus|coire|coeundi|'
     r'membrum|virile|penis|pudenda|futuere|mingere|venus|venere|in\s+coitu|'
-    r'cum|quasi|scilicet|sic|idem|vide)\b', re.I)
+    r'cum|quasi|scilicet|sic|idem|vide|sequi|obsequi)\b', re.I)
 FRENCH_WORDS = re.compile(
     r"(?:\bl['’]|\b(?:une?|les?|des|du|aux?|plus|tr[eè]s|homme|femme|basse|"
     r"extraction|chose|terre|qui|dans|pour|avec|sans)\b)", re.I)
@@ -101,6 +108,7 @@ IAST_DIACRITIC = re.compile(r'[āīūṛṝḷḹṅñṭḍṇśṣ]')
 # field: {%German%} kept beside the Russian, {#Sanskrit#}, and <ab>/<ls>/<is> tags.
 RETAINED_SPAN = re.compile(r'\{%.*?%\}|\{#.*?#\}|<(?:ab|ls|is)\b[^>]*>.*?</(?:ab|ls|is)>'
                            r'|<(?:ab|ls|is)\b[^>]*>', re.S | re.I)
+SANSKRIT_SPAN = re.compile(r'\{#.*?#\}', re.S)
 
 SENSE_REQUIRED = (
     'tag', 'german', 'russian', 'equivalence_type', 'source_type', 'stratum',
@@ -446,7 +454,12 @@ def looks_foreign_literal(gloss, context):
         return False
     if LATIN_FLAG_CONTEXT.search(context or ''):
         return True
-    if LATIN_BINOMIAL.match(value):
+    # LATIN_BINOMIAL ("Capitalized-word lowercase-word", meant for species names like
+    # "Homo sapiens") lacked the same GERMAN_GLOSS_WORDS guard its LATIN_WORDS/FRENCH_WORDS/
+    # ENGLISH_GLOSS_WORDS siblings have below -- German capitalizes every noun, so an ordinary
+    # capitalized abbreviation + lowercase verb ("Jmd zusammenkommen") matched unconditionally
+    # and was misflagged foreign_gloss_translated (gam~~h0_38_sam_a).
+    if LATIN_BINOMIAL.match(value) and not GERMAN_GLOSS_WORDS.search(value):
         return True
     if LATIN_WORDS.search(value) and not GERMAN_GLOSS_WORDS.search(value):
         return True
@@ -472,7 +485,12 @@ def braced_gloss_risks(german, russian, tag):
     risks = []
     src = braced_glosses(german)
     dst = braced_glosses(russian)
-    russian_norm = norm_text(russian)
+    # Scrub verbatim {#Sanskrit#} citation spans before the leaked-substring search below:
+    # a short gloss (e.g. "mit") can coincidentally be a literal substring of an unrelated
+    # SLP1 citation token (miTunO -> lowercased "mituno" contains "mit"), spuriously flagging
+    # a correctly-translated gloss as untranslated (gam~~h0_38_sam_a). {%...%} spans are left
+    # alone -- the rendered_echo/side-by-side checks below still need to find them.
+    russian_norm = norm_text(SANSKRIT_SPAN.sub(' ', russian))
     for i, gloss in enumerate(src):
         context = gloss_context(german, i)
         rendered = dst[i].strip() if i < len(dst) else ''

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -40,6 +40,7 @@ from prompt_rule_audit import (
     semantic_risks,
 )
 from fix_german_connectives import fix_text as fix_german_text
+import audit_coverage
 
 
 def fail(message):
@@ -316,7 +317,7 @@ def test_braced_gloss_audit():
     # untranslated German (the convention keeps them verbatim).
     for ger in ('{%inire feminam%}', '{%legere%}', '{%inveteratus%}',
                 "{%un homme de l'extraction la plus basse%}", '{%abhi%}',
-                '{%upanis%}', '{%āgamya%}'):
+                '{%upanis%}', '{%āgamya%}', '{%sequi, obsequi%}'):
         leftover = {r['id'] for r in braced_gloss_risks(ger, ger, '1')}
         if 'untranslated_braced_german_gloss' in leftover:
             fail('braced gloss audit wrongly flagged non-German literal: %s' % ger)
@@ -324,6 +325,31 @@ def test_braced_gloss_audit():
     side = braced_gloss_risks('{%herfallen über%}', 'нападать на ({%herfallen über%})', '1')
     if {r['id'] for r in side} & {'untranslated_braced_german_gloss'}:
         fail('braced gloss audit flagged required side-by-side German echo')
+
+    # gam~~h0_20_ava / gam~~h0_38_sam_a (2026-07-03): short/colloquial German that collides
+    # with a FRENCH_WORDS entry ("du") or matches LATIN_BINOMIAL's over-permissive
+    # Capitalized-word+lowercase-word shape ("Jmd zusammenkommen", "Jmd" being the common B&R
+    # abbreviation for "jemand") must be recognized as German and NOT flagged
+    # foreign_gloss_translated merely for being correctly translated into Russian.
+    colloquial = braced_gloss_risks(
+        '{%wie kommst du darauf? woraus schliessest du dieses?%}',
+        '{%как ты до этого дошёл? из чего ты это заключаешь?%}', '1')
+    if {r['id'] for r in colloquial} & {'foreign_gloss_translated'}:
+        fail('braced gloss audit misclassified colloquial German (du) as foreign literal')
+    abbrev = braced_gloss_risks('{%Jmd zusammenkommen%}', '{%встречаться с кем-л.%}', '1')
+    if {r['id'] for r in abbrev} & {'foreign_gloss_translated'}:
+        fail('braced gloss audit misclassified "Jmd ..." (LATIN_BINOMIAL shape) as Latin')
+
+    # gam~~h0_38_sam_a (2026-07-03): a correctly-translated short gloss ({%mit%} -> {%с%})
+    # was flagged untranslated because the "leaked" check did a raw substring search across
+    # the WHOLE Russian text, including verbatim {#Sanskrit#} citation spans -- "mit" is a
+    # literal substring of the unrelated SLP1 citation token "miTunO" (lowercased "mituno").
+    sanskrit_collision = braced_gloss_risks(
+        '{%mit%} (<ab>instr.</ab>) {#yadA vE miTunO samAgacCataH#} (fleischlich)',
+        '{%с%} (<ab>instr.</ab>) {#yadA vE miTunO samAgacCataH#} (плотски)', '1')
+    if {r['id'] for r in sanskrit_collision} & {'untranslated_braced_german_gloss'}:
+        fail('braced gloss audit flagged a gloss that only collided with an embedded '
+             'Sanskrit citation substring, not a real leak')
 
 
 def semantic_card_risk_ids(russian, german='{%nachgehen%}'):
@@ -894,6 +920,82 @@ def test_ru_coverage_denominator_not_silently_exempt():
             ru_coverage.REPO, ru_coverage.RU_STORE, sys.argv = old_repo, old_store, old_argv
 
 
+def test_coverage_gate_multi_layer_and_presplit():
+    """audit_coverage.raw_markers() must not mistake <div n="p"> (a STRUCTURAL prefix/
+    secondary-conjugation divider elsewhere in this codebase -- root_units.py,
+    scale_preflight.py's _DIVP, verify_root_glue.py) for a numbered sense boundary when a
+    sub-card bundles several independent '=== LAYER: ... ===' blocks (PW/SCH/PWKVN addenda,
+    e.g. gam~~h0_zz_pw04: 3 layers, 5 raw '<div n=' tags, all cross-reference continuations
+    -> the correct count is 3, one per layer, not 5). Also: a presplit/fragment-reassembled
+    card's granular per-fragment row count must skip the LOW/OVER thresholds entirely (its
+    row count is not comparable to a coarse raw marker count)."""
+    three_layer_raw = (
+        '=== LAYER: PW ===\n\n'
+        '√gam mit aByud 1〉 aByudgata aufgegangen (Sonne) <ls>X. 1</ls>.\n\n'
+        '=== LAYER: PW ===\n\n'
+        '√gam mit aBi Caus. auch zukommen lassen <ls>Y. 2</ls>.\n'
+        '<div n="p">— Mit nis Caus. auch verlieren <ls>Z. 3</ls>.\n\n'
+        '=== LAYER: PW ===\n\n'
+        '√gam mit aBi Caus. II. 5.\n'
+        '<div n="p">— Mit A II. Agamya so v. a. fuer <ls>W. 4</ls>.\n'
+        '<div n="p">— Mit aByud II. 3.\n'
+        '<div n="p">— Mit nis Caus. II. 5.\n'
+        '<div n="p">— Mit upanis hinausgehen zu <ls>V. 5</ls>.\n'
+    )
+    bodies = audit_coverage.layer_bodies(three_layer_raw)
+    if len(bodies) != 3:
+        fail('expected 3 layer blocks, got %d' % len(bodies))
+    counts = [audit_coverage.layer_sense_count(b) for b in bodies]
+    if counts != [1, 1, 1]:
+        fail('layer_sense_count must floor a pure-cross-reference layer at 1 sense, not count '
+             'every <div n="p"> continuation: got %r' % counts)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        in_dir = os.path.join(tmp, 'pilot', 'input')
+        os.makedirs(in_dir)
+        with open(os.path.join(in_dir, 'zz~~h0_zz_pw04.raw.txt'), 'w', encoding='utf-8') as f:
+            f.write(three_layer_raw)
+        with open(os.path.join(in_dir, 'zz~~presplit_card.raw.txt'), 'w', encoding='utf-8') as f:
+            f.write('=== LAYER: PW ===\n\n√gam 1〉 aufgegangen <ls>X. 1</ls>.\n')
+        old_in = audit_coverage.IN
+        audit_coverage.IN = in_dir
+        try:
+            rm = audit_coverage.raw_markers('zz~~h0_zz_pw04')
+            if rm != 3:
+                fail('multi-layer raw_markers must count 1 sense per addenda layer (3), got %r'
+                     % rm)
+
+            wf = os.path.join(tmp, 'wf_output.json')
+            with open(wf, 'w', encoding='utf-8') as f:
+                json.dump({'results': [
+                    {'key': 'zz~~h0_zz_pw04', 'presplit': False,
+                     'card': {'records': [{'senses': [{}, {}, {}]}]}},
+                    {'key': 'zz~~presplit_card', 'presplit': True,
+                     'card': {'records': [{'senses': [{}] * 20}]}},
+                ]}, f)
+            import io, contextlib
+            old_argv = sys.argv
+            sys.argv = ['audit_coverage', wf]
+            buf = io.StringIO()
+            rc = 0
+            try:
+                with contextlib.redirect_stdout(buf):
+                    audit_coverage.main()
+            except SystemExit as e:
+                rc = e.code if isinstance(e.code, int) else 1
+            finally:
+                sys.argv = old_argv
+            out = buf.getvalue()
+            if rc != 0:
+                fail('multi-layer addenda card + presplit card must both pass: %s' % out)
+            if 'COVERAGE-LOW' in out or 'COVERAGE-OVER' in out:
+                fail('coverage gate still flagged a multi-layer/presplit card: %s' % out)
+            if 'presplit' not in out:
+                fail('presplit card must be labeled as such, not silently ok: %s' % out)
+        finally:
+            audit_coverage.IN = old_in
+
+
 def test_en_residual_coverage_complete():
     """FL4: en_residual_keys 'done' means coverage-complete, not '>=1 English sense'. A card
     with 1 of 2 senses translated is a residual (its 1 untranslated sense must not be hidden);
@@ -1401,6 +1503,7 @@ def main():
         test_markup_loss_soft_flag_ru,
         test_markup_loss_soft_flag_en,
         test_ru_coverage_denominator_not_silently_exempt,
+        test_coverage_gate_multi_layer_and_presplit,
         test_en_residual_coverage_complete,
         test_en_split_triage_keeps_missing_input,
         test_whitney_homonym_safety,

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -18,7 +18,8 @@ Supersede mode (default): the new store replaces the old run_batch store (which 
 'legacy_needs_review' and therefore exported zero rows anyway). The prior file is backed up to
 <store>.legacy.bak unless --no-backup.
 
-  python src/promote_final_cards.py                 # promote -> src/pwg_ru_translated.jsonl
+  python src/promote_final_cards.py --gen-model-version claude-sonnet-5
+                                                   # promote -> src/pwg_ru_translated.jsonl
   python src/promote_final_cards.py --dry-run        # report coverage, write nothing
   python src/promote_final_cards.py --glob 'wf_output.sd.*.json'   # a subset
 
@@ -41,10 +42,9 @@ DEFAULT_STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
 DEFAULT_GLOB = 'wf_output*.json'
 MODEL = 'sonnet'                                    # the harness pins model:'sonnet' (gen_opt_harness2)
 # Tier + VERSION must both be recorded (models change — a bare 'sonnet' is ambiguous later;
-# same convention as promote_en.py). The wf_output meta does not carry the resolved version,
-# so it is recorded here; override per run with --gen-model-version if the alias mapping
-# changed for the run being promoted.
-GEN_MODEL_VERSION = 'claude-sonnet-4-6'             # alias 'sonnet' -> Sonnet 4.6 (RU runs)
+# same convention as promote_en.py). The wf_output meta does not reliably carry the resolved
+# version, so normal promotion must pass --gen-model-version explicitly.
+SELFTEST_MODEL_VERSION = 'claude-sonnet-5'
 
 
 def load_wf(path):
@@ -101,7 +101,7 @@ def collect_cards(paths):
     return best, conflicts, sorted(null_keys)
 
 
-def provenance(entry, subkey, model_version=GEN_MODEL_VERSION):
+def provenance(entry, subkey, model_version):
     meta = entry['meta']
     hashes = (meta.get('input_hashes') or {}).get(subkey) or {}
     card = entry.get('card') or {}
@@ -137,7 +137,7 @@ def provenance(entry, subkey, model_version=GEN_MODEL_VERSION):
     return prov
 
 
-def rows_for(subkey, entry, review_status, model_version=GEN_MODEL_VERSION):
+def rows_for(subkey, entry, review_status, model_version):
     card = entry['card']
     key1 = entry['meta'].get('root')               # the join key into assembled_cards.jsonl
     prov = provenance(entry, subkey, model_version)
@@ -175,7 +175,8 @@ def selftest():
              'source_type': 'attested', 'stratum': 'Vedic', 'differentia': ''},
             {'tag': '2', 'russian': '', 'german': 'x'},          # no russian -> skipped
         ]}]}, 'meta': meta, 'wf_file': 'wf_output.sc.pA.json'}
-    rows = list(rows_for('p_a~~h5_00_pwg00', entry, 'ai_translated'))
+    rows = list(rows_for('p_a~~h5_00_pwg00', entry, 'ai_translated',
+                         SELFTEST_MODEL_VERSION))
     assert len(rows) == 1, 'a sense without russian must be skipped'
     r = rows[0]
     assert r['key1'] == 'pA', 'key1 must be the HEADWORD meta.root, not the sub-card key'
@@ -183,14 +184,15 @@ def selftest():
     assert r['review_status'] == 'ai_translated', 'must not auto-approve (G5 gate)'
     p = r['provenance']
     assert p['model'] == 'sonnet' and p['rootmap_sha256'] == 'abc'
-    assert p['model_version'] == GEN_MODEL_VERSION, 'model VERSION recorded, not just the tier alias'
+    assert p['model_version'] == SELFTEST_MODEL_VERSION, 'model VERSION recorded, not just the tier alias'
     assert p['input_raw_sha256'] == 'r1' and p['generated_at'], 'provenance must be complete'
     assert 'partial_card' not in p, 'complete card carries no partial marker'
     # a partial (selfheal) card must be marked on every row it yields
     pentry = dict(entry)
     pentry['card'] = dict(entry['card'], partial=True, missing_fragments=['g2:f1'],
                           missing_groups=1, total_groups=3)
-    pr = list(rows_for('p_a~~h5_00_pwg00', pentry, 'ai_translated'))[0]['provenance']
+    pr = list(rows_for('p_a~~h5_00_pwg00', pentry, 'ai_translated',
+                       SELFTEST_MODEL_VERSION))[0]['provenance']
     assert pr['partial_card'] is True and pr['missing_fragments'] == ['g2:f1'], \
         'partial cards must be distinguishable in the store'
     # collect_cards: a non-null card wins over a null for the same sub-card key.
@@ -215,7 +217,8 @@ def selftest():
     best, _conf, _nulls = collect_cards(sorted([enf, fullf, nullf]))
     got = best['p_a~~h5_00_pwg00']
     assert got['meta'].get('lang') != 'en', 'EN wf file must be excluded from the RU bridge'
-    assert list(rows_for('p_a~~h5_00_pwg00', got, 'ai_translated')), 'RU rows survive the EN sibling'
+    assert list(rows_for('p_a~~h5_00_pwg00', got, 'ai_translated',
+                         SELFTEST_MODEL_VERSION)), 'RU rows survive the EN sibling'
     print('promote_final_cards selftest OK')
 
 
@@ -226,10 +229,9 @@ def main():
     ap.add_argument('--glob', default=DEFAULT_GLOB, help='wf_output glob, relative to repo root')
     ap.add_argument('--store', default=DEFAULT_STORE)
     ap.add_argument('--review-status', default='ai_translated')
-    ap.add_argument('--gen-model-version', default=GEN_MODEL_VERSION,
+    ap.add_argument('--gen-model-version', default=None, required='--selftest' not in sys.argv[1:],
                     help='resolved model version recorded in provenance.model_version '
-                         '(default %(default)s — what the harness\'s model:\'sonnet\' alias '
-                         'resolved to; override if the alias mapping changed for this run)')
+                         '(exact model id required; do not guess from the model alias)')
     ap.add_argument('--dry-run', action='store_true')
     ap.add_argument('--no-backup', action='store_true')
     ap.add_argument('--force', action='store_true',


### PR DESCRIPTION
## Summary
Replaces #118 (closed — conflicted with #116, which merged in the middle of this branch's work). Re-applied source-only on a fresh branch off `origin/master` per `/branch-contention-recover`.

- Root-caused and fixed 3 audit-gate false positives found while closing out H130's `gam` production run: a multi-layer `<div n="p">` over-count in `audit_coverage.py`, a `LATIN_BINOMIAL`/`FRENCH_WORDS`/`LATIN_WORDS` German-misclassification cluster in `prompt_rule_audit.py`, and a Sanskrit-citation substring collision in `braced_gloss_risks`. All three pinned by new `window_selftest.py` cases.
- Includes the `CARDS_SCHEMA` `$defs`-pruning fix in `gen_opt_harness2.py` (`_ref_names`/`_reachable_defs`) that unblocked every Workflow-tool `agent()` call in the first place — the tool's safety classifier was rejecting every StructuredOutput call pre-execution because the shared schema file's unused `judge`/`judge_issue` `$defs` pushed it over a size threshold.
- `gam` root: 109/127 -> 127/127 mechanically clean after the fixes plus one manual resolution of a genuinely ambiguous editorial hedge. Promoted locally with `--gen-model-version claude-sonnet-5`; provenance audit clean; card + fragment TM rebuilt (local/gitignored, not part of this diff).

## Test plan
- [x] `python src/pilot/window_selftest.py` — full suite green in the original working directory (has the local corpus cache); syntax + new pinning tests independently re-verified in this recovery worktree
- [x] `python src/audit_coverage.py wf_output.json` — 127/127 covered
- [x] `python src/pilot/audit_window.py wf_output.json --root gam --write-requeue` — 0 requeue
- [x] `python src/audit_translation_provenance.py` — 0 unresolved rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)