### PR TITLE
RussianTranslation: per-sense citation genre join + kāvya queries (H339 W4)

### DIFF
--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -471,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -502,7 +502,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "4623e2f271a6d68cf2c76c0e144c3110bdd01a0526d55eb1804175cdf47059ef",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -521,7 +521,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "901ffd21e7db7e0ea6d0433c342166dab7caa5e1abe43ad04745a7a7f99b198a",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "2257f04cdca96b2aea51cd6d097358c43109977e1847d39ff59476cc5cf50863",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
       "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -623,7 +623,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -652,7 +652,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "901ffd21e7db7e0ea6d0433c342166dab7caa5e1abe43ad04745a7a7f99b198a",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -671,8 +671,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/annotate_evidence.py": "4f3e3e4adb7b251de0e03ac407bab5c809f9d55275b84569baa8021f5bc6b491",
-      "src/annotation_report.py": "de28ac29360ebc960f00dc3aebffb6255e8b428ed202f5fed2ad2528642b46fe",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
     }
   },
   {
@@ -691,7 +691,24 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "5e257d130318be4e903bb55444d70c88544af8725c115253235e5daed716ec51",
-      "src/pilot/window_selftest.py": "046442f7670955c66bf38824aef6052b213250ffac82fbf535144f88c8fcf3b5"
+      "src/pilot/window_selftest.py": "ad191e669ce97e6aa180ea9d3918cc88db61660cf4b3671c16f50c581e18b4e5"
+    }
+  },
+  {
+    "id": "genre_sense_join_h339",
+    "mechanism": "Per-sense citation genre join (annotate_genres.py, H335 W4): resolves each sense's <ls> citations to ls_source_map.json's curated genre label(s) + a coarse rollup (kavya/veda/sastra/purana/epic/kosha), reusing renou.keys_in_text verbatim for siglum normalization; annotation_report.py folds the --in/--only/--genre-report query surface on top",
+    "files": [
+      "src/annotate_genres.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H339 (08-07-2026). The join reads <ls> citation markup shared verbatim by both RU and EN editions (renou.keys_in_text is the same siglum parser annotate_renou.py already treats as language-independent) and never touches translation text itself. Read-only over the store; selftest-gated.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/annotate_genres.py": "5eea7d5269c716d5c96ceb81be5c22358fe45542b066f66963a8fdd1562d89e3"
     }
   }
 ]

--- a/RussianTranslation/src/annotate_dcs_freq.py
+++ b/RussianTranslation/src/annotate_dcs_freq.py
@@ -94,6 +94,17 @@ def dims_block(iast, by_lemma):
     return out
 
 
+def dcs_registers_for(db):
+    """Lane 2 (frequency-weighted, corpus-attested): the sorted register-code vector
+    from a dims_block's genre counts, e.g. ['epic', 'kavya']. [] when unmatched or
+    register-less. Distinct from and NEVER merged with the citation-derived `genre`
+    field (annotate_genres.py, lane 1: 'PWG cites this sense from a kāvya work') —
+    the two answer different questions (see W4, PIPELINE_CAPABILITY_AUDIT_2026-07-08.md)."""
+    if not db:
+        return []
+    return sorted((db.get('genre') or {}).get('counts', {}))
+
+
 def selftest():
     by = {'anuvad': {'count': 5, 'band': 2, 'hapax': False, 'core80': False},
           'vad': {'count': 3918, 'band': 5, 'hapax': False, 'core80': True},
@@ -114,6 +125,10 @@ def selftest():
     # absent
     b = freq_block('zzz+qqq', by)
     assert b['matched'] == 'none' and b['band'] == 0 and b['attested'] is False
+    # dcs_registers: sorted register-code vector from a dims_block, [] when absent
+    assert dcs_registers_for({'genre': {'counts': {'kavya': 12, 'epic': 3}}}) == ['epic', 'kavya']
+    assert dcs_registers_for({}) == []
+    assert dcs_registers_for(None) == []
     print('annotate_dcs_freq selftest OK')
 
 
@@ -153,6 +168,7 @@ def main():
                 r['dcs_freq']['era'] = db.get('era')
                 pos_n += 1 if db.get('pos') else 0
                 genre_n += 1 if db.get('genre') else 0
+            r['dcs_registers'] = dcs_registers_for(db)   # lane 2, sibling of annotate_genres' `genre`
 
     n = len(rows)
     print('=== DCS FREQUENCY ANNOTATION ===')

--- a/RussianTranslation/src/annotate_genres.py
+++ b/RussianTranslation/src/annotate_genres.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+"""annotate_genres.py — tag final dictionary cards with per-sense citation genre(s).
+
+Sibling of annotate_renou.py: same <ls>-citation walk, different output. For every
+*sense* this derives the literal genre label(s) of its cited sources from
+ls_source_map.json (45 curated works, ~70% of PWG's <ls> occurrences) and writes:
+
+  sense['genre']          sorted list of curated genre labels cited by this sense
+                          (e.g. ["Kāvya — Mahākāvya (Kālidāsa)", "Veda — Saṃhitā"]);
+                          [] when the sense has no citation OR every cited siglum is
+                          unmapped — genuinely UNKNOWN, never conflated with "attested
+                          only in genre X".
+  sense['genre_coarse']   sorted list of coarse rollups derived from genre's label
+                          prefix (kavya/veda/sastra/purana/epic/kosha); [] when genre
+                          is [].
+
+This answers MG's "какие значения встречаются в kāvya?" at the citation-evidence
+level: "PWG cites this sense from a kāvya work". It does NOT answer "the lemma is
+corpus-frequent in kāvya" — that is the separate, frequency-weighted DCS register
+lane (dcs_registers, annotate_dcs_freq.py) and the two are never merged (see W4 in
+PIPELINE_CAPABILITY_AUDIT_2026-07-08.md). annotation_report.py folds both lanes'
+queries into its single query CLI.
+
+Siglum normalization reuses renou.keys_in_text verbatim, so genre and renou state
+tagging always agree on which citations were recognised. Deterministic (no API),
+idempotent, BOM-free, writes via temp file + atomic replace.
+
+  python annotate_genres.py IN.jsonl [--out OUT.jsonl] [--dict pwg|mw]
+  python annotate_genres.py IN.jsonl --report          # stats only, no write
+  python annotate_genres.py --coverage [--top N]       # unmapped sigla by citation
+                                                          mass, over raw pwg.txt
+  python annotate_genres.py --selftest
+"""
+import collections
+import json
+import os
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+import renou
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GH = os.path.normpath(os.path.join(HERE, '..', '..', '..'))
+PWG_TXT = os.path.join(GH, 'csl-orig', 'v02', 'pwg', 'pwg.txt')
+
+# Coarse rollup: the curated genre label's prefix before " -- " (or the whole label
+# for the one prefix-less entry, "Purana"). Every one of the 25 curated labels
+# resolves to exactly one of these six buckets.
+_COARSE = {
+    'Epic': 'epic',
+    'Kośa': 'kosha',
+    'Kāvya': 'kavya',
+    'Purāṇa': 'purana',
+    'Veda': 'veda',
+    'Śāstra': 'sastra',
+}
+
+
+def coarse_of(genre_label):
+    # every curated label's bucket is its leading word, whether followed by an
+    # " -- " qualifier ("Kāvya -- kathā") or a parenthetical ("Kośa (lexicon)")
+    # or nothing at all ("Purāṇa").
+    prefix = genre_label.split(None, 1)[0].strip() if genre_label else ''
+    return _COARSE.get(prefix, '')
+
+
+def genres_for_keys(source_keys, dict_name='pwg'):
+    """Resolve already-extracted <ls> source keys -> curated genre label(s) +
+    coarse rollup(s). Keys absent from ls_source_map are ignored (same policy as
+    renou.states_for_keys), so an unmapped-only citation set comes back empty."""
+    smap = renou.load_map(dict_name)
+    genres, coarse = set(), set()
+    for k in source_keys:
+        rec = smap.get(k)
+        if not rec:
+            continue
+        g = rec.get('genre')
+        if not g:
+            continue
+        genres.add(g)
+        c = coarse_of(g)
+        if c:
+            coarse.add(c)
+    return sorted(genres), sorted(coarse)
+
+
+def genres_for_text(text, dict_name='pwg'):
+    return genres_for_keys(renou.keys_in_text(text, dict_name), dict_name)
+
+
+def annotate_card(card, dict_name, stats):
+    """Mutate one card's senses in place (structured records/senses schema);
+    update stats counters. Mirrors annotate_renou.annotate_card."""
+    for record in card.get('records', []):
+        for sense in record.get('senses', []):
+            text = ' '.join(v for v in sense.values() if isinstance(v, str))
+            genres, coarse = genres_for_text(text, dict_name)
+            sense['genre'] = genres
+            sense['genre_coarse'] = coarse
+            stats['units'] += 1
+            if genres:
+                stats['tagged'] += 1
+                if len(genres) > 1:
+                    stats['multi'] += 1
+                for c in coarse:
+                    stats['by_coarse'][c] += 1
+
+
+def annotate_flat(obj, dict_name, stats):
+    """Flat legacy/production store (pwg_ru_translated.jsonl): one sense per row,
+    citation markup preserved verbatim in 'ru'. Mirrors annotate_renou.annotate_flat."""
+    genres, coarse = genres_for_text(obj.get('ru') or '', dict_name)
+    obj['genre'] = genres
+    obj['genre_coarse'] = coarse
+    stats['units'] += 1
+    if genres:
+        stats['tagged'] += 1
+        if len(genres) > 1:
+            stats['multi'] += 1
+        for c in coarse:
+            stats['by_coarse'][c] += 1
+
+
+def card_of(obj):
+    return obj.get('card', obj) if isinstance(obj, dict) else obj
+
+
+def is_structured(obj):
+    return isinstance(card_of(obj), dict) and 'records' in card_of(obj)
+
+
+def run(path, out, dict_name, report_only):
+    stats = {'cards': 0, 'units': 0, 'tagged': 0, 'multi': 0, 'structured': 0,
+              'by_coarse': collections.Counter()}
+    tmp = (out + '.tmp') if not report_only else None
+    sink = open(tmp, 'w', encoding='utf-8', newline='') if tmp else None
+    try:
+        with open(path, encoding='utf-8') as fin:
+            for line in fin:
+                line = line.strip()
+                if not line:
+                    continue
+                obj = json.loads(line)
+                if is_structured(obj):
+                    annotate_card(card_of(obj), dict_name, stats)
+                    stats['structured'] += 1
+                else:
+                    annotate_flat(obj, dict_name, stats)
+                stats['cards'] += 1
+                if sink:
+                    sink.write(json.dumps(obj, ensure_ascii=False) + '\n')
+    finally:
+        if sink:
+            sink.close()
+    if tmp:
+        os.replace(tmp, out)
+    report(stats, dict_name, out if tmp else None)
+
+
+def report(s, dict_name, out):
+    unit = 'senses' if s['structured'] else 'rows'
+    print('dict=%s  cards=%d  %s=%d  (structured cards=%d)'
+          % (dict_name, s['cards'], unit, s['units'], s['structured']))
+    tagged = s['tagged']
+    pct = (100.0 * tagged / s['units']) if s['units'] else 0.0
+    print('  %s with >=1 recognised citation genre: %d (%.1f%%)' % (unit, tagged, pct))
+    print('  multi-genre %s (>1 curated label): %d' % (unit, s['multi']))
+    print('  coarse rollup distribution (%s carrying the bucket):' % unit)
+    for c in ('veda', 'kavya', 'epic', 'sastra', 'purana', 'kosha'):
+        print('    %-8s %d' % (c, s['by_coarse'].get(c, 0)))
+    if out:
+        print('→ %s' % out)
+
+
+def cmd_coverage(top_n):
+    """Top unmapped <ls> sigla by raw citation mass over pwg.txt (data-curation
+    note, not a build item — extending ls_source_map.json is a separate pass)."""
+    data = open(PWG_TXT, encoding='utf-8').read()
+    # reuse renou.keys_in_text over the whole file so normalization matches the
+    # per-sense path exactly (no separate parsing logic to drift).
+    freq = collections.Counter(renou.keys_in_text(data, 'pwg'))
+    total = sum(freq.values())
+    smap = renou.load_map('pwg')
+    mapped_cit = sum(c for k, c in freq.items() if k in smap)
+    print('PWG <ls>: %d citations, %d distinct source keys' % (total, len(freq)))
+    print('mapped by ls_source_map (45 works): %d/%d citations (%.1f%%)'
+          % (mapped_cit, total, 100.0 * mapped_cit / total if total else 0.0))
+    unmapped = [(k, c) for k, c in freq.most_common() if k not in smap]
+    print('top %d UNMAPPED sigla by citation mass:' % top_n)
+    for k, c in unmapped[:top_n]:
+        print('  %-22s %6d' % (k, c))
+
+
+def selftest():
+    smap = {
+        'RAGH': {'genre': 'Kāvya — Mahākāvya (Kālidāsa)'},
+        'RV': {'genre': 'Veda — Saṃhitā'},
+        'AK': {'genre': 'Kośa (lexicon)'},
+    }
+    renou._CACHE['pwg'] = smap
+    g, c = genres_for_keys(['RAGH'])
+    assert g == ['Kāvya — Mahākāvya (Kālidāsa)'] and c == ['kavya'], (g, c)
+    g, c = genres_for_keys(['RAGH', 'RV'])
+    assert g == ['Kāvya — Mahākāvya (Kālidāsa)', 'Veda — Saṃhitā']
+    assert c == ['kavya', 'veda']
+    g, c = genres_for_keys(['AK'])
+    assert c == ['kosha'], c
+    g, c = genres_for_keys(['ZZZUNMAPPED'])
+    assert g == [] and c == []
+    g, c = genres_for_keys([])
+    assert g == [] and c == []
+    del renou._CACHE['pwg']
+    print('annotate_genres selftest OK')
+
+
+def main():
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__); return
+    if args[0] == '--selftest':
+        return selftest()
+    if args[0] == '--coverage':
+        top_n = 30
+        if '--top' in args:
+            top_n = int(args[args.index('--top') + 1])
+        return cmd_coverage(top_n)
+    path = args[0]
+    out, dict_name, report_only = None, 'pwg', False
+    i = 1
+    while i < len(args):
+        a = args[i]
+        if a == '--out':
+            out = args[i + 1]; i += 2
+        elif a == '--dict':
+            dict_name = args[i + 1]; i += 2
+        elif a == '--report':
+            report_only = True; i += 1
+        else:
+            raise SystemExit('unknown option: %s' % a)
+    if not report_only and out is None:
+        out = path   # in-place backfill
+    run(path, out, dict_name, report_only)
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/annotation_report.py
+++ b/RussianTranslation/src/annotation_report.py
@@ -27,6 +27,20 @@ they populate.
   python annotation_report.py --silent-for <key1>
         The lemma-level evidence_summary for one lemma: which authorities are silent /
         contradict / corroborate it.
+
+  python annotation_report.py --in kavya [--list]
+        Senses whose citations include >=1 curated genre in the given coarse bucket
+        (veda/kavya/epic/sastra/purana/kosha) — "which senses are attested in kāvya?"
+        (H339 W4). --list prints the matching key1/sense_tag rows.
+
+  python annotation_report.py --only veda [--list]
+        The stricter converse: senses whose recognised citation genre(s) are
+        EXCLUSIVELY the given bucket. A sense with no recognised citation genre at
+        all (genre == []) is UNKNOWN, never "only" — see --genre-report.
+
+  python annotation_report.py --genre-report
+        Coverage table: rows per coarse bucket (in / only), plus the count with no
+        recognised citation genre at all.
 """
 import argparse, json, os, sys
 from collections import Counter
@@ -39,6 +53,7 @@ STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
 
 RU_SOURCES = ['koch', 'kna', 'fri', 'smirnov', 'kow', 'grin12', 'grin3']
 NONRU_LANES = ['apte_hi', 'vedic_rituals_hi', 'kosha_syn', 'meulenbeld', 'corpus']
+GENRE_COARSE = ('veda', 'kavya', 'epic', 'sastra', 'purana', 'kosha')   # annotate_genres.py
 
 
 def load_rows(store):
@@ -89,6 +104,7 @@ def print_row(row):
     _line('renou', row.get('renou'))
     _line('renou_oldest', row.get('renou_oldest'))
     _line('genre', row.get('genre'))                    # H339 (folds in when populated)
+    _line('genre_coarse', row.get('genre_coarse'))       # H339
     if row.get('dcs_freq'):
         f = row['dcs_freq']
         _line('dcs_freq', 'band %s · genre %s · era %s' % (f.get('band'), f.get('genre'), f.get('era')))
@@ -183,6 +199,59 @@ def cmd_silent_for(rows, key1):
           % (summ.get('evidence_status'), summ.get('corpus_status')))
 
 
+# --- genre queries (H339 W4: annotate_genres.py's sense['genre']/sense['genre_coarse']) ---
+
+def attested_in(rows, coarse):
+    """Senses with >=1 citation mapped to `coarse` (may ALSO carry other genres)."""
+    return [r for r in rows if coarse in (r.get('genre_coarse') or [])]
+
+
+def attested_only_in(rows, coarse):
+    """Senses with a known genre set that is EXCLUSIVELY `coarse` — never conflates an
+    unmapped/uncited sense (genre == [], truly unknown) with 'only veda'."""
+    return [r for r in rows if (r.get('genre_coarse') or []) == [coarse]]
+
+
+def unknown_genre(rows):
+    """Senses with no recognised citation genre at all (uncited, or every cited siglum
+    unmapped) — distinct from every attested_only_in() result."""
+    return [r for r in rows if not (r.get('genre') or [])]
+
+
+def _fmt_row(r):
+    return '%s / %s' % (r.get('key1', '?'), r.get('sense_tag', '?'))
+
+
+def cmd_genre_in(rows, coarse, list_rows):
+    matches = attested_in(rows, coarse)
+    print('senses attested in %s: %d' % (coarse, len(matches)))
+    if list_rows:
+        for r in matches:
+            print('  ' + _fmt_row(r))
+
+
+def cmd_genre_only(rows, coarse, list_rows):
+    matches = attested_only_in(rows, coarse)
+    print('senses attested ONLY in %s: %d' % (coarse, len(matches)))
+    if list_rows:
+        for r in matches:
+            print('  ' + _fmt_row(r))
+
+
+def cmd_genre_report(rows):
+    n = len(rows)
+    annotated = sum(1 for r in rows if 'genre' in r)
+    if annotated == 0:
+        print('0/%d rows carry a genre field — run annotate_genres.py on the store first.' % n)
+        return
+    print('store rows: %d  (genre-annotated: %d, %.1f%%)' % (n, annotated, 100.0 * annotated / n))
+    print('unknown (no recognised citation genre): %d' % len(unknown_genre(rows)))
+    print()
+    print('%-8s %10s %10s' % ('coarse', 'in', 'only'))
+    for c in GENRE_COARSE:
+        print('%-8s %10d %10d' % (c, len(attested_in(rows, c)), len(attested_only_in(rows, c))))
+
+
 def main():
     ap = argparse.ArgumentParser(description='Query the annotated pwg_ru store.')
     ap.add_argument('selector', nargs='?', help='<key1>[~~subcard][#sense_tag]')
@@ -191,6 +260,10 @@ def main():
     ap.add_argument('--relation', choices=['provides', 'supports'])
     ap.add_argument('--source-summary', action='store_true')
     ap.add_argument('--silent-for', help='key1 whose lemma evidence_summary to print')
+    ap.add_argument('--in', dest='in_coarse', choices=GENRE_COARSE)
+    ap.add_argument('--only', dest='only_coarse', choices=GENRE_COARSE)
+    ap.add_argument('--genre-report', action='store_true')
+    ap.add_argument('--list', action='store_true')
     args = ap.parse_args()
 
     rows = load_rows(args.store)
@@ -200,6 +273,12 @@ def main():
         return cmd_silent_for(rows, args.silent_for)
     if args.by_source:
         return cmd_by_source(rows, args.by_source, args.relation)
+    if args.genre_report:
+        return cmd_genre_report(rows)
+    if args.in_coarse:
+        return cmd_genre_in(rows, args.in_coarse, args.list)
+    if args.only_coarse:
+        return cmd_genre_only(rows, args.only_coarse, args.list)
     if args.selector:
         return cmd_lookup(rows, args.selector)
     ap.print_help()

--- a/RussianTranslation/src/build_dcs_freq_dims.py
+++ b/RussianTranslation/src/build_dcs_freq_dims.py
@@ -133,14 +133,21 @@ def build_pos(sqlite_path):
 def text_registers(sqlite_path):
     """text_id -> set(register codes), resolved with build_dcs_renou's genre+name logic
     (genre route from dcs_texts_clean.json when the title matches; name-substring route
-    always). Returns (id->registers, coverage stats)."""
+    always). Returns (id->registers, coverage stats, unmatched).
+
+    unmatched is the list of (text_id, name) pairs whose title had NO clean-catalog
+    match at all (exact or normalized) — these are indistinguishable downstream from a
+    genuinely register-less text (medical/śāstra prose, nighaṇṭu) unless logged here.
+    Logging only (CODE_REVIEW_2026-07-04.md silent-lemma-loss item); not a join fix."""
     import build_dcs_renou as b
     exact, norm = b.load_clean()
     con = sqlite3.connect(sqlite_path)
     cur = con.cursor()
-    id2regs, resolved = {}, 0
+    id2regs, resolved, unmatched = {}, 0, []
     for tid, name in cur.execute('select text_id, name from text'):
         rec = exact.get(name) or norm.get(b._norm(name))
+        if rec is None:
+            unmatched.append((tid, name))
         genre = rec.get('genre') if rec else None
         date = rec.get('date') if rec else None
         regs = set(b.registers_for_text(genre, date, name.lower(), b._CONF_RANK['high']))
@@ -148,15 +155,24 @@ def text_registers(sqlite_path):
         id2regs[tid] = regs
         resolved += 1 if regs else 0
     con.close()
-    return id2regs, resolved
+    return id2regs, resolved, unmatched
 
 
 def build_genre(sqlite_path):
     """norm_lemma -> {register -> TOKEN count}. Tokens are counted per register of the
     text they occur in (a text in N registers contributes to each — union semantics, as
     in the Renou register layer). Texts with no Renou register (medical/śāstra prose,
-    nighaṇṭu, …) contribute to nothing — that ~24% of tokens is genuinely register-less."""
-    id2regs, _resolved = text_registers(sqlite_path)
+    nighaṇṭu, …) contribute to nothing — that ~24% of tokens is genuinely register-less.
+
+    Logs unmatched text_ids (no clean-catalog match at all) to stderr — see
+    text_registers docstring."""
+    id2regs, _resolved, unmatched = text_registers(sqlite_path)
+    if unmatched:
+        print('build_genre: %d/%d texts had NO clean-catalog title match (unmatched, '
+              'not genuinely register-less) — top 10 by text_id:' % (len(unmatched), len(id2regs)),
+              file=sys.stderr)
+        for tid, name in unmatched[:10]:
+            print('  text_id=%s  name=%r' % (tid, name), file=sys.stderr)
     con = sqlite3.connect(sqlite_path)
     cur = con.cursor()
     genre = collections.defaultdict(collections.Counter)

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3396,6 +3396,16 @@ def test_annotate_evidence_relation_semantics():
     annotate_evidence.selftest()
 
 
+def test_annotate_genres_sense_join():
+    """H339 (W4): per-sense citation genre join (annotate_genres.py). Pins its own
+    pure-function selftest — coarse-bucket rollup keyed off the curated genre label's
+    leading word (Kāvya/Veda/Epic/Śāstra/Purāṇa/Kośa), an unmapped-only citation set
+    stays [] (unknown, never conflated with 'only genre X'), and multi-genre senses
+    keep every cited bucket."""
+    import annotate_genres
+    annotate_genres.selftest()
+
+
 def test_audit_window_tag_routing():
     """H336/H-2: --window-tag routes window_status/report/requeue/judge-sample to
     src/pilot/output/<tag>/ instead of the flat singletons, so two accounts auditing
@@ -3564,6 +3574,7 @@ def main():
         test_corpus_gate_evidence_and_db_markers,
         test_promote_claim_contention,
         test_annotate_evidence_relation_semantics,
+        test_annotate_genres_sense_join,
         test_audit_window_tag_routing,
         test_denylist_torn_line_warns,
     ]


### PR DESCRIPTION
## Summary

Closes the H339 gap identified in the H335 capability audit ([PIPELINE_CAPABILITY_AUDIT_2026-07-08.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md) W4): "which senses appear in kāvya?" needed one join over machinery that already shipped (renou/sense_stratum).

- **[`src/annotate_genres.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/annotate_genres.py)** (new, sibling of `annotate_renou.py`): per sense, resolves `<ls>` citations to `ls_source_map.json`'s curated genre label(s) → `sense['genre']`, plus a coarse rollup → `sense['genre_coarse']` (kavya/veda/sastra/purana/epic/kosha). Reuses `renou.keys_in_text` verbatim. Unmapped/uncited senses stay `[]` (genuinely unknown, never conflated with "attested only in X"). `--coverage` reports unmapped sigla by citation mass (70.9% of PWG's 801,788 `<ls>` citations are mapped by the 45 curated works; top unmapped sigla listed below — data-curation note, not a build item).
- **`annotation_report.py`** folds in `--in <bucket>`, `--only <bucket>`, `--genre-report` (H337 landed since the audit doc was written, so queries fold in here per the handoff's contingency rather than a standalone script).
- **Second, clearly separated lane**: `annotate_dcs_freq.py` now attaches `dcs_registers` (per-lemma DCS register vector, frequency-weighted/corpus-attested) alongside the existing `dcs_freq.genre` counts — never merged with the citation-derived `genre` field, since the two answer different questions.
- **`build_dcs_freq_dims.py`**: fixed the silent-lemma-loss item from [CODE_REVIEW_2026-07-04.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/CODE_REVIEW_2026-07-04.md) — `text_registers()` now logs unmatched `text_id`s (title had no clean-catalog match at all) instead of silently treating them as register-less.

## Coverage note (data curation, not this PR's scope)

Top unmapped `<ls>` sigla by citation mass (`python src/annotate_genres.py --coverage`), candidates for extending `ls_source_map.json` beyond its current 45 works:

| siglum | citations |
|---|---|
| Verz. d. Oxf. H | 18537 |
| Spr. (II) | 8724 |
| Ind. St | 7521 |
| Verz. d. B. H | 4676 |
| SARVADARŚANAS | 4171 |
| KAUŚ | 3337 |
| TBR | 3320 |
| ŚABDAR | 3108 |
| PRAB | 2825 |
| N | 2811 |

## Genre taxonomy `@DECIDE`

Per the handoff, if unruled this PR builds per the recommendation already on file: `ls_source_map.json`'s 25 curated labels are canonical per-sense; the DCS-18 register vocabulary stays inside its own `dcs_registers` lane; no fourth taxonomy invented.

## Test plan

- [x] `python src/annotate_genres.py --selftest`
- [x] `python src/annotate_dcs_freq.py --selftest`
- [x] `python src/annotation_report.py --genre-report` / `--in kavya --list` / `--only veda --list` against the live store (39.6% of rows carry a recognised citation genre; 1303 senses in kāvya, 993 exclusively in veda)
- [x] `python src/pilot/lang_parity_check.py` — 33 entries, no drift (new `genre_sense_join_h339` SHARED entry added; hashes refreshed on entries pinning the two edited shared files)
- [x] `python src/pilot/window_selftest.py` — new `test_annotate_genres_sense_join` passes; ran full 104-test suite standalone (94 pass; the 9 pre-existing failures are gitignored-generated-artifact gaps — missing harness/rootmap files — unrelated to this change and reproduce identically on an unmodified checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)