### PR TITLE
H336: pwg_ru 3-account concurrency hardening (promote claim + window-tag + append hygiene)

### DIFF
--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   },
   {
@@ -207,7 +207,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "lang is a first-class parameter of the TM address (sha256(lang + ...)); --lang=ru|en both get full reuse.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "38c404a4d88c4ea0d34617721edc6725423c70250b49e91b40d93008cdcbdfba"
+      "src/pilot/translation_memory.py": "69ccc561e2a0090924176c969d52a088fbcc8d8b784bc10183994ace0905a579"
     }
   },
   {
@@ -279,7 +279,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
       "src/pilot/prompt_rule_audit.py": "bbd3fe10ff72b9d58e6d763069352129df8c246d4cb18ae41520ddcf6fee7525",
-      "src/pilot/audit_window.py": "4842e14d11c4830eeb3a7840c016d2d773d5268421c1ca9c2aa3d9cfdbfd60ae",
+      "src/pilot/audit_window.py": "4623e2f271a6d68cf2c76c0e144c3110bdd01a0526d55eb1804175cdf47059ef",
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2"
     }
   },
@@ -298,9 +298,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The denylist append and load_frag_tm filtering are lang-agnostic (fsha encodes lang; requeue_from_audit takes --lang), but the fshas EMITTER lives only in the RU auditor: audit_window_en.py reimplements its gates and does not compute requeue_defect_fshas or write the file, so an EN defect requeue does not auto-denylist its fragments.",
     "tracking": "Uprava/handoffs/H304-Fable_RussianTranslation_coordinator-driver-remake_07.07.26.md (EN-emitter port is the recorded follow-up)",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "4842e14d11c4830eeb3a7840c016d2d773d5268421c1ca9c2aa3d9cfdbfd60ae",
-      "src/pilot/window_reports.py": "1649a33f3cf65fdd9f770cd1f05bb84d3eccdbc8369132ee3a1800c0ea62a72e",
-      "src/pilot/requeue_from_audit.py": "a315cd02276908ffdcc64f09d226798865885a7eea47ca60681a256a240d6272"
+      "src/pilot/audit_window.py": "4623e2f271a6d68cf2c76c0e144c3110bdd01a0526d55eb1804175cdf47059ef",
+      "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
+      "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878"
     }
   },
   {
@@ -317,7 +317,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 (commit 8cb84f7): the helper is lang-agnostic (takes a root, not a --lang flag; gen_opt_harness2.py resolves lang from the rootmap), so the fix applies to any language's requeue in one place. Was a both-paths gap before the fix, not an RU/EN divergence.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/requeue_from_audit.py": "a315cd02276908ffdcc64f09d226798865885a7eea47ca60681a256a240d6272"
+      "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878"
     }
   },
   {
@@ -335,8 +335,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "47143a98618429e81897fca734c64ea0811f87ef698753d7218bfc10c90141ee",
-      "src/promote_en.py": "7c9b24b12371937735efb7cb3eb7f9b51238614d34b357621b1e8f1715c21420"
+      "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
+      "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b"
     }
   },
   {
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   },
   {
@@ -392,8 +392,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED same day (2026-07-04): PR #140 (feat(provenance): pipeline versioning) added pipeline_version stamping only to promote_final_cards.py; found as a GAP while re-affirming H169's parity re-hash, closed immediately. promote_en.py now calls `pipeline_version.stamp(model_version=gen_model_version)` inside `en_index()`'s per-subcard provenance block, stored as `en_provenance.pipeline` (mirrors RU's `provenance.pipeline`; a distinct field since EN attaches onto an existing RU row rather than owning it). Pinned by an added assertion in `promote_en.selftest()`.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "47143a98618429e81897fca734c64ea0811f87ef698753d7218bfc10c90141ee",
-      "src/promote_en.py": "7c9b24b12371937735efb7cb3eb7f9b51238614d34b357621b1e8f1715c21420"
+      "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
+      "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b"
     }
   },
   {
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   },
   {
@@ -430,7 +430,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 1.1. The layer is derived purely from the sub-card KEY structure, which is identical for RU and EN. promote_en.py ATTACHES english onto the RU-owned row and leaves it otherwise untouched, so EN inherits `layer` for free — no EN-specific code needed. layer_of() pinned by dict_merge.py selftest + a promote_final_cards.selftest assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "47143a98618429e81897fca734c64ea0811f87ef698753d7218bfc10c90141ee",
+      "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
       "src/dict_merge.py": "0266e11980e3b8b12d0699665b2051b9f7b8b16ed89d5810adfe5a458e880eea"
     }
   },
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/promote_final_cards.py": "47143a98618429e81897fca734c64ea0811f87ef698753d7218bfc10c90141ee"
+      "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d"
     }
   },
   {
@@ -471,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   },
   {
@@ -500,9 +500,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/preflight_remaining_gates.py": "00386c837b97986c9702abfceed9c29534736c3df3063af202ddfaae6b078b8f",
       "src/release_readiness.py": "db38a870bbc8b5dbe694e706e4a7b9089ba41211a3881ad9a1bd4eb02950c8a9",
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
-      "src/pilot/audit_window.py": "4842e14d11c4830eeb3a7840c016d2d773d5268421c1ca9c2aa3d9cfdbfd60ae",
+      "src/pilot/audit_window.py": "4623e2f271a6d68cf2c76c0e144c3110bdd01a0526d55eb1804175cdf47059ef",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   },
   {
@@ -520,8 +520,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H321 (code review 2026-07-04 item #3b): the fragment sidecar is content-addressed on the fragment SOURCE and was harvested append-only first-seen-wins with NO fidelity check, so a hand-edited/corrupt wf_output*.json (blanked or malformed senses) permanently poisoned reuse and a later good harvest of the same fsha could never override it. frag_senses_sane(senses, lang) keys on the CARD-shaped translation field ('russian'/'english') and is applied at BOTH harvest (never cache garbage; a cached-corrupt fsha maps to False so a good row overrides it) and serve (load_frag_tm drops any corrupt historical row). Entirely lang-agnostic — lang is a first-class parameter of frag_address/frag_senses_sane/load_frag_tm/build_frags, no RU/EN branch. Pinned by test_frag_tm_fidelity_gate_and_override. Extends translation_memory_card_and_fragment.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "38c404a4d88c4ea0d34617721edc6725423c70250b49e91b40d93008cdcbdfba",
-      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+      "src/pilot/translation_memory.py": "69ccc561e2a0090924176c969d52a088fbcc8d8b784bc10183994ace0905a579",
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "2257f04cdca96b2aea51cd6d097358c43109977e1847d39ff59476cc5cf50863",
-      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "12a5a7b3ec794d681433ba6f155c40b1240d44f9ba2f71fb8856f7692abc4f12"
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   },
   {
@@ -576,6 +576,83 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/government_census.py": "3ae290eed18a31baa864a01321a0b80c1ced6c616d050a6aa3716e80f1b0a228"
+    }
+  },
+  {
+    "id": "promotion_claim_file_h336",
+    "mechanism": "O_EXCL claim file (promote_lock.PromoteClaim) guarding the promotion read-guard-write window in promote_final_cards.py --merge and promote_en.py, plus a UNIQUE timestamped .premerge.<UTC>.bak / .preEN.<UTC>.bak backup name replacing the old fixed name (H335 W1 / H336 H-1)",
+    "files": [
+      "src/promote_lock.py",
+      "src/promote_final_cards.py",
+      "src/promote_en.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H336 (08-07-2026). The claim wraps whichever store path --store points at, and both promote_final_cards.py (RU bridge) and promote_en.py (EN attach) import the identical PromoteClaim class with identical TTL-only (no PID-liveness) staleness semantics and the same --steal-lock override — there is exactly one implementation, not a per-language reimplementation. Pinned by test_promote_claim_contention (pins promote_lock.py's own --selftest into the aggregate suite).",
+    "tracking": "",
+    "verified_sha256": {
+      "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
+      "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
+      "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b",
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+    }
+  },
+  {
+    "id": "window_tag_output_namespacing_h336",
+    "mechanism": "audit_window.py --window-tag routes window_status/report/requeue/judge-sample artifacts to src/pilot/output/<tag>/ instead of the flat singletons (default tag = --root when the flag is bare); requeue_from_audit.py --window-tag and root_window_status.py --window-tag read from the same tag dir. Untagged invocation is unchanged (writes the flat singletons) — H335 W1 / H336 H-2",
+    "files": [
+      "src/pilot/audit_window.py",
+      "src/pilot/requeue_from_audit.py",
+      "src/pilot/root_window_status.py",
+      "src/pilot/window_reports.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H336 (08-07-2026). window_reports.write_reports/write_window_status already took an out_dir parameter (pre-existing --out-dir escape hatch); --window-tag is a thin, lang-agnostic sugar layer over that same parameter computed once in audit_window.py and threaded through unchanged to requeue_from_audit.py/root_window_status.py. Neither RU nor EN branch differently. Pinned by test_audit_window_tag_routing.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/audit_window.py": "4623e2f271a6d68cf2c76c0e144c3110bdd01a0526d55eb1804175cdf47059ef",
+      "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
+      "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
+      "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+    }
+  },
+  {
+    "id": "jsonl_append_hygiene_h336",
+    "mechanism": "window_common.append_jsonl_line() writes ONE os.write() of a fully-encoded JSONL line per row (O_APPEND fd) instead of a buffered text-mode 'a' handle, used by every append-only sidecar (window_ledger, TM denylist, TM fragment sidecar, layer_version_log, auto_failures); translation_memory.load_denylist now WARNS loudly on a torn/undecodable line instead of silently dropping it (H335 W1 / H336 H-3)",
+    "files": [
+      "src/pilot/window_common.py",
+      "src/pilot/window_reports.py",
+      "src/pilot/requeue_from_audit.py",
+      "src/pilot/layer_versions.py",
+      "src/pilot/failure_capture.py",
+      "src/pilot/translation_memory.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H336 (08-07-2026). append_jsonl_line is a single shared primitive (window_common.py) used identically by every JSONL append site regardless of --lang; the TM denylist stores 'ru'/'en' addresses in the same file with no per-language code path. Pinned by test_denylist_torn_line_warns.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/window_common.py": "0a26bac1b0aa1ca63d8af5fe0b3f4431c97df371f5fd20a0f400b6900f86d1ac",
+      "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
+      "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
+      "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
+      "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
+      "src/pilot/translation_memory.py": "69ccc561e2a0090924176c969d52a088fbcc8d8b784bc10183994ace0905a579",
+      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -350,6 +350,19 @@ Sonnet agents on a single Max session. Slice D launched 18 at once → ~140–25
 runs measured **zero** transient failures. Run roots sequentially or ≤3-wide from one driver;
 a clean sequential sweep is faster end-to-end than a collapsed wide run plus its recovery pass.
 
+**Running 3 accounts at once (3 clones, not 3 chats in one clone)?** Read the
+[3-account operating protocol](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md#recommended-3-account-operating-protocol-no-code-changes-needed)
+(H335 W1) first: one worktree per account (never a shared clone), shard roots via
+`verb_worklist.py` before starting, only ONE account runs `promote_final_cards.py --merge`
+per catch-up (single-promoter rule), and the ≤3-wide rule above is **global across all
+accounts**, not per-account — 3 accounts × 3-wide each is the 429 danger band all over again.
+H336 hardened the direct-path collision matrix that protocol documents (promotion claim file,
+`--window-tag` output namespacing, JSONL append hygiene) — see
+[promote_lock.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_lock.py)
+and `audit_window.py --window-tag` / `requeue_from_audit.py --window-tag` — but the operating
+protocol (sharding + single-promoter) is still the primary defense; the hardening is a backstop,
+not a substitute for it.
+
 ## Flaky API / Internet Policy
 
 - There is no Claude API client in this repo for production PWG translation. Claude work runs

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -265,6 +265,13 @@ def main():
                          'audit_window.report.json (auto-enabled for a wf_output under the OS temp dir)')
     ap.add_argument('--out-dir',
                     help='write report/status/requeue artifacts to this directory instead of src/pilot/output')
+    ap.add_argument('--window-tag', nargs='?', const='', default=None,
+                    help='H336/H-2: route window_status/report/requeue/judge-sample artifacts to '
+                         'src/pilot/output/<tag>/ instead of the flat singletons, so 3 accounts '
+                         'auditing 3 different windows in ONE clone cannot clobber each other\'s '
+                         'status or requeue a sibling window\'s keys. Bare --window-tag (no value) '
+                         'defaults the tag to --root. Omit entirely for the untagged legacy '
+                         'behavior (writes src/pilot/output/ singletons, unchanged).')
     ap.add_argument('--judge-sample-rate', type=float, default=0.10,
                     help='deterministic clean-key semantic judge sample rate (default: 0.10)')
     ap.add_argument('--judge-sample-min', type=int, default=5,
@@ -297,8 +304,13 @@ def main():
     # FL8 fixture guard: a self-test / temp-file audit writes its status+report to a scratch
     # dir so it can never clobber the live singletons; a real repo run writes OUT as before.
     ephemeral = args.ephemeral or _under_tempdir(wf)
+    # Precedence: explicit --out-dir wins outright; else --window-tag namespaces under
+    # OUT/<tag> (tag defaults to --root when the flag is bare); else the ephemeral
+    # scratch-dir guard; else None (write the flat OUT singletons, untagged legacy path).
+    window_tag = (args.window_tag or args.root or 'default') if args.window_tag is not None else None
     report_out_dir = os.path.abspath(args.out_dir) if args.out_dir else (
-        tempfile.mkdtemp(prefix='pwg_audit_ephemeral_') if ephemeral else None)
+        os.path.join(OUT, safe_name(window_tag)) if window_tag else (
+        tempfile.mkdtemp(prefix='pwg_audit_ephemeral_') if ephemeral else None))
 
     _payload, wf_meta, results, keys, null_cards = workflow_payload(wf)
     emit_audit_event(

--- a/RussianTranslation/src/pilot/failure_capture.py
+++ b/RussianTranslation/src/pilot/failure_capture.py
@@ -16,6 +16,10 @@ import os
 import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+from window_common import append_jsonl_line  # noqa: E402
+
 REPO = os.path.normpath(os.path.join(HERE, '..', '..'))
 # Auto-captured incidents go to a SEPARATE, git-ignored log so the curated,
 # tracked post-mortems in failures/failures.jsonl stay pristine (human-authored
@@ -81,8 +85,7 @@ def append_failure(mode, symptom, severity='high', root=None, data=None,
         parent = os.path.dirname(os.path.abspath(path))
         if parent:
             os.makedirs(parent, exist_ok=True)
-        with open(path, 'a', encoding='utf-8') as f:
-            f.write(json.dumps(rec, ensure_ascii=False) + '\n')
+        append_jsonl_line(path, rec)
         return rec
     except Exception as e:
         print('warning: failure auto-capture failed: %s' % e, file=sys.stderr)

--- a/RussianTranslation/src/pilot/layer_versions.py
+++ b/RussianTranslation/src/pilot/layer_versions.py
@@ -40,6 +40,7 @@ if SRC not in sys.path:
     sys.path.insert(0, SRC)
 
 import dict_merge as dm            # noqa: E402  — csl-orig layer indexes + NWS layout
+from window_common import append_jsonl_line  # noqa: E402
 
 LOG = os.path.join(HERE, 'layer_version_log.jsonl')
 NWS_DIR = dm.NWS_DIR
@@ -173,8 +174,7 @@ def build_snapshot(counts=False):
 
 # --- log I/O ----------------------------------------------------------------
 def append_log(record, path=LOG):
-    with open(path, 'a', encoding='utf-8', newline='\n') as f:
-        f.write(json.dumps(record, ensure_ascii=False) + '\n')
+    append_jsonl_line(path, record)
 
 
 def read_log(path=LOG):

--- a/RussianTranslation/src/pilot/requeue_from_audit.py
+++ b/RussianTranslation/src/pilot/requeue_from_audit.py
@@ -30,7 +30,7 @@ REQUEUE = os.path.join(OUT, 'requeue.keys.txt')
 
 sys.path.insert(0, SRC)
 from safe_filename import safe_name
-from window_common import sha256_file
+from window_common import sha256_file, append_jsonl_line
 
 sys.path.insert(0, HERE)
 import translation_memory
@@ -44,8 +44,15 @@ def rootmap_path(root):
     return None
 
 
-def requeue_file(which):
-    return os.path.join(OUT, {
+def tag_out_dir(tag):
+    """H336/H-2: the same per-window namespacing audit_window.py --window-tag writes to.
+    None (untagged / legacy) resolves to the flat OUT singleton dir — unchanged default
+    behavior so an untagged invocation keeps reading the old singletons."""
+    return os.path.join(OUT, safe_name(tag)) if tag else OUT
+
+
+def requeue_file(which, tag=None):
+    return os.path.join(tag_out_dir(tag), {
         'transient': 'requeue.transient.keys.txt',   # null cards only — cheap re-run
         'defect': 'requeue.defect.keys.txt',         # real content failures — rework
     }.get(which, 'requeue.keys.txt'))
@@ -74,29 +81,30 @@ def append_tm_denylist(root, keys, which, lang='ru', fsha_file=None):
     now = datetime.datetime.now(datetime.timezone.utc).isoformat(
         timespec='seconds').replace('+00:00', 'Z')
     n = 0
-    with open(path, 'a', encoding='utf-8') as f:
-        for k in keys:
-            raw = os.path.join(INP, k + '.raw.txt')
-            if not os.path.exists(raw):
-                continue
-            address = '%s:%s' % (lang, sha256_file(raw))
-            f.write(json.dumps({'schema': 'pwg.translation_memory.denylist.v1',
-                                'kind': 'card', 'address': address, 'key': k,
-                                'root': root, 'lang': lang, 'reason': 'requeue_%s' % which,
-                                'blocked_at': now}, ensure_ascii=False) + '\n')
-            n += 1
+    for k in keys:
+        raw = os.path.join(INP, k + '.raw.txt')
+        if not os.path.exists(raw):
+            continue
+        address = '%s:%s' % (lang, sha256_file(raw))
+        # H336/H-3: one os.write() per row (window_common.append_jsonl_line) — a bare
+        # buffered 'a' handle can split one line across writes, and a concurrent
+        # appender (another account's requeue) can then tear it.
+        append_jsonl_line(path, {'schema': 'pwg.translation_memory.denylist.v1',
+                                 'kind': 'card', 'address': address, 'key': k,
+                                 'root': root, 'lang': lang, 'reason': 'requeue_%s' % which,
+                                 'blocked_at': now})
+        n += 1
     nf = 0
     fp = fsha_file or os.path.join(OUT, 'requeue.defect.fshas.txt')
     if os.path.exists(fp):
         fshas = [ln.strip() for ln in open(fp, encoding='utf-8') if ln.strip()]
-        with open(path, 'a', encoding='utf-8') as f:
-            for fsha in fshas:
-                f.write(json.dumps({'schema': 'pwg.translation_memory.denylist.v1',
-                                    'kind': 'frag', 'fsha': fsha,
-                                    'root': root, 'lang': lang,
-                                    'reason': 'requeue_%s_fragment' % which,
-                                    'blocked_at': now}, ensure_ascii=False) + '\n')
-                nf += 1
+        for fsha in fshas:
+            append_jsonl_line(path, {'schema': 'pwg.translation_memory.denylist.v1',
+                                     'kind': 'frag', 'fsha': fsha,
+                                     'root': root, 'lang': lang,
+                                     'reason': 'requeue_%s_fragment' % which,
+                                     'blocked_at': now})
+            nf += 1
     return n, nf
 
 
@@ -108,7 +116,13 @@ def main():
     group.add_argument('--defect', action='store_true')
     ap.add_argument('--lang', default='ru', choices=('ru', 'en'))
     ap.add_argument('--requeue-file',
-                    help='explicit requeue key file; default uses src/pilot/output singleton files')
+                    help='explicit requeue key file; default uses src/pilot/output singleton files, '
+                         'or src/pilot/output/<window-tag>/ if --window-tag is given')
+    ap.add_argument('--window-tag',
+                    help='H336/H-2: read requeue/fsha files from src/pilot/output/<tag>/ — the same '
+                         'tag audit_window.py --window-tag wrote them to. Closes the same-clone '
+                         'requeue TOCTOU: an untagged run reads whichever window last rewrote the '
+                         'singleton, possibly not this one.')
     ap.add_argument('--out',
                     help='explicit generated harness path; default is src/pilot/run_pilot_wf.opt2.js')
     ap.add_argument('--nominal', action='store_true',
@@ -129,7 +143,7 @@ def main():
         rm = json.load(open(rp, encoding='utf-8'))
         declared = {s['subkey'] for s in rm.get('sub_cards', [])}
         suffixes = {k.split('~~')[-1]: k for k in declared}
-    keys = read_requeue(args.requeue_file or requeue_file(which))
+    keys = read_requeue(args.requeue_file or requeue_file(which, tag=args.window_tag))
     resolved, invalid = [], []
     for k in keys:
         full = k if (args.nominal or k in declared) else suffixes.get(k)
@@ -143,10 +157,10 @@ def main():
             print('  ' + k)
         sys.exit(1)
     fsha_file = None
-    if args.requeue_file:
-        cand = os.path.join(os.path.dirname(os.path.abspath(args.requeue_file)),
-                            'requeue.defect.fshas.txt')
-        fsha_file = cand if os.path.exists(cand) else None
+    fsha_dir = (os.path.dirname(os.path.abspath(args.requeue_file)) if args.requeue_file
+                else tag_out_dir(args.window_tag))
+    cand = os.path.join(fsha_dir, 'requeue.defect.fshas.txt')
+    fsha_file = cand if os.path.exists(cand) else None
     denied, denied_frags = append_tm_denylist(root, resolved, which, lang=lang,
                                               fsha_file=fsha_file)
 

--- a/RussianTranslation/src/pilot/root_window_status.py
+++ b/RussianTranslation/src/pilot/root_window_status.py
@@ -65,8 +65,22 @@ def input_digest(subs):
     return h.hexdigest(), missing
 
 
-def latest_state(root):
-    status = latest_status(OUT)
+def tag_out_dir(tag, root):
+    """H336/H-2: prefer the per-window tag dir a tagged audit_window.py run wrote to,
+    falling back to the flat OUT singletons when no tag dir exists (untagged legacy runs,
+    or a tag dir that was never created for this root)."""
+    if tag:
+        cand = os.path.join(OUT, safe_name(tag))
+        if os.path.isdir(cand):
+            return cand
+    default_tag_dir = os.path.join(OUT, safe_name(root))
+    if not tag and os.path.isdir(default_tag_dir):
+        return default_tag_dir
+    return OUT
+
+
+def latest_state(root, out_dir=OUT):
+    status = latest_status(out_dir)
     if not status:
         return 'ready'
     if status.get('_error'):
@@ -100,13 +114,13 @@ def harness_matches(root, rootmap_sha, expected_keys=None):
     return ok, meta
 
 
-def next_action(root, failures, rootmap_sha=None, all_keys=None, pending_keys=None):
+def next_action(root, failures, rootmap_sha=None, all_keys=None, pending_keys=None, out_dir=OUT):
     if failures:
         return {
             'action': 'Fix root-split input issues before generating a harness.',
             'command': 'python src\\pilot\\root_window_status.py %s' % root,
         }
-    status = latest_status(OUT)
+    status = latest_status(out_dir)
     harness = os.path.join(HERE, 'run_pilot_wf.opt2.js')
     all_keys = list(all_keys or [])
     pending_keys = list(pending_keys or [])
@@ -127,8 +141,8 @@ def next_action(root, failures, rootmap_sha=None, all_keys=None, pending_keys=No
                 meta.get('error') if isinstance(meta, dict) and status and status.get('_error') else ''),
         }
     state = status.get('state') or 'unknown'
-    requeue, requeue_error = queue_lines(os.path.join(OUT, 'requeue.keys.txt'))
-    judge_sample, sample_error = queue_lines(os.path.join(OUT, 'judge_sample.keys.txt'))
+    requeue, requeue_error = queue_lines(os.path.join(out_dir, 'requeue.keys.txt'))
+    judge_sample, sample_error = queue_lines(os.path.join(out_dir, 'judge_sample.keys.txt'))
     if requeue_error or sample_error:
         return {
             'action': 'Queue files could not be read; inspect file permissions before continuing.',
@@ -182,8 +196,13 @@ def main():
     ap.add_argument('root')
     ap.add_argument('--prune-stale', action='store_true',
                     help='delete generated raw/portrait inputs for this root prefix that are not declared in the current rootmap')
+    ap.add_argument('--window-tag',
+                    help='H336/H-2: prefer src/pilot/output/<tag>/ for status/requeue reads (falls '
+                         'back to the flat singletons if the tag dir does not exist). Omit to auto-'
+                         'prefer a dir named after the root, if one exists, else the singletons.')
     args = ap.parse_args()
     root = args.root
+    status_dir = tag_out_dir(args.window_tag, root)
     rp, stem = rootmap_path(root)
     if not rp:
         sys.exit('FAIL: no rootmap for %r under %s' % (root, INP))
@@ -273,7 +292,7 @@ def main():
         failures.append('batch metadata errors: %d' % len(batch_errors))
 
     print('root              : %s (%s)' % (root, stem))
-    print('current state     : %s' % latest_state(root))
+    print('current state     : %s' % latest_state(root, out_dir=status_dir))
     print('rootmap           : %s' % rp)
     print('rootmap sha256    : %s' % rootmap_sha)
     print('input digest      : %s' % digest)
@@ -301,14 +320,14 @@ def main():
     if failures:
         print('FAIL:', '; '.join(failures))
         nxt = next_action(root, failures, rootmap_sha=rootmap_sha,
-                          all_keys=all_keys, pending_keys=pending_keys)
+                          all_keys=all_keys, pending_keys=pending_keys, out_dir=status_dir)
         print('next action       : %s' % nxt['action'])
         print('next command      : %s' % nxt['command'])
         if nxt.get('note'):
             print('next note         : %s' % nxt['note'])
         sys.exit(1)
     nxt = next_action(root, failures, rootmap_sha=rootmap_sha,
-                      all_keys=all_keys, pending_keys=pending_keys)
+                      all_keys=all_keys, pending_keys=pending_keys, out_dir=status_dir)
     print('next action       : %s' % nxt['action'])
     print('next command      : %s' % nxt['command'])
     if nxt.get('note'):

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -80,6 +80,8 @@ if HERE not in sys.path:
 if SRC not in sys.path:
     sys.path.insert(0, SRC)
 
+from window_common import append_jsonl_line  # noqa: E402
+
 DEFAULT_STORE = os.path.join(SRC, 'pwg_ru_translated.jsonl')
 FIELD = {'ru': 'ru', 'en': 'en'}                    # store column holding the translation
 TRUST_REVIEWED = 'reviewed_exact'
@@ -211,13 +213,21 @@ def load_denylist(path=None):
     if not os.path.exists(p):
         return out
     with open(p, encoding='utf-8') as f:
-        for line in f:
+        for lineno, line in enumerate(f, 1):
             line = line.strip()
             if not line:
                 continue
             try:
                 row = json.loads(line)
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as e:
+                # H336/H-3: a torn/undecodable denylist line used to be silently DROPPED
+                # here, which silently re-enables TM reuse of gate-rejected content — the
+                # single scariest failure mode in the collision matrix. WARN loudly instead
+                # so a torn append (concurrent writer, crash mid-write) surfaces immediately
+                # rather than as a quiet correctness hole.
+                print('warning: torn/undecodable denylist line %d in %s (%s) — a gate-'
+                      'rejected address may be silently missing from the deny set: %r'
+                      % (lineno, p, e, line[:200]), file=sys.stderr)
                 continue
             kind = row.get('kind')
             value = row.get('address') or row.get('fsha') or row.get('value')
@@ -564,10 +574,8 @@ def build_frags(glob_pattern, lang, out=None):
                     'reuse_policy': 'auto_exact', 'source_kind': 'frag_prov',
                     'supersedes': None, 'harvested_at': _utc_now(),
                 })
-    if new_rows:
-        with open(path, 'a', encoding='utf-8') as f:
-            for row in new_rows:
-                f.write(json.dumps(row, ensure_ascii=False) + '\n')
+    for row in new_rows:
+        append_jsonl_line(path, row)
     return path, added, len(seen)
 
 

--- a/RussianTranslation/src/pilot/window_common.py
+++ b/RussianTranslation/src/pilot/window_common.py
@@ -73,6 +73,24 @@ def defer_monster(target, reason, estimate=None, source='perf_preflight', keys=N
         return None
 
 
+def append_jsonl_line(path, obj):
+    """Append ONE JSONL row as a single os.write() of a fully-encoded line (H336/H-3).
+
+    A buffered text-mode 'a' handle can split one logical line across more than one
+    underlying write() syscall (large lines, buffer-full flush), so two processes
+    appending concurrently can interleave PARTWAY through a line and tear it — and
+    translation_memory.load_denylist used to silently DROP a torn line, silently
+    re-enabling TM reuse of gate-rejected content. A single write() to an O_APPEND
+    fd is the OS-level append primitive: each row lands whole, even if another
+    writer's row lands immediately before or after it."""
+    data = (json.dumps(obj, ensure_ascii=False) + '\n').encode('utf-8')
+    fd = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o644)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+
+
 def load_json(path):
     with open(path, encoding='utf-8') as f:
         return json.load(f)

--- a/RussianTranslation/src/pilot/window_reports.py
+++ b/RussianTranslation/src/pilot/window_reports.py
@@ -7,7 +7,7 @@ import math
 import os
 import re
 
-from window_common import HERE, OUT, load_json, rootmap_for, exact_file_exists
+from window_common import HERE, OUT, load_json, rootmap_for, exact_file_exists, append_jsonl_line
 from window_provenance import harness_matches_current_root
 
 import sys
@@ -145,8 +145,7 @@ def append_ledger(status, out_dir=None):
         'crashed': status.get('crashed'),
         'rootmap_sha256': status.get('rootmap_sha256'),
     }
-    with open(os.path.join(out_dir, os.path.basename(LEDGER)), 'a', encoding='utf-8') as f:
-        f.write(json.dumps(compact, ensure_ascii=False) + '\n')
+    append_jsonl_line(os.path.join(out_dir, os.path.basename(LEDGER)), compact)
 
 
 def write_window_status(report, out_dir=None):

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3320,6 +3320,82 @@ def test_corpus_gate_evidence_and_db_markers():
         cg.SOURCES_PRESENT.update(saved_present)
 
 
+def test_promote_claim_contention():
+    """H336/H-1: the O_EXCL promotion claim file — a second claimant on a live claim
+    must retry/error cleanly (not silently proceed to race the read-guard-write window),
+    a stale (TTL-expired) claim is reclaimed with NO PID-liveness check (meaningless
+    across clones/machines — the whole point of this claim over coordinator.DirLock),
+    and --steal-lock bypasses even a fresh claim. Pins promote_lock.py's own selftest
+    into the aggregate suite rather than re-deriving the contention scenario here."""
+    import promote_lock
+    promote_lock.selftest()
+
+
+def test_audit_window_tag_routing():
+    """H336/H-2: --window-tag routes window_status/report/requeue/judge-sample to
+    src/pilot/output/<tag>/ instead of the flat singletons, so two accounts auditing
+    different windows in ONE clone cannot clobber each other's status. Untagged
+    invocation must still write the flat singletons (backward compatible)."""
+    from safe_filename import safe_name
+    tag_dir = os.path.join(OUT, safe_name('selftest_tag_zzqq'))
+    if os.path.isdir(tag_dir):
+        shutil.rmtree(tag_dir)
+    with tempfile.NamedTemporaryFile('w', encoding='utf-8', suffix='.json', delete=False) as f:
+        wf_path = f.name
+        json.dump({'meta': {'rootmap_sha256': None}, 'results': []}, f)
+    try:
+        proc = run([sys.executable, os.path.join(SRC, 'pilot', 'audit_window.py'),
+                   wf_path, '--root', 'zzqq', '--window-tag', 'selftest_tag_zzqq',
+                   '--allow-stale'], expect=0)
+        status_path = os.path.join(tag_dir, 'window_status.json')
+        report_path = os.path.join(tag_dir, 'audit_window.report.json')
+        if not os.path.exists(status_path):
+            fail('--window-tag must write window_status.json under output/<tag>/, got:\n%s'
+                 % proc.stdout)
+        if not os.path.exists(report_path):
+            fail('--window-tag must write audit_window.report.json under output/<tag>/')
+        live_status = os.path.join(OUT, 'window_status.json')
+        live_before = (open(live_status, encoding='utf-8').read()
+                      if os.path.exists(live_status) else None)
+        # A bare --root run (no tag) must be unaffected by the tag dir's existence.
+        if live_before is not None:
+            got = json.loads(open(live_status, encoding='utf-8').read())
+            if got.get('root') == 'zzqq':
+                fail('a tagged run must not also overwrite the flat OUT singleton')
+    finally:
+        os.remove(wf_path)
+        if os.path.isdir(tag_dir):
+            shutil.rmtree(tag_dir)
+
+
+def test_denylist_torn_line_warns():
+    """H336/H-3: translation_memory.load_denylist must WARN loudly (stderr) on a torn/
+    undecodable JSONL line instead of silently dropping it — a silently-dropped denylist
+    row is a correctness hole (a gate-rejected address quietly becomes TM-reusable
+    again), the scariest single entry in the H335 collision matrix."""
+    import translation_memory as tm
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, 'denylist.jsonl')
+    good = {'schema': 'pwg.translation_memory.denylist.v1', 'kind': 'card',
+            'address': 'ru:deadbeef', 'key': 'x~~h0', 'root': 'x', 'lang': 'ru',
+            'reason': 'requeue_defect', 'blocked_at': '2026-07-08T00:00:00Z'}
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(json.dumps(good, ensure_ascii=False) + '\n')
+        f.write('{"kind": "card", "address": "ru:TORN_MID_LINE\n')   # deliberately truncated/torn
+    proc = subprocess.run(
+        [sys.executable, '-c',
+         "import sys; sys.path.insert(0, %r); import translation_memory as tm; "
+         "d = tm.load_denylist(%r); "
+         "assert 'ru:deadbeef' in d['addresses'], d; "
+         "print('OK')" % (HERE, path)],
+        capture_output=True, text=True, encoding='utf-8')
+    if proc.returncode != 0 or 'OK' not in proc.stdout:
+        fail('load_denylist must still load the well-formed row past a torn line:\n%s\n%s'
+            % (proc.stdout, proc.stderr))
+    if 'torn' not in proc.stderr.lower() and 'undecodable' not in proc.stderr.lower():
+        fail('load_denylist must WARN on stderr for a torn/undecodable line, got:\n%s' % proc.stderr)
+
+
 def main():
     tests = [
         test_translation_memory_addressing,
@@ -3419,6 +3495,9 @@ def main():
         test_ls_resolver_rv_av_anchored,
         test_frag_tm_fidelity_gate_and_override,
         test_corpus_gate_evidence_and_db_markers,
+        test_promote_claim_contention,
+        test_audit_window_tag_routing,
+        test_denylist_torn_line_warns,
     ]
     for test in tests:
         test()

--- a/RussianTranslation/src/promote_en.py
+++ b/RussianTranslation/src/promote_en.py
@@ -40,6 +40,7 @@ AFTER this (it is language-agnostic and idempotent) to (re)attach the dcs_freq b
   python src/promote_en.py --selftest
 """
 import argparse
+import datetime
 import difflib
 import glob
 import json
@@ -52,6 +53,7 @@ sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
 import pipeline_version
+from promote_lock import PromoteClaim, ClaimBusy
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)
@@ -263,6 +265,13 @@ def main():
                          '(default %(default)s)')
     ap.add_argument('--dry-run', action='store_true')
     ap.add_argument('--no-backup', action='store_true')
+    ap.add_argument('--steal-lock', action='store_true',
+                    help='H336/H-1: bypass a live promotion claim on --store unconditionally. Only '
+                         'for a claim you are certain is dead (crashed run) — no PID-liveness check '
+                         'is possible across clones/machines, so this is the only override.')
+    ap.add_argument('--lock-ttl-seconds', type=int, default=None,
+                    help='override the promotion claim staleness TTL (default: promote_lock.'
+                         'DEFAULT_TTL_SECONDS = 30 min)')
     args = ap.parse_args()
 
     if not os.path.exists(args.store):
@@ -300,22 +309,33 @@ def main():
     if args.dry_run:
         print('\n(dry run — store not written)')
         return
-    if not args.no_backup:
-        bak = args.store + '.preEN.bak'
-        with open(bak, 'w', encoding='utf-8') as f, open(args.store, encoding='utf-8') as src:
-            f.write(src.read())
-        print('\nbacked up store -> %s' % os.path.basename(bak))
-    # Atomic write: temp file + os.replace so a crash/kill mid-write cannot truncate
-    # the tri-lingual store (the "EN layer wiped" scar). Under --no-backup this is the
-    # ONLY thing standing between an interrupted write and total loss.
-    tmp = args.store + '.tmp'
-    with open(tmp, 'w', encoding='utf-8') as f:
-        for row in rows:
-            f.write(json.dumps(row, ensure_ascii=False) + '\n')
-    os.replace(tmp, args.store)
-    print('wrote tri-lingual store -> %s (%d rows, %d now carry en)'
-          % (os.path.relpath(args.store, ROOT), len(rows), stats['attached']))
-    print('NEXT: re-run `python src/annotate_dcs_freq.py` to (re)attach the dcs_freq block.')
+
+    # H336/H-1 (LANG_PARITY: SHARED with promote_final_cards.py): claim the store across
+    # the backup+write window so two concurrent promote_en runs can't race the same LWW
+    # write, and give each run its own timestamped backup instead of clobbering one
+    # '.preEN.bak'. See promote_lock.py for why staleness is TTL-only, not PID-based.
+    ttl_kwargs = {'ttl_seconds': args.lock_ttl_seconds} if args.lock_ttl_seconds else {}
+    try:
+        with PromoteClaim(args.store, steal=args.steal_lock, **ttl_kwargs):
+            if not args.no_backup:
+                stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+                bak = args.store + '.preEN.%s.bak' % stamp
+                with open(bak, 'w', encoding='utf-8') as f, open(args.store, encoding='utf-8') as src:
+                    f.write(src.read())
+                print('\nbacked up store -> %s' % os.path.basename(bak))
+            # Atomic write: temp file + os.replace so a crash/kill mid-write cannot truncate
+            # the tri-lingual store (the "EN layer wiped" scar). Under --no-backup this is the
+            # ONLY thing standing between an interrupted write and total loss.
+            tmp = args.store + '.tmp'
+            with open(tmp, 'w', encoding='utf-8') as f:
+                for row in rows:
+                    f.write(json.dumps(row, ensure_ascii=False) + '\n')
+            os.replace(tmp, args.store)
+            print('wrote tri-lingual store -> %s (%d rows, %d now carry en)'
+                  % (os.path.relpath(args.store, ROOT), len(rows), stats['attached']))
+            print('NEXT: re-run `python src/annotate_dcs_freq.py` to (re)attach the dcs_freq block.')
+    except ClaimBusy as e:
+        sys.exit(str(e))
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -28,6 +28,7 @@ is a requeue subset (the full Slice-C originals were overwritten; re-run or reco
 re-run this script — it is idempotent and supersede-safe).
 """
 import argparse
+import datetime
 import glob
 import json
 import os
@@ -38,6 +39,7 @@ sys.stderr.reconfigure(encoding='utf-8')
 
 import pipeline_version
 import dict_merge
+from promote_lock import PromoteClaim, ClaimBusy
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)                       # the RussianTranslation repo root
@@ -281,6 +283,13 @@ def main():
                          'translated sub-cards not in this run). Use for a per-root catch-up — the '
                          'default full overwrite WIPES any root whose wf_output file is no longer '
                          'on disk (the gam-RU loss mode).')
+    ap.add_argument('--steal-lock', action='store_true',
+                    help='H336/H-1: bypass a live promotion claim on --store unconditionally. Only '
+                         'for a claim you are certain is dead (crashed run) — no PID-liveness check '
+                         'is possible across clones/machines, so this is the only override.')
+    ap.add_argument('--lock-ttl-seconds', type=int, default=None,
+                    help='override the promotion claim staleness TTL (default: promote_lock.'
+                         'DEFAULT_TTL_SECONDS = 30 min)')
     args = ap.parse_args()
 
     paths = sorted(glob.glob(os.path.join(ROOT, args.glob)))
@@ -314,65 +323,86 @@ def main():
         print('  output was overwritten; re-run that root and re-run this script to complete it):')
         print('  ' + ', '.join('%s(%d)' % (r, per_root[r]['cards']) for r in thin))
 
-    # --merge: replace only the SUB-CARDS present in this run, keep every other row.
-    # Sub-card granularity (not root) is deliberate: a per-root CATCH-UP promotes only the
-    # missing sub-cards, which are disjoint from the ones already in the store — a root-level
-    # replace would delete the existing sub-cards (the exact gam-RU loss we are fixing).
-    # Guards against the full-overwrite wipe when only a subset of wf_output files is on disk.
-    kept = 0
-    if args.merge and os.path.exists(args.store):
-        promoted_subs = {r['subcard'] for r in rows}
-        touched_roots = {r['key1'] for r in rows}
-        keep_rows = []
-        with open(args.store, encoding='utf-8') as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                e = json.loads(line)
-                if e.get('subcard') not in promoted_subs:
-                    keep_rows.append(e)
-        kept = len(keep_rows)
-        print('\nMERGE: replacing %d sub-card(s) across root(s) %s; keeping %d existing row(s)'
-              % (len(promoted_subs), sorted(touched_roots), kept))
-        rows = keep_rows + rows
-
     if args.dry_run:
+        # A dry run never writes, so it needs no claim — but SKIP the merge-preview read of
+        # args.store here too (it would be a second, unlocked reader of a file a real promote
+        # run might be mid-write on); dry-run coverage above is computed from wf_output alone.
         print('\n(dry run — no store written)')
         return
 
-    # OVERWRITE GUARD: refuse to shrink the store to a small fraction of its current size.
-    # A default (non-merge) run rebuilds the store from whatever wf_output files are on disk;
-    # if most are gone (or only a subset is present) this silently WIPES the store — a
-    # 10,122-row store was once overwritten to 472. Require --force to shrink >50%.
-    if os.path.exists(args.store) and not args.force:
-        try:
-            with open(args.store, encoding='utf-8') as f:
-                existing = sum(1 for line in f if line.strip())
-        except OSError:
-            existing = 0
-        if existing and len(rows) < existing * 0.5:
-            sys.exit('REFUSED: would shrink store %d -> %d rows (>50%% loss). Use --merge for a '
-                     'per-root catch-up, or --force if a full rebuild is truly intended.'
-                     % (existing, len(rows)))
+    # H336/H-1: claim the store for the ENTIRE read-guard-write window — merge-read,
+    # overwrite guard, backup, final write — so two concurrent promote runs can never
+    # interleave. See promote_lock.py for why this is TTL-only, not PID-based.
+    ttl_kwargs = {'ttl_seconds': args.lock_ttl_seconds} if args.lock_ttl_seconds else {}
+    try:
+        claim_cm = PromoteClaim(args.store, steal=args.steal_lock, **ttl_kwargs)
+        with claim_cm:
+            # --merge: replace only the SUB-CARDS present in this run, keep every other row.
+            # Sub-card granularity (not root) is deliberate: a per-root CATCH-UP promotes only
+            # the missing sub-cards, disjoint from the ones already in the store — a root-level
+            # replace would delete the existing sub-cards (the exact gam-RU loss we are fixing).
+            # Guards against the full-overwrite wipe when only a subset of wf_output is on disk.
+            kept = 0
+            if args.merge and os.path.exists(args.store):
+                promoted_subs = {r['subcard'] for r in rows}
+                touched_roots = {r['key1'] for r in rows}
+                keep_rows = []
+                with open(args.store, encoding='utf-8') as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        e = json.loads(line)
+                        if e.get('subcard') not in promoted_subs:
+                            keep_rows.append(e)
+                kept = len(keep_rows)
+                print('\nMERGE: replacing %d sub-card(s) across root(s) %s; keeping %d existing row(s)'
+                      % (len(promoted_subs), sorted(touched_roots), kept))
+                rows_to_write = keep_rows + rows
+            else:
+                rows_to_write = rows
 
-    if os.path.exists(args.store) and not args.no_backup:
-        bak = args.store + ('.premerge.bak' if args.merge else '.legacy.bak')
-        os.replace(args.store, bak)
-        print('\nbacked up prior store -> %s' % os.path.basename(bak))
-    # Atomic write: stream to a temp file then os.replace, so a crash/kill mid-write
-    # can never leave the canonical store truncated (the store this project has lost
-    # before). Matches the tmp+replace pattern in run_batch.apply_review.
-    tmp = args.store + '.tmp'
-    with open(tmp, 'w', encoding='utf-8') as f:
-        for row in rows:
-            f.write(json.dumps(row, ensure_ascii=False) + '\n')
-    os.replace(tmp, args.store)
-    print('wrote canonical translated store -> %s (%d rows, review_status=%s)'
-          % (args.store, len(rows), args.review_status))
-    print('NOTE: rows are %s, NOT approved — export_interop keeps them out of the citable'
-          % args.review_status)
-    print('      edition until G5 human review flips review_status to approved.')
+            # OVERWRITE GUARD: refuse to shrink the store to a small fraction of its current
+            # size. A default (non-merge) run rebuilds the store from whatever wf_output files
+            # are on disk; if most are gone (or only a subset is present) this silently WIPES
+            # the store — a 10,122-row store was once overwritten to 472. Require --force to
+            # shrink >50%.
+            if os.path.exists(args.store) and not args.force:
+                try:
+                    with open(args.store, encoding='utf-8') as f:
+                        existing = sum(1 for line in f if line.strip())
+                except OSError:
+                    existing = 0
+                if existing and len(rows_to_write) < existing * 0.5:
+                    sys.exit('REFUSED: would shrink store %d -> %d rows (>50%% loss). Use --merge '
+                             'for a per-root catch-up, or --force if a full rebuild is truly '
+                             'intended.' % (existing, len(rows_to_write)))
+
+            if os.path.exists(args.store) and not args.no_backup:
+                # H336/H-1: a UNIQUE timestamped backup name — the old fixed '.premerge.bak'
+                # meant a second concurrent promote (even serialized seconds apart by this same
+                # claim) would overwrite the first run's only recovery copy of the pre-merge
+                # store. Each promote now keeps its own backup.
+                stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+                bak = args.store + ('.premerge.%s.bak' % stamp if args.merge
+                                    else '.legacy.%s.bak' % stamp)
+                os.replace(args.store, bak)
+                print('\nbacked up prior store -> %s' % os.path.basename(bak))
+            # Atomic write: stream to a temp file then os.replace, so a crash/kill mid-write
+            # can never leave the canonical store truncated (the store this project has lost
+            # before). Matches the tmp+replace pattern in run_batch.apply_review.
+            tmp = args.store + '.tmp'
+            with open(tmp, 'w', encoding='utf-8') as f:
+                for row in rows_to_write:
+                    f.write(json.dumps(row, ensure_ascii=False) + '\n')
+            os.replace(tmp, args.store)
+            print('wrote canonical translated store -> %s (%d rows, review_status=%s)'
+                  % (args.store, len(rows_to_write), args.review_status))
+            print('NOTE: rows are %s, NOT approved — export_interop keeps them out of the citable'
+                  % args.review_status)
+            print('      edition until G5 human review flips review_status to approved.')
+    except ClaimBusy as e:
+        sys.exit(str(e))
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/promote_lock.py
+++ b/RussianTranslation/src/promote_lock.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+"""H336/H-1 — O_EXCL claim file guarding the promotion read-guard-write window.
+
+Two concurrent `promote_final_cards.py --merge` runs (or a `--merge` overlapping a
+full rebuild) are last-writer-wins on the canonical store: nothing serializes the
+read-existing-store / merge-in-new-rows / os.replace window, and both runs also
+write the same fixed `.premerge.bak` name, so the loser's promoted rows AND the
+recovery backup of the loser's prior state are both gone. This is the single
+unrecoverable-loss path in the H335 collision matrix (PIPELINE_CAPABILITY_AUDIT_
+2026-07-08.md, W1).
+
+This is deliberately NOT coordinator.py's DirLock: DirLock's staleness check calls
+os.kill(pid, 0), which is meaningless once the "other" process is a different
+account's clone on the same box (three accounts, one machine, three trees) or a
+genuinely different machine — a stale claim from a dead run on one clone would
+never look stale to a PID check running in a different process table (or would
+collide with an unrelated live PID on the reader's own machine, which is worse:
+a false "still held"). So staleness here is TTL-only, and an operator gets an
+explicit `--steal-lock` escape hatch instead of PID guessing.
+"""
+import datetime
+import json
+import os
+import socket
+import sys
+
+DEFAULT_TTL_SECONDS = 30 * 60          # a promote run is seconds; 30 min covers a hang
+
+
+class ClaimBusy(SystemExit):
+    """Raised (as a SystemExit subclass) when a live claim is held by someone else."""
+
+
+def _utc_now():
+    return datetime.datetime.now(datetime.timezone.utc).isoformat(
+        timespec='seconds').replace('+00:00', 'Z')
+
+
+def _parse_ts(value):
+    if not value:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+
+
+def claim_path(store_path):
+    return store_path + '.promote.lock'
+
+
+class PromoteClaim:
+    """O_EXCL claim file at ``<store>.promote.lock``, held across the whole promotion
+    read-guard-write window. NO PID-liveness check (see module docstring) — staleness
+    is TTL-only, and ``steal`` bypasses it entirely for a deliberate operator override."""
+
+    def __init__(self, store_path, ttl_seconds=DEFAULT_TTL_SECONDS, steal=False):
+        self.path = claim_path(store_path)
+        self.ttl_seconds = ttl_seconds
+        self.steal = steal
+        self._acquired = False
+
+    def _payload(self):
+        return {'schema': 'pwg.promote_claim.v1', 'pid': os.getpid(),
+                'host': socket.gethostname(), 'claimed_at': _utc_now()}
+
+    def _read(self):
+        try:
+            with open(self.path, encoding='utf-8') as f:
+                return json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    def _stale(self):
+        meta = self._read()
+        claimed = _parse_ts((meta or {}).get('claimed_at'))
+        if not claimed:
+            return True                 # unreadable/corrupt claim file -> treat as stale
+        age = (datetime.datetime.now(datetime.timezone.utc) - claimed).total_seconds()
+        return age > self.ttl_seconds
+
+    def _try_remove_stale_or_stolen(self):
+        if self.steal:
+            try:
+                os.remove(self.path)
+            except OSError:
+                pass
+            return True
+        if self._stale():
+            try:
+                os.remove(self.path)
+            except OSError:
+                pass
+            return True
+        return False
+
+    def __enter__(self):
+        while True:
+            try:
+                fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            except FileExistsError:
+                if self._try_remove_stale_or_stolen():
+                    continue            # retry the O_EXCL create against the now-empty slot
+                meta = self._read() or {}
+                raise ClaimBusy(
+                    'promotion claim held by pid=%s host=%s since %s (< %ds old) — another '
+                    'promote run is in flight against this store. Wait for it to finish, or '
+                    'pass --steal-lock if you are certain it is dead (crashed process, no '
+                    'PID-liveness check is possible across clones/machines).'
+                    % (meta.get('pid'), meta.get('host'), meta.get('claimed_at'), self.ttl_seconds))
+            else:
+                with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                    json.dump(self._payload(), f)
+                self._acquired = True
+                return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._acquired:
+            try:
+                os.remove(self.path)
+            except OSError:
+                pass
+        return False
+
+
+def selftest():
+    import tempfile
+    d = tempfile.mkdtemp()
+    store = os.path.join(d, 'store.jsonl')
+    open(store, 'w', encoding='utf-8').close()
+
+    # A held claim blocks a second claimant (two processes, one wins).
+    first = PromoteClaim(store, ttl_seconds=DEFAULT_TTL_SECONDS)
+    with first:
+        assert os.path.exists(claim_path(store)), 'claim file must exist while held'
+        try:
+            with PromoteClaim(store, ttl_seconds=DEFAULT_TTL_SECONDS):
+                raise AssertionError('a second claimant must not acquire a live claim')
+        except ClaimBusy:
+            pass                        # the second claimant must retry/error cleanly
+    assert not os.path.exists(claim_path(store)), 'claim file must be removed on release'
+
+    # After release, a fresh claim succeeds immediately.
+    with PromoteClaim(store, ttl_seconds=DEFAULT_TTL_SECONDS):
+        pass
+
+    # A STALE claim (age > ttl) is reclaimed automatically — no PID check involved.
+    stale_meta = {'schema': 'pwg.promote_claim.v1', 'pid': 999999999, 'host': 'some-other-host',
+                  'claimed_at': '2000-01-01T00:00:00Z'}
+    with open(claim_path(store), 'w', encoding='utf-8') as f:
+        json.dump(stale_meta, f)
+    with PromoteClaim(store, ttl_seconds=DEFAULT_TTL_SECONDS):
+        assert True, 'a stale claim (age > ttl) must be reclaimed without any PID check'
+    assert not os.path.exists(claim_path(store))
+
+    # A FRESH claim (age < ttl) from a bogus/unreachable pid+host is NOT reclaimed
+    # without --steal-lock: staleness is TTL-only, never PID-liveness.
+    fresh_meta = {'schema': 'pwg.promote_claim.v1', 'pid': 999999999, 'host': 'some-other-host',
+                  'claimed_at': _utc_now()}
+    with open(claim_path(store), 'w', encoding='utf-8') as f:
+        json.dump(fresh_meta, f)
+    try:
+        with PromoteClaim(store, ttl_seconds=DEFAULT_TTL_SECONDS):
+            raise AssertionError('a fresh claim from an unreachable pid must still block '
+                                 '(no PID-liveness check across clones/machines)')
+    except ClaimBusy:
+        pass
+    # --steal-lock bypasses even a fresh claim.
+    with PromoteClaim(store, ttl_seconds=DEFAULT_TTL_SECONDS, steal=True):
+        assert True, '--steal-lock must bypass a live claim unconditionally'
+    assert not os.path.exists(claim_path(store))
+    print('promote_lock selftest OK')
+
+
+if __name__ == '__main__':
+    if '--selftest' in sys.argv[1:]:
+        selftest()
+    else:
+        sys.exit('usage: python promote_lock.py --selftest')


### PR DESCRIPTION
## Summary
- **H-1**: O_EXCL promotion claim file ([src/promote_lock.py](https://github.com/gasyoun/SanskritLexicography/blob/h336-pwg-ru-concurrency-hardening/RussianTranslation/src/promote_lock.py)) guards `promote_final_cards.py --merge` / `promote_en.py`'s read-guard-write window — TTL-only staleness (no PID-liveness, meaningless across clones/machines), `--steal-lock` override, unique timestamped `.premerge.<UTC>.bak` / `.preEN.<UTC>.bak` backups replacing the old fixed names.
- **H-2**: `audit_window.py --window-tag` routes status/report/requeue/judge-sample artifacts to `src/pilot/output/<tag>/` (default tag = `--root`), closing the same-clone clobber and the requeue TOCTOU; `requeue_from_audit.py` / `root_window_status.py --window-tag` read from the same tag dir. Untagged invocations are unchanged.
- **H-3**: `window_common.append_jsonl_line()` — one `os.write()` per fully-encoded JSONL row — applied to every append-only sidecar (window ledger, TM denylist, TM fragment sidecar, layer-version log, auto-failures); `translation_memory.load_denylist` now WARNS loudly on a torn/undecodable line instead of silently dropping it.
- H-4 (coordinator routing) is explicitly out of scope per the [H335 capability audit](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md).

Implements the H336 handoff (minted from the H335 W1 3-account concurrency audit).

## Test plan
- [x] `promote_lock.py --selftest`, `promote_final_cards.py --selftest`, `promote_en.py --selftest` all green
- [x] `translation_memory.py selftest` green
- [x] `layer_versions.py --selftest` green
- [x] `window_selftest.py` — 88/88 non-environmental tests pass (3 new: `test_promote_claim_contention`, `test_audit_window_tag_routing`, `test_denylist_torn_line_warns`); the 12 skipped tests (perf_preflight family + 4 harness/worklist tests) fail identically on unmodified `origin/master` in a bare worktree — pre-existing environmental gap documented in the handoff's Discipline section (gitignored generated artifacts absent outside the primary tree)
- [x] `lang_parity_check.py` — 30 entries, all verdicts complete, no drift (3 new SHARED entries for the H336 mechanisms + 20 re-verified hashes for entries whose tracked files were touched incidentally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)