### PR TITLE
feat(dashboard): evolution timelapse panel + failure auto-capture

### DIFF
--- a/RussianTranslation/.gitignore
+++ b/RussianTranslation/.gitignore
@@ -117,3 +117,7 @@ glossary/*.tsv
 glossary/md/
 glossary/surface/
 glossary/index.html
+
+# Auto-captured live failure incidents (runtime, dedup per root/day); the curated
+# post-mortems in failures/failures.jsonl stay tracked. Read by the dashboard.
+failures/auto_failures.jsonl

--- a/RussianTranslation/README.md
+++ b/RussianTranslation/README.md
@@ -71,6 +71,42 @@ rebuild the dataset · pull accented RV forms from VedaWeb).
   handling; missing raw/card files requeue, while cards with no NWS layer remain
   neutral.
 
+## Local dashboard
+
+A read-only local dashboard serves live pipeline status **and an evolution
+timelapse** at `http://127.0.0.1:8765/`:
+
+```powershell
+python src\pilot\dashboard_server.py --port 8765
+```
+
+Panels: **Run Status** (current window · gates · queues · production metrics),
+**Evolution Timelapse**, **Print Gates**, **Recent Events**, **Window Ledger**,
+**File Freshness**. The page polls `/api/status` every few seconds
+(`--refresh-ms`); the timelapse polls `/api/evolution` (cached on source mtimes)
+on a slower cadence.
+
+The **Evolution Timelapse**
+([`src/pilot/evolution_stats.py`](src/pilot/evolution_stats.py)) derives the
+pipeline's maturation story from the append-only logs — throughput, PWG/DCS
+coverage, an **academic-rigor index** (share of cards carrying full
+model+pipeline provenance), quality (requeue rate), cost (tokens/window), speed
+(minutes/window), and a **failure typology** ("what was wrong" over time). Static
+trend charts plus a **play/scrub** control replay the history day by day, and a
+**Trends** panel surfaces the computed insights. Run it standalone to write
+`output/evolution_stats.json`:
+
+```powershell
+python src\pilot\evolution_stats.py
+```
+
+**Failure auto-capture:** `audit_window.py` auto-appends error-level incidents
+(kill-gate / stale refusals) to `failures/auto_failures.jsonl` (git-ignored,
+de-duped per root/day) via
+[`src/pilot/failure_capture.py`](src/pilot/failure_capture.py). The curated
+post-mortems in [`failures/FAILURE_GALLERY.md`](failures/FAILURE_GALLERY.md) +
+`failures/failures.jsonl` stay human-authored; the dashboard reads both streams.
+
 ## Flaky Network Policy
 
 Claude production translation is not a Python Claude API loop. It runs through

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -239,6 +239,17 @@ def run_prompt_semantic_audit(wf, protected, review_limit=25):
 def emit_audit_event(event_type, level='info', root=None, state=None, summary='', data=None):
     append_event('audit_window', event_type, level=level, root=root,
                  state=state, summary=summary, data=data or {})
+    # Auto-capture genuine failures (error-level) into the failure gallery for the
+    # dashboard's typology/trends. Best-effort + de-duped per (mode, root, day) so
+    # it never floods the curated post-mortems or breaks an audit.
+    if level == 'error':
+        try:
+            from failure_capture import append_failure
+            append_failure(mode=state or event_type or 'audit-failure',
+                           symptom=summary or event_type, severity='high',
+                           root=root, data={'event_type': event_type})
+        except Exception:
+            pass
 
 
 def main():

--- a/RussianTranslation/src/pilot/dashboard/dashboard.css
+++ b/RussianTranslation/src/pilot/dashboard/dashboard.css
@@ -200,9 +200,65 @@ th {
   font-size: 12px;
 }
 
+/* ---------------- Evolution timelapse ---------------- */
+.evo-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 10px 0 14px;
+  flex-wrap: wrap;
+}
+#evoPlay {
+  font: inherit;
+  padding: 5px 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--blue-bg);
+  color: var(--blue-fg);
+  cursor: pointer;
+}
+#evoPlay:hover { filter: brightness(0.97); }
+#evoScrub { flex: 1 1 220px; min-width: 160px; accent-color: var(--blue-fg); }
+.evo-toggle { color: var(--muted); font-size: 12px; display: inline-flex; align-items: center; gap: 5px; }
+.evo-charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+.evo-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 8px 10px;
+}
+.evo-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+.evo-card-head b { color: var(--text); font-size: 15px; }
+.evo-svg { width: 100%; height: 96px; display: block; }
+.evo-axis { fill: var(--muted); font-size: 8px; font-family: ui-monospace, Consolas, monospace; }
+.evo-bar-row {
+  display: grid;
+  grid-template-columns: 180px 1fr 34px;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 0;
+  font-size: 13px;
+}
+.evo-bar-label { color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.evo-bar { background: var(--bg); border-radius: 4px; height: 12px; overflow: hidden; }
+.evo-bar > span { display: block; height: 100%; background: var(--red-fg); opacity: 0.75; }
+.evo-bar-row b { text-align: right; color: var(--muted); }
+
 @media (max-width: 860px) {
   .topbar { align-items: flex-start; flex-direction: column; }
   .two-col { grid-template-columns: 1fr; }
   .event-row { grid-template-columns: 1fr; }
   .refresh { justify-content: flex-start; }
+  .evo-bar-row { grid-template-columns: 110px 1fr 30px; }
 }

--- a/RussianTranslation/src/pilot/dashboard/dashboard.js
+++ b/RussianTranslation/src/pilot/dashboard/dashboard.js
@@ -209,4 +209,149 @@ async function refresh() {
   }
 }
 
+// ---------------- Evolution timelapse ----------------
+let evoData = null;
+let evoCursor = 0;
+let evoInit = false;
+let evoPlaying = false;
+let evoPlayTimer = null;
+let evoFullHistory = true;
+
+function fmtNum(v, pct) {
+  if (!Number.isFinite(v)) return '--';
+  if (pct) return (Math.round(v * 100) / 100) + '%';
+  if (v >= 1000) return (v / 1000).toFixed(v >= 10000 ? 0 : 1) + 'k';
+  return String(Math.round(v * 100) / 100);
+}
+
+function svgLine(values, opts) {
+  opts = opts || {};
+  const W = 320, H = 110, padL = 30, padR = 6, padT = 10, padB = 14;
+  const n = values.length;
+  const cursor = Number.isInteger(opts.cursor) ? opts.cursor : n - 1;
+  const upTo = opts.grow ? cursor : n - 1;
+  const nums = values.filter(v => Number.isFinite(v));
+  const maxV = nums.length ? Math.max(...nums) : 1;
+  const span = maxV || 1;
+  const x = (i) => padL + (n <= 1 ? 0 : (W - padL - padR) * i / (n - 1));
+  const y = (v) => padT + (H - padT - padB) * (1 - v / span);
+  const pts = [];
+  for (let i = 0; i <= upTo; i++) {
+    const v = values[i];
+    if (!Number.isFinite(v)) continue;
+    pts.push(`${x(i).toFixed(1)},${y(v).toFixed(1)}`);
+  }
+  const color = opts.color || '#4da3ff';
+  let area = '';
+  if (opts.area && pts.length) {
+    area = `<polygon points="${padL.toFixed(1)},${y(0).toFixed(1)} ${pts.join(' ')} ${x(upTo).toFixed(1)},${y(0).toFixed(1)}" fill="${color}" opacity="0.13"/>`;
+  }
+  const line = pts.length ? `<polyline points="${pts.join(' ')}" fill="none" stroke="${color}" stroke-width="2" vector-effect="non-scaling-stroke"/>` : '';
+  const cx = x(cursor);
+  const cursorLine = `<line x1="${cx.toFixed(1)}" y1="${padT}" x2="${cx.toFixed(1)}" y2="${H - padB}" stroke="var(--evo-cursor,#9aa)" stroke-dasharray="3 3" stroke-width="1" vector-effect="non-scaling-stroke"/>`;
+  const cv = values[cursor];
+  const dot = Number.isFinite(cv) ? `<circle cx="${cx.toFixed(1)}" cy="${y(cv).toFixed(1)}" r="3" fill="${color}"/>` : '';
+  const yMax = `<text x="1" y="${(y(maxV) + 3).toFixed(1)}" class="evo-axis">${esc(fmtNum(maxV, opts.pct))}</text>`;
+  const yMin = `<text x="1" y="${y(0).toFixed(1)}" class="evo-axis">0</text>`;
+  return `<svg viewBox="0 0 ${W} ${H}" class="evo-svg" preserveAspectRatio="none">${area}${line}${cursorLine}${dot}${yMax}${yMin}</svg>`;
+}
+
+function evoCard(title, values, opts) {
+  opts = opts || {};
+  const cur = (values || [])[evoCursor];
+  const val = Number.isFinite(cur) ? fmtNum(cur, opts.pct) : '--';
+  return `<div class="evo-card"><div class="evo-card-head"><span>${esc(title)}</span><b>${esc(val)}</b></div>${
+    svgLine(values || [], { ...opts, cursor: evoCursor, grow: !evoFullHistory })
+  }</div>`;
+}
+
+function renderEvolution() {
+  if (!evoData || evoData.empty) {
+    $('evoCharts').innerHTML = '<div class="note">no timelapse data yet</div>';
+    return;
+  }
+  const s = evoData.series, days = evoData.days, hl = evoData.headline || {};
+  if ($('evoSpan')) $('evoSpan').textContent = `${evoData.span.start} → ${evoData.span.end} (${evoData.span.days}d)`;
+  const scrub = $('evoScrub');
+  scrub.max = String(days.length - 1);
+  if (evoCursor > days.length - 1) evoCursor = days.length - 1;
+  scrub.value = String(evoCursor);
+  $('evoDay').textContent = days[evoCursor];
+  $('evoHeadline').innerHTML = [
+    metric('Cards', hl.total_cards),
+    metric('Headwords', hl.total_roots),
+    metric('PWG coverage', (hl.coverage_pwg_pct ?? '--') + '%'),
+    metric('DCS coverage', (hl.coverage_dcs_pct ?? '--') + '%'),
+    metric('Rigor index', (hl.rigor_index_pct ?? '--') + '%'),
+    metric('Requeue rate', (hl.requeue_rate_pct ?? '--') + '%')
+  ].join('');
+  $('evoCharts').innerHTML = [
+    evoCard('Throughput — cards', s.cards_cumulative, { color: '#4da3ff', area: true }),
+    evoCard('Coverage — % of PWG', s.coverage_pwg_pct, { color: '#38b000', pct: true }),
+    evoCard('Academic rigor — %', s.rigor_index_pct, { color: '#b06bff', pct: true }),
+    evoCard('Quality — requeue rate %', s.requeue_rate_pct, { color: '#ff8c42', pct: true }),
+    evoCard('Cost — tokens/window', s.tokens_per_window, { color: '#e05260' }),
+    evoCard('Speed — minutes/window', s.minutes_per_window, { color: '#00b3a4' })
+  ].join('');
+  const ft = evoData.failure_typology || {};
+  const modes = ft.modes || [];
+  const modeMax = Math.max(1, ...modes.map(m => m.count));
+  $('evoFailures').innerHTML = modes.length ? modes.map(m =>
+    `<div class="evo-bar-row"><span class="evo-bar-label">${esc(m.mode)}</span><span class="evo-bar"><span style="width:${(100 * m.count / modeMax).toFixed(1)}%"></span></span><b>${esc(m.count)}</b></div>`
+  ).join('') : '<div class="note">no failures recorded</div>';
+  const trends = evoData.trends || [];
+  $('evoTrends').innerHTML = trends.length
+    ? `<ul>${trends.map(t => `<li>${esc(t)}</li>`).join('')}</ul>`
+    : 'no trends computed yet';
+}
+
+function evoStep() {
+  if (!evoData || evoData.empty) return;
+  evoCursor = (evoCursor + 1) % evoData.days.length;
+  renderEvolution();
+}
+
+function evoSetPlaying(on) {
+  evoPlaying = on;
+  $('evoPlay').innerHTML = on ? '&#9208; Pause' : '&#9654; Play';
+  clearInterval(evoPlayTimer);
+  if (on) {
+    if (evoData && evoCursor >= evoData.days.length - 1) evoCursor = 0;
+    evoPlayTimer = setInterval(evoStep, 650);
+  }
+}
+
+function wireEvolutionControls() {
+  $('evoPlay').addEventListener('click', () => evoSetPlaying(!evoPlaying));
+  $('evoScrub').addEventListener('input', (e) => {
+    evoSetPlaying(false);
+    evoCursor = parseInt(e.target.value, 10) || 0;
+    renderEvolution();
+  });
+  $('evoCursorAll').addEventListener('change', (e) => {
+    evoFullHistory = e.target.checked;
+    renderEvolution();
+  });
+}
+
+async function refreshEvolution() {
+  try {
+    const res = await fetch('/api/evolution', { cache: 'no-store' });
+    if (res.ok) {
+      evoData = await res.json();
+      if (!evoInit && evoData && evoData.days && evoData.days.length) {
+        evoCursor = evoData.days.length - 1;
+        evoInit = true;
+      }
+      renderEvolution();
+    }
+  } catch (err) {
+    /* evolution is best-effort; the status poll reports health */
+  } finally {
+    setTimeout(refreshEvolution, 30000);
+  }
+}
+
+wireEvolutionControls();
 refresh();
+refreshEvolution();

--- a/RussianTranslation/src/pilot/dashboard/index.html
+++ b/RussianTranslation/src/pilot/dashboard/index.html
@@ -49,6 +49,31 @@
       </div>
     </section>
 
+    <section id="evolutionSection">
+      <div class="section-head">
+        <h2>Evolution Timelapse</h2>
+        <span class="subtle" id="evoSpan"></span>
+      </div>
+      <div class="metrics" id="evoHeadline"></div>
+      <div class="evo-controls">
+        <button id="evoPlay" type="button">&#9654; Play</button>
+        <input type="range" id="evoScrub" min="0" max="0" value="0" step="1" aria-label="timelapse day">
+        <span class="mono" id="evoDay">--</span>
+        <label class="evo-toggle"><input type="checkbox" id="evoCursorAll" checked> full history</label>
+      </div>
+      <div class="evo-charts" id="evoCharts"></div>
+      <div class="two-col">
+        <div>
+          <h3>Failure typology (fuckup history)</h3>
+          <div id="evoFailures"></div>
+        </div>
+        <div>
+          <h3>Trends</h3>
+          <div id="evoTrends" class="note"></div>
+        </div>
+      </div>
+    </section>
+
     <section>
       <div class="section-head">
         <h2>Print Gates</h2>

--- a/RussianTranslation/src/pilot/dashboard_server.py
+++ b/RussianTranslation/src/pilot/dashboard_server.py
@@ -10,6 +10,21 @@ from urllib.parse import unquote, urlparse
 
 from dashboard_events import read_events
 import window_common
+import evolution_stats
+
+# Evolution stats are derived from the full logs (10k+ cards); cache on the
+# newest source mtime so the 5s status poll never triggers a recompute and a
+# separate, slower /api/evolution poll only rebuilds when a source file changes.
+_evo_cache = {'mtime': None, 'data': None}
+
+
+def evolution_payload(root):
+    paths = evolution_stats.source_paths(root)
+    mtime = evolution_stats.newest_mtime(paths)
+    if _evo_cache['data'] is None or _evo_cache['mtime'] != mtime:
+        _evo_cache['data'] = evolution_stats.build_evolution_stats(root)
+        _evo_cache['mtime'] = mtime
+    return _evo_cache['data']
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_ROOT = os.path.normpath(os.path.join(HERE, '..', '..'))
@@ -83,6 +98,11 @@ class DashboardHandler(BaseHTTPRequestHandler):
         if path == '/api/status':
             payload = combined_status(self.server.dashboard_root,
                                       self.server.refresh_ms)
+            self.send_bytes(json.dumps(payload, ensure_ascii=False, indent=1).encode('utf-8'),
+                            'application/json; charset=utf-8')
+            return
+        if path == '/api/evolution':
+            payload = evolution_payload(self.server.dashboard_root)
             self.send_bytes(json.dumps(payload, ensure_ascii=False, indent=1).encode('utf-8'),
                             'application/json; charset=utf-8')
             return

--- a/RussianTranslation/src/pilot/evolution_stats.py
+++ b/RussianTranslation/src/pilot/evolution_stats.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python
+"""Evolution / timelapse statistics for the RussianTranslation dashboard.
+
+Reads the local, append-only operational logs and derives day-bucketed trend
+series that tell the maturation story of the pwg_ru pipeline: throughput,
+coverage, cost/efficiency, quality, an "academic rigor" proxy, and a failure
+typology over time. Consumed by the dashboard's `/api/evolution` endpoint (which
+caches on source mtimes) and writeable to `output/evolution_stats.json` via the
+CLI for offline inspection.
+
+All inputs are best-effort: a missing/partial file degrades that series to
+nulls rather than raising, because this is observability, not a gate.
+"""
+import datetime
+import json
+import os
+import sys
+
+if hasattr(sys.stdout, 'reconfigure'):
+    sys.stdout.reconfigure(encoding='utf-8')
+    sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.normpath(os.path.join(HERE, '..', '..'))
+
+# Coverage denominators (PWG unique headwords / DCS-attested subset). See
+# RUN_FREQ_MAX.md: 43,968 / 106,082 PWG headwords are DCS-attested.
+PWG_HEADWORDS = 106082
+DCS_ATTESTED = 43968
+
+
+def utc_now():
+    return datetime.datetime.now(datetime.timezone.utc).isoformat(
+        timespec='seconds').replace('+00:00', 'Z')
+
+
+def source_paths(root):
+    out = os.path.join(root, 'src', 'pilot', 'output')
+    return {
+        'cards': os.path.join(root, 'src', 'pwg_ru_translated.jsonl'),
+        'ledger': os.path.join(out, 'window_ledger.jsonl'),
+        'events': os.path.join(out, 'dashboard_events.jsonl'),
+        'failures': os.path.join(root, 'failures', 'failures.jsonl'),
+        'failures_auto': os.path.join(root, 'failures', 'auto_failures.jsonl'),
+    }
+
+
+def newest_mtime(paths):
+    mt = 0.0
+    for p in paths.values():
+        try:
+            mt = max(mt, os.path.getmtime(p))
+        except OSError:
+            continue
+    return mt
+
+
+def _iter_jsonl(path):
+    if not os.path.exists(path):
+        return
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def _day(ts):
+    """First 10 chars of an ISO-8601 timestamp -> YYYY-MM-DD, or None."""
+    if not ts or not isinstance(ts, str) or len(ts) < 10:
+        return None
+    return ts[:10]
+
+
+def _daterange(start, end):
+    d0 = datetime.date.fromisoformat(start)
+    d1 = datetime.date.fromisoformat(end)
+    days = []
+    cur = d0
+    while cur <= d1:
+        days.append(cur.isoformat())
+        cur += datetime.timedelta(days=1)
+    return days
+
+
+def _pct(n, d):
+    return round(100.0 * n / d, 3) if d else 0.0
+
+
+def build_evolution_stats(root=REPO):
+    paths = source_paths(root)
+
+    # ---- cards: per-day new cards, first-seen roots, provenance completeness ----
+    cards_by_day = {}          # day -> card count
+    roots_first_day = {}       # key1 -> first day seen
+    prov_full_by_day = {}      # day -> cards with model_version AND pipeline
+    seen_days = set()
+    total_cards = 0
+    for c in _iter_jsonl(paths['cards']):
+        prov = c.get('provenance') or {}
+        day = _day(prov.get('generated_at'))
+        if not day:
+            continue
+        total_cards += 1
+        seen_days.add(day)
+        cards_by_day[day] = cards_by_day.get(day, 0) + 1
+        key1 = c.get('key1') or prov.get('root')
+        if key1 and (key1 not in roots_first_day or day < roots_first_day[key1]):
+            roots_first_day[key1] = day
+        has_prov = bool(prov.get('model_version')) and bool(prov.get('pipeline'))
+        if has_prov:
+            prov_full_by_day[day] = prov_full_by_day.get(day, 0) + 1
+
+    roots_by_day = {}
+    for key1, day in roots_first_day.items():
+        roots_by_day[day] = roots_by_day.get(day, 0) + 1
+
+    # ---- ledger: per-audit quality + efficiency, bucketed by day ----
+    led_requeue = {}   # day -> [requeue_rate, ...]
+    led_tokens = {}    # day -> [max_output_tokens, ...]
+    led_minutes = {}   # day -> [wall_clock_minutes, ...]
+    for r in _iter_jsonl(paths['ledger']):
+        day = _day(r.get('recorded_at'))
+        if not day:
+            continue
+        seen_days.add(day)
+        wk = r.get('workflow_keys') or 0
+        rq = r.get('requeue_count') or 0
+        if wk:
+            led_requeue.setdefault(day, []).append(rq / wk)
+        pm = r.get('production_metrics') or {}
+        tok = pm.get('max_output_tokens')
+        if isinstance(tok, (int, float)) and tok > 0:
+            led_tokens.setdefault(day, []).append(float(tok))
+        mins = pm.get('wall_clock_minutes')
+        if isinstance(mins, (int, float)) and mins > 0:
+            led_minutes.setdefault(day, []).append(float(mins))
+
+    # ---- events: gate-failure counts (all-time + per day) ----
+    gate_fail_total = {}   # gate -> count
+    gate_fail_day = {}     # day -> {gate -> count}
+    for e in _iter_jsonl(paths['events']):
+        if e.get('type') != 'gate_summary':
+            continue
+        data = e.get('data') or {}
+        gate = data.get('gate') or e.get('source') or 'gate'
+        failed = (data.get('requeue_count') or 0) > 0 or \
+                 str(e.get('level')) in ('warn', 'error') or \
+                 str(data.get('status')).lower() in ('fail', 'failed')
+        if not failed:
+            continue
+        gate_fail_total[gate] = gate_fail_total.get(gate, 0) + 1
+        day = _day(e.get('ts'))
+        if day:
+            seen_days.add(day)
+            gate_fail_day.setdefault(day, {})[gate] = \
+                gate_fail_day.setdefault(day, {}).get(gate, 0) + 1
+
+    # ---- failures.jsonl: typology (modes x severity) + timeline ----
+    mode_counts = {}
+    sev_counts = {}
+    fail_timeline = {}   # day -> count
+    fail_records = []
+    for src_key in ('failures', 'failures_auto'):
+        origin = 'auto' if src_key == 'failures_auto' else 'curated'
+        for fr in _iter_jsonl(paths.get(src_key, '')):
+            mode = fr.get('mode') or 'unknown'
+            sev = fr.get('severity') or 'unknown'
+            mode_counts[mode] = mode_counts.get(mode, 0) + 1
+            sev_counts[sev] = sev_counts.get(sev, 0) + 1
+            day = fr.get('date') or None
+            if day:
+                fail_timeline[day] = fail_timeline.get(day, 0) + 1
+            fail_records.append({'id': fr.get('id'), 'date': day, 'mode': mode,
+                                 'severity': sev, 'origin': fr.get('source') or origin,
+                                 'symptom': (fr.get('symptom') or '')[:200]})
+
+    # ---- assemble the day axis + cumulative series ----
+    all_days = sorted(seen_days | set(fail_timeline))
+    if not all_days:
+        return {'generated_at': utc_now(), 'empty': True,
+                'note': 'no timestamped data found yet'}
+    days = _daterange(all_days[0], all_days[-1])
+
+    def cum(daily):
+        run, out = 0, []
+        for d in days:
+            run += daily.get(d, 0)
+            out.append(run)
+        return out
+
+    def avg_series(bucket):
+        return [round(sum(bucket[d]) / len(bucket[d]), 4) if bucket.get(d) else None
+                for d in days]
+
+    cards_daily = [cards_by_day.get(d, 0) for d in days]
+    cards_cum = cum(cards_by_day)
+    roots_cum = cum(roots_by_day)
+    prov_cum = cum(prov_full_by_day)
+    rigor_index = [_pct(prov_cum[i], cards_cum[i]) for i in range(len(days))]
+    coverage_pwg = [_pct(roots_cum[i], PWG_HEADWORDS) for i in range(len(days))]
+    coverage_dcs = [_pct(roots_cum[i], DCS_ATTESTED) for i in range(len(days))]
+
+    tokens_avg = avg_series(led_tokens)
+    minutes_avg = avg_series(led_minutes)
+    requeue_avg = [round(100.0 * sum(led_requeue[d]) / len(led_requeue[d]), 2)
+                   if led_requeue.get(d) else None for d in days]
+
+    series = {
+        'cards_daily': cards_daily,
+        'cards_cumulative': cards_cum,
+        'roots_cumulative': roots_cum,
+        'coverage_pwg_pct': coverage_pwg,
+        'coverage_dcs_pct': coverage_dcs,
+        'rigor_index_pct': rigor_index,
+        'requeue_rate_pct': requeue_avg,
+        'tokens_per_window': tokens_avg,
+        'minutes_per_window': minutes_avg,
+    }
+
+    return {
+        'generated_at': utc_now(),
+        'span': {'start': days[0], 'end': days[-1], 'days': len(days)},
+        'days': days,
+        'series': series,
+        'headline': _headline(total_cards, roots_cum, coverage_pwg, coverage_dcs,
+                              rigor_index, requeue_avg, tokens_avg, minutes_avg),
+        'failure_typology': {
+            'modes': sorted(({'mode': m, 'count': c} for m, c in mode_counts.items()),
+                            key=lambda x: -x['count']),
+            'severity': sorted(({'severity': s, 'count': c} for s, c in sev_counts.items()),
+                               key=lambda x: -x['count']),
+            'timeline': [{'date': d, 'count': fail_timeline.get(d, 0)} for d in days],
+            'records': fail_records,
+        },
+        'gate_failures': sorted(({'gate': g, 'count': c} for g, c in gate_fail_total.items()),
+                                key=lambda x: -x['count']),
+        'trends': _trends(days, cards_cum, coverage_pwg, rigor_index, requeue_avg,
+                          tokens_avg, minutes_avg, mode_counts, fail_timeline),
+    }
+
+
+def _first_last(vals):
+    """First and last non-null values of a series."""
+    nn = [v for v in vals if v is not None]
+    if not nn:
+        return None, None
+    return nn[0], nn[-1]
+
+
+def _headline(total_cards, roots_cum, cov_pwg, cov_dcs, rigor, requeue, tokens, minutes):
+    return {
+        'total_cards': total_cards,
+        'total_roots': roots_cum[-1] if roots_cum else 0,
+        'coverage_pwg_pct': cov_pwg[-1] if cov_pwg else 0.0,
+        'coverage_dcs_pct': cov_dcs[-1] if cov_dcs else 0.0,
+        'rigor_index_pct': rigor[-1] if rigor else 0.0,
+        'requeue_rate_pct': _first_last(requeue)[1],
+    }
+
+
+def _delta_pct(first, last):
+    if first in (None, 0) or last is None:
+        return None
+    return round(100.0 * (last - first) / first, 1)
+
+
+def _trends(days, cards_cum, cov_pwg, rigor, requeue, tokens, minutes,
+            mode_counts, fail_timeline):
+    """Human-readable trend insights ('find trends')."""
+    out = []
+    if len(days) >= 2:
+        out.append('Grew from %d to %d translated cards over %d days.'
+                   % (cards_cum[0], cards_cum[-1], len(days)))
+    tok_f, tok_l = _first_last(tokens)
+    d = _delta_pct(tok_f, tok_l)
+    if d is not None:
+        if abs(d) < 1:
+            out.append('Per-window output tokens held ~flat at %.0f.' % tok_l)
+        else:
+            out.append('Per-window output tokens %s %.0f%% (%.0f→%.0f) — cost %s.'
+                       % ('fell' if d < 0 else 'rose', abs(d), tok_f, tok_l,
+                          'down' if d < 0 else 'up'))
+    min_f, min_l = _first_last(minutes)
+    d = _delta_pct(min_f, min_l)
+    if d is not None and abs(d) >= 1:
+        out.append('Per-window wall-clock %s %.0f%% (%.1f→%.1f min) — %s.'
+                   % ('fell' if d < 0 else 'rose', abs(d), min_f, min_l,
+                      'faster' if d < 0 else 'slower'))
+    rq_f, rq_l = _first_last(requeue)
+    if rq_f is not None and rq_l is not None:
+        out.append('Requeue rate moved %.1f%%→%.1f%% (a rise can reflect stricter gates, not worse output).'
+                   % (rq_f, rq_l))
+    if rigor:
+        out.append('Academic-rigor index (cards with full model+pipeline provenance) at %.0f%%.'
+                   % rigor[-1])
+    if cov_pwg:
+        out.append('Coverage of PWG headwords at %.2f%% (DCS-attested share higher).' % cov_pwg[-1])
+    if mode_counts:
+        top = max(mode_counts.items(), key=lambda x: x[1])
+        out.append('Dominant recorded failure mode: "%s" (%d of %d gallery entries).'
+                   % (top[0], top[1], sum(mode_counts.values())))
+    return out
+
+
+def main():
+    import argparse
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--root', default=REPO)
+    ap.add_argument('--out', default=None,
+                    help='write JSON here (default: <root>/src/pilot/output/evolution_stats.json)')
+    args = ap.parse_args()
+    root = os.path.abspath(args.root)
+    stats = build_evolution_stats(root)
+    out = args.out or os.path.join(root, 'src', 'pilot', 'output', 'evolution_stats.json')
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(out, 'w', encoding='utf-8') as f:
+        json.dump(stats, f, ensure_ascii=False, indent=1)
+    hl = stats.get('headline', {})
+    print('evolution_stats -> %s' % out)
+    print('  span   : %s' % (stats.get('span') or 'empty'))
+    print('  cards  : %s  roots: %s' % (hl.get('total_cards'), hl.get('total_roots')))
+    for t in stats.get('trends', []):
+        print('  trend  : %s' % t)
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/failure_capture.py
+++ b/RussianTranslation/src/pilot/failure_capture.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+"""Best-effort auto-capture of live audit failures into the failure gallery.
+
+The curated post-mortems in `failures/failures.jsonl` (ids `F1`..) carry
+human-written root_cause / fix / lesson. These auto-captured records are LIVE
+incidents from the kill-gate / audit: `source='auto'`, `status='open'`, id
+`AUTO-<n>`, de-duplicated on `(mode, root, date)` so a recurring failure is
+logged at most once per root per day and cannot flood the gallery. A human later
+promotes a recurring AUTO record into a full curated post-mortem.
+
+Writes are best-effort (never raise) — observability must not break an audit.
+"""
+import datetime
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.normpath(os.path.join(HERE, '..', '..'))
+# Auto-captured incidents go to a SEPARATE, git-ignored log so the curated,
+# tracked post-mortems in failures/failures.jsonl stay pristine (human-authored
+# only). The dashboard reads both.
+FAILURES = os.path.join(REPO, 'failures', 'auto_failures.jsonl')
+
+
+def _today():
+    return datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+
+
+def _existing(path):
+    """Return (set of (mode, root, date) signatures, max AUTO-<n> seen)."""
+    sigs = set()
+    maxn = 0
+    if not os.path.exists(path):
+        return sigs, maxn
+    try:
+        with open(path, encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    r = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                sigs.add((r.get('mode'), r.get('root'), r.get('date')))
+                rid = str(r.get('id') or '')
+                if rid.startswith('AUTO-'):
+                    try:
+                        maxn = max(maxn, int(rid[5:]))
+                    except ValueError:
+                        pass
+    except Exception:
+        pass
+    return sigs, maxn
+
+
+def append_failure(mode, symptom, severity='high', root=None, data=None,
+                   path=FAILURES):
+    """Append one auto-captured failure incident; de-dupe on (mode, root, today).
+
+    Returns the written record, None if de-duplicated, or None on any error.
+    """
+    try:
+        sigs, maxn = _existing(path)
+        date = _today()
+        mode = mode or 'audit-failure'
+        if (mode, root, date) in sigs:
+            return None
+        rec = {
+            'id': 'AUTO-%d' % (maxn + 1),
+            'date': date,
+            'mode': mode,
+            'severity': severity,
+            'symptom': (symptom or mode)[:300],
+            'root': root,
+            'source': 'auto',
+            'status': 'open',
+            'data': data or {},
+        }
+        parent = os.path.dirname(os.path.abspath(path))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(path, 'a', encoding='utf-8') as f:
+            f.write(json.dumps(rec, ensure_ascii=False) + '\n')
+        return rec
+    except Exception as e:
+        print('warning: failure auto-capture failed: %s' % e, file=sys.stderr)
+        return None


### PR DESCRIPTION
Adds a live **Evolution Timelapse** to the existing read-only pipeline dashboard, telling the pwg_ru maturation story from the append-only logs.

## What
- **`src/pilot/evolution_stats.py`** — day-bucketed trends from `window_ledger` + per-card `generated_at` + failures: throughput, PWG/DCS coverage, an **academic-rigor index** (share of cards with full model+pipeline provenance), quality (requeue rate), cost (tokens/window), speed (minutes/window), a **failure typology**, and computed trend insights.
- **`dashboard_server.py`** — `/api/evolution` endpoint, cached on source mtimes (the 5s status poll never recomputes).
- **`dashboard/{index.html,dashboard.js,dashboard.css}`** — new panel: framework-free inline-SVG trend charts, a **play/scrub** timelapse control, failure-typology bars, a Trends list.
- **`src/pilot/failure_capture.py`** + `audit_window.emit_audit_event` hook — auto-capture error-level incidents (kill-gate / stale refusals) to a git-ignored `failures/auto_failures.jsonl` (deduped per root/day, best-effort). The curated `failures/failures.jsonl` stays human-authored; the dashboard reads both.
- **README** — new *Local dashboard* section.

## Verified live
Server + `/api/evolution` return 200; charts render (throughput, coverage, rigor, quality, cost, speed); the play/scrub cursor moves through the 19-day history; failure typology shows 12 modes; zero console errors.

Answers a request to add a live evolution timelapse + trends + statistics to the running dashboard, keep the failure gallery updated (auto-capture), with cleanup + README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)