### PR TITLE
H356: episteme dashboard — FINDINGS as the central core

### DIFF
--- a/epistemic_dashboard/build_epistemic_dashboard.py
+++ b/epistemic_dashboard/build_epistemic_dashboard.py
@@ -40,6 +40,11 @@ DOT = re.compile(r"(🔴|🟠|🟡)")
 ORIGIN = re.compile(r"(⚙️|✍️)")
 STALE_ROW = re.compile(r"^\|\s*\[§(\d+)\]")
 STALE_FLAG = re.compile(r"(🔴|🟡|🟢|⬜)")
+# FINDINGS.md — the settled-fact CORE the seven siblings orbit. Two layouts: the Sanskrit side
+# uses `### §N.` ATX headings, the infra side uses inline `🔴 **§N.**` bold.
+FINDING_ATX = re.compile(r"^### §(\d+)\.", re.M)
+FINDING_INLINE = re.compile(r"^(?:🔴|🟠|🟡)\s*\*\*§(\d+)\.", re.M)
+IMP = {"🔴": 3, "🟠": 2, "🟡": 1}
 
 
 def gh_slug(heading):
@@ -100,6 +105,19 @@ def parse_staleness(text):
     return total, flags
 
 
+def parse_findings_core(text):
+    """Count FINDINGS.md's settled facts + importance, from whichever layout it uses.
+    Importance = the first 🔴/🟠/🟡 dot in each finding's block."""
+    bounds = list(FINDING_ATX.finditer(text)) or list(FINDING_INLINE.finditer(text))
+    by_imp = {"3": 0, "2": 0, "1": 0}
+    for i, m in enumerate(bounds):
+        start, end = m.start(), (bounds[i + 1].start() if i + 1 < len(bounds) else len(text))
+        dm = DOT.search(text[start:end])
+        if dm:
+            by_imp[str(IMP[dm.group(1)])] += 1
+    return len(bounds), by_imp
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--dir", required=True)
@@ -158,16 +176,29 @@ def main():
         tot_cats += cats
         tot_ilinks += ilinks
 
+    # FINDINGS.md — the settled-fact CORE the seven siblings orbit (measured, all ✍️ human).
+    core = None
+    fp = root / "FINDINGS.md"
+    if fp.exists():
+        f_total, f_imp = parse_findings_core(fp.read_text(encoding="utf-8"))
+        core = {"key": "FINDINGS",
+                "act": "measuring — the settled facts the seven siblings graduate into",
+                "url": f"{args.repo_url}/FINDINGS.md",
+                "total": f_total, "by_importance": f_imp,
+                "by_origin": {"auto": 0, "human": f_total}}
+
     data = {
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "side": side_name,
         "repo_url": args.repo_url,
+        "core": core,
         "layers": layers,
         "staleness": staleness,
         "totals": {"rows": tot_rows, "auto": tot_auto, "human": tot_human,
                    "by_importance": tot_imp, "layers": len(layers),
                    "entry_rows": tot_entry, "candidates": tot_cand,
-                   "categories": tot_cats, "interlinks": tot_ilinks},
+                   "categories": tot_cats, "interlinks": tot_ilinks,
+                   "findings": core["total"] if core else 0},
     }
     Path(args.out).write_text(json.dumps(data, ensure_ascii=False, indent=1),
                               encoding="utf-8")

--- a/epistemic_dashboard/epistemic.json
+++ b/epistemic_dashboard/epistemic.json
@@ -1,7 +1,22 @@
 {
- "generated_at": "2026-07-08T13:31:03Z",
+ "generated_at": "2026-07-08T14:51:09Z",
  "side": "Sanskrit-data",
  "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
+ "core": {
+  "key": "FINDINGS",
+  "act": "measuring — the settled facts the seven siblings graduate into",
+  "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md",
+  "total": 69,
+  "by_importance": {
+   "3": 13,
+   "2": 40,
+   "1": 11
+  },
+  "by_origin": {
+   "auto": 0,
+   "human": 69
+  }
+ },
  "layers": [
   {
    "key": "ASSUMPTIONS",
@@ -438,6 +453,7 @@
   "entry_rows": 47,
   "candidates": 6,
   "categories": 19,
-  "interlinks": 47
+  "interlinks": 47,
+  "findings": 69
  }
 }

--- a/epistemic_dashboard/index.html
+++ b/epistemic_dashboard/index.html
@@ -35,16 +35,21 @@
   .auto { color: var(--auto); } .human { color: var(--human); }
   .swatch { display:inline-block; width:.7rem; height:.7rem; border-radius:2px;
             vertical-align:baseline; margin-right:.25rem; }
+  #core { background:var(--card); border:1px solid var(--line); border-left:4px solid var(--human);
+          border-radius:8px; padding:.8rem 1rem; margin:1rem 0; }
+  #core b.n { font-size:1.6rem; }
+  tr.core td { background:var(--card); font-weight:600; }
 </style>
 </head>
 <body>
 <h1 id="title">Epistemic registries — dashboard</h1>
 <p class="mut" id="lede"></p>
 
+<div id="core"></div>
 <div class="cards" id="cards"></div>
 
-<h2>The seven layers</h2>
-<p class="mut">Each layer holds one epistemic act that <a id="findings-link" href="#">FINDINGS.md</a>
+<h2>The core + its seven layers</h2>
+<p class="mut">The top row is <b>FINDINGS</b> — the settled, measured facts. Each row below it holds one epistemic act that <a id="findings-link" href="#">FINDINGS.md</a>
 (measured-fact-only) structurally can't. <span class="swatch" style="background:var(--auto)"></span><span class="auto">⚙️ auto</span> rows were emitted by a seed script and are <em>candidates</em> until a human confirms; <span class="swatch" style="background:var(--human)"></span><span class="human">✍️ human</span> rows were written by a session. Rows graduate into FINDINGS / CROSS_REPO_DECISIONS as they mature.</p>
 <table id="layers"></table>
 
@@ -58,7 +63,7 @@
 
 <h2>Conclusions</h2>
 <ul id="conclusions"></ul>
-<p class="mut">The seven layers are one system: a fact starts as an <b>assumption</b>, a <b>gap</b>, or a <b>contradiction</b>; a <b>recipe</b> says how to settle it; once settled it <b>graduates</b> into FINDINGS (or a decision); a failed attempt is parked as a <b>dead end</b>; <b>staleness</b> tells you when a settled fact needs re-checking; and the <b>glossary</b> is the shared vocabulary they are all written in. The exact confirm → promote → delete algorithm is <a href="https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/PROTOCOL.md">PROTOCOL.md</a>.</p>
+<p class="mut"><b>FINDINGS is the core; the seven layers orbit it.</b> A fact starts as an <b>assumption</b>, a <b>gap</b>, or a <b>contradiction</b>; a <b>recipe</b> says how to settle it; once settled it <b>graduates into FINDINGS</b> (or a decision); a failed attempt is parked as a <b>dead end</b>; <b>staleness</b> tells you when a settled FINDINGS fact needs re-checking; and the <b>glossary</b> is the shared vocabulary they are all written in. That is why FINDINGS sits at the top here, not on a separate page. The exact confirm → promote → delete algorithm is <a href="https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/PROTOCOL.md">PROTOCOL.md</a>.</p>
 
 <script>
 'use strict';
@@ -87,6 +92,23 @@ function bar(auto, human){
       : 'This is the <b>Sanskrit-data</b> side. Its infra twin lives in the private Uprava repo.');
   document.getElementById('findings-link').href = d.repo_url + '/FINDINGS.md';
 
+  // FINDINGS — the settled-fact CORE the seven siblings orbit and graduate into.
+  const coreEl = document.getElementById('core');
+  if (d.core) {
+    const ci = d.core.by_importance || {};
+    const dash = isInfra
+      ? `<a href="${esc(d.repo_url.replace('/blob/main/FINDINGS.md','/tree/main/findings_dashboard'))}">local FINDINGS dashboard</a>`
+      : `<a href="https://gasyoun.github.io/SanskritLexicography/findings/">FINDINGS dashboard</a>`;
+    coreEl.innerHTML =
+      `<b class="n human">${d.core.total}</b> <b>settled findings</b> — the measured-fact ` +
+      `<b>core</b> in <a href="${esc(d.core.url)}">FINDINGS.md</a> that the seven sibling ` +
+      `registries below orbit: assumptions and gaps <b>graduate into</b> it, dead-ends and ` +
+      `recipes support it, staleness watches it decay, the glossary defines its terms ` +
+      `(${ci['3']||0} 🔴 · ${ci['2']||0} 🟠 · ${ci['1']||0} 🟡). Its own detail view: ${dash}.`;
+  } else {
+    coreEl.style.display = 'none';
+  }
+
   const t = d.totals;
   const s0 = d.staleness || {total:0,green:0};
   const entry = t.entry_rows != null ? t.entry_rows : (t.rows - s0.total);
@@ -107,19 +129,21 @@ function bar(auto, human){
     card(t.interlinks != null ? t.interlinks : '—', '↔ interlinks'),
   ].join('');
 
+  const layerRow = (L, cls) => {
+    const bi = L.by_importance || {};
+    const org = L.by_origin || {auto:0,human:0};
+    const n = k => bi[k] || '';
+    return `<tr${cls ? ' class="'+cls+'"' : ''}><td><a href="${esc(L.url)}"><b>${esc(L.key)}</b></a></td>` +
+      `<td class="mut">${esc(L.act)}</td>` +
+      `<td class="num">${L.total}</td>` +
+      `<td class="num">${n(3)}</td><td class="num">${n(2)}</td><td class="num">${n(1)}</td>` +
+      `<td>${org.auto || org.human ? bar(org.auto, org.human) : '<span class="mut">measured</span>'}</td></tr>`;
+  };
   document.getElementById('layers').innerHTML =
     '<tr><th>Layer</th><th>Epistemic act</th><th class="num">rows</th>' +
     '<th class="num">🔴</th><th class="num">🟠</th><th class="num">🟡</th><th>origin</th></tr>' +
-    d.layers.map(L => {
-      const bi = L.by_importance || {};
-      const org = L.by_origin || {auto:0,human:0};
-      const n = k => bi[k] || '';
-      return `<tr><td><a href="${esc(L.url)}"><b>${esc(L.key)}</b></a></td>` +
-        `<td class="mut">${esc(L.act)}</td>` +
-        `<td class="num">${L.total}</td>` +
-        `<td class="num">${n(3)}</td><td class="num">${n(2)}</td><td class="num">${n(1)}</td>` +
-        `<td>${bar(org.auto, org.human)}</td></tr>`;
-    }).join('');
+    (d.core ? layerRow(d.core, 'core') : '') +
+    d.layers.map(L => layerRow(L)).join('');
 
   const s = d.staleness || {total:0,red:0,yellow:0,green:0,unknown:0};
   document.getElementById('stale').innerHTML =
@@ -147,6 +171,7 @@ function bar(auto, human){
   const candidates = entryLayers.reduce((n,L)=>n+(L.by_origin?.auto||0),0);
   const staleTotal = s.red + s.yellow;
   const cc = [];
+  if (d.core) cc.push(`<b>${d.core.total} settled findings</b> sit at the core; the seven sibling layers below hold <b>${t.rows} rows</b> of the acts around them — so for every settled fact there is roughly ${(t.rows/Math.max(d.core.total,1)).toFixed(1)}× as much structured "not-yet-settled" scaffolding pointing at it.`);
   cc.push(`<b>${t.rows} rows across ${t.layers} layers</b> — ${t.by_importance[3]||0} 🔴 · ${t.by_importance[2]||0} 🟠 · ${t.by_importance[1]||0} 🟡. The registries now hold as much structured "what we don't yet know / can't yet trust" as FINDINGS holds settled fact.`);
   cc.push(`<b>${autoPct}% of rows are machine-generated</b> (${t.auto} ⚙️ / ${t.human} ✍️), but almost all of that is the fully-auto STALENESS table; only <b>${candidates} entry rows are ⚙️ auto candidates</b> still awaiting a human confirm-or-delete — that is the actionable backlog to graduate.`);
   cc.push(staleTotal === 0


### PR DESCRIPTION
Answers MG's "why does /episteme/ miss findings? don't they belong here?" — yes. FINDINGS is the measured-fact **core** the seven siblings orbit: assumptions/gaps graduate into it, dead-ends/recipes support it, staleness watches it decay, the glossary defines its terms.

FINDINGS.md (69 settled facts) now appears as (1) a dedicated **core box** above the stat cards and (2) the **top row of the layer table** (marked, act = "measuring — the settled facts the seven siblings graduate into"), linking to its own [FINDINGS dashboard](https://gasyoun.github.io/SanskritLexicography/findings/). Intro + conclusions reframed around the core; the 12 sibling stat cards and one-line footer are unchanged. Vendored builder updated byte-identically. Mirrored on Uprava (main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)