### PR TITLE
H189 follow-up: scale budget kill-switch ceiling with word size (drop flat floor)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -21,7 +21,7 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   + [`perf_preflight.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/perf_preflight.py):
   (1) **presplit-lane re-batching** (budget 60/18: `pril10_w1` 174→69 groups, real `gam` giants 18→6
   agents); (2) **kill-gate recalibration** (floor 120→45 s, ceil 480→180 s); (3) **live budget
-  kill-switch** (`MAX_AGENTS=max(40, ⌈expected×3⌉)`, self-abort + requeue); (4) **harness-size guard**
+  kill-switch** (`MAX_AGENTS=⌈expected×3⌉+10 (size-proportional)`, self-abort + requeue); (4) **harness-size guard**
   (warn + key-split > 480 KB); (5) **preflight cost gate** (tokens/$/per-card, `--refuse-over-cost`).
   Plus a latent nominal crash fixed (`_slp1_lex_for_key` on empty `[]` portrait). Run detail:
   [`RUN_LOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_LOG.md)

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "5bbb029b2dc287f52d4efd4f9f44ff4a12952a15984554568afa645eec2804bd",
-      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
+      "src/pilot/window_selftest.py": "8fada81bc466f11acf10680fd017c72f1f308d44ba4872b67e64f67f706e205c"
     }
   },
   {
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108"
+      "src/pilot/gen_opt_harness2.py": "cee7dc9df489e2f6852dbce84b665e822cdbb3e58486e8b01aea371df0542c94"
     }
   },
   {
@@ -117,8 +117,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108",
-      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
+      "src/pilot/gen_opt_harness2.py": "cee7dc9df489e2f6852dbce84b665e822cdbb3e58486e8b01aea371df0542c94",
+      "src/pilot/window_selftest.py": "8fada81bc466f11acf10680fd017c72f1f308d44ba4872b67e64f67f706e205c"
     }
   },
   {
@@ -136,8 +136,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108",
-      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
+      "src/pilot/gen_opt_harness2.py": "cee7dc9df489e2f6852dbce84b665e822cdbb3e58486e8b01aea371df0542c94",
+      "src/pilot/window_selftest.py": "8fada81bc466f11acf10680fd017c72f1f308d44ba4872b67e64f67f706e205c"
     }
   },
   {
@@ -154,7 +154,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108"
+      "src/pilot/gen_opt_harness2.py": "cee7dc9df489e2f6852dbce84b665e822cdbb3e58486e8b01aea371df0542c94"
     }
   },
   {
@@ -171,7 +171,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108"
+      "src/pilot/gen_opt_harness2.py": "cee7dc9df489e2f6852dbce84b665e822cdbb3e58486e8b01aea371df0542c94"
     }
   },
   {
@@ -205,7 +205,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108"
+      "src/pilot/gen_opt_harness2.py": "cee7dc9df489e2f6852dbce84b665e822cdbb3e58486e8b01aea371df0542c94"
     }
   },
   {
@@ -222,7 +222,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108"
+      "src/pilot/gen_opt_harness2.py": "cee7dc9df489e2f6852dbce84b665e822cdbb3e58486e8b01aea371df0542c94"
     }
   },
   {
@@ -238,7 +238,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The bare 'sonnet' alias resolved to Sonnet 4.6 (not 5.0) on a prior EN run — pinned explicitly there after that surprise. RU's alias was never observed to misresolve, so it was left alone rather than touching a stable production path for a problem it doesn't have. Re-evaluate if RU is ever caught on a stale alias too.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108"
+      "src/pilot/gen_opt_harness2.py": "cee7dc9df489e2f6852dbce84b665e822cdbb3e58486e8b01aea371df0542c94"
     }
   },
   {
@@ -315,8 +315,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108",
-      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
+      "src/pilot/gen_opt_harness2.py": "cee7dc9df489e2f6852dbce84b665e822cdbb3e58486e8b01aea371df0542c94",
+      "src/pilot/window_selftest.py": "8fada81bc466f11acf10680fd017c72f1f308d44ba4872b67e64f67f706e205c"
     }
   },
   {
@@ -335,7 +335,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
+      "src/pilot/window_selftest.py": "8fada81bc466f11acf10680fd017c72f1f308d44ba4872b67e64f67f706e205c"
     }
   },
   {
@@ -372,8 +372,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108",
-      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
+      "src/pilot/gen_opt_harness2.py": "cee7dc9df489e2f6852dbce84b665e822cdbb3e58486e8b01aea371df0542c94",
+      "src/pilot/window_selftest.py": "8fada81bc466f11acf10680fd017c72f1f308d44ba4872b67e64f67f706e205c"
     }
   },
   {
@@ -410,13 +410,13 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108",
+      "src/pilot/gen_opt_harness2.py": "cee7dc9df489e2f6852dbce84b665e822cdbb3e58486e8b01aea371df0542c94",
       "src/promote_final_cards.py": "abb57e9a41e8969346e854fd4d4682b97abdabf203a102b6a5d11fa657eaaa22"
     }
   },
   {
     "id": "presplit_lane_amortization_and_budget_guards_h189",
-    "mechanism": "Presplit-PRIMARY cards are grouped at PRESPLIT_GROUP_CITE_BUDGET(60)/PRESPLIT_GROUP_SENSE_CAP(18) instead of the conservative SELFHEAL_GROUP_BUDGET(12), amortizing the ~27k framework across many fragments per agent() call; the wall-clock kill gate is recalibrated (floor 120s->45s, ceil 480s->180s) per MG's >60s-suspicious/>3min-unacceptable rule; a window-level budget kill-switch aborts+requeues once agent() calls exceed MAX_AGENTS=max(40, ceil(expected*3)); the generator warns + suggests a key-disjoint split when the harness exceeds MAX_HARNESS_BYTES(480k); perf_preflight adds a per-card / per-window cost gate that flags a window dominated by expensive cards",
+    "mechanism": "Presplit-PRIMARY cards are grouped at PRESPLIT_GROUP_CITE_BUDGET(60)/PRESPLIT_GROUP_SENSE_CAP(18) instead of the conservative SELFHEAL_GROUP_BUDGET(12), amortizing the ~27k framework across many fragments per agent() call; the wall-clock kill gate is recalibrated (floor 120s->45s, ceil 480s->180s) per MG's >60s-suspicious/>3min-unacceptable rule; a window-level budget kill-switch aborts+requeues once agent() calls exceed MAX_AGENTS=ceil(expected*3)+10); the generator warns + suggests a key-disjoint split when the harness exceeds MAX_HARNESS_BYTES(480k); perf_preflight adds a per-card / per-window cost gate that flags a window dominated by expensive cards",
     "files": [
       "src/pilot/gen_opt_harness2.py",
       "src/pilot/perf_preflight.py",
@@ -430,9 +430,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "752cbaa4e69cca3604f64078e02538421e8d5f30c69dcd1c4a52fe33adfe4108",
+      "src/pilot/gen_opt_harness2.py": "cee7dc9df489e2f6852dbce84b665e822cdbb3e58486e8b01aea371df0542c94",
       "src/pilot/perf_preflight.py": "7ec7ab37753ecde0eebc20f1ce251565e8bfbf59963592460be460016dee2a43",
-      "src/pilot/window_selftest.py": "8de7b0fd03c11c64d45951b6043842b2c99acc3546d33a26906790d2a4f448e9"
+      "src/pilot/window_selftest.py": "8fada81bc466f11acf10680fd017c72f1f308d44ba4872b67e64f67f706e205c"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/POSTMORTEM_pril10_w1.md
+++ b/RussianTranslation/src/pilot/POSTMORTEM_pril10_w1.md
@@ -37,7 +37,7 @@ Five fixes landed (all lang-agnostic → SHARED); all pinned by
 2. **Kill-gate recalibration** — floor 120 s → 45 s, ceil 480 s → 180 s (MG: ">60 s
    suspicious, >3 min unacceptable").
 3. **Live budget kill-switch** — the window self-aborts and requeues once agent() calls
-   exceed `MAX_AGENTS = max(40, ⌈expected × 3⌉)`.
+   exceed `MAX_AGENTS = ⌈expected × 3⌉ + 10`.
 4. **Harness-size guard** — the generator warns + prints an exact key-disjoint split when
    the harness exceeds 480 KB (the `F-harness-size-limit` scriptPath cap).
 5. **Preflight cost gate** — [`perf_preflight.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/perf_preflight.py)
@@ -147,7 +147,7 @@ classified SHARED in [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexic
 |---|---|---|---|
 | B | **presplit-lane re-batching** | presplit-primary cards group at `PRESPLIT_GROUP_CITE_BUDGET=60` **and** `PRESPLIT_GROUP_SENSE_CAP=18` (both under the proven-safe whole-card 90/20 ceiling), via `_group_by_budget(..., count_cap=)`. Heal-of-a-failed-whole-card keeps the conservative budget 12. | `pril10_w1` **174 → 69 groups**; real `gam` giants **18 → 6 agents**. Framework re-cache ~4.7 M → ~1.9 M tok. |
 | C1 | **kill-gate recalibration** | `FLOOR 120 s → 45 s`, `CEIL 480 s → 180 s`, `BASE 30 s → 20 s`. Kill → the abandoned call's cards fall to the fragment lane / binary-split (**requeued, never dropped**). | tiny fragment hard-killed ~60–70 s; nothing past 3 min. |
-| C4 | **live budget kill-switch** | harness counts agent() calls; past `MAX_AGENTS = max(40, ⌈expected × 3⌉)` every call throws `BudgetExceeded` (0 tokens, not an `isKill` → no more fragment spawns); remaining cards null with a `budget-kill-switch` reason for the normal requeue. `summary.budget_kill_switch_tripped` surfaces it. | a 174-estimate window aborts at ~522 calls; the real 230 would have been well within, but a true runaway now self-terminates instead of a manual kill. |
+| C4 | **live budget kill-switch** | harness counts agent() calls; past `MAX_AGENTS = ⌈expected × 3⌉ + 10` every call throws `BudgetExceeded` (0 tokens, not an `isKill` → no more fragment spawns); remaining cards null with a `budget-kill-switch` reason for the normal requeue. `summary.budget_kill_switch_tripped` surfaces it. | a 174-estimate window aborts at ~522 calls; the real 230 would have been well within, but a true runaway now self-terminates instead of a manual kill. |
 | C3 | **harness-size guard** | at write time, if the harness > `MAX_HARNESS_BYTES = 480 KB` the generator prints a concrete key-disjoint split (N sub-windows, exact `--keys=` each); `--refuse-oversize` makes it a hard error. | surfaces `F-harness-size-limit` at generation, not launch. |
 | C2 | **preflight cost gate** | `perf_preflight.py` estimates tokens/$ (184 K tok, $0.347/agent from this run, ×1.35 realism) and a **per-translated-card cost**; flags `OVER-CEILING` above `$2/card` or `$25/window`; `--refuse-over-cost` exits nonzero. | flags `pril10_w1` (~$4/card **even post-fix**) → routed to a human-budgeted lane; passes cheap high-count windows (`as`: $0.11/card). |
 

--- a/RussianTranslation/src/pilot/RUN_LOG.md
+++ b/RussianTranslation/src/pilot/RUN_LOG.md
@@ -263,7 +263,7 @@ Five guardrails shipped (all SHARED, 68/68 selftests green):
    `pril10_w1` **174 → 69** fragment-group calls; real `gam` giants **18 → 6** agents.
 2. **Kill-gate recalibration**: floor 120 s → **45 s**, ceil 480 s → **180 s** (MG rule).
 3. **Live budget kill-switch**: window self-aborts + requeues past
-   `MAX_AGENTS = max(40, ⌈expected×3⌉)`.
+   `MAX_AGENTS = ⌈expected×3⌉ + 10 (size-proportional)`.
 4. **Harness-size guard**: generator warns + prints an exact key-disjoint split > 480 KB.
 5. **Preflight cost gate**: `perf_preflight.py` estimates tokens/$/per-card and flags
    (or `--refuse-over-cost` refuses) a window over ceiling — flags `pril10_w1` (~$4/card

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -180,16 +180,25 @@ KILL_CEIL_MS = 180000       # hard ceiling — NOTHING runs past 3 min (MG). Was
 # not silently dropped) so a runaway retry/binary-split cascade self-terminates instead of
 # running to a manual kill. Tokens aren't observable inside the runtime (agent() returns
 # structured output, not a usage record), so the mechanical proxy is agent-CALL count —
-# which is exactly what blew up (230 vs 174). The ceiling is derived per window from the
-# preflight estimate: MAX_AGENTS = max(MAX_AGENTS_FLOOR, ceil(expected * MAX_AGENTS_FACTOR)),
-# so a small window isn't over-constrained and a large one still can't 10x its estimate.
+# which is exactly what blew up (230 vs 174). The ceiling is derived per window and must
+# SCALE WITH WORD SIZE, not be a one-size-fits-all floor: a `gam`-class word legitimately
+# needs dozens of calls, but a 3-card stub must never be allowed 40 — a flat floor would let
+# a small-word runaway burn 40 agents before the switch ever fired, defeating it for exactly
+# the words that need it. So the ceiling is proportional to the preflight estimate plus a
+# small fixed headroom for one hard card's heal/binary-split jitter:
+#   MAX_AGENTS = ceil(expected * MAX_AGENTS_FACTOR) + MAX_AGENTS_HEADROOM
+# e.g. expected 2 -> 16, 6 -> 28, 20 -> 70, 60 -> 190 — a continuous small/medium/large
+# typology, no cliff at a tier boundary and no "what counts as medium" to pin down.
 KILL_SWITCH = True          # --no-kill-switch disables; --max-agents=N sets an absolute override
 MAX_AGENTS_FACTOR = 3.0     # abort once actual agent() calls exceed 3x the preflight estimate
                             #  (pril10_w1 was 230/174 = 1.3x before the manual kill — 3x leaves
                             #  ample room for legitimate binary-split/heal while still catching a
                             #  true runaway well before a $80 outcome).
-MAX_AGENTS_FLOOR = 40       # never abort a window below this many calls regardless of estimate
-                            #  (a genuinely small window that heals a few cards stays unaffected).
+MAX_AGENTS_HEADROOM = 10    # additive jitter allowance so a TINY window (expected 1-2) whose one
+                            #  hard card binary-splits into ~5-7 heal agents isn't false-aborted —
+                            #  replaces the old flat floor of 40, which was far too loose for
+                            #  small/medium words (they never legitimately approach 40, so the
+                            #  floor let their runaways run unchecked to 40). H189 follow-up.
 MAX_AGENTS_OVERRIDE = None  # --max-agents=N: pin an absolute ceiling, bypassing the derivation
 # --- harness-size guard (H189 / F-harness-size-limit) -----------------------------
 # The emitted harness inlines every card's raw+portrait input, so its byte size scales with
@@ -1000,8 +1009,8 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     agent_expected = len(batches) + sum(len(frags.get(k, [None])) for k in presplit)
     if MAX_AGENTS_OVERRIDE:
         max_agents = MAX_AGENTS_OVERRIDE
-    else:
-        max_agents = max(MAX_AGENTS_FLOOR, int(math.ceil(agent_expected * MAX_AGENTS_FACTOR)))
+    else:   # proportional to word size + small jitter headroom (NOT a flat floor)
+        max_agents = int(math.ceil(agent_expected * MAX_AGENTS_FACTOR)) + MAX_AGENTS_HEADROOM
 
     meta = {
         'schema_version': 'pwg_ru.workflow_meta.v1', 'generator': 'gen_opt_harness2.batched-masked',
@@ -1032,6 +1041,7 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         'kill_switch': KILL_SWITCH,
         'max_agents': max_agents if KILL_SWITCH else None,
         'max_agents_factor': MAX_AGENTS_FACTOR,
+        'max_agents_headroom': MAX_AGENTS_HEADROOM,
         # H189 presplit-lane amortization budgets (fragments packed per agent() call).
         'presplit_group_cite_budget': PRESPLIT_GROUP_CITE_BUDGET,
         'presplit_group_sense_cap': PRESPLIT_GROUP_SENSE_CAP,

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -2318,10 +2318,15 @@ def test_budget_kill_switch_wired():
                 fail('BudgetExceeded must not be classified as a kill (would spawn more agents)')
             meta = json.loads(_re.search(r'^const META = (\{.*\})\n', js, _re.M).group(1))
             expected = meta.get('agent_expected_after_tm', 0)
-            want = max(gh.MAX_AGENTS_FLOOR, int(math.ceil(expected * gh.MAX_AGENTS_FACTOR)))
+            # H189 follow-up: the ceiling SCALES with word size (ceil(expected*factor)+headroom),
+            # NOT a flat floor — a flat floor let a small-word runaway burn 40 agents unchecked.
+            want = int(math.ceil(expected * gh.MAX_AGENTS_FACTOR)) + gh.MAX_AGENTS_HEADROOM
             if meta.get('max_agents') != want:
-                fail('meta.max_agents must be max(floor, ceil(expected*factor))=%d; got %r'
+                fail('meta.max_agents must be ceil(expected*factor)+headroom=%d; got %r'
                      % (want, meta.get('max_agents')))
+            if hasattr(gh, 'MAX_AGENTS_FLOOR'):
+                fail('the flat one-size-fits-all MAX_AGENTS_FLOOR must be gone — the ceiling '
+                     'must scale with word size so a small-word runaway is caught, not clamped to 40')
             # summary must expose the trip flag for the requeue path
             if 'budget_kill_switch_tripped' not in js:
                 fail('run summary must expose budget_kill_switch_tripped so a self-aborted '


### PR DESCRIPTION
Follow-up to [#158](https://github.com/gasyoun/SanskritLexicography/pull/158). MG flagged that the live budget kill-switch used a **flat floor**: `MAX_AGENTS = max(40, ⌈expected×3⌉)`.

**Defect:** the `max(40, …)` clamps every word with `expected ≤ 13` to the same ceiling of 40, so a **small-word runaway burns 40 agents before the switch ever fires** — useless for exactly the small/medium words that never legitimately approach 40. The `×3` scaling was right; the flat floor clobbered it for everything small and medium.

**Fix:** size-proportional ceiling + a small additive jitter headroom (a continuous small/medium/large typology, no tier cliffs):

```
MAX_AGENTS = ⌈expected × MAX_AGENTS_FACTOR⌉ + MAX_AGENTS_HEADROOM   (factor 3, headroom 10)
```

| word | expected | old (flat floor) | new (proportional) |
|---|---:|---:|---:|
| small stub | 2 | 40 | **16** |
| `gam` (cached) | 6 | 40 | **28** |
| medium | 20 | 60 | **70** |
| big fresh word | 60 | 190 | **190** |

Small words now trip at ~16 (a real runaway); big words still scale up (a fresh `gam`-class word gets far more than 40). The `+10` headroom covers one hard card's binary-split/heal cascade so a tiny window isn't false-aborted.

`window_selftest.py` updated to assert the scaled formula **and** that the flat `MAX_AGENTS_FLOOR` is gone; 68/68 green, parity ledger clean. Docs (POSTMORTEM/RUN_LOG/.ai_state/LANG_PARITY) updated to the new formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)