### PR TITLE
fix(pwg_ru): atomic store writes + robust collect + Latin-cue mask leak (review 2026-07-04)

### DIFF
--- a/RussianTranslation/CODE_REVIEW_2026-07-04.md
+++ b/RussianTranslation/CODE_REVIEW_2026-07-04.md
@@ -1,0 +1,78 @@
+# Code review — pwg_ru pipeline (2026-07-04)
+
+_Created: 04-07-2026 · Last updated: 04-07-2026_
+
+Full-tree review of `RussianTranslation/src` (34,668 LOC, ~90 Python files) by
+five parallel reviewers (Opus 4.8, `claude-opus-4-8`), each scoped to one
+subsystem, cross-checked and deduplicated. Findings are ranked by severity.
+`CONFIRMED` = traced in code / reproduced; `SUSPECTED` = strong but not executed
+to failure.
+
+**Fixed in this pass** (branch `fix/review-2026-07-04-dataloss-latinmask`): the
+🔴 data-loss trio + the 🟠 Latin-mask quality bug. Everything else is a
+prioritized backlog below, to be worked before/alongside the next scale run.
+
+---
+
+## ✅ Fixed in this PR
+
+| # | File | Defect | Fix |
+|---|---|---|---|
+| F1 | [promote_en.py:299](src/promote_en.py) | Non-atomic `open('w')` truncate-write of the whole tri-lingual store; a crash mid-write with `--no-backup` = total loss (the "EN layer wiped" scar). | Stream to `.tmp` + `os.replace` (atomic). |
+| F2 | [promote_final_cards.py:324](src/promote_final_cards.py) | Same non-atomic truncate-write on the RU→store bridge. | `.tmp` + `os.replace`. |
+| F3 | [run_batch.py:152](src/run_batch.py) | `cmd_collect` called `.get()` on a possibly-JSON-string `result`, crashing and stranding the run's generation output (the "run lost / re-driven" class); sibling loaders all handle the string case. | Normalise `result` (str→`json.loads`, non-dict→raw); also single-parse the batch file and coalesce per-row appends into one write to shrink the torn-last-line window. |
+| F4 | [pwg_mask.py:98](src/pwg_mask.py) | `classify_pct` looked for the Latin cue (`<ab>lat.</ab>`) in the already-masked body, so it saw `{Tn}` not `lat.` → **33 Latin/Greek cognate glosses across PWG** (e.g. `ignis`, `uncus`, `ansa`) were leaked into the translator prompt as German. | Expand trailing `{Tn}` placeholders + strip tags in the classify context. Round-trip stays lossless. Pinned by `window_selftest.test_pwg_mask_latin_cue_behind_ab_tag`; SHARED parity entry `latin_cue_masking`. |
+
+---
+
+## 🔴 Backlog — correctness (wrong output under a headword)
+
+- **Positional card misassignment** — [gen_opt_harness2.py:1259](src/pilot/gen_opt_harness2.py) (`resolveGroup`) and `healGroup` :1098. When the model drops/reorders a card, the `res.cards[i]` positional fallback assigns content to the wrong `key`. The `<ls>/{#`-count fidelity guard is **blind for zero-marker cross-ref stubs**, so two such cards can swap silently → Russian under the wrong Sanskrit headword. *Fix needs care (JS-in-Python harness); add a hard key-agreement assertion or drop-to-fragment-lane when `byKey1` misses instead of positional fallback.*
+- **`tm_card_sane` zero-`<ls>` guard bypass** — [gen_opt_harness2.py:585](src/pilot/gen_opt_harness2.py). `if ls and ls != raw.count('<ls')` short-circuits when the cached card has zero `<ls>`, so a citation-stripped/degraded cached card is served verbatim, dropping every citation. *Fix: check `ls is not None` / compare against source count unconditionally.*
+
+## 🟠 Backlog — broken validators (green light on defective output)
+
+- **Advertised HARD `DUP` gate never emitted** — [audit_window_en.py:252](src/pilot/audit_window_en.py). Two senses with identical English pass `--strict`. *Fix: emit a real `DUP` hard flag, or delete the false docstring claim.*
+- **RU gate recovers verdicts by regex-scraping subprocess stdout** — [audit_window.py:71](src/pilot/audit_window.py). Any wording drift in the child auditors → `[]` → flagged cards silently omitted from requeue, gate reports clean; the child returncode is not consulted. *Fix: assert a parseable verdict was emitted / consult returncode.*
+- **`--min-cards` mode skips the count-integrity check** — [validate_assembled_export.py:163](src/validate_assembled_export.py). Bounded runs can't catch dropped/duplicated cards (only a `>=` floor). *Fix: still assert exact count when known.*
+- **`reverse_index --show` entirely dead** — [reverse_index.py:155](src/reverse_index.py). A 4-vs-8 column guard is never true → `_representative` always `(None, None)`. *Fix: index the correct column (`parts[4]`).*
+
+## 🟡 Backlog — TM reuse & quality
+
+- **Whole card dropped from cache on one empty sense** — [translation_memory.py:265](src/pilot/translation_memory.py). One legitimately-blank xref sense → giant card re-translated every run. *Fix: cache per-sense / tolerate blank pass-through senses.*
+- **Partial/incomplete card content-addressed as an exact hit** (SUSPECTED, depends on save path) — [gen_opt_harness2.py:1204](src/pilot/gen_opt_harness2.py) + `reconstruct_cards`. A future byte-identical run serves an incomplete card with zero agents. *Fix: exclude `partial:true` cards from the exact card-TM.*
+- **`supersedes` string→char-iteration** — [translation_memory.py:190](src/pilot/translation_memory.py). Iterates a string SHA character-by-character, defeating supersession. **Latent** (0 store rows carry a string `supersedes` today — verified), but the TM is now a published schema; *coerce to list defensively.*
+- **`frag_prov` senses harvested with no fidelity check, first-seen-wins** — [translation_memory.py:481](src/pilot/translation_memory.py). A hand-edited/corrupt `wf_output*.json` permanently poisons the fragment TM. *Fix: validate `<ls>/{#` counts before caching; allow later-good override.*
+- **`degenerate_passthrough` can emit German as the Russian field** — [gen_opt_harness2.py:519](src/pilot/gen_opt_harness2.py). A borderline stub bypasses the LLM with German copied into the RU field, no downstream gate. *Fix: tighten the allowlist / gate passthrough rows.*
+
+## 🟡 Backlog — data builders (correctness)
+
+- **Cross-builder Unicode key mismatch** — `build_dcs_freq*` (`norm_lemma`, no NFC) vs `build_corpus_lexicon` (`form_key`) vs `build_dcs_renou` (raw CoNLL-U lemma). Three "co-keyed" tables normalized three ways → the same lemma counts as two. *Fix: one shared normalizer + NFC pass.*
+- **Silent lemma loss on genre join-key miss** — [build_dcs_freq_dims.py:133](src/build_dcs_freq_dims.py). A text whose name doesn't normalize-match gets zero genre attribution, indistinguishable from the intended register-less tail. *Fix: log unmatched `text_id`s.*
+- **Homograph Ru-gloss attribution is winner-take-all + nondeterministic tie order** — [build_rollup_glossaries.py:60](research/… → src/build_rollup_glossaries.py) `most_common` sorts by count only; equal-count lemmas ordered by file order. *Fix: stable tiebreak; split near-tied distributions.*
+- **Citation index dedup semantics disagree across two code paths** — [build_citation_index.py:136](src/build_citation_index.py) vs `occurrence_stats()`; `CITATION_SOURCES.md` and `UNCOVERED_SOURCES.md` can disagree on coverage. *Fix: single source of truth for coverage.*
+- **`ls_resolver` Ṛgveda/Atharva disambiguation is substring-based** — [ls_resolver.py:996](src/ls_resolver.py) `'rv' in kl or 'ṛ' in kl` mis-routes e.g. `ṚV. PRĀTIŚ.`. Bare `except: pass` at :1046/:965 hides resolver failures. *Fix: anchored match; surface exceptions.*
+
+## ⚡ Backlog — performance
+
+- **Biggest win: three full DCS-token-table scans** — `build_dcs_freq` (general) + `build_dcs_freq_dims` (POS + genre). Collapse to one indexed pass; verify indices on `token.lemma_id`, `token.sentence_id`, `sentence.chapter_id`.
+- **Source read + masked up to 3× per card** — [gen_opt_harness2.py:662/757/764](src/pilot/gen_opt_harness2.py). Cache the masked skeleton per key.
+- **`build_corpus_lexicon buildall` re-scans the full 1.09M-row lexicon per text** — [build_corpus_lexicon.py:188](src/build_corpus_lexicon.py). Build the resume set once.
+- **`assemble build` rebuilds whole-corpus caches every invocation** — [assemble.py:47](src/assemble.py); `--offset` with no N silently overwrites the whole export ([:296](src/assemble.py)); two-file publish not atomic ([:336](src/assemble.py)).
+
+## 🟢 Backlog — linguistic edge cases (lower frequency)
+
+- `compile_translatable.py` `REF` regex over-masks German like "Buch V, Kapitel" ([:111](src/compile_translatable.py)); `IAST_ONLY` can drop a German gloss containing one diacritic ([:104](src/compile_translatable.py)).
+- `corpus_gate.py` `_RU_END` lists `ого` twice and strips only one suffix ([:270](src/corpus_gate.py)); FTS `LIMIT 400` prefilter can under-report high-frequency coverage ([:249](src/corpus_gate.py)).
+- `microstructure.py` module-load `json.load(open(...))` raises at import if `ls_source_map.json` absent, taking down every importer ([:27](src/microstructure.py)); `MARK` regex can mis-split `a) … b)` German enumerations ([:40](src/microstructure.py)).
+- `pwg_mask.py` unclosed `<ls>` greedy `.*?` can span records ([:33](src/pwg_mask.py)); `records()` drops the first record if the file ever carries a BOM ([:45](src/pwg_mask.py)).
+- `nominal_grammar.py` `_stem_class` on raw (non-`form_key`) k1 misclassifies anusvāra/visarga/punctuated finals ([:225](src/nominal_grammar.py)).
+
+## Notes cleared (checked, NOT bugs)
+
+- Content-addressing (`lang:raw_sha256`) genuinely prevents stale reuse on source change.
+- The `parallel`/backfill invariant in the harness guards the whole-batch null-vanish loss the project's memory warns about.
+- `form_key` (corpus_gate) is correctly length-preserving (NFC + strip U+0300–036F only) — no NFD vowel-length/retroflex-dot loss.
+- The `devanagari_to_slp1` ळ→x gotcha does **not** touch these files (only `build_kosha`/`build_meulenbeld`/`build_indic`).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -67,6 +67,25 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
 ```json lang_parity_ledger
 [
   {
+    "id": "latin_cue_masking",
+    "mechanism": "classify_pct recovers the Latin/Greek cue from masked {Tn} placeholders (expand + de-tag the preceding window) so a {%...%} cognate after <ab>lat.</ab> is masked as Latin, not leaked into the prompt as untranslated German",
+    "files": [
+      "src/pwg_mask.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "Code review 2026-07-04: <ab>lat.</ab>/<ab>griech.</ab> cues are masked to {Tn} in mask() step 1 BEFORE classify_pct runs, so the end-anchored LATIN_CUE regex matched the placeholder, not the cue; measured 33 Latin/Greek cognate glosses across all of PWG (e.g. ignis, uncus, ansa after `lat.`) were being sent for German translation and leaked verbatim into the translator prompt. Fix expands trailing placeholders back to source and strips tags in the classify context window. Masking is stage-0 and runs before any --lang branch, so the fix is identical for RU and EN. Round-trip stays lossless. Pinned by window_selftest.test_pwg_mask_latin_cue_behind_ab_tag.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pwg_mask.py": "5bbb029b2dc287f52d4efd4f9f44ff4a12952a15984554568afa645eec2804bd",
+      "src/pilot/window_selftest.py": "54bd75e23fb1311076889a1e65ebf43a67b8686f06b5db247f45c51512e919f6"
+    }
+  },
+  {
     "id": "presplit_router",
     "mechanism": "Presplit router sends over-budget dense cards straight to the fragment lane",
     "files": [
@@ -99,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
-      "src/pilot/window_selftest.py": "6450db8535cd39b7630613e0ebb78249b379dd12d2f49f026a9209c4b99711cd"
+      "src/pilot/window_selftest.py": "54bd75e23fb1311076889a1e65ebf43a67b8686f06b5db247f45c51512e919f6"
     }
   },
   {
@@ -118,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
-      "src/pilot/window_selftest.py": "6450db8535cd39b7630613e0ebb78249b379dd12d2f49f026a9209c4b99711cd"
+      "src/pilot/window_selftest.py": "54bd75e23fb1311076889a1e65ebf43a67b8686f06b5db247f45c51512e919f6"
     }
   },
   {
@@ -277,8 +296,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "854b86a71ebfa20b06a9c31240b5f4b9ebf3cf3a7fc5fc935c813c4d9ead27b0",
-      "src/promote_en.py": "b2b97ad362fd7020549a778216dd6cfb230342db76a28883b32bdebd4d124bef"
+      "src/promote_final_cards.py": "9356c53c5f4a64e9e5ec264dd2c34ca43a7af2c40e912147d2815d81f10c5ca0",
+      "src/promote_en.py": "96e1928ad4ceae44aa7a9984d3f5b6cb7bb2f1877923fd3adbc46cab56bac022"
     }
   },
   {
@@ -297,7 +316,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
-      "src/pilot/window_selftest.py": "6450db8535cd39b7630613e0ebb78249b379dd12d2f49f026a9209c4b99711cd"
+      "src/pilot/window_selftest.py": "54bd75e23fb1311076889a1e65ebf43a67b8686f06b5db247f45c51512e919f6"
     }
   },
   {
@@ -316,7 +335,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
-      "src/pilot/window_selftest.py": "6450db8535cd39b7630613e0ebb78249b379dd12d2f49f026a9209c4b99711cd"
+      "src/pilot/window_selftest.py": "54bd75e23fb1311076889a1e65ebf43a67b8686f06b5db247f45c51512e919f6"
     }
   }
 ]

--- a/RussianTranslation/research/ACL_ANTHOLOGY_MONITOR.md
+++ b/RussianTranslation/research/ACL_ANTHOLOGY_MONITOR.md
@@ -1,6 +1,6 @@
 # ACL Anthology / NLP-for-DH Monitor
 
-_Created: 04-07-2026_
+_Created: 04-07-2026 · Last updated: 04-07-2026_
 
 Monthly monitor home for ACL Anthology and adjacent NLP-for-Digital-Humanities
 work relevant to the Sanskrit repos.
@@ -20,5 +20,134 @@ data statements / dataset cards, OCR, normalization, and cultural-heritage NLP.
 
 - Codex automation `monthly-acl-anthology-sanskrit-nlp-monitor` is active.
 - First run should append the first annotated bibliography below this section.
+
+## 04-07-2026 — First annotated bibliography (manual seed run)
+
+Mapped against the **pwg_ru** pipeline's actual subsystems. Each entry ends with
+an `Actionable for us?` verdict and the concrete file/decision it touches.
+
+### A. LLM-as-judge / MT evaluation (touches the Fable/Opus judge gate)
+
+1. **Kocmi & Federmann, "GEMBA-MQM: Detecting Translation Quality Error Spans
+   with GPT-4", WMT 2023** — [aclanthology.org/2023.wmt-1.64](https://aclanthology.org/2023.wmt-1.64/).
+   Reference-free MT quality estimation via a fixed **three-shot** prompt that
+   makes the model mark MQM **error spans with severity**, then scores by a
+   weighted error count; language-agnostic prompt, SOTA system-ranking, but the
+   authors warn against black-box-model dependence in scholarly use.
+   `Actionable for us? YES.` Our judge layer ([`FIDELITY_JUDGE_2026-06-30.md`](../FIDELITY_JUDGE_2026-06-30.md),
+   [`FABLE_JUDGE_S7_2026-07-02.md`](../FABLE_JUDGE_S7_2026-07-02.md),
+   [`fable_s7_verdicts_2026-07-02.json`](../fable_s7_verdicts_2026-07-02.json))
+   emits pass/flag verdicts; adopting **error-span + severity** output (not just a
+   verdict) gives per-sense localization for the review queue and a reproducible
+   fixed-shot prompt. The paper's own caveat = the argument for keeping a
+   **human-adjudicated gold** behind the judge (we already do via `/gold-adjudicate`).
+
+2. **"RUBRIC-MQM: Span-Level LLM-as-judge in MT for High-End Models", ACL 2025
+   Industry** — [aclanthology.org/2025.acl-industry.12](https://aclanthology.org/2025.acl-industry.12/).
+   Extends span-level MQM judging to strong models where errors are rare and
+   subtle — exactly our regime (Opus/Fable translating, Fable judging).
+   `Actionable for us? MONITOR → PILOT.` Worth a side-by-side against our current
+   holistic verdict on the existing `judge_ab_battery_*.jsonl` before committing.
+
+### B. Translation memory & retrieval-augmented translation (touches the TM subsystem)
+
+3. **Cai et al., "Neural Machine Translation with Monolingual Translation
+   Memory", ACL 2021 (best-paper)** — [aclanthology.org/2021.acl-long.567](https://aclanthology.org/2021.acl-long.567/).
+   Learnable cross-lingual retrieval over a **monolingual** target-side memory,
+   removing the bilingual-TM requirement and letting memory scale independently
+   of parallel data. `Actionable for us? CONCEPTUAL.` Validates our direction
+   ([`src/pilot/translation_memory.py`](../src/pilot/translation_memory.py)) but
+   ours is exact/fuzzy content-addressed, not learned-retrieval — the lesson is
+   that **target-side monolingual Russian** (e.g. Apresjan-style glosses) is a
+   legitimate memory even without a Sa→Ru pair.
+
+4. **Bouthors et al., "Retrieving Examples from Memory for Retrieval Augmented
+   NMT: A Systematic Comparison", Findings NAACL 2024** — [aclanthology.org/2024.findings-naacl.190](https://aclanthology.org/2024.findings-naacl.190/).
+   Systematically compares **how** RA-NMT selects which memory examples to feed —
+   the retrieval policy matters as much as the model. `Actionable for us? YES.`
+   Directly informs `best_reusable` / fragment selection in
+   [`translation_memory.py`](../src/pilot/translation_memory.py) (see review
+   finding on trust-ranked selection) — our "pick the highest-trust exact, else
+   best fragment" is a retrieval policy that should be **evaluated**, not assumed.
+
+5. **Hoang et al., "Improving Retrieval Augmented NMT by Controlling Source and
+   Fuzzy-Match Interactions", Findings EACL 2023** — [aclanthology.org/2023.findings-eacl.22](https://aclanthology.org/2023.findings-eacl.22/).
+   Shows uncontrolled fuzzy matches can **hurt**; gains come from gating how much
+   the match influences generation. `Actionable for us? YES — corroborates a
+   design choice.` It's the external evidence behind our rule that RU raw
+   MW-English suggestions are **blocked** and only curated Sa→Ru terminology rows
+   enter prompts ([`TRANSLATION_MEMORY_DECISIONS.md`](../TRANSLATION_MEMORY_DECISIONS.md)).
+
+### C. Dictionary / terminology-constrained prompting (touches terminology injection)
+
+6. **Lu et al., "Chain-of-Dictionary Prompting Elicits Translation in LLMs",
+   EMNLP 2024** — [aclanthology.org/2024.emnlp-main.55](https://aclanthology.org/2024.emnlp-main.55/).
+   Injecting **chained bilingual-dictionary** entries for source words into the
+   prompt materially improves LLM translation of low-resource languages.
+   `Actionable for us? HIGH.` This is the published form of what we do ad hoc —
+   our curated Sanskrit→Russian terminology TM rows are a dictionary chain. The
+   lesson: structure terminology injection **per-headword, multi-hop** and measure
+   the lift; candidate A/B on the terminology lane already in the harness.
+
+7. **Hasler et al. / Post & Vilar lineage, "NMT Decoding with Terminology
+   Constraints", NAACL 2018** — [aclanthology.org/N18-2081](https://aclanthology.org/N18-2081/).
+   Hard target-side terminology enforcement via constrained decoding.
+   `Actionable for us? REFERENCE.` We can't constrain-decode a hosted model, but
+   it frames why our approach is **soft** (prompt-level) constraint — cite when
+   documenting why terminology adherence is checked post-hoc in the audit gate,
+   not guaranteed at decode.
+
+### D. Structured-output reliability (touches the StructuredOutput stalls + kill gate)
+
+8. **"JSONSchemaBench: A Rigorous Benchmark of Structured Outputs for Language
+   Models", 2025 (preprint, adjacent)** — [arxiv.org/abs/2501.10868](https://arxiv.org/abs/2501.10868).
+   Benchmarks constrained-decoding/JSON-Schema frameworks on **schema coverage,
+   efficiency, and the quality cost** of forcing structure — the failure mode
+   behind our whole-card StructuredOutput stalls. `Actionable for us? YES.`
+   Independent evidence for [`FAILURE_MODES_AND_KILL_GATE_2026-07-04.md`](../FAILURE_MODES_AND_KILL_GATE_2026-07-04.md):
+   output volume vs schema complexity drives stalls; supports the **sense-presplit
+   trigger** and the wall-clock kill gate as the right structural mitigations.
+
+### E. Sanskrit-specific NLP & venue (prior art + the study's home community)
+
+9. **Nehrdich et al., "One Model is All You Need: ByT5-Sanskrit, a Unified Model
+   for Sanskrit NLP Tasks", Findings EMNLP 2024** — [aclanthology.org/2024.findings-emnlp.805](https://aclanthology.org/2024.findings-emnlp.805/).
+   A single byte-level model for segmentation, lemmatization, morphosyntax, and
+   compound/sandhi splitting — the tasks our grammar layer approximates.
+   `Actionable for us? EVALUATE (reuse-first).` Before extending
+   [`nominal_grammar.py`](../src/nominal_grammar.py) / sandhi handling, benchmark
+   ByT5-Sanskrit as an external morphology/segmentation supplier or validation
+   oracle — matches the org "don't reinvent" rule; cross-check with the
+   vidyut/DCS crosswalk we already wired.
+
+10. **Proceedings of the 7th International Sanskrit Computational Linguistics
+    Symposium (ISCLS 2024)** — [aclanthology.org/2024.iscls-1.0](https://aclanthology.org/2024.iscls-1.0/).
+    Includes **word-sense alignment of Sanskrit lexica**, digital editions with
+    commentaries, and Sanskrit lexicography tooling. `Actionable for us? YES —
+    venue + prior art.` This is the natural **publication venue** for the
+    pwg_ru / CDSL-article-comparison study, and the word-sense-alignment papers
+    are direct prior art for our sense-level TM and the article-comparison track.
+
+### F. Data documentation (touches the TM datasheet / DOI plan)
+
+11. **Bender & Friedman, "Data Statements for NLP", TACL 2018; Gebru et al.,
+    "Datasheets for Datasets"** — data-statement / datasheet standard (curation
+    rationale, language variety, annotator demographics, uses, risks).
+    `Actionable for us? ALREADY ADOPTED — keep aligned.`
+    [`TRANSLATION_MEMORY_DATASHEET.md`](../TRANSLATION_MEMORY_DATASHEET.md) and
+    [`schemas/translation_memory.schema.json`](../schemas/translation_memory.schema.json)
+    follow this; when the TM gets its DOI ([`DOI_PLAN.md`](../DOI_PLAN.md)),
+    cite these as the documentation standard the datasheet implements.
+
+### Follow-ups queued from this run
+
+- **[eval]** Prototype GEMBA-MQM-style **error-span + severity** judge output and
+  compare to the current holistic verdict on `judge_ab_battery_*.jsonl` (entry 1/2).
+- **[reuse]** Benchmark **ByT5-Sanskrit** as an external morphology/sandhi oracle
+  before extending the grammar layer (entry 9).
+- **[measure]** Treat `best_reusable` fragment selection as a **retrieval policy**
+  and evaluate it, per Bouthors et al. (entry 4).
+- **[venue]** Log **ISCLS** as target venue for the pwg_ru study in `Uprava/ARTICLES.md`
+  (entry 10).
 
 _Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -909,6 +909,29 @@ def test_en_gate_strict_has_teeth():
             os.remove(report_path)
 
 
+def test_pwg_mask_latin_cue_behind_ab_tag():
+    """Regression (review 2026-07-04): a Latin/Greek cue inside an <ab> span
+    (e.g. `<ab>lat.</ab> {%ignis%}`) is masked to a {Tn} placeholder in mask()
+    step 1, so classify_pct used to see "{T5}" instead of "lat." and misread the
+    following {%...%} cognate as German — leaking Latin verbatim into the
+    translator prompt. The cue must be recovered from the placeholder so the
+    Latin gloss is masked, while a genuine German gloss stays inline. SHARED
+    (masking runs before any --lang branch; identical for RU and EN)."""
+    import pwg_mask
+    body = 'Feuer <ab>lat.</ab> {%ignis%} und Wasser'
+    sk, ph, st = pwg_mask.mask(body)
+    if st['pct_la'] != 1 or st['pct_de'] != 0:
+        fail('Latin cue behind <ab> not caught: %r' % st)
+    if '{%ignis%}' in sk:
+        fail('Latin gloss leaked into skeleton unmasked: %r' % sk)
+    if pwg_mask.restore(sk, ph) != body:
+        fail('mask round-trip not lossless after Latin-cue fix')
+    # a genuine German gloss (no Latin cue) must still be kept inline for translation
+    sk2, ph2, st2 = pwg_mask.mask('das <ab>Subst.</ab> {%Feuer%}')
+    if st2['pct_de'] != 1 or st2['pct_la'] != 0:
+        fail('German gloss wrongly masked as Latin: %r' % st2)
+
+
 def test_markup_loss_soft_flag_ru():
     """S7 rec 1 (RU): a dropped {%..%} gloss wrapper is a SOFT, report-only signal —
     markup_wrapper_dropped fires at low severity and is NEVER a requeue trigger; a retained
@@ -1974,6 +1997,7 @@ def main():
         test_attested_text_signal_redesign,
         test_nws_fp_suppressed,
         test_en_gate_strict_has_teeth,
+        test_pwg_mask_latin_cue_behind_ab_tag,
         test_markup_loss_soft_flag_ru,
         test_markup_loss_soft_flag_en,
         test_en_de_residue_french_guard,

--- a/RussianTranslation/src/promote_en.py
+++ b/RussianTranslation/src/promote_en.py
@@ -296,9 +296,14 @@ def main():
         with open(bak, 'w', encoding='utf-8') as f, open(args.store, encoding='utf-8') as src:
             f.write(src.read())
         print('\nbacked up store -> %s' % os.path.basename(bak))
-    with open(args.store, 'w', encoding='utf-8') as f:
+    # Atomic write: temp file + os.replace so a crash/kill mid-write cannot truncate
+    # the tri-lingual store (the "EN layer wiped" scar). Under --no-backup this is the
+    # ONLY thing standing between an interrupted write and total loss.
+    tmp = args.store + '.tmp'
+    with open(tmp, 'w', encoding='utf-8') as f:
         for row in rows:
             f.write(json.dumps(row, ensure_ascii=False) + '\n')
+    os.replace(tmp, args.store)
     print('wrote tri-lingual store -> %s (%d rows, %d now carry en)'
           % (os.path.relpath(args.store, ROOT), len(rows), stats['attached']))
     print('NEXT: re-run `python src/annotate_dcs_freq.py` to (re)attach the dcs_freq block.')

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -321,9 +321,14 @@ def main():
         bak = args.store + ('.premerge.bak' if args.merge else '.legacy.bak')
         os.replace(args.store, bak)
         print('\nbacked up prior store -> %s' % os.path.basename(bak))
-    with open(args.store, 'w', encoding='utf-8') as f:
+    # Atomic write: stream to a temp file then os.replace, so a crash/kill mid-write
+    # can never leave the canonical store truncated (the store this project has lost
+    # before). Matches the tmp+replace pattern in run_batch.apply_review.
+    tmp = args.store + '.tmp'
+    with open(tmp, 'w', encoding='utf-8') as f:
         for row in rows:
             f.write(json.dumps(row, ensure_ascii=False) + '\n')
+    os.replace(tmp, args.store)
     print('wrote canonical translated store -> %s (%d rows, review_status=%s)'
           % (args.store, len(rows), args.review_status))
     print('NOTE: rows are %s, NOT approved — export_interop keeps them out of the citable'

--- a/RussianTranslation/src/pwg_mask.py
+++ b/RussianTranslation/src/pwg_mask.py
@@ -93,11 +93,22 @@ def mask(body):
         return take(m)
     body = PAIRED_RE.sub(paired, body)
 
-    # 2) {%…%}: German kept inline, Latin masked, ambiguous flagged-but-kept
+    # 2) {%…%}: German kept inline, Latin masked, ambiguous flagged-but-kept.
+    # The Latin cue ("<ab>lat.</ab>", "griech.") is overwhelmingly inside an <ab>
+    # span, which step 1 has ALREADY masked to a {Tn} placeholder — so the raw
+    # `preceding` window would show "{T5}", not "lat.", and every tagged cue would
+    # be misread as German and leaked inline. Expand any placeholders back to their
+    # source and drop tags before classifying, so the cue is visible again.
+    def _cue_context(text):
+        def _back(mm):
+            idx = int(mm.group(1)) - 1
+            return ph[idx] if 0 <= idx < len(ph) else mm.group(0)
+        return TAG_RE.sub('', re.sub(r'\{T(\d+)\}', _back, text))
+
     out, last = [], 0
     for m in PCT_RE.finditer(body):
         out.append(body[last:m.start()])
-        kind = classify_pct(m.group(1).strip(), body[max(0, m.start() - 35):m.start()])
+        kind = classify_pct(m.group(1).strip(), _cue_context(body[max(0, m.start() - 40):m.start()]))
         if kind == 'la':
             stats['pct_la'] += 1
             ph.append(m.group(0))

--- a/RussianTranslation/src/run_batch.py
+++ b/RussianTranslation/src/run_batch.py
@@ -149,43 +149,59 @@ def cmd_collect(args):
     wf = args[0]
     model = args[1] if len(args) > 1 else None      # optional translate-model override
     raw = json.load(open(wf, encoding='utf-8'))
-    res = raw.get('result', raw).get('results', raw.get('results', []))
+    # A workflow result is often a JSON-encoded STRING, not a nested object — every
+    # sibling loader (save_and_audit, promote_en, promote_final_cards) handles that;
+    # this one used to call .get() on the string and crash, stranding the whole run's
+    # generation output (the "run lost / re-driven" class). Normalise first.
+    result = raw.get('result', raw)
+    if isinstance(result, str):
+        result = json.loads(result)
+    if not isinstance(result, dict):
+        result = raw
+    res = result.get('results', raw.get('results', []))
     by_i = {r['i']: r for r in res if 'i' in r}
-    batch = {json.loads(l)['i']: json.loads(l) for l in open(BATCH_IN, encoding='utf-8')}
+    batch = {}
+    for l in open(BATCH_IN, encoding='utf-8'):
+        rec_in = json.loads(l)            # single parse per line (was parsed twice)
+        batch[rec_in['i']] = rec_in
     prov = provenance(os.path.splitext(os.path.basename(wf))[0], model)
     appended = ok = bad = mism = needs = 0
+    out_lines = []
+    for i, card in batch.items():
+        r = by_i.get(i)
+        if not r:
+            continue
+        ph = card['placeholders']
+        src = set(re.findall(r'\{T(\d+)\}', card['de_skeleton']))
+        got = set(re.findall(r'\{T(\d+)\}', r['ru_skeleton']))
+        integrity = src == got
+        ru = re.sub(r'\{T(\d+)\}',
+                    lambda m: ph[int(m.group(1)) - 1] if 0 < int(m.group(1)) <= len(ph) else m.group(0),
+                    r['ru_skeleton'])
+        keymatch = r.get('key1') == card['key1']
+        v = r.get('verdict') or {}   # judge may be null (e.g. rate-limited) → treat as pending
+        good = bool(v.get('ok')) and integrity and keymatch
+        sev = v.get('severity')
+        # review state machine: an LLM verdict is never final for print —
+        # anything failing or sev>=3 or with a structural mismatch queues for a human.
+        review_status = 'judged' if (good and (sev or 0) < 3) else 'needs_review'
+        rec = {'ord': card['ord'], 'key1': card['key1'], 'key2': card['key2'], 'ru': ru,
+               'placeholders_ok': integrity, 'key_match': keymatch, 'verdict': v,
+               'ok': good, 'severity': sev,
+               'review_status': review_status, 'reviewer': None,
+               'attested': card.get('attested', []),     # persist the reuse evidence (rec 1)
+               'provider_gate': card.get('provider_gate', {}),
+               'provenance': prov}
+        out_lines.append(json.dumps(rec, ensure_ascii=False) + '\n')
+        appended += 1
+        ok += 1 if good else 0
+        bad += 0 if good else 1
+        mism += 0 if (integrity and keymatch) else 1
+        needs += 1 if review_status == 'needs_review' else 0
+    # One append syscall instead of one-per-row shrinks the window in which a crash
+    # can leave a torn final JSONL line that breaks every later json.loads pass.
     with open(STORE, 'a', encoding='utf-8', newline='') as out:
-        for i, card in batch.items():
-            r = by_i.get(i)
-            if not r:
-                continue
-            ph = card['placeholders']
-            src = set(re.findall(r'\{T(\d+)\}', card['de_skeleton']))
-            got = set(re.findall(r'\{T(\d+)\}', r['ru_skeleton']))
-            integrity = src == got
-            ru = re.sub(r'\{T(\d+)\}',
-                        lambda m: ph[int(m.group(1)) - 1] if 0 < int(m.group(1)) <= len(ph) else m.group(0),
-                        r['ru_skeleton'])
-            keymatch = r.get('key1') == card['key1']
-            v = r.get('verdict') or {}   # judge may be null (e.g. rate-limited) → treat as pending
-            good = bool(v.get('ok')) and integrity and keymatch
-            sev = v.get('severity')
-            # review state machine: an LLM verdict is never final for print —
-            # anything failing or sev>=3 or with a structural mismatch queues for a human.
-            review_status = 'judged' if (good and (sev or 0) < 3) else 'needs_review'
-            rec = {'ord': card['ord'], 'key1': card['key1'], 'key2': card['key2'], 'ru': ru,
-                   'placeholders_ok': integrity, 'key_match': keymatch, 'verdict': v,
-                   'ok': good, 'severity': sev,
-                   'review_status': review_status, 'reviewer': None,
-                   'attested': card.get('attested', []),     # persist the reuse evidence (rec 1)
-                   'provider_gate': card.get('provider_gate', {}),
-                   'provenance': prov}
-            out.write(json.dumps(rec, ensure_ascii=False) + '\n')
-            appended += 1
-            ok += 1 if good else 0
-            bad += 0 if good else 1
-            mism += 0 if (integrity and keymatch) else 1
-            needs += 1 if review_status == 'needs_review' else 0
+        out.write(''.join(out_lines))
     print('collected %d → %s  (ok %d, flagged %d, placeholder-mismatch %d, needs_review %d)'
           % (appended, os.path.basename(STORE), ok, bad, mism, needs))
     print('  provenance: %s @ %s (pwg %s, prompts %s)'


### PR DESCRIPTION
## Code review — pwg_ru pipeline (2026-07-04)

Full-tree review of `RussianTranslation/src` (34,668 LOC, ~90 files) by five parallel Opus 4.8 (`claude-opus-4-8`) reviewers, cross-checked. This PR lands the **critical subset**; the full prioritized backlog is in [CODE_REVIEW_2026-07-04.md](https://github.com/gasyoun/SanskritLexicography/blob/fix/review-2026-07-04-dataloss-latinmask/RussianTranslation/CODE_REVIEW_2026-07-04.md).

### 🔴 Data-loss (the project's historical scars)
- **[promote_en.py](https://github.com/gasyoun/SanskritLexicography/blob/fix/review-2026-07-04-dataloss-latinmask/RussianTranslation/src/promote_en.py)** / **[promote_final_cards.py](https://github.com/gasyoun/SanskritLexicography/blob/fix/review-2026-07-04-dataloss-latinmask/RussianTranslation/src/promote_final_cards.py)**: non-atomic `open('w')` truncate-write of the tri-lingual store → a crash mid-write with `--no-backup` truncates the one file everything reads (the "EN layer wiped / output lost" history). Now stream to `.tmp` + `os.replace`.
- **[run_batch.py](https://github.com/gasyoun/SanskritLexicography/blob/fix/review-2026-07-04-dataloss-latinmask/RussianTranslation/src/run_batch.py) `cmd_collect`**: crashed calling `.get()` on a JSON-**string** `result`, stranding the run's generation output. Now normalises `result` like the sibling loaders; single-parses the batch file; coalesces per-row appends into one write.

### 🟠 Quality
- **[pwg_mask.py](https://github.com/gasyoun/SanskritLexicography/blob/fix/review-2026-07-04-dataloss-latinmask/RussianTranslation/src/pwg_mask.py) `classify_pct`** saw the Latin cue (`<ab>lat.</ab>`) **after** step-1 masking turned it into `{Tn}`, so **33 Latin/Greek cognate glosses across PWG** (`ignis`, `uncus`, `ansa`…) were leaked into the translator prompt as German. Now expands trailing placeholders + strips tags in the classify window. Round-trip stays lossless.

### Tests & parity
- New `window_selftest.test_pwg_mask_latin_cue_behind_ab_tag`; full suite **54/54**.
- LANG_PARITY: new SHARED entry `latin_cue_masking`; re-affirmed 5 pre-existing drifted entries (stale `window_selftest.py` hash from H155 + the two promotion scripts).

### Docs
- [research/ACL_ANTHOLOGY_MONITOR.md](https://github.com/gasyoun/SanskritLexicography/blob/fix/review-2026-07-04-dataloss-latinmask/RussianTranslation/research/ACL_ANTHOLOGY_MONITOR.md): first annotated bibliography (GEMBA-MQM, Chain-of-Dictionary, RA-NMT retrieval, JSONSchemaBench, ByT5-Sanskrit, ISCLS) mapped to our subsystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)