### PR TITLE
H356: epistemic dashboard (public) + retrospective seed candidates

### DIFF
--- a/.github/workflows/findings-dashboard.yml
+++ b/.github/workflows/findings-dashboard.yml
@@ -27,12 +27,21 @@ jobs:
       - name: Build data + timeseries snapshot
         run: python findings_dashboard/build_findings_data.py
 
+      - name: Build epistemic-registries dashboard data
+        # The seven epistemic sibling registries (H356) — parse the Sanskrit-data side
+        # only (the infra side lives in the private Uprava repo and is not published).
+        run: |
+          python epistemic_dashboard/build_epistemic_dashboard.py \
+            --dir . --side sanskrit \
+            --repo-url https://github.com/gasyoun/SanskritLexicography/blob/master \
+            --out epistemic_dashboard/epistemic.json
+
       - name: Commit data to master
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add findings_dashboard/data.json findings_dashboard/timeseries.json
-          git diff --cached --quiet || git commit -m "chore(findings-dashboard): monthly data refresh [skip ci]"
+          git add findings_dashboard/data.json findings_dashboard/timeseries.json epistemic_dashboard/epistemic.json
+          git diff --cached --quiet || git commit -m "chore(dashboards): monthly data refresh [skip ci]"
           git push
 
       - uses: actions/checkout@v7
@@ -40,14 +49,15 @@ jobs:
           ref: gh-pages
           path: pages
 
-      - name: Publish to gh-pages/findings/
+      - name: Publish to gh-pages/findings/ and gh-pages/epistemic/
         run: |
-          mkdir -p pages/findings
+          mkdir -p pages/findings pages/epistemic
           cp findings_dashboard/index.html findings_dashboard/data.json findings_dashboard/timeseries.json pages/findings/
           [ -f findings_dashboard/platform_status.json ] && cp findings_dashboard/platform_status.json pages/findings/ || true
+          cp epistemic_dashboard/index.html epistemic_dashboard/epistemic.json pages/epistemic/
           cd pages
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add findings
-          git diff --cached --quiet || git commit -m "chore(findings-dashboard): publish monthly refresh"
+          git add findings epistemic
+          git diff --cached --quiet || git commit -m "chore(dashboards): publish monthly refresh"
           git push

--- a/DEAD_ENDS.md
+++ b/DEAD_ENDS.md
@@ -59,4 +59,17 @@ Don't retry unless: never — use synthetic autoincrement surrogates or position
 
 ---
 
+## ⚙️ Auto-seeded candidates (unconfirmed — `seed_dead_ends.py`, 08-07-2026)
+
+Surfaced by [`seed_dead_ends.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/seed_dead_ends.py) from `QUESTIONS_LOG.md` **refuted** rows. `⚙️ auto` **candidates** — a human confirms the refutation generalises to a whole *approach* (→ `✍️`) or deletes it. (Several of the seeder's raw rows were duplicates of §1–§6 above or malformed table-cell grabs; only the one genuinely new approach is transcribed here.)
+
+### §7. Generalising dictionary-level sense-inheritance direction to corpus scale — refuted
+🟠 ⚙️ **Assuming the sense-inheritance *descent direction* observed at the dictionary level (the *dharma* exemplar) holds at corpus scale.**
+Failed because: it did NOT hold — the classifier over the full corpus reversed the exemplar (SKD 53.3% fused vs VCP 77.6% fused); §7 of the fusion analysis was re-scoped to record-type-dependent, not dictionary-level. This is the corpus-scale twin of [CONTRADICTIONS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md).
+Evidence: R2606-06 (refuted 02-07-2026), `r2_kosa_fusion.json`, [csl-atlas PR #184](https://github.com/sanskrit-lexicon/csl-atlas/pull/184).
+Don't retry unless: you compute the direction at corpus scale from the start — never generalise a single hand-picked lemma's fusion direction to a dictionary-level rule.
+> **Source:** [QUESTIONS_LOG R2606-06](https://github.com/gasyoun/Uprava/blob/main/QUESTIONS_LOG.md) · csl-atlas · 08-07-2026 · auto (seed_dead_ends.py)
+
+---
+
 _Dr. Mārcis Gasūns_

--- a/GAPS.md
+++ b/GAPS.md
@@ -59,4 +59,45 @@ How to close: a proper-noun lookup table validated against a Sanskrit onomastico
 
 ---
 
+## ⚙️ Auto-seeded candidates (unconfirmed — `seed_gaps.py`, 08-07-2026)
+
+Surfaced by [`seed_gaps.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/seed_gaps.py) as a set-difference over the [kosha manifest](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json): datasets that exist but carry **no** FINDINGS row measuring them. These are `⚙️ auto` **candidates** — a human confirms (→ `✍️`, promote to FINDINGS once measured) or deletes. Row counts are the manifest's; the "why it matters" is a first pass to be sharpened.
+
+### §7. `dcs-stem-cooccurrence-full` (353,352 stem-pair rows) is uncharacterised
+🟡 ⚙️ **We have the full Sanskrit-stem co-occurrence table (353,352 pairs, IDs 1–222342) but NO FINDINGS row on what its network structure shows.**
+Why it matters: a corpus-wide collocation graph would ground compound-formation, synonym-cluster, and semantic-field claims that are currently asserted per-lemma; feeds any distributional-semantics analysis.
+Blocker: no tool — needs a graph/statistics pass (degree distribution, top collocates, hapax rate), not a row count.
+How to close: load the pair table, compute the obvious network statistics, append a FINDINGS row; owner VisualDCS.
+> **Source:** manifest `dcs-stem-cooccurrence-full` (H291) · kosha · 08-07-2026 · auto (seed_gaps.py)
+
+### §8. DCS syntagmatic collocation tables (Прил. 6 + 7) are unanalysed
+🟡 ⚙️ **We have the per-lemma collocate tables — all-corpus (`dcs-sintagmatic-appendix7`, 82,800 rows) and per-historical-period (`dcs-sintagmatic-appendix6-periods`, 19,076 rows, 7 files) — but NO FINDINGS row comparing them.**
+Why it matters: the period-split vs all-corpus pair is exactly the data to test whether collocations are epoch-stable (the varga question §62, but at the lexical layer); a genuine diachronic-collocation finding.
+Blocker: no tool — needs a per-period vs all-corpus diff; the appendix7 copy also has a byte-different UTF-16LE Cyrillic twin (H291) to dedup first.
+How to close: align the period files against the all-corpus table, measure collocation drift; owner VisualDCS.
+> **Source:** manifest `dcs-sintagmatic-appendix7` / `dcs-sintagmatic-appendix6-periods` (H291) · kosha · 08-07-2026 · auto (seed_gaps.py)
+
+### §9. `heritage-forms-crosswalk-extras` disagreement classes are uncounted
+🟡 ⚙️ **We have the Heritage form-level crosswalk extras (1,037,239 rows, incl. a `heritage_forms_oracle_disagreements` form→disagreement-class table) but NO FINDINGS row on how often Heritage and kosha disagree, or on what.**
+Why it matters: the disagreement rate + its classes are the missing quality metric for the Heritage morphology witness ([GAPS §3](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md)); tells us whether to trust Heritage forms as an oracle.
+Blocker: data tier — `restricted` (Heritage LGPLLR composition), so the count is publishable but the rows aren't public.
+How to close: tally the disagreement-class distribution, append a FINDINGS row (rate only); owner SanskritLexicography HeadwordLists.
+> **Source:** manifest `heritage-forms-crosswalk-extras` (H291) · kosha · 08-07-2026 · auto (seed_gaps.py)
+
+### §10. Which-dictionary routing benchmark has single-annotator gold, no κ
+🟠 ⚙️ **The 24-scenario routing shared-task benchmark (`which-dictionary-routing-benchmark`) has single-annotator gold (Fable 5, one pass) — NO inter-annotator agreement measured over its 44-code answer space.**
+Why it matters: a shared-task benchmark with no κ can't quantify its own gold reliability, which caps the credibility of any leaderboard result built on it (csl-guides `/about/shared-tasks`).
+Blocker: needs a second independent annotation pass (see `/gold-adjudicate`), not just a rerun.
+How to close: second-annotate the 24 scenarios, compute κ + a confusion table, append a FINDINGS row.
+> **Source:** manifest `which-dictionary-routing-benchmark` (H281) · kosha/csl-guides · 08-07-2026 · auto (seed_gaps.py)
+
+### §11. `dcs-verb-form-frequency-prelim` is flagged preliminary, never finalised
+🟡 ⚙️ **The DCS verb-form frequency table (106 rows) is explicitly `preliminary` in the manifest — NO FINDINGS row, and no final version.**
+Why it matters: verb forms are the top of the frequency dictionary (roots dominate §64/§16); a finalised verb-form frequency would directly feed the freq-first translation queue.
+Blocker: unclear — the "preliminary" marker's reason isn't recorded (coverage? method?); needs the owner to state what makes it non-final.
+How to close: identify the preliminary caveat, finalise or document why it can't be, append a FINDINGS row; owner VisualDCS.
+> **Source:** manifest `dcs-verb-form-frequency-prelim` (H291) · kosha · 08-07-2026 · auto (seed_gaps.py)
+
+---
+
 _Dr. Mārcis Gasūns_

--- a/epistemic_dashboard/README.md
+++ b/epistemic_dashboard/README.md
@@ -1,0 +1,30 @@
+# epistemic_dashboard — the seven epistemic sibling registries at a glance
+
+_Created: 08-07-2026 · Last updated: 08-07-2026_
+
+A companion to [`findings_dashboard/`](https://github.com/gasyoun/SanskritLexicography/tree/master/findings_dashboard), over the **seven epistemic sibling registries** minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md): [`ASSUMPTIONS`](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) · [`CONTRADICTIONS`](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) · [`GAPS`](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) · [`DEAD_ENDS`](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) · [`RECIPES`](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) · [`STALENESS`](https://github.com/gasyoun/SanskritLexicography/blob/master/STALENESS.md) · [`GLOSSARY`](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md).
+
+**Published (Sanskrit-data side only):** <https://gasyoun.github.io/SanskritLexicography/epistemic/> — refreshed monthly by the [`findings-dashboard`](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/workflows/findings-dashboard.yml) workflow (3rd of each month). The **infra / process** side lives in the private [Uprava](https://github.com/gasyoun/Uprava) repo and is viewed locally, never published.
+
+## What it shows
+
+- Total rows, layer count, and the **⚙️ auto vs ✍️ human** origin split — the health signal, since the registries are designed to be machine-seeded and hand-confirmed.
+- A per-layer table: the epistemic act each holds, row count, importance breakdown (🔴🟠🟡), and an origin bar.
+- The STALENESS decay summary (🔴 >6 mo · 🟡 3–6 mo · 🟢 fresh · ⬜ undated).
+
+## Files
+
+- [`index.html`](index.html) — self-contained (no external assets), fetches `epistemic.json`.
+- `epistemic.json` — generated; the per-layer parse of the registries.
+- [`build_epistemic_dashboard.py`](build_epistemic_dashboard.py) — **vendored, byte-identical** copy of the canonical builder in [`sanskrit-util/tools/epistemic/`](https://github.com/sanskrit-lexicon/sanskrit-util/tree/main/tools/epistemic); re-vendor on version bump via [`/cologne-sanskrit-util-sync`](https://github.com/gasyoun/github-spine/blob/main/SHARED_CODE.md). Kept in-repo so CI self-builds without installing the package.
+
+## Regenerate locally
+
+```sh
+python epistemic_dashboard/build_epistemic_dashboard.py \
+  --dir . --side sanskrit \
+  --repo-url https://github.com/gasyoun/SanskritLexicography/blob/master \
+  --out epistemic_dashboard/epistemic.json
+```
+
+_Dr. Mārcis Gasūns_

--- a/epistemic_dashboard/build_epistemic_dashboard.py
+++ b/epistemic_dashboard/build_epistemic_dashboard.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""build_epistemic_dashboard.py — parse the seven epistemic sibling registries in a directory
+into one `epistemic.json` for the dashboard (H356 Wave 4).
+
+Reads whichever of ASSUMPTIONS / CONTRADICTIONS / GAPS / DEAD_ENDS / RECIPES / STALENESS /
+GLOSSARY exist in `--dir`, and emits per-layer counts (rows, importance 🔴🟠🟡, origin
+⚙️ auto / ✍️ human) plus a STALENESS flag summary and grand totals. The dashboard `index.html`
+renders this file; the same generator serves both the Sanskrit-data side (public) and the
+infra side (local-only), so the two dashboards are byte-for-byte the same code.
+
+No `Date.now()` in any derived count — the generation timestamp is the only clock read, and it
+is stamped, not computed-against, so re-runs over unchanged registries diff cleanly.
+
+Usage:
+    python build_epistemic_dashboard.py --dir <registries-dir> --side {sanskrit|infra} \
+        --repo-url <blob-base> --out <epistemic.json>
+"""
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+
+IMPORTANCE = {"🔴": 3, "🟠": 2, "🟡": 1}
+# layer key -> (the epistemic act it holds)
+LAYERS = [
+    ("ASSUMPTIONS", "relying on an unproven premise"),
+    ("CONTRADICTIONS", "≥2 sources disagree, no verdict"),
+    ("GAPS", "not-yet-knowing (the frontier)"),
+    ("DEAD_ENDS", "abandoning an approach"),
+    ("RECIPES", "reproducing a fact"),
+    ("STALENESS", "decaying — confidence over time"),
+    ("GLOSSARY", "defining canonical terms"),
+]
+ENTRY = re.compile(r"^### (.+?)\s*$")
+DOT = re.compile(r"(🔴|🟠|🟡)")
+ORIGIN = re.compile(r"(⚙️|✍️)")
+STALE_ROW = re.compile(r"^\|\s*\[§(\d+)\]")
+STALE_FLAG = re.compile(r"(🔴|🟡|🟢|⬜)")
+
+
+def gh_slug(heading):
+    out = []
+    for ch in heading.strip().lower():
+        if ch in " -":
+            out.append(ch)
+        elif ch.isalnum():
+            out.append(ch)
+    return "".join(out).replace(" ", "-")
+
+
+def parse_entry_layer(text, file_url):
+    """Layers whose rows are `### …` entries (all but STALENESS)."""
+    lines = text.split("\n")
+    entries = []
+    i = 0
+    while i < len(lines):
+        m = ENTRY.match(lines[i])
+        if m:
+            heading = m.group(1)
+            # look at the next few non-blank lines for the dot + origin
+            imp = origin = None
+            for k in range(i + 1, min(i + 4, len(lines))):
+                if imp is None:
+                    dm = DOT.search(lines[k])
+                    if dm:
+                        imp = IMPORTANCE[dm.group(1)]
+                if origin is None:
+                    om = ORIGIN.search(lines[k])
+                    if om:
+                        origin = "auto" if om.group(1) == "⚙️" else "human"
+                if imp and origin:
+                    break
+            entries.append({
+                "title": heading,
+                "importance": imp,
+                "origin": origin or "human",  # glossary/plain entries default human
+                "url": f"{file_url}#{gh_slug(heading)}",
+            })
+        i += 1
+    return entries
+
+
+def parse_staleness(text):
+    flags = {"red": 0, "yellow": 0, "green": 0, "unknown": 0}
+    total = 0
+    for line in text.split("\n"):
+        if not STALE_ROW.match(line):
+            continue
+        total += 1
+        cells = line.split("|")
+        # the Flag column is the 6th cell (idx 5) in | § | disc | last | age | flag | recipe |
+        flagcell = cells[5] if len(cells) > 5 else ""
+        fm = STALE_FLAG.search(flagcell)
+        g = fm.group(1) if fm else "⬜"
+        flags[{"🔴": "red", "🟡": "yellow", "🟢": "green", "⬜": "unknown"}[g]] += 1
+    return total, flags
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dir", required=True)
+    ap.add_argument("--side", choices=["sanskrit", "infra"], required=True)
+    ap.add_argument("--repo-url", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    from pathlib import Path
+    root = Path(args.dir)
+    side_name = "Sanskrit-data" if args.side == "sanskrit" else "infra / process"
+
+    layers = []
+    staleness = None
+    tot_rows = tot_auto = tot_human = 0
+    tot_imp = {"3": 0, "2": 0, "1": 0}
+
+    for key, act in LAYERS:
+        p = root / f"{key}.md"
+        if not p.exists():
+            continue
+        text = p.read_text(encoding="utf-8")
+        file_url = f"{args.repo_url}/{key}.md"
+        if key == "STALENESS":
+            total, flags = parse_staleness(text)
+            layers.append({"key": key, "act": act, "url": file_url,
+                           "total": total, "by_importance": None,
+                           "by_origin": {"auto": total, "human": 0},
+                           "flags": flags, "entries": []})
+            staleness = {"total": total, **flags}
+            tot_rows += total
+            tot_auto += total
+            continue
+        entries = parse_entry_layer(text, file_url)
+        by_imp = {"3": 0, "2": 0, "1": 0}
+        by_org = {"auto": 0, "human": 0}
+        for e in entries:
+            if e["importance"] in (3, 2, 1):
+                by_imp[str(e["importance"])] += 1
+                tot_imp[str(e["importance"])] += 1
+            by_org[e["origin"]] += 1
+        layers.append({"key": key, "act": act, "url": file_url,
+                       "total": len(entries), "by_importance": by_imp,
+                       "by_origin": by_org, "entries": entries})
+        tot_rows += len(entries)
+        tot_auto += by_org["auto"]
+        tot_human += by_org["human"]
+
+    data = {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "side": side_name,
+        "repo_url": args.repo_url,
+        "layers": layers,
+        "staleness": staleness,
+        "totals": {"rows": tot_rows, "auto": tot_auto, "human": tot_human,
+                   "by_importance": tot_imp, "layers": len(layers)},
+    }
+    Path(args.out).write_text(json.dumps(data, ensure_ascii=False, indent=1),
+                              encoding="utf-8")
+    print(f"wrote {args.out}: {len(layers)} layers, {tot_rows} rows "
+          f"(⚙️{tot_auto}/✍️{tot_human}); staleness={staleness}")
+
+
+if __name__ == "__main__":
+    main()

--- a/epistemic_dashboard/epistemic.json
+++ b/epistemic_dashboard/epistemic.json
@@ -1,0 +1,427 @@
+{
+ "generated_at": "2026-07-08T10:14:40Z",
+ "side": "Sanskrit-data",
+ "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
+ "layers": [
+  {
+   "key": "ASSUMPTIONS",
+   "act": "relying on an unproven premise",
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md",
+   "total": 6,
+   "by_importance": {
+    "3": 4,
+    "2": 2,
+    "1": 0
+   },
+   "by_origin": {
+    "auto": 0,
+    "human": 6
+   },
+   "entries": [
+    {
+     "title": "§1. DCS lemma == CDSL headword",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#1-dcs-lemma--cdsl-headword"
+    },
+    {
+     "title": "§2. One transliteration scheme keys all DCS files",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#2-one-transliteration-scheme-keys-all-dcs-files"
+    },
+    {
+     "title": "§3. A dict's giant verb root lives at homonym index 0",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#3-a-dicts-giant-verb-root-lives-at-homonym-index-0"
+    },
+    {
+     "title": "§4. A worklist built by iterating PWG keys covers the local layer universe",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#4-a-worklist-built-by-iterating-pwg-keys-covers-the-local-layer-universe"
+    },
+    {
+     "title": "§5. A shared markup tag means the same thing across dicts",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#5-a-shared-markup-tag-means-the-same-thing-across-dicts"
+    },
+    {
+     "title": "§6. A verified correction queue stays valid until filed",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#6-a-verified-correction-queue-stays-valid-until-filed"
+    }
+   ]
+  },
+  {
+   "key": "CONTRADICTIONS",
+   "act": "≥2 sources disagree, no verdict",
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md",
+   "total": 5,
+   "by_importance": {
+    "3": 0,
+    "2": 5,
+    "1": 0
+   },
+   "by_origin": {
+    "auto": 0,
+    "human": 5
+   },
+   "entries": [
+    {
+     "title": "§1. Derivative ī/ū-stem gen.pl accent (Whitney, internal)",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md#1-derivative-īū-stem-genpl-accent-whitney-internal"
+    },
+    {
+     "title": "§2. Varga-diachrony: 2014 dissertation prose vs its own χ² table",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md#2-varga-diachrony-2014-dissertation-prose-vs-its-own-χ²-table"
+    },
+    {
+     "title": "§3. Krylov's 2014 Palsule-exclusion charge vs vidyut dhātupāṭha",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md#3-krylovs-2014-palsule-exclusion-charge-vs-vidyut-dhātupāṭha"
+    },
+    {
+     "title": "§4. SKD/VCP citation-fusion direction: one-lemma exemplar vs corpus count",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md#4-skdvcp-citation-fusion-direction-one-lemma-exemplar-vs-corpus-count"
+    },
+    {
+     "title": "§5. Sense-granularity: two runs disagree on the year-correlation",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md#5-sense-granularity-two-runs-disagree-on-the-year-correlation"
+    }
+   ]
+  },
+  {
+   "key": "GAPS",
+   "act": "not-yet-knowing (the frontier)",
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md",
+   "total": 11,
+   "by_importance": {
+    "3": 0,
+    "2": 4,
+    "1": 7
+   },
+   "by_origin": {
+    "auto": 5,
+    "human": 6
+   },
+   "entries": [
+    {
+     "title": "§1. Derivative ī/ū gen.pl accent split (D3) — n=2, unresolvable",
+     "importance": 1,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#1-derivative-īū-genpl-accent-split-d3--n2-unresolvable"
+    },
+    {
+     "title": "§2. Error population of 40 of 43 dictionaries",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#2-error-population-of-40-of-43-dictionaries"
+    },
+    {
+     "title": "§3. Heritage inflected-form morphology XML — never ingested",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#3-heritage-inflected-form-morphology-xml--never-ingested"
+    },
+    {
+     "title": "§4. Homonym token frequency beyond the 26+5 splittable groups",
+     "importance": 1,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#4-homonym-token-frequency-beyond-the-265-splittable-groups"
+    },
+    {
+     "title": "§5. `Stopovye` parallel-passage bundle vs full export — never content-diffed",
+     "importance": 1,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#5-stopovye-parallel-passage-bundle-vs-full-export--never-content-diffed"
+    },
+    {
+     "title": "§6. Cyrillic-only Sanskrit name glossaries — no join key exists",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#6-cyrillic-only-sanskrit-name-glossaries--no-join-key-exists"
+    },
+    {
+     "title": "§7. `dcs-stem-cooccurrence-full` (353,352 stem-pair rows) is uncharacterised",
+     "importance": 1,
+     "origin": "auto",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#7-dcs-stem-cooccurrence-full-353352-stem-pair-rows-is-uncharacterised"
+    },
+    {
+     "title": "§8. DCS syntagmatic collocation tables (Прил. 6 + 7) are unanalysed",
+     "importance": 1,
+     "origin": "auto",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#8-dcs-syntagmatic-collocation-tables-прил-6--7-are-unanalysed"
+    },
+    {
+     "title": "§9. `heritage-forms-crosswalk-extras` disagreement classes are uncounted",
+     "importance": 1,
+     "origin": "auto",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#9-heritage-forms-crosswalk-extras-disagreement-classes-are-uncounted"
+    },
+    {
+     "title": "§10. Which-dictionary routing benchmark has single-annotator gold, no κ",
+     "importance": 2,
+     "origin": "auto",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#10-which-dictionary-routing-benchmark-has-single-annotator-gold-no-κ"
+    },
+    {
+     "title": "§11. `dcs-verb-form-frequency-prelim` is flagged preliminary, never finalised",
+     "importance": 1,
+     "origin": "auto",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#11-dcs-verb-form-frequency-prelim-is-flagged-preliminary-never-finalised"
+    }
+   ]
+  },
+  {
+   "key": "DEAD_ENDS",
+   "act": "abandoning an approach",
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md",
+   "total": 7,
+   "by_importance": {
+    "3": 5,
+    "2": 2,
+    "1": 0
+   },
+   "by_origin": {
+    "auto": 1,
+    "human": 6
+   },
+   "entries": [
+    {
+     "title": "§1. Body-text / reverse-dict headword mining — abandoned",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#1-body-text--reverse-dict-headword-mining--abandoned"
+    },
+    {
+     "title": "§2. Corpus-derived present-class attribution — abandoned",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#2-corpus-derived-present-class-attribution--abandoned"
+    },
+    {
+     "title": "§3. Sandhi-join lookup for prefixed-verb corpus evidence — abandoned",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#3-sandhi-join-lookup-for-prefixed-verb-corpus-evidence--abandoned"
+    },
+    {
+     "title": "§4. Bulk-respell of \"typo\" headword-correction lists — abandoned",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#4-bulk-respell-of-typo-headword-correction-lists--abandoned"
+    },
+    {
+     "title": "§5. NFD-decompose-then-strip-Mn as a Sanskrit normalization key — abandoned",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#5-nfd-decompose-then-strip-mn-as-a-sanskrit-normalization-key--abandoned"
+    },
+    {
+     "title": "§6. `OccId` / `sent_id` as a DCS primary key — abandoned",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#6-occid--sentid-as-a-dcs-primary-key--abandoned"
+    },
+    {
+     "title": "§7. Generalising dictionary-level sense-inheritance direction to corpus scale — refuted",
+     "importance": 2,
+     "origin": "auto",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#7-generalising-dictionary-level-sense-inheritance-direction-to-corpus-scale--refuted"
+    }
+   ]
+  },
+  {
+   "key": "RECIPES",
+   "act": "reproducing a fact",
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md",
+   "total": 6,
+   "by_importance": {
+    "3": 2,
+    "2": 4,
+    "1": 0
+   },
+   "by_origin": {
+    "auto": 0,
+    "human": 6
+   },
+   "entries": [
+    {
+     "title": "§1. Whitney accent axis validation (17→18/19 GO) → reproduce",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md#1-whitney-accent-axis-validation-171819-go--reproduce"
+    },
+    {
+     "title": "§2. DCS↔CDSL crosswalk (81.4% linked) → reproduce",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md#2-dcscdsl-crosswalk-814-linked--reproduce"
+    },
+    {
+     "title": "§3. DeepSeek word-alignment grounding cross-check (6.6% ungrounded) → reproduce",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md#3-deepseek-word-alignment-grounding-cross-check-66-ungrounded--reproduce"
+    },
+    {
+     "title": "§4. Varga diachrony + Cramér's V (0.037) → reproduce",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md#4-varga-diachrony--cramérs-v-0037--reproduce"
+    },
+    {
+     "title": "§5. Cross-dict union headword index (323,425 / PWG∩MW=94,753) → reproduce",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md#5-cross-dict-union-headword-index-323425--pwgmw94753--reproduce"
+    },
+    {
+     "title": "§6. Correction loci census (39,540 records) → reproduce",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md#6-correction-loci-census-39540-records--reproduce"
+    }
+   ]
+  },
+  {
+   "key": "STALENESS",
+   "act": "decaying — confidence over time",
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/STALENESS.md",
+   "total": 66,
+   "by_importance": null,
+   "by_origin": {
+    "auto": 66,
+    "human": 0
+   },
+   "flags": {
+    "red": 0,
+    "yellow": 0,
+    "green": 66,
+    "unknown": 0
+   },
+   "entries": []
+  },
+  {
+   "key": "GLOSSARY",
+   "act": "defining canonical terms",
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md",
+   "total": 12,
+   "by_importance": {
+    "3": 4,
+    "2": 7,
+    "1": 1
+   },
+   "by_origin": {
+    "auto": 0,
+    "human": 12
+   },
+   "entries": [
+    {
+     "title": "form_key",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md#formkey"
+    },
+    {
+     "title": "headword vs lemma",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md#headword-vs-lemma"
+    },
+    {
+     "title": "homonym index",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md#homonym-index"
+    },
+    {
+     "title": "ls source map",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md#ls-source-map"
+    },
+    {
+     "title": "gaṇa",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md#gaṇa"
+    },
+    {
+     "title": "Renou period-state",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md#renou-period-state"
+    },
+    {
+     "title": "varga",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md#varga"
+    },
+    {
+     "title": "SLP1 vs IAST",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md#slp1-vs-iast"
+    },
+    {
+     "title": "key1 vs key2",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md#key1-vs-key2"
+    },
+    {
+     "title": "Zaliznyak index (a–f accent axis)",
+     "importance": 1,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md#zaliznyak-index-af-accent-axis"
+    },
+    {
+     "title": "`<ls>` / iti register",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md#ls--iti-register"
+    },
+    {
+     "title": "dhātupāṭha citation form",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md#dhātupāṭha-citation-form"
+    }
+   ]
+  }
+ ],
+ "staleness": {
+  "total": 66,
+  "red": 0,
+  "yellow": 0,
+  "green": 66,
+  "unknown": 0
+ },
+ "totals": {
+  "rows": 113,
+  "auto": 72,
+  "human": 41,
+  "by_importance": {
+   "3": 15,
+   "2": 24,
+   "1": 8
+  },
+  "layers": 7
+ }
+}

--- a/epistemic_dashboard/index.html
+++ b/epistemic_dashboard/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Epistemic registries dashboard</title>
+<style>
+  :root { --fg:#1f2328; --mut:#59636e; --bg:#fff; --card:#f6f8fa; --line:#d1d9e0;
+          --auto:#8250df; --human:#1a7f37; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg:#e6edf3; --mut:#9198a1; --bg:#0d1117; --card:#161b22; --line:#30363d;
+            --auto:#a371f7; --human:#3fb950; }
+  }
+  body { font: 15px/1.5 system-ui, sans-serif; color:var(--fg); background:var(--bg);
+         max-width: 1080px; margin: 0 auto; padding: 1.5rem; }
+  h1 { font-size: 1.5rem; margin-bottom:.2rem; } h2 { font-size: 1.15rem; margin-top: 2rem; }
+  .mut { color: var(--mut); font-size: .85rem; }
+  .cards { display: flex; gap: .8rem; flex-wrap: wrap; margin: 1rem 0; }
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+          padding: .7rem 1.1rem; min-width: 7rem; }
+  .card b { font-size: 1.5rem; display: block; }
+  table { border-collapse: collapse; width: 100%; font-size: .9rem; }
+  th, td { text-align: left; padding: .4rem .6rem; border-bottom: 1px solid var(--line);
+           vertical-align: top; }
+  th { color: var(--mut); font-weight: 600; }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  a { color: inherit; }
+  .bar { display:flex; height:.5rem; border-radius:4px; overflow:hidden; min-width:6rem;
+         background:var(--line); }
+  .bar i { display:block; }
+  .auto { color: var(--auto); } .human { color: var(--human); }
+  .swatch { display:inline-block; width:.7rem; height:.7rem; border-radius:2px;
+            vertical-align:baseline; margin-right:.25rem; }
+</style>
+</head>
+<body>
+<h1 id="title">Epistemic registries — dashboard</h1>
+<p class="mut" id="lede"></p>
+
+<div class="cards" id="cards"></div>
+
+<h2>The seven layers</h2>
+<p class="mut">Each layer holds one epistemic act that <a id="findings-link" href="#">FINDINGS.md</a>
+(measured-fact-only) structurally can't. <span class="swatch" style="background:var(--auto)"></span><span class="auto">⚙️ auto</span> rows were emitted by a seed script and are <em>candidates</em> until a human confirms; <span class="swatch" style="background:var(--human)"></span><span class="human">✍️ human</span> rows were written by a session. Rows graduate into FINDINGS / CROSS_REPO_DECISIONS as they mature.</p>
+<table id="layers"></table>
+
+<h2>STALENESS — confidence decay</h2>
+<p class="mut">The fully-auto-generated layer. Flag = 🔴 &gt;6 mo since last re-verify · 🟡 3–6 mo · 🟢 fresh (&lt;3 mo) · ⬜ undated.</p>
+<div class="cards" id="stale"></div>
+
+<h2>Origin mix — how much is machine-seeded vs human-written</h2>
+<p class="mut">The registries are designed to be seeded automatically and confirmed by hand. A healthy layer trends from ⚙️ toward ✍️ over time as candidates are confirmed or deleted.</p>
+<table id="origin"></table>
+
+<script>
+'use strict';
+const DOT = {3:'🔴', 2:'🟠', 1:'🟡'};
+const esc = s => String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+async function j(f){ try { const r = await fetch(f); return r.ok ? r.json() : null; } catch { return null; } }
+
+function bar(auto, human){
+  const t = auto + human || 1;
+  return `<span class="bar" title="⚙️ ${auto} auto · ✍️ ${human} human">
+    <i style="width:${100*auto/t}%;background:var(--auto)"></i>
+    <i style="width:${100*human/t}%;background:var(--human)"></i></span>`;
+}
+
+(async () => {
+  const d = await j('epistemic.json');
+  if (!d) { document.getElementById('lede').textContent = 'epistemic.json not found.'; return; }
+  const isInfra = /infra/i.test(d.side);
+  document.getElementById('title').textContent =
+    `Epistemic registries — ${d.side} side`;
+  document.getElementById('lede').innerHTML =
+    `Seven sibling registries to <a href="${esc(d.repo_url)}/FINDINGS.md">FINDINGS.md</a>, ` +
+    `minted under <a href="https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md">H356</a>. ` +
+    (isInfra
+      ? 'This is the <b>infra / process</b> side — private, viewed locally (not published). '
+      : 'This is the <b>Sanskrit-data</b> side. Its infra twin lives in the private Uprava repo. ') +
+    `Generated ${esc(d.generated_at)}.`;
+  document.getElementById('findings-link').href = d.repo_url + '/FINDINGS.md';
+
+  const t = d.totals;
+  document.getElementById('cards').innerHTML =
+    `<div class="card"><b>${t.rows}</b>rows</div>` +
+    `<div class="card"><b>${t.layers}</b>layers</div>` +
+    `<div class="card"><b class="auto">${t.auto}</b>⚙️ auto</div>` +
+    `<div class="card"><b class="human">${t.human}</b>✍️ human</div>` +
+    [3,2,1].map(i => `<div class="card"><b>${t.by_importance[i]||0}</b>${DOT[i]}</div>`).join('');
+
+  document.getElementById('layers').innerHTML =
+    '<tr><th>Layer</th><th>Epistemic act</th><th class="num">rows</th>' +
+    '<th class="num">🔴</th><th class="num">🟠</th><th class="num">🟡</th><th>origin</th></tr>' +
+    d.layers.map(L => {
+      const bi = L.by_importance || {};
+      const org = L.by_origin || {auto:0,human:0};
+      const n = k => bi[k] || '';
+      return `<tr><td><a href="${esc(L.url)}"><b>${esc(L.key)}</b></a></td>` +
+        `<td class="mut">${esc(L.act)}</td>` +
+        `<td class="num">${L.total}</td>` +
+        `<td class="num">${n(3)}</td><td class="num">${n(2)}</td><td class="num">${n(1)}</td>` +
+        `<td>${bar(org.auto, org.human)}</td></tr>`;
+    }).join('');
+
+  const s = d.staleness || {total:0,red:0,yellow:0,green:0,unknown:0};
+  document.getElementById('stale').innerHTML =
+    `<div class="card"><b>${s.total}</b>findings dated</div>` +
+    `<div class="card"><b>${s.red}</b>🔴 &gt;6 mo</div>` +
+    `<div class="card"><b>${s.yellow}</b>🟡 3–6 mo</div>` +
+    `<div class="card"><b>${s.green}</b>🟢 fresh</div>` +
+    (s.unknown ? `<div class="card"><b>${s.unknown}</b>⬜ undated</div>` : '');
+
+  document.getElementById('origin').innerHTML =
+    '<tr><th>Layer</th><th class="num">⚙️ auto</th><th class="num">✍️ human</th><th>mix</th></tr>' +
+    d.layers.map(L => {
+      const o = L.by_origin || {auto:0,human:0};
+      return `<tr><td>${esc(L.key)}</td><td class="num auto">${o.auto}</td>` +
+        `<td class="num human">${o.human}</td><td>${bar(o.auto, o.human)}</td></tr>`;
+    }).join('') +
+    `<tr><td><b>total</b></td><td class="num auto"><b>${t.auto}</b></td>` +
+    `<td class="num human"><b>${t.human}</b></td><td>${bar(t.auto, t.human)}</td></tr>`;
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Follow-up to [#239](https://github.com/gasyoun/SanskritLexicography/pull/239) (H356). Two things MG asked for:

**1. The combined epistemic dashboard** (the one deferred Wave-3 piece — the handoff gated it on '≥2 layers have content', now satisfied). `epistemic_dashboard/` extends the `findings_dashboard/` pattern over the seven registries, wired into [`findings-dashboard.yml`](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/workflows/findings-dashboard.yml) to publish monthly at **/epistemic/**. Shows per-layer rows, importance breakdown, the **⚙️ auto vs ✍️ human** origin split (the health signal), and the STALENESS decay summary. Builder is a byte-identical vendored copy of [sanskrit-util#…](https://github.com/sanskrit-lexicon/sanskrit-util/pull/16) so CI self-builds. Sanskrit-data side only — the infra side stays private in Uprava (local-only view).

**2. Retrospective seed pass.** Ran the seeders over the back-catalogue and appended real `⚙️ auto` candidate rows: **GAPS +5** (kosha datasets with no FINDINGS row — stem-cooccurrence, syntagmatic tables, Heritage disagreements, routing-benchmark κ, verb-form freq) and **DEAD_ENDS +1** (R2606-06 corpus-scale sense-inheritance). Honestly marked ⚙️ candidates awaiting human confirm (→ ✍️) — the design's intended fill mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)