### PR TITLE
H356: episteme dashboard — 12-stat 2-row header + byline/date footer

### DIFF
--- a/epistemic_dashboard/build_epistemic_dashboard.py
+++ b/epistemic_dashboard/build_epistemic_dashboard.py
@@ -115,7 +115,10 @@ def main():
     layers = []
     staleness = None
     tot_rows = tot_auto = tot_human = 0
+    tot_entry = tot_cand = tot_cats = tot_ilinks = 0
     tot_imp = {"3": 0, "2": 0, "1": 0}
+    cat_re = re.compile(r"^## (?:[A-Z]\.|⚙️)", re.M)   # thematic category headers (not Conclusions)
+    ilink_re = re.compile(r"^↔ Interlinks:", re.M)
 
     for key, act in LAYERS:
         p = root / f"{key}.md"
@@ -141,12 +144,19 @@ def main():
                 by_imp[str(e["importance"])] += 1
                 tot_imp[str(e["importance"])] += 1
             by_org[e["origin"]] += 1
+        cats = len(cat_re.findall(text))
+        ilinks = len(ilink_re.findall(text))
         layers.append({"key": key, "act": act, "url": file_url,
                        "total": len(entries), "by_importance": by_imp,
-                       "by_origin": by_org, "entries": entries})
+                       "by_origin": by_org, "categories": cats,
+                       "interlinks": ilinks, "entries": entries})
         tot_rows += len(entries)
         tot_auto += by_org["auto"]
         tot_human += by_org["human"]
+        tot_entry += len(entries)
+        tot_cand += by_org["auto"]
+        tot_cats += cats
+        tot_ilinks += ilinks
 
     data = {
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -155,7 +165,9 @@ def main():
         "layers": layers,
         "staleness": staleness,
         "totals": {"rows": tot_rows, "auto": tot_auto, "human": tot_human,
-                   "by_importance": tot_imp, "layers": len(layers)},
+                   "by_importance": tot_imp, "layers": len(layers),
+                   "entry_rows": tot_entry, "candidates": tot_cand,
+                   "categories": tot_cats, "interlinks": tot_ilinks},
     }
     Path(args.out).write_text(json.dumps(data, ensure_ascii=False, indent=1),
                               encoding="utf-8")

--- a/epistemic_dashboard/epistemic.json
+++ b/epistemic_dashboard/epistemic.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-08T11:53:17Z",
+ "generated_at": "2026-07-08T12:27:43Z",
  "side": "Sanskrit-data",
  "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
  "layers": [
@@ -17,6 +17,8 @@
     "auto": 0,
     "human": 6
    },
+   "categories": 3,
+   "interlinks": 6,
    "entries": [
     {
      "title": "§1. DCS lemma == CDSL headword",
@@ -70,6 +72,8 @@
     "auto": 0,
     "human": 5
    },
+   "categories": 3,
+   "interlinks": 5,
    "entries": [
     {
      "title": "§1. Derivative ī/ū-stem gen.pl accent (Whitney, internal)",
@@ -117,6 +121,8 @@
     "auto": 5,
     "human": 6
    },
+   "categories": 3,
+   "interlinks": 11,
    "entries": [
     {
      "title": "§1. Derivative ī/ū gen.pl accent split (D3) — n=2, unresolvable",
@@ -200,6 +206,8 @@
     "auto": 1,
     "human": 6
    },
+   "categories": 3,
+   "interlinks": 7,
    "entries": [
     {
      "title": "§1. Body-text / reverse-dict headword mining — abandoned",
@@ -259,6 +267,8 @@
     "auto": 0,
     "human": 6
    },
+   "categories": 3,
+   "interlinks": 6,
    "entries": [
     {
      "title": "§1. Whitney accent axis validation (17→18/19 GO) → reproduce",
@@ -330,6 +340,8 @@
     "auto": 0,
     "human": 12
    },
+   "categories": 4,
+   "interlinks": 12,
    "entries": [
     {
      "title": "form_key",
@@ -422,6 +434,10 @@
    "2": 24,
    "1": 8
   },
-  "layers": 7
+  "layers": 7,
+  "entry_rows": 47,
+  "candidates": 6,
+  "categories": 19,
+  "interlinks": 47
  }
 }

--- a/epistemic_dashboard/index.html
+++ b/epistemic_dashboard/index.html
@@ -16,6 +16,10 @@
   h1 { font-size: 1.5rem; margin-bottom:.2rem; } h2 { font-size: 1.15rem; margin-top: 2rem; }
   .mut { color: var(--mut); font-size: .85rem; }
   .cards { display: flex; gap: .8rem; flex-wrap: wrap; margin: 1rem 0; }
+  /* header stat cards: a fixed 6-wide grid so 12 cards fill exactly two rows */
+  #cards { display: grid; grid-template-columns: repeat(6, 1fr); gap: .7rem; }
+  #cards .card { min-width: 0; padding: .6rem .7rem; }
+  @media (max-width: 760px) { #cards { grid-template-columns: repeat(3, 1fr); } }
   .card { background: var(--card); border: 1px solid var(--line); border-radius: 8px;
           padding: .7rem 1.1rem; min-width: 7rem; }
   .card b { font-size: 1.5rem; display: block; }
@@ -85,12 +89,24 @@ function bar(auto, human){
   document.getElementById('findings-link').href = d.repo_url + '/FINDINGS.md';
 
   const t = d.totals;
-  document.getElementById('cards').innerHTML =
-    `<div class="card"><b>${t.rows}</b>rows</div>` +
-    `<div class="card"><b>${t.layers}</b>layers</div>` +
-    `<div class="card"><b class="auto">${t.auto}</b>⚙️ auto</div>` +
-    `<div class="card"><b class="human">${t.human}</b>✍️ human</div>` +
-    [3,2,1].map(i => `<div class="card"><b>${t.by_importance[i]||0}</b>${DOT[i]}</div>`).join('');
+  const s0 = d.staleness || {total:0,green:0};
+  const entry = t.entry_rows != null ? t.entry_rows : (t.rows - s0.total);
+  const cand = t.candidates != null ? t.candidates : (t.auto - s0.total);
+  const card = (v, label, cls) => `<div class="card"><b${cls ? ' class="'+cls+'"' : ''}>${v}</b>${label}</div>`;
+  document.getElementById('cards').innerHTML = [
+    card(t.rows, 'rows'),
+    card(t.layers, 'layers'),
+    card(entry, 'entry rows'),
+    card(cand, '⚙️ candidates', 'auto'),
+    card(t.human, '✍️ human', 'human'),
+    card(s0.total, '⚙️ auto table'),
+    card(t.by_importance[3]||0, '🔴'),
+    card(t.by_importance[2]||0, '🟠'),
+    card(t.by_importance[1]||0, '🟡'),
+    card(s0.green, '🟢 fresh'),
+    card(t.categories != null ? t.categories : '—', 'categories'),
+    card(t.interlinks != null ? t.interlinks : '—', '↔ interlinks'),
+  ].join('');
 
   document.getElementById('layers').innerHTML =
     '<tr><th>Layer</th><th>Epistemic act</th><th class="num">rows</th>' +
@@ -140,7 +156,19 @@ function bar(auto, human){
   if (biggestHuman) cc.push(`The most human-curated layer is <b>${esc(biggestHuman.key)}</b> (${biggestHuman.by_origin.human} ✍️ rows); the highest-stakes layer by 🔴 count is <b>${esc(mostRed.key)}</b> — start confirmations there.`);
   cc.push(`Each row carries an <b>↔ Interlinks</b> line, so the seven docs read as one graph: an assumption points to the recipe that would settle it and the dead end that shows what breaks if it fails.`);
   document.getElementById('conclusions').innerHTML = cc.map(x => `<li>${x}</li>`).join('');
+
+  // Footer — authored-doc dated header + a live "data generated" stamp.
+  const gen = d.generated_at || '';
+  const g = gen.slice(0, 10);  // YYYY-MM-DD
+  document.getElementById('lastup').textContent = g ? `${g.slice(8,10)}-${g.slice(5,7)}-${g.slice(0,4)}` : '—';
+  document.getElementById('genstamp').textContent = gen ? `Data generated ${gen} by build_epistemic_dashboard.py.` : '';
 })();
 </script>
+
+<footer style="margin-top:2.5rem;border-top:1px solid var(--line);padding-top:1rem;text-align:right;font-style:italic;color:var(--mut);font-size:.85rem">
+  <div>Created: 08-07-2026 · Last updated: <span id="lastup">—</span></div>
+  <div id="genstamp"></div>
+  <div>Dr. Mārcis Gasūns</div>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
Per MG's dashboard review:

- **Header now fills two full lines** — 12 stat cards in a fixed 6-column grid (mobile → 3): rows · layers · entry rows · ⚙️ candidates · ✍️ human · ⚙️ auto table · 🔴 · 🟠 · 🟡 · 🟢 fresh · categories · ↔ interlinks. Verified 6×2 at desktop width (each card ~171px).
- **Footer added** — 'Created: 08-07-2026 · Last updated: <build date>', a live 'Data generated … by build_epistemic_dashboard.py' stamp, and the **Dr. Mārcis Gasūns** byline (the previously-missing author/date).
- Vendored builder + regenerated `epistemic.json` carry the new totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)