### PR TITLE
fix(pwg_ru): QA-gate teeth — real DUP hard flag + RU-gate verdict-parse guard (H169)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,34 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
+- **H169 QA-gate teeth (real `DUP` hard flag + RU-gate verdict-parse guard) — ✅ DONE
+  04-07-2026 (Sonnet 5, `claude-sonnet-5`).** Fixed the 2 🟠 "broken validators" findings
+  from [`CODE_REVIEW_2026-07-04.md`](CODE_REVIEW_2026-07-04.md) deferred out of PR #138.
+  **(1)** [`audit_window_en.py`](src/pilot/audit_window_en.py): the advertised HARD `DUP`
+  gate was never emitted — two senses with identical english slid through `--strict`
+  clean because the only signal was soft `SAME-GLOSS`, gated on `>=3` content words. Now
+  emits a real HARD `DUP` flag on any identical-english pair within a record regardless of
+  length; added to `HARD`. **(2)** [`audit_window.py`](src/pilot/audit_window.py): the RU
+  gate recovered `translation`/`coverage`/`sense_dupes` verdicts by regex-scraping child
+  stdout — any wording drift silently returned `[]`, dropping flagged cards from the
+  requeue with the gate reporting clean. [`audit_translation.py`](src/audit_translation.py),
+  [`audit_coverage.py`](src/audit_coverage.py), and
+  [`audit_sense_dupes.py`](src/audit_sense_dupes.py) now also emit a strict
+  `FLAGGED_JSON: [...]` line; the parent parses it strictly and treats a missing/malformed
+  line as unparseable — requeueing every card in the window and marking the gate crashed,
+  never silently passing. Dead `parse_nws` removed. Pinned by 2 new
+  `window_selftest.py` cases (`test_en_gate_dup_has_teeth`,
+  `test_ru_gate_fails_loud_on_unparseable_child`); full suite green (52 tests).
+  **Parity:** DUP fix logged as `en_dup_hard_gate_20260704` (SHARED, GAP-closing per the
+  handoff's classification — see [`LANG_PARITY.md`](LANG_PARITY.md) note for the nuance
+  that RU's own within-record duplicate signal is softer, all-senses-only). Re-affirmed
+  drifted hashes on 7 unrelated entries this branch's edits touched (all Case-C
+  re-snapshots, no behavior change). **Incidental finding while re-affirming parity:**
+  PR #140's pipeline-version stamping landed only on `promote_final_cards.py` (RU), not
+  `promote_en.py` — logged as a new GAP ledger entry `pipeline_version_stamp_en_gap`,
+  tracked in [`Uprava/GTD_NEXT_ACTIONS.md`](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md)
+  @DO, not fixed here (out of H169's scope).
+
 - **Publication-grade TM schema hardening — ✅ DONE 04-07-2026 (Codex/GPT-5).** Upgraded
   the translation memory from cache-only toward a scholarly audit artifact: added a tracked
   publication schema contract (`schemas/translation_memory.schema.json`), a reusable datasheet

--- a/RussianTranslation/CODE_REVIEW_2026-07-04.md
+++ b/RussianTranslation/CODE_REVIEW_2026-07-04.md
@@ -23,6 +23,14 @@ prioritized backlog below, to be worked before/alongside the next scale run.
 | F3 | [run_batch.py:152](src/run_batch.py) | `cmd_collect` called `.get()` on a possibly-JSON-string `result`, crashing and stranding the run's generation output (the "run lost / re-driven" class); sibling loaders all handle the string case. | Normalise `result` (str→`json.loads`, non-dict→raw); also single-parse the batch file and coalesce per-row appends into one write to shrink the torn-last-line window. |
 | F4 | [pwg_mask.py:98](src/pwg_mask.py) | `classify_pct` looked for the Latin cue (`<ab>lat.</ab>`) in the already-masked body, so it saw `{Tn}` not `lat.` → **33 Latin/Greek cognate glosses across PWG** (e.g. `ignis`, `uncus`, `ansa`) were leaked into the translator prompt as German. | Expand trailing `{Tn}` placeholders + strip tags in the classify context. Round-trip stays lossless. Pinned by `window_selftest.test_pwg_mask_latin_cue_behind_ab_tag`; SHARED parity entry `latin_cue_masking`. |
 
+**Fixed in H169** (branch `fix/qa-gate-teeth`): the two 🟠 QA-gate-teeth
+defects below (real `DUP` hard flag + RU-gate verdict-parse guard).
+
+| # | File | Defect | Fix |
+|---|---|---|---|
+| F5 | [audit_window_en.py:252](src/pilot/audit_window_en.py) | Advertised HARD `DUP` gate never emitted — two senses with identical english passed `--strict`; the only signal was soft SAME-GLOSS, gated on `>=3` content words. | Emit a real `DUP` hard flag on any identical-english pair within a record, independent of word count; added to `HARD`. Pinned by `window_selftest.test_en_gate_dup_has_teeth`; SHARED parity entry `en_dup_hard_gate_20260704`. |
+| F6 | [audit_window.py:71](src/pilot/audit_window.py) | RU gate recovered child-auditor verdicts by regex-scraping prose stdout (`\| flagged: ...`) — any wording drift in `audit_translation.py` / `audit_coverage.py` / `audit_sense_dupes.py` silently returned `[]`, dropping flagged cards from the requeue with the gate reporting clean. | Child auditors now also emit a strict machine-readable `FLAGGED_JSON: [...]` line; the parent parses it strictly and treats a missing/malformed line as unparseable — requeueing every card in the window and marking the gate crashed rather than silently passing. Dead `parse_nws` removed. Pinned by `window_selftest.test_ru_gate_fails_loud_on_unparseable_child`. |
+
 ---
 
 ## 🔴 Backlog — correctness (wrong output under a headword)
@@ -32,8 +40,6 @@ prioritized backlog below, to be worked before/alongside the next scale run.
 
 ## 🟠 Backlog — broken validators (green light on defective output)
 
-- **Advertised HARD `DUP` gate never emitted** — [audit_window_en.py:252](src/pilot/audit_window_en.py). Two senses with identical English pass `--strict`. *Fix: emit a real `DUP` hard flag, or delete the false docstring claim.*
-- **RU gate recovers verdicts by regex-scraping subprocess stdout** — [audit_window.py:71](src/pilot/audit_window.py). Any wording drift in the child auditors → `[]` → flagged cards silently omitted from requeue, gate reports clean; the child returncode is not consulted. *Fix: assert a parseable verdict was emitted / consult returncode.*
 - **`--min-cards` mode skips the count-integrity check** — [validate_assembled_export.py:163](src/validate_assembled_export.py). Bounded runs can't catch dropped/duplicated cards (only a `>=` floor). *Fix: still assert exact count when known.*
 - **`reverse_index --show` entirely dead** — [reverse_index.py:155](src/reverse_index.py). A 4-vs-8 column guard is never true → `_representative` always `(None, None)`. *Fix: index the correct column (`parts[4]`).*
 

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "5bbb029b2dc287f52d4efd4f9f44ff4a12952a15984554568afa645eec2804bd",
-      "src/pilot/window_selftest.py": "54bd75e23fb1311076889a1e65ebf43a67b8686f06b5db247f45c51512e919f6"
+      "src/pilot/window_selftest.py": "db2b80ebe49a658bb6ae4ef8b14e7f7c78e725b2fd6e90bd3e43e83384385efb"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
-      "src/pilot/window_selftest.py": "54bd75e23fb1311076889a1e65ebf43a67b8686f06b5db247f45c51512e919f6"
+      "src/pilot/window_selftest.py": "db2b80ebe49a658bb6ae4ef8b14e7f7c78e725b2fd6e90bd3e43e83384385efb"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
-      "src/pilot/window_selftest.py": "54bd75e23fb1311076889a1e65ebf43a67b8686f06b5db247f45c51512e919f6"
+      "src/pilot/window_selftest.py": "db2b80ebe49a658bb6ae4ef8b14e7f7c78e725b2fd6e90bd3e43e83384385efb"
     }
   },
   {
@@ -258,10 +258,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED 2026-07-04 (was GAP, task_d29bb788): audited audit_window_en.py against all 3 fixes. (1) multi-layer over-count is N/A -- EN has no analogous raw-marker-vs-card-sense coverage check to carry the bug. (2) the Sanskrit-span leak is already safe -- audit_window_en.py's prose() already scrubs {#..#} spans before residue matching, unlike RU's pre-fix braced_gloss_risks. (3) a REAL EN analogue existed in DE-RESIDUE: 'des' is both a German article and a French partitive article, and gen_fidelity_judge_en.py's own prompt preserves French/Latin literals verbatim -- fixed by extracting LATIN_WORDS/FRENCH_WORDS into a new shared src/pilot/foreign_literal_guards.py imported by both prompt_rule_audit.py and audit_window_en.py, with a French-context guard on the ambiguous 'des' hit. Pinned by test_en_de_residue_french_guard in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/audit_coverage.py": "8c54aa22943140624238273b5bb6a2cbe9aceded5f8295cb84cd36bd994904c0",
+      "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
       "src/pilot/prompt_rule_audit.py": "bbd3fe10ff72b9d58e6d763069352129df8c246d4cb18ae41520ddcf6fee7525",
-      "src/pilot/audit_window.py": "91019c993e877311cdd90812c286a50d1b2094eb8a9473bb4b4ff9b11f032f88",
-      "src/pilot/audit_window_en.py": "068a6c410076ede4235afa3a280199028d0f6a2e399df6cde95b000a56513c19"
+      "src/pilot/audit_window.py": "dd2d71c2b67546b4cd89cd92d3487242c1eaa5d5b9130f997143216fcef450d2",
+      "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2"
     }
   },
   {
@@ -296,7 +296,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "9356c53c5f4a64e9e5ec264dd2c34ca43a7af2c40e912147d2815d81f10c5ca0",
+      "src/promote_final_cards.py": "57bf1030c3dd9ca46ea06f13d8225ea16ef3160e57462e2babc5c856f1906da8",
       "src/promote_en.py": "96e1928ad4ceae44aa7a9984d3f5b6cb7bb2f1877923fd3adbc46cab56bac022"
     }
   },
@@ -316,7 +316,44 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
-      "src/pilot/window_selftest.py": "54bd75e23fb1311076889a1e65ebf43a67b8686f06b5db247f45c51512e919f6"
+      "src/pilot/window_selftest.py": "db2b80ebe49a658bb6ae4ef8b14e7f7c78e725b2fd6e90bd3e43e83384385efb"
+    }
+  },
+  {
+    "id": "en_dup_hard_gate_20260704",
+    "mechanism": "audit_window_en.py's DUP check (two senses in one record share identical english) is promoted from a soft, >=3-content-word-gated SAME-GLOSS signal to a real HARD gate that fires regardless of gloss length, matching the docstring's advertised --strict failure set",
+    "files": [
+      "src/pilot/audit_window_en.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H169 (2026-07-04 review, 'broken validators'): the advertised HARD DUP gate was never emitted -- the only within-record duplicate signal was soft SAME-GLOSS, gated on >=3 content words, so a short duplicate ('to go'/'to go') produced zero flags and --strict passed. Classified GAP-being-closed rather than INTENTIONAL-DIVERGENCE: RU's within-record duplicate protection is the cross-part audit_sense_dupes.py gate (already SHARED, see gate_fixes_20260703_ru_only/PR #135) plus the soft, all-senses-only identical_russian_glosses risk in prompt_rule_audit.py (MEDIUM, not high-confidence) -- neither is a pairwise HARD gate. EN now closes that with a real HARD pairwise DUP check; RU getting an equivalent pairwise HARD gate (rather than its current all-or-nothing soft signal) is left as a natural follow-up, not blocking this fix. Pinned by test_en_gate_dup_has_teeth in window_selftest.py.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
+      "src/pilot/window_selftest.py": "db2b80ebe49a658bb6ae4ef8b14e7f7c78e725b2fd6e90bd3e43e83384385efb"
+    }
+  },
+  {
+    "id": "pipeline_version_stamp_en_gap",
+    "mechanism": "promote_final_cards.py (RU) stamps provenance.pipeline (semver of the promotion tooling, orthogonal to the Claude model version) on every promoted row via pipeline_version.stamp(); promote_en.py (EN) was not updated in the same PR and has no equivalent stamp",
+    "files": [
+      "src/promote_final_cards.py",
+      "src/promote_en.py"
+    ],
+    "languages": [
+      "ru"
+    ],
+    "verdict": "GAP",
+    "note": "Found incidentally while re-affirming parity for H169 (unrelated QA-gate-teeth fix). PR #140 (feat(provenance): pipeline versioning, 2026-07-04) added pipeline_version stamping only to promote_final_cards.py; promote_en.py has no `import pipeline_version` and no `provenance.pipeline` field, so a future tooling bugfix cannot tell which promoted EN rows predate it the way it can for RU rows.",
+    "tracking": "Uprava/GTD_NEXT_ACTIONS.md @DO — port pipeline_version stamping to promote_en.py",
+    "verified_sha256": {
+      "src/promote_final_cards.py": "57bf1030c3dd9ca46ea06f13d8225ea16ef3160e57462e2babc5c856f1906da8",
+      "src/promote_en.py": "96e1928ad4ceae44aa7a9984d3f5b6cb7bb2f1877923fd3adbc46cab56bac022"
     }
   },
   {
@@ -335,7 +372,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
-      "src/pilot/window_selftest.py": "54bd75e23fb1311076889a1e65ebf43a67b8686f06b5db247f45c51512e919f6"
+      "src/pilot/window_selftest.py": "db2b80ebe49a658bb6ae4ef8b14e7f7c78e725b2fd6e90bd3e43e83384385efb"
     }
   }
 ]

--- a/RussianTranslation/src/audit_coverage.py
+++ b/RussianTranslation/src/audit_coverage.py
@@ -131,6 +131,10 @@ def main():
     print('\n%s: %d/%d covered%s' % (
         'PASS' if not fails else 'FAIL', len(results) - len(fails), len(results),
         '' if not fails else ' | flagged: ' + ', '.join(fails)))
+    # Machine-readable verdict line — the parent audit_window.py parses THIS strictly rather
+    # than scraping the prose summary above, so a future wording tweak here can never silently
+    # drop flagged cards from the requeue (H169 defect 2).
+    print('FLAGGED_JSON: %s' % json.dumps(fails))
     sys.exit(0 if not fails else 1)
 
 

--- a/RussianTranslation/src/audit_sense_dupes.py
+++ b/RussianTranslation/src/audit_sense_dupes.py
@@ -151,10 +151,16 @@ def main():
              and not is_dupe_exempt(k[0], k[1], v, exempt)}
     if not dupes:
         print('SENSE-DUPE GATE: PASS — no numbered sense rendered by >1 head-part per homonym')
+        print('FLAGGED_JSON: []')
         return 0
     print('SENSE-DUPE GATE: FAIL — %d duplicated sense(s):' % len(dupes))
     for (hom, t), keys in sorted(dupes.items()):
         print('  %s sense "%s" rendered by: %s' % (hom, t, ', '.join(sorted(keys))))
+    # Machine-readable verdict line — the parent audit_window.py parses THIS strictly rather
+    # than scraping the "rendered by:" prose above, so a future wording tweak here can never
+    # silently drop flagged cards from the requeue (H169 defect 2).
+    flagged = sorted({k for keys in dupes.values() for k in keys})
+    print('FLAGGED_JSON: %s' % json.dumps(flagged))
     return 1
 
 

--- a/RussianTranslation/src/audit_translation.py
+++ b/RussianTranslation/src/audit_translation.py
@@ -114,6 +114,10 @@ def main():
     print('\n%s: %d/%d units clean%s'
           % ('PASS' if not fails else 'FAIL', len(stems) - len(fails), len(stems),
              '' if not fails else ' | flagged: ' + ', '.join(fails)))
+    # Machine-readable verdict line — the parent audit_window.py parses THIS strictly rather
+    # than scraping the prose summary above, so a future wording tweak here can never silently
+    # drop flagged cards from the requeue (H169 defect 2).
+    print('FLAGGED_JSON: %s' % json.dumps(fails))
     sys.exit(0 if not fails else 1)
 
 

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -68,39 +68,29 @@ def run_py(args, env=None):
             'seconds': round(time.perf_counter() - t0, 3)}
 
 
-def parse_flagged(stdout):
-    m = re.search(r'\|\s*flagged:\s*(.+)$', stdout, re.M)
+def parse_flagged_json(stdout):
+    """Strict parse of a child auditor's machine-readable verdict line
+    (`FLAGGED_JSON: [...]`, emitted by audit_translation.py / audit_coverage.py /
+    audit_sense_dupes.py). Returns None — never `[]` — when the line is missing or
+    malformed, so the caller can tell "genuinely clean" apart from "unparseable
+    output" instead of silently treating a wording drift as a clean pass (H169
+    defect 2: the old prose-scraping parser returned [] on any drift and dropped
+    flagged cards from the requeue without a trace)."""
+    m = re.search(r'^FLAGGED_JSON:\s*(.+)$', stdout, re.M)
     if not m:
-        return []
-    return [x.strip() for x in m.group(1).split(',') if x.strip()]
+        return None
+    try:
+        parsed = json.loads(m.group(1))
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, list):
+        return None
+    return sorted(str(x).strip() for x in parsed if str(x).strip())
 
 
-def parse_translation(stdout):
-    return parse_flagged(stdout)
-
-
-def parse_coverage(stdout):
-    return parse_flagged(stdout)
-
-
-def parse_dupes(stdout):
-    keys = set()
-    for line in stdout.splitlines():
-        m = re.search(r'rendered by:\s*(.+)$', line)
-        if m:
-            keys.update(k.strip() for k in m.group(1).split(',') if k.strip())
-    return sorted(keys)
-
-
-def parse_nws(stdout):
-    keys = set()
-    m = re.search(r'GATE: FAIL[^\n]*\n\s*rejected:\s*(.+)', stdout)
-    if m:
-        keys.update(k.strip() for k in m.group(1).split() if k.strip())
-    for line in stdout.splitlines():
-        if 'MISATTRIBUTION' in line:
-            keys.add(line.split()[0])
-    return sorted(keys)
+parse_translation = parse_flagged_json
+parse_coverage = parse_flagged_json
+parse_dupes = parse_flagged_json
 
 
 def exact_file_exists(directory, name):
@@ -378,7 +368,16 @@ def main():
             name, parser = futures[fut]
             res = fut.result()
             if parser:
-                res['requeue'] = parser(res['stdout'])
+                parsed = parser(res['stdout'])
+                if parsed is None:
+                    # Unparseable child verdict (missing/malformed FLAGGED_JSON line): never
+                    # silently treat this as "no flags". Fail loud and requeue every card in
+                    # the window so a wording drift in the child auditor cannot silently drop
+                    # flagged cards (H169 defect 2).
+                    res['requeue'] = sorted(keys)
+                    res['unparseable_verdict'] = True
+                else:
+                    res['requeue'] = parsed
             gates[name] = res
 
     for name in ['nws', 'translation', 'coverage', 'sense_dupes', 'prompt_semantic']:
@@ -432,6 +431,8 @@ def main():
         gate_requeue.update(gate.get('requeue') or [])
         if gate['returncode'] not in (0, 1):
             crashed.append(name)
+        if gate.get('unparseable_verdict'):
+            crashed.append(name + '-unparseable-verdict')
     requeue.update(gate_requeue)
     if glue and glue['returncode'] != 0:
         crashed.append('glue')

--- a/RussianTranslation/src/pilot/audit_window_en.py
+++ b/RussianTranslation/src/pilot/audit_window_en.py
@@ -194,13 +194,19 @@ def audit_card(result, tm, do_mw):
             norm = re.sub(r'\s+', ' ', ep).strip().lower()
             if norm and norm == h.lower():
                 soft.append('CIRCULAR')
-            # Within-card identical-gloss check (soft): skip structural headers and trivial
-            # prose — preverb headers ("With ...") legitimately repeat. The canonical
-            # cross-card tag dedup is delegated to audit_sense_dupes.py below.
+            # Within-card identical-gloss check: skip structural headers — preverb headers
+            # ("With ...") legitimately repeat. The canonical cross-card tag dedup is
+            # delegated to audit_sense_dupes.py below.
+            # DUP (HARD): two senses share the exact same english, regardless of length —
+            # a real duplicate is a real duplicate whether it's one word or ten.
+            # SAME-GLOSS (soft): kept as a lower-confidence variant gated on >=3 content
+            # words, for callers that only want the historical soft signal.
             headerlike = any(hk in tag for hk in HEADERLIKE)
-            if norm and not headerlike and len(words) >= 3:
+            if norm and not headerlike:
                 if norm in seen:
-                    soft.append('SAME-GLOSS(=%s)' % seen[norm])
+                    hard.append('DUP(=%s)' % seen[norm])
+                    if len(words) >= 3:
+                        soft.append('SAME-GLOSS(=%s)' % seen[norm])
                 else:
                     seen[norm] = tag
             for fl in hard + soft:
@@ -249,7 +255,7 @@ def run_sense_dupes(mod, path):
     return {'returncode': rc, 'summary': line.strip()}
 
 
-HARD = ('MISSING-EN', 'LS-LOSS', 'SAN-LOSS', 'AB-LOSS', 'SENSE-DUPE')
+HARD = ('MISSING-EN', 'LS-LOSS', 'SAN-LOSS', 'AB-LOSS', 'SENSE-DUPE', 'DUP')
 
 
 def is_hard(flag):

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -909,6 +909,61 @@ def test_en_gate_strict_has_teeth():
             os.remove(report_path)
 
 
+def test_en_gate_dup_has_teeth():
+    """H169 defect 1: two senses in one record sharing identical english used to slide
+    through clean — the only within-record duplicate signal was the soft SAME-GLOSS flag,
+    gated on >=3 content words, so a short duplicate ("to go" / "to go") produced zero flags
+    and --strict passed. DUP must fire HARD regardless of gloss length."""
+    fixture = {'meta': {'root': 'zz'}, 'results': [
+        {'key': 'zz~~h0_00_pwg00', 'card': {'iast': 'zz', 'records': [
+            {'h': 'zz', 'senses': [
+                {'tag': '1', 'german': '{%gehen%}', 'english': 'to go'},
+                {'tag': '2', 'german': '{%gehen%}', 'english': 'to go'}]}]}},
+    ]}
+    with tempfile.NamedTemporaryFile('w', encoding='utf-8', suffix='.json', delete=False) as f:
+        wf_path = f.name
+        json.dump(fixture, f, ensure_ascii=False)
+    report_path = wf_path + '.report.json'
+    en_audit = os.path.join(HERE, 'audit_window_en.py')
+    try:
+        # report-only: still exits 0 even with the hard DUP flag present
+        run([sys.executable, en_audit, wf_path, '--no-mw'], expect=0)
+        run([sys.executable, en_audit, wf_path, '--no-mw', '--strict', '--report', report_path],
+            expect=1)
+        rep = json.load(open(report_path, encoding='utf-8'))
+        if not any(fl['flag'].startswith('DUP') for ff in rep['files'] for fl in ff['flags']):
+            fail('EN gate did not emit a DUP flag for two identical-english senses')
+        if not any('hard flag' in r for r in rep.get('strict_reasons') or []):
+            fail('EN gate report did not record a strict failure reason for the DUP hard flag')
+    finally:
+        os.remove(wf_path)
+        if os.path.exists(report_path):
+            os.remove(report_path)
+
+
+def test_ru_gate_fails_loud_on_unparseable_child():
+    """H169 defect 2: the RU gate used to recover child-auditor verdicts by regex-scraping
+    prose stdout (`| flagged: ...`) — any wording drift in audit_translation.py /
+    audit_coverage.py / audit_sense_dupes.py made the parser return [] and silently drop
+    flagged cards from the requeue while the gate reported clean. The fixed parser must
+    return None (never []) when the strict `FLAGGED_JSON:` verdict line is missing or
+    malformed, so the caller can fail loud instead of passing silently."""
+    from audit_window import parse_flagged_json
+    drifted_stdout = 'FAIL: 2/5 units clean | flagged: root_a, root_b\n'
+    if parse_flagged_json(drifted_stdout) is not None:
+        fail('parser must return None (unparseable) when the child emits no FLAGGED_JSON '
+             'line, not silently treat wording drift as a clean pass')
+    malformed = 'FLAGGED_JSON: {not valid json\n'
+    if parse_flagged_json(malformed) is not None:
+        fail('parser must return None on malformed JSON, not crash or silently drop flags')
+    clean_line = 'PASS: 5/5 units clean\nFLAGGED_JSON: []\n'
+    if parse_flagged_json(clean_line) != []:
+        fail('parser did not parse a genuinely clean FLAGGED_JSON: [] line')
+    flagged_line = 'FAIL: 3/5 units clean | flagged: root_a, root_b\nFLAGGED_JSON: ["root_a", "root_b"]\n'
+    if parse_flagged_json(flagged_line) != ['root_a', 'root_b']:
+        fail('parser did not parse a well-formed FLAGGED_JSON line correctly')
+
+
 def test_pwg_mask_latin_cue_behind_ab_tag():
     """Regression (review 2026-07-04): a Latin/Greek cue inside an <ab> span
     (e.g. `<ab>lat.</ab> {%ignis%}`) is masked to a {Tn} placeholder in mask()
@@ -1997,6 +2052,8 @@ def main():
         test_attested_text_signal_redesign,
         test_nws_fp_suppressed,
         test_en_gate_strict_has_teeth,
+        test_en_gate_dup_has_teeth,
+        test_ru_gate_fails_loud_on_unparseable_child,
         test_pwg_mask_latin_cue_behind_ab_tag,
         test_markup_loss_soft_flag_ru,
         test_markup_loss_soft_flag_en,


### PR DESCRIPTION
## Summary
- `audit_window_en.py`'s advertised HARD `DUP` gate (identical-english senses within a record) was never emitted — the only signal was soft `SAME-GLOSS`, gated on `>=3` content words, so a short duplicate passed `--strict` clean. Now emits a real HARD `DUP` flag regardless of gloss length.
- `audit_window.py` recovered `translation`/`coverage`/`sense_dupes` verdicts by regex-scraping child stdout, so any wording drift in `audit_translation.py` / `audit_coverage.py` / `audit_sense_dupes.py` silently returned `[]` and dropped flagged cards from the requeue while the gate reported clean. Child auditors now also emit a strict `FLAGGED_JSON:` line; the parent fails loud (requeues everything, marks the gate crashed) when it's missing/malformed instead of silently passing. Removed dead `parse_nws`.
- `LANG_PARITY.md`: logged `en_dup_hard_gate_20260704` (SHARED, GAP-closing), re-affirmed 7 unrelated drifted entries, and logged an incidentally-found unrelated GAP (`pipeline_version_stamp_en_gap` — PR #140's stamping only landed on the RU promote path) for a separate follow-up (GTD @DO added).

## Test plan
- [x] `python src/pilot/window_selftest.py` — 52/52 green, incl. 2 new cases (`test_en_gate_dup_has_teeth`, `test_ru_gate_fails_loud_on_unparseable_child`)
- [x] `python src/pilot/lang_parity_check.py` — 17 entries, all verdicts complete, no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)