### PR TITLE
chore: gitignore .claude/settings.local.json

### DIFF
--- a/RussianTranslation/.gitignore
+++ b/RussianTranslation/.gitignore
@@ -1,4 +1,7 @@
 
+# Claude Code local session config — not a deliverable, differs per machine/session.
+.claude/settings.local.json
+
 # Generated per-root pwg_ru harnesses (derived from gen_opt_harness2.py et al.; inlined inputs)
 src/pilot/run_fidelity_judge.js
 src/pilot/run_pilot_wf.opt.js


### PR DESCRIPTION
## Summary
- Sessions started inside RussianTranslation (rather than the org root) see `.claude/settings.local.json` as untracked every time — only the org-level `SanskritLexicography/.gitignore` covered this repo's `.claude/` dir. Adds the same entry already used in `csl-observatory` and `Uprava`.

## Test plan
- [x] `git status --short` no longer lists `.claude/settings.local.json`