### PR TITLE
H215 Slice 4 — oral register of the publication-grade Sa→Ru TM

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,23 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **H215 Slice 4 — oral register — ✅ DONE 07-07-2026 (Opus 4.8 `claude-opus-4-8`).**
+  New [`src/ingest_oral.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ingest_oral.py):
+  cleaned VTT/SRT/JSON transcript of spoken Sanskrit + Russian → `corpus_builder/<work>.jsonl`
+  tagged `modality=oral` + `t_start`/`t_end`/`source_media`/`asr_conf` + canonical `iast_to_slp1`
+  key; index-pairing with a hard mismatch guard; never-invent guards. Threaded `modality`/anchors
+  through [`build_l0.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_l0.py)
+  → [`build_tmx.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_tmx.py)
+  (`l0_tu_xml` emits the oral props; written TMX byte-unchanged). **Lowered base grade** in one
+  place: shared `build_tmx.oral_cap()` (A→B unless human-adjudicated) + `tm_grade.ORAL_PENALTY=0.15`.
+  Shared schema/design (coordinated with [H174](https://github.com/gasyoun/Uprava/blob/main/handoffs/H174-Opus_spoken-sanskrit-corpus_spoken_sanskrit_corpus_scaffold_04.07.26.md)):
+  [`src/ORAL_INGEST.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ORAL_INGEST.md).
+  Fixture pilot end-to-end (ingest→L0→grade→TMX validates); same corroborated units grade **6×A written
+  vs 6×B oral** (mean composite 0.892→0.743). Selftests pass: `ingest_oral.py`, `build_tmx.py`,
+  `tm_grade.py`, `build_l0.py`, `py_compile` all green. **➡️ Scale is asset-gated** — no oral recordings
+  in a tracked repo yet (H174 unbuilt); scale-ingest runs once H174 delivers cleaned transcripts.
+  Slice 5 (FAIR release) stays rights-gated (per-source clearance, human).
+
 - **Launch-failure guardrails — ✅ DONE 07-07-2026 (Codex/GPT-5).**
   Added the mandatory post-launch incident ledger [`LAUNCH_FUCKUPS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LAUNCH_FUCKUPS.md)
   with a compact failure typology and seven seeded incidents (Slice D, H189/H191,

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,24 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### H215 Slice 4 — oral register of the publication-grade TM
+- New [`src/ingest_oral.py`](src/ingest_oral.py): a deterministic converter turning a
+  *cleaned* timecoded transcript (WebVTT/SRT/JSON, or `--pairs` JSONL) of spoken
+  Sanskrit + its Russian rendering into the `corpus_builder/<work>.jsonl` schema the
+  L0 pipeline already consumes — tagged `modality=oral` with `t_start`/`t_end` time
+  anchors, `source_media`, optional `asr_conf`, and a canonical `iast_to_slp1` key. No
+  ASR, no cleaning (that is [H174](https://github.com/gasyoun/Uprava/blob/main/handoffs/H174-Opus_spoken-sanskrit-corpus_spoken_sanskrit_corpus_scaffold_04.07.26.md)'s
+  upstream stage — this is the Sa→Ru-alignment half). Parallel tracks pair by index;
+  a cue-count mismatch is a hard error, never a silent `zip()` truncation.
+- **Lowered base grade for oral** in one place: shared `build_tmx.oral_cap()` forbids
+  grade A for an oral unit on automatic signals (capped at B; only human adjudication
+  lifts it), plus `tm_grade.ORAL_PENALTY` (0.15) on the composite. `build_l0.py` and
+  `build_tmx.py` thread `modality`/anchors through unchanged for written sources.
+- Design + shared schema (coordinated with H174): [`src/ORAL_INGEST.md`](src/ORAL_INGEST.md).
+  Fixture pilot: end-to-end ingest→L0→grade→TMX validates; same corroborated units
+  grade **6×A written vs 6×B oral** (mean composite 0.892→0.743). Selftests added to
+  `ingest_oral.py`, `build_tmx.py`, `tm_grade.py`.
+
 ## [1.4.0] - 2026-07-06
 
 ### no-PWG supplement-chain lane (H214) — PWG-missing headwords become translatable

--- a/RussianTranslation/src/BUILD_TMX.md
+++ b/RussianTranslation/src/BUILD_TMX.md
@@ -189,6 +189,25 @@ F1): rows with a non-Cyrillic `ru`, an empty SLP1 key, or `ru == sa` are dropped
 `tuid`s are content-derived (deterministic — no clock/random), so the same lexicon
 yields byte-identical TMX.
 
+## Slice 4 — the oral register
+
+Recorded/spoken Sanskrit with a Russian rendering flows through this same L0 → grade
+→ TMX pipeline via
+[`src/ingest_oral.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ingest_oral.py)
+(cleaned VTT/SRT transcript → `corpus_builder/<work>.jsonl` tagged `modality=oral`
+with `t_start`/`t_end` time anchors + `source_media`). See
+[`ORAL_INGEST.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ORAL_INGEST.md)
+for the shared schema (coordinated with
+[H174](https://github.com/gasyoun/Uprava/blob/main/handoffs/H174-Opus_spoken-sanskrit-corpus_spoken_sanskrit_corpus_scaffold_04.07.26.md)),
+the grade policy, and the pilot results.
+
+Two touch-points here: `l0_tu_xml` emits `modality`/`t_start`/`t_end`/`source_media`/
+`asr_conf` props (absent on written L0, so written TMX is byte-unchanged), and the
+shared `oral_cap()` — the **lowered base grade** — forbids grade **A** for an oral
+unit on the automatic signals alone (capped at B; only human adjudication lifts it),
+paired with `tm_grade.ORAL_PENALTY` on the composite. Fixture pilot: the same
+corroborated units grade 6×A written vs 6×B oral.
+
 ## Rights — why the output is gitignored
 
 `corpus_lexicon.jsonl` mixes public-domain and **in-copyright** named modern Russian

--- a/RussianTranslation/src/ORAL_INGEST.md
+++ b/RussianTranslation/src/ORAL_INGEST.md
@@ -1,0 +1,172 @@
+# Oral-corpus ingest — the spoken register of the Sa→Ru TM (H215 Slice 4)
+
+_Created: 07-07-2026 · Last updated: 07-07-2026_
+
+This is the design + shared-schema doc for
+[`src/ingest_oral.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ingest_oral.py),
+the oral half of the publication-grade translation memory built by
+[H215](https://github.com/gasyoun/Uprava/blob/main/handoffs/H215-Opus_RussianTranslation_pwg_ru_publication_grade_tm_tmx_and_oral_06.07.26.md).
+Slices 1–3 turned **written** verse-aligned scholarly translations into a graded
+[TMX](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/BUILD_TMX.md);
+Slice 4 adds the **oral** register (recorded/spoken Sanskrit with a Russian
+rendering) through the *same* L0 → grade → TMX pipeline, not a forked one.
+
+## Coordination with H174 — one schema, two owners
+
+The spoken material itself is owned by
+[H174 · spoken-sanskrit-corpus](https://github.com/gasyoun/Uprava/blob/main/handoffs/H174-Opus_spoken-sanskrit-corpus_spoken_sanskrit_corpus_scaffold_04.07.26.md):
+sourcing the recordings/subtitles and **ASR-transcript cleaning** (Data-Juicer:
+disfluency/filler removal, garbled-segment filtering, near-dup collapse). H174 is
+still 🟡 (repo not built yet), so this doc **defines the contract** it will produce
+against. The division of labour:
+
+| Stage | Owner | Output |
+|---|---|---|
+| Source recordings, subtitles, `.doc`/`.pdf` companions | **H174** | raw transcripts |
+| ASR-noise cleaning (disfluency, garble, dedup) | **H174** (Data-Juicer) | *cleaned* timecoded transcript (VTT/SRT) |
+| Cleaned transcript → graded Sa↔Ru parallel unit | **H215 Slice 4** (`ingest_oral.py`) | `corpus_builder/<work>.jsonl` → L0 → TMX |
+
+`ingest_oral.py` does **no ASR** (per H174's interview the material is *existing*
+machine-transcripts, not raw audio needing fresh recognition) and does **no
+cleaning** (that is H174's Data-Juicer stage upstream). It parses a *cleaned*
+subtitle track, pairs Sanskrit with Russian, applies the never-invent guards, and
+emits the corpus schema below.
+
+## The pipeline
+
+```
+cleaned VTT/SRT (sa) + (ru)                     [H174 delivers these]
+        │  ingest_oral.py convert
+        ▼
+SamudraManthanam/web/corpus_builder/jsonl/<work>.jsonl   (modality:oral + anchors)
+        │  build_l0.py build --sm <dir>
+        ▼
+release/corpus_tm/corpus_l0.jsonl               (L0 verse units, modality carried)
+        │  tm_grade.py grade   (oral units: lowered base grade)
+        │  build_tmx.py build --l0 …
+        ▼
+release/corpus_tm/corpus_tm.sa-ru.tmx           (TMX 1.4b, modality/t_start/t_end props)
+```
+
+Everything downstream of the source jsonl is the **existing written pipeline** —
+oral flows through it unchanged except for the modality mark and the grade policy.
+
+## Source schema — the extension to `corpus_builder/<work>.jsonl`
+
+The written ingest format ([`ADDING_TEXTS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ADDING_TEXTS.md))
+is one JSONL line per segment: `{group, seg, text, passage, lang}`. Oral adds four
+**optional** provenance fields on the segment records — absent on written sources,
+so the written path is byte-for-byte unchanged:
+
+```json
+{"group": "gita-lecture-01:1", "seg": "sa", "passage": "1",
+ "text": "yogaḥ karmasu kauśalam", "slp1": "yogaH karmasu kauSalam",
+ "modality": "oral", "t_start": 1.0, "t_end": 5.0, "source_media": "gita01.mp3"}
+{"group": "gita-lecture-01:1", "seg": "ru", "passage": "1", "lang": "ru",
+ "text": "йога есть искусность в действиях",
+ "modality": "oral", "t_start": 1.0, "t_end": 5.0, "source_media": "gita01.mp3"}
+```
+
+| Field | Meaning |
+|---|---|
+| `modality` | `oral` \| `written` (default `written` when absent) |
+| `t_start` / `t_end` | float **seconds** into `source_media` — the time anchor |
+| `source_media` | the audio/video filename the segment was spoken in (provenance) |
+| `asr_conf` | optional 0–1 recognition confidence, if the cleaned transcript kept it |
+
+`slp1` is filled by the **canonical** transcoder (`build_src.iast_to_slp1`, the same
+one the written corpus uses) so oral units carry a real SLP1 key, not just the IAST
+surface. `group` must stay globally unique — prefix it with the work name.
+
+These fields flow through unchanged: `build_l0.py` copies `modality`/`t_start`/
+`t_end`/`source_media`/`asr_conf` onto each L0 unit, and `build_tmx.py` emits them
+as TMX `<prop>`s on the `<tu>`.
+
+## Grade policy — the "lowered base grade" for oral
+
+MG's spec: *"Oral units get a lower base grade by default"* (live interpretation is
+noisier — translationese, paraphrase, hesitation). Implemented in **one place**
+(`build_tmx.oral_cap`, applied by both the L0 exporter and the L1 grader) plus a
+composite penalty in the grader:
+
+1. **Composite penalty** — `tm_grade.ORAL_PENALTY = 0.15` is subtracted from an oral
+   unit's composite score before thresholding, representing the higher noise floor.
+2. **A-gate lock** — `oral_cap()` forbids grade **A** for an oral unit on the
+   automatic signals alone: a unit that would score A when written is capped at **B**
+   when oral. **Only human adjudication** (`/gold-adjudicate`, the `adjudicated` flag)
+   lifts an oral unit to A. B and C pass through unchanged.
+
+So an oral unit's ceiling is B unless a human confirms it — matching A's definition
+("publication / hard gloss") which oral live-interpretation cannot claim unreviewed.
+
+## Pairing rule — parallel tracks must share segmentation
+
+`convert --sa X.vtt --ru Y.vtt` pairs cues **by index**: cue *i* of the Sanskrit
+track ↔ cue *i* of the Russian track. This is correct only when both tracks segment
+the **same** recording identically. A cue-count mismatch is a **hard error**, never a
+silent `zip()` truncation — mis-segmented tracks would fabricate wrong Sa↔Ru pairs
+(the F1 hallucination lesson,
+[FAILURE_GALLERY](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/failures/FAILURE_GALLERY.md)).
+When tracks are independently segmented, align them upstream and pass `--pairs` with
+explicit `{sa, ru, t_start, t_end}` rows instead. The never-invent guards still apply
+at emit: a Sanskrit surface must be present and the Russian must carry Cyrillic, or
+the pair is dropped (reported, never fabricated).
+
+## Formats accepted
+
+- **WebVTT** (`.vtt`) and **SRT** (`.srt`) — the yt-dlp / Whisper subtitle outputs.
+  Inline VTT tags (`<c>`, `<00:00:01.000>`) are stripped; `WEBVTT`/`NOTE`/`STYLE`
+  headers are skipped; hours in the timestamp are optional.
+- **JSON/JSONL** cue lists (`[{t_start, t_end, text, asr_conf?}]`) — a pre-parsed
+  transcript.
+- **`--pairs` JSONL** (`{sa, ru, t_start, t_end, asr_conf?, passage?}`) — already
+  paired, bypassing the index-pairing step.
+
+## Pilot results (07-07-2026, fixture)
+
+No oral recordings are in a tracked repo yet (H174 unbuilt), so Slice 4 ships with a
+**fixture pilot** proving the schema end-to-end and quantifying the grade policy.
+
+**End-to-end chain** — a 3-cue parallel VTT pair (Bhagavad-Gītā lines) runs
+`ingest_oral convert` → `build_l0 build --sm` → `build_tmx build --l0` and produces a
+well-formed TMX 1.4b whose oral `<tu>`s each carry `modality=oral`, `t_start`/`t_end`,
+and `source_media` props (validated by `build_tmx validate`). `slp1` is populated by
+the canonical transcoder (`yogaḥ karmasu kauśalam` → `yogaH karmasu kauSalam`).
+
+**Grade shift (lowered base)** — the *same* 6 clean, corroborated (≥2 works agreeing)
+verse units, graded written vs oral, deterministic proxy QE:
+
+| modality | A | B | C | mean composite |
+|---|---:|---:|---:|---:|
+| written | 6 | 0 | 0 | 0.892 |
+| oral | 0 | 6 | 0 | 0.743 |
+
+The −0.149 mean-score drop is `ORAL_PENALTY` (0.15); the A→B collapse is `oral_cap`'s
+A-gate lock. Units that only reach B/C when written are unaffected by the cap (only
+the penalty moves them). Reproduce: `python tm_grade.py selftest` (asserts the
+written-A / oral-B / adjudicated-oral-A gates) and `python ingest_oral.py selftest`.
+
+_Model provenance: deterministic — no LLM. Pilot generated under Opus 4.8
+(`claude-opus-4-8`), H215 Slice 4._
+
+## Follow-ups (not this slice)
+
+- **Handout `.doc`/`.pdf` companions** (Slice 4 pipeline #5): a lecture's written
+  handout of the same passage → the `docx-to-md` skill → `.mdx`, ingested as a
+  **second reference** of the same verse (spoken vs handout → multi-reference
+  consensus). Requires real handout assets (MG-gated).
+- **Real audio → ASR** (pipeline #3): Whisper→WhisperX/MFA forced alignment for
+  material that arrives as raw audio rather than cleaned subtitles — H174's ASR stage.
+- **Scale ingest** is asset-gated: no oral recordings are in a tracked repo yet
+  (H174 not built). This slice ships the schema + tooling + an end-to-end fixture
+  pilot; scale runs when H174 delivers cleaned transcripts.
+
+## Rights
+
+Recorded third-party speech is consent/rights-gated **more** than written sources
+(H174 guardrail). No public release before
+[`/publish-safety-check`](https://github.com/gasyoun/Uprava) + per-source clearance
+(H215 Slice 5). Emitted jsonl/TMX stay under the gitignored `release/corpus_tm/`
+tree, exactly like the written corpus.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/build_l0.py
+++ b/RussianTranslation/src/build_l0.py
@@ -146,6 +146,13 @@ def units_for_group(group, d, work, strata, with_comm=True):
         return
     st = strata.get(work, {})
     passage = sa.get('passage', '') or ''
+    # H215 Slice 4: oral provenance. The verse-anchoring Sanskrit segment carries the
+    # modality + media (a whole recording is one modality); time anchors can differ
+    # per segment (the Russian cue may span a different window), so they're read from
+    # the emitting seg with a fallback to the Sanskrit anchor. Written sources omit
+    # all of these -> modality defaults 'written', anchors stay absent (unchanged TMX).
+    modality = (sa.get('modality') or 'written')
+    source_media = sa.get('source_media')
     base = {'work': work, 'group': group,
             'genre': st.get('genre'), 'period': st.get('period'),
             'date': st.get('date_median')}
@@ -158,13 +165,27 @@ def units_for_group(group, d, work, strata, with_comm=True):
         if not has_cyr(ru):            # untranslated placeholder -> never emit
             return None
         toks = sa_tokens(sa_slp1)
-        return {**base, 'l0id': l0id(group, seg), 'seg': seg, 'kind': kind,
-                'passage': rec.get('passage', passage) or passage,
-                'sa': sa_iast, 'slp1': sa_slp1, 'ru': ru,
-                'n_sa_tok': len(toks),
-                'n_ru_tok': len(re.findall(r'[Ѐ-ӿ]+', ru)),
-                'speaker_sa': (sa.get('author') or '').strip() or None,
-                'speaker_ru': (rec.get('author') or '').strip() or None}
+        out = {**base, 'l0id': l0id(group, seg), 'seg': seg, 'kind': kind,
+               'passage': rec.get('passage', passage) or passage,
+               'sa': sa_iast, 'slp1': sa_slp1, 'ru': ru,
+               'n_sa_tok': len(toks),
+               'n_ru_tok': len(re.findall(r'[Ѐ-ӿ]+', ru)),
+               'speaker_sa': (sa.get('author') or '').strip() or None,
+               'speaker_ru': (rec.get('author') or '').strip() or None}
+        if modality and modality != 'written':
+            out['modality'] = modality
+            t_start = rec.get('t_start', sa.get('t_start'))
+            t_end = rec.get('t_end', sa.get('t_end'))
+            if t_start is not None:
+                out['t_start'] = t_start
+            if t_end is not None:
+                out['t_end'] = t_end
+            if source_media:
+                out['source_media'] = source_media
+            asr = rec.get('asr_conf', sa.get('asr_conf'))
+            if asr is not None:
+                out['asr_conf'] = asr
+        return out
 
     u = emit('ru', 'translation')
     if u:

--- a/RussianTranslation/src/build_tmx.py
+++ b/RussianTranslation/src/build_tmx.py
@@ -59,6 +59,17 @@ def has_cyr(s):
     return bool(s) and bool(CYR.search(s))
 
 
+# H215 Slice 4 -- the "lowered base grade" for oral units, in ONE place so build_tmx
+# (L0) and tm_grade (L1) apply the identical rule. Live interpretation is noisier
+# (translationese, paraphrase, hesitation), so an oral unit never reaches A on the
+# automatic signals alone -- only human adjudication lifts it there. B and C pass
+# through unchanged; written units are untouched.
+def oral_cap(grade, modality, adjudicated=False):
+    if modality == 'oral' and not adjudicated and grade == 'A':
+        return 'B'
+    return grade
+
+
 def q(s):
     """Escape text for an XML element body."""
     return escape('' if s is None else str(s))
@@ -113,10 +124,14 @@ def l0_tu_xml(rec, grade=L0_GRADE):
     sa = (rec.get('sa') or '').strip()
     ru = (rec.get('ru') or '').strip()
     src = slp1 or sa
+    # H215 Slice 4: modality/time anchors flow from the L0 record (build_l0.py) when
+    # the source was oral; written L0 records omit them -> DEFAULT_MODALITY, no anchors.
+    modality = rec.get('modality') or DEFAULT_MODALITY
+    grade = oral_cap(grade, modality, adjudicated=bool(rec.get('adjudicated')))
     parts = ['<tu tuid=%s segtype="block">\n' % quoteattr(rec.get('l0id') or tuid(rec))]
     parts.append(_prop('layer', 'L0'))
     parts.append(_prop('grade', grade))
-    parts.append(_prop('modality', DEFAULT_MODALITY))
+    parts.append(_prop('modality', modality))
     parts.append(_prop('kind', rec.get('kind')))
     parts.append(_prop('surface', sa))
     parts.append(_prop('work', rec.get('work')))
@@ -125,6 +140,11 @@ def l0_tu_xml(rec, grade=L0_GRADE):
     parts.append(_prop('genre', rec.get('genre')))
     parts.append(_prop('period', rec.get('period')))
     parts.append(_prop('date', rec.get('date')))
+    # oral-only provenance props (absent -> no prop line, so written TMX is unchanged)
+    parts.append(_prop('t_start', rec.get('t_start')))
+    parts.append(_prop('t_end', rec.get('t_end')))
+    parts.append(_prop('source_media', rec.get('source_media')))
+    parts.append(_prop('asr_conf', rec.get('asr_conf')))
     parts.append('  <tuv xml:lang="%s"><seg>%s</seg></tuv>\n' % (SRCLANG, q(src)))
     parts.append('  <tuv xml:lang="%s"><seg>%s</seg></tuv>\n' % (TGTLANG, q(ru)))
     parts.append(' </tu>\n')
@@ -361,8 +381,35 @@ def selftest():
 
     # tuid is deterministic.
     assert tuid(FIXTURE[0]) == tuid(dict(FIXTURE[0])), 'tuid not deterministic'
-    print('build_tmx selftest OK -- 3/6 rows kept, escaping + props + validation clean')
+
+    # H215 Slice 4: an oral L0 unit emits modality=oral + time anchors, and the
+    # shared oral_cap forbids A on the automatic default. A written L0 unit is
+    # unchanged (modality=written, no anchor props).
+    oral_l0 = {'l0id': 'l0-oral1', 'kind': 'translation', 'slp1': 'yogaH',
+               'sa': 'yogaḥ', 'ru': 'йога', 'work': 'gita-lecture', 'passage': '1',
+               'modality': 'oral', 't_start': 1.0, 't_end': 4.5,
+               'source_media': 'gita01.mp3', 'asr_conf': 0.82}
+    xml = l0_tu_xml(oral_l0, grade='A')      # try to force A ...
+    props = dict(re.findall(r'<prop type="([^"]+)">([^<]*)</prop>', xml))
+    assert props.get('modality') == 'oral', props
+    assert props.get('grade') == 'B', 'oral_cap must knock A->B on L0, got %s' % props.get('grade')
+    assert props.get('t_start') == '1.0' and props.get('t_end') == '4.5', props
+    assert props.get('source_media') == 'gita01.mp3', props
+    written_l0 = {'l0id': 'l0-w1', 'kind': 'translation', 'slp1': 'yogaH',
+                  'sa': 'yogaḥ', 'ru': 'йога', 'work': 'w', 'passage': '1'}
+    wprops = dict(re.findall(r'<prop type="([^"]+)">([^<]*)</prop>', l0_tu_xml(written_l0)))
+    assert wprops.get('modality') == 'written' and 't_start' not in wprops, wprops
+    assert assert_oral_cap(), 'oral_cap unit checks'
+    print('build_tmx selftest OK -- 3/6 rows kept, escaping + props + validation + oral L0 clean')
     return 0
+
+
+def assert_oral_cap():
+    assert oral_cap('A', 'oral') == 'B'
+    assert oral_cap('A', 'oral', adjudicated=True) == 'A'
+    assert oral_cap('B', 'oral') == 'B' and oral_cap('C', 'oral') == 'C'
+    assert oral_cap('A', 'written') == 'A'
+    return True
 
 
 def main():

--- a/RussianTranslation/src/ingest_oral.py
+++ b/RussianTranslation/src/ingest_oral.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python
+r"""H215 Slice 4 -- oral-corpus ingest: timecoded transcript -> corpus jsonl.
+
+The written TM (Slices 1-3) turns verse-aligned scholarly translations into a
+graded TMX. Slice 4 adds the **oral register**: recorded/spoken Sanskrit with a
+Russian rendering, carrying time anchors and a `modality: oral` mark, ingested
+into the *same* L0 pipeline (build_l0.py -> tm_grade.py -> build_tmx.py) rather
+than a forked one.
+
+This is the **Sa->Ru-alignment half of H174** (spoken-sanskrit-corpus): H174 owns
+sourcing + ASR-transcript cleaning of the raw material; this owns turning a
+*cleaned, timecoded* transcript into a graded parallel-corpus unit. The schema
+emitted here is the shared contract -- see ORAL_INGEST.md.
+
+No ASR call happens here: per H174's interview the material is *existing*
+machine-transcripts (VTT/SRT subtitles, yt-dlp/Whisper output), not raw audio
+needing fresh recognition. This tool parses those subtitle formats, pairs the
+Sanskrit cues with their Russian rendering, applies the never-invent guards, and
+emits the corpus_builder `<work>.jsonl` format build_l0.py already consumes --
+plus `modality=oral`, `t_start`/`t_end` time anchors, `source_media`, and (when
+the transcript carried it) a per-cue `asr_conf`.
+
+  python ingest_oral.py convert --sa lecture.sa.vtt --ru lecture.ru.vtt \
+         --work induizm-lecture-01 --media lecture01.mp3 --out <work>.jsonl
+  python ingest_oral.py convert --pairs prealigned.jsonl --work W --out OUT
+  python ingest_oral.py inspect lecture.sa.vtt      parse + show cue stats
+  python ingest_oral.py selftest                    fixture -> convert, assert
+
+The emitted `<work>.jsonl` goes in SamudraManthanam/web/corpus_builder/jsonl/
+exactly like a written source (ADDING_TEXTS.md), then:
+  python build_l0.py build --work <work>            -> corpus_l0.jsonl (modality carried)
+  python tm_grade.py grade ...                        -> oral units get the lowered base grade
+  python build_tmx.py build --l0 corpus_l0.jsonl     -> TMX with modality/time props
+
+RIGHTS: recorded third-party speech is consent/rights-gated MORE than written
+sources (H174 guardrail) -- no public release before /publish-safety-check +
+per-source clearance (H215 Slice 5). Emitted jsonl stays under the gitignored
+corpus tree.
+
+Model provenance: deterministic parser (no LLM, no clock in the record) -- the
+same transcript yields byte-identical output.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+import build_tmx  # has_cyr() -- reuse the one canonical never-invent guard
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+MODALITY_ORAL = 'oral'
+
+# A cue whose Sanskrit or Russian is shorter than this (stripped) is transcription
+# noise (a stray timecode fragment, a lone punctuation mark) -- dropped, not paired.
+MIN_CUE_CHARS = 2
+
+
+def _to_slp1(iast):
+    """IAST Sanskrit verse -> SLP1, using the SAME canonical transcoder the written
+    corpus path uses (build_src.iast_to_slp1), so oral units carry a real SLP1 key
+    (matches the written L0 `slp1`), not just the IAST surface. Lazy import with a
+    graceful fallback: if the transcoder is unavailable the field is left empty and
+    build_l0 falls back to the IAST surface as the source segment (still valid, just
+    not SLP1-normalized). Whole-verse transliteration, NOT the per-word form_key."""
+    iast = (iast or '').strip()
+    if not iast:
+        return ''
+    try:
+        import build_src
+        return build_src.iast_to_slp1(iast)
+    except Exception:
+        return ''
+
+
+# --------------------------------------------------------------- subtitle parsers
+_TS = re.compile(r'(?:(\d+):)?(\d{1,2}):(\d{2})[.,](\d{1,3})')
+
+
+def _ts_to_sec(m):
+    """A VTT/SRT timestamp match -> float seconds. Hours optional; ',' or '.' ms."""
+    h = int(m.group(1) or 0)
+    return h * 3600 + int(m.group(2)) * 60 + int(m.group(3)) + int(m.group(4)) / 1000.0
+
+
+def _parse_cue_block(block):
+    """A subtitle cue block (lines) -> (t_start, t_end, text) or None. Shared by the
+    VTT and SRT readers: both put `START --> END` on one line, text on the following
+    lines; SRT prefixes an integer index line which we skip."""
+    lines = [ln.rstrip() for ln in block.splitlines() if ln.strip()]
+    if not lines:
+        return None
+    ts_line_i = None
+    for i, ln in enumerate(lines):
+        if '-->' in ln:
+            ts_line_i = i
+            break
+    if ts_line_i is None:
+        return None
+    left, _, right = lines[ts_line_i].partition('-->')
+    ms, me = _TS.search(left), _TS.search(right)
+    if not (ms and me):
+        return None
+    text = ' '.join(lines[ts_line_i + 1:]).strip()
+    if not text:
+        return None
+    return (_ts_to_sec(ms), _ts_to_sec(me), text)
+
+
+def parse_subtitles(text):
+    """Parse VTT or SRT text into a list of cues [{t_start, t_end, text}]. Cue
+    blocks are separated by blank lines in both formats; a leading `WEBVTT` header
+    and `NOTE`/`STYLE` blocks (VTT) are skipped by the per-block timestamp check."""
+    # normalize newlines; strip a BOM if the file carried one
+    text = text.lstrip('﻿').replace('\r\n', '\n').replace('\r', '\n')
+    cues = []
+    for block in re.split(r'\n\s*\n', text):
+        cue = _parse_cue_block(block)
+        if cue is not None:
+            t0, t1, body = cue
+            # strip VTT inline tags (<c>, <00:00:01.000>) that some ASR emits
+            body = re.sub(r'<[^>]+>', '', body).strip()
+            # keep EVERY non-empty cue -- length/guard filtering happens in
+            # to_corpus_rows, never here: dropping a short cue at parse time would
+            # desync parallel Sa/Ru tracks and fabricate wrong index pairings.
+            if body:
+                cues.append({'t_start': round(t0, 3), 't_end': round(t1, 3),
+                             'text': body})
+    return cues
+
+
+def parse_cue_file(path):
+    ext = os.path.splitext(path)[1].lower()
+    with open(path, encoding='utf-8') as f:
+        data = f.read()
+    if ext in ('.vtt', '.srt'):
+        return parse_subtitles(data)
+    if ext in ('.json', '.jsonl'):
+        # a pre-parsed cue list: [{t_start, t_end, text}] or JSONL of the same
+        out = []
+        data = data.strip()
+        if data.startswith('['):
+            rows = json.loads(data)
+        else:
+            rows = [json.loads(l) for l in data.splitlines() if l.strip()]
+        for r in rows:
+            if r.get('text'):
+                out.append({'t_start': r.get('t_start'), 't_end': r.get('t_end'),
+                            'text': str(r['text']).strip(),
+                            'asr_conf': r.get('asr_conf')})
+        return out
+    sys.exit('unsupported cue file (want .vtt/.srt/.json/.jsonl): %s' % path)
+
+
+# ------------------------------------------------------------------- pairing
+def pair_cues(sa_cues, ru_cues):
+    """Pair Sanskrit cues with their Russian rendering by cue index -- the common
+    case for parallel subtitle tracks of the SAME recording (same segmentation).
+    Returns [{i, t_start, t_end, sa, ru, asr_conf}]. A length mismatch is a hard
+    error (mis-segmented tracks must be fixed upstream, never silently truncated --
+    a silent zip() would fabricate wrong Sa<->Ru pairs, the F1 lesson)."""
+    if len(sa_cues) != len(ru_cues):
+        sys.exit('cue count mismatch: %d Sanskrit vs %d Russian cues. Parallel '
+                 'subtitle tracks must share segmentation; align them upstream or '
+                 'pass --pairs with explicit pairing.'
+                 % (len(sa_cues), len(ru_cues)))
+    pairs = []
+    for i, (s, r) in enumerate(zip(sa_cues, ru_cues)):
+        pairs.append({'i': i, 't_start': s.get('t_start'), 't_end': s.get('t_end'),
+                      'sa': s.get('text', ''), 'ru': r.get('text', ''),
+                      'asr_conf': s.get('asr_conf')})
+    return pairs
+
+
+def load_pairs(path):
+    """Already-paired input: JSONL of {sa, ru, t_start, t_end[, asr_conf, passage]}."""
+    pairs = []
+    with open(path, encoding='utf-8') as f:
+        for i, line in enumerate(f):
+            line = line.strip()
+            if not line:
+                continue
+            r = json.loads(line)
+            pairs.append({'i': i, 't_start': r.get('t_start'), 't_end': r.get('t_end'),
+                          'sa': (r.get('sa') or '').strip(),
+                          'ru': (r.get('ru') or '').strip(),
+                          'asr_conf': r.get('asr_conf'),
+                          'passage': r.get('passage')})
+    return pairs
+
+
+# ------------------------------------------------------------------- emit
+def to_corpus_rows(pairs, work, media=None):
+    """Turn paired cues into corpus_builder jsonl rows (build_l0.py input schema),
+    tagged oral with time anchors. Two rows per kept pair (seg=sa, seg=ru), sharing
+    one globally-unique `group`. Applies the never-invent guards: a Sanskrit surface
+    present AND a Cyrillic-bearing Russian -- an untranslated/garbled cue is dropped
+    (reported), never emitted as a fabricated pair."""
+    rows = []
+    kept = dropped = 0
+    for p in pairs:
+        sa = (p.get('sa') or '').strip()
+        ru = (p.get('ru') or '').strip()
+        passage = p.get('passage') or str(p['i'] + 1)
+        if len(sa) < MIN_CUE_CHARS or not build_tmx.has_cyr(ru):
+            dropped += 1
+            continue
+        group = '%s:%s' % (work, passage)
+        anchors = {'modality': MODALITY_ORAL,
+                   't_start': p.get('t_start'), 't_end': p.get('t_end')}
+        if media:
+            anchors['source_media'] = media
+        if p.get('asr_conf') is not None:
+            anchors['asr_conf'] = p['asr_conf']
+        sa_row = {'group': group, 'seg': 'sa', 'passage': passage,
+                  'text': sa, **anchors}
+        slp1 = _to_slp1(sa)
+        if slp1:
+            sa_row['slp1'] = slp1
+        rows.append(sa_row)
+        rows.append({'group': group, 'seg': 'ru', 'passage': passage,
+                     'text': ru, 'lang': 'ru', **anchors})
+        kept += 1
+    return rows, kept, dropped
+
+
+def convert(sa_path, ru_path, pairs_path, work, media, out_path, sample=None):
+    if pairs_path:
+        pairs = load_pairs(pairs_path)
+        src_note = 'pairs=%s' % os.path.basename(pairs_path)
+    else:
+        if not (sa_path and ru_path):
+            sys.exit('convert needs either --pairs, or both --sa and --ru')
+        sa_cues = parse_cue_file(sa_path)
+        ru_cues = parse_cue_file(ru_path)
+        pairs = pair_cues(sa_cues, ru_cues)
+        src_note = 'sa=%s ru=%s' % (os.path.basename(sa_path), os.path.basename(ru_path))
+    if sample is not None:
+        pairs = pairs[:sample]
+    rows, kept, dropped = to_corpus_rows(pairs, work, media)
+    if not rows:
+        sys.exit('convert: 0 valid oral pairs (all cues failed the never-invent '
+                 'guards). Check that the Russian track carries Cyrillic. (%s)' % src_note)
+    os.makedirs(os.path.dirname(os.path.abspath(out_path)), exist_ok=True)
+    with open(out_path, 'w', encoding='utf-8', newline='\n') as out:
+        for r in rows:
+            out.write(json.dumps(r, ensure_ascii=False) + '\n')
+    print('ingest_oral: %s -> %s' % (src_note, out_path))
+    print('  %d oral verse-pairs kept, %d dropped (guard), %d jsonl rows, work=%s%s'
+          % (kept, dropped, len(rows), work, (' media=%s' % media) if media else ''))
+    print('  next: copy to SamudraManthanam/web/corpus_builder/jsonl/%s.jsonl, then '
+          '`python build_l0.py build --work %s`' % (work, work))
+    return 0
+
+
+def inspect(path):
+    cues = parse_cue_file(path)
+    if not cues:
+        sys.exit('inspect: 0 cues parsed from %s' % path)
+    dur = (cues[-1].get('t_end') or 0) - (cues[0].get('t_start') or 0)
+    ncyr = sum(1 for c in cues if build_tmx.has_cyr(c['text']))
+    print('inspect: %s' % path)
+    print('  %d cues, span %.1fs .. %.1fs (%.1fs), %d carry Cyrillic'
+          % (len(cues), cues[0].get('t_start') or 0, cues[-1].get('t_end') or 0,
+             dur, ncyr))
+    for c in cues[:3]:
+        print('  [%.2f-%.2f] %s' % (c.get('t_start') or 0, c.get('t_end') or 0,
+                                    c['text'][:60]))
+    return 0
+
+
+# ------------------------------------------------------------------- selftest
+SA_VTT = """WEBVTT
+
+NOTE auto-generated, cleaned
+
+1
+00:00:01.000 --> 00:00:04.500
+dharmakṣetre kurukṣetre samavetā yuyutsavaḥ
+
+2
+00:00:04.500 --> 00:00:08.000
+māmakāḥ pāṇḍavāś caiva kim akurvata sañjaya
+
+3
+00:00:08.000 --> 00:00:10.000
+<c>uh</c> ...
+"""
+
+RU_VTT = """WEBVTT
+
+1
+00:00:01.000 --> 00:00:04.500
+На поле дхармы, на поле Куру, сошлись жаждущие битвы
+
+2
+00:00:04.500 --> 00:00:08.000
+мои и сыновья Панду — что они делали, о Санджая?
+
+3
+00:00:08.000 --> 00:00:10.000
+…
+"""
+
+
+def selftest():
+    import tempfile
+    # parser: hours-optional timestamps, inline-tag stripping, blank-line splitting
+    sa_cues = parse_subtitles(SA_VTT)
+    ru_cues = parse_subtitles(RU_VTT)
+    assert len(sa_cues) == 3, 'expected 3 sa cues, got %d' % len(sa_cues)
+    assert len(ru_cues) == 3, 'expected 3 ru cues, got %d' % len(ru_cues)
+    assert sa_cues[0]['t_start'] == 1.0 and sa_cues[0]['t_end'] == 4.5, sa_cues[0]
+    assert sa_cues[2]['text'] == 'uh ...', 'inline <c> tag not stripped: %r' % sa_cues[2]['text']
+
+    pairs = pair_cues(sa_cues, ru_cues)
+    assert len(pairs) == 3
+    rows, kept, dropped = to_corpus_rows(pairs, 'gita-lecture', media='gita01.mp3')
+    # cue 3: sa='uh ...' (>=2 chars) but ru='…' has no Cyrillic -> dropped by guard
+    assert kept == 2, 'guard should keep 2 real pairs, kept %d' % kept
+    assert dropped == 1, 'guard should drop the untranslated cue, dropped %d' % dropped
+    assert len(rows) == 4, 'two rows per kept pair, got %d' % len(rows)
+
+    sa_row = rows[0]
+    assert sa_row['seg'] == 'sa' and sa_row['modality'] == 'oral'
+    assert sa_row['t_start'] == 1.0 and sa_row['t_end'] == 4.5, sa_row
+    assert sa_row['source_media'] == 'gita01.mp3'
+    assert sa_row['group'] == 'gita-lecture:1', sa_row['group']
+    ru_row = rows[1]
+    assert ru_row['seg'] == 'ru' and ru_row['lang'] == 'ru'
+    assert build_tmx.has_cyr(ru_row['text']), 'ru row must carry Cyrillic'
+    assert ru_row['group'] == sa_row['group'], 'sa/ru share the group'
+
+    # mismatch is a hard error, never a silent zip-truncation
+    try:
+        pair_cues(sa_cues, ru_cues[:2])
+    except SystemExit:
+        pass
+    else:
+        raise AssertionError('cue-count mismatch must be a hard error')
+
+    # round-trip through a file: convert -> valid corpus jsonl
+    d = tempfile.mkdtemp(prefix='oral_selftest_')
+    sap = os.path.join(d, 'l.sa.vtt'); rup = os.path.join(d, 'l.ru.vtt')
+    out = os.path.join(d, 'gita-lecture.jsonl')
+    open(sap, 'w', encoding='utf-8').write(SA_VTT)
+    open(rup, 'w', encoding='utf-8').write(RU_VTT)
+    convert(sap, rup, None, 'gita-lecture', 'gita01.mp3', out)
+    got = [json.loads(l) for l in open(out, encoding='utf-8') if l.strip()]
+    assert len(got) == 4 and all(r['modality'] == 'oral' for r in got), got
+    print('ingest_oral selftest OK -- VTT parse, index pairing, guards, anchors, mismatch-guard')
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Oral transcript -> corpus jsonl (H215 Slice 4)')
+    sub = ap.add_subparsers(dest='cmd', required=True)
+
+    c = sub.add_parser('convert', help='paired subtitle tracks -> corpus_builder jsonl')
+    c.add_argument('--sa', help='Sanskrit transcript (.vtt/.srt/.json)')
+    c.add_argument('--ru', help='Russian rendering (.vtt/.srt/.json), same segmentation')
+    c.add_argument('--pairs', help='pre-aligned JSONL of {sa,ru,t_start,t_end}')
+    c.add_argument('--work', required=True, help='work name (globally-unique group prefix)')
+    c.add_argument('--media', default=None, help='source audio/video filename (provenance)')
+    c.add_argument('--out', required=True, help='output <work>.jsonl')
+    c.add_argument('--sample', type=int, default=None)
+
+    i = sub.add_parser('inspect', help='parse a cue file and show stats')
+    i.add_argument('path')
+
+    sub.add_parser('selftest', help='fixture -> convert, assert')
+
+    a = ap.parse_args()
+    if a.cmd == 'convert':
+        return convert(a.sa, a.ru, a.pairs, a.work, a.media, a.out, sample=a.sample)
+    if a.cmd == 'inspect':
+        return inspect(a.path)
+    if a.cmd == 'selftest':
+        return selftest()
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/RussianTranslation/src/tm_grade.py
+++ b/RussianTranslation/src/tm_grade.py
@@ -70,6 +70,12 @@ T_B = 0.55   # composite floor for B
 CONSENSUS_MIN_REFS = 2      # A needs >=2 works ...
 CONSENSUS_MIN_AGREE = 0.50  # ... and >=50% of them agreeing on the modal rendering
 
+# H215 Slice 4: oral units start from a lower base. The composite score carries a
+# fixed penalty for the higher noise floor of live interpretation (translationese,
+# paraphrase, hesitation), and build_tmx.oral_cap additionally forbids A unless a
+# human adjudicated it. Versioned constant so the policy is auditable.
+ORAL_PENALTY = 0.15
+
 CYR_TOKEN = re.compile(r'[Ѐ-ӿ]+')
 LATIN = re.compile(r'[A-Za-zĀ-ſḀ-ỿ]')
 REJECT_RU = {'нет', 'неизвестно', '—', '-', '?', '...', '…'}
@@ -231,8 +237,11 @@ def grade_unit(rec, weights, qe_fn, consensus_idx, adjudicated=False,
     # the Slice-2 token-count proxy when supplied via `grade --align <sidecar>`.
     align = align_proxy(rec) if align_override is None else align_override
     n_refs, cons = consensus_signal(rec, consensus_idx)
+    modality = rec.get('modality') or 'written'
     score = (W['qe'] * qe + W['source'] * src
              + W['consensus'] * cons + W['align'] * align)
+    if modality == 'oral':
+        score = max(0.0, score - ORAL_PENALTY)   # lowered base for live interpretation
     corroborated = n_refs >= CONSENSUS_MIN_REFS and cons >= CONSENSUS_MIN_AGREE
     if adjudicated and qe > 0:
         grade = 'A'
@@ -242,11 +251,13 @@ def grade_unit(rec, weights, qe_fn, consensus_idx, adjudicated=False,
         grade = 'B'
     else:
         grade = 'C'
+    # oral never reaches A on automatic signals alone -- only human adjudication.
+    grade = build_tmx.oral_cap(grade, modality, adjudicated=adjudicated)
     return {'grade': grade, 'score': round(score, 4),
             'qe': round(qe, 4), 'source_weight': round(src, 4),
             'alignment_confidence': round(align, 4),
             'align_source': 'proxy' if align_override is None else 'tm_align',
-            'consensus': round(cons, 4), 'n_refs': n_refs}
+            'consensus': round(cons, 4), 'n_refs': n_refs, 'modality': modality}
 
 
 # ------------------------------------------------------------------------- cmds
@@ -418,7 +429,19 @@ def selftest():
     # adjudicated overlay forces A
     gAdj = grade_unit(runon, FIXTURE_WEIGHTS, qe_fn, {}, adjudicated=True)
     assert gAdj['grade'] == 'A', 'adjudicated unit should be A'
-    print('tm_grade selftest OK -- qe ordering, source override, consensus, grade gates')
+
+    # H215 Slice 4: an oral unit gets the lowered base -- same clean corroborated
+    # gloss that reaches A when written is capped at B when oral, and its composite
+    # carries the penalty; human adjudication still lifts it to A.
+    oral = dict(clean, modality='oral')
+    gOral = grade_unit(oral, FIXTURE_WEIGHTS, qe_fn, idx)
+    assert gA['grade'] == 'A' and gOral['grade'] == 'B', \
+        'oral corroborated gloss must cap at B, got %s (written was %s)' % (gOral['grade'], gA['grade'])
+    assert gOral['score'] < gA['score'], 'oral penalty must lower the composite'
+    assert gOral['modality'] == 'oral'
+    gOralAdj = grade_unit(oral, FIXTURE_WEIGHTS, qe_fn, idx, adjudicated=True)
+    assert gOralAdj['grade'] == 'A', 'human-adjudicated oral unit may reach A'
+    print('tm_grade selftest OK -- qe ordering, source override, consensus, grade gates, oral cap')
     return 0
 
 


### PR DESCRIPTION
## What

Adds **Slice 4** of [H215](https://github.com/gasyoun/Uprava/blob/main/handoffs/H215-Opus_RussianTranslation_pwg_ru_publication_grade_tm_tmx_and_oral_06.07.26.md) — the **oral register** of the publication-grade Sa→Ru translation memory. Recorded/spoken Sanskrit with a Russian rendering now flows through the **same** L0 → grade → TMX pipeline as the written corpus (Slices 1–3), not a forked one. Design-first, fixture-piloted; scale is asset-gated.

Coordinated with [H174 · spoken-sanskrit-corpus](https://github.com/gasyoun/Uprava/blob/main/handoffs/H174-Opus_spoken-sanskrit-corpus_spoken_sanskrit_corpus_scaffold_04.07.26.md): H174 owns sourcing + ASR-transcript cleaning; this PR owns turning a *cleaned* timecoded transcript into a graded Sa↔Ru parallel unit. The schema in [`ORAL_INGEST.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ORAL_INGEST.md) is the shared contract H174 will produce against.

## Changes

- **New [`src/ingest_oral.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ingest_oral.py)** — deterministic converter: cleaned WebVTT/SRT/JSON transcript (or `--pairs` JSONL) → `corpus_builder/<work>.jsonl` tagged `modality=oral` with `t_start`/`t_end` anchors, `source_media`, optional `asr_conf`, and a canonical `iast_to_slp1` key (same transcoder the written path uses). No ASR, no cleaning. Parallel tracks pair **by index**; a cue-count mismatch is a **hard error** (never a silent `zip()` truncation that would fabricate wrong pairs — the F1 lesson). Never-invent guards drop untranslated cues.
- **Lowered base grade for oral, in one place** — shared `build_tmx.oral_cap()` forbids grade **A** for an oral unit on the automatic signals alone (capped at **B**; only human adjudication lifts it), paired with `tm_grade.ORAL_PENALTY = 0.15` on the composite.
- **Threaded through the existing spine** — `build_l0.py` carries `modality`/anchors onto each L0 unit; `build_tmx.py` `l0_tu_xml` emits them as TMX `<prop>`s. **Written sources are byte-unchanged** (fields absent → no prop, modality defaults `written`).
- **[`src/ORAL_INGEST.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ORAL_INGEST.md)** — shared schema, grade policy, pilot results. `BUILD_TMX.md` / `CHANGELOG.md` / `.ai_state.md` updated.

## Pilot (fixture — no oral recordings tracked yet)

End-to-end `ingest_oral convert` → `build_l0 build --sm` → `build_tmx build --l0` produces a well-formed TMX 1.4b whose oral `<tu>`s carry `modality=oral` + time anchors (validated). Same corroborated units, written vs oral:

| modality | A | B | C | mean composite |
|---|---:|---:|---:|---:|
| written | 6 | 0 | 0 | 0.892 |
| oral | 0 | 6 | 0 | 0.743 |

The −0.149 drop is `ORAL_PENALTY`; the A→B collapse is the `oral_cap` A-gate lock.

## Testing

`ingest_oral.py`, `build_tmx.py`, `tm_grade.py`, `build_l0.py` selftests + `py_compile` all green (new oral cases added to the first three). Deterministic — no LLM calls.

## Scope / follow-ups

- **Scale ingest is asset-gated**: no oral recordings are in a tracked repo yet (H174 unbuilt). This ships the schema + tooling + fixture pilot; scale runs when H174 delivers cleaned transcripts.
- **Slice 5 (FAIR release)** stays rights-gated — recorded third-party speech needs per-source clearance via `/publish-safety-check` before any public TMX.

_Authored under Opus 4.8 (`claude-opus-4-8`), isolated worktree off `origin/master` (shared tree held a concurrent Codex session)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)