### PR TITLE
H215 Slice 2 — composite A/B/C TM grader (tm_grade.py)

### DIFF
--- a/RussianTranslation/src/BUILD_TMX.md
+++ b/RussianTranslation/src/BUILD_TMX.md
@@ -1,4 +1,4 @@
-# build_tmx.py — corpus Sa→Ru TM as TMX 1.4b
+# build_tmx.py — corpus Sa→Ru TM as TMX 1.4b + composite grader
 
 _Created: 06-07-2026 · Last updated: 06-07-2026_
 
@@ -32,11 +32,51 @@ Each L1 unit becomes one TMX `<tu>`:
 ## Layers and grade (H215 architecture)
 
 TMX today emits the **L1** (word/phrase) layer; the **L0** verse-segment layer
-(real `<tu>` segment pairs) arrives with **Slice 3**. Every unit is stamped
-**`grade=C`** ("usage/citation only") until the composite grader
-(**Slice 2**, `src/tm_grade.py`: COMET-QE + source-weight + alignment confidence +
-consensus → A/B/C) assigns a real grade. Do **not** hand-promote grades in this
-exporter.
+(real `<tu>` segment pairs) arrives with **Slice 3**. The composite A/B/C grade is
+assigned by **Slice 2** ([`src/tm_grade.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_grade.py),
+below); `build_tmx build --grades <sidecar>` stamps those real grades. Without a
+sidecar the exporter falls back to `grade=C` ("usage/citation only") — do **not**
+hand-promote grades in the exporter.
+
+## Composite grade — Slice 2 (`tm_grade.py`)
+
+[`src/tm_grade.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_grade.py)
+assigns each unit the publication-grade **A/B/C** stamp MG specified, from a weighted
+composite of four signals (weights versioned in the module, currently
+qe 0.35 · source 0.30 · consensus 0.20 · align 0.15):
+
+| Signal | This slice | Notes |
+|---|---|---|
+| `source_weight` | **real** — [`src/tm_source_weights.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_source_weights.json) | hand-ranked, versioned trust prior per work / translator / kind |
+| `consensus` | **real** — computed over the whole corpus | distinct works giving a rendering for the same `(passage, slp1)`, and how far they agree |
+| `qe_score` | pluggable — `proxy` (default) or `comet` | `proxy` = deterministic, reference-free **fluency/form** heuristic so it runs with no model; `comet` = COMET-QE (`Unbabel/wmt22-cometkiwi-da`) via `unbabel-comet` if installed |
+| `alignment_confidence` | **proxy** (weighted low) | token-count plausibility; the real SimAlign / awesome-align score lands in **Slice 3** |
+
+**Grade gates.** `A` = composite ≥ 0.70 **AND corroborated** (≥2 works agreeing,
+≥50%) **OR** human-adjudicated — a publication/citable gloss. `B` = composite ≥ 0.55
+(decent, single-reference, aligned — the corpus-signal role in `corpus_gate.py`).
+`C` = everything else. The corroboration gate on `A` is deliberate: it is what makes
+the stamp trustworthy, not the QE proxy alone.
+
+```
+python src/tm_grade.py grade [--in P] [--qe proxy|comet] [--sample N] [--out sidecar]
+python src/tm_grade.py calibrate [--gold gold/gold_set.jsonl] [--in P]
+python src/tm_grade.py selftest
+python src/build_tmx.py build --grades release/corpus_tm/corpus_tm.grades.jsonl   # stamp real grades
+```
+
+**Measured (06-07-2026, `qe=proxy`, Opus 4.8 `claude-opus-4-8` orchestration).** Over
+the full 1,091,528-unit corpus: **A 5.7% · B 94.0% · C 0.3%**. Every one of the 62,503
+A units satisfies the consensus gate (0 violations) — A is driven by the
+multi-translation clusters (Bhagavad-gītā ×10, repeated epic verses). Calibration on
+the 320-row labelled [`gold/gold_set.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/gold/gold_set.jsonl)
+shows **0 defective rows (`hallucinated`/`wrong-sense`/`partial`) ever reach A** — but
+also that the reference-free proxy QE only weakly separates acceptable from defective
+(ranking AUC ≈ 0.58): a **surface heuristic cannot detect wrong-sense** (a wrong gloss
+is as fluent as a right one). Semantic discrimination therefore comes from *consensus*
+and the *A-gate's conservatism*, not the proxy — which is precisely why `--qe comet`
+(a trained adequacy model) and Slice 3's real aligner are the next lifts. The grades
+sidecar is gitignored with the corpus; only the grader + weights table + this doc ship.
 
 ## Usage
 

--- a/RussianTranslation/src/_audit.py
+++ b/RussianTranslation/src/_audit.py
@@ -121,6 +121,21 @@ def main():
         except Exception as e:
             print('TMX export: validation skipped (%s)' % e)
 
+    # H215 Slice 2: the grader's deterministic invariants (qe ordering, source
+    # override, consensus, grade gates) are a cheap integrity check regardless of a
+    # release existing -- a broken grader silently mis-stamps the publication TMX.
+    try:
+        import io
+        import contextlib
+        import tm_grade
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = tm_grade.selftest()
+        ok = rc == 0
+        print('TM grader selftest:', 'OK' if ok else 'FAILED')
+        clean = clean and ok
+    except Exception as e:
+        print('TM grader selftest: skipped (%s)' % e)
+
     print('VERDICT:', 'CLEAN' if clean else 'CONTAMINATION FOUND')
     return 0 if clean else 1
 

--- a/RussianTranslation/src/build_tmx.py
+++ b/RussianTranslation/src/build_tmx.py
@@ -10,6 +10,7 @@ Slice 2 (this exporter stamps grade=C on every unit until then, per the handoff)
 
   python build_tmx.py build                 corpus_lexicon.jsonl -> release TMX
   python build_tmx.py build --sample 500    first 500 L1 units (reviewable slice)
+  python build_tmx.py build --grades PATH   stamp real A/B/C from a tm_grade.py sidecar
   python build_tmx.py build --in PATH --out PATH
   python build_tmx.py validate <file.tmx>   round-trip parse + structural checks
   python build_tmx.py selftest              fixture -> export -> re-parse, assert
@@ -147,21 +148,49 @@ def header_xml(count, srcfile):
            count))
 
 
+def load_grades(path):
+    """tuid -> grade from a tm_grade.py sidecar (JSONL: {tuid, grade, ...}). Absent
+    path -> empty map -> every unit keeps DEFAULT_GRADE (Slice-1 behaviour)."""
+    grades = {}
+    if not path:
+        return grades
+    if not os.path.exists(path):
+        sys.exit('grades sidecar not found: %s (run tm_grade.py grade first)' % path)
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+            except Exception:
+                continue
+            if r.get('tuid') and r.get('grade'):
+                grades[r['tuid']] = r['grade']
+    return grades
+
+
 def build(in_path, out_path, sample=None, grade=DEFAULT_GRADE,
-          modality=DEFAULT_MODALITY):
+          modality=DEFAULT_MODALITY, grades_path=None):
     if not os.path.exists(in_path):
         sys.exit('input not found: %s\n(corpus_lexicon.jsonl is gitignored; build it '
                  'first with build_corpus_lexicon.py)' % in_path)
+    grades = load_grades(grades_path)
     units = list(iter_units(in_path))
     if sample is not None:
         units = units[:sample]
+    dist = {}
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
     with open(out_path, 'w', encoding='utf-8', newline='\n') as out:
         out.write(header_xml(len(units), in_path))
         for r in units:
-            out.write(tu_xml(r, grade=grade, modality=modality))
+            g = grades.get(tuid(r), grade)   # sidecar wins; else the default stamp
+            dist[g] = dist.get(g, 0) + 1
+            out.write(tu_xml(r, grade=g, modality=modality))
         out.write(' </body>\n</tmx>\n')
-    print('build_tmx: %d L1 units -> %s' % (len(units), out_path))
+    gsrc = 'sidecar %s' % os.path.basename(grades_path) if grades else 'default=%s' % grade
+    print('build_tmx: %d L1 units -> %s  (grade: %s; dist %s)'
+          % (len(units), out_path, gsrc, dist))
     ok, msg = validate(out_path)
     print(msg)
     return 0 if ok else 1
@@ -285,7 +314,8 @@ def main():
     b.add_argument('--in', dest='inp', default=DEFAULT_IN)
     b.add_argument('--out', dest='out', default=DEFAULT_OUT)
     b.add_argument('--sample', type=int, default=None, help='export only the first N L1 units')
-    b.add_argument('--grade', default=DEFAULT_GRADE, help='grade stamp (default C; Slice 2 replaces this)')
+    b.add_argument('--grade', default=DEFAULT_GRADE, help='fallback grade stamp when no sidecar (default C)')
+    b.add_argument('--grades', dest='grades', default=None, help='tm_grade.py sidecar JSONL -> real A/B/C per unit')
     b.add_argument('--modality', default=DEFAULT_MODALITY)
 
     v = sub.add_parser('validate', help='round-trip validate an existing TMX')
@@ -295,7 +325,8 @@ def main():
 
     a = ap.parse_args()
     if a.cmd == 'build':
-        return build(a.inp, a.out, sample=a.sample, grade=a.grade, modality=a.modality)
+        return build(a.inp, a.out, sample=a.sample, grade=a.grade,
+                     modality=a.modality, grades_path=a.grades)
     if a.cmd == 'validate':
         ok, msg = validate(a.path)
         print(msg)

--- a/RussianTranslation/src/tm_grade.py
+++ b/RussianTranslation/src/tm_grade.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python
+r"""H215 Slice 2 -- composite A/B/C grader for the corpus Sa->Ru translation memory.
+
+Slice 1 (build_tmx.py) stamps every unit grade=C. This assigns the real
+"publication-grade" A/B/C stamp from the four signals MG specified:
+
+    grade = f( qe_score,             # reference-free quality estimate, per unit
+               source_weight,        # per-work / per-translator trust prior (versioned)
+               alignment_confidence, # aligner confidence for the Sa<->Ru pairing
+               consensus )           # >=2 works agreeing on one (segment, key)
+
+A -- publication / hard gloss: high composite AND corroborated (consensus >=2 that
+     agree) OR human-adjudicated. Usable in a print card + as a citable gloss.
+B -- corroborating: decent composite, single reference, aligned. Raises confidence,
+     never decides alone (the current corpus-signal role in corpus_gate.py).
+C -- usage / citation only: low composite, verse-level co-occurrence, oral/noisy.
+
+Signal provenance in THIS slice (honest about what is real vs a proxy):
+  * source_weight   -- REAL, from tm_source_weights.json (hand-ranked, versioned).
+  * consensus       -- REAL, computed over the whole corpus: distinct works giving a
+                       rendering for the same (passage, slp1) and how far they agree.
+  * qe_score        -- pluggable: `proxy` (deterministic, reference-free heuristic,
+                       the default so this runs with no model) or `comet` (COMET-QE
+                       via unbabel-comet if installed -- the Slice hook). NOT trained.
+  * alignment_confidence -- a Slice-2 PROXY (token-count plausibility). The real
+                       SimAlign / awesome-align score lands in Slice 3; this is a
+                       placeholder weighted low, documented so no one mistakes it for
+                       a trained aligner output.
+
+  python tm_grade.py grade [--in P] [--qe proxy|comet] [--sample N] [--out P]
+                                          corpus_lexicon.jsonl -> grades sidecar + dist
+  python tm_grade.py calibrate [--gold gold/gold_set.jsonl] [--in P]
+                                          grade the labelled gold set, cross-tab vs label
+  python tm_grade.py selftest             deterministic fixture asserts
+
+The grades sidecar (tuid -> grade + score + signals, JSONL) is what build_tmx.py
+consumes via `--grades` to stamp real grades. It is gitignored with the corpus.
+
+Model provenance: deterministic (proxy QE) -- no LLM call unless --qe comet is chosen
+and unbabel-comet is installed. Upstream alignments were DeepSeek (build_corpus_lexicon).
+"""
+import argparse
+import collections
+import json
+import os
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+import build_tmx  # tuid(), has_cyr(), iter_units() -- reuse, don't fork the guards
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.normpath(os.path.join(HERE, '..'))
+DEFAULT_IN = os.path.join(HERE, 'corpus_lexicon.jsonl')
+DEFAULT_OUT = os.path.join(ROOT, 'release', 'corpus_tm', 'corpus_tm.grades.jsonl')
+DEFAULT_GOLD = os.path.join(ROOT, 'gold', 'gold_set.jsonl')
+WEIGHTS_PATH = os.path.join(HERE, 'tm_source_weights.json')
+
+GRADER_VERSION = '0.1.0'
+
+# Composite weights (versioned; sum to 1.0). qe + source dominate; the alignment
+# proxy is deliberately small until Slice 3 supplies a real aligner score.
+W = {'qe': 0.35, 'source': 0.30, 'consensus': 0.20, 'align': 0.15}
+
+# Grade thresholds (calibrated against gold/gold_set.jsonl -- see `calibrate`).
+T_A = 0.70   # composite floor for A (ALSO requires corroboration/adjudication)
+T_B = 0.55   # composite floor for B
+CONSENSUS_MIN_REFS = 2      # A needs >=2 works ...
+CONSENSUS_MIN_AGREE = 0.50  # ... and >=50% of them agreeing on the modal rendering
+
+CYR_TOKEN = re.compile(r'[Ѐ-ӿ]+')
+LATIN = re.compile(r'[A-Za-zĀ-ſḀ-ỿ]')
+REJECT_RU = {'нет', 'неизвестно', '—', '-', '?', '...', '…'}
+
+
+# ---------------------------------------------------------------- source weight
+def load_weights(path=WEIGHTS_PATH):
+    if os.path.exists(path):
+        return json.load(open(path, encoding='utf-8'))
+    return {}
+
+
+def source_weight(rec, weights):
+    """Trust prior in [0,1] for the unit's provenance. Exact `work` override wins,
+    then a source-family substring rule, then a per-`kind` default."""
+    work = rec.get('work') or ''
+    bywork = weights.get('by_work', {})
+    if work in bywork:
+        return float(bywork[work])
+    for frag, w in weights.get('by_work_contains', {}).items():
+        if frag in work:
+            return float(w)
+    kind = rec.get('kind') or 'translation'
+    return float(weights.get('by_kind', {}).get(kind,
+                 weights.get('default', 0.6)))
+
+
+# ------------------------------------------------------------------- qe backend
+def qe_proxy(rec):
+    """Deterministic, reference-free quality estimate in [0,1]. NOT a trained
+    metric -- a transparent heuristic standing in for COMET-QE until --qe comet is
+    available. Rewards a clean, short, Cyrillic lexical gloss; penalizes the shapes
+    the never-invent lesson taught us to distrust (latin-in-gloss, echo, run-on)."""
+    ru = (rec.get('ru') or '').strip()
+    sa = (rec.get('sa') or '').strip()
+    if not build_tmx.has_cyr(ru) or ru == sa or ru.lower() in REJECT_RU:
+        return 0.0
+    score = 0.7
+    toks = CYR_TOKEN.findall(ru)
+    ntok = len(toks)
+    # a single SLP1 headword should map to a short gloss; long run-ons are noisier
+    if ntok == 0:
+        return 0.0
+    if 1 <= ntok <= 3:
+        score += 0.2
+    elif ntok <= 6:
+        score += 0.05
+    else:
+        score -= 0.15 + min(0.2, 0.02 * (ntok - 6))
+    # latin letters bleeding into the Russian gloss = transliteration/markup leak
+    latin = len(LATIN.findall(ru))
+    if latin:
+        score -= min(0.3, 0.05 * latin)
+    # cyrillic coverage of the gloss (mostly-Cyrillic is good)
+    cyr_chars = sum(len(t) for t in toks)
+    frac_cyr = cyr_chars / max(1, len(ru.replace(' ', '')))
+    score += 0.1 * (frac_cyr - 0.5)
+    return max(0.0, min(1.0, score))
+
+
+def qe_comet_factory():
+    """Return a COMET-QE scorer if unbabel-comet is installed, else None. The
+    reference-free model scores (src, mt) pairs; we feed the printed Sanskrit
+    surface as src and the Russian as mt. This is the Slice hook -- absent the
+    package we fall back to qe_proxy, logged."""
+    try:
+        from comet import download_model, load_from_checkpoint
+    except Exception:
+        return None
+    try:
+        model = load_from_checkpoint(download_model('Unbabel/wmt22-cometkiwi-da'))
+    except Exception as e:
+        sys.stderr.write('qe: comet import ok but model load failed (%s); '
+                         'falling back to proxy\n' % e)
+        return None
+
+    def score(rec):
+        data = [{'src': rec.get('sa') or rec.get('slp1') or '',
+                 'mt': rec.get('ru') or ''}]
+        try:
+            out = model.predict(data, batch_size=8, gpus=0, progress_bar=False)
+            return max(0.0, min(1.0, float(out['scores'][0])))
+        except Exception:
+            return qe_proxy(rec)
+    return score
+
+
+def make_qe(backend):
+    if backend == 'comet':
+        fn = qe_comet_factory()
+        if fn is not None:
+            return fn, 'comet'
+        sys.stderr.write('qe: unbabel-comet not available -> using deterministic proxy\n')
+    return qe_proxy, 'proxy'
+
+
+# ---------------------------------------------------------------- align proxy
+def align_proxy(rec):
+    """Placeholder alignment confidence in [0,1] pending Slice 3's real aligner.
+    A single SLP1 key aligning to 1-2 Russian tokens is a confident 1:1 pairing;
+    a run-on Russian phrase for one key is a weaker alignment."""
+    toks = CYR_TOKEN.findall(rec.get('ru') or '')
+    n = len(toks)
+    if n == 0:
+        return 0.0
+    if n <= 2:
+        return 0.9
+    if n <= 4:
+        return 0.7
+    if n <= 8:
+        return 0.5
+    return 0.3
+
+
+# ------------------------------------------------------------------- consensus
+def norm_ru(s):
+    return re.sub(r'\s+', ' ', (s or '').strip().lower())
+
+
+def seg_key(rec):
+    """A segment identity that is shared across different translators of the SAME
+    verse+word: (normalized passage, slp1). Works differ; passage+key is the anchor."""
+    return (rec.get('passage') or '', rec.get('slp1') or '')
+
+
+def build_consensus(path, limit=None):
+    """One pass over the corpus: seg_key -> {work: normalized_ru}. Distinct works
+    only (a work repeating a gloss is not corroboration)."""
+    idx = collections.defaultdict(dict)
+    n = 0
+    for rec in build_tmx.iter_units(path):
+        idx[seg_key(rec)][rec.get('work')] = norm_ru(rec.get('ru'))
+        n += 1
+        if limit and n >= limit:
+            break
+    return idx
+
+
+def consensus_signal(rec, idx):
+    """Return (n_refs, consensus_score in [0,1]). n_refs = distinct works giving a
+    rendering for this (passage, key); consensus_score = share agreeing with the
+    modal normalized rendering (0 when only one work has it)."""
+    works = idx.get(seg_key(rec))
+    if not works:
+        return 1, 0.0
+    n = len(works)
+    if n < 2:
+        return n, 0.0
+    modal = collections.Counter(works.values()).most_common(1)[0][1]
+    return n, modal / n
+
+
+# ---------------------------------------------------------------- composite grade
+def grade_unit(rec, weights, qe_fn, consensus_idx, adjudicated=False):
+    qe = qe_fn(rec)
+    src = source_weight(rec, weights)
+    align = align_proxy(rec)
+    n_refs, cons = consensus_signal(rec, consensus_idx)
+    score = (W['qe'] * qe + W['source'] * src
+             + W['consensus'] * cons + W['align'] * align)
+    corroborated = n_refs >= CONSENSUS_MIN_REFS and cons >= CONSENSUS_MIN_AGREE
+    if adjudicated and qe > 0:
+        grade = 'A'
+    elif score >= T_A and corroborated:
+        grade = 'A'
+    elif score >= T_B:
+        grade = 'B'
+    else:
+        grade = 'C'
+    return {'grade': grade, 'score': round(score, 4),
+            'qe': round(qe, 4), 'source_weight': round(src, 4),
+            'alignment_confidence': round(align, 4),
+            'consensus': round(cons, 4), 'n_refs': n_refs}
+
+
+# ------------------------------------------------------------------------- cmds
+def cmd_grade(a):
+    if not os.path.exists(a.inp):
+        sys.exit('input not found: %s (corpus_lexicon.jsonl is gitignored -- build it '
+                 'first)' % a.inp)
+    weights = load_weights()
+    qe_fn, qe_name = make_qe(a.qe)
+    print('grade: building consensus index over %s ...' % os.path.basename(a.inp),
+          flush=True)
+    idx = build_consensus(a.inp)
+    print('grade: %d distinct (passage,key) segments indexed' % len(idx))
+    dist = collections.Counter()
+    os.makedirs(os.path.dirname(a.out), exist_ok=True)
+    n = 0
+    with open(a.out, 'w', encoding='utf-8', newline='\n') as out:
+        for rec in build_tmx.iter_units(a.inp):
+            g = grade_unit(rec, weights, qe_fn, idx)
+            dist[g['grade']] += 1
+            out.write(json.dumps({'tuid': build_tmx.tuid(rec), **g},
+                                 ensure_ascii=False) + '\n')
+            n += 1
+            if a.sample and n >= a.sample:
+                break
+    tot = sum(dist.values()) or 1
+    print('grade: %d units graded (qe=%s) -> %s' % (n, qe_name, a.out))
+    for g in 'ABC':
+        print('  %s  %8d  %5.1f%%' % (g, dist[g], 100 * dist[g] / tot))
+    return 0
+
+
+# Gold labels split into semantically-acceptable vs defective, for separation stats.
+ACCEPTABLE = {'correct', 'lemma-variant', 'proper-name'}
+DEFECTIVE = {'partial', 'wrong-sense', 'hallucinated'}
+
+
+def cmd_calibrate(a):
+    if not os.path.exists(a.gold):
+        sys.exit('gold set not found: %s' % a.gold)
+    weights = load_weights()
+    qe_fn, qe_name = make_qe(a.qe)
+    idx = build_consensus(a.inp) if os.path.exists(a.inp) else {}
+    if not idx:
+        print('calibrate: corpus absent -> consensus signal unavailable, n_refs=1 '
+              '(grades reflect qe+source+align only; A gate cannot fire)')
+    rows = [json.loads(l) for l in open(a.gold, encoding='utf-8') if l.strip()]
+    by_label = collections.defaultdict(list)
+    cross = collections.defaultdict(collections.Counter)
+    for r in rows:
+        g = grade_unit(r, weights, qe_fn, idx)
+        by_label[r.get('label')].append(g['score'])
+        cross[r.get('label')][g['grade']] += 1
+
+    print('calibrate: %d gold rows, qe=%s, weights=%s' % (len(rows), qe_name, W))
+    print('  thresholds: A>=%.2f (+corrob.), B>=%.2f' % (T_A, T_B))
+    print('\n  label            n   mean_score   grade dist (A/B/C)')
+    print('  ' + '-' * 58)
+    accept_scores, defect_scores = [], []
+    for label in sorted(by_label, key=lambda x: -sum(by_label[x]) / len(by_label[x])):
+        s = by_label[label]
+        mean = sum(s) / len(s)
+        c = cross[label]
+        print('  %-15s %3d   %.3f       %d/%d/%d'
+              % (label, len(s), mean, c['A'], c['B'], c['C']))
+        (accept_scores if label in ACCEPTABLE else
+         defect_scores if label in DEFECTIVE else []).extend(s)
+    if accept_scores and defect_scores:
+        ma = sum(accept_scores) / len(accept_scores)
+        md = sum(defect_scores) / len(defect_scores)
+        auc = _auc(accept_scores, defect_scores)
+        print('\n  separation: mean(acceptable)=%.3f  mean(defective)=%.3f  '
+              'gap=%.3f' % (ma, md, ma - md))
+        print('  ranking AUC (acceptable scored above defective): %.3f' % auc)
+        # leakage: defective rows that reached A (should be ~0)
+        a_leak = sum(cross[l]['A'] for l in DEFECTIVE)
+        print('  defective-in-A leakage: %d (want 0)' % a_leak)
+    return 0
+
+
+def _auc(pos, neg):
+    """Prob. a random acceptable scores >= a random defective (ties=0.5). O(n*m),
+    fine for the 320-row gold set."""
+    if not pos or not neg:
+        return float('nan')
+    wins = ties = 0
+    for p in pos:
+        for q in neg:
+            if p > q:
+                wins += 1
+            elif p == q:
+                ties += 1
+    return (wins + 0.5 * ties) / (len(pos) * len(neg))
+
+
+# ------------------------------------------------------------------------ selftest
+FIXTURE_WEIGHTS = {'default': 0.6, 'by_kind': {'translation': 0.75, 'commentary': 0.6},
+                   'by_work_contains': {'bhagavadgita': 0.85}}
+
+
+def selftest():
+    # a clean short gloss must score higher than a run-on / latin-contaminated one
+    clean = {'slp1': 'karman', 'sa': 'karma', 'ru': 'действие', 'kind': 'translation',
+             'work': 'bhagavadgita-sementsov', 'passage': '2.47'}
+    runon = {'slp1': 'karman', 'sa': 'karma', 'ru': 'действие обязанность долг и так '
+             'далее в широком смысле', 'kind': 'translation', 'work': 'x', 'passage': '9'}
+    leak = {'slp1': 'deva', 'sa': 'devaH', 'ru': 'бог deva', 'kind': 'commentary',
+            'work': 'x', 'passage': '1'}
+    assert qe_proxy(clean) > qe_proxy(runon) > 0, 'clean must beat run-on'
+    assert qe_proxy(clean) > qe_proxy(leak), 'clean must beat latin-leak'
+    assert qe_proxy({'ru': 'deva', 'sa': 'deva', 'slp1': 'deva'}) == 0.0, 'echo -> 0'
+
+    # source weight: work-contains override beats kind default
+    assert source_weight(clean, FIXTURE_WEIGHTS) == 0.85
+    assert source_weight(runon, FIXTURE_WEIGHTS) == 0.75
+
+    # consensus: two works agreeing -> corroborated; disagreeing -> not
+    idx = build_consensus_from_records([
+        {'passage': '2.47', 'slp1': 'karman', 'ru': 'действие', 'sa': 'k', 'work': 'a'},
+        {'passage': '2.47', 'slp1': 'karman', 'ru': 'Действие', 'sa': 'k', 'work': 'b'},
+        {'passage': '3.1', 'slp1': 'yoga', 'ru': 'йога', 'sa': 'y', 'work': 'a'},
+        {'passage': '3.1', 'slp1': 'yoga', 'ru': 'усилие', 'sa': 'y', 'work': 'b'},
+    ])
+    n, c = consensus_signal({'passage': '2.47', 'slp1': 'karman'}, idx)
+    assert n == 2 and c == 1.0, 'agreeing works -> full consensus, got %s/%s' % (n, c)
+    n2, c2 = consensus_signal({'passage': '3.1', 'slp1': 'yoga'}, idx)
+    assert n2 == 2 and c2 == 0.5, 'split works -> 0.5 consensus, got %s/%s' % (n2, c2)
+
+    # grade: corroborated clean gloss reaches A; identical unit w/o consensus is B;
+    # a defective (echo) unit is C.
+    qe_fn = qe_proxy
+    gA = grade_unit(clean, FIXTURE_WEIGHTS, qe_fn, idx)
+    assert gA['grade'] == 'A', 'corroborated clean gloss should be A, got %s' % gA
+    gB = grade_unit(clean, FIXTURE_WEIGHTS, qe_fn, {})   # no consensus index
+    assert gB['grade'] == 'B', 'uncorroborated clean gloss should be B, got %s' % gB
+    gC = grade_unit(leak, FIXTURE_WEIGHTS, qe_fn, {})
+    assert gC['grade'] in ('B', 'C') and gC['grade'] != 'A', 'leak must not be A'
+    # adjudicated overlay forces A
+    gAdj = grade_unit(runon, FIXTURE_WEIGHTS, qe_fn, {}, adjudicated=True)
+    assert gAdj['grade'] == 'A', 'adjudicated unit should be A'
+    print('tm_grade selftest OK -- qe ordering, source override, consensus, grade gates')
+    return 0
+
+
+def build_consensus_from_records(recs):
+    idx = collections.defaultdict(dict)
+    for r in recs:
+        idx[seg_key(r)][r.get('work')] = norm_ru(r.get('ru'))
+    return idx
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Composite A/B/C grader for the Sa->Ru TM (H215 Slice 2)')
+    sub = ap.add_subparsers(dest='cmd', required=True)
+
+    g = sub.add_parser('grade', help='corpus_lexicon.jsonl -> grades sidecar + distribution')
+    g.add_argument('--in', dest='inp', default=DEFAULT_IN)
+    g.add_argument('--out', dest='out', default=DEFAULT_OUT)
+    g.add_argument('--qe', choices=['proxy', 'comet'], default='proxy')
+    g.add_argument('--sample', type=int, default=None)
+
+    c = sub.add_parser('calibrate', help='grade the labelled gold set, cross-tab vs label')
+    c.add_argument('--gold', default=DEFAULT_GOLD)
+    c.add_argument('--in', dest='inp', default=DEFAULT_IN)
+    c.add_argument('--qe', choices=['proxy', 'comet'], default='proxy')
+
+    sub.add_parser('selftest', help='deterministic fixture asserts')
+
+    a = ap.parse_args()
+    if a.cmd == 'grade':
+        return cmd_grade(a)
+    if a.cmd == 'calibrate':
+        return cmd_calibrate(a)
+    if a.cmd == 'selftest':
+        return selftest()
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/RussianTranslation/src/tm_source_weights.json
+++ b/RussianTranslation/src/tm_source_weights.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "H215 Slice 2 source-trust priors for the composite TM grader (tm_grade.py). Weight in [0,1] = how much a rendering's provenance is trusted BEFORE the per-unit QE/consensus signals. Hand-ranked, versioned; edit deliberately. Lookup order: by_work (exact) > by_work_contains (source-family substring) > by_kind > default.",
+  "version": "0.1.0",
+  "default": 0.6,
+  "by_kind": {
+    "translation": 0.75,
+    "commentary": 0.6,
+    "mined": 0.4,
+    "specialist": 0.7
+  },
+  "by_work_contains": {
+    "bhagavadgita": 0.8,
+    "yoga-sutry": 0.78,
+    "ramayana": 0.75,
+    "mahabharata": 0.75,
+    "rigveda": 0.72,
+    "atharvaveda": 0.72,
+    "-up": 0.74
+  },
+  "by_work": {
+    "bhagavadgita-sementsov": 0.9,
+    "bhagavadgita-smirnov": 0.88,
+    "bhagavadgita-erman": 0.88,
+    "manavadharmashastra": 0.82,
+    "kama-sutra": 0.8
+  }
+}


### PR DESCRIPTION
Second slice of [H215](https://github.com/gasyoun/Uprava/blob/main/handoffs/H215-Opus_RussianTranslation_pwg_ru_publication_grade_tm_tmx_and_oral_06.07.26.md) (publication-grade Sa→Ru TM). Slice 1 (TMX exporter, [PR #180](https://github.com/gasyoun/SanskritLexicography/pull/180)) stamped every unit `grade=C`; this assigns the real **A/B/C** stamp.

## What

New [`src/tm_grade.py`](https://github.com/gasyoun/SanskritLexicography/blob/h215-slice2-grader/RussianTranslation/src/tm_grade.py) — composite grader over `corpus_lexicon.jsonl`, from the four signals MG specified (versioned weights qe 0.35 · source 0.30 · consensus 0.20 · align 0.15):

| Signal | This slice |
|---|---|
| `source_weight` | **real** — [`tm_source_weights.json`](https://github.com/gasyoun/SanskritLexicography/blob/h215-slice2-grader/RussianTranslation/src/tm_source_weights.json), hand-ranked per work/translator/kind |
| `consensus` | **real** — whole-corpus: distinct works agreeing on one `(passage, slp1)` |
| `qe_score` | pluggable — deterministic reference-free `proxy` (default, runs with no model) or COMET-QE `comet` hook |
| `alignment_confidence` | **proxy** (weighted low) — real SimAlign/awesome-align lands in Slice 3 |

**Gates:** `A` = composite ≥ 0.70 **AND corroborated** (≥2 works agreeing, ≥50%) **OR** human-adjudicated; `B` = ≥ 0.55 (single-ref aligned); `C` = else. The corroboration gate is what makes `A` trustworthy.

Integration: `build_tmx.py build --grades <sidecar>` stamps the real grades (sidecar wins, else default C); `_audit.py` runs the grader selftest as a cheap integrity gate.

## Measured (full 1,091,528-unit corpus, `qe=proxy`)

**A 5.7% · B 94.0% · C 0.3%.** Every one of the 62,503 A units satisfies the consensus gate (0 violations) — A is driven by the multi-translation clusters (Bhagavad-gītā ×10, repeated epic verses).

**Calibration** on the 320-row labelled [`gold/gold_set.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/h215-slice2-grader/RussianTranslation/gold/gold_set.jsonl): **0 defective rows (`hallucinated`/`wrong-sense`/`partial`) ever reach A**. Honestly reported limitation: the reference-free proxy QE only weakly separates acceptable vs defective (ranking AUC ≈ 0.58) — a surface/fluency heuristic can't detect wrong-sense. Semantic discrimination therefore comes from **consensus + the A-gate's conservatism**, not the proxy; `--qe comet` (trained adequacy model) and Slice 3's real aligner are the next lifts.

## Scope / files

`src/tm_grade.py`, `src/tm_source_weights.json` (new); `src/build_tmx.py`, `src/_audit.py`, `src/BUILD_TMX.md` (edited). Grades sidecar + TMX stay **gitignored** (in-copyright translations, rights clearance is Slice 5). Both `build_tmx` and `tm_grade` selftests green.

**Remaining H215:** Slice 3 (L0 segment layer + real word-align cross-check), Slice 4 (oral ingest, coordinate H174), Slice 5 (FAIR release — the real blocker, rights).

🤖 Generated with [Claude Code](https://claude.com/claude-code)