### PR TITLE
fix(pwg-ru): port RU gate-bug fixes to EN audit path (LANG_PARITY GAP)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -144,6 +144,51 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
   untracked Max spend on the same hand-off gap. Once resolved (either a recovered
   output or a confirmed clean re-run), the very next step is
   `audit_window.py wf_output.json --root vid --write-requeue`, same as any other root.
+- **EN audit gate ported the 2026-07-03 RU gate-bug fixes — audited + 1 real fix ported,
+  2026-07-04 (Sonnet 5, `claude-sonnet-5`).** Audited [`audit_window_en.py`](src/pilot/audit_window_en.py)
+  against the 3 RU gate-bug fixes in [`audit_coverage.py`](src/audit_coverage.py) /
+  [`prompt_rule_audit.py`](src/pilot/prompt_rule_audit.py) (see the 2026-07-03 "3 gate-bug
+  fixes" entry above). Verdict per fix:
+  1. **Multi-layer raw-marker over-count (`raw_markers`/`layer_sense_count`) — N/A.**
+     `audit_window_en.py` never calls `audit_coverage.py` or compares raw `.raw.txt`
+     sense-marker counts against card senses at all; its only coverage check is per-sense
+     `MISSING-EN` (empty english when german had gloss prose). No analogous mechanism exists
+     to carry the bug.
+  2. **`braced_gloss_risks` Sanskrit-span leak (`SANSKRIT_SPAN` scrub) — already safe.**
+     `audit_window_en.py`'s `prose()` helper already strips `{#..#}` Sanskrit citation spans
+     (via `SAN.sub`) before any residue/DE-RESIDUE/RU-RESIDUE matching runs — the EN gate was
+     never vulnerable to the SLP1-substring collision that hit RU's `braced_gloss_risks`.
+  3. **German/Latin/French misclassification (LATIN_BINOMIAL/FRENCH_WORDS/LATIN_WORDS) —
+     REAL EN analogue found and fixed.** `prompt_rule_audit.py`'s per-braced-gloss
+     foreign-vs-German classification (`looks_foreign_literal`/`looks_german_gloss`) has no
+     EN counterpart (EN's `MARKUP-LOSS` is a pure `{%..%}`/`<div>` occurrence count, not
+     content classification), so that half of fix 2 doesn't apply. But EN's `DE-RESIDUE`
+     check (`DE_WORDS` regex over the translated english prose) has the SAME collision class:
+     `des` is both the German genitive/plural article ("des Todes") and a French
+     partitive/plural article, and `gen_fidelity_judge_en.py`'s own judge prompt explicitly
+     instructs the EN generation to preserve French/Latin literals verbatim (e.g. "de basse
+     extraction", "inire feminam") — exactly the material RU's fix 2 was protecting. Verified
+     the collision live (`DE_WORDS.findall('des chevaux') -> ['des']`) before fixing.
+  **Fix:** extracted `LATIN_WORDS`/`FRENCH_WORDS` out of `prompt_rule_audit.py` into a new
+  shared module [`foreign_literal_guards.py`](src/pilot/foreign_literal_guards.py) (imported
+  by both `prompt_rule_audit.py` and `audit_window_en.py`, per the "shared helper" pattern),
+  added `AMBIGUOUS_DE_FR_WORDS = {'des'}` and a `FRENCH_CONTEXT_WORDS` regex (FRENCH_WORDS
+  minus `des`/`du`, so the French-confirmation check can't trivially match on the very token
+  being disambiguated), and guarded `audit_sense`'s DE-RESIDUE: a bare `des` hit with no other
+  unambiguous German marker, alongside a confirming French word elsewhere in the prose, is
+  now suppressed as a preserved French literal rather than flagged. Pinned by
+  `test_en_de_residue_french_guard` in
+  [`window_selftest.py`](src/pilot/window_selftest.py) (French "des basse extraction" must
+  NOT fire DE-RESIDUE; German "des Todes" alone still must). Full `window_selftest.py` run
+  confirmed green on every test this change could affect (`test_en_gate_strict_has_teeth`,
+  both `test_markup_loss_soft_flag_*`, `test_coverage_gate_multi_layer_and_presplit`,
+  `test_en_residual_coverage_complete`, the new test) — `test_perf_preflight_small_tm_and_no_tm`
+  fails on this worktree both before and after the change (`no rootmap for 'gam'`, an
+  unrelated pre-existing environment/data gap, confirmed via `git stash`).
+  **Also found (out of scope, fixed by a separately-spawned task):** this file
+  (`.ai_state.md`) carried literal unresolved `git stash`/merge conflict markers committed
+  into HEAD around the H148 vid-run entry — resolved by `task_5568538f` (already landed on
+  `master` by the time this branch rebased onto it).
 - **H130 gam Max run — Workflow-tool schema bug FOUND + FIXED, gam translated + mechanically
   audited 2026-07-03 (Sonnet 5, `claude-sonnet-5`).** Executing
   [`H130_SanskritLexicography_pwg_ru_gam_max_run.md`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H130_SanskritLexicography_pwg_ru_gam_max_run.md)

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a18b05f265ac30880f2ea7507a200091108d8b812236bee29d6211aed9324549",
-      "src/pilot/window_selftest.py": "9fbc2e20074f7711d95e6cd0a9e92114334882b0a844f5d9831b19ddc69461b2"
+      "src/pilot/window_selftest.py": "0f7e260c53317a0dc9ae46f1d9be9c03e0da89a4bccbb70e48d559922b107d2f"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a18b05f265ac30880f2ea7507a200091108d8b812236bee29d6211aed9324549",
-      "src/pilot/window_selftest.py": "9fbc2e20074f7711d95e6cd0a9e92114334882b0a844f5d9831b19ddc69461b2"
+      "src/pilot/window_selftest.py": "0f7e260c53317a0dc9ae46f1d9be9c03e0da89a4bccbb70e48d559922b107d2f"
     }
   },
   {
@@ -239,6 +239,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED 2026-07-04 (was GAP, task_d29bb788): audited audit_window_en.py against all 3 fixes. (1) multi-layer over-count is N/A -- EN has no analogous raw-marker-vs-card-sense coverage check to carry the bug. (2) the Sanskrit-span leak is already safe -- audit_window_en.py's prose() already scrubs {#..#} spans before residue matching, unlike RU's pre-fix braced_gloss_risks. (3) a REAL EN analogue existed in DE-RESIDUE: 'des' is both a German article and a French partitive article, and gen_fidelity_judge_en.py's own prompt preserves French/Latin literals verbatim -- fixed by extracting LATIN_WORDS/FRENCH_WORDS into a new shared src/pilot/foreign_literal_guards.py imported by both prompt_rule_audit.py and audit_window_en.py, with a French-context guard on the ambiguous 'des' hit. Pinned by test_en_de_residue_french_guard in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
+      "src/audit_coverage.py": "8c54aa22943140624238273b5bb6a2cbe9aceded5f8295cb84cd36bd994904c0",
       "src/pilot/prompt_rule_audit.py": "bbd3fe10ff72b9d58e6d763069352129df8c246d4cb18ae41520ddcf6fee7525",
       "src/pilot/audit_window.py": "91019c993e877311cdd90812c286a50d1b2094eb8a9473bb4b4ff9b11f032f88",
       "src/pilot/audit_window_en.py": "068a6c410076ede4235afa3a280199028d0f6a2e399df6cde95b000a56513c19"
@@ -296,7 +297,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a18b05f265ac30880f2ea7507a200091108d8b812236bee29d6211aed9324549",
-      "src/pilot/window_selftest.py": "9fbc2e20074f7711d95e6cd0a9e92114334882b0a844f5d9831b19ddc69461b2"
+      "src/pilot/window_selftest.py": "0f7e260c53317a0dc9ae46f1d9be9c03e0da89a4bccbb70e48d559922b107d2f"
     }
   },
   {
@@ -315,7 +316,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a18b05f265ac30880f2ea7507a200091108d8b812236bee29d6211aed9324549",
-      "src/pilot/window_selftest.py": "9fbc2e20074f7711d95e6cd0a9e92114334882b0a844f5d9831b19ddc69461b2"
+      "src/pilot/window_selftest.py": "0f7e260c53317a0dc9ae46f1d9be9c03e0da89a4bccbb70e48d559922b107d2f"
     }
   }
 ]

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -232,16 +232,16 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/audit_window_en.py"
     ],
     "languages": [
-      "ru"
+      "ru",
+      "en"
     ],
-    "verdict": "GAP",
-    "note": "audit_window_en.py reimplements its own gates from scratch rather than importing the RU modules (its own comment: 'the RU gate is wired around Russian-specific semantic checks'), so none of the 3 July fixes reached EN. EN cards from the same PWG/PW/SCH source have the same multi-layer/addenda structure, so the same false-positive classes plausibly apply there too.",
-    "tracking": "spawned task chip task_d29bb788 (2026-07-04): 'Port RU gate fixes to audit_window_en.py' — running",
+    "verdict": "SHARED",
+    "note": "RESOLVED 2026-07-04 (was GAP, task_d29bb788): audited audit_window_en.py against all 3 fixes. (1) multi-layer over-count is N/A -- EN has no analogous raw-marker-vs-card-sense coverage check to carry the bug. (2) the Sanskrit-span leak is already safe -- audit_window_en.py's prose() already scrubs {#..#} spans before residue matching, unlike RU's pre-fix braced_gloss_risks. (3) a REAL EN analogue existed in DE-RESIDUE: 'des' is both a German article and a French partitive article, and gen_fidelity_judge_en.py's own prompt preserves French/Latin literals verbatim -- fixed by extracting LATIN_WORDS/FRENCH_WORDS into a new shared src/pilot/foreign_literal_guards.py imported by both prompt_rule_audit.py and audit_window_en.py, with a French-context guard on the ambiguous 'des' hit. Pinned by test_en_de_residue_french_guard in window_selftest.py.",
+    "tracking": "",
     "verified_sha256": {
-      "src/audit_coverage.py": "8c54aa22943140624238273b5bb6a2cbe9aceded5f8295cb84cd36bd994904c0",
-      "src/pilot/prompt_rule_audit.py": "ae9fc97ba288e2dbd0aac38f03f7dd8df230b29782c94ca41bad23f673e165fa",
+      "src/pilot/prompt_rule_audit.py": "bbd3fe10ff72b9d58e6d763069352129df8c246d4cb18ae41520ddcf6fee7525",
       "src/pilot/audit_window.py": "91019c993e877311cdd90812c286a50d1b2094eb8a9473bb4b4ff9b11f032f88",
-      "src/pilot/audit_window_en.py": "f6e6519d06a664f1c1f6c6f1e0564415d35b1f2a089be269c5e8dd3b77d73056"
+      "src/pilot/audit_window_en.py": "068a6c410076ede4235afa3a280199028d0f6a2e399df6cde95b000a56513c19"
     }
   },
   {
@@ -334,12 +334,17 @@ the file. Run `python src/pilot/window_selftest.py` to confirm the gate
 passes.
 
 **Case B — you found a fix that landed on one language and not the other.**
-(Real example, `gate_fixes_20260703_ru_only` above.) You don't fix the gap in
-the same session unless it's trivial — classify **GAP**, write `note`
-explaining the asymmetry (what's different about the two paths that let this
-happen), and `tracking` MUST point somewhere real: a spawned task id, an
-`H###` handoff, or a GTD row. `lang_parity_check.py` will refuse an empty
-`tracking` field — this is the mechanism, not a suggestion.
+You don't fix the gap in the same session unless it's trivial — classify
+**GAP**, write `note` explaining the asymmetry (what's different about the
+two paths that let this happen), and `tracking` MUST point somewhere real: a
+spawned task id, an `H###` handoff, or a GTD row. `lang_parity_check.py` will
+refuse an empty `tracking` field — this is the mechanism, not a suggestion.
+(`gate_fixes_20260703_ru_only` was this case originally, GAP + `tracking:
+task_d29bb788`; that task closed the gap the same day by porting the one
+sub-fix that actually applied to EN into a shared helper, so the entry was
+re-verdicted to **SHARED** and `tracking` cleared — see its current `note`
+for the worked resolution, including the two sub-fixes that turned out to be
+non-issues on EN and shouldn't be "ported" at all.)
 
 **Case C — you touched a file a ledger entry already tracks, for an
 unrelated reason.** `window_selftest.py` will fail with a drift message

--- a/RussianTranslation/src/pilot/audit_window_en.py
+++ b/RussianTranslation/src/pilot/audit_window_en.py
@@ -56,6 +56,10 @@ SRC = os.path.dirname(HERE)                                # .../src
 OUT = os.path.join(HERE, 'output')
 DEFAULT_MW_TM = os.path.join(SRC, 'mw_en_tm.json')
 
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+from foreign_literal_guards import FRENCH_CONTEXT_WORDS, AMBIGUOUS_DE_FR_WORDS
+
 LS = re.compile(r'<ls\b')
 SAN = re.compile(r'\{#.*?#\}', re.S)
 AB = re.compile(r'<(?:ab|lex|lang)\b')
@@ -142,6 +146,14 @@ def audit_sense(german, english):
     if CYR.search(ep):
         soft.append('RU-RESIDUE')
     de_hits = set(m.lower() for m in DE_WORDS.findall(ep))
+    # "des" is both a German genitive/plural article ("des Todes") and a French
+    # partitive/plural article ("des chevaux") -- the gen_fidelity_judge_en prompt
+    # explicitly preserves French/Latin literals verbatim in the english field, so a
+    # bare "des" hit with no other unambiguous German marker, alongside other French
+    # vocabulary (FRENCH_WORDS), is a preserved French literal, not German residue.
+    # Mirrors the RU "du"-vs-French collision fixed 2026-07-03 (prompt_rule_audit.py).
+    if de_hits <= AMBIGUOUS_DE_FR_WORDS and FRENCH_CONTEXT_WORDS.search(ep):
+        de_hits.clear()
     # Umlaut/eszett never occurs in IAST, but DOES occur in scholar names (Graßmann,
     # Böhtlingk) that legitimately survive. Genuine German residue (eig., überh., übertr.)
     # is lowercase, so only count an umlaut inside a non-capitalized token.

--- a/RussianTranslation/src/pilot/foreign_literal_guards.py
+++ b/RussianTranslation/src/pilot/foreign_literal_guards.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""foreign_literal_guards.py — shared Latin/French preserved-literal patterns.
+
+B&R (and the derived PWG/PW/SCH cards) deliberately leave certain glosses untranslated
+verbatim: Latin euphemisms (esp. indelicate ones, e.g. "inire feminam") and French or
+scientific-Latin terms. Both the RU gate (`prompt_rule_audit.py`) and the EN gate
+(`audit_window_en.py`) need to recognize these so a correctly-preserved literal is never
+mistaken for untranslated German/English residue. Single source of truth so a fix to one
+gate's word list is not silently missing from the other's.
+"""
+import re
+
+# Latin and Romance glosses B&R deliberately leave untranslated (esp. indelicate
+# euphemisms written in Latin, e.g. "inire feminam"). These must NOT be flagged as
+# untranslated German/English residue -- the convention keeps them verbatim.
+LATIN_WORDS = re.compile(
+    r'\b(?:inire|feminam?|legere|inveteratus|convenire|coitus|coire|coeundi|'
+    r'membrum|virile|penis|pudenda|futuere|mingere|venus|venere|in\s+coitu|'
+    r'cum|quasi|scilicet|sic|idem|vide|sequi|obsequi)\b', re.I)
+
+FRENCH_WORDS = re.compile(
+    r"(?:\bl['’]|\b(?:une?|les?|des|du|aux?|plus|tr[eè]s|homme|femme|basse|"
+    r"extraction|chose|terre|qui|dans|pour|avec|sans)\b)", re.I)
+
+# Ambiguous single tokens that legitimately belong to BOTH the German short-word set
+# (RU's GERMAN_GLOSS_WORDS / EN's DE_WORDS) and ordinary French vocabulary -- "des" is a
+# German genitive/plural article ("des Todes") AND a French partitive/plural article
+# ("des chevaux"). A bare hit on one of these alone, with no other unambiguous German
+# marker present, is not reliable evidence of German residue when the surrounding text
+# also carries other French markers (mirrors the RU "du" collision fixed 2026-07-03 for
+# FRENCH_WORDS vs German "du").
+AMBIGUOUS_DE_FR_WORDS = frozenset({'des'})
+
+# FRENCH_WORDS minus "des"/"du" -- a French CONFIRMATION marker, used to decide whether a
+# lone ambiguous hit ("des") sits in French context rather than German. Must exclude
+# "des"/"du" itself, or checking "does this text look French" would trivially match on the
+# very token being disambiguated (FRENCH_WORDS includes "des"/"du" for prompt_rule_audit's
+# own foreign-vs-German classification, which is guarded the other way -- see
+# looks_foreign_literal's "not GERMAN_GLOSS_WORDS.search(...)").
+FRENCH_CONTEXT_WORDS = re.compile(
+    r"(?:\bl['’]|\b(?:une?|les?|aux?|plus|tr[eè]s|homme|femme|basse|"
+    r"extraction|chose|terre|qui|dans|pour|avec|sans)\b)", re.I)

--- a/RussianTranslation/src/pilot/prompt_rule_audit.py
+++ b/RussianTranslation/src/pilot/prompt_rule_audit.py
@@ -35,6 +35,7 @@ if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
 from workflow_payload import workflow_payload
+from foreign_literal_guards import LATIN_WORDS, FRENCH_WORDS
 
 GERMAN_RESIDUE = re.compile(
     r'\b(?:der|die|das|den|dem|des|und|oder|mit|ohne|von|für|nicht|eine|einer|'
@@ -86,16 +87,9 @@ LEXICOGRAPHIC_CITATION = re.compile(
     r'kośa|lexicographic)',
     re.I)
 
-# Latin and Romance glosses B&R deliberately leave untranslated (esp. indelicate
-# euphemisms written in Latin, e.g. "inire feminam"). These must NOT be flagged as
-# untranslated German — the convention keeps them verbatim.
-LATIN_WORDS = re.compile(
-    r'\b(?:inire|feminam?|legere|inveteratus|convenire|coitus|coire|coeundi|'
-    r'membrum|virile|penis|pudenda|futuere|mingere|venus|venere|in\s+coitu|'
-    r'cum|quasi|scilicet|sic|idem|vide|sequi|obsequi)\b', re.I)
-FRENCH_WORDS = re.compile(
-    r"(?:\bl['’]|\b(?:une?|les?|des|du|aux?|plus|tr[eè]s|homme|femme|basse|"
-    r"extraction|chose|terre|qui|dans|pour|avec|sans)\b)", re.I)
+# LATIN_WORDS / FRENCH_WORDS (Latin euphemisms + French/Romance glosses B&R deliberately
+# leaves untranslated, e.g. "inire feminam") now live in foreign_literal_guards.py, shared
+# with the EN gate (audit_window_en.py) — see that module's docstring.
 # Sanskrit preverbs / transliterated tokens that appear braced on messy layer cards
 # (e.g. SCH) and are not German glosses.
 SANSKRIT_PREVERBS = {

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -945,6 +945,22 @@ def test_markup_loss_soft_flag_en():
             os.remove(report_path)
 
 
+def test_en_de_residue_french_guard():
+    """EN analogue of the 2026-07-03 RU 'du'-vs-French collision fix (prompt_rule_audit.py):
+    'des' is both a German article ("des Todes") and a French partitive article (as in "de
+    basse extraction", a stock B&R euphemism for "of low birth"). gen_fidelity_judge_en.py's
+    prompt explicitly preserves French literals verbatim, so a bare 'des' hit alongside
+    another confirming French word must NOT fire DE-RESIDUE; genuine German residue ('des
+    Todes', no other French markers) still must."""
+    from audit_window_en import audit_sense
+    _, soft_french = audit_sense('{%des basse extraction%}', 'des basse extraction')
+    if any(s.startswith('DE-RESIDUE') for s in soft_french):
+        fail('DE-RESIDUE wrongly fired on a preserved French literal ("des basse extraction")')
+    _, soft_german = audit_sense('{%Todesangst%}', 'fear of des Todes')
+    if not any(s.startswith('DE-RESIDUE') for s in soft_german):
+        fail('DE-RESIDUE did not fire on genuine German residue ("des Todes")')
+
+
 def test_ru_coverage_denominator_not_silently_exempt():
     """FL3: a corrupt EN denominator must FAIL the coverage gate (not be silently skipped),
     and a RU root with no denominator must be surfaced as UNVERIFIABLE (the gam 6/127 blind
@@ -1855,6 +1871,7 @@ def main():
         test_en_gate_strict_has_teeth,
         test_markup_loss_soft_flag_ru,
         test_markup_loss_soft_flag_en,
+        test_en_de_residue_french_guard,
         test_ru_coverage_denominator_not_silently_exempt,
         test_coverage_gate_multi_layer_and_presplit,
         test_en_residual_coverage_complete,


### PR DESCRIPTION
## Summary

Audits `RussianTranslation/src/pilot/audit_window_en.py` against the 3 gate-bug fixes shipped 2026-07-03 on the RU path (multi-layer sense over-count, German/Latin/French misclassification, Sanskrit-span gloss-leak), per the `gate_fixes_20260703_ru_only` GAP entry in [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md).

Verdict per fix:
1. **Multi-layer raw-marker over-count** — N/A. `audit_window_en.py` has no analogous raw-`.raw.txt`-vs-card-sense coverage check at all.
2. **`braced_gloss_risks` Sanskrit-span leak** — already safe. `prose()` already scrubs `{#..#}` spans before residue matching.
3. **German/Latin/French misclassification** — **real EN analogue found and fixed**: `DE-RESIDUE` treated `des` as an unambiguous German marker, but it's also a French partitive article, and `gen_fidelity_judge_en.py`'s own prompt explicitly preserves French/Latin literals verbatim (the exact material RU's fix was protecting). Verified the collision live before fixing.

## Changes

- Extracted `LATIN_WORDS`/`FRENCH_WORDS` out of `prompt_rule_audit.py` into a new shared `src/pilot/foreign_literal_guards.py`, imported by both `prompt_rule_audit.py` (RU) and `audit_window_en.py` (EN).
- Added a French-context guard so a bare `des` hit in EN's `DE-RESIDUE` check is suppressed only when confirmed by another French word, never by "des" alone (which is circular).
- Pinned by `test_en_de_residue_french_guard` in `window_selftest.py`.
- Re-verdicted the `gate_fixes_20260703_ru_only` ledger entry in `LANG_PARITY.md` from GAP to SHARED, per the ledger's own binding policy.
- Updated `.ai_state.md` with the audit findings.

## Notes for reviewer

- `test_perf_preflight_small_tm_and_no_tm` fails on a bare local checkout (`no rootmap for 'gam'`) — reproduced identically on unmodified `origin/master` via `git stash`, unrelated to this change.
- `LANG_PARITY.md`'s `verified_sha256` hashes are computed from git blob content (LF-normalized), not local disk bytes, because `lang_parity_check.py` hashes raw disk bytes and this Windows checkout has `core.autocrlf=true` (CRLF on disk) — running the tool locally reports false-positive drift on files nobody touched, reproduced on unmodified `origin/master` too. This pre-existing non-portability is flagged as its own follow-up (not fixed here) rather than mixed into this PR.
- Found (and separately flagged, not fixed here) that `.ai_state.md` briefly carried committed `git stash`/merge conflict markers; that was resolved by another spawned task before this branch was rebased onto `master`.

## Test plan

- [x] `python src/pilot/window_selftest.py` — all EN/RU gate tests this change could affect pass (`test_en_gate_strict_has_teeth`, both `test_markup_loss_soft_flag_*`, `test_coverage_gate_multi_layer_and_presplit`, `test_en_residual_coverage_complete`, new `test_en_de_residue_french_guard`)
- [x] `python src/pilot/prompt_rule_audit.py` runs clean after the import refactor
- [x] Manually verified the French/German regex collision and its fix with standalone repros

🤖 Generated with [Claude Code](https://claude.com/claude-code)