### PR TITLE
H304: coordinator hardening — presplit-sound topup, fragment gate-outcome denylist, better-attempt-wins merge, cap-and-defer monster ledger

### DIFF
--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,6 +1,6 @@
 # LANG_PARITY.md — cross-language fix/feature parity ledger
 
-_Created: 04-07-2026 · Last updated: 06-07-2026_
+_Created: 04-07-2026 · Last updated: 07-07-2026_
 
 This repo runs the same PWG→Russian and PWG→English translation pipeline through
 shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "5bbb029b2dc287f52d4efd4f9f44ff4a12952a15984554568afa645eec2804bd",
-      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
+      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
+      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
+      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
+      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
     }
   },
   {
@@ -279,8 +279,28 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
       "src/pilot/prompt_rule_audit.py": "bbd3fe10ff72b9d58e6d763069352129df8c246d4cb18ae41520ddcf6fee7525",
-      "src/pilot/audit_window.py": "0ec016f09fa2e770ef538251882b829a4d7ea3e9ea61995fc47d0963138c0206",
+      "src/pilot/audit_window.py": "0a2256245f35ef9468d722e8bd7c7714586f8186178d32abcc92e6d71facf440",
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2"
+    }
+  },
+  {
+    "id": "defect_fragment_denylist_h304",
+    "mechanism": "audit emits requeue.defect.fshas.txt (the defect cards' frag_prov content addresses); requeue_from_audit appends them to the TM denylist so the fragment sidecar can never re-serve a gate-flagged fragment (build_frags harvests wf_output BEFORE gates run)",
+    "files": [
+      "src/pilot/audit_window.py",
+      "src/pilot/window_reports.py",
+      "src/pilot/requeue_from_audit.py"
+    ],
+    "languages": [
+      "ru"
+    ],
+    "verdict": "GAP",
+    "note": "The denylist append and load_frag_tm filtering are lang-agnostic (fsha encodes lang; requeue_from_audit takes --lang), but the fshas EMITTER lives only in the RU auditor: audit_window_en.py reimplements its gates and does not compute requeue_defect_fshas or write the file, so an EN defect requeue does not auto-denylist its fragments.",
+    "tracking": "Uprava/handoffs/H304-Fable_RussianTranslation_coordinator-driver-remake_07.07.26.md (EN-emitter port is the recorded follow-up)",
+    "verified_sha256": {
+      "src/pilot/audit_window.py": "0a2256245f35ef9468d722e8bd7c7714586f8186178d32abcc92e6d71facf440",
+      "src/pilot/window_reports.py": "1649a33f3cf65fdd9f770cd1f05bb84d3eccdbc8369132ee3a1800c0ea62a72e",
+      "src/pilot/requeue_from_audit.py": "a315cd02276908ffdcc64f09d226798865885a7eea47ca60681a256a240d6272"
     }
   },
   {
@@ -297,7 +317,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 (commit 8cb84f7): the helper is lang-agnostic (takes a root, not a --lang flag; gen_opt_harness2.py resolves lang from the rootmap), so the fix applies to any language's requeue in one place. Was a both-paths gap before the fix, not an RU/EN divergence.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/requeue_from_audit.py": "a121e99b5e4a5f2a205e094de0a49e1b86674a4ceabf382a67d89b70f875f2cf"
+      "src/pilot/requeue_from_audit.py": "a315cd02276908ffdcc64f09d226798865885a7eea47ca60681a256a240d6272"
     }
   },
   {
@@ -335,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
+      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
     }
   },
   {
@@ -354,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
+      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
     }
   },
   {
@@ -392,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
+      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
     }
   },
   {
@@ -451,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "31c82a4467816f438f3224c6fb06396eec718d4e0aa38d645cdc192602a2474e"
+      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
     }
   }
 ]

--- a/RussianTranslation/PIPELINE_HISTORY.md
+++ b/RussianTranslation/PIPELINE_HISTORY.md
@@ -580,6 +580,22 @@ likely the SAME class, not a new bug:
   parity classification mandatory before closing a session, drive the
   Workflow from the Claude Code session (not a manual Max-surface save), and
   update/check `LAUNCH_FUCKUPS.md` before closing any launch-shaped handoff.
+- Coordinator hardening (Phase 15, H304, 07-07-2026 — four operator-memory
+  rules became code): (1) `autosplit_requeue.frag_groups()` now reconstructs
+  a PRESPLIT card's fragment partition with the same H189 budgets the harness
+  used to mint the `gN:fM` ids (was: heal-budget always → topup of exactly
+  the giant cards mis-mapped); (2) gate-outcome memory — `audit_window`
+  emits `requeue.defect.fshas.txt` and `requeue_from_audit` denylists those
+  fragments, so the fragment TM can never re-serve gate-flagged content
+  (RU-emitter only so far — `defect_fragment_denylist_h304` GAP in
+  `LANG_PARITY.md`); (3) `save_and_audit --merge` is better-attempt-wins
+  (complete beats partial, fewer `missing_fragments` beat more — the gam
+  2→3→7 regression class is dead); (4) cap-and-defer — `coordinator.py`
+  claim/prepare act on the `perf_preflight` cost gate: an over-ceiling
+  window is parked in `src/pilot/deferred_monsters.jsonl` (append-only,
+  committed) and refused unless `prepare --allow-over-cost` in a dedicated
+  human-budgeted session. Closes the kAla-class monster-card `@DECIDE`
+  (MG ruling 07-07-2026: cap-and-defer).
 
 ## Where to go next
 

--- a/RussianTranslation/save_and_audit.py
+++ b/RussianTranslation/save_and_audit.py
@@ -64,13 +64,34 @@ def main():
             existing = None
         old_nn = nn(existing) if isinstance(existing, dict) else 0
         if isinstance(existing, dict) and "--merge" in flags:
+            # Better-attempt-wins (H304): "latest requeue wins" is WRONG — a requeue can
+            # regress a card (gam h0_63_sam_0 went 2->3->7 missing fragments). Rank:
+            # any card > none; complete > partial; fewer missing fragments > more.
+            # Ties go to the NEW attempt (fresh gen, same completeness).
+            def q(r):
+                c = (r or {}).get("card")
+                if not c:
+                    return (0, 0, 0)
+                partial = bool(c.get("partial") or (r or {}).get("partial"))
+                missing = len(c.get("missing_fragments")
+                              or (r or {}).get("missing_fragments") or [])
+                return (1, 0 if partial else 1, -missing)
+
             by_key = {r.get("key"): r for r in (existing.get("results") or [])}
+            kept_better = []
             for r in result.get("results") or []:
-                if r.get("card") or r.get("key") not in by_key:
-                    by_key[r.get("key")] = r        # new non-null fills; new keys append
+                k = r.get("key")
+                if k not in by_key:
+                    by_key[k] = r                    # new keys append
+                elif r.get("card") and q(r) >= q(by_key[k]):
+                    by_key[k] = r                    # equal-or-better non-null replaces
+                elif r.get("card"):
+                    kept_better.append(k)            # worse attempt: keep the prior card
             existing["results"] = list(by_key.values())
             result = existing                        # keep the full-set meta; write merged
             print(f"Merged into {os.path.basename(out_path)}: {old_nn} -> {nn(result)} non-null")
+            if kept_better:
+                print("kept better prior attempt for: " + ", ".join(kept_better))
         elif old_nn > new_nn and "--force" not in flags:
             sys.exit(f"REFUSED: {os.path.basename(out_path)} has {old_nn} non-null cards; new has "
                      f"only {new_nn}. Use --merge to fill nulls, or --force to overwrite.")

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -84,6 +84,20 @@ tracked-file drift and is wired into `window_selftest.py`
 - The per-root loop below is unchanged — "all roots next batch" scales the QUEUE, not the
   width. Roots still run **one at a time (≤3-wide max)**; the Slice-D 18×-parallel collapse
   (117 transient nulls) is the standing counter-example.
+- **H304 hardening (07-07-2026) — four operator-memory rules are now code paths:**
+  (1) **cap-and-defer** — `coordinator.py claim/prepare` act on the `perf_preflight` cost
+  gate: an over-ceiling (kAla-class) window is parked in
+  [`deferred_monsters.jsonl`](deferred_monsters.jsonl) and refused (`prepare
+  --allow-over-cost` only inside a dedicated human-budgeted monster session — MG ruling
+  07-07-2026); (2) **gate-outcome memory** — the RU audit writes
+  `output/requeue.defect.fshas.txt` and `requeue_from_audit.py` denylists those fragment
+  addresses, so `--tm=auto` can never re-serve a gate-flagged fragment (EN emitter is a
+  tracked GAP: `defect_fragment_denylist_h304` in [`LANG_PARITY.md`](../../LANG_PARITY.md));
+  (3) **better-attempt-wins** — `save_and_audit.py --merge` keeps the better prior attempt
+  per card (complete > partial, fewer `missing_fragments` > more), so a requeue can no
+  longer regress a card; (4) **presplit topup is sound** — `autosplit_requeue.frag_groups()`
+  reconstructs the fragment partition with the budgets of the run that minted the `gN:fM`
+  ids (pass the wf `meta` + key), instead of always the heal budget.
 
 The earlier "Opus-judged-every-card" framing was the validation phase; "Sonnet-bulk/Opus-on-reject"
 was the 2026-06-26 escalation policy; the per-card LLM judge itself is now dropped from the bulk path.

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -499,6 +499,17 @@ def main():
                       if e.startswith('fidelity-reject') or e.startswith('stitched-fidelity')}
     report['requeue_transient'] = sorted(set(null_cards) - fidelity_nulls)
     report['requeue_defect'] = sorted((gate_requeue - set(null_cards)) | fidelity_nulls)
+    # H304 gate-outcome memory: the fragment TM is harvested from raw wf_output BEFORE any
+    # gate runs, so a defect card's fragments would otherwise stay silently reusable
+    # (frag_address keys on the input SHA, not on whether the output passed). Surface every
+    # defect card's frag_prov fsha here; requeue_from_audit appends them to the TM denylist
+    # alongside the card addresses. Conservative by design — the gates flag CARDS, so all of
+    # a flagged card's fragments are blocked (a re-translation is cheap; a re-served defect
+    # is the gam requeue trap at fragment granularity).
+    defect_set = set(report['requeue_defect'])
+    report['requeue_defect_fshas'] = sorted(
+        {fp['fsha'] for r in results or [] if r and r.get('key') in defect_set
+         for fp in ((r.get('card') or {}).get('frag_prov') or []) if fp.get('fsha')})
     report['prompt_rules'] = gates.get('prompt_semantic', {}).get('prompt_rules')
     report['semantic_risks'] = gates.get('prompt_semantic', {}).get('card_risks')
     report['judge_sample_rate'] = args.judge_sample_rate

--- a/RussianTranslation/src/pilot/autosplit_requeue.py
+++ b/RussianTranslation/src/pilot/autosplit_requeue.py
@@ -236,15 +236,28 @@ def missing_file_path(lang, root):
     return os.path.join(HERE, 'output', 'autosplit_missing_%s_%s.json' % (lang, safe_name(root)))
 
 
-def frag_groups(raw):
+def frag_groups(raw, meta=None, key=None):
     """Reconstruct the EXACT selfHeal fragment-group partition gen_opt_harness2 builds for a
     card, so a 'gN:fM' missing-fragment id maps back to a plan() fragment. Returns
     [[(si, pi, text), ...], ...] — groups in document order, the same partition as FRAGS[k].
     Lazy-imports the harness grouper (a) to stay byte-identical to the producer of the ids and
-    (b) to avoid the autosplit<->harness circular import at module load."""
-    from gen_opt_harness2 import _group_by_budget, SELFHEAL_GROUP_BUDGET
+    (b) to avoid the autosplit<->harness circular import at module load.
+
+    H304: the harness groups a PRESPLIT card at PRESPLIT_GROUP_CITE_BUDGET with a sense
+    count_cap (H189 re-batching), not at SELFHEAL_GROUP_BUDGET — so reconstructing every card
+    with the heal budget mis-maps gN:fM ids for exactly the giant cards topup exists for.
+    Pass the wf_output `meta` + the card's `key`: the lane and its budgets are read from the
+    run that MINTED the ids (falling back to current constants for older metas)."""
+    from gen_opt_harness2 import (_group_by_budget, SELFHEAL_GROUP_BUDGET,
+                                  PRESPLIT_GROUP_CITE_BUDGET, PRESPLIT_GROUP_SENSE_CAP)
     pl = plan(raw)
-    return _group_by_budget(pl, lambda f: 1 + f[2].count('<ls'), SELFHEAL_GROUP_BUDGET)
+    meta = meta or {}
+    if key is not None and key in (meta.get('presplit_keys') or []):
+        cite = meta.get('presplit_group_cite_budget') or PRESPLIT_GROUP_CITE_BUDGET
+        cap = meta.get('presplit_group_sense_cap') or PRESPLIT_GROUP_SENSE_CAP
+        return _group_by_budget(pl, lambda f: 1 + f[2].count('<ls'), cite, count_cap=cap)
+    heal = meta.get('selfheal_group_budget') or SELFHEAL_GROUP_BUDGET
+    return _group_by_budget(pl, lambda f: 1 + f[2].count('<ls'), heal)
 
 
 def resolve_frag_ids(groups, missing_fragments):
@@ -277,6 +290,7 @@ def topup_fragments(wf_file, lang):
     if isinstance(res, str):
         res = json.loads(res)
     frag_cache = load_frag_tm(lang)
+    wf_meta = res.get('meta') or {}
     cards = []
     for r in res.get('results') or []:
         card = (r or {}).get('card')
@@ -288,7 +302,7 @@ def topup_fragments(wf_file, lang):
             if fp.get('fsha') and fp.get('senses'):
                 resolved.setdefault(fp['fsha'], fp['senses'])
         raw = read_text(input_paths(orig)[0])
-        groups = frag_groups(raw)
+        groups = frag_groups(raw, meta=wf_meta, key=orig)
         missing = resolve_frag_ids(groups, card['missing_fragments'])
         missing_set = {(si, pi) for si, pi, _ in missing}
         planrows, unresolvable = [], []

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -41,6 +41,7 @@ import promote_final_cards  # noqa: E402
 from safe_filename import safe_name  # noqa: E402
 import translation_memory  # noqa: E402
 import verb_worklist  # noqa: E402
+from window_common import defer_monster  # noqa: E402
 
 
 def utc_now():
@@ -265,7 +266,18 @@ def verb_candidates(state, limit=20):
     for root in roots:
         report = by_root.get(root) or {'root': root, 'agent_expected_after_tm': 9999}
         action = report.get('recommended_action')
-        if action == 'defer-calibrate':
+        cost_gate = report.get('cost_gate') or {}
+        # Cap-and-defer (H304, MG ruling 07-07-2026): a window the cost gate flags is
+        # never claimable as bulk — it goes to the deferred-monsters ledger and waits
+        # for a dedicated human-budgeted session (see deferred_monsters.jsonl).
+        if action == 'defer-calibrate' or cost_gate.get('over_ceiling'):
+            reason = ('cost_gate_over_ceiling' if cost_gate.get('over_ceiling')
+                      else 'defer-calibrate')
+            defer_monster(root, reason, source='coordinator.claim',
+                          estimate={k: cost_gate.get(k) for k in
+                                    ('est_tokens', 'est_cost_usd', 'est_cost_per_card_usd')
+                                    if cost_gate.get(k) is not None} or None,
+                          keys=(report.get('cost_partition') or {}).get('defer_monster'))
             continue
         ordered.append(report)
     ordered.sort(key=lambda r: (r.get('agent_expected_after_tm', 9999),
@@ -362,6 +374,38 @@ def claim(args):
     print(json.dumps(lease, ensure_ascii=False, indent=1))
 
 
+def enforce_cost_gate(preflight_path, target, allow_over_cost=False):
+    """Cap-and-defer at prepare time (H304): a lease whose preflight trips the H189/H191
+    cost gate is parked in the deferred-monsters ledger and refused, instead of handing the
+    operator a harness that repeats the pril10_w1 blow-up ($79.83/3 cards). Pass
+    --allow-over-cost only inside an explicitly human-budgeted monster session."""
+    try:
+        with open(preflight_path, encoding='utf-8') as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return
+    for rep in (data.get('reports') or [data]):
+        cg = rep.get('cost_gate') or {}
+        if not cg.get('over_ceiling'):
+            continue
+        part = rep.get('cost_partition') or {}
+        defer_monster(target or rep.get('root'), 'cost_gate_over_ceiling',
+                      source='coordinator.prepare',
+                      estimate={k: cg.get(k) for k in
+                                ('est_tokens', 'est_cost_usd', 'est_cost_per_card_usd')
+                                if cg.get(k) is not None} or None,
+                      keys=part.get('defer_monster'))
+        if not allow_over_cost:
+            raise SystemExit(
+                'COST-GATE: %s over ceiling (est ~$%.2f window, ~$%.2f/card) — parked in '
+                'deferred_monsters.jsonl. Re-claim with only cost_partition.run_now keys '
+                '(%d run-now / %d monster), or re-run prepare with --allow-over-cost in a '
+                'dedicated human-budgeted session.'
+                % (target or rep.get('root'), cg.get('est_cost_usd') or 0.0,
+                   cg.get('est_cost_per_card_usd') or 0.0,
+                   len(part.get('run_now') or []), len(part.get('defer_monster') or [])))
+
+
 def prepare(args):
     with DirLock(paths()['lock']):
         state = load_state()
@@ -375,6 +419,8 @@ def prepare(args):
                          root, '--json'])
             with open(preflight_path, 'w', encoding='utf-8') as f:
                 f.write(p.stdout)
+            enforce_cost_gate(preflight_path, lease.get('target'),
+                              allow_over_cost=getattr(args, 'allow_over_cost', False))
             harness = os.path.join(adir, 'run_pilot_wf.%s.js' % lease['id'])
             run_cmd([sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'),
                      root, '--out=%s' % harness])
@@ -389,6 +435,8 @@ def prepare(args):
                          root, '--nominal', '--no-grammar', '--keys=%s' % key_arg, '--json'])
             with open(preflight_path, 'w', encoding='utf-8') as f:
                 f.write(p.stdout)
+            enforce_cost_gate(preflight_path, lease.get('target'),
+                              allow_over_cost=getattr(args, 'allow_over_cost', False))
             harness = os.path.join(adir, 'run_pilot_wf.%s.js' % lease['id'])
             run_cmd([sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'),
                      root, '--nominal', '--no-grammar', '--keys=%s' % key_arg,
@@ -629,6 +677,9 @@ def main(argv=None):
     c.set_defaults(func=claim)
     p = sub.add_parser('prepare')
     p.add_argument('lease_id')
+    p.add_argument('--allow-over-cost', action='store_true',
+                   help='H304 cap-and-defer override: prepare a cost-gate-flagged window '
+                        'anyway (dedicated human-budgeted monster session only)')
     p.set_defaults(func=prepare)
     r = sub.add_parser('record-output')
     r.add_argument('lease_id')

--- a/RussianTranslation/src/pilot/requeue_from_audit.py
+++ b/RussianTranslation/src/pilot/requeue_from_audit.py
@@ -60,10 +60,16 @@ def read_requeue(path):
     return keys
 
 
-def append_tm_denylist(root, keys, which, lang='ru'):
-    """Invalidate exact card-TM addresses for defect/all requeues. Append-only and local-only."""
+def append_tm_denylist(root, keys, which, lang='ru', fsha_file=None):
+    """Invalidate exact card-TM addresses for defect/all requeues. Append-only and local-only.
+
+    H304: also invalidate the flagged cards' FRAGMENT addresses. build_frags harvests
+    frag_prov from raw wf_output before any gate runs, so without this a defect card's
+    fragments stay reusable in the sidecar and --tm=auto re-serves the flagged content on
+    the next window that shares a fragment. audit_window writes the fshas to
+    requeue.defect.fshas.txt next to the requeue key files."""
     if which == 'transient':
-        return 0
+        return 0, 0
     path = translation_memory.denylist_path()
     now = datetime.datetime.now(datetime.timezone.utc).isoformat(
         timespec='seconds').replace('+00:00', 'Z')
@@ -79,7 +85,19 @@ def append_tm_denylist(root, keys, which, lang='ru'):
                                 'root': root, 'lang': lang, 'reason': 'requeue_%s' % which,
                                 'blocked_at': now}, ensure_ascii=False) + '\n')
             n += 1
-    return n
+    nf = 0
+    fp = fsha_file or os.path.join(OUT, 'requeue.defect.fshas.txt')
+    if os.path.exists(fp):
+        fshas = [ln.strip() for ln in open(fp, encoding='utf-8') if ln.strip()]
+        with open(path, 'a', encoding='utf-8') as f:
+            for fsha in fshas:
+                f.write(json.dumps({'schema': 'pwg.translation_memory.denylist.v1',
+                                    'kind': 'frag', 'fsha': fsha,
+                                    'root': root, 'lang': lang,
+                                    'reason': 'requeue_%s_fragment' % which,
+                                    'blocked_at': now}, ensure_ascii=False) + '\n')
+                nf += 1
+    return n, nf
 
 
 def main():
@@ -124,7 +142,13 @@ def main():
         for k in invalid:
             print('  ' + k)
         sys.exit(1)
-    denied = append_tm_denylist(root, resolved, which, lang=lang)
+    fsha_file = None
+    if args.requeue_file:
+        cand = os.path.join(os.path.dirname(os.path.abspath(args.requeue_file)),
+                            'requeue.defect.fshas.txt')
+        fsha_file = cand if os.path.exists(cand) else None
+    denied, denied_frags = append_tm_denylist(root, resolved, which, lang=lang,
+                                              fsha_file=fsha_file)
 
     cmd = [sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'),
            root, '--keys=' + ','.join(resolved)]
@@ -153,6 +177,8 @@ def main():
     print('requeue keys      : %d' % len(resolved))
     if denied:
         print('tm denylist       : +%d card address(es)' % denied)
+    if denied_frags:
+        print('tm denylist       : +%d fragment fsha(s)' % denied_frags)
     print('generated harness : %s' % harness)
     print('keys:')
     for k in resolved:

--- a/RussianTranslation/src/pilot/window_common.py
+++ b/RussianTranslation/src/pilot/window_common.py
@@ -30,6 +30,49 @@ def sha256_file(path):
     return h.hexdigest()
 
 
+# Cap-and-defer monster ledger (H304, MG ruling 07-07-2026). A card/window the
+# perf_preflight cost gate flags over-ceiling is never bulk-run; it is appended here
+# and excluded, accumulating for an occasional dedicated human-budgeted session.
+# Committed (not gitignored): the ledger IS the queue of deferred work — losing it
+# silently drops the most expensive (usually highest-value) entries.
+DEFERRED_MONSTERS = os.path.join(HERE, 'deferred_monsters.jsonl')
+
+
+def defer_monster(target, reason, estimate=None, source='perf_preflight', keys=None,
+                  path=None):
+    """Append one cap-and-defer row, deduped on (target, reason, UTC day) so a daily
+    coordinator sweep can't flood the ledger. Returns the row, or None if deduped.
+    Best-effort like failure_capture: a ledger write must never break a claim/prepare."""
+    p = path or DEFERRED_MONSTERS
+    today = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d')
+    try:
+        if os.path.exists(p):
+            with open(p, encoding='utf-8') as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if (row.get('target') == target and row.get('reason') == reason
+                            and row.get('date') == today):
+                        return None
+        row = {'schema': 'pwg.deferred_monsters.v1', 'date': today, 'target': target,
+               'reason': reason, 'source': source, 'status': 'deferred'}
+        if estimate:
+            row['estimate'] = estimate
+        if keys:
+            row['keys'] = list(keys)
+        with open(p, 'a', encoding='utf-8') as f:
+            f.write(json.dumps(row, ensure_ascii=False) + '\n')
+        return row
+    except OSError as e:
+        print('warning: deferred_monsters ledger write failed: %s' % e, file=sys.stderr)
+        return None
+
+
 def load_json(path):
     with open(path, encoding='utf-8') as f:
         return json.load(f)

--- a/RussianTranslation/src/pilot/window_reports.py
+++ b/RussianTranslation/src/pilot/window_reports.py
@@ -428,8 +428,12 @@ def write_reports(report, write_requeue, write_requeue_file=True, out_dir=None):
         with open(requeue_path, 'w', encoding='utf-8') as f:
             f.write('\n'.join(report['requeue']) + ('\n' if report['requeue'] else ''))
         # Split files so a cheap transient re-run never triggers expensive defect rework.
+        # requeue.defect.fshas.txt (H304): the defect cards' frag_prov content addresses —
+        # requeue_from_audit appends these to the TM denylist so the fragment sidecar can
+        # never re-serve a gate-flagged fragment.
         for fname, keys_ in (('requeue.transient.keys.txt', report.get('requeue_transient')),
-                             ('requeue.defect.keys.txt', report.get('requeue_defect'))):
+                             ('requeue.defect.keys.txt', report.get('requeue_defect')),
+                             ('requeue.defect.fshas.txt', report.get('requeue_defect_fshas'))):
             if keys_ is None:
                 continue
             with open(os.path.join(out_dir, fname), 'w', encoding='utf-8') as f:

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -1005,8 +1005,11 @@ def test_requeue_transient_vs_defect_state():
                 f.write('source')
             deny = os.path.join(tmp, 'deny.jsonl')
             rq.translation_memory.denylist_path = lambda out=None: deny
-            n_en = rq.append_tm_denylist('zz', ['k1'], 'defect', lang='en')
-            n_ru = rq.append_tm_denylist('zz', ['k1'], 'defect', lang='ru')
+            no_fshas = os.path.join(tmp, 'no_fshas.txt')   # keep the frag channel out of scope
+            n_en, _ = rq.append_tm_denylist('zz', ['k1'], 'defect', lang='en',
+                                            fsha_file=no_fshas)
+            n_ru, _ = rq.append_tm_denylist('zz', ['k1'], 'defect', lang='ru',
+                                            fsha_file=no_fshas)
             if (n_en, n_ru) != (1, 1):
                 fail('denylist should append one row per lang')
             rows = [json.loads(line) for line in open(deny, encoding='utf-8')]
@@ -2039,7 +2042,7 @@ def test_coordinator_defect_requeue_uses_no_tm_and_out():
         old_argv = sys.argv[:]
         rq.INP = inp
         rq.subprocess.run = fake_run
-        rq.append_tm_denylist = lambda *_args, **_kwargs: 1
+        rq.append_tm_denylist = lambda *_args, **_kwargs: (1, 0)
         sys.argv = ['requeue_from_audit.py', 'nominal_selftest', '--defect',
                     '--nominal', '--no-grammar', '--requeue-file=%s' % rqfile,
                     '--out=%s' % out]
@@ -2933,6 +2936,196 @@ def test_launch_failure_ledger_rejects_incomplete_entry():
         fail('incomplete launch ledger entry must reject missing actual.tokens: %r' % violations)
 
 
+def test_frag_groups_presplit_parity():
+    """H304: frag_groups must reconstruct the SAME partition the harness used to mint the
+    gN:fM ids. A presplit card groups at PRESPLIT_GROUP_CITE_BUDGET with a sense count_cap
+    (H189), not at SELFHEAL_GROUP_BUDGET — reconstructing with the heal budget mis-maps the
+    ids for exactly the giant cards topup exists for."""
+    import autosplit_requeue as ar
+    from gen_opt_harness2 import _group_by_budget
+    fixture = [(si, 0, 'sense %d <ls>A</ls> <ls>B</ls>' % si) for si in range(1, 41)]
+    old_plan = ar.plan
+    ar.plan = lambda raw, ls_budget=None: fixture
+    try:
+        meta = {'presplit_keys': ['X'], 'presplit_group_cite_budget': 60,
+                'presplit_group_sense_cap': 18, 'selfheal_group_budget': 12}
+        sizer = lambda f: 1 + f[2].count('<ls')
+        want_presplit = _group_by_budget(fixture, sizer, 60, count_cap=18)
+        want_heal = _group_by_budget(fixture, sizer, 12)
+        if want_presplit == want_heal:
+            fail('fixture too small — presplit and heal partitions must differ for the test')
+        got_presplit = ar.frag_groups('ignored', meta=meta, key='X')
+        if got_presplit != want_presplit:
+            fail('frag_groups(presplit key) does not match the harness presplit partition '
+                 '(%d vs %d groups)' % (len(got_presplit), len(want_presplit)))
+        got_heal = ar.frag_groups('ignored', meta=meta, key='Y')
+        if got_heal != want_heal:
+            fail('frag_groups(non-presplit key) must keep the heal-budget partition')
+        got_legacy = ar.frag_groups('ignored')
+        if got_legacy != want_heal:
+            fail('frag_groups without meta must keep the pre-H304 heal-budget behavior')
+    finally:
+        ar.plan = old_plan
+
+
+def test_defect_fragment_denylist_round_trip():
+    """H304 gate-outcome memory: a defect card's frag_prov fshas (requeue.defect.fshas.txt)
+    are appended to the TM denylist by requeue_from_audit, and load_frag_tm then refuses to
+    serve them — a gate-flagged fragment is never re-served by --tm=auto."""
+    import requeue_from_audit as rfa
+    import translation_memory as tm
+    tmp = tempfile.mkdtemp()
+    deny_path = os.path.join(tmp, 'denylist.jsonl')
+    fsha_good = tm.frag_address('ru', 'clean fragment')
+    fsha_bad = tm.frag_address('ru', 'flagged fragment')
+    fsha_file = os.path.join(tmp, 'requeue.defect.fshas.txt')
+    with open(fsha_file, 'w', encoding='utf-8') as f:
+        f.write(fsha_bad + '\n')
+    old_dp = rfa.translation_memory.denylist_path
+    rfa.translation_memory.denylist_path = lambda path=None: deny_path
+    try:
+        n, nf = rfa.append_tm_denylist('h304root', [], 'defect', lang='ru',
+                                       fsha_file=fsha_file)
+    finally:
+        rfa.translation_memory.denylist_path = old_dp
+    if (n, nf) != (0, 1):
+        fail('append_tm_denylist defect fsha count: got %r, want (0, 1)' % ((n, nf),))
+    deny = tm.load_denylist(deny_path)
+    if fsha_bad not in deny['frags']:
+        fail('defect fsha missing from the loaded denylist frag set')
+    senses = [{'tag': '1', 'german': 'x', 'russian': 'y'}]
+    sidecar = os.path.join(tmp, 'translation_memory.frag.ru.jsonl')
+    with open(sidecar, 'w', encoding='utf-8') as f:
+        for fsha in (fsha_good, fsha_bad):
+            f.write(json.dumps({'fsha': fsha, 'senses': senses}) + '\n')
+    cache = tm.load_frag_tm('ru', sidecar, denylist=deny_path)
+    if fsha_bad in cache:
+        fail('denylisted fragment still served by load_frag_tm')
+    if fsha_good not in cache:
+        fail('clean fragment wrongly dropped by the denylist')
+    # transient requeues must not denylist anything
+    n, nf = rfa.append_tm_denylist('h304root', [], 'transient', lang='ru')
+    if (n, nf) != (0, 0):
+        fail('transient requeue must never append denylist rows')
+
+
+def test_write_reports_emits_defect_fsha_file():
+    """H304: --write-requeue also persists requeue.defect.fshas.txt so requeue_from_audit
+    can denylist the flagged fragments without re-reading the wf_output."""
+    from window_reports import write_reports
+    tmp = tempfile.mkdtemp()
+    report = {'workflow': 'wf.json', 'root': 'h304root', 'keys': ['k1'],
+              'null_cards': [], 'requeue': ['k1'], 'crashed': [],
+              'gates': {}, 'glue': None, 'collect': {},
+              'requeue_transient': [], 'requeue_defect': ['k1'],
+              'requeue_defect_fshas': ['a' * 64, 'b' * 64],
+              'judge_sample': {'keys': [], 'sample_count': 0, 'seed': None,
+                               'clean_key_count': 0}}
+    write_reports(report, True, out_dir=tmp)
+    p = os.path.join(tmp, 'requeue.defect.fshas.txt')
+    if not os.path.exists(p):
+        fail('requeue.defect.fshas.txt not written by write_reports')
+    got = [ln.strip() for ln in open(p, encoding='utf-8') if ln.strip()]
+    if got != ['a' * 64, 'b' * 64]:
+        fail('defect fsha file content mismatch: %r' % got)
+
+
+def test_save_merge_better_attempt_wins():
+    """H304: 'latest requeue wins' is WRONG — a requeue can regress a card (gam h0_63_sam_0
+    went 2->3->7 missing fragments). --merge must keep the better prior attempt: complete
+    beats partial, fewer missing fragments beat more; a complete fresh card still replaces."""
+    from window_common import REPO as repo_root
+    save = os.path.join(repo_root, 'save_and_audit.py')
+    root, tag = 'h304tmp', 'sftest'
+    out_path = os.path.join(repo_root, 'wf_output.%s.%s.json' % (tag, root))
+    tmp = tempfile.mkdtemp()
+
+    def wf(card):
+        return {'result': {'meta': {'root': root},
+                           'results': [{'key': 'k1', 'card': card}]}}
+
+    def save_run(name, card, *extra):
+        p = os.path.join(tmp, name)
+        with open(p, 'w', encoding='utf-8') as f:
+            json.dump(wf(card), f)
+        run([sys.executable, save, root, p, tag, '--no-audit'] + list(extra), expect=0)
+
+    try:
+        complete = {'key1': 'k1', 'senses_marker': 'first-complete'}
+        save_run('a.json', complete)
+        worse = {'key1': 'k1', 'partial': True,
+                 'missing_fragments': ['g1:f0', 'g1:f1'], 'senses_marker': 'regression'}
+        save_run('b.json', worse, '--merge')
+        got = json.load(open(out_path, encoding='utf-8'))
+        card = got['results'][0]['card']
+        if card.get('partial') or card.get('senses_marker') != 'first-complete':
+            fail('--merge let a partial attempt regress a complete card')
+        fresh = {'key1': 'k1', 'senses_marker': 'second-complete'}
+        save_run('c.json', fresh, '--merge')
+        got = json.load(open(out_path, encoding='utf-8'))
+        if got['results'][0]['card'].get('senses_marker') != 'second-complete':
+            fail('an equal-quality fresh card must still replace (ties go to new)')
+    finally:
+        if os.path.exists(out_path):
+            os.remove(out_path)
+
+
+def test_defer_monster_ledger_dedupes():
+    """H304 cap-and-defer: the deferred-monsters ledger is append-only and deduped on
+    (target, reason, UTC day) so a daily coordinator sweep cannot flood it."""
+    from window_common import defer_monster
+    tmp = tempfile.mkdtemp()
+    p = os.path.join(tmp, 'deferred_monsters.jsonl')
+    row = defer_monster('kAla', 'cost_gate_over_ceiling',
+                        estimate={'est_cost_usd': 79.83}, keys=['kAla~~h0_00'], path=p)
+    if not row or row.get('schema') != 'pwg.deferred_monsters.v1':
+        fail('first defer_monster call must write a schema-stamped row')
+    if defer_monster('kAla', 'cost_gate_over_ceiling', path=p) is not None:
+        fail('same (target, reason, day) must dedupe to None')
+    if defer_monster('kAla', 'defer-calibrate', path=p) is None:
+        fail('a different reason for the same target must append')
+    lines = [ln for ln in open(p, encoding='utf-8') if ln.strip()]
+    if len(lines) != 2:
+        fail('ledger must hold exactly 2 rows, got %d' % len(lines))
+
+
+def test_coordinator_cost_gate_enforced():
+    """H304: coordinator prepare refuses a cost-gate-flagged window (parks it in the
+    deferred ledger) unless --allow-over-cost; a clean window passes untouched."""
+    import coordinator as co
+    tmp = tempfile.mkdtemp()
+    flagged = os.path.join(tmp, 'preflight.json')
+    with open(flagged, 'w', encoding='utf-8') as f:
+        json.dump({'reports': [{'root': 'kAla',
+                                'cost_gate': {'over_ceiling': True, 'est_cost_usd': 79.83,
+                                              'est_cost_per_card_usd': 4.0},
+                                'cost_partition': {'run_now': ['a'],
+                                                   'defer_monster': ['b', 'c']}}]}, f)
+    clean = os.path.join(tmp, 'preflight_clean.json')
+    with open(clean, 'w', encoding='utf-8') as f:
+        json.dump({'reports': [{'root': 'vah', 'cost_gate': {'over_ceiling': False}}]}, f)
+    captured = []
+    old = co.defer_monster
+    co.defer_monster = lambda *a, **k: captured.append((a, k))
+    try:
+        try:
+            co.enforce_cost_gate(flagged, 'kAla')
+            fail('enforce_cost_gate must refuse an over-ceiling window')
+        except SystemExit as e:
+            if 'deferred_monsters' not in str(e):
+                fail('cost-gate refusal must point at the deferred ledger: %s' % e)
+        if len(captured) != 1:
+            fail('refusal must park the window in the ledger exactly once')
+        co.enforce_cost_gate(flagged, 'kAla', allow_over_cost=True)   # no raise
+        if len(captured) != 2:
+            fail('--allow-over-cost must still record the ledger row')
+        co.enforce_cost_gate(clean, 'vah')
+        if len(captured) != 2:
+            fail('a clean window must not touch the ledger')
+    finally:
+        co.defer_monster = old
+
+
 def main():
     tests = [
         test_translation_memory_addressing,
@@ -3020,6 +3213,12 @@ def main():
         test_release_manifest_hash_validation,
         test_lang_parity_ledger_complete,
         test_lang_parity_hash_crlf_independent,
+        test_frag_groups_presplit_parity,
+        test_defect_fragment_denylist_round_trip,
+        test_write_reports_emits_defect_fsha_file,
+        test_save_merge_better_attempt_wins,
+        test_defer_monster_ledger_dedupes,
+        test_coordinator_cost_gate_enforced,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
Executes [H304](https://github.com/gasyoun/Uprava/blob/main/handoffs/H304-Fable_RussianTranslation_coordinator-driver-remake_07.07.26.md) (MG rulings 07-07-2026 via AskUserQuestion: coordinator-driver rebuild scope, frag-TM folded in, cap-and-defer monsters, this-session build). Prior-art check reduced the planned "new driver" to targeted hardening: [coordinator.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/coordinator.py) already IS the stage machine, and the H068 fragment-TM channel was already live — the real gaps were four operator-memory rules that weren't code:

1. **Presplit topup soundness** — `autosplit_requeue.frag_groups(raw, meta, key)` now reconstructs a presplit card's fragment partition with the H189 budgets of the run that minted the `gN:fM` ids. Reconstructing with the heal budget (12, no sense cap) mis-mapped or crashed topup for exactly the kAla/ka-class giants topup exists for.
2. **Fragment gate-outcome memory** — `audit_window` emits `requeue.defect.fshas.txt`; `requeue_from_audit` appends `kind:'frag'` denylist rows. `build_frags` harvests wf_output BEFORE gates run, so a defect card's fragments were silently reusable by `--tm=auto`. EN emitter is a tracked GAP (`defect_fragment_denylist_h304` in [LANG_PARITY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md)).
3. **Better-attempt-wins merge** — `save_and_audit --merge` keeps the better prior attempt (complete > partial, fewer `missing_fragments` > more, ties to new). Kills the gam `h0_63_sam_0` 2→3→7 regression class.
4. **Cap-and-defer** (closes the kAla-class GTD `@DECIDE`) — coordinator claim skips and prepare refuses cost-gate-flagged windows, parking them in `src/pilot/deferred_monsters.jsonl`; `prepare --allow-over-cost` is the explicit human-budgeted override.

**Verification:** `python src/pilot/window_selftest.py` — 90/90 PASS (84 existing + 6 new: presplit parity, denylist round-trip, fshas file emission, better-attempt-wins cross-process, ledger dedupe, coordinator cost-gate enforcement). Lang-parity ledger re-affirmed; new GAP entry tracked to H304.

Built by Fable 5 (`claude-fable-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)