### PR TITLE
feat(pwg_ru): plan no-PWG scale windows

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1413,6 +1413,23 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## 🚧 Current Work-In-Progress (WIP)
 
+- **H188/H255 Codex deterministic scale prep — 07-07-2026 (Codex/GPT-5; no Workflow tool in this session).**
+  H188 itself was already complete and explicitly says not to re-run; H255 is the live scale handoff,
+  but this Codex session cannot run Sonnet Workflow generation. Deterministic guardrail work done
+  instead: added `src/pilot/no_pwg_scale_plan.py`, which reads the 232-lemma backfill queue, drains
+  `no_pwg_w1.still_null.txt` first at sub-card granularity, keeps windows <=30 headwords, generates
+  sidecars through `_pilot_gen_merged.py`, emits unique `run_pilot_wf.no_pwg_wNN.js` harness paths
+  with `--output-budget=1`, and writes `src/pilot/output/no_pwg_scale_plan.json` with preflight
+  evidence and exact next commands. Also taught `perf_preflight.py --output-budget=1` so cost/agent
+  accounting matches the actual no-fallback single-card harness. Prepared `no_pwg_w02`: 20 still-null
+  headwords / 34 sub-cards / 34 one-card batches / est. 34 agent calls / ~$15.93, under H189 gates;
+  harness syntax OK. Validation: `python src/pilot/window_selftest.py` PASS, `python
+  src/pilot/lang_parity_check.py` PASS, `node --check src/pilot/run_pilot_wf.no_pwg_w02.js` PASS.
+  **Next physical action:** open a Workflow-capable Opus/Sonnet session, run
+  `src/pilot/run_pilot_wf.no_pwg_w02.js`, save as `src/pilot/output/wf_output.no_pwg_w02.json`,
+  then `python src/pilot/audit_window.py no_pwg_w02`; promote only clean rows and regenerate the next
+  window with `python src/pilot/no_pwg_scale_plan.py --window-size 20 --limit-windows 1 --start-index 3`.
+
 - **Nominal grammar layer SHIPPED 2026-06-29** ([`H028-Sonnet_RussianTranslation_nominal_grammar_layer_29.06.26.md`](H028-Sonnet_RussianTranslation_nominal_grammar_layer_29.06.26.md)).
   All 5 build steps complete:
   (0) vidyut subanta confirmed (`Pratipadika.basic('deva')` → `['devaH']`);

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H189",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/perf_preflight.py": "4593a0499b74b1a9557e07b69280e9dd352c01bd816571895a7b3fc1e5ebbb2f",
+      "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
       "src/pilot/window_selftest.py": "14bd0d81cd7589aa037a0c84ad133a874c03a745923f4ce66ef50c662ea25456"
     }
   }

--- a/RussianTranslation/src/pilot/no_pwg_scale_plan.py
+++ b/RussianTranslation/src/pilot/no_pwg_scale_plan.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python
+"""Plan and prepare no-PWG supplement-chain drain windows.
+
+This is the deterministic wrapper for the H255 no-PWG scale run. It does not run
+Workflow generation locally. Instead it:
+
+* reads the 232-lemma backfill queue;
+* skips headwords already present in the translated store;
+* drains the no_pwg_w1 still-null sub-card tail first;
+* generates the exact input sidecars through _pilot_gen_merged.py;
+* emits a per-window harness with --output-budget=1 and a unique --out path;
+* runs perf_preflight.py and writes a manifest the Workflow-capable session can
+  follow without hand-picking stale lists.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+RT = os.path.dirname(os.path.dirname(HERE))
+SRC = os.path.join(RT, 'src')
+OUT = os.path.join(HERE, 'output')
+QUEUE = os.path.join(HERE, 'lexical_cores', 'pwg_miss_backfill_queue.md')
+STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+STILL_NULL = os.path.join(OUT, 'no_pwg_w1.still_null.txt')
+
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+from safe_filename import decode_safe_name, safe_name  # noqa: E402
+
+
+def read_store_heads(path=STORE):
+    done = set()
+    if not os.path.exists(path):
+        return done
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                key = json.loads(line).get('key1')
+            except json.JSONDecodeError:
+                continue
+            if key:
+                done.add(key)
+    return done
+
+
+def read_queue(path=QUEUE):
+    rows, seen = [], set()
+    row_re = re.compile(r'^\|\s*([^|`\s][^|]*?)\s*\|\s*([^|]*?)\s*\|\s*([^|]*?)\s*\|')
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            m = row_re.match(line)
+            if not m:
+                continue
+            key = m.group(1).strip()
+            if key in ('key1', '---') or key.startswith('-'):
+                continue
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append({
+                'key1': key,
+                'iast': m.group(2).strip(),
+                'layers': [x for x in m.group(3).strip().split('/') if x],
+            })
+    if not rows:
+        raise SystemExit('FAIL: no queue rows parsed from %s' % path)
+    return rows
+
+
+def subcard_head(subcard):
+    stem = subcard.split('~~', 1)[0]
+    try:
+        return decode_safe_name(stem)
+    except Exception:
+        return stem
+
+
+def read_still_null(path=STILL_NULL):
+    if not os.path.exists(path):
+        return []
+    out, seen = [], set()
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            key = line.strip()
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            out.append(key)
+    return out
+
+
+def chunked(seq, n):
+    for i in range(0, len(seq), n):
+        yield seq[i:i + n]
+
+
+def existing_subcards(head):
+    prefix = safe_name(head) + '~~h0_zz_'
+    keys = []
+    if not os.path.isdir(OUT):
+        return keys
+    for name in sorted(os.listdir(OUT)):
+        if name.startswith(prefix) and name.endswith('.raw.txt'):
+            keys.append(name[:-len('.raw.txt')])
+    return keys
+
+
+def run_cmd(cmd, capture=False):
+    kwargs = {
+        'cwd': RT,
+        'encoding': 'utf-8',
+        'errors': 'replace',
+    }
+    if capture:
+        kwargs.update({'stdout': subprocess.PIPE, 'stderr': subprocess.STDOUT})
+    p = subprocess.run(cmd, **kwargs)
+    if p.returncode:
+        if capture and p.stdout:
+            sys.stderr.write(p.stdout)
+        raise SystemExit('FAIL: command exited %d: %s' % (p.returncode, ' '.join(cmd)))
+    return p.stdout if capture else ''
+
+
+def build_order(queue_rows, promoted, still_null):
+    queued = [r['key1'] for r in queue_rows if r['key1'] not in promoted]
+    queued_set = set(queued)
+    tail_heads = []
+    for key in still_null:
+        head = subcard_head(key)
+        if head in queued_set and head not in tail_heads:
+            tail_heads.append(head)
+    rest = [k for k in queued if k not in set(tail_heads)]
+    return tail_heads + rest, tail_heads
+
+
+def preflight_json(root, keys):
+    cmd = [
+        sys.executable, 'src/pilot/perf_preflight.py', root,
+        '--nominal',
+        '--keys=' + ','.join(keys),
+        '--output-budget=1',
+        '--json',
+        '--cost-ceiling-window=25',
+        '--cost-ceiling-per-card=2',
+    ]
+    return json.loads(run_cmd(cmd, capture=True))
+
+
+def prepare_window(args, index, heads, still_null_keys, tail_mode):
+    root = '%s%02d' % (args.prefix, index)
+    print('preparing %s: %d headword(s)%s' %
+          (root, len(heads), ' [still-null tail]' if tail_mode else ''))
+    run_cmd([sys.executable, 'src/_pilot_gen_merged.py'] + heads)
+
+    if tail_mode:
+        head_set = set(heads)
+        subcards = [k for k in still_null_keys if subcard_head(k) in head_set]
+    else:
+        subcards = []
+        for head in heads:
+            subcards.extend(existing_subcards(head))
+
+    subcards = [k for i, k in enumerate(subcards) if k and k not in set(subcards[:i])]
+    if not subcards:
+        raise SystemExit('FAIL: %s produced no no-PWG subcards' % root)
+
+    harness = os.path.join(HERE, 'run_pilot_wf.%s.js' % root)
+    gen_cmd = [
+        sys.executable, 'src/pilot/gen_opt_harness2.py', root,
+        '--nominal',
+        '--keys=' + ','.join(subcards),
+        '--output-budget=1',
+        '--out=' + harness,
+        '--refuse-oversize',
+    ]
+    run_cmd(gen_cmd)
+    preflight = preflight_json(root, subcards)
+    wf_out = os.path.join(OUT, 'wf_output.%s.json' % root)
+    return {
+        'root': root,
+        'mode': 'still_null_tail' if tail_mode else 'queue',
+        'headwords': heads,
+        'subcards': subcards,
+        'harness': os.path.relpath(harness, RT).replace('\\', '/'),
+        'workflow_output': os.path.relpath(wf_out, RT).replace('\\', '/'),
+        'audit_command': 'python src/pilot/audit_window.py %s' % root,
+        'promote_command': 'python src/promote_final_cards.py --merge',
+        'preflight': {
+            'selected_keys': len(preflight.get('selected_keys') or []),
+            'batches': preflight.get('batch_count'),
+            'agent_expected_after_tm': preflight.get('agent_expected_after_tm'),
+            'cost_gate': preflight.get('cost_gate'),
+            'warnings': preflight.get('warnings') or [],
+        },
+    }
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description='Plan/prepare H255 no-PWG scale windows.')
+    ap.add_argument('--window-size', type=int, default=20,
+                    help='headwords per prepared queue window (default %(default)s; keep <=30)')
+    ap.add_argument('--prefix', default='no_pwg_w',
+                    help='window root prefix (default %(default)s)')
+    ap.add_argument('--start-index', type=int, default=2,
+                    help='first numeric suffix; w1 was the pilot (default %(default)s)')
+    ap.add_argument('--limit-windows', type=int, default=1,
+                    help='prepare only this many windows now; 0 means plan all without preparing')
+    ap.add_argument('--plan-only', action='store_true',
+                    help='write the manifest without generating sidecars/harnesses')
+    ap.add_argument('--manifest', default=os.path.join(OUT, 'no_pwg_scale_plan.json'),
+                    help='manifest output path')
+    args = ap.parse_args(argv)
+
+    if args.window_size < 1 or args.window_size > 30:
+        raise SystemExit('FAIL: --window-size must be between 1 and 30 for H255')
+
+    queue = read_queue()
+    promoted = read_store_heads()
+    still_null = read_still_null()
+    ordered, tail_heads = build_order(queue, promoted, still_null)
+    windows = []
+    tail_set = set(tail_heads)
+    tail_order = [h for h in ordered if h in tail_set]
+    rest_order = [h for h in ordered if h not in tail_set]
+    window_heads = list(chunked(tail_order, args.window_size)) + list(chunked(rest_order, args.window_size))
+
+    to_prepare = 0 if args.plan_only else args.limit_windows
+    for offset, heads in enumerate(window_heads):
+        idx = args.start_index + offset
+        tail_mode = all(h in tail_set for h in heads)
+        if to_prepare and offset < to_prepare:
+            windows.append(prepare_window(args, idx, heads, still_null, tail_mode))
+        else:
+            windows.append({
+                'root': '%s%02d' % (args.prefix, idx),
+                'mode': 'still_null_tail' if tail_mode else 'queue',
+                'headwords': heads,
+                'subcards': None,
+                'harness': None,
+                'workflow_output': None,
+                'preflight': None,
+            })
+
+    payload = {
+        'schema': 'pwg.no_pwg_scale_plan.v1',
+        'queue_rows': len(queue),
+        'store_path': os.path.relpath(STORE, RT).replace('\\', '/'),
+        'store_present': os.path.exists(STORE),
+        'promoted_headwords_seen': len(promoted),
+        'still_null_subcards_seen': len(still_null),
+        'remaining_headwords': len(ordered),
+        'tail_headwords_first': tail_heads,
+        'window_size': args.window_size,
+        'prepared_windows': len([w for w in windows if w.get('harness')]),
+        'windows': windows,
+    }
+    os.makedirs(os.path.dirname(args.manifest), exist_ok=True)
+    with open(args.manifest, 'w', encoding='utf-8', newline='\n') as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+        f.write('\n')
+    print('wrote %s' % args.manifest)
+    if not os.path.exists(STORE):
+        print('WARNING: promoted store not found at %s; dedup will become exact when the '
+              'gitignored local store is restored/present' % os.path.relpath(STORE, RT))
+    print('remaining headwords: %d | windows: %d | prepared: %d'
+          % (payload['remaining_headwords'], len(windows), payload['prepared_windows']))
+    if windows:
+        first = windows[0]
+        print('next window: %s (%s) %d headword(s)' %
+              (first['root'], first['mode'], len(first['headwords'])))
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/perf_preflight.py
+++ b/RussianTranslation/src/pilot/perf_preflight.py
@@ -251,6 +251,10 @@ def build_report(args, root):
     keylist = split_csv(args.keys) if args.keys else None
     rootmap, keys = selected(root, keylist, args.nominal)
     tm_path = (args.tm_path or default_tm_path(args.lang)) if args.tm_auto else None
+    old_output_budget = gh.OUTPUT_BUDGET
+    output_budget = getattr(args, 'output_budget', None)
+    if output_budget is not None:
+        gh.OUTPUT_BUDGET = None if output_budget in ('off', '0', 'none') else int(output_budget)
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         js, _batches = gh.build(root, keys, rootmap, args.budget,
@@ -319,6 +323,7 @@ def build_report(args, root):
             % (report['cost_gate']['est_tokens'], report['cost_gate']['est_cost_usd'],
                report['cost_gate']['est_cost_per_card_usd'],
                report['cost_gate']['per_card_ceiling_usd']))
+    gh.OUTPUT_BUDGET = old_output_budget
     return report
 
 
@@ -412,6 +417,8 @@ def main(argv=None):
                     help='H189 cost gate: flag a window whose est $ per translated card exceeds this (default %(default)s).')
     ap.add_argument('--cost-ceiling-window', type=float, default=COST_CEIL_WINDOW_USD,
                     help='H189 cost gate: flag a window whose total est $ exceeds this (default %(default)s).')
+    ap.add_argument('--output-budget', default=None,
+                    help='Mirror gen_opt_harness2.py --output-budget for accurate preflight accounting.')
     ap.add_argument('--refuse-over-cost', action='store_true',
                     help='H189 cost gate: exit nonzero if any window exceeds a cost ceiling (for automated callers).')
     ap.add_argument('--json', action='store_true')


### PR DESCRIPTION
## PR Type
- [ ] data
- [x] build
- [ ] docs
- [ ] navigation

## Summary
- What changed: Added `RussianTranslation/src/pilot/no_pwg_scale_plan.py`, a deterministic planner for H255 no-PWG supplement-chain scale windows. It reads the backfill queue, prioritizes the `no_pwg_w1.still_null.txt` tail, chunks windows, regenerates inputs, emits unique Workflow harness paths, and records preflight/accounting metadata. `perf_preflight.py` now accepts `--output-budget` so the preflight estimate can mirror no-PWG `--output-budget=1` harnesses.
- Why this change exists: H255 was runnable only as a manual loop, which left too much room to repeat the same daily failure modes: stale hand-picked key lists, skipped still-null cards, unsafe window sizing, generated harness path collisions, and misleading preflight accounting.

## Test Surface
- Automated checks: `python -m py_compile RussianTranslation\src\pilot\no_pwg_scale_plan.py RussianTranslation\src\pilot\perf_preflight.py`; `python src\pilot\lang_parity_check.py` from `RussianTranslation`.
- Manual checks: `python src\pilot\no_pwg_scale_plan.py --window-size 20 --limit-windows 0 --plan-only` writes the plan and reports the missing gitignored promoted store instead of silently claiming dedup.
- Pure helpers / decision points covered: Queue parsing, still-null prioritization, promoted-store presence reporting, one-card no-PWG preflight accounting via `--output-budget=1`.
- If build-related: import-safe verified? yes.

## Invariants
- Must stay true: Codex does not run or fake Sonnet Workflow generation; the planner only prepares deterministic inputs/harnesses and manifests.
- Counts / alignment / join rules: no-PWG still-null sub-cards are preserved at sub-card granularity; non-tail windows remain headword chunks of at most 30.
- Source-of-truth assumptions: `src/pilot/lexical_cores/pwg_miss_backfill_queue.md` owns the 232-lemma queue; `src/pilot/pwg_ru_translated.jsonl` is a gitignored local promoted store and may be absent in a clean worktree.
- What would count as regression: preflight undercounts a `--output-budget=1` no-PWG window, a missing store looks like real zero-promoted state, or the planner commits/generated-runtime artifacts instead of regenerable commands.

## Safety
- Fallback / failure mode: If the promoted store is missing, the manifest includes `store_present: false` and stdout warns that dedup becomes exact only when the local store is present.
- Observable marker or sanity check: `src/pilot/output/no_pwg_scale_plan.json` records window roots, headwords, sub-cards when prepared, cost gate, and exact audit/promote commands.
- Rebuild / validate / verify command: `python src/pilot/no_pwg_scale_plan.py --window-size 20 --limit-windows 1` prepares the next window; `python src/pilot/perf_preflight.py no_pwg_wNN --nominal --keys=<keys> --output-budget=1 --json` mirrors the harness accounting.

## Reader-Facing Done
- Navigation / entry point updated: `.ai_state.md` records the H188/H255 deterministic-prep status and the next Workflow-capable action.
- Docs / changelog / handoff updated: `.ai_state.md` only; no changelog because this is an operational helper for an active handoff.
- Known limits or caveats exposed: The generated `run_pilot_wf.no_pwg_w02.js` is intentionally not committed; it is runtime output. A clean worktree lacks gitignored rootmap/store fixtures, so full `window_selftest.py` did not complete there after fixture regeneration changed the expected `gam` sub-card shape. The same full suite passed in the original populated worktree before PR worktree isolation.
- If not applicable, say why: N/A.

## Type-Specific Notes
- If `data`: N/A.
- If `build`: Helper writes generated harness/manifest files under existing runtime-output locations; these are not part of the committed diff.
- If `docs`: N/A.
- If `navigation`: N/A.
