### PR TITLE
H397: koch см. X cross-reference resolution for the evidence lane (H337 follow-up)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,24 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### H397 — koch `см. X` cross-reference resolution for the evidence lane (H337 follow-up)
+- New [`src/koch_xref.py`](src/koch_xref.py): resolves koch's bare `см. X` redirects
+  (3,472 of koch's 4,048 no-meaning entries — a headword pointing to a different
+  headword's real gloss) instead of reporting them as `silent`. Builds a Devanagari →
+  SLP1 crosswalk from koch's own self-describing `<devanagari> /iast/` headword prefix
+  (no external transliterator needed), resolves one hop (chain-safe up to 2, visited-set
+  cycle guard), and leaves genuinely unresolvable pointers untouched. 3,204/3,472
+  (92.3%) resolve dictionary-wide. `annotate_evidence.py`'s `gather()` now resolves the
+  koch lane before relation classification (`--no-resolve-xref` reproduces H337
+  exactly); resolved glosses carry a `«см.→» ` provenance prefix. Store backfill:
+  koch `provides` 143→155, `supports` 560→578, `silent` 79→74 (145-lemma current
+  store — the dictionary-wide 92.3% lift materializes further as more lemmas are
+  translated). See [PIPELINE_CAPABILITY_AUDIT_2026-07-08.md §W2](PIPELINE_CAPABILITY_AUDIT_2026-07-08.md#w2-extension--koch-см-x-cross-reference-resolution--executed-09-07-2026-h397).
+- Spot-checked 20 randomly-sampled resolved xrefs: all matched the redirect's stated
+  target headword, zero fabricated meanings.
+- LANG_PARITY: `koch_xref_resolution_h397`, INTENTIONAL-DIVERGENCE (koch is
+  Sanskrit→Russian only).
+
 ### H337 — per-sense evidence provenance retrofit + annotation_report query CLI (H335 W2)
 - New [`src/annotate_evidence.py`](src/annotate_evidence.py): deterministic, LLM-free
   backfill of corpus_gate's 7 evidence lanes onto the store as queryable per-sense

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -471,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -502,7 +502,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "4623e2f271a6d68cf2c76c0e144c3110bdd01a0526d55eb1804175cdf47059ef",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -521,7 +521,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "901ffd21e7db7e0ea6d0433c342166dab7caa5e1abe43ad04745a7a7f99b198a",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "2257f04cdca96b2aea51cd6d097358c43109977e1847d39ff59476cc5cf50863",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
       "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -623,7 +623,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -652,7 +652,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "901ffd21e7db7e0ea6d0433c342166dab7caa5e1abe43ad04745a7a7f99b198a",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -670,9 +670,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H337 (08-07-2026). The evidence lanes are inherently Russian: corpus_gate joins a PWG headword to the independent Sanskrit->RUSSIAN dictionaries (Кочергина/Кнауэр/Фриш/Смирнов/Коссович), the Гринцер specialist glossaries, and the SamudraManthanam RU-aligned corpus; the relation classifier tokenises Russian glosses. The EN pilot has no Sanskrit-English authority set wired here, so evidence retrofit is inherently RU-only — the same divergence already recorded for corpus_gate_evidence_markers_fl7_h321. annotation_report.py is a lang-neutral query CLI but reads the RU store; it would generalise if an EN correctness gate is ever built. Pinned by test_annotate_evidence_relation_semantics (annotate_evidence.py's own pure-function --selftest, no gate-source file IO so it runs in CI).",
     "tracking": "",
     "verified_sha256": {
-      "src/annotate_evidence.py": "4f3e3e4adb7b251de0e03ac407bab5c809f9d55275b84569baa8021f5bc6b491",
+      "src/annotate_evidence.py": "4d5991b82647e0f19382f170da253c302e99928161e2696f01f809dd5e688a99",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -691,7 +691,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "5e257d130318be4e903bb55444d70c88544af8725c115253235e5daed716ec51",
-      "src/pilot/window_selftest.py": "795a14d8af3593856493f72440957cdef498d01ea481e2371e3d7b0df61ff29a"
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   },
   {
@@ -709,6 +709,26 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/annotate_genres.py": "5eea7d5269c716d5c96ceb81be5c22358fe45542b066f66963a8fdd1562d89e3"
+    }
+  },
+  {
+    "id": "koch_xref_resolution_h397",
+    "mechanism": "koch_xref.py resolves koch's bare `см. X` cross-reference glosses (a redirect with no meaning of its own, e.g. `-aSrika` -> \"см. अश्रि अश्रिक -aśrika\") to the target headword's real gloss via a Devanagari self-header crosswalk harvested from koch.jsonl itself, chain-safe up to 2 hops with a visited-set cycle guard; annotate_evidence.py's gather() calls resolve_koch_lane() on the koch lane before best_relation/source_meaning_tokens run, so a resolvable redirect counts as provides/supports evidence instead of H337's `silent` classification",
+    "files": [
+      "src/koch_xref.py",
+      "src/annotate_evidence.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru"
+    ],
+    "verdict": "INTENTIONAL-DIVERGENCE",
+    "note": "H397 (09-07-2026, H337 follow-up). koch is a Sanskrit->RUSSIAN dictionary only (Кочергина); its `см.` (Russian \"see\") cross-reference marker and the Devanagari self-header crosswalk this module builds are RU-lexicographic conventions with no EN counterpart in this pipeline — same divergence basis already recorded for evidence_retrofit_annotate_h337 and corpus_gate_evidence_markers_fl7_h321. Pinned by test_koch_xref_resolution (koch_xref.py's own pure-function --selftest, no koch.jsonl file IO so it runs in CI).",
+    "tracking": "",
+    "verified_sha256": {
+      "src/koch_xref.py": "2a75adb79fc5296ae737bcc195fbb4f411b6d7c446b7cc69d571d52988b7a9ae",
+      "src/annotate_evidence.py": "4d5991b82647e0f19382f170da253c302e99928161e2696f01f809dd5e688a99",
+      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
     }
   }
 ]

--- a/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md
+++ b/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md
@@ -1,6 +1,6 @@
 # PWG→RU pipeline capability audit — 3-account concurrency · per-sense evidence provenance · case-government · per-sense genre (H335)
 
-_Created: 08-07-2026 · Last updated: 09-07-2026_
+_Created: 08-07-2026 · Last updated: 09-07-2026 (H397)_
 
 Audit-only pass answering MG's four capability questions of 08-07-2026
 ([H335](https://github.com/gasyoun/Uprava/blob/main/handoffs/H335-Fable_RussianTranslation_pipeline-capability-audit_08.07.26.md)).
@@ -243,6 +243,59 @@ reflects the current store content, not a defect. `silent` deliberately folds "a
 together with "present but no usable Russian meaning gloss" (Smirnov citation-lists,
 Kossovich bare transliteration); a source is marked `contradicts` only when it carries
 a real Russian gloss overlapping no sense — avoiding false-disagreement claims.
+
+### W2 extension — koch `см. X` cross-reference resolution — EXECUTED 09-07-2026 (H397)
+
+**Verdict: DELIVERED.** H337 measured koch (Кочергина) at the whole-dictionary level:
+**4,048 / 29,177 (13.9%)** entries carry no usable Russian meaning gloss, and
+**3,472 of those are bare `см. X` cross-references** (a redirect with no meaning of
+its own — `-aSrika` -> "см. अश्रि अश्रिक -aśrika" = "see aśri"), classified `silent`
+because the redirect target's real meaning lives under a *different* headword.
+[`src/koch_xref.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/koch_xref.py)
+resolves the pointer instead of reporting silence: ~94% of koch entries open with
+their own Devanagari headword immediately followed by `/iast/`
+(`रूपधारिन् /rūpa-dhārin/ ...`) — harvested across all of koch.jsonl, that
+self-describing prefix doubles as a Devanagari → SLP1 crosswalk with no external
+transliterator needed (reuses koch's own data). A `см. X` target's Devanagari token
+is looked up in that crosswalk and joined back into koch's own key1 index for the
+resolved gloss, chain-safe up to 2 hops with a visited-set cycle guard; unresolvable
+pointers are left untouched (still `silent` — never fabricated).
+
+**koch.jsonl-level resolution** (`python src/koch_xref.py --report`):
+
+| | count | % of bare xrefs |
+|---|--:|--:|
+| koch entries | 29,177 | — |
+| Devanagari head crosswalk (collisions: 4, first-wins) | 27,447 | — |
+| bare `см. X` xrefs | 3,472 | 100% |
+| **resolved** | **3,204** | **92.3%** |
+| unresolved (stay `silent`) | 268 | 7.7% |
+
+Target was ≥2,500/3,471 (H397 handoff stop condition) — met at 92.3%.
+
+`annotate_evidence.py`'s `gather()` calls `resolve_koch_lane()` on the koch lane
+before `best_relation`/`source_meaning_tokens` run (`--no-resolve-xref` reproduces
+H337 exactly). Store-level backfill re-run (145 lemmas currently translated — only
+some hold a koch xref, so the store-level lift is smaller than the dictionary-wide
+92.3%, but real):
+
+| source | provides (before→after) | supports (before→after) | contradicts (before→after) | silent (before→after) |
+|---|--:|--:|--:|--:|
+| koch | 143 → 155 (+12) | 560 → 578 (+18) | 14 → 17 (+3) | 79 → 74 (−5) |
+
+All other lanes (kna/fri/smirnov/kow/grin12/grin3/apte_hi/vedic_rituals_hi/kosha_syn/meulenbeld/corpus)
+unchanged — H397 touches only the koch lane. `rows with >=1 evidence` rose
+2,239 → 2,269 (+30, 19.9% → 20.1%). Resolved glosses carry a `«см.→» ` provenance
+prefix in `gloss_ref` so the annotation report shows they came from a redirect, not
+a direct koch gloss. Spot-checked 20 randomly-sampled resolved xrefs (`random.seed(42)`
+over the 3,204): all 20 targets matched the redirect's stated Devanagari headword with
+no fabricated meaning (e.g. `चञ्चू /cañcū/ см. चञ्चु` → `चञ्चु /cañcu/ f. клюв- нос`;
+`वेश्या /veśyā/ см. वेशवधू` → `वेशवधू /veśa-vadhū/ f. 1) любовница 2) куртизанка`).
+Annotated by Sonnet 5 (`claude-sonnet-5`). Pinned by
+`test_koch_xref_resolution` (`koch_xref.py`'s own pure-function `--selftest`, no
+koch.jsonl file IO so it runs in CI). LANG_PARITY: `koch_xref_resolution_h397`,
+INTENTIONAL-DIVERGENCE (koch is Sanskrit→Russian only, same basis as
+`evidence_retrofit_annotate_h337`).
 
 ---
 

--- a/RussianTranslation/src/annotate_evidence.py
+++ b/RussianTranslation/src/annotate_evidence.py
@@ -59,8 +59,14 @@ if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
 import corpus_gate as cg
+import koch_xref
 
 STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+
+# H397: resolve koch's bare `см. X` cross-refs to their target's real gloss before
+# best_relation/source_meaning_tokens run, so a resolvable redirect counts as
+# provides/supports evidence instead of silence. --no-resolve-xref reproduces H337 exactly.
+RESOLVE_KOCH_XREF = True
 
 # Russian-glossing, token-comparable authorities (relation = provides/supports/contradicts/silent).
 RU_SOURCES = ['koch', 'kna', 'fri', 'smirnov', 'kow', 'grin12', 'grin3']
@@ -165,6 +171,9 @@ def gather(idx, key1):
         ru['kow'].append(g)
     for g in cg.lookup_specialist(key1, None):
         ru[g['code']].append(g['gloss'])
+
+    if RESOLVE_KOCH_XREF and ru.get('koch'):
+        ru['koch'], _n_resolved = koch_xref.resolve_koch_lane(ru['koch'])
 
     sense_codes = {s['code'] for s in cg.lookup_sense(key1, None)}
     nonru = {
@@ -318,9 +327,14 @@ def main():
     ap.add_argument('--no-backup', action='store_true')
     ap.add_argument('--limit', type=int, default=None, help='annotate only the first N rows (smoke test)')
     ap.add_argument('--selftest', action='store_true')
+    ap.add_argument('--no-resolve-xref', dest='resolve_xref', action='store_false', default=True,
+                     help='disable H397 koch `см. X` xref resolution (reproduces H337 exactly)')
     args = ap.parse_args()
     if args.selftest:
         return selftest()
+
+    global RESOLVE_KOCH_XREF
+    RESOLVE_KOCH_XREF = args.resolve_xref
 
     idx = cg.load_index()
     if cg.evidence_status() != 'ok':

--- a/RussianTranslation/src/koch_xref.py
+++ b/RussianTranslation/src/koch_xref.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python
+"""koch_xref.py — resolve koch bare `см. X` cross-reference glosses to their target's
+real meaning gloss (H397, H337 evidence-lane follow-up).
+
+H337 measured koch: 4,048 / 29,177 (13.9%) entries carry no usable Russian meaning
+gloss, and 3,471 of those are `см. X` redirects (e.g. `-aSrika` -> "см. अश्रि अश्रिक
+-aśrika" = "see aśri"). `annotate_evidence.py` classifies these as `silent` via
+`source_meaning_tokens()` returning empty — correct but lossy: the real meaning lives
+under the target headword. This module resolves the pointer one (or two, chain-safe)
+hops and returns the target's real gloss, so the koch lane recovers signal instead of
+reporting silence for a resolvable redirect.
+
+Resolution strategy: koch glosses are Devanagari script, not the SLP1/IAST the store
+joins on, so there is no direct key1 lookup for a `см. X` target out of the box. But
+~94% of koch entries open with their OWN Devanagari headword followed by `/iast/`
+(`रूपधारिन् /rūpa-dhārin/ ...`) — that self-describing prefix, harvested across the
+whole koch.jsonl, doubles as a Devanagari -> SLP1 crosswalk with no external
+transliterator needed (reuses koch's own data, per the prior-art rule). A `см. X`
+target's Devanagari token is looked up in that crosswalk, then joined into koch's own
+key1 index for the resolved gloss.
+
+Deterministic, offline (no gate-source file IO happens at import time — lazy-loaded on
+first `resolve_koch_lane()` call, so `--selftest` stays pure-function / CI-safe like
+annotate_evidence.py's own selftest).
+
+  python koch_xref.py --report      # koch.jsonl xref resolution stats (no store write)
+  python koch_xref.py --selftest
+"""
+import argparse, json, os, re, sys
+from collections import defaultdict
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import corpus_gate as cg
+
+KOCH_PATH = os.path.join(HERE, 'koch.jsonl')
+MAX_HOPS = 2          # depth cap: A -> B (hop 1) -> C (hop 2); never further
+XREF_MARK = '«см.→» '   # «см.→» — provenance prefix on a resolved gloss
+
+_TAG_RE = re.compile(r'<[^>]+>')
+_PLACEHOLDER_RE = re.compile(r'\{T\d+\}')
+_RU_END = cg._RU_END                              # reuse the shared stemming suffix regex
+_CM_RE = re.compile(r'см\.\s*')
+_DEVA_RE = re.compile(r'[ऀ-ॿ]+')
+_HEAD_RE = re.compile(r'^([^\s/]+)\s*/([^/]+)/')  # leading "<devanagari> /<iast>/" self-header
+
+
+def has_meaning(text):
+    """True if `text` carries >=1 usable Russian content token (cf.
+    annotate_evidence.source_meaning_tokens — duplicated narrowly here to avoid a
+    circular import; same regex, same >=3-char-after-stemming rule)."""
+    if not text:
+        return False
+    t = _PLACEHOLDER_RE.sub(' ', text)
+    t = _TAG_RE.sub(' ', t)
+    for tok in re.findall(r'[а-яёА-ЯЁ]{2,}', t.lower()):
+        if len(_RU_END.sub('', tok)) >= 3:
+            return True
+    return False
+
+
+def is_bare_xref(gloss):
+    """A koch gloss that carries a `см.` redirect and no meaning of its own —
+    the H337 `silent`-via-xref case this module recovers."""
+    return bool(gloss) and 'см.' in gloss and not has_meaning(gloss)
+
+
+def extract_targets(gloss):
+    """Devanagari token(s) immediately following each `см.` occurrence, in order."""
+    out = []
+    for m in _CM_RE.finditer(gloss):
+        dm = _DEVA_RE.match(gloss[m.end():].lstrip())
+        if dm:
+            out.append(dm.group(0))
+    return out
+
+
+def load_koch_raw(path=KOCH_PATH):
+    entries = []
+    if not os.path.exists(path):
+        return entries
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                entries.append(json.loads(line))
+    return entries
+
+
+def build_resolution_index(entries):
+    """devanagari-headword -> slp1 (first-wins on the rare homograph collision), and
+    form_key(slp1) -> [glosses] (koch's own key1 index, mirrors corpus_gate.load_index's
+    aggregation for the koch lane alone)."""
+    head_to_slp1 = {}
+    key1_to_glosses = defaultdict(list)
+    collisions = 0
+    for e in entries:
+        g = e.get('gloss', '')
+        slp1 = e.get('slp1', '')
+        m = _HEAD_RE.match(g)
+        if m:
+            dev = m.group(1)
+            if dev in head_to_slp1 and head_to_slp1[dev] != slp1:
+                collisions += 1
+            else:
+                head_to_slp1.setdefault(dev, slp1)
+        k = cg.form_key(slp1)
+        if k:
+            key1_to_glosses[k].append(g)
+    return head_to_slp1, key1_to_glosses, collisions
+
+
+def resolve_one(gloss, head_to_slp1, key1_to_glosses, depth=0, visited=None):
+    """Resolve one bare `см. X` gloss to a target's real gloss, chain-safe.
+    Returns (resolved_gloss_or_None, target_key1_or_None, hops_used)."""
+    if visited is None:
+        visited = set()
+    if depth >= MAX_HOPS:
+        return None, None, depth
+    targets = extract_targets(gloss)
+    if not targets:
+        return None, None, depth
+    slp1 = head_to_slp1.get(targets[0])
+    if not slp1:
+        return None, None, depth              # target headword not in koch's own crosswalk
+    k = cg.form_key(slp1)
+    if not k or k in visited:
+        return None, None, depth              # cycle guard
+    visited.add(k)
+    for g in key1_to_glosses.get(k) or []:
+        if has_meaning(g):
+            return g, k, depth + 1
+    for g in key1_to_glosses.get(k) or []:      # target itself a further bare xref: one more hop
+        if is_bare_xref(g):
+            sub_g, sub_k, sub_depth = resolve_one(g, head_to_slp1, key1_to_glosses, depth + 1, visited)
+            if sub_g:
+                return sub_g, sub_k, sub_depth
+    return None, None, depth
+
+
+_HEAD_MAP = None
+_KEY1_GLOSSES = None
+_COLLISIONS = 0
+
+
+def _ensure_loaded():
+    global _HEAD_MAP, _KEY1_GLOSSES, _COLLISIONS
+    if _HEAD_MAP is None:
+        _HEAD_MAP, _KEY1_GLOSSES, _COLLISIONS = build_resolution_index(load_koch_raw())
+    return _HEAD_MAP, _KEY1_GLOSSES
+
+
+def resolve_koch_lane(glosses):
+    """Given the koch gloss list for one key1 (as assembled by corpus_gate.load_index),
+    replace each bare `см. X` pointer with its resolved target gloss (provenance-marked
+    with XREF_MARK), leaving unresolvable pointers untouched (they stay `silent`
+    downstream — never fabricate). Returns (new_glosses, n_resolved)."""
+    head_map, key1_glosses = _ensure_loaded()
+    out, n_resolved = [], 0
+    for g in glosses:
+        if not is_bare_xref(g):
+            out.append(g)
+            continue
+        resolved, _k, _hops = resolve_one(g, head_map, key1_glosses)
+        if resolved:
+            out.append(XREF_MARK + resolved)
+            n_resolved += 1
+        else:
+            out.append(g)
+    return out, n_resolved
+
+
+def report():
+    entries = load_koch_raw()
+    if not entries:
+        sys.stderr.write('koch.jsonl not found at %s — nothing to report.\n' % KOCH_PATH)
+        raise SystemExit(2)
+    head_map, key1_glosses, collisions = build_resolution_index(entries)
+    n_total = len(entries)
+    n_bare = 0
+    n_resolved = 0
+    n_unresolved = 0
+    for e in entries:
+        g = e.get('gloss', '')
+        if not is_bare_xref(g):
+            continue
+        n_bare += 1
+        resolved, _k, _hops = resolve_one(g, head_map, key1_glosses)
+        if resolved:
+            n_resolved += 1
+        else:
+            n_unresolved += 1
+    print('=== koch xref resolution ===')
+    print('koch entries          : %d' % n_total)
+    print('devanagari head map   : %d (collisions: %d, first-wins)' % (len(head_map), collisions))
+    print('bare `см. X` xrefs     : %d' % n_bare)
+    print('  resolved            : %d (%.1f%%)' % (n_resolved, 100.0 * n_resolved / max(1, n_bare)))
+    print('  unresolved (stay silent): %d' % n_unresolved)
+
+
+# ---- selftest (pure functions only — no koch.jsonl IO, so it runs in CI) --------------
+def selftest():
+    assert has_meaning('огонь, бог огня')
+    assert not has_meaning('см. अश्रि अश्रिक -aśrika')
+    assert not has_meaning('(A. pr. /ghaṭṭate/) см. घट्ट् II घट्ट् I -ghaṭṭ')
+    assert is_bare_xref('см. रूपधर')
+    assert is_bare_xref('रूपधारिन् /rūpa-dhārin/ см. रूपधर'), 'см. not at string start is still bare'
+    assert not is_bare_xref('तापनीय /tāpanīya/ 1) золотой 2) см. उपानिषद्'), 'has a real sense besides the xref'
+
+    assert extract_targets('см. अश्रि अश्रिक -aśrika') == ['अश्रि']
+    assert extract_targets('रूपधारिन् /rūpa-dhārin/ см. रूपधर') == ['रूपधर']
+    assert extract_targets('огонь, пламя') == []
+
+    head_map = {'रूपधर': 'rUpaDara', 'अश्रि': 'aSri', 'चक्र': 'cakra'}
+    fake_entries = [
+        {'slp1': 'rUpaDara', 'gloss': 'रूपधर /rūpa-dhara/ m. принявший облик'},
+        {'slp1': 'aSri', 'gloss': 'अश्रि /aśri/ f. край, грань'},
+        {'slp1': 'cakra', 'gloss': 'चक्र /cakra/ см. रूपधर'},          # a target that is ITSELF a bare xref
+    ]
+    key1_glosses = defaultdict(list)
+    for e in fake_entries:
+        key1_glosses[cg.form_key(e['slp1'])].append(e['gloss'])
+
+    resolved, k, hops = resolve_one('см. रूपधर', head_map, key1_glosses)
+    assert resolved == 'रूपधर /rūpa-dhara/ m. принявший облик', resolved
+    assert k == cg.form_key('rUpaDara') and hops == 1
+
+    resolved2, _k2, hops2 = resolve_one('см. अश्रि अश्रिक -aśrika', head_map, key1_glosses)
+    assert resolved2 == 'अश्रि /aśri/ f. край, грань', resolved2
+
+    # unresolvable: target not in the head map at all
+    r3, _k3, _h3 = resolve_one('см. नास्ति', head_map, key1_glosses)
+    assert r3 is None
+
+    # cycle guard: A -> см. A (self-pointing garbage) must terminate, not fabricate
+    head_map_cyc = {'A': 'a'}
+    key1_glosses_cyc = defaultdict(list, {cg.form_key('a'): ['см. A']})
+    r4, _k4, _h4 = resolve_one('см. A', head_map_cyc, key1_glosses_cyc)
+    assert r4 is None, 'a pure self-cycle must never resolve'
+
+    global _HEAD_MAP, _KEY1_GLOSSES
+    _saved = (_HEAD_MAP, _KEY1_GLOSSES)
+    _HEAD_MAP, _KEY1_GLOSSES = head_map, key1_glosses
+    try:
+        new_glosses, n = resolve_koch_lane(['см. रूपधर', 'огонь настоящий', 'см. नास्ति'])
+    finally:
+        _HEAD_MAP, _KEY1_GLOSSES = _saved
+    assert n == 1, (n, new_glosses)
+    assert new_glosses[0].startswith(XREF_MARK) and 'принявший облик' in new_glosses[0]
+    assert new_glosses[1] == 'огонь настоящий'
+    assert new_glosses[2] == 'см. नास्ति'          # unresolved -> left untouched, still silent
+
+    print('koch_xref selftest OK')
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--report', action='store_true')
+    ap.add_argument('--selftest', action='store_true')
+    args = ap.parse_args()
+    if args.selftest:
+        return selftest()
+    if args.report:
+        return report()
+    ap.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3565,6 +3565,16 @@ def test_annotate_genres_sense_join():
     annotate_genres.selftest()
 
 
+def test_koch_xref_resolution():
+    """H397 (H337 follow-up): koch's bare `см. X` cross-reference resolver — the
+    Devanagari self-header crosswalk, one-hop resolution, chain-safe cycle guard, and
+    the resolve_koch_lane() wrapper annotate_evidence.gather() calls. Pins
+    koch_xref.py's own pure-function selftest (no koch.jsonl file IO, so it runs in CI
+    where the gitignored src/*.jsonl dictionaries are absent)."""
+    import koch_xref
+    koch_xref.selftest()
+
+
 def test_audit_window_tag_routing():
     """H336/H-2: --window-tag routes window_status/report/requeue/judge-sample to
     src/pilot/output/<tag>/ instead of the flat singletons, so two accounts auditing
@@ -3734,6 +3744,7 @@ def main():
         test_promote_claim_contention,
         test_annotate_evidence_relation_semantics,
         test_annotate_genres_sense_join,
+        test_koch_xref_resolution,
         test_audit_window_tag_routing,
         test_denylist_torn_line_warns,
     ]


### PR DESCRIPTION
## Summary
- New [`src/koch_xref.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/koch_xref.py): resolves koch's bare `см. X` redirects (3,472 of koch's 4,048 no-meaning entries, H337) to their target headword's real gloss instead of reporting `silent`. Builds a Devanagari → SLP1 crosswalk from koch's own self-describing `<devanagari> /iast/` headword prefix (no external transliterator needed), resolves one hop (chain-safe up to 2, visited-set cycle guard). **3,204/3,472 (92.3%) resolve dictionary-wide** — target was ≥2,500.
- Wired into `annotate_evidence.py`'s `gather()` (`--no-resolve-xref` reproduces H337 exactly). Resolved glosses carry a `«см.→» ` provenance prefix.
- Store backfill (145 currently-translated lemmas): koch `provides` 143→155, `supports` 560→578, `silent` 79→74. All other lanes unchanged.
- Spot-checked 20 randomly-sampled resolved xrefs (`random.seed(42)`): all matched the redirect's stated target headword, zero fabricated meanings.
- `PIPELINE_CAPABILITY_AUDIT_2026-07-08.md` §W2 extended, CHANGELOG entry added, LANG_PARITY sibling entry `koch_xref_resolution_h397` (INTENTIONAL-DIVERGENCE).

## Test plan
- [x] `python src/annotate_evidence.py --selftest` — PASS
- [x] `python src/koch_xref.py --selftest` — PASS
- [x] `python src/koch_xref.py --report` — 3,204/3,472 (92.3%) resolved
- [x] `window_selftest.py::test_annotate_evidence_relation_semantics` + `test_koch_xref_resolution` — PASS
- [x] `python src/pilot/lang_parity_check.py` — 34 entries, no drift
- [x] Real backfill write against the live gitignored store, verified only `evidence`/`evidence_summary` fields changed
- [x] 20-sample spot-check of resolved xrefs — zero fabricated meanings

🤖 Generated with [Claude Code](https://claude.com/claude-code)