### PR TITLE
fix(pwg-ru): harden workflow reuse guards

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -20,6 +20,16 @@ Two live tracks:
 
 ## ➡️ Next Steps (Queue)
 
+- [x] **pwg_ru code-hardening fix plan implemented (2026-07-06, Codex/GPT-5).**
+      Local safety fixes landed before any new Max generation: strict key-only full-card
+      response matching, fragment key checks, zero-marker TM sanity checks, partial-card
+      exclusion from exact TM, defensive `supersedes` handling, nominal provenance without
+      rootmaps, fixed `reverse_index --show`, and `validate_assembled_export.py --expected-cards`.
+      Validation passed: `window_selftest.py`, `lang_parity_check.py`,
+      `translation_memory.py selftest`, `reverse_index.py --show "m·8n*"`, and assembled-card
+      fixture validation in both `--min-cards` and `--expected-cards` modes. H201 Max Workflow
+      run remains not executed and still needs the external Sonnet/Max surface.
+
 - [x] **pwg_ru H191 verify/optimize + 100-small nominal staging shipped (2026-07-05,
       Codex/GPT-5).** Deterministic only: no Max/Workflow generation run. On branch
       `codex/h191-pwg-ru-verify-optimize-100small`, H189 was re-verified

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "5bbb029b2dc287f52d4efd4f9f44ff4a12952a15984554568afa645eec2804bd",
-      "src/pilot/window_selftest.py": "627a671f20375e83d096781ec77efe159f4ac3112f5f6a4d76b0d73035e694c6"
+      "src/pilot/window_selftest.py": "11f03300636ea4ac28c814e3c1d8ee31dfdb2ca130aab30edc60ba77a2c5b7b3"
     }
   },
   {
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "c29028a775500850ba5e904194a5afba41581deb2e59b6f61de11f3a7fe6bd93"
+      "src/pilot/gen_opt_harness2.py": "538f766a3daab042a8edce17c003e13cba92d910869226d49afa25abb2a8581c"
     }
   },
   {
@@ -117,8 +117,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "c29028a775500850ba5e904194a5afba41581deb2e59b6f61de11f3a7fe6bd93",
-      "src/pilot/window_selftest.py": "627a671f20375e83d096781ec77efe159f4ac3112f5f6a4d76b0d73035e694c6"
+      "src/pilot/gen_opt_harness2.py": "538f766a3daab042a8edce17c003e13cba92d910869226d49afa25abb2a8581c",
+      "src/pilot/window_selftest.py": "11f03300636ea4ac28c814e3c1d8ee31dfdb2ca130aab30edc60ba77a2c5b7b3"
     }
   },
   {
@@ -136,8 +136,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "c29028a775500850ba5e904194a5afba41581deb2e59b6f61de11f3a7fe6bd93",
-      "src/pilot/window_selftest.py": "627a671f20375e83d096781ec77efe159f4ac3112f5f6a4d76b0d73035e694c6"
+      "src/pilot/gen_opt_harness2.py": "538f766a3daab042a8edce17c003e13cba92d910869226d49afa25abb2a8581c",
+      "src/pilot/window_selftest.py": "11f03300636ea4ac28c814e3c1d8ee31dfdb2ca130aab30edc60ba77a2c5b7b3"
     }
   },
   {
@@ -154,7 +154,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "c29028a775500850ba5e904194a5afba41581deb2e59b6f61de11f3a7fe6bd93"
+      "src/pilot/gen_opt_harness2.py": "538f766a3daab042a8edce17c003e13cba92d910869226d49afa25abb2a8581c"
     }
   },
   {
@@ -171,7 +171,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "c29028a775500850ba5e904194a5afba41581deb2e59b6f61de11f3a7fe6bd93"
+      "src/pilot/gen_opt_harness2.py": "538f766a3daab042a8edce17c003e13cba92d910869226d49afa25abb2a8581c"
     }
   },
   {
@@ -188,7 +188,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "lang is a first-class parameter of the TM address (sha256(lang + ...)); --lang=ru|en both get full reuse.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "11d32e2cdb5ca2faeb18a6d8ac67c30e2927c073baf493c2a963150d12b55d60"
+      "src/pilot/translation_memory.py": "7067832e30e9e0c93b43fd010a90758335d605ce1bd25ca431c2121d205472c9"
     }
   },
   {
@@ -205,7 +205,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "c29028a775500850ba5e904194a5afba41581deb2e59b6f61de11f3a7fe6bd93"
+      "src/pilot/gen_opt_harness2.py": "538f766a3daab042a8edce17c003e13cba92d910869226d49afa25abb2a8581c"
     }
   },
   {
@@ -222,7 +222,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "c29028a775500850ba5e904194a5afba41581deb2e59b6f61de11f3a7fe6bd93"
+      "src/pilot/gen_opt_harness2.py": "538f766a3daab042a8edce17c003e13cba92d910869226d49afa25abb2a8581c"
     }
   },
   {
@@ -238,7 +238,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The bare 'sonnet' alias resolved to Sonnet 4.6 (not 5.0) on a prior EN run — pinned explicitly there after that surprise. RU's alias was never observed to misresolve, so it was left alone rather than touching a stable production path for a problem it doesn't have. Re-evaluate if RU is ever caught on a stale alias too.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "c29028a775500850ba5e904194a5afba41581deb2e59b6f61de11f3a7fe6bd93"
+      "src/pilot/gen_opt_harness2.py": "538f766a3daab042a8edce17c003e13cba92d910869226d49afa25abb2a8581c"
     }
   },
   {
@@ -315,8 +315,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "c29028a775500850ba5e904194a5afba41581deb2e59b6f61de11f3a7fe6bd93",
-      "src/pilot/window_selftest.py": "627a671f20375e83d096781ec77efe159f4ac3112f5f6a4d76b0d73035e694c6"
+      "src/pilot/gen_opt_harness2.py": "538f766a3daab042a8edce17c003e13cba92d910869226d49afa25abb2a8581c",
+      "src/pilot/window_selftest.py": "11f03300636ea4ac28c814e3c1d8ee31dfdb2ca130aab30edc60ba77a2c5b7b3"
     }
   },
   {
@@ -335,7 +335,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "627a671f20375e83d096781ec77efe159f4ac3112f5f6a4d76b0d73035e694c6"
+      "src/pilot/window_selftest.py": "11f03300636ea4ac28c814e3c1d8ee31dfdb2ca130aab30edc60ba77a2c5b7b3"
     }
   },
   {
@@ -372,8 +372,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "c29028a775500850ba5e904194a5afba41581deb2e59b6f61de11f3a7fe6bd93",
-      "src/pilot/window_selftest.py": "627a671f20375e83d096781ec77efe159f4ac3112f5f6a4d76b0d73035e694c6"
+      "src/pilot/gen_opt_harness2.py": "538f766a3daab042a8edce17c003e13cba92d910869226d49afa25abb2a8581c",
+      "src/pilot/window_selftest.py": "11f03300636ea4ac28c814e3c1d8ee31dfdb2ca130aab30edc60ba77a2c5b7b3"
     }
   },
   {
@@ -410,7 +410,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "c29028a775500850ba5e904194a5afba41581deb2e59b6f61de11f3a7fe6bd93",
+      "src/pilot/gen_opt_harness2.py": "538f766a3daab042a8edce17c003e13cba92d910869226d49afa25abb2a8581c",
       "src/promote_final_cards.py": "abb57e9a41e8969346e854fd4d4682b97abdabf203a102b6a5d11fa657eaaa22"
     }
   },
@@ -430,9 +430,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "c29028a775500850ba5e904194a5afba41581deb2e59b6f61de11f3a7fe6bd93",
+      "src/pilot/gen_opt_harness2.py": "538f766a3daab042a8edce17c003e13cba92d910869226d49afa25abb2a8581c",
       "src/pilot/perf_preflight.py": "4593a0499b74b1a9557e07b69280e9dd352c01bd816571895a7b3fc1e5ebbb2f",
-      "src/pilot/window_selftest.py": "627a671f20375e83d096781ec77efe159f4ac3112f5f6a4d76b0d73035e694c6"
+      "src/pilot/window_selftest.py": "11f03300636ea4ac28c814e3c1d8ee31dfdb2ca130aab30edc60ba77a2c5b7b3"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -695,9 +695,9 @@ def tm_card_sane(card, lang, field, raw):
               for s in rec.get('senses') or []))
     sk = sum(((s.get('german') or '').count('{#') for rec in card.get('records') or []
               for s in rec.get('senses') or []))
-    if ls and ls != raw.count('<ls'):
+    if ls != raw.count('<ls'):
         return False, '<ls> count drift'
-    if sk and sk != raw.count('{#'):
+    if sk != raw.count('{#'):
         return False, '{# count drift'
     return True, ''
 
@@ -1194,6 +1194,11 @@ const cardTokens = card => { let a = []; for (const rec of (card.records || []))
 // '=== CARD <key> ===' header). Used to match responses by KEY first, position second —
 // positional-only matching silently misassigns every card after an omitted/reordered one.
 const byKey1 = cards => { const m = {}; for (const c of cards) if (c && c.key1 !== undefined && !(c.key1 in m)) m[c.key1] = c; return m }
+const exactCard = (cards, km, expected, fallbackIndex) => {
+  if (km[expected] !== undefined) return km[expected]
+  const c = cards[fallbackIndex]
+  return (c && c.key1 === expected) ? c : null
+}
 function restoreCard(card, k) {
   const ph = PH[k] || []
   for (const rec of (card.records || [])) for (const s of (rec.senses || [])) {
@@ -1271,8 +1276,14 @@ async function healGroup(k, idxs, grp, label) {
     }
     if (res && Array.isArray(res.cards)) {
       const km = byKey1(res.cards)
-      // match by echoed key1 first; fall back to position within the pending set
-      pending.forEach((fi, idx) => { acceptFrag(km[fkey(fi)] !== undefined ? km[fkey(fi)] : res.cards[idx], fi) })
+      // Fragments may arrive reordered, but a positional fallback is safe only when the
+      // fallback card still echoes the exact fragment key and passes the token multiset guard.
+      pending.forEach((fi, idx) => {
+        const fk = fkey(fi)
+        const cand = exactCard(res.cards, km, fk, idx)
+        if (!cand) { noteFail(fk, 'missing-or-mismatched-fragment-key'); return }
+        acceptFrag(cand, fi)
+      })
     } else {
       pending.forEach(fi => noteFail(fkey(fi), res ? 'malformed-response (no cards[])' : 'agent-returned-null'))
     }
@@ -1428,14 +1439,13 @@ async function resolveGroup(pending, label) {
       break
     }
     if (res && Array.isArray(res.cards)) {
-      // Match responses by their echoed key1 FIRST, position second. Positional-only
-      // matching shifts every card after an omitted/reordered one onto the wrong key;
-      // accept()'s count guard catches MOST such shifts, but two cards with equal
-      // <ls>/{# counts would swap silently — content under the wrong headword.
+      // Match responses by their echoed key1 ONLY. Positional fallback can silently put
+      // content under the wrong headword when a model omits/reorders cards, especially for
+      // zero-marker cross-reference stubs where count-based fidelity guards are blind.
       const km = byKey1(res.cards)
       cur.forEach((k, i) => {
-        const cand = km[k] !== undefined ? km[k] : res.cards[i]
-        if (cand === undefined || cand === null) { noteFail(k, 'missing-from-response'); return }
+        const cand = km[k]
+        if (cand === undefined || cand === null) { noteFail(k, 'missing-or-mismatched-key'); return }
         const c = accept(cand, k)
         if (c) resolved[k] = c
       })

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -171,6 +171,14 @@ def _entry_time(row):
     return ''
 
 
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
 def reusable(row):
     if not row:
         return False
@@ -187,7 +195,7 @@ def best_reusable(rows):
     candidates = [r for r in rows if reusable(r)]
     if not candidates:
         return None
-    superseded = {s for r in candidates for s in (r.get('supersedes') or []) if s}
+    superseded = {s for r in candidates for s in _as_list(r.get('supersedes')) if s}
     candidates = [r for r in candidates if not r.get('id') or r.get('id') not in superseded]
     if not candidates:
         return None
@@ -253,6 +261,12 @@ def reconstruct_cards(store_path, lang):
 
     entries, skipped = {}, Counter()
     for sub, rows in by_sub.items():
+        if any((r.get('provenance') or {}).get('partial_card') or
+               (r.get('provenance') or {}).get('missing_fragments') or
+               (r.get('provenance') or {}).get('missing_groups')
+               for r in rows):
+            skipped['partial-card'] += 1
+            continue
         shas = {(r.get('provenance') or {}).get('input_raw_sha256') for r in rows}
         shas.discard(None)
         if not shas:
@@ -1184,7 +1198,8 @@ def validation_ok(stats):
 def selftest():
     import tempfile
     # Two sub-cards; the second row-set disagrees on the source sha (must be skipped),
-    # the third is missing a translation (must be skipped), the fourth has no sha (skipped).
+    # the third is missing a translation (must be skipped), the fourth has no sha (skipped),
+    # and the fifth is a partial selfheal card (usable as output evidence, but not exact TM).
     rows = [
         {'subcard': 'x~~h0_1', 'key1': 'x', 'iast': 'xa', 'h': 'xa', 'sense_tag': '1',
          'ru': 'один', 'de': 'eins', 'equivalence_type': 'equivalent', 'source_type': 'attested',
@@ -1202,6 +1217,10 @@ def selftest():
          'ru': '', 'de': 'fuenf', 'provenance': {'input_raw_sha256': 'DDD'}},         # missing ru
         {'subcard': 'w~~h0_1', 'key1': 'w', 'iast': 'wa', 'h': 'wa', 'sense_tag': '1',
          'ru': 'шесть', 'de': 'sechs', 'provenance': {}},                             # no sha
+        {'subcard': 'p~~h0_1', 'key1': 'p', 'iast': 'pa', 'h': 'pa', 'sense_tag': '1',
+         'ru': 'семь', 'de': 'sieben',
+         'provenance': {'input_raw_sha256': 'EEE', 'partial_card': True,
+                        'missing_fragments': ['g1:f2']}},                              # partial
     ]
     fd, store = tempfile.mkstemp(suffix='.jsonl'); os.close(fd)
     fd, out = tempfile.mkstemp(suffix='.json'); os.close(fd)
@@ -1220,6 +1239,7 @@ def selftest():
         assert skipped['sha-disagreement'] == 1, skipped
         assert skipped['incomplete-ru'] == 1, skipped
         assert skipped['no-raw-sha'] == 1, skipped
+        assert skipped['partial-card'] == 1, skipped
         # build + load + lookup round-trip
         path, n, _ = build(store, 'ru', out=out)
         assert n == 1, n
@@ -1308,6 +1328,9 @@ def _trust_selftest():
     assert best_reusable([good_old, good_new])['id'] == 'new'
     assert best_reusable([good_new, reviewed])['id'] == 'rev'
     assert best_reusable([blocked]) is None
+    superseded = dict(good_new, id='newer', supersedes='old')
+    assert best_reusable([good_old, superseded])['id'] == 'newer', \
+        'string supersedes must be treated as one id, not iterated character-by-character'
     mixed_rows = [
         {'review_status': 'approved', 'gate_status': 'human_reviewed'},
         {'review_status': 'rejected', 'gate_status': 'defect'},

--- a/RussianTranslation/src/pilot/window_provenance.py
+++ b/RussianTranslation/src/pilot/window_provenance.py
@@ -11,7 +11,38 @@ if SRC not in sys.path:
 from safe_filename import safe_name
 
 
-def current_root_provenance(root, selected_keys=None):
+def current_root_provenance(root, selected_keys=None, nominal=False):
+    if nominal:
+        keys = selected_keys or []
+        if not keys:
+            return {'ok': False, 'rootmap_path': None,
+                    'error': 'nominal window %r has no selected_keys' % root}
+        input_hashes = {}
+        missing = []
+        for key in keys:
+            raw_path, portrait_path = input_paths(key, input_dir=INP)
+            rec = {}
+            if os.path.exists(raw_path):
+                rec['raw_sha256'] = sha256_file(raw_path)
+            else:
+                missing.append(key + '.raw.txt')
+            if os.path.exists(portrait_path):
+                rec['portrait_sha256'] = sha256_file(portrait_path)
+            else:
+                missing.append(key + '.portrait.json')
+            input_hashes[key] = rec
+        return {
+            'ok': True,
+            'root': root,
+            'safe_root': safe_name(root),
+            'nominal': True,
+            'rootmap_path': None,
+            'rootmap_sha256': None,
+            'root_keys': keys,
+            'selected_keys': keys,
+            'input_hashes': input_hashes,
+            'missing_inputs': missing,
+        }
     rootmap = rootmap_for(root)
     if not rootmap:
         return {'ok': False, 'rootmap_path': None, 'error': 'no rootmap for %r' % root}
@@ -58,7 +89,8 @@ def stale_check(root, workflow_meta, workflow_keys):
         selected_keys = None
     else:
         selected_keys = workflow_meta.get('selected_keys') or None
-    current = current_root_provenance(root, selected_keys)
+    nominal = bool((workflow_meta or {}).get('nominal'))
+    current = current_root_provenance(root, selected_keys, nominal=nominal)
     check['current'] = current
     if not current.get('ok'):
         check['ok'] = False
@@ -68,7 +100,7 @@ def stale_check(root, workflow_meta, workflow_keys):
 
     root_keys = current['root_keys']
     expected_keys = current['selected_keys']
-    if selected_keys:
+    if selected_keys and not nominal:
         invalid = sorted(set(selected_keys) - set(root_keys))
         if invalid:
             check['errors'].append('workflow selected keys not in current rootmap: %s' %
@@ -94,7 +126,7 @@ def stale_check(root, workflow_meta, workflow_keys):
         if workflow_meta.get('safe_root') and workflow_meta.get('safe_root') != safe_name(root):
             check['errors'].append('workflow safe_root %r != current safe_root %r' %
                                    (workflow_meta.get('safe_root'), safe_name(root)))
-        if workflow_meta.get('rootmap_sha256') != current['rootmap_sha256']:
+        if not nominal and workflow_meta.get('rootmap_sha256') != current['rootmap_sha256']:
             check['errors'].append('rootmap hash mismatch')
         workflow_hashes = workflow_meta.get('input_hashes') or {}
         for key in expected_keys:
@@ -120,15 +152,19 @@ def harness_matches_current_root(report):
     current = stale.get('current') or {}
     expected = current.get('selected_keys') or []
     meta = harness_meta()
-    if not root or not current.get('rootmap_sha256') or not expected:
+    nominal = bool((report.get('workflow_meta') or {}).get('nominal') or
+                   (stale.get('workflow_meta') or {}).get('nominal') or current.get('nominal'))
+    if not root or not expected:
+        return False, meta
+    if not nominal and not current.get('rootmap_sha256'):
         return False, meta
     if not meta.get('ok'):
         return False, meta
-    ok = (
-        meta.get('root') == root and
-        meta.get('rootmap_sha256') == current.get('rootmap_sha256') and
-        (meta.get('selected_keys') or []) == expected
-    )
+    ok = (meta.get('root') == root and (meta.get('selected_keys') or []) == expected)
+    if nominal:
+        ok = ok and bool((meta.get('meta') or {}).get('nominal'))
+    else:
+        ok = ok and meta.get('rootmap_sha256') == current.get('rootmap_sha256')
     if not ok:
         meta['scope_error'] = 'harness scope does not match current rootmap selection'
     return ok, meta

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -133,11 +133,15 @@ def test_harness_scope_and_tools():
     meta = harness_meta()  # canonical opt2 harness (window_common.OPT_HARNESS)
     if not meta.get('ok'):
         fail('optimized harness missing or invalid: %s' % meta.get('error'))
-    current = current_root_provenance(meta.get('root'), meta.get('selected_keys'))
+    is_nominal = bool((meta.get('meta') or {}).get('nominal'))
+    current = current_root_provenance(meta.get('root'), meta.get('selected_keys'),
+                                      nominal=is_nominal)
     if not current.get('ok'):
         fail('current root provenance unavailable: %s' % current.get('error'))
-    if meta.get('rootmap_sha256') != current.get('rootmap_sha256'):
+    if not is_nominal and meta.get('rootmap_sha256') != current.get('rootmap_sha256'):
         fail('optimized harness rootmap hash does not match current rootmap')
+    if is_nominal and meta.get('rootmap_sha256') is not None:
+        fail('nominal optimized harness must not pretend to have a rootmap hash')
     if meta.get('selected_keys') != current.get('selected_keys'):
         fail('optimized harness selected_keys do not match current rootmap selection')
     text = open(meta['path'], encoding='utf-8').read()
@@ -160,7 +164,8 @@ def test_stale_check_key_order_independent():
     if not meta.get('ok'):
         fail('optimized harness missing or invalid: %s' % meta.get('error'))
     root = meta.get('root')
-    current = current_root_provenance(root, meta.get('selected_keys'))
+    is_nominal = bool((meta.get('meta') or {}).get('nominal'))
+    current = current_root_provenance(root, meta.get('selected_keys'), nominal=is_nominal)
     if not current.get('ok'):
         fail('current root provenance unavailable: %s' % current.get('error'))
     workflow_meta = {
@@ -169,6 +174,7 @@ def test_stale_check_key_order_independent():
         'rootmap_sha256': current['rootmap_sha256'],
         'selected_keys': current['selected_keys'],
         'input_hashes': current['input_hashes'],
+        'nominal': is_nominal,
     }
     reordered_keys = list(reversed(current['selected_keys']))
     check = stale_check(root, workflow_meta, reordered_keys)
@@ -176,6 +182,46 @@ def test_stale_check_key_order_independent():
         fail('stale_check flagged reordered-but-identical key set as a mismatch')
     if check['stale']:
         fail('stale_check treated an order-only difference as stale: %s' % check.get('errors'))
+
+
+def test_nominal_provenance_without_rootmap():
+    """Nominal windows use selected headword keys directly; lack of a rootmap is expected."""
+    import gen_opt_harness2 as gh
+    from window_common import input_paths
+    keys = ['_selftest_nominal_prov']
+    rp, pp = input_paths(keys[0])
+    old_raw = open(rp, encoding='utf-8').read() if os.path.exists(rp) else None
+    old_portrait = open(pp, encoding='utf-8').read() if os.path.exists(pp) else None
+    try:
+        os.makedirs(os.path.dirname(rp), exist_ok=True)
+        with open(rp, 'w', encoding='utf-8') as f:
+            f.write('<L>1<pc>1<k1>a<k2>a<h>1\n<body>{#a#} x</body>\n')
+        with open(pp, 'w', encoding='utf-8') as f:
+            json.dump({'key1': 'a', 'lex': 'm.'}, f)
+        current = current_root_provenance('nominal_selftest', keys, nominal=True)
+        if not current.get('ok') or current.get('rootmap_sha256') is not None:
+            fail('nominal provenance must succeed without a rootmap')
+        workflow_meta = {
+            'root': 'nominal_selftest',
+            'safe_root': current['safe_root'],
+            'rootmap_sha256': None,
+            'selected_keys': keys,
+            'input_hashes': current['input_hashes'],
+            'nominal': True,
+        }
+        check = stale_check('nominal_selftest', workflow_meta, list(reversed(keys)))
+        if check['stale']:
+            fail('nominal stale_check must not require a rootmap: %s' % check.get('errors'))
+    finally:
+        for path, old in ((rp, old_raw), (pp, old_portrait)):
+            if old is None:
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+            else:
+                with open(path, 'w', encoding='utf-8') as f:
+                    f.write(old)
 
 
 def test_prompt_rule_audit_template():
@@ -1345,7 +1391,7 @@ def test_tm_pre_resolves_cards():
     in TM_RESOLVED, excluded from every translate lane), and the total-accounting invariant
     (tm ∪ batched ∪ presplit == selected, disjoint) holds. Uses a real root's on-disk inputs."""
     import gen_opt_harness2 as gh
-    from window_common import rootmap_path, input_paths, sha256_file
+    from window_common import rootmap_path, input_paths, sha256_file, read_text
     root = 'gam'
     rmpath, _ = rootmap_path(root)
     if not rmpath:
@@ -1359,9 +1405,10 @@ def test_tm_pre_resolves_cards():
     try:
         entries = {}
         for k in cached:
-            sha = sha256_file(input_paths(k)[0])
+            raw_path = input_paths(k)[0]
+            sha = sha256_file(raw_path)
             entries['ru:%s' % sha] = {'card': {'key1': k, 'iast': None,
-                'records': [{'h': None, 'senses': [{'tag': '1', 'german': 'g', 'russian': 'р',
+                'records': [{'h': None, 'senses': [{'tag': '1', 'german': read_text(raw_path), 'russian': 'р',
                     'equivalence_type': 'equivalent', 'source_type': 'attested',
                     'stratum': '', 'differentia': ''}]}]}, 'src_key': k}
         with open(tmfile, 'w', encoding='utf-8') as f:
@@ -1394,6 +1441,55 @@ def test_tm_pre_resolves_cards():
             os.remove(tmfile)
         except OSError:
             pass
+
+
+def test_tm_card_sane_rejects_zero_marker_drift():
+    """A cached card with zero citations/Sanskrit markers must not satisfy a cited source."""
+    import gen_opt_harness2 as gh
+    raw = '{#agni#}¦ Feuer <ls>RV. 1</ls>.'
+    card = {'records': [{'senses': [{'tag': '1', 'german': 'Feuer',
+                                     'russian': 'огонь'}]}]}
+    ok, why = gh.tm_card_sane(card, 'ru', 'russian', raw)
+    if ok or '<ls>' not in why:
+        fail('zero-<ls> cached card must be refused for cited source, got ok=%r why=%r' %
+             (ok, why))
+    raw2 = '{#agni#}¦ Feuer.'
+    card2 = {'records': [{'senses': [{'tag': '1', 'german': 'Feuer',
+                                      'russian': 'огонь'}]}]}
+    ok2, why2 = gh.tm_card_sane(card2, 'ru', 'russian', raw2)
+    if ok2 or '{#' not in why2:
+        fail('zero-{# cached card must be refused for Sanskrit-marked source, got ok=%r why=%r' %
+             (ok2, why2))
+
+
+def test_generated_harness_strict_key_matching():
+    """Generated JS must not positionally assign a returned full card to another key."""
+    import gen_opt_harness2 as gh
+    raw = '<L>1<pc>1<k1>a<k2>a<h>1\n{#a#}¦ {%eins%}.\n'
+    d = tempfile.mkdtemp()
+    keys = ['zz_key_a', 'zz_key_b']
+    saved_ip = gh.input_paths
+    try:
+        for k in keys:
+            with open(os.path.join(d, k + '.raw.txt'), 'w', encoding='utf-8') as f:
+                f.write(raw)
+            with open(os.path.join(d, k + '.portrait.json'), 'w', encoding='utf-8') as f:
+                f.write('{}')
+        gh.input_paths = lambda k, input_dir=None: (
+            os.path.join(d, k + '.raw.txt'), os.path.join(d, k + '.portrait.json'))
+        js, _batches = gh.build('zz', keys, None, 12000, nominal=True,
+                                grammar_on=False, tm_path=None)
+        if 'const cand = km[k]' not in js:
+            fail('full-card lane must use strict key lookup, not positional fallback')
+        if 'res.cards[i]' in js or 'res.cards[idx], fi' in js:
+            fail('generated harness still has unsafe positional response assignment')
+        if 'missing-or-mismatched-key' not in js:
+            fail('missing/mismatched full-card keys must get an explicit failure reason')
+        if 'missing-or-mismatched-fragment-key' not in js:
+            fail('missing/mismatched fragment keys must get an explicit failure reason')
+    finally:
+        gh.input_paths = saved_ip
+        shutil.rmtree(d, ignore_errors=True)
 
 
 def test_tm_auto_no_sidecar_metadata():
@@ -2455,6 +2551,8 @@ def main():
     tests = [
         test_translation_memory_addressing,
         test_tm_pre_resolves_cards,
+        test_tm_card_sane_rejects_zero_marker_drift,
+        test_generated_harness_strict_key_matching,
         test_tm_auto_no_sidecar_metadata,
         test_suggest_tm_does_not_skip_agents,
         test_tm_publication_fixtures_validate,
@@ -2495,6 +2593,7 @@ def main():
         test_requeue_transient_vs_defect_state,
         test_harness_scope_and_tools,
         test_stale_check_key_order_independent,
+        test_nominal_provenance_without_rootmap,
         test_prompt_rule_audit_template,
         test_prompt_rule_audit_missing_blocks,
         test_semantic_risk_checker,

--- a/RussianTranslation/src/reverse_index.py
+++ b/RussianTranslation/src/reverse_index.py
@@ -150,9 +150,11 @@ def _representative(token):
     """First (k1, lex) headword carrying `token`, from headword_index.tsv (built on demand)."""
     if not os.path.exists(HW_TSV):
         build()
-    for line in open(HW_TSV, encoding='utf-8'):
+    for i, line in enumerate(open(HW_TSV, encoding='utf-8')):
         parts = line.rstrip('\n').split('\t')
-        if len(parts) == 4 and parts[3] == token:
+        if i == 0:
+            continue
+        if len(parts) >= 5 and parts[4] == token:
             return parts[0], parts[2]            # k1, lex
     return None, None
 

--- a/RussianTranslation/src/validate_assembled_export.py
+++ b/RussianTranslation/src/validate_assembled_export.py
@@ -8,7 +8,7 @@ This gate checks the local output of:
 It deliberately uses only the standard library. The export itself is gitignored,
 but the validator is committed so G4 can be reproduced before a print cut.
 
-  python validate_assembled_export.py [--min-cards N] [--cards PATH] [--quarantine PATH]
+  python validate_assembled_export.py [--expected-cards N | --min-cards N] [--cards PATH] [--quarantine PATH]
 """
 import argparse
 import json, os, sys
@@ -139,6 +139,8 @@ def parse_args():
         description='Validate the deterministic assembled-card export.')
     ap.add_argument('--min-cards', type=int,
                     help='minimum card count for bounded/fixture validation')
+    ap.add_argument('--expected-cards', type=int,
+                    help='exact card count for bounded/fixture validation')
     ap.add_argument('--cards', default=OUT,
                     help='assembled cards JSONL path')
     ap.add_argument('--quarantine', default=QUARANTINE,
@@ -146,12 +148,17 @@ def parse_args():
     args = ap.parse_args()
     if args.min_cards is not None and args.min_cards < 1:
         ap.error('--min-cards must be a positive integer')
+    if args.expected_cards is not None and args.expected_cards < 1:
+        ap.error('--expected-cards must be a positive integer')
+    if args.min_cards is not None and args.expected_cards is not None:
+        ap.error('--min-cards and --expected-cards are mutually exclusive')
     return args
 
 
 def main():
     args = parse_args()
     min_cards = args.min_cards
+    expected_cards = args.expected_cards
     out, quarantine_path = args.cards, args.quarantine
     if not os.path.exists(out):
         fail('missing %s; run python assemble.py build first' % os.path.basename(out))
@@ -160,13 +167,17 @@ def main():
 
     cards = load_jsonl(out)
     quarantine = load_jsonl(quarantine_path)
-    expected = expected_card_count() if min_cards is None else None
-    if min_cards is None and len(cards) != expected:
-        fail('assembled card count %d does not match PWG grouped count %d' %
-             (len(cards), expected))
+    expected = expected_card_count() if min_cards is None and expected_cards is None else expected_cards
+    if expected is not None and len(cards) != expected:
+        label = 'PWG grouped count' if expected_cards is None else 'expected bounded count'
+        fail('assembled card count %d does not match %s %d' %
+             (len(cards), label, expected))
     if min_cards is not None and len(cards) < min_cards:
         fail('assembled card count %d is below required minimum %d' %
              (len(cards), min_cards))
+    if min_cards is not None:
+        print('warning: --min-cards is a floor-only bounded check; use --expected-cards when the fixture count is known',
+              file=sys.stderr)
 
     covered = quarantined_in_cards = 0
     for line_no, card in cards:
@@ -180,7 +191,7 @@ def main():
              (quarantined_in_cards, len(quarantine)))
 
     pct = 100.0 * covered / max(len(cards), 1)
-    mode = 'full' if min_cards is None else 'bounded'
+    mode = 'full' if min_cards is None and expected_cards is None else 'bounded'
     print('assembled export validation OK (%s): %d cards, %d covered (%.1f%%), %d quarantined record(s)' %
           (mode, len(cards), covered, pct, len(quarantine)))
 


### PR DESCRIPTION
## PR Type
- [ ] data
- [ ] build
- [x] docs
- [ ] navigation

## Summary
- What changed: Hardened the PWG→RU/EN workflow guardrails around response key matching, exact-card TM reuse, nominal provenance, reverse-index display, and bounded assembled-export validation.
- Why this change exists: The next production Max runs should not be able to silently accept wrong-headword cards, citation-stripped cached cards, partial selfheal rows as exact TM hits, or nominal workflow artifacts that fail stale checks only because they have no rootmap by design.

## Test Surface
- Automated checks: `python src/pilot/window_selftest.py`; `python src/pilot/lang_parity_check.py`; `python src/pilot/translation_memory.py selftest`.
- Manual checks: `python src/reverse_index.py --show "m·8n*"`; `python src/validate_assembled_export.py --expected-cards 1 --cards src/fixtures/assembled_card.fixture.jsonl --quarantine src/fixtures/assembled_quarantine.fixture.jsonl`.
- Pure helpers / decision points covered: strict key matching, zero-marker TM drift rejection, partial-card TM exclusion, `supersedes` coercion, nominal stale-check path, exact bounded validator mode.
- If build-related: import-safe verified? n/a

## Invariants
- Must stay true: Full-card workflow responses are matched by exact `key1`; fragments only use fallback when the echoed fragment key also matches.
- Counts / alignment / join rules: Exact-card TM must preserve `<ls>` and `{#` marker counts against the current source, including zero-count cache rows; partial cards remain excluded from exact-card TM.
- Source-of-truth assumptions: Nominal windows use `meta.selected_keys` as the authoritative card set and intentionally have no rootmap hash.
- What would count as regression: `window_selftest.py` fails on key-mismatch, TM marker-drift, nominal provenance, or parity-ledger checks.

## Safety
- Fallback / failure mode: Mismatched or missing workflow keys become explicit null/requeue rows instead of positional assignment.
- Observable marker or sanity check: Failure reasons include `missing-or-mismatched-key` / `missing-or-mismatched-fragment-key`; `validate_assembled_export.py --min-cards` now warns when only a floor is checked.
- Rebuild / validate / verify command: `python src/pilot/window_selftest.py`.

## Reader-Facing Done
- Navigation / entry point updated: n/a.
- Docs / changelog / handoff updated: repo `.ai_state.md` notes the hardening milestone.
- Known limits or caveats exposed: H201 Max Workflow execution is not part of this PR and still requires the external Sonnet/Max surface.
- If not applicable, say why: No user-facing dictionary data is changed; this is pipeline safety hardening.

## Type-Specific Notes
- If `data`: n/a.
- If `build`: n/a.
- If `docs`: The `.ai_state.md` entry records the verification commands and that H201 was not run.
- If `navigation`: n/a.