### PR TITLE
feat(pwg_ru): launch-failure guardrail ledger (H220)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,19 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **Launch-failure guardrails — ✅ DONE 07-07-2026 (Codex/GPT-5).**
+  Added the mandatory post-launch incident ledger [`LAUNCH_FUCKUPS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LAUNCH_FUCKUPS.md)
+  with a compact failure typology and seven seeded incidents (Slice D, H189/H191,
+  H201, H178, H214, H220, H234). Added
+  [`src/pilot/check_launch_ledger.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/check_launch_ledger.py)
+  (`--handoff H###`, `--since YYYY-MM-DD`) and wired two selftests into
+  `window_selftest.py`. Refreshed [`PIPELINE_HISTORY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_HISTORY.md)
+  with H220 + post-launch discipline, and [`RUN_FREQ_MAX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_FREQ_MAX.md)
+  with the closeout checklist and lane-specific calibration rule. Verified:
+  `check_launch_ledger.py`, `check_launch_ledger.py --handoff H220`,
+  `check_launch_ledger.py --since 2026-07-05`, `py_compile`,
+  `lang_parity_check.py`, and full `window_selftest.py` all pass.
+
 - **H283 docs pass — ✅ DONE 07-07-2026 (Fable 5 `claude-fable-5`).** [`README.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/README.md) rewritten researcher-first (mw_ru + pwg_ru framing, method paragraph, FAIR datasets table, consumer use cases for student/lexicographer/NLP-researcher/CAT-translator, 14-phase milestone table, operator quickstart); [`PIPELINE_HISTORY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_HISTORY.md) Timeline extended with Phases 10–13 (H189→H191→H201 nominal arc · H184/H186/H224/H215 TM industrialization · H180 re-glue verdict · H234 orchestration guards) + "Current state" refreshed to 07-07; [`USE_CASES.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/USE_CASES.md) +§§14–18 (TM mining, TMX grading/export, re-glue, synth_dispatch fan-out, learner/addenda builders). All four scope forks ruled by MG in-session; handoff record [H283](https://github.com/gasyoun/Uprava/blob/main/handoffs/H283-Fable_SanskritLexicography_russiantranslation_readme_timeline_usecases_07.07.26.md).
 
 - **H178 ACL-grade verify-and-improve pass — ✅ DONE 06/07-07-2026 (Fable 5 `claude-fable-5` orchestrating; generation Sonnet 5 `claude-sonnet-5`).**
@@ -807,7 +820,7 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   is gitignored (derived from the local-only store, regenerable).
   **NEXT INCREMENT (sub-card sense/fragment reuse) — ✅ SHIPPED 2026-07-02 (Opus 4.8
   `claude-opus-4-8`); see the fragment-TM bullet below. The
-  [H068-Opus_RussianTranslation_pwg_tm_sense_level_02.07.26.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/archive/H068-Opus_RussianTranslation_pwg_tm_sense_level_02.07.26.md)
+  [H068-Opus_RussianTranslation_pwg_tm_sense_level_02.07.26.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/H068-Opus_RussianTranslation_pwg_tm_sense_level_02.07.26.md)
   it pointed at is SPENT — do not re-execute.**
 
 - **Fragment-level TM (sub-card sense/fragment reuse) SHIPPED + wired + LIVE-VALIDATED

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "5bbb029b2dc287f52d4efd4f9f44ff4a12952a15984554568afa645eec2804bd",
-      "src/pilot/window_selftest.py": "14bd0d81cd7589aa037a0c84ad133a874c03a745923f4ce66ef50c662ea25456"
+      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "14bd0d81cd7589aa037a0c84ad133a874c03a745923f4ce66ef50c662ea25456"
+      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "14bd0d81cd7589aa037a0c84ad133a874c03a745923f4ce66ef50c662ea25456"
+      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "14bd0d81cd7589aa037a0c84ad133a874c03a745923f4ce66ef50c662ea25456"
+      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
     }
   },
   {
@@ -335,7 +335,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "14bd0d81cd7589aa037a0c84ad133a874c03a745923f4ce66ef50c662ea25456"
+      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
     }
   },
   {
@@ -354,7 +354,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "14bd0d81cd7589aa037a0c84ad133a874c03a745923f4ce66ef50c662ea25456"
+      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
     }
   },
   {
@@ -392,7 +392,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "14bd0d81cd7589aa037a0c84ad133a874c03a745923f4ce66ef50c662ea25456"
+      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
     }
   },
   {
@@ -451,7 +451,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "14bd0d81cd7589aa037a0c84ad133a874c03a745923f4ce66ef50c662ea25456"
+      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
     }
   }
 ]

--- a/RussianTranslation/LAUNCH_FUCKUPS.md
+++ b/RussianTranslation/LAUNCH_FUCKUPS.md
@@ -1,0 +1,231 @@
+# PWG-RU launch failure ledger
+
+_Created: 07-07-2026 · Owner: every session that launches Workflow/API work_
+
+This is the canonical per-launch failure ledger for `RussianTranslation`.
+[`PIPELINE_HISTORY.md`](PIPELINE_HISTORY.md) is the curated narrative map; this
+file is the operational incident register. Every Workflow/API launch that hits a
+failure, drift, retry, kill, stale artifact, cost blow-up, or suspicious
+residual gets one entry here before the handoff is closed.
+
+## Closeout rule
+
+A launch handoff is not done until each failure is classified as one of the
+categories below and has a disposition: fixed, structurally guarded,
+accepted-as-proven-residual, or routed to a new bug-hunt handoff. Do not leave a
+second occurrence of the same `unknown` shape in this ledger; the second
+occurrence requires a bug-hunt handoff.
+
+Run the check before closing launch work:
+
+```powershell
+python src\pilot\check_launch_ledger.py --handoff H220
+python src\pilot\check_launch_ledger.py --since 2026-07-05
+```
+
+## Failure typology
+
+- `concurrency/api`: rate limits, connection loss, mid-stream stalls, provider
+  throttling, transient API nulls.
+- `structured-output-limit`: model cannot emit the required schema because the
+  whole-card/whole-batch output is too large or complex.
+- `complexity-estimate-drift`: preflight or cost estimate misses real agent,
+  token, or fragment fan-out.
+- `kill-gate-calibration`: timeout budget is too loose, too strict, or lacks a
+  fallback lane for this launch shape.
+- `gate-bug`: deterministic audit or semantic-risk gate misclassifies a valid
+  or invalid card.
+- `artifact/provenance`: stale output, rootmap/input hash mismatch, ordering
+  bug, missing SHA/provenance, or manual-save loss.
+- `tm/cache`: translation memory or cache serves content that should have been
+  regenerated or rejected.
+- `filesystem/watcher`: untracked/gitignored output is deleted or overwritten
+  by local repo automation.
+- `key/schema-mismatch`: valid model output is dropped because keys, safe names,
+  wrappers, or schema paths disagree.
+- `operator/process`: concurrency discipline, claim/registry drift, manual
+  capture, or handoff procedure fails.
+- `external-api`: non-Workflow service quirks such as JSON-mode requirements,
+  escaped-character parsing, or retriable DeepSeek failures.
+- `unknown`: not yet explained. A repeated `unknown` shape must be escalated to
+  a bug-hunt handoff.
+
+## Machine ledger
+
+Keep this fenced block valid JSON. The checker enforces required fields, valid
+classes, expected-vs-actual metrics, residual status, and unknown recurrence.
+
+```json launch_failure_ledger
+[
+  {
+    "id": "SLICE_D_2026-06-30",
+    "handoff": "H151",
+    "date": "2026-06-30",
+    "title": "Slice D 18-wide bulk run collapsed into transient nulls",
+    "lane": "verb batch",
+    "model": "claude-sonnet-5",
+    "orchestrator": "Workflow",
+    "expected": {
+      "agents": "one root at a time; no 18-root fan-out",
+      "tokens": "not recorded"
+    },
+    "actual": {
+      "agents": "~140-250 peak concurrent agents",
+      "tokens": "not recorded"
+    },
+    "passes": 1,
+    "symptoms": "80+ server-side 429s and 117 transient null cards after 18 roots were launched in parallel.",
+    "classification": "concurrency/api",
+    "root_cause": "Provider/server concurrency cliff; the same period's single-root run had zero transient failures.",
+    "guardrail": "Standing production discipline: roots run one at a time, <=3-wide maximum, and no bulk parallel Workflow fan-out.",
+    "residual_status": "structurally-guarded",
+    "residual_risk": "Only process drift can reintroduce this; check launch width before every run."
+  },
+  {
+    "id": "PRIL10_W1_2026-07-05",
+    "handoff": "H189",
+    "date": "2026-07-05",
+    "title": "pril10_w1 nominal monster window cost and latency blow-up",
+    "lane": "nominal monster",
+    "model": "claude-sonnet-5",
+    "orchestrator": "Opus 4.8 Max/Workflow surface",
+    "expected": {
+      "agents": "174 fragment groups estimated before the fix",
+      "tokens": "nominal bulk economics expected to be viable"
+    },
+    "actual": {
+      "agents": "230 agents over 581 turns before abort",
+      "tokens": "42,316,604 total tokens; about $79.83"
+    },
+    "passes": 1,
+    "symptoms": "After about 20 minutes only about 3 of 8 monster cards were done; agents burned 3-6.5 minutes and up to about 900K tokens each.",
+    "classification": "complexity-estimate-drift",
+    "root_cause": "Nominal presplit mode made each fragment an agent call, defeating opt2 batching and re-paying framework cache overhead per fragment.",
+    "guardrail": "H189/H191 added presplit-lane re-batching, tighter kill budgets, a live agent kill-switch, harness-size split warnings, and perf_preflight cost partition/defer-monster gating.",
+    "residual_status": "structurally-guarded",
+    "residual_risk": "kAla-class monster windows remain human-budgeted/defer lane work, not ordinary bulk launches."
+  },
+  {
+    "id": "NOMINAL_W1_100SMALL_2026-07-06",
+    "handoff": "H201",
+    "date": "2026-07-06",
+    "title": "nominal_w1_100small pass-1 transient outage",
+    "lane": "nominal small",
+    "model": "claude-sonnet-5",
+    "orchestrator": "Opus 4.8 Max/Workflow surface",
+    "expected": {
+      "agents": "3 expected agents for one clean pass",
+      "tokens": "~745,200 tokens; about $1.41"
+    },
+    "actual": {
+      "agents": "37 agents across three passes",
+      "tokens": "2,498,796 subagent tokens"
+    },
+    "passes": 3,
+    "symptoms": "Pass 1 returned 5 ok / 95 null with budget_kill_switch_tripped after all batches, including a 4-card batch, hit Connection closed mid-response.",
+    "classification": "concurrency/api",
+    "root_cause": "Transient infrastructure/network outage during the run window, not content complexity or batch sizing.",
+    "guardrail": "Treat same transport error across all batches as transient infra; rerun cleanly and requeue only real residual nulls.",
+    "residual_status": "accepted-as-proven-residual",
+    "residual_risk": "A transient pass can still double spend; expected-vs-actual ledger must record clean-pass estimate and actual passes separately."
+  },
+  {
+    "id": "DAH_TAIL_2026-07-06",
+    "handoff": "H178",
+    "date": "2026-07-06",
+    "title": "dah tail topup left one documented PW-addenda residual",
+    "lane": "verb batch",
+    "model": "claude-sonnet-5",
+    "orchestrator": "Fable 5 Workflow surface",
+    "expected": {
+      "agents": "1 defect requeue agent plus 17 topup fragment agents per attempt",
+      "tokens": "not pre-estimated in the log"
+    },
+    "actual": {
+      "agents": "35 agents across defect requeue and two topup attempts",
+      "tokens": "2,368,224 subagent tokens"
+    },
+    "passes": 3,
+    "symptoms": "dah~~h0_zz_pw__s10p0 hard-failed the StructuredOutput retry cap on both fresh topup attempts; the union recovered 16/17 fragments.",
+    "classification": "structured-output-limit",
+    "root_cause": "A single PW-addenda sense fragment still exceeded the schema-emission envelope even after bounded topup retries.",
+    "guardrail": "H178 accepted the card only after the two-attempt cap and documented the exact residual; TM was rebuilt and provenance audited clean.",
+    "residual_status": "accepted-as-proven-residual",
+    "residual_risk": "This is a known StructuredOutput retry-cap residual, not the H220 kill-gate class; future similar fragments should be routed through the same bounded topup/acceptance rule."
+  },
+  {
+    "id": "NO_PWG_W1_FIRST_RUN_2026-07-06",
+    "handoff": "H214",
+    "date": "2026-07-06",
+    "title": "no_pwg_w1 first run validated plumbing but exposed throughput blockers",
+    "lane": "no-PWG single",
+    "model": "claude-sonnet-5",
+    "orchestrator": "Opus 4.8 Workflow surface",
+    "expected": {
+      "agents": "preflight about 497K tokens / $0.94 for the first 58-card lane run",
+      "tokens": "~497K tokens preflight estimate"
+    },
+    "actual": {
+      "agents": "three Workflow passes, including batched, 9-batch, and 46 single-card rounds",
+      "tokens": "~3.4M subagent tokens"
+    },
+    "passes": 3,
+    "symptoms": "Only 21/58 distinct sub-cards were ok; budget kill-switches tripped, audit needed nominal no-rootmap handling, and the path was validated but not promotable at first.",
+    "classification": "kill-gate-calibration",
+    "root_cause": "The no-PWG lane combined no-fallback singleton latency, strict key echo behavior, and nominal audit assumptions that were inherited from rootmap-backed lanes.",
+    "guardrail": "H214 fixed the Lbody pointer leak and nominal audit crash; H220 then fixed the no-fallback kill budget and nominal key echo mismatch, raising the diagnostic window to 10/10.",
+    "residual_status": "fixed",
+    "residual_risk": "Scale no-PWG through small single-card windows and keep H220 lane-specific calibration; do not use stale nominal audit defect counts as requeue truth."
+  },
+  {
+    "id": "NO_PWG_DIAG_2026-07-06",
+    "handoff": "H220",
+    "date": "2026-07-06",
+    "title": "no-PWG single-card throughput false kills and key echo drops",
+    "lane": "no-PWG single",
+    "model": "claude-sonnet-5",
+    "orchestrator": "Opus 4.8 Max/Workflow surface",
+    "expected": {
+      "agents": "diagnostic 10-card window should converge without structural nulls",
+      "tokens": "not recorded"
+    },
+    "actual": {
+      "agents": "9 agents on verified rerun",
+      "tokens": "not recorded"
+    },
+    "passes": 2,
+    "symptoms": "Before the fix, the diagnostic window yielded about 40%; 6 of 6 nulls were kill-timeouts, and some valid outputs were dropped by strict key matching.",
+    "classification": "kill-gate-calibration",
+    "root_cause": "The kill gate was calibrated on dense verb batches; no-fallback single supplement cards have fixed StructuredOutput latency and no selfheal lane. Separately, clean SLP1 portrait keys pulled the model away from mangled safe-name headers.",
+    "guardrail": "No-fallback singles now receive the 180s CEIL budget, nominal windows use a gated nominal_keymap re-key, and selfHeal preserves upstream failure reasons.",
+    "residual_status": "fixed",
+    "residual_risk": "Recalibrate per lane; never apply the dense-root kill profile blindly to no-fallback singleton launches."
+  },
+  {
+    "id": "ARMB_SYNTH_FANOUT_2026-07-06",
+    "handoff": "H234",
+    "date": "2026-07-06",
+    "title": "Arm-B 10-agent synthesis fan-out orchestration failure",
+    "lane": "synth fan-out",
+    "model": "claude-opus-4-8",
+    "orchestrator": "Opus 4.8 async sub-agents",
+    "expected": {
+      "agents": "10 synthesis agents",
+      "tokens": "not recorded"
+    },
+    "actual": {
+      "agents": "10 initial agents plus replacements/resumes",
+      "tokens": "not recorded"
+    },
+    "passes": 2,
+    "symptoms": "False-stall kill from 0-byte transcripts, mid-stream API stalls at 10-wide, a 34-minute silent hang, watcher-wiped outputs, zombie overwrite, and free-form collapse on >800 citation entries.",
+    "classification": "operator/process",
+    "root_cause": "Bare async fan-out used unsafe liveness signals, shared output paths, repo-local untracked outputs, and too-wide concurrency for large Opus generations.",
+    "guardrail": "src/synth_dispatch.py now caps concurrency, watches output-file growth only, confirms dead-before-redispatch, uses private staging and watcher-safe landing, seals outputs, and routes >800 <ls> entries to deterministic assembly.",
+    "residual_status": "structurally-guarded",
+    "residual_risk": "All future pwg_ru multi-agent fan-outs must go through synth_dispatch.py; bare fan-outs are banned."
+  }
+]
+```
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/PIPELINE_HISTORY.md
+++ b/RussianTranslation/PIPELINE_HISTORY.md
@@ -433,6 +433,47 @@ handoffs (H178 ACL verify-and-improve, H188 full pipeline audit, H220 no-PWG
 throughput) plus one human `@DECIDE` (H143) — the registry, not the work,
 had drifted.
 
+### Phase 14 — no-PWG throughput and the launch-failure ledger (H220, 07-06 → 07-07)
+
+H220 closed the no-PWG supplement-chain throughput gap with an actual
+diagnostic Workflow run, not speculation: a 10-card no-PWG window first
+measured the lane at ~40% yield, then root-caused the failures to two
+different guardrail mistakes. **First**, the wall-clock kill gate was
+calibrated on dense verb-root batches, where a slow schema call usually means
+"too complex, fall to fragments"; a no-PWG supplement singleton has no
+selfheal lane, and its fixed StructuredOutput latency can legitimately sit in
+the same 55-105 s band the old byte-scaled budget treated as suspicious. Six
+of six nulls were kill-timeouts, and four would have passed if allowed to
+finish. **Second**, strict key matching dropped valid output when the portrait's
+clean SLP1 `key1` pulled the model away from the mangled safe-name card header.
+
+The fix is lane-specific, not global: no-fallback singles now receive the
+180-second ceiling budget, nominal windows may re-key through a scoped
+`nominal_keymap`, and the selfheal path preserves the real upstream failure
+reason instead of overwriting it with `no-selfheal-fallback`. The same
+diagnostic window reran at **10/10 ok, 0 kill-timeouts, 9 agents**, and the
+232-lemma no-PWG backfill lane is unblocked for ordinary scheduling.
+
+This phase also adds the post-launch discipline that the history itself had
+been missing: [`LAUNCH_FUCKUPS.md`](LAUNCH_FUCKUPS.md) is now the mandatory
+per-launch incident ledger, checked by
+[`src/pilot/check_launch_ledger.py`](src/pilot/check_launch_ledger.py). This
+file (`PIPELINE_HISTORY.md`) remains the curated narrative map; the ledger is
+the exhaustive closeout register for Workflow/API failures, expected-vs-actual
+economics, classification, guardrail, and residual risk.
+
+## Post-launch discipline
+
+Every Workflow/API launch that hits a failure, null wave, stall, kill,
+stale-artifact refusal, cost drift, retry, or suspicious residual must get a
+classified entry in [`LAUNCH_FUCKUPS.md`](LAUNCH_FUCKUPS.md) before the handoff
+is closed. Use the compact typology there (`concurrency/api`,
+`structured-output-limit`, `complexity-estimate-drift`,
+`kill-gate-calibration`, `gate-bug`, `artifact/provenance`, `tm/cache`,
+`filesystem/watcher`, `key/schema-mismatch`, `operator/process`,
+`external-api`, `unknown`). A repeated `unknown` shape is not an accepted
+residual; it becomes a bug-hunt handoff.
+
 ## Recurring failure patterns (read this before assuming something new is broken)
 
 These are the failure *shapes* that have recurred across the project — if a
@@ -499,6 +540,11 @@ likely the SAME class, not a new bug:
   other.** See [`LANG_PARITY.md`](LANG_PARITY.md), shipped this session
   specifically because this had already happened once (3 gate fixes,
   RU-only, undiscovered for a day).
+- **Kill-gate calibration is lane-specific.** H220 proved that a budget tuned
+  for dense verb batches false-kills no-fallback no-PWG singleton cards. Verb
+  batch, nominal small, nominal monster, no-PWG single, synth fan-out, and
+  external API mining launches keep separate calibration evidence; do not
+  blindly promote one lane's timeout envelope to another.
 
 ## Current state (as of 07-07-2026)
 
@@ -511,8 +557,9 @@ likely the SAME class, not a new bug:
   own historical false positives (Phase 6); `audit_window_en.py` (EN) has
   NOT yet received the same fixes — tracked as a GAP in `LANG_PARITY.md`.
 - Nominal lane: production-proven at 100/100 cards (Phase 10, H201); the
-  PWG-miss drop is fixed and no-PWG supplement-chain cards render (Phase 9);
-  the 232-lemma backfill queue is documented, awaiting ordinary scheduling.
+  PWG-miss drop is fixed, no-PWG supplement-chain cards render (Phase 9), and
+  no-PWG singleton throughput is fixed/calibrated (Phase 14); the 232-lemma
+  backfill queue is documented, awaiting ordinary scheduling.
 - Cost/performance: `perf_preflight.py` gives a now-accurate agent-count
   estimate (fixed Phase 8); TM (card + fragment level) is the main
   standing cost lever; `OUTPUT_BUDGET=90` is the calibrated default.
@@ -531,7 +578,8 @@ likely the SAME class, not a new bug:
 - Process discipline (all MG-locked, do not re-litigate): opt2 canonical
   harness, ≤3-wide concurrency, `--no-tm` mandatory on requeue, lang-fix
   parity classification mandatory before closing a session, drive the
-  Workflow from the Claude Code session (not a manual Max-surface save).
+  Workflow from the Claude Code session (not a manual Max-surface save), and
+  update/check `LAUNCH_FUCKUPS.md` before closing any launch-shaped handoff.
 
 ## Where to go next
 
@@ -542,6 +590,9 @@ likely the SAME class, not a new bug:
 - **A card/batch stalled, or wondering what else can blow the retry cap?** →
   [`FAILURE_MODES_AND_KILL_GATE_2026-07-04.md`](FAILURE_MODES_AND_KILL_GATE_2026-07-04.md):
   the full driver taxonomy + the wall-clock kill-gate design and calibration.
+- **Closing a launch after failures or retries?** →
+  [`LAUNCH_FUCKUPS.md`](LAUNCH_FUCKUPS.md) + `python src/pilot/check_launch_ledger.py
+  --handoff H###` are the mandatory incident register and checker.
 - **What's queued/in-flight/blocked right now?** → [`.ai_state.md`](.ai_state.md),
   the live journal (this document doesn't replace it — it's the map, not the
   territory).

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -382,6 +382,34 @@ measurements in `window_status.json` and `window_ledger.jsonl`. Append milestone
 `PILOT_COST.md` §6 when a root or run-to-cap tranche is complete. The point is to answer the
 feasibility question: one Max seat over roughly two months vs a paid API bulk run.
 
+## Post-launch closeout
+
+Every Workflow/API launch with a failure, null wave, stall, kill, stale-artifact refusal,
+retry pass, cost drift, or suspicious residual must be registered in
+[`../../LAUNCH_FUCKUPS.md`](../../LAUNCH_FUCKUPS.md) before the handoff is closed. The
+entry must include expected vs actual agents/tokens, pass count, failure class, root cause,
+guardrail/fix, and residual risk. This is the exhaustive incident register; the narrative
+history in [`../../PIPELINE_HISTORY.md`](../../PIPELINE_HISTORY.md) only gets curated
+phase-level lessons.
+
+Closeout checklist:
+
+```powershell
+# Update the live state and launch evidence.
+# - .ai_state.md: handoff result and next physical action
+# - src\pilot\RUN_LOG.md: launch metrics and pass/fail narrative
+# - LAUNCH_FUCKUPS.md: classified failure record for any non-clean launch
+
+python src\pilot\check_launch_ledger.py --handoff H220
+python src\pilot\check_launch_ledger.py --since 2026-07-05
+```
+
+Calibration is lane-specific. Keep separate evidence for `verb batch`, `nominal small`,
+`nominal monster`, `no-PWG single`, `synth fan-out`, and `external API mining`; do not copy
+one lane's kill-budget, cost, or concurrency envelope into another without a measured
+launch/replay. H220 is the standing counter-example: the dense-root kill gate was correct
+for verb batches but false-killed valid no-fallback no-PWG singleton cards.
+
 ## Worked example — one real root, start to finish (vid, 04-07-2026)
 
 A concrete run, with real numbers, so the loop above isn't just abstract steps.
@@ -413,7 +441,10 @@ A concrete run, with real numbers, so the loop above isn't just abstract steps.
 8. **Promote + rebuild TM:** `promote_final_cards.py --gen-model-version claude-sonnet-5`,
    then `translation_memory.py build --lang ru` (+ `build-frags` if any heal emitted
    `frag_prov`).
-9. **Micro-commit**, move to the next queued root.
+9. **Close out the launch ledger:** if the run had nulls, retries, kills, stale-artifact
+   refusals, or cost drift, update `LAUNCH_FUCKUPS.md` and run
+   `python src\pilot\check_launch_ledger.py --handoff H151` (or the active handoff ID).
+10. **Micro-commit**, move to the next queued root.
 
 What this run taught (folded into the process above, not left as trivia): the
 preflight's agent-count estimate was badly wrong for presplit-heavy roots (now
@@ -429,4 +460,6 @@ The frequency queue milestone is done when:
   glued nested article;
 - zero `*.merged.REJECTED.md` files remain for that window;
 - rootmap-backed giant roots have matching `*.NESTED.md` outputs;
-- the cost/quota table has enough windows to estimate the run duration.
+- the cost/quota table has enough windows to estimate the run duration;
+- every non-clean Workflow/API launch in the window has a complete
+  `LAUNCH_FUCKUPS.md` entry and passes `check_launch_ledger.py`.

--- a/RussianTranslation/src/pilot/check_launch_ledger.py
+++ b/RussianTranslation/src/pilot/check_launch_ledger.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python
+"""Mechanical check for LAUNCH_FUCKUPS.md.
+
+  python src/pilot/check_launch_ledger.py
+  python src/pilot/check_launch_ledger.py --handoff H220
+  python src/pilot/check_launch_ledger.py --since 2026-07-05
+
+The ledger is a human Markdown file with one fenced JSON block. This checker
+does not infer root cause; it only enforces that every recorded launch failure
+has enough structured information to be useful at handoff closeout time.
+"""
+import argparse
+import datetime as _dt
+import json
+import os
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(os.path.dirname(HERE))
+LEDGER_MD = os.path.join(REPO_ROOT, 'LAUNCH_FUCKUPS.md')
+RUN_LOG_MD = os.path.join(HERE, 'RUN_LOG.md')
+FENCE_RE = re.compile(r'```json launch_failure_ledger\r?\n(.*?)```', re.DOTALL)
+RUNLOG_HEADING_RE = re.compile(r'^(#{2,4})\s+(\d{4}-\d{2}-\d{2})\s+[—-]\s+(.*)$')
+HANDOFF_RE = re.compile(r'\bH\d{3}\b')
+
+VALID_CLASSES = {
+    'concurrency/api',
+    'structured-output-limit',
+    'complexity-estimate-drift',
+    'kill-gate-calibration',
+    'gate-bug',
+    'artifact/provenance',
+    'tm/cache',
+    'filesystem/watcher',
+    'key/schema-mismatch',
+    'operator/process',
+    'external-api',
+    'unknown',
+}
+
+VALID_RESIDUAL = {
+    'fixed',
+    'structurally-guarded',
+    'accepted-as-proven-residual',
+    'bug-hunt-handoff',
+}
+
+REQUIRED_TEXT = (
+    'id',
+    'date',
+    'title',
+    'lane',
+    'model',
+    'orchestrator',
+    'symptoms',
+    'classification',
+    'root_cause',
+    'guardrail',
+    'residual_status',
+    'residual_risk',
+)
+
+
+def parse_date(s):
+    try:
+        return _dt.date.fromisoformat(s)
+    except ValueError:
+        raise SystemExit('invalid date %r, expected YYYY-MM-DD' % s)
+
+
+def load_ledger(path=LEDGER_MD):
+    text = open(path, encoding='utf-8').read()
+    m = FENCE_RE.search(text)
+    if not m:
+        raise SystemExit('no ```json launch_failure_ledger fenced block found in %s' % path)
+    try:
+        entries = json.loads(m.group(1))
+    except json.JSONDecodeError as e:
+        raise SystemExit('invalid JSON launch ledger: %s' % e)
+    if not isinstance(entries, list):
+        raise SystemExit('launch ledger JSON must be a list')
+    return entries
+
+
+def _has_value(v):
+    if v is None:
+        return False
+    if isinstance(v, str):
+        return bool(v.strip())
+    if isinstance(v, (int, float)):
+        return True
+    return bool(v)
+
+
+def check_entries(entries):
+    violations = []
+    seen_ids = set()
+    unknown_shapes = {}
+    for i, e in enumerate(entries):
+        label = e.get('id') or '<entry %d>' % (i + 1)
+        if not isinstance(e, dict):
+            violations.append('%s: entry must be an object' % label)
+            continue
+        if label in seen_ids:
+            violations.append('%s: duplicate id' % label)
+        seen_ids.add(label)
+        for key in REQUIRED_TEXT:
+            if not _has_value(e.get(key)):
+                violations.append('%s: missing non-empty %s' % (label, key))
+        if e.get('classification') and e.get('classification') not in VALID_CLASSES:
+            violations.append('%s: classification %r is not valid' % (label, e.get('classification')))
+        if e.get('residual_status') and e.get('residual_status') not in VALID_RESIDUAL:
+            violations.append('%s: residual_status %r is not valid' % (label, e.get('residual_status')))
+        try:
+            parse_date(e.get('date', ''))
+        except SystemExit as exc:
+            violations.append('%s: %s' % (label, exc))
+        for bucket in ('expected', 'actual'):
+            value = e.get(bucket)
+            if not isinstance(value, dict):
+                violations.append('%s: %s must be an object with agents/tokens' % (label, bucket))
+                continue
+            for field in ('agents', 'tokens'):
+                if not _has_value(value.get(field)):
+                    violations.append('%s: %s.%s is required' % (label, bucket, field))
+        if not isinstance(e.get('passes'), int) or e.get('passes') < 1:
+            violations.append('%s: passes must be an integer >= 1' % label)
+        if e.get('classification') == 'unknown':
+            shape = (e.get('lane', '').strip(), e.get('symptoms', '').strip().lower())
+            unknown_shapes.setdefault(shape, []).append(label)
+    for shape, labels in unknown_shapes.items():
+        if len(labels) > 1:
+            violations.append(
+                'unknown recurrence requires bug-hunt handoff: %s share %r' %
+                (', '.join(labels), shape[1][:80]))
+    return violations
+
+
+def launch_headings_since(since, run_log=RUN_LOG_MD):
+    if not os.path.exists(run_log):
+        return []
+    headings = []
+    with open(run_log, encoding='utf-8', errors='replace') as f:
+        for line in f:
+            m = RUNLOG_HEADING_RE.match(line.rstrip('\n'))
+            if not m:
+                continue
+            day = parse_date(m.group(2))
+            title = m.group(3)
+            if day < since:
+                continue
+            lowered = title.lower()
+            if 'no max/workflow' in lowered or 'no workflow' in lowered:
+                continue
+            if not any(token in lowered for token in ('run', 'aborted', 'workflow', 'max', 'api', 'promoted')):
+                continue
+            handoffs = HANDOFF_RE.findall(title)
+            if handoffs:
+                headings.append((day.isoformat(), title, sorted(set(handoffs))))
+    return headings
+
+
+def check_requested(entries, handoff=None, since=None):
+    violations = []
+    if handoff:
+        matches = [e for e in entries if e.get('handoff') == handoff]
+        if not matches:
+            violations.append('%s: no launch-failure ledger entry' % handoff)
+    if since:
+        present = {e.get('handoff') for e in entries if e.get('handoff')}
+        for day, title, handoffs in launch_headings_since(since):
+            for h in handoffs:
+                if h not in present:
+                    violations.append(
+                        '%s: RUN_LOG launch heading on %s lacks ledger entry: %s' %
+                        (h, day, title))
+    return violations
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument('--handoff', help='require at least one entry for this H### handoff')
+    p.add_argument('--since', help='scan RUN_LOG launch headings since YYYY-MM-DD')
+    p.add_argument('--ledger', default=LEDGER_MD, help=argparse.SUPPRESS)
+    args = p.parse_args(argv)
+
+    entries = load_ledger(args.ledger)
+    violations = check_entries(entries)
+    if args.handoff or args.since:
+        since = parse_date(args.since) if args.since else None
+        violations.extend(check_requested(entries, args.handoff, since))
+    if violations:
+        print('LAUNCH FAILURE LEDGER: %d violation(s)' % len(violations))
+        for v in violations:
+            print('  - ' + v)
+        return 1
+    print('LAUNCH FAILURE LEDGER: %d entries complete' % len(entries))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -2890,6 +2890,49 @@ def test_perf_preflight_cost_gate():
         fail('a fully-cached (zero-agent) window must never trip the cost gate')
 
 
+def test_launch_failure_ledger_complete():
+    """Launch failures must be classified with expected/actual economics before a
+    handoff closes; H220 must stay represented because that incident was previously
+    easier to find in .ai_state/RUN_LOG than in the narrative history."""
+    import check_launch_ledger as cl
+    entries = cl.load_ledger()
+    violations = cl.check_entries(entries)
+    if violations:
+        fail('launch failure ledger has violations: %r' % violations)
+    missing = cl.check_requested(entries, handoff='H220')
+    if missing:
+        fail('H220 must have a launch failure ledger entry: %r' % missing)
+
+
+def test_launch_failure_ledger_rejects_incomplete_entry():
+    """A ledger block that omits classification / metrics must fail loudly, so the
+    closeout ritual cannot silently decay into narrative-only notes."""
+    import check_launch_ledger as cl
+    bad = [{
+        'id': 'BAD',
+        'date': '2026-07-07',
+        'title': 'incomplete',
+        'lane': 'verb batch',
+        'model': 'claude-sonnet-5',
+        'orchestrator': 'Workflow',
+        'expected': {'agents': '1'},
+        'actual': {'agents': '2'},
+        'passes': 1,
+        'symptoms': 'nulls',
+        'root_cause': 'unknown',
+        'guardrail': 'none',
+        'residual_status': 'fixed',
+        'residual_risk': 'none',
+    }]
+    violations = cl.check_entries(bad)
+    if not any('classification' in v for v in violations):
+        fail('incomplete launch ledger entry must reject missing classification: %r' % violations)
+    if not any('expected.tokens' in v for v in violations):
+        fail('incomplete launch ledger entry must reject missing expected.tokens: %r' % violations)
+    if not any('actual.tokens' in v for v in violations):
+        fail('incomplete launch ledger entry must reject missing actual.tokens: %r' % violations)
+
+
 def main():
     tests = [
         test_translation_memory_addressing,
@@ -2934,6 +2977,8 @@ def main():
         test_budget_kill_switch_wired,
         test_harness_size_guard,
         test_perf_preflight_cost_gate,
+        test_launch_failure_ledger_complete,
+        test_launch_failure_ledger_rejects_incomplete_entry,
         test_autosplit_topup_targets_and_reassembles,
         test_workflow_payload_nested,
         test_sense_dupe_batch_override,


### PR DESCRIPTION
## Summary
- Add `RussianTranslation/LAUNCH_FUCKUPS.md` — failure typology + 7 seeded launch incidents.
- Add `RussianTranslation/src/pilot/check_launch_ledger.py` — `--handoff H###` / `--since YYYY-MM-DD` ledger queries.
- Wire the closeout checklist + lane-specific calibration rule into `RUN_FREQ_MAX.md`, add verifier coverage to `window_selftest.py`, and record H220 in `PIPELINE_HISTORY.md` / `.ai_state.md` / `LANG_PARITY.md` hashes.

## Test plan
- [x] `python src/pilot/check_launch_ledger.py`
- [x] `python src/pilot/check_launch_ledger.py --handoff H220`
- [x] `python src/pilot/check_launch_ledger.py --since 2026-07-05`
- [x] `python -m py_compile src/pilot/check_launch_ledger.py`
- [x] `python src/pilot/lang_parity_check.py`
- [x] `python src/pilot/window_selftest.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)