### PR TITLE
docs(pwg-ru): pril10_w1 nominal window cost/latency blow-up post-mortem (H189)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,24 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **⛔ BLOCKER — nominal window `pril10_w1` ABORTED on cost/latency blow-up 05-07-2026 (gen Sonnet 5
+  `claude-sonnet-5`; post-mortem Opus 4.8 `claude-opus-4-8`).** First nominal production run (top-8
+  largest PWG heads) killed by MG after ~20 min: **42.3 M tokens / ~$79.83 / ~3 of 8 cards**, agents
+  running 3–6.5 min and up to 903 K tokens each. Root cause: nominal+presplit makes **every fragment
+  its own `agent()` call** (8 cards → **230 agents**, ~29/card), each re-establishing the ~30 K
+  framework cache → **cache-write = 60% of the bill**; the opt2 batching amortization is defeated.
+  Per-card cost (~5.29 M tok) is ~145× the batched verb runs (~36 K/card) → **not viable at scale**
+  (10 K entries ≈ $100 K). **DO NOT run any Max window (verb or nominal) until the fixes land.**
+  Full post-mortem + fix mandate (why / fix / never-again): **H189** —
+  `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H189-Opus_RussianTranslation_pwg_ru_nominal_cost_blowup_postmortem_05.07.26.md and execute it.`
+  Run detail in [`RUN_LOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_LOG.md)
+  (2026-07-05 block).
+
+- **H151 verb-root drain — ⏸ PARKED 05-07-2026 (Opus 4.8, `claude-opus-4-8`).** Its guardrail said
+  "keep draining until the nominal window produces output," but the nominal window is now **blocked
+  pending H189**, and the same per-fragment cost blow-up affects dense verb roots too. H151 stays
+  parked (not draining) until H189 §5.B/§5.C guardrails land. Do not resume the drain meanwhile.
+
 - **H179 nominal lexical-core queue adapter + `layer` field — ✅ DONE 05-07-2026 (orchestration
   Opus 4.8, `claude-opus-4-8`; NO generation ran — Step 3 drain is the Sonnet 5 follow-on).
   [PR #152](https://github.com/gasyoun/SanskritLexicography/pull/152) merged.**
@@ -1270,6 +1288,18 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   they are not pwg_ru deliverables.
 
 ## 🧠 Dev Notes & Hypotheses
+
+- **Cost model is fragment-count-driven, not card-count-driven — the `pril10_w1` lesson (2026-07-05).**
+  The opt2 harness amortizes the ~30 K fixed framework by packing many cards per `agent()` call.
+  That amortization **only holds when cards are batched**. In nominal+presplit mode each fragment is
+  its own agent call, so a window's true cost ≈ (agent count) × (framework re-cache + per-fragment
+  I/O), and **agent count = Σ fragments, not Σ cards**. Measured: 8 cards → 230 agents → cache-write
+  = 60% of a $80 bill. **Any cost/throughput estimate must be over expected *agent* count** (the
+  generator already prints `agent_expected_after_tm` — surface it as tokens+$ pre-flight). Hypotheses
+  to confirm in H189: (1) batch fragments per call to re-amortize; (2) share one cached system prefix
+  across a window's agents if the runtime allows; (3) route `kAla`-class monster heads (349 `<ls>`)
+  to a separate human-budgeted lane; (4) recalibrate the kill gate (`KILL_CEIL_MS` 8 min → well under
+  3 min; > ~60 s single-fragment = suspicious, per MG). See H189.
 
 - **Translation-memory policy questions answered (2026-07-04, MG; do not re-ask in fix plans).**
   Standing decision record: [`TRANSLATION_MEMORY_DECISIONS.md`](TRANSLATION_MEMORY_DECISIONS.md).

--- a/RussianTranslation/src/pilot/RUN_LOG.md
+++ b/RussianTranslation/src/pilot/RUN_LOG.md
@@ -217,3 +217,36 @@ F-gate-nws-fp false positive. This satisfies the handoff's "fresh sTA is
 mechanically clean **or has a targeted rerun plan**" gate for advancing to Stage B.
 Open follow-ups left for later (not blocking BU): fix `has_text_signal()` to count
 NWS owner citations; optional Opus retranslate of the ~6 real braced-gloss failers.
+
+---
+
+## 2026-07-05 — nominal window `pril10_w1` — ⛔ ABORTED (cost/latency blow-up) — **Sonnet 5** gen
+
+First nominal production attempt: top-8 largest PWG heads (`kAla, rasa, rUpa,
+brahman, arTa, sva, manas, antara`). Harness was 1.03 MB (> 512 KB cap), split into
+3 sub-windows (wA/wB/wC) and run concurrently. **Killed by MG after ~20 min** — only
+~3 of 8 cards done, agents burning 3–6.5 min and up to ~900 K tokens each.
+
+| metric | value |
+|---|---:|
+| tokens (all 3, exact) | **42,316,604** |
+| cost (Sonnet 4.x rates — order-of-magnitude) | **~$79.83** |
+| cache-write share of $ | **60% ($47.77)** — framework re-cached per agent |
+| wall-clock | 20.1 min (concurrent) |
+| agents spawned | **230** (vs 174 est., +32%) over 581 turns |
+| cards completed | ~3 of 8 |
+| per intended card | ~5.29 M tok / ~$9.98 |
+| max single agent | 390 s (6.5 min) / 903 K tok |
+| agents > 60 s / > 120 s / > 180 s | 19 / 10 / 8 |
+
+**Root cause (short):** in nominal+presplit mode every *fragment* is its own
+`agent()` call (8 cards → 230 agents, ~29/card), each re-establishing the ~30 K
+framework cache — so the opt2 batching amortization is defeated and **cache-write
+dominates the bill**. Compare Stage A+B verb runs: **~36 K tok/card** (batched);
+this nominal run: **~5.29 M tok/card** — ~145× worse. Extrapolation: 10 K entries
+≈ $100 K, 50 K ≈ $500 K → not viable at scale. Kill gate (`KILL_CEIL_MS=480000`,
+8 min) far too loose vs the MG rule that a subcard > ~60 s is suspicious.
+
+Full post-mortem + fix mandate: [`Uprava/H189`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H189-Opus_RussianTranslation_pwg_ru_nominal_cost_blowup_postmortem_05.07.26.md).
+No Max windows to run until H189 §5 guardrails land. Post-mortem by **Opus 4.8
+(`claude-opus-4-8`)**.

--- a/RussianTranslation/src/pilot/_merge_subwindows.py
+++ b/RussianTranslation/src/pilot/_merge_subwindows.py
@@ -1,0 +1,54 @@
+"""Reassemble split sub-window Workflow results into one root-scoped wf_output.json.
+
+F-harness-size-limit workaround (EVOLUTION_TIMELINE.md): the pril10_w1 nominal
+harness (8 largest PWG entries) is ~1MB, over the Workflow tool's 512KB scriptPath
+cap, so it was split into 3 key-disjoint sub-windows (wA/wB/wC) run separately.
+This merges their .result payloads back into a single pril10_w1 wf_output.json,
+identical in shape to what an un-split run would have returned.
+
+Usage: python _merge_subwindows.py out.json partA.json partB.json partC.json
+"""
+import sys, json
+
+def main():
+    out_path, parts = sys.argv[1], sys.argv[2:]
+    metas, results, seen = [], [], set()
+    for p in parts:
+        with open(p, encoding='utf-8') as f:
+            payload = json.load(f)
+        metas.append(payload['meta'])
+        for r in payload['results']:
+            if r['key'] in seen:
+                raise SystemExit('duplicate key across sub-windows: %r' % r['key'])
+            seen.add(r['key'])
+            results.append(r)
+    # Single canonical META for the whole window: take the first, restore the full
+    # key list + merged keymap so downstream (audit/promote) sees one pril10_w1 window.
+    meta = dict(metas[0])
+    all_keys, keymap, input_hashes = [], {}, {}
+    for m in metas:
+        all_keys += m['selected_keys']
+        keymap.update(m.get('nominal_keymap') or {})
+        # MUST merge input_hashes from EVERY sub-window: audit_window.py stale-checks
+        # each key against meta.input_hashes; carrying only chunk-1's map fails the
+        # check for every other chunk's keys (the documented `i`-split reassembly bug,
+        # RUN_LOG 2026-06-29). Union all per-key hash maps.
+        input_hashes.update(m.get('input_hashes') or {})
+    meta['selected_keys'] = all_keys
+    meta['input_hashes'] = input_hashes
+    if meta.get('nominal'):
+        meta['nominal_keymap'] = keymap
+    meta['split_subwindows'] = [
+        {'keys': m['selected_keys'], 'generated_at': m['generated_at']} for m in metas
+    ]
+    ok = sum(1 for r in results if r.get('card'))
+    with open(out_path, 'w', encoding='utf-8') as f:
+        json.dump({'meta': meta, 'results': results}, f, ensure_ascii=False, indent=1)
+    print('wrote %s | root=%s | cards=%d ok=%d null=%d | keys=%d'
+          % (out_path, meta['root'], len(results), ok, len(results) - ok, len(all_keys)))
+    null_keys = [r['key'] for r in results if not r.get('card')]
+    if null_keys:
+        print('null keys (will requeue):', null_keys)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What

Records the aborted first **nominal** PWG→RU production window `pril10_w1` (top-8 largest PWG heads: kāla/rasa/rūpa/brahman/artha/sva/manas/antara) and wires the blocker across the pipeline docs.

**Outcome:** killed by MG after ~20 min — **42.3 M tokens / ~$79.83 (Sonnet-4.x rates) / ~3 of 8 cards done**; single agents ran **3–6.5 min** and up to **903 K tokens** each.

**Root cause:** in nominal+presplit mode **every fragment is its own `agent()` call** (8 cards → **230 agents**, ~29/card), each re-establishing the ~30 K framework prompt cache → **cache-write = 60% of the bill**. The opt2 "batched+masked" amortization is defeated; cost scales with Σ fragments, not Σ cards. Per-card ~5.29 M tok ≈ **145× the batched verb runs** → not viable at scale (10 K entries ≈ \$100 K).

## Changes (docs + one helper only — no pipeline behavior change)

- **`RUN_LOG.md`** — 2026-07-05 aborted-run block with the exact token/cost/timing split.
- **`.ai_state.md`** — ⛔ BLOCKER + H151 parked in Next Steps; fragment-cost Dev Note.
- **`_merge_subwindows.py`** — reusable sub-window reassembly helper (unions `results` **and** `meta.input_hashes`, per the documented `i`-root `F-harness-size-limit` split→run→merge precedent).

## Follow-up

Full post-mortem + fix mandate (why / fix-economics / never-again guardrails) is [`Uprava/H189`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H189-Opus_RussianTranslation_pwg_ru_nominal_cost_blowup_postmortem_05.07.26.md). **All Max windows (verb + nominal) are suspended until the economics fix + guardrails land.**

Generation model: Sonnet 5 (`claude-sonnet-5`); post-mortem: Opus 4.8 (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)