### PR TITLE
Add Indische Sprüche (Böhtlingk) full-corpus dataset

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -754,6 +754,16 @@ Two live tracks:
 
 ## ✅ Completed (Recent only)
 
+- **Indische Sprüche dataset extracted — DONE (2026-07-03, Sonnet 5 `claude-sonnet-5`).**
+  New [IndischeSprueche/](https://github.com/gasyoun/SanskritLexicography/tree/master/IndischeSprueche)
+  data asset: full Böhtlingk *Indische Sprüche* (2nd ed. 1870–1873), 7,537 sayings,
+  exported from `VisualDCS` archive.sqlite `subhashita` table via the new
+  `VisualDCS/src/DCS-data-2026/export_subhashita_jsonl.py`. `subhashita_ramayana`
+  intentionally excluded (separate, likely-positional pairing artifact). PWG cites
+  this collection 6,666 times and PWK 138 times as `Spr. N` — the citation crosswalk
+  is scoped, not built, in [Uprava H143](https://github.com/gasyoun/Uprava/blob/main/handoffs/H143_pwg_pwk_indische_sprueche_crosswalk.md).
+  Released `v1.1.5`. PROJECT_INTERLINKS.md updated.
+
 - **A33 referee + polish pass — DONE (2026-07-03, Fable 5 `claude-fable-5`, H123/S14 + follow-up).**
   Hostile pre-submission review [papers/A33_review_fable5.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A33_review_fable5.md)
   ([PR #109](https://github.com/gasyoun/SanskritLexicography/pull/109) merged): References

--- a/IndischeSprueche/README.md
+++ b/IndischeSprueche/README.md
@@ -1,0 +1,81 @@
+# Indische Sprüche (Böhtlingk)
+
+_Created: 03-07-2026 · Last updated: 03-07-2026_
+
+Otto von Böhtlingk's **Indische Sprüche** (2nd ed., St. Petersburg, 1870–1873,
+3 vols.) — ~7,537 Sanskrit gnomic verses / subhāṣitas, each given in Devanāgarī,
+his own German translation, a source citation to the original text (epic,
+dramatic, or gnomic anthology), and critical-apparatus notes on variant
+readings. Public domain (Böhtlingk d. 1904).
+
+This is a **separate publication from Böhtlingk's dictionaries** (PWG, PWK) —
+not part of the Cologne XML dictionary corpus — but the two are tightly linked:
+both dictionaries cite this collection internally as an attestation source,
+abbreviated `Spr. N` (e.g. `Spr. 1249`):
+
+| Dictionary | `Spr. N` citation count |
+|---|---|
+| PWG (`csl-orig/v02/pwg/pwg.txt`) | 6,666 |
+| PWK (`csl-orig/v02/pwkvn/pwkvn.txt`) | 138 |
+
+See [`H143_pwg_pwk_indische_sprueche_crosswalk.md`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H143_pwg_pwk_indische_sprueche_crosswalk.md)
+for the scoped follow-on that resolves those citations against this dataset.
+
+## Provenance
+
+```
+VisualDCS/non-derived/Sanskritskie-izrecheniya/Subhash_Bt.xlsx   (digitized workbook)
+    -> VisualDCS/src/DCS-data-2026/import_archive.py `subhashita` cmd (D4)
+    -> VisualDCS/src/DCS-data-2026/archive.sqlite, table `subhashita`
+    -> VisualDCS/src/DCS-data-2026/export_subhashita_jsonl.py
+    -> data/indische_sprueche.jsonl  (this directory)
+```
+
+Regenerate with:
+
+```sh
+cd VisualDCS/src/DCS-data-2026
+python export_subhashita_jsonl.py
+```
+
+**Excluded on purpose:** the `subhashita_ramayana` table (source: the "Btlnk,
+Ram, Mh" workbook sheet) pairs subhāṣita rows with Rāmāyaṇa verses + Russian
+translation, but the pairing looks positional/sequential rather than a genuine
+cross-reference from Böhtlingk's own apparatus — it is a separate artifact, out
+of scope for this edition, and not exported here.
+
+**10 curated, hand-verified verses** (clean anuṣṭubh, metrically scanned) were
+already imported separately into [`SanskritKaraoke/verses/data/`](https://github.com/gasyoun/SanskritKaraoke/tree/main/verses/data)
+by [`SanskritKaraoke/tools/import_subhashita.py`](https://github.com/gasyoun/SanskritKaraoke/blob/main/tools/import_subhashita.py)
+for the karaoke text-only feed — that subset is a curated derivative of the
+full corpus here, not a duplicate source.
+
+## Data
+
+[`data/indische_sprueche.jsonl`](data/indische_sprueche.jsonl) — 7,537 records,
+one per line:
+
+```json
+{
+  "num": 1249,
+  "saying_id": "Saying 1249",
+  "page": "1.237",
+  "deva": "उद्यमेन हि सिध्यन्ति कार्याणि न मनोरथैः।/नहि सुप्तस्य सिंहस्य प्रविशन्ति मुखे मृगाः॥",
+  "iast": "udyamena hi sidhyanti kāryāṇi na manorathaiḥ |/nahi suptasya siṃhasya praviśanti mukhe mṛgāḥ ||",
+  "translation_de": "Durch Anstrengung kommen ja Werke zu Stande, nicht durch Wünsche: ...",
+  "source_attribution": "1249) Pañcatantra / Hitopadeśa ...",
+  "notes": "critical-apparatus / variant-reading notes, or null"
+}
+```
+
+`num` is the running Sprüche number — the same number cited in PWG/PWK as
+`Spr. N`, and in secondary literature as "Böhtlingk, Spr. N" or "IndSpr N".
+
+## Rights
+
+Sanskrit text and Böhtlingk's German translation: public domain (author
+d. 1904). No modern translation is included or implied.
+
+---
+
+_Dr. Mārcis Gasūns_

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,19 @@ then **cut a new version every time the changelog is updated** (promote
 
 ## [Unreleased]
 
+## [1.1.5] - 2026-07-03
+
+### Added — Indische Sprüche dataset
+- New [`IndischeSprueche/`](https://github.com/gasyoun/SanskritLexicography/tree/master/IndischeSprueche)
+  data asset: the full Böhtlingk *Indische Sprüche* collection (2nd ed. 1870–1873),
+  7,537 sayings exported from `VisualDCS` archive.sqlite's `subhashita` table (D4)
+  via the new `VisualDCS/src/DCS-data-2026/export_subhashita_jsonl.py`, as
+  [`IndischeSprueche/data/indische_sprueche.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/IndischeSprueche/data/indische_sprueche.jsonl).
+  PWG cites this collection 6,666 times and PWK 138 times as `Spr. N` — see
+  [`IndischeSprueche/README.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/IndischeSprueche/README.md)
+  for provenance and the scoped PWG/PWK citation-crosswalk follow-on
+  ([Uprava H143](https://github.com/gasyoun/Uprava/blob/main/handoffs/H143_pwg_pwk_indische_sprueche_crosswalk.md)).
+
 ## [1.1.4] - 2026-07-03
 
 ## [0.0.42] - 2026-07-02


### PR DESCRIPTION
## Summary
- Extracts all 7,537 sayings of Böhtlingk's *Indische Sprüche* (2nd ed. 1870–1873) from `VisualDCS` archive.sqlite's `subhashita` table into `IndischeSprueche/data/indische_sprueche.jsonl`, with provenance/rights in `IndischeSprueche/README.md`.
- Found PWG cites this collection `Spr. N` 6,666 times and PWK 138 times — real crosswalk value, scoped (not built) as [Uprava H143](https://github.com/gasyoun/Uprava/blob/main/handoffs/H143_pwg_pwk_indische_sprueche_crosswalk.md).
- `subhashita_ramayana` intentionally excluded (looks like a separate positional pairing, not part of Böhtlingk's own apparatus).
- Changelog promoted to `1.1.5`; `.ai_state.md` updated.

## Test plan
- [x] Row count verified: 7,537 records match `SELECT COUNT(*) FROM subhashita`.
- [x] Spot-checked sample records against the source workbook fields (Devanagari, IAST, German, source citation, notes).
- [x] Markdown lint conventions followed (dated header, byline, full blob URLs, no HTML).

Model: Sonnet 5 (`claude-sonnet-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)