### PR TITLE
H151 dah drain: 29/31 sub-cards promoted (Sonnet 5), 2 held

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,31 @@ Two live tracks (full cold-start brief: [`HANDOFF_2026-06-25_pwg_ru_max.md`](HAN
 
 ## ➡️ Next Steps (Queue)
 
+- **H151 `dah` drain — 🟡 PARTIAL DONE 04-07-2026 (orchestration Opus 4.8, `claude-opus-4-8`;
+  generation Sonnet 5, `claude-sonnet-5`, hardcoded `model:'sonnet'` in the harness).**
+  Resumed the standing H151 drain after a prior **Sonnet** session stopped on H151 believing the
+  Workflow surface was unavailable — that was a **session-tooling gap, not a pipeline bug**: that
+  session genuinely had no Workflow/agent tool, whereas this Opus 4.8 Claude Code session does, so
+  the harness (`run_pilot_wf.opt2.js`, already a valid `export const meta` Workflow script) was
+  driven directly per the H145 guardrail (no manual Max-surface save; `.result` captured to
+  `wf_output.json` programmatically). **Base run** (15 agents, ~1.13M tokens, ~6.5 min):
+  **31/31 cards ok, 0 null, 0 failures, 1 healed.** Audit: **26 clean, 5 flagged** (4 gate-defect +
+  1 partial). One **`--no-tm` requeue round** (4 keys, 3 agents, ~1.5 min; `--no-tm` verified on the
+  harness) cleared 3 → **29/31 clean**. Promoted the **29 clean sub-cards**
+  (`promote_final_cards.py --merge --gen-model-version claude-sonnet-5`, store now 10,857 rows,
+  other roots preserved); TM rebuilt (`translation_memory.ru.json` **2,204 cards**); no `frag_prov`
+  among the promoted cards so `build-frags` not needed. **2 cards HELD unpromoted** (MG directive
+  mid-session: *finish what's started, do not start new translations*) — `dah~~h0_zz_nws00`
+  (NWS-layer gate-defect, survived 1 requeue) + `dah~~h0_zz_pw` (partial PW-addenda card, 17 missing
+  fragments in groups g2/g3 of 7). Full 31-card run preserved at
+  [`src/pilot/output/dah.run31.hold.json`](src/pilot/output/dah.run31.hold.json) (outside the
+  promote glob) so the 2 held cards can be finished later without re-running the clean 29:
+  requeue `dah~~h0_zz_nws00` (`--no-tm`) + `autosplit_requeue.py topup` `dah~~h0_zz_pw`, then
+  `promote_final_cards.py --merge`. Worklist after: **REMAINING 701, promoted 48**; `dah` is off
+  the runnable queue. **Next runnable head (`verb_worklist.py --top`): `sTA`(61.6, defer-calibrate)
+  `BU`(60.2) `yuj`(58.2) `as`(57.5) `i`(57.4) `tap`(49.4)** — do NOT start `sTA` without its own
+  calibration session.
+
 - **Full PWG→RU 30-day SLA documentation — ✅ DONE 04-07-2026 (Codex/GPT-5).**
   Added [`FULL_PWG_RU_30_DAY_SLA_PLAN.md`](FULL_PWG_RU_30_DAY_SLA_PLAN.md) as the
   docs-only hard-SLA plan for a full PWG Russian pass (**120,173 headword cards /


### PR DESCRIPTION
Standing [H151](https://github.com/gasyoun/Uprava/blob/main/handoffs/H151-Sonnet_RussianTranslation_pwg_ru_verb_batch_drain_04.07.26.md) verb-root drain — root `dah`.

**Run** (Workflow tool driven from the Claude Code session per the H145 guardrail — no manual Max-surface save; orchestration Opus 4.8 `claude-opus-4-8`, generation Sonnet 5 `claude-sonnet-5` hardcoded in the harness):
- Base: 15 agents, ~1.13M tokens, ~6.5 min → **31/31 cards ok, 0 null, 0 failures, 1 healed**.
- Audit: 26 clean, 5 flagged (4 gate-defect + 1 partial).
- One `--no-tm` requeue (4 keys, 3 agents) cleared 3 → **29/31 clean**.
- Promoted 29 sub-cards (`--merge --gen-model-version claude-sonnet-5`); store 10,857 rows; TM rebuilt to 2,204 cards.

**2 cards HELD unpromoted** (per MG directive: finish what's started, no new translations):
- `dah~~h0_zz_nws00` — NWS-layer gate-defect, survived 1 requeue.
- `dah~~h0_zz_pw` — partial PW-addenda card, 17 missing fragments (g2/g3 of 7).

Full 31-card run preserved locally at [`RussianTranslation/src/pilot/output/dah.run31.hold.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/output/dah.run31.hold.json) (gitignored) so the 2 held cards can be finished later (requeue + topup + `promote --merge`) without re-running the clean 29.

Only tracked change: `RussianTranslation/.ai_state.md` (translation store, TM, and wf outputs are gitignored bulk data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)