### PR TITLE
docs(pwg-ru): cut changelog 1.4.0 (H214 no-PWG lane + H182 watcher)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,12 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **H214 no-PWG lane — SHIPPED + first run + blockers fixed; throughput follow-on = H220. ✅/🟡 06-07-2026 (Opus 4.8, `claude-opus-4-8`; gen Sonnet 5 `claude-sonnet-5`).**
+  The no-PWG supplement-chain render path shipped ([PR #178](https://github.com/gasyoun/SanskritLexicography/pull/178)); first live run (`no_pwg_w1`, 24 headwords / 58 sub-cards, 3 Workflow passes, ~3.4 M tokens) validated the path end-to-end. Two blockers found + fixed ([PR #183](https://github.com/gasyoun/SanskritLexicography/pull/183)): `{{Lbody=NNNN}}` alternate-headword-pointer leak (`dict_merge.resolve_lbody()`) and the nominal audit crash (`audit_window.py` skips glue for no-rootmap windows). **5 verified-clean sub-cards promoted** (store 11,163→11,185, `ai_translated`, held for G5). Full write-up: [RUN_LOG.md `no_pwg_w1` block](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_LOG.md). Released as **pwg_ru 1.4.0** (rolls up H182 + H214). **➡️ Unsolved = low single-card throughput (~36%, stochastic StructuredOutput failures); resume via H220 before scaling the 232-lemma lane:**
+  ```
+  Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H220-Sonnet_RussianTranslation_pwg_ru_no_pwg_throughput_06.07.26.md and execute it.
+  ```
+
 - **H215 Slice 1 — corpus Sa→Ru TM → TMX 1.4b exporter — ✅ DONE 06-07-2026 (Opus 4.8,
   `claude-opus-4-8`; deterministic, no LLM call).** New
   [`src/build_tmx.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_tmx.py)

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,35 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-06
+
+### no-PWG supplement-chain lane (H214) — PWG-missing headwords become translatable
+- PWG-missing headwords that carry a PW/SCH/PWKVN/NWS record now render as
+  standalone **supplement-chain sub-cards** (`<key>~~h0_zz_<layer>`) via new
+  [`_pilot_gen_merged.no_pwg_parts()` / `gen_no_pwg_card()`](src/_pilot_gen_merged.py) —
+  **no fabricated PWG base portrait** (supersedes decisions #2/#4 of
+  [PWG_MISS_RENDER_PATH_DECISIONS.md](PWG_MISS_RENDER_PATH_DECISIONS.md)). Reuses
+  `dict_merge.merged()`; renders raw NWS + the authoritative owner map. Run through the
+  nominal harness (keymap `subcard→key1`, no rootmap). Layer identity survives raw →
+  sub-card id (`dict_merge.layer_of`) → provenance → promoted `layer`.
+- **Per-card `source_profile`** on every promoted row (`no_pwg_supplement_chain` /
+  `pwg_with_supplements` (MIXED) / `pwg_only` / `pwg_supplement_subcard`) via
+  [`gen_opt_harness2.card_source_profile()`](src/pilot/gen_opt_harness2.py) →
+  [`promote_final_cards.provenance()`](src/promote_final_cards.py) — filter
+  `pwg_with_supplements` to find all mixed cards.
+- [`nominals_worklist.py`](src/pilot/nominals_worklist.py): the 232 PWG-miss lemmas
+  become a `no_pwg_runnable` lane, kept separate from PWG-rooted counts.
+- **Fixed — `{{Lbody=NNNN}}` leak:** it is a Cologne alternate-headword pointer (~12,186
+  PW records); [`dict_merge.resolve_lbody()`](src/dict_merge.py) + `id_index()` resolve it
+  to the referenced entry's real gloss in `merged()`, so it no longer leaks into `russian`.
+- **Fixed — nominal audit crash:** [`audit_window.py`](src/pilot/audit_window.py) skips the
+  root-glue step for a nominal / no-rootmap window instead of crashing, so the content gates
+  run to a real verdict.
+- First live run (`no_pwg_w1`, 24 headwords) validated end-to-end; **5 verified-clean
+  sub-cards promoted** (store 11,163→11,185, held for G5). Residual: low single-card
+  translation throughput (~36%) tracked in [H220](../../Uprava/handoffs/H220-Sonnet_RussianTranslation_pwg_ru_no_pwg_throughput_06.07.26.md)
+  and the [RUN_LOG.md `no_pwg_w1` block](src/pilot/RUN_LOG.md).
+
 ### Upstream-change watcher (H182) — Cologne + NWS monthly drift → stale worklist
 - Added [`src/pilot/layer_versions.py`](src/pilot/layer_versions.py) +
   append-only [`src/pilot/layer_version_log.jsonl`](src/pilot/layer_version_log.jsonl):


### PR DESCRIPTION
Promotes accumulated `[Unreleased]` to **pwg_ru 1.4.0** (minor): the H214 no-PWG supplement-chain lane + per-card `source_profile` + `{{Lbody}}` resolution + nominal-audit fix ([PR #178](https://github.com/gasyoun/SanskritLexicography/pull/178)/[#183](https://github.com/gasyoun/SanskritLexicography/pull/183)) plus the H182 watcher unreleased since 05-07. `.ai_state` → [H220](https://github.com/gasyoun/Uprava/blob/main/handoffs/H220-Sonnet_RussianTranslation_pwg_ru_no_pwg_throughput_06.07.26.md). Tag `v1.4.0` follows after merge. Per new /handoff Phase 6b. Opus 4.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)