### PR TITLE
H316: pwg_ru code hardening — BOM record-drop, subprocess encoding, hang guards

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1707,6 +1707,19 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H316 code-hardening pass (07-07-2026, Fable 5 `claude-fable-5`).** Closed the FL6/CODE_REVIEW
+  BOM class: `src/pwg_mask.py records()` now reads `utf-8-sig` (a BOM-bearing PWG source no longer
+  silently drops the FIRST record) and warns on stderr for a truncated final record instead of
+  dropping it silently. Windows cp1252 pitfall: `encoding='utf-8'` added to the capture-output
+  `subprocess.run` calls in `src/make_edition_cut.py`, `src/preflight_remaining_gates.py`,
+  `src/release_readiness.py`. Hang guards: timeouts on the shell-outs in `save_and_audit.py`
+  (1800s), `src/pilot/audit_window.py` (1800s), `src/pilot/autosplit_requeue.py` (600s).
+  Pinned by 3 new selftests (`test_pwg_mask_bom_source_keeps_first_record`,
+  `test_pwg_mask_truncated_final_record_not_silent`, `test_subprocess_gate_calls_hardened`);
+  LANG_PARITY ledger entry `subprocess_and_bom_hardening_h316` (SHARED), all hashes re-verified,
+  no drift. Remaining 🔴 correctness backlog (positional card misassignment, TM poisoning,
+  corpus-gate silent degradation) deliberately NOT touched — parked in H316's backlog section.
+
 - **H136: corpus-lexicon RECALL gold measurement + consolidated A42 P/R memo (2026-07-07,
   Fable 5 `claude-fable-5`).** The precision half existed (gold/precision_report.md, 84.4%,
   2026-06-16); this session built the missing recall half. New committed sampler

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -81,8 +81,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Code review 2026-07-04: <ab>lat.</ab>/<ab>griech.</ab> cues are masked to {Tn} in mask() step 1 BEFORE classify_pct runs, so the end-anchored LATIN_CUE regex matched the placeholder, not the cue; measured 33 Latin/Greek cognate glosses across all of PWG (e.g. ignis, uncus, ansa after `lat.`) were being sent for German translation and leaked verbatim into the translator prompt. Fix expands trailing placeholders back to source and strips tags in the classify context window. Masking is stage-0 and runs before any --lang branch, so the fix is identical for RU and EN. Round-trip stays lossless. Pinned by window_selftest.test_pwg_mask_latin_cue_behind_ab_tag.",
     "tracking": "",
     "verified_sha256": {
-      "src/pwg_mask.py": "5bbb029b2dc287f52d4efd4f9f44ff4a12952a15984554568afa645eec2804bd",
-      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
+      "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
+      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
+      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
+      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
+      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
     }
   },
   {
@@ -279,7 +279,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
       "src/pilot/prompt_rule_audit.py": "bbd3fe10ff72b9d58e6d763069352129df8c246d4cb18ae41520ddcf6fee7525",
-      "src/pilot/audit_window.py": "0a2256245f35ef9468d722e8bd7c7714586f8186178d32abcc92e6d71facf440",
+      "src/pilot/audit_window.py": "4842e14d11c4830eeb3a7840c016d2d773d5268421c1ca9c2aa3d9cfdbfd60ae",
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2"
     }
   },
@@ -298,7 +298,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The denylist append and load_frag_tm filtering are lang-agnostic (fsha encodes lang; requeue_from_audit takes --lang), but the fshas EMITTER lives only in the RU auditor: audit_window_en.py reimplements its gates and does not compute requeue_defect_fshas or write the file, so an EN defect requeue does not auto-denylist its fragments.",
     "tracking": "Uprava/handoffs/H304-Fable_RussianTranslation_coordinator-driver-remake_07.07.26.md (EN-emitter port is the recorded follow-up)",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "0a2256245f35ef9468d722e8bd7c7714586f8186178d32abcc92e6d71facf440",
+      "src/pilot/audit_window.py": "4842e14d11c4830eeb3a7840c016d2d773d5268421c1ca9c2aa3d9cfdbfd60ae",
       "src/pilot/window_reports.py": "1649a33f3cf65fdd9f770cd1f05bb84d3eccdbc8369132ee3a1800c0ea62a72e",
       "src/pilot/requeue_from_audit.py": "a315cd02276908ffdcc64f09d226798865885a7eea47ca60681a256a240d6272"
     }
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
+      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
+      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
     }
   },
   {
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
+      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
     }
   },
   {
@@ -471,7 +471,38 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "3255052a7ba933d420d13e565945fe74a317bb39e4e09c620fbfd55b72f7429b"
+      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
+    }
+  },
+  {
+    "id": "subprocess_and_bom_hardening_h316",
+    "mechanism": "pwg_mask.records() reads utf-8-sig (BOM on the PWG source no longer drops the FIRST record) and warns loudly on a truncated final record instead of silently dropping it; every gate/driver subprocess.run that captures child output passes encoding='utf-8' (Windows cp1252 pitfall); save_and_audit/audit_window/autosplit_requeue shell-outs carry timeouts so a wedged child cannot hang the driver",
+    "files": [
+      "src/pwg_mask.py",
+      "src/make_edition_cut.py",
+      "src/preflight_remaining_gates.py",
+      "src/release_readiness.py",
+      "save_and_audit.py",
+      "src/pilot/audit_window.py",
+      "src/pilot/autosplit_requeue.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H316 code-hardening pass (2026-07-07). All fixes sit below the --lang branch: stage-0 masking (records feeds both RU and EN lanes), gate shell-out plumbing, and hang guards are language-agnostic by construction. Pinned by test_pwg_mask_bom_source_keeps_first_record, test_pwg_mask_truncated_final_record_not_silent, and the static wiring pin test_subprocess_gate_calls_hardened.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
+      "src/make_edition_cut.py": "5a24d8c96611f50f008689609f8140ef47b02731524dbc255438426b36d306fd",
+      "src/preflight_remaining_gates.py": "00386c837b97986c9702abfceed9c29534736c3df3063af202ddfaae6b078b8f",
+      "src/release_readiness.py": "db38a870bbc8b5dbe694e706e4a7b9089ba41211a3881ad9a1bd4eb02950c8a9",
+      "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
+      "src/pilot/audit_window.py": "4842e14d11c4830eeb3a7840c016d2d773d5268421c1ca9c2aa3d9cfdbfd60ae",
+      "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
+      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
     }
   }
 ]

--- a/RussianTranslation/save_and_audit.py
+++ b/RussianTranslation/save_and_audit.py
@@ -122,7 +122,7 @@ def main():
     if not os.path.exists(audit):
         print(f"({os.path.basename(audit)} not found — saved only)")
         return
-    p = subprocess.run(cmd, text=True, encoding="utf-8")
+    p = subprocess.run(cmd, text=True, encoding="utf-8", timeout=1800)
 
     # RU path: also run the anti-silent-partial coverage gate for this root (FL3). Advisory
     # (--warn-only) because it reads the promoted store (pwg_ru_translated.jsonl), which this
@@ -134,7 +134,7 @@ def main():
         if os.path.exists(cov):
             print("\n=== RU coverage (advisory, current store) ===")
             subprocess.run([sys.executable, cov, "--root", root, "--warn-only"],
-                           text=True, encoding="utf-8")
+                           text=True, encoding="utf-8", timeout=1800)
     sys.exit(p.returncode)
 
 

--- a/RussianTranslation/src/make_edition_cut.py
+++ b/RussianTranslation/src/make_edition_cut.py
@@ -24,7 +24,8 @@ INTEROP = ('tei_lex0.xml', 'ontolex.ttl', 'reverse_index.jsonl')
 
 
 def run(cmd):
-    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True, timeout=120)
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True,
+                       encoding='utf-8', timeout=120)
     if r.returncode != 0:
         raise RuntimeError('%s\n%s' % (' '.join(cmd), r.stderr.strip() or r.stdout.strip()))
     return r.stdout.strip()

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -62,7 +62,7 @@ PROTECTED = {'aMSa', 'anna', 'ap'}
 def run_py(args, env=None):
     t0 = time.perf_counter()
     p = subprocess.run([sys.executable] + args, cwd=SRC, capture_output=True,
-                       text=True, encoding='utf-8', env=env)
+                       text=True, encoding='utf-8', env=env, timeout=1800)
     return {'argv': [sys.executable] + args, 'returncode': p.returncode,
             'stdout': p.stdout, 'stderr': p.stderr,
             'seconds': round(time.perf_counter() - t0, 3)}

--- a/RussianTranslation/src/pilot/autosplit_requeue.py
+++ b/RussianTranslation/src/pilot/autosplit_requeue.py
@@ -427,7 +427,8 @@ def cmd_topup(root, lang, wf_file):
     out = os.path.join(HERE, 'run_pilot_wf.%s_%s_topup.js' % (lang, safe_name(root)))
     subprocess.run([sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'), root,
                     '--nominal', '--no-grammar', '--lang=%s' % lang,
-                    '--keys=' + ','.join(fragkeys), '--budget=1', '--out=' + out], check=True)
+                    '--keys=' + ','.join(fragkeys), '--budget=1', '--out=' + out],
+                   check=True, timeout=600)
     data = open(out, 'rb').read().replace(b'\r\n', b'\n').replace(b'\r', b'\n')  # LF for Workflow
     open(out, 'wb').write(data)
     total = sum(len(c['plan']) for c in cards)
@@ -512,7 +513,8 @@ def cmd_gen(root, lang, keys):
     # lookup can't key on; the fragment header already carries prefix/root context.
     subprocess.run([sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'), root,
                     '--nominal', '--no-grammar', '--lang=%s' % lang,
-                    '--keys=' + ','.join(fragkeys), '--budget=1', '--out=' + out], check=True)
+                    '--keys=' + ','.join(fragkeys), '--budget=1', '--out=' + out],
+                   check=True, timeout=600)
     data = open(out, 'rb').read().replace(b'\r\n', b'\n').replace(b'\r', b'\n')  # LF for Workflow
     open(out, 'wb').write(data)
     print('\n%d fragment(s) from %d card(s); manifest %s' % (len(fragkeys), len(keys), mpath))

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3126,6 +3126,82 @@ def test_coordinator_cost_gate_enforced():
         co.defer_monster = old
 
 
+def test_pwg_mask_bom_source_keeps_first_record():
+    """Hardening (H316; FL6 / CODE_REVIEW 2026-07-04): a UTF-8 BOM on the PWG
+    source used to leave the first line as BOM+'<L>...', which
+    startswith('<L>') misses -- the FIRST record of the dictionary was silently
+    dropped. records() now reads utf-8-sig (a no-op on BOM-less files).
+    SHARED (stage-0 masking, before any --lang branch)."""
+    import tempfile
+    import pwg_mask
+    body = ('<L>1<pc>1,1<k1>agni<k2>agni\nFeuer\n<LEND>\n'
+            '<L>2<pc>1,1<k1>ap<k2>ap\nWasser\n<LEND>\n')
+    for bom, label in ((b'\xef\xbb\xbf', 'BOM'), (b'', 'no-BOM')):
+        tf = tempfile.NamedTemporaryFile('wb', suffix='.txt', delete=False)
+        tf.write(bom + body.encode('utf-8'))
+        tf.close()
+        old = pwg_mask.PWG
+        pwg_mask.PWG = tf.name
+        try:
+            recs = list(pwg_mask.records())
+        finally:
+            pwg_mask.PWG = old
+            os.unlink(tf.name)
+        if len(recs) != 2:
+            fail('%s source: expected 2 records, got %d' % (label, len(recs)))
+        if not recs[0][0].startswith('<L>1'):
+            fail('%s source: first record dropped/mangled: %r' % (label, recs[0][0]))
+
+
+def test_pwg_mask_truncated_final_record_not_silent():
+    """Hardening (H316): a final record opened with <L> but never closed by
+    <LEND> (truncated source) must not be yielded downstream -- but it must not
+    vanish silently either: records() warns on stderr."""
+    import contextlib
+    import io
+    import tempfile
+    import pwg_mask
+    body = ('<L>1<pc>1,1<k1>agni<k2>agni\nFeuer\n<LEND>\n'
+            '<L>2<pc>1,1<k1>ap<k2>ap\nWasser\n')  # no closing <LEND>
+    tf = tempfile.NamedTemporaryFile('w', suffix='.txt', delete=False, encoding='utf-8')
+    tf.write(body)
+    tf.close()
+    old = pwg_mask.PWG
+    pwg_mask.PWG = tf.name
+    err = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(err):
+            recs = list(pwg_mask.records())
+    finally:
+        pwg_mask.PWG = old
+        os.unlink(tf.name)
+    if len(recs) != 1:
+        fail('truncated source: expected 1 complete record, got %d' % len(recs))
+    if 'truncated final record' not in err.getvalue():
+        fail('truncated final record dropped SILENTLY -- warning missing')
+
+
+def test_subprocess_gate_calls_hardened():
+    """Hardening (H316): Windows cp1252 pitfall + hang guard. Gate/driver
+    subprocess.run calls that capture child output must pass encoding='utf-8';
+    shell-outs wrapping potentially long children must carry a timeout. Static
+    wiring pin so a refactor cannot silently regress either."""
+    checks = [
+        (os.path.join(SRC, 'make_edition_cut.py'), "encoding='utf-8'"),
+        (os.path.join(SRC, 'preflight_remaining_gates.py'), "encoding='utf-8'"),
+        (os.path.join(SRC, 'release_readiness.py'), "encoding='utf-8'"),
+        (os.path.normpath(os.path.join(SRC, '..', 'save_and_audit.py')), 'timeout=1800'),
+        (os.path.join(HERE, 'audit_window.py'), 'timeout=1800'),
+        (os.path.join(HERE, 'autosplit_requeue.py'), 'timeout=600'),
+    ]
+    for path, needle in checks:
+        with open(path, encoding='utf-8') as f:
+            src_txt = f.read()
+        if 'subprocess.run' in src_txt and needle not in src_txt:
+            fail('%s: expected %r on its subprocess.run call(s)'
+                 % (os.path.basename(path), needle))
+
+
 def main():
     tests = [
         test_translation_memory_addressing,
@@ -3219,6 +3295,9 @@ def main():
         test_save_merge_better_attempt_wins,
         test_defer_monster_ledger_dedupes,
         test_coordinator_cost_gate_enforced,
+        test_pwg_mask_bom_source_keeps_first_record,
+        test_pwg_mask_truncated_final_record_not_silent,
+        test_subprocess_gate_calls_hardened,
     ]
     for test in tests:
         test()

--- a/RussianTranslation/src/preflight_remaining_gates.py
+++ b/RussianTranslation/src/preflight_remaining_gates.py
@@ -28,7 +28,8 @@ G10 = 'G10_immutable_edition_cut'
 
 
 def run(label, cmd, ok_codes=(0,)):
-    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True, timeout=180)
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True,
+                       encoding='utf-8', timeout=180)
     status = 'ok' if r.returncode in ok_codes else 'fail'
     detail = (r.stdout.strip() or r.stderr.strip()).splitlines()
     return label, status, detail[-1] if detail else ''

--- a/RussianTranslation/src/pwg_mask.py
+++ b/RussianTranslation/src/pwg_mask.py
@@ -41,8 +41,11 @@ HOMOGRAPH = {'in', 'an', 'un', 'et', 'ut', 'a', 'i'}  # de/lat ambiguous short t
 
 
 def records(limit=None):
+    # utf-8-sig on READ only: strips a leading BOM if the source ever carries one
+    # (a plain utf-8 read leaves '﻿<L>' unmatched and silently DROPS the
+    # first record — FL6/CODE_REVIEW 2026-07-04). No-op on BOM-less files.
     buf, n = [], 0
-    with open(PWG, encoding='utf-8') as f:
+    with open(PWG, encoding='utf-8-sig') as f:
         for line in f:
             line = line.rstrip('\n')
             if line.startswith('<L>'):
@@ -56,6 +59,11 @@ def records(limit=None):
                 buf = []
             elif buf:
                 buf.append(line)
+    if buf:
+        # a record opened with <L> but never closed by <LEND> (truncated source);
+        # never yield it downstream, but never lose it silently either
+        print('pwg_mask: WARNING — truncated final record dropped (no <LEND>): %r'
+              % buf[0][:80], file=sys.stderr)
 
 
 def parse(buf):

--- a/RussianTranslation/src/release_readiness.py
+++ b/RussianTranslation/src/release_readiness.py
@@ -71,7 +71,8 @@ def gold_counts():
 def interop_ok(release_dir):
     r = subprocess.run([sys.executable, os.path.join(HERE, 'validate_interop.py'),
                         '--dir', release_dir],
-                       cwd=ROOT, capture_output=True, text=True, timeout=120)
+                       cwd=ROOT, capture_output=True, text=True,
+                       encoding='utf-8', timeout=120)
     return r.returncode == 0, (r.stdout.strip() or r.stderr.strip())
 
 


### PR DESCRIPTION
Executes [H316-Fable_RussianTranslation_code-hardening_07.07.26.md](https://github.com/gasyoun/Uprava/blob/main/handoffs/H316-Fable_RussianTranslation_code-hardening_07.07.26.md) (Fable 5 `claude-fable-5`, 07-07-2026).

## What

- [src/pwg_mask.py](https://github.com/gasyoun/SanskritLexicography/blob/h316-code-hardening/RussianTranslation/src/pwg_mask.py): `records()` reads `utf-8-sig` — a UTF-8 BOM on the PWG source used to leave the first line as `BOM+<L>`, silently dropping the FIRST dictionary record (FL6 / [CODE_REVIEW_2026-07-04.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/CODE_REVIEW_2026-07-04.md), previously note-only). A truncated final record (no `<LEND>`) now warns on stderr instead of vanishing silently.
- Windows cp1252 pitfall: `encoding='utf-8'` added to the capture-output `subprocess.run` calls in [make_edition_cut.py](https://github.com/gasyoun/SanskritLexicography/blob/h316-code-hardening/RussianTranslation/src/make_edition_cut.py), [preflight_remaining_gates.py](https://github.com/gasyoun/SanskritLexicography/blob/h316-code-hardening/RussianTranslation/src/preflight_remaining_gates.py), [release_readiness.py](https://github.com/gasyoun/SanskritLexicography/blob/h316-code-hardening/RussianTranslation/src/release_readiness.py) — Cyrillic/IAST in child stdout no longer crashes/mojibakes a gate.
- Hang guards: timeouts on the shell-outs in [save_and_audit.py](https://github.com/gasyoun/SanskritLexicography/blob/h316-code-hardening/RussianTranslation/save_and_audit.py) (1800s), [audit_window.py](https://github.com/gasyoun/SanskritLexicography/blob/h316-code-hardening/RussianTranslation/src/pilot/audit_window.py) (1800s), [autosplit_requeue.py](https://github.com/gasyoun/SanskritLexicography/blob/h316-code-hardening/RussianTranslation/src/pilot/autosplit_requeue.py) (600s).

## Verification

- 3 new pins in [window_selftest.py](https://github.com/gasyoun/SanskritLexicography/blob/h316-code-hardening/RussianTranslation/src/pilot/window_selftest.py) — `test_pwg_mask_bom_source_keeps_first_record`, `test_pwg_mask_truncated_final_record_not_silent`, `test_subprocess_gate_calls_hardened` — all PASS. (Full suite aborts earlier at `test_perf_preflight_*` in a fresh worktree for lack of gitignored data — same failure at pristine HEAD, pre-existing/environmental, not from this change.)
- `python src/pilot/lang_parity_check.py`: 23 entries, all verdicts complete, no drift — new SHARED entry `subprocess_and_bom_hardening_h316`, stale hashes re-verified.
- `py_compile` clean on all touched files.

Deliberately NOT touched: the open 🔴 correctness backlog (positional card misassignment, `tm_card_sane` zero-`<ls>` bypass, TM first-seen poisoning, corpus-gate silent evidence degradation) — parked with selftest-gated fix instructions in the H316 handoff backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)