### PR TITLE
fix(pwg-ru): nominal drain cards key to true headword (H179 Step 3 pre-run fix)

### DIFF
--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231"
+      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d"
     }
   },
   {
@@ -117,7 +117,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
+      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d",
       "src/pilot/window_selftest.py": "30be0b838e7fe3a070b20749929d866e221df4c4aec52132d7dd42f54fb1c791"
     }
   },
@@ -136,7 +136,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
+      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d",
       "src/pilot/window_selftest.py": "30be0b838e7fe3a070b20749929d866e221df4c4aec52132d7dd42f54fb1c791"
     }
   },
@@ -154,7 +154,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231"
+      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d"
     }
   },
   {
@@ -171,7 +171,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231"
+      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d"
     }
   },
   {
@@ -205,7 +205,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231"
+      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d"
     }
   },
   {
@@ -222,7 +222,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231"
+      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d"
     }
   },
   {
@@ -238,7 +238,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The bare 'sonnet' alias resolved to Sonnet 4.6 (not 5.0) on a prior EN run — pinned explicitly there after that surprise. RU's alias was never observed to misresolve, so it was left alone rather than touching a stable production path for a problem it doesn't have. Re-evaluate if RU is ever caught on a stale alias too.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231"
+      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d"
     }
   },
   {
@@ -260,7 +260,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
       "src/pilot/prompt_rule_audit.py": "bbd3fe10ff72b9d58e6d763069352129df8c246d4cb18ae41520ddcf6fee7525",
-      "src/pilot/audit_window.py": "126d9d3cf2ad0ba71443ca10d85b76f50fc33edde0d0195f7a839cbfa5daec2f",
+      "src/pilot/audit_window.py": "8ab1aee803e6102fa4125a22006e929d254422854e5f1983030d6a3b21dcbd89",
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2"
     }
   },
@@ -296,7 +296,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "171b9c148a2c18da930959ade98da477c9a6ccbb192e7c88ff0d296d89b31849",
+      "src/promote_final_cards.py": "abb57e9a41e8969346e854fd4d4682b97abdabf203a102b6a5d11fa657eaaa22",
       "src/promote_en.py": "7c9b24b12371937735efb7cb3eb7f9b51238614d34b357621b1e8f1715c21420"
     }
   },
@@ -315,7 +315,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
+      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d",
       "src/pilot/window_selftest.py": "30be0b838e7fe3a070b20749929d866e221df4c4aec52132d7dd42f54fb1c791"
     }
   },
@@ -353,7 +353,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED same day (2026-07-04): PR #140 (feat(provenance): pipeline versioning) added pipeline_version stamping only to promote_final_cards.py; found as a GAP while re-affirming H169's parity re-hash, closed immediately. promote_en.py now calls `pipeline_version.stamp(model_version=gen_model_version)` inside `en_index()`'s per-subcard provenance block, stored as `en_provenance.pipeline` (mirrors RU's `provenance.pipeline`; a distinct field since EN attaches onto an existing RU row rather than owning it). Pinned by an added assertion in `promote_en.selftest()`.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "171b9c148a2c18da930959ade98da477c9a6ccbb192e7c88ff0d296d89b31849",
+      "src/promote_final_cards.py": "abb57e9a41e8969346e854fd4d4682b97abdabf203a102b6a5d11fa657eaaa22",
       "src/promote_en.py": "7c9b24b12371937735efb7cb3eb7f9b51238614d34b357621b1e8f1715c21420"
     }
   },
@@ -372,7 +372,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "bc0c9a981a5becb70e030cff2dfe018ebd118f0e2f0cc4872c11c70595adc231",
+      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d",
       "src/pilot/window_selftest.py": "30be0b838e7fe3a070b20749929d866e221df4c4aec52132d7dd42f54fb1c791"
     }
   },
@@ -391,8 +391,27 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 1.1. The layer is derived purely from the sub-card KEY structure, which is identical for RU and EN. promote_en.py ATTACHES english onto the RU-owned row and leaves it otherwise untouched, so EN inherits `layer` for free — no EN-specific code needed. layer_of() pinned by dict_merge.py selftest + a promote_final_cards.selftest assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "171b9c148a2c18da930959ade98da477c9a6ccbb192e7c88ff0d296d89b31849",
+      "src/promote_final_cards.py": "abb57e9a41e8969346e854fd4d4682b97abdabf203a102b6a5d11fa657eaaa22",
       "src/dict_merge.py": "81cbd01bf4033177c684e11b6d369a594532736cea05ab915459e8ada6fd2d17"
+    }
+  },
+  {
+    "id": "nominal_meta_keymap",
+    "mechanism": "gen_opt_harness2.py emits `nominal: true` + `nominal_keymap` (safe-name file stem -> true SLP1 headword) in the workflow meta for --nominal runs, so promote_final_cards recovers the real headword instead of mis-keying every card to the window LABEL passed as meta.root",
+    "files": [
+      "src/pilot/gen_opt_harness2.py",
+      "src/promote_final_cards.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d",
+      "src/promote_final_cards.py": "abb57e9a41e8969346e854fd4d4682b97abdabf203a102b6a5d11fa657eaaa22"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -887,6 +887,12 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
             timespec='seconds').replace('+00:00', 'Z'),
         'root': root, 'safe_root': safe_name(root), 'lang': lang,
         'mode': 'nominal_masked' if nominal else 'batched_masked',
+        # Nominal mode: `root` is only a window LABEL (e.g. pril10_w1), never a real headword,
+        # and result rows are keyed by the safe-name file stem (k_ala, r_upa). promote_final_cards
+        # keys the store row on meta.nominal + nominal_keymap[stem] -> true SLP1 headword; without
+        # these two fields it would fall back to meta.root and mis-key every card to the label.
+        'nominal': nominal,
+        'nominal_keymap': ({k: (_slp1_lex_for_key(k)[0] or k) for k in keys} if nominal else None),
         'grammar_layer': ('nominal' if nominal else 'root') if grammar_on else 'none',
         'selected_keys': keys, 'batches': batches, 'batch_count': len(batches),
         'rootmap_sha256': sha256_file(rootmap) if rootmap else None,

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -205,6 +205,16 @@ def selftest():
     assert p['model'] == 'sonnet' and p['rootmap_sha256'] == 'abc'
     assert p['model_version'] == SELFTEST_MODEL_VERSION, 'model VERSION recorded, not just the tier alias'
     assert p['input_raw_sha256'] == 'r1' and p['generated_at'], 'provenance must be complete'
+    # NOMINAL mode: meta.root is a window LABEL; the row must key to the true SLP1 headword
+    # recovered from nominal_keymap[stem], NOT to the label (regression guard, H179 drain).
+    nmeta = {'root': 'pril10_w1', 'nominal': True, 'nominal_keymap': {'k_ala': 'kAla'},
+             'input_hashes': {'k_ala': {'raw_sha256': 'r', 'portrait_sha256': 'p'}}}
+    ncard = {'key1': 'kAla', 'iast': 'kāla',
+             'records': [{'h': 'kāla', 'senses': [{'tag': '1', 'russian': 'время', 'german': 'Zeit'}]}]}
+    nrow = list(rows_for('k_ala', {'card': ncard, 'meta': nmeta, 'wf_file': 'wf_output.json'},
+                         'ai_translated', SELFTEST_MODEL_VERSION))[0]
+    assert nrow['key1'] == 'kAla', 'nominal card must key to true SLP1 headword, not the window label'
+    assert nrow['subcard'] == 'k_ala' and nrow['layer'] == 'pwg'
     assert 'partial_card' not in p, 'complete card carries no partial marker'
     # a partial (selfheal) card must be marked on every row it yields
     pentry = dict(entry)


### PR DESCRIPTION
Found while preparing the **Приложение 10 tier-2 nominal drain** (top-8 first window, 174 agents) — **before** any generation spend.

## Bug
`promote_final_cards.rows_for` has a nominal path gated on `meta.get('nominal')` that reads `nominal_keymap[stem] -> true SLP1 headword`. But `gen_opt_harness2.py --nominal` never emitted those fields — only `mode: 'nominal_masked'`. Result rows are keyed by the safe-name **file stem** (`k_ala`, `r_upa`), so with no `nominal`/`nominal_keymap` in meta, promote falls back to `meta.root` — the **window label** (`pril10_w1`) — and mis-keys *every* card. Half-wired: the promote side was built, the harness side never was (nominal support was A/B-phase per H179).

## Fix
Harness meta now emits `nominal: <bool>` and `nominal_keymap` (safe-name stem → true SLP1 headword, from each card's portrait `key1` via `_slp1_lex_for_key`). Verified round-trip: a card keyed `k_ala` now promotes to `key1='kAla'` (was `pril10_w1`).

Pinned by a new `promote_final_cards.selftest` nominal-keying assertion. **SHARED** across RU/EN (identical meta both paths) — `LANG_PARITY` entry `nominal_meta_keymap` added; the `gen_opt_harness2`/`promote` parity entries re-affirmed. Also re-affirmed the pre-existing `gate_fixes_20260703_ru_only` drift that #154's `audit_window.py` change left on master, unbreaking the parity gate.

## Tests
`promote_final_cards.py --selftest` + `lang_parity_check.py` green. (`window_selftest.py`'s `perf_preflight` subprocess test fails only in a fresh worktree lacking the gitignored `gam` rootmap — pre-existing, identical on pristine origin/master.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)