### PR TITLE
chore(pwg_ru): ignore generated workflow harnesses

### DIFF
--- a/RussianTranslation/.gitignore
+++ b/RussianTranslation/.gitignore
@@ -159,3 +159,7 @@ pwg_ru/reglue/synth_outputs/*
 # committed. decisions.json votes land here too (personal review artifacts).
 pwg_ru/eval/
 review/h178_*_sheet.html
+
+# Generated Workflow harnesses embed source/portrait payloads and are local-only.
+src/pilot/run_pilot_wf.*.js
+!src/pilot/run_pilot_wf.js


### PR DESCRIPTION
## PR Type
- [ ] data
- [ ] build
- [x] docs
- [ ] navigation

## Summary
- What changed: `RussianTranslation/.gitignore` now ignores tagged generated Workflow harnesses (`src/pilot/run_pilot_wf.*.js`) while explicitly keeping the committed template `src/pilot/run_pilot_wf.js` trackable.
- Why this change exists: generated pwg_ru Workflow harnesses inline source/portrait payloads and should remain local-only; without this ignore rule they can appear as stageable artifacts during audit and PR hygiene work.

## Test Surface
- Automated checks: `python src/h178_eval_bakeoff.py selftest` passed.
- Manual checks: `git check-ignore -v RussianTranslation/src/pilot/run_pilot_wf.no_pwg_diag.js` reports the new ignore rule; `git check-ignore -v RussianTranslation/src/pilot/run_pilot_wf.js` does not ignore the committed template.
- Pure helpers / decision points covered: verified the pattern only catches tagged generated harnesses and leaves the canonical template available to git.
- If build-related: import-safe verified? n/a

## Invariants
- Must stay true: generated Workflow harnesses that embed local payloads are not accidentally staged; the canonical `run_pilot_wf.js` remains tracked.
- Counts / alignment / join rules: n/a
- Source-of-truth assumptions: `.gitignore` is the repo-level guard for local generated harnesses; production behavior is unchanged.
- What would count as regression: `run_pilot_wf.*.js` generated files show up in `git status`, or `run_pilot_wf.js` becomes ignored.

## Safety
- Fallback / failure mode: removing these ignore lines returns to the previous status-noise behavior without changing runtime code.
- Observable marker or sanity check: `git check-ignore -v` should identify `.gitignore` for tagged generated harnesses only.
- Rebuild / validate / verify command: `python src/h178_eval_bakeoff.py selftest`; `git check-ignore -v RussianTranslation/src/pilot/run_pilot_wf.no_pwg_diag.js`; `git check-ignore -v RussianTranslation/src/pilot/run_pilot_wf.js`.

## Reader-Facing Done
- Navigation / entry point updated: n/a
- Docs / changelog / handoff updated: n/a; local artifact hygiene only.
- Known limits or caveats exposed: `python src/pilot/window_selftest.py` was attempted in the fresh PR worktree but stopped at `no rootmap for 'gam'` because the clean worktree lacks local gitignored rootmap/input artifacts. The same broad suite had passed earlier in the populated working tree before isolating this PR.
- If not applicable, say why: no user-facing documentation changes.

## Type-Specific Notes
- If `data`: n/a
- If `build`: n/a
- If `docs`: stale wording removed, authoritative docs confirmed — n/a; this is `.gitignore` hygiene.
- If `navigation`: n/a
