### PR TITLE
docs: FEATURES_INDEX E38 — <ls> citation-frequency graph

### DIFF
--- a/FEATURES_INDEX.md
+++ b/FEATURES_INDEX.md
@@ -99,6 +99,7 @@ actual files (⚪-tier / *schema*-marked = gitignored / binary / too large, so t
 | 🟡 E30 | `surface_dcs_misses.tsv` | DCS resolution-gap analysis — forms that failed DCS lookup | 6.5 MB | `'maratejasi   'maratejasi   1   …` | 07/26 | [SanskritRussian](https://github.com/gasyoun/SanskritRussian) |
 | 🟡 E31 | Zaliznyak grammar index | Compact Zaliznyak-style grammar tokens over all PWG: 98,639 headwords, 335 tokens | 98,639 rows · 5.8 MB | `a   2   f.   a   f·1   a-stem` (headword · G·T · stem-class) | 06/26 | [headword_index.tsv](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/headword_index.tsv) |
 | 🟢 E32 | `correction_events_release.csv` | Correction event log: 50,953 events × 43 dicts × 210 correctors, 2014–2026 | ~52k · 58.7 MB | `1a1bd21d909e0bb0, 2014-03-18, form, apes, pain, ghad → ghaṭ` | 06/26 | [csl-observatory](https://github.com/sanskrit-lexicon/csl-observatory) |
+| 🟡 E38 | `<ls>` citation-frequency graph | Which classical texts each dict quotes via `<ls>`, canonicalized to shared nodes across 11 dicts; 828,505 resolved citations, 912 texts. MW non-text markers filtered | 912 texts · 1,707 edges · ~150 KB | `pwg   Mahābhārata   39130` (edge) · `Mahābhārata   56818   8   MAHĀBHĀRATA; MBh; …` (node) | 07/26 | [csl-atlas/data/citations](https://github.com/sanskrit-lexicon/csl-atlas/tree/main/data/citations) |
 
 ### F · Text collections & other
 
@@ -290,7 +291,8 @@ is rendered on the interactive artifact._
 
 | When | Change |
 |---|---|
-| 07/26 | **Initial index** — 44 dictionaries · 20 interfaces (16 live) · 37 datasets · 14 tools + 4 external stacks catalogued, each with a real example, a severity tier, a first-introduced date and a stable per-section ID. |
+| 07/26 | **E38** — `<ls>` citation-frequency graph (csl-atlas, [PR #220](https://github.com/sanskrit-lexicon/csl-atlas/pull/220)): 828,505 canonicalized citations → 912 texts across 11 dicts. |
+| 07/26 | **Initial index** — 44 dictionaries · 20 interfaces (16 live) · 38 datasets · 14 tools + 4 external stacks catalogued, each with a real example, a severity tier, a first-introduced date and a stable per-section ID. |
 
 ---
 


### PR DESCRIPTION
Registers the new **E38** dataset — the `<ls>` citation-frequency graph — in the capability inventory under section E (Frequency & corpus).

828,505 canonicalized `<ls>` source-citations from 11 Cologne dicts → 912 shared text nodes, with MW grammatical-marker pollution filtered. Dataset lives in [`csl-atlas/data/citations`](https://github.com/sanskrit-lexicon/csl-atlas/tree/main/data/citations) ([PR #220](https://github.com/sanskrit-lexicon/csl-atlas/pull/220)); paper A50 scaffolded ([csl-atlas PR #221](https://github.com/sanskrit-lexicon/csl-atlas/pull/221)). Origin: [H213](https://github.com/gasyoun/Uprava/blob/main/handoffs/H213-Opus_csl-atlas_ls_citation_graph_canonicalization_06.07.26.md).

Model: Opus 4.8 (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)