### PR TITLE
docs: log H309 corpus-lexicon recall fix in .ai_state.md

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,23 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **H309 corpus-lexicon commentary-tail + adverb recall fix — ✅ DONE 08-07-2026 (Sonnet 5 `claude-sonnet-5`).**
+  Fixed the two H136-measured recall failure classes ([recall_report.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/gold/recall_report.md)):
+  widened [build_corpus_lexicon.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_corpus_lexicon.py)
+  `SYS`/`SYS_BATCH` prompts to include ADVERB (was missing entirely from the content-word
+  category list) + an explicit exhaustiveness instruction. Root-caused "commentary-tail
+  unaligned" to single-pass dilution on a dense fused verse+commentary `sa` blob (not a
+  skipped `comm1` segment as originally hypothesized). Targeted REPLACE re-harvest of the
+  two genre-tagged commentary works (`gitartha-samgraha_yamunacharya` + `gitarthasamgraha-
+  abhinavagupta`, 780 groups; 12,841→14,704 rows). **Medieval recall 84.0%→95.1%** (re-measured
+  on the same 8 frozen `recall_set.jsonl` groups, 9/13 misses resolved, 4 residual documented);
+  **overall recall 92.1%→95.4%** (Wilson CI 92.2–97.3). `PR_MEMO_A42.md` refreshed. The
+  adverb/exhaustiveness prompt fix applies to all future harvests; the ~58k groups outside
+  the targeted population were deliberately NOT re-harvested (documented residual, matches
+  the "targeted, not full rebuild" mandate). [PR #250](https://github.com/gasyoun/SanskritLexicography/pull/250)
+  MERGED (`30da847`), delivered via isolated worktree (`SanskritLexicography-h309`, removed
+  after merge). `corpus_lexicon.jsonl` (gitignored) updated in the main checkout to match.
+
 - **H335 pipeline capability audit — ✅ DONE 08-07-2026 (Fable 5 `claude-fable-5`; audit-only, no behavior change).**
   [`PIPELINE_CAPABILITY_AUDIT_2026-07-08.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md)
   answers MG's four capability questions: **W1** 3-account concurrency = MISSING (no locking on the


### PR DESCRIPTION
## Summary
- Records the H309 corpus-lexicon commentary-tail + adverb recall fix ([PR #250](https://github.com/gasyoun/SanskritLexicography/pull/250), merged) in the pwg_ru session journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)