### PR TITLE
docs: VedaWeb rights CONFIRMED same-day — FINDINGS §64 resolved, roadmap Phase 4 updated

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1662,10 +1662,24 @@ annotation layer, regardless of how the platform's hosting terms are eventually 
 Implication: any future VedaWeb-derived feed with a `license: null` catalog entry needs
 its own rights call before landing (bulk import), not an inherited blanket assumption —
 see [`VisualDCS/non-derived/vedaweb/LAYERS_TRIAGE.md`](https://github.com/gasyoun/VisualDCS/blob/main/non-derived/vedaweb/LAYERS_TRIAGE.md)
-for the full 36-layer table and the open `@DECIDE` to confirm or narrow H096's own claim.
+for the full 36-layer table.
+
+**✅ Resolved 08-07-2026:** [H359](https://github.com/gasyoun/Uprava/blob/main/handoffs/H359-Sonnet_Uprava_vedaweb_rights_outreach_send_08.07.26.md)'s
+outreach email to VedaWeb got an explicit written reply from Prof. Daniel Kölligan
+(writing also on behalf of Prof. Uta Reinöhl): the 4 candidate layers this finding flagged
+as DECIDE (Metrical Data 2024, Elizarenkova RU, Geldner de, Grassmann de) are confirmed
+**CC BY 4.0**, and — directly answering the "implication" above — VedaWeb confirmed the
+34-null-license-field gap is a metadata omission on their side, not an absence of rights,
+and committed to backfilling all 34 entries with CC BY 4.0. This retroactively confirms
+H096's own blanket claim was correct, even though it had not been independently verified
+at the time it was made. Full reply:
+[`Uprava/handoffs/OUTREACH_2026-07-08_vedaweb_kolligan_reinohl_rights.md`](https://github.com/gasyoun/Uprava/blob/main/handoffs/OUTREACH_2026-07-08_vedaweb_kolligan_reinohl_rights.md).
+The general lesson stands independent of this specific happy outcome: a `license: null`
+field is not evidence of *no* rights, but it is also not evidence *of* rights — ask, don't
+assume, and here asking took one email and about a day's turnaround.
 
 > **Source:** H098 triage ([VisualDCS](https://github.com/gasyoun/VisualDCS/tree/main/non-derived/vedaweb)),
-> Sonnet 5 `claude-sonnet-5` · 2026-07-08
+> Sonnet 5 `claude-sonnet-5` · 2026-07-08; resolution via H359, Sonnet 5 `claude-sonnet-5` · 2026-07-08
 
 ---
 

--- a/ROADMAP_VEDAWEB_REUSE.md
+++ b/ROADMAP_VEDAWEB_REUSE.md
@@ -88,23 +88,30 @@ Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H097-Sonnet_VisualDCS_gra_ve
 
 Sonnet-tier chat in `GitHub\VisualDCS`.
 
-### Phase 4 — meter + translation layers triage — ✅ DONE 08-07-2026 (DECIDE outcome, not GO)
+### Phase 4 — meter + translation layers triage — ✅ DONE 08-07-2026, rights CONFIRMED same day
 
 - [x] Full 36-layer inventory confirmed (Elizarenkova Russian layer real, 10,551
   Cyrillic-text stanzas; a VedaWeb-generated metrical-scansion layer with per-pada
   long/short marks + meter-type label, both sample-exported and field-mapped). **Rights
   finding: only 2/36 catalog resources carry an explicit `license` field** — the blanket
-  "CC BY 4.0 for everything" framing above (Standing constraints) is an unverified
-  assumption, not a re-confirmed fact; see
+  "CC BY 4.0 for everything" framing above (Standing constraints) was an unverified
+  assumption at triage time; see
   [FINDINGS.md §64](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).
-  **No layer in this triage's scope (meter/translation/German gloss/morphology-beyond-RV)
-  cleared the guardrail for a GO** — every candidate is DECIDE pending rights
-  confirmation (Elizarenkova RU explicitly in-copyright to ~2078, Renou to ~2036; PD-era
-  translators' VedaWeb-specific digitized editions still unconfirmed). Full table + per-
+  Triage originally parked all 4 meter/translation candidates DECIDE pending confirmation
+  (Elizarenkova RU explicitly in-copyright to ~2078, Renou to ~2036). Full table + per-
   consumer effort estimates:
   [`VisualDCS/non-derived/vedaweb/LAYERS_TRIAGE.md`](https://github.com/gasyoun/VisualDCS/blob/main/non-derived/vedaweb/LAYERS_TRIAGE.md).
-  `@DECIDE` rows opened in GTD. Handoff:
-  [H098](https://github.com/gasyoun/Uprava/blob/main/handoffs/H098-Sonnet_VisualDCS_vedaweb_meter_translations_triage_03.07.26.md).
+  Handoff: [H098](https://github.com/gasyoun/Uprava/blob/main/handoffs/H098-Sonnet_VisualDCS_vedaweb_meter_translations_triage_03.07.26.md).
+- [x] **Rights confirmed same day** — [H359](https://github.com/gasyoun/Uprava/blob/main/handoffs/H359-Sonnet_Uprava_vedaweb_rights_outreach_send_08.07.26.md)'s
+  outreach email to VedaWeb (Prof. Kölligan/Reinöhl) got an explicit written reply: all 4
+  candidate layers (Metrical Data 2024, Elizarenkova RU, Geldner de, Grassmann de)
+  confirmed **CC BY 4.0**, same terms as H096's already-landed layers — retroactively
+  confirming H096's blanket claim too. VedaWeb also confirmed the 34-null-license gap is a
+  metadata omission, not an absence of rights, and will backfill it. Consumer handoffs
+  minted: [H360](https://github.com/gasyoun/Uprava/blob/main/handoffs/H360-Sonnet_SanskritKaraoke_vedaweb_metrical_verse_seeds_08.07.26.md)
+  (SanskritKaraoke meter), [H361](https://github.com/gasyoun/Uprava/blob/main/handoffs/H361-Sonnet_SanskritLexicography_vedaweb_elizarenkova_ru_witness_08.07.26.md)
+  (RussianTranslation RU witness), [H362](https://github.com/gasyoun/Uprava/blob/main/handoffs/H362-Sonnet_VisualDCS_vedaweb_geldner_grassmann_pwg_gloss_08.07.26.md)
+  (PWG German gloss witness).
 
 ```
 Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H098-Sonnet_VisualDCS_vedaweb_meter_translations_triage_03.07.26.md and execute it.


### PR DESCRIPTION
## Summary
- H359's outreach email got an explicit written reply confirming CC BY 4.0 for the 4 DECIDE-tier layers, retroactively confirming H096's blanket claim.
- FINDINGS.md §64 resolution addendum; ROADMAP_VEDAWEB_REUSE.md Phase 4 updated.
- Consumer handoffs H360/H361/H362 minted and cross-linked.

Companion PR: [VisualDCS#20](https://github.com/gasyoun/VisualDCS/pull/20).

## Test plan
- [x] Docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)