### PR TITLE
chore: rename Renou pilot review sheet to naming convention

### DIFF
--- a/RussianTranslation/review/sanskritlexicography-renou-hypotheses_pilot_review.html
+++ b/RussianTranslation/review/sanskritlexicography-renou-hypotheses_pilot_review.html
@@ -76,7 +76,7 @@
   </div>
 </header>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button>
+  <button class="dl" id="downloadBtn">Download sanskritlexicography-renou-hypotheses_pilot_decisions.json</button>
   <div class="filterbar" id="filterbar">
     <button data-filter="all" class="active">all</button>
     <button data-filter="A">A</button>
@@ -2335,7 +2335,7 @@
   &middot; Defer = can't tell from the evidence shown. Keyboard: <kbd>a</kbd> approve
   &middot; <kbd>r</kbd> reject &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd>
   next/prev card. Votes autosave to this browser's localStorage as you click;
-  click "Download decisions.json" when done (or partway — unvoted items are
+  click "Download sanskritlexicography-renou-hypotheses_pilot_decisions.json" when done (or partway — unvoted items are
   included with decision:null).
 </footer>
 <script>
@@ -2421,7 +2421,7 @@
     var url = URL.createObjectURL(blob);
     var a = document.createElement('a');
     a.href = url;
-    a.download = 'decisions.json';
+    a.download = 'sanskritlexicography-renou-hypotheses_pilot_decisions.json';
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);


### PR DESCRIPTION
## Summary
- Renames `RussianTranslation/review/renou_pilot_sheet.html` → `sanskritlexicography-renou-hypotheses_pilot_review.html` per the new `/review-sheet` naming convention (05-07-2026).
- Patches the sheet's internal decisions-download filename to match.

See [Uprava/REVIEW_SHEETS_INDEX.md](https://github.com/gasyoun/Uprava/blob/main/REVIEW_SHEETS_INDEX.md) and [FINDINGS.md §34](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md).

## Test plan
- [x] File renamed, content byte-identical apart from the download filename patch
- [x] GTD_NEXT_ACTIONS.md row updated to the new path (separate Uprava commit)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>