### PR TITLE
docs(pwg_ru): H178 Part A — re-audit memo, dah 31/31, execution-model + source doc fixes

### DIFF
--- a/RussianTranslation/pwg_ru/H178_REAUDIT_2026-07-06.md
+++ b/RussianTranslation/pwg_ru/H178_REAUDIT_2026-07-06.md
@@ -1,0 +1,137 @@
+# H178 Part A — historical re-audit memo (gate-fixes + source-completeness)
+
+_Created: 06-07-2026 · Last updated: 06-07-2026_
+
+Session: Fable 5 (`claude-fable-5`) orchestrating; generation (A-2 re-runs) Sonnet 5
+(`claude-sonnet-5`) via the harness's hardcoded `model:'sonnet'`. Handoff:
+[H178](https://github.com/gasyoun/Uprava/blob/main/handoffs/H178-Fable_RussianTranslation_pwg_ru_acl_verify_improve_05.07.26.md).
+All audits below are deterministic (0 LLM tokens) unless marked.
+
+## A-1(b) — source-completeness date partition: ✅ CONFIRM-CLEAN, 0 pre-merge roots
+
+The 5-layer all-in-one source
+([`_pilot_gen_merged.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/_pilot_gen_merged.py):
+PWG main+Nachträge + PW + SCH + PWKVN + NWS) went live in commit `1dad0dd` on **17-06-2026
+(14:56Z cutoff)**. Partition of the live promoted store (11,185 rows / 50 roots-or-window-keys at
+audit time; 11,261 / 50 after the A-2 `dah` promotions below) by max `provenance.generated_at`
+per root:
+
+- **Pre-merge (pure-PWG) roots: 0. Post-merge (all-in-one) roots: 50.**
+- Earliest generation event in the store: **2026-06-29T11:40Z** (`han`) — the bulk freq-drain
+  began ~12 days after the merge landed. Latest: 2026-07-06 (`no_pwg_w1`).
+- **No re-runs required.** The preliminary 05-07 partition is confirmed; the promoted store is
+  entirely all-in-one. Per-root first/last generation timestamps are reproducible with the
+  partition recipe in H178 A-1(b) (group by `provenance.root`, bucket max `generated_at` vs
+  `2026-06-17T14:56Z`).
+- Incidental finding: **9 `vid` rows carry no `generated_at` / no input SHAs** — these are the
+  known H188 🟠 finding (stripped-meta autosplit merge, fixed forward by `_autosplit_meta()` in
+  [PR #197](https://github.com/gasyoun/SanskritLexicography/pull/197); the 9 legacy rows were
+  not backfilled). Content spot-checked complete and well-formed (see A-1(a)).
+- The stale 217-card a-section PoC (`pwg_ru_translated.enriched/.renou.jsonl`) is pre-merge
+  pure-PWG but superseded and **not** in the live store — stale-artifact cleanup, not a content
+  gap (unchanged from the 05-07 note).
+
+## A-1(a) — gate-fix re-audit sweep (PR #119 + H169 loud-fail + H155 presplit gates)
+
+Every surviving RU-lane `wf_output` artifact was re-audited with
+[`audit_window.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window.py)
+under the CURRENT gates in forensic `--allow-stale --ephemeral` mode: **65 artifacts total**
+(19 with modern `lang` metadata + 46 legacy `lang=None` windows from
+`archive/legacy_runtime_2026-07-04/`), covering ~2,900 audited cards across all 48 legacy
+promoted roots plus `dah`, `nominal_w1_100small`, `no_pwg_w1`.
+
+### Headline results
+
+| window class | result |
+|---|---|
+| `dah` promoted 29 (`wf_output.json`) | **0 requeue — CLEAR.** The two 04-07 held cards (`dah~~h0_zz_nws00`, `dah~~h0_zz_pw`) are still flagged in `dah.run31.hold.json` — gates are consistent with the hold decision |
+| `no_pwg_w1` promoted 5 | **0 requeue — CLEAR** |
+| `nominal_w1_100small` (100 + requeue7) | 93/100 + 7/7 flagged = **the documented allow-stale nominal misfire**, reproduced exactly (no rootmap ⇒ `missing_required_sense_field` misfires; see the ⚠ caveat in [RUN_LOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_LOG.md), 2026-07-06 block, where manual inspection cleared the same keys). **Not defects** |
+| 46 legacy verb windows (generated 29-06 → 01-07) | 464 / 2,148 cards flagged (~22 %) in forensic mode — see decomposition below |
+
+### Decomposition of the legacy-window flags — mostly forensic-mode artifacts, not defects
+
+1. **Source-render drift, not translation defects.** The flagged coverage failures
+   (53 × `COVERAGE-OVER`, 57 × `COVERAGE-LOW` across 52 distinct root-reports) compare
+   June-generation cards against **today's** source render, which has since evolved
+   (`{{Lbody=NNNN}}` alternate-headword resolution in
+   [PR #183](https://github.com/gasyoun/SanskritLexicography/pull/183), layer routing changes).
+   Example: `vas~~h0_zz_pw00` — card 57 senses vs today's raw render 11 (`COVERAGE-OVER(57/11)`);
+   the store row set matches the card, i.e. the *render* moved, not the translation.
+2. **Superseded artifacts.** 6 flagged keys (3 × `gam` incl. the 01-07 window superseded by the
+   03-07 full 673-card re-run, `_ap~~h3_00_pwg00`, `gam~~h0_01_sec_1_0`, `vid` autosplit) point
+   at artifacts whose promoted rows come from a later, healed run.
+3. **Promoted-as-is, low-confidence flags — the true "newly-flagged" candidate list (16 keys):**
+   `car~~h0_23_up_a`, `car~~h0_zz_pw03`, `jan~~h0_11__a`, `jan~~h0_zz_pw00`, `ji~~h0_zz_sch`,
+   `ji~~h3_00_pwg00`, `muc~~h0_20_pra`, `vah~~h0_zz_pw03`, `vah~~h3_00_pwg00`,
+   `vas~~h0_zz_pw00`, `vas~~h0_zz_pw01`, `vas~~h0_zz_pw03`, `vas~~h13_00_pwg00`,
+   `vi_s~~h0_zz_pw01`, plus `vid~~h0_10_ni` (the H188 SHA-less rows; RU content spot-checked
+   complete) and the semantic-risk tail. **All are `high_confidence=0` heuristic risks**
+   (`missing_required_sense_field` / `likely_circular_gloss` / `markup_wrapper_dropped` classes)
+   — judge-sample material, not auto-requeue defects, under the runbook's own policy that
+   forensic allow-stale requeue counts are advisory.
+4. **High-confidence semantic-risk keys: 214 across all 52 root-reports** — the deterministic
+   ~10 % judge sample the QA policy already routes to the LLM judge lane.
+
+### Verdict + recommendation
+
+- **No mass re-translation is justified** (and the H178 guardrail forbids re-translating clean
+  promoted roots). The store is as clean as the ledgers claim *under the gates it was promoted
+  with*; the current-gate flags decompose into source-render drift + known nominal misfire +
+  low-confidence heuristics.
+- **Actionable residue:** (a) fold the 16 promoted-as-is flagged keys + a slice of the 214
+  high-confidence semantic-risk keys into the **H178 Part B-1 human-evaluation sample** as a
+  deliberate oversample of suspected-weak cards — that converts an untrusted forensic signal
+  into a human-verdict signal; (b) treat store-vs-current-render sense-count drift as a known
+  property when re-rendering for publication (the G5 gate re-renders from the store, not from
+  the old raw units).
+
+## A-2 — `dah` tail: ✅ 31/31 promoted (1 documented 🟡 residual)
+
+Workflow tool present in this session (Step 0: full scope). Two Workflow-driven repair runs,
+generation Sonnet 5 (`claude-sonnet-5`), TM denylist (`--no-tm` equivalent) on:
+
+- **`dah~~h0_zz_nws00`** — regenerated whole-card via
+  `requeue_from_audit.py dah --defect` (single-key requeue file): **1/1 ok on attempt 1**
+  (20 owner-mapped NWS entries, complete). Promoted (+20 rows).
+- **`dah~~h0_zz_pw`** — 17 missing fragments re-translated via `autosplit_requeue.py topup`;
+  attempt 1: 12/17, attempt 2: 15/17; **union 16/17**. Fragment `dah~~h0_zz_pw__s10p0` failed
+  the StructuredOutput retry cap (5×) on **both** fresh attempts → per the H178 2-attempt cap
+  and the `vid` precedent the card is promoted as a **documented 🟡 residual**
+  (residual class: *single PW-addenda sense fragment, StructuredOutput retry-cap hard-failure,
+  schema-emission — not the H220 kill-gate class*). Promoted partial (+56 rows,
+  `partial:true`).
+
+Store: **11,185 → 11,261 rows**; `dah` complete at 31/31 cards. TM rebuilt:
+`translation_memory.ru.json` = **2,302 content-addressed cards** (partial + no-raw-sha cards
+correctly excluded), fragment TM 217, publication TM 2,392 — all validations green.
+
+## A-3 — integrity + provenance selftests: ✅ all green
+
+- `window_selftest.py` — **all PASS** (incl. lang-parity ledger tests).
+- `translation_memory.py selftest` — OK; `validate --lang ru` — card 2,302 / frag 217 /
+  publication 2,392, all ok.
+- `audit_translation_provenance.py` — 11,261 rows: **11,261 with exact
+  `model_version=claude-sonnet-5`, 11,261 with the H170 `provenance.pipeline` stamp
+  (1.0.0/1.0.0/1.0.0), 0 stale**. 9 rows missing input SHAs = the known H188 `vid` legacy
+  (documented above); 70 partial-card rows (14 prior + 56 from the `dah~~h0_zz_pw` residual).
+
+## A-4 — execution-model + source docs: ✅ corrected
+
+- [H151](https://github.com/gasyoun/Uprava/blob/main/handoffs/H151-Sonnet_RussianTranslation_pwg_ru_verb_batch_drain_04.07.26.md)
+  step 2 no longer says "Select Sonnet 5 in the model picker" — it now requires a
+  **Workflow-tool-capable session** and states generation is always Sonnet 5 via the hardcoded
+  harness. Verified mechanism honestly: Workflow availability is a per-session tooling fact
+  (Opus 4.8 + Fable 5 sessions had it; one Sonnet chat did not); no "Sonnet can't use Workflow"
+  over-claim.
+- [`RUN_FREQ_MAX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_FREQ_MAX.md)
+  "Current operating truth" now leads with the session/generation-model rule **and** the 5-layer
+  source description; the "main+Nachträge" line in the prompt-nits section was widened to the
+  full 5 layers.
+- H151 guardrail + this handoff's guardrail now both state `pwg.txt` = **PWG layer input only**;
+  the H178 guardrail already carried the corrected wording (MG round-2, 05-07-2026).
+- `project_pwg_ru` memory: **already correct** (frontmatter + body state the 5-layer all-in-one
+  and "the Workflow tool IS the Max-subscription runner") — confirm-clean, no edit, so no
+  claude-config backup sync required for this item.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -43,6 +43,18 @@ tracked-file drift and is wired into `window_selftest.py`
 
 ## Current operating truth
 
+- **Session + generation model (H178 A-4a, 06-07-2026):** run in a session that **HAS the
+  Workflow tool** — the session model picker does NOT control generation. Generation is
+  **always Sonnet 5 (`claude-sonnet-5`)**: the generated harness hardcodes `model:'sonnet'`
+  on every `agent()` call. Workflow-tool availability is a per-session tooling fact, not a
+  tier rule (Opus 4.8 and Fable 5 sessions had it; one Sonnet chat did not) — check the
+  toolset at session start instead of selecting a "generation tier".
+- **The translated source is the 5-layer all-in-one** built by
+  [`_pilot_gen_merged.py`](../_pilot_gen_merged.py) — PWG main+Nachträge + PW + SCH + PWKVN +
+  NWS (owner-mapped) — live since commit `1dad0dd` (17-06-2026), never reverted.
+  `csl-orig/v02/pwg/pwg.txt` is read-only and is only the **PWG layer input**, not "the
+  source"; the `_zz_pw` / `_zz_sch` / `_zz_pwkvn` / `_zz_nws00` card-ID suffixes are the live
+  per-layer routing (H178 A-4b).
 - The optimized **translate-only** Max harness is live and is generated per root by
   [`gen_opt_harness2.py`](gen_opt_harness2.py). It masks and batches raw/portrait inputs,
   disables translate-agent tools, auto-uses translation-memory sidecars when present,
@@ -118,7 +130,8 @@ These four were folded into the inlined prompt of
   `CONV` line + **HARD RULE 3**;
 - ✅ render **every** PWG Nachträge patch — **HARD RULE 4** ("ALL RECORDS,
   INCLUDING NACHTRÄGE … dropping any single patch fails coverage"); inputs are
-  assembled main+Nachträge by `_pilot_gen_merged.py`;
+  assembled by `_pilot_gen_merged.py` as the **5-layer all-in-one** (PWG main+Nachträge
+  + PW + SCH + PWKVN + NWS), not main+Nachträge alone;
 - ✅ treat `<is>...</is>` source italics as siglum text, never `{%...%}` gloss —
   `CONV` line + **HARD RULE 3**;
 - ✅ `nws_split.py` owner-map gate — **HARD RULE 5** (authoritative pre-parsed

--- a/RussianTranslation/src/pilot/RUN_LOG.md
+++ b/RussianTranslation/src/pilot/RUN_LOG.md
@@ -4,6 +4,26 @@ One block per Max run. **Record the model tier on every step** (Sonnet / Opus /
 Haiku / none), not just runtime and tokens. Failures are logged, not hidden.
 History of how the harness got here: [`EVOLUTION_TIMELINE.md`](EVOLUTION_TIMELINE.md).
 
+## 2026-07-06 — `dah` tail (H178 A-2) — gen **Sonnet 5** (`claude-sonnet-5`) / orchestration **Fable 5** (`claude-fable-5`) — ✅ 31/31 PROMOTED (1 documented 🟡 residual)
+
+Finished the two 04-07 held `dah` cards via three Workflow runs (TM-denylisted):
+
+| run | target | result | agents | subagent tokens | wall-clock |
+|---|---|---|---|---|---|
+| defect requeue | `dah~~h0_zz_nws00` (whole card, single-key requeue file) | ✅ 1/1 ok | 1 | 75,693 | ~68s |
+| topup attempt 1 | `dah~~h0_zz_pw` — 17 missing fragments | 12/17 ok, 5 retry-cap nulls | 17 | 1,144,751 | ~67s |
+| topup attempt 2 | same 17 | 15/17 ok, 2 retry-cap nulls | 17 | 1,147,780 | ~78s |
+
+Union of both topup attempts = **16/17 fragments**; only `dah~~h0_zz_pw__s10p0` hard-failed the
+StructuredOutput retry cap (5×) on BOTH fresh attempts → per the H178 2-attempt cap + the `vid`
+precedent, the card is promoted as a **documented 🟡 residual** (residual class: single
+PW-addenda sense fragment, StructuredOutput retry-cap schema-emission failure — NOT the H220
+kill-gate class). Promotions via `promote_final_cards.py --merge --gen-model-version
+claude-sonnet-5`: store **11,185 → 11,261 rows**; `dah` = **31/31 cards**. TM rebuilt (card
+2,302 / frag 217 / publication 2,392, all validate green); provenance audit clean (11,261/11,261
+model_version + pipeline stamps). Full memo:
+[`pwg_ru/H178_REAUDIT_2026-07-06.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H178_REAUDIT_2026-07-06.md).
+
 ## 2026-07-06 — `no_pwg_w1` (H214 no-PWG lane, FIRST run) — gen **Sonnet 5** / orchestration **Opus 4.8** — ⚠️ VALIDATED-NOT-PROMOTED
 
 First-ever translation run of the [H214](https://github.com/gasyoun/Uprava/blob/main/handoffs/H214-Opus_RussianTranslation_pwg_ru_no_pwg_supplement_cards_06.07.26.md)


### PR DESCRIPTION
Part A of [H178](https://github.com/gasyoun/Uprava/blob/main/handoffs/H178-Fable_RussianTranslation_pwg_ru_acl_verify_improve_05.07.26.md) (Fable 5 `claude-fable-5` orchestrating, generation Sonnet 5 `claude-sonnet-5`).

- **A-1(a)** historical gate-fix re-audit over 65 surviving RU artifacts: [`pwg_ru/H178_REAUDIT_2026-07-06.md`](https://github.com/gasyoun/SanskritLexicography/blob/pwg-ru/h178-reaudit/RussianTranslation/pwg_ru/H178_REAUDIT_2026-07-06.md) — dah/no_pwg_w1 CLEAR, nominal allow-stale misfire reproduced-known, legacy flags decomposed (render drift, not defects), 16 promoted-as-is keys routed to the B-1 human-eval oversample
- **A-1(b)** source-completeness partition: **0 pre-merge roots** (confirm-clean)
- **A-2** `dah` 31/31 promoted; `dah~~h0_zz_pw__s10p0` documented 🟡 residual (2-attempt cap); store 11,185→11,261; TM rebuilt+green
- **A-3** all selftests + provenance clean (11,261/11,261 model_version + pipeline stamps)
- **A-4** RUN_FREQ_MAX.md now states the Workflow-tool session rule + 5-layer all-in-one source (twin H151 fix pushed to Uprava)

🤖 Generated with [Claude Code](https://claude.com/claude-code)