### PR TITLE
H356: episteme Source lines normalized + glossary examples

### DIFF
--- a/ASSUMPTIONS.md
+++ b/ASSUMPTIONS.md
@@ -24,7 +24,7 @@ Relied on by: `dcs_cdsl_xref.tsv` (kosha manifest `dcs-cdsl-xref`), `build_xref.
 Verified?: ⚠️ spot-checked once (11-06-2026, n=15,902 lemmas) — 81.4% link, 18.6% (2,956 lemmas) have NO CDSL headword.
 Test to confirm: recount linked/total in [`dcs_cdsl_xref.tsv`](https://github.com/sanskrit-lexicon/csl-apidev/blob/master/simple-search/dcs_xref/dcs_cdsl_xref.tsv); any pipeline assuming 100% coverage silently drops ~1/5 of corpus vocabulary.
 ↔ Interlinks: [RECIPES §2](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) reproduces the 81.4% number that bounds this premise · [GLOSSARY "headword vs lemma"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) defines the distinction this assumption blurs · the unlinked 18.6% is the frontier next to [GAPS §3](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (Heritage as a third witness).
-> **Source:** [FINDINGS §12](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword) · csl-apidev · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §12](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword) · [csl-apidev](https://github.com/sanskrit-lexicon/csl-apidev) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ### §2. One transliteration scheme keys all DCS files
 🔴 ✍️ **A frequency/lemma join can assume a single transliteration across the DCS-derived files.**
@@ -32,7 +32,7 @@ Relied on by: `freq_route.py`, any join between `VisualDCS/dcs_lemma_summary.jso
 Verified?: ⚠️ spot-checked once (24-06-2026) — the two files are keyed in DIFFERENT schemes (SLP1 vs IAST).
 Test to confirm: diff a sample of keys across both files; a raw string join misses every non-ASCII-coincident lemma unless one side is transcoded via `sanskrit-util`.
 ↔ Interlinks: [GLOSSARY "SLP1 vs IAST"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) is the term this premise trips over · [DEAD_ENDS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) is the *wrong* way to bridge schemes (NFD+strip) · [RECIPES §2](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) shows the transcode-then-join done right.
-> **Source:** [FINDINGS §7](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations) · VisualDCS/RussianTranslation · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §7](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations) · [VisualDCS](https://github.com/gasyoun/VisualDCS)/[RussianTranslation](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ---
 
@@ -45,7 +45,7 @@ Relied on by: `gen_root_split()`, any PWG root-portrait/segmentation walk over h
 Verified?: ⚠️ spot-checked once (24-06-2026, top-50 freq roots) — 19 of 50 have a giant homonym at index > 0 (√i at 2, √mā at 2, √as at 1).
 Test to confirm: re-run [`audit_root_split.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/audit_root_split.py); iterate ALL homonym records, never `bufs[0]`.
 ↔ Interlinks: [GLOSSARY "homonym index"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) defines the ordinal this premise mis-assumes · [GAPS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (homonym token frequency) is what stays unreachable while this holds.
-> **Source:** [FINDINGS §16](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes) · csl-orig (pwg)/RussianTranslation · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §16](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes) · [csl-orig](https://github.com/sanskrit-lexicon/csl-orig) (pwg)/[RussianTranslation](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ### §4. A worklist built by iterating PWG keys covers the local layer universe
 🔴 ✍️ **Enumerating "headwords" by walking PWG records reaches the whole pwg_ru merge universe.**
@@ -53,7 +53,7 @@ Relied on by: the verb-root worklist (`verbs01`/PWG), any pwg_ru queue builder.
 Verified?: ⚠️ spot-checked once (05-07-2026, n=167,988 headwords) — ≈35,900 headwords (≈36%) carry ZERO PWG record; PW-only alone = 40,338 (24%).
 Test to confirm: re-run the `dict_merge.py` index tally in [`PWG_LAYER_COMBINATIONS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/PWG_LAYER_COMBINATIONS.md); PW/SCH/PWKVN-only entries need their own queue path.
 ↔ Interlinks: [RECIPES §5](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (union headword index) is the asset that *measures* the true universe this premise underestimates.
-> **Source:** [FINDINGS §64](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1-pwg-is-not-the-sole-spine-of-the-local-layer-universe) · SanskritLexicography · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §64](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1-pwg-is-not-the-sole-spine-of-the-local-layer-universe) · [SanskritLexicography](https://github.com/gasyoun/SanskritLexicography) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ---
 
@@ -66,7 +66,7 @@ Relied on by: any cross-dict tag-count survey (etymology detectors, `<ls>` densi
 Verified?: ⚠️ spot-checked once (26-06-2026) — `<ab>E.</ab>` = Etymology in WIL but "Epithet of" in CAE, "Epic" in MD; SKD/VCP score 0 on Western markers by construction, not for lack of content.
 Test to confirm: read entry contexts per dict before parsing; count the meaning, not the marker.
 ↔ Interlinks: [CONTRADICTIONS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) is the same "tag effect is record-type-bound" trap at corpus scale · [GLOSSARY "`<ls>` / iti register"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) is the register confound this premise ignores.
-> **Source:** [FINDINGS §34](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#34-the-e-abbreviation-tag-is-polysemous-across-dicts) + [§19](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#19-skd-and-vcp-carry-essentially-zero-western-markup) · csl-orig · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §34](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#34-the-e-abbreviation-tag-is-polysemous-across-dicts) + [§19](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#19-skd-and-vcp-carry-essentially-zero-western-markup) · [csl-orig](https://github.com/sanskrit-lexicon/csl-orig) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ### §6. A verified correction queue stays valid until filed
 🟠 ✍️ **A triaged correction stays applicable against live csl-orig between triage and filing.**
@@ -74,7 +74,7 @@ Relied on by: the monthly csl-orig batch PR, the SanskritSpellCheck FILE-FIRST q
 Verified?: ⚠️ spot-checked once (02-07-2026, n=122) — ≈0.8%/week decay; 1 candidate already fixed upstream within ~1 week.
 Test to confirm: re-verify every row against current `csl-orig` immediately before filing; a stale row reads as bot noise.
 ↔ Interlinks: this is the ASSUMPTIONS-layer restatement of the *decay* that [STALENESS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/STALENESS.md) makes generic across all findings · [DEAD_ENDS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) (blind typo respell) is what happens when a stale queue is filed unchecked · [RECIPES §6](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (correction loci) is the census this queue feeds.
-> **Source:** [FINDINGS §25](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#25-a-verified-correction-queue-decays-against-live-csl-orig) · SanskritSpellCheck · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §25](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#25-a-verified-correction-queue-decays-against-live-csl-orig) · [SanskritSpellCheck](https://github.com/drdhaval2785/SanskritSpellCheck) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ---
 

--- a/CONTRADICTIONS.md
+++ b/CONTRADICTIONS.md
@@ -29,7 +29,7 @@ Positions:
 Status: 🟡 provisional pick — encode as a per-lemma variant, NOT a rule; §54 weakly favours `stem_final` but n=2.
 Blocks: the D3 genitive-plural cell of the ZALIZNYAK_INDEX a–f accent emission.
 ↔ Interlinks: [GAPS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) is the n=2 data scarcity that keeps this unrulable — close that and this resolves · [RECIPES §1](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (Whitney accent validation) is the pass that measures which of the three answers the corpus supports.
-> **Source:** [FINDINGS §42](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#42-whitney-self-contradicts-on-derivative-ī-stem-genpl-accent) + [§54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) · WhitneyRoots · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §42](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#42-whitney-self-contradicts-on-derivative-ī-stem-genpl-accent) + [§54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) · [WhitneyRoots](https://github.com/gasyoun/WhitneyRoots) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ### §2. Varga-diachrony: 2014 dissertation prose vs its own χ² table
 🟠 ✍️ **The 2014 Gasūns dissertation prose labels as "gaining popularity" exactly the vargas its own χ² p-table shows as statistically unchanged.**
@@ -41,7 +41,7 @@ Positions:
 Status: 🟡 provisional pick — the 2026 shares + p-table AGREE against the 2014 prose; the prose is the error.
 Blocks: the GasunsDhatu 2026 §2.6 Table 5 / П9 correction (manifest `varga-series-diachrony`).
 ↔ Interlinks: [RECIPES §4](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (varga diachrony) is the reproducible pass whose χ² table the prose misread · [GAPS §8](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) is the same epoch-stability question one layer down (collocations vs vargas) · [GLOSSARY "varga"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) defines the unit in dispute.
-> **Source:** [FINDINGS §62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) · SanskritGrammar/VisualDCS · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) · [SanskritGrammar](https://github.com/gasyoun/SanskritGrammar)/[VisualDCS](https://github.com/gasyoun/VisualDCS) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ## B. A claim overturned (or split) by machine-scale evidence
 *A scholarly charge or a hand-picked exemplar checked against a full machine dataset — the count adjudicates.*
@@ -56,7 +56,7 @@ Positions:
 Status: 🟡 provisional pick — vidyut adjudicates: Krylov right on `4añc`/`2and`, wrong on `ast`.
 Blocks: the GasunsDhatu 2014 revision's response to the ведущая организация review.
 ↔ Interlinks: [GLOSSARY "dhātupāṭha citation form"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) defines the citation form the charge turns on · [ASSUMPTIONS §3](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) is the parallel verb-root record premise the same dhātu data underlies.
-> **Source:** [FINDINGS §63](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian) · SanskritGrammar · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §63](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian) · [SanskritGrammar](https://github.com/gasyoun/SanskritGrammar) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ### §4. SKD/VCP citation-fusion direction: one-lemma exemplar vs corpus count
 🟠 ✍️ **The hand-picked *dharma* exemplar's fusion direction reverses at corpus scale.**
@@ -68,7 +68,7 @@ Positions:
 Status: 🟡 provisional pick — a record-type/genre effect, not a per-dictionary convention; the corpus count wins.
 Blocks: any "dictionary X marks citations this way" generalization from a single lemma.
 ↔ Interlinks: [ASSUMPTIONS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) is the same "a shared tag/convention means the same across dicts" premise this refutes at record-type level · [DEAD_ENDS §7](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) (sense-inheritance at corpus scale) is the sibling generalization that also failed when scaled up.
-> **Source:** [FINDINGS §43](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#43-skdvcp-sensecitation-fusion-is-a-record-type-effect-not-a-dictionary-level-one) · csl-atlas · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §43](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#43-skdvcp-sensecitation-fusion-is-a-record-type-effect-not-a-dictionary-level-one) · [csl-atlas](https://github.com/sanskrit-lexicon/csl-atlas) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ## C. Two runs disagree
 *The same measurement, recomputed, gives two numbers — a reproducibility contradiction to reconcile before either is cited.*
@@ -83,7 +83,7 @@ Positions:
 Status: 🟡 provisional pick — the paper's numbers are canonical; either way the trend is flat and school-bound.
 Blocks: any per-sense-normalized cross-dict metric that doesn't family-control.
 ↔ Interlinks: [DEAD_ENDS §7](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) (sense-inheritance at corpus scale) is the neighbouring sense-count claim that also collapsed · [GAPS §10](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) is the same "two independent passes disagree" reliability worry for a benchmark's gold.
-> **Source:** [FINDINGS §27](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#27-sense-granularity-is-a-family-trait-not-a-diachronic-trend) · csl-atlas · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §27](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#27-sense-granularity-is-a-family-trait-not-a-diachronic-trend) · [csl-atlas](https://github.com/sanskrit-lexicon/csl-atlas) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ---
 

--- a/DEAD_ENDS.md
+++ b/DEAD_ENDS.md
@@ -26,7 +26,7 @@ Failed because: 38.6% precision overall (bor 18%, bur 32% transcode-garbage, ae 
 Evidence: adversarial classification, csl-atlas broad-headword review (15-06-2026); the measuring extractor `scripts/lib/dict-body-headwords.mjs` was deleted with the rejected experiment (numbers survive only in the review record).
 Don't retry unless: you have a fundamentally different signal — a corpus inflected-form→lemma index (DCS) or vidyut sandhi/compound splitting, which raises findability, not distinct-lemma count.
 ↔ Interlinks: [GAPS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) is the broad-headword-coverage frontier this mining tried and failed to move · [RECIPES §5](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (union headword index) is the *real* asset that measures true distinct-lemma count · [ASSUMPTIONS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (PWG-worklist scope) is the adjacent "what covers the universe" premise.
-> **Source:** [FINDINGS §30](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#30-body-text-headword-mining-is-a-dead-end-386-percent-precision) · csl-atlas · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §30](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#30-body-text-headword-mining-is-a-dead-end-386-percent-precision) · [csl-atlas](https://github.com/sanskrit-lexicon/csl-atlas) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ### §2. Corpus-derived present-class attribution — abandoned
 🔴 ✍️ **Deriving verb present-class (I vs VI, IV vs passive) from the DCS corpus.**
@@ -34,7 +34,7 @@ Failed because: the corpus carries no pitch accent, and the class distinction re
 Evidence: a corpus-derived class pass produced 117 spurious I/VI additions — all reverted (120 unsound total vs 19 kept); WhitneyRoots CHANGELOG revert.
 Don't retry unless: you have a grammar / Zaliznyak cross-check for every corpus-derived class — never write one into reviewed data raw.
 ↔ Interlinks: [CONTRADICTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) (Whitney gen.pl accent) is the sibling case where the missing accent signal bites · [GLOSSARY "SLP1 vs IAST"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) covers why the corpus surface strings carry no pitch · [RECIPES §1](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) is the accent-validation path that *does* have the signal (attested RV forms).
-> **Source:** [FINDINGS §8](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#8-unaccented-dcs-cannot-distinguish-present-class-i-from-vi) · WhitneyRoots · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §8](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#8-unaccented-dcs-cannot-distinguish-present-class-i-from-vi) · [WhitneyRoots](https://github.com/gasyoun/WhitneyRoots) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ### §3. Sandhi-join lookup for prefixed-verb corpus evidence — abandoned
 🟠 ✍️ **Building a `upasarga+root` sandhi-join lookup to gain prefixed-verb corpus attestations.**
@@ -42,7 +42,7 @@ Failed because: it's a no-op — the corpus lemmatizes prefixed verbs to the roo
 Evidence: `pwg_preverb1.txt` join measured in `subcard_portrait()` / FREQ_TEST_RUNBOOK.
 Don't retry unless: a different corpus that keeps prefixed surface forms is available; otherwise defer to the dictionary's own gloss for the ~80%.
 ↔ Interlinks: [ASSUMPTIONS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (one transliteration keys all DCS files) is the join premise this attestation walk sat on · [GAPS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (homonym token frequency) is a neighbouring corpus-coverage gap · [GLOSSARY "headword vs lemma"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) frames why the corpus lemmatizes prefixed verbs away.
-> **Source:** [FINDINGS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#5-the-parallel-corpus-rarely-attests-prefixed-verb-forms) · RussianTranslation · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#5-the-parallel-corpus-rarely-attests-prefixed-verb-forms) · [RussianTranslation](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ---
 
@@ -55,7 +55,7 @@ Failed because: ~9% of "typo" corrections are collisions — the "correct" spell
 Evidence: source-verification of all 122 FILE-FIRST candidates vs csl-orig (02-07-2026) — YAT 5, MW 2, PWG 2, PW 1 dual-listings; `file_first_verified.tsv`.
 Don't retry unless: the filing offers a third editorial category (merge vs respell vs leave) and checks whether the "right" form already exists as its own entry first.
 ↔ Interlinks: [ASSUMPTIONS §6](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (a verified correction queue stays valid) is the premise a blind bulk respell violates · [RECIPES §6](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (correction loci census) is the audited path these corrections should flow through instead.
-> **Source:** [FINDINGS §24](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#24-about-9-percent-of-typo-corrections-are-collisions) · SanskritSpellCheck · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §24](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#24-about-9-percent-of-typo-corrections-are-collisions) · [SanskritSpellCheck](https://github.com/drdhaval2785/SanskritSpellCheck) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ### §5. NFD-decompose-then-strip-Mn as a Sanskrit normalization key — abandoned
 🔴 ✍️ **Using blanket NFD + strip-combining-marks to make an IAST comparison/join key.**
@@ -63,7 +63,7 @@ Failed because: it destroys vowel length (`ā`→`a`) and retroflex dots (`ṣ`�
 Evidence: the `form_key` design note in sanskrit_util; the recurring failure mode behind poisoned siglum folds (§45: `samk` merges Śaṃk°+Sāṃk°).
 Don't retry unless: you use a length-preserving `form_key` (never blanket NFD+strip); for `<ls>` sigla, consult the curated alias table, never fold-key similarity.
 ↔ Interlinks: [ASSUMPTIONS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (one transliteration keys all files) is the join premise this is the *wrong* way to satisfy · [GLOSSARY "form_key"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) and [GLOSSARY "SLP1 vs IAST"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) define the length-preserving key that replaces it.
-> **Source:** [FINDINGS §36](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily) + [§45](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#45-siglum-prefix-families-routinely-bundle-several-distinct-works-the-diacritic-stripping-fold-has-poisoned-keys) · sanskrit-util/csl-atlas · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §36](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily) + [§45](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#45-siglum-prefix-families-routinely-bundle-several-distinct-works-the-diacritic-stripping-fold-has-poisoned-keys) · [sanskrit-util](https://github.com/sanskrit-lexicon/sanskrit-util)/[csl-atlas](https://github.com/sanskrit-lexicon/csl-atlas) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ### §6. `OccId` / `sent_id` as a DCS primary key — abandoned
 🔴 ✍️ **Keying the DCS CoNLL-U import on `OccId` or `sent_id`.**
@@ -71,7 +71,7 @@ Failed because: both are non-unique — `OccId` is reused across a line's sub-se
 Evidence: `DCS_CONLLU_IMPORT_PLAN.md` §M5–M6, `m5_validation.md`/`m6_validation.md`.
 Don't retry unless: never — use synthetic autoincrement surrogates or position-within-text; the stable cross-corpus key is `LemmaId`.
 ↔ Interlinks: [ASSUMPTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (DCS lemma == CDSL headword) is the join layer these ids were meant to feed · [RECIPES §3](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (DeepSeek alignment grounding) is a DCS-import pipeline that depends on a stable per-token key.
-> **Source:** [FINDINGS §9](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#9-dcs-occid-and-sent_id-are-not-unique-keys) · VisualDCS · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §9](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#9-dcs-occid-and-sent_id-are-not-unique-keys) · [VisualDCS](https://github.com/gasyoun/VisualDCS) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ---
 
@@ -85,7 +85,7 @@ Failed because: it did NOT hold — the classifier over the full corpus reversed
 Evidence: R2606-06 (refuted 02-07-2026), `r2_kosa_fusion.json`, [csl-atlas PR #184](https://github.com/sanskrit-lexicon/csl-atlas/pull/184).
 Don't retry unless: you compute the direction at corpus scale from the start — never generalise a single hand-picked lemma's fusion direction to a dictionary-level rule.
 ↔ Interlinks: [CONTRADICTIONS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) (SKD/VCP fusion) is the corpus-scale contradiction this refuted approach became · [ASSUMPTIONS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (a shared tag means one thing across dicts) is the same "record-type-bound, not dictionary-level" trap.
-> **Source:** [QUESTIONS_LOG R2606-06](https://github.com/gasyoun/Uprava/blob/main/QUESTIONS_LOG.md) · csl-atlas · 08-07-2026 · auto (seed_dead_ends.py)
+> **Source:** [QUESTIONS_LOG R2606-06](https://github.com/gasyoun/Uprava/blob/main/QUESTIONS_LOG.md) · [csl-atlas](https://github.com/sanskrit-lexicon/csl-atlas) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · auto (seed_dead_ends.py)
 
 ---
 

--- a/GAPS.md
+++ b/GAPS.md
@@ -24,7 +24,7 @@ Why it matters: it is the one unresolved cell blocking the ZALIZNYAK_INDEX a–f
 Blocker: needs a wider VedaWeb 2.0 pull — blocked mid-run by a `vedaweb.uni-koeln.de` outage; only n=2 attested forms (`raTI`, `vaDU`) so far.
 How to close: resume the VedaWeb export per [`SERVER_OUTAGES.md`](https://github.com/gasyoun/Uprava/blob/main/SERVER_OUTAGES.md), grow n, split by adjective (`bahvī́`) vs noun (`nadī́`) type.
 ↔ Interlinks: closing this gap rules [CONTRADICTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) (Whitney's own §319a/§356 self-contradiction) · [RECIPES §1](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (Whitney accent validation) is the pass that would consume the wider pull.
-> **Source:** [FINDINGS §54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) · WhitneyRoots · 08-07-2026
+> **Source:** [FINDINGS §54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) · [WhitneyRoots](https://github.com/gasyoun/WhitneyRoots) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09)
 
 ### §2. Error population of 40 of 43 dictionaries
 🟠 ✍️ **We have NOT estimated the error-prone-record population for 40 of 43 dicts.**
@@ -32,7 +32,7 @@ Why it matters: correction-campaign planning currently assumes convergence; only
 Blocker: needs a corpus rerun / more overlapping corrections — Chapman mark–recapture requires ≥10 two-era recaptures per dict.
 How to close: accumulate a second correction era per dict, or use a different estimator; owner csl-observatory `error_recapture.md` (paper A48).
 ↔ Interlinks: [RECIPES §6](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (correction loci census) is the per-dict correction-density base this estimate builds on · [ASSUMPTIONS §6](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (a correction queue stays valid) is the perishability that makes a second era hard to accrue.
-> **Source:** [FINDINGS §46](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#46-twelve-years-of-corrections-cover-only-1014--of-the-estimated-error-population) · csl-observatory · 08-07-2026
+> **Source:** [FINDINGS §46](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#46-twelve-years-of-corrections-cover-only-1014--of-the-estimated-error-population) · [csl-observatory](https://github.com/sanskrit-lexicon/csl-observatory) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09)
 
 ### §3. Heritage inflected-form morphology XML — never ingested
 🟠 ✍️ **We have NOT ingested Heritage's inflected-form morphology XML (1,286,615 forms / 32,837 stems).**
@@ -40,7 +40,7 @@ Why it matters: would be a third morphology witness (3× kosha's vidyut-built 42
 Blocker: data access — the XML is NOT in either git repo (GitHub mirror or INRIA GitLab); only downloadable behind the Anubis wall from `sanskrit.inria.fr/DATA/XML/{SL,WX}_morph.xml.gz` (v3.81).
 How to close: a human browser download of the two `.xml.gz` URLs (bookmarked in §51), then ingest; LGPLLR-vs-BY-SA composition @DECIDE first.
 ↔ Interlinks: a third morphology witness stresses [ASSUMPTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (DCS lemma == CDSL headword — the very join whose 18.6% unlinked residue Heritage could cover) · [DEAD_ENDS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) (corpus present-class attribution) is why an independent morphology source, not corpus inference, is needed.
-> **Source:** [FINDINGS §47](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#47-heritage-data-is-acquirable-despite-the-anubis-wall--via-a-github-mirror-the-morphology-xml-is-not-in-it) + [§51](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#51-huet-correspondence-predates-this-session-2021--the-morphology-xml-gate-was-already-resolved-in-writing-direct-download-urls-recovered) · SanskritLexicography · 08-07-2026
+> **Source:** [FINDINGS §47](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#47-heritage-data-is-acquirable-despite-the-anubis-wall--via-a-github-mirror-the-morphology-xml-is-not-in-it) + [§51](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#51-huet-correspondence-predates-this-session-2021--the-morphology-xml-gate-was-already-resolved-in-writing-direct-download-urls-recovered) · [SanskritLexicography](https://github.com/gasyoun/SanskritLexicography) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09)
 
 ## B. Blocked on a tool or method, not data
 *The data is in hand; what's missing is a statistics pass, a schema-aware parse, or a validated lookup that doesn't exist yet.*
@@ -51,7 +51,7 @@ Why it matters: token-level "N in this sense · M for the lemma" displays are im
 Blocker: no tool — gaṇa is undistinguishing (unaccented corpus, §8); needs manual gloss adjudication (DCS `meanings` ↔ Warnemyr gloss).
 How to close: extend the coverage≥0.55 gloss-mapping approach in `crosswalk/token_attribution.json`; owner WhitneyRoots.
 ↔ Interlinks: [ASSUMPTIONS §3](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (giant verb root at homonym index 0) is the record-reach premise that must hold to even enumerate these groups · [DEAD_ENDS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) (corpus present-class attribution) is the refuted shortcut — gaṇa can't disambiguate them · [GLOSSARY "homonym index"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) defines the ordinal in play.
-> **Source:** [FINDINGS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling) · WhitneyRoots · 08-07-2026
+> **Source:** [FINDINGS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling) · [WhitneyRoots](https://github.com/gasyoun/WhitneyRoots) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09)
 
 ### §5. `Stopovye` parallel-passage bundle vs full export — never content-diffed
 🟡 ✍️ **We have NOT content-diffed the 1.17 GB `PARA/Stopovye` bundle against `dcs-parallel-passages-full` (506,787 rows).**
@@ -59,7 +59,7 @@ Why it matters: it is the largest single derived-data bundle in VisualDCS; wheth
 Blocker: no tool — needs a schema-aware per-file alignment parse, not a line count.
 How to close: parse the per-passage CSV records, diff against the full-export sample; owner VisualDCS / manifest `stopovye-parallel-passages`.
 ↔ Interlinks: [DEAD_ENDS §6](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) (OccId/sent_id as a key) is the passage-id keying trap this schema-aware diff must avoid · [ASSUMPTIONS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (one transliteration keys all DCS files) is the keying premise any DCS-side alignment leans on.
-> **Source:** kosha [datasets.json](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json) `stopovye-parallel-passages` note (H291) · 08-07-2026
+> **Source:** [kosha](https://github.com/gasyoun/kosha) [datasets.json](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json) `stopovye-parallel-passages` note (H291) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09)
 
 ### §6. Cyrillic-only Sanskrit name glossaries — no join key exists
 🟠 ✍️ **We have NOT (and cannot safely) build a Cyrillic→SLP1 key for the 3 fully-Cyrillic name glossaries.**
@@ -67,7 +67,7 @@ Why it matters: 3 of 6 SamudraManthanam name indices (Потапова, Эрма
 Blocker: no tool that is safe — practical Russian transcription collapses dental/retroflex (т = त and ट); a rule-based converter manufactures wrong keys for exactly the retroflex-bearing epic names.
 How to close: a proper-noun lookup table validated against a Sanskrit onomasticon (not character rules), checked as its own artifact first.
 ↔ Interlinks: [DEAD_ENDS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) (NFD-normalization as a key) is the same class of lossy character-rule bridge that manufactures wrong keys here · [GLOSSARY "SLP1 vs IAST"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) frames the scheme mismatch a Cyrillic→SLP1 map would have to cross.
-> **Source:** [FINDINGS §60](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-practical-russian-transcription-of-sanskrit-names-has-no-safe-reverse-transliteration) · RussianTranslation · 08-07-2026
+> **Source:** [FINDINGS §60](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-practical-russian-transcription-of-sanskrit-names-has-no-safe-reverse-transliteration) · [RussianTranslation](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09)
 
 ---
 
@@ -81,7 +81,7 @@ Why it matters: a corpus-wide collocation graph would ground compound-formation,
 Blocker: no tool — needs a graph/statistics pass (degree distribution, top collocates, hapax rate), not a row count.
 How to close: load the pair table, compute the obvious network statistics, append a FINDINGS row; owner VisualDCS.
 ↔ Interlinks: [RECIPES §2](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (DCS↔CDSL crosswalk) is the join a collocation graph would enrich into dictionary-grounded semantic fields · [GLOSSARY "form_key"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) is the keying the stem-pair rows must share to align.
-> **Source:** manifest `dcs-stem-cooccurrence-full` (H291) · kosha · 08-07-2026 · auto (seed_gaps.py)
+> **Source:** manifest `dcs-stem-cooccurrence-full` (H291) · [kosha](https://github.com/gasyoun/kosha) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · auto (seed_gaps.py)
 
 ### §8. DCS syntagmatic collocation tables (Прил. 6 + 7) are unanalysed
 🟡 ⚙️ **We have the per-lemma collocate tables — all-corpus (`dcs-sintagmatic-appendix7`, 82,800 rows) and per-historical-period (`dcs-sintagmatic-appendix6-periods`, 19,076 rows, 7 files) — but NO FINDINGS row comparing them.**
@@ -89,7 +89,7 @@ Why it matters: the period-split vs all-corpus pair is exactly the data to test 
 Blocker: no tool — needs a per-period vs all-corpus diff; the appendix7 copy also has a byte-different UTF-16LE Cyrillic twin (H291) to dedup first.
 How to close: align the period files against the all-corpus table, measure collocation drift; owner VisualDCS.
 ↔ Interlinks: [CONTRADICTIONS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) is the same epoch-stability question one layer up (vargas) whose χ² method this reuses at the lexical layer · [RECIPES §4](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (varga diachrony) is the diachronic-comparison pass to mirror.
-> **Source:** manifest `dcs-sintagmatic-appendix7` / `dcs-sintagmatic-appendix6-periods` (H291) · kosha · 08-07-2026 · auto (seed_gaps.py)
+> **Source:** manifest `dcs-sintagmatic-appendix7` / `dcs-sintagmatic-appendix6-periods` (H291) · [kosha](https://github.com/gasyoun/kosha) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · auto (seed_gaps.py)
 
 ### §9. `heritage-forms-crosswalk-extras` disagreement classes are uncounted
 🟡 ⚙️ **We have the Heritage form-level crosswalk extras (1,037,239 rows, incl. a `heritage_forms_oracle_disagreements` form→disagreement-class table) but NO FINDINGS row on how often Heritage and kosha disagree, or on what.**
@@ -97,7 +97,7 @@ Why it matters: the disagreement rate + its classes are the missing quality metr
 Blocker: data tier — `restricted` (Heritage LGPLLR composition), so the count is publishable but the rows aren't public.
 How to close: tally the disagreement-class distribution, append a FINDINGS row (rate only); owner SanskritLexicography HeadwordLists.
 ↔ Interlinks: [ASSUMPTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (DCS lemma == CDSL headword) is the join whose quality this disagreement rate would quantify · [GLOSSARY "headword vs lemma"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) defines the form/lemma distinction the disagreement classes turn on.
-> **Source:** manifest `heritage-forms-crosswalk-extras` (H291) · kosha · 08-07-2026 · auto (seed_gaps.py)
+> **Source:** manifest `heritage-forms-crosswalk-extras` (H291) · [kosha](https://github.com/gasyoun/kosha) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · auto (seed_gaps.py)
 
 ### §10. Which-dictionary routing benchmark has single-annotator gold, no κ
 🟠 ⚙️ **The 24-scenario routing shared-task benchmark (`which-dictionary-routing-benchmark`) has single-annotator gold (Fable 5, one pass) — NO inter-annotator agreement measured over its 44-code answer space.**
@@ -105,7 +105,7 @@ Why it matters: a shared-task benchmark with no κ can't quantify its own gold r
 Blocker: needs a second independent annotation pass (see `/gold-adjudicate`), not just a rerun.
 How to close: second-annotate the 24 scenarios, compute κ + a confusion table, append a FINDINGS row.
 ↔ Interlinks: [CONTRADICTIONS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) is the same "two independent passes disagree" reliability worry, there for a correlation instead of a gold set · [GLOSSARY "ls source map"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) frames the dictionary-code answer space κ would be computed over.
-> **Source:** manifest `which-dictionary-routing-benchmark` (H281) · kosha/csl-guides · 08-07-2026 · auto (seed_gaps.py)
+> **Source:** manifest `which-dictionary-routing-benchmark` (H281) · [kosha](https://github.com/gasyoun/kosha)/[csl-guides](https://github.com/sanskrit-lexicon/csl-guides) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · auto (seed_gaps.py)
 
 ### §11. `dcs-verb-form-frequency-prelim` is flagged preliminary, never finalised
 🟡 ⚙️ **The DCS verb-form frequency table (106 rows) is explicitly `preliminary` in the manifest — NO FINDINGS row, and no final version.**
@@ -113,7 +113,7 @@ Why it matters: verb forms are the top of the frequency dictionary (roots domina
 Blocker: unclear — the "preliminary" marker's reason isn't recorded (coverage? method?); needs the owner to state what makes it non-final.
 How to close: identify the preliminary caveat, finalise or document why it can't be, append a FINDINGS row; owner VisualDCS.
 ↔ Interlinks: [ASSUMPTIONS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (a PWG-key worklist covers the universe) and [ASSUMPTIONS §3](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (the verb-root record) are the root-frequency premises a finalised verb-form table would feed the freq-first translation queue.
-> **Source:** manifest `dcs-verb-form-frequency-prelim` (H291) · kosha · 08-07-2026 · auto (seed_gaps.py)
+> **Source:** manifest `dcs-verb-form-frequency-prelim` (H291) · [kosha](https://github.com/gasyoun/kosha) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · auto (seed_gaps.py)
 
 ---
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -16,18 +16,21 @@ _Created: 08-07-2026 · Last updated: 08-07-2026_
 ### form_key
 🔴 **Means:** a length-preserving normalization key for Sanskrit strings, used to join across schemes without losing distinctions (`ā`≠`a`).
 **Not:** blanket NFD-decompose + strip-combining-marks — that destroys vowel length (`ā`→`a`) and retroflex (`ṣ`→`s`), and collides `ś`'s acute with the pitch mark (see [FINDINGS §36](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily); the abandoned path is [DEAD_ENDS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md)).
+**Examples:** `ā` stays ≠ `a` (length preserved) · `ś` kept distinct from `s` + acute accent · `agní` and `agni` don't collide.
 **Canonical in:** [`form_key` in sanskrit_util](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/py/sanskrit_util/__init__.py).
 ↔ Interlinks: [ASSUMPTIONS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (one-scheme-keys-all premise) leans on this key existing · [DEAD_ENDS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) is the NFD+strip anti-pattern this term is defined *against* · [RECIPES §2](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) is the transcode-then-join that uses it correctly.
 
 ### SLP1 vs IAST
 🔴 **Means:** two transliteration schemes — SLP1 (ASCII-safe, one char per phoneme, native PWG `key1` join key) and IAST (diacritic Unicode).
 **Not:** interchangeable in DCS-derived files — `dcs_lemma_summary.json` is SLP1-keyed, `dcs_lemma_renou.json` is IAST-keyed; a join must transcode one side (FINDINGS §7; [ASSUMPTIONS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md)).
+**Examples:** SLP1 `aByAsa` = IAST `abhyāsa` · SLP1 `S` = `ś`, `z` = `ṣ` · SLP1 `M` = anusvāra `ṃ`.
 **Canonical in:** [FINDINGS §7](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations) · transcoder in [`sanskrit-util`](https://github.com/sanskrit-lexicon/sanskrit-util).
 ↔ Interlinks: [ASSUMPTIONS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) is the premise that a single scheme keys all DCS files (false) · [DEAD_ENDS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) is the lossy NFD bridge between the two · [RECIPES §2](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) transcodes one side before the DCS↔CDSL join.
 
 ### key1 vs key2
 🟠 **Means:** `key1` is a dictionary's computational/normalized headword key (join on this); `key2` is the printed form, carrying the udātta `/` accent mark in PWG (`agni/` = agní).
 **Not:** cross-dict-joinable via `key2` — the same lemma keys differently between dicts (MW bare stem `agni` vs Apte nominative `agniH`); always join on `key1` (FINDINGS §23).
+**Examples:** key1 `agni` (join on this) · key2 `agni/` (printed, udātta mark) · MW stem `agni` vs Apte nom. `agniH`.
 **Canonical in:** [FINDINGS §23](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#23-apte-is-three-dictionaries-keys-differ-stem-vs-nominative).
 ↔ Interlinks: [ASSUMPTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (DCS lemma == CDSL headword) is a join that only holds on `key1` · [RECIPES §5](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (union headword index) is built by folding every dict on `key1`, never `key2`.
 
@@ -39,18 +42,21 @@ _Created: 08-07-2026 · Last updated: 08-07-2026_
 ### headword vs lemma
 🔴 **Means:** a *headword* is a dictionary entry key (`<L>`/`<k1>` in a CDSL dict); a *lemma* is a corpus dictionary-form assigned by a lemmatizer (DCS `LemmaId`).
 **Not:** interchangeable — 18.6% of DCS lemmas have no CDSL headword at all (FINDINGS §12); they are keyed and populated independently (see [ASSUMPTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md)).
+**Examples:** headword `<L>agni</L>` (a CDSL entry) · lemma `agni` (DCS `LemmaId`) · a DCS lemma with no CDSL headword (one of the 18.6%).
 **Canonical in:** [FINDINGS §12](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword) · [union_headwords.tsv](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/union/union_headwords.tsv).
 ↔ Interlinks: [ASSUMPTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) is the join that blurs the two, measured 81.4% linked · [RECIPES §2](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) is the DCS↔CDSL crosswalk that keeps them distinct · [GAPS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (homonym token freq) is the frontier the unlinked lemmas fall into.
 
 ### homonym index
 🔴 **Means:** the ordinal on repeated identical headwords (`1 √as`, `2 √as`); a dict's giant verb root frequently sits at a non-zero index.
 **Not:** guaranteed to be 0 for the "main" sense — 19 of the top-50 freq roots have a giant homonym at index > 0 (FINDINGS §16); iterate all records, never `bufs[0]` ([ASSUMPTIONS §3](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md)).
+**Examples:** `1 √as` (to be) vs `2 √as` (to throw) · `√i` giant record sitting at index 2 · never assume `bufs[0]` is the main sense.
 **Canonical in:** [FINDINGS §16](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes).
 ↔ Interlinks: [ASSUMPTIONS §3](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) is the `bufs[0]` premise this term refutes · [GAPS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (homonym token frequency) is what stays unreachable while a walk mis-assumes index 0.
 
 ### ls source map
 🟠 **Means:** `ls_source_map.json` / `ls_resolver.py` — the mapping from a PWG `<ls>` citation siglum to a dated primary source (and its scanned-edition page URL).
 **Not:** complete — recognises 72.4% of PWG `<ls>` keys (45 dated sources); the unrecognised 27.6% is late catalogues/secondary literature (FINDINGS §20). Also not a fold-key: sigla families bundle several works (§45).
+**Examples:** `<ls>RV.</ls>` → Ṛgveda · `<ls>MBh.</ls>` → Mahābhārata · an unrecognised late-catalogue siglum (the 27.6%).
 **Canonical in:** [FINDINGS §20](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#20-the-ls-source-map-recognises-724-percent-of-pwg-citations) · tool `ls_resolver.py`.
 ↔ Interlinks: [ASSUMPTIONS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (a shared tag means one thing) is the confound that makes an `<ls>` siglum polysemous · [CONTRADICTIONS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) (SKD/VCP fusion) is why a raw `<ls>` count under-reads indigenous citation.
 
@@ -62,30 +68,35 @@ _Created: 08-07-2026 · Last updated: 08-07-2026_
 ### gaṇa
 🟠 **Means:** a Pāṇinian verb present-class group (bhvādi = class 1, tudādi = class 6, …); the axis on which some homonym roots split.
 **Not:** recoverable from an unaccented corpus — only 5 of 38 DCS-lumped homonym groups are gaṇa-splittable; class I vs VI needs pitch accent the corpus lacks (FINDINGS §2, §8).
+**Examples:** bhvādi = class 1 (`bhū`) · tudādi = class 6 (`tud`) · divādi = class 4 (`div`).
 **Canonical in:** [FINDINGS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling) · vidyut dhātupāṭha.
 ↔ Interlinks: [CONTRADICTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) (Whitney accent) is the accent signal a gaṇa split would need · [RECIPES §1](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (accent recipe) is where that signal is recovered when it exists.
 
 ### Renou period-state
 🟠 **Means:** a diachronic era tag I–V (Vedic → late) assigned per entry from multi-signal evidence (`ls`/`dcs`/`bhs`/`wl`), covering 770k entries in 8 dicts.
 **Not:** reliable on high-frequency closed-class words — DCS homograph collapse gives `ca`/`idam` the union of all their homographs' eras (spuriously broad); apply a min-support gate (FINDINGS §14).
+**Examples:** Vedic (I) `índra` · a kāvya-only word tagged Classical (later) · a closed-class word (`ca`) spuriously spanning all eras.
 **Canonical in:** [`RENOU.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU.md).
 ↔ Interlinks: [ASSUMPTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (DCS==CDSL) is the join feeding the `dcs` era signal · [GAPS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (Stopovye) is the closed-class residue the min-support gate leaves unmeasured.
 
 ### varga
 🟠 **Means:** a consonant series (5 groups: guttural/palatal/cerebral/dental/labial) aggregating the 25 sparśa varṇas; the unit of the DCS diachrony analysis.
 **Not:** a phonetically shifting distribution over time — series composition is near epoch-stable (Cramér's V = 0.037 across ~2 kyr); p-values carry no signal at DCS scale (FINDINGS §62).
+**Examples:** guttural (ka-varga: k kh g gh ṅ) · dental (ta-varga: t th d dh n) · labial (pa-varga: p ph b bh m).
 **Canonical in:** [FINDINGS §62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) · manifest `varga-series-diachrony`.
 ↔ Interlinks: [CONTRADICTIONS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) is the prose-vs-χ² reversal this stability result corrects · [RECIPES §4](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) is the varga-diachrony recipe that produces the series counts.
 
 ### Zaliznyak index (a–f accent axis)
 🟡 **Means:** a compact per-word grammar token scheme (335 tokens over 98,639 PWG headwords) plus a Vedic accent-mobility axis (a–f schemes) encoded from Whitney's declension rules.
 **Not:** a proven translation aid — a blind A/B showed injecting the grammar token does NOT improve DE→RU translation, so it stays structured-data-only (FINDINGS §4); the accent axis is Vedic-only (Classical entries lack `/`).
+**Examples:** a compact grammar token on a PWG headword · the Vedic a–f accent-mobility scheme · Classical entries lack the `/` mark (no axis).
 **Canonical in:** [`ZALIZNYAK_INDEX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ZALIZNYAK_INDEX.md) · manifest `zaliznyak-grammar-index`.
 ↔ Interlinks: [CONTRADICTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) (Whitney accent) is the source the a–f axis is encoded from · [RECIPES §1](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (accent recipe) shares that accent-mobility groundwork.
 
 ### dhātupāṭha citation form
 🟠 **Means:** the canonical listing form of a verbal root in the Pāṇinian root-catalogue, used as the normalization target (CANON) for root-recovery joins.
 **Not:** the same as vidyut's surface forms (which keep the thematic `-a` and must NOT seed CANON), nor a stem grab (`sada` for `sad`) — normalize to citation form before comparing; grep vidyut as `ancu`, not SLP1 `aYc`, and strip anubandha `~ \ ^` (§63).
+**Examples:** `sad` (root) not `sada` (stem grab) · vidyut surface `ancu` not SLP1 `aYc` · strip anubandha markers `~ \ ^`.
 **Canonical in:** [`mw_roots.tsv`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/mw/mw_roots.tsv) · [FINDINGS §35](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#35-root-recovery-tiers-err-on-root-form-not-identity).
 ↔ Interlinks: [CONTRADICTIONS §3](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) (Krylov/vidyut) is where vidyut's surface forms diverge from CANON · [GAPS §11](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (verb-form frequency) is the layer these root joins feed.
 
@@ -97,6 +108,7 @@ _Created: 08-07-2026 · Last updated: 08-07-2026_
 ### `<ls>` / iti register
 🟠 **Means:** the two ways dictionaries cite sources — Western `<ls>` markup tags (PWG/MW) vs the indigenous `iti`/quotation register (SKD/VCP/KRM).
 **Not:** comparable by a raw `<ls>` counter — SKD's ~80k citations, KRM's densest-in-corpus 6.00/entry all score zero under an `<ls>` detector; and a "space-preceded" `iti` counter hides `<s>iti` (~2/3 of KRM's citations). Control for register before ranking (FINDINGS §26).
+**Examples:** Western `<ls>RV.</ls>` (PWG/MW) · indigenous `… iti` quotation (SKD/VCP) · `<s>iti` hidden from a space-preceded counter.
 **Canonical in:** [FINDINGS §26](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#26-citation-density-is-register-bound-not-comparable-raw).
 ↔ Interlinks: [ASSUMPTIONS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (a shared tag means one thing) is the premise this register split breaks · [CONTRADICTIONS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) (SKD/VCP fusion) is the same register confound seen at corpus scale.
 

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -27,7 +27,7 @@ Command: score per [`ACCENT_VALIDATION_SPEC.md`](https://github.com/gasyoun/Whit
 Expected: 18/19 cells GO at ≥90% position accuracy, 0 NO-GO, 1 measurement-only (`T2/T4/T6·monosyllable`, n≤1) — ties back to FINDINGS §54.
 Env/runtime: VedaWeb API (`vedaweb.uni-koeln.de/api`) — check liveness first (`curl -sI --max-time 15 …/api/openapi.json`); the host has an extended outage history (§48, [SERVER_OUTAGES](https://github.com/gasyoun/Uprava/blob/main/SERVER_OUTAGES.md)).
 ↔ Interlinks: [CONTRADICTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) (Whitney gen.pl accent) is the accent disagreement this validation adjudicates · [GAPS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (ī/ū split, n=2) is the thin-evidence frontier the same axis runs up against · [DEAD_ENDS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) is the failed corpus-only route that lacked the accent signal this recipe supplies.
-> **Source:** [FINDINGS §54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) · WhitneyRoots v1.3.0 · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) · [WhitneyRoots](https://github.com/gasyoun/WhitneyRoots) v1.3.0 · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ---
 
@@ -41,7 +41,7 @@ Command: `python build_xref.py` (csl-apidev `simple-search/dcs_xref/`) → `dcs_
 Expected: 12,946 of 15,902 (81.4%) link; 2,956 corpus-only — ties back to FINDINGS §12 / manifest `dcs-cdsl-xref` (15,902 rows).
 Env/runtime: Python, offline once DCS CoNLL-U + CDSL keys are local; it is a LOD linkset — consume, never re-derive.
 ↔ Interlinks: [ASSUMPTIONS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (DCS lemma == CDSL headword) is the premise this recipe *bounds* at 81.4% · [GLOSSARY "headword vs lemma"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) defines the two sides being joined · [GAPS §3](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (Heritage as a third witness) is where the unlinked 18.6% could be recovered.
-> **Source:** [FINDINGS §12](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword) + kosha [datasets.json](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json) · csl-apidev · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §12](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword) + kosha [datasets.json](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json) · [csl-apidev](https://github.com/sanskrit-lexicon/csl-apidev) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ### §3. DeepSeek word-alignment grounding cross-check (6.6% ungrounded) → reproduce
 🟠 ✍️ (reproduces [FINDINGS §65](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse))
@@ -50,7 +50,7 @@ Command: [`src/tm_align.py`](https://github.com/gasyoun/SanskritLexicography/blo
 Expected: mean grounding 0.684, 93.4% grounded, 6.6% score 0; grade A 5.7%→5.3%, C 0.3%→0.9% — ties back to FINDINGS §65.
 Env/runtime: Python, offline; corpus_lexicon is restricted-tier (published-RU-translation rights), regenerable via `build_corpus_lexicon.py` but single-copy.
 ↔ Interlinks: [ASSUMPTIONS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (one transliteration keys all DCS files) is the keying premise the alignment join depends on · [GAPS §10](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (routing κ) is the adjacent grade-confidence measurement · [DEAD_ENDS §6](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) (OccId/sent_id key) is the id trap a DCS-import alignment must avoid.
-> **Source:** [FINDINGS §65](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse) · RussianTranslation · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §65](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse) · [RussianTranslation](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ---
 
@@ -64,7 +64,7 @@ Command: [`varga_shares.py`](https://github.com/gasyoun/SanskritGrammar/blob/cho
 Expected: dentals ≈47–52%, labials ≈24–27%, gutturals 8.9→14.9%; 5×5 varga×epoch Cramér's V = 0.0372 (χ² = 54,890) — ties back to FINDINGS §62 / manifest `varga-series-diachrony`.
 Env/runtime: Python stdlib, offline, deterministic; outputs `slot_era_map.csv` alongside.
 ↔ Interlinks: [CONTRADICTIONS §2](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) (varga prose vs χ²) is the dissertation-prose contradiction this recomputation exposes · [GLOSSARY "varga"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) defines the phonetic class being counted · [GAPS §11](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (verb-form-freq prelim) is a neighbouring diachronic-frequency measurement.
-> **Source:** [FINDINGS §62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) · SanskritGrammar/VisualDCS · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) · [SanskritGrammar](https://github.com/gasyoun/SanskritGrammar)/[VisualDCS](https://github.com/gasyoun/VisualDCS) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ### §5. Cross-dict union headword index (323,425 / PWG∩MW=94,753) → reproduce
 🔴 ✍️ (reproduces [FINDINGS §29](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index))
@@ -73,7 +73,7 @@ Command: the HeadwordLists union build → [`union_headwords.tsv`](https://githu
 Expected: 323,425 union headwords; PWG-bearing 106,054, MW-bearing 193,852, both 94,753 — ties back to FINDINGS §29 / manifest `union-headwords` (323,425 rows, 12.4 MB). CONSUME, don't rebuild (a new pairwise-overlap script is reinvention).
 Env/runtime: Python; the built asset is public-tier in `data-v0.1.0`.
 ↔ Interlinks: [ASSUMPTIONS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (PWG worklist covers the universe) is the scope premise this index actually measures · [DEAD_ENDS §1](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) (body-text headword mining) is the failed shortcut this canonical asset replaces · [GLOSSARY "headword vs lemma"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) frames the `<L>` headword unit being unioned.
-> **Source:** [FINDINGS §29](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index) · SanskritLexicography · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [FINDINGS §29](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index) · [SanskritLexicography](https://github.com/gasyoun/SanskritLexicography) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ### §6. Correction loci census (39,540 records) → reproduce
 🟠 ✍️ (reproduces the kosha `correction-loci` manifest row, H294)
@@ -82,7 +82,7 @@ Command: [`scripts/build_correction_loci.py --selftest`](https://github.com/sans
 Expected: 39,540 records = 39,536 old→new + 4 old→del; `process∈{bulk,human}` splits the two machine markup batches (BOR 21,990 + LRV/markhom 8,063 = 76%) from human correction — manifest `correction-loci` (9.6 MB, 39,540 rows).
 Env/runtime: Python, offline; keyed on (dict, L, k1) — line numbers are batch-time only, never a join key. Corrector identity excluded (public tier).
 ↔ Interlinks: [ASSUMPTIONS §6](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (a correction queue stays valid) is the perishability premise this census feeds · [DEAD_ENDS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) (bulk typo respell) is the failure mode a proper loci census guards against · [GAPS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (Stopovye diff) is an adjacent correction-coverage gap.
-> **Source:** kosha [datasets.json](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json) `correction-loci` (H294) · csl-corrections · 08-07-2026 · Opus 4.8 (`claude-opus-4-8`)
+> **Source:** [kosha](https://github.com/gasyoun/kosha) [datasets.json](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json) `correction-loci` (H294) · [csl-corrections](https://github.com/sanskrit-lexicon/csl-corrections) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
 ---
 

--- a/epistemic_dashboard/index.html
+++ b/epistemic_dashboard/index.html
@@ -54,7 +54,7 @@
 
 <h2>Conclusions</h2>
 <ul id="conclusions"></ul>
-<p class="mut">The seven layers are one system: a fact starts as an <b>assumption</b>, a <b>gap</b>, or a <b>contradiction</b>; a <b>recipe</b> says how to settle it; once settled it <b>graduates</b> into FINDINGS (or a decision); a failed attempt is parked as a <b>dead end</b>; <b>staleness</b> tells you when a settled fact needs re-checking; and the <b>glossary</b> is the shared vocabulary they are all written in.</p>
+<p class="mut">The seven layers are one system: a fact starts as an <b>assumption</b>, a <b>gap</b>, or a <b>contradiction</b>; a <b>recipe</b> says how to settle it; once settled it <b>graduates</b> into FINDINGS (or a decision); a failed attempt is parked as a <b>dead end</b>; <b>staleness</b> tells you when a settled fact needs re-checking; and the <b>glossary</b> is the shared vocabulary they are all written in. The exact confirm → promote → delete algorithm is <a href="https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/PROTOCOL.md">PROTOCOL.md</a>.</p>
 
 <script>
 'use strict';


### PR DESCRIPTION
Applies MG's review feedback to the episteme registries:

1. **Clickable repos** — every `> **Source:**` repo tag is now a link (the flagged `kosha/csl-guides` → [kosha](https://github.com/gasyoun/kosha)/[csl-guides](https://github.com/sanskrit-lexicon/csl-guides)); compound tags link each repo.
2. **Bare model id** — `Opus 4.8 (`claude-opus-4-8`)` → ``claude-opus-4-8`` (the version alone; tier prefix dropped in these compact lines).
3. **Linked date** — the provenance date now links to that day's commits in the repo.
4. **Glossary examples** — each of the 12 terms gains an `**Examples:**` line (≤3 concrete, distinct examples).
5. Dashboard links [PROTOCOL.md](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/PROTOCOL.md) (the graduation algorithm).

Applied by the idempotent [`normalize_provenance.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/normalize_provenance.py); entry content otherwise unchanged (dashboard counts identical). Mirrored on the infra side (Uprava, on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)