### PR TITLE
test(pwg-ru): pin build() nominal meta+keymap emission (guards H179/#155)

### DIFF
--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -1814,6 +1814,38 @@ def test_promote_nominal_key1():
         fail('nominal promotion must map safe runtime keys back to assembled key1')
 
 
+def test_build_emits_nominal_keymap():
+    """Producer-side twin of test_promote_nominal_key1: build(nominal=True) MUST emit
+    meta.nominal + meta.nominal_keymap. Without them promote_final_cards.rows_for falls
+    back to meta.root (the window LABEL, e.g. pril10_w1) and mis-keys every nominal card.
+    The consumer test hand-builds its meta, so it cannot catch build() dropping the fields;
+    this test does (guards PR #155 against a silent regression)."""
+    import re as _re
+    import gen_opt_harness2 as gh
+    from window_common import input_paths
+    key = 'ab'
+    rp, pp = input_paths(key)
+    if not (os.path.exists(rp) and os.path.exists(pp)):
+        return  # fixture-gated, same as the sibling nominal build() tests
+    js, _batches = gh.build(key, [key], None, 12000, nominal=True, tm_path=None)
+    meta = json.loads(_re.search(r'const META = (\{.*?\})\n', js, _re.S).group(1))
+    if meta.get('nominal') is not True:
+        fail('build(nominal=True) must set meta.nominal=True (else promote falls back to the window label)')
+    keymap = meta.get('nominal_keymap')
+    if not isinstance(keymap, dict) or key not in keymap:
+        fail('build(nominal=True) must emit meta.nominal_keymap mapping each safe key to its SLP1 headword')
+    slp1 = gh._slp1_lex_for_key(key)[0] or key
+    if keymap[key] != slp1:
+        fail('nominal_keymap must map the safe key to the portrait SLP1 (%r), got %r' % (slp1, keymap[key]))
+    # Negative: a non-nominal (batched) build must NOT carry the nominal routing fields.
+    js2, _b2 = gh.build(key, [key], None, 12000, nominal=False, tm_path=None)
+    meta2 = json.loads(_re.search(r'const META = (\{.*?\})\n', js2, _re.S).group(1))
+    if meta2.get('nominal'):
+        fail('batched (non-nominal) build must not set meta.nominal')
+    if meta2.get('nominal_keymap') is not None:
+        fail('batched (non-nominal) build must leave meta.nominal_keymap null')
+
+
 def test_calibration_arm_set_conservative_emit_only():
     with tempfile.TemporaryDirectory() as tmp:
         out_dir = os.path.join(tmp, 'perf_smoke_preflight')
@@ -2192,6 +2224,7 @@ def main():
         test_coordinator_lock_replaces_stale_dead_owner,
         test_coordinator_defect_requeue_uses_no_tm_and_out,
         test_promote_nominal_key1,
+        test_build_emits_nominal_keymap,
         test_calibration_arm_set_conservative_emit_only,
         test_frag_tm_reuse,
         test_no_fallback_batch_isolation,


### PR DESCRIPTION
## What

Adds a **producer-side pinning test** — `test_build_emits_nominal_keymap` in [`window_selftest.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_selftest.py) — for the nominal card-keying that [PR #155](https://github.com/gasyoun/SanskritLexicography/pull/155) landed (H179 Step 3).

## Why

The existing `test_promote_nominal_key1` tests the **consumer** ([`promote_final_cards.rows_for`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_final_cards.py)) by **hand-building** a `meta` dict with `nominal` + `nominal_keymap`. So it cannot catch the **producer** — [`gen_opt_harness2.build()`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py) — dropping those two fields in a refactor. If `build()` stops emitting them, every nominal drain card silently falls back to `meta.root` (the window **label**, e.g. `pril10_w1`) instead of its true SLP1 headword, corrupting the promoted store — and the consumer test stays green.

This test closes that gap: it asserts `build(nominal=True)` emits `meta.nominal is True` and a `nominal_keymap` mapping each safe key → its portrait SLP1, and that a non-nominal (batched) build carries neither field.

## Notes

- **Fixture-gated** on the `ab` portrait, exactly like the sibling nominal `build()` tests (`test_degenerate_passthrough_accounted` etc.) — skips cleanly where the gitignored local input fixtures are absent (fresh worktrees / CI), runs+passes in a dev checkout that has them. Verified passing against the live `ab` fixture (producer emits `nominal: True`, `nominal_keymap: {'ab': 'ab'}`).
- Test-only; no behavior change. `py_compile` clean.
- Context: raised during the H188 pwg_ru pre-run audit scoping — the `build()` nominal-keymap emission was found only as an uncommitted working-tree overlay on the H179 branch, then confirmed already merged to master via #155; this adds the missing guard so it can't silently regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)