### PR TITLE
pwg-ru: full-run readiness audit — 703-root verb batch drain scoped (H151)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,60 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
+<<<<<<< Updated upstream
+=======
+- **FULL-RUN READINESS AUDIT + scope ruling — ✅ DONE 04-07-2026 (Fable 5, `claude-fable-5`).**
+  MG asked "is everything ready for full PWG→RU; I get bugs and half translations all the time;
+  next batch = all the verbal roots." Audit verdict: **READY, no open stoppers** — selftests
+  green (`window_selftest.py` 31+, `translation_memory.py selftest`), TM fresh (2,122 cards,
+  rebuilt 03-07 22:42), all historical silent-loss classes FIXED with pinned tests (S10 F1–F14;
+  FL1–FL5+FL8 via PRs [#79](https://github.com/gasyoun/SanskritLexicography/pull/79)/[#80](https://github.com/gasyoun/SanskritLexicography/pull/80)/[#81](https://github.com/gasyoun/SanskritLexicography/pull/81)/[#82](https://github.com/gasyoun/SanskritLexicography/pull/82)/[#92](https://github.com/gasyoun/SanskritLexicography/pull/92)/[#93](https://github.com/gasyoun/SanskritLexicography/pull/93)/[#94](https://github.com/gasyoun/SanskritLexicography/pull/94);
+  schema-classifier + 3 gate FPs in [#119](https://github.com/gasyoun/SanskritLexicography/pull/119)).
+  The "half translations" causes were: silent-null key loss (fixed by total-accounting), TM
+  re-serving gate-flagged content on requeue (fixed: `--no-tm` mandatory on requeue), wide-
+  concurrency rate-limit collapse (process-fixed: ≤3-wide), giant-head overflow (fixed: presplit
+  router + fragment TM), and the manual Max-surface save gap (H145 `vid` — see next line).
+  Known-open non-blockers: FL6/FL7 (low sev), G5/G6/G7 human print-gates (downstream only).
+  **H148 executed inside this session:** MG confirmed the `vid` output is LOST (nothing on
+  disk — repo/Downloads/Desktop swept); `wf_output.json` verified still the promoted `gam`.
+  Hardening: save-verification checklist added to [`RUN_FREQ_MAX.md`](src/pilot/RUN_FREQ_MAX.md)
+  + production preference = drive the Workflow from the Claude Code session (H130 pattern),
+  no manual save step.
+  **Scope ruling (MG): next batch = ALL remaining DCS-attested verb roots.** New
+  [`verb_worklist.py`](src/pilot/verb_worklist.py) enumerates them reproducibly (verbs01
+  universe 1,882 ∩ freq manifest = 749 attested − 46 promoted = **703 remaining, ~5.3 MB
+  source ≈ 2.3× everything done so far**). Standing resumable drain handoff =
+  [H151](https://github.com/gasyoun/Uprava/blob/main/handoffs/H151_SanskritLexicography_pwg_ru_verb_batch_drain.md)
+  (Sonnet 5 sessions, roots one-at-a-time ≤3-wide, RUN_FREQ_MAX loop verbatim, promote + TM
+  rebuild per root; Wave-1 head = `vid` clean re-run → `as` → `BU` → `yuj` → `sTA`/`i` solo;
+  one-time pre-wave task = the historical gate-fix re-audit sweep from the 03-07 open
+  question). H145 is superseded — do not execute its file.
+  **Next:**
+  `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H151_SanskritLexicography_pwg_ru_verb_batch_drain.md and execute it.`
+  (Sonnet 5 chat in this directory.)
+
+- **H145 `vid` Max run — ~~🟡 BLOCKED~~ ✅ SUPERSEDED by H151 04-07-2026 (output confirmed
+  lost; clean re-run = H151 Wave-1 head). Original record: 🟡 BLOCKED 03-07-2026 on a Max-Workflow hand-off gap, NOT a code
+  bug (Sonnet 5, `claude-sonnet-5`).** Preflight was clean (55 keys, 13 expected agents,
+  `run-now-low`) and `gen_opt_harness2.py vid` wrote a fresh `run_pilot_wf.opt2.js`
+  (`meta.name: 'pwgru-opt2-vid'`). M.G. reported running it in the Claude Max Workflow
+  surface and saving the result as `wf_output.json`, but the file on disk never changed:
+  `meta.root` stayed `"gam"`, `meta.generated_at` stayed `2026-07-03T16:34:44Z` (the same
+  `gam` output `window_status.json` already recorded `state: clean` for at `19:42:01Z`,
+  hours earlier), across two independent checks ~15 min apart (23:22 and 23:38
+  wall-clock). No other `wf_output*.json` in the directory carries `root: vid`. The
+  stale-provenance check worked exactly as designed — it just has nothing to compare
+  against because no new file ever landed. **Routed to
+  [`H148`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H148_SanskritLexicography_max_workflow_handoff_gap_audit.md)
+  (Fable 5, `claude-fable-5`)** to characterize whether the Workflow output is
+  recoverable (wrong save path / still visible in Workflow run history) or genuinely
+  lost, since that requires either M.G.'s direct input on what happened in the Workflow
+  surface, or evidence this repo's Python tooling has no visibility into. **Do not
+  re-run `vid`'s harness until H148 resolves** — re-running blind risks a second
+  untracked Max spend on the same hand-off gap. Once resolved (either a recovered
+  output or a confirmed clean re-run), the very next step is
+  `audit_window.py wf_output.json --root vid --write-requeue`, same as any other root.
+>>>>>>> Stashed changes
 - **H130 gam Max run — Workflow-tool schema bug FOUND + FIXED, gam translated + mechanically
   audited 2026-07-03 (Sonnet 5, `claude-sonnet-5`).** Executing
   [`H130_SanskritLexicography_pwg_ru_gam_max_run.md`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H130_SanskritLexicography_pwg_ru_gam_max_run.md)

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -49,13 +49,15 @@ and eliminated the transient dropouts.
   and G10 edition cut remain blocked until human review/gold work is done.
   `preflight_remaining_gates.py` and `release_readiness.py` are report-only by default; add
   `--fail-on-blocked` when using them as CI/go-no-go gates.
-- Canonical next roots: finish the `sTA` re-batch cleanup, then run
-  `BU`, `gam`, `yuj`, `as`, `i`, `vid`, `han`.
-- Do **not** run 10 big roots in one broad Max push yet. The current staged plan
-  is: fresh `sTA` only; then clean-ready roots `BU`, `as`, and `i`; then prune
-  and recheck stale roots `gam`, `yuj`, `vid`, and `han` before any Max spend.
-  This produces enough audit/cost data without mixing clean roots with avoidable
-  stale generated inputs.
+- **Scope ruling (MG, 04-07-2026): drain ALL remaining DCS-attested verb roots**, in
+  frequency order, root-by-root. The worklist is enumerated reproducibly by
+  [`verb_worklist.py`](verb_worklist.py) (verbs01 universe ∩ freq manifest − promoted
+  store): 749 attested verb roots, 46 promoted, **703 remaining** (~5.3 MB source) as of
+  04-07-2026. Drain discipline lives in the standing handoff
+  [`H151`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H151_SanskritLexicography_pwg_ru_verb_batch_drain.md).
+- The per-root loop below is unchanged — "all roots next batch" scales the QUEUE, not the
+  width. Roots still run **one at a time (≤3-wide max)**; the Slice-D 18×-parallel collapse
+  (117 transient nulls) is the standing counter-example.
 
 The earlier "Opus-judged-every-card" framing was the validation phase; "Sonnet-bulk/Opus-on-reject"
 was the 2026-06-26 escalation policy; the per-card LLM judge itself is now dropped from the bulk path.
@@ -208,7 +210,14 @@ then audit the fresh `wf_output.json`.
 
 Run the generated harness (default `src\pilot\run_pilot_wf.opt2.js`, or the legacy
 `run_pilot_wf.opt.js`) in the Claude/Max Workflow surface and save the JSON result as
-`wf_output.json`. Both are self-contained: they inline inputs, disable translate-agent tools
+`wf_output.json`.
+**Immediately after saving, verify the file actually landed before closing the Workflow
+tab:** `meta.root` in the freshly-saved `wf_output.json` must equal the root you just ran and
+`meta.generated_at` must be newer than the harness generation time. The H145 `vid` run
+(03-07-2026) was lost exactly here — the Workflow completed but the save never reached disk,
+and the stale file silently still held the previous root. A Claude Code session driving the
+Workflow tool writes the file itself and does not have this manual hand-off gap; prefer that
+route for production windows. Both are self-contained: they inline inputs, disable translate-agent tools
 with `tools: []`, and return top-level workflow provenance (`meta`: root, mode, selected keys,
 rootmap SHA-256, per-input SHA-256). The v2 harness additionally batches, masks, and restores
 `{Tn}` in-JS — its output is already canonical, so the audit step is unchanged. It is the

--- a/RussianTranslation/src/pilot/verb_worklist.py
+++ b/RussianTranslation/src/pilot/verb_worklist.py
@@ -1,0 +1,93 @@
+"""verb_worklist.py — enumerate the remaining DCS-attested PWG verb roots for the RU batch drain.
+
+Universe = verbs01 `pwg_preverb1.txt` case headers (k1), the vetted PWG verb-root
+list. A root is in scope when it appears in `scale_manifest.freq.json`
+(DCS-attested) and is NOT yet promoted into the RU store
+(`src/pwg_ru_translated.jsonl`). Output is score-ranked (freq order), the same
+order the drain consumes it in.
+
+Usage:
+  python src/pilot/verb_worklist.py            # print summary + write worklist JSON
+  python src/pilot/verb_worklist.py --top 20   # also print the next N roots
+
+Writes: src/pilot/output/verb_batch_worklist.json (gitignored, regenerable).
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+RT = os.path.dirname(os.path.dirname(HERE))  # RussianTranslation/
+PREVERB = os.path.normpath(os.path.join(RT, '..', '..', 'PWG', 'verbs01', 'pwg_preverb1.txt'))
+MANIFEST = os.path.join(HERE, 'output', 'scale_manifest.freq.json')
+STORE = os.path.join(RT, 'src', 'pwg_ru_translated.jsonl')
+OUT = os.path.join(HERE, 'output', 'verb_batch_worklist.json')
+
+CASE = re.compile(r';; Case \d+: L=\d+, k1=(\S+), k2=\S+, code=\S+,')
+
+
+def verb_universe(path=PREVERB):
+    roots = set()
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            m = CASE.match(line)
+            if m:
+                roots.add(m.group(1))
+    return roots
+
+
+def store_roots(path=STORE):
+    done = set()
+    if not os.path.exists(path):
+        return done
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                done.add(json.loads(line).get('key1'))
+    return done
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--top', type=int, default=0, help='print the next N roots')
+    ap.add_argument('--json', action='store_true', help='print the full worklist JSON to stdout')
+    args = ap.parse_args()
+
+    verbs = verb_universe()
+    freq = {it['key1']: it for it in json.load(open(MANIFEST, encoding='utf-8'))}
+    done = store_roots()
+    attested = [k for k in verbs if k in freq]
+    remain = sorted((k for k in attested if k not in done), key=lambda k: -freq[k]['score'])
+
+    payload = {
+        'universe_verbs01': len(verbs),
+        'dcs_attested': len(attested),
+        'done_promoted': sorted(done & verbs),
+        'remaining': remain,
+        'remaining_count': len(remain),
+        'remaining_bytes': sum(freq[k]['bytes'] for k in remain),
+    }
+    os.makedirs(os.path.dirname(OUT), exist_ok=True)
+    with open(OUT, 'w', encoding='utf-8') as f:
+        json.dump(payload, f, ensure_ascii=False, indent=1)
+
+    print(f"verbs01 universe: {len(verbs)}  DCS-attested: {len(attested)}  "
+          f"promoted: {len(done & verbs)}  REMAINING: {len(remain)} "
+          f"({payload['remaining_bytes']:,} source bytes)")
+    print(f"worklist written: {OUT}")
+    if args.top:
+        for k in remain[:args.top]:
+            it = freq[k]
+            print(f"  {k:12s} score={it['score']:.1f} band={it['band']} bytes={it['bytes']}")
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, indent=1))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What

Readiness audit for the full PWG→RU run, per MG's 04-07-2026 ruling: **next batch = ALL remaining DCS-attested verb roots.**

- **[verb_worklist.py](https://github.com/gasyoun/SanskritLexicography/blob/audit/pwg-ru-verb-batch-readiness/RussianTranslation/src/pilot/verb_worklist.py)** — reproducible worklist: verbs01 universe (1,882) ∩ `scale_manifest.freq.json` (749 DCS-attested) − promoted store (46) = **703 remaining roots, ~5.3 MB source (≈2.3× done so far)**.
- **[RUN_FREQ_MAX.md](https://github.com/gasyoun/SanskritLexicography/blob/audit/pwg-ru-verb-batch-readiness/RussianTranslation/src/pilot/RUN_FREQ_MAX.md)** — scope ruling + H148 hardening: verify `meta.root` immediately after every manual Workflow save (the H145 `vid` output was lost exactly there); prefer session-driven Workflow runs (H130 pattern).
- **[.ai_state.md](https://github.com/gasyoun/SanskritLexicography/blob/audit/pwg-ru-verb-batch-readiness/RussianTranslation/.ai_state.md)** — audit verdict (no open stoppers), H148 resolved (vid LOST, MG confirmed; disk swept), H145 superseded.

Standing drain handoff: [H151](https://github.com/gasyoun/Uprava/blob/main/handoffs/H151_SanskritLexicography_pwg_ru_verb_batch_drain.md) (Sonnet 5 sessions, roots one-at-a-time ≤3-wide, Wave 1 = vid→as→BU→yuj, then sTA/i solo).

Audit run by Fable 5 (`claude-fable-5`); readiness evidence: `window_selftest.py` + `translation_memory.py selftest` green, TM 2,122 cards fresh (03-07 22:42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)