### PR TITLE
feat(pwg_ru): H186 Track B — running-text term mining (mined TM tier)

### DIFF
--- a/RussianTranslation/REUSE_MAP.md
+++ b/RussianTranslation/REUSE_MAP.md
@@ -1,6 +1,6 @@
 # pwg_ru — Russian reuse-source map
 
-_Created: 05-07-2026 · Last updated: 05-07-2026_
+_Created: 05-07-2026 · Last updated: 06-07-2026_
 
 Canonical inventory of every Russian Sa→Ru reuse asset available to the `pwg_ru`
 (PWG→RU) pipeline, and how to consume each — written so no future session
@@ -80,6 +80,19 @@ confidence `mined` TM layer — see
 Track B. H186 Track A additionally aligns ~12 not-yet-added parallel Sa-Ru
 texts. This map's "context only" framing applies to what `corpus_gate.py`
 currently does with these sources — H186 is the tracked plan to go further.
+
+**H186 outcome (06-07-2026, Opus 4.8 `claude-opus-4-8` + DeepSeek `deepseek-chat`):**
+- **Track B DONE (pilot).** A `mined` TM tier now exists —
+  [`src/mine_running_text.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/mine_running_text.py)
+  → `src/corpus_lexicon.mined.jsonl` (gitignored), `tier: "mined"`, quarantined from the
+  1.09M. Pilot mined 421 pairs from `induizm-dzhaynizm-sikkhizm` + `mify_759_ind` +
+  `syrkin_tom_1_utf`; 30-row precision gate = **97% correct-equivalence, 80% useful
+  meaning-gloss, 3.3% hard error** → scale approved. Design + guards + precision:
+  [`pwg_ru/RUNNING_TEXT_MINING.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/RUNNING_TEXT_MINING.md).
+- **Track A BLOCKED.** None of MG's ~12 parallel texts exist in verse-aligned jsonl the
+  aligner can consume (raw GRETIL Sanskrit + separate Russian glossaries/prose only) —
+  building parallel corpora is an upstream SamudraManthanam `corpus_builder` job needing
+  human edition/alignment decisions. See `RUNNING_TEXT_MINING.md` § Track A status.
 
 ## 5. Etymology / future additions
 

--- a/RussianTranslation/pwg_ru/RUNNING_TEXT_MINING.md
+++ b/RussianTranslation/pwg_ru/RUNNING_TEXT_MINING.md
@@ -1,0 +1,143 @@
+# pwg_ru — running-text term mining (the `mined` TM tier)
+
+_Created: 06-07-2026 · Last updated: 06-07-2026_
+
+Design + pilot record for **H186 Track B**: mining Sanskrit→Russian term glosses out of
+Russian **running prose** (monographs, term-encyclopedias, lecture transcripts) that
+carries *no* verse-level alignment, into a **separate, lower-confidence `mined` TM
+layer** — kept strictly apart from the clean 1.09M verse-aligned
+[`corpus_lexicon.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_corpus_lexicon.py).
+
+Handoff:
+[H186](https://github.com/gasyoun/Uprava/blob/main/handoffs/H186-Opus_RussianTranslation_pwg_ru_tm_corpus_mining_expansion_05.07.26.md)
+· map context:
+[REUSE_MAP.md §4](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/REUSE_MAP.md).
+Model: orchestration + this design = Opus 4.8 (`claude-opus-4-8`); extraction =
+**DeepSeek** `deepseek-chat` (`--backend` = direct `api.deepseek.com`), temperature 0,
+JSON mode.
+
+## Why a separate tier (not the 1.09M corpus)
+
+Verse-aligned texts give a *word-for-word* Sa↔Ru pairing that
+[`build_corpus_lexicon.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_corpus_lexicon.py)
+can align deterministically. Running prose does not: it *mentions* Sanskrit terms and
+glosses *some* of them in passing ("Дити (др.-инд. *Diti*, букв. «связанность»)"). That
+is genuine lexical evidence, but noisier — proper-name transliterations, contextual
+(not lexical) glosses, and list-scoping mistakes all creep in. So mined pairs land in
+[`src/corpus_lexicon.mined.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/mine_running_text.py)
+tagged `tier: "mined"` and are **never** written into `corpus_lexicon.jsonl`. Harvest/QA
+weight the `mined` tier **below** the dictionaries and the verse-aligned corpus.
+
+## The 166k-hallucination guard applies here too
+
+The prior corpus build let DeepSeek fabricate fluent Russian for translations that did
+not exist (81% invention). Mining has the same risk in a new shape — the model
+supplying a gloss from *world knowledge* instead of *the passage*. Guards (all in
+[`mine_running_text.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/mine_running_text.py),
+reusing `build_corpus_lexicon`'s `has_cyr` / `to_slp1` / `REJECT_RU`):
+
+1. **Never-invent system prompt** — the gloss MUST be stated in *this* passage; a term
+   named but not glossed is omitted.
+2. **`ru` verbatim-in-passage check** — a deterministic backstop: if the extracted
+   Russian gloss does not occur as a substring of the source passage, the row is
+   dropped. This alone kills world-knowledge fabrications the prompt lets slip.
+3. **`has_cyr(ru)`** — a "gloss" with no Cyrillic is a placeholder/echo → dropped.
+4. **`ru != sa`, not in `REJECT_RU`** — no echoing the Sanskrit, no refusal strings.
+5. **`to_slp1(sa)` non-empty** — `sa` must transliterate to a real SLP1 key; a
+   Cyrillic-only "term" with no IAST is dropped.
+6. **Per-passage dedup** on `(slp1, ru)`.
+
+## Pipeline
+
+```
+python mine_running_text.py test  <textfile> [N]           # extract + print, no write
+python mine_running_text.py mine  <textfile> [N] [workers]  # → corpus_lexicon.mined.jsonl
+python mine_running_text.py status                          # rows + distinct keys + per-source
+```
+
+- **Candidate pre-filter** (`term_bearing`) — a passage is sent to DeepSeek only if it
+  carries an IAST diacritic, Devanagari, or a Sanskrit-origin marker (`санскр`,
+  `др.-инд.`, `от корня`, `букв.`). Keeps cost and false-positive rate down.
+- **Resumable** by `(work, passage)` — re-running skips already-mined passages.
+- **Row schema**: `{slp1, sa, ru, work, passage, group, kind:"mined", tier:"mined"}`.
+- Output is gitignored (`RussianTranslation/src/*.jsonl`) — code + this doc + the
+  row-count/precision deltas are the deliverable, not the bulk `.jsonl`.
+
+## Sources
+
+| Source (SamudraManthanam jsonl) | Shape | Yield |
+|---|---|---|
+| [`induizm-dzhaynizm-sikkhizm`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/REUSE_MAP.md) | philosophy term-encyclopedia (headword + inline gloss) | high, clean |
+| `mify_759_ind` | mythological encyclopedia (`Term (др.-инд. X, «gloss»)`) | high, clean |
+| `syrkin_tom_1_utf` | running scholarly prose, terms scattered | lower, noisier |
+| `pandey`, `stepanyants`, `stati-makhabkharaty`, Eliade-Yoga | prose monographs | queued (scale phase) |
+| samskrtam.ru lecture transcripts (`/l/…`) | **Sanskrit verse + Russian exegesis** | route to **Track A** (parallel-ish), not mined here — see below |
+
+## Pilot (06-07-2026)
+
+Mined 3 sources → **421 pairs, 0 API failures**, 408 distinct `(slp1, ru)`:
+
+| Source | Term-bearing passages | Mined pairs |
+|---|---|---|
+| `induizm-dzhaynizm-sikkhizm` | 120 | 226 |
+| `mify_759_ind` | 120 | 160 |
+| `syrkin_tom_1_utf` | 41 | 35 |
+
+### Precision gate
+
+Stratified deterministic 30-row sample (~10/source), each adjudicated against its source
+passage (sample kept at
+[`pwg_ru/running_text_mining_precision_sample.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/running_text_mining_precision_sample.jsonl)):
+
+| Verdict | Count | Rate |
+|---|---|---|
+| Correct meaning-gloss (e.g. `itihāsa`→эпос, `Duryodhana`→«с кем трудно сражаться») | 24 | 80% |
+| Correct but low-information transliteration / proper-name (`Kṛṣṇa`→Кришна, `kāma`→кама) | 5 | 17% |
+| **Hard error** (`asteya`→«отказ от 5 видов недолжного поведения» — grabbed the list *category*, not the item's meaning) | 1 | 3.3% |
+
+**Correct-equivalence precision = 29/30 (97%); useful meaning-gloss precision = 24/30
+(80%); hard-error rate = 3.3%.** The single hard error is a list-scoping mistake (a term
+that is one of an enumerated set gets the set's description). The verbatim-in-passage
+guard held — zero fabricated (not-in-passage) glosses survived to the sample.
+
+### Scale decision
+
+**Proceed** — precision clears the bar for a quarantined lower-confidence tier. Mine the
+remainder of the two encyclopedias and the prose monographs (`pandey`, `stepanyants`,
+`stati-makhabkharaty`, Eliade-Yoga) in the scale phase, keeping the tier quarantined.
+Known noise to weight down, not to "fix" in the miner: (a) proper-name transliterations
+carry low lexical information; (b) list-category mis-scoping is the dominant hard-error
+mode. Neither justifies polluting the clean corpus — that is exactly why the tier is
+separate.
+
+## Track A status (parallel-text alignment) — BLOCKED on missing verse-aligned input
+
+H186 Track A asked to align ~12 "not-yet-added parallel Sa-Ru texts" via the existing
+`build_corpus_lexicon.py`. **Investigation (06-07-2026) shows none of the 12 exist in
+verse-aligned form** the aligner can consume — so the specified reuse-path has no input:
+
+- `corpus_lexicon.jsonl` already covers **every** verse-aligned Sa↔Ru text present in
+  SamudraManthanam's `web/corpus_builder/jsonl/` (116 works) — confirming the H184
+  scout's "~98% already wired". Every unaligned jsonl there yields **0** alignable
+  groups.
+- `vishnu-purana.jsonl` (MG's list) is **Russian prose only** (`seg=None`, no parallel
+  Sanskrit) → a `mined`/context source, not alignable.
+- `13_mahabharata-anushasanaparva.jsonl` has full Sanskrit but **every Russian segment
+  is `…`** (untranslated) → correctly excluded by `has_cyr`.
+- Hitopadeśa, Bāṇa's Kādambarī, Bhāsa, Garuḍa-purāṇa exist only as **raw GRETIL TEI
+  Sanskrit** (`GRETIL-1_sanskr/tei/sa_*.xml`); the Russian sides exist separately as
+  glossaries / HTML (`ramayana-potapovoy.html`, the Grintser glossaries already wired
+  SPECIALIST in H184). They are **not** verse-aligned to each other.
+- Panchatantra / Классическая поэзия / Древнеиндийская литература / Schlegel — not in
+  the corpus at all.
+
+**Prerequisite before any Track A alignment**: building parallel verse-aligned jsonl
+(source the Sanskrit, segment it, align verses to the chosen Russian edition) — a
+**SamudraManthanam `corpus_builder` ingestion job upstream of the aligner**, needing
+per-text edition + alignment decisions (prose works like Kādambarī/Panchatantra have no
+verse numbers to anchor on). This is a scoping + sourcing call for a human — routed to
+[GTD](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md). It is *not*
+reusable work the aligner can do today, and must not be faked by aligning
+non-parallel prose.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/pwg_ru/running_text_mining_precision_sample.jsonl
+++ b/RussianTranslation/pwg_ru/running_text_mining_precision_sample.jsonl
@@ -1,0 +1,30 @@
+{"slp1": "Aditi", "sa": "Aditi", "ru": "несвязанность, бесконечность", "work": "induizm-dzhaynizm-sikkhizm", "passage": "p22", "group": "induizm-dzhaynizm-sikkhizm:p22", "kind": "mined", "tier": "mined"}
+{"slp1": "budDa", "sa": "buddha", "ru": "Будда", "work": "induizm-dzhaynizm-sikkhizm", "passage": "p11", "group": "induizm-dzhaynizm-sikkhizm:p11", "kind": "mined", "tier": "mined"}
+{"slp1": "brahman", "sa": "brahman", "ru": "священное слово, молитва", "work": "induizm-dzhaynizm-sikkhizm", "passage": "p102", "group": "induizm-dzhaynizm-sikkhizm:p102", "kind": "mined", "tier": "mined"}
+{"slp1": "puzwi-mArga", "sa": "puṣṭi-mārga", "ru": "пушти-марг", "work": "induizm-dzhaynizm-sikkhizm", "passage": "p147", "group": "induizm-dzhaynizm-sikkhizm:p147", "kind": "mined", "tier": "mined"}
+{"slp1": "jyotiza", "sa": "jyotiṣa", "ru": "астрономия", "work": "induizm-dzhaynizm-sikkhizm", "passage": "p167", "group": "induizm-dzhaynizm-sikkhizm:p167", "kind": "mined", "tier": "mined"}
+{"slp1": "gokula", "sa": "gokula", "ru": "семейство, стадо коров", "work": "induizm-dzhaynizm-sikkhizm", "passage": "p220", "group": "induizm-dzhaynizm-sikkhizm:p220", "kind": "mined", "tier": "mined"}
+{"slp1": "devatA", "sa": "devatā", "ru": "божество", "work": "induizm-dzhaynizm-sikkhizm", "passage": "p299", "group": "induizm-dzhaynizm-sikkhizm:p299", "kind": "mined", "tier": "mined"}
+{"slp1": "asteya", "sa": "asteya", "ru": "отказ от 5 видов недолжного поведения", "work": "induizm-dzhaynizm-sikkhizm", "passage": "p321", "group": "induizm-dzhaynizm-sikkhizm:p321", "kind": "mined", "tier": "mined"}
+{"slp1": "itihAsa", "sa": "itihāsa", "ru": "эпос", "work": "induizm-dzhaynizm-sikkhizm", "passage": "p426", "group": "induizm-dzhaynizm-sikkhizm:p426", "kind": "mined", "tier": "mined"}
+{"slp1": "nAsti", "sa": "nāsti", "ru": "нет", "work": "induizm-dzhaynizm-sikkhizm", "passage": "p486", "group": "induizm-dzhaynizm-sikkhizm:p486", "kind": "mined", "tier": "mined"}
+{"slp1": "dAmyata", "sa": "dāmyata", "ru": "подавление своих страстей", "work": "syrkin_tom_1_utf", "passage": "c4.p2", "group": "syrkin_tom_1_utf:c4.p2", "kind": "mined", "tier": "mined"}
+{"slp1": "trivarga", "sa": "trivarga", "ru": "три блага", "work": "syrkin_tom_1_utf", "passage": "c5.p2", "group": "syrkin_tom_1_utf:c5.p2", "kind": "mined", "tier": "mined"}
+{"slp1": "kAma", "sa": "kāma", "ru": "кама", "work": "syrkin_tom_1_utf", "passage": "c5.p2", "group": "syrkin_tom_1_utf:c5.p2", "kind": "mined", "tier": "mined"}
+{"slp1": "sAman", "sa": "sāman", "ru": "песнопение Самаведы", "work": "syrkin_tom_1_utf", "passage": "c3.p1", "group": "syrkin_tom_1_utf:c3.p1", "kind": "mined", "tier": "mined"}
+{"slp1": "kfzRamrUpam", "sa": "kṛṣṇam rūpam", "ru": "черный образ", "work": "syrkin_tom_1_utf", "passage": "c3.p1", "group": "syrkin_tom_1_utf:c3.p1", "kind": "mined", "tier": "mined"}
+{"slp1": "mAyA", "sa": "māyā", "ru": "хитрость", "work": "syrkin_tom_1_utf", "passage": "c7.p1", "group": "syrkin_tom_1_utf:c7.p1", "kind": "mined", "tier": "mined"}
+{"slp1": "KfzRa", "sa": "Kṛṣṇa", "ru": "Кришна", "work": "syrkin_tom_1_utf", "passage": "c9.p4", "group": "syrkin_tom_1_utf:c9.p4", "kind": "mined", "tier": "mined"}
+{"slp1": "SvapnacintAmaRi", "sa": "Svapnacintāmaṇi", "ru": "Волшебное сокровище сновидений", "work": "syrkin_tom_1_utf", "passage": "c10.p3", "group": "syrkin_tom_1_utf:c10.p3", "kind": "mined", "tier": "mined"}
+{"slp1": "Darma", "sa": "dharma", "ru": "закон", "work": "syrkin_tom_1_utf", "passage": "c13.p2", "group": "syrkin_tom_1_utf:c13.p2", "kind": "mined", "tier": "mined"}
+{"slp1": "jYAna", "sa": "jñāna", "ru": "знание", "work": "syrkin_tom_1_utf", "passage": "c13.p2", "group": "syrkin_tom_1_utf:c13.p2", "kind": "mined", "tier": "mined"}
+{"slp1": "adi-budDa", "sa": "adi-buddha", "ru": "первоначальный будда", "work": "mify_759_ind", "passage": "p12", "group": "mify_759_ind:p12", "kind": "mined", "tier": "mined"}
+{"slp1": "ApAmNapAt", "sa": "Apām Napāt", "ru": "сын вод", "work": "mify_759_ind", "passage": "p47", "group": "mify_759_ind:p47", "kind": "mined", "tier": "mined"}
+{"slp1": "VaiSravaRa", "sa": "Vaiśravaṇa", "ru": "Вайшравана", "work": "mify_759_ind", "passage": "p91", "group": "mify_759_ind:p91", "kind": "mined", "tier": "mined"}
+{"slp1": "taTAgata", "sa": "tathāgata", "ru": "так пришедший", "work": "mify_759_ind", "passage": "p108", "group": "mify_759_ind:p108", "kind": "mined", "tier": "mined"}
+{"slp1": "VasizWa", "sa": "Vasiṣṭha", "ru": "самый богатый", "work": "mify_759_ind", "passage": "p144", "group": "mify_759_ind:p144", "kind": "mined", "tier": "mined"}
+{"slp1": "Gana-ISa", "sa": "Gana-īśa", "ru": "повелителя ганы", "work": "mify_759_ind", "passage": "p188", "group": "mify_759_ind:p188", "kind": "mined", "tier": "mined"}
+{"slp1": "Diti", "sa": "Diti", "ru": "связанность", "work": "mify_759_ind", "passage": "p259", "group": "mify_759_ind:p259", "kind": "mined", "tier": "mined"}
+{"slp1": "DuryoDana", "sa": "Duryodhana", "ru": "с кем трудно сражаться", "work": "mify_759_ind", "passage": "p281", "group": "mify_759_ind:p281", "kind": "mined", "tier": "mined"}
+{"slp1": "kalacakra", "sa": "kalacakra", "ru": "колесо времени", "work": "mify_759_ind", "passage": "p347", "group": "mify_759_ind:p347", "kind": "mined", "tier": "mined"}
+{"slp1": "kfzRa", "sa": "kṛṣṇa", "ru": "чёрный", "work": "mify_759_ind", "passage": "p385", "group": "mify_759_ind:p385", "kind": "mined", "tier": "mined"}

--- a/RussianTranslation/src/mine_running_text.py
+++ b/RussianTranslation/src/mine_running_text.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+"""H186 Track B — running-text term mining (SEPARATE, lower-confidence `mined` TM layer).
+
+Russian scholarly prose (monographs, term-encyclopedias, lecture transcripts) mentions
+Sanskrit terms *in passing* and glosses some of them inline — but carries NO verse-level
+Sanskrit↔Russian alignment, so `build_corpus_lexicon.py` (which needs aligned sa/ru
+verse pairs) cannot touch it. This miner asks DeepSeek to pull ONLY the Sanskrit→Russian
+term glosses that a passage EXPLICITLY states, and lands them in a quarantined
+`corpus_lexicon.mined.jsonl` tagged `tier: mined` — NEVER the clean 1.09M
+`corpus_lexicon.jsonl`. Mined pairs are noisier; harvest/QA weight them below the
+dictionaries and the verse-aligned corpus.
+
+Reuses build_corpus_lexicon.deepseek() (retry/backoff), .to_slp1(), .has_cyr() — no new
+aligner, no new HTTP client. The never-invent / has_cyr / ru!=sa guards are mandatory
+(the 166k-hallucination lesson applies here too — a "gloss" DeepSeek fabricates from
+world-knowledge instead of the passage is exactly the failure mode we refuse).
+
+  python mine_running_text.py test  <textfile> [N]   extract, print (no write)
+  python mine_running_text.py mine  <textfile> [N] [workers]   → corpus_lexicon.mined.jsonl
+  python mine_running_text.py status                 mined rows + distinct keys + per-source
+"""
+import json, os, re, sys, time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+import build_corpus_lexicon as bcl   # deepseek(), to_slp1(), has_cyr(), SM, REJECT_RU
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SM = bcl.SM
+OUT = os.path.join(HERE, 'corpus_lexicon.mined.jsonl')
+
+# A passage is worth an API call only if it plausibly carries a Sanskrit term to gloss:
+# a Latin token with IAST diacritics, Devanagari, or an explicit Sanskrit-origin marker.
+IAST = re.compile('[āīūṛṝḷḹṃṁḥṅñṭḍṇśṣ]', re.I)
+DEV = re.compile('[ऀ-ॿ]')
+MARKER = re.compile(r'санскр|древнеинд\.|от\s+корня|от\s+санскр|букв\.|IAST|деванагар', re.I)
+
+
+def term_bearing(text):
+    return bool(text) and (bool(IAST.search(text)) or bool(DEV.search(text))
+                           or bool(MARKER.search(text)))
+
+
+SYS_MINE = (
+    'You extract Sanskrit→Russian TERM GLOSSES from a passage of Russian scholarly '
+    'prose that discusses Sanskrit terms. For each Sanskrit term the passage '
+    'EXPLICITLY glosses or translates, output {"sa": <the Sanskrit term in IAST '
+    'transliteration, dictionary/citation form>, "ru": <the Russian meaning/equivalent '
+    'AS STATED IN THIS PASSAGE>}. HARD RULES: '
+    '(1) The Russian gloss MUST be literally present or directly stated in THIS passage '
+    '— never invent, infer, or add outside knowledge; if the passage names a term but '
+    'gives no Russian meaning for it, OMIT that term. '
+    '(2) "sa" must be a genuine Sanskrit word in IAST (Latin letters + diacritics), not '
+    'a Russified Cyrillic spelling; if the passage gives only a Cyrillic form with no '
+    'Latin/IAST and no unambiguous transliteration, OMIT it. '
+    '(3) Give the short lexical gloss, not a whole sentence. '
+    'Output ONLY JSON: {"pairs":[{"sa":"...","ru":"..."}]}. Empty list if nothing '
+    'qualifies. Never echo the Sanskrit as its own gloss.')
+
+
+def mine_passage(text):
+    out = bcl.deepseek('Passage (Russian):\n%s' % text[:2400], system=SYS_MINE)
+    if not out:
+        return None          # None = API/JSON failure (distinct from "0 pairs found")
+    try:
+        return json.loads(out).get('pairs', [])
+    except Exception:
+        return []
+
+
+def entries(textfile):
+    """Yield (passage_ref, group, text) for term-bearing Russian passages of a work."""
+    work = textfile.replace('.jsonl', '')
+    for line in open(os.path.join(SM, textfile), encoding='utf-8'):
+        e = json.loads(line)
+        if e.get('deleted') or e.get('lang') not in (None, 'ru'):
+            continue
+        t = e.get('text') or ''
+        if term_bearing(t):
+            yield e.get('passage', e.get('group', '')), e.get('group', ''), t, work
+
+
+def done_refs():
+    s = set()
+    if os.path.exists(OUT):
+        for line in open(OUT, encoding='utf-8'):
+            try:
+                r = json.loads(line)
+                s.add((r.get('work'), r.get('passage')))
+            except Exception:
+                pass
+    return s
+
+
+def rows_from(passage, group, text, work):
+    pairs = mine_passage(text)
+    if pairs is None:
+        return None
+    rows, seen = [], set()
+    for p in pairs:
+        sa_w = (p.get('sa') or '').strip()
+        ru_w = (p.get('ru') or '').strip()
+        slp1 = bcl.to_slp1(sa_w)
+        if not (slp1 and bcl.has_cyr(ru_w)):          # gloss must be real Russian
+            continue
+        if ru_w == sa_w or ru_w in bcl.REJECT_RU:      # echo / refusal string
+            continue
+        # the extracted Cyrillic gloss must actually occur in the source passage —
+        # a cheap, deterministic anti-hallucination check on top of the model prompt.
+        if ru_w not in text:
+            continue
+        key = (slp1, ru_w)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append({'slp1': slp1, 'sa': sa_w, 'ru': ru_w, 'work': work,
+                     'passage': passage, 'group': group,
+                     'kind': 'mined', 'tier': 'mined'})
+    return rows
+
+
+def cmd_test(args):
+    tf = args[0]
+    n = int(args[1]) if len(args) > 1 else 5
+    for i, (passage, group, text, work) in enumerate(entries(tf)):
+        if i >= n:
+            break
+        print('=' * 20, work, passage)
+        print(' ', text[:200])
+        rows = rows_from(passage, group, text, work)
+        for r in (rows or []):
+            print('    %-20s → slp1=%-14s → %s' % (r['sa'], r['slp1'], r['ru']))
+
+
+def cmd_mine(args):
+    tf = args[0]
+    n = int(args[1]) if len(args) > 1 else 10**9
+    workers = int(args[2]) if len(args) > 2 else 8
+    done = done_refs()
+    work0 = tf.replace('.jsonl', '')
+    items = [(p, g, t, w) for p, g, t, w in entries(tf) if (work0, p) not in done][:n]
+    wrote = failed = 0
+    with open(OUT, 'a', encoding='utf-8', newline='') as out, ThreadPoolExecutor(workers) as ex:
+        futs = {ex.submit(rows_from, p, g, t, w): p for p, g, t, w in items}
+        for fut in as_completed(futs):
+            rows = fut.result()
+            if rows is None:
+                failed += 1
+                continue
+            for r in rows:
+                out.write(json.dumps(r, ensure_ascii=False) + '\n')
+                wrote += 1
+            out.flush()
+    print('%s: %d term-bearing passages → %d mined pairs, %d API failures → %s'
+          % (work0, len(items), wrote, failed, os.path.basename(OUT)))
+
+
+def cmd_status(args):
+    import collections
+    if not os.path.exists(OUT):
+        print('no', OUT); return
+    per = collections.Counter(); keys = set(); n = 0
+    for line in open(OUT, encoding='utf-8'):
+        try:
+            r = json.loads(line); n += 1
+            per[r.get('work')] += 1; keys.add((r.get('slp1'), r.get('ru')))
+        except Exception:
+            pass
+    print('mined rows: %d | distinct (slp1,ru): %d' % (n, len(keys)))
+    for w, c in per.most_common():
+        print('  %6d  %s' % (c, w))
+
+
+if __name__ == '__main__':
+    cmd = sys.argv[1] if len(sys.argv) > 1 else 'status'
+    rest = sys.argv[2:]
+    {'test': cmd_test, 'mine': cmd_mine, 'status': cmd_status}.get(cmd, cmd_status)(rest)


### PR DESCRIPTION
## H186 Track B — running-text term mining

Mines Sanskrit→Russian term glosses from Russian **running prose** (monographs / term-encyclopedias) that carries no verse alignment, into a **separate, lower-confidence `mined` TM layer** — [`src/corpus_lexicon.mined.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/mine_running_text.py) (`tier: "mined"`), **never** the clean 1.09M [`corpus_lexicon.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_corpus_lexicon.py).

### What's here
- [`src/mine_running_text.py`](https://github.com/gasyoun/SanskritLexicography/blob/h186-track-b-running-text-mining/RussianTranslation/src/mine_running_text.py) — reuses `build_corpus_lexicon.deepseek()`/`to_slp1()`/`has_cyr()` (no new aligner). **Never-invent** prompt + a deterministic **verbatim-in-passage** guard (drops any gloss not literally in the source passage — the 166k-hallucination lesson).
- [`pwg_ru/RUNNING_TEXT_MINING.md`](https://github.com/gasyoun/SanskritLexicography/blob/h186-track-b-running-text-mining/RussianTranslation/pwg_ru/RUNNING_TEXT_MINING.md) — design, guards, pilot, precision gate, scale decision, Track A blocker.
- [`REUSE_MAP.md §4`](https://github.com/gasyoun/SanskritLexicography/blob/h186-track-b-running-text-mining/RussianTranslation/REUSE_MAP.md) updated.

### Pilot + precision
421 pairs from `induizm-dzhaynizm-sikkhizm` + `mify_759_ind` + `syrkin_tom_1_utf`, 0 API failures. 30-row stratified precision gate (adjudicated vs source passages): **97% correct-equivalence, 80% useful meaning-gloss, 3.3% hard error** → scale approved.

### Track A (parallel-text alignment) — BLOCKED, routed to a human
None of MG's ~12 texts exist in verse-aligned jsonl the aligner can consume (raw GRETIL Sanskrit + separate Russian glossaries/prose only). Building parallel corpora is an **upstream SamudraManthanam `corpus_builder` ingestion job** needing per-text edition/alignment decisions — see the doc's Track A section.

Model: Opus 4.8 (`claude-opus-4-8`) orchestration/design; DeepSeek `deepseek-chat` extraction. Bulk `*.jsonl` gitignored; code + docs + precision sample committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)