### PR TITLE
pwg_ru: sense-density presplit trigger + wall-clock kill gate (H155 + follow-up)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,39 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
+- **H155 — `tyaj~~h0_zz_pw` StructuredOutput stall root-caused + FIXED — ✅ DONE 04-07-2026
+  (Opus 4.8, `claude-opus-4-8`).** `tyaj`'s drain stalled ~7 min on one agent retrying the
+  identical `agent()` call (`root: must have required property 'cards' / must NOT have
+  additional properties`) and never producing valid output; MG stopped it. **Root cause:** the
+  presplit router (built for 150-`<ls>` citation giants) prices output complexity as `1+<ls>`,
+  which is **blind to SENSE density**. `tyaj~~h0_zz_pw` is a PW addenda card compressing a whole
+  root article (base verb + Caus/Desid + every prefix combo) into **35 senses / 47 divs / 67
+  gloss-spans** carrying only **11 `<ls>`** → weight `1+<ls>=12` ranked it among the *lightest*
+  cards while its real output surface was the *heaviest* of the root, so it deterministically
+  blew the whole-card StructuredOutput retry cap (the model can't emit the full card as valid
+  StructuredOutput, so it never returns `{cards:[…]}`). NOT schema-broken (the schema is one
+  shared const across all 5 batches; only this batch failed) and NOT stochastic (identical error
+  every retry). The `_zz_pw` addenda class is a known cap-trigger (`gam~~h0_zz_pw01` hit it
+  before, recovered only via selfheal after the doomed retries). **Fix** (lang-agnostic →
+  SHARED): a **second, orthogonal presplit trigger** keyed on the deterministic fragment count
+  (== sense-objects the model must emit) vs a new `SENSE_PRESPLIT_BUDGET=20` — routes sense-dense
+  cards straight to the proven fragment lane, converting up-to-5 doomed retries + binary-split
+  cascade into zero. Threshold 20 sits on a clean shelf (survey: only ~0.2% of 8,391 sampled
+  cards exceed 20 senses; every known-good whole-card head is far below — sam 6, pari 8).
+  Independent of the citation trigger and of byte/citation batching mode; tunable via
+  `--sense-presplit-budget=N` (`off` disables). **Validated live** (fresh Workflow, store
+  untouched): the `[sam, zz_pw]` pair that stalled now returns **cards:2 / ok:2 / null:0**, with
+  `zz_pw` routed via presplit and healed **complete** (4 fragment groups, `partial_keys:[]`),
+  6 agents / ~4 min. Pinned by `window_selftest.py::test_sense_dense_card_presplit` (synthetic
+  30-sense/1-`<ls>` card; 46/46 green). LANG_PARITY entry `sense_presplit_trigger` (SHARED) +
+  all drifted hashes re-affirmed → parity gate clean (13 entries). Files:
+  [`src/pilot/gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py),
+  [`src/pilot/window_selftest.py`](src/pilot/window_selftest.py),
+  [`LANG_PARITY.md`](LANG_PARITY.md), [`PIPELINE_HISTORY.md`](PIPELINE_HISTORY.md) (Phase 8 #5 +
+  recurring-pattern). `tyaj` is otherwise clean — resume its drain via the standing
+  [H151](https://github.com/gasyoun/Uprava/blob/main/handoffs/H151_SanskritLexicography_pwg_ru_verb_batch_drain.md)
+  loop, no special procedure.
+
 - **FULL-RUN READINESS AUDIT + scope ruling — ✅ DONE 04-07-2026 (Fable 5, `claude-fable-5`).**
   MG asked "is everything ready for full PWG→RU; I get bugs and half translations all the time;
   next batch = all the verbal roots." Audit verdict: **READY, no open stoppers** — selftests

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,33 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
+- **H155 follow-up — failure-mode taxonomy + wall-clock KILL GATE — ✅ DONE 04-07-2026
+  (Opus 4.8, `claude-opus-4-8`).** MG: "sense-count is just one case — what other cases are
+  possible? Plan in advance. And add a gate: if a translation runs too long, kill it, don't
+  wait for miracles." **(1) Taxonomy** — [`FAILURE_MODES_AND_KILL_GATE_2026-07-04.md`](FAILURE_MODES_AND_KILL_GATE_2026-07-04.md)
+  enumerates every whole-card/batch StructuredOutput-stall driver from the timeline: citations
+  (#1, handled), senses (#2, handled H155), **gloss-prose volume (#3), masked-token count (#4),
+  multi-layer nesting (#5), batch-level sums (#6)** — all the same disease (too much output),
+  surfacing via whichever attribute spikes first; any single-metric budget is blind to the
+  rest. **(2) Kill gate** — runtime backstop for the un-triggered drivers: every schema-bearing
+  `agent()` call is raced against a `setTimeout` budget scaled to its masked-skeleton byte
+  volume (best time predictor — output ≈ 2× skeleton); overrun by `KILL_FACTOR=2×` → abandoned,
+  cards routed to the bounded fragment lane instead of the full ~5-deep retry cap. Runtime
+  probe: `setTimeout`/`Promise.race` work (relative timer; `Date.now()` banned), **no
+  `AbortController`** so a killed call keeps running in the background until its own cap — the
+  harness just stops blocking. Constants calibrated from a 13-call `tyaj --no-tm` benchmark
+  (legit ≤84 s @ ~25 ms/skel-byte): BASE 30 s, SLOPE 45 ms/byte, FLOOR 120 s, CEIL 480 s →
+  budgets 127 s (744 B) … 416 s (3956 B). On kill, `resolveGroup` breaks to BINARY_SPLIT and
+  `healGroup` bisects, so a killed card is **recovered, never dropped**. Proven: zero-token
+  behavioural test (`kill_mechanism_test.mjs` 9/9) + static wiring selftest
+  `test_kill_gate_wired`; full suite green (47 tests). LANG_PARITY entry `wall_clock_kill_gate`
+  (SHARED, lang-agnostic — keys on skeleton bytes, no RU/EN branching); gate clean (14 entries).
+  **Discipline:** when a new stall class appears in a real run, promote it from kill-gate-caught
+  to its own structural trigger (as senses did) so the next one spends zero doomed tokens.
+  Files: [`src/pilot/gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py),
+  [`src/pilot/window_selftest.py`](src/pilot/window_selftest.py),
+  [`LANG_PARITY.md`](LANG_PARITY.md), [`PIPELINE_HISTORY.md`](PIPELINE_HISTORY.md) Phase 8 #6.
+
 - **H155 — `tyaj~~h0_zz_pw` StructuredOutput stall root-caused + FIXED — ✅ DONE 04-07-2026
   (Opus 4.8, `claude-opus-4-8`).** `tyaj`'s drain stalled ~7 min on one agent retrying the
   identical `agent()` call (`root: must have required property 'cards' / must NOT have

--- a/RussianTranslation/FAILURE_MODES_AND_KILL_GATE_2026-07-04.md
+++ b/RussianTranslation/FAILURE_MODES_AND_KILL_GATE_2026-07-04.md
@@ -1,0 +1,177 @@
+# Whole-card StructuredOutput failure modes + the wall-clock kill gate
+
+_Created: 04-07-2026 · Last updated: 04-07-2026_
+
+Written after H155 (the `tyaj~~h0_zz_pw` ~7-minute stall) as MG's follow-up:
+**"card complexity is sense-count, not citations — that's just a single case.
+What other cases are possible? Plan in advance. And add a gate: if a
+translation runs too long, kill it — don't wait for miracles."** This doc
+answers both: (1) a forward-looking taxonomy of every whole-card/whole-batch
+StructuredOutput failure driver, grounded in the
+[`PIPELINE_HISTORY.md`](PIPELINE_HISTORY.md) timeline, and (2) the design +
+calibration of a per-`agent()`-call wall-clock kill gate as the backstop for
+the drivers we *haven't* characterized yet.
+
+## The unifying failure model
+
+A single `agent()` call carrying a StructuredOutput schema **stalls** (burns
+the internal StructuredOutput retry cap, ~5 attempts, each re-emitting the
+same doomed output) when the model cannot produce a valid `{cards:[…]}`
+object at the root. That happens when the required **output** is too large or
+too complex for the model to emit coherently within its output-token budget.
+The tell (H155): the paired error `root: must have required property 'cards'`
++ `root: must NOT have additional properties` — i.e. the model emitted a bare
+card object (or wrong wrapper) instead of the `{cards:[…]}` envelope, because
+it ran out of room to build the whole structure.
+
+**Output complexity is a SUM of independent contributors. Any budget keyed on
+one contributor is blind to the others** — which is exactly why the
+citation-only presplit metric (`1+<ls>`) waved through a 35-sense card whose
+citations were trivial. Every fix so far has been "we discovered the *next*
+contributor." The taxonomy below enumerates them so we stop rediscovering
+them one production stall at a time.
+
+## Taxonomy of output-complexity drivers
+
+| # | Driver | What it is | First seen | Caught by | Status |
+|---|--------|-----------|-----------|-----------|--------|
+| 1 | **Citation density** | `<ls>` count per card; long citation lists per sense | Phase 0/4 — 150–200+ `<ls>` `pwg00` heads failed even solo | presplit citation trigger (`1+<ls> > OUTPUT_BUDGET`) + citation-weighted batch sizer | ✅ handled |
+| 2 | **Sense / fragment count** | numbered senses + prefix sub-blocks = one `sense` object each | H155 — `tyaj~~h0_zz_pw`, 35 senses / 11 `<ls>` | presplit **sense** trigger (`frag_count > SENSE_PRESPLIT_BUDGET`, H155) | ✅ handled per-card · ⚠️ **batch-level gap** (see #6) |
+| 3 | **Gloss-prose volume** | total `{%…%}` chars ≈ masked skeleton bytes; the model ECHOES german **and** writes russian ≈ 2× the skeleton | latent — a card with few senses/citations but long verbose definitions is large in *output tokens* | nothing structural today (input-byte size was refuted as a splitter heuristic in Phase 4, but that was INPUT bytes incl. portrait, not output gloss volume) | 🩹 kill-gate backstop only |
+| 4 | **Masked-token count** | `{Tn}` placeholders to reproduce verbatim, in order, in both fields | latent | partially — `accept()` fidelity guard rejects miscounts (a *different*, caught failure), but a `{Tn}`-heavy card can still stall before that | 🩹 partial + kill-gate backstop |
+| 5 | **Structural nesting / multi-layer** | multiple `<hom>` homonyms or stacked `=== LAYER: ===` blocks (PW/SCH/PWKVN addenda) | `_zz_pw` / `_zz_sch` class | insofar as layers inflate fragment count (→ #2); a 2-layer card with moderate senses each is not directly gated | 🩹 partial + kill-gate backstop |
+| 6 | **Batch-level SUM of any of the above** | several individually-fine cards whose combined output exceeds the limit | Phase 0 (original per-card-budget failures) | batch sizer sums **citations** only (`OUTPUT_BUDGET`); blind to summed **senses / gloss volume** | ⚠️ **gap — fixed this session for senses** (see below) |
+| — | *(non-stall failure classes, listed to avoid conflation)* | model calling file-read tools (Phase 2 yuj blowup, fixed: `tools:[]`); concurrency 429 transient nulls (Phase 3, process fix ≤3-wide); gate false-positives (Phases 5–6) | — | — | ✅ out of scope here |
+
+**The pattern across #1–#6:** they are all the same disease (too much output),
+surfacing through whichever attribute happened to spike first. A truly robust
+structural fix is a *composite* complexity estimate; but each additive change
+to the batch sizer risks re-calibrating the A/B-tuned `OUTPUT_BUDGET`, so we
+extend conservatively (per-card presplit triggers + a sense-aware batch
+sizer) and lean on the kill gate for the long tail.
+
+## Two-layer defense
+
+1. **Structural triggers (proactive).** Route a card to the fragment lane
+   *before* running it when a known driver predicts whole-card failure. Cheap,
+   deterministic, no wasted tokens. Covers #1 (citations) and #2 (senses)
+   today; #6 (batch senses) added this session. Can never cover an
+   *un-characterized* driver.
+2. **Wall-clock kill gate (reactive backstop).** For every driver we haven't
+   turned into a structural trigger (#3, #4, #5, and whatever #7 turns out to
+   be), detect the stall *at runtime* — "this call is taking far longer than a
+   call of its complexity should" — abandon it, and fall to the bounded
+   fragment lane instead of waiting out the full retry cap. This is MG's "if
+   it runs too long, kill it, don't wait for miracles."
+
+## Kill-gate design
+
+### Runtime constraints (probed 04-07-2026, `probe_runtime.js`)
+
+| Capability | Result | Consequence |
+|---|---|---|
+| `setTimeout` / `clearTimeout` | ✅ available | a **relative** timeout is possible — no `Date.now()` needed (which is banned in Workflow scripts, would break resume) |
+| `Promise.race([...])` | ✅ works | `Promise.race([agent(...), timeout])` cleanly returns whichever finishes first |
+| `AbortController` | ❌ undefined | **cannot truly cancel** the underlying agent — a killed call keeps running in the background until it dies on its own retry cap. But the harness stops *blocking* and the card recovers immediately via fragments. This is the accepted cost. |
+| `performance` | ❌ undefined | no high-res timer; irrelevant given `setTimeout` suffices |
+
+### Mechanism
+
+Wrap every schema-bearing `agent()` call in a race against a relative
+`setTimeout`:
+
+```
+budgetMs = clamp(KILL_FLOOR_MS, KILL_FACTOR × expectedMs(units), KILL_CEIL_MS)
+Promise.race([ agent(prompt, opts), rejectAfter(budgetMs) ])
+  → on timeout: noteFail(k, 'kill-timeout …') and route to the SAME fallback
+    as a hard agent() failure (selfheal for a batch, mark-missing for a heal
+    group). Never emit a partial/garbled card.
+```
+
+- `units` = the call's summed complexity in the same currency the sizer uses
+  (citations + senses), so the budget scales with what the call actually has
+  to emit.
+- `expectedMs(units)` = a linear model `base + slope × units` fitted from the
+  benchmark below.
+- `KILL_FACTOR = 2` — MG's "200% higher". A legit call should finish well
+  under 2× its expected time; a doomed stall (≥5× on H155) blows past it.
+- `KILL_FLOOR_MS` — a generous floor so network jitter on a tiny card never
+  trips it. `KILL_CEIL_MS` — a hard ceiling; nothing should ever run past it.
+- Default ON; `--no-kill` disables, `--kill-factor=N` tunes. Applies to the
+  main batch lane and the heal-group lane.
+
+### Why this is the right backstop, not a replacement for the triggers
+
+The kill gate does **not** save the tokens the doomed call already burned up
+to the timeout — without `AbortController` it can't. It saves the *rest*
+(the remaining retries and the binary-split cascade) and, crucially, unblocks
+the run so the card is recovered the cheap way. The structural triggers remain
+the primary defense (they spend **zero** doomed tokens); the kill gate is the
+net under the trapeze for drivers not yet on the trigger list.
+
+## Benchmark — per-`agent()`-call speed vs complexity
+
+Method: one full `tyaj` run (`--no-tm`, so every card genuinely translates),
+19 cards across all lanes; per-agent wall-clock = last − first `timestamp` in
+each `agent-*.jsonl` transcript, correlated to the call's complexity units.
+
+13 agent calls, `--no-tm`, 0 nulls. Skeleton bytes vs wall-clock (main-batch
+calls; fragment-lane calls omitted — their skel-byte attribution is per-group,
+not whole-card):
+
+| lane | cards/frags | Σ `<ls>` | Σ senses | skel bytes | wall-clock | ms / skel byte |
+|---|---|---|---|---|---|---|
+| batch | 3 | 34 | 1 | 744 | 15.7 s | 21.1 |
+| batch | 3 | 34 | 6 | 1182 | 19.8 s | 16.8 |
+| batch | 4 | 20 | 5 | 1118 | 27.0 s | 24.2 |
+| batch (`pari`, citation-dense) | 1 | 86 | 8 | 1801 | 32.5 s | 18.1 |
+| heal group (`sam`) | — | 34 | 6 | 1182 | 52.0 s | 44.0 ← slowest/byte |
+| batch | 5 | 83 | 4 | 1828 | 60.7 s | 33.2 |
+| batch (11 tiny no-fallback cards) | 11 | 62 | 5 | 2929 | 83.8 s | 28.6 |
+| `zz_pw` fragment groups (presplit) | 9–13 frags | — | — | — | 70–108 s | — |
+
+**Read:** wall-clock tracks **skeleton bytes** far better than `<ls>` or sense
+count alone (the citation-dense `pari` at 86 `<ls>` ran *faster* than the
+low-citation 11-card batch — because output volume, not citation count, is what
+takes time). Centre ≈ 25 ms/skel-byte; observed ceiling ≈ 44; nothing legit
+ran past 84 s. skeleton bytes are therefore the kill-gate's complexity signal.
+
+## Decisions
+
+Calibrated constants (in [`gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py),
+emitted into every harness; tunable via `--kill-factor=N` / `--no-kill`):
+
+| const | value | rationale |
+|---|---|---|
+| `KILL_FACTOR` | 2.0 | MG's "200%" — kill at 2× expected-for-complexity |
+| `KILL_BASE_MS` | 30 000 | fixed per-call latency (spin-up + framing) |
+| `KILL_SLOPE_MS` | 45 | ms per skel byte — set *above* the 44 ms/byte observed ceiling |
+| `KILL_FLOOR_MS` | 120 000 | never kill before 2 min (jitter guard on tiny calls) |
+| `KILL_CEIL_MS` | 480 000 | hard 8-min ceiling regardless of size |
+
+Resulting budgets (`FACTOR × (BASE + SLOPE × skelBytes)`, clamped): 744 B →
+127 s · 1182 B → 166 s · 1828 B → 225 s · 2929 B → 324 s · 3956 B → 416 s ·
+≥8 kB → 480 s (ceil). Every observed legit call (≤ 84 s) sits **far** under its
+budget; a stall at the full ~5-deep retry cap (the original `zz_pw` ~7 min at
+3956 B) blows past. Conservative on purpose — a false kill costs one selfheal,
+and we want *zero* on rollout; tighten `--kill-factor` once real runs confirm
+the envelope holds.
+
+**On kill:** `resolveGroup` marks the call's cards pending and `break`s so
+`BINARY_SPLIT` isolates the slow card (halves get proportionally smaller
+budgets), bottoming out to per-card selfheal; `healGroup` bisects the fragment
+group. A killed card is therefore **recovered**, never dropped. Proven in a
+zero-token behavioural test (`kill_mechanism_test.mjs`, 9/9) and a static
+harness-wiring selftest (`test_kill_gate_wired`).
+
+### What the kill gate is NOT
+
+It does **not** recover the tokens the doomed call already spent up to the
+timeout (no `AbortController`). It bounds the *tail* (remaining retries +
+binary-split cascade) and unblocks the run. The structural presplit triggers
+(#1, #2) remain the primary, zero-waste defense; the kill gate is the backstop
+for #3–#5 and the unknown. When a *new* stall class shows up in a real run,
+promote it from "caught by the kill gate" to its own structural trigger (as
+H155 did for senses) so the next occurrence spends zero doomed tokens.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -80,7 +80,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488"
+      "src/pilot/gen_opt_harness2.py": "132fb699c64c203e51abc7cc5ddf85d8aa075321dd7ebb7caeb2f5a0ff539e0c"
     }
   },
   {
@@ -98,8 +98,27 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488",
-      "src/pilot/window_selftest.py": "3a5702ee855139c23455c5eda758f6bdd26835d39afdab08ed0a06a2c50c44d3"
+      "src/pilot/gen_opt_harness2.py": "132fb699c64c203e51abc7cc5ddf85d8aa075321dd7ebb7caeb2f5a0ff539e0c",
+      "src/pilot/window_selftest.py": "47185b0c84a6b54d464039d037e1ab5fcc53c852f7dc75957a39626e071faff6"
+    }
+  },
+  {
+    "id": "wall_clock_kill_gate",
+    "mechanism": "Every schema-bearing agent() call is raced against a setTimeout budget scaled to its skeleton-byte output volume (KILL_FACTOR x (BASE + SLOPE x skelBytes)); a call that overruns is abandoned (KillTimeout) and its cards routed to the fragment lane, instead of waiting out the full StructuredOutput retry cap",
+    "files": [
+      "src/pilot/gen_opt_harness2.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "132fb699c64c203e51abc7cc5ddf85d8aa075321dd7ebb7caeb2f5a0ff539e0c",
+      "src/pilot/window_selftest.py": "47185b0c84a6b54d464039d037e1ab5fcc53c852f7dc75957a39626e071faff6"
     }
   },
   {
@@ -116,7 +135,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488"
+      "src/pilot/gen_opt_harness2.py": "132fb699c64c203e51abc7cc5ddf85d8aa075321dd7ebb7caeb2f5a0ff539e0c"
     }
   },
   {
@@ -133,7 +152,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488"
+      "src/pilot/gen_opt_harness2.py": "132fb699c64c203e51abc7cc5ddf85d8aa075321dd7ebb7caeb2f5a0ff539e0c"
     }
   },
   {
@@ -167,7 +186,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488"
+      "src/pilot/gen_opt_harness2.py": "132fb699c64c203e51abc7cc5ddf85d8aa075321dd7ebb7caeb2f5a0ff539e0c"
     }
   },
   {
@@ -184,7 +203,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488"
+      "src/pilot/gen_opt_harness2.py": "132fb699c64c203e51abc7cc5ddf85d8aa075321dd7ebb7caeb2f5a0ff539e0c"
     }
   },
   {
@@ -200,7 +219,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The bare 'sonnet' alias resolved to Sonnet 4.6 (not 5.0) on a prior EN run — pinned explicitly there after that surprise. RU's alias was never observed to misresolve, so it was left alone rather than touching a stable production path for a problem it doesn't have. Re-evaluate if RU is ever caught on a stale alias too.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488"
+      "src/pilot/gen_opt_harness2.py": "132fb699c64c203e51abc7cc5ddf85d8aa075321dd7ebb7caeb2f5a0ff539e0c"
     }
   },
   {
@@ -219,7 +238,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "audit_window_en.py reimplements its own gates from scratch rather than importing the RU modules (its own comment: 'the RU gate is wired around Russian-specific semantic checks'), so none of the 3 July fixes reached EN. EN cards from the same PWG/PW/SCH source have the same multi-layer/addenda structure, so the same false-positive classes plausibly apply there too.",
     "tracking": "spawned task chip task_d29bb788 (2026-07-04): 'Port RU gate fixes to audit_window_en.py' — running",
     "verified_sha256": {
-      "src/audit_coverage.py": "8c54aa22943140624238273b5bb6a2cbe9aceded5f8295cb84cd36bd994904c0",
+      "src/audit_coverage.py": "f9d224ff876a401008cd6d695cf4da71432f6a883255f7d1464758f2aa1cf79f",
       "src/pilot/prompt_rule_audit.py": "293b580cdf8866c8ae0d892dd77981e34561398e2c0142623aed1127740019b0",
       "src/pilot/audit_window.py": "2f9e418010d2ed9bc5c49be934eb95d672cae9ad3f01aa4099756dc7cf0e44a1",
       "src/pilot/audit_window_en.py": "4775368d2da38f0d6aede470d838becb6cc863de4914a785aa855baf45735fd8"
@@ -257,7 +276,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "572bb45477ce4856f6caba7e813e00a146bbeeedf3ae04b471e4616dafaa8935",
+      "src/promote_final_cards.py": "ed223728fce3e5c71449a2df56c333cc3ff64f9708bb97cdaa1d1e6442dd8dc1",
       "src/promote_en.py": "7d3ce9680e304fff8ba0bcaba843945c36c6f0894441a56e8695ec58a6b5ebfe"
     }
   },
@@ -276,8 +295,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488",
-      "src/pilot/window_selftest.py": "3a5702ee855139c23455c5eda758f6bdd26835d39afdab08ed0a06a2c50c44d3"
+      "src/pilot/gen_opt_harness2.py": "132fb699c64c203e51abc7cc5ddf85d8aa075321dd7ebb7caeb2f5a0ff539e0c",
+      "src/pilot/window_selftest.py": "47185b0c84a6b54d464039d037e1ab5fcc53c852f7dc75957a39626e071faff6"
     }
   },
   {
@@ -295,8 +314,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488",
-      "src/pilot/window_selftest.py": "3a5702ee855139c23455c5eda758f6bdd26835d39afdab08ed0a06a2c50c44d3"
+      "src/pilot/gen_opt_harness2.py": "132fb699c64c203e51abc7cc5ddf85d8aa075321dd7ebb7caeb2f5a0ff539e0c",
+      "src/pilot/window_selftest.py": "47185b0c84a6b54d464039d037e1ab5fcc53c852f7dc75957a39626e071faff6"
     }
   }
 ]

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -80,7 +80,26 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cde5e4c2243a293a9e958f7d76deae214489f3c61d4757d6404c3b47906c2433"
+      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488"
+    }
+  },
+  {
+    "id": "sense_presplit_trigger",
+    "mechanism": "Second, orthogonal presplit trigger: a card whose deterministic fragment count (== sense-objects the model must emit) exceeds SENSE_PRESPLIT_BUDGET (20) is routed straight to the fragment lane, catching SENSE-dense cards the citation metric (1+<ls>) is blind to",
+    "files": [
+      "src/pilot/gen_opt_harness2.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488",
+      "src/pilot/window_selftest.py": "3a5702ee855139c23455c5eda758f6bdd26835d39afdab08ed0a06a2c50c44d3"
     }
   },
   {
@@ -97,7 +116,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cde5e4c2243a293a9e958f7d76deae214489f3c61d4757d6404c3b47906c2433"
+      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488"
     }
   },
   {
@@ -114,7 +133,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cde5e4c2243a293a9e958f7d76deae214489f3c61d4757d6404c3b47906c2433"
+      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488"
     }
   },
   {
@@ -148,7 +167,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cde5e4c2243a293a9e958f7d76deae214489f3c61d4757d6404c3b47906c2433"
+      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488"
     }
   },
   {
@@ -165,7 +184,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cde5e4c2243a293a9e958f7d76deae214489f3c61d4757d6404c3b47906c2433"
+      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488"
     }
   },
   {
@@ -181,7 +200,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The bare 'sonnet' alias resolved to Sonnet 4.6 (not 5.0) on a prior EN run — pinned explicitly there after that surprise. RU's alias was never observed to misresolve, so it was left alone rather than touching a stable production path for a problem it doesn't have. Re-evaluate if RU is ever caught on a stale alias too.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cde5e4c2243a293a9e958f7d76deae214489f3c61d4757d6404c3b47906c2433"
+      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488"
     }
   },
   {
@@ -257,8 +276,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cde5e4c2243a293a9e958f7d76deae214489f3c61d4757d6404c3b47906c2433",
-      "src/pilot/window_selftest.py": "c0838db18869807a5b03da8b31542a38ffa10e17adfc8ba95ea9ebc0712b8a5a"
+      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488",
+      "src/pilot/window_selftest.py": "3a5702ee855139c23455c5eda758f6bdd26835d39afdab08ed0a06a2c50c44d3"
     }
   },
   {
@@ -276,8 +295,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cde5e4c2243a293a9e958f7d76deae214489f3c61d4757d6404c3b47906c2433",
-      "src/pilot/window_selftest.py": "c0838db18869807a5b03da8b31542a38ffa10e17adfc8ba95ea9ebc0712b8a5a"
+      "src/pilot/gen_opt_harness2.py": "2c0c6789f7b77b5dcf6964161ffcbef0c4c28a1ac55f79bef9f986dae9935488",
+      "src/pilot/window_selftest.py": "3a5702ee855139c23455c5eda758f6bdd26835d39afdab08ed0a06a2c50c44d3"
     }
   }
 ]

--- a/RussianTranslation/PIPELINE_HISTORY.md
+++ b/RussianTranslation/PIPELINE_HISTORY.md
@@ -180,6 +180,29 @@ same session rather than worked around:
    The `_zz_pw` addenda class was a known StructuredOutput-cap trigger
    (`gam~~h0_zz_pw01` hit it before and only recovered via selfheal after the
    doomed retries); this makes the recovery *immediate* instead of paid-for.
+6. **A wall-clock kill gate — the runtime backstop for the failure drivers
+   we haven't turned into structural triggers yet** (H155 follow-up, MG:
+   *"card complexity is sense-count — that's just one case; what else is
+   possible? Add a gate: if a translation runs too long, kill it, don't wait
+   for miracles"*). #5 fixes the *known* sense driver proactively, but the
+   taxonomy in [`FAILURE_MODES_AND_KILL_GATE_2026-07-04.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/FAILURE_MODES_AND_KILL_GATE_2026-07-04.md)
+   lists more (gloss-prose volume, masked-token count, multi-layer nesting,
+   batch-level sums, and whatever hasn't surfaced) — any single-metric budget
+   is blind to the others. So every schema-bearing `agent()` call is now raced
+   against a `setTimeout` budget scaled to its masked-skeleton byte volume
+   (the best time predictor — output ≈ 2× skeleton — measured from a 13-call
+   `tyaj --no-tm` benchmark: legit calls ran ≤ 84 s at ~25 ms/byte). A call
+   that overruns `KILL_FACTOR=2 ×` its expected time is abandoned and its cards
+   fall to the bounded fragment lane, instead of waiting out the full ~5-deep
+   retry cap. Runtime constraints shaped it: `setTimeout` works (a *relative*
+   timer — `Date.now()` is banned), but `AbortController` is absent, so a
+   killed call keeps running in the background until its own cap — the harness
+   just stops *blocking* on it. Default ON (`--no-kill` / `--kill-factor=N`);
+   proven by a zero-token behavioural test (9/9) + a static wiring selftest.
+   **The discipline going forward:** when a new stall class appears in a real
+   run, promote it from "caught by the kill gate" to its own structural
+   trigger (as #5 did for senses) so the next occurrence spends zero doomed
+   tokens.
 
 A cross-language audit also found that 3 of the Phase-6 gate-bug fixes
 never reached the EN audit path (a separate implementation,
@@ -303,6 +326,9 @@ likely the SAME class, not a new bug:
   is the exact loop, verbatim.
 - **Touching RU or EN-specific code?** → [`LANG_PARITY.md`](LANG_PARITY.md)'s
   policy: classify SHARED / INTENTIONAL-DIVERGENCE / GAP before closing out.
+- **A card/batch stalled, or wondering what else can blow the retry cap?** →
+  [`FAILURE_MODES_AND_KILL_GATE_2026-07-04.md`](FAILURE_MODES_AND_KILL_GATE_2026-07-04.md):
+  the full driver taxonomy + the wall-clock kill-gate design and calibration.
 - **What's queued/in-flight/blocked right now?** → [`.ai_state.md`](.ai_state.md),
   the live journal (this document doesn't replace it — it's the map, not the
   territory).

--- a/RussianTranslation/PIPELINE_HISTORY.md
+++ b/RussianTranslation/PIPELINE_HISTORY.md
@@ -161,6 +161,25 @@ same session rather than worked around:
    — any run whose harness emitted results in completion order rather than
    rootmap-declared order (the normal case) was wrongly refused as
    `stale_artifact`, blocking gates/glue outright. Fixed to compare as sets.
+5. **The presplit router was blind to SENSE density** (H155). `tyaj`'s drain
+   stalled ~7 min on one agent retrying the identical call and never
+   producing valid output — the `tyaj~~h0_zz_pw` PW addenda card compresses a
+   whole root article (base verb + Caus/Desid + every prefix combination)
+   into ~35 terse senses carrying only 11 `<ls>`, so its citation weight
+   `1+<ls>=12` ranked it among the *lightest* cards while its real output
+   surface (dozens of `{tag,german,russian}` sense objects + ~140 masked
+   tokens to reproduce exactly) was the *heaviest* — it deterministically
+   blew the whole-card StructuredOutput retry cap. The presplit router
+   (built in Phase 5 for the 150-`<ls>` citation giants) only measured
+   citations, so it waved this card through into a normal batch. Fixed by
+   adding a second, orthogonal presplit trigger keyed on the deterministic
+   fragment count (== sense-objects to emit) vs a new `SENSE_PRESPLIT_BUDGET`
+   (20; only ~0.2% of cards exceed it, a clean shelf above every known-good
+   whole-card head). Validated live: the `[sam, zz_pw]` pair that stalled now
+   returns ok:2/null:0 with `zz_pw` healed complete via 4 fragment groups.
+   The `_zz_pw` addenda class was a known StructuredOutput-cap trigger
+   (`gam~~h0_zz_pw01` hit it before and only recovered via selfheal after the
+   doomed retries); this makes the recovery *immediate* instead of paid-for.
 
 A cross-language audit also found that 3 of the Phase-6 gate-bug fixes
 never reached the EN audit path (a separate implementation,
@@ -243,6 +262,18 @@ likely the SAME class, not a new bug:
   and this session's presplit-agent-count bug undercounted exactly the same
   kind of thing: a card that needs to be broken into many pieces was priced
   as if it were one piece.
+- **A complexity metric tuned for one failure driver is blind to a second
+  one.** The presplit router priced output complexity as `1+<ls>` (citation
+  count), which correctly flags 150-`<ls>` citation giants but *silently
+  waves through* SENSE-dense cards — a PW `_zz_` addenda card can pack ~35
+  senses into ~11 `<ls>`, looking trivial by citations while being the
+  heaviest card to actually emit. Symptom: one agent stuck retrying the
+  identical `agent()` call for minutes on `root: must have required property
+  'cards' / must NOT have additional properties` (the model can't emit the
+  whole card as valid StructuredOutput, so it never returns `{cards:[…]}`).
+  If a card looks light but has dozens of senses, it belongs in the fragment
+  lane (H155 fix: the fragment-count trigger now routes it there). The
+  `_zz_pw`/`_zz_sch` addenda class is the usual suspect.
 - **A fix that lands on one language path doesn't automatically reach the
   other.** See [`LANG_PARITY.md`](LANG_PARITY.md), shipped this session
   specifically because this had already happened once (3 gate fixes,

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -99,6 +99,39 @@ SENSE_PRESPLIT_BUDGET = 20  # --sense-presplit-budget=N (0/off to disable). SECO
                    #  below it (sam 6, pari 8). Senses are far heavier per unit than citations
                    #  (sam translates fine at 34 <ls>), so this budget is intentionally much
                    #  lower than OUTPUT_BUDGET and independent of byte/citation batching mode.
+# --- wall-clock kill gate (H155 follow-up, 2026-07-04) ----------------------------
+# The structural presplit triggers above catch the KNOWN whole-card failure drivers
+# (citation + sense density) BEFORE a run. The kill gate is the runtime BACKSTOP for
+# the drivers we haven't characterized yet (gloss-prose volume, masked-token count,
+# multi-layer nesting, novel shapes — see FAILURE_MODES_AND_KILL_GATE_2026-07-04.md):
+# every schema-bearing agent() call is budgeted a wall-clock allowance scaled to its
+# complexity, and a call that runs past KILL_FACTOR x its expected time is abandoned
+# (the harness stops blocking and routes its cards to the bounded fragment lane)
+# instead of waiting out the full ~5-deep StructuredOutput retry cap (the ~7-min
+# tyaj~~h0_zz_pw stall MG stopped by hand). Implemented in-JS with setTimeout (a
+# RELATIVE timer — Date.now() is banned in Workflow scripts); AbortController is
+# unavailable in the runtime, so an abandoned call keeps running in the background
+# until it dies on its own cap — we stop WAITING on it, which is the win.
+# Budget model (fitted from the tyaj --no-tm benchmark, 13 agent calls, 2026-07-04):
+# a call's expected ms ~= KILL_BASE_MS + KILL_SLOPE_MS * skel_bytes, where skel_bytes =
+# the summed MASKED-SKELETON byte length of the call's cards/fragments. Skeleton bytes
+# are the best single time predictor because the model's OUTPUT is ~2x the skeleton (echo
+# the german + write the russian), and they are a natural COMPOSITE of every driver in
+# FAILURE_MODES_AND_KILL_GATE_2026-07-04.md — citations (as {Tn}), senses (more lines),
+# and gloss prose all land in the skeleton. Benchmark: legit main-batch calls ran
+# ~25 ms/skel_byte (max ~44 on a slow-variance call), 16-84 s wall-clock. The SLOPE below
+# is set ABOVE the observed ceiling and then KILL_FACTOR is applied on top, so no legit
+# call (even a +50% variance one) is ever killed, while a doomed stall (the ~7-min
+# zz_pw retry-cap loop = ~5x normal) blows past. Budget = KILL_FACTOR * (BASE + SLOPE *
+# skel_bytes), clamped to [KILL_FLOOR_MS, KILL_CEIL_MS]. Conservative first cut on
+# purpose (a false kill costs one selfheal, but we still want zero of them on rollout);
+# tighten with --kill-factor once real runs confirm the envelope.
+KILL = True                 # --no-kill disables; --kill-factor=N tunes the multiple
+KILL_FACTOR = 2.0           # MG's "200%": kill a call at 2x its expected-for-complexity time
+KILL_BASE_MS = 30000        # fixed per-call latency (model spin-up + fixed framing)
+KILL_SLOPE_MS = 45          # ms per masked-skeleton byte (above the ~44 ms/byte observed ceiling)
+KILL_FLOOR_MS = 120000      # never kill before 2 min (jitter guard on tiny calls)
+KILL_CEIL_MS = 480000       # hard ceiling — nothing runs past 8 min even at max size
 
 
 def grammar_text(root):
@@ -224,6 +257,12 @@ def parse_args(argv):
         elif a.startswith('--sense-presplit-budget='):
             v = a.split('=', 1)[1].strip().lower()
             globals()['SENSE_PRESPLIT_BUDGET'] = None if v in ('off', '0', 'none') else int(v)
+        elif a == '--no-kill':
+            globals()['KILL'] = False
+        elif a == '--kill':
+            globals()['KILL'] = True         # default; kept for documented runbooks
+        elif a.startswith('--kill-factor='):
+            globals()['KILL_FACTOR'] = float(a.split('=', 1)[1])
         elif a == '--binary-split':
             globals()['BINARY_SPLIT'] = True # default since 2026-07-02; kept for documented runbooks
         elif a == '--no-binary-split':
@@ -575,6 +614,8 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
             die('mask round-trip not lossless for %s' % k)
         inputs[k] = {'skeleton': skel, 'portrait': portrait,
                      'ls': raw.count('<ls'), 'sk': raw.count('{#'),
+                     'senses': raw.count('〉'),  # '〉' sense-delimiter count — coarse
+                                                     # output-complexity signal for the kill budget
                      'nws': 1 if 'NWS' in raw else 0}
         raws[k] = raw
         portraits[k] = portrait
@@ -783,6 +824,9 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         'selfheal_cards': {k: len(v) for k, v in frags.items()} if SELFHEAL else {},
         'binary_split': BINARY_SPLIT, 'output_budget': OUTPUT_BUDGET,
         'sense_presplit_budget': SENSE_PRESPLIT_BUDGET if SELFHEAL else None,
+        'kill': KILL,
+        'kill_gate': ({'factor': KILL_FACTOR, 'base_ms': KILL_BASE_MS, 'slope_ms': KILL_SLOPE_MS,
+                       'floor_ms': KILL_FLOOR_MS, 'ceil_ms': KILL_CEIL_MS} if KILL else None),
         'presplit_keys': presplit,
         'tm': os.path.basename(tm_path) if tm_path else None,
         'tm_auto': bool(tm_auto),
@@ -828,6 +872,13 @@ const FRAGS = %(frags)s
 const PHF = %(phf)s
 const BINARY_SPLIT = %(binary_split)s
 const PRESPLIT = %(presplit)s
+// Wall-clock kill gate (H155 follow-up). See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.
+const KILL = %(kill)s
+const KILL_FACTOR = %(kill_factor)s
+const KILL_BASE_MS = %(kill_base_ms)s
+const KILL_SLOPE_MS = %(kill_slope_ms)s
+const KILL_FLOOR_MS = %(kill_floor_ms)s
+const KILL_CEIL_MS = %(kill_ceil_ms)s
 // --tm: cards pre-resolved from the content-addressed translation memory (source-SHA hit).
 // Emitted verbatim as canonical rows with tm:true and NO agent() call — their markup is
 // already restored (they come from the promoted store), so they bypass restore/accept.
@@ -851,6 +902,27 @@ const countOf = (card, re) => { let n = 0; for (const rec of (card.records || []
 // per-row (results[].error) and in summary.failures.
 const FAIL = {}
 const noteFail = (k, why) => { FAIL[k] = String(why).slice(0, 300) }
+// --- wall-clock kill gate ---------------------------------------------------------
+// Budget each schema-bearing agent() call a wall-clock allowance scaled to its output
+// volume (skelBytes = summed masked-skeleton length of its cards/fragments — the model's
+// output is ~2x this, and it's a natural composite of every failure driver); a call that
+// runs past KILL_FACTOR x its expected time is abandoned so the caller can fall to the
+// bounded fragment lane instead of waiting out the full StructuredOutput retry cap.
+// setTimeout is a RELATIVE timer (Date.now() is banned in the runtime); AbortController
+// is unavailable, so an abandoned call keeps running in the background until it dies on
+// its own cap — we stop BLOCKING on it, which is the whole point.
+class KillTimeout extends Error {}
+const isKill = e => (e instanceof KillTimeout) || (e && /kill-timeout/.test(String(e && e.message)))
+const killBudgetMs = skelBytes => Math.min(KILL_CEIL_MS, Math.max(KILL_FLOOR_MS, KILL_FACTOR * (KILL_BASE_MS + KILL_SLOPE_MS * skelBytes)))
+const skelBytesOfKeys = keys => keys.reduce((n, k) => n + (INPUTS[k] ? INPUTS[k].skeleton.length : 0), 0)
+async function agentKill(prompt, opts, skelBytes) {
+  if (!KILL) return agent(prompt, opts)
+  const ms = killBudgetMs(skelBytes)
+  let timer
+  const guard = new Promise((_, rej) => { timer = setTimeout(() => rej(new KillTimeout('kill-timeout ' + Math.round(ms / 1000) + 's @ skelBytes=' + skelBytes)), ms) })
+  try { return await Promise.race([agent(prompt, opts), guard]) }
+  finally { clearTimeout(timer) }
+}
 // Masked-token multiset of a text: the {Tn} placeholders it carries, order-insensitive.
 // Two texts with equal token multisets restore to identical citation/markup content.
 const tokensOf = t => ((t || '').match(/\\{T\\d+\\}/g) || []).sort().join(' ')
@@ -912,7 +984,16 @@ async function healGroup(k, idxs, grp, label) {
   for (let att = 0; att < 3 && pending.length; att++) {
     const blocks = pending.map(i => '\\n\\n=== CARD ' + fkey(i) + ' (fragment ' + (i + 1) + '/' + grp.length + ') ===\\n--- masked German (translatable only; {Tn}=masked span) ---\\n' + grp[i].skeleton).join('')
     const prompt = PREAMBLE + GRAMMAR + CONV_TR + blocks
-    const res = await agent(prompt, { label: label + '[' + pending.length + ']' + (att ? '(r' + att + ')' : ''), phase: 'Translate', schema: CARDS_SCHEMA, model: '%(model)s', tools: [] })
+    const gskel = pending.reduce((n, fi) => n + (grp[fi].skeleton ? grp[fi].skeleton.length : 0), 0)
+    let res
+    try {
+      res = await agentKill(prompt, { label: label + '[' + pending.length + ']' + (att ? '(r' + att + ')' : ''), phase: 'Translate', schema: CARDS_SCHEMA, model: '%(model)s', tools: [] }, gskel)
+    } catch (e) {
+      if (!isKill(e)) throw e   // real hard failure — propagate (caught by selfHeal's per-group try)
+      pending.forEach(fi => noteFail(fkey(fi), e.message))
+      log(label + ': ' + e.message + ' — abandoned, bisecting ' + pending.length + ' fragment(s)')
+      break   // stop retrying this group; fall to the bisection below (smaller, cheaper halves)
+    }
     if (res && Array.isArray(res.cards)) {
       const km = byKey1(res.cards)
       // match by echoed key1 first; fall back to position within the pending set
@@ -1059,7 +1140,18 @@ async function resolveGroup(pending, label) {
     // (full mode: NWS_RULE is '' and the NWS rule already lives inside CONV_TR).
     const nws = (NWS_RULE && cur.some(k => INPUTS[k].nws)) ? ('\\n\\n' + NWS_RULE + '\\n') : ''
     const prompt = PREAMBLE + GRAMMAR + CONV_TR + nws + cur.map(cardBlock).join('')
-    const res = await agent(prompt, { label: label + '[' + cur.length + ']' + (attempt ? '(retry)' : ''), phase: 'Translate', schema: CARDS_SCHEMA, model: '%(model)s', tools: [] })
+    let res
+    try {
+      res = await agentKill(prompt, { label: label + '[' + cur.length + ']' + (attempt ? '(retry)' : ''), phase: 'Translate', schema: CARDS_SCHEMA, model: '%(model)s', tools: [] }, skelBytesOfKeys(cur))
+    } catch (e) {
+      if (!isKill(e)) throw e   // real hard failure — propagate as before (translateBatch -> selfheal)
+      // Kill: stop RE-billing this whole call — a stall re-times-out identically. Mark the
+      // still-pending cards and break so BINARY_SPLIT can isolate the slow one (smaller halves
+      // get proportionally smaller budgets), bottoming out to selfHeal per card.
+      cur.forEach(k => noteFail(k, e.message))
+      log(label + ': ' + e.message + ' — abandoned, routing ' + cur.length + ' card(s) to split/heal')
+      break
+    }
     if (res && Array.isArray(res.cards)) {
       // Match responses by their echoed key1 FIRST, position second. Positional-only
       // matching shifts every card after an omitted/reordered one onto the wrong key;
@@ -1205,6 +1297,9 @@ return { meta: META, summary, results: out }
         'phmaps': json.dumps(phmaps, ensure_ascii=True), 'meta': json.dumps(meta, ensure_ascii=True),
         'frags': json.dumps(frags, ensure_ascii=True), 'phf': json.dumps(phf, ensure_ascii=True),
         'binary_split': json.dumps(BINARY_SPLIT), 'presplit': json.dumps(presplit),
+        'kill': json.dumps(KILL), 'kill_factor': json.dumps(KILL_FACTOR),
+        'kill_base_ms': json.dumps(KILL_BASE_MS), 'kill_slope_ms': json.dumps(KILL_SLOPE_MS),
+        'kill_floor_ms': json.dumps(KILL_FLOOR_MS), 'kill_ceil_ms': json.dumps(KILL_CEIL_MS),
         'tm_resolved': json.dumps(tm_resolved, ensure_ascii=True),
         'degenerate_resolved': json.dumps(degenerate_resolved, ensure_ascii=True),
         'frag_tm': json.dumps(frag_tm, ensure_ascii=True),

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -79,6 +79,26 @@ OUTPUT_BUDGET = 90 # DEFAULT 90 citation-weighted units since 2026-07-03 (raised
                    #  Byte mode is still reachable: an EXPLICIT --budget=N (without
                    #  --output-budget) or --output-budget=off — keeps documented byte-budget
                    #  invocations (e.g. FU1 --budget=6000) exact.
+SENSE_PRESPLIT_BUDGET = 20  # --sense-presplit-budget=N (0/off to disable). SECOND, orthogonal
+                   #  presplit trigger added 2026-07-04 (H155, tyaj~~h0_zz_pw stall). The
+                   #  citation metric (1 + <ls>) predicts whole-card StructuredOutput failure for
+                   #  CITATION giants (150-<ls> pwg00 heads) but is BLIND to SENSE-dense cards: a
+                   #  PW addenda card that compresses a whole root article (base verb + Caus/Desid
+                   #  + every prefix combination) can carry ~35 senses in only ~11 <ls>, so its
+                   #  1+<ls>=12 weight ranks it as one of the LIGHTEST cards while its actual
+                   #  output surface (dozens of {tag,german,russian} sense objects + reproducing
+                   #  ~140 masked tokens in exact positions) is the HEAVIEST — deterministically
+                   #  blowing the retry cap as a whole card (tyaj~~h0_zz_pw: 35 senses, stalled
+                   #  ~7 min retrying the identical call before MG stopped it; the gam~~h0_zz_pw01
+                   #  precedent hit the cap and only recovered via selfheal). A card whose
+                   #  deterministic FRAGMENT count (== sense-units the model must emit) exceeds
+                   #  this budget is routed STRAIGHT to the proven fragment lane, same as the
+                   #  citation giants — converting up-to-5 doomed retries + binary-split cascade
+                   #  into zero. Threshold 20 sits on a clean shelf: only ~0.2% of cards carry
+                   #  >20 senses (survey 2026-07-04), and every known-good whole-card head is far
+                   #  below it (sam 6, pari 8). Senses are far heavier per unit than citations
+                   #  (sam translates fine at 34 <ls>), so this budget is intentionally much
+                   #  lower than OUTPUT_BUDGET and independent of byte/citation batching mode.
 
 
 def grammar_text(root):
@@ -201,6 +221,9 @@ def parse_args(argv):
             globals()['SELFHEAL'] = False
         elif a.startswith('--selfheal-budget='):
             globals()['SELFHEAL_GROUP_BUDGET'] = int(a.split('=', 1)[1])
+        elif a.startswith('--sense-presplit-budget='):
+            v = a.split('=', 1)[1].strip().lower()
+            globals()['SENSE_PRESPLIT_BUDGET'] = None if v in ('off', '0', 'none') else int(v)
         elif a == '--binary-split':
             globals()['BINARY_SPLIT'] = True # default since 2026-07-02; kept for documented runbooks
         elif a == '--no-binary-split':
@@ -616,7 +639,7 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
             print('  frag-tm: %d cached fragment(s) available from %s'
                   % (len(frag_cache), os.path.basename(frag_file)))
 
-    frags, phf, frag_tm = {}, {}, {}
+    frags, phf, frag_tm, frag_n = {}, {}, {}, {}
     if SELFHEAL:
         import translation_memory as _tm
         for k in keys:
@@ -649,6 +672,8 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
             if not fl:
                 continue
             groups = _group_by_budget(fl, lambda it: 1 + it['ls'], SELFHEAL_GROUP_BUDGET)
+            frag_n[k] = len(pl)   # raw deterministic fragment count == sense-units the model
+                                  # must emit; drives the sense-density presplit trigger below
             frags[k] = [[{'skeleton': it['skeleton'], 'ls': it['ls'], 'sk': it['sk'],
                           'fsha': it['fsha'], 'si': it['si']} for it in g] for g in groups]
             phf[k] = [[it['ph'] for it in g] for g in groups]
@@ -659,21 +684,39 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
             if any(slot for grp in gview for slot in grp):
                 frag_tm[k] = gview
 
-    # Pre-split router (MG decision 2026-07-02): a card whose citation-weighted output
-    # complexity (1 + <ls>) alone exceeds the WHOLE per-batch output budget is near-certain
-    # to blow the StructuredOutput retry cap as a whole card (observed: the 125-<ls> pwg00
-    # heads failed even solo — HANDOFF_2026-07-01_pwg_en_fu1_finalize.md), and every one of
-    # those up-to-5 retries is paid-for waste. Route such cards STRAIGHT to the proven
-    # selfheal fragment path at run time instead of letting them fail first. Only cards with
-    # a usable fragment fallback are routed; unsplittable ones keep the old solo-batch try.
+    # Pre-split router (MG decision 2026-07-02): a card whose output complexity alone is
+    # near-certain to blow the StructuredOutput retry cap as a whole card is routed STRAIGHT to
+    # the proven selfheal fragment path at run time instead of letting it fail first (every one
+    # of those up-to-5 retries + the binary-split cascade is paid-for waste). TWO orthogonal
+    # triggers, because two independent things drive whole-card failure:
+    #   (a) CITATION density — 1 + <ls> exceeds the whole per-batch output budget (the 125-150
+    #       <ls> pwg00 heads failed even solo — HANDOFF_2026-07-01_pwg_en_fu1_finalize.md).
+    #   (b) SENSE density — the deterministic fragment count (== sense-objects the model must
+    #       emit) exceeds SENSE_PRESPLIT_BUDGET. A PW addenda card can pack ~35 senses into ~11
+    #       <ls>, so (a) sees weight 12 and waves it through while its real output surface is the
+    #       heaviest of the root — the tyaj~~h0_zz_pw stall (H155, 2026-07-04). Independent of
+    #       byte/citation batching mode: a sense-dense card fails whole regardless of how the
+    #       OTHER cards are batched.
+    # Only cards with a usable fragment fallback are routed; unsplittable ones keep the old
+    # solo-batch try.
     presplit = []
-    if SELFHEAL and OUTPUT_BUDGET is not None:
-        presplit = [k for k in keys
-                    if k not in tm_keys and k not in degenerate_keys
-                    and (1 + inputs[k]['ls']) > OUTPUT_BUDGET and k in frags]
-        for k in presplit:
-            print('  presplit: %s (%d <ls> exceeds output budget %d) -> direct fragment translation'
-                  % (k, inputs[k]['ls'], OUTPUT_BUDGET))
+    if SELFHEAL:
+        cite_budget = OUTPUT_BUDGET  # None in byte mode -> citation trigger off, sense trigger stays
+        for k in keys:
+            if k in tm_keys or k in degenerate_keys or k not in frags:
+                continue
+            cite_hit = cite_budget is not None and (1 + inputs[k]['ls']) > cite_budget
+            sense_hit = SENSE_PRESPLIT_BUDGET is not None and frag_n.get(k, 0) > SENSE_PRESPLIT_BUDGET
+            if not (cite_hit or sense_hit):
+                continue
+            presplit.append(k)
+            why = []
+            if cite_hit:
+                why.append('%d <ls> exceeds output budget %d' % (inputs[k]['ls'], cite_budget))
+            if sense_hit:
+                why.append('%d senses/fragments exceed sense budget %d'
+                           % (frag_n[k], SENSE_PRESPLIT_BUDGET))
+            print('  presplit: %s (%s) -> direct fragment translation' % (k, '; '.join(why)))
     batch_keys = [k for k in keys if k not in presplit and k not in tm_keys and k not in degenerate_keys]
 
     # --output-budget=N (default 60): size batches by citation-weighted OUTPUT complexity
@@ -739,6 +782,7 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         'selfheal': SELFHEAL, 'selfheal_group_budget': SELFHEAL_GROUP_BUDGET if SELFHEAL else None,
         'selfheal_cards': {k: len(v) for k, v in frags.items()} if SELFHEAL else {},
         'binary_split': BINARY_SPLIT, 'output_budget': OUTPUT_BUDGET,
+        'sense_presplit_budget': SENSE_PRESPLIT_BUDGET if SELFHEAL else None,
         'presplit_keys': presplit,
         'tm': os.path.basename(tm_path) if tm_path else None,
         'tm_auto': bool(tm_auto),

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -139,7 +139,10 @@ def test_harness_scope_and_tools():
     if meta.get('selected_keys') != current.get('selected_keys'):
         fail('optimized harness selected_keys do not match current rootmap selection')
     text = open(meta['path'], encoding='utf-8').read()
-    agent_calls = text.count('agent(prompt, {')
+    # Every schema-bearing model call must carry tools: [] (the yuj file-read-blowup guard).
+    # Since the kill gate (H155 follow-up) the call sites go through agentKill(prompt, {..}),
+    # not a bare agent(prompt, {..}); count both so the guard still holds whichever is used.
+    agent_calls = text.count('agentKill(prompt, {') + text.count('agent(prompt, {')
     tool_guards = text.count('tools: []')
     if agent_calls != tool_guards or not tool_guards:
         fail('optimized harness tools guard mismatch: %d agent calls, %d guards' %
@@ -1723,6 +1726,69 @@ def test_sense_dense_card_presplit():
         shutil.rmtree(d, ignore_errors=True)
 
 
+def test_kill_gate_wired():
+    """H155 follow-up (2026-07-04): the wall-clock kill gate must be wired into every
+    schema-bearing agent() call so a stalled/doomed call (the ~7-min tyaj~~h0_zz_pw
+    retry-cap loop, or any un-characterized future driver) is abandoned at KILL_FACTOR x
+    its expected-for-complexity time and routed to the bounded fragment lane — instead of
+    burning the full StructuredOutput retry cap. Static regression guard on the generated
+    harness: the kill consts render, the budget helper + both call sites use agentKill,
+    INPUTS carries the skeleton (the complexity signal), and --no-kill disables it."""
+    import re as _re
+    import gen_opt_harness2 as gh
+    raw = ('=== LAYER: PW — Böhtlingk kürzere Fassung ===\n\n'
+           '<hom>1.</hom> √{#gam#}¦ <ls>X. 1</ls>.\n'
+           '<div n="1">— 1〉 {%verlassen%} <ls>Y. 2</ls>.\n')
+    key = 'zz~~synthetic_kill'
+    d = tempfile.mkdtemp()
+    try:
+        rp = os.path.join(d, key + '.raw.txt')
+        pp = os.path.join(d, key + '.portrait.json')
+        with open(rp, 'w', encoding='utf-8') as f:
+            f.write(raw)
+        with open(pp, 'w', encoding='utf-8') as f:
+            f.write('[]')
+        saved_ip = gh.input_paths
+        gh.input_paths = lambda k, input_dir=None: (rp, pp) if k == key else saved_ip(k)
+        try:
+            js, _b = gh.build('zz', [key], None, 12000, nominal=True, grammar_on=False, tm_path=None)
+            # consts present with the calibrated defaults
+            if 'const KILL = true' not in js:
+                fail('kill gate must default ON (const KILL = true) in the generated harness')
+            for c in ('KILL_FACTOR', 'KILL_BASE_MS', 'KILL_SLOPE_MS', 'KILL_FLOOR_MS', 'KILL_CEIL_MS'):
+                if not _re.search(r'^const %s = [0-9.]+$' % c, js, _re.M):
+                    fail('kill const %s missing/malformed in the generated harness' % c)
+            # helper + BOTH call sites (resolveGroup main lane + healGroup fragment lane) use it
+            n = js.count('agentKill(')
+            if n < 3:
+                fail('agentKill must appear 3x (definition + main-batch call + heal-group call); '
+                     'got %d — a call site is unguarded' % n)
+            if 'class KillTimeout' not in js or 'const isKill' not in js:
+                fail('KillTimeout/isKill classifier must be present so a kill is distinguished '
+                     'from a real hard failure')
+            # the complexity signal (skeleton bytes) must be carried per card
+            inputs = json.loads(_re.search(r'^const INPUTS = (\{.*?\})\nconst PH', js, _re.S | _re.M).group(1))
+            if 'skeleton' not in inputs[key] or 'senses' not in inputs[key]:
+                fail('INPUTS must carry skeleton (kill-budget signal) + senses; got keys %r'
+                     % sorted(inputs[key]))
+            meta = json.loads(_re.search(r'^const META = (\{.*\})\n', js, _re.M).group(1))
+            if not meta.get('kill') or not meta.get('kill_gate'):
+                fail('meta must record the kill-gate provenance (kill + kill_gate)')
+            # --no-kill disables it
+            saved_kill = gh.KILL
+            gh.KILL = False
+            try:
+                js2, _b2 = gh.build('zz', [key], None, 12000, nominal=True, grammar_on=False, tm_path=None)
+            finally:
+                gh.KILL = saved_kill
+            if 'const KILL = false' not in js2:
+                fail('--no-kill / KILL=False must render const KILL = false (disables the gate)')
+        finally:
+            gh.input_paths = saved_ip
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def main():
     tests = [
         test_translation_memory_addressing,
@@ -1742,6 +1808,7 @@ def main():
         test_cit_split_never_tears_open_span,
         test_selfheal_fragment_si_threaded_and_tags_normalized,
         test_sense_dense_card_presplit,
+        test_kill_gate_wired,
         test_autosplit_topup_targets_and_reassembles,
         test_workflow_payload_nested,
         test_sense_dupe_batch_override,

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -1664,6 +1664,65 @@ def test_selfheal_fragment_si_threaded_and_tags_normalized():
                 os.remove(p)
 
 
+def test_sense_dense_card_presplit():
+    """H155 (2026-07-04): a SENSE-dense card must presplit even when its CITATION weight
+    (1+<ls>) is FAR below the output budget. A PW addenda card compresses a whole root article
+    (base verb + Caus/Desid + every prefix combination) into dozens of terse senses carrying
+    few citations, so the citation metric (1+<ls>) ranks it as one of the LIGHTEST cards while
+    its real output surface (dozens of {tag,german,russian} sense objects) is the HEAVIEST — it
+    deterministically blows the whole-card StructuredOutput retry cap (tyaj~~h0_zz_pw: 35 senses
+    in 11 <ls>, weight 12, stalled ~7 min retrying the identical call). The fragment-count
+    trigger (frag count > SENSE_PRESPLIT_BUDGET) routes it straight to the proven fragment lane,
+    same as the citation giants — independent of the citation trigger and of byte/citation
+    batching mode. Uses a synthetic card (30 senses, 1 <ls>) so it never depends on a specific
+    corpus fixture."""
+    import gen_opt_harness2 as gh
+    senses = '\n'.join('<div n="1">— %d〉 {%%Bedeutung %d%%}.' % (i, i)
+                       for i in range(1, 31))
+    raw = ('=== LAYER: PW — Böhtlingk kürzere Fassung ===\n\n'
+           '<hom>1.</hom> √{#gam#}¦ <ls>X. 1</ls>.\n' + senses + '\n')
+    key = 'zz~~synthetic_sense_dense'
+    d = tempfile.mkdtemp()
+    try:
+        rp = os.path.join(d, key + '.raw.txt')
+        pp = os.path.join(d, key + '.portrait.json')
+        with open(rp, 'w', encoding='utf-8') as f:
+            f.write(raw)
+        with open(pp, 'w', encoding='utf-8') as f:
+            f.write('[]')  # empty portrait — exactly the real tyaj~~h0_zz_pw shape
+        saved_ip = gh.input_paths
+        gh.input_paths = lambda k, input_dir=None: (rp, pp) if k == key else saved_ip(k)
+        try:
+            # citation weight 1+<ls>=2 is far below OUTPUT_BUDGET(90): only the SENSE trigger
+            # can route this card. nominal mode makes the key its own card (no rootmap needed).
+            js, batches = gh.build('zz', [key], None, 12000, nominal=True, grammar_on=False, tm_path=None)
+            import re as _re
+            presplit = json.loads(_re.search(r'^const PRESPLIT = (.*)$', js, _re.M).group(1))
+            batched = {k for b in batches for k in b}
+            if key not in presplit:
+                fail('a sense-dense card (30 senses, 1 <ls>) must be routed to presplit by the '
+                     'fragment-count trigger; got PRESPLIT=%r batches=%r' % (presplit, batches))
+            if key in batched:
+                fail('a presplit card must be pulled OUT of the whole-card batch lane, got it in '
+                     '%r' % (batches,))
+            # the citation trigger alone must NOT explain it (proves the sense trigger is load-
+            # bearing): with the sense trigger disabled, the card falls back to a batch.
+            saved_sb = gh.SENSE_PRESPLIT_BUDGET
+            gh.SENSE_PRESPLIT_BUDGET = None
+            try:
+                js2, batches2 = gh.build('zz', [key], None, 12000, nominal=True, grammar_on=False, tm_path=None)
+                presplit2 = json.loads(_re.search(r'^const PRESPLIT = (.*)$', js2, _re.M).group(1))
+            finally:
+                gh.SENSE_PRESPLIT_BUDGET = saved_sb
+            if key in presplit2:
+                fail('with --sense-presplit-budget=off the citation-light card must NOT presplit '
+                     '(only the sense trigger should route it); got PRESPLIT=%r' % presplit2)
+        finally:
+            gh.input_paths = saved_ip
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def main():
     tests = [
         test_translation_memory_addressing,
@@ -1682,6 +1741,7 @@ def main():
         test_no_fallback_batch_isolation,
         test_cit_split_never_tears_open_span,
         test_selfheal_fragment_si_threaded_and_tags_normalized,
+        test_sense_dense_card_presplit,
         test_autosplit_topup_targets_and_reassembles,
         test_workflow_payload_nested,
         test_sense_dupe_batch_override,


### PR DESCRIPTION
Two whole-card StructuredOutput reliability fixes for the PWG→RU/EN batch harness, from the `tyaj~~h0_zz_pw` ~7-minute stall MG caught live during the H151 verb-batch drain. Re-landed cleanly off current `master` (replaces the diverged #129).

## 1. Sense-density presplit trigger (H155)

**Root cause:** the presplit router prices output complexity as `1+<ls>` (citation count), **blind to sense density**. `tyaj~~h0_zz_pw` — a PW addenda card compressing a whole root article — packs **35 senses into 11 `<ls>`**, so its weight `1+<ls>=12` ranked it among the *lightest* cards while its real output surface (dozens of `{tag,german,russian}` objects + ~140 masked tokens) was the *heaviest*. It deterministically blew the whole-card StructuredOutput retry cap and never emitted `{cards:[…]}`. Not a broken schema (one shared const across all 5 batches — only this batch failed) and not model variance (identical error every retry).

**Fix:** a second, orthogonal presplit trigger keyed on the deterministic fragment count (== sense-objects to emit) vs `SENSE_PRESPLIT_BUDGET=20` (only ~0.2% of cards exceed it). Sense-dense cards route straight to the proven fragment lane. **Validated live:** the `[sam, zz_pw]` pair that stalled now returns `ok:2 / null:0`, zz_pw healed complete via 4 fragment groups.

## 2. Wall-clock kill gate + failure-mode taxonomy (follow-up)

Answering MG's "sense-count is just one case — what else? add a gate: if it runs too long, kill it, don't wait for miracles."

- **Taxonomy** — `FAILURE_MODES_AND_KILL_GATE_2026-07-04.md` enumerates every whole-card/batch stall driver from the pipeline timeline: citations (#1 ✅), senses (#2 ✅ H155), gloss-prose volume (#3), masked-token count (#4), multi-layer nesting (#5), batch-level sums (#6). All the same disease (too much output); any single-metric budget is blind to the rest.
- **Kill gate** — the runtime backstop for the un-triggered drivers. Every schema-bearing `agent()` call is raced against a `setTimeout` budget scaled to its masked-skeleton byte volume (best time predictor — output ≈ 2× skeleton). Overrun by `KILL_FACTOR=2×` → abandoned, cards routed to the bounded fragment lane instead of the full ~5-deep retry cap. On kill, `resolveGroup` breaks to `BINARY_SPLIT` and `healGroup` bisects — a killed card is **recovered, never dropped**.
- **Runtime constraints** (probed): `setTimeout`/`Promise.race` work (relative timer; `Date.now()` is banned), but **no `AbortController`** — a killed call keeps running in the background until its own cap; the harness just stops blocking. Constants calibrated from a 13-call `tyaj --no-tm` benchmark (legit calls ≤84s @ ~25 ms/skel-byte): BASE 30s, SLOPE 45ms/byte, FLOOR 120s, CEIL 480s. Default ON; `--no-kill` / `--kill-factor=N`.

## Tests & parity
- `window_selftest.py` **49/49 green** (incl. master's `test_cit_split_never_tears_open_span` from #127) — new `test_sense_dense_card_presplit` + `test_kill_gate_wired`. `test_harness_scope_and_tools` updated for the `agentKill` wrapper (the `tools: []` guard still enforced).
- Kill mechanism proven behaviourally (zero-token node test, 9/9).
- `LANG_PARITY.md`: `sense_presplit_trigger` + `wall_clock_kill_gate` both **SHARED** (lang-agnostic); gate clean (14 entries).
- `PIPELINE_HISTORY.md` Phase 8 #5/#6 + recurring-failure-patterns updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)