### PR TITLE
H264 P2 (WIP): ACC×NCC Tier C/D adjudication tooling — blocked on MG vote

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -29,8 +29,29 @@ Two live tracks:
       edit-distance (rapidfuzz, new dependency), blocked by (first-letter, length-bucket)
       for tractability against the 32k×125k cross-product. C/D are flagged for adjudication
       only, never auto-merged, per the roadmap. See
-      [ROADMAP_ACC_NCC.md](ROADMAP_ACC_NCC.md) P1 section. **P2 (human adjudication via
-      `/review-sheet`) is the next step** — handoff minted, see `Uprava/handoffs/`.
+      [ROADMAP_ACC_NCC.md](ROADMAP_ACC_NCC.md) P1 section.
+- [ ] **ACC×NCC P2 tooling shipped, BLOCKED on MG's human vote (2026-07-09, Sonnet 5
+      `claude-sonnet-5`, [H264](https://github.com/gasyoun/Uprava/blob/main/handoffs/H264-Sonnet_SanskritLexicography_acc_ncc_p2_adjudication_06.07.26.md), branch
+      `feat/acc-ncc-p2-adjudication`, [draft PR #264](https://github.com/gasyoun/SanskritLexicography/pull/264)).**
+      Sample-size ruling (asked via AskUserQuestion, since the mission explicitly flags this
+      as a human call): **full 49,019-row sheet, no sampling** — Tier C (5,353) + Tier D
+      (43,666), over stratified-sample/threshold-triage alternatives. Shipped
+      `HeadwordLists/works_catalogue/build_p2_sheet.py` (generates a virtualized-scroll
+      single-file HTML sheet — only visible rows render to DOM, decisions persist to
+      `localStorage`, a/r/d keyboard shortcuts, tier/vote/text filters; 22 MB data, JS
+      syntax + embedded-JSON parse validated with `node`) and
+      `HeadwordLists/works_catalogue/apply_p2_decisions.py` (the `/decisions-apply`
+      consumer — auto-accepts Tier A/B, includes only voted-`approve` C/D rows in
+      `works_crosswalk.tsv`, logs voted-`reject` rows to `works_crosswalk_rejected.tsv` as
+      confirmed non-matches, emits `P2_COUNTS.md`; smoke-tested against a synthetic partial
+      `decisions.json`). Registered in
+      [Uprava/REVIEW_SHEETS_INDEX.md](https://github.com/gasyoun/Uprava/blob/main/REVIEW_SHEETS_INDEX.md)
+      and [Uprava/GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md)
+      § Waiting on Me. **Next action is MG's vote** (sheet is local-only, gitignored under
+      `review/`, not committed) — once a `decisions.json` comes back, re-run
+      `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H264-Sonnet_SanskritLexicography_acc_ncc_p2_adjudication_06.07.26.md and execute it.`
+      to finish P2 (run `apply_p2_decisions.py`, commit `works_crosswalk.tsv`/`P2_COUNTS.md`,
+      mark PR #264 ready, update `ROADMAP_ACC_NCC.md`, mint the P3 kosha-consumption handoff).
 - [x] **pwg_ru code-hardening fix plan implemented (2026-07-06, Codex/GPT-5).**
       Local safety fixes landed before any new Max generation: strict key-only full-card
       response matching, fragment key checks, zero-marker TM sanity checks, partial-card

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ literature/*
 # H099/HERITAGE_INRIA_ROADMAP.md Phase 0 @DECIDE): raw data stays local-only,
 # only derived measurements/crosswalks are committed.
 HeadwordLists/heritage_mirror/
+
+# H264 review sheets (personal working artifacts, not repo deliverables)
+review/

--- a/HeadwordLists/works_catalogue/apply_p2_decisions.py
+++ b/HeadwordLists/works_catalogue/apply_p2_decisions.py
@@ -1,0 +1,142 @@
+"""ACC x NCC P2 -- ingest /review-sheet votes, emit the confirmed crosswalk.
+
+Per ROADMAP_ACC_NCC.md P2: reads crosswalk_candidates.jsonl.gz (P1 output,
+read-only) plus a decisions.json exported by the review sheet
+(review/build_p2_sheet.py) and produces:
+
+  - works_crosswalk.tsv[.gz]  one row per confirmed ACC<->NCC link:
+      Tier A/B rows are auto-accepted (P1 already partitions them as
+      unambiguous); Tier C/D rows are included only if their id (acc_L +
+      "__" + ncc_id) was voted "approve" in decisions.json.
+  - P2_COUNTS.md              rows voted, accept/reject/defer counts per
+      tier, and (only if the vote set is a documented sample, not this
+      run's full-49,019-row pass) an extrapolated estimate for the
+      un-sampled remainder.
+
+Rejected rows are NOT deleted -- they are written to
+works_crosswalk_rejected.tsv as confirmed non-matches (provenance, so a
+future pass doesn't re-propose the same pair). Deferred and never-voted
+rows are omitted from both outputs and remain pending a future P2 pass.
+
+Usage:
+    python HeadwordLists/works_catalogue/apply_p2_decisions.py <decisions.json>
+"""
+import sys
+import os
+import json
+import gzip
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CANDIDATES_PATH = os.path.join(HERE, "crosswalk_candidates.jsonl.gz")
+OUT_TSV = os.path.join(HERE, "works_crosswalk.tsv")
+OUT_REJECTED_TSV = os.path.join(HERE, "works_crosswalk_rejected.tsv")
+COUNTS_PATH = os.path.join(HERE, "P2_COUNTS.md")
+
+TSV_COLS = ["acc_L", "ncc_id", "match_tier", "score", "acc_match_key",
+            "ncc_match_key", "provenance"]
+
+
+def load_candidates():
+    rows = []
+    with gzip.open(CANDIDATES_PATH, 'rt', encoding='utf-8') as f:
+        for line in f:
+            rows.append(json.loads(line))
+    return rows
+
+
+def load_decisions(path):
+    with open(path, encoding='utf-8') as f:
+        payload = json.load(f)
+    by_id = {}
+    for item in payload.get("items", []):
+        by_id[item["id"]] = item.get("decision")
+    return by_id, payload
+
+
+def tsv_row(r, tier, provenance):
+    return "\t".join([
+        r["acc_L"], r["ncc_id"], tier, str(r["score"]),
+        r["acc_match_key"], r["ncc_match_key"], provenance,
+    ])
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python apply_p2_decisions.py <decisions.json>", file=sys.stderr)
+        sys.exit(1)
+    decisions_path = sys.argv[1]
+
+    candidates = load_candidates()
+    decisions, payload = load_decisions(decisions_path)
+
+    accepted = []
+    rejected = []
+    tier_counts = {"A": 0, "B": 0, "C": {"approve": 0, "reject": 0, "defer": 0, "unvoted": 0},
+                   "D": {"approve": 0, "reject": 0, "defer": 0, "unvoted": 0}}
+
+    for r in candidates:
+        tier = r["tier"]
+        if tier in ("A", "B"):
+            accepted.append(tsv_row(r, tier, "auto"))
+            tier_counts[tier] += 1
+            continue
+        rid = f"{r['acc_L']}__{r['ncc_id']}"
+        dec = decisions.get(rid)
+        key = dec if dec in ("approve", "reject", "defer") else "unvoted"
+        tier_counts[tier][key] += 1
+        if dec == "approve":
+            accepted.append(tsv_row(r, tier, "adjudicated"))
+        elif dec == "reject":
+            rejected.append(tsv_row(r, tier, "adjudicated"))
+
+    with open(OUT_TSV, 'w', encoding='utf-8') as f:
+        f.write("\t".join(TSV_COLS) + "\n")
+        for row in accepted:
+            f.write(row + "\n")
+
+    with open(OUT_REJECTED_TSV, 'w', encoding='utf-8') as f:
+        f.write("\t".join(TSV_COLS) + "\n")
+        for row in rejected:
+            f.write(row + "\n")
+
+    c_total = sum(tier_counts["C"].values())
+    d_total = sum(tier_counts["D"].values())
+    lines = [
+        "# ACC x NCC P2 -- adjudication counts",
+        "",
+        f"Sheet: `sanskritlexicography-acc_ncc_p2_c_d_review.html` · decisions file: `{os.path.basename(decisions_path)}`"
+        f" · decided={payload.get('decided', 'n/a')} · exported={payload.get('generated', 'n/a')}",
+        "",
+        "| Tier | Rows | Approved | Rejected | Deferred | Unvoted |",
+        "|---|---:|---:|---:|---:|---:|",
+        f"| A (auto) | {tier_counts['A']} | {tier_counts['A']} | 0 | 0 | 0 |",
+        f"| B (auto) | {tier_counts['B']} | {tier_counts['B']} | 0 | 0 | 0 |",
+        f"| C | {c_total} | {tier_counts['C']['approve']} | {tier_counts['C']['reject']} | {tier_counts['C']['defer']} | {tier_counts['C']['unvoted']} |",
+        f"| D | {d_total} | {tier_counts['D']['approve']} | {tier_counts['D']['reject']} | {tier_counts['D']['defer']} | {tier_counts['D']['unvoted']} |",
+        "",
+        f"**Confirmed crosswalk rows (works_crosswalk.tsv):** {len(accepted)} "
+        f"({tier_counts['A']} Tier A + {tier_counts['B']} Tier B auto + "
+        f"{tier_counts['C']['approve']} Tier C + {tier_counts['D']['approve']} Tier D adjudicated).",
+        "",
+        f"**Confirmed non-matches logged (works_crosswalk_rejected.tsv):** {len(rejected)}.",
+        "",
+        "No sampling was used for this P2 pass (MG ruling 09-07-2026): every Tier C/D row in "
+        "crosswalk_candidates.jsonl.gz was included in the review sheet, so unvoted counts above "
+        "reflect rows not yet reached in the voting pass, not an intentional sample -- a future "
+        "P2 continuation pass can pick up where this decisions.json left off (unvoted rows carry "
+        "`decision: null` and are still present in the sheet/candidate set).",
+        "",
+    ]
+    with open(COUNTS_PATH, 'w', encoding='utf-8') as f:
+        f.write("\n".join(lines))
+
+    print(f"Wrote {OUT_TSV} ({len(accepted)} rows)")
+    print(f"Wrote {OUT_REJECTED_TSV} ({len(rejected)} rows)")
+    print(f"Wrote {COUNTS_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/HeadwordLists/works_catalogue/build_p2_sheet.py
+++ b/HeadwordLists/works_catalogue/build_p2_sheet.py
@@ -1,0 +1,293 @@
+import sys
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+import gzip, json, html, re, os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, '..', '..'))
+SRC = os.path.join(HERE, 'crosswalk_candidates.jsonl.gz')
+OUT_HTML = os.path.join(REPO_ROOT, 'review', 'sanskritlexicography-acc_ncc_p2_c_d_review.html')
+SHEET_ID = 'sanskritlexicography-acc_ncc_p2_c_d_review'
+
+def trim_html(body, maxlen=280):
+    if not body:
+        return ''
+    text = re.sub(r'<[^>]+>', ' ', body)
+    text = re.sub(r'\s+', ' ', text).strip()
+    if len(text) > maxlen:
+        text = text[:maxlen].rsplit(' ', 1)[0] + '…'
+    return text
+
+rows = []
+with gzip.open(SRC, 'rt', encoding='utf-8') as f:
+    for line in f:
+        r = json.loads(line)
+        if r['tier'] not in ('C', 'D'):
+            continue
+        rid = f"{r['acc_L']}__{r['ncc_id']}"
+        rows.append({
+            'id': rid,
+            'tier': r['tier'],
+            'score': round(r['score'], 3),
+            'acc_L': r['acc_L'],
+            'ncc_id': r['ncc_id'],
+            'acc_key': r['acc_match_key'],
+            'ncc_key': r['ncc_match_key'],
+            'acc_slp1': r['acc_k1_slp1'],
+            'acc_body': r['acc_body'],
+            'ncc_iast': r['ncc_iast'],
+            'ncc_deva': r['ncc_deva'],
+            'ncc_snip': trim_html(r.get('ncc_body_html', '')),
+        })
+
+# Deterministic order: Tier C first (smaller, higher precision), then Tier D by score desc
+rows.sort(key=lambda r: (0 if r['tier'] == 'C' else 1, -r['score']))
+
+print(f"Total C+D rows: {len(rows)}", file=sys.stderr)
+
+data_json = json.dumps(rows, ensure_ascii=False, separators=(',', ':'))
+print(f"Embedded data size: {len(data_json)/1e6:.1f} MB", file=sys.stderr)
+
+TEMPLATE = r'''<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>ACC×NCC P2 — Tier C/D adjudication</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body { font-family: system-ui, sans-serif; margin: 0; padding: 0; background: #f4f4f6; color: #1a1a1a; }
+  @media (prefers-color-scheme: dark) { body { background: #17181c; color: #e8e8ea; } }
+  header { position: sticky; top: 0; z-index: 10; background: #20242c; color: #fff; padding: 10px 16px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap; font-size: 14px; }
+  header h1 { font-size: 15px; margin: 0; font-weight: 600; }
+  #tally { display: flex; gap: 10px; margin-left: auto; font-variant-numeric: tabular-nums; }
+  #tally span { padding: 2px 8px; border-radius: 10px; background: #2e333d; }
+  #tally .acc { background: #1f5c34; } #tally .rej { background: #6b1f1f; } #tally .def { background: #5c4a1f; } #tally .unv { background: #333; }
+  #controls { display: flex; gap: 8px; align-items: center; }
+  #controls input[type=text] { padding: 4px 8px; border-radius: 4px; border: 1px solid #444; width: 160px; }
+  #controls select { padding: 4px 6px; border-radius: 4px; }
+  #downloadBtn { background: #3a7; color: #fff; border: none; padding: 6px 12px; border-radius: 4px; cursor: pointer; font-weight: 600; }
+  #downloadBtn:hover { background: #2c6; }
+  #scrollHost { height: calc(100vh - 52px); overflow-y: auto; position: relative; }
+  #spacer { position: relative; width: 100%; }
+  .row { position: absolute; left: 0; right: 0; display: grid; grid-template-columns: 70px 1fr 1fr 210px; gap: 10px; padding: 8px 16px; border-bottom: 1px solid #ddd; align-items: start; }
+  @media (prefers-color-scheme: dark) { .row { border-bottom-color: #333; } }
+  .row.voted-approve { background: rgba(46,160,67,0.12); }
+  .row.voted-reject { background: rgba(200,40,40,0.12); }
+  .row.voted-defer { background: rgba(200,160,40,0.12); }
+  .row .meta { font-size: 12px; opacity: 0.75; line-height: 1.5; }
+  .row .acc-col b, .row .ncc-col b { font-size: 14px; }
+  .row .acc-col, .row .ncc-col { font-size: 12.5px; line-height: 1.4; overflow-wrap: break-word; }
+  .row .snip { opacity: 0.85; }
+  .row .actions { display: flex; flex-direction: column; gap: 4px; }
+  .row .actions .btns { display: flex; gap: 4px; }
+  .row button { cursor: pointer; border: 1px solid #999; background: #fff; border-radius: 4px; padding: 3px 8px; font-size: 12px; }
+  @media (prefers-color-scheme: dark) { .row button { background: #24262b; color: #eee; border-color: #555; } }
+  .row button.active-approve { background: #2ea043; color: #fff; border-color: #2ea043; }
+  .row button.active-reject { background: #c82828; color: #fff; border-color: #c82828; }
+  .row button.active-defer { background: #c8a028; color: #fff; border-color: #c8a028; }
+  .row .note { width: 100%; font-size: 11px; padding: 2px 4px; }
+  #jump { display: flex; gap: 4px; align-items: center; }
+  #hint { font-size: 11px; opacity: 0.7; }
+</style>
+</head>
+<body>
+<header>
+  <h1>ACC×NCC P2 — Tier C/D adjudication (__ROWCOUNT__ rows)</h1>
+  <div id="controls">
+    <select id="filterTier"><option value="">all tiers</option><option value="C">Tier C</option><option value="D">Tier D</option></select>
+    <select id="filterVote"><option value="">all votes</option><option value="unvoted">unvoted</option><option value="approve">approved</option><option value="reject">rejected</option><option value="defer">deferred</option></select>
+    <input type="text" id="searchBox" placeholder="filter acc/ncc key…">
+    <div id="jump"><span id="hint">a/r/d = vote focused row</span></div>
+  </div>
+  <div id="tally">
+    <span class="acc">✅ <span id="cApprove">0</span></span>
+    <span class="rej">❌ <span id="cReject">0</span></span>
+    <span class="def">⏸ <span id="cDefer">0</span></span>
+    <span class="unv">— <span id="cUnvoted">__ROWCOUNT__</span></span>
+  </div>
+  <button id="downloadBtn">Download decisions.json</button>
+</header>
+<div id="scrollHost">
+  <div id="spacer"></div>
+</div>
+<script>
+const SHEET_ID = "__SHEET_ID__";
+const DATA = __DATA_JSON__;
+const ROW_HEIGHT = 92;
+const STORE_KEY = "reviewsheet_" + SHEET_ID;
+
+let decisions = {};
+try {
+  const saved = JSON.parse(localStorage.getItem(STORE_KEY) || "{}");
+  decisions = saved;
+} catch (e) { decisions = {}; }
+
+let filtered = DATA;
+let focusedIdx = -1;
+
+const scrollHost = document.getElementById('scrollHost');
+const spacer = document.getElementById('spacer');
+const filterTier = document.getElementById('filterTier');
+const filterVote = document.getElementById('filterVote');
+const searchBox = document.getElementById('searchBox');
+
+function escapeHtml(s) {
+  return (s || '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
+function applyFilters() {
+  const t = filterTier.value;
+  const v = filterVote.value;
+  const q = searchBox.value.trim().toLowerCase();
+  filtered = DATA.filter(r => {
+    if (t && r.tier !== t) return false;
+    const dec = decisions[r.id] && decisions[r.id].decision;
+    if (v === 'unvoted' && dec) return false;
+    if (v && v !== 'unvoted' && dec !== v) return false;
+    if (q && !(r.acc_key.toLowerCase().includes(q) || r.ncc_key.toLowerCase().includes(q))) return false;
+    return true;
+  });
+  spacer.style.height = (filtered.length * ROW_HEIGHT) + 'px';
+  renderVisible();
+}
+
+function rowHtml(r, idx) {
+  const dec = decisions[r.id] || {};
+  const cls = dec.decision ? ('voted-' + dec.decision) : '';
+  const note = dec.note || '';
+  return `<div class="row ${cls}" data-idx="${idx}" data-id="${r.id}" style="top:${idx * ROW_HEIGHT}px; height:${ROW_HEIGHT}px;">
+    <div class="meta">tier ${r.tier}<br>score ${r.score}<br><span style="opacity:.6">${escapeHtml(r.acc_L)}</span></div>
+    <div class="acc-col"><b>${escapeHtml(r.acc_slp1)}</b><br>${escapeHtml((r.acc_body||'').slice(0,220))}</div>
+    <div class="ncc-col"><b>${escapeHtml(r.ncc_iast)}</b> <span style="opacity:.7">${escapeHtml(r.ncc_deva)}</span><br><span class="snip">${escapeHtml(r.ncc_snip)}</span></div>
+    <div class="actions">
+      <div class="btns">
+        <button data-act="approve" class="${dec.decision==='approve'?'active-approve':''}">✅</button>
+        <button data-act="reject" class="${dec.decision==='reject'?'active-reject':''}">❌</button>
+        <button data-act="defer" class="${dec.decision==='defer'?'active-defer':''}">⏸</button>
+      </div>
+      <input class="note" type="text" placeholder="note" value="${escapeHtml(note)}">
+    </div>
+  </div>`;
+}
+
+function renderVisible() {
+  const scrollTop = scrollHost.scrollTop;
+  const viewH = scrollHost.clientHeight;
+  const startIdx = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - 5);
+  const endIdx = Math.min(filtered.length, Math.ceil((scrollTop + viewH) / ROW_HEIGHT) + 5);
+  let buf = '';
+  for (let i = startIdx; i < endIdx; i++) {
+    buf += rowHtml(filtered[i], i);
+  }
+  spacer.innerHTML = buf;
+}
+
+function vote(id, act) {
+  const existing = decisions[id] || {};
+  if (existing.decision === act) {
+    delete decisions[id];
+  } else {
+    decisions[id] = { decision: act, note: existing.note || '' };
+  }
+  persist();
+  updateTally();
+  renderVisible();
+}
+
+function setNote(id, note) {
+  if (!decisions[id]) decisions[id] = { decision: null, note: '' };
+  decisions[id].note = note;
+  persist();
+}
+
+function persist() {
+  localStorage.setItem(STORE_KEY, JSON.stringify(decisions));
+}
+
+function updateTally() {
+  let a=0,r=0,d=0;
+  for (const k in decisions) {
+    const dec = decisions[k].decision;
+    if (dec === 'approve') a++;
+    else if (dec === 'reject') r++;
+    else if (dec === 'defer') d++;
+  }
+  document.getElementById('cApprove').textContent = a;
+  document.getElementById('cReject').textContent = r;
+  document.getElementById('cDefer').textContent = d;
+  document.getElementById('cUnvoted').textContent = DATA.length - a - r - d;
+}
+
+scrollHost.addEventListener('scroll', () => window.requestAnimationFrame(renderVisible));
+window.addEventListener('resize', renderVisible);
+
+spacer.addEventListener('click', (e) => {
+  const btn = e.target.closest('button');
+  if (btn) {
+    const rowEl = e.target.closest('.row');
+    vote(rowEl.dataset.id, btn.dataset.act);
+    focusedIdx = parseInt(rowEl.dataset.idx, 10);
+    return;
+  }
+  const rowEl = e.target.closest('.row');
+  if (rowEl) focusedIdx = parseInt(rowEl.dataset.idx, 10);
+});
+spacer.addEventListener('change', (e) => {
+  if (e.target.classList.contains('note')) {
+    const rowEl = e.target.closest('.row');
+    setNote(rowEl.dataset.id, e.target.value);
+  }
+});
+
+document.addEventListener('keydown', (e) => {
+  if (document.activeElement && document.activeElement.tagName === 'INPUT') return;
+  if (focusedIdx < 0) return;
+  const row = filtered[focusedIdx];
+  if (!row) return;
+  if (e.key === 'a') vote(row.id, 'approve');
+  else if (e.key === 'r') vote(row.id, 'reject');
+  else if (e.key === 'd') vote(row.id, 'defer');
+  else if (e.key === 'ArrowDown') { focusedIdx = Math.min(filtered.length - 1, focusedIdx + 1); scrollHost.scrollTop = focusedIdx * ROW_HEIGHT - 100; }
+  else if (e.key === 'ArrowUp') { focusedIdx = Math.max(0, focusedIdx - 1); scrollHost.scrollTop = focusedIdx * ROW_HEIGHT - 100; }
+});
+
+filterTier.addEventListener('change', applyFilters);
+filterVote.addEventListener('change', applyFilters);
+searchBox.addEventListener('input', applyFilters);
+
+document.getElementById('downloadBtn').addEventListener('click', () => {
+  const items = DATA.map(r => ({
+    id: r.id,
+    decision: (decisions[r.id] && decisions[r.id].decision) || null,
+    note: (decisions[r.id] && decisions[r.id].note) || ''
+  }));
+  const payload = { sheet_id: SHEET_ID, generated: new Date().toISOString(), decided: Object.keys(decisions).length, items };
+  const blob = new Blob([JSON.stringify(payload, null, 1)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = SHEET_ID + '_decisions.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+});
+
+applyFilters();
+updateTally();
+</script>
+</body>
+</html>
+'''
+
+out = (TEMPLATE
+       .replace('__ROWCOUNT__', str(len(rows)))
+       .replace('__SHEET_ID__', SHEET_ID)
+       .replace('__DATA_JSON__', data_json))
+
+os.makedirs(os.path.dirname(OUT_HTML), exist_ok=True)
+with open(OUT_HTML, 'w', encoding='utf-8') as f:
+    f.write(out)
+
+print(f"Wrote {OUT_HTML} ({len(out)/1e6:.1f} MB)", file=sys.stderr)

--- a/ROADMAP_ACC_NCC.md
+++ b/ROADMAP_ACC_NCC.md
@@ -1,6 +1,6 @@
 # ROADMAP_ACC_NCC — Catalogue-of-Works asset (Aufrecht × New Catalogus Catalogorum)
 
-_Created: 03-07-2026 · Last updated: 03-07-2026_
+_Created: 03-07-2026 · Last updated: 09-07-2026_
 
 Goal: build a **catalogue-of-works data asset** by joining **ACC** (Aufrecht's
 *Catalogus Catalogorum*, Cologne) as the spine with **NCC** (*New Catalogus
@@ -101,6 +101,14 @@ consumption pattern.
 - `/review-sheet` HTML voting sheet over Tier C/D candidates → `decisions.json` → `/decisions-apply`.
 - Full fuzzy manufactures false joins by design; C/D never auto-merge.
 - **Deliverable:** `works_crosswalk.tsv` (accepted/rejected/deferred, with provenance).
+- **Status (09-07-2026, H264, Sonnet 5 `claude-sonnet-5`): tooling shipped, BLOCKED on MG's
+  vote.** Sample-size ruling (asked, not silently picked): full 49,019-row sheet, no
+  sampling. [`HeadwordLists/works_catalogue/build_p2_sheet.py`](https://github.com/gasyoun/SanskritLexicography/blob/feat/acc-ncc-p2-adjudication/HeadwordLists/works_catalogue/build_p2_sheet.py)
+  generates the virtualized-scroll sheet;
+  [`apply_p2_decisions.py`](https://github.com/gasyoun/SanskritLexicography/blob/feat/acc-ncc-p2-adjudication/HeadwordLists/works_catalogue/apply_p2_decisions.py)
+  is the smoke-tested `decisions.json` consumer. [Draft PR #264](https://github.com/gasyoun/SanskritLexicography/pull/264),
+  branch `feat/acc-ncc-p2-adjudication`. GTD: [Uprava/GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md)
+  § Waiting on Me.
 
 ### P3 — kosha consumption (product repo)
 - kosha adds a `works` table (canonical headword deva/IAST/SLP1; ACC body + sigla + `pc_scan`; NCC body + mss-witnesses; `match_tier`; `ncc_coverage`; per-source `license`), loading this repo's `works_crosswalk.tsv` — mirrors the union-spine load in [kosha `build_db.py`](https://github.com/gasyoun/kosha/blob/main/scripts/build_db.py).


### PR DESCRIPTION
## Summary
- Prep-only PR for [H264](https://github.com/gasyoun/Uprava/blob/main/handoffs/H264-Sonnet_SanskritLexicography_acc_ncc_p2_adjudication_06.07.26.md) P2 (Tier C/D adjudication of the ACC×NCC works-catalogue crosswalk).
- Sample-size ruling made 09-07-2026: **full 49,019-row sheet, no sampling** (Tier C 5,353 + Tier D 43,666).
- Adds `HeadwordLists/works_catalogue/build_p2_sheet.py` — generates a virtualized-scroll, single-file HTML `/review-sheet` (only visible rows render to DOM; decisions persist to `localStorage`; a/r/d keyboard shortcuts; tier/vote/text filters). The 22 MB generated sheet itself is gitignored (personal working artifact, registered in [Uprava/REVIEW_SHEETS_INDEX.md](https://github.com/gasyoun/Uprava/blob/main/REVIEW_SHEETS_INDEX.md)).
- Adds `HeadwordLists/works_catalogue/apply_p2_decisions.py` — the `/decisions-apply` consumer; smoke-tested against a synthetic partial `decisions.json` (auto-accepts Tier A/B, includes only voted-`approve` Tier C/D rows in `works_crosswalk.tsv`, logs voted-`reject` rows to `works_crosswalk_rejected.tsv` as confirmed non-matches, and reports per-tier approve/reject/defer/unvoted counts in `P2_COUNTS.md`).

## Why draft
This PR does **not** yet contain `works_crosswalk.tsv` or `P2_COUNTS.md` — those require MG's human vote on the 49,019-row sheet (Tier C/D full-fuzzy matches must never auto-merge per `ROADMAP_ACC_NCC.md`). GTD row added: [Uprava/GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md) § Waiting on Me. Once a `decisions.json` is in hand, a follow-up commit here runs `apply_p2_decisions.py` and this PR is marked ready for review.

## Test plan
- [x] `build_p2_sheet.py` run — 49,019 rows embedded, 24 MB HTML, JS syntax validated with `node --check`, embedded JSON parse-validated with `node`.
- [x] `apply_p2_decisions.py` smoke-tested against a synthetic 30-row partial decisions file (approve/reject/defer/unvoted mix) — correct TSV row counts and P2_COUNTS.md output confirmed, test artifacts removed before commit.
- [ ] Real `decisions.json` from MG's vote (blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)