### PR TITLE
fix(pwg_ru): port pipeline_version stamping to promote_en.py

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,17 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
+- **`pipeline_version_stamp_en_gap` closed same day — ✅ DONE 04-07-2026 (Sonnet 5,
+  `claude-sonnet-5`).** Follow-up to the H169 parity re-affirm below: PR #140 stamped
+  `provenance.pipeline` on RU rows (`promote_final_cards.py`) but never on EN
+  (`promote_en.py`). [`promote_en.py`](src/promote_en.py)'s `en_index()` now calls
+  `pipeline_version.stamp(model_version=gen_model_version)` per sub-card and stores it as
+  `en_provenance.pipeline` (a distinct field from RU's `provenance.pipeline` since EN
+  attaches onto an existing row rather than owning it). Pinned by a new assertion in
+  `promote_en.selftest()`. LANG_PARITY entry `pipeline_version_stamp_en_gap` re-verdicted
+  GAP → SHARED. `window_selftest.py` 52/52 green, `lang_parity_check.py` clean (17
+  entries), `promote_en.py --selftest` and `pipeline_version.py --selftest` both pass.
+
 - **H169 QA-gate teeth (real `DUP` hard flag + RU-gate verdict-parse guard) — ✅ DONE
   04-07-2026 (Sonnet 5, `claude-sonnet-5`).** Fixed the 2 🟠 "broken validators" findings
   from [`CODE_REVIEW_2026-07-04.md`](CODE_REVIEW_2026-07-04.md) deferred out of PR #138.

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -297,7 +297,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/promote_final_cards.py": "57bf1030c3dd9ca46ea06f13d8225ea16ef3160e57462e2babc5c856f1906da8",
-      "src/promote_en.py": "96e1928ad4ceae44aa7a9984d3f5b6cb7bb2f1877923fd3adbc46cab56bac022"
+      "src/promote_en.py": "7c9b24b12371937735efb7cb3eb7f9b51238614d34b357621b1e8f1715c21420"
     }
   },
   {
@@ -340,20 +340,21 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
   },
   {
     "id": "pipeline_version_stamp_en_gap",
-    "mechanism": "promote_final_cards.py (RU) stamps provenance.pipeline (semver of the promotion tooling, orthogonal to the Claude model version) on every promoted row via pipeline_version.stamp(); promote_en.py (EN) was not updated in the same PR and has no equivalent stamp",
+    "mechanism": "promote_final_cards.py (RU) stamps provenance.pipeline (semver of the promotion tooling, orthogonal to the Claude model version) on every promoted row via pipeline_version.stamp(); promote_en.py (EN) now stamps the same pipeline block into en_provenance.pipeline",
     "files": [
       "src/promote_final_cards.py",
       "src/promote_en.py"
     ],
     "languages": [
-      "ru"
+      "ru",
+      "en"
     ],
-    "verdict": "GAP",
-    "note": "Found incidentally while re-affirming parity for H169 (unrelated QA-gate-teeth fix). PR #140 (feat(provenance): pipeline versioning, 2026-07-04) added pipeline_version stamping only to promote_final_cards.py; promote_en.py has no `import pipeline_version` and no `provenance.pipeline` field, so a future tooling bugfix cannot tell which promoted EN rows predate it the way it can for RU rows.",
-    "tracking": "Uprava/GTD_NEXT_ACTIONS.md @DO — port pipeline_version stamping to promote_en.py",
+    "verdict": "SHARED",
+    "note": "RESOLVED same day (2026-07-04): PR #140 (feat(provenance): pipeline versioning) added pipeline_version stamping only to promote_final_cards.py; found as a GAP while re-affirming H169's parity re-hash, closed immediately. promote_en.py now calls `pipeline_version.stamp(model_version=gen_model_version)` inside `en_index()`'s per-subcard provenance block, stored as `en_provenance.pipeline` (mirrors RU's `provenance.pipeline`; a distinct field since EN attaches onto an existing RU row rather than owning it). Pinned by an added assertion in `promote_en.selftest()`.",
+    "tracking": "",
     "verified_sha256": {
       "src/promote_final_cards.py": "57bf1030c3dd9ca46ea06f13d8225ea16ef3160e57462e2babc5c856f1906da8",
-      "src/promote_en.py": "96e1928ad4ceae44aa7a9984d3f5b6cb7bb2f1877923fd3adbc46cab56bac022"
+      "src/promote_en.py": "7c9b24b12371937735efb7cb3eb7f9b51238614d34b357621b1e8f1715c21420"
     }
   },
   {

--- a/RussianTranslation/src/promote_en.py
+++ b/RussianTranslation/src/promote_en.py
@@ -51,6 +51,8 @@ from collections import defaultdict
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
+import pipeline_version
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)
 DEFAULT_STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
@@ -124,6 +126,10 @@ def en_index(paths, gen_model_version=GEN_MODEL_VERSION):
                     'rootmap_sha256': rootmap_sha256,
                     'input_sha256': ih.get('raw_sha256'),
                     'mw_used': None,
+                    # semver of OUR tooling at promotion time — orthogonal to model_version;
+                    # mirrors provenance.pipeline on the RU side (promote_final_cards.py) so a
+                    # later bugfix can flag which EN rows predate it too (pipeline_version.py).
+                    'pipeline': pipeline_version.stamp(model_version=gen_model_version),
                 }
     return idx, prov
 
@@ -212,7 +218,8 @@ def selftest():
     ]}
     prov = {'p_a~~h0': {'model': 'sonnet', 'model_version': 'claude-sonnet-4-6', 'judge': None,
                         'generated_at': '2026-06-30T00:00:00Z', 'rootmap_sha256': 'deadbeef',
-                        'input_sha256': 'cafe', 'mw_used': None}}
+                        'input_sha256': 'cafe', 'mw_used': None,
+                        'pipeline': pipeline_version.stamp(model_version='claude-sonnet-4-6')}}
     judge = {'p_a~~h0': {'model': 'opus', 'model_version': 'claude-opus-4-8', 'ok': True,
                          'severity': 1, 'verdict': 'ok', 'note': 'fine'}}
     stats = attach(rows, idx, 0.92, prov=prov, judge=judge)
@@ -227,6 +234,8 @@ def selftest():
     p0 = rows[0].get('en_provenance')
     assert p0 and p0['model'] == 'sonnet' and p0['input_sha256'] == 'cafe', 'en_provenance attached'
     assert p0['model_version'] == 'claude-sonnet-4-6', 'gen model VERSION recorded (not just tier)'
+    assert p0.get('pipeline') and p0['pipeline'].get('schema') == pipeline_version.PIPELINE_SCHEMA, \
+        'en_provenance carries a pipeline stamp, mirroring the RU side'
     assert p0['judge'] and p0['judge']['model'] == 'opus' and p0['judge']['verdict'] == 'ok', 'judge folded'
     assert p0['judge']['model_version'] == 'claude-opus-4-8', 'judge model VERSION recorded'
     assert 'en_provenance' not in rows[2], 'no provenance on unmatched rows'


### PR DESCRIPTION
## Summary
- PR #140 (`feat(provenance): pipeline versioning`) stamped `provenance.pipeline` on RU rows via `promote_final_cards.py` but never on EN via `promote_en.py` — found incidentally while re-affirming `LANG_PARITY.md` for H169.
- `promote_en.py`'s `en_index()` now calls `pipeline_version.stamp(model_version=gen_model_version)` per sub-card and stores it as `en_provenance.pipeline` (a sibling field to RU's `provenance.pipeline`, since EN attaches onto an existing row rather than owning it).
- `LANG_PARITY.md`: `pipeline_version_stamp_en_gap` re-verdicted GAP → SHARED.

## Test plan
- [x] `python src/promote_en.py --selftest` — pass, incl. new pipeline-stamp assertion
- [x] `python src/pipeline_version.py --selftest` — pass
- [x] `python src/pilot/window_selftest.py` — 52/52 green
- [x] `python src/pilot/lang_parity_check.py` — 17 entries, all verdicts complete, no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)