### PR TITLE
H290 (Slice 4a): calibrate ru+cit extractor on real sample

### DIFF
--- a/RussianTranslation/src/ORAL_INGEST.md
+++ b/RussianTranslation/src/ORAL_INGEST.md
@@ -204,6 +204,46 @@ is a representative real sample (one transcript + its PDF); until it arrives the
 (`align='placeholder-*'`), and the real LaBSE/LASER + Vecalign backend + heuristic
 calibration are the gated steps 3–4.
 
+### Calibration on a real `ru+cit` sample (07-07-2026)
+
+MG supplied the first real sample: two samskrtam.ru lecture-course pages (`/l/sgi/01`,
+`/l/vvip/01` — "Sacred Geography of India" and "Introduction to Indian Philosophy",
+fetched via the `defuddle` skill, no companion PDF). Both correctly detect as `ru+cit`
+(304/409 lines, ~2–4% Sanskrit-line share). Running `ingest` surfaced two real
+false-positive families the synthetic fixture never exercised, both fixed on this
+branch in `_is_latin_sa()`:
+
+1. **Markdown/HTML markup** — `[▶](https://samskrtam.ru/...?t=29 "0:29")` timecode
+   links and a `YT/RT/AU` site UI tag contain bare Latin letters and were extracted as
+   "Sanskrit citations". Fixed by requiring a candidate token to be pure letters (no
+   slash/colon/bracket/digit) — markup is never a bare word.
+2. **All-caps Roman numerals** — century markers ("XII век") and slide numbers
+   (XVIII/XIX/XX/II/VI/XIV) matched the same non-Cyrillic-alphabetic test. Fixed by
+   excluding all-caps tokens drawn entirely from `{I,V,X,L,C,D,M}` — a real SLP1/HK word
+   is never all-caps-only from that charset (lower/mixed-case Sanskrit prefixes like
+   `vi`/`sa` are unaffected, since the exclusion only fires on `.isupper()`).
+
+After both fixes, `sgi/01` yields 6 clean pairs (down from 166 pre-fix, mostly noise)
+and `vvip/01` yields 8 clean pairs (down from 19), including real hits:
+`Bhārat Gaṇarājya`, `Āstika`, `Nāstika`.
+
+**Residual open finding — English contamination (not fixed, needs a design call):**
+both samples still surface bare **English** words/proper nouns the lecturer cites
+inline — slide captions ("Bibliography", "Republic of", "British") and a transliterated
+political-party name ("Janata Bharatiya", `vvip/01`) — that a script-only heuristic
+cannot distinguish from SLP1/HK romanized Sanskrit (both are pure ASCII words). Options
+for a future pass: (a) a small English-stopword/dictionary check to reject common
+English tokens, (b) a minimum-length + no-common-suffix heuristic, (c) route low-
+confidence Latin-only "citations" to the human reviewable sample instead of auto-
+accepting. Tracked as an `@DECIDE` in
+[`Uprava/GTD_NEXT_ACTIONS.md`](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md) —
+not blocking, since these lectures have no companion PDF (no multi-reference consensus
+signal to corroborate/reject against yet).
+
+Test artefacts (fetched HTML→md, jsonl output) live under the gitignored
+`release/corpus_tm/oral_samples/` — not committed (rights: third-party recorded
+lectures, per the Rights section below).
+
 ### ⚠️ Open policy conflict — oral → A gate (MG ruling 4 vs merged Slice 4)
 
 MG ruling 4 (H290): an oral unit is **distrusted by default but not barred from

--- a/RussianTranslation/src/build_oral_l0.py
+++ b/RussianTranslation/src/build_oral_l0.py
@@ -79,10 +79,37 @@ ORALITY_HANDOUT = 'handout'          # PDF handout side of a (sa+pdf) pair
 DEVA = re.compile('[ऀ-ॿ]')                       # Devanagari block U+0900..097F
 IAST = re.compile('[Ā-ſḀ-ỿāīūṛṝḷṅñṇśṣṭḍṃḥ]')     # precomposed IAST diacritics
 LATIN = re.compile('[A-Za-z]')                    # ASCII incl. SLP1/HK romanization
+_PURE_WORD = re.compile(r'^[A-Za-z]+$')           # bare-letters only -- see _is_latin_sa
 
 
 def _has(rx, s):
     return bool(s) and bool(rx.search(s))
+
+
+_ROMAN_NUMERAL = re.compile(r'^[IVXLCDM]+$')      # all-caps roman-numeral charset only
+
+
+def _is_latin_sa(tok):
+    """True if an ASCII token PLAUSIBLY carries romanized (SLP1/HK) Sanskrit, e.g.
+    `yogaH`/`karmasu`. A real transcript rendered from HTML (the H290 calibration
+    sample, 07-07-2026: samskrtam.ru lecture pages via defuddle) carries two noise
+    families that also contain bare Latin letters and were false-flagged as Sanskrit
+    citations before this guard:
+      - markdown markup -- `[▶](https://...)` timecode links, a `YT/RT/AU` site UI tag
+        -- excluded by requiring pure letters (no slash/colon/bracket/digit);
+      - all-caps ROMAN NUMERALS used as century markers ("XII век", slide numbers
+        XVIII/XIX/XX) -- excluded by the all-caps + roman-numeral-charset check below.
+        Lower/mixed-case tokens (`vi`, `kauSalam`) are unaffected -- a real SLP1 word is
+        never all-caps-only from {IVXLCDM}.
+    A residual ambiguity this does NOT resolve: bare English words/proper nouns cited by
+    the lecturer (book titles, "Bibliography", "Republic of") are still indistinguishable
+    from SLP1/HK romanization by a script-only heuristic -- logged as an open calibration
+    finding in ORAL_INGEST.md rather than guessed at here."""
+    if not _PURE_WORD.match(tok):
+        return False
+    if tok.isupper() and _ROMAN_NUMERAL.match(tok):
+        return False
+    return True
 
 
 def script_ratios(text):
@@ -96,7 +123,7 @@ def script_ratios(text):
     sample per the Slice-4a prerequisite.)"""
     toks = re.findall(r'\S+', text or '')
     alpha = [t for t in toks
-             if build_tmx.has_cyr(t) or _has(DEVA, t) or _has(IAST, t) or _has(LATIN, t)]
+             if build_tmx.has_cyr(t) or _has(DEVA, t) or _has(IAST, t) or _is_latin_sa(t)]
     if not alpha:
         return {'cyr': 0.0, 'sa': 0.0, 'n': 0}
     cyr = sum(1 for t in alpha if build_tmx.has_cyr(t))
@@ -256,7 +283,7 @@ def pairs_ru_citation(text):
         # remainder is the gloss.
         sa_toks = [t for t in re.findall(r'\S+', ln)
                    if not build_tmx.has_cyr(t) and (_has(DEVA, t) or _has(IAST, t)
-                                                    or _has(LATIN, t))]
+                                                    or _is_latin_sa(t))]
         ru_toks = [t for t in re.findall(r'\S+', ln) if build_tmx.has_cyr(t)]
         sa = ' '.join(sa_toks).strip(' .,:;—–-')
         ru = ' '.join(ru_toks).strip()


### PR DESCRIPTION
## Summary
- Ingested the first real H290 sample (two samskrtam.ru lecture pages, `ru+cit` shape, no companion PDF) and fixed two real false-positive families it surfaced in `build_oral_l0.py`'s Sanskrit-citation extractor: markdown/timecode-link markup and all-caps Roman-numeral century markers, both previously misread as Sanskrit citations.
- Documented the calibration run + a residual open finding (bare English-word contamination, not fixable by a script-only heuristic) in `ORAL_INGEST.md`, tracked as an `@DECIDE`.

## Test plan
- [x] `python build_oral_l0.py selftest` passes (3/3 source-types, 3/3 pdf-roles, guards intact)
- [x] Re-ran `detect`/`ingest` on both real samples pre/post-fix: noise pairs dropped (166→6, 19→8), genuine hits retained (`Bhārat Gaṇarājya`, `Āstika`, `Nāstika`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)