### PR TITLE
docs(pwg-ru): record H179 done + Step 3 resume point

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,46 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **H179 nominal lexical-core queue adapter + `layer` field — ✅ DONE 05-07-2026 (orchestration
+  Opus 4.8, `claude-opus-4-8`; NO generation ran — Step 3 drain is the Sonnet 5 follow-on).
+  [PR #152](https://github.com/gasyoun/SanskritLexicography/pull/152) merged.**
+  Step 2 (the switch-enabler for the Приложение 5 nominal drain) + Step 1 items 1 & 3:
+  - [`extract_lexical_cores.py`](src/pilot/extract_lexical_cores.py) — VisualDCS Приложение
+    10/5 + Сборное ядро `.xls`/`.xlsx` (lemmas are **IAST**, not SLP1) → deduped SLP1
+    wordlists + TSV via `build_src.iast_to_slp1`.
+  - [`nominals_worklist.py`](src/pilot/nominals_worklist.py) — flat-nominal sibling of
+    `verb_worklist.py`; `form_key` join into merged PWG index, hit/miss coverage, DCS-score
+    ordering (period-spread tiebreak), cumulative dedup vs the store. Verbs (POS=`v`) set
+    aside to the H151 verb drain.
+  - [`lexical_cores/`](src/pilot/lexical_cores/) — committed SLP1 lists + coverage: **pril10
+    286 / pril5 4292 / sbornoe 4798 runnable nominals**. Flat-nominal generation validated on
+    `indra`/`agni`/`kAla`.
+  - **Step 1.1** — explicit `layer` field (pwg/pw/sch/pwkvn/nws) on every promoted row via
+    new `dict_merge.layer_of()`; local store backfilled (10,857 rows). SHARED across RU/EN
+    (EN inherits via `promote_en` attach); LANG_PARITY `layer_field_on_promoted_rows` added.
+  - **Step 1.3** — [`layer_presence_audit.py`](src/pilot/layer_presence_audit.py) report-only
+    `LAYER-DROPPED` gate; `--exclude-nws` surfaces 10 real overlay gaps (e.g. `dah dropped=pw`).
+  - **⚠️ FINDING (needs a human ruling):** H179's "Приложение 5 = 3,493" is the single
+    **longest period column**; Step 2.1's requested **7-period union is 6,337 lemmas → 4,292
+    runnable nominals**. Used the union (per the Step-2 instruction); flagged in
+    [`lexical_cores/README.md`](src/pilot/lexical_cores/README.md).
+  - **⚠️ Concurrency:** a **separate session** has in-flight failure-gallery/dashboard work
+    uncommitted in the main working tree (`audit_window.py`, `dashboard/*`,
+    `evolution_stats.py`, `pwg-layers.md`) — this PR was authored via a fresh worktree and
+    deliberately excludes those files; do not clobber them.
+  - **➡️ RESUME (Step 3 — the actual nominal drain):** lead with Приложение 10 (tier 2), then
+    Приложение 5 (tier 3), under the standard drain discipline (branches+PRs from
+    `origin/master`, `--no-tm` on requeue, ≤3-wide, `--gen-model-version claude-sonnet-5`):
+    ```
+    python src/pilot/nominals_worklist.py src/pilot/lexical_cores/pril10.slp1.txt --top 30
+    python src/_pilot_gen_merged.py <top keys>
+    python src/pilot/gen_opt_harness2.py pril10 --nominal --keys=<ordered> --gen-model-version claude-sonnet-5
+    ```
+    Then audit → promote → TM rebuild per batch. **Park H151 the moment this drain starts**
+    (not before — no idle window). **Deferred: Step 1.2** (`provenance.relationship` inline
+    sidecar) belongs to the FIRST batch that runs a live translate pass — wire it into the
+    translate prompt then.
+
 - **H151 `dah` drain — 🟡 PARTIAL DONE 04-07-2026 (orchestration Opus 4.8, `claude-opus-4-8`;
   generation Sonnet 5, `claude-sonnet-5`, hardcoded `model:'sonnet'` in the harness).**
   Resumed the standing H151 drain after a prior **Sonnet** session stopped on H151 believing the


### PR DESCRIPTION
Follow-up to #152 — updates [`RussianTranslation/.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md) with the H179 completion entry (Step 2 adapter + Step 1.1 layer field + Step 1.3 layer gate), the ⚠️ 3,493-vs-6,337 count finding, the concurrency note, and the literal Step 3 nominal-drain resume commands. No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)