### PR TITLE
feat: add PWG RU ramp planner

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,22 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
+- **H151 runnable-queue hardening — ✅ DONE 04-07-2026 (Codex/GPT-5).** Follow-up to the
+  readiness review that found two non-token-spend blockers before starting `sTA`: the live
+  worklist could advertise roots with no rootmap (`SrI`), and H151/pwg-drain still carried
+  stale `sTA`/`i` agent estimates. [`verb_worklist.py`](src/pilot/verb_worklist.py) now keeps
+  the full unpromoted backlog in `remaining*` fields but exposes runnable operator order via
+  `runnable_remaining`, `runnable_count`, `runnable_bytes`, with missing-rootmap roots preserved
+  in `blocked_missing_rootmap`; `--top` prints runnable roots by default, and
+  `--include-unrunnable` is audit/debug only. Pinned by
+  `window_selftest.py::test_verb_worklist_excludes_missing_rootmaps`. H151, `/pwg-drain`, and
+  [`RUN_FREQ_MAX.md`](src/pilot/RUN_FREQ_MAX.md) now say to trust live `perf_preflight.py`
+  output and record the current `sTA` calibration warning (123 cards, 19 batches, 241 expected
+  agents, `defer-calibrate`) instead of the old ~30-agent prose estimate. **Next safe resume:**
+  create the actual drain branch from `origin/master`, run
+  `python src\pilot\verb_worklist.py --top 20`, then preflight the runnable roots; do not start
+  a Max Workflow run from stale fixed-order prose.
+
 - **`pipeline_version_stamp_en_gap` closed same day — ✅ DONE 04-07-2026 (Sonnet 5,
   `claude-sonnet-5`).** Follow-up to the H169 parity re-affirm below: PR #140 stamped
   `provenance.pipeline` on RU rows (`promote_final_cards.py`) but never on EN

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "5bbb029b2dc287f52d4efd4f9f44ff4a12952a15984554568afa645eec2804bd",
-      "src/pilot/window_selftest.py": "db2b80ebe49a658bb6ae4ef8b14e7f7c78e725b2fd6e90bd3e43e83384385efb"
+      "src/pilot/window_selftest.py": "c2b42a29571cd28548c243ecd5b9dfa42fb008a94648b855f49b55a403f80b08"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
-      "src/pilot/window_selftest.py": "db2b80ebe49a658bb6ae4ef8b14e7f7c78e725b2fd6e90bd3e43e83384385efb"
+      "src/pilot/window_selftest.py": "c2b42a29571cd28548c243ecd5b9dfa42fb008a94648b855f49b55a403f80b08"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
-      "src/pilot/window_selftest.py": "db2b80ebe49a658bb6ae4ef8b14e7f7c78e725b2fd6e90bd3e43e83384385efb"
+      "src/pilot/window_selftest.py": "c2b42a29571cd28548c243ecd5b9dfa42fb008a94648b855f49b55a403f80b08"
     }
   },
   {
@@ -316,7 +316,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
-      "src/pilot/window_selftest.py": "db2b80ebe49a658bb6ae4ef8b14e7f7c78e725b2fd6e90bd3e43e83384385efb"
+      "src/pilot/window_selftest.py": "c2b42a29571cd28548c243ecd5b9dfa42fb008a94648b855f49b55a403f80b08"
     }
   },
   {
@@ -335,7 +335,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "db2b80ebe49a658bb6ae4ef8b14e7f7c78e725b2fd6e90bd3e43e83384385efb"
+      "src/pilot/window_selftest.py": "c2b42a29571cd28548c243ecd5b9dfa42fb008a94648b855f49b55a403f80b08"
     }
   },
   {
@@ -373,7 +373,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
-      "src/pilot/window_selftest.py": "db2b80ebe49a658bb6ae4ef8b14e7f7c78e725b2fd6e90bd3e43e83384385efb"
+      "src/pilot/window_selftest.py": "c2b42a29571cd28548c243ecd5b9dfa42fb008a94648b855f49b55a403f80b08"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -62,11 +62,12 @@ tracked-file drift and is wired into `window_selftest.py`
   and G10 edition cut remain blocked until human review/gold work is done.
   `preflight_remaining_gates.py` and `release_readiness.py` are report-only by default; add
   `--fail-on-blocked` when using them as CI/go-no-go gates.
-- **Scope ruling (MG, 04-07-2026): drain ALL remaining DCS-attested verb roots**, in
-  frequency order, root-by-root. The worklist is enumerated reproducibly by
-  [`verb_worklist.py`](verb_worklist.py) (verbs01 universe ∩ freq manifest − promoted
-  store): 749 attested verb roots, 46 promoted, **703 remaining** (~5.3 MB source) as of
-  04-07-2026. Drain discipline lives in the standing handoff
+- **Scope ruling (MG, 04-07-2026): drain ALL remaining DCS-attested verb roots**, root-by-root.
+  The worklist is enumerated reproducibly by [`verb_worklist.py`](verb_worklist.py) (verbs01
+  universe ∩ freq manifest − promoted store): 749 attested verb roots, 46 promoted,
+  **703 remaining** (~5.3 MB source) as of 04-07-2026. Operator `--top` output is filtered
+  to roots with existing rootmaps; the JSON keeps the full backlog plus
+  `blocked_missing_rootmap`. Drain discipline lives in the standing handoff
   [`H151`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H151_SanskritLexicography_pwg_ru_verb_batch_drain.md).
 - The per-root loop below is unchanged — "all roots next batch" scales the QUEUE, not the
   width. Roots still run **one at a time (≤3-wide max)**; the Slice-D 18×-parallel collapse
@@ -92,7 +93,9 @@ Observed state:
 
 - `scale_manifest.freq.json`: **43,968 / 106,082** PWG headwords are DCS-attested
   (**41%**).
-- Frequency top 8: `sTA`, `BU`, `gam`, `yuj`, `as`, `i`, `vid`, `han`.
+- Frequency top lists are advisory unless they come from current
+  `verb_worklist.py --top` runnable output; roots missing rootmaps are reported separately in
+  `blocked_missing_rootmap`.
 - Top 3 with `--root-split`: already generated locally (`0 to generate`), so the
   machine has the required rootmaps/sub-cards for `sTA`, `BU`, and `gam`.
 - `verify_root_glue.py`: **ALL GATES PASS**; lossless round-trip, 0 secondary
@@ -133,13 +136,14 @@ manner/position forcing) as soft-judged guidance (judge check 7). Source tables:
 The loop is fixed: **preflight → generate optimized harness → Max Workflow → deterministic
 audit → requeue or sampled semantic judging**. Do not skip or reorder these steps.
 
-For enough data to estimate speed and quality, use staged roots:
+For enough data to estimate speed and quality, use the live runnable queue plus
+`perf_preflight.py`:
 
-1. **Stage A:** run fresh `sTA` only and audit/requeue until mechanically clean.
-2. **Stage B:** run `BU`, `as`, and `i` one root at a time after `sTA` clears.
-3. **Stage C:** before `gam`, `yuj`, `vid`, or `han`, run
-   `root_window_status.py <root> --prune-stale`, recheck, then generate harnesses
-   only for roots that are structurally clean.
+1. Generate the current runnable queue with `python src\pilot\verb_worklist.py --top 20`.
+2. Run `perf_preflight.py` over the next runnable roots and follow its recommended order.
+3. Give any `defer-calibrate` root a dedicated calibration/session. Current calibration
+   warning: `sTA` live preflight on 04-07-2026 reports 123 cards, 19 batches, 241 expected
+   agents, `defer-calibrate`; do not use the older ~30-agent estimate.
 
 ```powershell
 cd RussianTranslation\src
@@ -156,7 +160,8 @@ Preflight the root before spending Claude/Max tokens:
 ```powershell
 python src\pilot\root_window_status.py sTA
 python src\pilot\perf_preflight.py sTA
-python src\pilot\perf_preflight.py sTA BU gam as i yuj vid han
+python src\pilot\verb_worklist.py --top 20
+python src\pilot\perf_preflight.py sTA BU yuj as i tap dah ram
 ```
 
 The first command prints the structural state plus one `next action` and one

--- a/RussianTranslation/src/pilot/verb_worklist.py
+++ b/RussianTranslation/src/pilot/verb_worklist.py
@@ -1,10 +1,11 @@
-"""verb_worklist.py — enumerate the remaining DCS-attested PWG verb roots for the RU batch drain.
+"""verb_worklist.py — enumerate runnable DCS-attested PWG verb roots for the RU batch drain.
 
 Universe = verbs01 `pwg_preverb1.txt` case headers (k1), the vetted PWG verb-root
 list. A root is in scope when it appears in `scale_manifest.freq.json`
 (DCS-attested) and is NOT yet promoted into the RU store
-(`src/pwg_ru_translated.jsonl`). Output is score-ranked (freq order), the same
-order the drain consumes it in.
+(`src/pwg_ru_translated.jsonl`). Operator output is further filtered to roots
+with an existing rootmap, so the drain queue only names runnable windows. The
+full backlog is still written to JSON for audit/debug use.
 
 Usage:
   python src/pilot/verb_worklist.py            # print summary + write worklist JSON
@@ -23,12 +24,19 @@ sys.stderr.reconfigure(encoding='utf-8')
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 RT = os.path.dirname(os.path.dirname(HERE))  # RussianTranslation/
+SRC = os.path.join(RT, 'src')
 PREVERB = os.path.normpath(os.path.join(RT, '..', '..', 'PWG', 'verbs01', 'pwg_preverb1.txt'))
 MANIFEST = os.path.join(HERE, 'output', 'scale_manifest.freq.json')
 STORE = os.path.join(RT, 'src', 'pwg_ru_translated.jsonl')
 OUT = os.path.join(HERE, 'output', 'verb_batch_worklist.json')
+ROOTMAP_DIR = os.path.join(HERE, 'input')
 
 CASE = re.compile(r';; Case \d+: L=\d+, k1=(\S+), k2=\S+, code=\S+,')
+
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+from safe_filename import candidate_names  # noqa: E402
 
 
 def verb_universe(path=PREVERB):
@@ -53,38 +61,68 @@ def store_roots(path=STORE):
     return done
 
 
-def main():
-    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument('--top', type=int, default=0, help='print the next N roots')
-    ap.add_argument('--json', action='store_true', help='print the full worklist JSON to stdout')
-    args = ap.parse_args()
+def has_rootmap(root, rootmap_dir=ROOTMAP_DIR):
+    for stem in candidate_names(root):
+        if os.path.exists(os.path.join(rootmap_dir, stem + '.rootmap.json')):
+            return True
+    return False
 
-    verbs = verb_universe()
-    freq = {it['key1']: it for it in json.load(open(MANIFEST, encoding='utf-8'))}
-    done = store_roots()
+
+def build_worklist(preverb=PREVERB, manifest=MANIFEST, store=STORE, rootmap_dir=ROOTMAP_DIR):
+    verbs = verb_universe(preverb)
+    freq = {it['key1']: it for it in json.load(open(manifest, encoding='utf-8'))}
+    done = store_roots(store)
     attested = [k for k in verbs if k in freq]
     remain = sorted((k for k in attested if k not in done), key=lambda k: -freq[k]['score'])
+    runnable = [k for k in remain if has_rootmap(k, rootmap_dir)]
+    runnable_set = set(runnable)
+    blocked = [k for k in remain if k not in runnable_set]
 
-    payload = {
+    return {
         'universe_verbs01': len(verbs),
         'dcs_attested': len(attested),
         'done_promoted': sorted(done & verbs),
         'remaining': remain,
         'remaining_count': len(remain),
         'remaining_bytes': sum(freq[k]['bytes'] for k in remain),
+        'runnable_remaining': runnable,
+        'runnable_count': len(runnable),
+        'runnable_bytes': sum(freq[k]['bytes'] for k in runnable),
+        'blocked_missing_rootmap': blocked,
     }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--top', type=int, default=0, help='print the next N roots')
+    ap.add_argument('--json', action='store_true', help='print the full worklist JSON to stdout')
+    ap.add_argument('--include-unrunnable', action='store_true',
+                    help='print raw remaining roots for audit/debug; default --top shows runnable roots only')
+    args = ap.parse_args()
+
+    payload = build_worklist()
+    freq = {it['key1']: it for it in json.load(open(MANIFEST, encoding='utf-8'))}
     os.makedirs(os.path.dirname(OUT), exist_ok=True)
     with open(OUT, 'w', encoding='utf-8') as f:
         json.dump(payload, f, ensure_ascii=False, indent=1)
 
-    print(f"verbs01 universe: {len(verbs)}  DCS-attested: {len(attested)}  "
-          f"promoted: {len(done & verbs)}  REMAINING: {len(remain)} "
+    print(f"verbs01 universe: {payload['universe_verbs01']}  DCS-attested: {payload['dcs_attested']}  "
+          f"promoted: {len(payload['done_promoted'])}  REMAINING: {payload['remaining_count']} "
           f"({payload['remaining_bytes']:,} source bytes)")
+    print(f"runnable: {payload['runnable_count']} ({payload['runnable_bytes']:,} source bytes)  "
+          f"missing rootmap: {len(payload['blocked_missing_rootmap'])}")
     print(f"worklist written: {OUT}")
     if args.top:
-        for k in remain[:args.top]:
+        roots = payload['remaining'] if args.include_unrunnable else payload['runnable_remaining']
+        label = 'raw remaining' if args.include_unrunnable else 'runnable'
+        print(f"top {min(args.top, len(roots))} {label} roots:")
+        for k in roots[:args.top]:
             it = freq[k]
             print(f"  {k:12s} score={it['score']:.1f} band={it['band']} bytes={it['bytes']}")
+        blocked = payload['blocked_missing_rootmap']
+        if blocked:
+            print('WARNING: %d remaining root(s) missing rootmaps; first: %s' %
+                  (len(blocked), ', '.join(blocked[:10])), file=sys.stderr)
     if args.json:
         print(json.dumps(payload, ensure_ascii=False, indent=1))
 

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -1652,6 +1652,41 @@ def test_perf_preflight_fragment_tm_empty_warning():
             fail('empty fragment TM warning must state when no frag_prov source exists')
 
 
+def test_verb_worklist_excludes_missing_rootmaps():
+    import verb_worklist as vw
+    with tempfile.TemporaryDirectory() as tmp:
+        preverb = os.path.join(tmp, 'pwg_preverb1.txt')
+        manifest = os.path.join(tmp, 'scale_manifest.freq.json')
+        store = os.path.join(tmp, 'pwg_ru_translated.jsonl')
+        rootmaps = os.path.join(tmp, 'input')
+        os.makedirs(rootmaps, exist_ok=True)
+        with open(preverb, 'w', encoding='utf-8') as f:
+            f.write(';; Case 1: L=1, k1=SrI, k2=x, code=x,\n')
+            f.write(';; Case 2: L=2, k1=dah, k2=x, code=x,\n')
+        with open(manifest, 'w', encoding='utf-8') as f:
+            json.dump([
+                {'key1': 'SrI', 'score': 99.0, 'band': 5, 'bytes': 900},
+                {'key1': 'dah', 'score': 10.0, 'band': 5, 'bytes': 100},
+            ], f)
+        with open(store, 'w', encoding='utf-8') as f:
+            f.write('')
+        with open(os.path.join(rootmaps, 'dah.rootmap.json'), 'w', encoding='utf-8') as f:
+            json.dump({'meta': {'root': 'dah'}, 'items': []}, f)
+
+        payload = vw.build_worklist(preverb=preverb, manifest=manifest,
+                                    store=store, rootmap_dir=rootmaps)
+        if payload.get('remaining') != ['SrI', 'dah']:
+            fail('verb_worklist must preserve the raw score-ranked backlog')
+        if payload.get('runnable_remaining') != ['dah']:
+            fail('verb_worklist --top must be backed by runnable roots only')
+        if payload.get('blocked_missing_rootmap') != ['SrI']:
+            fail('missing-rootmap roots must remain visible in blocked_missing_rootmap')
+        if payload.get('remaining_count') != 2 or payload.get('runnable_count') != 1:
+            fail('verb_worklist count fields must distinguish backlog from runnable queue')
+        if payload.get('remaining_bytes') != 1000 or payload.get('runnable_bytes') != 100:
+            fail('verb_worklist byte fields must distinguish backlog from runnable queue')
+
+
 def test_calibration_arm_set_conservative_emit_only():
     with tempfile.TemporaryDirectory() as tmp:
         out_dir = os.path.join(tmp, 'perf_smoke_preflight')
@@ -2025,6 +2060,7 @@ def main():
         test_perf_preflight_degenerate_zero_agent,
         test_perf_preflight_multi_root_matrix_and_order,
         test_perf_preflight_fragment_tm_empty_warning,
+        test_verb_worklist_excludes_missing_rootmaps,
         test_calibration_arm_set_conservative_emit_only,
         test_frag_tm_reuse,
         test_no_fallback_batch_isolation,


### PR DESCRIPTION
## PR Type
- [ ] data
- [ ] build
- [x] docs
- [x] navigation

## Summary
- What changed: added a live PWG→RU ramp planner (`src/pilot/ramp_plan.py`) for the 100 → 1,000 → 10,000 card milestones, kept `verb_worklist.py` runnable-aware, refreshed operator docs around `run_pilot_wf.opt2.js`, and recorded the ACL-style readiness/cleanup audit.
- Why this change exists: the H151 drain needs an operator-safe way to choose the next tranche by cards/sub-cards without copying stale prose. The current runnable pool is only 810 cards, so the 1,000-card milestone must explicitly expose the rootmap-expansion blocker before anyone spends Max tokens.

## Test Surface
- Automated checks: `python -m py_compile src\pilot\ramp_plan.py src\pilot\window_selftest.py`; `python src\pilot\window_selftest.py`; `python src\pilot\lang_parity_check.py`; `python src\pilot\translation_memory.py validate --lang ru`; `python src\validate_interop.py`.
- Manual checks: `python src\pilot\ramp_plan.py` and `python src\pilot\ramp_plan.py --json` report next 100 = `tyaj` → `dah` → `kzip` (106 cards / 45 expected agents), current runnable pool = 13 roots / 810 cards, and 190 more cards needed from new/recovered rootmaps before the 1,000-card milestone.
- Pure helpers / decision points covered: selftests lock that missing-rootmap roots stay visible but out of the runnable queue, and that the ramp planner preserves the first 100-card tranche plus the 1,000-card rootmap gate.
- If build-related: import-safe verified? n/a

## Invariants
- Must stay true: `remaining*` remains the full unpromoted backlog; `runnable*` is the operator queue; milestones count PWG cards/sub-cards, not roots or arbitrary headwords.
- Counts / alignment / join rules: `ramp_plan.py` derives card and agent counts from live `perf_preflight.py`, not hardcoded stale estimates.
- Source-of-truth assumptions: rootmaps decide runnability; live preflight output overrides older handoff prose; `run_pilot_wf.opt2.js` is the current operator harness.
- What would count as regression: `--top` naming a missing-rootmap root as runnable, `ramp_plan.py` hiding the 1,000-card rootmap shortfall, or docs sending operators back to the deprecated `opt.js` path.

## Safety
- Fallback / failure mode: if `kzip` fails structural preflight, the runbook says to fill the first 100-card tranche with `aS` → `tap` → `SaMs`; rootmap-blocked roots stay in `blocked_missing_rootmap` until generated/recovered.
- Observable marker or sanity check: `ramp_plan.py` prints the next 100 table, current runnable tail, and the exact rootmap blocker; `verb_worklist.py` prints runnable and missing-rootmap counts.
- Rebuild / validate / verify command: `python src\pilot\ramp_plan.py --json`.

## Reader-Facing Done
- Navigation / entry point updated: README and USE_CASES now point to `ramp_plan.py`; RUN_FREQ_MAX has a dedicated 100 → 1,000 → 10,000 checkpoint section.
- Docs / changelog / handoff updated: repo and RussianTranslation `.ai_state.md` entries record the audit, cleanup, and ramp implementation.
- Known limits or caveats exposed: this PR does not run the Max Workflow translation itself and does not generate the missing rootmaps; it makes those prerequisites explicit.
- If not applicable, say why: n/a

## Type-Specific Notes
- If `data`: n/a
- If `build`: n/a
- If `docs`: stale `opt.js` operator wording was corrected to `opt2.js`, and generated runtime archives now carry tracked README/.gitignore manifests only.
- If `navigation`: ramp planning is discoverable from README, USE_CASES, and RUN_FREQ_MAX in one or two clicks.
