### PR TITLE
docs(pwg_ru): H180 addenda-typology / re-glue / learner research track (first pass)

### DIFF
--- a/RussianTranslation/pwg_ru/ADDENDA_TO_ADDENDA_PROBE.md
+++ b/RussianTranslation/pwg_ru/ADDENDA_TO_ADDENDA_PROBE.md
@@ -1,0 +1,71 @@
+# Addenda-to-Addenda probe (PWG vol. 7 & PW Nachträge)
+
+_Created: 06-07-2026 · Last updated: 06-07-2026_
+
+**Deliverable 5 (NOW-track) of
+[H180](https://github.com/gasyoun/Uprava/blob/main/handoffs/H180-Opus_RussianTranslation_pwg_ru_addenda_typology_glue_learner_05.07.26.md)**
+(MG ruling 05-07-2026: "explore Addenda-to-Addenda now, defer the rest"). Question: does
+the supplement-to-a-supplement material (PWG's *Nachträge* in vol. 7; PW's *Nachträge*)
+already live in csl-orig, and how does it fold into
+[`ADDENDA_TYPOLOGY.md`](ADDENDA_TYPOLOGY.md)?
+
+## Finding — yes, it is already in csl-orig, and already in the merge
+
+### 1. PWG *Nachträge* live in vol. 7 of csl-orig `pwg`
+
+`pwg.txt` entries are stamped `<pc>V-PPPP` (volume-page). Volume 7 runs to `<pc>7-1822`
+and holds **25,748 entries** — this is where PWG's *Nachträge und Berichtigungen*
+(addenda & corrigenda, appended to the 7-volume großes PW, 1855–1875) sit. They are
+**structurally ordinary `<L>` entries**, not flagged as addenda; isolating them requires
+a page-range boundary within vol. 7 (the point where the main dictionary ends and the
+Nachträge begin), which is a page-mapping task deferred to a second pass.
+
+The German word *Nachtrag* also appears **341×** inside PWG definition prose (e.g.
+`agniSeza` "Nachtrag zu … der Taitt. Saṃh."), but those are **semantic uses**, not
+structural addenda — do not count them as A2A instances.
+
+### 2. PW *Nachträge* live in vol. 7 of csl-orig `pw` (35,581 entries, to `<pc>7-390`).
+
+### 3. The `pwkvn` layer IS the PW-Nachträge material, already merged and translated
+
+The five-layer merge's **`pwkvn` layer** (= PW *Nachträge* vol. 7 + von Negelein) is
+exactly this Addenda-to-Addenda content, already pulled onto the PWG skeleton. Evidence
+— a real translated `pwkvn` sub-card:
+
+```
+Ap  subcard=_ap~~h0_zz_pwkvn  sense_tag=ava_caus
+de: {#Ap#}¦ mit {#ava#} <ab>Caus.</ab> … {%erlangen [Page1-297-b] lassen%} <ls>NAIṢ. 8,89</ls>.
+```
+
+The embedded `[Page1-297-b]` is a **back-reference to PWG vol. 1 page 297** — i.e. the
+Nachträge entry explicitly *relocates* onto a specific PWG page/sense. That is the
+`relocate` operation of [`ADDENDA_TYPOLOGY.md`](ADDENDA_TYPOLOGY.md) §3.5 (`subtype=a2a`),
+made concrete. There are **129 `pwkvn` sub-cards** in the current translated set.
+
+## Fold-in rule
+
+- A2A material = `op=relocate`, `direction=additive`, `subtype=a2a`, carried by the
+  `pwkvn` layer.
+- Its `insertion_point.target_sense` is recoverable from the `[PageV-PPP-x]` anchor
+  embedded in the card body → resolve the anchor to the PWG homonym+sense it points at.
+- No separate scrape needed — the material is already merged and translated; the only
+  remaining work is anchor-resolution to populate `insertion_point`.
+
+## Deferred backlog (catalogue only — no near-term work)
+
+Per MG ruling, listed for the paper's "future data layers" section:
+
+| layer | what it is | likely contribution |
+|---|---|---|
+| **Reviews of PWG** (Winternitz et al.) | contemporary scholarly reviews | entry-level corrections/critiques flagged by reviewers |
+| **Böhtlingk–Roth letters** *Briefe zum Petersburger Wörterbuch 1852–1885* (Wiesbaden 2008) | editorial correspondence | rationale behind specific inclusion/abridgement decisions |
+| **Kulikov 2010 review** (*Acta Orientalia Vilnensia*) | modern review | entry-level insight on the tradition's method |
+
+## Next pass
+
+1. Detect the vol.-7 page boundary where PWG's Nachträge begin (isolate them from the
+   main vol. 7 body).
+2. Resolve `[PageV-PPP-x]` anchors in `pwkvn` cards → PWG homonym/sense, populating
+   `insertion_point` for the `a2a` instances.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/pwg_ru/ADDENDA_TYPOLOGY.md
+++ b/RussianTranslation/pwg_ru/ADDENDA_TYPOLOGY.md
@@ -1,0 +1,191 @@
+# PWG addenda / operation typology
+
+_Created: 06-07-2026 · Last updated: 06-07-2026_
+
+A **typed operation algebra** for every cross-layer change in the five-layer PWG→RU
+merge (PWG · PW · SCH · PWKVN · NWS), plus the abridging descendants (MW · AP). It is
+the metadata contract that lets [`REGLUE_SPEC.md`](REGLUE_SPEC.md) place each supplement
+at its correct PWG sense with **zero re-translation**, and the empirical spine of the
+research paper (Deliverable 5 of
+[H180](https://github.com/gasyoun/Uprava/blob/main/handoffs/H180-Opus_RussianTranslation_pwg_ru_addenda_typology_glue_learner_05.07.26.md)).
+
+Status: **first-pass design, LLM-proposed.** Relationship instances are to be emitted
+with `confidence: llm`; the human gold standard is a separate, later deliverable
+(do not conflate).
+
+## 0. What the data already gives us (measured 06-07-2026)
+
+The per-sense translated store
+[`src/pwg_ru_translated.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_ru_translated.jsonl)
+(10,857 sub-cards) already carries the fields this typology attaches to — the
+[H179](https://github.com/gasyoun/Uprava/blob/main/handoffs/H179-Opus_RussianTranslation_pwg_ru_nominal_core_queue_reorder_05.07.26.md)
+Step-1 `layer` field landed:
+
+| `layer` | sub-cards | role |
+|---|---:|---|
+| `pwg`   | 5,276 | skeleton (the only translated *base*) |
+| `pw`    | 5,048 | Böhtlingk shorter — abridging **and** correcting |
+| `sch`   | 146   | Schmidt *Nachträge* — additive |
+| `pwkvn` | 129   | PW *Nachträge* (v.7) + von Negelein — additive |
+| `nws`   | 258   | Neues Wörterbuch scrape — additive, often foreign-language |
+
+Each sub-card also has `subcard` (e.g. `_ap~~h0_00_pwg01`, `_cid~~h0_zz_nws00`),
+`sense_tag` (e.g. `6`, `NWS-1`, `anu_desid`, `ava_caus`), and an empty
+`provenance.relationship` slot — **this typology fills that slot.**
+
+Multi-layer richness (distinct layers per headword, in the translated set):
+
+| # layers | headwords | examples |
+|---:|---:|---|
+| 5 | 7  | `yat`, `vraj`, `rakz`, `jIv`, `gA`, `Sam`, `Cid` |
+| 4 | 25 | `yaj`, `yA`, `vas`, `vah`, `vA`, `pat`, `pA`, `nI` |
+| 3 | 11 | … |
+
+These 5-layer roots are the natural pilot set for
+[`REGLUE_SPEC.md`](REGLUE_SPEC.md).
+
+## 1. The three axes
+
+Every cross-layer change is `(operation, target, direction)` plus an **insertion point**.
+
+### Axis A — Operation
+
+| op | meaning | typical layer |
+|---|---|---|
+| `add` | a sense / source / form absent from PWG | sch, pwkvn, nws |
+| `delete` / `cancel` | PWG material a later layer withdraws | pw |
+| `correct` | same referent, changed value (gender, form, reading) | pw |
+| `restate` | same content, reworded / re-sourced | pw, sch |
+| `relocate` | material moved to a different headword/sense (incl. a supplement *to a supplement*) | pwkvn (Nachträge) |
+| `merge` | two PWG senses collapsed | pw |
+| `split` | one PWG sense divided | pw, sch |
+
+### Axis B — Target
+
+`headword` · `sense/meaning` · `source/citation (<ls>)` · `grammar/gender (<lex>)` ·
+`orthography` · `cross-reference (<ab>vgl.</ab>)`.
+
+### Axis C — Direction
+
+- **Additive** `{pwg_nachtr, sch, pwkvn, nws}` — *grow* the entry (skeleton + supplements).
+- **Abridging** `{pw, mw, ap}` — *shrink* it (a simplification of PWG).
+
+MG's framing, honoured: **addenda and abridgement are the same algebra in two
+directions.** An `add` read backwards is a `delete`; a `split` backwards is a `merge`.
+The typology is therefore *signed*: an instance records `direction` and the same seven
+ops cover both.
+
+## 2. Insertion point (the field REGLUE consumes)
+
+Every non-skeleton instance must resolve **where on the PWG skeleton it attaches**:
+
+```
+insertion_point:
+  key1:          "Ap"          # PWG headword
+  homonym:       "h0"          # PWG homonym slot (from subcard ...~~h0...)
+  target_sense:  "6"           # PWG sense number, or "*whole" / "*new"
+  anchor:        "sense"       # headword | sense | citation | grammar | xref
+```
+
+`target_sense` is the crux of MG's "NWS adds to a *specific* PWG sense (e.g. sense 2),
+not at the end." When a layer supplies a genuinely new sense with no PWG parent,
+`target_sense = "*new"` and the reglue appends it, flagged as an addition.
+
+## 3. First-class special cases (MG-named), with real instances
+
+Each is a `(op, target, direction)` triple with a dedicated `subtype` tag so the reglue
+and the paper can count them.
+
+### 3.1 `pw_cancels` — PW withdraws a PWG word / sense / source / gender
+`op=delete`, `direction=abridging`, `subtype=pw_cancel`. The canonical case is a
+**gender correction** ("PWG n. vs PW m.") — modelled as `delete` of the PWG `<lex>`
+value plus a paired `correct`. Detected by comparing the PWG `<lex>` token against the
+PW sub-card's for the same `key1`+sense.
+
+### 3.2 `sch_star` — SCH adds a new meaning marked `*`
+`op=add`, `target=sense`, `direction=additive`, `subtype=sch_star`.
+**Real instance** — `Ap`, sub-card `_ap~~h0_zz_sch`, `sense_tag=anu_desid`: Schmidt
+adds the preverb+desiderative sense *"einstimmen / соглашаться"* (VP. 4,2,11) absent
+from the PWG skeleton. `target_sense="*new"`.
+
+### 3.3 `nws_at_sense` — NWS adds to a *specific* PWG sense
+`op=add`, `target=sense`, `direction=additive`, `subtype=nws_at_sense`.
+**Real instance** — `Cid`, sub-card `_cid~~h0_zz_nws00`, `sense_tag=NWS-1`: NWS adds a
+mathematical sense *"(in math.) to divide"* (Sūryasiddhānta iv,26). Here `target_sense`
+is a new technical sense → `*new`; when the NWS card names an existing PWG sense the
+`sense_tag` carries it.
+
+### 3.4 `foreign_fragment` — NWS entry partly in FR / LA / **EN**
+`op=add`, `subtype=foreign_fragment`, plus a `needs_ru_from_{fr,la,en}` flag.
+**Correction to the handoff:** the handoff named French/Latin; the scrape shows **English
+too** — the `Cid` NWS card above is authored in English ("(in math.) to divide"). The
+flag must therefore cover `en` as well as `fr`/`la`. These already receive a Russian
+rendering in the translated store, so the flag is provenance, not a translation gap.
+
+### 3.5 `a2a` — Addenda-to-Addenda (nested supplement)
+`op=relocate`, `subtype=a2a`. PWG's *Nachträge* (vol. 7) and PW's *Nachträge* are
+supplements-to-a-supplement. Measured presence in csl-orig and folding rules are in
+[`ADDENDA_TO_ADDENDA_PROBE.md`](ADDENDA_TO_ADDENDA_PROBE.md); the `pwkvn` layer (129
+sub-cards) is exactly this material already pulled into the merge.
+
+### 3.6 `pwkvn_caus` etc. — grammar-derived sub-senses
+`op=add`, `target=grammar`, `subtype=derived_sense`. **Real instance** — `Ap`,
+`_ap~~h0_zz_pwkvn`, `sense_tag=ava_caus`: adds the causative-with-*ava* sense
+("заставлять достигать", NAIṢ. 8,89). The `sense_tag` (`<preverb>_<derivation>`) is
+already a machine-readable attachment key.
+
+## 4. The `provenance.relationship` sidecar schema
+
+Written per non-`pwg` sub-card (the `pwg` skeleton needs none):
+
+```json
+"relationship": {
+  "op": "add",
+  "target": "sense",
+  "direction": "additive",
+  "subtype": "sch_star",
+  "insertion_point": {"key1":"Ap","homonym":"h0","target_sense":"*new","anchor":"sense"},
+  "confidence": "llm",
+  "evidence": "sense_tag=anu_desid; SCH-only preverb+desiderative not in PWG skeleton"
+}
+```
+
+- One row per sub-card; the rollup table in §5 aggregates by `(subtype, layer)`.
+- `confidence`: `llm` (proposed) → `human` (gold, later). Never overwrite an `llm` value
+  in place — append a `human` verdict alongside so κ can be computed.
+- Emitting script (to build): `src/build_relationships.py`, reading
+  `pwg_ru_translated.jsonl` + PWG skeleton, writing the sidecar back per sub-card and a
+  `pwg_ru/relationships_rollup.tsv`. **No workflow / translate call** — pure metadata.
+
+## 5. Rollup table (to be populated by the emitter)
+
+| subtype | op | direction | layer(s) | count | notes |
+|---|---|---|---|---:|---|
+| `sch_star` | add | additive | sch | _tbd_ | new `*` senses |
+| `nws_at_sense` | add | additive | nws | _tbd_ | attach to PWG sense N |
+| `foreign_fragment` | add | additive | nws | _tbd_ | `needs_ru_from_{fr,la,en}` |
+| `derived_sense` | add | additive | pwkvn, sch | _tbd_ | preverb/caus/desid |
+| `a2a` | relocate | additive | pwkvn | _tbd_ | Nachträge-to-Nachträge |
+| `pw_cancel` | delete | abridging | pw | _tbd_ | gender/sense/source withdrawal |
+| `pw_correct` | correct | abridging | pw | _tbd_ | changed value, same referent |
+
+## 6. Validation plan (first pass)
+
+- **Labelled sample:** hand-label `relationship` on the 7 five-layer roots' non-`pwg`
+  sub-cards (~a few dozen) + a random 30 sub-cards, as an interactive HTML voting sheet
+  (never markdown checkboxes — [[feedback_interactive_review_not_checkboxes]]), and
+  compute κ vs the LLM proposal where a second signal exists (the `sense_tag` gives a
+  weak automatic second label for `derived_sense`/`nws_at_sense`).
+- **`pw_cancel` gender check:** deterministic — join PWG vs PW `<lex>` per sense; every
+  disagreement is a candidate `pw_cancel`/`pw_correct`. This needs no LLM and calibrates
+  precision of the abridging-direction ops.
+
+## 7. Guardrails carried from H180
+
+- Never blocks or delays the H179 translation run; consumes its sidecar, does not gate it.
+- No re-translation — operates on already-translated sub-cards.
+- Reuse before deriving: `union_headwords`, `corpus_lexicon`, existing MW/AP crosswalks
+  (check [`SHARED_CODE.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/SHARED_CODE.md)
+  / [`PROJECT_INTERLINKS.md`](https://github.com/gasyoun/Uprava/blob/main/PROJECT_INTERLINKS.md)).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/pwg_ru/LEARNER_APPARATUS_SPEC.md
+++ b/RussianTranslation/pwg_ru/LEARNER_APPARATUS_SPEC.md
@@ -1,0 +1,142 @@
+# Learner-simplified edition — apparatus spec
+
+_Created: 06-07-2026 · Last updated: 06-07-2026_
+
+**Deliverable 4 of
+[H180](https://github.com/gasyoun/Uprava/blob/main/handoffs/H180-Opus_RussianTranslation_pwg_ru_addenda_typology_glue_learner_05.07.26.md).**
+Design for a *lighter PWG for Russian students*: PWG stays the only translated
+skeleton, and the descendant dictionaries **vote** on which senses a learner needs.
+Honours MG's two corrections (05-07-2026): the learner signal is the **Russian student
+tier**, not PW/MW/AP; and edition deltas are tracked at **headword level**.
+
+## 1. The three-tier descendant ladder
+
+All headword counts measured 06-07-2026 (`<L>` entry markers in csl-orig, or line count
+in the extracted jsonl). "Present" = confirmed on disk this session.
+
+### BIG — scholarly abridgements (a *separate* scholarly axis, **NOT** the learner signal)
+
+| code | dict | entries | join | note |
+|---|---|---:|---|---|
+| PW | Böhtlingk kürzere Fassung | 170,556 | csl-orig `pw` | abridging **and** correcting PWG |
+| MW | Monier-Williams | 286,525 | csl-orig `mw` | **larger** than PWG — "abridgement" = entry *depth*, not fewer headwords |
+| AP | Apte (full) | 90,843 | csl-orig `ap` | |
+
+### MEDIUM — scholarly, single-language
+
+| code | dict | entries | lang | note |
+|---|---|---:|---|---|
+| CAE | Cappeller | 40,069 | Sa→En | "based upon the St. Petersburg Lexicons" |
+| **CCS** | Cappeller | 30,010 | Sa→**German** | a same-language abridgement of PW/PWG — unusually useful |
+| MD | Macdonell | 20,749 | Sa→En | |
+
+### SMALL — the **Russian student dictionaries = THE learner signal**
+
+The edition is *for Russian students*, so what these keep is what a learner needs.
+**All already extracted — CONSUME, don't rebuild** ([[reference_corpus_lexicon]]); each is
+a flat `{source, slp1, iast, gloss}` jsonl folded into `corpus_lexicon.jsonl`:
+
+| weight | code | dict | jsonl | entries |
+|---:|---|---|---|---:|
+| **1.00** | KCH | Kochergina 1987 (the modern Sa→Ru anchor, "above all") | `src/koch.jsonl` | 29,177 |
+| 0.70 | KOW | Kossovich 1854 | `src/kow.jsonl` | 13,488 |
+| 0.70 | KNA | Knauer 1908 | `src/kna.jsonl` | (present) |
+| 0.60 | SMI | Smirnov (SamudraManthanam) | `src/smirnov.jsonl` | (present) |
+| 0.50 | FRI | Frisch | `src/fri.jsonl` | (present) |
+
+LAN (Lanman, 4,944, Sa→En) is a secondary English glossary, not weighted in the Russian
+learner core.
+
+## 2. Learner-core score
+
+For each PWG **headword** `k` (SLP1 `key1`):
+
+```
+learner_score(k) = Σ_i  w_i · present_i(k)          # SMALL Russian tier, weighted
+support_score(k) = mean over MEDIUM tier of present(k)   # CAE/CCS/MD backing
+scholarly_score(k) = mean over BIG tier of present(k)    # PW/MW/AP — reported, not gating
+```
+
+- `present_i(k)` joins on normalized SLP1 (see §4 caveat). A headword kept by Kochergina
+  alone already clears a low threshold; kept by ≥2 Russian dicts → solidly learner-core.
+- **Threshold** on `learner_score` (backed by `support_score`) selects the learner
+  edition's headword set. Calibrate the cut on a small human-labelled sample
+  (interactive HTML sheet, not checkboxes — [[feedback_interactive_review_not_checkboxes]]).
+- `scholarly_score` is the **second, independent axis** (MG: PW/MW/AP are
+  abridged-but-scholarly, never for students) — reported alongside, never used to admit a
+  sense into the learner set.
+
+### Sense-level refinement (later)
+
+The student jsonls are **headword→gloss (flat)**, so first-pass retention is
+headword-level. Per-*sense* retention requires aligning each student `gloss` (Russian)
+against the PWG sense glosses — a gloss-to-sense alignment reusing
+`corpus_lexicon.jsonl`, deferred to a second pass. Until then the learner edition keeps
+the full PWG sense set for admitted headwords and only *prunes headwords*.
+
+## 3. Edition deltas at headword level (measured 06-07-2026)
+
+The later editions had access to more PWG entries **and** the completed PW, so
+add/keep/drop vs the earlier edition is itself a learner-relevance signal (what a mature
+editor thought worth adding). Computed by set-diff on `<k1>` SLP1 keys.
+
+### Raw
+
+| pair | old uniq | new uniq | kept | added | dropped |
+|---|---:|---:|---:|---:|---:|
+| AP90 → AP | 34,277 | 88,869 | 26,056 | 62,813 | 8,221 |
+| MW72 → MW | 51,159 | 194,084 | 45,856 | 148,228 | 5,303 |
+
+### ⚠️ Normalization caveat (measured, not assumed)
+
+The raw "dropped" sets are **inflated by orthographic drift between editions**, chiefly
+**final anusvara `-M` vs `-m`** (e.g. AP90 `ABAsanaM` "dropped" ↔ AP `ABAsanam` "added" —
+the *same* word). Collapsing final `M→m` before the diff:
+
+| pair | kept | added | dropped |
+|---|---:|---:|---:|
+| AP90 → AP | 30,240 | 58,628 | **4,030** (was 8,221) |
+| MW72 → MW | 45,856 | 148,209 | **5,301** |
+
+Final-`M` normalization alone **halves** AP90's apparent drops. Residual dropped keys
+still show *internal* anusvara variants (`AByaMtara`, `AKaMqalaH`) → a full delta needs
+proper SLP1 normalization (all anusvara, sandhi-final, homonym-number stripping), not
+just the final-char fix. **Design rule:** the edition-delta and every student-dict join
+in §2 must run through a shared `slp1_norm()` (anusvara + final-sandhi + homonym strip)
+before set operations, or the learner signal inherits this OCR/citation-form noise.
+
+## 4. Secondary aids (not primary sources)
+
+- **English→Sanskrit for disambiguation/essentiality:** MWE (MW reverse, 32,378) + BOR
+  (Borooah, 24,609, En→Sa) — reverse-lookup a candidate sense to narrow the Sanskrit; a
+  word present in the small En→Sa BOR is likely learner-core. Secondary weight only.
+- **PD (Deccan College *Encyclopedic Dictionary of Sanskrit on Historical Principles*,
+  Poona):** **not yet in Cologne** — confirmed absent this session. An OED-scale future
+  comparand; when it lands, compare whether PD exceeds PWG for the **a-** range (ref
+  counts: PWG a- 12,167 · MW 21,742 · AP 6,338 · CAE 3,946). No near-term work.
+- **Etymological layer — KEWA / EWA (Mayrhofer):** an *etymology* signal orthogonal to
+  gloss. `KEWA.txt` (SamudraManthanam) is a word index where **dhātus appear as finite
+  verb forms** (e.g. `bhavati` for root `bhū`) — a normalization gotcha to resolve before
+  joining on roots. Add EWA later; document the crosswalk.
+
+## 5. Build plan (first pass, no re-translation)
+
+1. `src/slp1_norm.py` — the shared normalizer (§3 caveat). Reuse existing transcoder
+   from [`SHARED_CODE.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/SHARED_CODE.md)
+   §1 rather than writing anusvara handling from scratch.
+2. `src/build_learner_scores.py` — join PWG `key1` against the five student jsonls +
+   three MEDIUM + three BIG dicts (all on disk), emit
+   `pwg_ru/learner_scores.tsv` (`key1, learner_score, support_score, scholarly_score,
+   dicts_present`). **No workflow / translate call.**
+3. Calibrate the threshold on a human-labelled sample (HTML sheet).
+4. Doubles as evidence for the Deliverable-5 paper ("how the Petersburg tradition
+   abridged itself").
+
+## 6. Guardrails (H180)
+
+- Never blocks the H179 run; operates on already-translated sub-cards.
+- Reuse before deriving — every dict above is already extracted; do not re-parse.
+- Small human annotation now is OK to calibrate; full gold is a separate later task
+  ([[feedback_second_annotator_deferred]] — do **not** open a recruit-annotator GTD item).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/pwg_ru/NWS_STALENESS_REPORT.md
+++ b/RussianTranslation/pwg_ru/NWS_STALENESS_REPORT.md
@@ -1,0 +1,107 @@
+# NWS-vs-Cologne staleness report
+
+_Created: 06-07-2026 · Last updated: 06-07-2026_
+
+**Deliverable 2 of
+[H180](https://github.com/gasyoun/Uprava/blob/main/handoffs/H180-Opus_RussianTranslation_pwg_ru_addenda_typology_glue_learner_05.07.26.md).**
+Tests MG's hypothesis that **NWS embeds an outdated ~2013 Cologne (Th. Malten) snapshot
+of PW/SCH**, so current csl-orig may carry fixes NWS lacks (or vice-versa), letting NWS
+content silently shadow a corrected Cologne reading.
+
+## Verdict (first pass)
+
+> **The strong staleness hypothesis is NOT confirmed for SCH content.** NWS's embedded
+> Schmidt fragments are **content-identical** to current csl-orig SCH (mean token
+> Jaccard **0.992**, 98.0 % identical). The measurable divergence is **PW coverage**,
+> not content: on a 4,200-headword sample, csl-orig indexes PW material for **10.0 %**
+> of headwords where NWS's snapshot carries none. NWS therefore does **not** silently
+> shadow a *corrected* SCH reading; the open risk is narrower — a *coverage* gap in PW.
+
+## Method
+
+Measured with
+[`src/_nws_drift.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/_nws_drift.py)
+(pre-existing; prior-art reused, not rebuilt) and a sampled driver
+[`src/_nws_drift_sample.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/_nws_drift_sample.py)
+(every 40th scraped **a-**card → 4,200 headwords, for tractability over the 167,991-card
+scrape in `src/pilot/nws/`).
+
+Each scraped card stores its own `sch` (full text), `nws` (full text) and `pw_len`
+(**only the length** of NWS's PW fragment — full PW text was not retained). So:
+- **SCH** — coverage (presence) **and** content (token Jaccard, boilerplate stripped).
+- **PW** — coverage (presence) **and** a coarse length-delta only.
+
+Both NWS and csl-orig digitize the *same print*, so their diff measures what Cologne
+has corrected/added since NWS forked ~2013.
+
+## Results — SCH (Schmidt)
+
+Coverage (4,200 headwords):
+
+| bucket | count | % |
+|---|---:|---:|
+| both | 752 | 17.9 |
+| nws_only (NWS keeps, csl-orig no longer indexes) | 9 | 0.2 |
+| orig_only (Cologne has, NWS 2013 lacks) | 5 | 0.1 |
+| neither | 3,434 | 81.8 |
+
+Content drift on the 752 in-both:
+
+| bucket | count | % |
+|---|---:|---:|
+| identical (Jaccard ≥.95) | 737 | 98.0 |
+| minor (.8–.95) | 2 | 0.3 |
+| moderate (.5–.8) | 6 | 0.8 |
+| major (<.5) | 7 | 0.9 |
+
+**mean Jaccard 0.992.**
+
+**The 7 "major" cases are markup/tokenization artifacts, not editorial drift.** Verified
+`kandala` (Jaccard 0.4): the two texts carry the *same* glosses (*Schädel*, *junger
+Sproß*, *˚Kampf*, *sanfter Ton*) and the *same* citations (S I,117,3; 320,6; 545,6; S
+II,231,10 …); they differ only in markup density — csl-orig wraps `{%…%}` / `<ls>…</ls>`
+/ `{part=…}` metadata that the plain-text NWS fragment lacks, plus NWS's `― Schmidt S.
+133 (show scan)` provenance tail. On short entries a handful of un-stripped markup tokens
+tanks the ratio. So the *true* SCH content-identity is ≥ 99 %, and no verified case shows
+a Cologne correction absent from NWS.
+
+Sampled low-Jaccard keys (for the record): `amlAna` 0.40, `dAS` 0.40,
+`duzpraBaYjana` 0.40, `ekAdaSavyUha` 0.47, `kUrdana` 0.38, `kandala` 0.43, `pAli` 0.41.
+
+## Results — PW (Böhtlingk)
+
+| bucket | count | % |
+|---|---:|---:|
+| both | 3,343 | 79.6 |
+| nws_only | 3 | 0.1 |
+| **orig_only (Cologne indexes PW, NWS snapshot lacks)** | **419** | **10.0** |
+| neither | 435 | 10.4 |
+
+Coarse length delta on the 3,343 in-both: `|Δlen| > 50 %` in **242 (7.2 %)** — but this
+is length-only (full PW text was not stored), so it cannot distinguish a real content
+change from markup/whitespace. **This is the one genuinely open question**: the 10 %
+orig_only + 7 % length-divergent PW cases need the full PW text to adjudicate.
+
+`orig_only` SCH sample (Cologne has, NWS lacks — the rare case that *does* fit the
+hypothesis, but for coverage not correction): `alakzmIka`, `apapivaMs`,
+`bahirvESravaRa`, `cittam`, `pfzwimAMsAdana`.
+
+## Consequence for the merge
+
+- **SCH:** safe. NWS's SCH content matches current Cologne; no silent shadowing of a
+  corrected reading was found. The reglue can trust NWS SCH fragments.
+- **PW:** treat NWS's PW fragment as **potentially under-covered**, never as
+  authoritative over csl-orig PW. Where both exist, prefer csl-orig PW; where only NWS
+  has it, keep but flag `pw_source=nws_snapshot`.
+
+## Next pass (to reach "confirmed")
+
+1. **Re-scrape PW full text** (currently only `pw_len`) for a sample of the 419
+   orig_only + 242 length-divergent headwords, then re-run the Jaccard on PW to convert
+   the coarse length signal into a real content-drift number.
+2. Extend beyond the **a-** section (the scrape is a-only) once other sections are
+   scraped.
+3. Fold the confirmed `orig_only`/`corrected` cases into
+   [`ADDENDA_TYPOLOGY.md`](ADDENDA_TYPOLOGY.md) as `pw_correct` / coverage instances.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/pwg_ru/REGLUE_SPEC.md
+++ b/RussianTranslation/pwg_ru/REGLUE_SPEC.md
@@ -1,0 +1,108 @@
+# Content-aware re-glue spec
+
+_Created: 06-07-2026 · Last updated: 06-07-2026_
+
+**Deliverable 3 of
+[H180](https://github.com/gasyoun/Uprava/blob/main/handoffs/H180-Opus_RussianTranslation_pwg_ru_addenda_typology_glue_learner_05.07.26.md)**
+(canonical after-translation track). The five layers are today glued **mechanically**
+(fixed order PWG → PW → SCH → PWKVN → NWS, no sense-aware placement). This spec designs
+a **content-aware remix** that interleaves the *already-translated* sub-cards so each
+supplement sits at its relevant PWG sense — proving the re-glue is **free** (zero
+re-translation).
+
+## 1. Canonical design ruling (MG 05-07-2026)
+
+- The **layered, provenance-preserving store stays canonical.** Synthesis is a *derived
+  presentation*, built after translation, never replacing the per-sub-card store.
+- Sub-cards stay individually translated + auditable (free re-glue preserved).
+- The remix step **never calls the translate workflow** — it consumes
+  [`src/pwg_ru_translated.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_ru_translated.jsonl)
+  only. This is the proof that re-glue is free.
+
+## 2. Inputs (all already on disk)
+
+Per sub-card, keyed by `key1` + `subcard`:
+- `layer` (H179 Step 1): `pwg` | `pw` | `sch` | `pwkvn` | `nws`.
+- `sense_tag`: PWG sense number (`6`) or supplement tag (`NWS-1`, `anu_desid`, `ava_caus`).
+- `provenance.relationship.insertion_point` (from
+  [`ADDENDA_TYPOLOGY.md`](ADDENDA_TYPOLOGY.md) §2/§4): `{homonym, target_sense, anchor}`.
+- `ru` (translated body) + `de` (source) + the markup (`{%…%}`, `<ls>`, `<lex>`).
+
+## 3. Algorithm (deterministic + light LLM assist)
+
+For each `key1`:
+
+1. **Skeleton.** Take all `layer=pwg` sub-cards, ordered by homonym then `sense_tag`
+   numeric — this is the frame. Everything else hangs off it (MG: "PWG remains the
+   skeleton").
+2. **Attach.** For each non-`pwg` sub-card, read `insertion_point.target_sense`:
+   - a PWG sense number → splice **inside** that sense block as a marked supplement
+     (`— [SCH] …`, `— [NWS] …`), carrying its layer badge + source citations.
+   - `*new` → append as a new, badged sense at the end of the homonym, flagged *addition*.
+   - `*whole` → attach at entry head (applies to the whole headword).
+3. **Cancellations.** A `pw_cancel` / `pw_correct` instance (op=`delete`/`correct`)
+   renders the PWG value **struck / annotated** in place (`PWG n. → PW m.`), never
+   silently dropped — provenance is visible.
+4. **Foreign fragments.** `foreign_fragment` sub-cards (NWS in FR/LA/**EN**) render the
+   Russian translation as the body with the original-language source shown beneath
+   (badge `‹fr›`/`‹la›`/`‹en›`).
+5. **Deterministic first, LLM only for prose smoothing.** Steps 1–4 are pure data
+   placement. An **optional** LLM pass only *smooths connective prose* between spliced
+   blocks (never invents content, never re-translates) and is marked
+   `reglue_smoothed: llm` so it is auditable and skippable.
+
+Output per entry = a **print-oriented card**: PWG skeleton with SCH/NWS/PW/PWKVN
+additions inline at their sense, cancellations struck/annotated, foreign-origin bits
+shown with their RU translation.
+
+## 4. Output artifact
+
+`pwg_ru/reglue/<key1>.json` (+ a rendered `.md`/`.html` for eyeballing), schema:
+
+```json
+{"key1":"gA","homonyms":[
+  {"h":"h0","senses":[
+    {"sense":"1","pwg_ru":"…","supplements":[
+      {"layer":"sch","subtype":"sch_star","ru":"…","source":"…","confidence":"llm"}]},
+    {"sense":"*new","added_by":"nws","ru":"…","source":"Sūryas iv,26","lang":"en"}
+  ]}]}
+```
+
+No field here requires a new translation — every `ru` is copied from the sub-card store.
+
+## 5. Pilot (15 rich multi-layer headwords, zero re-translation)
+
+Chosen from the translated set (measured 06-07-2026; the corpus is verb-root-first per
+H179/H201, so the pilot is roots):
+
+- **5 layers** (pwg+pw+sch+pwkvn+nws): `gA` (319 sub-cards), `Cid` (154 — includes the
+  NWS English foreign-fragment case), `Sam` (172), `jIv` (78), `rakz` (67), `vraj`
+  (128), `yat`.
+- **4 layers**: `DA` (803 — the stress test), `Ap` (152), `Bid` (205), `Buj` (104),
+  `banD` (137), `Sru` (80).
+- **3 layers** (handoff-named family): `viS` (537, pwg+pw+pwkvn), `siD` (187).
+
+`DA` (803 sub-cards) is the load/coherence stress case; `Cid` exercises the
+foreign-fragment path; `gA` exercises all five layers at once.
+
+**Success criteria:** (a) byte-identical `ru` bodies vs the sub-card store (proves zero
+re-translation); (b) every supplement lands at a real PWG sense or a flagged `*new`;
+(c) no cancellation silently dropped; (d) human spot-check of the 15 rendered cards on
+an interactive HTML sheet.
+
+Builder to write: `src/build_reglue.py` (consumes `pwg_ru_translated.jsonl` +
+relationship sidecar; emits `pwg_ru/reglue/`). Depends on
+[`ADDENDA_TYPOLOGY.md`](ADDENDA_TYPOLOGY.md)'s `build_relationships.py` having populated
+`insertion_point`.
+
+## 6. Guardrails
+
+- Never blocks the H179 run; consumes its output.
+- **No re-translation** — assert byte-identity of every `ru` against the store in CI.
+- The layered store remains canonical; `reglue/` is derived and regenerable.
+- LLM smoothing is optional, marked, and content-neutral.
+
+See [`SYNTHESIS_PILOT_10.md`](SYNTHESIS_PILOT_10.md) for the bake-off that tests whether
+*synthesize-German-first* ever beats this after-translation remix.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/pwg_ru/SYNTHESIS_PILOT_10.md
+++ b/RussianTranslation/pwg_ru/SYNTHESIS_PILOT_10.md
@@ -1,0 +1,86 @@
+# Synthesis pilot — synthesize-first vs after-translation remix (10 words)
+
+_Created: 06-07-2026 · Last updated: 06-07-2026_
+
+**Deliverable 3 (comparison pilot) of
+[H180](https://github.com/gasyoun/Uprava/blob/main/handoffs/H180-Opus_RussianTranslation_pwg_ru_addenda_typology_glue_learner_05.07.26.md).**
+Before committing the whole corpus to after-translation remixing
+([`REGLUE_SPEC.md`](REGLUE_SPEC.md)), MG asked for a **bake-off**: for 10 maximally
+diverse headwords, produce two outputs and compare.
+
+- **Arm A — after-translation remix** (canonical): interleave the *already-translated*
+  sub-cards per [`REGLUE_SPEC.md`](REGLUE_SPEC.md). Zero new translation.
+- **Arm B — synthesize-German-first**: for each headword, **synthesize ONE coherent
+  German entry from all its layers, THEN translate that single entry to Russian.** This
+  *loses* free re-glue (a new translation per headword) and can drift from the source —
+  the pilot measures whether the coherence gain is ever worth that cost.
+
+This pilot answers "how good or bad synthesize-first is" *before* the whole mix — it does
+**not** change the canonical ruling (Arm A stays canonical unless Arm B decisively wins).
+
+## The 10 words (measured 06-07-2026 — span the full 1→5 layer range)
+
+The translated corpus is verb-root-first (per H179/H201), so all ten are roots; they are
+chosen to be as different as possible in **layer count, sub-card volume, and special-case
+coverage**:
+
+| # | key1 | layers | sub-cards | why chosen |
+|---|---|---|---:|---|
+| 1 | `dah` | 1 (pwg) | 63 | PWG-only baseline — Arm A ≡ Arm B should be ~identical (control) |
+| 2 | `As` | 2 (pwg,pw) | 90 | minimal abridging layer |
+| 3 | `car` | 2 (pwg,pw) | 257 | larger 2-layer; PW abridgement stress |
+| 4 | `siD` | 3 (pwg,pw,pwkvn) | 187 | Nachträge layer present |
+| 5 | `viS` | 3 (pwg,pw,pwkvn) | 537 | high-volume 3-layer (handoff-named) |
+| 6 | `Ap` | 4 (pwg,pw,sch,pwkvn) | 152 | SCH `*`-sense + PWKVN caus (real special cases) |
+| 7 | `DA` | 4 (pwg,pw,pwkvn,sch) | 803 | volume stress — coherence under load |
+| 8 | `Cid` | 5 | 154 | NWS **English** foreign-fragment (`needs_ru_from_en`) |
+| 9 | `gA` | 5 | 319 | all five layers, high volume |
+| 10 | `Sam` | 5 | 172 | all five layers, second 5-layer point |
+
+## Metrics (per word, both arms)
+
+| axis | how scored |
+|---|---|
+| **fidelity** | does every source sense/citation survive? (count vs the layered store) |
+| **coherence** | reads as one entry vs a pile-up (1–5 human) |
+| **redundancy** | duplicated glosses across layers (lower better) |
+| **fluency** | Russian readability (1–5 human) |
+| **provenance-loss** | can each sense still be traced to its layer? (Arm B risk) |
+| **hallucination risk** | any sense/citation not in any source? (Arm B risk; must be 0) |
+| **cost** | Arm A = 0 new translations; Arm B = 1 synth + 1 translate per word |
+
+Fidelity, redundancy, provenance-loss, hallucination are **machine-checkable** against
+the layered store; coherence + fluency need a small human pass (interactive HTML sheet —
+[[feedback_interactive_review_not_checkboxes]]).
+
+## Procedure
+
+1. Arm A: run `src/build_reglue.py` (per [`REGLUE_SPEC.md`](REGLUE_SPEC.md)) on the 10.
+2. Arm B: `src/synth_de_first.py` — assemble all layers' German (`de`) for a headword →
+   one LLM synthesis prompt → one translation prompt. **Isolated, pilot-only script; not
+   wired into the production pipeline.** Report tier + exact model version at both steps.
+3. Score both on the six axes + cost; write the side-by-side table here.
+4. **Recommendation:** does synthesize-first ever beat after-translation-remix by enough
+   to justify losing free re-glue and accepting hallucination risk? Default expectation
+   (to be tested): Arm B may win *coherence/fluency* on the 5-layer monsters (`gA`, `Sam`,
+   `Cid`) but loses *provenance* and *cost* everywhere; the PWG-only control (`dah`)
+   should tie. State the verdict per layer-count band, not just overall.
+
+## Result table (to fill after runs)
+
+| key1 | arm | fidelity | coherence | redundancy | fluency | prov-loss | halluc | cost |
+|---|---|---|---|---|---|---|---|---|
+| dah | A | | | | | | | 0 |
+| dah | B | | | | | | | 1+1 |
+| … | | | | | | | | |
+
+## Guardrails
+
+- Arm B is a **calibration probe only** — running it does not commit the corpus to
+  synthesize-first, and it must not touch the production translate pipeline or the
+  canonical layered store.
+- Never blocks the H179 run.
+- Report model tier + exact version for every Arm-B generation
+  ([[feedback_state_model_tier]]).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/_nws_drift_sample.py
+++ b/RussianTranslation/src/_nws_drift_sample.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""Sampled NWS-vs-csl-orig drift (first-pass D2). Every Nth scraped a-card."""
+import os, sys, glob, json, collections
+sys.stdout.reconfigure(encoding='utf-8'); sys.stderr.reconfigure(encoding='utf-8')
+import dict_merge as dm, corpus_gate as cg
+import _nws_drift as D
+
+STEP = int(sys.argv[1]) if len(sys.argv)>1 else 20
+OUT = D.OUT
+files = sorted(f for f in glob.glob(os.path.join(OUT,'*.json'))
+               if os.path.basename(f) not in D.CONTROL)
+files = files[::STEP]
+sch_idx, pw_idx = dm.index('sch'), dm.index('pw')
+def joined(idx,k): return ' '.join('\n'.join(b[1:]) for b in idx.get(cg.form_key(k),[]))
+
+n=0; sch=collections.Counter(); pw=collections.Counter(); sims=[]
+changed=[]; missing=[]; pwlen=[]
+for f in files:
+    try: d=json.load(open(f,encoding='utf-8'))
+    except Exception: continue
+    k=d.get('key1');
+    if not k: continue
+    n+=1
+    nws_sch,nws_pw=bool(d.get('sch')),bool(d.get('pw_len'))
+    o_sch,o_pw=joined(sch_idx,k),joined(pw_idx,k)
+    os_has,op_has=bool(o_sch.strip()),bool(o_pw.strip())
+    sch[('both' if nws_sch and os_has else 'nws_only' if nws_sch else 'orig_only' if os_has else 'neither')]+=1
+    pw[('both' if nws_pw and op_has else 'nws_only' if nws_pw else 'orig_only' if op_has else 'neither')]+=1
+    if nws_sch and os_has:
+        s=D.jaccard(D.tokens(d['sch']),D.tokens(o_sch)); sims.append(s)
+        if s<0.5 and len(changed)<10: changed.append((k,round(s,2)))
+    if nws_pw and op_has: pwlen.append((d['pw_len'],len(o_pw)))
+    if os_has and not nws_sch and len(missing)<10: missing.append(k)
+
+print(f"=== NWS drift vs csl-orig — SAMPLED every {STEP}th a-card ({n} cards) ===")
+print("\n-- SCH (Schmidt) coverage --")
+for kk in ('both','nws_only','orig_only','neither'):
+    print("  %-9s %6d (%4.1f%%)"%(kk,sch[kk],100*sch[kk]/n))
+if sims:
+    b=collections.Counter()
+    for s in sims:
+        b['identical (>=.95)' if s>=.95 else 'minor (.8-.95)' if s>=.8 else 'moderate (.5-.8)' if s>=.5 else 'major (<.5)']+=1
+    print(f"\n-- SCH content drift (Jaccard, {len(sims)} in-both) --")
+    for lab in ('identical (>=.95)','minor (.8-.95)','moderate (.5-.8)','major (<.5)'):
+        print("  %-18s %6d (%4.1f%%)"%(lab,b[lab],100*b[lab]/len(sims)))
+    print("  mean Jaccard: %.3f"%(sum(sims)/len(sims)))
+    print("  sample changed (key,sim):",changed)
+print("\n-- PW (Boehtlingk) coverage --")
+for kk in ('both','nws_only','orig_only','neither'):
+    print("  %-9s %6d (%4.1f%%)"%(kk,pw[kk],100*pw[kk]/n))
+if pwlen:
+    big=sum(1 for a,b2 in pwlen if b2 and abs(a-b2)/max(b2,1)>0.5)
+    print("  pw len |d|>50%% (coarse): %d/%d (%.1f%%)"%(big,len(pwlen),100*big/len(pwlen)))
+print("\n  SCH orig_only sample (Cologne has, NWS lacks):",missing)


### PR DESCRIPTION
First pass of the [H180](https://github.com/gasyoun/Uprava/blob/main/handoffs/H180-Opus_RussianTranslation_pwg_ru_addenda_typology_glue_learner_05.07.26.md) multi-session research track — content-aware re-glue / addenda typology / learner-simplification spine for the five-layer PWG→RU merge. Consumes the H179 `layer` sidecar with **zero re-translation**; **never blocks the H179/H201 translation run**.

## Deliverables — [`RussianTranslation/pwg_ru/`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru)

- [`ADDENDA_TYPOLOGY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/ADDENDA_TYPOLOGY.md) — signed operation algebra (7 ops × 6 targets × 2 directions; addenda == abridgement backwards), MG special cases grounded in real translated sub-cards (`sch_star`=Ap/anu_desid, `nws_at_sense`+**English** foreign-fragment=Cid, `derived_sense`=Ap/ava_caus) + `provenance.relationship` sidecar schema.
- [`NWS_STALENESS_REPORT.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/NWS_STALENESS_REPORT.md) — **measured** via existing `_nws_drift.py`: NWS's ~2013 Schmidt snapshot is content-identical to current csl-orig SCH (mean Jaccard **0.992**; the ~1% "major" cases are markup artifacts, verified on `kandala`). Strong staleness hypothesis largely **refuted** for SCH; real signal is PW coverage (10% orig_only).
- [`REGLUE_SPEC.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/REGLUE_SPEC.md) + [`SYNTHESIS_PILOT_10.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/SYNTHESIS_PILOT_10.md) — after-translation remix (canonical, byte-identity asserted) with a 15-headword pilot; synthesize-first bake-off on 10 roots spanning 1→5 layers.
- [`LEARNER_APPARATUS_SPEC.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/LEARNER_APPARATUS_SPEC.md) — 3-tier descendant ladder (Russian-student tier = learner signal, Kochergina 1.00); edition deltas AP90→AP / MW72→MW **measured** with the final-anusvara normalization caveat.
- [`ADDENDA_TO_ADDENDA_PROBE.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/ADDENDA_TO_ADDENDA_PROBE.md) — PWG/PW Nachträge confirmed in csl-orig vol.7; the `pwkvn` layer IS that A2A material, page-anchored `relocate`, already merged.

Paper registered as **A49** in [`Uprava/ARTICLES.md`](https://github.com/gasyoun/Uprava/blob/main/ARTICLES.md). LLM-proposed (`confidence: llm`); human gold deferred. Model: Opus 4.8 (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)