### PR TITLE
docs(RussianTranslation): .ai_state.md — H397 completed note

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1779,6 +1779,23 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H397 — koch `см. X` cross-reference resolution — DONE 09-07-2026 (Sonnet 5
+  `claude-sonnet-5`).** New `src/koch_xref.py`: resolves koch's bare `см. X`
+  redirects (3,472 of koch's 4,048 no-meaning entries, H337) to the target
+  headword's real gloss via a Devanagari→SLP1 crosswalk harvested from koch's own
+  self-describing `<devanagari> /iast/` headword prefix (no external
+  transliterator). 3,204/3,472 (92.3%) resolve dictionary-wide (target was
+  ≥2,500), chain-safe up to 2 hops with a cycle guard, never fabricates. Wired
+  into `annotate_evidence.py`'s koch lane before relation classification
+  (`--no-resolve-xref` reproduces H337 exactly). Live store backfilled: koch
+  `provides` 143→155, `supports` 560→578, `silent` 79→74 (145-lemma current
+  store). 20-sample spot-check: zero fabricated meanings. `PIPELINE_CAPABILITY_AUDIT_2026-07-08.md`
+  §W2 extended, CHANGELOG entry added, `LANG_PARITY.md` sibling entry
+  `koch_xref_resolution_h397` (INTENTIONAL-DIVERGENCE). Built in an isolated
+  worktree since the main tree had an unresolved merge conflict from a
+  concurrent Codex session at the time; worktree removed after merge.
+  [SanskritLexicography PR #271](https://github.com/gasyoun/SanskritLexicography/pull/271) merged.
+
 - **FIX_PLAN_2026-07-09 closeout selftest portability — DONE 09-07-2026 (Codex/GPT-5).**
   `window_selftest.py` no longer fails in a checkout missing gitignored runtime
   rootmaps/inputs: perf-preflight tests now provision minimal temporary rootmap,


### PR DESCRIPTION
Small doc-only follow-up: records H397 (koch xref resolution, PR #271) in .ai_state.md's Completed section.