### PR TITLE
docs(ReverseDictionary): publication prep — canonical version, errata check, schema, data statement (H270)

### DIFF
--- a/ReverseDictionary/.gitignore
+++ b/ReverseDictionary/.gitignore
@@ -8,6 +8,10 @@
 !README.md
 !INDEX.md
 !ACL_DH_COMPATIBILITY_ANALYSIS.md
+!CHANGELOG.md
+!SCHEMA.md
+!DATA_STATEMENT.md
+!CITATION.cff
 !*/
 !*.mdx
 !*_media/**

--- a/ReverseDictionary/ACL_DH_COMPATIBILITY_ANALYSIS.md
+++ b/ReverseDictionary/ACL_DH_COMPATIBILITY_ANALYSIS.md
@@ -219,4 +219,53 @@ as an `@DECIDE`. Nothing in this report pre-empts the ruling.
    [sighum.wordpress.com](https://sighum.wordpress.com/)) with **WSC 2027** (Dec 2027, IIT
    Bombay) as the flagship target; final venue pick via `/decision-record` when the CFPs are out.
 
+---
+
+## 5. Option (b)'s cost — measured 07-07-2026 ([H270](https://github.com/gasyoun/Uprava/blob/main/handoffs/H270-Sonnet_SanskritLexicography_reverse-dict-publication-prep_07.07.26.md))
+
+**Method used, and why the originally-named source changed.** The plan was to cross
+`187992 headwords.txt` (described as "multi-source attestation tags") against the
+master list. On inspection, that file is **not** a per-word attestation dataset — it is
+a 30-line category-count *legend* (e.g. "74009 headwords coded as cpd1: simple compound
+of 2 parts...") with only 3 illustrative example lines, not the full tagged list its
+name implies. It cannot answer "which headwords are attested only in in-copyright
+sources." Recorded here rather than silently substituted, per this handoff's standing
+rule to investigate rather than guess.
+
+**What was used instead:** the master list's own single-letter source-code column
+(documented in [`SCHEMA.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/SCHEMA.md)).
+Since PWK (public domain) is the implicit default and every other source is marked
+*only when the word is not already coverable from PWK or a higher-priority source*, a
+headword's marked code is a genuine (if imperfect — see caveat below) proxy for "this
+word's presence in the merged list depends on this specific source."
+
+**Result.** Of the 12 source codes actually used in the 266,820-line file, exactly two
+belong to the `ACL_DH_COMPATIBILITY_ANALYSIS.md` §3.1 "in copyright — clear risk" tier:
+
+| Code | Source | Headwords |
+|---|---|--:|
+| `H` | Edgerton, *Buddhist Hybrid Sanskrit Dictionary* (1953) | 12,552 |
+| `P` | Vettam Mani, *Puranic Encyclopaedia* (1979) | 1,919 |
+| **Total** | | **14,471** |
+
+**14,471 / 266,820 = 5.4%** of the full list is tagged to a genuinely in-copyright
+source under this reading — i.e. option (b) (drop/mask risky-source-unique headwords)
+would cost roughly **1 in 18 headwords**, concentrated almost entirely in two sources.
+
+**Important caveat, stated honestly:** the other five "clear risk" sources named in
+§3.1 — Stchoupak–Nitti–Renou, Turner *CDIAL*, Mylius, Kochergina, Pujol — **never
+appear as a marked source-code in the file at all** (see `SCHEMA.md`'s note on the 18
+declared-but-unused codes). This does not prove they contributed zero headwords; it
+means the single-letter-per-line scheme cannot isolate their *unique* contribution from
+whatever higher-priority source a shared headword got tagged under instead. **14,471 is
+therefore a lower bound**, not a final figure — the true cost of option (b) could be
+higher if, e.g., a Kochergina-only headword happens to coincide in form with a PWK
+headword and was silently absorbed as unmarked. Establishing a tighter bound would need
+per-source headword lists for the five silent sources (not available in this folder) to
+diff against the canonical list — out of scope for this pass.
+
+→ This count (14,471 confirmed + caveat) is mirrored to the `@DECIDE` row in
+[`Uprava/GTD_NEXT_ACTIONS.md`](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md)
+so the licensing ruling can weigh it — the ruling itself remains unresolved by this pass.
+
 _Dr. Mārcis Gasūns_

--- a/ReverseDictionary/CHANGELOG.md
+++ b/ReverseDictionary/CHANGELOG.md
@@ -1,0 +1,111 @@
+# Reverse Dictionary of Sanskrit — changelog
+
+_Created: 07-07-2026 · Last updated: 07-07-2026_
+
+Tracks version/canonicity decisions and applied-corrections for the reverse-dictionary
+dataset, per [`ACL_DH_COMPATIBILITY_ANALYSIS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/ACL_DH_COMPATIBILITY_ANALYSIS.md)
+§4 steps 1–2 ([H270](https://github.com/gasyoun/Uprava/blob/main/handoffs/H270-Sonnet_SanskritLexicography_reverse-dict-publication-prep_07.07.26.md)).
+The master `.txt` itself is gitignored (personal-materials-dump folder policy — see
+[`README.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/README.md)
+"Commit scope"); this file is the tracked record of what was declared/verified/changed
+against it.
+
+## [Unreleased]
+
+### Canonical version declared — 07-07-2026
+
+**`.doc.pdf/266820-reverse-Gasuns.txt` is the canonical reverse-dictionary word list.**
+Verified directly (not assumed): 266,820 data lines (`SOURCE_LETTER<TAB>IAST-word<CRLF>`,
+the final line lacking a trailing CRLF — hence "266,819 lines" in earlier notes, which
+counted CRLF-terminated lines only), UTF-8 with a leading BOM (`EF BB BF`), all lines
+already NFC-normalized (checked with Python `unicodedata.normalize`), zero exact
+duplicate lines, and zero duplicate *words* even when the source-letter column is
+ignored — every one of the 266,820 headwords is textually unique.
+
+The following earlier-stage drafts are **superseded** and kept only as historical
+snapshots (per-README, already documented as such — this entry makes the declaration
+formal and dated):
+
+| Draft | Headword count | Form | Status |
+|---|---|---|---|
+| `.doc.pdf/reverse-250026-dev.doc` / `.txt` / `.pdf` | 250,026 | Devanagari script, space-delimited (not the `SOURCE<TAB>word` TSV schema) | Superseded |
+| `.doc.pdf/reverse-255882.doc` | 255,882 | Not converted (26 MB `.doc`, no plain-text sibling) | Superseded |
+| `.doc.pdf/reverse-250026-IAST.pdf` / `reverse-250026-IAST_031213_b3.doc` | 250,026 | IAST transliteration, PDF/Word only | Superseded |
+| `.doc.pdf/266820-reverse-Gasuns.txt` | **266,820** | IAST, `SOURCE<TAB>word` TSV | **Canonical** |
+
+**Why the count grew — investigated, not fully determinable cheaply.** The compiler's
+own preface (`Обратный словарь санскрита.mdx`) frames the three counts as "different
+stages of the compilation," not different editions. A cheap, direct diff of the drafts
+against the canonical list was attempted and found **not feasible without a
+non-trivial conversion step**:
+
+- The 250,026-word draft's only plain-text form (`reverse-250026-dev.txt`) is in
+  **Devanagari script**, space-delimited, not the canonical file's IAST/TSV schema —
+  comparing headword sets across the two would require a Devanagari→IAST
+  transliteration pass first (a real conversion project, not a cheap check).
+- The 255,882-word draft has **no plain-text form at all** — only a 26 MB `.doc`,
+  already excluded from this session's doc→mdx conversion pass (see README "What was
+  converted this session") as disproportionate to convert.
+- The IAST-script variant of the 250,026 draft exists only as PDF/`.doc`, not `.txt`.
+
+**Honest conclusion:** the exact source of growth (new source dictionaries added
+between drafts vs. error corrections vs. both) is **not established here** — recorded
+as "growth unexplained" rather than guessed, per this task's own instruction. A future
+session could resolve this cheaply only after a Devanagari-to-IAST transliteration
+pass over `reverse-250026-dev.txt` (out of scope for this pass).
+
+### Outstanding errata — investigated, found already resolved — 07-07-2026
+
+[`Опечатки которые не успели.mdx`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/%D0%9E%D0%BF%D0%B5%D1%87%D0%B0%D1%82%D0%BA%D0%B8%20%D0%BA%D0%BE%D1%82%D0%BE%D1%80%D1%8B%D0%B5%20%D0%BD%D0%B5%20%D1%83%D1%81%D0%BF%D0%B5%D0%BB%D0%B8.mdx)
+is a pdftotext extraction of the source PDF and lost all Cyrillic/Devanagari text and
+diacritics (the PDF's embedded fonts have no usable ToUnicode mapping for those glyphs)
+— the `.mdx` alone is not reliable enough to drive an automated find/replace against a
+266,820-line canonical dataset. The source PDF was instead **rendered to page images**
+(`PyMuPDF`/`fitz`, since `pdftoppm` is not installed locally) and read visually — the
+table is a clean "стр. (page) / было (was) / заменить на (replace with)" errata table
+titled *"Опечатки, которые не успели исправить к лету 2018"* ("Typos we didn't get to
+by summer 2018"), i.e. corrections outstanding against a **2018 print-layout draft** of
+the full glossed dictionary (page numbers, Russian glosses, grammatical tags, and
+front-alphabetized section headers like `ca`/`da`/`pa` — a different, richer artifact
+than this folder's bare `SOURCE<TAB>word` reverse-index list).
+
+Of the ~30 rows, most are not applicable to the reverse-index list at all (Russian gloss
+wording fixes, added glosses/meanings, Devanagari ligature-only touch-ups with the IAST
+spelling unchanged, entry-order swaps, section-header formatting) — the reverse index
+carries no glosses, meanings, grammatical tags, or Devanagari. The rows that *do* name a
+plain IAST word change were checked directly against the canonical 266,820-line list:
+
+| Page | Was (2018 draft) | Corrected to | In canonical list? |
+|---|---|---|---|
+| 197 | `sprh` | `sparh` | `sparh` present; `spṛh` (the correctly-formed root, not the draft's truncated `sprh`) is also present as a separate, valid headword — not a duplicate to resolve |
+| 314 | `baviṣyati` | `bhaviṣyati` | Wrong form absent; corrected form absent too (this is a conjugated example form in a grammar note, not a headword in this list) |
+| 317 | `glāpayati` | `glapayati` | Neither present (conjugated causative-paradigm example, not a headword here) |
+| 323 | `mimāṃsat` | `mimāṃsati` | Neither present (conjugated desiderative-paradigm example, not a headword here) |
+| 326 | `śiks` | `śikṣ` | Neither present (root-paradigm example, not a headword here) |
+| 341 | `kṛṣivala` | `kṛṣīvala` | Wrong form **absent**, corrected form **present** |
+| 350 | *(word missing)* | `dviṣ` | Present |
+| 355 | *(word missing)* | `parivart` | **Absent** (see note below) |
+| 357 | *(word missing)* | `pūjā` | Present |
+| 359 | `baliyaṃs` | `balīyaṃs` | Wrong form **absent**, corrected form **present** |
+| 364 | `mūrtirmant` | `mūrtimant` | Wrong form **absent**, corrected form **present** |
+| 366 | *(word missing)* | `yuyutsu` | Present |
+| 372 | *(word missing)* | `vṛddha` | Present (also `vṛddhā`, tagged `M`=MW, present separately — a legitimate distinct headword, not a duplicate) |
+
+**Finding: no correction needed.** For every checkable word-level row, the erroneous
+2018-draft form is either absent from the canonical list or the already-correct form is
+what's present — i.e. **the canonical 266,820-entry list already reflects this errata
+sheet**, compiled/updated after summer 2018 from corrected source material. The one
+exception, `parivart` (p355, "add this word after `parimitāhāra`"), is genuinely absent
+from the canonical list — but that row is an *addition* (a new headword the compiler
+meant to insert into the glossed 2018 dictionary), not a substitution of a wrong
+existing headword, and adding a never-before-listed headword to a *reverse index*
+(rather than to the full glossed dictionary this errata sheet corrects) is an editorial
+call outside this pass's remit — flagged here rather than silently added.
+
+**No changes were applied to the master file this pass** — the investigation confirmed
+the current canonical list needs none, which is itself the documented, honest outcome
+this step called for.
+
+---
+
+_Dr. Mārcis Gasūns_

--- a/ReverseDictionary/CITATION.cff
+++ b/ReverseDictionary/CITATION.cff
@@ -1,0 +1,64 @@
+cff-version: 1.2.0
+message: "If you use the Reverse Dictionary of Sanskrit, please cite it using the metadata below."
+title: >-
+  Reverse Dictionary of Sanskrit: a suffix-sorted headword index merging
+  ~30 source dictionaries (1822-2005)
+abstract: >-
+  A reverse (suffix-first, rückläufiges) index of Sanskrit headwords, sorted by
+  final letter, then penultimate letter, recursively -- built for word-formation
+  research, verse/rhyme composition, and identifying partial word-forms in damaged
+  manuscripts. Merges headwords from ~30 source Sanskrit dictionaries spanning
+  1822-2005 (Böhtlingk & Roth's Petersburger Wörterbuch, PWK, Monier-Williams,
+  Apte, Macdonell, Turner, Schmidt's Nachträge, Kochergina, Grassmann,
+  Vachaspatyam, Śabdakalpadruma, and others) into a single list of 266,820
+  headwords, roughly double the size of its main predecessor (Wolfgang Schwarz's
+  1974 German reverse dictionary of Sanskrit, ~130,000 words). This dataset is
+  the bare headword + source-attribution list only (no definitions/glosses) --
+  see DATA_STATEMENT.md for scope, restrictions, and current distribution status.
+type: dataset
+authors:
+  - family-names: Gasūns
+    given-names: Mārcis
+    # orcid: "https://orcid.org/0000-0000-0000-0000"  # TODO: insert real ORCID and uncomment
+  - name: "Dhaval Patel"
+    # role: algorithmic sorting (reverse-Devanagari sort, reverse15.php, 2013)
+  - name: "Anton Pilyuganov"
+    # role: statistical appendices
+date-released: "2026-07-07"
+version: "1.0.0"
+repository-code: "https://github.com/gasyoun/SanskritLexicography"
+keywords:
+  - sanskrit
+  - lexicography
+  - reverse dictionary
+  - rhyming dictionary
+  - digital humanities
+  - word formation
+  - indology
+# `license` deliberately omitted (optional per CFF 1.2.0) rather than asserted:
+# publication tier (open / PD-subset / restricted) awaits the licensing @DECIDE
+# ruling -- see ACL_DH_COMPATIBILITY_ANALYSIS.md §3.1 / GTD_NEXT_ACTIONS.md. The
+# merged headword list draws on ~30 source dictionaries of mixed copyright
+# status; asserting a license here before that ruling would misstate the
+# dataset's actual, still-undecided legal status.
+references:
+  - type: generic
+    title: "Sanskrit-Wörterbuch in kürzerer Fassung"
+    authors:
+      - family-names: Böhtlingk
+        given-names: Otto
+    year: 1889
+    notes: "Default/unmarked source (PWK), merged with Schmidt's Nachträge — see SCHEMA.md"
+  - type: generic
+    title: "A Sanskrit-English Dictionary"
+    authors:
+      - family-names: Monier-Williams
+        given-names: Monier
+    year: 1899
+  - type: generic
+    title: "Rückläufiges Wörterbuch des Altindischen"
+    authors:
+      - family-names: Schwarz
+        given-names: Wolfgang
+    year: 1974
+    notes: "Main predecessor work (~130,000 words); this dataset is roughly double its size."

--- a/ReverseDictionary/DATA_STATEMENT.md
+++ b/ReverseDictionary/DATA_STATEMENT.md
@@ -1,0 +1,127 @@
+# Data statement — Reverse Dictionary of Sanskrit
+
+_Created: 07-07-2026 · Last updated: 07-07-2026_
+
+A [Bender & Friedman (2018)](https://aclanthology.org/Q18-1041/)-style data statement,
+following the current [schema v3 (2024)](https://techpolicylab.uw.edu/data-statements/)
+(17 fine-grained elements from Curation Rationale through Dataset Maintenance, grouped
+below under their core headings). Written per
+[`ACL_DH_COMPATIBILITY_ANALYSIS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/ACL_DH_COMPATIBILITY_ANALYSIS.md)
+§4 step 4 ([H270](https://github.com/gasyoun/Uprava/blob/main/handoffs/H270-Sonnet_SanskritLexicography_reverse-dict-publication-prep_07.07.26.md)),
+which explicitly calls for honesty about undecided distribution status rather than
+waiting for the licensing ruling — several elements below are marked **undecided** on
+purpose, not left blank by oversight.
+
+## A. Curation rationale
+
+Compiled to fill an acknowledged gap in Indological reference tooling: no reverse
+(suffix-sorted) dictionary of Sanskrit existed at this scale before this project
+(Schwarz 1974's ~130,000-word German reverse dictionary was the prior state of the art).
+A reverse index supports word-formation research, verse/meter composition (finding
+words ending in a given syllable), and identifying partial word-forms in damaged
+manuscripts — uses a front-alphabetized dictionary cannot serve. Selection criterion:
+every headword attested in any of ~30 merged source dictionaries, normalized to stem
+form, with ~20,000 inflected "false" forms manually removed. Full rationale in the
+compiler's preface,
+[`Обратный словарь санскрита.mdx`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/%D0%9E%D0%B1%D1%80%D0%B0%D1%82%D0%BD%D1%8B%D0%B9%20%D1%81%D0%BB%D0%BE%D0%B2%D0%B0%D1%80%D1%8C%20%D1%81%D0%B0%D0%BD%D1%81%D0%BA%D1%80%D0%B8%D1%82%D0%B0.mdx).
+
+## B. Language variety
+
+Sanskrit (classical + Vedic; individual source dictionaries span both registers without
+a per-headword register tag). BCP-47: `sa`. Transliteration: IAST (International
+Alphabet of Sanskrit Transliteration), not the Devanagari script — a Devanagari edition
+was estimated (832 pp.) but never typeset (see
+[`README.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/README.md)
+"Towards a 2-volume book").
+
+## C. Speaker demographic
+
+Not applicable — this is a compiled lexicographic resource drawing on published
+dictionaries, not elicited or transcribed speech/text from living speakers.
+
+## D. Annotator demographic
+
+**Compiler:** Mārcis Gasūns (primary compilation, editorial rulings on sandhi-final
+ambiguity, homonym handling). **Algorithmic sorting:** Dhaval Patel (reverse-Devanagari
+sort engine,
+[`reverse15.php`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/reverse15.php),
+2013). **Statistical appendices:** Anton Pilyuganov. No further annotator demographic
+data (age, gender, training) is on record for this project — typical for a
+single/small-team lexicographic compilation rather than a crowd-annotation effort.
+
+## E. Speech situation / F. Text characteristics
+
+Not applicable in the usual NLP sense (no recorded speech, no running text corpus) —
+the unit of data is the isolated headword, drawn from 30 published Sanskrit dictionaries
+spanning 1822–2005 (see the source table in
+[`SCHEMA.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/SCHEMA.md)).
+Each source dictionary has its own compilation era, editorial register, and scholarly
+convention (e.g. PWG/PWK are 19th-c. German-school Sanskritology; Kochergina is a
+Soviet-era Russian pedagogical dictionary) — this heterogeneity is inherent to a
+merged-dictionary reverse index and is not normalized away.
+
+## G. Recording quality
+
+Not applicable (no audio/video).
+
+## H. Other quality control
+
+Cross-checking against Monier-Williams as a control list surfaced digitization/print
+errors in other sources, some fed back upstream to the `sanskrit-lexicon` GitHub
+organization's own correction workflow (per the compiler's preface). A known outstanding
+errata sheet (2018, "typos not fixed by that summer") was investigated this pass
+([`CHANGELOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/CHANGELOG.md))
+and found to already be reflected in the current canonical list. NFC-normalization and
+exact/near-duplicate audits were run directly against the canonical file (documented in
+`SCHEMA.md`) — zero duplicate lines, zero duplicate words, 100% NFC-conformant.
+
+## I. Provenance appendix
+
+Merge pipeline is **not algorithmically reproducible end-to-end**: most of the 30
+sources cannot be freely redistributed, and many editorial rulings (sandhi-final
+ambiguity, homonym/POS disambiguation, which of ~20,000 inflected forms to strip) were
+manual, not scripted. What *is* documented and reusable: the sort algorithm
+([`reverse15.php`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/reverse15.php))
+and the editorial rulebook
+([`Состав и строй словаря.mdx`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/%D0%A1%D0%BE%D1%81%D1%82%D0%B0%D0%B2%20%D0%B8%20%D1%81%D1%82%D1%80%D0%BE%D0%B9%20%D1%81%D0%BB%D0%BE%D0%B2%D0%B0%D1%80%D1%8F.mdx),
+§1–§10: sort order, exclusions, homonym handling, accent-mark sourcing). Source
+coverage stops at 2005 — the Cologne Digital Sanskrit Dictionaries project has
+continued digitizing/correcting dictionaries since (the same `sanskrit-lexicon` org
+this repo's parent tree serves); a currency check against present-day `csl-orig` would
+likely surface both new source dictionaries and corrections, and has not been done in
+this pass.
+
+## J. Distribution — **undecided, documented honestly**
+
+**Not currently distributed in any tier.** Publication tier is gated on a pending
+human ruling among three options (§3.1 of
+[`ACL_DH_COMPATIBILITY_ANALYSIS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/ACL_DH_COMPATIBILITY_ANALYSIS.md)):
+**(a)** publish the full 266,820-word list openly (facts-not-expression reading),
+**(b)** publish a PD-only subset (drop headwords unique to the ~10 sources still in
+copyright somewhere — this pass measured that cost, see
+`ACL_DH_COMPATIBILITY_ANALYSIS.md` §5 and the mirrored
+[`GTD_NEXT_ACTIONS.md`](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md)
+`@DECIDE` row), or **(c)** keep the data restricted-tier and publish only a descriptive
+paper + statistics (the org's existing
+[kosha `tier: restricted`](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json)
+pattern). This data statement, `SCHEMA.md`, and `CITATION.cff` are written now,
+independent of that ruling, so the documentation exists regardless of which tier is
+chosen — and so the [Responsible NLP Research checklist](https://aclrollingreview.org/responsibleNLPresearch/)
+§B (per-artifact license/provenance disclosure) can be satisfied honestly once a
+paper is drafted.
+
+## K. Maintenance — **undecided, documented honestly**
+
+No maintenance commitment currently exists — this is unpublished personal research
+material (see `README.md` "This is a data/research workspace, not a finished
+publication"). If a distribution tier is ruled and the dataset is registered (kosha
+manifest / `FEATURES_INDEX.md`, per the analysis's step 7), maintenance would follow
+the org's existing pattern for other registered derived datasets — versioned releases
+via [`/cut-release`](https://github.com/gasyoun/github-spine/blob/main/CLAUDE.md), a
+single maintainer (Gasūns) with corrections routed through the same GitHub-issue
+workflow the org already uses for the Cologne dictionaries. No commitment beyond that
+exists today.
+
+---
+
+_Dr. Mārcis Gasūns_

--- a/ReverseDictionary/README.md
+++ b/ReverseDictionary/README.md
@@ -1,6 +1,6 @@
 # Reverse Dictionary of Sanskrit — working materials
 
-_Created: 06-07-2026 · Last updated: 06-07-2026_
+_Created: 06-07-2026 · Last updated: 07-07-2026_
 
 ## What this is
 
@@ -213,12 +213,20 @@ proposed volume — reusable as a starting layout template, but the content spli
   comparison spreadsheet) was never turned into the comparison table the preface promises —
   worth doing before Volume 2's apparatus is drafted, not after.
 
+## Publication-prep documents (added 07-07-2026, [H270](https://github.com/gasyoun/Uprava/blob/main/handoffs/H270-Sonnet_SanskritLexicography_reverse-dict-publication-prep_07.07.26.md))
+
+- [`ACL_DH_COMPATIBILITY_ANALYSIS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/ACL_DH_COMPATIBILITY_ANALYSIS.md) — venue landscape, DH data-standard gap analysis, and the licensing `@DECIDE` with per-source facts.
+- [`CHANGELOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/CHANGELOG.md) — canonical-version declaration (`266820-reverse-Gasuns.txt`) and the outstanding-errata investigation.
+- [`SCHEMA.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/SCHEMA.md) — TSV column semantics, source-code→bibliography-key table, encoding audit.
+- [`DATA_STATEMENT.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/DATA_STATEMENT.md) / [`CITATION.cff`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/CITATION.cff) — Bender & Friedman data statement + citation metadata (distribution tier honestly marked undecided pending the licensing ruling).
+
 ## See also
 
 - [`INDEX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/INDEX.md) — full 413-file inventory with relevance classification.
 - [`../CLAUDE.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/CLAUDE.md) — Sanskrit Lexicography repo conventions (encoding/BOM caveats
   apply to the `.txt` corpora in this folder too — check before re-saving any of them).
 - [`../FEATURES_INDEX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md) — org-wide capability inventory; this reverse
-  dictionary is not yet registered there and should be, once a canonical word list is declared.
+  dictionary is not yet registered there — registration follows the licensing ruling
+  (see `ACL_DH_COMPATIBILITY_ANALYSIS.md` §4 step 7).
 
 _Dr. Mārcis Gasūns_

--- a/ReverseDictionary/SCHEMA.md
+++ b/ReverseDictionary/SCHEMA.md
@@ -1,0 +1,96 @@
+# Reverse Dictionary — dataset schema
+
+_Created: 07-07-2026 · Last updated: 07-07-2026_
+
+Documents the column semantics, source-code table, and encoding audit for the canonical
+master list `.doc.pdf/266820-reverse-Gasuns.txt` (declared canonical in
+[`CHANGELOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/CHANGELOG.md)).
+Written per [`ACL_DH_COMPATIBILITY_ANALYSIS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/ACL_DH_COMPATIBILITY_ANALYSIS.md)
+§4 step 3 ([H270](https://github.com/gasyoun/Uprava/blob/main/handoffs/H270-Sonnet_SanskritLexicography_reverse-dict-publication-prep_07.07.26.md)).
+This documents the file's *actual* format, verified directly against the bytes, not a
+proposed or aspirational one — a bare TSV, honestly, per the DH-standards analysis's own
+recommendation not to force a premature TEI Lex-0 conversion.
+
+## File format
+
+- **Encoding:** UTF-8 with a leading BOM (`EF BB BF`) — verified with a raw byte read.
+  Preserve this BOM in any tool that resaves the file (repo rule: never silently
+  add/strip a BOM — see
+  [`../CLAUDE.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/CLAUDE.md)).
+- **Line ending:** CRLF (`\r\n`) throughout, except the final line, which has no
+  trailing line terminator at all.
+- **Row count:** 266,820 data lines (266,819 CRLF-terminated + 1 unterminated final
+  line — this is why some notes elsewhere say "266,819 lines").
+- **Delimiter:** one horizontal tab (`\t`) per line, exactly two columns.
+- **Normalization:** every line is already Unicode NFC (checked with Python
+  `unicodedata.normalize('NFC', line) == line` for all 266,820 lines — zero
+  exceptions).
+- **Duplicates:** zero exact-duplicate lines; zero duplicate *words* even ignoring the
+  source-code column — every headword string is unique across the whole file.
+
+## Columns
+
+| # | Name | Content |
+|---|---|---|
+| 1 | `source_code` | A single letter (or empty) marking which dictionary this headword's *non-default* attestation comes from — see table below. Empty means "found in PWK" (the implicit default source, never itself marked — see "Source priority" in [`README.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/README.md)). |
+| 2 | `headword` | The Sanskrit word in IAST transliteration, normalized to stem form (nominal endings stripped to the bare prātipadika; verbs cited as roots with MW's prefixes attached — see README "Methodology"). |
+
+## Source-code → bibliography-key table
+
+The bibliography ([`Словари-источники.mdx`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/%D0%A1%D0%BB%D0%BE%D0%B2%D0%B0%D1%80%D0%B8-%D0%B8%D1%81%D1%82%D0%BE%D1%87%D0%BD%D0%B8%D0%BA%D0%B8.mdx))
+declares 30 letter codes (a 26-letter alphabet plus `Ā/Ö/Ś/Ü/ß` inserted to fit all 30
+sources without reusing a letter). **Only 12 of those 30 codes actually appear** as a
+marked source in the canonical file — checked directly by scanning the distinct values
+of column 1 across all 266,820 lines:
+
+| Code in file | Bibliography letter | Bib. key | Source | Lines | Copyright tier (per [`ACL_DH_COMPATIBILITY_ANALYSIS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/ACL_DH_COMPATIBILITY_ANALYSIS.md) §3.1) |
+|---|---|---|---|--:|---|
+| *(empty)* | K | `pwk` | Böhtlingk & Roth, *Sanskrit-Wörterbuch in kürzerer Fassung* (PWK), merged with Schmidt's *Nachträge* — the implicit default/unmarked source | 131,916 | Public domain |
+| `M` | M | `mwe` | Monier-Williams, *A Sanskrit–English Dictionary* (1899) | 57,177 | Public domain |
+| `A` | Ā | `apt` | Apte, *The Practical Sanskrit-English Dictionary* (1957–59 rev. ed.) | 21,081 | Likely PD, verify (base 1890 ed. is PD; 1957–59 revision's own status is the open question) |
+| `H` | H | `bhs` | Edgerton, *Buddhist Hybrid Sanskrit Grammar and Dictionary* (1953) | 12,552 | **In copyright** |
+| `S` | S | `sch` | Schmidt, *Nachträge zum Sanskrit-Wörterbuch* (1928) | 10,311 | Public domain |
+| `G` | G | `pwg` | Böhtlingk & Roth, *Sanskrit-Wörterbuch* (large PWG, 1855–75) | 7,551 | Public domain |
+| `B` | B | `bur` | Burnouf, *Dictionnaire classique sanscrit-français* (1866) | 6,851 | Public domain |
+| `I` | I | `pui` | Dīkshitar, *The Purana Index* (1951–55) | 6,714 | Likely PD, verify (author d. 1953 → India life+60 expired 2014) |
+| `R` | R | `shs` | *Shabda-Sagara Sanskrit-English Dictionary* | 6,620 | Public domain |
+| `N` | N | `inm` | Sørensen, *Index to the Names in the Mahabharata* (1904–14) | 3,551 | Public domain |
+| `P` | P | `pex` | Vettam Mani, *Puranic Encyclopaedia* (1979, English) | 1,919 | **In copyright** |
+| `V` | V | `vac` | Tarkavācaspati, *Vachaspatyam* (1969–70 reprint of 1873–84 orig.) | 577 | Public domain |
+
+**Note on the `A`/`Ā` mismatch:** the bibliography table's letter for Apte is `Ā` (A with
+macron, since plain `A` was needed for a different position in the 30-symbol scheme as
+originally laid out); the actual corpus uses plain ASCII `A` (`U+0041`) for every Apte
+row — verified byte-for-byte (`hex(ord(c))` for every distinct code in the file). The
+macron was evidently dropped when the single-letter marker was typed into the working
+file, since it's a bare symbol, not real Sanskrit text needing diacritics. The mapping
+above is by **position in the bibliography list**, not by literal character match, and
+is unambiguous: none of the 12 codes actually used in the file collide with each other
+under this reading.
+
+**The other 18 declared sources** (`C/cap`, `D/mcd`, `E/vei`, `F/stc`, `J/snp`, `L/acc`,
+`O/puj`, `Q/kch`, `Ś/skd`, `ß/bop`, `T/tur`, `Ü/gst`, `U/hue`, `W/wil`, `X/mci`, `Y/yat`,
+`Z/myl`) **never appear as a marked source-code** in the canonical file. This does not
+mean they were unused in compiling the dictionary — the preface describes all 30 as
+consulted — it means every headword uniquely or first attested in one of those 18 was
+apparently absorbed under a higher-priority marked/default code rather than tagged with
+its own letter, or simply contributed no headword that needed disambiguating from a
+higher-priority source. This single-letter-per-line scheme cannot by itself answer
+"which of the 30 sources does this headword ultimately come from" for those 18 — see the
+caveat in the licensing-cost measurement note (mirrored to
+[`GTD_NEXT_ACTIONS.md`](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md)).
+
+## Why not TEI Lex-0
+
+[TEI Lex-0](https://lex-0.org/) is the DH-standard lexicographic markup, but it's
+designed for full dictionary *entries* (`<form>`/`<sense>`/`<gramGrp>`). This file has no
+senses, no grammar tags, no glosses — it is a bare headword + attribution list. Wrapping
+two flat TSV columns in `<entry><form>` tags would add structure without adding
+information, and there is no current consumer that needs it. A documented TSV schema
+(this file) is the honest, sufficient standard for what this dataset actually is; TEI
+Lex-0 remains a legitimate *later* interoperability layer if/when this data is joined
+with a Cologne TEI dictionary that does carry senses.
+
+---
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
## Summary
- Executes [ACL_DH_COMPATIBILITY_ANALYSIS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/ACL_DH_COMPATIBILITY_ANALYSIS.md) §4 steps 1-5 (H265 follow-on) — all 5 agent-doable prep steps, no code/data changes to the master list itself.
- **Step 1:** declares `266820-reverse-Gasuns.txt` canonical in [CHANGELOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/CHANGELOG.md); 250,026/255,882 drafts marked superseded; investigated why the count grew and recorded honestly that a cheap diff isn't feasible (Devanagari-script/no-plain-text drafts).
- **Step 2:** investigated the 2018 outstanding-errata sheet via PDF page-image reading (pdftotext lost all Cyrillic/Devanagari) and found it **already reflected** in the canonical list — every checkable word-level row already shows the corrected form. No data changes needed; documented in CHANGELOG.md.
- **Step 3:** [SCHEMA.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/SCHEMA.md) — TSV column semantics, source-code→bibliography-key table (only 12 of 30 declared codes actually used), full encoding/NFC/duplicate audit (all clean).
- **Step 4:** [DATA_STATEMENT.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/DATA_STATEMENT.md) + [CITATION.cff](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/CITATION.cff) drafted, distribution/license honestly marked undecided pending the licensing `@DECIDE`.
- **Step 5:** measured option (b)'s cost — 14,471/266,820 headwords (5.4%, lower bound) tagged to genuinely in-copyright sources — appended to `ACL_DH_COMPATIBILITY_ANALYSIS.md` §5 and mirrored to the GTD `@DECIDE` row.

## Test plan
- [x] All new tracked files whitelisted in `ReverseDictionary/.gitignore`
- [x] Word-level presence checks for errata candidates run directly against the canonical file (documented in CHANGELOG.md)
- [x] NFC/duplicate audit run directly against the canonical file's bytes (documented in SCHEMA.md)
- No code changes; docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)