### PR TITLE
docs(pwg_ru): record confirmed H182 cologne baseline in .ai_state

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -46,6 +46,17 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   [`.github/workflows/upstream-watch.yml`](../.github/workflows/upstream-watch.yml) + a local
   `schtasks` recipe in [UPSTREAM_WATCHER.md](UPSTREAM_WATCHER.md). **Guardrail:** flags only —
   re-runs stay on the H179/H151 drain discipline; the watcher never re-translates.
+  Merged: [PR #174](https://github.com/gasyoun/SanskritLexicography/pull/174) (watcher) +
+  [PR #176](https://github.com/gasyoun/SanskritLexicography/pull/176) (fuller `--counts` backfill
+  entry: csl-orig records/headwords **pwg 123,366/106,082 · pw 170,556/151,349 · sch 29,125/28,455 ·
+  pwkvn 24,976/14,995**; NWS `net_new` left null — reading all ~168k gitignored cards is
+  filesystem-bound >15 min). **Baseline re-confirmed 06-07-2026**: an incremental `cologne` run
+  (not a re-seed) diffed `last-seen..HEAD` and found **0 drift** across all 4 layers — csl-orig
+  HEAD still `78cbb257`, matching the seeded baseline in
+  [`upstream_changes/_state.json`](src/pilot/upstream_changes/_state.json). Steady-state path
+  verified: nothing upstream moved → nothing flagged. Note: the csl-orig 4-layer index is ~5s
+  run alone (earlier "minutes" was disk thrashing from parallel runs); only the 168k-file NWS
+  net-new tally is genuinely slow.
 
 - **H191 deterministic verify + 100-small nominal staging — ✅ DONE 05-07-2026 (Codex/GPT-5; no
   Max/Workflow generation run).** Executed the H191 verify/optimize handoff on branch


### PR DESCRIPTION
Records the H182 completion state in [`RussianTranslation/.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md): the merged PRs (#174 watcher, #176 counts backfill) and the 06-07-2026 incremental `cologne` run that **re-confirmed the baseline — 0 drift across all 4 layers, csl-orig HEAD still `78cbb257`**. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)