### PR TITLE
H337 — pwg_ru per-sense evidence provenance retrofit + annotation_report CLI (H335 W2)

### DIFF
--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -471,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -502,7 +502,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "4623e2f271a6d68cf2c76c0e144c3110bdd01a0526d55eb1804175cdf47059ef",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -521,7 +521,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "69ccc561e2a0090924176c969d52a088fbcc8d8b784bc10183994ace0905a579",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "2257f04cdca96b2aea51cd6d097358c43109977e1847d39ff59476cc5cf50863",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
       "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -623,7 +623,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   },
   {
@@ -652,7 +652,27 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "69ccc561e2a0090924176c969d52a088fbcc8d8b784bc10183994ace0905a579",
-      "src/pilot/window_selftest.py": "0fab11659575a19de1a4fd682d1354f17af9abe317abaa9515dcd24e87b6daad"
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+    }
+  },
+  {
+    "id": "evidence_retrofit_annotate_h337",
+    "mechanism": "annotate_evidence.py retrofits per-sense evidence provenance (evidence[] + lemma evidence_summary) onto the store by re-assembling corpus_gate's 7 evidence lanes and classifying each Russian authority's relation (provides/supports/contradicts/silent) to each sense; annotation_report.py queries it ('which senses did Grintser support?')",
+    "files": [
+      "src/annotate_evidence.py",
+      "src/annotation_report.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru"
+    ],
+    "verdict": "INTENTIONAL-DIVERGENCE",
+    "note": "H337 (08-07-2026). The evidence lanes are inherently Russian: corpus_gate joins a PWG headword to the independent Sanskrit->RUSSIAN dictionaries (Кочергина/Кнауэр/Фриш/Смирнов/Коссович), the Гринцер specialist glossaries, and the SamudraManthanam RU-aligned corpus; the relation classifier tokenises Russian glosses. The EN pilot has no Sanskrit-English authority set wired here, so evidence retrofit is inherently RU-only — the same divergence already recorded for corpus_gate_evidence_markers_fl7_h321. annotation_report.py is a lang-neutral query CLI but reads the RU store; it would generalise if an EN correctness gate is ever built. Pinned by test_annotate_evidence_relation_semantics (annotate_evidence.py's own pure-function --selftest, no gate-source file IO so it runs in CI).",
+    "tracking": "",
+    "verified_sha256": {
+      "src/annotate_evidence.py": "4f3e3e4adb7b251de0e03ac407bab5c809f9d55275b84569baa8021f5bc6b491",
+      "src/annotation_report.py": "de28ac29360ebc960f00dc3aebffb6255e8b428ed202f5fed2ad2528642b46fe",
+      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
     }
   }
 ]

--- a/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md
+++ b/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md
@@ -1,6 +1,6 @@
 # PWG→RU pipeline capability audit — 3-account concurrency · per-sense evidence provenance · case-government · per-sense genre (H335)
 
-_Created: 08-07-2026 · Last updated: 08-07-2026_
+_Created: 08-07-2026 · Last updated: 09-07-2026_
 
 Audit-only pass answering MG's four capability questions of 08-07-2026
 ([H335](https://github.com/gasyoun/Uprava/blob/main/handoffs/H335-Fable_RussianTranslation_pipeline-capability-audit_08.07.26.md)).
@@ -204,6 +204,45 @@ assembly is fully deterministic and local.
 - **Leonov**: reserve `source: "leonov"` now (777-note Sundarakāṇḍa apparatus,
   org memory `project_sundara_commentary_apparatus`); it becomes a lane only
   when that apparatus ships as a machine-usable glossary — do not build.
+
+### W2 retrofit — EXECUTED 08-07-2026 (H337)
+
+**Verdict now: DELIVERED.** [`src/annotate_evidence.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/annotate_evidence.py)
+(deterministic, LLM-free) backfilled all **11,261** store rows (145 distinct
+lemmas/roots currently translated); [`src/annotation_report.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/annotation_report.py)
+answers MG's queries. Schema (D1): optional `evidence[]` on `$defs.sense` +
+lemma-level `evidence_summary` on `$defs.card` ([`schemas/pwg_ru_final_card.schema.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/schemas/pwg_ru_final_card.schema.json)).
+**2,239 rows (19.9%) carry ≥1 per-sense evidence entry.**
+
+Per-source tally (provides/supports = sense-level; contradicts/silent/present =
+lemma-level over the 145 lemmas); the annotation is deterministic code (no model
+tier), run by Opus 4.8 (`claude-opus-4-8`):
+
+| source | provides | supports | contradicts | silent | present |
+|---|--:|--:|--:|--:|--:|
+| koch | 143 | 560 | 14 | 79 | 0 |
+| kna | 824 | 494 | 9 | 89 | 0 |
+| fri | 23 | 15 | 10 | 126 | 0 |
+| smirnov | 530 | 489 | 4 | 103 | 0 |
+| kow | 202 | 359 | 9 | 116 | 0 |
+| grin12 | 0 | 0 | 1 | 144 | 0 |
+| grin3 | 0 | 0 | 0 | 145 | 0 |
+| apte_hi | 0 | 0 | 0 | 60 | 85 |
+| vedic_rituals_hi | 0 | 0 | 0 | 140 | 5 |
+| kosha_syn | 0 | 0 | 0 | 114 | 31 |
+| meulenbeld | 0 | 0 | 0 | 144 | 1 |
+| corpus | 0 | 0 | 0 | 53 | 92 |
+
+**Honest caveat on the Grintser query.** MG's literal question ("which senses did
+Grintser support") is now *answerable* but currently *near-empty*: the store today
+holds 145 verb-roots + nominal windows, while the Гринцер glossaries (grin12/grin3,
+457+206 entries) are **Rāmāyaṇa proper-noun** vocabularies — silent for ~all
+current-store roots (grin12 hits 1 lemma, grin3 hits 0). The machinery is in place
+and populates as name-lemmas/nominals are translated; the near-empty result faithfully
+reflects the current store content, not a defect. `silent` deliberately folds "absent"
+together with "present but no usable Russian meaning gloss" (Smirnov citation-lists,
+Kossovich bare transliteration); a source is marked `contradicts` only when it carries
+a real Russian gloss overlapping no sense — avoiding false-disagreement claims.
 
 ---
 

--- a/RussianTranslation/schemas/pwg_ru_final_card.schema.json
+++ b/RussianTranslation/schemas/pwg_ru_final_card.schema.json
@@ -47,6 +47,9 @@
         },
         "notes": {
           "type": "string"
+        },
+        "evidence_summary": {
+          "$ref": "#/$defs/evidence_summary"
         }
       }
     },
@@ -158,6 +161,104 @@
             ""
           ],
           "description": "The Renou state of this sense's earliest-dated <ls> citation, or empty when no dated citation is present."
+        },
+        "evidence": {
+          "type": "array",
+          "description": "OPTIONAL. Per-sense evidence provenance from the corpus_gate lanes (H335 W2 / H337). Each entry records a Russian-glossing authority that PROVIDES or SUPPORTS this sense's Russian gloss. Lemma-level standing (silent/contradicts, and the non-Russian corroboration lanes) lives in the card's evidence_summary. Deterministic, LLM-free; the supports/provides split is a token-overlap heuristic. Added by annotate_evidence.py; also written per-row on the flat store.",
+          "items": {
+            "$ref": "#/$defs/evidence_item"
+          }
+        }
+      }
+    },
+    "evidence_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "relation"
+      ],
+      "properties": {
+        "source": {
+          "enum": [
+            "koch",
+            "kna",
+            "fri",
+            "smirnov",
+            "kow",
+            "grin12",
+            "grin3",
+            "apte_hi",
+            "vedic_rituals_hi",
+            "kosha_syn",
+            "meulenbeld",
+            "corpus",
+            "leonov"
+          ],
+          "description": "Evidence lane source code. leonov is RESERVED (Sundarakāṇḍa apparatus, not yet machine-usable) — never emitted, only reserved so the enum is stable."
+        },
+        "relation": {
+          "enum": [
+            "provides",
+            "supports",
+            "contradicts",
+            "silent"
+          ],
+          "description": "provides = source states this sense's exact Russian equivalent; supports = token containment with the sense ru at/above corpus_gate.THRESHOLD; contradicts/silent are lemma-level and appear in evidence_summary, not in a sense's evidence[]."
+        },
+        "gloss_ref": {
+          "type": "string",
+          "description": "The matched source gloss / synonym / passage snippet."
+        },
+        "match": {
+          "enum": [
+            "lemma",
+            "stem"
+          ],
+          "description": "Whether the lane joined on the lemma key or its bare stem (the Hindi SENSE / botanical lanes index on both)."
+        }
+      }
+    },
+    "evidence_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "OPTIONAL. Lemma-level (per key1) evidence roll-up (D1, DECISIONS_PIPELINE_CAPABILITY_H335.md): recorded once per lemma — on the structured card, and identically on every flat store row sharing the key1 (the flat store has no lemma object). Added by annotate_evidence.py.",
+      "properties": {
+        "silent": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Source codes absent for this lemma, or present but carrying no usable Russian meaning gloss (e.g. a Smirnov citation-list, Kossovich bare transliteration) — an uninformative silence, deliberately NOT a contradicts."
+        },
+        "contradicts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Russian-glossing sources that have a usable gloss for the lemma but overlap NO sense of it (a heuristic disagreement candidate)."
+        },
+        "present": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "source": { "type": "string" },
+              "match": { "enum": ["lemma", "stem"] }
+            },
+            "required": ["source"]
+          },
+          "description": "Non-Russian corroboration lanes present for the lemma (apte_hi/vedic_rituals_hi/kosha_syn/meulenbeld/corpus) — presence signal only, never a correctness verdict."
+        },
+        "supports_senses": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Russian source codes that provided/supported >=1 sense of the lemma (their per-sense detail is in each sense's evidence[])."
+        },
+        "evidence_status": {
+          "type": "string",
+          "description": "corpus_gate.evidence_status() at annotation time: 'ok' when >=1 INDEP authority was loaded, else 'evidence_unavailable' (so a false 'silent' from missing sources is distinguishable)."
+        },
+        "corpus_status": {
+          "type": "string",
+          "description": "corpus_gate corpus_examples_with_status() status: ok / db_absent / db_error / skipped_short_term."
         }
       }
     },

--- a/RussianTranslation/src/annotate_evidence.py
+++ b/RussianTranslation/src/annotate_evidence.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python
+"""annotate_evidence.py — retrofit per-sense evidence provenance onto the pwg_ru store.
+
+For every store sense row it re-assembles corpus_gate's deterministic evidence lanes
+for the row's `key1` (a pure offline join — H335 W2 verified the assembly is LLM-free
+and reproducible from `key1` alone) and records, per sense:
+
+  row['evidence']  list of {source, relation, gloss_ref, match} for the Russian-
+                   glossing authorities — INDEP (koch/kna/fri/smirnov), REF (kow),
+                   SPECIALIST (grin12/grin3) — that PROVIDE or SUPPORT this sense's
+                   Russian gloss. Only token-comparable (Russian) lanes go here; a
+                   source that supports no sense contributes nothing to that sense's
+                   list (its lemma-level standing is in evidence_summary).
+
+and, per lemma (D1 ruling 08-07-2026, DECISIONS_PIPELINE_CAPABILITY_H335.md: in-store,
+no sidecar — so it is attached identically to every store row sharing that `key1`,
+the flat store having no lemma object):
+
+  row['evidence_summary']  {silent, contradicts, present, supports_senses,
+                            evidence_status, corpus_status} — the lemma-level roll-up:
+                            which sources are SILENT (absent, or carry no usable
+                            Russian meaning gloss — e.g. Smirnov citation-lists,
+                            Kossovich bare transliteration), which CONTRADICT (have a
+                            usable Russian gloss that overlaps no sense of the lemma),
+                            which non-Russian lanes are PRESENT as corroboration
+                            (apte_hi/vedic_rituals_hi/kosha_syn/meulenbeld/corpus),
+                            and which Russian sources supported >=1 sense.
+
+Relation semantics (all deterministic; the supports/contradicts split IS a token-
+overlap heuristic — labelled as such, per the W2 spec):
+  provides     a source gloss states this sense's exact Russian equivalent
+  supports     token containment with the sense's `ru` at/above corpus_gate.THRESHOLD
+  contradicts  (lemma-level) source has a usable Russian gloss but overlaps no sense
+  silent       (lemma-level) source absent, or its entry carries no usable Russian
+               meaning tokens
+
+The LLM-judged relation upgrade is exactly what the never-run 4_korpus gate would add;
+it slots into the same field without a schema change.
+
+`leonov` is a RESERVED source value (777-note Sundarakāṇḍa apparatus, org memory
+project_sundara_commentary_apparatus) — NOT assembled here; reserved so the schema
+enum is stable when that apparatus ships as a machine-usable glossary.
+
+Deterministic, idempotent (a re-run overwrites only `evidence`/`evidence_summary`,
+preserving renou/dcs_freq/etc.), BOM-free, in-place with a `.pre_evidence.bak` backup
+unless --no-backup.
+
+  python annotate_evidence.py [--store PATH] [--dry-run] [--no-backup] [--limit N]
+  python annotate_evidence.py --selftest
+"""
+import argparse, json, os, re, sys
+from collections import defaultdict, Counter
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import corpus_gate as cg
+
+STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+
+# Russian-glossing, token-comparable authorities (relation = provides/supports/contradicts/silent).
+RU_SOURCES = ['koch', 'kna', 'fri', 'smirnov', 'kow', 'grin12', 'grin3']
+# Non-Russian corroboration lanes (presence-only: present/silent, never a correctness verdict).
+NONRU_LANES = ['apte_hi', 'vedic_rituals_hi', 'kosha_syn', 'meulenbeld', 'corpus']
+# Reserved, not built — see module docstring.
+RESERVED_SOURCES = ['leonov']
+
+# Mirrors corpus_gate.ru_tokens' stemming/content regex, WITHOUT the HEAD_SENSE_ONLY
+# ';'-truncation: here we compare one already-split sense (or a source gloss that may
+# itself list several senses), so the full text must be tokenised, not just sense 1.
+_RU_END = cg._RU_END
+_TAG_RE = re.compile(r'<[^>]+>')
+_SANSKRIT_RE = re.compile(r'\{#.*?#\}')              # {#SLP1 citation#} — drop (not a meaning)
+_MEANING_DELIM_RE = re.compile(r'\{%|%\}')           # {%…%} meaning delimiters — strip, KEEP the gloss inside
+_PLACEHOLDER_RE = re.compile(r'\{T\d+\}')
+_SENSE_NUM_RE = re.compile(r'^\s*\d+[\)\.]\s*')      # leading "6)" / "1." sense number
+
+
+def ru_tokens_full(text):
+    """Stemmed Russian content tokens over the WHOLE text (cf. corpus_gate.ru_tokens,
+    which keeps only the head sense)."""
+    if not text:
+        return set()
+    text = _PLACEHOLDER_RE.sub(' ', text)
+    text = _TAG_RE.sub(' ', text)
+    toks = re.findall(r'[а-яёА-ЯЁ]{2,}', text.lower())
+    return {_RU_END.sub('', t) for t in toks if len(_RU_END.sub('', t)) >= 3}
+
+
+def phrase_equivalents(text):
+    """Normalised full-phrase equivalents of a Russian gloss/sense — for exact-equivalent
+    (`provides`) detection. Strips markup, {#..#}/{%..%} spans, a leading sense number,
+    then splits on ; , / and dashes; keeps phrases with a Cyrillic letter and length>=3."""
+    if not text:
+        return set()
+    t = _TAG_RE.sub(' ', text)
+    t = _SANSKRIT_RE.sub(' ', t)
+    t = _MEANING_DELIM_RE.sub(' ', t)
+    t = _PLACEHOLDER_RE.sub(' ', t)
+    t = _SENSE_NUM_RE.sub(' ', t)
+    out = set()
+    for p in re.split(r'[;,/]|\s[—–-]\s', t):
+        p = p.lower()
+        m = re.search(r'[а-яё]', p)                     # drop a Devanagari/translit/POS/"1)" prefix:
+        if not m:                                       # keep the Russian core of the equivalent only
+            continue
+        p = re.sub(r'\s+', ' ', p[m.start():]).strip().strip('.()[]{}·- ')
+        if len(p) >= 3 and re.search(r'[а-яё]', p):
+            out.add(p)
+    return out
+
+
+def gloss_ref(text, limit=160):
+    """A readable snippet of the matched gloss for the evidence record."""
+    t = _TAG_RE.sub(' ', text or '')
+    t = re.sub(r'\s+', ' ', t).strip()
+    return t[:limit]
+
+
+def source_meaning_tokens(glosses):
+    """Union of usable Russian meaning tokens across a source's glosses. Empty ⇒ the
+    source carries no usable meaning here (a citation-list / bare translit), so its
+    silence is UNINFORMATIVE, never a `contradicts`."""
+    toks = set()
+    for g in glosses:
+        toks |= ru_tokens_full(g)
+    return toks
+
+
+def best_relation(sense_ru, glosses):
+    """(relation, gloss_ref) for one Russian source vs one sense's `ru`:
+    'provides' (exact equivalent), 'supports' (containment >= THRESHOLD), or (None,'')."""
+    a_tok = ru_tokens_full(sense_ru)
+    if not a_tok:
+        return None, ''                     # a pure cross-ref / citation sense asserts no meaning
+    a_phr = phrase_equivalents(sense_ru)
+    best_ov, best_g = 0.0, ''
+    for g in glosses:
+        if a_phr and (a_phr & phrase_equivalents(g)):
+            return 'provides', gloss_ref(g)
+        b = ru_tokens_full(g)
+        if not b:
+            continue
+        ov = len(a_tok & b) / len(a_tok)
+        if ov > best_ov:
+            best_ov, best_g = ov, g
+    if best_ov >= cg.THRESHOLD:
+        return 'supports', gloss_ref(best_g)
+    return None, ''
+
+
+# ---- lane assembly (needs the gate source jsonls; NOT exercised by --selftest) --------
+def gather(idx, key1):
+    """Assemble the evidence lanes for one lemma. RU lanes -> {code: [glosses]};
+    non-RU lanes -> {code: {present, match}}."""
+    indep, kow = cg.lookup(idx, key1, None)
+    ru = defaultdict(list)
+    for g in indep:
+        ru[g['code']].append(g['gloss'])
+    for g in kow:
+        ru['kow'].append(g)
+    for g in cg.lookup_specialist(key1, None):
+        ru[g['code']].append(g['gloss'])
+
+    sense_codes = {s['code'] for s in cg.lookup_sense(key1, None)}
+    nonru = {
+        'apte_hi': {'present': 'apte_hi' in sense_codes, 'match': 'stem'},
+        'vedic_rituals_hi': {'present': 'vedic_rituals_hi' in sense_codes, 'match': 'stem'},
+        'kosha_syn': {'present': bool(cg.lookup_synonyms(key1, None)), 'match': 'lemma'},
+        'meulenbeld': {'present': bool(cg.lookup_binomials(key1, None)), 'match': 'stem'},
+    }
+    ex, cstat = cg.corpus_examples_with_status(key1)
+    nonru['corpus'] = {'present': bool(ex), 'match': 'lemma'}
+    return {'ru': ru, 'nonru': nonru, 'evidence_status': cg.evidence_status(), 'corpus_status': cstat}
+
+
+def annotate_rows(rows, idx, tally):
+    """Mutate store rows in place, adding `evidence` (per sense) and `evidence_summary`
+    (per lemma). `tally` accumulates per-source relation counts for the report."""
+    by_key = defaultdict(list)
+    for i, r in enumerate(rows):
+        by_key[r.get('key1') or ''].append(i)
+
+    stats = Counter()
+    for key1, idxs in sorted(by_key.items()):
+        if not key1:
+            for i in idxs:
+                rows[i]['evidence'] = []
+                rows[i]['evidence_summary'] = {'silent': [], 'contradicts': [], 'present': [],
+                                               'supports_senses': [], 'evidence_status': 'no_key1',
+                                               'corpus_status': 'skipped_short_term'}
+                stats['rows'] += 1
+            continue
+
+        lanes = gather(idx, key1)
+        ru_supported = set()
+        for i in idxs:
+            r = rows[i]
+            ev = []
+            for code in RU_SOURCES:
+                glosses = lanes['ru'].get(code) or []
+                if not glosses:
+                    continue
+                rel, ref = best_relation(r.get('ru') or '', glosses)
+                if rel:
+                    ev.append({'source': code, 'relation': rel, 'gloss_ref': ref, 'match': 'lemma'})
+                    ru_supported.add(code)
+                    tally[code][rel] += 1
+            r['evidence'] = ev
+            stats['rows'] += 1
+            if ev:
+                stats['rows_with_evidence'] += 1
+
+        silent, contradicts, present = [], [], []
+        for code in RU_SOURCES:
+            glosses = lanes['ru'].get(code) or []
+            if not glosses or not source_meaning_tokens(glosses):
+                silent.append(code)
+            elif code in ru_supported:
+                pass                                 # positive standing recorded per sense
+            else:
+                contradicts.append(code)
+        for code in NONRU_LANES:
+            info = lanes['nonru'][code]
+            (present.append({'source': code, 'match': info['match']}) if info['present']
+             else silent.append(code))
+
+        summary = {'silent': silent, 'contradicts': contradicts, 'present': present,
+                   'supports_senses': sorted(ru_supported),
+                   'evidence_status': lanes['evidence_status'], 'corpus_status': lanes['corpus_status']}
+        for i in idxs:
+            rows[i]['evidence_summary'] = summary
+
+        stats['lemmas'] += 1
+        for c in contradicts:
+            tally[c]['contradicts'] += 1
+        for c in silent:
+            tally[c]['silent'] += 1
+        for p in present:
+            tally[p['source']]['present'] += 1
+    return stats
+
+
+def report(stats, tally):
+    print('=== EVIDENCE ANNOTATION ===')
+    print('store rows            : %d' % stats['rows'])
+    print('lemmas (distinct key1): %d' % stats['lemmas'])
+    print('rows with >=1 evidence: %d (%.1f%%)'
+          % (stats['rows_with_evidence'], 100.0 * stats['rows_with_evidence'] / max(1, stats['rows'])))
+    print('\nper-source tallies (provides/supports = sense-level; contradicts/silent/present = lemma-level):')
+    print('  %-18s %8s %8s %11s %8s %8s' % ('source', 'provides', 'supports', 'contradicts', 'silent', 'present'))
+    for code in RU_SOURCES + NONRU_LANES:
+        t = tally.get(code, {})
+        print('  %-18s %8d %8d %11d %8d %8d'
+              % (code, t.get('provides', 0), t.get('supports', 0),
+                 t.get('contradicts', 0), t.get('silent', 0), t.get('present', 0)))
+
+
+# ---- selftest (pure functions only — no gate-source file IO, so it runs in CI) --------
+def selftest():
+    # provides: exact equivalent phrase intersection
+    rel, ref = best_relation('огонь', ['अग्नि /agni/ m. 1) огонь, пламя; бог огня'])
+    assert rel == 'provides', ('provides expected', rel, ref)
+    # supports: token containment >= THRESHOLD but no exact-phrase equivalent
+    rel, _ = best_relation('лотос дневной', ['padma m. n. лотос (водяной)'])
+    assert rel == 'supports', ('supports expected', rel)
+    # no relation: disjoint meaning
+    rel, _ = best_relation('огонь', ['время, срок, эпоха'])
+    assert rel is None, ('no relation expected', rel)
+    # a pure citation/cross-ref sense (no Russian meaning tokens) never yields evidence
+    rel, _ = best_relation('<ls>M. 2,109.</ls> {#mAturAptAMSca#}', ['огонь, пламя'])
+    assert rel is None, ('citation-only sense must not match', rel)
+    # source with no usable meaning tokens (Smirnov citation-list) -> uninformative, not contradicts
+    assert source_meaning_tokens(['(II-2) IV, 19, 24, 25; VIII,']) == set(), 'citation-list must have no meaning tokens'
+    assert source_meaning_tokens(['огонь, бог огня']), 'a real gloss must have meaning tokens'
+    # phrase_equivalents strips a leading sense number and markup
+    assert 'близкий' in phrase_equivalents('6) {%близкий, родственный%}; <lex>m.</lex>')
+    # gloss_ref collapses markup/whitespace and truncates
+    assert '<' not in gloss_ref('<ls>M.</ls>  огонь\n  пламя')
+    # idempotency of the per-lemma summary shape: build a fake two-sense lemma without file IO
+    _lanes = {'ru': {'koch': ['agni m. огонь'], 'smirnov': ['(II-2) IV, 19']},
+              'nonru': {'apte_hi': {'present': True, 'match': 'stem'},
+                        'vedic_rituals_hi': {'present': False, 'match': 'stem'},
+                        'kosha_syn': {'present': True, 'match': 'lemma'},
+                        'meulenbeld': {'present': False, 'match': 'stem'},
+                        'corpus': {'present': True, 'match': 'lemma'}},
+              'evidence_status': 'ok', 'corpus_status': 'ok'}
+    rows = [{'key1': 'agni', 'ru': 'огонь'}, {'key1': 'agni', 'ru': 'молния, вспышка'}]
+    tally = defaultdict(Counter)
+
+    def _fake_gather(_idx, _k):
+        return _lanes
+    global gather
+    real_gather, gather = gather, _fake_gather
+    try:
+        st = annotate_rows(rows, None, tally)
+    finally:
+        gather = real_gather
+    assert rows[0]['evidence'] and rows[0]['evidence'][0]['source'] == 'koch', 'koch must support огонь'
+    assert rows[1]['evidence'] == [], 'молния has no supporting gloss here'
+    summ = rows[0]['evidence_summary']
+    assert 'koch' in summ['supports_senses'], summ
+    assert 'smirnov' in summ['silent'], ('smirnov citation-list is silent, not contradicts', summ)
+    assert {'source': 'kosha_syn', 'match': 'lemma'} in summ['present'], summ
+    assert 'vedic_rituals_hi' in summ['silent'] and 'meulenbeld' in summ['silent'], summ
+    assert rows[0]['evidence_summary'] is rows[1]['evidence_summary'], 'summary is lemma-scoped'
+    print('annotate_evidence selftest OK')
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--store', default=STORE)
+    ap.add_argument('--dry-run', action='store_true')
+    ap.add_argument('--no-backup', action='store_true')
+    ap.add_argument('--limit', type=int, default=None, help='annotate only the first N rows (smoke test)')
+    ap.add_argument('--selftest', action='store_true')
+    args = ap.parse_args()
+    if args.selftest:
+        return selftest()
+
+    idx = cg.load_index()
+    if cg.evidence_status() != 'ok':
+        sys.stderr.write('REFUSING: no independent Sanskrit-Russian authority (INDEP) loaded — '
+                         'gate sources not built; every lane would read "silent" falsely. '
+                         'Build src/*.jsonl (build_src.py) first.\n')
+        raise SystemExit(2)
+
+    rows = []
+    with open(args.store, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    if args.limit:
+        rows = rows[:args.limit]
+
+    tally = defaultdict(Counter)
+    stats = annotate_rows(rows, idx, tally)
+    report(stats, tally)
+
+    if args.dry_run:
+        print('\n(dry run — store not written)')
+        return
+    if not args.no_backup and args.limit is None:
+        os.replace(args.store, args.store + '.pre_evidence.bak')
+    with open(args.store, 'w', encoding='utf-8') as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + '\n')
+    print('\nwrote annotated store -> %s' % args.store)
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/annotation_report.py
+++ b/RussianTranslation/src/annotation_report.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+"""annotation_report.py — query everything known about a pwg_ru lemma / subcard / sense.
+
+The single query surface over the annotated store (H335 W2). It reads the store and
+its in-store annotations only; it degrades gracefully on any absent optional field
+(evidence not yet retrofitted, no renou/government/genre, etc.). H338 (government) and
+H339 (genre) fold their queries into this CLI, so new lanes print automatically as
+they populate.
+
+  python annotation_report.py <selector>
+        Print every field on the matching store row(s): translation (ru / de / layer /
+        equivalence_type / source_type / stratum / differentia), government, renou /
+        renou_oldest, genre / dcs_freq (when present), provenance, and the evidence
+        lanes (per-sense evidence[] + the lemma's evidence_summary).
+        <selector> = <key1>[~~subcard][#sense_tag]; a bare key1 matches by key1, a
+        longer string matches the subcard exactly or as a prefix, #tag filters the sense.
+
+  python annotation_report.py --by-source grin12 [--relation supports|provides]
+        Every sense whose evidence[] carries that source (optionally that relation) —
+        answers MG's literal question "which senses did Grintser (grin12/grin3) /
+        Kossovich (kow) support/provide?".
+
+  python annotation_report.py --source-summary
+        Per-source provides / supports / contradicts / silent / present tallies over
+        the whole store (the same table annotate_evidence.py prints after a backfill).
+
+  python annotation_report.py --silent-for <key1>
+        The lemma-level evidence_summary for one lemma: which authorities are silent /
+        contradict / corroborate it.
+"""
+import argparse, json, os, sys
+from collections import Counter
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+
+RU_SOURCES = ['koch', 'kna', 'fri', 'smirnov', 'kow', 'grin12', 'grin3']
+NONRU_LANES = ['apte_hi', 'vedic_rituals_hi', 'kosha_syn', 'meulenbeld', 'corpus']
+
+
+def load_rows(store):
+    if not os.path.exists(store):
+        sys.stderr.write('store not found: %s (it is gitignored — regenerate via the bridge)\n' % store)
+        raise SystemExit(2)
+    rows = []
+    with open(store, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def parse_selector(sel):
+    tag = None
+    if '#' in sel:
+        sel, tag = sel.split('#', 1)
+    return sel, tag
+
+
+def row_matches(row, sel, tag):
+    if tag is not None and (row.get('sense_tag') or '') != tag:
+        return False
+    sub = row.get('subcard') or ''
+    return row.get('key1') == sel or sub == sel or sub.startswith(sel)
+
+
+def _line(label, value):
+    if value in (None, '', [], {}):
+        return
+    print('  %-16s %s' % (label + ':', value))
+
+
+def print_row(row):
+    print('── %s  %s  [%s]  sense %s ─────────────'
+          % (row.get('key1'), row.get('subcard'), row.get('layer') or '?', row.get('sense_tag')))
+    _line('iast', row.get('iast'))
+    _line('h', row.get('h'))
+    _line('ru', row.get('ru'))
+    _line('de', row.get('de'))
+    _line('equivalence', row.get('equivalence_type'))
+    _line('source_type', row.get('source_type'))
+    _line('stratum', row.get('stratum'))
+    _line('differentia', row.get('differentia'))
+    _line('government', row.get('government'))          # H338 (folds in when populated)
+    _line('renou', row.get('renou'))
+    _line('renou_oldest', row.get('renou_oldest'))
+    _line('genre', row.get('genre'))                    # H339 (folds in when populated)
+    if row.get('dcs_freq'):
+        f = row['dcs_freq']
+        _line('dcs_freq', 'band %s · genre %s · era %s' % (f.get('band'), f.get('genre'), f.get('era')))
+    _line('review_status', row.get('review_status'))
+    prov = row.get('provenance') or {}
+    _line('model', prov.get('model_version') or prov.get('model'))
+
+    ev = row.get('evidence')
+    if ev is None:
+        print('  evidence:        (not retrofitted — run annotate_evidence.py)')
+    elif not ev:
+        print('  evidence:        (none supports/provides this sense)')
+    else:
+        print('  evidence:')
+        for e in ev:
+            print('    [%s] %-9s %s' % (e.get('source'), e.get('relation'), (e.get('gloss_ref') or '')[:120]))
+    summ = row.get('evidence_summary')
+    if summ:
+        present = ', '.join(p['source'] for p in summ.get('present') or [])
+        print('  lemma evidence:  supports=%s | contradicts=%s | present=%s | silent=%s'
+              % (','.join(summ.get('supports_senses') or []) or '-',
+                 ','.join(summ.get('contradicts') or []) or '-',
+                 present or '-', ','.join(summ.get('silent') or []) or '-'))
+
+
+def cmd_lookup(rows, sel):
+    key, tag = parse_selector(sel)
+    hits = [r for r in rows if row_matches(r, key, tag)]
+    if not hits:
+        print('no store row matches %r' % sel)
+        return
+    for r in hits:
+        print_row(r)
+    print('\n%d matching sense row(s).' % len(hits))
+
+
+def cmd_by_source(rows, source, relation):
+    n = 0
+    for r in rows:
+        for e in r.get('evidence') or []:
+            if e.get('source') != source:
+                continue
+            if relation and e.get('relation') != relation:
+                continue
+            n += 1
+            print('%s  %s  #%s  [%s]  %s'
+                  % (r.get('key1'), r.get('subcard'), r.get('sense_tag'),
+                     e.get('relation'), (r.get('ru') or '')[:70]))
+    rel = (' with relation=%s' % relation) if relation else ''
+    print('\n%d sense(s) where %s appears in evidence%s.' % (n, source, rel))
+
+
+def cmd_source_summary(rows):
+    tally = {c: Counter() for c in RU_SOURCES + NONRU_LANES}
+    seen_lemma = {}                                     # key1 -> summary (count each lemma once)
+    for r in rows:
+        for e in r.get('evidence') or []:
+            src, rel = e.get('source'), e.get('relation')
+            if src in tally and rel in ('provides', 'supports'):
+                tally[src][rel] += 1
+        summ = r.get('evidence_summary')
+        k = r.get('key1')
+        if summ and k not in seen_lemma:
+            seen_lemma[k] = summ
+    for summ in seen_lemma.values():
+        for c in summ.get('contradicts') or []:
+            tally.get(c, Counter())['contradicts'] += 1
+        for c in summ.get('silent') or []:
+            tally.get(c, Counter())['silent'] += 1
+        for p in summ.get('present') or []:
+            tally.get(p['source'], Counter())['present'] += 1
+    print('store rows: %d | lemmas with a summary: %d' % (len(rows), len(seen_lemma)))
+    print('  %-18s %8s %8s %11s %8s %8s' % ('source', 'provides', 'supports', 'contradicts', 'silent', 'present'))
+    for code in RU_SOURCES + NONRU_LANES:
+        t = tally[code]
+        print('  %-18s %8d %8d %11d %8d %8d'
+              % (code, t['provides'], t['supports'], t['contradicts'], t['silent'], t['present']))
+
+
+def cmd_silent_for(rows, key1):
+    summ = next((r.get('evidence_summary') for r in rows
+                 if r.get('key1') == key1 and r.get('evidence_summary')), None)
+    if not summ:
+        print('no evidence_summary for %r (not retrofitted, or lemma absent)' % key1)
+        return
+    print('lemma %s evidence_summary:' % key1)
+    print('  supports (>=1 sense): %s' % (', '.join(summ.get('supports_senses') or []) or '-'))
+    print('  contradicts        : %s' % (', '.join(summ.get('contradicts') or []) or '-'))
+    print('  present (corrob.)  : %s' % (', '.join(p['source'] for p in summ.get('present') or []) or '-'))
+    print('  silent             : %s' % (', '.join(summ.get('silent') or []) or '-'))
+    print('  evidence_status    : %s | corpus_status: %s'
+          % (summ.get('evidence_status'), summ.get('corpus_status')))
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Query the annotated pwg_ru store.')
+    ap.add_argument('selector', nargs='?', help='<key1>[~~subcard][#sense_tag]')
+    ap.add_argument('--store', default=STORE)
+    ap.add_argument('--by-source', help='source code (koch/kna/fri/smirnov/kow/grin12/grin3)')
+    ap.add_argument('--relation', choices=['provides', 'supports'])
+    ap.add_argument('--source-summary', action='store_true')
+    ap.add_argument('--silent-for', help='key1 whose lemma evidence_summary to print')
+    args = ap.parse_args()
+
+    rows = load_rows(args.store)
+    if args.source_summary:
+        return cmd_source_summary(rows)
+    if args.silent_for:
+        return cmd_silent_for(rows, args.silent_for)
+    if args.by_source:
+        return cmd_by_source(rows, args.by_source, args.relation)
+    if args.selector:
+        return cmd_lookup(rows, args.selector)
+    ap.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3331,6 +3331,17 @@ def test_promote_claim_contention():
     promote_lock.selftest()
 
 
+def test_annotate_evidence_relation_semantics():
+    """H337 (W2): the per-sense evidence relation classifier. Pins annotate_evidence.py's
+    own pure-function selftest (provides = exact Russian equivalent; supports = token
+    containment >= corpus_gate.THRESHOLD; a citation-only sense yields nothing; a source
+    with no usable meaning tokens is SILENT not contradicts; the lemma summary is
+    lemma-scoped and shared across a lemma's rows). No gate-source file IO, so it runs in
+    CI where the gitignored src/*.jsonl dictionaries are absent."""
+    import annotate_evidence
+    annotate_evidence.selftest()
+
+
 def test_audit_window_tag_routing():
     """H336/H-2: --window-tag routes window_status/report/requeue/judge-sample to
     src/pilot/output/<tag>/ instead of the flat singletons, so two accounts auditing
@@ -3496,6 +3507,7 @@ def main():
         test_frag_tm_fidelity_gate_and_override,
         test_corpus_gate_evidence_and_db_markers,
         test_promote_claim_contention,
+        test_annotate_evidence_relation_semantics,
         test_audit_window_tag_routing,
         test_denylist_torn_line_warns,
     ]


### PR DESCRIPTION
Executes [H337](https://github.com/gasyoun/Uprava/blob/main/handoffs/H337-Opus_RussianTranslation_pwg-ru-evidence-retrofit_08.07.26.md) (H335 W2). Makes corpus_gate's 7 evidence lanes — assembled then discarded until now — **queryable per sense**, answering MG's literal question *"which senses did Grintser (Гринцер) / Kossovich (Коссович) support?"*.

### Rulings applied ([DECISIONS_PIPELINE_CAPABILITY_H335.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/DECISIONS_PIPELINE_CAPABILITY_H335.md))
- **D1** — in-store field, silence once per lemma: optional `evidence[]` on `$defs.sense` + lemma-level `evidence_summary` on `$defs.card`. No sidecar.
- **D2** — retrofit all 11,261 rows now (deterministic offline join, no LLM/Workflow spend).

### What landed
- **[schemas/pwg_ru_final_card.schema.json](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/schemas/pwg_ru_final_card.schema.json)** — `evidence_item` / `evidence_summary` `$defs`; `leonov` reserved in the source enum (not built — Sundarakāṇḍa apparatus not yet machine-usable).
- **[src/annotate_evidence.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/annotate_evidence.py)** — deterministic, LLM-free backfill. Per Russian authority: `provides` (exact equivalent) / `supports` (token containment ≥ `corpus_gate.THRESHOLD`) per sense; `contradicts` / `silent` per lemma. Non-Russian lanes (`apte_hi`/`vedic_rituals_hi`/`kosha_syn`/`meulenbeld`/`corpus`) = lemma-level presence corroboration. A source with no usable Russian meaning tokens is **silent, never contradicts** (guards against false disagreement on Smirnov citation-lists / Kossovich bare transliteration). Idempotent, BOM-free, `.pre_evidence.bak` backup.
- **[src/annotation_report.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/annotation_report.py)** — the single query surface (H338/H339 fold their queries in): `<selector>` full row dump · `--by-source X [--relation provides|supports]` · `--source-summary` · `--silent-for <key1>`.

### Backfill executed (live gitignored store)
**11,261 rows / 145 lemmas · 2,239 (19.9%) carry ≥1 per-sense evidence entry.** Full per-source table persisted in [PIPELINE_CAPABILITY_AUDIT §W2](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md#w2-retrofit--executed-08-07-2026-h337).

| source | provides | supports | contradicts | silent | present |
|---|--:|--:|--:|--:|--:|
| koch | 143 | 560 | 14 | 79 | 0 |
| kna | 824 | 494 | 9 | 89 | 0 |
| smirnov | 530 | 489 | 4 | 103 | 0 |
| kow | 202 | 359 | 9 | 116 | 0 |
| grin12 | 0 | 0 | 1 | 144 | 0 |
| apte_hi | 0 | 0 | 0 | 60 | 85 |
| corpus | 0 | 0 | 0 | 53 | 92 |

**Honest caveat:** the Grintser query is *answerable* but currently *near-empty* — the store today is 145 verb-roots + nominals, while grin12/grin3 are Rāmāyaṇa **proper-noun** glossaries (grin12 hits 1 lemma, grin3 0). The machinery populates as name-lemmas are translated; the near-empty result faithfully reflects current store content.

### LANG_PARITY
`evidence_retrofit_annotate_h337` = **INTENTIONAL-DIVERGENCE** (RU-only; lanes are Sanskrit→Russian sourced, mirroring the existing `corpus_gate_evidence_markers_fl7_h321`). Ledger re-hashed after the additive test.

### Verification
- `annotate_evidence.py --selftest` green (pinned as `test_annotate_evidence_relation_semantics` — pure functions, no gate-source file IO, CI-safe).
- `lang_parity_check` green (0 violations); schema JSON valid.
- `annotation_report.py` end-to-end on the live annotated store (lookup / `--by-source` / `--source-summary` / `--silent-for`).
- Full `window_selftest.py` runtime-dependent tests need the gitignored runtime state (rootmaps/harness in the main checkout) and were not re-run from the isolated worktree; the change is additive (one pure test + parity re-hash).

Store backfill was run against the live gitignored store; store is never committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)