### PR TITLE
feat(provenance): auto-write pipeline footer on rendered RU cards

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -31,6 +31,14 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   needing re-translation; `stamp-md` refreshes a `_pipeline …_` footer on rendered
   `.md` cards; `backfill` stamps legacy unversioned rows with *explicitly asserted*
   versions (never guessed), mirroring the no-guessing philosophy of the provenance audit.
+- The `.md` footer is now written automatically at render time, not only via a batch
+  `stamp-md` pass: `_pilot_collect.py` stamps each whole card it emits (model + date from
+  the wf meta), and `root_glue_translated.py` stamps the assembled `.NESTED.md` once at
+  the end. Split-root **sub-cards deliberately carry no footer** — `root_glue`'s `body_of`
+  keeps everything after the title, so a per-sub-card footer would scatter through the
+  glued article; the glue step stamps the whole card instead. The render-side files are
+  intentionally NOT in the `script` hash set (a footer-format tweak must not force a
+  re-translation), so this changes no component version.
 - Live store state at introduction: 10,794 rows, all pre-versioning → bucketed as
   "unversioned legacy" (NOT flagged stale, so the deploy does not falsely mark every
   historical row for re-run). Baseline frozen at prompt/glossary/script v1.0.0.

--- a/RussianTranslation/src/_pilot_collect.py
+++ b/RussianTranslation/src/_pilot_collect.py
@@ -8,6 +8,7 @@ sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
 from safe_filename import safe_name
+import pipeline_version
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 OUT = os.path.join(HERE, 'pilot', 'output')
@@ -27,6 +28,24 @@ def find_results(o):
             r = find_results(v)
             if r is not None:
                 return r
+    return None
+
+
+def find_meta(o):
+    """First dict value carried under a 'meta' key anywhere in the wf wrapper —
+    for the model id + generated_at that go into the .md footer."""
+    if isinstance(o, dict):
+        if isinstance(o.get('meta'), dict):
+            return o['meta']
+        for v in o.values():
+            m = find_meta(v)
+            if m is not None:
+                return m
+    if isinstance(o, list):
+        for v in o:
+            m = find_meta(v)
+            if m is not None:
+                return m
     return None
 
 
@@ -53,7 +72,18 @@ def render(res):
 
 def main():
     wf = sys.argv[1]
-    results = find_results(json.loads(open(wf, encoding='utf-8').read())) or []
+    parsed = json.loads(open(wf, encoding='utf-8').read())
+    results = find_results(parsed) or []
+    meta = find_meta(parsed) or {}
+    # pipeline footer: stamp from the CURRENT tooling (same source as run_batch/promote),
+    # model + date from the wf meta. Warn on drift, like run_batch.py collect.
+    model = meta.get('translate_model') or meta.get('model')
+    pipeline = pipeline_version.stamp(model_version=model)
+    footer = pipeline_version.md_footer(pipeline, model, meta.get('generated_at'))
+    for d in pipeline_version.check():
+        print('  WARNING pipeline drift: %s files changed but version still v%s '
+              '(recorded %s → now %s) — bump pipeline_versions.json + freeze'
+              % (d['component'], d['version'], d['recorded_sha'], d['current_sha']))
     os.makedirs(OUT, exist_ok=True)
     print('=== PILOT JUDGE SUMMARY (%d cards) ===' % len(results))
     print('%-12s %-4s %-4s %-7s %-6s %-6s %-13s %s' %
@@ -78,10 +108,14 @@ def main():
             combined.append(md)
             combined.append('\n---\n')
             continue
-        md = render(res)
         # root-split sub-card keys (e.g. man~~h0_00_pwg00) are ALREADY safe stems — keep them
         # verbatim so root_glue_translated finds <subkey>.merged.md; only headword keys get safe_name.
-        stem = k if '~~' in (k or '') else safe_name(k)
+        # The footer goes ONLY on whole cards; a sub-card's footer would scatter through the
+        # glued .NESTED.md (root_glue_translated.body_of keeps everything after the title), so
+        # the glue step stamps the assembled card once instead.
+        is_subcard = '~~' in (k or '')
+        md = render(res).rstrip('\n') + ('' if is_subcard else '\n\n' + footer) + '\n'
+        stem = k if is_subcard else safe_name(k)
         out_md = os.path.join(OUT, stem + '.merged.md')
         if k in PROTECTED and os.path.exists(out_md):
             print('  %s protected — kept existing %s' % (k, os.path.basename(out_md)))

--- a/RussianTranslation/src/root_glue_translated.py
+++ b/RussianTranslation/src/root_glue_translated.py
@@ -19,6 +19,7 @@ sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
 from safe_filename import safe_name
+import pipeline_version
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 INP = os.path.join(HERE, 'pilot', 'input')
@@ -86,6 +87,10 @@ def glue(root, outdir):
             parts.append('_[перевод под-карточки `%s` ещё не готов в этом сэмпле]_' % s['subkey'])
             miss += 1
         parts.append('')
+    # one pipeline-provenance footer for the whole assembled card (sub-cards carry none, so
+    # nothing scatters mid-document). Versions come from the current tooling; the model id
+    # stays authoritative in the JSONL store.
+    parts.append(pipeline_version.md_footer(pipeline_version.stamp()))
     nested = os.path.join(outdir, safe_name(root) + '.NESTED.md')
     open(nested, 'w', encoding='utf-8').write('\n'.join(parts) + '\n')
     print('glue-after-translate  %s: %d sub-cards (%d translated, %d pending) -> %s'


### PR DESCRIPTION
Follow-on to [PR #140](https://github.com/gasyoun/SanskritLexicography/pull/140) — the deferred `.md`-footer wiring from [H170](https://github.com/gasyoun/Uprava/blob/main/handoffs/H170-Opus_RussianTranslation_pipeline_versioning_04.07.26.md).

## What

The pipeline footer (`_pipeline prompt v… · glossary v… · script v… · <model> · <date>_`) is now written **at render time**, not only via a manual `stamp-md` pass:

- **[`src/_pilot_collect.py`](https://github.com/gasyoun/SanskritLexicography/blob/main/RussianTranslation/src/_pilot_collect.py)** — stamps each **whole** card it emits; model + `generated_at` pulled from the workflow `meta`. Also warns on pipeline drift, matching `run_batch.py collect`.
- **[`src/root_glue_translated.py`](https://github.com/gasyoun/SanskritLexicography/blob/main/RussianTranslation/src/root_glue_translated.py)** — stamps the assembled `.NESTED.md` once at the end.

## Why sub-cards get no footer

`root_glue.body_of` keeps everything after the title, so a footer on each split-root sub-card would scatter through the glued article. Sub-cards (`~~` keys) are left unstamped; the glue step stamps the whole assembled card instead.

## Safety

- Verified the footer does not perturb the deterministic gates: `audit_translation.py` counts only `<ls>`/`{#…#}`/Cyrillic, none of which the footer adds or removes.
- The two render-side files are **outside** the manifest `script` hash set — a footer-format tweak must not force a re-translation — so `pipeline_version.py check` stays clean and no component version bumps.
- End-to-end tested in a temp dir: whole card ends with the footer, sub-card has none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)