### PR TITLE
docs(pwg-ru): H201 nominal_w1_100small STAGED & verified-ready (not run)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -33,6 +33,22 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   [`src/pilot/NOMINAL_W1_100SMALL.selection.json`](src/pilot/NOMINAL_W1_100SMALL.selection.json),
   [`src/pilot/NOMINAL_W1_100SMALL.preflight.json`](src/pilot/NOMINAL_W1_100SMALL.preflight.json).
 
+- **H201 run — ⏸ STAGED & VERIFIED-READY, NOT RUN 05-07-2026 (prep Opus 4.8, `claude-opus-4-8`;
+  Claude Code session — NOT a Max Workflow surface).** Re-ran H201's deterministic prep on a clean
+  worktree off `origin/codex/h191-…` and re-confirmed the window is green: preflight **3 batches /
+  3 expected agents / 745,200 tok / $1.41**, verdict `ok` under both ceilings; harness
+  `run_pilot_wf.nominal_w1_100small.js` regenerated at **315,896 bytes** (< 480 KB cap, 100 cards /
+  3 batches [4, 69, 26], mode NOMINAL) and `node --check` **passes**. The `agent()`-driven
+  translation was **NOT** run — the harness needs the in-chat **Max Workflow** runtime (it has no
+  local `agent()` and ends in a top-level `return`; standalone `node` fails by design), and this
+  Opus 4.8 Claude Code session does not have that tool. **No run metrics exist yet.** A **Sonnet Max
+  Workflow** session must run §2→§3 and log wall-clock / tokens / promoted count. **⚠ Gotcha:**
+  `NOMINAL_W1_100SMALL.keys.txt` is CRLF — build the `--keys` list with
+  `tr -d '\r' < …keys.txt | paste -sd,` (a raw `paste` leaves `\r` on each key → `missing input`);
+  the handoff's PowerShell `(Get-Content) -join ','` is already safe. Also junction/copy the
+  gitignored `src/pilot/input/` (218K generated files) into any fresh worktree before preflight.
+  Detail: [`RUN_LOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_LOG.md) (2026-07-05 STAGED block).
+
 - **✅ H189 cost-blow-up fixes LANDED 05-07-2026 (Opus 4.8, `claude-opus-4-8`; gen of the aborted run
   Sonnet 5 `claude-sonnet-5`).** The `pril10_w1` blow-up (42.3 M tok / ~$79.83 / ~3 of 8 cards; every
   §4 hypothesis CONFIRMED, economics reproduced to the digit) is fully diagnosed and guardrailed.

--- a/RussianTranslation/src/pilot/RUN_LOG.md
+++ b/RussianTranslation/src/pilot/RUN_LOG.md
@@ -308,3 +308,31 @@ and estimated **745,200 tokens / ~$1.41**. Tracked staging artifacts:
 
 **Next:** Sonnet/Max executes
 `C:\Users\user\Documents\GitHub\Uprava\handoffs\H201-Sonnet_RussianTranslation_pwg_ru_nominal_w1_100small_run_05.07.26.md`.
+
+---
+
+## 2026-07-05 — nominal window `nominal_w1_100small` — ✅ STAGED & VERIFIED-READY (no Max/Workflow run) — prep by **Opus 4.8** (`claude-opus-4-8`)
+
+H201 executed on a **Claude Code (Opus 4.8) session, which is NOT a Max Workflow surface** —
+so the `agent()`-driven translation was **not** run here. Everything deterministic up to the
+Workflow hand-off was done and verified on a clean worktree off `origin/codex/h191-pwg-ru-verify-optimize-100small`:
+
+| check | result |
+|---|---|
+| base | `origin/codex/h191-…` (has H179 adapter #152 + **H189 cost guardrails** #158/#159 + staging) |
+| preflight | 3 batches / **3 expected agents** / **745,200 tok / $1.41** / verdict `ok`, under per-card ($2) + window ($25) ceilings |
+| harness | `run_pilot_wf.nominal_w1_100small.js` = **315,896 bytes** (< 480 KB cap), 100 cards / 3 batches [4, 69, 26], mode NOMINAL, `degenerate_passthrough=1` |
+| `node --check` | **passed** |
+| standalone `node` run | fails by design (no local `agent()`; top-level `return`) — confirms it needs the Workflow runtime |
+
+**⚠ Gotcha (bash executors):** `NOMINAL_W1_100SMALL.keys.txt` is **CRLF**. The handoff's
+PowerShell `(Get-Content …) -join ','` strips `
+` correctly, but a bash `paste -sd,` keeps it —
+every key becomes `n_ar_i
+`, and `gen_opt_harness2.py` dies with `missing input for <key>`.
+Strip it first: `tr -d '\r' < NOMINAL_W1_100SMALL.keys.txt | paste -sd,`. (Preflight is more
+lenient and passed either way; only generation failed.)
+
+**Note:** the fresh worktree lacks the gitignored `src/pilot/input/` (218K generated files); junction/copy it from an existing checkout before preflight/gen.
+
+**Next:** run the generated harness on a **Sonnet Max Workflow** surface, save `wf_output.nominal_w1_100small.json`, then audit → promote per [RUN_FREQ_MAX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_FREQ_MAX.md). No run metrics (wall-clock / tokens / promoted count) exist yet — they get logged by the session that actually runs it.


### PR DESCRIPTION
Records the H201 outcome: the PWG→RU `nominal_w1_100small` window is **staged and verified-ready**, but **was not run** — the run needs a Sonnet **Max Workflow** surface, and the executing session (Opus 4.8 Claude Code) does not have the in-chat Workflow tool that injects the harness's global `agent()`.

### What was re-verified (deterministic prep, off master's staging)
- **Preflight:** 3 batches / **3 expected agents** / **745,200 tok / \$1.41**, verdict `ok`, under per-card (\$2) + window (\$25) ceilings.
- **Harness** [`run_pilot_wf.nominal_w1_100small.js`] regenerated at **315,896 bytes** (< 480 KB cap), 100 cards / 3 batches `[4, 69, 26]`, mode NOMINAL; `node --check` **passes**.
- Standalone `node` on the harness fails **by design** (no local `agent()`; top-level `return`) — confirms it requires the Workflow runtime.

### Gotcha logged (for the next executor)
[`NOMINAL_W1_100SMALL.keys.txt`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/NOMINAL_W1_100SMALL.keys.txt) is **CRLF**. A raw bash `paste -sd,` leaves `\r` on each key → `gen_opt_harness2.py` dies with `missing input`. Use `tr -d '\r' < …keys.txt | paste -sd,`. The handoff's PowerShell `(Get-Content) -join ','` path is already safe. Also: a fresh worktree lacks the gitignored `src/pilot/input/` (218K generated files) — junction/copy it before preflight.

### Not included
No `wf_output.nominal_w1_100small.json` and **no run metrics** (wall-clock / tokens / promoted count) — those are logged by the Sonnet Max Workflow session that actually runs §2→§3 of [H201](https://github.com/gasyoun/Uprava/blob/main/handoffs/H201-Sonnet_RussianTranslation_pwg_ru_nominal_w1_100small_run_05.07.26.md).

Touches only [`.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md) and [`RUN_LOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_LOG.md) (docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)