### PR TITLE
pwg-ru: fix fragment-tag collision causing SENSE-DUPE false positives on giant single-sense heads

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1079,6 +1079,32 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ✅ Completed (Recent only)
 
+- **Fragment-tag collision fix + SAN-LOSS hardening (2026-07-04, Sonnet 5
+  `claude-sonnet-5`).** Traced the SENSE-DUPE false positive on `vid`'s giant
+  single-sense heads (`h0_00_pwg00`/`h2_00_pwg0*`) to `gen_opt_harness2.py`
+  discarding `split_plan()`'s `sense_ord` when building the selfHeal fragment
+  fallback — citation-batch fragments of ONE source sense had no shared
+  identity, so the model fabricated fresh incrementing tags per fragment that
+  collided with a sibling rootmap part's real senses in
+  `audit_sense_dupes.py`. Fixed: `sense_ord` now threads through as `si` in
+  `FRAGS[k]`; JS `selfHeal()` normalizes every fragment's tag to its group's
+  first-seen tag per `si` (`siTag`/`applyTag`). Also hardened
+  `autosplit_requeue._cit_parts()` against a related SAN-LOSS hypothesis (a
+  `{#...#}` Sanskrit span, unlike `<ls>...</ls>`, never counted toward the
+  citation budget that decides cut points, so it could be torn mid-span,
+  leaking unmasked Sanskrit into the model prompt) via a new `_span_open()`
+  guard — defensive, NOT empirically reproduced against the actual failing
+  data (the run's raw fragment files were no longer present in-tree). Both
+  fixes covered by new `window_selftest.py` fixtures
+  (`test_selfheal_fragment_si_threaded_and_tags_normalized`,
+  `test_cit_split_never_tears_open_span`), full suite re-run green (only
+  pre-existing `gam`-fixture-dependent failure unrelated to this change, and
+  `translation_memory.py selftest` OK); generated JS harness syntax-checked
+  with `node --check`. Written up as Phase 8 item 5 in
+  [`PIPELINE_HISTORY.md`](PIPELINE_HISTORY.md). Same-shape risk flagged for
+  BU/yuj/as/sTA/i (H151 queue) — worth a SENSE-DUPE re-check on already-
+  promoted cards once this fix has run on a live drain.
+
 - **Translation provenance audit/backfill shipped (2026-07-03, Codex/GPT-5).**
   Added [`src/audit_translation_provenance.py`](src/audit_translation_provenance.py)
   and hardened [`src/promote_final_cards.py`](src/promote_final_cards.py) so future

--- a/RussianTranslation/PIPELINE_HISTORY.md
+++ b/RussianTranslation/PIPELINE_HISTORY.md
@@ -172,6 +172,44 @@ cause: an undersized (non-splittable) card shares a batch with denser
 content, the batch blows its retry cap, and the small card has zero
 recovery mechanism of its own — flagged as a follow-up, not yet fixed.
 
+5. **Fragment-tag collision (SENSE-DUPE false positive) on giant single-sense
+   heads.** `vid`'s homonym head `h0`'s giant single-sense part
+   (`h0_00_pwg00`, source sense "1", 168 `<ls>` citations) is tier-2
+   citation-split by `autosplit_requeue.plan()` into many fragments, ALL
+   belonging to the same source sense (`sense_ord`/`si` == 0) — but
+   `gen_opt_harness2.py`'s `FRAGS[k]` builder discarded that `sense_ord`
+   (bound to `_si` and thrown away), so the JS `selfHeal()` heal path had no
+   way to tell "these fragments are citation batches of ONE sense" from
+   "these are genuinely different senses." Translating each fragment
+   independently, the model fabricated fresh incrementing tags per fragment
+   (2, 3, 4...) that then collided with a sibling rootmap part's REAL
+   different senses in `audit_sense_dupes.py`'s cross-part duplicate check —
+   a deterministic tagging artifact (reproduced identically across 2
+   independent live requeue rounds), not model stochasticity. Fixed by
+   threading `sense_ord` into `FRAGS` as `si` and normalizing every
+   fragment's tag to its group's first-seen tag per `si` in JS `selfHeal()`
+   (`siTag`/`applyTag`). Same-session, also hardened the SAME split path
+   against a second, adjacent hypothesis: `_cit_parts()` decided its budget
+   cuts purely on running `<ls>` counts with zero awareness of `{#...#}`
+   Sanskrit-span state — a `<ls>...</ls>` span can never straddle a cut (a
+   new `<ls>` can only open once the previous one closed), but `{#...#}`
+   never contributed to the count at all, so a still-open `{#...#}` block
+   could get torn across a cut forced by a later, unrelated `<ls>` tag. A
+   torn span can no longer be matched by `pwg_mask`'s PAIRED regex, so its
+   Sanskrit content passes through UNMASKED into the model's "translatable"
+   prose — a plausible mechanism for the SAN-LOSS pattern observed on the
+   same giant heads, though NOT empirically reproduced against the actual
+   failing `vid` data (the run's raw fragment files were no longer present
+   in-tree to inspect). Fixed defensively via `_span_open()`: defer the cut
+   until the accumulated fragment text is `<ls>`/`{#..#}` balanced. Both
+   fixes covered by new `window_selftest.py` fixtures
+   (`test_selfheal_fragment_si_threaded_and_tags_normalized`,
+   `test_cit_split_never_tears_open_span`). Same-shape risk: any other
+   already-promoted or future-drained root with a citation-dense
+   single-sense giant head (BU/yuj/as/sTA/i in the H151 queue are candidates)
+   can hit the same tag-collision pattern — worth a SENSE-DUPE re-check on
+   promoted cards once the fix has run.
+
 ## Recurring failure patterns (read this before assuming something new is broken)
 
 These are the failure *shapes* that have recurred across the project — if a

--- a/RussianTranslation/src/pilot/autosplit_requeue.py
+++ b/RussianTranslation/src/pilot/autosplit_requeue.py
@@ -80,13 +80,27 @@ def _blocks(raw):
     return header, blocks
 
 
+def _span_open(text):
+    """True if `text` ends with an unterminated <ls>...</ls> or {#...#} span (a paired
+    span opened but not yet closed). Citation/Sanskrit spans can legitimately run across
+    several lines; cutting a fragment in the middle of one leaves BOTH halves holding an
+    unbalanced tag that pwg_mask.mask() can no longer match (its PAIRED regex requires a
+    complete open+close pair even with re.S), so the Sanskrit/citation text passes through
+    UNMASKED as ordinary translatable prose — the model then paraphrases or drops it,
+    producing LS-LOSS/SAN-LOSS specifically on the giant citation-dense heads that need
+    tier-2 splitting (see PIPELINE_HISTORY.md)."""
+    return text.count('<ls') > text.count('</ls>') or text.count('{#') > text.count('#}')
+
+
 def _cit_parts(block, ls_budget):
-    """Split one (sub)sense block into parts each <= ls_budget <ls>, on line boundaries."""
+    """Split one (sub)sense block into parts each <= ls_budget <ls>, on line boundaries —
+    but never inside an open <ls>/{#...#} span (see _span_open); the budget cut is deferred
+    to the next line where the accumulated text is tag-balanced."""
     lines = block.split('\n')
     parts, cur, c = [], [], 0
     for l in lines:
         n = l.count('<ls')
-        if cur and c + n > ls_budget:
+        if cur and c + n > ls_budget and not _span_open('\n'.join(cur)):
             parts.append('\n'.join(cur)); cur, c = [], 0
         cur.append(l); c += n
     if cur:

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -627,7 +627,7 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
                 print('  selfheal: %s has no fallback (card does not split — <2 fragments)' % k)
                 continue
             fl = []
-            for _si, _pi, t in pl:
+            for si, _pi, t in pl:
                 fsk, fph, _ = pwg_mask.mask(t)
                 if pwg_mask.restore(fsk, fph) != t:
                     fl = []
@@ -637,14 +637,20 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
                     break
                 fsha = _tm.frag_address(lang, t)
                 cached = frag_cache.get(fsha)
+                # si (sense_ord from split_plan) travels with the fragment into FRAGS so the
+                # JS heal path can tell "these fragments are all citation-batches of the SAME
+                # source sense" apart from "these are genuinely different senses" — without it,
+                # the model tags each fragment independently and fabricates fresh incrementing
+                # tags for citation continuations that carry no sense-boundary marker of their
+                # own (see PIPELINE_HISTORY.md fragment-tag-collision entry).
                 fl.append({'skeleton': fsk, 'ls': t.count('<ls'), 'sk': t.count('{#'),
-                           'ph': fph, 'fsha': fsha,
+                           'ph': fph, 'fsha': fsha, 'si': si,
                            'tm': cached.get('senses') if cached else None})
             if not fl:
                 continue
             groups = _group_by_budget(fl, lambda it: 1 + it['ls'], SELFHEAL_GROUP_BUDGET)
             frags[k] = [[{'skeleton': it['skeleton'], 'ls': it['ls'], 'sk': it['sk'],
-                          'fsha': it['fsha']} for it in g] for g in groups]
+                          'fsha': it['fsha'], 'si': it['si']} for it in g] for g in groups]
             phf[k] = [[it['ph'] for it in g] for g in groups]
             # FRAG_TM[k]: same group shape, each slot = cached restored senses or null.
             # Only emitted when this card has at least one cached fragment (keeps the JS lean
@@ -918,6 +924,18 @@ async function selfHeal(k) {
   const fragProv = []           // {fsha, senses} per FRESHLY-resolved fragment — harvested by
                                 // translation_memory.py build-frags into the fragment TM so the
                                 // next run reuses it (ground truth captured at the moment of success)
+  // siTag: canonical tag per source sense_ord (FRAGS[k][gi][i].si), fixed to whatever tag the
+  // FIRST fragment of that sense_ord reports. Citation-batch continuations of the same oversized
+  // sense carry no sense-boundary marker of their own, so the model tags them independently and
+  // fabricates fresh incrementing numbers (1,2,3...) that then collide with a sibling rootmap
+  // part's REAL different senses in audit_sense_dupes.py's cross-part check. Forcing every
+  // fragment sharing a sense_ord onto the same tag is the fix (see PIPELINE_HISTORY.md).
+  const siTag = {}
+  const applyTag = (si, s) => {
+    if (si === undefined || si === null) return
+    if (siTag[si] === undefined) siTag[si] = s.tag
+    else s.tag = siTag[si]
+  }
   for (let gi = 0; gi < groups.length; gi++) {
     const grp = groups[gi]
     const gph = (PHF[k] || [])[gi] || []
@@ -941,8 +959,10 @@ async function selfHeal(k) {
     for (let i = 0; i < grp.length; i++) {
       if (gtm[i]) {
         // cached senses are ALREADY restored to source markup (validated at their harvest run);
-        // slot them in at their document position — do NOT re-restore (no {Tn} remain).
-        for (const s of gtm[i]) senses.push(s)
+        // slot them in at their document position — do NOT re-restore (no {Tn} remain). Tag
+        // normalization still applies: an older cache entry harvested before this fix may carry
+        // a fabricated tag.
+        for (const s of gtm[i]) { applyTag(grp[i].si, s); senses.push(s) }
         continue
       }
       const card = r.resolved[i]
@@ -952,6 +972,7 @@ async function selfHeal(k) {
       for (const rec of (card.records || [])) for (const s of (rec.senses || [])) {
         if (s.german !== undefined) s.german = restore(s.german, ph)
         if (s.%(field)s !== undefined) s.%(field)s = restore(s.%(field)s, ph)
+        applyTag(grp[i].si, s)
         senses.push(s); fsenses.push(s)
       }
       if (grp[i].fsha && fsenses.length) fragProv.push({ fsha: grp[i].fsha, senses: fsenses })

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -1571,6 +1571,99 @@ def test_no_fallback_batch_isolation():
         fail('fallback key must still be owed by some batch')
 
 
+def test_cit_split_never_tears_open_span():
+    """SAN-LOSS hypothesis (2026-07-04 vid drain): autosplit_requeue._cit_parts split a
+    (sub)sense purely on running <ls> counts per line, with NO awareness of {#...#} span
+    state. A well-formed <ls>...</ls> span can never straddle a cut (a NEW <ls> can only
+    open once the PREVIOUS one has closed, and the algorithm never lets the running count
+    exceed budget), but a {#...#} span never contributes to that count at all — so a
+    {#...#} block that is still open when a LATER, unrelated <ls> tag pushes the running
+    <ls> count over budget got torn across the cut. A torn {#...#} span can no longer be
+    matched by pwg_mask's PAIRED regex (needs a complete open+close pair), so its Sanskrit
+    content passed through UNMASKED as ordinary translatable prose — the model then
+    paraphrases or drops it, producing SAN-LOSS on exactly the citation-dense giant heads
+    that need tier-2 splitting. Fixed via _span_open(): defer the cut until the accumulated
+    fragment text is <ls>/{#..#} balanced. This constructs the vulnerable shape (a
+    {#...#} span straddling what would otherwise be the cut point) and asserts every
+    returned fragment is internally balanced."""
+    from autosplit_requeue import plan as split_plan
+    raw = (
+        '<ls n="1">a</ls>\n'
+        '{#Sanskrit quote start\n'
+        '<ls n="2">b</ls>\n'
+        'quote end#}\n'
+        '<ls n="3">c</ls>\n'
+    )
+    parts = split_plan(raw, ls_budget=1)
+    if len(parts) < 2:
+        fail('fixture did not force a split — adjust ls_budget/fixture')
+    for _si, _pi, text in parts:
+        if text.count('<ls') != text.count('</ls>'):
+            fail('a returned fragment has an unbalanced <ls>/</ls> pair — span torn across '
+                 'a cut: %r' % text)
+        if text.count('{#') != text.count('#}'):
+            fail('a returned fragment has an unbalanced {#/#} pair — Sanskrit span torn '
+                 'across a cut: %r' % text)
+
+
+def test_selfheal_fragment_si_threaded_and_tags_normalized():
+    """Regression for the 2026-07-04 vid drain SENSE-DUPE false-positive: root vid's
+    homonym head h0's giant single-sense part (h0_00_pwg00, source sense '1', 168 <ls>
+    citations) was tier-2 split into many citation-batch fragments, all belonging to the
+    SAME source sense — but FRAGS[k] (the fragment fallback fed to the JS selfHeal path)
+    discarded split_plan()'s sense_ord (previously bound to `_si` and thrown away), so the
+    JS heal path had no way to know the fragments shared a parent sense. Translating each
+    fragment independently, the model fabricated fresh incrementing tags per fragment
+    (2,3,4...) that then collided with a sibling rootmap part's REAL different senses in
+    audit_sense_dupes.py's cross-part duplicate check — a deterministic tagging artifact,
+    not model stochasticity (reproduced identically across 2 independent live requeue
+    rounds). Fixed by threading sense_ord into FRAGS as 'si' (Python side, gen_opt_harness2)
+    and normalizing every fragment's tag to its group's first-seen tag per si in JS
+    selfHeal() (siTag/applyTag — verified by code inspection; window_selftest has no JS
+    runtime). This test exercises the Python-side wiring: a citation-dense single-sense
+    fixture card must produce >=2 FRAGS fragments that ALL carry the same si."""
+    import re as _re
+    import gen_opt_harness2 as gh
+    from window_common import input_paths
+    from autosplit_requeue import plan as split_plan
+    key = '_selftest_giant~~h0_00_pwgtest'
+    lines = ['Uebersicht der Citate zu diesem einzigen Sinn dieses Testkopfes.']
+    for i in range(25):
+        lines.append('Wort%d <ls n="RV.%d.1">citation text %d</ls> und mehr erlaeuternder Text.'
+                     % (i, i, i))
+    raw = '\n'.join(lines)
+    rp, pp = input_paths(key)
+    if os.path.exists(rp) or os.path.exists(pp):
+        fail('selftest fixture key collides with a real input file — pick a different key')
+    os.makedirs(os.path.dirname(rp), exist_ok=True)
+    try:
+        with open(rp, 'w', encoding='utf-8') as f:
+            f.write(raw)
+        with open(pp, 'w', encoding='utf-8') as f:
+            f.write('{}')
+        pl = split_plan(raw)
+        if len(pl) < 2:
+            fail('fixture did not produce a multi-fragment plan — adjust the fixture')
+        if len({si for si, _pi, _t in pl}) != 1:
+            fail('fixture should be ONE giant sense split into citation batches (all si==0)')
+        js, _batches = gh.build('_selftest_giant', [key], None, 100000, tm_path=None)
+        frags = json.loads(_re.search(r'^const FRAGS = (.*)$', js, _re.M).group(1))
+        if key not in frags:
+            fail('selfheal fallback was not computed for the fixture card')
+        sis = [frag.get('si') for grp in frags[key] for frag in grp]
+        if len(sis) < 2:
+            fail('fixture did not thread into >=2 FRAGS fragments')
+        if any(si is None for si in sis):
+            fail('FRAGS fragments are missing the si (sense_ord) field — the '
+                 'fragment-tag-collision fix regressed')
+        if len(set(sis)) != 1:
+            fail('all fragments of one giant sense must share the SAME si, got %r' % sis)
+    finally:
+        for p in (rp, pp):
+            if os.path.exists(p):
+                os.remove(p)
+
+
 def main():
     tests = [
         test_translation_memory_addressing,
@@ -1587,6 +1680,8 @@ def main():
         test_calibration_arm_set_conservative_emit_only,
         test_frag_tm_reuse,
         test_no_fallback_batch_isolation,
+        test_cit_split_never_tears_open_span,
+        test_selfheal_fragment_si_threaded_and_tags_normalized,
         test_autosplit_topup_targets_and_reassembles,
         test_workflow_payload_nested,
         test_sense_dupe_batch_override,


### PR DESCRIPTION
## Summary
- Traced a real, deterministic bug (reproduced identically across 2 live requeue rounds) in the 2026-07-04 `vid` drain: giant single-sense heads (`h0_00_pwg00`/`h2_00_pwg0*`, 168 `<ls>` citations) are tier-2 citation-split into many fragments belonging to the SAME source sense, but `gen_opt_harness2.py` discarded `split_plan()`'s `sense_ord` when building the selfHeal fragment fallback — so the model fabricated fresh incrementing tags per fragment (2,3,4...) that collided with a sibling rootmap part's real senses, producing SENSE-DUPE gate false-positive failures.
- Fix: thread `sense_ord` through as `si` in `FRAGS[k]`; JS `selfHeal()` now normalizes every fragment's tag to its group's first-seen tag per `si` (`siTag`/`applyTag`), including cached (`--tm`) fragments.
- Also hardens `autosplit_requeue._cit_parts()` against an adjacent SAN-LOSS hypothesis observed on the same giant heads: a `{#...#}` Sanskrit span never counted toward the citation budget deciding cut points (unlike `<ls>...</ls>`, which is safe by construction), so it could be torn mid-span and leak unmasked Sanskrit into the translation prompt. Defensive fix via a new `_span_open()` guard — plausible mechanism, but NOT empirically reproduced against the original failing data (the run's raw fragment files were no longer present in-tree).
- Adds two `window_selftest.py` fixtures covering both fixes, and a Phase-8 write-up in `PIPELINE_HISTORY.md`.

## Test plan
- [x] `python src/pilot/window_selftest.py` — full suite green (only a pre-existing, environment-dependent `gam`-fixture failure unrelated to this change, confirmed via `git stash` on the unmodified tree)
- [x] `python src/pilot/translation_memory.py selftest` — OK
- [x] Generated JS harness (including the edited `selfHeal()`) syntax-checked with `node --check`
- [ ] Re-run the H151 `vid` drain and confirm the SENSE-DUPE gate no longer false-positives on the giant heads

🤖 Generated with [Claude Code](https://claude.com/claude-code)