### PR TITLE
H388: SkillOpt B-arm held-out benchmark + protected-field draft

### DIFF
--- a/RussianTranslation/src/pilot/eval/skillopt/README.md
+++ b/RussianTranslation/src/pilot/eval/skillopt/README.md
@@ -1,0 +1,58 @@
+# SkillOpt B-arm held-out benchmark (H388)
+
+_Created: 08-07-2026 · Last updated: 08-07-2026_
+
+The frozen "exam" the SkillOpt PWG→RU pilot grades every skill-document edit
+against. Design + rationale:
+[`Uprava/docs/SKILLOPT_PIPELINE_MEMO.md`](https://github.com/gasyoun/Uprava/blob/main/docs/SKILLOPT_PIPELINE_MEMO.md)
+§5; loop:
+[`Uprava/tools/skillopt/`](https://github.com/gasyoun/Uprava/tree/main/tools/skillopt);
+handoff:
+[`H388`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H388-Opus_Uprava_skillopt_skill_optimizer_pwg_pilot_08.07.26.md).
+
+## Files
+
+- [`build_heldout.py`](build_heldout.py) — reproducible builder. Embeds a **dated
+  snapshot** of the runnable-root universe (a frozen exam must not drift with the
+  live queue) and emits the fixture deterministically.
+- [`heldout_v1.json`](heldout_v1.json) — the frozen fixture (schema
+  `pwg.skillopt.heldout.v1`).
+
+## The split (16 active roots, 2:1:7)
+
+| Split | N | Sizes | Roots | Role (SkillOpt §3.1) |
+|---|---|---|---|---|
+| train | 3 | 1L·1M·1S | i, as, SaMs | supplies rollout experience |
+| selection | 2 | 1M·1S | tap, muh | **GATES every edit** — a candidate skill is kept only if it beats the current one here |
+| test | 11 | 2L·3M·6S | yuj, BU, kzip, ram, Baj, aS, nu, sev, tyaj, hu, pU | **report-only** — looked at once, at the end |
+
+`sTA` (241 expected agents, defer-calibrate) is held aside as a **cost-deferred
+control**, not scored — one monster must not dominate B-arm cost.
+
+## Score `r` per root
+
+The deterministic gate `r ∈ [0,1]` = `audit_window.py --json` clean fraction
+(optionally composited with `ru_coverage.py`). **No LLM judge** — this is the
+pilot's advantage: a reproducible, un-gameable signal.
+
+## Honest constraints (surfaced, not padded)
+
+1. **N is 16, not 25.** Only 17 roots were runnable (had rootmaps) on 08-07-2026;
+   684 remain rootmap-less. A larger exam is possible only after **generating more
+   rootmaps first** — a prerequisite task, tracked separately, not conjured here.
+2. **Unit = root (coarse).** Card-level scoring (denser, per-card `r`) is a later
+   refinement once the loop proves out at root granularity.
+3. **Stratified, documented sampling** by size band (small <30 KB · medium
+   30–80 KB · large >80 KB) so no split is size-skewed. No silent truncation.
+4. **Cost.** Scoring a root means a real Sonnet-5 generation of its cards. The
+   3 train + 2 sel roots (~5) are the per-epoch cost; the 11 test roots are
+   generated once for the final report. Run under `perf_preflight.py
+   --refuse-over-cost`.
+
+## Regenerate
+
+```bash
+python build_heldout.py     # deterministic; overwrites heldout_v1.json
+```
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/eval/skillopt/build_heldout.py
+++ b/RussianTranslation/src/pilot/eval/skillopt/build_heldout.py
@@ -1,0 +1,154 @@
+"""Build the FROZEN SkillOpt B-arm held-out benchmark for the PWG->RU pilot (H388).
+
+A held-out benchmark must be reproducible and stable, so this script embeds a
+DATED SNAPSHOT of the runnable-root universe (from `verb_worklist.py --top`,
+08-07-2026) rather than reading live worklist state -- a frozen exam must not
+drift when the queue changes. It emits `heldout_v1.json`: N roots split 2:1:7
+into train / selection / test, stratified by size band, deterministically.
+
+Honest constraints (surfaced, not padded -- see README):
+  * Only 17 roots are RUNNABLE (have rootmaps); 684 remain rootmap-less. A larger
+    exam REQUIRES generating more rootmaps first -- that is a prerequisite task,
+    not something this fixture can conjure.
+  * `sTA` is a 241-agent defer-monster (own budgeted session per /pwg-drain
+    guardrails); it is held aside as a cost-deferred control, NOT in the scored
+    16-root benchmark, so a single monster can't dominate B-arm cost.
+  * Unit = root here (coarse). Card-level scoring (denser signal) is a later
+    refinement once the loop proves out at root granularity.
+
+Split contract (SkillOpt §3.1): train supplies experience, selection GATES every
+edit, test is touched ONLY for the final report. Assignment is size-stratified so
+each split spans small/medium/large roots -- an edit that only helps big roots
+can't hide behind a size-skewed selection split.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8")
+
+SNAPSHOT_DATE = "08-07-2026"
+SNAPSHOT_SOURCE = "verb_worklist.py --top 40 (runnable=17)"
+
+# Frozen snapshot: (root, source_bytes, worklist_score). From the 08-07-2026 run.
+RUNNABLE = [
+    ("sTA", 184881, 61.6), ("BU", 102570, 60.2), ("yuj", 106851, 58.2),
+    ("as", 59006, 57.5), ("i", 146340, 57.4), ("tap", 39184, 49.4),
+    ("ram", 35782, 48.1), ("Baj", 34013, 47.4), ("kzip", 37869, 46.7),
+    ("aS", 21710, 46.1), ("SaMs", 26005, 45.2), ("tyaj", 17387, 45.0),
+    ("muh", 21894, 44.5), ("nu", 20679, 44.4), ("hu", 16988, 44.0),
+    ("sev", 20037, 43.4), ("pU", 14411, 43.3),
+]
+
+# sTA: 241 expected agents on live preflight (defer-calibrate). Excluded from the
+# scored benchmark; kept as a documented cost-deferred control.
+DEFER_MONSTERS = {"sTA"}
+
+
+def size_band(byts: int) -> str:
+    if byts >= 80_000:
+        return "large"
+    if byts >= 30_000:
+        return "medium"
+    return "small"
+
+
+def build():
+    active = [(r, b, s) for (r, b, s) in RUNNABLE if r not in DEFER_MONSTERS]
+    buckets: dict[str, list] = {"large": [], "medium": [], "small": []}
+    for r, b, s in active:
+        buckets[size_band(b)].append((r, b, s))
+    for band in buckets:
+        buckets[band].sort(key=lambda t: -t[1])
+
+    n = len(active)
+    want = {"train": round(0.2 * n), "sel": max(1, round(0.1 * n))}
+    want["test"] = n - want["train"] - want["sel"]
+
+    # Stratified allocation: draw WITHIN each size band so every split spans sizes.
+    # train takes the top of each band (one per band) -> train is size-balanced;
+    # sel takes the 2nd of the two largest bands -> sel spans two sizes; test gets
+    # the rest -> test spans all sizes. Requires large>=1, medium>=2, small>=2.
+    splits: dict[str, list] = {"train": [], "sel": [], "test": []}
+    assigned = set()
+
+    # train: one per band (top by bytes)
+    for band in ("large", "medium", "small"):
+        if buckets[band]:
+            pick = buckets[band][0]
+            splits["train"].append(pick)
+            assigned.add(pick[0])
+
+    # sel: 2nd member of the two most-populous bands (small, medium here)
+    for band in sorted(buckets, key=lambda b: -len(buckets[b]))[:want["sel"]]:
+        for item in buckets[band]:
+            if item[0] not in assigned:
+                splits["sel"].append(item)
+                assigned.add(item[0])
+                break
+
+    # test: everything not yet assigned, size-interleaved for readability
+    for band in ("large", "medium", "small"):
+        for item in buckets[band]:
+            if item[0] not in assigned:
+                splits["test"].append(item)
+                assigned.add(item[0])
+
+    want = {k: len(v) for k, v in splits.items()}  # actual counts after strat
+    return active, buckets, splits, want
+
+
+def main():
+    active, buckets, splits, want = build()
+    here = os.path.dirname(os.path.abspath(__file__))
+
+    def rows(items):
+        return [{"root": r, "source_bytes": b, "worklist_score": s,
+                 "size_band": size_band(b)} for (r, b, s) in items]
+
+    fixture = {
+        "schema": "pwg.skillopt.heldout.v1",
+        "created": SNAPSHOT_DATE,
+        "handoff": "H388",
+        "snapshot_source": SNAPSHOT_SOURCE,
+        "split_ratio": "2:1:7 (train:selection:test)",
+        "unit": "root",
+        "n_active": len(active),
+        "notes": [
+            "Only 17 roots were runnable (had rootmaps) on the snapshot date; a "
+            "larger exam requires generating more rootmaps first (prerequisite).",
+            "sTA (241 expected agents, defer-calibrate) held aside as a "
+            "cost-deferred control, NOT scored in this benchmark.",
+            "selection split GATES every edit; test split is report-only.",
+        ],
+        "size_band_counts": {b: len(v) for b, v in buckets.items()},
+        "splits": {k: rows(v) for k, v in splits.items()},
+        "deferred_controls": [
+            {"root": "sTA", "source_bytes": 184881, "reason":
+             "241 expected agents (defer-calibrate) — own budgeted session"}
+        ],
+    }
+    out = os.path.join(here, "heldout_v1.json")
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(fixture, f, ensure_ascii=False, indent=2)
+
+    print(f"SkillOpt held-out fixture (H388) — {len(active)} active roots, 2:1:7")
+    print(f"  size bands: {fixture['size_band_counts']}")
+    for split in ("train", "sel", "test"):
+        items = splits[split]
+        bands = {}
+        for (r, b, s) in items:
+            bands[size_band(b)] = bands.get(size_band(b), 0) + 1
+        roots = ", ".join(r for (r, _, _) in items)
+        print(f"  {split:5} ({len(items):2}) [{bands}]: {roots}")
+    print("  deferred control: sTA (241 agents)")
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/RussianTranslation/src/pilot/eval/skillopt/heldout_v1.json
+++ b/RussianTranslation/src/pilot/eval/skillopt/heldout_v1.json
@@ -1,0 +1,130 @@
+{
+  "schema": "pwg.skillopt.heldout.v1",
+  "created": "08-07-2026",
+  "handoff": "H388",
+  "snapshot_source": "verb_worklist.py --top 40 (runnable=17)",
+  "split_ratio": "2:1:7 (train:selection:test)",
+  "unit": "root",
+  "n_active": 16,
+  "notes": [
+    "Only 17 roots were runnable (had rootmaps) on the snapshot date; a larger exam requires generating more rootmaps first (prerequisite).",
+    "sTA (241 expected agents, defer-calibrate) held aside as a cost-deferred control, NOT scored in this benchmark.",
+    "selection split GATES every edit; test split is report-only."
+  ],
+  "size_band_counts": {
+    "large": 3,
+    "medium": 5,
+    "small": 8
+  },
+  "splits": {
+    "train": [
+      {
+        "root": "i",
+        "source_bytes": 146340,
+        "worklist_score": 57.4,
+        "size_band": "large"
+      },
+      {
+        "root": "as",
+        "source_bytes": 59006,
+        "worklist_score": 57.5,
+        "size_band": "medium"
+      },
+      {
+        "root": "SaMs",
+        "source_bytes": 26005,
+        "worklist_score": 45.2,
+        "size_band": "small"
+      }
+    ],
+    "sel": [
+      {
+        "root": "muh",
+        "source_bytes": 21894,
+        "worklist_score": 44.5,
+        "size_band": "small"
+      },
+      {
+        "root": "tap",
+        "source_bytes": 39184,
+        "worklist_score": 49.4,
+        "size_band": "medium"
+      }
+    ],
+    "test": [
+      {
+        "root": "yuj",
+        "source_bytes": 106851,
+        "worklist_score": 58.2,
+        "size_band": "large"
+      },
+      {
+        "root": "BU",
+        "source_bytes": 102570,
+        "worklist_score": 60.2,
+        "size_band": "large"
+      },
+      {
+        "root": "kzip",
+        "source_bytes": 37869,
+        "worklist_score": 46.7,
+        "size_band": "medium"
+      },
+      {
+        "root": "ram",
+        "source_bytes": 35782,
+        "worklist_score": 48.1,
+        "size_band": "medium"
+      },
+      {
+        "root": "Baj",
+        "source_bytes": 34013,
+        "worklist_score": 47.4,
+        "size_band": "medium"
+      },
+      {
+        "root": "aS",
+        "source_bytes": 21710,
+        "worklist_score": 46.1,
+        "size_band": "small"
+      },
+      {
+        "root": "nu",
+        "source_bytes": 20679,
+        "worklist_score": 44.4,
+        "size_band": "small"
+      },
+      {
+        "root": "sev",
+        "source_bytes": 20037,
+        "worklist_score": 43.4,
+        "size_band": "small"
+      },
+      {
+        "root": "tyaj",
+        "source_bytes": 17387,
+        "worklist_score": 45.0,
+        "size_band": "small"
+      },
+      {
+        "root": "hu",
+        "source_bytes": 16988,
+        "worklist_score": 44.0,
+        "size_band": "small"
+      },
+      {
+        "root": "pU",
+        "source_bytes": 14411,
+        "worklist_score": 43.3,
+        "size_band": "small"
+      }
+    ]
+  },
+  "deferred_controls": [
+    {
+      "root": "sTA",
+      "source_bytes": 184881,
+      "reason": "241 expected agents (defer-calibrate) — own budgeted session"
+    }
+  ]
+}

--- a/RussianTranslation/src/pilot/eval/skillopt/protected_field_draft.md
+++ b/RussianTranslation/src/pilot/eval/skillopt/protected_field_draft.md
@@ -1,0 +1,61 @@
+# Protected slow-update field — DRAFT for approval (H388 @DECIDE)
+
+_Created: 08-07-2026 · Last updated: 08-07-2026_
+
+SkillOpt's optimizer **rewrites the translation skill document on its own**. The
+rules below must never be auto-edited or deleted, so they sit inside the
+`<!-- SLOW_UPDATE_START -->` / `<!-- SLOW_UPDATE_END -->` markers, which
+[`Uprava/tools/skillopt/edits.py`](https://github.com/gasyoun/Uprava/blob/main/tools/skillopt/edits.py)
+physically refuses to touch (`_touches_protected`). Only the epoch-wise
+slow-update process (also validated by the gate) may write here.
+
+**This is a DRAFT.** A human should decide whether the fenced set below is
+complete — add anything missing, strike anything that should stay
+optimizer-editable — before the first live H388 run.
+
+## Proposed protected block (paste verbatim into the skill doc)
+
+```markdown
+<!-- SLOW_UPDATE_START -->
+## Locked discipline — never edit or remove (MG-locked, per /pwg-drain)
+
+- **opt2 harness is canonical** — `gen_opt_harness2.py`; do not substitute another
+  generation harness.
+- **`--output-budget=90`** on generation.
+- **`--tm=auto` on the first pass**; `--no-tm` is mandatory on every
+  requeue-for-audit-failure round (a plain requeue re-serves the exact flagged
+  content — the "gam trap").
+- **≤3-wide concurrency** — never more than 3 roots/agents concurrent (the Slice-D
+  18× collapse = 117 transient nulls is the counter-example).
+- **PWG sense order is preserved** — never reorder senses; lean-TR is rejected.
+- **`csl-orig/v02/pwg/pwg.txt` is read-only** — always.
+- **On a requeue regression, keep the better prior attempt** — never overwrite a
+  complete card with a fresh partial ("latest requeue wins" is WRONG).
+- **Provenance records the exact model version** — `claude-sonnet-5`, never a bare
+  "sonnet".
+<!-- SLOW_UPDATE_END -->
+```
+
+## Why each is fenced (for the review)
+
+| Rule | If the optimizer edited it away… |
+|---|---|
+| opt2 canonical | a different harness silently changes output shape; gates misread |
+| `--output-budget=90` | truncation/overrun the gates weren't calibrated for |
+| `--no-tm` on requeue | the "gam trap" — re-serving flagged content as if fixed |
+| ≤3-wide | the 18× concurrency collapse (117 transient nulls) returns |
+| PWG sense order | citation IDs and scan anchors drift; lean-TR quality loss |
+| csl-orig read-only | corrupts the canonical source |
+| better-prior-attempt | a regression overwrites good cards with partials |
+| exact model version | provenance becomes a defect (bare-tier) |
+
+## What is intentionally LEFT optimizer-editable
+
+Everything about *how to translate well* — fragment-splitting heuristics, RU
+register choices, handling of commentary vs. verse, format-defect avoidance, the
+failure-mode guardrails distilled in
+[`best_skill.pwg.md`](https://github.com/gasyoun/Uprava/tree/main/tools/skillopt).
+That is exactly what SkillOpt is meant to improve; fencing it would defeat the
+loop. The fence is only around **run discipline**, not translation craft.
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Two setup artifacts for the SkillOpt PWG→RU pilot ([H388](https://github.com/gasyoun/Uprava/blob/main/handoffs/H388-Opus_Uprava_skillopt_skill_optimizer_pwg_pilot_08.07.26.md)), each needing one human sign-off before the first live run.

## 1. Held-out benchmark — the "exam" (@DO)
[`heldout_v1.json`](https://github.com/gasyoun/SanskritLexicography/blob/skillopt/heldout-fixture/RussianTranslation/src/pilot/eval/skillopt/heldout_v1.json) + reproducible [`build_heldout.py`](https://github.com/gasyoun/SanskritLexicography/blob/skillopt/heldout-fixture/RussianTranslation/src/pilot/eval/skillopt/build_heldout.py). A frozen 2:1:7 root split every skill-edit is gated against.

| Split | N | Sizes | Roots |
|---|---|---|---|
| train | 3 | 1L·1M·1S | i, as, SaMs |
| selection (gates edits) | 2 | 1M·1S | tap, muh |
| test (report-only) | 11 | 2L·3M·6S | yuj, BU, kzip, ram, Baj, aS, nu, sev, tyaj, hu, pU |

**Honest constraints (not padded):** N=16 not 25 — only 17 roots were runnable (684 rootmap-less); `sTA` (241 agents) held aside as a cost-deferred control; size-stratified; `r` = `audit_window.py` clean fraction, no LLM judge.

## 2. Protected-field draft — the "fence" (@DECIDE)
[`protected_field_draft.md`](https://github.com/gasyoun/SanskritLexicography/blob/skillopt/heldout-fixture/RussianTranslation/src/pilot/eval/skillopt/protected_field_draft.md) — the MG-locked run discipline (opt2 canonical, `--output-budget=90`, ≤3-wide, PWG sense order, csl-orig read-only, …) fenced inside `<!-- SLOW_UPDATE_* -->` so the optimizer can't edit it. Translation *craft* stays optimizer-editable.

**Sign-off needed:** confirm the 16-root split is acceptable and the fenced rule set is complete. Then H388's live gate step can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)