### PR TITLE
H189: fix nominal-window cost blow-up + cost/kill/size guardrails

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,23 +12,33 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
-- **⛔ BLOCKER — nominal window `pril10_w1` ABORTED on cost/latency blow-up 05-07-2026 (gen Sonnet 5
-  `claude-sonnet-5`; post-mortem Opus 4.8 `claude-opus-4-8`).** First nominal production run (top-8
-  largest PWG heads) killed by MG after ~20 min: **42.3 M tokens / ~$79.83 / ~3 of 8 cards**, agents
-  running 3–6.5 min and up to 903 K tokens each. Root cause: nominal+presplit makes **every fragment
-  its own `agent()` call** (8 cards → **230 agents**, ~29/card), each re-establishing the ~30 K
-  framework cache → **cache-write = 60% of the bill**; the opt2 batching amortization is defeated.
-  Per-card cost (~5.29 M tok) is ~145× the batched verb runs (~36 K/card) → **not viable at scale**
-  (10 K entries ≈ $100 K). **DO NOT run any Max window (verb or nominal) until the fixes land.**
-  Full post-mortem + fix mandate (why / fix / never-again): **H189** —
-  `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H189-Opus_RussianTranslation_pwg_ru_nominal_cost_blowup_postmortem_05.07.26.md and execute it.`
-  Run detail in [`RUN_LOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_LOG.md)
-  (2026-07-05 block).
+- **✅ H189 cost-blow-up fixes LANDED 05-07-2026 (Opus 4.8, `claude-opus-4-8`; gen of the aborted run
+  Sonnet 5 `claude-sonnet-5`).** The `pril10_w1` blow-up (42.3 M tok / ~$79.83 / ~3 of 8 cards; every
+  §4 hypothesis CONFIRMED, economics reproduced to the digit) is fully diagnosed and guardrailed.
+  Verified post-mortem: [`POSTMORTEM_pril10_w1.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/POSTMORTEM_pril10_w1.md).
+  Five SHARED fixes (68/68 selftests green, parity ledger clean), all in
+  [`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py)
+  + [`perf_preflight.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/perf_preflight.py):
+  (1) **presplit-lane re-batching** (budget 60/18: `pril10_w1` 174→69 groups, real `gam` giants 18→6
+  agents); (2) **kill-gate recalibration** (floor 120→45 s, ceil 480→180 s); (3) **live budget
+  kill-switch** (`MAX_AGENTS=max(40, ⌈expected×3⌉)`, self-abort + requeue); (4) **harness-size guard**
+  (warn + key-split > 480 KB); (5) **preflight cost gate** (tokens/$/per-card, `--refuse-over-cost`).
+  Plus a latent nominal crash fixed (`_slp1_lex_for_key` on empty `[]` portrait). Run detail:
+  [`RUN_LOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_LOG.md)
+  (2026-07-05 H189 block).
+  **⚠️ Standing rule — a window of `kAla`-class monsters must NOT run as bulk:** the cost gate flags
+  `pril10_w1` at ~$4/card **even post-fix** (8 top-heads are intrinsically expensive). MG `@DECIDE`:
+  choose the monster-card handling (dedicated human-budgeted lane vs cap-and-defer) before the next
+  nominal window; the first nominal window should be *typical* heads, not top-8-by-size.
 
-- **H151 verb-root drain — ⏸ PARKED 05-07-2026 (Opus 4.8, `claude-opus-4-8`).** Its guardrail said
-  "keep draining until the nominal window produces output," but the nominal window is now **blocked
-  pending H189**, and the same per-fragment cost blow-up affects dense verb roots too. H151 stays
-  parked (not draining) until H189 §5.B/§5.C guardrails land. Do not resume the drain meanwhile.
+- **H151 verb-root drain — ▶ UNPARKED 05-07-2026 (Opus 4.8, `claude-opus-4-8`).** The park condition
+  ("until H189 §5.B/§5.C guardrails land") is now **met** — the per-fragment cost blow-up that also
+  threatened dense verb roots is fixed (presplit-lane re-batching) and bounded (recalibrated kill
+  gate + live budget kill-switch + preflight cost gate). H151 may resume with the new guardrails
+  active. **Discipline for the resume:** run [`perf_preflight.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/perf_preflight.py)
+  on each candidate root FIRST and heed the cost-gate verdict — a root the gate flags `OVER-CEILING`
+  is a `kAla`-class monster and goes to the human-budgeted lane, not the bulk drain; the kill-switch
+  now self-aborts a runaway instead of a manual kill.
 
 - **H179 nominal lexical-core queue adapter + `layer` field — ✅ DONE 05-07-2026 (orchestration
   Opus 4.8, `claude-opus-4-8`; NO generation ran — Step 3 drain is the Sonnet 5 follow-on).

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "5bbb029b2dc287f52d4efd4f9f44ff4a12952a15984554568afa645eec2804bd",
-      "src/pilot/window_selftest.py": "30be0b838e7fe3a070b20749929d866e221df4c4aec52132d7dd42f54fb1c791"
+      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
     }
   },
   {
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d"
+      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108"
     }
   },
   {
@@ -117,8 +117,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d",
-      "src/pilot/window_selftest.py": "30be0b838e7fe3a070b20749929d866e221df4c4aec52132d7dd42f54fb1c791"
+      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108",
+      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
     }
   },
   {
@@ -136,8 +136,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d",
-      "src/pilot/window_selftest.py": "30be0b838e7fe3a070b20749929d866e221df4c4aec52132d7dd42f54fb1c791"
+      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108",
+      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
     }
   },
   {
@@ -154,7 +154,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d"
+      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108"
     }
   },
   {
@@ -171,7 +171,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d"
+      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108"
     }
   },
   {
@@ -205,7 +205,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d"
+      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108"
     }
   },
   {
@@ -222,7 +222,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d"
+      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108"
     }
   },
   {
@@ -238,7 +238,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The bare 'sonnet' alias resolved to Sonnet 4.6 (not 5.0) on a prior EN run — pinned explicitly there after that surprise. RU's alias was never observed to misresolve, so it was left alone rather than touching a stable production path for a problem it doesn't have. Re-evaluate if RU is ever caught on a stale alias too.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d"
+      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108"
     }
   },
   {
@@ -315,8 +315,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d",
-      "src/pilot/window_selftest.py": "30be0b838e7fe3a070b20749929d866e221df4c4aec52132d7dd42f54fb1c791"
+      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108",
+      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
     }
   },
   {
@@ -335,7 +335,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "30be0b838e7fe3a070b20749929d866e221df4c4aec52132d7dd42f54fb1c791"
+      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
     }
   },
   {
@@ -372,8 +372,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d",
-      "src/pilot/window_selftest.py": "30be0b838e7fe3a070b20749929d866e221df4c4aec52132d7dd42f54fb1c791"
+      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108",
+      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
     }
   },
   {
@@ -410,8 +410,29 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "055a57a41805a54d0a3874fc711499e61cd105f1aa72bcd3a86c56591744179d",
+      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108",
       "src/promote_final_cards.py": "abb57e9a41e8969346e854fd4d4682b97abdabf203a102b6a5d11fa657eaaa22"
+    }
+  },
+  {
+    "id": "presplit_lane_amortization_and_budget_guards_h189",
+    "mechanism": "Presplit-PRIMARY cards are grouped at PRESPLIT_GROUP_CITE_BUDGET(60)/PRESPLIT_GROUP_SENSE_CAP(18) instead of the conservative SELFHEAL_GROUP_BUDGET(12), amortizing the ~27k framework across many fragments per agent() call; the wall-clock kill gate is recalibrated (floor 120s->45s, ceil 480s->180s) per MG's >60s-suspicious/>3min-unacceptable rule; a window-level budget kill-switch aborts+requeues once agent() calls exceed MAX_AGENTS=max(40, ceil(expected*3)); the generator warns + suggests a key-disjoint split when the harness exceeds MAX_HARNESS_BYTES(480k); perf_preflight adds a per-card / per-window cost gate that flags a window dominated by expensive cards",
+    "files": [
+      "src/pilot/gen_opt_harness2.py",
+      "src/pilot/perf_preflight.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
+    "tracking": "H189",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108",
+      "src/pilot/perf_preflight.py": "7ec7ab37753ecde0eebc20f1ce251565e8bfbf59963592460be460016dee2a43",
+      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/POSTMORTEM_pril10_w1.md
+++ b/RussianTranslation/src/pilot/POSTMORTEM_pril10_w1.md
@@ -1,0 +1,201 @@
+# Post-mortem — `pril10_w1` nominal-window cost/latency blow-up (H189)
+
+_Created: 05-07-2026 · Last updated: 05-07-2026_
+
+> **Model provenance.** Generation of the aborted run: **Sonnet 5 (`claude-sonnet-5`)** —
+> every `agent()` call in [`run_pilot_wf.opt2.js`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py)
+> pins `model:'sonnet'`. Forensics, root-cause, fix, and this write-up:
+> **Opus 4.8 (`claude-opus-4-8`)**. All `$` figures use
+> [`parse_workflow_cost.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/parse_workflow_cost.py)'s
+> hardcoded **Sonnet 4.x** rates ($3 / $15 / $3.75 / $0.30 per-M for input / output /
+> cache-write / cache-read); Sonnet 5 list rates may differ, so treat **$ as
+> order-of-magnitude**. The **token counts and the relative cost split are exact and
+> model-independent.** This doc is the verified counterpart to the
+> [H189 handoff](https://github.com/gasyoun/Uprava/blob/main/handoffs/H189-Opus_RussianTranslation_pwg_ru_nominal_cost_blowup_postmortem_05.07.26.md).
+
+---
+
+## TL;DR
+
+The first nominal production window — the **8 largest PWG headwords**
+(`kAla, rasa, rUpa, brahman, arTa, sva, manas, antara`) — burned **42,316,604 tokens /
+~$79.83 and produced ~3 of 8 cards in ~20 min** before it was killed by hand. Every
+number in the incoming handoff's §3 was **reproduced exactly** from the transcripts, and
+every §4 hypothesis is **CONFIRMED**. The dominant cause: in nominal mode all 8 cards were
+routed to the fragment lane (`BATCHES = 0`), which grouped their **448 fragments into 174
+tiny agent() calls** (~2.6 fragments/call) — so the ~27 K-token framework prompt was
+re-cached ~230 times and **cache-write alone was 60 % of the bill**. The batching that
+whole-card mode uses to amortize the framework bought nothing.
+
+Five fixes landed (all lang-agnostic → SHARED); all pinned by
+[`window_selftest.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_selftest.py)
+(68/68 green):
+
+1. **Presplit-lane re-batching** — group presplit-primary cards at 60 citation-units / 18
+   fragments per call (was 12): **174 → 69 groups on `pril10_w1`**, and on real `gam` its
+   2 presplit giants dropped **18 → 6 agent calls**.
+2. **Kill-gate recalibration** — floor 120 s → 45 s, ceil 480 s → 180 s (MG: ">60 s
+   suspicious, >3 min unacceptable").
+3. **Live budget kill-switch** — the window self-aborts and requeues once agent() calls
+   exceed `MAX_AGENTS = max(40, ⌈expected × 3⌉)`.
+4. **Harness-size guard** — the generator warns + prints an exact key-disjoint split when
+   the harness exceeds 480 KB (the `F-harness-size-limit` scriptPath cap).
+5. **Preflight cost gate** — [`perf_preflight.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/perf_preflight.py)
+   now estimates tokens / $ / per-card cost and flags (or, with `--refuse-over-cost`,
+   refuses) a window above a per-card ceiling.
+
+**The load-bearing lesson:** the amortization fix cuts the presplit lane ~2.5×, but 8
+`kAla`-class heads are *intrinsically* expensive per card — no grouping makes them cheap.
+Viability comes from **not running a window of monsters as "bulk" at all**: the cost gate
+(fix 5) is what keeps such windows out of the pipeline. Typical cards were never the
+problem — the batched verb runs cost ~36 K tokens/card.
+
+---
+
+## 1. Verified economics
+
+Re-derived with `python src/pilot/parse_workflow_cost.py <wA> <wB> <wC>` over the three
+sub-window transcript dirs (`wf_34133e5b-777`, `wf_41d050b6-722`, `wf_1640c173-628`):
+
+| | tokens | $ (Sonnet 4.x) | % of $ |
+|---|---:|---:|---:|
+| fresh input | 5,306,817 | $15.92 | 20 % |
+| **cache-write** | **12,738,510** | **$47.77** | **60 %** |
+| cache-read | 23,668,772 | $7.10 | 9 % |
+| output | 602,505 | $9.04 | 11 % |
+| **TOTAL** | **42,316,604** | **$79.83** | |
+
+Matches the handoff's §3 to the digit. **Per intended card: ~5.29 M tokens / ~$9.98.**
+
+### Per-agent forensics (230 agents, 581 assistant turns)
+
+| metric | value |
+|---|---|
+| agents spawned | **230** (wA 74 + wB 99 + wC 57) vs 174 estimated (**+32 %**) |
+| assistant turns | 581 → **2.53 turns/agent** (heavy in-agent retry) |
+| duration (s) | median 20 · mean 34 · p90 54 · **max 390 (6.5 min)** |
+| agents > 60 s / 120 s / 180 s / 300 s | **19 / 10 / 8 / 2** |
+| max single agent | **902,914 tokens over 10 turns, only 9,114 output** (pure retry waste) |
+| multi-turn agents | **78 %** (mode = **3 turns**; 1-turn only 20 %) |
+| **first-turn (framework) cache-write** | **5,819,916 tok = 46 % of all cache-write ≈ $21.82 = 27 % of the whole bill**, at ~25.3 K tok/agent × 230 |
+
+### Fragment structure (the mechanism)
+
+From the harness `FRAGS`/`BATCHES` consts: **`BATCHES = 0`** — all 8 cards presplit — into
+**448 fragments / 174 groups** (`= agent_expected_after_tm = 174`), ~2.6 fragments/group.
+
+| head | fragments | groups (old, budget 12) |
+|---|---:|---:|
+| kAla | 130 | 32 |
+| antara | 59 | 32 |
+| rasa | 76 | 27 |
+| brahman | 47 | 21 |
+| sva | 34 | 19 |
+| arTa | 41 | 18 |
+| rUpa | 42 | 15 |
+| manas | 19 | 10 |
+
+Fragment weight (`1 + <ls>`) is bimodal: **median 2, p90 14, max 180** (one fragment with
+179 citations). 6 fragments exceed weight 90 — themselves un-emittable in one call.
+
+---
+
+## 2. Hypotheses — all CONFIRMED
+
+**1. 🔴 Batching amortization defeated by per-fragment agents — DOMINANT, CONFIRMED.**
+8 cards → 174 groups → ~230 agents (~29/card). The `_group_by_budget` call built each
+group at `SELFHEAL_GROUP_BUDGET = 12` citation-units, packing only ~2.6 fragments. Each of
+the 174 groups re-establishes the ~25.3 K framework prompt cache → framework re-cache =
+**46 % of cache-write (5.82 M tok, ~$21.82)**, and cache-write overall = **60 % of the
+bill**. The whole point of "batched + masked" (amortize the framework across many cards)
+was nullified because the fragment lane grouped at 12, not near the whole-card ceiling.
+
+**2. 🔴 Presplit explodes on exactly these heads — CONFIRMED.** `BATCHES = 0`: every one of
+the 8 most polysemous words in the language tripped the citation- or sense-presplit trigger
+and went to the fragment lane. 448 fragments total; `kAla` alone shatters into 130. The
+window was chosen as the *heaviest possible* first window (top-8 by DCS score) — worst-case,
+not representative.
+
+**3. 🟠 Kill gate far too loose — CONFIRMED.** Constants were
+`FACTOR 2 · BASE 30 s · SLOPE 45 ms/byte · FLOOR 120 s · CEIL 480 s`. The budget formula
+`min(480 s, max(120 s, 2·(30 s + 45 ms·skelBytes)))` gave every call **2–8 min**. The
+2-min floor meant a tiny fragment could never be killed before 2 min; the worst agent ran
+**390 s (6.5 min)** inside the ceiling, and **8 agents ran > 3 min**. MG's rule (">60 s
+suspicious, >3 min unacceptable") was violated by construction.
+
+**4. 🟠 Retry/heal multiplication — CONFIRMED.** 581 turns / 230 agents = 2.53; **78 % of
+agents took > 1 turn, mode 3**. The pathological agent retried **10 times for 903 K tokens
+and 9 K output**. Every retry re-pays the framework cache-write (compounding hypothesis 1),
+and the 230-vs-174 agent gap is the binary-split/heal cascade on the pathological fragments.
+
+**5. 🟡 No cross-agent prompt-cache reuse — CONFIRMED by construction.** Each agent() is a
+fresh subagent context; its ~25.3 K framework cache-write is discarded at agent end and
+re-paid by the next of the 230 calls. Nothing shares a cached prefix across a window's
+agents. (Whether the runtime *could* share one is unknown and not assumed — see §4.)
+
+---
+
+## 3. The fix that landed
+
+All in [`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py)
++ [`perf_preflight.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/perf_preflight.py),
+pinned in [`window_selftest.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_selftest.py),
+classified SHARED in [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md)
+(`presplit_lane_amortization_and_budget_guards_h189`).
+
+| # | fix | mechanism | measured effect |
+|---|---|---|---|
+| B | **presplit-lane re-batching** | presplit-primary cards group at `PRESPLIT_GROUP_CITE_BUDGET=60` **and** `PRESPLIT_GROUP_SENSE_CAP=18` (both under the proven-safe whole-card 90/20 ceiling), via `_group_by_budget(..., count_cap=)`. Heal-of-a-failed-whole-card keeps the conservative budget 12. | `pril10_w1` **174 → 69 groups**; real `gam` giants **18 → 6 agents**. Framework re-cache ~4.7 M → ~1.9 M tok. |
+| C1 | **kill-gate recalibration** | `FLOOR 120 s → 45 s`, `CEIL 480 s → 180 s`, `BASE 30 s → 20 s`. Kill → the abandoned call's cards fall to the fragment lane / binary-split (**requeued, never dropped**). | tiny fragment hard-killed ~60–70 s; nothing past 3 min. |
+| C4 | **live budget kill-switch** | harness counts agent() calls; past `MAX_AGENTS = max(40, ⌈expected × 3⌉)` every call throws `BudgetExceeded` (0 tokens, not an `isKill` → no more fragment spawns); remaining cards null with a `budget-kill-switch` reason for the normal requeue. `summary.budget_kill_switch_tripped` surfaces it. | a 174-estimate window aborts at ~522 calls; the real 230 would have been well within, but a true runaway now self-terminates instead of a manual kill. |
+| C3 | **harness-size guard** | at write time, if the harness > `MAX_HARNESS_BYTES = 480 KB` the generator prints a concrete key-disjoint split (N sub-windows, exact `--keys=` each); `--refuse-oversize` makes it a hard error. | surfaces `F-harness-size-limit` at generation, not launch. |
+| C2 | **preflight cost gate** | `perf_preflight.py` estimates tokens/$ (184 K tok, $0.347/agent from this run, ×1.35 realism) and a **per-translated-card cost**; flags `OVER-CEILING` above `$2/card` or `$25/window`; `--refuse-over-cost` exits nonzero. | flags `pril10_w1` (~$4/card **even post-fix**) → routed to a human-budgeted lane; passes cheap high-count windows (`as`: $0.11/card). |
+
+Also fixed in passing: `_slp1_lex_for_key` crashed on an **empty-list portrait `[]`** (the
+real `tyaj~~h0_zz_pw` / addenda shape) via the PR #155 `nominal_keymap` emission — a latent
+generation crash for any nominal window containing such a card, surfaced only because a
+fresh checkout's selftest aborts on missing `gam` data before reaching that test.
+
+---
+
+## 4. Residual & forward guidance
+
+- **Monster cards need their own lane.** Amortization makes *moderate* presplit cards
+  cheaper, but a `kAla` (130 fragments) is intrinsically expensive. The cost gate flags
+  such windows; the intended follow-up is a **human-budgeted lane** for the `kAla`-class
+  handful, keeping them out of the bulk pipeline (handoff §5.B option 4). The first nominal
+  window should be *typical* heads, not the top-8 by size.
+- **Monster fragments (weight > 90) should sub-split.** 6 fragments carry > 90 citations
+  (max 179); each is alone in its group and can still blow one call. A within-sense
+  citation-batch sub-split for fragments above a threshold would remove the retry tail;
+  until then the recalibrated kill gate + binary-split bound them.
+- **Framework shrink / cross-agent cache (hypotheses 5, §5.B option 2)** are the next lever
+  but runtime-dependent (whether a cached system prefix can be shared across a window's
+  agents is unverified). Not attempted here; the amortization + gate fixes are runtime-safe.
+- **TM-resolved cards still inline their input**, bloating the harness (gam: 124/127 cached
+  yet 1.1 MB). Not translated, but they push the file over the size cap — a candidate future
+  optimization (omit `INPUTS` for TM-resolved keys).
+- **The $ rate basis is Sonnet 4.x.** Reconfirm `parse_workflow_cost.py`'s rate table and
+  the cost-gate constants against Sonnet 5 list rates before trusting absolute $ (token
+  counts and per-card ratios are already model-independent).
+
+---
+
+## 5. How to reproduce / validate
+
+```
+# economics (exact)
+python src/pilot/parse_workflow_cost.py <wf_34133e5b-777> <wf_41d050b6-722> <wf_1640c173-628>
+
+# the fix, end-to-end
+python src/pilot/window_selftest.py          # 68/68 green (incl. the 6 H189 tests)
+python src/pilot/lang_parity_check.py         # 20 entries, no drift
+python src/pilot/perf_preflight.py gam han as vid   # cost columns + gate verdicts
+```
+
+Transcripts:
+`C:\Users\user\.claude\projects\C--Users-user-Documents-GitHub\8f358868-0537-4497-a2f8-08cb4a0a7583\subagents\workflows\`
+(`wf_34133e5b-777` = wA `kAla,rasa` · `wf_41d050b6-722` = wB `brahman,antara,sva` ·
+`wf_1640c173-628` = wC `arTa,rUpa,manas`).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/RUN_LOG.md
+++ b/RussianTranslation/src/pilot/RUN_LOG.md
@@ -250,3 +250,26 @@ this nominal run: **~5.29 M tok/card** — ~145× worse. Extrapolation: 10 K ent
 Full post-mortem + fix mandate: [`Uprava/H189`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H189-Opus_RussianTranslation_pwg_ru_nominal_cost_blowup_postmortem_05.07.26.md).
 No Max windows to run until H189 §5 guardrails land. Post-mortem by **Opus 4.8
 (`claude-opus-4-8`)**.
+
+### 2026-07-05 — H189 fixes LANDED (Opus 4.8, `claude-opus-4-8`)
+
+Every §4 hypothesis **CONFIRMED** (economics reproduced to the digit via
+[`parse_workflow_cost.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/parse_workflow_cost.py))
+— full verified breakdown in
+[`POSTMORTEM_pril10_w1.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/POSTMORTEM_pril10_w1.md).
+Five guardrails shipped (all SHARED, 68/68 selftests green):
+
+1. **Presplit-lane re-batching** (`PRESPLIT_GROUP_CITE_BUDGET=60`/`SENSE_CAP=18`):
+   `pril10_w1` **174 → 69** fragment-group calls; real `gam` giants **18 → 6** agents.
+2. **Kill-gate recalibration**: floor 120 s → **45 s**, ceil 480 s → **180 s** (MG rule).
+3. **Live budget kill-switch**: window self-aborts + requeues past
+   `MAX_AGENTS = max(40, ⌈expected×3⌉)`.
+4. **Harness-size guard**: generator warns + prints an exact key-disjoint split > 480 KB.
+5. **Preflight cost gate**: `perf_preflight.py` estimates tokens/$/per-card and flags
+   (or `--refuse-over-cost` refuses) a window over ceiling — flags `pril10_w1` (~$4/card
+   **even post-fix**) → monster-card windows route to a human-budgeted lane, not bulk.
+
+Also fixed a latent nominal-generation crash (`_slp1_lex_for_key` on an empty `[]`
+portrait). **Standing rule remains: do not launch a window of `kAla`-class monsters as
+bulk** — the amortization fix cuts the presplit lane ~2.5× but such heads are intrinsically
+expensive; the cost gate is the guardrail that keeps them out of the pipeline.

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -32,6 +32,7 @@ Writes: src/pilot/run_pilot_wf.opt2.js  (or --out=PATH — use a per-root/per-ch
 """
 import datetime
 import json
+import math
 import os
 import re
 import sys
@@ -62,6 +63,30 @@ SELFHEAL_GROUP_BUDGET = 12   # --selfheal-budget=N: fragments are grouped (in do
                    #  light (low-<ls>) fragments share one call, cutting a 13-fragment card to a
                    #  handful of calls instead of 13, without recombining the dense units that
                    #  caused the original failure.
+# --- presplit-PRIMARY fragment lane budget (H189, 2026-07-05) ----------------------
+# SELFHEAL_GROUP_BUDGET=12 above is deliberately conservative: it groups the fragments of
+# a card that ALREADY FAILED as a whole card, so small safe groups matter more than
+# amortization. But a PRESPLIT card is routed to the fragment lane as its PRIMARY path
+# (it never attempts the whole-card batch), and in nominal-window runs EVERY card can be
+# presplit — so grouping them at 12 means each ~25-30k-token framework prompt is amortized
+# across only ~2-3 fragments per agent() call. The pril10_w1 blow-up (H189): 8 heads ->
+# 448 fragments -> 174 groups (~2.6 frags/group) -> the framework re-cached ~230x ->
+# cache-write was 60% of a $80 / 3-card bill. The fix: group PRESPLIT cards at a budget
+# close to the proven-safe whole-card ceiling instead. A single fragment-lane agent() call
+# can safely emit as much as the batch lane already emits for a whole card (OUTPUT_BUDGET=90
+# citation-units / SENSE_PRESPLIT_BUDGET=20 senses); staying just UNDER both keeps the same
+# retry-cap safety while packing ~6x more fragments per call. Measured on pril10_w1's real
+# fragment weights: 60/18 takes 174 -> 69 groups (kAla 32->11, antara 32->9), i.e. the
+# framework is re-cached ~2.5x fewer times, at zero new output-size risk (each group stays
+# smaller than a batch the batch lane already runs). The heal-of-a-failed-whole-card path
+# keeps SELFHEAL_GROUP_BUDGET; only the presplit-PRIMARY grouping uses these.
+PRESPLIT_GROUP_CITE_BUDGET = 60  # --presplit-group-budget=N: citation-weighted (1+<ls>) cap
+                   #  per presplit-lane agent() call. 60 < OUTPUT_BUDGET 90 -> each call is
+                   #  strictly lighter than a batch the batch lane already handles.
+PRESPLIT_GROUP_SENSE_CAP = 18    # AND at most this many fragments (== senses emitted) per call,
+                   #  so a run of many tiny (0-<ls>) fragments can't silently pack >18 senses
+                   #  into one call and re-trigger the sense-density failure. 18 < the
+                   #  SENSE_PRESPLIT_BUDGET=20 whole-card ceiling, with margin.
 BINARY_SPLIT = True   # DEFAULT ON since 2026-07-02 (MG decision): when a whole batch call
                    #  fails/comes back malformed (not just individual cards inside it), bisect
                    #  the still-pending cards into two halves and retry each half recursively
@@ -130,10 +155,53 @@ SENSE_PRESPLIT_BUDGET = 20  # --sense-presplit-budget=N (0/off to disable). SECO
 # tighten with --kill-factor once real runs confirm the envelope.
 KILL = True                 # --no-kill disables; --kill-factor=N tunes the multiple
 KILL_FACTOR = 2.0           # MG's "200%": kill a call at 2x its expected-for-complexity time
-KILL_BASE_MS = 30000        # fixed per-call latency (model spin-up + fixed framing)
+KILL_BASE_MS = 20000        # fixed per-call latency (model spin-up + fixed framing). Lowered
+                            #  from 30000 (H189): 30s was fitted to WHOLE-CARD batch calls; the
+                            #  fragment lane (now the primary path for presplit cards) has less
+                            #  fixed framing, and MG's directive is that a subcard >~60 s is
+                            #  already suspicious.
 KILL_SLOPE_MS = 45          # ms per masked-skeleton byte (above the ~44 ms/byte observed ceiling)
-KILL_FLOOR_MS = 120000      # never kill before 2 min (jitter guard on tiny calls)
-KILL_CEIL_MS = 480000       # hard ceiling — nothing runs past 8 min even at max size
+KILL_FLOOR_MS = 45000       # H189 recalibration (MG: ">~60 s per subcard is suspicious; >3 min
+                            #  unacceptable"). Was 120000 (2 min) — far too loose for a single
+                            #  fragment: it guaranteed nothing was killed before 2 min even for a
+                            #  tiny call, so the pril10_w1 fragments ran 3-6.5 min each. 45 s floor
+                            #  + BASE/SLOPE puts a tiny fragment's hard-kill at ~60-70 s.
+KILL_CEIL_MS = 180000       # hard ceiling — NOTHING runs past 3 min (MG). Was 480000 (8 min); the
+                            #  worst pril10_w1 agent ran 390 s (6.5 min) inside the old ceiling. On
+                            #  kill the call is abandoned and its cards fall to the bounded fragment
+                            #  lane / binary-split, so a killed unit is REQUEUED, never silently
+                            #  lost (see resolveGroup/healGroup below).
+# --- live budget kill-switch (H189, 2026-07-05) -----------------------------------
+# The per-call kill gate above bounds ANY SINGLE agent() call, but nothing bounded the
+# WHOLE WINDOW: pril10_w1 spawned 230 agents (est. 174) and burned 42 M tokens before MG
+# killed it by hand. This is an absolute, window-level backstop: the harness counts every
+# agent() call it makes and, once the count crosses MAX_AGENTS, refuses to start further
+# calls (the remaining cards are nulled with a `budget-kill-switch` reason and REQUEUED,
+# not silently dropped) so a runaway retry/binary-split cascade self-terminates instead of
+# running to a manual kill. Tokens aren't observable inside the runtime (agent() returns
+# structured output, not a usage record), so the mechanical proxy is agent-CALL count —
+# which is exactly what blew up (230 vs 174). The ceiling is derived per window from the
+# preflight estimate: MAX_AGENTS = max(MAX_AGENTS_FLOOR, ceil(expected * MAX_AGENTS_FACTOR)),
+# so a small window isn't over-constrained and a large one still can't 10x its estimate.
+KILL_SWITCH = True          # --no-kill-switch disables; --max-agents=N sets an absolute override
+MAX_AGENTS_FACTOR = 3.0     # abort once actual agent() calls exceed 3x the preflight estimate
+                            #  (pril10_w1 was 230/174 = 1.3x before the manual kill — 3x leaves
+                            #  ample room for legitimate binary-split/heal while still catching a
+                            #  true runaway well before a $80 outcome).
+MAX_AGENTS_FLOOR = 40       # never abort a window below this many calls regardless of estimate
+                            #  (a genuinely small window that heals a few cards stays unaffected).
+MAX_AGENTS_OVERRIDE = None  # --max-agents=N: pin an absolute ceiling, bypassing the derivation
+# --- harness-size guard (H189 / F-harness-size-limit) -----------------------------
+# The emitted harness inlines every card's raw+portrait input, so its byte size scales with
+# card count and CAN exceed the Workflow `scriptPath` cap (the `i` 204-card harness = 567 KB
+# > 512 KB, EVOLUTION_TIMELINE F-harness-size-limit; pril10_w1 = 1.03 MB, unlaunchable). The
+# generator now measures the emitted size and, when it exceeds MAX_HARNESS_BYTES, prints a
+# LOUD warning plus a concrete key-disjoint sub-window split (the exact --keys=... for each
+# piece) so the limit is surfaced at GENERATION, not discovered at launch. Warn (not hard
+# refuse) by default because some large single-root harnesses do launch via other surfaces;
+# --refuse-oversize makes it a hard error for unattended/automated callers.
+MAX_HARNESS_BYTES = 480000  # ~480 KB, a safety margin under the 512 KB scriptPath cap
+REFUSE_OVERSIZE = False     # --refuse-oversize: exit nonzero instead of warning when oversize
 
 
 def grammar_text(root):
@@ -282,6 +350,20 @@ def parse_args(argv):
             v = a.split('=', 1)[1].strip().lower()
             globals()['OUTPUT_BUDGET'] = None if v in ('off', '0', 'none') else int(v)
             output_explicit = True
+        elif a.startswith('--presplit-group-budget='):   # H189: citation cap per presplit-lane call
+            globals()['PRESPLIT_GROUP_CITE_BUDGET'] = int(a.split('=', 1)[1])
+        elif a.startswith('--presplit-sense-cap='):       # H189: fragment (sense) cap per call
+            globals()['PRESPLIT_GROUP_SENSE_CAP'] = int(a.split('=', 1)[1])
+        elif a == '--no-kill-switch':                     # H189: disable the window budget switch
+            globals()['KILL_SWITCH'] = False
+        elif a == '--kill-switch':
+            globals()['KILL_SWITCH'] = True               # default; kept for documented runbooks
+        elif a.startswith('--max-agents='):               # H189: absolute agent()-count ceiling override
+            globals()['MAX_AGENTS_OVERRIDE'] = int(a.split('=', 1)[1])
+        elif a == '--refuse-oversize':                    # H189: hard-error instead of warn when oversize
+            globals()['REFUSE_OVERSIZE'] = True
+        elif a.startswith('--max-harness-bytes='):
+            globals()['MAX_HARNESS_BYTES'] = int(a.split('=', 1)[1])
     if budget_explicit and not output_explicit:
         # An explicit --budget=N with no --output-budget means the caller wants BYTE-mode
         # batching (backward compat: every pre-2026-07-02 documented invocation that tuned
@@ -327,18 +409,37 @@ def compress_rule3(tr):
     return tr2
 
 
-def _group_by_budget(items, sizer, budget):
+def _group_by_budget(items, sizer, budget, count_cap=None):
     """Greedily group `items` (kept in order) into batches whose summed sizer() stays
-    <= budget; a single oversize item still gets its own group (never dropped)."""
+    <= budget; a single oversize item still gets its own group (never dropped).
+
+    count_cap (H189): when set, also close a group once it already holds count_cap
+    items, regardless of summed size — so a run of many tiny (size-1) items can't pack
+    an unbounded COUNT into one group. Needed for the presplit fragment lane, where the
+    item count == senses the model must emit and a group of 40 size-1 fragments would
+    re-trigger the very sense-density failure presplit exists to avoid. Default None
+    preserves the original size-only behavior for every existing caller.
+    """
     groups, cur, sz = [], [], 0
     for it in items:
         isz = sizer(it)
-        if cur and sz + isz > budget:
+        if cur and (sz + isz > budget or (count_cap and len(cur) >= count_cap)):
             groups.append(cur); cur, sz = [], 0
         cur.append(it); sz += isz
     if cur:
         groups.append(cur)
     return groups
+
+
+def _presplit_hit(ls, nfrag, cite_budget):
+    """Shared predicate: does a card's CITATION density (1+<ls> over the output budget)
+    or SENSE density (fragment count over SENSE_PRESPLIT_BUDGET) route it to the
+    presplit-primary fragment lane? Returns (cite_hit, sense_hit). Kept in one place so
+    the frags-loop grouping choice and the presplit-list construction can never drift
+    (H189 — before this, the two sites replicated the condition independently)."""
+    cite_hit = cite_budget is not None and (1 + ls) > cite_budget
+    sense_hit = SENSE_PRESPLIT_BUDGET is not None and nfrag > SENSE_PRESPLIT_BUDGET
+    return cite_hit, sense_hit
 
 
 def selected_keys(root, keyfilter):
@@ -372,6 +473,8 @@ def _slp1_lex_for_key(k):
     except Exception:
         return '', ''
     e = port[0] if isinstance(port, list) and port else port
+    if not isinstance(e, dict):   # empty-list portrait ([]) or unexpected shape -> no grammar key
+        return '', ''             # (the real tyaj~~h0_zz_pw / addenda shape; keymap falls back to k)
     slp1 = e.get('key1') or e.get('slp1') or ''
     val = e.get('lex') or e.get('pos') or e.get('gender') or ''
     if isinstance(val, (list, tuple)):
@@ -783,9 +886,21 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
                            'tm': cached.get('senses') if cached else None})
             if not fl:
                 continue
-            groups = _group_by_budget(fl, lambda it: 1 + it['ls'], SELFHEAL_GROUP_BUDGET)
             frag_n[k] = len(pl)   # raw deterministic fragment count == sense-units the model
                                   # must emit; drives the sense-density presplit trigger below
+            # H189: a card that WILL be routed to presplit uses the fragment lane as its
+            # PRIMARY path (no whole-card attempt), so group it at a budget close to the
+            # proven-safe whole-card ceiling — the ~27k framework then amortizes across many
+            # fragments per call instead of ~2-3. A card without a presplit hit keeps the
+            # conservative SELFHEAL_GROUP_BUDGET (it only reaches these groups via the
+            # heal-of-a-failed-whole-card path, where small safe groups matter more).
+            _cite_hit, _sense_hit = _presplit_hit(inputs[k]['ls'], frag_n[k], OUTPUT_BUDGET)
+            if _cite_hit or _sense_hit:
+                groups = _group_by_budget(fl, lambda it: 1 + it['ls'],
+                                          PRESPLIT_GROUP_CITE_BUDGET,
+                                          count_cap=PRESPLIT_GROUP_SENSE_CAP)
+            else:
+                groups = _group_by_budget(fl, lambda it: 1 + it['ls'], SELFHEAL_GROUP_BUDGET)
             frags[k] = [[{'skeleton': it['skeleton'], 'ls': it['ls'], 'sk': it['sk'],
                           'fsha': it['fsha'], 'si': it['si']} for it in g] for g in groups]
             phf[k] = [[it['ph'] for it in g] for g in groups]
@@ -817,8 +932,7 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         for k in keys:
             if k in tm_keys or k in degenerate_keys or k not in frags:
                 continue
-            cite_hit = cite_budget is not None and (1 + inputs[k]['ls']) > cite_budget
-            sense_hit = SENSE_PRESPLIT_BUDGET is not None and frag_n.get(k, 0) > SENSE_PRESPLIT_BUDGET
+            cite_hit, sense_hit = _presplit_hit(inputs[k]['ls'], frag_n.get(k, 0), cite_budget)
             if not (cite_hit or sense_hit):
                 continue
             presplit.append(k)
@@ -881,6 +995,14 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     if lang == 'en':                                    # inject MW TM once per root (root mode)
         single_grammar = mw_tm_block(root, mw_tm_path) + single_grammar
 
+    # Preflight-parity agent estimate (one call per batch + one per presplit fragment group)
+    # and the H189 live budget kill-switch ceiling derived from it.
+    agent_expected = len(batches) + sum(len(frags.get(k, [None])) for k in presplit)
+    if MAX_AGENTS_OVERRIDE:
+        max_agents = MAX_AGENTS_OVERRIDE
+    else:
+        max_agents = max(MAX_AGENTS_FLOOR, int(math.ceil(agent_expected * MAX_AGENTS_FACTOR)))
+
     meta = {
         'schema_version': 'pwg_ru.workflow_meta.v1', 'generator': 'gen_opt_harness2.batched-masked',
         'generated_at': datetime.datetime.now(datetime.timezone.utc).isoformat(
@@ -904,6 +1026,15 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         'kill': KILL,
         'kill_gate': ({'factor': KILL_FACTOR, 'base_ms': KILL_BASE_MS, 'slope_ms': KILL_SLOPE_MS,
                        'floor_ms': KILL_FLOOR_MS, 'ceil_ms': KILL_CEIL_MS} if KILL else None),
+        # H189 live budget kill-switch: the harness aborts (and requeues remaining cards) once
+        # it makes more than max_agents agent() calls — a window-level backstop against the
+        # runaway that spent 230/174 agents on pril10_w1 before a manual kill.
+        'kill_switch': KILL_SWITCH,
+        'max_agents': max_agents if KILL_SWITCH else None,
+        'max_agents_factor': MAX_AGENTS_FACTOR,
+        # H189 presplit-lane amortization budgets (fragments packed per agent() call).
+        'presplit_group_cite_budget': PRESPLIT_GROUP_CITE_BUDGET,
+        'presplit_group_sense_cap': PRESPLIT_GROUP_SENSE_CAP,
         'presplit_keys': presplit,
         'tm': os.path.basename(tm_path) if tm_path else None,
         'tm_auto': bool(tm_auto),
@@ -933,7 +1064,7 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         # 102 agents against a 13-agent preflight estimate, almost entirely from its 5 presplit
         # giants each needing ~10-20 fragment calls). This is still an optimistic floor — it
         # ignores retries and whole-batch selfheal fallback on non-presplit cards.
-        'agent_expected_after_tm': len(batches) + sum(len(frags.get(k, [None])) for k in presplit),
+        'agent_expected_after_tm': agent_expected,
     }
     print('  lanes: tm_cards=%d frag_tm_cards=%d degenerate_passthrough=%d agent_expected_after_tm=%d'
           % (meta['tm_cards'], len(meta['frag_tm_cards']),
@@ -968,6 +1099,13 @@ const KILL_BASE_MS = %(kill_base_ms)s
 const KILL_SLOPE_MS = %(kill_slope_ms)s
 const KILL_FLOOR_MS = %(kill_floor_ms)s
 const KILL_CEIL_MS = %(kill_ceil_ms)s
+// H189 live budget kill-switch: abort the whole window once it has made more than
+// MAX_AGENTS agent() calls (a runaway retry/binary-split cascade), instead of running to a
+// manual kill. Tokens aren't observable in-runtime, so agent-CALL count is the proxy (230
+// vs 174 estimate on pril10_w1). Remaining cards are nulled with a budget-kill-switch reason
+// and requeued by the normal audit path — nothing is silently dropped.
+const KILL_SWITCH = %(kill_switch)s
+const MAX_AGENTS = %(max_agents)s
 // --tm: cards pre-resolved from the content-addressed translation memory (source-SHA hit).
 // Emitted verbatim as canonical rows with tm:true and NO agent() call — their markup is
 // already restored (they come from the promoted store), so they bypass restore/accept.
@@ -1007,7 +1145,21 @@ class KillTimeout extends Error {}
 const isKill = e => (e instanceof KillTimeout) || (e && /kill-timeout/.test(String(e && e.message)))
 const killBudgetMs = skelBytes => Math.min(KILL_CEIL_MS, Math.max(KILL_FLOOR_MS, KILL_FACTOR * (KILL_BASE_MS + KILL_SLOPE_MS * skelBytes)))
 const skelBytesOfKeys = keys => keys.reduce((n, k) => n + (INPUTS[k] ? INPUTS[k].skeleton.length : 0), 0)
+// H189 live budget kill-switch state. AGENTS_SPENT counts real agent() calls; once it
+// reaches MAX_AGENTS every further agentKill() throws BudgetExceeded WITHOUT calling agent()
+// (0 tokens), so retry/binary-split cascades short-circuit to instant no-ops and the window
+// winds down at ~MAX_AGENTS calls. BudgetExceeded is deliberately NOT an isKill() (a kill
+// routes to MORE fragment calls — the opposite of what a budget stop wants); the caller's
+// generic catch nulls the card with a budget-kill-switch reason for the normal requeue path.
+class BudgetExceeded extends Error {}
+let AGENTS_SPENT = 0
+let BUDGET_TRIPPED = false
 async function agentKill(prompt, opts, skelBytes) {
+  if (KILL_SWITCH && MAX_AGENTS != null && AGENTS_SPENT >= MAX_AGENTS) {
+    BUDGET_TRIPPED = true
+    throw new BudgetExceeded('budget-kill-switch: window hit MAX_AGENTS=' + MAX_AGENTS + ' agent() calls; remaining cards requeued')
+  }
+  AGENTS_SPENT++
   if (!KILL) return agent(prompt, opts)
   const ms = killBudgetMs(skelBytes)
   let timer
@@ -1379,6 +1531,11 @@ const summary = { root: META.root, lang: META.lang, cards: out.length, ok: _ok,
                   presplit: PRESPLIT.length, tm: out.filter(r => r.tm).length,
                   degenerate_passthrough: out.filter(r => r.degenerate_passthrough).length,
                   frag_tm_fragments: META.frag_tm_fragments || 0,
+                  // H189: agents_spent surfaces the real call count vs META.max_agents;
+                  // budget_kill_switch_tripped=true means the window self-aborted and its
+                  // null_keys must be requeued (they were not translated, not defective).
+                  agents_spent: AGENTS_SPENT, max_agents: (KILL_SWITCH ? MAX_AGENTS : null),
+                  budget_kill_switch_tripped: BUDGET_TRIPPED,
                   null_keys: out.filter(r => !r.card).map(r => r.key),
                   partial_keys: out.filter(r => r.card && r.card.partial).map(r => r.key),
                   failures: _failures }
@@ -1404,6 +1561,7 @@ return { meta: META, summary, results: out }
         'kill': json.dumps(KILL), 'kill_factor': json.dumps(KILL_FACTOR),
         'kill_base_ms': json.dumps(KILL_BASE_MS), 'kill_slope_ms': json.dumps(KILL_SLOPE_MS),
         'kill_floor_ms': json.dumps(KILL_FLOOR_MS), 'kill_ceil_ms': json.dumps(KILL_CEIL_MS),
+        'kill_switch': json.dumps(KILL_SWITCH), 'max_agents': json.dumps(max_agents if KILL_SWITCH else None),
         'tm_resolved': json.dumps(tm_resolved, ensure_ascii=True),
         'degenerate_resolved': json.dumps(degenerate_resolved, ensure_ascii=True),
         'frag_tm': json.dumps(frag_tm, ensure_ascii=True),
@@ -1413,6 +1571,41 @@ return { meta: META, summary, results: out }
         if bad in js:
             die('residual node-ism: %s' % bad)
     return js, batches
+
+
+def _even_chunks(seq, n):
+    """Split `seq` into n contiguous, near-equal chunks (order preserved)."""
+    n = max(1, min(n, len(seq)))
+    q, r = divmod(len(seq), n)
+    out, i = [], 0
+    for j in range(n):
+        take = q + (1 if j < r else 0)
+        out.append(seq[i:i + take])
+        i += take
+    return out
+
+
+def harness_size_report(root, keys, nominal, js_len, max_bytes):
+    """H189 harness-size guard: if the emitted harness exceeds max_bytes (the Workflow
+    scriptPath cap, F-harness-size-limit), compute a key-disjoint split into sub-windows
+    each expected under the cap and return the human-facing warning lines + suggested
+    commands. Returns (oversize: bool, lines: [str])."""
+    if js_len <= max_bytes:
+        return False, []
+    # Leave headroom for the fixed framework (CONV_TR/PREAMBLE/SCHEMA) duplicated per
+    # sub-window; 0.85 * cap keeps each piece safely under the real limit.
+    n = max(2, int(math.ceil(js_len / (max_bytes * 0.85))))
+    chunks = _even_chunks(list(keys), n)
+    lines = ['HARNESS OVERSIZE: %d bytes > %d cap (Workflow scriptPath limit, F-harness-size-limit).'
+             % (js_len, max_bytes),
+             '  A harness this large cannot launch as one workflow. Split into %d key-disjoint '
+             'sub-windows (regenerate each, verify each is under the cap):' % len(chunks)]
+    prefix = ('--nominal --keys=' if nominal else '%s --keys=' % root)
+    for i, ch in enumerate(chunks, 1):
+        lines.append('  w%d: python src/pilot/gen_opt_harness2.py %s%s --out=run_pilot_wf.opt2.w%d.js'
+                     % (i, prefix, ','.join(ch), i))
+    lines.append('  Then merge the sub-window results (see _merge_subwindows.py / H189).')
+    return True, lines
 
 
 def main():
@@ -1436,6 +1629,13 @@ def main():
         'LEAN(rejected)' if lean else 'NWS-GATE' if nws_gate else 'full')
     print('wrote', out, len(js), 'bytes |', len(keys), 'cards in', len(batches), 'batches',
           '(sizes', [len(b) for b in batches], ') | mode', mode)
+    # H189 harness-size guard: surface the scriptPath cap at generation, not at launch.
+    oversize, lines = harness_size_report(root, keys, nominal, len(js), MAX_HARNESS_BYTES)
+    if oversize:
+        for ln in lines:
+            print(ln)
+        if REFUSE_OVERSIZE:
+            die('refusing oversize harness (--refuse-oversize); split as shown above')
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pilot/perf_preflight.py
+++ b/RussianTranslation/src/pilot/perf_preflight.py
@@ -27,6 +27,57 @@ import translation_memory  # noqa: F401  # pre-import before stdout capture; mod
 from window_common import INP, input_paths, read_text
 
 
+# --- H189 cost gate ----------------------------------------------------------------
+# Empirical per-agent figures from the pril10_w1 blow-up (parse_workflow_cost.py over the
+# three sub-window transcripts: 230 agents, 42,316,604 tokens, $79.83 at Sonnet 4.x rates):
+#   184,000 tokens/agent (mean), $0.347/agent.
+# agent_expected_after_tm is an optimistic FLOOR (one call per batch/fragment-group, no
+# retries) — the real run spent 230 vs a 174 estimate (1.32x) — so a realism multiplier is
+# applied before pricing. The $ figures inherit parse_workflow_cost.py's Sonnet 4.x rates
+# (order-of-magnitude for Sonnet 5); the TOKEN estimate and the per-card RATIO are the
+# model-independent, load-bearing parts of the gate.
+PER_AGENT_TOKENS = 184000
+PER_AGENT_USD = 0.347
+REALISM_FACTOR = 1.35
+COST_CEIL_PER_CARD_USD = 2.00   # a window whose est cost per TRANSLATED card exceeds this is
+                                #  flagged: a healthy batched card is ~$0.07, but pril10_w1 was
+                                #  ~$10-27/card — a window of kAla-class monsters must be gated
+                                #  out of the bulk pipeline, not run silently.
+COST_CEIL_WINDOW_USD = 25.00    # absolute per-window backstop regardless of card count
+
+
+def cost_estimate(report, per_card_ceiling=COST_CEIL_PER_CARD_USD,
+                  window_ceiling=COST_CEIL_WINDOW_USD, realism=REALISM_FACTOR):
+    """H189: estimate tokens + $ + a per-card cost for a window and decide whether it
+    exceeds a ceiling. Read-only accounting; the verdict lets an operator (or a wrapper via
+    --refuse-over-cost) refuse to launch a window that would silently run into a
+    $80 / 3-card outcome again."""
+    agents = report.get('agent_expected_after_tm', 0) or 0
+    est_agents = agents * realism
+    est_tokens = int(round(est_agents * PER_AGENT_TOKENS))
+    est_cost = round(est_agents * PER_AGENT_USD, 2)
+    # cards that actually cost an agent() call — exclude TM-resolved and degenerate stubs.
+    cards_to_translate = max(0, len(report.get('selected_keys', []))
+                             - int(report.get('tm_cards', 0) or 0)
+                             - len(report.get('degenerate_passthrough_keys', [])))
+    per_card = round(est_cost / cards_to_translate, 2) if cards_to_translate else 0.0
+    over_card = cards_to_translate > 0 and per_card > per_card_ceiling
+    over_window = est_cost > window_ceiling
+    return {
+        'est_agents_with_realism': round(est_agents, 1),
+        'realism_factor': realism,
+        'est_tokens': est_tokens,
+        'est_cost_usd': est_cost,
+        'cards_to_translate': cards_to_translate,
+        'est_cost_per_card_usd': per_card,
+        'per_card_ceiling_usd': per_card_ceiling,
+        'window_ceiling_usd': window_ceiling,
+        'over_ceiling': bool(over_card or over_window),
+        'verdict': 'OVER-CEILING' if (over_card or over_window) else 'ok',
+        'rate_basis': 'Sonnet 4.x rates (order-of-magnitude); token estimate is model-independent',
+    }
+
+
 def split_csv(text):
     return [x.strip() for x in str(text).split(',') if x.strip()]
 
@@ -180,6 +231,18 @@ def build_report(args, root):
         'generator_log': [line for line in buf.getvalue().splitlines() if line.strip()],
     }
     report['recommended_action'] = recommendation(report)
+    report['cost_gate'] = cost_estimate(
+        report,
+        per_card_ceiling=getattr(args, 'cost_ceiling_per_card', COST_CEIL_PER_CARD_USD),
+        window_ceiling=getattr(args, 'cost_ceiling_window', COST_CEIL_WINDOW_USD))
+    if report['cost_gate']['over_ceiling']:
+        report['warnings'].append(
+            'COST-GATE: est ~%d tokens / ~$%.2f (~$%.2f per translated card, ceiling $%.2f) — '
+            'this window is dominated by expensive cards; split off the monster cards to a '
+            'human-budgeted lane before launching (H189).'
+            % (report['cost_gate']['est_tokens'], report['cost_gate']['est_cost_usd'],
+               report['cost_gate']['est_cost_per_card_usd'],
+               report['cost_gate']['per_card_ceiling_usd']))
     return report
 
 
@@ -200,6 +263,11 @@ def print_human(report):
     print('  batches: %d' % report['batch_count'])
     print('  agent_expected_after_tm: %d' % report['agent_expected_after_tm'])
     print('  recommendation: %s' % report['recommended_action'])
+    cg = report.get('cost_gate') or {}
+    print('  est cost: ~%d tokens / ~$%.2f  (~$%.2f per translated card; ceiling $%.2f; %s)'
+          % (cg.get('est_tokens', 0), cg.get('est_cost_usd', 0.0),
+             cg.get('est_cost_per_card_usd', 0.0), cg.get('per_card_ceiling_usd', 0.0),
+             cg.get('verdict', 'ok')))
     for warning in report.get('warnings') or []:
         print('  WARNING: %s' % warning)
 
@@ -215,14 +283,16 @@ def recommended_order(reports):
 
 def print_matrix(reports):
     print('pwg_ru performance preflight matrix (%s)' % reports[0]['lang'])
-    header = ('root', 'keys', 'tm', 'frag', 'deg', 'near', 'pre', 'batches', 'agents', 'action')
+    header = ('root', 'keys', 'tm', 'frag', 'deg', 'near', 'pre', 'batches', 'agents', '$est', '$/card', 'action')
     rows = []
     for r in reports:
+        cg = r.get('cost_gate') or {}
         rows.append((
             r['root'], len(r['selected_keys']), r['tm_cards'], r['frag_tm_fragments'],
             len(r['degenerate_passthrough_keys']), len(r['near_degenerate_candidates']),
             len(r['presplit_keys']), r['batch_count'], r['agent_expected_after_tm'],
-            r['recommended_action'],
+            '%.2f' % cg.get('est_cost_usd', 0.0), '%.2f' % cg.get('est_cost_per_card_usd', 0.0),
+            r['recommended_action'] + ('!COST' if cg.get('over_ceiling') else ''),
         ))
     widths = [max(len(str(row[i])) for row in [header] + rows) for i in range(len(header))]
     fmt = '  '.join('%%-%ds' % w for w in widths)
@@ -256,6 +326,12 @@ def main(argv=None):
                     help='Disable auto sidecar lookup for what-if accounting.')
     ap.add_argument('--wf-glob', default='wf_output*.json',
                     help='Workflow-output glob, relative to RussianTranslation/, used only for frag_prov warnings.')
+    ap.add_argument('--cost-ceiling-per-card', type=float, default=COST_CEIL_PER_CARD_USD,
+                    help='H189 cost gate: flag a window whose est $ per translated card exceeds this (default %(default)s).')
+    ap.add_argument('--cost-ceiling-window', type=float, default=COST_CEIL_WINDOW_USD,
+                    help='H189 cost gate: flag a window whose total est $ exceeds this (default %(default)s).')
+    ap.add_argument('--refuse-over-cost', action='store_true',
+                    help='H189 cost gate: exit nonzero if any window exceeds a cost ceiling (for automated callers).')
     ap.add_argument('--json', action='store_true')
     ap.set_defaults(tm_auto=True)
     args = ap.parse_args(argv)
@@ -264,6 +340,7 @@ def main(argv=None):
     if len(args.roots) > 1 and args.nominal:
         raise SystemExit('FAIL: --nominal requires one root/key namespace per preflight')
     reports = [build_report(args, root) for root in args.roots]
+    over = [r for r in reports if r.get('cost_gate', {}).get('over_ceiling')]
     if args.json:
         if len(reports) == 1:
             payload = reports[0]
@@ -281,6 +358,10 @@ def main(argv=None):
         print_human(reports[0])
     else:
         print_matrix(reports)
+    if args.refuse_over_cost and over:
+        sys.exit('FAIL: %d window(s) exceed the H189 cost ceiling ($%.2f/card, $%.2f/window): %s'
+                 % (len(over), args.cost_ceiling_per_card, args.cost_ceiling_window,
+                    ', '.join(r['root'] for r in over)))
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -9,6 +9,7 @@ only. It does not require a fresh Max run.
 import hashlib
 import datetime
 import json
+import math
 import os
 import shutil
 import subprocess
@@ -1578,16 +1579,19 @@ def test_perf_preflight_dense_presplit():
 
 
 def test_perf_preflight_presplit_counts_fragments_not_one():
-    """agent_expected_after_tm for a presplit giant must be its true fragment-group count,
-    not 1 — the old len(presplit) formula underestimated vid's real 102-agent run as 13."""
+    """agent_expected_after_tm for a presplit giant must be its true fragment-GROUP count,
+    not 1 — the old len(presplit) formula underestimated vid's real 102-agent run as 13.
+    H189: the group count is now LOWER than the pre-H189 per-12-citation grouping (the
+    presplit lane amortizes at PRESPLIT_GROUP_CITE_BUDGET=60), but it must still be >1 (a
+    150+-<ls> giant does not collapse to a single call) — that's the invariant this guards."""
     key = 'gam~~h0_00_pwg00'
     proc = run([sys.executable, 'src/pilot/perf_preflight.py', 'gam',
                 '--keys=%s' % key, '--no-tm', '--json'], 0)
     report = json.loads(proc.stdout)
     if key not in report.get('presplit_keys', []):
         fail('fixture card must still route to presplit')
-    if report.get('agent_expected_after_tm', 0) < 5:
-        fail('a 150+-<ls> presplit giant needs many fragment calls, not ~1 — '
+    if report.get('agent_expected_after_tm', 0) < 2:
+        fail('a 150+-<ls> presplit giant needs several fragment-group calls, not ~1 — '
              'got agent_expected_after_tm=%r' % report.get('agent_expected_after_tm'))
 
 
@@ -1618,14 +1622,21 @@ def test_perf_preflight_multi_root_matrix_and_order():
         fail('han should be recognized as fully cached / zero-agent in the local TM preflight')
     if 'han' not in matrix.get('recommended_order', {}).get('skip_cached', []):
         fail('fully cached roots must be listed in skip_cached')
-    # vid and as each carry presplit giants (fragment-lane cards), so their true
-    # agent_expected_after_tm is dozens, not the ~13-14 the pre-fix len(presplit) formula
-    # reported (the real 2026-07-04 vid run spent 102 agents) — they belong in defer, not
-    # run_first, once the estimate reflects real fragment-call counts.
-    deferred = matrix.get('recommended_order', {}).get('defer', [])
-    if 'vid' not in deferred or 'as' not in deferred:
-        fail('presplit-giant roots should defer-calibrate once agent_expected_after_tm '
-             'reflects real fragment-call counts, not the old len(presplit) undercount')
+    # `as` carries presplit giants and is uncached in the local TM, so its true
+    # agent_expected_after_tm must EXCEED its presplit-key count (the pre-fix len(presplit)
+    # formula undercounted vid's real 102-agent run as 13) and it defers rather than
+    # run_first. H189 note: the per-call count is now lower than pre-H189 (the presplit lane
+    # amortizes at PRESPLIT_GROUP_CITE_BUDGET), but the no-undercount invariant still holds.
+    # vid is NOT asserted: its classification depends on how much of it the local TM has
+    # cached (a mostly-cached vid is legitimately cheap / run-now), same live-state caveat
+    # as han's skip-cached above.
+    as_r = reports['as']
+    if as_r.get('agent_expected_after_tm', 0) <= len(as_r.get('presplit_keys', [])):
+        fail('a presplit-giant root must count real fragment-GROUP calls, exceeding its '
+             'len(presplit) — got agents=%r presplit=%r'
+             % (as_r.get('agent_expected_after_tm'), len(as_r.get('presplit_keys', []))))
+    if 'as' not in matrix.get('recommended_order', {}).get('defer', []):
+        fail('an uncached presplit-giant root should defer-calibrate, not run_first')
 
 
 def test_perf_preflight_fragment_tm_empty_warning():
@@ -2204,6 +2215,170 @@ def test_kill_gate_wired():
         shutil.rmtree(d, ignore_errors=True)
 
 
+def test_group_by_budget_count_cap():
+    """H189: _group_by_budget's count_cap closes a group once it holds count_cap items
+    regardless of summed size, so a run of many tiny (size-1) fragments can't pack an
+    unbounded COUNT (== senses to emit) into one presplit-lane call. Default (no cap)
+    keeps the size-only behavior every pre-H189 caller relied on."""
+    import gen_opt_harness2 as gh
+    items = [{'w': 1}] * 40
+    sizer = lambda it: it['w']
+    # size-only: 40 weight-1 items at budget 60 = 1 group (nothing caps count)
+    if len(gh._group_by_budget(items, sizer, 60)) != 1:
+        fail('size-only grouping of 40 size-1 items at budget 60 must be a single group')
+    # count_cap=18: 40 -> ceil(40/18) = 3 groups even though total size (40) < budget (60)
+    capped = gh._group_by_budget(items, sizer, 60, count_cap=18)
+    if len(capped) != 3 or any(len(g) > 18 for g in capped):
+        fail('count_cap=18 must yield 3 groups of <=18 for 40 items; got sizes %r'
+             % [len(g) for g in capped])
+
+
+def test_presplit_card_uses_amortized_grouping():
+    """H189 core fix: a card routed to the presplit-PRIMARY lane is grouped at
+    PRESPLIT_GROUP_CITE_BUDGET/PRESPLIT_GROUP_SENSE_CAP (amortizing the ~27k framework
+    across many fragments per call), NOT the conservative SELFHEAL_GROUP_BUDGET. A
+    30-sense/1-<ls> card must group by the sense cap (ceil(30/18)=2), not by the old
+    per-12-citation budget (ceil(30/12)=3) — proving fewer, larger fragment-lane calls."""
+    import re as _re
+    import gen_opt_harness2 as gh
+    senses = '\n'.join('<div n="1">— %d〉 {%%Bedeutung %d%%}.' % (i, i)
+                       for i in range(1, 31))
+    raw = ('=== LAYER: PW — Böhtlingk kürzere Fassung ===\n\n'
+           '<hom>1.</hom> √{#gam#}¦ <ls>X. 1</ls>.\n' + senses + '\n')
+    key = 'zz~~synthetic_amortize'
+    d = tempfile.mkdtemp()
+    try:
+        rp = os.path.join(d, key + '.raw.txt')
+        pp = os.path.join(d, key + '.portrait.json')
+        with open(rp, 'w', encoding='utf-8') as f:
+            f.write(raw)
+        with open(pp, 'w', encoding='utf-8') as f:
+            f.write('[]')
+        saved_ip = gh.input_paths
+        gh.input_paths = lambda k, input_dir=None: (rp, pp) if k == key else saved_ip(k)
+        try:
+            js, _b = gh.build('zz', [key], None, 12000, nominal=True, grammar_on=False, tm_path=None)
+            frags = json.loads(_re.search(r'^const FRAGS = (\{.*?\})\nconst PHF', js, _re.S | _re.M).group(1))
+            groups = frags.get(key) or []
+            if not (1 < len(groups) <= 2):
+                fail('a 30-sense presplit card must group into 2 amortized fragment calls '
+                     '(sense cap 18), not the old ~3 at budget 12; got %d groups' % len(groups))
+            if any(len(g) > gh.PRESPLIT_GROUP_SENSE_CAP for g in groups):
+                fail('no presplit group may exceed PRESPLIT_GROUP_SENSE_CAP fragments')
+        finally:
+            gh.input_paths = saved_ip
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_kill_gate_recalibrated_envelope():
+    """H189 (MG: '>~60s per subcard suspicious; >3 min unacceptable'): the kill envelope
+    must be the tightened one — floor <= 45s, ceil <= 180s (3 min) — never a regression
+    back to the 2 min floor / 8 min ceiling that let pril10_w1 fragments run 6.5 min."""
+    import gen_opt_harness2 as gh
+    if gh.KILL_FLOOR_MS > 45000:
+        fail('KILL_FLOOR_MS must be <= 45000 (was 120000) so a tiny subcard is killed '
+             'near MG\'s ~60s suspicion line; got %d' % gh.KILL_FLOOR_MS)
+    if gh.KILL_CEIL_MS > 180000:
+        fail('KILL_CEIL_MS must be <= 180000 (3 min hard ceiling, was 480000); got %d'
+             % gh.KILL_CEIL_MS)
+
+
+def test_budget_kill_switch_wired():
+    """H189: the harness must carry a window-level budget kill-switch — count agent()
+    calls and abort (requeue remaining) once past MAX_AGENTS — so a runaway retry/binary-
+    split cascade self-terminates instead of running to a manual kill (pril10_w1: 230
+    agents, 42M tokens, $80 before MG stopped it). MAX_AGENTS is derived from the preflight
+    estimate: max(floor, ceil(expected * factor))."""
+    import re as _re
+    import gen_opt_harness2 as gh
+    raw = ('=== LAYER: PW — Böhtlingk kürzere Fassung ===\n\n'
+           '<hom>1.</hom> √{#gam#}¦ <ls>X. 1</ls>.\n'
+           '<div n="1">— 1〉 {%verlassen%} <ls>Y. 2</ls>.\n')
+    key = 'zz~~synthetic_switch'
+    d = tempfile.mkdtemp()
+    try:
+        rp = os.path.join(d, key + '.raw.txt')
+        pp = os.path.join(d, key + '.portrait.json')
+        with open(rp, 'w', encoding='utf-8') as f:
+            f.write(raw)
+        with open(pp, 'w', encoding='utf-8') as f:
+            f.write('[]')
+        saved_ip = gh.input_paths
+        gh.input_paths = lambda k, input_dir=None: (rp, pp) if k == key else saved_ip(k)
+        try:
+            js, _b = gh.build('zz', [key], None, 12000, nominal=True, grammar_on=False, tm_path=None)
+            for tok in ('const KILL_SWITCH = true', 'const MAX_AGENTS =',
+                        'class BudgetExceeded', 'AGENTS_SPENT++', 'BUDGET_TRIPPED'):
+                if tok not in js:
+                    fail('budget kill-switch token %r missing from the harness' % tok)
+            # BudgetExceeded must NOT be treated as a kill (a kill routes to MORE fragment
+            # calls — the opposite of a budget stop).
+            if _re.search(r'isKill\s*=.*BudgetExceeded', js):
+                fail('BudgetExceeded must not be classified as a kill (would spawn more agents)')
+            meta = json.loads(_re.search(r'^const META = (\{.*\})\n', js, _re.M).group(1))
+            expected = meta.get('agent_expected_after_tm', 0)
+            want = max(gh.MAX_AGENTS_FLOOR, int(math.ceil(expected * gh.MAX_AGENTS_FACTOR)))
+            if meta.get('max_agents') != want:
+                fail('meta.max_agents must be max(floor, ceil(expected*factor))=%d; got %r'
+                     % (want, meta.get('max_agents')))
+            # summary must expose the trip flag for the requeue path
+            if 'budget_kill_switch_tripped' not in js:
+                fail('run summary must expose budget_kill_switch_tripped so a self-aborted '
+                     'window\'s null cards are requeued, not read as defective')
+        finally:
+            gh.input_paths = saved_ip
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_harness_size_guard():
+    """H189 / F-harness-size-limit: the generator must surface an oversize harness at
+    generation with a concrete key-disjoint split, so the Workflow scriptPath cap is not
+    discovered at launch (pril10_w1: 1.03 MB, unlaunchable). Small harness -> no split."""
+    import gen_opt_harness2 as gh
+    keys = ['k%d' % i for i in range(9)]
+    over, lines = gh.harness_size_report('kAla', keys, True, 1_030_000, 480_000)
+    if not over or not lines:
+        fail('a 1.03 MB harness over the 480 KB cap must report oversize with a split')
+    split_cmds = [ln for ln in lines if '--keys=' in ln]
+    if len(split_cmds) < 2:
+        fail('oversize report must suggest >=2 key-disjoint sub-windows; got %d' % len(split_cmds))
+    # every original key must appear in exactly one sub-window (disjoint, complete)
+    seen = []
+    for ln in split_cmds:
+        seen += ln.split('--keys=')[1].split(' --out=')[0].split(',')
+    if sorted(seen) != sorted(keys):
+        fail('the suggested split must partition the keys exactly once each; got %r' % seen)
+    under, lines2 = gh.harness_size_report('kAla', keys, True, 100_000, 480_000)
+    if under or lines2:
+        fail('a harness under the cap must not report oversize')
+
+
+def test_perf_preflight_cost_gate():
+    """H189: the preflight cost gate must FLAG a window whose estimated $ per translated
+    card exceeds the ceiling (a window of kAla-class monsters — exactly pril10_w1) and must
+    PASS a cheap high-card-count window (e.g. `as`: many cards, low per-card cost). The
+    per-card ratio is the load-bearing, model-independent signal."""
+    import perf_preflight as pp
+    # pril10_w1-shape: 8 cards, ~69 fragment-group agents (post-fix) -> ~$4/card >> ceiling
+    monster = {'agent_expected_after_tm': 69, 'selected_keys': ['k%d' % i for i in range(8)],
+               'tm_cards': 0, 'degenerate_passthrough_keys': []}
+    cg = pp.cost_estimate(monster)
+    if not cg['over_ceiling'] or cg['est_cost_per_card_usd'] <= cg['per_card_ceiling_usd']:
+        fail('a window of 8 monster cards costing ~$4/card must trip the cost gate; got %r' % cg)
+    # cheap high-count window: 98 cards, 24 agents -> pennies/card -> passes
+    cheap = {'agent_expected_after_tm': 24, 'selected_keys': ['k%d' % i for i in range(98)],
+             'tm_cards': 0, 'degenerate_passthrough_keys': []}
+    if pp.cost_estimate(cheap)['over_ceiling']:
+        fail('a large but cheap-per-card window must NOT trip the cost gate')
+    # fully cached window: 0 agents -> $0 -> never gated
+    cached = {'agent_expected_after_tm': 0, 'selected_keys': ['k1'], 'tm_cards': 1,
+              'degenerate_passthrough_keys': []}
+    if pp.cost_estimate(cached)['over_ceiling']:
+        fail('a fully-cached (zero-agent) window must never trip the cost gate')
+
+
 def main():
     tests = [
         test_translation_memory_addressing,
@@ -2232,6 +2407,12 @@ def main():
         test_selfheal_fragment_si_threaded_and_tags_normalized,
         test_sense_dense_card_presplit,
         test_kill_gate_wired,
+        test_group_by_budget_count_cap,
+        test_presplit_card_uses_amortized_grouping,
+        test_kill_gate_recalibrated_envelope,
+        test_budget_kill_switch_wired,
+        test_harness_size_guard,
+        test_perf_preflight_cost_gate,
         test_autosplit_topup_targets_and_reassembles,
         test_workflow_payload_nested,
         test_sense_dupe_batch_override,


### PR DESCRIPTION
Post-mortem + fix for the `pril10_w1` nominal-window cost/latency blow-up (**42.3M tokens / ~\$79.83 / ~3 of 8 cards** before a manual kill). Executes the [H189 handoff](https://github.com/gasyoun/Uprava/blob/main/handoffs/H189-Opus_RussianTranslation_pwg_ru_nominal_cost_blowup_postmortem_05.07.26.md) mandate (why / fix / never-again).

## Verified WHY
Economics reproduced **to the digit** via [`parse_workflow_cost.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/parse_workflow_cost.py); every §4 hypothesis **CONFIRMED**. Full breakdown: [`POSTMORTEM_pril10_w1.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/POSTMORTEM_pril10_w1.md).

**Root cause:** in nominal mode all 8 cards were routed to the fragment lane (`BATCHES = 0`), grouping their **448 fragments into 174 tiny `agent()` calls** (~2.6/call), so the ~27 K framework prompt was re-cached ~230× → **cache-write = 60 % of the bill**. 78 % of agents took >1 turn (one retried 10× for 903 K tokens / 9 K output); the kill gate's 2-min floor / 8-min ceiling let fragments run 6.5 min.

## Five fixes (all SHARED; 68/68 selftests green, parity ledger clean)
| fix | effect |
|---|---|
| **Presplit-lane re-batching** (budget 60/18 via `_group_by_budget` count_cap) | `pril10_w1` **174 → 69** groups; real `gam` giants **18 → 6** agents |
| **Kill-gate recalibration** (floor 120→45 s, ceil 480→180 s) | tiny fragment killed ~60–70 s; nothing past 3 min; kill still requeues |
| **Live budget kill-switch** (`MAX_AGENTS = max(40, ⌈expected×3⌉)`) | window self-aborts + requeues a runaway instead of a manual kill |
| **Harness-size guard** (>480 KB) | generator warns + prints an exact key-disjoint split (`F-harness-size-limit`) |
| **Preflight cost gate** (`perf_preflight.py`) | tokens/\$/per-card estimate; flags/`--refuse-over-cost` refuses over ceiling — flags `pril10_w1` at ~\$4/card **even post-fix** |

Also fixes a **latent nominal-generation crash**: `_slp1_lex_for_key` crashed on an empty-list portrait `[]` (the real `tyaj~~h0_zz_pw` shape) via the `nominal_keymap` emission.

## Load-bearing lesson
Amortization cuts the presplit lane ~2.5×, but 8 `kAla`-class heads are *intrinsically* expensive per card. Viability = **not running a window of monsters as bulk** — the cost gate keeps such windows out of the pipeline. Typical batched cards were never the problem (~36 K tok/card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)