### PR TITLE
chore: git-level pre-commit guard against direct commits in the shared main tree

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Refuse commits made directly in the canonical SanskritLexicography main-tree
+# checkout — force all local work through a git worktree instead.
+#
+# Why: adopted 06-07-2026 after the H214 tree-intermix incident — a Codex
+# session and a Claude session implemented the same handoff in this shared
+# working directory at the same time, undetected until PR time. Git-level
+# enforcement is the only mechanism that binds BOTH tools identically: neither
+# Claude Code hooks nor Codex's `notify` lifecycle can see the other agent's
+# session, but both invoke real `git commit` through this same hooks path
+# (worktrees of this repo all share .git/config, so this applies to every
+# worktree unless a fresh clone re-sets core.hooksPath — see AGENTS.md/CLAUDE.md
+# Session state protocol).
+#
+# Escape hatch: ALLOW_MAIN_TREE_COMMIT=1 git commit ...  (deliberate override,
+# e.g. for a genuinely solo quick fix with no concurrent session risk).
+
+CANONICAL_MAIN_TREE="C:/Users/user/Documents/GitHub/SanskritLexicography"
+
+if [ -n "$ALLOW_MAIN_TREE_COMMIT" ]; then
+  exit 0
+fi
+
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null)
+# Normalize backslashes/case for a Windows-safe comparison.
+norm_toplevel=$(printf '%s' "$toplevel" | tr 'A-Z' 'a-z' | tr '\\' '/')
+norm_canonical=$(printf '%s' "$CANONICAL_MAIN_TREE" | tr 'A-Z' 'a-z' | tr '\\' '/')
+
+if [ "$norm_toplevel" = "$norm_canonical" ]; then
+  echo "" >&2
+  echo "BLOCKED: direct commit in the shared SanskritLexicography main tree." >&2
+  echo "" >&2
+  echo "This checkout is used by multiple concurrent sessions (Claude Code +" >&2
+  echo "Codex) and committing here risks a repeat of the H214 tree-intermix" >&2
+  echo "incident (06-07-2026). Do your work in a git worktree instead:" >&2
+  echo "" >&2
+  echo "  git worktree add -b <branch> ../SanskritLexicography-<slug> origin/master" >&2
+  echo "" >&2
+  echo "Deliberate override (solo quick fix, no concurrent-session risk):" >&2
+  echo "  ALLOW_MAIN_TREE_COMMIT=1 git commit ..." >&2
+  echo "" >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Adds `.githooks/pre-commit`, wired via `core.hooksPath` (shared across all worktrees of this repo), refusing commits made directly in the canonical SanskritLexicography main-tree checkout.
- The one enforcement mechanism that binds both Claude Code and Codex identically — neither tool's hook/notify layer can see the other's session, but both invoke real `git commit` through this same hooks path.
- Escape hatch: `ALLOW_MAIN_TREE_COMMIT=1 git commit ...` for a genuinely solo change.

Adopted after the H214 tree-intermix incident (06-07-2026): a Codex session and a Claude session implemented the same handoff in the same shared working tree simultaneously, undetected until PR time. Reproduced live while building this very fix — a concurrent Codex session checked out a different branch in the shared main tree mid-edit, landing the first commit attempt on their branch tip until recovered via worktree cherry-pick (see commit message).

Companion change already merged: `CLAUDE.md`/`AGENTS.md` now both instruct checking `.ai_state.md` WIP + the GTD claim-stamp before starting a handoff-shaped task (`github-spine` commit `bf5264a`/`5a9bfe0`) — that's the soft, convention-level signal; this PR is the hard, git-level backstop.

## Test plan
- [x] Verified the hook blocks a commit in the canonical main-tree path (tested live)
- [x] Verified a sibling worktree resolves a different `git rev-parse --show-toplevel` and is unaffected, while inheriting the same `core.hooksPath` config