### PR TITLE
ci(pwg_ru): gate the LOD-graph acceptance in RussianTranslation gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,14 @@ jobs:
             RussianTranslation/src/make_edition_cut.py \
             RussianTranslation/src/validate_release.py \
             RussianTranslation/src/release_readiness.py \
-            RussianTranslation/src/preflight_remaining_gates.py
+            RussianTranslation/src/preflight_remaining_gates.py \
+            RussianTranslation/src/export_lod.py \
+            RussianTranslation/src/lod_acceptance.py
+      - name: LOD graph acceptance (fixture-only, H350/E7)
+        working-directory: RussianTranslation
+        run: |
+          pip install rdflib pyshacl
+          python src/lod_acceptance.py --cards /nonexistent
       - name: Validate roadmap
         working-directory: RussianTranslation
         run: python src/roadmap_check.py


### PR DESCRIPTION
Follow-up to [#234](https://github.com/gasyoun/SanskritLexicography/pull/234) (H350/E7): wire the LOD-graph acceptance into CI. The RussianTranslation gates job now `py_compile`s [`src/export_lod.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/export_lod.py) + [`src/lod_acceptance.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/lod_acceptance.py) and runs the **fixture-only** acceptance (federated SPARQL join + RDF round-trip isomorphism + SHACL conformance) as a gate — so the graph model can't regress silently. Fixture-only mode needs no gitignored source. Model: Opus 4.8 (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)