### PR TITLE
pwg-ru: vid verb-root drain complete (H151), branch-contention recovery

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,27 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
+- **H151 `vid` drain — ✅ DONE 04-07-2026 (Sonnet 5, `claude-sonnet-5`), driven from a second
+  concurrent Claude Code session (main checkout, not a worktree — 5 other worktree sessions
+  were active on the same H151 queue at the time; MG explicitly authorized continuing the
+  main-tree `vid` state rather than starting fresh).** Took over an in-flight `wf_output.json`
+  (root `vid`, `needs_requeue`, 47/55 clean) and drove 3 more `--no-tm` requeue rounds via the
+  Workflow tool directly (H130 pattern — no manual Max-surface save): round 2 (8 keys, 62
+  agents) → 51/55; round 3 (4 keys, 48 agents) → 52/55; round 4 (3 keys, 36 agents) → 54/55,
+  coverage + sense-dupe gates PASS. The 2 remaining partial cards (`h0_10_ni`, `h2_00_pwg01`,
+  1 missing fragment group each) cleared via `autosplit_requeue.py topup`/`topup-merge` (2
+  agents) instead of a full requeue. **1 documented residual left:** `vid~~h0_00_pwg01`'s
+  `foreign_gloss_translated` high-confidence flag fired on a CORRECT translation ("Sieger sein
+  werde" → «будет победителем») across all 3 requeue attempts — suspected the same
+  German-capitalization false-positive class as the gam `LATIN_BINOMIAL` bug fixed in
+  [PR #119](https://github.com/gasyoun/SanskritLexicography/pull/119), NOT re-investigated
+  this session (worth a follow-up gate audit if it recurs on other roots). Promoted
+  `claude-sonnet-5` (2 merge passes: full 55-card file, then the 2-card topup file to override
+  the stale partials), TM rebuilt (2,175 cards, +177 fragments). Ledger row added to
+  [H151](https://github.com/gasyoun/Uprava/blob/main/handoffs/H151_SanskritLexicography_pwg_ru_verb_batch_drain.md).
+  **Next queue head (per `verb_worklist.py --top 20`): `sTA`(61.6) `BU`(60.2) `yuj`(58.2)
+  `as`(57.5) `i`(57.4)** — `vid` now clears the Wave-1 head.
+
 - **H155 follow-up — failure-mode taxonomy + wall-clock KILL GATE — ✅ DONE 04-07-2026
   (Opus 4.8, `claude-opus-4-8`).** MG: "sense-count is just one case — what other cases are
   possible? Plan in advance. And add a gate: if a translation runs too long, kill it, don't

--- a/RussianTranslation/.gitignore
+++ b/RussianTranslation/.gitignore
@@ -93,6 +93,7 @@ src/pilot/run_pilot_wf.en_*.js
 # list can't keep up — glob it).
 src/pilot/run_pilot_wf.opt2.*_requeue*.js
 src/pilot/run_pilot_wf.opt2.*_translate.js
+src/pilot/run_pilot_wf.*_topup.js
 
 # Pre-operation safety snapshots of the local-only translated store / wf_output
 # (regenerable-adjacent backups taken before a risky merge/overlay, never a


### PR DESCRIPTION
## Summary
- H151 standing drain: `vid` (Wave-1 queue head) taken from an in-flight main-tree state (47/55 clean) to 54/55 clean via 3 more `--no-tm` requeue rounds + an `autosplit_requeue.py topup` pass on the last 2 partial cards. Coverage + sense-dupe gates PASS. 1 documented residual (`vid~~h0_00_pwg01`, suspected gate false-positive, same class as the gam `LATIN_BINOMIAL` fix in #119 — not re-investigated this session).
- Promoted `claude-sonnet-5`, TM rebuilt (2,175 cards, +177 fragments). Store/TM/wf_output artifacts are all gitignored, not part of this PR.
- `.gitignore`: added `run_pilot_wf.*_topup.js` to the generated-harness glob family.
- **Branch-contention recovery**: a concurrent session was actively checking out/committing in the same shared `RussianTranslation` working directory mid-session; my original commit landed on `chore/gitignore-claude-settings-local` instead of a pwg-ru branch. Per `/branch-contention-recover`, re-extracted the pure source delta (`.gitignore` + `.ai_state.md`, 22 lines) and re-applied it in a fresh worktree off `origin/master`. No generated/derived files are part of this PR.

## Test plan
- [x] `git apply --check` clean re-application of the source delta
- [x] Diff reviewed — only `.gitignore` + `.ai_state.md`, no code/pipeline changes
- N/A — no code paths changed; the actual translation work (store/TM) is gitignored and already on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)