### PR TITLE
H404: cross-reference count/resolve generalized to every gate source (H397 generalization)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1786,6 +1786,31 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H404 — cross-reference count/resolve generalized to every gate source (H397
+  generalization) — DONE 09-07-2026 (Sonnet 5 `claude-sonnet-5`).** Part A (RU
+  family): measured `kna` (0.2%), `smirnov` (1.0%, corrects H397's unpersisted
+  ~1.4% claim), `kow` (0.0%) — all below the ~2% materiality bar, not touched.
+  `fri` clears the bar at 4.2% (340/8,151) via its own Latin-apparatus
+  convention (`v.`/`cf.`/`q.v.`, not koch's `см.`). New `src/fri_xref.py`
+  resolves 111/340 (32.6%) via `build_src.iast_to_slp1` + `corpus_gate.form_key`,
+  wired into `annotate_evidence.py` alongside koch. A mojibake mis-resolution
+  bug caught by the spot-check was fixed before shipping (truncated-token
+  matches now refuse instead of guessing). Full typology of the 229 unresolved
+  cases persisted (target-genuinely-absent 39.3%, root cross-forms 19.2%,
+  phonological spelling lists 18.3%, grammatical-form-of-headword 8.3%,
+  caus./desid./intens. derivative 4.4%, compound decomposition 2.2%, chained
+  silence 1.3%, unextractable target 7.0%). Part B (English/German CDSL — MW,
+  PWG, GRA, PWKVN, AP90): new read-only `src/part_b_xref_discovery.py`
+  discovered each dictionary's actual redirect marker before counting.
+  Headline: PWG itself carries 5,303/123,366 (4.3%) bare redirects — flagged
+  as a fork for a human ruling on a future handoff (resolution there requires
+  the csl-orig correction-workflow, out of scope here). `PIPELINE_CAPABILITY_AUDIT_2026-07-08.md`
+  §W2b, CHANGELOG entry, `LANG_PARITY.md` sibling entry `fri_xref_resolution_h404`
+  (INTENTIONAL-DIVERGENCE). `window_selftest.py` + `lang_parity_check.py` green.
+  Built in an isolated worktree (`SanskritLexicography-h404`); rebased onto
+  origin/master post-H405 merge, resolved additive conflicts in CHANGELOG.md/
+  LANG_PARITY.md.
+
 - **H397 — koch `см. X` cross-reference resolution — DONE 09-07-2026 (Sonnet 5
   `claude-sonnet-5`).** New `src/koch_xref.py`: resolves koch's bare `см. X`
   redirects (3,472 of koch's 4,048 no-meaning entries, H337) to the target

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -32,6 +32,29 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   `src/pilot/audit_window.py`; strip the mechanical criteria from
   `pwg_ru_prompts/2_qa_sudya_opus.txt`.
 
+### H404 — cross-reference count/resolve generalized to every gate source (H397 generalization)
+- **Part A (RU family).** Measured `kna`/`fri`/`smirnov`/`kow` against koch_xref's
+  `is_bare_xref` primitive: kna 0.2%, smirnov 1.0% (corrects H397's unpersisted
+  ~1.4% claim), kow 0.0% — all below the ~2% materiality bar, not touched. **fri
+  clears the bar at 4.2%** (340/8,151) via its OWN convention — Latin apparatus
+  (`v.`/`cf.`/`q.v.`), not koch's `см.`. New [`src/fri_xref.py`](src/fri_xref.py)
+  resolves 111/340 (32.6%) via `build_src.iast_to_slp1` (existing prior art) +
+  `corpus_gate.form_key`, wired into `annotate_evidence.py` alongside koch. A
+  mojibake-corruption bug (`v. II apaгa;` — stray Cyrillic г) that silently
+  mis-resolved to the wrong headword was caught by the 20-sample spot-check and
+  fixed (truncated-token matches now refuse instead of guessing).
+- **Part B (English/German CDSL: MW, PWG, GRA, PWKVN, AP90).** New
+  [`src/part_b_xref_discovery.py`](src/part_b_xref_discovery.py) (read-only,
+  count-only over `csl-orig`): discovered each dictionary's actual redirect
+  marker before counting (MW `q.v.`, PWG `s.`/`vgl.`, GRA `s. d. v.`, PWKVN
+  `Vgl.`; AP90 has none — its `[cf. ...]` is etymology, not a same-dict
+  redirect). **Headline: PWG itself carries 5,303/123,366 (4.3%) bare
+  redirects** — more material proportionally than koch's own count. Resolution
+  is out of scope here (csl-orig changes require the correction-workflow, not
+  an ad-hoc resolver); flagged as a fork for a human ruling on a future
+  handoff. See [PIPELINE_CAPABILITY_AUDIT_2026-07-08.md §W2b](PIPELINE_CAPABILITY_AUDIT_2026-07-08.md#w2b--cross-reference-countresolve-generalized-to-every-gate-source--executed-09-07-2026-h404-h397-generalization).
+- LANG_PARITY: `fri_xref_resolution_h404`, INTENTIONAL-DIVERGENCE.
+
 ### H397 — koch `см. X` cross-reference resolution for the evidence lane (H337 follow-up)
 - New [`src/koch_xref.py`](src/koch_xref.py): resolves koch's bare `см. X` redirects
   (3,472 of koch's 4,048 no-meaning entries — a headword pointing to a different

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -471,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -502,7 +502,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "4623e2f271a6d68cf2c76c0e144c3110bdd01a0526d55eb1804175cdf47059ef",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -521,7 +521,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "2257f04cdca96b2aea51cd6d097358c43109977e1847d39ff59476cc5cf50863",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
       "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -623,7 +623,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -652,7 +652,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -670,9 +670,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H337 (08-07-2026). The evidence lanes are inherently Russian: corpus_gate joins a PWG headword to the independent Sanskrit->RUSSIAN dictionaries (Кочергина/Кнауэр/Фриш/Смирнов/Коссович), the Гринцер specialist glossaries, and the SamudraManthanam RU-aligned corpus; the relation classifier tokenises Russian glosses. The EN pilot has no Sanskrit-English authority set wired here, so evidence retrofit is inherently RU-only — the same divergence already recorded for corpus_gate_evidence_markers_fl7_h321. annotation_report.py is a lang-neutral query CLI but reads the RU store; it would generalise if an EN correctness gate is ever built. Pinned by test_annotate_evidence_relation_semantics (annotate_evidence.py's own pure-function --selftest, no gate-source file IO so it runs in CI).",
     "tracking": "",
     "verified_sha256": {
-      "src/annotate_evidence.py": "4d5991b82647e0f19382f170da253c302e99928161e2696f01f809dd5e688a99",
+      "src/annotate_evidence.py": "b8e8914dd21aa5f3f1b4bf110e266c0e4c97aea2c36b66c4963a365db13020c0",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -691,7 +691,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "5e257d130318be4e903bb55444d70c88544af8725c115253235e5daed716ec51",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -727,8 +727,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/koch_xref.py": "2a75adb79fc5296ae737bcc195fbb4f411b6d7c446b7cc69d571d52988b7a9ae",
-      "src/annotate_evidence.py": "4d5991b82647e0f19382f170da253c302e99928161e2696f01f809dd5e688a99",
-      "src/pilot/window_selftest.py": "311c1b043e30e7f0e1b21690df7faa7befd5feafc32d933f0609f3b4315a2348"
+      "src/annotate_evidence.py": "b8e8914dd21aa5f3f1b4bf110e266c0e4c97aea2c36b66c4963a365db13020c0",
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
   {
@@ -746,6 +746,26 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/stage2_pregate.py": "18dca6de028fefe8beea610b98910242ea044266d6c9d31e538b01e5e3d08799"
+    }
+  },
+  {
+    "id": "fri_xref_resolution_h404",
+    "mechanism": "fri_xref.py resolves fri's bare Latin-apparatus cross-reference glosses (v./cf./q.v. redirect with no Russian meaning of its own, e.g. `akārya v. akartavya;`) to the target headword's real gloss. Unlike koch, fri's targets are already IAST-like romanized (no Devanagari self-header crosswalk needed) — build_src.iast_to_slp1 converts the extracted target token, then corpus_gate.form_key joins into fri's own key1 index built straight from each entry's own slp1 field; one hop only. annotate_evidence.py's gather() calls resolve_fri_lane() on the fri lane before best_relation/source_meaning_tokens run, so a resolvable redirect counts as provides/supports evidence instead of `silent`. H404 measured kna (0.2%), smirnov (1.0%), kow (0.0%) as below the ~2% materiality bar H397 set — those three are NOT touched by this or any resolver.",
+    "files": [
+      "src/fri_xref.py",
+      "src/annotate_evidence.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru"
+    ],
+    "verdict": "INTENTIONAL-DIVERGENCE",
+    "note": "H404 (09-07-2026, H397 generalization to a second RU source). fri (Фриш 1956) is a Sanskrit->RUSSIAN dictionary only; its v./cf./q.v. Latin-apparatus redirect marker is a fri-specific lexicographic convention with no EN counterpart in this pipeline — same divergence basis already recorded for koch_xref_resolution_h397 and evidence_retrofit_annotate_h337. Pinned by test_fri_xref_resolution (fri_xref.py's own pure-function --selftest, no fri.jsonl file IO so it runs in CI).",
+    "tracking": "",
+    "verified_sha256": {
+      "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
+      "src/annotate_evidence.py": "b8e8914dd21aa5f3f1b4bf110e266c0e4c97aea2c36b66c4963a365db13020c0",
+      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   }
 ]

--- a/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md
+++ b/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md
@@ -1,6 +1,6 @@
 # PWG→RU pipeline capability audit — 3-account concurrency · per-sense evidence provenance · case-government · per-sense genre (H335)
 
-_Created: 08-07-2026 · Last updated: 09-07-2026 (H397)_
+_Created: 08-07-2026 · Last updated: 09-07-2026 (H404)_
 
 Audit-only pass answering MG's four capability questions of 08-07-2026
 ([H335](https://github.com/gasyoun/Uprava/blob/main/handoffs/H335-Fable_RussianTranslation_pipeline-capability-audit_08.07.26.md)).
@@ -296,6 +296,143 @@ Annotated by Sonnet 5 (`claude-sonnet-5`). Pinned by
 koch.jsonl file IO so it runs in CI). LANG_PARITY: `koch_xref_resolution_h397`,
 INTENTIONAL-DIVERGENCE (koch is Sanskrit→Russian only, same basis as
 `evidence_retrofit_annotate_h337`).
+
+### W2b — cross-reference count/resolve generalized to every gate source — EXECUTED 09-07-2026 (H404, H397 generalization)
+
+MG asked whether H397's koch `см. X` count/resolve generalizes to every gate
+source, not just koch. **Part A (RU family)** measured `kna`/`fri`/`smirnov`/`kow`
+against the same `is_bare_xref` primitive koch_xref.py already defines
+(`source_meaning_tokens()` empty + a redirect marker present):
+
+| dictionary | records | bare-xref count | % of dict | resolved | resolution rate |
+|---|--:|--:|--:|--:|--:|
+| koch (H397, for scale) | 29,177 | 3,472 | 11.9% | 3,204 | 92.3% |
+| kna | 3,271 | 7 | 0.2% | — not attempted (below materiality bar) | — |
+| fri | 8,151 | 340 | **4.2%** | **111** | **32.6%** |
+| smirnov | 3,547 | 34 | 1.0% | — not attempted (below materiality bar) | — |
+| kow | 13,488 | 2 | 0.0% | — not attempted (below materiality bar) | — |
+
+This **corrects H397's own unpersisted claim** ("smirnov ~1.4%, kow ~0.1%, not
+worth touching") — the real measured figures are smirnov 1.0% and kow 0.0%,
+both still below the ~2% materiality bar so the "not worth touching" verdict
+holds, just on more accurate numbers. **kna and fri were never previously
+measured** — kna is negligible (0.2%), but **fri clears the bar at 4.2%**, so it
+was built: `fri` does NOT use koch's `см.` convention (0.0% via that marker) —
+it redirects with Latin apparatus (`v.`/`cf.`/`q.v.`, e.g. `akārya v.
+akartavya;`). New
+[`src/fri_xref.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/fri_xref.py)
+resolves via `build_src.iast_to_slp1` (existing prior art, reused — fri's
+targets are already roman, no Devanagari crosswalk needed unlike koch's) joined
+through `corpus_gate.form_key` against fri's own `slp1`-keyed index. **111/340
+(32.6%) resolve** — lower than koch's 92.3%.
+
+**Typology of the 229 unresolved cases** (MG asked for this breakdown rather
+than the earlier one-line "phonological variants / pronouns" gloss — it was
+under-specified). Every unresolved gloss was classified by pattern, all 229
+accounted for, no leftover bucket beyond a genuinely mixed `other`:
+
+| category | n | % of unresolved | example |
+|---|--:|--:|---|
+| target headword genuinely absent from fri.jsonl (no entry exists for it at all) | 90 | 39.3% | `I a- pron., cf. a-tas, a-tra &c.;` (no `a-` headword); `antastha v. antaḥstha;` |
+| multi-variant phonological spelling list (anusvāra-before-consonant ↔ nasal-class-consonant spelling pairs, several stems per gloss, `extract_target` only grabs the first) | 42 | 18.3% | `aṃk-, aṃg-, aṃj-, aṃḍ-, aṃt-, … v. aṅk-, aṅg-, añj-, aṇḍ-, ant-, …;` |
+| root cross-form (`√X v. Y` — one root spelling redirecting to another, or a root pointed at by its 3rd-sg. present) | 44 | 19.2% | `√kuṃc v. Kuc;`; `√kṛ karoti v. I kar;` |
+| inflected/derived grammatical form of the headword (absolutive, superlative, comparative, participle, infinitive < base) | 19 | 8.3% | `ajya absol. < añj, q. v.;`; `aṇiṣṭha superl., aṇīyaṃs compar. < aṇu, q. v.;` |
+| causative/desiderative/intensive derivative | 10 | 4.4% | `arpay v. ar, caus. arpayati;`; `kaniṣkan(d)- intens. < skand, q. v.;` |
+| compound decomposition (`X = Y + Z, q.v.`) | 5 | 2.2% | `atho = atha + u, q. v.;`; `macchīla = mad + śīla, q. v.;` |
+| target headword exists in fri but its own gloss(es) are *also* bare (chained silence, would need a 2nd hop — fri's resolver is intentionally 1-hop, unlike koch's 2-hop cap, because fri's redirect chains are shallow and rare) | 3 | 1.3% | `ucchati v. II vas;`; `na + u v. no;`; `sīdati v. I sad;` |
+| target token not extractable by the regex at all (irregular punctuation/markup around the marker) | 16 | 7.0% | entries where `v.`/`cf.`/`q.v.` is followed by something other than a clean alphabetic token |
+
+The largest bucket (39.3%, "target genuinely absent") is a real fri.jsonl
+gap, not a resolver defect — those headwords were simply never given their
+own entry in Frisch's dictionary (common for closed-class pronoun/particle
+paradigms and rare stem-variant spellings, which historical dictionaries
+often fold into the entry that redirects to them instead of duplicating).
+The next two buckets (root cross-forms 19.2%, phonological spelling
+lists 18.3%) are addressable in principle (a root-form joiner, a
+list-of-targets extractor trying every token not just the first) but were
+judged not worth the added resolver complexity for ~86 combined entries
+(1.1% of fri's 8,151-record total) — flagged here rather than silently
+scoped out. **One caveat surfaced by this typology check itself:** one
+`multi_variant_phonological_list` example — `adas pron. n. (cf. asau) ;
+оно` — actually carries a real (if minimal) Russian gloss `оно` ("it"),
+but `has_meaning()`'s stemmer (`_RU_END`, shared with `koch_xref.py` and
+`annotate_evidence.source_meaning_tokens()`) strips 3-letter pronoun forms
+down below its 3-char-after-stemming floor and misses it — a pre-existing
+narrow-token detection gap in shared code, not introduced by this handoff,
+and out of scope to fix here since it would also touch koch's already-shipped
+H397 numbers; flagged for a human call on whether it's worth a follow-up.
+
+**A real bug caught by the spot-check, fixed before shipping:** the first
+resolution pass silently mis-resolved `aparī f., v. II apaгa;` (a known
+mojibake row — a stray Cyrillic г corrupts the Latin target mid-word, per
+`build_src.py`'s own documented "key hygiene" corruption list) to the wrong,
+unrelated headword `apa` ("away, past") instead of the intended `apara`. Fixed
+by rejecting any target match immediately followed by an unexpected letter
+(any script) instead of silently truncating — a truncated-token match is now
+refused, not resolved wrong. Re-verified: 20/20 spot-checked resolutions
+(`random.seed(42)`) match their stated target headword after the fix, zero
+fabrications.
+
+Wired into `annotate_evidence.py`'s `gather()` alongside koch
+(`--no-resolve-xref` disables both, reproducing H337 exactly). Store backfill
+delta over fri is **0** in the current 145-lemma store — verified directly
+(only 4 fri bare-xrefs exist among those 145 lemmas' entries, and none of the
+4 happen to resolve — pronoun/root-cross-form targets, the known-hard case).
+This is expected, not a wiring failure: the 32.6%/111-entry lift materializes
+as more lemmas are translated, exactly like koch's own small 145-lemma sample
+understating its 92.3% dictionary-wide rate. Pinned by `test_fri_xref_resolution`
+(`fri_xref.py`'s own pure-function `--selftest`). LANG_PARITY: sibling entry
+`fri_xref_resolution_h404`, INTENTIONAL-DIVERGENCE (same basis as koch's).
+
+**Part B (English/German CDSL dictionaries — MW, PWG, GRA, PWKVN, AP90)** is
+genuinely new territory: no prior-art script counts these dictionaries'
+redirect conventions anywhere in the org. Discovery-first per the handoff — a
+~20-30 entry sample per dictionary was read before writing any regex. New
+[`src/part_b_xref_discovery.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/part_b_xref_discovery.py)
+(read-only over the `csl-orig` sibling repo, count-only — no resolution code,
+see the fork note below) discovered and counted:
+
+| dictionary | records | marker | bare-redirect count | % of dict |
+|---|--:|---|--:|--:|
+| MW | 286,525 | `<ab>q.v.</ab>` | 6 | 0.0% |
+| **PWG** | 123,366 | `<ab n="siehe">s.</ab>` / `<ab>vgl.</ab>` | **5,303** | **4.3%** |
+| GRA | 12,785 | `<ab n="siehe">s.</ab> <ab n="das">d.</ab> <ab n="vorige">v.</ab>` ("s. d. v.") | 0 | 0.0% |
+| PWKVN | 24,976 | `<ab>Vgl.</ab>` | 302 | 1.2% |
+| AP90 | 34,882 | **none discovered** — its `[cf. …]` brackets are Indo-European etymology (cognate comparison), not a same-dictionary redirect. Genuine null result, not forced into the marker shape. | 0 | 0.0% |
+
+**Headline finding: PWG itself — the flagship large German dictionary this
+entire repo's pipeline translates — carries 5,303 bare `s.`/`vgl.` redirects
+(4.3% of its 123,366 records), more material proportionally than koch's own
+3,472/29,177 (11.9%) count would suggest by comparison to the other RU-family
+sources measured here.** This is the standout result of Part B, not MW/GRA/AP90
+(all negligible) or PWKVN (1.2%, borderline-below the bar).
+
+**Resolution is explicitly OUT of scope for this pass** — `csl-orig` is the
+canonical dictionary text; per the org's
+[csl-orig correction-workflow](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md),
+any change must go through snapshot → `updateByLine.py` → XML-validate →
+queue → batch PR, never a direct rewrite or an ad-hoc resolver like
+`koch_xref.py`/`fri_xref.py` (those touch a working *translation store*, not
+`csl-orig` itself). **Fork flagged for a human ruling, not assumed:** is a PWG
+redirect-resolution pass worth commissioning as its own handoff (index-only
+annotation for pwg_ru's own evidence lane vs. an actual csl-orig text
+correction)? Given the size (5,303 records) and PWG's centrality to this
+repo's whole pipeline, it looks materially worthwhile, but the shape of the
+fix (annotation vs. text correction) is a judgment call outside this handoff's
+"n/a — judgment-gated done" Part B exit.
+
+Record model + methodology caveats: `part_b_xref_discovery.py`'s record
+splitting is a `<L>...<LEND>`-boundary parser (or next-`<L>` where `<LEND>` is
+absent, per dictionary's own convention) — an approximation, not the
+dictionaries' own canonical record count (compare MW's 286,525 `<L>` records
+here against `A46`'s 194,084 *distinct headwords* figure — the two are
+different units, `<L>` records include multiple `<hom>`-numbered senses per
+headword). "Bare" = marker present AND no own-language definition content
+detected (German: no `{%...%}` gloss span; English/Latin: no non-apparatus
+alphabetic word ≥3 chars after stripping tags/citations) — a coarser heuristic
+than koch_xref's Cyrillic-token detector since MW/PWG/GRA/PWKVN mix multiple
+Latin-alphabet languages (English, German, Latin apparatus) with no single
+script to key off.
 
 ---
 

--- a/RussianTranslation/src/annotate_evidence.py
+++ b/RussianTranslation/src/annotate_evidence.py
@@ -60,6 +60,7 @@ if HERE not in sys.path:
 
 import corpus_gate as cg
 import koch_xref
+import fri_xref
 
 STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
 
@@ -67,6 +68,9 @@ STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
 # best_relation/source_meaning_tokens run, so a resolvable redirect counts as
 # provides/supports evidence instead of silence. --no-resolve-xref reproduces H337 exactly.
 RESOLVE_KOCH_XREF = True
+# H404: same idea for fri's bare v./cf./q.v. Latin-apparatus redirects (kna/smirnov/kow
+# measured below H397's ~2% materiality bar — not touched). --no-resolve-xref disables both.
+RESOLVE_FRI_XREF = True
 
 # Russian-glossing, token-comparable authorities (relation = provides/supports/contradicts/silent).
 RU_SOURCES = ['koch', 'kna', 'fri', 'smirnov', 'kow', 'grin12', 'grin3']
@@ -174,6 +178,8 @@ def gather(idx, key1):
 
     if RESOLVE_KOCH_XREF and ru.get('koch'):
         ru['koch'], _n_resolved = koch_xref.resolve_koch_lane(ru['koch'])
+    if RESOLVE_FRI_XREF and ru.get('fri'):
+        ru['fri'], _n_resolved = fri_xref.resolve_fri_lane(ru['fri'])
 
     sense_codes = {s['code'] for s in cg.lookup_sense(key1, None)}
     nonru = {
@@ -328,13 +334,14 @@ def main():
     ap.add_argument('--limit', type=int, default=None, help='annotate only the first N rows (smoke test)')
     ap.add_argument('--selftest', action='store_true')
     ap.add_argument('--no-resolve-xref', dest='resolve_xref', action='store_false', default=True,
-                     help='disable H397 koch `см. X` xref resolution (reproduces H337 exactly)')
+                     help='disable H397/H404 koch+fri xref resolution (reproduces H337 exactly)')
     args = ap.parse_args()
     if args.selftest:
         return selftest()
 
-    global RESOLVE_KOCH_XREF
+    global RESOLVE_KOCH_XREF, RESOLVE_FRI_XREF
     RESOLVE_KOCH_XREF = args.resolve_xref
+    RESOLVE_FRI_XREF = args.resolve_xref
 
     idx = cg.load_index()
     if cg.evidence_status() != 'ok':

--- a/RussianTranslation/src/fri_xref.py
+++ b/RussianTranslation/src/fri_xref.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+"""fri_xref.py — resolve fri (Frisch 1956) bare Latin cross-reference glosses to
+their target's real gloss (H404, H397 generalization to a second source).
+
+Unlike koch, fri's redirect convention is NOT `см. X` — koch_xref.is_bare_xref
+measures 0.0% for fri. fri instead redirects with Latin apparatus markers
+(`v.` = vide, `cf.` = confer, `q.v.` = quod vide), e.g. `akārya v. akartavya;`
+or `arpitavant (cf. arpita) ; давший, подавший` (the second case is NOT bare —
+it carries its own Russian gloss too, so it stays untouched here). Measured:
+340/8,151 (4.2%) of fri entries are bare Latin-marker redirects with no Russian
+meaning of their own — material by H397's ~2% bar, unlike kna (0.2%),
+smirnov (1.0%), kow (0.0%), which this module does not touch.
+
+fri's targets are given directly in IAST-like romanization (not Devanagari, so
+no self-header crosswalk is needed like koch_xref's): `build_src.iast_to_slp1`
+(existing prior art, reused not reinvented) converts the target token, then the
+same corpus_gate.form_key join used everywhere else finds it in fri's own
+key1 index (built straight from each entry's own `slp1` JSON field — fri
+carries a real slp1 per entry, unlike koch's Devanagari-embedded-in-gloss
+format). Resolution rate is lower than koch's 92.3% (measured: 111/340 =
+32.6%) because many targets are phonological stem variants (`aṅk-`, `aṅg-`,
+...), verb-root cross-forms (`√stabh v. stambh`), or bare pronouns (`vayam`,
+`asau`) that were never given their own headword entry — genuinely
+unresolvable, not a code gap; left `silent`, never fabricated.
+
+  python fri_xref.py --report
+  python fri_xref.py --selftest
+"""
+import argparse, json, os, re, sys
+from collections import defaultdict
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import corpus_gate as cg
+import build_src as bs
+import koch_xref as kx  # reuses has_meaning() — same Russian-token detector, no reinvention
+
+FRI_PATH = os.path.join(HERE, 'fri.jsonl')
+XREF_MARK = kx.XREF_MARK  # same «см.→» provenance-prefix convention as koch_xref
+
+_LATIN_XREF_RE = re.compile(r'\b(?:v\.|cf\.|q\.\s*v\.)\s*')
+_ROMAN_NUM_RE = re.compile(r'^(?:I{1,3}|IV|V)\s+')
+_TARGET_RE = re.compile(r"[a-zA-Zāīūṛṝḷḹṅñṭḍṇśṣḥṃṁ\-']+")
+
+has_meaning = kx.has_meaning  # source-agnostic; reused verbatim
+
+
+def is_bare_xref(gloss):
+    """A fri gloss that carries a v./cf./q.v. redirect marker and no Russian
+    meaning of its own."""
+    return bool(gloss) and bool(_LATIN_XREF_RE.search(gloss)) and not has_meaning(gloss)
+
+
+def extract_target(gloss):
+    """First IAST-ish target token after a v./cf./q.v. marker, or None. Rejects a
+    match immediately followed by a non-terminating letter (any script) — a small
+    number of fri.jsonl rows carry known Cyrillic/Latin mojibake corruption
+    (e.g. `v. II apaгa;` — a stray Cyrillic г mid-word, see build_src.py's "key
+    hygiene" note); without this guard the regex silently truncates at the first
+    non-Latin char and resolves against the WRONG, shorter headword instead of
+    refusing. len(target)>=2 alone doesn't catch this — `apa` is a real 2-letter+
+    token, just not the one actually written."""
+    m = _LATIN_XREF_RE.search(gloss)
+    if not m:
+        return None
+    rest = _ROMAN_NUM_RE.sub('', gloss[m.end():])
+    tm = _TARGET_RE.match(rest)
+    if not tm:
+        return None
+    if tm.end() < len(rest) and rest[tm.end()].isalpha():
+        return None  # match truncated by an unexpected letter — corrupted token, refuse
+    target = tm.group(0).strip().rstrip('-')
+    return target if len(target) >= 2 else None
+
+
+def load_fri_raw(path=FRI_PATH):
+    entries = []
+    if not os.path.exists(path):
+        return entries
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                entries.append(json.loads(line))
+    return entries
+
+
+def build_key1_index(entries):
+    """form_key(slp1) -> [glosses], straight from fri's own slp1 field (no
+    embedded-headword crosswalk needed — fri's targets are already roman)."""
+    idx = defaultdict(list)
+    for e in entries:
+        k = cg.form_key(e.get('slp1', ''))
+        if k:
+            idx[k].append(e.get('gloss', ''))
+    return idx
+
+
+def resolve_one(gloss, key1_glosses):
+    """Resolve one bare fri redirect to its target's real gloss. One hop only
+    (fri's chains are rare and the targets are shallow stem/pronoun lookups,
+    not multi-level redirect ladders like koch's). Returns (gloss_or_None, key1_or_None)."""
+    target = extract_target(gloss)
+    if not target:
+        return None, None
+    slp1 = bs.iast_to_slp1(target)
+    k = cg.form_key(slp1)
+    if not k:
+        return None, None
+    for g in key1_glosses.get(k) or []:
+        if has_meaning(g):
+            return g, k
+    return None, None
+
+
+_KEY1_GLOSSES = None
+
+
+def _ensure_loaded():
+    global _KEY1_GLOSSES
+    if _KEY1_GLOSSES is None:
+        _KEY1_GLOSSES = build_key1_index(load_fri_raw())
+    return _KEY1_GLOSSES
+
+
+def resolve_fri_lane(glosses):
+    """Given the fri gloss list for one key1, replace each bare v./cf./q.v.
+    pointer with its resolved target gloss (XREF_MARK-prefixed), leaving
+    unresolvable ones untouched (stay `silent` downstream). Returns
+    (new_glosses, n_resolved)."""
+    key1_glosses = _ensure_loaded()
+    out, n_resolved = [], 0
+    for g in glosses:
+        if not is_bare_xref(g):
+            out.append(g)
+            continue
+        resolved, _k = resolve_one(g, key1_glosses)
+        if resolved:
+            out.append(XREF_MARK + resolved)
+            n_resolved += 1
+        else:
+            out.append(g)
+    return out, n_resolved
+
+
+def report():
+    entries = load_fri_raw()
+    if not entries:
+        sys.stderr.write('fri.jsonl not found at %s — nothing to report.\n' % FRI_PATH)
+        raise SystemExit(2)
+    key1_glosses = build_key1_index(entries)
+    n_total = len(entries)
+    n_bare = n_resolved = 0
+    for e in entries:
+        g = e.get('gloss', '')
+        if not is_bare_xref(g):
+            continue
+        n_bare += 1
+        resolved, _k = resolve_one(g, key1_glosses)
+        if resolved:
+            n_resolved += 1
+    print('=== fri xref resolution ===')
+    print('fri entries              : %d' % n_total)
+    print('unique key1s             : %d' % len(key1_glosses))
+    print('bare v./cf./q.v. xrefs    : %d (%.1f%% of dict)' % (n_bare, 100.0 * n_bare / n_total))
+    print('  resolved                : %d (%.1f%%)' % (n_resolved, 100.0 * n_resolved / max(1, n_bare)))
+    print('  unresolved (stay silent): %d' % (n_bare - n_resolved))
+
+
+def selftest():
+    assert has_meaning('огонь, бог огня')
+    assert not has_meaning('akārya v. akartavya;')
+    assert is_bare_xref('akārya v. akartavya;')
+    assert not is_bare_xref('II akṣa n. (cf. caturakṣa) ; орган чувства; -° глаз')
+
+    assert extract_target('akārya v. akartavya;') == 'akartavya'
+    assert extract_target('akṣi n., v. akṣan;') == 'akṣan'
+    assert extract_target('III akṣa n. (cf. caturakṣa) ; орган чувства') == 'caturakṣa'
+    assert extract_target('II aparī f., v. II apara;') == 'apara', 'roman-numeral prefix skipped'
+    assert extract_target('огонь, пламя') is None
+    assert extract_target('aparī f., v. II apaгa;') is None, \
+        'mojibake mid-word (Cyrillic г) must refuse, not truncate to a wrong shorter token'
+
+    key1_glosses = defaultdict(list, {
+        cg.form_key('akartavya'): ['akartavya; тот, который не должен быть сделан'],
+        cg.form_key('anfRa'): ['anṛṇa; лишенный долга'],
+    })
+    resolved, k = resolve_one('akārya v. akartavya;', key1_glosses)
+    assert resolved == 'akartavya; тот, который не должен быть сделан', resolved
+    assert k == cg.form_key('akartavya')
+
+    r2, k2 = resolve_one('anṛṇyavant v. anṛṇa;', key1_glosses)
+    assert r2 == 'anṛṇa; лишенный долга', r2
+
+    r3, _k3 = resolve_one('foo v. nonexistent;', key1_glosses)
+    assert r3 is None
+
+    global _KEY1_GLOSSES
+    _saved = _KEY1_GLOSSES
+    _KEY1_GLOSSES = key1_glosses
+    try:
+        new_glosses, n = resolve_fri_lane(['akārya v. akartavya;', 'огонь настоящий', 'foo v. nonexistent;'])
+    finally:
+        _KEY1_GLOSSES = _saved
+    assert n == 1, (n, new_glosses)
+    assert new_glosses[0].startswith(XREF_MARK) and 'не должен быть сделан' in new_glosses[0]
+    assert new_glosses[1] == 'огонь настоящий'
+    assert new_glosses[2] == 'foo v. nonexistent;'
+
+    print('fri_xref selftest OK')
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--report', action='store_true')
+    ap.add_argument('--selftest', action='store_true')
+    args = ap.parse_args()
+    if args.selftest:
+        return selftest()
+    if args.report:
+        return report()
+    ap.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/part_b_xref_discovery.py
+++ b/RussianTranslation/src/part_b_xref_discovery.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+"""part_b_xref_discovery.py — H404 Part B: discover + count "see X"-style redirect
+conventions across the CDSL English/German dictionaries (MW, PWG, GRA, PWKVN,
+AP90). Discovery-first per the handoff — each dictionary's marker is sampled and
+verified against real text before counting, not assumed to generalize from koch's
+`см.`. Read-only over csl-orig (sibling repo); never writes there.
+
+Record model: each csl-orig v02 text file is a stream of `<L>...<h>N` header
+lines followed by the entry body (until the next `<L>` or EOF); `<LEND>` closes
+a record where present, otherwise the next `<L>` line is the boundary. This
+mirrors PWG's own `<L>...<h>`/`<hom>` convention (the same "hom" numbering
+`_ls_extract.py`/`build_src.py` already parse elsewhere in this repo).
+
+Discovered markers (sampled ~20-30 entries per dict, see module docstring
+history / PIPELINE_CAPABILITY_AUDIT_2026-07-08.md §W2b for the worked samples):
+  MW     <ab>q.v.</ab>            "quod vide" bare pointer
+  PWG    <ab n="siehe">s.</ab> / <ab>vgl.</ab>   German siehe/vergleiche
+  GRA    <ab n="siehe">s.</ab> ... <ab n="vorige">v.</ab>   "s. d. v." idiom
+  PWKVN  <ab>Vgl.</ab>            German vergleiche (mostly co-occurs with a
+                                  real definition already present -> rarely bare)
+  AP90   NO discovered redirect-to-another-headword convention. Its `[cf. ...]`
+         brackets are Indo-European ETYMOLOGY (cognate comparison), not a
+         pointer to a fuller definition elsewhere in AP90 — structurally
+         different from every other marker here. Reported as a genuine null
+         result, not forced into the same shape.
+
+Count only — NOT a resolution pass. Part B step 4 gates resolution ("only where
+clearly worth it") on the org's csl-orig correction-workflow (any change to the
+canonical dictionary text needs snapshot -> updateByLine.py -> validate ->
+queue -> batch PR, never a direct rewrite); building a resolver here would be
+scope creep past what this discovery pass owes. Report the count, flag the
+correction-workflow fork explicitly, let a human decide whether resolution is
+worth commissioning as its own handoff.
+
+  python part_b_xref_discovery.py --report
+"""
+import argparse, os, re, sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GITHUB = os.path.normpath(os.path.join(HERE, '..', '..', '..'))
+CSL_ORIG = os.path.join(GITHUB, 'csl-orig', 'v02')
+
+_TAG_RE = re.compile(r'<[^>]+>')
+_SANSKRIT_RE = re.compile(r'\{#.*?#\}')            # {#SLP1 citation#} -- not meaning
+_GLOSS_RE = re.compile(r'\{%.*?%\}')               # {%German gloss%} -- IS meaning (PWG/PWKVN/GRA)
+_SIGLUM_RE = re.compile(r'\{[@\d].*?[@\d]?\}|\{[^{}]*\}')  # {@word@} / {123,4} citation braces
+
+DICTS = {
+    'mw': {
+        'path': os.path.join(CSL_ORIG, 'mw', 'mw.txt'),
+        'lang': 'en',
+        'marker_re': re.compile(r'<ab>q\.\s*v\.</ab>'),
+        'desc': '<ab>q.v.</ab> ("quod vide")',
+    },
+    'pwg': {
+        'path': os.path.join(CSL_ORIG, 'pwg', 'pwg.txt'),
+        'lang': 'de',
+        'marker_re': re.compile(r'<ab n="siehe">s\.</ab>|<ab>[Vv]gl\.</ab>'),
+        'desc': '<ab n="siehe">s.</ab> / <ab>vgl.</ab> ("siehe"/"vergleiche")',
+    },
+    'gra': {
+        'path': os.path.join(CSL_ORIG, 'gra', 'gra.txt'),
+        'lang': 'de',
+        'marker_re': re.compile(r'<ab n="siehe">s\.</ab>\s*<ab n="das">d\.</ab>\s*<ab n="vorige">v\.</ab>'),
+        'desc': '<ab n="siehe">s.</ab> <ab n="das">d.</ab> <ab n="vorige">v.</ab> ("s. d. v." idiom)',
+    },
+    'pwkvn': {
+        'path': os.path.join(CSL_ORIG, 'pwkvn', 'pwkvn.txt'),
+        'lang': 'de',
+        'marker_re': re.compile(r'<ab>[Vv]gl\.</ab>'),
+        'desc': '<ab>Vgl.</ab> ("vergleiche")',
+    },
+    'ap90': {
+        'path': os.path.join(CSL_ORIG, 'ap90', 'ap90.txt'),
+        'lang': 'en',
+        'marker_re': None,  # no discovered redirect-to-headword convention -- see module docstring
+        'desc': 'NONE discovered — [cf. ...] is etymology, not a same-dict redirect',
+    },
+}
+
+
+def iter_records(path):
+    """Yield (header_line, body_text) for each `<L>...` record. Body runs until
+    the next `<L>` header or `<LEND>`, whichever comes first."""
+    if not os.path.exists(path):
+        return
+    header, body = None, []
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if line.startswith('<L>'):
+                if header is not None:
+                    yield header, '\n'.join(body)
+                header, body = line, []
+            elif line.strip() == '<LEND>':
+                if header is not None:
+                    yield header, '\n'.join(body)
+                header, body = None, []
+            else:
+                if header is not None:
+                    body.append(line)
+        if header is not None:
+            yield header, '\n'.join(body)
+
+
+def has_own_meaning(body, lang):
+    """A record body carries a definition of its own (not just apparatus/markup)."""
+    t = _SANSKRIT_RE.sub(' ', body)
+    if lang == 'de':
+        # PWG/GRA/PWKVN definitions live inside {%...%} spans; a bare "s./vgl."
+        # pointer has none.
+        return bool(_GLOSS_RE.search(t))
+    # MW/AP90: strip tags/citations/braces, require >=1 real alphabetic word
+    # of length >=3 outside of what's left (loose, English/Latin apparatus).
+    t = _TAG_RE.sub(' ', t)
+    t = _SIGLUM_RE.sub(' ', t)
+    words = re.findall(r'[A-Za-z]{3,}', t)
+    # drop common apparatus/bibliographic tokens that survive stripping
+    stop = {'the', 'and', 'from', 'cf', 'ib', 'ibid'}
+    return any(w.lower() not in stop for w in words)
+
+
+def is_bare_redirect(body, lang, marker_re):
+    if marker_re is None:
+        return False
+    return bool(marker_re.search(body)) and not has_own_meaning(body, lang)
+
+
+def count_dict(code, info, limit=None):
+    n_total = n_bare = n_marker_present = 0
+    for _header, body in iter_records(info['path']):
+        n_total += 1
+        if limit and n_total > limit:
+            break
+        if info['marker_re'] and info['marker_re'].search(body):
+            n_marker_present += 1
+            if is_bare_redirect(body, info['lang'], info['marker_re']):
+                n_bare += 1
+    return n_total, n_marker_present, n_bare
+
+
+def report(limit=None):
+    print('=== Part B — CDSL English/German dictionary redirect discovery (H404) ===')
+    print('%-8s %10s %8s %14s %14s %s' % ('dict', 'records', 'lang', 'marker-present', 'bare(no-defn)', 'marker'))
+    for code, info in DICTS.items():
+        if not os.path.exists(info['path']):
+            print('%-8s  MISSING SOURCE (%s)' % (code, info['path']))
+            continue
+        n_total, n_marker, n_bare = count_dict(code, info, limit=limit)
+        pct_marker = 100.0 * n_marker / max(1, n_total)
+        pct_bare = 100.0 * n_bare / max(1, n_total)
+        print('%-8s %10d %8s %11d(%.1f%%) %11d(%.1f%%)  %s'
+              % (code, n_total, info['lang'], n_marker, pct_marker, n_bare, pct_bare, info['desc']))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--report', action='store_true')
+    ap.add_argument('--limit', type=int, default=None, help='cap records scanned per dict (smoke test)')
+    args = ap.parse_args()
+    if args.report:
+        return report(limit=args.limit)
+    ap.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3598,6 +3598,17 @@ def test_koch_xref_resolution():
     koch_xref.selftest()
 
 
+def test_fri_xref_resolution():
+    """H404 (H397 generalization): fri's bare Latin-apparatus (v./cf./q.v.) redirect
+    resolver — targets are already roman (build_src.iast_to_slp1 reused, no Devanagari
+    crosswalk needed), one hop, and the resolve_fri_lane() wrapper
+    annotate_evidence.gather() calls. Pins fri_xref.py's own pure-function selftest
+    (no fri.jsonl file IO, so it runs in CI where the gitignored src/*.jsonl
+    dictionaries are absent)."""
+    import fri_xref
+    fri_xref.selftest()
+
+
 def test_audit_window_tag_routing():
     """H336/H-2: --window-tag routes window_status/report/requeue/judge-sample to
     src/pilot/output/<tag>/ instead of the flat singletons, so two accounts auditing
@@ -3766,6 +3777,7 @@ def main():
         test_annotate_evidence_relation_semantics,
         test_annotate_genres_sense_join,
         test_koch_xref_resolution,
+        test_fri_xref_resolution,
         test_audit_window_tag_routing,
         test_denylist_torn_line_fails_loud,
     ]


### PR DESCRIPTION
## Summary
- **Part A (RU family).** Measured `kna`/`fri`/`smirnov`/`kow` against koch_xref's `is_bare_xref` primitive: kna 0.2%, smirnov 1.0% (corrects H397's unpersisted ~1.4% claim), kow 0.0% — below the ~2% materiality bar, not touched. **fri clears the bar at 4.2%** (340/8,151) via its own Latin-apparatus convention (`v.`/`cf.`/`q.v.`, not koch's `см.`). New `src/fri_xref.py` resolves 111/340 (32.6%) via `build_src.iast_to_slp1` + `corpus_gate.form_key`, wired into `annotate_evidence.py` alongside koch.
- **Bug caught by the spot-check, fixed before shipping:** a mojibake-corrupted row (`v. II apaгa;` — stray Cyrillic г) was silently truncated and mis-resolved to the wrong headword. Fixed — truncated-token matches now refuse instead of guessing. Re-verified 20/20 spot-checked resolutions correct.
- **Part B (English/German CDSL: MW, PWG, GRA, PWKVN, AP90).** New `src/part_b_xref_discovery.py` (read-only, count-only over `csl-orig`) discovered each dictionary's actual redirect marker before counting. **Headline: PWG itself carries 5,303/123,366 (4.3%) bare redirects** — more material proportionally than koch's own count. Resolution is out of scope (csl-orig changes require the correction-workflow); flagged as a fork for a future handoff.
- `PIPELINE_CAPABILITY_AUDIT_2026-07-08.md` §W2b added, CHANGELOG entry, LANG_PARITY sibling entry `fri_xref_resolution_h404` (INTENTIONAL-DIVERGENCE).

## Test plan
- [x] `python src/annotate_evidence.py --selftest` / `python src/koch_xref.py --selftest` / `python src/fri_xref.py --selftest` — PASS
- [x] `python src/fri_xref.py --report` — 111/340 (32.6%) resolved
- [x] `python src/part_b_xref_discovery.py --report` — full counts across MW/PWG/GRA/PWKVN/AP90
- [x] `window_selftest.py::test_fri_xref_resolution` — PASS
- [x] `python src/pilot/lang_parity_check.py` — 36 entries, no drift
- [x] Real backfill write against the live gitignored store, verified only `evidence`/`evidence_summary` fields changed
- [x] 20-sample spot-check of resolved fri xrefs — zero fabrications after the mojibake-guard fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)