### PR TITLE
H356: seven epistemic sibling registries (Sanskrit-data side)

### DIFF
--- a/ASSUMPTIONS.md
+++ b/ASSUMPTIONS.md
@@ -1,0 +1,62 @@
+# ASSUMPTIONS — unverified premises the Sanskrit-data pipelines rely on
+
+_Created: 08-07-2026 · Last updated: 08-07-2026_
+
+**Epistemic sibling of [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).** FINDINGS holds *measured, past-tense* facts. This file holds the act FINDINGS structurally cannot: **relying** on an unproven premise. An assumption is *depended-upon but unverified* — the moment its **Test** passes, it **graduates** to a FINDINGS row (delete it here, cite the finding there). One of the seven epistemic registries minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md). Its infra twin is [`Uprava/ASSUMPTIONS.md`](https://github.com/gasyoun/Uprava/blob/main/ASSUMPTIONS.md).
+
+**How to read a row.** Every row opens with two glyphs:
+
+- **Importance dot** (identical scale to FINDINGS): 🔴 3 high · 🟠 2 medium · 🟡 1 minor — here the dot rates **blast radius**: 🔴 many downstream datasets/layers cascade if the premise is false · 🟠 one pipeline · 🟡 local.
+- **Origin marker:** ⚙️ auto (a script emitted this candidate — a *candidate* until a human confirms) · ✍️ human (a session wrote it from judgment).
+
+Then the premise as a claim, `Relied on by:`, `Verified?:` (❌ never · ⚠️ spot-checked once · ✅ → graduate to FINDINGS), `Test to confirm:`, and a `> **Source:**` line.
+
+**Auto-seed:** [`scan_assumptions.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/scan_assumptions.py) greps the code spine for `# ASSUMES:` / `# INVARIANT:` tag comments and bare `assert` premises in dataset builders, prefilling `Relied on by` from the enclosing script. Candidates arrive as ⚙️ rows; a human promotes or deletes them.
+
+---
+
+### §1. DCS lemma == CDSL headword
+🔴 ✍️ **Any join that treats a DCS corpus lemma as if it has a matching CDSL dictionary headword.**
+Relied on by: `dcs_cdsl_xref.tsv` (kosha manifest `dcs-cdsl-xref`), `build_xref.py`, the kosha frequency LEFT-JOIN, Sa→Ru glossary form→lemma resolution.
+Verified?: ⚠️ spot-checked once (11-06-2026, n=15,902 lemmas) — 81.4% link, 18.6% (2,956 lemmas) have NO CDSL headword.
+Test to confirm: recount linked/total in [`dcs_cdsl_xref.tsv`](https://github.com/sanskrit-lexicon/csl-apidev/blob/master/simple-search/dcs_xref/dcs_cdsl_xref.tsv); any pipeline assuming 100% coverage silently drops ~1/5 of corpus vocabulary.
+> **Source:** [FINDINGS §12](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword) · csl-apidev · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §2. One transliteration scheme keys all DCS files
+🔴 ✍️ **A frequency/lemma join can assume a single transliteration across the DCS-derived files.**
+Relied on by: `freq_route.py`, any join between `VisualDCS/dcs_lemma_summary.json` (SLP1) and `RussianTranslation/src/dcs_lemma_renou.json` (IAST).
+Verified?: ⚠️ spot-checked once (24-06-2026) — the two files are keyed in DIFFERENT schemes (SLP1 vs IAST).
+Test to confirm: diff a sample of keys across both files; a raw string join misses every non-ASCII-coincident lemma unless one side is transcoded via `sanskrit-util`.
+> **Source:** [FINDINGS §7](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations) · VisualDCS/RussianTranslation · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §3. A dict's giant verb root lives at homonym index 0
+🔴 ✍️ **A per-record split can read `bufs[0]` and assume the first homonym record holds the verb root.**
+Relied on by: `gen_root_split()`, any PWG root-portrait/segmentation walk over homonym records.
+Verified?: ⚠️ spot-checked once (24-06-2026, top-50 freq roots) — 19 of 50 have a giant homonym at index > 0 (√i at 2, √mā at 2, √as at 1).
+Test to confirm: re-run [`audit_root_split.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/audit_root_split.py); iterate ALL homonym records, never `bufs[0]`.
+> **Source:** [FINDINGS §16](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes) · csl-orig (pwg)/RussianTranslation · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §4. A worklist built by iterating PWG keys covers the local layer universe
+🔴 ✍️ **Enumerating "headwords" by walking PWG records reaches the whole pwg_ru merge universe.**
+Relied on by: the verb-root worklist (`verbs01`/PWG), any pwg_ru queue builder.
+Verified?: ⚠️ spot-checked once (05-07-2026, n=167,988 headwords) — ≈35,900 headwords (≈36%) carry ZERO PWG record; PW-only alone = 40,338 (24%).
+Test to confirm: re-run the `dict_merge.py` index tally in [`PWG_LAYER_COMBINATIONS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/PWG_LAYER_COMBINATIONS.md); PW/SCH/PWKVN-only entries need their own queue path.
+> **Source:** [FINDINGS §64](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1-pwg-is-not-the-sole-spine-of-the-local-layer-universe) · SanskritLexicography · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §5. A shared markup tag means the same thing across dicts
+🟠 ✍️ **The same `<ab>` / marker tag carries one meaning that can be counted dict-agnostically.**
+Relied on by: any cross-dict tag-count survey (etymology detectors, `<ls>` density rankers, marker-based structure detectors).
+Verified?: ⚠️ spot-checked once (26-06-2026) — `<ab>E.</ab>` = Etymology in WIL but "Epithet of" in CAE, "Epic" in MD; SKD/VCP score 0 on Western markers by construction, not for lack of content.
+Test to confirm: read entry contexts per dict before parsing; count the meaning, not the marker.
+> **Source:** [FINDINGS §34](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#34-the-e-abbreviation-tag-is-polysemous-across-dicts) + [§19](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#19-skd-and-vcp-carry-essentially-zero-western-markup) · csl-orig · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §6. A verified correction queue stays valid until filed
+🟠 ✍️ **A triaged correction stays applicable against live csl-orig between triage and filing.**
+Relied on by: the monthly csl-orig batch PR, the SanskritSpellCheck FILE-FIRST queue.
+Verified?: ⚠️ spot-checked once (02-07-2026, n=122) — ≈0.8%/week decay; 1 candidate already fixed upstream within ~1 week.
+Test to confirm: re-verify every row against current `csl-orig` immediately before filing; a stale row reads as bot noise.
+> **Source:** [FINDINGS §25](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#25-a-verified-correction-queue-decays-against-live-csl-orig) · SanskritSpellCheck · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+---
+
+_Dr. Mārcis Gasūns_

--- a/CONTRADICTIONS.md
+++ b/CONTRADICTIONS.md
@@ -1,0 +1,76 @@
+# CONTRADICTIONS — Sanskrit-data source disagreements with no verdict
+
+_Created: 08-07-2026 · Last updated: 08-07-2026_
+
+**Epistemic sibling of [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).** FINDINGS states *one* fact. This file holds the act FINDINGS cannot: **disagreeing** — ≥2 sources give incompatible values and no ruling has been made. The moment a contradiction is ruled, it **graduates** to a [`CROSS_REPO_DECISIONS`](https://github.com/gasyoun/csl-observatory/blob/main/docs/CROSS_REPO_DECISIONS.md) `D##` (leave a one-line "→ D##, resolved" tombstone here). One of the seven epistemic registries minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md). Its infra twin is [`Uprava/CONTRADICTIONS.md`](https://github.com/gasyoun/Uprava/blob/main/CONTRADICTIONS.md).
+
+**How to read a row.** Every row opens with two glyphs:
+
+- **Importance dot** (identical scale to FINDINGS): 🔴 3 high · 🟠 2 medium · 🟡 1 minor — here the dot rates the **impact of leaving it unresolved**.
+- **Origin marker:** ⚙️ auto (a crosswalk-mismatch script emitted this candidate) · ✍️ human (a session flagged it).
+
+Then a `Positions:` table (source · value · evidence loc), a `Status:` line (🔴 unresolved · 🟡 provisional pick · ✅ → `D##`), a `Blocks:` line, and a `> **Source:**` line.
+
+**Auto-seed:** [`seed_contradictions.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/seed_contradictions.py) runs over existing crosswalks (`mw_roots`, `union_headwords`, DCS↔Whitney) — rows where two datasets keyed on the same `form_key()` carry different values become ⚙️ candidate contradictions.
+
+---
+
+### §1. Derivative ī/ū-stem gen.pl accent (Whitney, internal)
+🟠 ✍️ **Whitney's Grammar gives three incompatible answers for the same cell.**
+Positions:
+| Source | Value | Evidence loc |
+|--------|-------|--------------|
+| Whitney §320 | tone NOT thrown forward onto ending | [FINDINGS §42](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#42-whitney-self-contradicts-on-derivative-ī-stem-genpl-accent) |
+| Whitney §319a (RV) | "usually" shifts (`bahvīnā́m`) | same |
+| Whitney §356 (own paradigm) | prints `rathī́nām, nadī́nām` (no shift) | same |
+Status: 🟡 provisional pick — encode as a per-lemma variant, NOT a rule; §54 weakly favours `stem_final` but n=2.
+Blocks: the D3 genitive-plural cell of the ZALIZNYAK_INDEX a–f accent emission.
+> **Source:** [FINDINGS §42](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#42-whitney-self-contradicts-on-derivative-ī-stem-genpl-accent) + [§54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) · WhitneyRoots · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §2. Varga-diachrony: 2014 dissertation prose vs its own χ² table
+🟠 ✍️ **The 2014 Gasūns dissertation prose labels as "gaining popularity" exactly the vargas its own χ² p-table shows as statistically unchanged.**
+Positions:
+| Source | Value | Evidence loc |
+|--------|-------|--------------|
+| Gasūns-2014 prose (§2.6/П9) | labials/cerebrals/palatals "gaining" | [FINDINGS §62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) |
+| 2026 recompute (Cramér's V = 0.037) | those vargas near-stable; high p misread as growth | [varna_freq.csv](https://github.com/gasyoun/VisualDCS/blob/main/derived-data/Fonetika/regen-2026/varna_freq.csv) |
+Status: 🟡 provisional pick — the 2026 shares + p-table AGREE against the 2014 prose; the prose is the error.
+Blocks: the GasunsDhatu 2026 §2.6 Table 5 / П9 correction (manifest `varga-series-diachrony`).
+> **Source:** [FINDINGS §62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) · SanskritGrammar/VisualDCS · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §3. Krylov's 2014 Palsule-exclusion charge vs vidyut dhātupāṭha
+🟠 ✍️ **The 2014 defense review charged the concordance keeps Palsule-only roots and drops Paninian ones; the machine dhātupāṭha only partly agrees.**
+Positions:
+| Source | Value | Evidence loc |
+|--------|-------|--------------|
+| Krylov 2014 review | `ast` is a Palsule-only intruder; `4añc` wrongly dropped | [FINDINGS §63](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian) |
+| vidyut dhātupāṭha (2,259 dhātu) | `asta~` (10.0169) IS Paninian; `4añc` real+recoverable; no `and-` dhātu | [PALSULE_AUDIT.md](https://github.com/gasyoun/SanskritGrammar/blob/chore/errata-kochergina-waiting/GasunsDhatu_2014/revision-2026/PALSULE_AUDIT.md) |
+Status: 🟡 provisional pick — vidyut adjudicates: Krylov right on `4añc`/`2and`, wrong on `ast`.
+Blocks: the GasunsDhatu 2014 revision's response to the ведущая организация review.
+> **Source:** [FINDINGS §63](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian) · SanskritGrammar · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §4. SKD/VCP citation-fusion direction: one-lemma exemplar vs corpus count
+🟠 ✍️ **The hand-picked *dharma* exemplar's fusion direction reverses at corpus scale.**
+Positions:
+| Source | Value | Evidence loc |
+|--------|-------|--------------|
+| *dharma* exemplar | SKD fuses citation into synonym-run; VCP keeps separate | [FINDINGS §43](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#43-skdvcp-sensecitation-fusion-is-a-record-type-effect-not-a-dictionary-level-one) |
+| Full-corpus classifier | SKD 53.3%/46.7% even; VCP skews TOWARD fusion 77.6% | [r2_kosa_fusion.json](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/lexico/r2_kosa_fusion.json) |
+Status: 🟡 provisional pick — a record-type/genre effect, not a per-dictionary convention; the corpus count wins.
+Blocks: any "dictionary X marks citations this way" generalization from a single lemma.
+> **Source:** [FINDINGS §43](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#43-skdvcp-sensecitation-fusion-is-a-record-type-effect-not-a-dictionary-level-one) · csl-atlas · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §5. Sense-granularity: two runs disagree on the year-correlation
+🟠 ✍️ **Two runs disagree on the sense-count↔year correlation, and both refute the intuitive "senses grow over time" reading.**
+Positions:
+| Source | Value | Evidence loc |
+|--------|-------|--------------|
+| paper canonical run | r = 0.036 over 1822–1957; family means 1.0–2.4 | [FINDINGS §27](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#27-sense-granularity-is-a-family-trait-not-a-diachronic-trend) |
+| earlier `docs/R2_FINDINGS.md` run | r = 0.06, Benfey 2.53 | same |
+Status: 🟡 provisional pick — the paper's numbers are canonical; either way the trend is flat and school-bound.
+Blocks: any per-sense-normalized cross-dict metric that doesn't family-control.
+> **Source:** [FINDINGS §27](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#27-sense-granularity-is-a-family-trait-not-a-diachronic-trend) · csl-atlas · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+---
+
+_Dr. Mārcis Gasūns_

--- a/DEAD_ENDS.md
+++ b/DEAD_ENDS.md
@@ -1,0 +1,62 @@
+# DEAD_ENDS — the Sanskrit-data negative-results graveyard
+
+_Created: 08-07-2026 · Last updated: 08-07-2026_
+
+**Epistemic sibling of [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).** FINDINGS is *confirmed-true*. This file holds the act FINDINGS cannot: **abandoning** an approach — a whole method that was tried and does not work, so the next session does not pay to rediscover the failure. Distinct from a single refuted hypothesis (that lives per-row in [`Uprava/QUESTIONS_LOG.md`](https://github.com/gasyoun/Uprava/blob/main/QUESTIONS_LOG.md)); a dead end is per-*approach*. One of the seven epistemic registries minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md). Its infra twin is [`Uprava/DEAD_ENDS.md`](https://github.com/gasyoun/Uprava/blob/main/DEAD_ENDS.md).
+
+**How to read a row.** Every row opens with two glyphs:
+
+- **Importance dot** (identical scale to FINDINGS): 🔴 3 high · 🟠 2 medium · 🟡 1 minor — here the dot rates the **cost of a naive re-attempt** (🔴 = expensive to rediscover that it fails).
+- **Origin marker:** ⚙️ auto (harvested from a QUESTIONS_LOG refuted row / reverted branch) · ✍️ human (a session wrote it).
+
+Then `Failed because:`, `Evidence:`, `Don't retry unless:`, and a `> **Source:**` line.
+
+**Auto-seed:** [`seed_dead_ends.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/seed_dead_ends.py) harvests [`QUESTIONS_LOG.md`](https://github.com/gasyoun/Uprava/blob/main/QUESTIONS_LOG.md) **refuted** rows, [`SERVER_OUTAGES.md`](https://github.com/gasyoun/Uprava/blob/main/SERVER_OUTAGES.md) **permanently-dead** hosts, and git-log reverted feature branches (merged-then-reverted) across repos.
+
+---
+
+### §1. Body-text / reverse-dict headword mining — abandoned
+🔴 ✍️ **Mining "hidden" headwords from dictionary bodies to grow the CDSL lemma vocabulary.**
+Failed because: 38.6% precision overall (bor 18%, bur 32% transcode-garbage, ae 34%, mw72 36%); `<k2>` is just `<k1>` re-encoded (the "+152k new lemmas" was a normalization artifact, ~0 real); big forward dicts already split compounds into their own `<L>` records.
+Evidence: adversarial classification, csl-atlas broad-headword review (15-06-2026); the measuring extractor `scripts/lib/dict-body-headwords.mjs` was deleted with the rejected experiment (numbers survive only in the review record).
+Don't retry unless: you have a fundamentally different signal — a corpus inflected-form→lemma index (DCS) or vidyut sandhi/compound splitting, which raises findability, not distinct-lemma count.
+> **Source:** [FINDINGS §30](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#30-body-text-headword-mining-is-a-dead-end-386-percent-precision) · csl-atlas · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §2. Corpus-derived present-class attribution — abandoned
+🔴 ✍️ **Deriving verb present-class (I vs VI, IV vs passive) from the DCS corpus.**
+Failed because: the corpus carries no pitch accent, and the class distinction rests on it — class I (`cárati`) and VI (`tudáti`) have identical surface stems where guṇa doesn't change the vowel.
+Evidence: a corpus-derived class pass produced 117 spurious I/VI additions — all reverted (120 unsound total vs 19 kept); WhitneyRoots CHANGELOG revert.
+Don't retry unless: you have a grammar / Zaliznyak cross-check for every corpus-derived class — never write one into reviewed data raw.
+> **Source:** [FINDINGS §8](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#8-unaccented-dcs-cannot-distinguish-present-class-i-from-vi) · WhitneyRoots · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §3. Sandhi-join lookup for prefixed-verb corpus evidence — abandoned
+🟠 ✍️ **Building a `upasarga+root` sandhi-join lookup to gain prefixed-verb corpus attestations.**
+Failed because: it's a no-op — the corpus lemmatizes prefixed verbs to the root or lacks them; the sandhi-join produces the SAME surface strings as a naïve concat, so spelling was never the limiter. Of √man's 15 prefixed forms only 3 appear in the corpus; ~80% miss.
+Evidence: `pwg_preverb1.txt` join measured in `subcard_portrait()` / FREQ_TEST_RUNBOOK.
+Don't retry unless: a different corpus that keeps prefixed surface forms is available; otherwise defer to the dictionary's own gloss for the ~80%.
+> **Source:** [FINDINGS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#5-the-parallel-corpus-rarely-attests-prefixed-verb-forms) · RussianTranslation · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §4. Bulk-respell of "typo" headword-correction lists — abandoned
+🔴 ✍️ **Applying a spell-check typo list as blind `<k1>` respells.**
+Failed because: ~9% of "typo" corrections are collisions — the "correct" spelling already exists as its own entry, so a respell creates a duplicate headword or clobbers apparatus rather than fixing anything.
+Evidence: source-verification of all 122 FILE-FIRST candidates vs csl-orig (02-07-2026) — YAT 5, MW 2, PWG 2, PW 1 dual-listings; `file_first_verified.tsv`.
+Don't retry unless: the filing offers a third editorial category (merge vs respell vs leave) and checks whether the "right" form already exists as its own entry first.
+> **Source:** [FINDINGS §24](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#24-about-9-percent-of-typo-corrections-are-collisions) · SanskritSpellCheck · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §5. NFD-decompose-then-strip-Mn as a Sanskrit normalization key — abandoned
+🔴 ✍️ **Using blanket NFD + strip-combining-marks to make an IAST comparison/join key.**
+Failed because: it destroys vowel length (`ā`→`a`) and retroflex dots (`ṣ`→`s`), and `ś` = `s`+U+0301 collides with the pitch-accent mark — lossy, manufactures false matches.
+Evidence: the `form_key` design note in sanskrit_util; the recurring failure mode behind poisoned siglum folds (§45: `samk` merges Śaṃk°+Sāṃk°).
+Don't retry unless: you use a length-preserving `form_key` (never blanket NFD+strip); for `<ls>` sigla, consult the curated alias table, never fold-key similarity.
+> **Source:** [FINDINGS §36](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily) + [§45](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#45-siglum-prefix-families-routinely-bundle-several-distinct-works-the-diacritic-stripping-fold-has-poisoned-keys) · sanskrit-util/csl-atlas · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §6. `OccId` / `sent_id` as a DCS primary key — abandoned
+🔴 ✍️ **Keying the DCS CoNLL-U import on `OccId` or `sent_id`.**
+Failed because: both are non-unique — `OccId` is reused across a line's sub-sentences (M5 lost ~20 tokens); `sent_id` collides within a chapter (M6 dropped 449 sentences) — silently, before the keys were replaced.
+Evidence: `DCS_CONLLU_IMPORT_PLAN.md` §M5–M6, `m5_validation.md`/`m6_validation.md`.
+Don't retry unless: never — use synthetic autoincrement surrogates or position-within-text; the stable cross-corpus key is `LemmaId`.
+> **Source:** [FINDINGS §9](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#9-dcs-occid-and-sent_id-are-not-unique-keys) · VisualDCS · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+---
+
+_Dr. Mārcis Gasūns_

--- a/GAPS.md
+++ b/GAPS.md
@@ -1,0 +1,62 @@
+# GAPS — the Sanskrit-data known-unknowns frontier
+
+_Created: 08-07-2026 · Last updated: 08-07-2026_
+
+**Epistemic sibling of [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).** FINDINGS is what is *known*. This file is its **negative space** — the act FINDINGS cannot hold: **not-yet-knowing**, the frontier of things we have explicitly NOT measured. The moment a gap is measured, it **graduates** to a FINDINGS row (delete it here, cite the finding there). One of the seven epistemic registries minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md). Its infra twin is [`Uprava/GAPS.md`](https://github.com/gasyoun/Uprava/blob/main/GAPS.md).
+
+**How to read a row.** Every row opens with two glyphs:
+
+- **Importance dot** (identical scale to FINDINGS): 🔴 3 high · 🟠 2 medium · 🟡 1 minor — here the dot rates the **value if measured** (what it would unblock).
+- **Origin marker:** ⚙️ auto (a set-difference script emitted this — a dataset with no FINDINGS row) · ✍️ human (a session flagged it).
+
+Then `Why it matters:`, `Blocker:`, `How to close:`, and a `> **Source:**` line.
+
+**Auto-seed:** [`seed_gaps.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/seed_gaps.py) does a set-difference — datasets present in [`FEATURES_INDEX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md) / [`kosha` manifest](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json) that have **no** FINDINGS row, plus the "per-layer statistics still to compute" backlog named in [`DATA_LAYERS_CENSUS.md`](https://github.com/gasyoun/Uprava/blob/main/DATA_LAYERS_CENSUS.md).
+
+---
+
+### §1. Derivative ī/ū gen.pl accent split (D3) — n=2, unresolvable
+🟡 ✍️ **We have NOT measured the empirical `-īnā́m` vs `-ī́nām` split at usable n.**
+Why it matters: it is the one unresolved cell blocking the ZALIZNYAK_INDEX a–f accent axis emission; would settle Whitney's own §319a/§356 contradiction ([CONTRADICTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md)).
+Blocker: needs a wider VedaWeb 2.0 pull — blocked mid-run by a `vedaweb.uni-koeln.de` outage; only n=2 attested forms (`raTI`, `vaDU`) so far.
+How to close: resume the VedaWeb export per [`SERVER_OUTAGES.md`](https://github.com/gasyoun/Uprava/blob/main/SERVER_OUTAGES.md), grow n, split by adjective (`bahvī́`) vs noun (`nadī́`) type.
+> **Source:** [FINDINGS §54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) · WhitneyRoots · 08-07-2026
+
+### §2. Error population of 40 of 43 dictionaries
+🟠 ✍️ **We have NOT estimated the error-prone-record population for 40 of 43 dicts.**
+Why it matters: correction-campaign planning currently assumes convergence; only PW (~14% done), MW (~10%), BUR are estimable — the other 40 have <10 two-era recaptures.
+Blocker: needs a corpus rerun / more overlapping corrections — Chapman mark–recapture requires ≥10 two-era recaptures per dict.
+How to close: accumulate a second correction era per dict, or use a different estimator; owner csl-observatory `error_recapture.md` (paper A48).
+> **Source:** [FINDINGS §46](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#46-twelve-years-of-corrections-cover-only-1014--of-the-estimated-error-population) · csl-observatory · 08-07-2026
+
+### §3. Heritage inflected-form morphology XML — never ingested
+🟠 ✍️ **We have NOT ingested Heritage's inflected-form morphology XML (1,286,615 forms / 32,837 stems).**
+Why it matters: would be a third morphology witness (3× kosha's vidyut-built 426,410 forms); unblocks Heritage roadmap Phase 4; `heritage_forms_oracle` is only a partial alignment without it.
+Blocker: data access — the XML is NOT in either git repo (GitHub mirror or INRIA GitLab); only downloadable behind the Anubis wall from `sanskrit.inria.fr/DATA/XML/{SL,WX}_morph.xml.gz` (v3.81).
+How to close: a human browser download of the two `.xml.gz` URLs (bookmarked in §51), then ingest; LGPLLR-vs-BY-SA composition @DECIDE first.
+> **Source:** [FINDINGS §47](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#47-heritage-data-is-acquirable-despite-the-anubis-wall--via-a-github-mirror-the-morphology-xml-is-not-in-it) + [§51](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#51-huet-correspondence-predates-this-session-2021--the-morphology-xml-gate-was-already-resolved-in-writing-direct-download-urls-recovered) · SanskritLexicography · 08-07-2026
+
+### §4. Homonym token frequency beyond the 26+5 splittable groups
+🟡 ✍️ **We have NOT attributed token frequency for the 33 of 38 DCS-lumped homonym groups that share a present class.**
+Why it matters: token-level "N in this sense · M for the lemma" displays are impossible for these without sense/gloss adjudication; it is the ceiling on per-sense frequency accuracy.
+Blocker: no tool — gaṇa is undistinguishing (unaccented corpus, §8); needs manual gloss adjudication (DCS `meanings` ↔ Warnemyr gloss).
+How to close: extend the coverage≥0.55 gloss-mapping approach in `crosswalk/token_attribution.json`; owner WhitneyRoots.
+> **Source:** [FINDINGS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling) · WhitneyRoots · 08-07-2026
+
+### §5. `Stopovye` parallel-passage bundle vs full export — never content-diffed
+🟡 ✍️ **We have NOT content-diffed the 1.17 GB `PARA/Stopovye` bundle against `dcs-parallel-passages-full` (506,787 rows).**
+Why it matters: it is the largest single derived-data bundle in VisualDCS; whether it is a stop-word-filtered variant or independent data determines if it is separately citable; its row count is still `null` (no schema-aware parse).
+Blocker: no tool — needs a schema-aware per-file alignment parse, not a line count.
+How to close: parse the per-passage CSV records, diff against the full-export sample; owner VisualDCS / manifest `stopovye-parallel-passages`.
+> **Source:** kosha [datasets.json](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json) `stopovye-parallel-passages` note (H291) · 08-07-2026
+
+### §6. Cyrillic-only Sanskrit name glossaries — no join key exists
+🟠 ✍️ **We have NOT (and cannot safely) build a Cyrillic→SLP1 key for the 3 fully-Cyrillic name glossaries.**
+Why it matters: 3 of 6 SamudraManthanam name indices (Потапова, Эрман-Темкин, Бадь Kadambari) are 100% Cyrillic — blocked from any pwg_ru corpus_gate reuse.
+Blocker: no tool that is safe — practical Russian transcription collapses dental/retroflex (т = त and ट); a rule-based converter manufactures wrong keys for exactly the retroflex-bearing epic names.
+How to close: a proper-noun lookup table validated against a Sanskrit onomasticon (not character rules), checked as its own artifact first.
+> **Source:** [FINDINGS §60](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-practical-russian-transcription-of-sanskrit-names-has-no-safe-reverse-transliteration) · RussianTranslation · 08-07-2026
+
+---
+
+_Dr. Mārcis Gasūns_

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,73 @@
+# GLOSSARY — canonical Sanskrit-data terminology
+
+_Created: 08-07-2026 · Last updated: 08-07-2026_
+
+**Epistemic sibling of [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).** FINDINGS holds facts; this file holds the act it cannot: **defining** the terms those facts are stated in. **It aggregates, it does not supersede** (MG ruling, 08-07-2026): each entry gathers where a term is already used/defined and states the working definition, but existing in-context definitions stand — an entry's job is "here is what this means and everywhere it appears," not "this overrides all other definitions." One of the seven epistemic registries minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md). Its infra twin is [`Uprava/GLOSSARY.md`](https://github.com/gasyoun/Uprava/blob/main/GLOSSARY.md).
+
+**How to read an entry.** Each opens with the shared **importance dot** (🔴 3 · 🟠 2 · 🟡 1) — here rating **how costly the term is to get wrong** (🔴 = a confusion that has actually poisoned data). Then `Means:`, `Not:` (the common confusion to avoid), and `Canonical in:` (where the term is authoritative). Auto-assist only: token-frequency across the hubs *surfaces* undefined jargon; humans write the definitions.
+
+---
+
+### form_key
+🔴 **Means:** a length-preserving normalization key for Sanskrit strings, used to join across schemes without losing distinctions (`ā`≠`a`).
+**Not:** blanket NFD-decompose + strip-combining-marks — that destroys vowel length (`ā`→`a`) and retroflex (`ṣ`→`s`), and collides `ś`'s acute with the pitch mark (see [FINDINGS §36](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily); the abandoned path is [DEAD_ENDS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md)).
+**Canonical in:** [`form_key` in sanskrit_util](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/py/sanskrit_util/__init__.py).
+
+### headword vs lemma
+🔴 **Means:** a *headword* is a dictionary entry key (`<L>`/`<k1>` in a CDSL dict); a *lemma* is a corpus dictionary-form assigned by a lemmatizer (DCS `LemmaId`).
+**Not:** interchangeable — 18.6% of DCS lemmas have no CDSL headword at all (FINDINGS §12); they are keyed and populated independently (see [ASSUMPTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md)).
+**Canonical in:** [FINDINGS §12](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword) · [union_headwords.tsv](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/union/union_headwords.tsv).
+
+### homonym index
+🔴 **Means:** the ordinal on repeated identical headwords (`1 √as`, `2 √as`); a dict's giant verb root frequently sits at a non-zero index.
+**Not:** guaranteed to be 0 for the "main" sense — 19 of the top-50 freq roots have a giant homonym at index > 0 (FINDINGS §16); iterate all records, never `bufs[0]` ([ASSUMPTIONS §3](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md)).
+**Canonical in:** [FINDINGS §16](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes).
+
+### ls source map
+🟠 **Means:** `ls_source_map.json` / `ls_resolver.py` — the mapping from a PWG `<ls>` citation siglum to a dated primary source (and its scanned-edition page URL).
+**Not:** complete — recognises 72.4% of PWG `<ls>` keys (45 dated sources); the unrecognised 27.6% is late catalogues/secondary literature (FINDINGS §20). Also not a fold-key: sigla families bundle several works (§45).
+**Canonical in:** [FINDINGS §20](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#20-the-ls-source-map-recognises-724-percent-of-pwg-citations) · tool `ls_resolver.py`.
+
+### gaṇa
+🟠 **Means:** a Pāṇinian verb present-class group (bhvādi = class 1, tudādi = class 6, …); the axis on which some homonym roots split.
+**Not:** recoverable from an unaccented corpus — only 5 of 38 DCS-lumped homonym groups are gaṇa-splittable; class I vs VI needs pitch accent the corpus lacks (FINDINGS §2, §8).
+**Canonical in:** [FINDINGS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling) · vidyut dhātupāṭha.
+
+### Renou period-state
+🟠 **Means:** a diachronic era tag I–V (Vedic → late) assigned per entry from multi-signal evidence (`ls`/`dcs`/`bhs`/`wl`), covering 770k entries in 8 dicts.
+**Not:** reliable on high-frequency closed-class words — DCS homograph collapse gives `ca`/`idam` the union of all their homographs' eras (spuriously broad); apply a min-support gate (FINDINGS §14).
+**Canonical in:** [`RENOU.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU.md).
+
+### varga
+🟠 **Means:** a consonant series (5 groups: guttural/palatal/cerebral/dental/labial) aggregating the 25 sparśa varṇas; the unit of the DCS diachrony analysis.
+**Not:** a phonetically shifting distribution over time — series composition is near epoch-stable (Cramér's V = 0.037 across ~2 kyr); p-values carry no signal at DCS scale (FINDINGS §62).
+**Canonical in:** [FINDINGS §62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) · manifest `varga-series-diachrony`.
+
+### SLP1 vs IAST
+🔴 **Means:** two transliteration schemes — SLP1 (ASCII-safe, one char per phoneme, native PWG `key1` join key) and IAST (diacritic Unicode).
+**Not:** interchangeable in DCS-derived files — `dcs_lemma_summary.json` is SLP1-keyed, `dcs_lemma_renou.json` is IAST-keyed; a join must transcode one side (FINDINGS §7; [ASSUMPTIONS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md)).
+**Canonical in:** [FINDINGS §7](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations) · transcoder in [`sanskrit-util`](https://github.com/sanskrit-lexicon/sanskrit-util).
+
+### key1 vs key2
+🟠 **Means:** `key1` is a dictionary's computational/normalized headword key (join on this); `key2` is the printed form, carrying the udātta `/` accent mark in PWG (`agni/` = agní).
+**Not:** cross-dict-joinable via `key2` — the same lemma keys differently between dicts (MW bare stem `agni` vs Apte nominative `agniH`); always join on `key1` (FINDINGS §23).
+**Canonical in:** [FINDINGS §23](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#23-apte-is-three-dictionaries-keys-differ-stem-vs-nominative).
+
+### Zaliznyak index (a–f accent axis)
+🟡 **Means:** a compact per-word grammar token scheme (335 tokens over 98,639 PWG headwords) plus a Vedic accent-mobility axis (a–f schemes) encoded from Whitney's declension rules.
+**Not:** a proven translation aid — a blind A/B showed injecting the grammar token does NOT improve DE→RU translation, so it stays structured-data-only (FINDINGS §4); the accent axis is Vedic-only (Classical entries lack `/`).
+**Canonical in:** [`ZALIZNYAK_INDEX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ZALIZNYAK_INDEX.md) · manifest `zaliznyak-grammar-index`.
+
+### `<ls>` / iti register
+🟠 **Means:** the two ways dictionaries cite sources — Western `<ls>` markup tags (PWG/MW) vs the indigenous `iti`/quotation register (SKD/VCP/KRM).
+**Not:** comparable by a raw `<ls>` counter — SKD's ~80k citations, KRM's densest-in-corpus 6.00/entry all score zero under an `<ls>` detector; and a "space-preceded" `iti` counter hides `<s>iti` (~2/3 of KRM's citations). Control for register before ranking (FINDINGS §26).
+**Canonical in:** [FINDINGS §26](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#26-citation-density-is-register-bound-not-comparable-raw).
+
+### dhātupāṭha citation form
+🟠 **Means:** the canonical listing form of a verbal root in the Pāṇinian root-catalogue, used as the normalization target (CANON) for root-recovery joins.
+**Not:** the same as vidyut's surface forms (which keep the thematic `-a` and must NOT seed CANON), nor a stem grab (`sada` for `sad`) — normalize to citation form before comparing; grep vidyut as `ancu`, not SLP1 `aYc`, and strip anubandha `~ \ ^` (§63).
+**Canonical in:** [`mw_roots.tsv`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/mw/mw_roots.tsv) · [FINDINGS §35](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#35-root-recovery-tiers-err-on-root-form-not-identity).
+
+---
+
+_Dr. Mārcis Gasūns_

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -1,0 +1,68 @@
+# RECIPES — reproduction recipes for the Sanskrit-data findings & datasets
+
+_Created: 08-07-2026 · Last updated: 08-07-2026_
+
+**Epistemic sibling of [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).** FINDINGS cites *a number*; this file holds the act it cannot: **reproducing** — the exact runnable path back to that number. One recipe per derived dataset or heavy FINDINGS row, so a fact can be re-checked rather than trusted. This is what [`STALENESS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/STALENESS.md)'s "Re-check recipe" column points at. One of the seven epistemic registries minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md). Its infra twin is [`Uprava/RECIPES.md`](https://github.com/gasyoun/Uprava/blob/main/RECIPES.md).
+
+**How to read a row.** Every row opens with two glyphs:
+
+- **Importance dot** (identical scale to FINDINGS): 🔴 3 high · 🟠 2 medium · 🟡 1 minor — here the dot rates **reproduction weight** (🔴 = a canonical/expensive derived asset others consume, must be reproducible; 🟡 = a light one-liner check).
+- **Origin marker:** ⚙️ auto (a stub emitted from the manifest builder / a FINDINGS script-citation) · ✍️ human (a session wrote the full recipe).
+
+Then `Inputs:`, `Command:`, `Expected:` (ties back to the FINDINGS §N it reproduces), `Env/runtime:`, and a `> **Source:**` line.
+
+**Auto-seed:** [`seed_recipes.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/seed_recipes.py) emits a stub per [`kosha` manifest](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json) row (each names a builder) and per FINDINGS row whose Evidence cites a `*.py`/`*.sh`.
+
+---
+
+### §1. Whitney accent axis validation (17→18/19 GO) → reproduce
+🟠 ✍️ (reproduces [FINDINGS §54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents))
+Inputs: [`crosswalk/accent_rules.json`](https://github.com/gasyoun/WhitneyRoots/blob/main/crosswalk/accent_rules.json) (18 rules, 19-cell matrix), attested accented RV forms from VedaWeb 2.0 + Casaretto et al. (2025), PWG `key2` udātta positions ([`headword_index.tsv`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/headword_index.tsv)).
+Command: score per [`ACCENT_VALIDATION_SPEC.md`](https://github.com/gasyoun/WhitneyRoots/blob/main/docs/ACCENT_VALIDATION_SPEC.md); note the `per_case` override trap (9 of 19 cells define a `G.pl`/`N.A.du.n` override the generic strong/middle/weakest slot ignores).
+Expected: 18/19 cells GO at ≥90% position accuracy, 0 NO-GO, 1 measurement-only (`T2/T4/T6·monosyllable`, n≤1) — ties back to FINDINGS §54.
+Env/runtime: VedaWeb API (`vedaweb.uni-koeln.de/api`) — check liveness first (`curl -sI --max-time 15 …/api/openapi.json`); the host has an extended outage history (§48, [SERVER_OUTAGES](https://github.com/gasyoun/Uprava/blob/main/SERVER_OUTAGES.md)).
+> **Source:** [FINDINGS §54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) · WhitneyRoots v1.3.0 · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §2. DCS↔CDSL crosswalk (81.4% linked) → reproduce
+🔴 ✍️ (reproduces [FINDINGS §12](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword))
+Inputs: DCS-2026 IAST lemmas (15,902), CDSL normalized keys; transcoder from `wf1/build_wf_from_dcs.py`.
+Command: `python build_xref.py` (csl-apidev `simple-search/dcs_xref/`) → `dcs_cdsl_xref.tsv`; frequency map `wf0/wf.txt` (50,474) → `wf1/wf.txt` (50,574).
+Expected: 12,946 of 15,902 (81.4%) link; 2,956 corpus-only — ties back to FINDINGS §12 / manifest `dcs-cdsl-xref` (15,902 rows).
+Env/runtime: Python, offline once DCS CoNLL-U + CDSL keys are local; it is a LOD linkset — consume, never re-derive.
+> **Source:** [FINDINGS §12](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword) + kosha [datasets.json](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json) · csl-apidev · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §3. DeepSeek word-alignment grounding cross-check (6.6% ungrounded) → reproduce
+🟠 ✍️ (reproduces [FINDINGS §65](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse))
+Inputs: `corpus_lexicon.jsonl` (1,091,528 word-pairs — GITIGNORED, single copy on MG disk), L0 verse units rebuilt by [`src/build_l0.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_l0.py) (99,733 units / 116 works) from SamudraManthanam.
+Command: [`src/tm_align.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_align.py) cross-checks each pair against its L0 verse; feed `alignment_confidence` into [`tm_grade.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_grade.py).
+Expected: mean grounding 0.684, 93.4% grounded, 6.6% score 0; grade A 5.7%→5.3%, C 0.3%→0.9% — ties back to FINDINGS §65.
+Env/runtime: Python, offline; corpus_lexicon is restricted-tier (published-RU-translation rights), regenerable via `build_corpus_lexicon.py` but single-copy.
+> **Source:** [FINDINGS §65](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse) · RussianTranslation · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §4. Varga diachrony + Cramér's V (0.037) → reproduce
+🟠 ✍️ (reproduces [FINDINGS §62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards))
+Inputs: [VisualDCS `derived-data/Fonetika/regen-2026/varna_freq.csv`](https://github.com/gasyoun/VisualDCS/blob/main/derived-data/Fonetika/regen-2026/varna_freq.csv) (DCS pin 2026-03-05, 9,940,591 stop/nasal varṇas across time-slots 1–5).
+Command: [`varga_shares.py`](https://github.com/gasyoun/SanskritGrammar/blob/chore/errata-kochergina-waiting/GasunsDhatu_2014/revision-2026/varga_shares.py) / `aggregate_vargas.py` (deterministic).
+Expected: dentals ≈47–52%, labials ≈24–27%, gutturals 8.9→14.9%; 5×5 varga×epoch Cramér's V = 0.0372 (χ² = 54,890) — ties back to FINDINGS §62 / manifest `varga-series-diachrony`.
+Env/runtime: Python stdlib, offline, deterministic; outputs `slot_era_map.csv` alongside.
+> **Source:** [FINDINGS §62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) · SanskritGrammar/VisualDCS · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §5. Cross-dict union headword index (323,425 / PWG∩MW=94,753) → reproduce
+🔴 ✍️ (reproduces [FINDINGS §29](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index))
+Inputs: 15 dicts' `<L>` headwords from `csl-orig/v02/`, SLP1-keyed.
+Command: the HeadwordLists union build → [`union_headwords.tsv`](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/union/union_headwords.tsv) (per-dict membership + gender flags).
+Expected: 323,425 union headwords; PWG-bearing 106,054, MW-bearing 193,852, both 94,753 — ties back to FINDINGS §29 / manifest `union-headwords` (323,425 rows, 12.4 MB). CONSUME, don't rebuild (a new pairwise-overlap script is reinvention).
+Env/runtime: Python; the built asset is public-tier in `data-v0.1.0`.
+> **Source:** [FINDINGS §29](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index) · SanskritLexicography · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+### §6. Correction loci census (39,540 records) → reproduce
+🟠 ✍️ (reproduces the kosha `correction-loci` manifest row, H294)
+Inputs: all `batch_*/batches/*` change files across csl-corrections.
+Command: [`scripts/build_correction_loci.py --selftest`](https://github.com/sanskrit-lexicon/csl-corrections/pull/291) (census invariants frozen 2026-07-07) → `data/derived/correction_loci.tsv`.
+Expected: 39,540 records = 39,536 old→new + 4 old→del; `process∈{bulk,human}` splits the two machine markup batches (BOR 21,990 + LRV/markhom 8,063 = 76%) from human correction — manifest `correction-loci` (9.6 MB, 39,540 rows).
+Env/runtime: Python, offline; keyed on (dict, L, k1) — line numbers are batch-time only, never a join key. Corrector identity excluded (public tier).
+> **Source:** kosha [datasets.json](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json) `correction-loci` (H294) · csl-corrections · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+
+---
+
+_Dr. Mārcis Gasūns_

--- a/STALENESS.md
+++ b/STALENESS.md
@@ -1,0 +1,88 @@
+# STALENESS — confidence-decay table over [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
+
+_Created: 08-07-2026 · Last updated: 08-07-2026_
+
+**⚙️ FULLY AUTO-GENERATED — do not hand-edit the table below.** Regenerate with [`sanskrit-util/tools/epistemic/derive_staleness.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/derive_staleness.py). This is the STALENESS epistemic sibling of [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) (Sanskrit-data side) — one of the seven registries minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md). It answers the one question FINDINGS structurally cannot: *when was each fact last re-checked, and which are decaying?*
+
+Every FINDINGS finding measures a fact **at a moment**. A count true in June may be stale by December (`csl-orig` moved, a corpus was re-exported, a host came back). This table dates each finding's discovery, its most recent re-verification (if any), and flags the age.
+
+**Flag** — the FINDINGS 🔴🟠🟡 dots re-purposed onto a decay axis (§2 of the H356 handoff: *the dot always rates importance, but what it rates varies by layer*; here it rates re-check urgency, and adds 🟢 for fresh):
+
+- 🔴 **>6 months** since the last dated activity — re-verify before citing.
+- 🟡 **3–6 months** — verify if the underlying source may have moved.
+- 🟢 **fresh** (<3 months) — trust as-is.
+
+**Snapshot (08-07-2026):** 66 findings — 🔴 0 · 🟡 0 · 🟢 66.
+
+> **Discovered** = earliest date in the finding's block · **Last re-verified** = latest date if the block carries more than one (a re-check leaves a second date) · **Age** = days from the newest dated activity to the regeneration date · **Re-check recipe** = the RECIPES row that reproduces this finding (Wave 2 fills the numbers; `§TBD` until then).
+
+| FINDINGS § | Discovered | Last re-verified | Age | Flag | Re-check recipe |
+|------------|-----------|------------------|-----|------|-----------------|
+| [§8](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#8-unaccented-dcs-cannot-distinguish-present-class-i-from-vi) | 01-06-2026 | — | 37d | 🟢 | RECIPES §TBD |
+| [§19](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#19-skd-and-vcp-carry-essentially-zero-western-markup) | 01-06-2026 | — | 37d | 🟢 | RECIPES §TBD |
+| [§23](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#23-apte-is-three-dictionaries-keys-differ-stem-vs-nominative) | 01-06-2026 | — | 37d | 🟢 | RECIPES §TBD |
+| [§36](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily) | 01-06-2026 | — | 37d | 🟢 | RECIPES §TBD |
+| [§37](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#37-bom-state-is-inconsistent-across-exports) | 01-06-2026 | — | 37d | 🟢 | RECIPES §TBD |
+| [§39](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#39-devanagaritoslp1-mis-routes-retroflex-la) | 01-06-2026 | — | 37d | 🟢 | RECIPES §TBD |
+| [§28](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#28-mw-inherited-the-pwg-apparatus-skeleton-not-its-prose) | 03-06-2026 | — | 35d | 🟢 | RECIPES §TBD |
+| [§9](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#9-dcs-occid-and-sentid-are-not-unique-keys) | 06-06-2026 | — | 32d | 🟢 | RECIPES §TBD |
+| [§10](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#10-dcs-ud-tense-marking-conflates-aorist-and-perfect) | 06-06-2026 | — | 32d | 🟢 | RECIPES §TBD |
+| [§11](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#11-dcs-2021-and-2026-vintages-are-not-directly-comparable) | 06-06-2026 | — | 32d | 🟢 | RECIPES §TBD |
+| [§12](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword) | 11-06-2026 | — | 27d | 🟢 | RECIPES §TBD |
+| [§3](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#3-the-warnemyr-scrape-union-smears-homonym-classes) | 13-06-2026 | — | 25d | 🟢 | RECIPES §TBD |
+| [§2](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling) | 14-06-2026 | — | 24d | 🟢 | RECIPES §TBD |
+| [§27](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#27-sense-granularity-is-a-family-trait-not-a-diachronic-trend) | 15-06-2026 | — | 23d | 🟢 | RECIPES §TBD |
+| [§30](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#30-body-text-headword-mining-is-a-dead-end-386-percent-precision) | 15-06-2026 | — | 23d | 🟢 | RECIPES §TBD |
+| [§32](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#32-correction-events-concentrate-in-sense-text) | 17-06-2026 | — | 21d | 🟢 | RECIPES §TBD |
+| [§5](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#5-the-parallel-corpus-rarely-attests-prefixed-verb-forms) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
+| [§6](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#6-no-printed-frequency-dictionary-of-sanskrit-exists) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
+| [§7](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
+| [§15](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#15-pwg-encodes-secondary-stems-inline-not-in-div-markup) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
+| [§16](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
+| [§17](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#17-pwg-orders-senses-genetically-not-historically) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
+| [§18](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#18-vedic-citation-density-separates-the-dictionary-traditions) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
+| [§20](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#20-the-ls-source-map-recognises-724-percent-of-pwg-citations) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
+| [§31](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#31-detector-precision-stratifies-by-digitization-quality) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
+| [§22](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#22-mw-has-no-sense-level-div-markup) | 26-06-2026 | — | 12d | 🟢 | RECIPES §TBD |
+| [§29](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index) | 26-06-2026 | — | 12d | 🟢 | RECIPES §TBD |
+| [§33](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#33-indigenous-dictionaries-agree-on-derivation-wilson-is-the-outlier) | 26-06-2026 | — | 12d | 🟢 | RECIPES §TBD |
+| [§34](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#34-the-e-abbreviation-tag-is-polysemous-across-dicts) | 26-06-2026 | — | 12d | 🟢 | RECIPES §TBD |
+| [§35](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#35-root-recovery-tiers-err-on-root-form-not-identity) | 26-06-2026 | — | 12d | 🟢 | RECIPES §TBD |
+| [§40](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#40-gloss-language-spelling-drift-tracks-reform-type-not-age) | 26-06-2026 | — | 12d | 🟢 | RECIPES §TBD |
+| [§38](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#38-injected-boms-crash-the-hw-record-parser) | 27-06-2026 | — | 11d | 🟢 | RECIPES §TBD |
+| [§4](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#4-pwg-nominal-grammar-compresses-into-335-paradigm-tokens) | 29-06-2026 | — | 9d | 🟢 | RECIPES §TBD |
+| [§13](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#13-sa-ru-glossary-token-coverage-plateaus-at-866-percent) | 01-07-2026 | — | 7d | 🟢 | RECIPES §TBD |
+| [§14](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#14-renou-period-state-tagging-covers-770k-entries-in-8-dicts) | 01-07-2026 | — | 7d | 🟢 | RECIPES §TBD |
+| [§42](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#42-whitney-self-contradicts-on-derivative-ī-stem-genpl-accent) | 02-07-2026 | — | 6d | 🟢 | RECIPES §TBD |
+| [§21](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#21-pwg-citation-occurrences-track-distinct-references) | 02-07-2026 | — | 6d | 🟢 | RECIPES §TBD |
+| [§24](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#24-about-9-percent-of-typo-corrections-are-collisions) | 01-07-2026 | 02-07-2026 | 6d | 🟢 | RECIPES §TBD |
+| [§25](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#25-a-verified-correction-queue-decays-against-live-csl-orig) | 01-07-2026 | 02-07-2026 | 6d | 🟢 | RECIPES §TBD |
+| [§26](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#26-citation-density-is-register-bound-not-comparable-raw) | 13-06-2026 | 02-07-2026 | 6d | 🟢 | RECIPES §TBD |
+| [§41](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#41-the-sanskrit-dictionary-platform-landscape-probed-live) | 16-02-2026 | 02-07-2026 | 6d | 🟢 | RECIPES §TBD |
+| [§43](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#43-skdvcp-sensecitation-fusion-is-a-record-type-effect-not-a-dictionary-level-one) | 02-07-2026 | — | 6d | 🟢 | RECIPES §TBD |
+| [§44](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#44-raw-latin-string-tallies-over-gloss-text-include-etymological-false-positives-bopp-lacks-yabh) | 02-07-2026 | — | 6d | 🟢 | RECIPES §TBD |
+| [§45](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#45-siglum-prefix-families-routinely-bundle-several-distinct-works-the-diacritic-stripping-fold-has-poisoned-keys) | 02-07-2026 | — | 6d | 🟢 | RECIPES §TBD |
+| [§1](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#1-whitney-accent-mobility-rules-are-machine-encodable) | 29-06-2026 | 03-07-2026 | 5d | 🟢 | RECIPES §TBD |
+| [§46](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#46-twelve-years-of-corrections-cover-only-1014--of-the-estimated-error-population) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§47](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#47-heritage-data-is-acquirable-despite-the-anubis-wall--via-a-github-mirror-the-morphology-xml-is-not-in-it) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§48](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#48-vedaweb-20s-resource-export-is-an-async-task-behind-a-pickup-key-not-a-direct-get--and-the-server-went-unresponsive-mid-attempt) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§49](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#49-mwheritage-coverage-highlighting-is-a-duplicate-anchor-pattern-not-a-css-class--and-the-mirrors-current-dictionary-is-a-different-scope-asset-than-the-2014-reader-stem-list) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§50](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#50-cdsl-display-paths-are-not-uniformly-2020web--and-two-new-digitizations-landed-in-june-2026) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§51](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#51-huet-correspondence-predates-this-session-2021--the-morphology-xml-gate-was-already-resolved-in-writing-direct-download-urls-recovered) | 30-03-2021 | 03-07-2026 | 5d | 🟢 | RECIPES §TBD |
+| [§52](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#52-heritage-vs-kosha-forms-diff-the-small-raw-overlap-is-mostly-convention--model-difference-and-disagreements-are-two-thirds-lemmatization-policy-not-error) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§53](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#53-the-wil-etymology-extractions-affix-field-is-half-noise--wilson-outlier-figures-are-substantially-a-measurement-artifact) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§56](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#56-dicos-entry-anchors-nest-three-structural-roles-under-one-html-class--only-one-is-a-true-entry-boundary) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§55](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#55-genoptharness2py-output-budget-coarser-wins-on-both-knobs-in-opposite-directions) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§57](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#57-samskrtamruz-is-id-addressed-with-no-name-lookup--deep-linking-needs-a-scraped-rootid-table-8-primer-basic-roots-are-absent) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§58](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#58-pwg-ru-promoted-store-has-input-level-provenance-but-old-ru-rows-lacked-exact-model-versions) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§59](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#59-böhtlingks-indische-sprüche-both-editions-already-fully-digitized-in-sanskrit-lexicon-scans-not-just-sanskrit-lexicon) | 06-05-2026 | 03-07-2026 | 5d | 🟢 | RECIPES §TBD |
+| [§54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) | 03-07-2026 | 05-07-2026 | 3d | 🟢 | RECIPES §TBD |
+| [§64](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1--pwg-is-not-the-sole-spine-of-the-local-layer-universe) | 05-07-2026 | — | 3d | 🟢 | RECIPES §TBD |
+| [§60](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-practical-russian-transcription-of-sanskrit-names-has-no-safe-reverse-transliteration) | 05-07-2026 | — | 3d | 🟢 | RECIPES §TBD |
+| [§60](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-pwgru-tm-composite-grade-a-is-consensus-gated-57-and-a-reference-free-surface-qe-cannot-detect-wrong-sense) | 03-07-2026 | 06-07-2026 | 2d | 🟢 | RECIPES §TBD |
+| [§63](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian) | 07-07-2026 | — | 1d | 🟢 | RECIPES §TBD |
+| [§62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) | 05-03-2026 | 07-07-2026 | 1d | 🟢 | RECIPES §TBD |
+| [§65](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse) | 07-07-2026 | — | 1d | 🟢 | RECIPES §TBD |
+| [§61](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#61-the-reverse-dictionarys-30-sources-split-18-pd-vs-10-in-copyright--the-merged-headword-list-is-not-automatically-publishable) | 26-06-2026 | 07-07-2026 | 1d | 🟢 | RECIPES §TBD |
+
+_Auto-generated by [`derive_staleness.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/derive_staleness.py); regenerate on FINDINGS change, do not edit by hand._


### PR DESCRIPTION
Part of [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md). Adds the seven epistemic sibling registries next to [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) — the epistemic acts FINDINGS (measured-fact-only) structurally can't hold:

| File | Act |
|---|---|
| [`ASSUMPTIONS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) | relying on an unproven premise |
| [`CONTRADICTIONS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) | ≥2 sources disagree, no verdict |
| [`GAPS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) | not-yet-knowing (the frontier) |
| [`DEAD_ENDS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) | abandoning an approach |
| [`RECIPES.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) | reproducing a fact |
| [`STALENESS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/STALENESS.md) | decaying — **fully auto-generated** |
| [`GLOSSARY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) | defining canonical terms (aggregates, does not supersede) |

Every row seeded from **real** FINDINGS / FEATURES_INDEX / kosha-manifest content (no hollow templates), opens with the same 🔴🟠🟡 importance dots, and carries a ⚙️ auto / ✍️ human origin marker. Graduation rule: rows empty into FINDINGS / CROSS_REPO_DECISIONS as they mature. Mirrored by the infra-side copy in Uprava (on main). STALENESS generated by [`sanskrit-util/tools/epistemic/derive_staleness.py`](https://github.com/sanskrit-lexicon/sanskrit-util/pull/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)