### PR TITLE
fix: fail closed on torn TM denylists

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1537,12 +1537,12 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- **FIX_PLAN_2026-07-09 P0 continuation — VERIFIED 09-07-2026 (Codex/GPT-5 + Sonnet 5 `claude-sonnet-5` PR pass).**
+- **FIX_PLAN_2026-07-09 P0 safety patch — PR READY 09-07-2026 (Codex/GPT-5).**
   P0 requeue/TM safeguards are present and now testable without old ignored runtime fixtures:
   `requeue_from_audit.py` forces `--no-tm` for defect/all requeues, appends card + fragment
-  denylist rows with atomic JSONL appends, `translation_memory.load_denylist()` warns on torn
+  denylist rows with atomic JSONL appends, `translation_memory.load_denylist()` fails closed on torn
   JSONL, and `window_selftest.py` covers defect fragment denylist, coordinator defect `--no-tm`,
-  window-tagged requeue output, and torn denylist warnings. Added hermetic `gam`/`ab` pilot
+  window-tagged requeue output, and torn denylist failure. Added hermetic `gam`/`ab` pilot
   fixtures inside `window_selftest.py` for the preflight tests and made stale harness provenance
   checks skip only when the old ignored `dah` input/rootmap artifacts are absent (the `tools: []`
   guard still runs). `LAUNCH_FUCKUPS.md`'s H317 `residual_status` was already fixed to the

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -207,7 +207,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "lang is a first-class parameter of the TM address (sha256(lang + ...)); --lang=ru|en both get full reuse.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "901ffd21e7db7e0ea6d0433c342166dab7caa5e1abe43ad04745a7a7f99b198a"
+      "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c"
     }
   },
   {
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -471,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -502,7 +502,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "4623e2f271a6d68cf2c76c0e144c3110bdd01a0526d55eb1804175cdf47059ef",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -520,8 +520,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H321 (code review 2026-07-04 item #3b): the fragment sidecar is content-addressed on the fragment SOURCE and was harvested append-only first-seen-wins with NO fidelity check, so a hand-edited/corrupt wf_output*.json (blanked or malformed senses) permanently poisoned reuse and a later good harvest of the same fsha could never override it. frag_senses_sane(senses, lang) keys on the CARD-shaped translation field ('russian'/'english') and is applied at BOTH harvest (never cache garbage; a cached-corrupt fsha maps to False so a good row overrides it) and serve (load_frag_tm drops any corrupt historical row). Entirely lang-agnostic — lang is a first-class parameter of frag_address/frag_senses_sane/load_frag_tm/build_frags, no RU/EN branch. Pinned by test_frag_tm_fidelity_gate_and_override. Extends translation_memory_card_and_fragment.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "901ffd21e7db7e0ea6d0433c342166dab7caa5e1abe43ad04745a7a7f99b198a",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "2257f04cdca96b2aea51cd6d097358c43109977e1847d39ff59476cc5cf50863",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
       "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -623,7 +623,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -651,8 +651,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
-      "src/pilot/translation_memory.py": "901ffd21e7db7e0ea6d0433c342166dab7caa5e1abe43ad04745a7a7f99b198a",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -672,7 +672,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "4d5991b82647e0f19382f170da253c302e99928161e2696f01f809dd5e688a99",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -691,7 +691,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "5e257d130318be4e903bb55444d70c88544af8725c115253235e5daed716ec51",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   },
   {
@@ -728,7 +728,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "2a75adb79fc5296ae737bcc195fbb4f411b6d7c446b7cc69d571d52988b7a9ae",
       "src/annotate_evidence.py": "4d5991b82647e0f19382f170da253c302e99928161e2696f01f809dd5e688a99",
-      "src/pilot/window_selftest.py": "f4e0ae4822a3fa5de54b059e17b134ea7f140268fd19ddfb936bff7b3e50b285"
+      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -112,6 +112,10 @@ SUGGEST_PROFILES = {
 _LOAD_TM_CACHE = {}
 
 
+class DenylistError(RuntimeError):
+    """A TM denylist cannot be trusted."""
+
+
 def tm_path(lang, out=None):
     return out or os.path.join(HERE, 'translation_memory.%s.json' % lang)
 
@@ -228,15 +232,12 @@ def load_denylist(path=None):
             try:
                 row = json.loads(line)
             except json.JSONDecodeError as e:
-                # H336/H-3: a torn/undecodable denylist line used to be silently DROPPED
-                # here, which silently re-enables TM reuse of gate-rejected content — the
-                # single scariest failure mode in the collision matrix. WARN loudly instead
-                # so a torn append (concurrent writer, crash mid-write) surfaces immediately
-                # rather than as a quiet correctness hole.
-                print('warning: torn/undecodable denylist line %d in %s (%s) — a gate-'
-                      'rejected address may be silently missing from the deny set: %r'
-                      % (lineno, p, e, line[:200]), file=sys.stderr)
-                continue
+                # H336/H-3 / P0.1: a torn denylist cannot be trusted. Continuing here can
+                # silently re-enable TM reuse of gate-rejected cards/fragments, so make the
+                # caller fix the append/merge before any TM lookup proceeds.
+                raise DenylistError(
+                    'torn/undecodable denylist line %d in %s (%s): %r' %
+                    (lineno, p, e, line[:200]))
             kind = row.get('kind')
             value = row.get('address') or row.get('fsha') or row.get('value')
             if kind in ('card', 'address') and value:

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3183,29 +3183,52 @@ def test_frag_groups_presplit_parity():
 
 def test_defect_fragment_denylist_round_trip():
     """H304 gate-outcome memory: a defect card's frag_prov fshas (requeue.defect.fshas.txt)
-    are appended to the TM denylist by requeue_from_audit, and load_frag_tm then refuses to
-    serve them — a gate-flagged fragment is never re-served by --tm=auto."""
+    are appended to the TM denylist by requeue_from_audit, card addresses are denylisted from
+    their raw input sha, and the runtime loaders then refuse to serve either class — a
+    gate-flagged card/fragment is never re-served by --tm=auto."""
     import requeue_from_audit as rfa
     import translation_memory as tm
     tmp = tempfile.mkdtemp()
+    inp = os.path.join(tmp, 'input')
+    os.makedirs(inp)
     deny_path = os.path.join(tmp, 'denylist.jsonl')
+    key = 'h304root~~h0'
+    raw_path = os.path.join(inp, key + '.raw.txt')
+    with open(raw_path, 'w', encoding='utf-8') as f:
+        f.write('flagged raw card')
+    card_address = 'ru:%s' % sha256(raw_path)
     fsha_good = tm.frag_address('ru', 'clean fragment')
     fsha_bad = tm.frag_address('ru', 'flagged fragment')
     fsha_file = os.path.join(tmp, 'requeue.defect.fshas.txt')
     with open(fsha_file, 'w', encoding='utf-8') as f:
         f.write(fsha_bad + '\n')
     old_dp = rfa.translation_memory.denylist_path
+    old_inp = rfa.INP
     rfa.translation_memory.denylist_path = lambda path=None: deny_path
+    rfa.INP = inp
     try:
-        n, nf = rfa.append_tm_denylist('h304root', [], 'defect', lang='ru',
+        n, nf = rfa.append_tm_denylist('h304root', [key], 'defect', lang='ru',
                                        fsha_file=fsha_file)
     finally:
         rfa.translation_memory.denylist_path = old_dp
-    if (n, nf) != (0, 1):
-        fail('append_tm_denylist defect fsha count: got %r, want (0, 1)' % ((n, nf),))
+        rfa.INP = old_inp
+    if (n, nf) != (1, 1):
+        fail('append_tm_denylist defect deny count: got %r, want (1, 1)' % ((n, nf),))
     deny = tm.load_denylist(deny_path)
+    if card_address not in deny['addresses']:
+        fail('defect card address missing from the loaded denylist address set')
     if fsha_bad not in deny['frags']:
         fail('defect fsha missing from the loaded denylist frag set')
+    card_tm = os.path.join(tmp, 'translation_memory.ru.json')
+    with open(card_tm, 'w', encoding='utf-8') as f:
+        json.dump({'schema': tm.CARD_SCHEMA, 'lang': 'ru', 'entries': {
+            card_address: {'id': card_address,
+                           'card': {'records': [{'senses': [{'russian': 'bad cached card'}]}]},
+                           'trust_level': tm.TRUST_MACHINE,
+                           'gate_status': 'machine_gated',
+                           'reuse_policy': 'auto_exact'}}}, f, ensure_ascii=False)
+    if tm.load_tm('ru', card_tm, denylist=deny_path):
+        fail('denylisted defect card still served by load_tm')
     senses = [{'tag': '1', 'german': 'x', 'russian': 'y'}]
     sidecar = os.path.join(tmp, 'translation_memory.frag.ru.jsonl')
     with open(sidecar, 'w', encoding='utf-8') as f:
@@ -3612,10 +3635,10 @@ def test_audit_window_tag_routing():
             shutil.rmtree(tag_dir)
 
 
-def test_denylist_torn_line_warns():
-    """H336/H-3: translation_memory.load_denylist must WARN loudly (stderr) on a torn/
-    undecodable JSONL line instead of silently dropping it — a silently-dropped denylist
-    row is a correctness hole (a gate-rejected address quietly becomes TM-reusable
+def test_denylist_torn_line_fails_loud():
+    """P0.1 / H336-H3: translation_memory.load_denylist must FAIL loudly on a torn/
+    undecodable JSONL line instead of continuing with a partial deny set — a silently-dropped
+    denylist row is a correctness hole (a gate-rejected address quietly becomes TM-reusable
     again), the scariest single entry in the H335 collision matrix."""
     import translation_memory as tm
     d = tempfile.mkdtemp()
@@ -3629,15 +3652,13 @@ def test_denylist_torn_line_warns():
     proc = subprocess.run(
         [sys.executable, '-c',
          "import sys; sys.path.insert(0, %r); import translation_memory as tm; "
-         "d = tm.load_denylist(%r); "
-         "assert 'ru:deadbeef' in d['addresses'], d; "
-         "print('OK')" % (HERE, path)],
+         "tm.load_denylist(%r)" % (HERE, path)],
         capture_output=True, text=True, encoding='utf-8')
-    if proc.returncode != 0 or 'OK' not in proc.stdout:
-        fail('load_denylist must still load the well-formed row past a torn line:\n%s\n%s'
-            % (proc.stdout, proc.stderr))
-    if 'torn' not in proc.stderr.lower() and 'undecodable' not in proc.stderr.lower():
-        fail('load_denylist must WARN on stderr for a torn/undecodable line, got:\n%s' % proc.stderr)
+    if proc.returncode == 0:
+        fail('load_denylist must fail on a torn line, got success:\n%s\n%s'
+             % (proc.stdout, proc.stderr))
+    if 'DenylistError' not in proc.stderr or 'torn/undecodable denylist line' not in proc.stderr:
+        fail('load_denylist must surface a DenylistError for a torn line, got:\n%s' % proc.stderr)
 
 
 def main():
@@ -3746,7 +3767,7 @@ def main():
         test_annotate_genres_sense_join,
         test_koch_xref_resolution,
         test_audit_window_tag_routing,
-        test_denylist_torn_line_warns,
+        test_denylist_torn_line_fails_loud,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
## PR Type
- [ ] data
- [ ] build
- [ ] docs
- [x] navigation

## Summary
- What changed: tightened the P0 TM safety path so a torn `translation_memory.denylist.jsonl` now raises `DenylistError` and fails closed; expanded `window_selftest.py` to prove defect requeues denylist both card addresses and fragment fshas, and that neither card TM nor fragment TM can re-serve them.
- Why this change exists: `FIX_PLAN_2026-07-09.md` makes operational P0 safety the immediate next target before BLI/WSD/COMET-style research work. A partial denylist is not trustworthy enough for TM reuse.

## Test Surface
- Automated checks:
  - `python -m py_compile src\pilot\translation_memory.py src\pilot\window_selftest.py src\pilot\lang_parity_check.py`
  - `python src\pilot\check_launch_ledger.py --since 2026-07-05`
  - `python src\pilot\window_selftest.py`
  - `python src\pilot\lang_parity_check.py`
- Manual checks: inspected existing P0 surfaces on current `origin/master`; defect/all requeues already pass `--no-tm`, child gate malformed/crash output is already fail-closed, and launch ledger closeout is already queryable by date/handoff.
- Pure helpers / decision points covered: `load_denylist`, `load_tm`, `load_frag_tm`, and `requeue_from_audit.append_tm_denylist` failure-mode fixtures.
- If build-related: import-safe verified? n/a

## Invariants
- Must stay true: gate-rejected card addresses and fragment fshas must never be served from TM when present in the denylist.
- Counts / alignment / join rules: no production generated artifacts are required; the added tests use hermetic temp fixtures.
- Source-of-truth assumptions: `translation_memory.denylist.jsonl` is append-only evidence; if it is torn or malformed, the only truthful behavior is to stop and repair it.
- What would count as regression: any malformed denylist row being silently skipped, or a defect card/fragment being served from TM after denylisting.

## Safety
- Fallback / failure mode: fail closed with `DenylistError` before TM lookup proceeds.
- Observable marker or sanity check: `PASS: test_denylist_torn_line_fails_loud` in `window_selftest.py`.
- Rebuild / validate / verify command: `python src\pilot\window_selftest.py && python src\pilot\lang_parity_check.py`

## Reader-Facing Done
- Navigation / entry point updated: `.ai_state.md` records the P0 safety patch as PR-ready.
- Docs / changelog / handoff updated: language-parity hashes restamped after the code/test change.
- Known limits or caveats exposed: this PR intentionally does not start BLI/WSD/COMET work; those remain deferred until gold samples and sufficient translated coverage exist.
- If not applicable, say why: no public-facing docs needed for this internal guardrail patch.

## Type-Specific Notes
- If `navigation`: this keeps the operational next-action state accurate while the roadmap remains strategic backlog.