### PR TITLE
fix(rt): harden coordinator orchestration

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -820,6 +820,15 @@ Two live tracks:
 
 ## ✅ Completed (Recent only)
 
+- **RussianTranslation coordinator orchestration hardening — DONE 09-07-2026 (Codex/GPT-5).**
+  In `RussianTranslation`, hardened `src/pilot/coordinator.py`: abandoned pre-prepare
+  `claimed` leases now expire and release the global 3-lane cap, while prepared
+  harness leases remain durable pending Workflow capture; fresh-worktree coordinator
+  locks create their parent dir; coordinator registry/daily JSONL appends now use
+  the shared atomic append primitive. H317 launch ledger schema
+  repaired, `RUN_FREQ_MAX.md` concurrency doctrine tightened (clean solo reference before
+  trusting concurrent width), LANG_PARITY updated, and full `window_selftest.py` passes.
+
 - **Indische Sprüche dataset extracted — DONE (2026-07-03, Sonnet 5 `claude-sonnet-5`).**
   New [IndischeSprueche/](https://github.com/gasyoun/SanskritLexicography/tree/master/IndischeSprueche)
   data asset: full Böhtlingk *Indische Sprüche* (2nd ed. 1870–1873), 7,537 sayings,

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1754,6 +1754,19 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **Coordinator orchestration hardening audit — DONE 09-07-2026 (Codex/GPT-5).**
+  `src/pilot/coordinator.py` now enforces lease TTL only for abandoned pre-prepare
+  `claimed` leases (freeing the global 3-lane cap) while preserving already
+  `prepared` harness leases as durable operator artifacts; coordinator locks now
+  create their parent dir in a fresh worktree; coordinator registry/daily JSONL
+  appends now reuse the shared atomic `append_jsonl_line()` primitive. Added
+  `test_coordinator_expired_leases_release_cap` to `window_selftest.py`, recorded
+  parity as `coordinator_claim_expiry_and_atomic_jsonl`, and updated
+  `RUN_FREQ_MAX.md` so 3-wide is an upper bound after a clean solo reference, not
+  the default. Verified: `py_compile`, `check_launch_ledger.py --since 2026-07-05`,
+  `lang_parity_check.py`, full `window_selftest.py`, and live coordinator status
+  still shows the three H151 leases as `prepared`.
+
 - **RussianTranslation performance audit + TM load optimization — ✅ DONE 08-07-2026 (Codex/GPT-5).**
   Audited the live H317/pilot performance surface and measured the canonical generator path:
   `gen_opt_harness2.py dah` pre-resolves 26/31 cards from `translation_memory.ru.json` and emits

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -471,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -502,7 +502,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "4623e2f271a6d68cf2c76c0e144c3110bdd01a0526d55eb1804175cdf47059ef",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -521,7 +521,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "901ffd21e7db7e0ea6d0433c342166dab7caa5e1abe43ad04745a7a7f99b198a",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "2257f04cdca96b2aea51cd6d097358c43109977e1847d39ff59476cc5cf50863",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
       "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -623,7 +623,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -652,7 +652,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "901ffd21e7db7e0ea6d0433c342166dab7caa5e1abe43ad04745a7a7f99b198a",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   },
   {
@@ -672,7 +672,26 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "4f3e3e4adb7b251de0e03ac407bab5c809f9d55275b84569baa8021f5bc6b491",
       "src/annotation_report.py": "de28ac29360ebc960f00dc3aebffb6255e8b428ed202f5fed2ad2528642b46fe",
-      "src/pilot/window_selftest.py": "8f78477d25c1e9335e3091f9c2c1d64450f086e43ce592f1d125899e6d29089e"
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+    }
+  },
+  {
+    "id": "coordinator_claim_expiry_and_atomic_jsonl",
+    "mechanism": "coordinator.py enforces TTL only for pre-prepare claimed leases so abandoned claims release the global translation cap, while prepared harness leases remain durable operator artifacts; coordinator registry/daily JSONL appends use the shared append_jsonl_line() single-write primitive",
+    "files": [
+      "src/pilot/coordinator.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/coordinator.py": "5e257d130318be4e903bb55444d70c88544af8725c115253235e5daed716ec51",
+      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -343,12 +343,15 @@ deterministic 10 % sample of clean translated keys. It is NOT the mechanical req
 
 ## Concurrency — run a throttled driver, not N parallel chats
 
-**Do not launch more than ~3 root harnesses as separate Workflows at once.** Each generated
-harness internally fans out to ~8–14 agents, so N concurrent root-harnesses peak at N×~12
-Sonnet agents on a single Max session. Slice D launched 18 at once → ~140–250 peak agents →
-~80+ `Server is temporarily limiting requests` 429s → 117 transient null cards; single-root
-runs measured **zero** transient failures. Run roots sequentially or ≤3-wide from one driver;
-a clean sequential sweep is faster end-to-end than a collapsed wide run plus its recovery pass.
+**Default to one Workflow window at a time; treat 3-wide as an upper bound, not a target.**
+Each generated harness internally fans out to ~8–14 agents, so N concurrent root-harnesses
+peak at N×~12 Sonnet agents on a single Max session. Slice D launched 18 at once →
+~140–250 peak agents → ~80+ `Server is temporarily limiting requests` 429s → 117 transient
+null cards. H317 then showed that even **3 concurrent medium windows** can collapse if the
+session/provider is already unstable (0/38 clean, and the solo retry still saw repeated
+`Connection closed mid-response`). In any session with fresh transport errors, first run a
+single solo reference window and see it return mostly clean before trusting any concurrent
+width. A clean sequential sweep is faster end-to-end than a collapsed wide run plus recovery.
 
 **Running 3 accounts at once (3 clones, not 3 chats in one clone)?** Read the
 [3-account operating protocol](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md#recommended-3-account-operating-protocol-no-code-changes-needed)

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -41,7 +41,7 @@ import promote_final_cards  # noqa: E402
 from safe_filename import safe_name  # noqa: E402
 import translation_memory  # noqa: E402
 import verb_worklist  # noqa: E402
-from window_common import defer_monster  # noqa: E402
+from window_common import append_jsonl_line, defer_monster  # noqa: E402
 
 
 def utc_now():
@@ -99,6 +99,7 @@ class DirLock:
         deadline = time.time() + 30
         while True:
             try:
+                os.makedirs(os.path.dirname(self.path), exist_ok=True)
                 os.mkdir(self.path)
                 self.write_meta()
                 return self
@@ -158,6 +159,7 @@ def load_state():
 
 def save_state(state):
     p = ensure_dirs()
+    expire_stale_leases(state)
     state['updated_at'] = utc_now()
     tmp = p['state'] + '.tmp'
     with open(tmp, 'w', encoding='utf-8') as f:
@@ -167,7 +169,38 @@ def save_state(state):
 
 
 def terminal_state(state):
-    return state in ('released', 'promoted', 'abandoned', 'blocked')
+    return state in ('released', 'promoted', 'abandoned', 'blocked', 'expired')
+
+
+def lease_expired(lease, now=None):
+    if terminal_state(lease.get('state')):
+        return False
+    if lease.get('state') != 'claimed':
+        return False
+    expires = parse_ts(lease.get('expires_at'))
+    if not expires:
+        return False
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    return expires <= now
+
+
+def expire_stale_leases(state):
+    """Turn TTL-expired non-terminal leases into terminal expired leases.
+
+    The coordinator's global <=3 translation cap is only useful if dead
+    pre-prepare claims eventually release their slots. Prepared leases are
+    durable operator artifacts: they may wait for a human Workflow run and should
+    not be invalidated merely because the handoff spans days.
+    """
+    now = datetime.datetime.now(datetime.timezone.utc)
+    changed = []
+    for lease in state.get('leases', []):
+        if lease_expired(lease, now=now):
+            lease['previous_state'] = lease.get('state')
+            lease['state'] = 'expired'
+            lease['expired_at'] = utc_now()
+            changed.append(lease)
+    return changed
 
 
 def translation_lease(lease):
@@ -175,6 +208,7 @@ def translation_lease(lease):
 
 
 def active_translation_leases(state):
+    expire_stale_leases(state)
     return [
         lease for lease in state.get('leases', [])
         if translation_lease(lease) and not terminal_state(lease.get('state'))
@@ -194,8 +228,7 @@ def artifact_dir(lease_id):
 
 def append_jsonl(path, rec):
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, 'a', encoding='utf-8') as f:
-        f.write(json.dumps(rec, ensure_ascii=False) + '\n')
+    append_jsonl_line(path, rec)
 
 
 def registry_event(lease, event_type, data=None):
@@ -241,6 +274,7 @@ def load_store_key1s(store=None):
 
 
 def active_targets(state):
+    expire_stale_leases(state)
     return {lease.get('target') for lease in state.get('leases', [])
             if not terminal_state(lease.get('state'))}
 

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -1999,6 +1999,51 @@ def test_coordinator_state_dashboard_and_cap():
                 os.environ['PWG_COORDINATOR_DIR'] = old
 
 
+def test_coordinator_expired_leases_release_cap():
+    """A killed/offline pre-prepare claim must not hold one global translation lane
+    forever, while an already-prepared harness remains a durable operator artifact."""
+    import coordinator
+    old = os.environ.get('PWG_COORDINATOR_DIR')
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ['PWG_COORDINATOR_DIR'] = tmp
+        try:
+            expired_at = (datetime.datetime.now(datetime.timezone.utc) -
+                          datetime.timedelta(seconds=1)).isoformat(
+                              timespec='seconds').replace('+00:00', 'Z')
+            future_at = (datetime.datetime.now(datetime.timezone.utc) +
+                         datetime.timedelta(hours=1)).isoformat(
+                             timespec='seconds').replace('+00:00', 'Z')
+            state = coordinator.default_state()
+            state['leases'] = [
+                {'id': 'old-claim', 'lane': 'a', 'kind': 'verb', 'owner': 'selftest',
+                 'target': 'gam', 'state': 'claimed', 'expires_at': expired_at},
+                {'id': 'old-prepared', 'lane': 'b', 'kind': 'verb', 'owner': 'selftest',
+                 'target': 'tyaj', 'state': 'prepared', 'expires_at': expired_at},
+                {'id': 'live', 'lane': 'b', 'kind': 'verb', 'owner': 'selftest',
+                 'target': 'dah', 'state': 'prepared', 'expires_at': future_at},
+            ]
+            coordinator.save_state(state)
+            loaded = coordinator.load_state()
+            active = coordinator.active_translation_leases(loaded)
+            if [l.get('id') for l in active] != ['old-prepared', 'live']:
+                fail('only expired pre-prepare coordinator claims must release the LLM cap')
+            if loaded['leases'][0].get('state') != 'expired':
+                fail('expired coordinator claim must be marked terminal')
+            if loaded['leases'][1].get('state') != 'prepared':
+                fail('prepared coordinator leases must not expire just because the TTL passed')
+            if coordinator.active_targets(loaded) != {'tyaj', 'dah'}:
+                fail('only the expired claim target must be reclaimable')
+            coordinator.save_state(loaded)
+            persisted = coordinator.load_state()
+            if persisted['leases'][0].get('state') != 'expired':
+                fail('expired coordinator claim state must persist to disk')
+        finally:
+            if old is None:
+                os.environ.pop('PWG_COORDINATOR_DIR', None)
+            else:
+                os.environ['PWG_COORDINATOR_DIR'] = old
+
+
 def test_coordinator_lock_replaces_stale_dead_owner():
     import coordinator
     with tempfile.TemporaryDirectory() as tmp:
@@ -2011,6 +2056,15 @@ def test_coordinator_lock_replaces_stale_dead_owner():
         with coordinator.DirLock(lock_path, ttl_seconds=1):
             if not os.path.exists(os.path.join(lock_path, 'owner.json')):
                 fail('coordinator lock did not recreate owner metadata')
+
+
+def test_coordinator_lock_creates_parent_dir():
+    import coordinator
+    with tempfile.TemporaryDirectory() as tmp:
+        lock_path = os.path.join(tmp, 'missing', 'coordinator', '.state.lock')
+        with coordinator.DirLock(lock_path, ttl_seconds=1):
+            if not os.path.exists(os.path.join(lock_path, 'owner.json')):
+                fail('coordinator lock must create its parent directory before locking')
 
 
 def test_coordinator_defect_requeue_uses_no_tm_and_out():
@@ -3427,7 +3481,9 @@ def main():
         test_perf_preflight_partitions_mixed_monster_window,
         test_verb_worklist_excludes_missing_rootmaps,
         test_coordinator_state_dashboard_and_cap,
+        test_coordinator_expired_leases_release_cap,
         test_coordinator_lock_replaces_stale_dead_owner,
+        test_coordinator_lock_creates_parent_dir,
         test_coordinator_defect_requeue_uses_no_tm_and_out,
         test_promote_nominal_key1,
         test_build_emits_nominal_keymap,


### PR DESCRIPTION
## PR Type
- [ ] data
- [x] build
- [x] docs
- [ ] navigation

## Summary
- What changed: hardened `RussianTranslation` coordinator orchestration by expiring abandoned `claimed` leases, preserving prepared harness leases, creating lock parent directories in fresh worktrees, and routing coordinator JSONL writes through the shared atomic append helper. Also added focused selftests, tightened Max/Workflow concurrency guidance, updated parity hashes, and recorded the session journals.
- Why this change exists: abandoned pre-prepare claims could keep global translation capacity occupied after a killed session, fresh worktrees could crash on `coordinator.py status` before coordinator output dirs existed, and H317 showed the existing 3-wide concurrency note was too easy to overread as a target during provider instability.

## Test Surface
- Automated checks: `python -m py_compile src\pilot\coordinator.py src\pilot\window_selftest.py`; `python src\pilot\check_launch_ledger.py --since 2026-07-05`; `python src\pilot\lang_parity_check.py`; `python src\pilot\window_selftest.py`.
- Manual checks: `python src\pilot\coordinator.py status` from a fresh worktree after the lock parent-dir fix.
- Pure helpers / decision points covered: claim-only lease expiry, prepared-lease durability, coordinator lock parent creation, and SHARED language parity ledger coverage.
- If build-related: import-safe verified? yes.

## Invariants
- Must stay true: `prepared` leases remain durable operator artifacts and are not expired by TTL cleanup.
- Counts / alignment / join rules: expired `claimed` leases release active target/cap accounting; active `prepared` leases still count as active leases.
- Source-of-truth assumptions: coordinator state stays in `src/pilot/output/coordinator/state.json`; shared append semantics live in `window_common.append_jsonl_line()`.
- What would count as regression: a stale `claimed` lease continues blocking the cap, a `prepared` harness lease is auto-expired, JSONL writes bypass the shared append primitive, or fresh-worktree `coordinator.py status` crashes before state dirs exist.

## Safety
- Fallback / failure mode: stale `claimed` leases become terminal `expired` records instead of being deleted, preserving auditability.
- Observable marker or sanity check: `coordinator.py status` shows expired claims under terminal status and active cap reflects only non-expired work.
- Rebuild / validate / verify command: `python src\pilot\window_selftest.py` plus `python src\pilot\coordinator.py status`.

## Reader-Facing Done
- Navigation / entry point updated: n/a; no reader navigation changed.
- Docs / changelog / handoff updated: `RussianTranslation/src/pilot/RUN_FREQ_MAX.md`, root `.ai_state.md`, and `RussianTranslation/.ai_state.md` updated.
- Known limits or caveats exposed: default Workflow launch guidance is now one window; 3-wide is an upper bound only after a clean solo reference run.
- If not applicable, say why: no public data or UI surface changed.

## Type-Specific Notes
- If `build`: runtime side effects remain scoped to coordinator state cleanup and append behavior; ignored pilot fixture artifacts were used only to verify the fresh worktree selftest and are not committed.
- If `docs`: stale concurrency wording was replaced with H317-informed launch guidance.