### PR TITLE
fix(pwg-ru): H214 no-PWG lane blockers — Lbody resolution + nominal audit; promote 5

### DIFF
--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "5bbb029b2dc287f52d4efd4f9f44ff4a12952a15984554568afa645eec2804bd",
-      "src/pilot/window_selftest.py": "a1d51b6987ff3bf96b509712779fe5e9dec464ee7f231aeecfdbf1d8b36f1c67"
+      "src/pilot/window_selftest.py": "502fa836dbc0c86a2147d8157aefd5bbf3ca00683df6401e86ee4ffe8f025c22"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "98673632dcdaec7c9adb64a8e5e646cd7a085768c17d4a6cfc3561b256fcd321",
-      "src/pilot/window_selftest.py": "a1d51b6987ff3bf96b509712779fe5e9dec464ee7f231aeecfdbf1d8b36f1c67"
+      "src/pilot/window_selftest.py": "502fa836dbc0c86a2147d8157aefd5bbf3ca00683df6401e86ee4ffe8f025c22"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "98673632dcdaec7c9adb64a8e5e646cd7a085768c17d4a6cfc3561b256fcd321",
-      "src/pilot/window_selftest.py": "a1d51b6987ff3bf96b509712779fe5e9dec464ee7f231aeecfdbf1d8b36f1c67"
+      "src/pilot/window_selftest.py": "502fa836dbc0c86a2147d8157aefd5bbf3ca00683df6401e86ee4ffe8f025c22"
     }
   },
   {
@@ -260,7 +260,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
       "src/pilot/prompt_rule_audit.py": "bbd3fe10ff72b9d58e6d763069352129df8c246d4cb18ae41520ddcf6fee7525",
-      "src/pilot/audit_window.py": "8ab1aee803e6102fa4125a22006e929d254422854e5f1983030d6a3b21dcbd89",
+      "src/pilot/audit_window.py": "0ec016f09fa2e770ef538251882b829a4d7ea3e9ea61995fc47d0963138c0206",
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2"
     }
   },
@@ -316,7 +316,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "98673632dcdaec7c9adb64a8e5e646cd7a085768c17d4a6cfc3561b256fcd321",
-      "src/pilot/window_selftest.py": "a1d51b6987ff3bf96b509712779fe5e9dec464ee7f231aeecfdbf1d8b36f1c67"
+      "src/pilot/window_selftest.py": "502fa836dbc0c86a2147d8157aefd5bbf3ca00683df6401e86ee4ffe8f025c22"
     }
   },
   {
@@ -335,7 +335,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "a1d51b6987ff3bf96b509712779fe5e9dec464ee7f231aeecfdbf1d8b36f1c67"
+      "src/pilot/window_selftest.py": "502fa836dbc0c86a2147d8157aefd5bbf3ca00683df6401e86ee4ffe8f025c22"
     }
   },
   {
@@ -373,7 +373,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "98673632dcdaec7c9adb64a8e5e646cd7a085768c17d4a6cfc3561b256fcd321",
-      "src/pilot/window_selftest.py": "a1d51b6987ff3bf96b509712779fe5e9dec464ee7f231aeecfdbf1d8b36f1c67"
+      "src/pilot/window_selftest.py": "502fa836dbc0c86a2147d8157aefd5bbf3ca00683df6401e86ee4ffe8f025c22"
     }
   },
   {
@@ -392,7 +392,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/promote_final_cards.py": "47143a98618429e81897fca734c64ea0811f87ef698753d7218bfc10c90141ee",
-      "src/dict_merge.py": "81cbd01bf4033177c684e11b6d369a594532736cea05ab915459e8ada6fd2d17"
+      "src/dict_merge.py": "0266e11980e3b8b12d0699665b2051b9f7b8b16ed89d5810adfe5a458e880eea"
     }
   },
   {
@@ -432,7 +432,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "98673632dcdaec7c9adb64a8e5e646cd7a085768c17d4a6cfc3561b256fcd321",
       "src/pilot/perf_preflight.py": "4593a0499b74b1a9557e07b69280e9dd352c01bd816571895a7b3fc1e5ebbb2f",
-      "src/pilot/window_selftest.py": "a1d51b6987ff3bf96b509712779fe5e9dec464ee7f231aeecfdbf1d8b36f1c67"
+      "src/pilot/window_selftest.py": "502fa836dbc0c86a2147d8157aefd5bbf3ca00683df6401e86ee4ffe8f025c22"
     }
   }
 ]

--- a/RussianTranslation/src/dict_merge.py
+++ b/RussianTranslation/src/dict_merge.py
@@ -115,6 +115,44 @@ def index(code):
     return idx
 
 
+# `{{Lbody=NNNN}}` is a Cologne ALTERNATE-HEADWORD pointer: an alt-spelling record (e.g.
+# `<L>205646.1<k1>CAyA` body `{{Lbody=205646}}`) carries no independent gloss — its content is
+# the body of the primary entry NNNN (`<L>205646<k1>CAya`). 12,186 PW records (~7%) are these.
+# Left unresolved they reach the translator as a bare pointer and leak verbatim into `russian`
+# (H214 no-PWG run finding, 2026-07-06). Resolve them to the referenced entry's real body.
+_LBODY_RE = re.compile(r'\{\{Lbody=(\d+(?:\.\d+)?)\}\}')
+_IDIDX = {}
+
+
+def id_index(code):
+    """L-id (HEADER_RE group 1, e.g. '205646' / '205646.1') -> that record's body text."""
+    if code in _IDIDX:
+        return _IDIDX[code]
+    idx = {}
+    for buf in records_of(code):
+        m = pwg_mask.HEADER_RE.match(buf[0])
+        if m:
+            idx[m.group(1)] = '\n'.join(buf[1:])
+    _IDIDX[code] = idx
+    return idx
+
+
+def resolve_lbody(code, body, _depth=0):
+    """Resolve `{{Lbody=NNNN}}` alternate-headword pointers to the referenced entry's real
+    body (bounded depth; an unresolvable or self-referential pointer is left untouched)."""
+    if _depth > 3 or '{{Lbody=' not in body:
+        return body
+    idx = id_index(code)
+
+    def sub(m):
+        target = idx.get(m.group(1))
+        if target is None or ('{{Lbody=%s}}' % m.group(1)) in target:
+            return m.group(0)                    # unresolvable / self-ref -> leave as-is
+        return resolve_lbody(code, target, _depth + 1)
+
+    return _LBODY_RE.sub(sub, body)
+
+
 def merged(key1):
     fk = cg.form_key(key1)
     out = []
@@ -122,7 +160,7 @@ def merged(key1):
         recs = index(code).get(fk, [])
         if recs:
             out.append({'layer': code, 'role': role, 'blurb': blurb,
-                        'records': ['\n'.join(b[1:]) for b in recs]})
+                        'records': [resolve_lbody(code, '\n'.join(b[1:])) for b in recs]})
     nws = nws_record(fk)               # external addendum, last; only if net-new
     if nws:
         code, role, blurb = NWS_LAYER
@@ -188,6 +226,18 @@ def cmd_selftest(_args):
         assert got == want, 'layer_of(%r) = %r, expected %r' % (sub, got, want)
     assert set(cases.values()) <= set(LAYER_VALUES)
     print('dict_merge.layer_of selftest OK (%d cases)' % len(cases))
+
+    # resolve_lbody: an alternate-headword pointer resolves to the referenced entry's real
+    # body; a non-pointer body is unchanged; an unresolvable id is left intact (no crash).
+    assert resolve_lbody('pw', 'plain gloss') == 'plain gloss'
+    assert resolve_lbody('pw', '{{Lbody=999999999}}') == '{{Lbody=999999999}}'
+    resolved = resolve_lbody('pw', '{{Lbody=205646}}')
+    assert '{{Lbody=' not in resolved and 'Abschrift' in resolved, \
+        'Lbody pointer must resolve to the primary entry body, got %r' % resolved[:120]
+    # and it flows through merged(): no CAyA pw record leaks a raw pointer
+    caya_pw = [r for L in merged('CAyA') if L['layer'] == 'pw' for r in L['records']]
+    assert caya_pw and all('{{Lbody=' not in r for r in caya_pw), 'merged() must resolve Lbody'
+    print('dict_merge.resolve_lbody selftest OK')
 
 
 def main():

--- a/RussianTranslation/src/pilot/RUN_LOG.md
+++ b/RussianTranslation/src/pilot/RUN_LOG.md
@@ -30,11 +30,32 @@ First-ever translation run of the [H214](https://github.com/gasyoun/Uprava/blob/
   (no rootmap) and in that mode the glue gates crash (H201 caveat) — so these no-PWG cards can't be
   mechanically vetted before promotion.
 
-**Decision: NOT promoted** (pushing `{{Lbody}}`-leak / untranslated rows would pollute the store).
-**Two blockers to clear before the no-PWG lane is drainable:** (1) the supplement-card translation
-quality/masking leak + low single-card yield; (2) a nominal-compatible audit path. Do **not** scale to
-the full 232 lemmas until both are fixed. wf_outputs kept at `src/pilot/output/wf_output.no_pwg_w1*.json`
-(gitignored) for the fix session to resume from.
+**Initial decision: NOT promoted** (pushing `{{Lbody}}`-leak / untranslated rows would pollute the store).
+
+### ✅ RESOLUTION (same day, 2026-07-06, Opus 4.8) — both blockers fixed, 5 verified-clean promoted
+
+- **Blocker 1 root-caused + fixed:** `{{Lbody=NNNN}}` is not a masking bug — it is a Cologne
+  **alternate-headword pointer** (record `205646.1` `CAyA` reuses the body of primary entry `205646`
+  `CAya`; ~12,186 PW records / 7 % are these). Added `dict_merge.resolve_lbody()` + `id_index()`
+  (L-id → body) and applied it in `merged()`, so every consumer now gets the referenced entry's real
+  gloss instead of a bare pointer (e.g. `CAyA` pw → `…bedeutet nach J. BURGESS auch {%Abschrift,
+  Copie%}`). Lang-agnostic (SHARED); pinned by `dict_merge.py resolve_lbody selftest`.
+- **Blocker 2 fixed:** `audit_window.py` now **skips the root-glue step for a nominal / no-rootmap
+  window** (`meta.nominal` or no rootmap on disk) instead of crashing, so the content gates
+  (translation / coverage / sense-dupes / nws / prompt-semantic) run to completion and give a real
+  clean/requeue verdict.
+- **Promoted 5 verified-clean** (audit clean, 0 flags): `Bagavat~~h0_zz_nws00`, `SAKA~~h0_zz_nws00`,
+  `SAKA~~h0_zz_pw`, `devI~~h0_zz_pw`, `duzkfta~~h0_zz_pw` → store **11,163 → 11,185** (+22 sense rows,
+  `ai_translated`, held for G5). Every row carries `layer` + `provenance.source_profile =
+  no_pwg_supplement_chain`. TM rebuilt (2,301 cards). The audit correctly **rejected 2 of the 7**
+  leak/quality-clean candidates (`devI~~h0_zz_nws00`, `mAyA~~h0_zz_nws00` — NWS F12 owner
+  misattribution + coverage-over), which is why only 5, not 7, were promoted.
+
+**Still open before scaling to the full 232:** the low single-card yield (~36 % this window; stochastic
+StructuredOutput failures on masked nominal supplement cards) is a **throughput** issue, not a
+correctness one — the Lbody fix removes one failure class but the strict-key-echo / Workflow-runtime
+interaction remains to be root-caused. Re-run w1's still-null keys (now Lbody-resolved) before adding
+new lemmas. wf_outputs kept at `src/pilot/output/wf_output.no_pwg_w1*.json` (gitignored).
 
 ## Stage A+B summary (2026-06-29) — all **Sonnet**, no Opus
 

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -418,7 +418,16 @@ def main():
             gates['nws']['stdout'] += '  quarantined        : %s\n' % ' '.join(rejected)
 
     glue = None
-    if args.root:
+    # Root-article glue reassembles a PWG root's sub-cards from its rootmap. A NOMINAL window
+    # (keys-based, meta.nominal / no rootmap on disk — e.g. the H214 no-PWG supplement lane) has
+    # no rootmap, so root_glue_translated crashes there (H201/H214 caveat). Skip glue cleanly in
+    # that case: the content gates above still vet the cards; there is simply no root to glue.
+    rootmap_path = os.path.join(OUT, safe_name(args.root) + '.rootmap.json') if args.root else None
+    nominal_window = bool((wf_meta or {}).get('nominal')) or (
+        bool(args.root) and not os.path.exists(rootmap_path))
+    if args.root and nominal_window:
+        print('\n=== glue %s: skipped (nominal / no-rootmap window) ===' % args.root)
+    elif args.root:
         print('\n=== glue %s ===' % args.root)
         res = run_py([os.path.join(SRC, 'root_glue_translated.py'), args.root])
         print(res['stdout'].rstrip())

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -287,14 +287,13 @@ def test_no_pwg_worklist_runnable_lane():
     NOT reclassify a true miss (absent from every layer) as runnable, nor mix it into the
     PWG-rooted runnable count."""
     import nominals_worklist as nw
-    fd, path = tempfile.mkstemp(suffix='.slp1.txt')
-    os.close(fd)
-    try:
-        with open(path, 'w', encoding='utf-8') as f:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, 'sample.slp1.txt')
+        store = os.path.join(tmp, 'store.jsonl')      # isolated empty store: the runnable/promoted
+        with open(path, 'w', encoding='utf-8') as f:  # split must not depend on the live store
             f.write('Bagavat\nAkulita\nZZzznotaword\n')      # pw-only, sch-only, true miss
-        payload = nw.build_worklist(path)
-    finally:
-        os.remove(path)
+        open(store, 'w', encoding='utf-8').close()
+        payload = nw.build_worklist(path, store=store)
     runnable = set(payload['no_pwg_runnable'])
     if 'Bagavat' not in runnable or 'Akulita' not in runnable:
         fail('no_pwg_runnable must contain the PW/SCH-only lemmas: %s' % sorted(runnable))


### PR DESCRIPTION
Resolves the two blockers from the [no-PWG lane first-run finding](https://github.com/gasyoun/SanskritLexicography/pull/182) and promotes the verified-clean cards.

### Blocker 1 — `{{Lbody=NNNN}}` leak → **fixed**
Root cause: not a masking bug. `{{Lbody=NNNN}}` is a Cologne **alternate-headword pointer** — record `205646.1` (`CAyA`) carries no gloss; its body is the primary entry `205646` (`CAya`). ~12,186 PW records (7%) are these. Added [`dict_merge.resolve_lbody()`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/dict_merge.py) + `id_index()` (L-id→body), applied in `merged()` so every consumer gets the referenced entry's real gloss (`CAyA` pw → `…bedeutet nach J. BURGESS auch {%Abschrift, Copie%}`). Lang-agnostic (SHARED); selftest-pinned.

### Blocker 2 — nominal audit crash → **fixed**
[`audit_window.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window.py) now **skips the root-glue step for a nominal / no-rootmap window** (`meta.nominal` or no rootmap on disk) instead of crashing (the H201/H214 caveat). The content gates (translation/coverage/sense-dupes/nws/prompt-semantic) run to completion and give a real verdict.

### Promotion — 5 verified-clean (not 7)
Audited the 7 leak/quality-clean candidates through the now-working nominal audit; it **rejected 2** (`devI~~h0_zz_nws00`, `mAyA~~h0_zz_nws00` — NWS F12 owner-misattribution + coverage-over). Promoted the **5 that verify clean** (`Bagavat`/`SAKA` nws+pw, `devI` pw, `duzkfta` pw) → store **11,163 → 11,185** (+22 sense rows, `ai_translated`, held for G5). Every row carries `layer` + `provenance.source_profile = no_pwg_supplement_chain`. TM rebuilt (2,301). *(Store/TM are gitignored runtime artifacts — the promotion is local; this PR is the code + RUN_LOG resolution.)*

### Still open (documented in RUN_LOG)
The low single-card **throughput** (~36% this window, stochastic StructuredOutput failures on masked nominal supplement cards) is not a correctness issue — the Lbody fix removes one failure class; the strict-key-echo / Workflow-runtime interaction remains to root-cause before scaling past w1.

`window_selftest.py` + `lang_parity_check.py` green. Opus 4.8 (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)