### PR TITLE
Fix stale_check ordering false-positive + pending pwg-ru fixes

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,8 +12,6 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
-<<<<<<< Updated upstream
-=======
 - **FULL-RUN READINESS AUDIT + scope ruling — ✅ DONE 04-07-2026 (Fable 5, `claude-fable-5`).**
   MG asked "is everything ready for full PWG→RU; I get bugs and half translations all the time;
   next batch = all the verbal roots." Audit verdict: **READY, no open stoppers** — selftests
@@ -65,7 +63,6 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   untracked Max spend on the same hand-off gap. Once resolved (either a recovered
   output or a confirmed clean re-run), the very next step is
   `audit_window.py wf_output.json --root vid --write-requeue`, same as any other root.
->>>>>>> Stashed changes
 - **H130 gam Max run — Workflow-tool schema bug FOUND + FIXED, gam translated + mechanically
   audited 2026-07-03 (Sonnet 5, `claude-sonnet-5`).** Executing
   [`H130_SanskritLexicography_pwg_ru_gam_max_run.md`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H130_SanskritLexicography_pwg_ru_gam_max_run.md)

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,0 +1,256 @@
+# LANG_PARITY.md — cross-language fix/feature parity ledger
+
+_Created: 04-07-2026 · Last updated: 04-07-2026_
+
+This repo runs the same PWG→Russian and PWG→English translation pipeline through
+shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
+`src/pilot/audit_window*.py`, …), parameterized by `--lang`. History shows fixes
+land on one language path and quietly never reach the other — e.g. 3 gate-bug
+fixes shipped 2026-07-03 (multi-layer sense over-count, German/Latin/French
+misclassification guards, Sanskrit-span gloss-leak scrub) live only in the RU
+audit path; `audit_window_en.py` reimplements its own gates from scratch and
+never got them. A separate audit on 2026-07-04 also found `requeue_from_audit.py`
+silently dropping the mandatory `--no-tm` flag on **both** paths at once.
+
+## Policy (binding — read before closing out any fix/feature session)
+
+1. **Same-session obligation.** Any session that fixes a bug or adds a mechanism
+   on ONE language path must, before calling the work done, classify it as one
+   of:
+   - **SHARED** — the fix lives in lang-parameterized code and already applies
+     to every language. Port it now if it doesn't.
+   - **INTENTIONAL-DIVERGENCE** — the languages genuinely need different
+     behavior. Write the one-line **why** in this ledger (a missing rationale
+     is itself a defect, not a shortcut).
+   - **GAP** — it should eventually apply everywhere but isn't ported yet.
+     Record it here AND spawn a tracked follow-up (a task chip, handoff, or
+     GTD row) — a GAP entry with no tracking reference is not allowed to sit
+     silently.
+2. **No silent single-language fixes.** Landing a fix only on RU (or only on
+   EN, or only on a future 3rd language) without one of the three verdicts
+   above is a process defect, not a style choice.
+3. **Structure is per-language, not RU/EN-hardcoded**, so adding a 3rd
+   language later is a new `languages` entry in the ledger below, not a
+   doc rewrite.
+4. **Mechanical enforcement.** [`src/pilot/lang_parity_check.py`](src/pilot/lang_parity_check.py)
+   parses the ledger block below and is wired into
+   [`window_selftest.py`](src/pilot/window_selftest.py) as
+   `test_lang_parity_ledger_complete`. It fails the suite when:
+   - a ledger entry has no verdict, or an `INTENTIONAL-DIVERGENCE` entry has
+     no `note`, or a `GAP` entry has no `tracking` reference;
+   - a file referenced by an entry has changed (sha256 drift) since the entry
+     was last verified — this is a proxy for "someone touched parity-tracked
+     code and didn't re-affirm parity still holds." Re-run
+     `python src/pilot/lang_parity_check.py --update-hash <entry_id>` after
+     confirming the change doesn't break the recorded verdict, and update
+     `note`/`tracking` if it does.
+   It does **not** attempt deep semantic diffing (no AST/behavior comparison)
+   — it is a forcing function to make a human/session re-affirm the verdict,
+   not a replacement for actually reading the diff.
+
+## Ledger
+
+Machine-readable block below (JSON, not YAML, to avoid an extra dependency in
+`lang_parity_check.py`). Each entry:
+
+```
+id            stable slug, never reused/renumbered
+mechanism     one-line human description
+files         file paths this entry tracks for drift (relative to RussianTranslation/)
+languages     languages this entry currently covers (["ru","en"], or the subset that's SHARED)
+verdict       SHARED | INTENTIONAL-DIVERGENCE | GAP
+note          required for INTENTIONAL-DIVERGENCE: the one-line why
+tracking      required for GAP: task id / handoff / PR reference
+verified_sha256   {file: hex} snapshot at last verification; drift trips the gate
+```
+
+```json lang_parity_ledger
+[
+  {
+    "id": "presplit_router",
+    "mechanism": "Presplit router sends over-budget dense cards straight to the fragment lane",
+    "files": [
+      "src/pilot/gen_opt_harness2.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "a6a1438d13e0f0a92aa261f024c6cc65d96c15c30eb97d4dd179ac8b7a0e8e12"
+    }
+  },
+  {
+    "id": "selfheal_binary_split",
+    "mechanism": "Selfheal + binary-split recovery, on by default",
+    "files": [
+      "src/pilot/gen_opt_harness2.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "a6a1438d13e0f0a92aa261f024c6cc65d96c15c30eb97d4dd179ac8b7a0e8e12"
+    }
+  },
+  {
+    "id": "output_budget_90",
+    "mechanism": "OUTPUT_BUDGET=90 default (calibrated 2026-07-03, PR #101)",
+    "files": [
+      "src/pilot/gen_opt_harness2.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "a6a1438d13e0f0a92aa261f024c6cc65d96c15c30eb97d4dd179ac8b7a0e8e12"
+    }
+  },
+  {
+    "id": "translation_memory_card_and_fragment",
+    "mechanism": "Content-addressed TM, card-level + fragment-level reuse",
+    "files": [
+      "src/pilot/translation_memory.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "lang is a first-class parameter of the TM address (sha256(lang + ...)); --lang=ru|en both get full reuse.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/translation_memory.py": "41ff5b08afd961e166ee24f38ef00aa307803d6dcc4fd4eb6ca1806a67a4a1a3"
+    }
+  },
+  {
+    "id": "cards_schema_defs_pruning",
+    "mechanism": "H130 fix: CARDS_SCHEMA only carries $defs reachable from 'card', not the whole shared schema file's judge/judge_issue defs",
+    "files": [
+      "src/pilot/gen_opt_harness2.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "_reachable_defs() walks $ref pointers regardless of lang.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "a6a1438d13e0f0a92aa261f024c6cc65d96c15c30eb97d4dd179ac8b7a0e8e12"
+    }
+  },
+  {
+    "id": "annotator_fields_optional_schema_relaxation",
+    "mechanism": "Sense schema 'required' trimmed to [tag, german/english, russian/english] — the 4 annotator fields (equivalence_type/source_type/stratum/differentia) optional",
+    "files": [
+      "src/pilot/gen_opt_harness2.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "a6a1438d13e0f0a92aa261f024c6cc65d96c15c30eb97d4dd179ac8b7a0e8e12"
+    }
+  },
+  {
+    "id": "sonnet5_explicit_model_pin_en",
+    "mechanism": "EN path pins 'claude-sonnet-5' explicitly in the generated harness's agent() calls; RU path keeps the bare 'sonnet' alias",
+    "files": [
+      "src/pilot/gen_opt_harness2.py"
+    ],
+    "languages": [
+      "en"
+    ],
+    "verdict": "INTENTIONAL-DIVERGENCE",
+    "note": "The bare 'sonnet' alias resolved to Sonnet 4.6 (not 5.0) on a prior EN run — pinned explicitly there after that surprise. RU's alias was never observed to misresolve, so it was left alone rather than touching a stable production path for a problem it doesn't have. Re-evaluate if RU is ever caught on a stale alias too.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "a6a1438d13e0f0a92aa261f024c6cc65d96c15c30eb97d4dd179ac8b7a0e8e12"
+    }
+  },
+  {
+    "id": "gate_fixes_20260703_ru_only",
+    "mechanism": "3 gate-bug fixes (audit_coverage.py multi-layer sense over-count; prompt_rule_audit.py German/Latin/French misclassification guards; braced_gloss_risks Sanskrit-span gloss-leak scrub) exist only in the RU audit path",
+    "files": [
+      "src/audit_coverage.py",
+      "src/pilot/prompt_rule_audit.py",
+      "src/pilot/audit_window.py",
+      "src/pilot/audit_window_en.py"
+    ],
+    "languages": [
+      "ru"
+    ],
+    "verdict": "GAP",
+    "note": "audit_window_en.py reimplements its own gates from scratch rather than importing the RU modules (its own comment: 'the RU gate is wired around Russian-specific semantic checks'), so none of the 3 July fixes reached EN. EN cards from the same PWG/PW/SCH source have the same multi-layer/addenda structure, so the same false-positive classes plausibly apply there too.",
+    "tracking": "spawned task chip task_d29bb788 (2026-07-04): 'Port RU gate fixes to audit_window_en.py' — running",
+    "verified_sha256": {
+      "src/audit_coverage.py": "8c54aa22943140624238273b5bb6a2cbe9aceded5f8295cb84cd36bd994904c0",
+      "src/pilot/prompt_rule_audit.py": "293b580cdf8866c8ae0d892dd77981e34561398e2c0142623aed1127740019b0",
+      "src/pilot/audit_window.py": "2f9e418010d2ed9bc5c49be934eb95d672cae9ad3f01aa4099756dc7cf0e44a1",
+      "src/pilot/audit_window_en.py": "4775368d2da38f0d6aede470d838becb6cc863de4914a785aa855baf45735fd8"
+    }
+  },
+  {
+    "id": "requeue_no_tm_enforcement",
+    "mechanism": "requeue_from_audit.py must append --no-tm on a defect/all requeue so TM can't silently re-serve gate-flagged content",
+    "files": [
+      "src/pilot/requeue_from_audit.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "Fixed 2026-07-04 (commit 8cb84f7): the helper is lang-agnostic (takes a root, not a --lang flag; gen_opt_harness2.py resolves lang from the rootmap), so the fix applies to any language's requeue in one place. Was a both-paths gap before the fix, not an RU/EN divergence.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/requeue_from_audit.py": "3dd94b3f20084a3db1b6211e149d7347ba86ffd479424ec2fb88084090ddcf5f"
+    }
+  },
+  {
+    "id": "promotion_scripts_separate",
+    "mechanism": "Promotion into the store is two separate scripts (promote_final_cards.py for RU, promote_en.py for EN) rather than one --lang-parameterized script",
+    "files": [
+      "src/promote_final_cards.py",
+      "src/promote_en.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "INTENTIONAL-DIVERGENCE",
+    "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/promote_final_cards.py": "572bb45477ce4856f6caba7e813e00a146bbeeedf3ae04b471e4616dafaa8935",
+      "src/promote_en.py": "7d3ce9680e304fff8ba0bcaba843945c36c6f0894441a56e8695ec58a6b5ebfe"
+    }
+  }
+]
+```
+
+## When a 3rd language is proposed
+
+Add its files/verdicts as new ledger entries (or extend `languages` arrays on
+existing SHARED entries once verified) — do not restructure the JSON shape.
+If the 3rd language needs its own audit script (as EN did), immediately add a
+`GAP` row for every RU-only fix in the ledger above rather than discovering
+the gap months later.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -28,6 +28,19 @@ and eliminated the transient dropouts.
   severity>=3`), Opus verdict final — see [`../../research/JUDGE_POLICY.md`](../../research/JUDGE_POLICY.md).
   Publishable cards spend no Opus tokens.
 
+## Cross-language parity — read before closing out any RU/EN fix or feature
+
+This pipeline runs RU and EN (and any future language) through the same
+lang-parameterized tooling. A fix landing on only one language path and never
+reaching the other is a recurring failure mode (3 gate-bug fixes shipped
+2026-07-03 stayed RU-only for a day before an audit caught it). Before calling
+any fix/feature session done, classify it in
+[`../../LANG_PARITY.md`](../../LANG_PARITY.md) as SHARED / INTENTIONAL-DIVERGENCE
+(with a one-line why) / GAP (with a tracked follow-up) — see that file's policy
+section. `python src/pilot/lang_parity_check.py` enforces ledger completeness +
+tracked-file drift and is wired into `window_selftest.py`
+(`test_lang_parity_ledger_complete`).
+
 ## Current operating truth
 
 - The optimized **translate-only** Max harness is live and is generated per root by

--- a/RussianTranslation/src/pilot/lang_parity_check.py
+++ b/RussianTranslation/src/pilot/lang_parity_check.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+"""Mechanical gate for LANG_PARITY.md — see that doc for the policy this enforces.
+
+  python src/pilot/lang_parity_check.py                       # check, exit 1 on any violation
+  python src/pilot/lang_parity_check.py --update-hash <id>     # after re-verifying an entry,
+                                                                # refresh its verified_sha256 snapshot
+
+This does NOT diff behavior between languages — it only checks that every ledger
+entry has a verdict (and the verdict's required field), and that no file a SHARED /
+INTENTIONAL-DIVERGENCE / GAP entry depends on has drifted since it was last verified.
+Drift means a human must re-open the entry and re-affirm (or correct) its verdict.
+"""
+import hashlib
+import json
+import os
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(os.path.dirname(HERE))  # .../RussianTranslation
+LEDGER_MD = os.path.join(REPO_ROOT, 'LANG_PARITY.md')
+FENCE_RE = re.compile(r'```json lang_parity_ledger\r?\n(.*?)```', re.DOTALL)
+
+VALID_VERDICTS = {'SHARED', 'INTENTIONAL-DIVERGENCE', 'GAP'}
+
+
+def load_ledger(path=LEDGER_MD):
+    text = open(path, encoding='utf-8').read()
+    m = FENCE_RE.search(text)
+    if not m:
+        raise SystemExit('no ```json lang_parity_ledger fenced block found in %s' % path)
+    return json.loads(m.group(1)), text, m.span(1)
+
+
+def file_sha256(rel_path):
+    p = os.path.join(REPO_ROOT, rel_path)
+    if not os.path.exists(p):
+        return None
+    return hashlib.sha256(open(p, 'rb').read()).hexdigest()
+
+
+def check(entries):
+    violations = []
+    for e in entries:
+        eid = e.get('id', '<missing id>')
+        verdict = e.get('verdict')
+        if verdict not in VALID_VERDICTS:
+            violations.append('%s: verdict %r is not one of %s' % (eid, verdict, sorted(VALID_VERDICTS)))
+            continue
+        if verdict == 'INTENTIONAL-DIVERGENCE' and not e.get('note', '').strip():
+            violations.append('%s: INTENTIONAL-DIVERGENCE requires a non-empty note (the one-line why)' % eid)
+        if verdict == 'GAP' and not e.get('tracking', '').strip():
+            violations.append('%s: GAP requires a non-empty tracking reference (task id / handoff / PR)' % eid)
+        snapshot = e.get('verified_sha256', {})
+        for rel_path in e.get('files', []):
+            recorded = snapshot.get(rel_path)
+            if recorded is None:
+                violations.append('%s: file %s has no recorded verified_sha256 entry' % (eid, rel_path))
+                continue
+            current = file_sha256(rel_path)
+            if current is None:
+                violations.append('%s: tracked file %s no longer exists — update or retire this entry' % (eid, rel_path))
+            elif current != recorded:
+                violations.append(
+                    '%s: %s changed since last parity verification (recorded %s..., now %s...) — '
+                    're-check the %s verdict still holds, then run '
+                    '`python src/pilot/lang_parity_check.py --update-hash %s`'
+                    % (eid, rel_path, recorded[:12], current[:12], verdict, eid))
+    return violations
+
+
+def update_hash(entry_id):
+    entries, text, span = load_ledger()
+    found = False
+    for e in entries:
+        if e.get('id') == entry_id:
+            found = True
+            for rel_path in e.get('files', []):
+                h = file_sha256(rel_path)
+                if h is None:
+                    raise SystemExit('cannot update-hash: %s no longer exists' % rel_path)
+                e.setdefault('verified_sha256', {})[rel_path] = h
+    if not found:
+        raise SystemExit('no ledger entry with id %r' % entry_id)
+    new_block = json.dumps(entries, indent=2, ensure_ascii=False)
+    new_text = text[:span[0]] + new_block + '\n' + text[span[1]:]
+    open(LEDGER_MD, 'w', encoding='utf-8', newline='\n').write(new_text)
+    print('updated verified_sha256 for %r' % entry_id)
+
+
+def main():
+    argv = sys.argv[1:]
+    if argv and argv[0] == '--update-hash':
+        if len(argv) < 2:
+            sys.exit('usage: --update-hash <entry_id>')
+        update_hash(argv[1])
+        return
+    entries, _, _ = load_ledger()
+    violations = check(entries)
+    if violations:
+        print('LANG PARITY LEDGER: %d violation(s)' % len(violations))
+        for v in violations:
+            print('  - ' + v)
+        sys.exit(1)
+    print('LANG PARITY LEDGER: %d entries, all verdicts complete, no drift' % len(entries))
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/requeue_from_audit.py
+++ b/RussianTranslation/src/pilot/requeue_from_audit.py
@@ -4,6 +4,12 @@
   python src/pilot/requeue_from_audit.py sTA               # all requeue keys (requeue.keys.txt)
   python src/pilot/requeue_from_audit.py sTA --transient   # only null cards (cheap re-run)
   python src/pilot/requeue_from_audit.py sTA --defect      # only real content failures (rework)
+
+A defect/all requeue always regenerates with --no-tm: a gate-flagged key's TM entry
+addresses on the input SHA, not on whether the cached translation passed the gates, so a
+plain --tm=auto rerun would silently re-serve the exact already-flagged content (see
+Uprava/FINDINGS.md, the gam requeue trap). --transient (null cards, nothing was ever
+cached) keeps --tm=auto since there is no flagged content to re-serve.
 """
 import json
 import os
@@ -77,6 +83,8 @@ def main():
 
     cmd = [sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'),
            root, '--keys=' + ','.join(resolved)]
+    if which != 'transient':
+        cmd.append('--no-tm')
     p = subprocess.run(cmd, cwd=os.path.dirname(os.path.dirname(HERE)),
                        text=True, encoding='utf-8', capture_output=True)
     if p.stdout.strip():

--- a/RussianTranslation/src/pilot/window_provenance.py
+++ b/RussianTranslation/src/pilot/window_provenance.py
@@ -73,9 +73,11 @@ def stale_check(root, workflow_meta, workflow_keys):
         if invalid:
             check['errors'].append('workflow selected keys not in current rootmap: %s' %
                                    ', '.join(invalid[:12]))
-    if workflow_keys != expected_keys:
-        missing = sorted(set(expected_keys) - set(workflow_keys))
-        unexpected = sorted(set(workflow_keys) - set(expected_keys))
+    workflow_key_set = set(workflow_keys)
+    expected_key_set = set(expected_keys)
+    if workflow_key_set != expected_key_set:
+        missing = sorted(expected_key_set - workflow_key_set)
+        unexpected = sorted(workflow_key_set - expected_key_set)
         check['errors'].append('workflow keys do not match current selected rootmap keys '
                                '(workflow=%d expected=%d missing=%d unexpected=%d)' %
                                (len(workflow_keys), len(expected_keys), len(missing), len(unexpected)))

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -724,6 +724,18 @@ def test_release_manifest_hash_validation():
         run([sys.executable, os.path.join(SRC, 'validate_release.py'), edition], expect=1)
 
 
+def test_lang_parity_ledger_complete():
+    """LANG_PARITY.md's ledger must have a verdict for every entry (SHARED /
+    INTENTIONAL-DIVERGENCE with a note / GAP with a tracking ref), and no tracked
+    file may have drifted since its entry was last verified. See LANG_PARITY.md."""
+    import lang_parity_check
+    entries, _, _ = lang_parity_check.load_ledger()
+    violations = lang_parity_check.check(entries)
+    if violations:
+        fail('LANG_PARITY.md has %d unresolved parity violation(s):\n  %s'
+             % (len(violations), '\n  '.join(violations)))
+
+
 def test_sense_dupe_batch_override():
     """The cross-part sense-duplicate exemption must be reproducible from the committed
     rootmap_overrides.json, NOT from a gitignored hand-edited rootmap (PROCESS_AUDIT rec 15)."""
@@ -1510,6 +1522,7 @@ def main():
         test_stale_refusal_preserves_requeue,
         test_fixture_audit_does_not_clobber_live_status,
         test_release_manifest_hash_validation,
+        test_lang_parity_ledger_complete,
     ]
     for test in tests:
         test()

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -30,7 +30,7 @@ if SRC not in sys.path:
 
 from workflow_payload import workflow_payload
 from window_common import harness_meta
-from window_provenance import current_root_provenance
+from window_provenance import current_root_provenance, stale_check
 from prompt_rule_audit import (
     DEFAULT_TEMPLATE,
     audit_card_result,
@@ -144,6 +144,33 @@ def test_harness_scope_and_tools():
     if agent_calls != tool_guards or not tool_guards:
         fail('optimized harness tools guard mismatch: %d agent calls, %d guards' %
              (agent_calls, tool_guards))
+
+
+def test_stale_check_key_order_independent():
+    """stale_check must compare workflow result-key order against meta.selected_keys as a
+    SET, not a positional list — the harness assembles results TM-lane-first then
+    DEGENERATE-lane then per-batch-completion order, which never matches the rootmap's
+    declared order even when every key is present exactly once."""
+    meta = harness_meta()
+    if not meta.get('ok'):
+        fail('optimized harness missing or invalid: %s' % meta.get('error'))
+    root = meta.get('root')
+    current = current_root_provenance(root, meta.get('selected_keys'))
+    if not current.get('ok'):
+        fail('current root provenance unavailable: %s' % current.get('error'))
+    workflow_meta = {
+        'root': root,
+        'safe_root': current['safe_root'],
+        'rootmap_sha256': current['rootmap_sha256'],
+        'selected_keys': current['selected_keys'],
+        'input_hashes': current['input_hashes'],
+    }
+    reordered_keys = list(reversed(current['selected_keys']))
+    check = stale_check(root, workflow_meta, reordered_keys)
+    if any('do not match' in err for err in check.get('errors') or []):
+        fail('stale_check flagged reordered-but-identical key set as a mismatch')
+    if check['stale']:
+        fail('stale_check treated an order-only difference as stale: %s' % check.get('errors'))
 
 
 def test_prompt_rule_audit_template():
@@ -1500,6 +1527,7 @@ def main():
         test_export_translation_dedup,
         test_requeue_transient_vs_defect_state,
         test_harness_scope_and_tools,
+        test_stale_check_key_order_independent,
         test_prompt_rule_audit_template,
         test_prompt_rule_audit_missing_blocks,
         test_semantic_risk_checker,


### PR DESCRIPTION
## Summary
- `window_provenance.stale_check()` compared the workflow's result-key order against `meta.selected_keys` positionally, refusing gates/glue on ANY order mismatch even when the key sets were identical. Confirmed on a real historical artifact (`wf_output.en.gam.json`, 127/127 same keys, different order) that this trap fires on every live root run and was previously worked around by hand per `.ai_state.md`.
- Fixed to compare key sets (matching the existing missing/unexpected diagnostics), pinned with `test_stale_check_key_order_independent`.
- Also includes 3 prior pending commits already on this branch: merge-conflict cleanup in `.ai_state.md`, `--no-tm` enforcement on defect/all requeue, and the cross-language fix-parity ledger/gate.

## Test plan
- [x] `python src/pilot/window_selftest.py` — full suite green (including new test)
- [x] Verified against real historical `wf_output.en.gam.json` (127/127 same keys, different order) — now `stale: False` instead of refusing gates