### PR TITLE
pwg-ru: close the open CODE_REVIEW correctness backlog (H321)

### DIFF
--- a/RussianTranslation/CODE_REVIEW_2026-07-04.md
+++ b/RussianTranslation/CODE_REVIEW_2026-07-04.md
@@ -1,6 +1,6 @@
 # Code review — pwg_ru pipeline (2026-07-04)
 
-_Created: 04-07-2026 · Last updated: 04-07-2026_
+_Created: 04-07-2026 · Last updated: 07-07-2026_
 
 Full-tree review of `RussianTranslation/src` (34,668 LOC, ~90 Python files) by
 five parallel reviewers (Opus 4.8, `claude-opus-4-8`), each scoped to one
@@ -33,10 +33,26 @@ defects below (real `DUP` hard flag + RU-gate verdict-parse guard).
 
 ---
 
+## ✅ Resolved in H321 (2026-07-07, Opus 4.8 `claude-opus-4-8`, [PR to master](https://github.com/gasyoun/SanskritLexicography/pulls))
+
+The [H321 handoff](https://github.com/gasyoun/Uprava/blob/main/handoffs/H321-Opus_RussianTranslation_pwg-ru-correctness-backlog_07.07.26.md) worked the open 🔴/🟡 items below. Several were already closed by intervening PRs (verified against current `master`); the rest were fixed or measured this pass. Each fix lands behind a `window_selftest.py` pin + a [LANG_PARITY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md) ledger entry.
+
+| Item | Disposition |
+|---|---|
+| 🔴 Positional card misassignment (`resolveGroup`/`healGroup`) | **Already fixed** — `resolveGroup` matches on `byKey1(res.cards)` only (`missing-or-mismatched-key` on miss, never positional); `healGroup`'s `exactCard` positional fallback requires the candidate to echo the exact key. Pinned by `test_generated_harness_strict_key_matching` (present on `master`). Verified, no change needed. |
+| 🔴 `tm_card_sane` zero-`<ls>` bypass | **Already fixed** in [PR #175](https://github.com/gasyoun/SanskritLexicography/pull/175) — the guard now compares `<ls>`/`{#` against the source count unconditionally (no `if ls and …`). Pinned by `test_tm_card_sane_rejects_zero_marker_drift`. Verified. |
+| 🟡 Whole card dropped on one blank sense (`translation_memory.py:265`) | **Deliberate NO-CHANGE (measured):** 0/2313 sub-cards in the live 11,261-row store carry a blank non-partial sense — zero incidence. Caching a blank-sense card is also unsafe: `tm_card_sane` refuses it at serve, so it would churn or force serving incomplete output. Kept as-is; a code comment now records this. |
+| 🟡 Partial card content-addressed as exact hit (`:1204`) | **Already fixed** — `reconstruct_cards` excludes `partial_card`/`missing_fragments`/`missing_groups` from the exact TM (pinned by `translation_memory.selftest` `skipped['partial-card']`). Verified. |
+| 🟡 `frag_prov` first-seen, no fidelity (`:481`) | **Fixed (H321)** — `frag_senses_sane` gates harvest AND serve; a corrupt/blanked `wf_output` is refused, and a later good harvest overrides a previously-cached corrupt row. Pinned by `test_frag_tm_fidelity_gate_and_override`; ledger `frag_tm_fidelity_gate_h321`. |
+| 🟡 `ls_resolver` RV/AV substring + bare `except: pass` | **Fixed (H321)** — anchored `_is_rv_prefix` (startswith), and both swallowed excepts surface via `_warn_swallowed`. Pinned by `test_ls_resolver_rv_av_anchored`; ledger `ls_resolver_rv_av_anchor_h321`. |
+| FL7 corpus-gate silent evidence degradation | **Fixed (H321)** — `build_card` marks `evidence_status` (`evidence_unavailable`) + `corpus_status` (`db_absent`/`db_error`/`skipped_short_term`/`ok`). Pinned by `test_corpus_gate_evidence_and_db_markers`; ledger `corpus_gate_evidence_markers_fl7_h321` (INTENTIONAL-DIVERGENCE, RU-only gate). |
+
+Not in H321 scope (still open): the 🟠 broken-validator items, `supersedes` string-iteration (latent), `degenerate_passthrough` German-in-RU, and the 🟡 data-builder items below.
+
 ## 🔴 Backlog — correctness (wrong output under a headword)
 
-- **Positional card misassignment** — [gen_opt_harness2.py:1259](src/pilot/gen_opt_harness2.py) (`resolveGroup`) and `healGroup` :1098. When the model drops/reorders a card, the `res.cards[i]` positional fallback assigns content to the wrong `key`. The `<ls>/{#`-count fidelity guard is **blind for zero-marker cross-ref stubs**, so two such cards can swap silently → Russian under the wrong Sanskrit headword. *Fix needs care (JS-in-Python harness); add a hard key-agreement assertion or drop-to-fragment-lane when `byKey1` misses instead of positional fallback.*
-- **`tm_card_sane` zero-`<ls>` guard bypass** — [gen_opt_harness2.py:585](src/pilot/gen_opt_harness2.py). `if ls and ls != raw.count('<ls')` short-circuits when the cached card has zero `<ls>`, so a citation-stripped/degraded cached card is served verbatim, dropping every citation. *Fix: check `ls is not None` / compare against source count unconditionally.*
+- ✅ **Positional card misassignment** — see the H321 table above (already fixed; verified). ~~[gen_opt_harness2.py:1259](src/pilot/gen_opt_harness2.py) (`resolveGroup`) and `healGroup` :1098. When the model drops/reorders a card, the `res.cards[i]` positional fallback assigns content to the wrong `key`.~~
+- ✅ **`tm_card_sane` zero-`<ls>` guard bypass** — see the H321 table above (fixed in PR #175). ~~[gen_opt_harness2.py:585](src/pilot/gen_opt_harness2.py).~~
 
 ## 🟠 Backlog — broken validators (green light on defective output)
 
@@ -45,10 +61,10 @@ defects below (real `DUP` hard flag + RU-gate verdict-parse guard).
 
 ## 🟡 Backlog — TM reuse & quality
 
-- **Whole card dropped from cache on one empty sense** — [translation_memory.py:265](src/pilot/translation_memory.py). One legitimately-blank xref sense → giant card re-translated every run. *Fix: cache per-sense / tolerate blank pass-through senses.*
-- **Partial/incomplete card content-addressed as an exact hit** (SUSPECTED, depends on save path) — [gen_opt_harness2.py:1204](src/pilot/gen_opt_harness2.py) + `reconstruct_cards`. A future byte-identical run serves an incomplete card with zero agents. *Fix: exclude `partial:true` cards from the exact card-TM.*
-- **`supersedes` string→char-iteration** — [translation_memory.py:190](src/pilot/translation_memory.py). Iterates a string SHA character-by-character, defeating supersession. **Latent** (0 store rows carry a string `supersedes` today — verified), but the TM is now a published schema; *coerce to list defensively.*
-- **`frag_prov` senses harvested with no fidelity check, first-seen-wins** — [translation_memory.py:481](src/pilot/translation_memory.py). A hand-edited/corrupt `wf_output*.json` permanently poisons the fragment TM. *Fix: validate `<ls>/{#` counts before caching; allow later-good override.*
+- ✅ **Whole card dropped from cache on one empty sense** — [translation_memory.py:265](src/pilot/translation_memory.py). H321: deliberate NO-CHANGE (0/2313 incidence measured; unsafe — see the H321 table above).
+- ✅ **Partial/incomplete card content-addressed as an exact hit** — already fixed: `reconstruct_cards` excludes `partial:true`/`missing_*` (see the H321 table above).
+- **`supersedes` string→char-iteration** — [translation_memory.py:190](src/pilot/translation_memory.py). Iterates a string SHA character-by-character, defeating supersession. **Latent** (0 store rows carry a string `supersedes` today — verified), but the TM is now a published schema; *coerce to list defensively.* (Still open — not in H321 scope.)
+- ✅ **`frag_prov` senses harvested with no fidelity check, first-seen-wins** — [translation_memory.py:481](src/pilot/translation_memory.py). H321: fixed (`frag_senses_sane` at harvest+serve, later-good override) — see the H321 table above.
 - **`degenerate_passthrough` can emit German as the Russian field** — [gen_opt_harness2.py:519](src/pilot/gen_opt_harness2.py). A borderline stub bypasses the LLM with German copied into the RU field, no downstream gate. *Fix: tighten the allowlist / gate passthrough rows.*
 
 ## 🟡 Backlog — data builders (correctness)
@@ -57,7 +73,7 @@ defects below (real `DUP` hard flag + RU-gate verdict-parse guard).
 - **Silent lemma loss on genre join-key miss** — [build_dcs_freq_dims.py:133](src/build_dcs_freq_dims.py). A text whose name doesn't normalize-match gets zero genre attribution, indistinguishable from the intended register-less tail. *Fix: log unmatched `text_id`s.*
 - **Homograph Ru-gloss attribution is winner-take-all + nondeterministic tie order** — [build_rollup_glossaries.py:60](research/… → src/build_rollup_glossaries.py) `most_common` sorts by count only; equal-count lemmas ordered by file order. *Fix: stable tiebreak; split near-tied distributions.*
 - **Citation index dedup semantics disagree across two code paths** — [build_citation_index.py:136](src/build_citation_index.py) vs `occurrence_stats()`; `CITATION_SOURCES.md` and `UNCOVERED_SOURCES.md` can disagree on coverage. *Fix: single source of truth for coverage.*
-- **`ls_resolver` Ṛgveda/Atharva disambiguation is substring-based** — [ls_resolver.py:996](src/ls_resolver.py) `'rv' in kl or 'ṛ' in kl` mis-routes e.g. `ṚV. PRĀTIŚ.`. Bare `except: pass` at :1046/:965 hides resolver failures. *Fix: anchored match; surface exceptions.*
+- ✅ **`ls_resolver` Ṛgveda/Atharva disambiguation is substring-based** — [ls_resolver.py](src/ls_resolver.py). H321: fixed (anchored `_is_rv_prefix`; bare excepts now surface via `_warn_swallowed`) — see the H321 table above.
 
 ## ⚡ Backlog — performance
 

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
+      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
+      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
+      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
+      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
     }
   },
   {
@@ -207,7 +207,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "lang is a first-class parameter of the TM address (sha256(lang + ...)); --lang=ru|en both get full reuse.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "7067832e30e9e0c93b43fd010a90758335d605ce1bd25ca431c2121d205472c9"
+      "src/pilot/translation_memory.py": "38c404a4d88c4ea0d34617721edc6725423c70250b49e91b40d93008cdcbdfba"
     }
   },
   {
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
+      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
+      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
     }
   },
   {
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
+      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
     }
   },
   {
@@ -471,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
+      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
     }
   },
   {
@@ -502,7 +502,63 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "4842e14d11c4830eeb3a7840c016d2d773d5268421c1ca9c2aa3d9cfdbfd60ae",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "a26f2d2a85f4bb6a40cb51bfe1593d1e76772b2aee3c2300a22af82929f23a12"
+      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+    }
+  },
+  {
+    "id": "frag_tm_fidelity_gate_h321",
+    "mechanism": "build_frags refuses a corrupt/blanked frag_prov (frag_senses_sane) instead of first-seen-wins caching it, load_frag_tm applies the same fidelity filter at serve, and a later GOOD harvest of an fsha whose only cached rows are corrupt can override them",
+    "files": [
+      "src/pilot/translation_memory.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H321 (code review 2026-07-04 item #3b): the fragment sidecar is content-addressed on the fragment SOURCE and was harvested append-only first-seen-wins with NO fidelity check, so a hand-edited/corrupt wf_output*.json (blanked or malformed senses) permanently poisoned reuse and a later good harvest of the same fsha could never override it. frag_senses_sane(senses, lang) keys on the CARD-shaped translation field ('russian'/'english') and is applied at BOTH harvest (never cache garbage; a cached-corrupt fsha maps to False so a good row overrides it) and serve (load_frag_tm drops any corrupt historical row). Entirely lang-agnostic — lang is a first-class parameter of frag_address/frag_senses_sane/load_frag_tm/build_frags, no RU/EN branch. Pinned by test_frag_tm_fidelity_gate_and_override. Extends translation_memory_card_and_fragment.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/translation_memory.py": "38c404a4d88c4ea0d34617721edc6725423c70250b49e91b40d93008cdcbdfba",
+      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+    }
+  },
+  {
+    "id": "corpus_gate_evidence_markers_fl7_h321",
+    "mechanism": "corpus_gate.build_card marks evidence_status (evidence_unavailable when NO independent Sanskrit-Russian authority is loaded) and corpus_status (db_absent / db_error / skipped_short_term / ok), so a missing source or a DB failure is no longer indistinguishable from a genuinely uncovered headword degrading silently to the LLM verdict",
+    "files": [
+      "src/corpus_gate.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru"
+    ],
+    "verdict": "INTENTIONAL-DIVERGENCE",
+    "note": "H321 (architecture audit FL7 / code review 2026-07-04 item #4). corpus_gate.py is the RU-only stage-4 correctness gate: it joins a PWG headword to the independent Sanskrit->RUSSIAN dictionaries (Кочергина/Кнауэр/Фриш/Смирнов/Коссович) and the SamudraManthanam RU-aligned verse corpus. The EN pilot has no analogous corpus gate (no Sanskrit-English authority set is wired here), so this fix is inherently Russian-only — an INTENTIONAL-DIVERGENCE, not a GAP to port. The marker mechanism (SOURCES_PRESENT / evidence_status() / corpus_examples_with_status) would generalize if an EN correctness gate is ever built; revisit then. Pinned by test_corpus_gate_evidence_and_db_markers.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/corpus_gate.py": "2257f04cdca96b2aea51cd6d097358c43109977e1847d39ff59476cc5cf50863",
+      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+    }
+  },
+  {
+    "id": "ls_resolver_rv_av_anchor_h321",
+    "mechanism": "ls_resolver Ṛgveda/Atharva hymn-URL disambiguation is anchored on the leading citation abbreviation (_is_rv_prefix: startswith ṛv/rv) instead of a bare substring containment that mis-routed any citation merely containing rv/ṛ (parv., gṛ., kṛ.) to the RV scans; the two pattern-engine swallowed-exception sites now surface via _warn_swallowed",
+    "files": [
+      "src/ls_resolver.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H321 (code review 2026-07-04 item #5). ls_resolver resolves an <ls> citation to a scan/hymns URL independent of the translation language (it keys on the citation abbreviation + numbers, never on RU/EN prose), so both language editions' link-targets share it. The anchored _is_rv_prefix and the _warn_swallowed exception surfacing are pure link-resolution correctness, no lang branch. Pinned by test_ls_resolver_rv_av_anchored.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
+      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
     }
   }
 ]

--- a/RussianTranslation/src/corpus_gate.py
+++ b/RussianTranslation/src/corpus_gate.py
@@ -110,12 +110,32 @@ def slp1_to_ascii(s):
     return ''.join(c for c in nfd if not unicodedata.combining(c)).lower()
 
 # ---- dictionary index ----------------------------------------------------
+# Which correctness-authority source files were present at the last load_index().
+# FL7 (architecture audit 2026-07-02 / code review 2026-07-04): an absent evidence
+# jsonl was silently skipped, so "no independent gloss" could mean EITHER "sources
+# not built" OR "this headword is genuinely uncovered" — indistinguishable. This
+# set lets build_card mark evidence_unavailable explicitly instead of degrading
+# to an unmarked LLM-verdict.
+SOURCES_PRESENT = set()
+
+
+def evidence_status():
+    """'ok' if >=1 independent correctness authority (INDEP) is loaded; else
+    'evidence_unavailable' — meaning a 'no independent gloss' precheck reflects
+    MISSING SOURCES, not an uncovered headword. Fail loud rather than silently
+    degrade to the LLM verdict as if the evidence had been consulted and found
+    nothing."""
+    return 'ok' if any(c in SOURCES_PRESENT for c in INDEP) else 'evidence_unavailable'
+
+
 def load_index():
     idx = defaultdict(lambda: defaultdict(list))
+    SOURCES_PRESENT.clear()
     for code in INDEP + [REF]:
         path = os.path.join(HERE, code + '.jsonl')
         if not os.path.exists(path):
             continue
+        SOURCES_PRESENT.add(code)
         with open(path, encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
@@ -279,12 +299,20 @@ def close_corpus_connection():
 atexit.register(close_corpus_connection)
 
 
-def corpus_examples(slp1, limit=3):
+def corpus_examples_with_status(slp1, limit=3):
+    """Query aligned corpus verses, returning (examples, status). status is one of:
+      'ok'                — the query RAN; [] then genuinely means no aligned verse
+      'db_absent'         — the corpus DB file isn't present (evidence not available)
+      'db_error'          — the DB is present but the query raised (evidence NOT
+                            confirmed empty — a failure, not an absence of matches)
+      'skipped_short_term'— the search term was <2 chars, deliberately not queried
+    FL7: before this, every one of these returned a bare [] indistinguishable from
+    'no matches', so a build/query failure silently read as 'word uncovered'."""
     if not os.path.exists(CORPUS_DB):
-        return []
+        return [], 'db_absent'
     term = slp1_to_ascii(slp1)
     if len(term) < 2:
-        return []
+        return [], 'skipped_short_term'
     out = []
     try:
         con = corpus_connection()
@@ -308,8 +336,14 @@ def corpus_examples(slp1, limit=3):
                 if len(out) >= limit:
                     break
     except Exception as ex:
-        sys.stderr.write('corpus query skipped: %s\n' % ex)
-    return out
+        sys.stderr.write('corpus query FAILED (evidence NOT confirmed empty): %s\n' % ex)
+        return out, 'db_error'
+    return out, 'ok'
+
+
+def corpus_examples(slp1, limit=3):
+    """Back-compatible list-only wrapper (see corpus_examples_with_status)."""
+    return corpus_examples_with_status(slp1, limit)[0]
 
 # ---- heuristic correctness pre-check (LLM is the real verdict) -----------
 _RU_END = re.compile(r'(ого|ому|ыми|ами|ого|ая|ое|ые|ый|ий|ом|ой|ах|ам|ов|у|ю|и|ы|а|я|о|е|ь|й|х|м)$')
@@ -359,14 +393,20 @@ def deterministic_precheck(pwg_ru, indep):
 
 def build_card(idx, key1, key2, pwg_ru):
     indep, kow = lookup(idx, key1, key2)
+    corpus_ex, corpus_stat = corpus_examples_with_status(key1)
     return {'key1': key1, 'key2': key2 or key1, 'pwg_ru': pwg_ru,
             'independent_glosses': [{'source': g['source'], 'code': g['code'],
                                      'gloss': g['gloss']} for g in indep],
             'kow_reference': kow,
             'specialist_glosses': lookup_specialist(key1, key2),  # text-specific name glossaries, evidence-only
             'deterministic_precheck': deterministic_precheck(pwg_ru, indep),
+            # FL7 markers: distinguish "evidence not built/available" from
+            # "consulted and empty" so the LLM verdict prompt never mistakes a
+            # missing source for an uncovered headword.
+            'evidence_status': evidence_status(),
             'hindi_sense': lookup_sense(key1, key2),   # soft sense signal, not correctness
-            'corpus_examples': corpus_examples(key1),
+            'corpus_examples': corpus_ex,
+            'corpus_status': corpus_stat,
             'latin_binomials': lookup_binomials(key1, key2),   # Meulenbeld/SNP, botanical
             'skd_vcp_synonyms': lookup_synonyms(key1, key2)}   # Sanskrit kosha synonyms
 

--- a/RussianTranslation/src/ls_resolver.py
+++ b/RussianTranslation/src/ls_resolver.py
@@ -15,6 +15,33 @@ where `key` is computed internally via extractFirstKey (as the Dart caller does)
 import re
 import sys
 
+# Swallowed-exception surface. The two pattern-engine try/except blocks below
+# used to `except Exception: pass` — a malformed regex/template silently
+# produced a dead link with no trace. Route them through here instead so a
+# resolver failure is at least visible on stderr (the caller's control flow —
+# fall through to the next pattern / return '' — is unchanged; this only makes
+# the failure observable). Set LS_RESOLVER_QUIET=1 to silence in bulk runs.
+import os as _os
+
+
+def _warn_swallowed(where, exc, data1):
+    if _os.environ.get('LS_RESOLVER_QUIET'):
+        return
+    sys.stderr.write('ls_resolver: %s swallowed %s: %s (data1=%r)\n'
+                     % (where, type(exc).__name__, exc, data1))
+
+
+def _is_rv_prefix(key):
+    """True iff the leading citation abbreviation is the Ṛgveda (ṚV/RV), so a
+    rvAvHymnUrl citation routes to rv-, else av-. ANCHORED on the abbreviation
+    prefix (startswith), NOT a bare containment test: matching the rv/ṛ
+    characters anywhere mis-routed any citation that merely CONTAINS them
+    (parv., gṛ., kṛ., …) to Ṛgveda. AV and everything else fall through to the
+    av default."""
+    kl = (key or '').lower()
+    return kl.startswith('ṛv') or kl.startswith('rv')
+
+
 # ---------------------------------------------------------------------------
 # Roman numeral helpers  (LsService.romanInt / romanInt20)
 # ---------------------------------------------------------------------------
@@ -962,8 +989,8 @@ def _evaluate_conditional(expr: str, match):
             for i in range(1, match.re.groups + 1):
                 result_url = result_url.replace('$' + str(i), match.group(i) or '')
             return result_url
-    except Exception:
-        pass
+    except Exception as exc:
+        _warn_swallowed('_evaluate_conditional', exc, expr)
     return ''
 
 
@@ -992,16 +1019,10 @@ def _generate_href_from_patterns(dict_code: str, data1: str):
 
                 # Special URL generators reachable from pwg list.
                 if url == 'rvAvHymnUrl':
-                    key = extract_first_key(data1)
-                    kl = (key or '').lower()
-                    is_rv = ('rv' in kl) or ('ṛ' in kl) or kl.startswith('ṛ')
-                    pfx = 'rv' if is_rv else 'av'
+                    pfx = 'rv' if _is_rv_prefix(extract_first_key(data1)) else 'av'
                     return href_rv_av(pfx, data1, dict_code)
                 elif url == 'rvAvHymnUrl2':
-                    key = extract_first_key(data1)
-                    kl = (key or '').lower()
-                    is_rv = ('rv' in kl) or ('ṛ' in kl) or kl.startswith('ṛ')
-                    pfx = 'rv' if is_rv else 'av'
+                    pfx = 'rv' if _is_rv_prefix(extract_first_key(data1)) else 'av'
                     return href_rv_av2(pfx, data1, dict_code)
                 elif url == 'ramayanaUrl':
                     return href_ramayana(data1, dict_code)
@@ -1043,8 +1064,8 @@ def _generate_href_from_patterns(dict_code: str, data1: str):
 
                 if url:
                     return url
-        except Exception:
-            pass
+        except Exception as exc:
+            _warn_swallowed('_generate_href_from_patterns', exc, data1)
     return None
 
 

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -276,6 +276,15 @@ def reconstruct_cards(store_path, lang):
             skipped['sha-disagreement'] += 1
             continue
         raw_sha = next(iter(shas))
+        # A card with ANY blank sense is NOT content-addressed into the exact TM.
+        # H321 (code review 2026-07-04 item #3a) proposed caching such cards
+        # "per-sense" to avoid re-translating a giant card that has one blank
+        # xref sense — but measured 0/2313 sub-cards in the live store carry a
+        # blank non-partial sense (zero incidence), and the change is unsafe:
+        # tm_card_sane refuses any card with a blank sense at SERVE, so caching
+        # it would either churn (cached-then-refused) or force serving an
+        # incomplete card as complete. Kept as-is deliberately; consistent with
+        # the serve-time guard and the audit completeness gates.
         if any(not (r.get(field) or '').strip() for r in rows):
             skipped['incomplete-%s' % lang] += 1
             continue
@@ -413,6 +422,31 @@ def frag_tm_path(lang, out=None):
     return out or os.path.join(HERE, 'translation_memory.frag.%s.jsonl' % lang)
 
 
+# frag_prov senses are CARD-shaped (harvested from wf_output cards), so the
+# translation lives under 'russian'/'english' — NOT the store column names in FIELD.
+_FRAG_TRANSLATION_FIELD = {'ru': 'russian', 'en': 'english'}
+
+
+def frag_senses_sane(senses, lang):
+    """A frag_prov `senses[]` is usable only if it is a non-empty list of sense
+    objects each carrying a non-empty translation in `lang`.
+
+    The fragment sidecar is content-addressed on the fragment SOURCE and was
+    previously harvested first-seen-wins with NO fidelity check (code review
+    2026-07-04): a hand-edited or corrupt `wf_output*.json` — blanked or
+    malformed senses — permanently poisoned fragment reuse, and a later good
+    harvest of the same fsha could never override it. This gate is applied at
+    BOTH harvest (never cache garbage; let a good row override a cached bad one)
+    and serve (never hand a corrupt historical row to the harness)."""
+    if not isinstance(senses, list) or not senses:
+        return False
+    field = _FRAG_TRANSLATION_FIELD.get(lang, 'russian')
+    for s in senses:
+        if not isinstance(s, dict) or not (s.get(field) or '').strip():
+            return False
+    return True
+
+
 def _normalize_frag_row(row):
     row = dict(row or {})
     row.setdefault('id', row.get('fsha'))
@@ -445,7 +479,10 @@ def load_frag_tm(lang, path=None, denylist=None):
             except json.JSONDecodeError:
                 continue
             fsha = row.get('fsha')
-            if fsha and fsha not in deny['frags'] and row.get('senses'):
+            # Serve-time fidelity filter: a corrupt/blanked historical row is
+            # never handed to the harness, regardless of when it was harvested.
+            if (fsha and fsha not in deny['frags']
+                    and frag_senses_sane(row.get('senses'), lang)):
                 by_fsha[fsha].append(_normalize_frag_row(row))
     for fsha, candidates in by_fsha.items():
         best = best_reusable(candidates)
@@ -459,9 +496,13 @@ def build_frags(glob_pattern, lang, out=None):
     append-only fragment sidecar. Idempotent: a fragment already present (by fsha) is never
     duplicated. Returns (path, added, total)."""
     path = frag_tm_path(lang, out)
-    seen = set(load_frag_tm(lang, path))
+    # seen[fsha] == True once a SANE row for that fsha is cached. A fsha whose only
+    # cached rows are corrupt maps to False, so a later good harvest can override it
+    # (previously first-seen-wins locked in the poisoned row). load_frag_tm already
+    # applies the serve-time fidelity filter, so its keys are exactly the sane fshas.
+    seen = {fsha: True for fsha in load_frag_tm(lang, path)}
     files = sorted(_glob.glob(os.path.join(REPO, glob_pattern)))
-    new_rows, added = [], 0
+    new_rows, added, refused = [], 0, 0
     for fp in files:
         try:
             with open(fp, encoding='utf-8') as f:
@@ -493,12 +534,23 @@ def build_frags(glob_pattern, lang, out=None):
                 continue
             for fpv in card.get('frag_prov') or []:
                 fsha, senses = fpv.get('fsha'), fpv.get('senses')
-                if not fsha or not senses or fsha in seen:
+                if not fsha or not senses:
+                    continue
+                if not frag_senses_sane(senses, lang):
+                    # Never cache a corrupt/blanked fragment (poison guard).
+                    refused += 1
+                    print('warning: refusing corrupt frag_prov %s (senses fail %s fidelity) in %s'
+                          % (fsha[:12], lang, os.path.basename(fp)), file=sys.stderr)
+                    continue
+                if seen.get(fsha):
+                    # A sane row is already cached — idempotent skip. (A previously
+                    # cached CORRUPT row maps to False here, so this good row falls
+                    # through and overrides it.)
                     continue
                 src_key = r.get('key')
                 raw_sha = ((input_hashes.get(src_key) or {}).get('raw_sha256')
                            if src_key else None)
-                seen.add(fsha)
+                seen[fsha] = True
                 added += 1
                 new_rows.append({
                     'schema': FRAG_SCHEMA, 'lang': lang, 'fsha': fsha,

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3202,6 +3202,124 @@ def test_subprocess_gate_calls_hardened():
                  % (os.path.basename(path), needle))
 
 
+def test_ls_resolver_rv_av_anchored():
+    """H321 item #5: Ṛgveda/Atharva disambiguation must be ANCHORED on the leading
+    citation abbreviation, not a bare `'rv' in kl or 'ṛ' in kl` substring that
+    mis-routes any citation merely CONTAINING those characters (parv., gṛ., kṛ.)
+    to the RV hymn URL."""
+    import ls_resolver as L
+    # RV-family abbreviations → rv; AV / everything else → av (default).
+    for key, want in [('ṚV.', True), ('RV.', True), ('ṛv.', True),
+                      ('AV.', False), ('Nir.', False),
+                      ('parv.', False), ('Gṛ.', False), ('kṛ.', False)]:
+        got = L._is_rv_prefix(key)
+        if got != want:
+            fail('_is_rv_prefix(%r) = %r, want %r (anchored, not substring)' % (key, got, want))
+    # The fragile substring form must be gone from the source.
+    src_txt = open(os.path.join(SRC, 'ls_resolver.py'), encoding='utf-8').read()
+    if "'rv' in kl" in src_txt or "'ṛ' in kl" in src_txt:
+        fail('ls_resolver still uses the substring RV/AV disambiguation')
+    # The two pattern-engine excepts must surface, not silently `pass`.
+    if src_txt.count('except Exception:\n            pass') or '_warn_swallowed' not in src_txt:
+        fail('ls_resolver pattern-engine excepts must surface via _warn_swallowed, not pass')
+    # Live resolution still correct for genuine RV/AV samhita citations.
+    if 'rvhymns' not in (L.generate_href('pwg', 'ṚV. ', '10,85,24') or ''):
+        fail('ṚV. citation must still resolve to the rv hymns URL')
+    if 'avhymns' not in (L.generate_href('pwg', 'AV. ', '11,4,26') or ''):
+        fail('AV. citation must still resolve to the av hymns URL')
+
+
+def test_frag_tm_fidelity_gate_and_override():
+    """H321 item #3b: build_frags must NOT harvest a corrupt/blanked frag_prov
+    (first-seen-wins previously let a hand-edited wf_output poison content-addressed
+    fragment reuse), load_frag_tm must not SERVE such a row, and a later good harvest
+    must be able to override a previously-cached corrupt row."""
+    import translation_memory as tm
+    # 1) frag_senses_sane: blank/malformed senses are rejected.
+    if tm.frag_senses_sane([{'tag': '1', 'russian': 'фу'}], 'ru') is not True:
+        fail('a sane ru fragment sense must pass frag_senses_sane')
+    if tm.frag_senses_sane([{'tag': '1', 'russian': '  '}], 'ru') is not False:
+        fail('a blank-translation fragment sense must fail frag_senses_sane')
+    if tm.frag_senses_sane([], 'ru') is not False:
+        fail('empty senses must fail frag_senses_sane')
+
+    d = tempfile.mkdtemp()
+    old_repo = tm.REPO
+    try:
+        tm.REPO = d
+        good_src = '=== h ===\n1) foo <ls>ṚV.</ls>'
+        bad_src = '=== h ===\n1) bar <ls>AV.</ls>'
+        good_fsha = tm.frag_address('ru', good_src)
+        bad_fsha = tm.frag_address('ru', bad_src)
+        good_senses = [{'tag': '1', 'german': 'foo', 'russian': 'фу'}]
+        blank_senses = [{'tag': '1', 'german': 'bar', 'russian': ''}]
+        wf = {'meta': {'lang': 'ru', 'root': 'zz'}, 'results': [
+            {'key': 'zz~~h0', 'card': {'key1': 'zz', 'records': [{'senses': good_senses}],
+                                       'frag_prov': [{'fsha': good_fsha, 'senses': good_senses},
+                                                     {'fsha': bad_fsha, 'senses': blank_senses}]}}]}
+        with open(os.path.join(d, 'wf_output.sc.zz.json'), 'w', encoding='utf-8') as f:
+            json.dump(wf, f, ensure_ascii=False)
+        sidecar = os.path.join(d, 'frag.ru.jsonl')
+        _p, added, _tot = tm.build_frags('wf_output.sc.*.json', 'ru', out=sidecar)
+        served = tm.load_frag_tm('ru', sidecar)
+        if good_fsha not in served:
+            fail('a sane fragment must be harvested and served')
+        if bad_fsha in served:
+            fail('a corrupt (blank-sense) fragment must NOT be harvested/served')
+
+        # 2) Later-good override: pre-seed a CORRUPT row for an fsha, then harvest a
+        # good one for the same fsha — the good row must win at serve.
+        d2 = tempfile.mkdtemp()
+        try:
+            tm.REPO = d2
+            sidecar2 = os.path.join(d2, 'frag.ru.jsonl')
+            with open(sidecar2, 'w', encoding='utf-8') as f:
+                f.write(json.dumps({'schema': tm.FRAG_SCHEMA, 'lang': 'ru', 'fsha': good_fsha,
+                                    'senses': [{'tag': '1', 'russian': ''}],  # corrupt
+                                    'trust_level': tm.TRUST_MACHINE,
+                                    'harvested_at': '2026-01-01T00:00:00Z'}, ensure_ascii=False) + '\n')
+            if tm.load_frag_tm('ru', sidecar2):
+                fail('serve-time filter must drop a corrupt historical row (empty served map)')
+            with open(os.path.join(d2, 'wf_output.sc.zz.json'), 'w', encoding='utf-8') as f:
+                json.dump(wf, f, ensure_ascii=False)
+            tm.build_frags('wf_output.sc.*.json', 'ru', out=sidecar2)
+            served2 = tm.load_frag_tm('ru', sidecar2)
+            if good_fsha not in served2:
+                fail('a later GOOD harvest must override a previously-cached corrupt row')
+        finally:
+            shutil.rmtree(d2, ignore_errors=True)
+    finally:
+        tm.REPO = old_repo
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_corpus_gate_evidence_and_db_markers():
+    """H321 item #4 (FL7): corpus_gate must distinguish 'evidence not built/available'
+    from 'consulted and empty' — an absent evidence source or a DB failure previously
+    degraded to a bare [] indistinguishable from a genuinely uncovered headword."""
+    import corpus_gate as cg
+    saved_db = cg.CORPUS_DB
+    saved_present = set(cg.SOURCES_PRESENT)
+    try:
+        cg.SOURCES_PRESENT.clear()
+        cg.CORPUS_DB = os.path.join(tempfile.gettempdir(), 'zz_no_such_corpus.db')
+        if cg.evidence_status() != 'evidence_unavailable':
+            fail('no INDEP source loaded must report evidence_unavailable, not ok')
+        ex, st = cg.corpus_examples_with_status('agni')
+        if ex != [] or st != 'db_absent':
+            fail('absent DB must yield ([], "db_absent"), got (%r, %r)' % (ex, st))
+        card = cg.build_card({}, 'agni', None, 'огонь')
+        if card.get('evidence_status') != 'evidence_unavailable' or card.get('corpus_status') != 'db_absent':
+            fail('build_card must surface evidence_status + corpus_status markers')
+        # back-compat: corpus_examples still returns a bare list.
+        if cg.corpus_examples('agni') != []:
+            fail('corpus_examples must stay a list-returning wrapper')
+    finally:
+        cg.CORPUS_DB = saved_db
+        cg.SOURCES_PRESENT.clear()
+        cg.SOURCES_PRESENT.update(saved_present)
+
+
 def main():
     tests = [
         test_translation_memory_addressing,
@@ -3298,6 +3416,9 @@ def main():
         test_pwg_mask_bom_source_keeps_first_record,
         test_pwg_mask_truncated_final_record_not_silent,
         test_subprocess_gate_calls_hardened,
+        test_ls_resolver_rv_av_anchored,
+        test_frag_tm_fidelity_gate_and_override,
+        test_corpus_gate_evidence_and_db_markers,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
Executes [H321](https://github.com/gasyoun/Uprava/blob/main/handoffs/H321-Opus_RussianTranslation_pwg-ru-correctness-backlog_07.07.26.md) — the deliberately-unfixed 🔴/🟡 items from [CODE_REVIEW_2026-07-04.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/CODE_REVIEW_2026-07-04.md) and [ARCHITECTURE_AUDIT_2026-07-02.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) (FL7). Model: Opus 4.8 (`claude-opus-4-8`). Isolated worktree off `origin/master`. Each fix lands behind a `window_selftest.py` pin + a [LANG_PARITY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md) ledger entry.

## Already fixed on master (verified this pass, no change)
- **🔴 Positional card misassignment** — `resolveGroup` matches on `byKey1` only (`missing-or-mismatched-key` on miss, never positional); `healGroup`'s `exactCard` positional fallback requires the candidate to echo the exact key. Pin `test_generated_harness_strict_key_matching`.
- **🔴 `tm_card_sane` zero-`<ls>` bypass** — fixed in [#175](https://github.com/gasyoun/SanskritLexicography/pull/175) (unconditional source-count compare). Pin `test_tm_card_sane_rejects_zero_marker_drift`.
- **🟡 Partial card as exact hit** — `reconstruct_cards` already excludes `partial_card`/`missing_fragments`/`missing_groups`.

## Fixed this pass
- **🟡 `frag_prov` first-seen, no fidelity** ([translation_memory.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/translation_memory.py)) — new `frag_senses_sane()` gates **harvest** (`build_frags` refuses a corrupt/blanked `wf_output`; a cached-corrupt fsha can be overridden by a later good harvest) **and serve** (`load_frag_tm` drops any corrupt historical row). Pin `test_frag_tm_fidelity_gate_and_override`; ledger `frag_tm_fidelity_gate_h321` (SHARED).
- **🟡 FL7 corpus-gate silent evidence degradation** ([corpus_gate.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/corpus_gate.py)) — `build_card` marks `evidence_status` (`evidence_unavailable` when no independent Sanskrit-Russian authority is loaded) + `corpus_status` (`db_absent`/`db_error`/`skipped_short_term`/`ok`), so a missing source or DB failure is no longer indistinguishable from an uncovered headword. Pin `test_corpus_gate_evidence_and_db_markers`; ledger `corpus_gate_evidence_markers_fl7_h321` (INTENTIONAL-DIVERGENCE — RU-only gate).
- **🟡 `ls_resolver` RV/AV substring + bare `except: pass`** ([ls_resolver.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ls_resolver.py)) — anchored `_is_rv_prefix` (startswith `ṛv`/`rv`) instead of a substring that mis-routed `parv.`/`gṛ.`/`kṛ.` to the RV scans; both pattern-engine swallowed excepts surface via `_warn_swallowed`. Pin `test_ls_resolver_rv_av_anchored`; ledger `ls_resolver_rv_av_anchor_h321` (SHARED).

## Deliberate NO-CHANGE (measured)
- **🟡 Whole card dropped on one blank sense** — measured **0/2313** sub-cards in the live 11,261-row store carry a blank non-partial sense (zero incidence). Caching one is also unsafe: `tm_card_sane` refuses any blank-sense card at serve, so it would churn or force serving incomplete output. Kept as-is; recorded in a code comment + the CODE_REVIEW resolution table.

## Verification
- `python src/pilot/window_selftest.py` → **97 pass, 0 fail** (run with the gitignored runtime data — store + input rootmaps + opt2 harness — staged into the worktree).
- `python src/pilot/lang_parity_check.py` → **26 entries, all verdicts complete, no drift** (10 pre-existing entries re-affirmed after adding 3 tests; 3 new entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)