### PR TITLE
ci: fetch-depth 2 for RussianTranslation gates (fix all-day changelog-guard red)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2   # the changelog guard diffs HEAD~1..HEAD on push; depth 1 has no HEAD~1
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"


### PR DESCRIPTION
The `RussianTranslation gates` job has failed on **every merge to the default branch all day** (from `6c4b3bf` at 08:43 onward — across many sessions' merges), at the **Guard review changelog updates** step.

**Root cause (not data, not any one PR):** the guard runs `git diff HEAD~1..HEAD` on push events, but the gates-job [`actions/checkout@v7`](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/workflows/ci.yml) had no `fetch-depth`, so the shallow (depth-1) clone has **no `HEAD~1`** → git errors → the step exits 1. It passes on the PR path (which fetches the base) and locally (full history), which is why it slipped in. The link-check job in the same file already sets `fetch-depth: 2` for the same reason.

**Fix:** one line — `fetch-depth: 2` on the gates-job checkout.

Surfaced while verifying the [H350/E7](https://github.com/gasyoun/SanskritLexicography/pull/234) LOD acceptance gate (its own step, `LOD graph acceptance`, is green). Model: Opus 4.8 (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)