### PR TITLE
H361: Elizarenkova RV citation/context witness

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,16 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### H361 — Elizarenkova RV citation/context witness (VedaWeb, CC BY 4.0)
+- New [`src/vedaweb_ru_witness.py`](src/vedaweb_ru_witness.py): RV `location` →
+  Elizarenkova's published Russian rendering, reading the committed
+  [`VisualDCS/non-derived/vedaweb/elizarenkova_ru_1989_1999.json`](https://github.com/gasyoun/VisualDCS/blob/main/non-derived/vedaweb/elizarenkova_ru_1989_1999.json)
+  feed (10,552 stanzas, CC BY 4.0 confirmed 08-07-2026). Advisory/citation-context
+  only — never written into `headword_index.tsv` or any reviewed store data. See
+  [CORPUS_PROVENANCE.md § RV citation witness](CORPUS_PROVENANCE.md#rv-citation-witness-vedaweb-cc-by-40--distinct-from-the-corpus-above)
+  for why this is a distinct rights posture from the grey-rights Elizarenkova copy
+  already inside the `SamudraManthanam` corpus DB.
+
 ### H350 / E7 — flat OntoLex export → real LOD graph (OntoLex + vartrans + PROV-O + LiLa)
 - New [`src/export_lod.py`](src/export_lod.py): upgrades the flat one-way string
   export ([`src/export_interop.py`](src/export_interop.py) → `release/ontolex.ttl`,

--- a/RussianTranslation/CORPUS_PROVENANCE.md
+++ b/RussianTranslation/CORPUS_PROVENANCE.md
@@ -52,7 +52,35 @@ from the lexicon.
   print the actual **verse pair + the published Russian translation it's quoted from**
   (Елизаренкова РВ/АВ, academic Mahābhārata, …). Currently wired for 4 flagship headwords
   (agni, anya, akṣara, ananta); generalize its `WORDS` map to document any headword that
-  way. Requires the SamudraManthanam sibling repo.
+  way. Requires the SamudraManthanam sibling repo. **This corpus's Elizarenkova text is
+  grey-rights** (not cleared for redistribution, per `SamudraManthanam/README.md`) — it
+  stays internal to that application, never surfaced in a public artifact.
+
+## RV citation witness (VedaWeb, CC BY 4.0 — distinct from the corpus above)
+
+[`src/vedaweb_ru_witness.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/vedaweb_ru_witness.py)
+([H361](https://github.com/gasyoun/Uprava/blob/main/handoffs/H361-Sonnet_SanskritLexicography_vedaweb_elizarenkova_ru_witness_08.07.26.md))
+looks up Elizarenkova's published Russian rendering by **RV location**
+(`mandala.hymn.stanza`), reading the committed
+[`VisualDCS/non-derived/vedaweb/elizarenkova_ru_1989_1999.json`](https://github.com/gasyoun/VisualDCS/blob/main/non-derived/vedaweb/elizarenkova_ru_1989_1999.json)
+feed (10,552 stanzas, sibling repo). This is a **different source and a different rights
+posture** from the `_build_corpus_ru.py` DB above: VedaWeb (Universität zu Köln) holds an
+explicit written CC BY 4.0 grant for this specific hosted resource (confirmed 08-07-2026,
+see the feed's own README), so it is committed openly — the SamudraManthanam copy is not,
+and the two must never be conflated when citing "Elizarenkova via this org."
+
+```
+python src/vedaweb_ru_witness.py 1.1.1          # one stanza
+python src/vedaweb_ru_witness.py --hymn 1.1     # every stanza in a hymn
+python src/vedaweb_ru_witness.py --citation     # full bibliographic citation
+```
+
+**Advisory/citation-context only** — this is a lookup tool, not a data pipeline. It is
+meant to be run by hand (or from an ad-hoc script) when a PWG/MW headword's RV citation
+would benefit from the published Russian rendering as scholarly context. Nothing it
+returns is ever written into `headword_index.tsv` or any other reviewed store data —
+per the org's I/VI accent-collapse lesson, external corpus/translation data stays
+read-only and advisory everywhere.
 
 ## So, to answer "why is this Russian here?"
 

--- a/RussianTranslation/DATA_LICENSE.md
+++ b/RussianTranslation/DATA_LICENSE.md
@@ -32,6 +32,12 @@ relicense third-party material:
   — may be quoted verbatim, with attribution, as before.
 - **Modern corpus translations** remain tied to their source corpus/project
   permissions. Keep citation/provenance metadata on every reused passage.
+- **Elizarenkova's Russian Rig-Veda translation** (accessed via
+  [`src/vedaweb_ru_witness.py`](src/vedaweb_ru_witness.py), sourced from VedaWeb 2.0,
+  Universität zu Köln) is **CC BY 4.0**, confirmed explicitly for that specific hosted
+  resource (see [`CORPUS_PROVENANCE.md`](CORPUS_PROVENANCE.md#rv-citation-witness-vedaweb-cc-by-40--distinct-from-the-corpus-above)).
+  This is a separate copy/rights posture from the Elizarenkova text inside the
+  `SamudraManthanam` corpus (grey-rights, not redistributed here or anywhere public).
 
 The **code** in this repository is licensed separately; see the repository's
 top-level `LICENSE`.

--- a/RussianTranslation/src/vedaweb_ru_witness.py
+++ b/RussianTranslation/src/vedaweb_ru_witness.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""Cite Elizarenkova's published Russian Rig-Veda rendering for an RV location.
+
+Advisory/citation-context witness ONLY (H361) — surfaces the published Russian
+translation for a Rig-Veda stanza a PWG/MW headword cites (e.g. `<ls>RV.1.1.1</ls>`),
+for scholarly context alongside the headword card. Never written into
+headword_index.tsv or any other reviewed store data; this is a read-only lookup
+over a committed external feed.
+
+Source: VedaWeb 2.0 (Universitaet zu Koeln) export of Elizarenkova, Tatyana.
+1989/1995/1999. Rigveda: Izbrannye gimny (Rigveda: Selected Hymns), Vols 1-3.
+Moskau: Nauka. CC BY 4.0, confirmed 08-07-2026 (see VisualDCS/non-derived/vedaweb/README.md).
+
+**Distinct from** the Elizarenkova text already inside SamudraManthanam's parallel
+corpus (grey-rights, not redistributable) -- do not conflate the two sources; this
+module reads only the VedaWeb-sourced, explicitly-licensed copy.
+
+  python src/vedaweb_ru_witness.py 1.1.1          exact RV location (mandala.hymn.stanza)
+  python src/vedaweb_ru_witness.py --hymn 1.1     every stanza in a hymn
+  python src/vedaweb_ru_witness.py --citation     print the full bibliographic citation
+"""
+import json
+import os
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+FEED = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    '..', '..', '..', 'VisualDCS', 'non-derived', 'vedaweb', 'elizarenkova_ru_1989_1999.json',
+)
+
+
+def load_feed():
+    path = os.path.normpath(FEED)
+    if not os.path.exists(path):
+        print(
+            f"ERROR: feed not found at {path}\n"
+            "Expected VisualDCS as a sibling of SanskritLexicography "
+            "(see VisualDCS/non-derived/vedaweb/README.md for retrieval).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    with open(path, encoding='utf-8') as f:
+        return json.load(f)
+
+
+def by_location(feed):
+    return {entry['location']: entry['text'] for entry in feed.get('contents', [])}
+
+
+def print_citation(feed):
+    citation = feed.get('citation')
+    if isinstance(citation, list):
+        for block in citation:
+            print(block)
+    else:
+        print(citation)
+
+
+def main():
+    args = sys.argv[1:]
+    if not args or '--citation' in args:
+        feed = load_feed()
+        if '--citation' in args:
+            print_citation(feed)
+            return
+        print(__doc__)
+        return
+
+    feed = load_feed()
+    locs = by_location(feed)
+
+    if args[0] == '--hymn':
+        if len(args) < 2:
+            print("usage: --hymn <mandala.hymn>", file=sys.stderr)
+            sys.exit(1)
+        prefix = args[1] + '.'
+        matches = sorted(
+            (loc for loc in locs if loc.startswith(prefix)),
+            key=lambda loc: int(loc.split('.')[-1]),
+        )
+        if not matches:
+            print(f"No stanzas found for hymn {args[1]}", file=sys.stderr)
+            sys.exit(1)
+        for loc in matches:
+            print(f"[{loc}] {locs[loc]}")
+        return
+
+    location = args[0]
+    text = locs.get(location)
+    if text is None:
+        print(f"No Elizarenkova rendering found for location {location!r}", file=sys.stderr)
+        sys.exit(1)
+    print(f"[{location}] {text}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- New `src/vedaweb_ru_witness.py`: RV `location` → Elizarenkova's published Russian rendering, reading the committed [VisualDCS](https://github.com/gasyoun/VisualDCS) feed (`elizarenkova_ru_1989_1999.json`, CC BY 4.0 confirmed 08-07-2026 via [H359](https://github.com/gasyoun/Uprava/blob/main/handoffs/H359-Sonnet_Uprava_vedaweb_rights_outreach_send_08.07.26.md))
- Advisory/citation-context only — never written into `headword_index.tsv` or any reviewed store data
- Documents the distinct rights posture from the grey-rights Elizarenkova copy already inside the `SamudraManthanam` corpus DB (`_build_corpus_ru.py`) — the two sources must not be conflated
- Updates `CORPUS_PROVENANCE.md`, `DATA_LICENSE.md`, `CHANGELOG.md`

Companion PR: [VisualDCS#23](https://github.com/gasyoun/VisualDCS/pull/23) (merged) — lands the underlying feed.

## Test plan
- [x] `python src/vedaweb_ru_witness.py 1.1.1` → correct Cyrillic stanza matching H098's prior sample
- [x] `--hymn 1.1` → all stanzas in the hymn
- [x] `--citation` → full bibliographic citation
- [x] missing location → clean error, exit 1

Sonnet 5 (`claude-sonnet-5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)