### PR TITLE
feat(RussianTranslation): H405 wire Stage-2 pre-gate into audit_window_en.py (EN parity)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,8 +12,8 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
-- **H405 Stage-2 mechanical pre-gate — RU WIRING DONE 09-07-2026 (Opus 4.8 `claude-opus-4-8`); only the EN port remains.**
-  [`src/stage2_pregate.py`](src/stage2_pregate.py) built + selftest-green + LANG_PARITY SHARED; measured 99.72% CLEAN / 0.10% hard-FAIL over the 11,261-row store (13 real defects surfaced). `--wf` window-gate mode wired into [`src/pilot/audit_window.py`](src/pilot/audit_window.py) as `stage2_mechanical`; mechanical criteria stripped from both judge prompts ([`2_qa_sudya_opus.txt`](pwg_ru_prompts/2_qa_sudya_opus.txt) + YandexGPT twin); `window_selftest.py` green. **Remaining:** wire the pre-gate into the EN auditor [`src/pilot/audit_window_en.py`](src/pilot/audit_window_en.py) — it audits in-process per-card (not the file-pair subprocess model), so it needs an in-process adapter feeding `audit_card`'s (source, translation) to `pregate()`. Tracked as GAP `stage2_pregate_en_wiring_h405` in [LANG_PARITY.md](LANG_PARITY.md).
+- **H405 Stage-2 mechanical pre-gate — FULLY DONE 09-07-2026 (Opus 4.8 `claude-opus-4-8`), RU + EN.**
+  [`src/stage2_pregate.py`](src/stage2_pregate.py) built + selftest-green; measured 99.72% CLEAN / 0.10% hard-FAIL over the 11,261-row store (13 real defects surfaced). `--wf` window-gate mode wired into [`src/pilot/audit_window.py`](src/pilot/audit_window.py) as `stage2_mechanical`; mechanical criteria stripped from both judge prompts ([`2_qa_sudya_opus.txt`](pwg_ru_prompts/2_qa_sudya_opus.txt) + YandexGPT twin). EN auditor [`src/pilot/audit_window_en.py`](src/pilot/audit_window_en.py) wired via in-process `audit_sense`→`pregate(g,e)` adapter contributing only net-new hard flags (IS-LOSS, STRANDED-ANCHOR, anchor backstops); LS/SAN/AB stay owned by `audit_sense`. Parity GAP closed → `stage2_pregate_en_wiring_h405` SHARED; LANG_PARITY 37 entries no drift; `window_selftest.py` green. No follow-ups.
 
 - **H317 pwg-ru medium50 test — resume once a clean environment is confirmed.** Closed this
   session at 0/50 promoted (transient API instability + kill-gate cascade, see the Completed

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -34,8 +34,15 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   `stage2_mechanical` gate, so a hard-failed card joins the requeue. Mechanical criteria
   stripped from both judge prompts ([`2_qa_sudya_opus.txt`](pwg_ru_prompts/2_qa_sudya_opus.txt)
   + YandexGPT twin) — the judge now rules only on semantics (`anchors` kept as a backstop).
-  `window_selftest.py` green. The EN auditor (`audit_window_en.py`, in-process per-card) is a
-  tracked GAP (`stage2_pregate_en_wiring_h405`).
+  `window_selftest.py` green.
+- **EN auditor wired too (09-07-2026).** [`src/pilot/audit_window_en.py`](src/pilot/audit_window_en.py)
+  audits in-process per-sense, so `audit_sense(german, english)` now calls `pregate(g, e)` and
+  folds in only the net-new hard flags its own checks lack — `IS-LOSS` (the EN `AB` regex omits
+  `<is>`), `STRANDED-ANCHOR`, and the anchor-leak/mismatch backstops — while `LS/SAN/AB` stay
+  owned by `audit_sense` (no double-reporting); these were added to the `HARD` tuple so `--strict`
+  fails on them. Parity GAP closed: `stage2_pregate_en_wiring_h405` → SHARED. Both editions now
+  run the same `pregate()` module; only the adapter differs (RU: subprocess `--wf` over file
+  pairs; EN: in-process per-sense).
 
 ### H404 — cross-reference count/resolve generalized to every gate source (H397 generalization)
 - **Part A (RU family).** Measured `kna`/`fri`/`smirnov`/`kow` against koch_xref's

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -280,7 +280,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
       "src/pilot/prompt_rule_audit.py": "d2c578eb62a1919c5c22c0726940df952dee7ead0791bf61d1a1bc7c83f26fdf",
       "src/pilot/audit_window.py": "2a0478b0779e1aba2bf2e2a0e7d5b50807f7acccf44ae4b00a7dc3af3ff29005",
-      "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2"
+      "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a"
     }
   },
   {
@@ -373,7 +373,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H169 (2026-07-04 review, 'broken validators'): the advertised HARD DUP gate was never emitted -- the only within-record duplicate signal was soft SAME-GLOSS, gated on >=3 content words, so a short duplicate ('to go'/'to go') produced zero flags and --strict passed. Classified GAP-being-closed rather than INTENTIONAL-DIVERGENCE: RU's within-record duplicate protection is the cross-part audit_sense_dupes.py gate (already SHARED, see gate_fixes_20260703_ru_only/PR #135) plus the soft, all-senses-only identical_russian_glosses risk in prompt_rule_audit.py (MEDIUM, not high-confidence) -- neither is a pairwise HARD gate. EN now closes that with a real HARD pairwise DUP check; RU getting an equivalent pairwise HARD gate (rather than its current all-or-nothing soft signal) is left as a natural follow-up, not blocking this fix. Pinned by test_en_gate_dup_has_teeth in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2",
+      "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a",
       "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
     }
   },
@@ -743,7 +743,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "H405 (09-07-2026, PIPELINE_CAPABILITY_AUDIT W5 recommendation). Language-agnostic by construction: it compares markup/anchor STRUCTURE across the source↔translation pair and never inspects meaning, so the RU and EN editions are gated identically (the untranslatable spans it preserves — <ls>/{#…#}/<ab>/<is>/<lex>/<lang> and {Tn} — are the same in both). The only language-touching check, NO-RUSSIAN, keys on presence of ANY translation-script letters and is a non-blocking warning; the EN edition would swap the Cyrillic class for a Latin-prose check but the SHARED gate logic is unchanged. The pregate MODULE + the RU audit_window.py wiring are shipped here; the EN audit_window_en.py wiring is a separate GAP (see stage2_pregate_en_wiring_h405) because that edition audits in-process per-card (audit_card), not via the .raw.txt/.merged.md subprocess file-pair model this gate reuses. Pinned by stage2_pregate.py's own pure-function --selftest (11 cases + a masker-sync assertion; no store file IO, runs in CI).",
+    "note": "H405 (09-07-2026, PIPELINE_CAPABILITY_AUDIT W5 recommendation). Language-agnostic by construction: it compares markup/anchor STRUCTURE across the source↔translation pair and never inspects meaning, so the RU and EN editions are gated identically (the untranslatable spans it preserves — <ls>/{#…#}/<ab>/<is>/<lex>/<lang> and {Tn} — are the same in both). The only language-touching check, NO-RUSSIAN, keys on presence of ANY translation-script letters and is a non-blocking warning; the EN edition would swap the Cyrillic class for a Latin-prose check but the SHARED gate logic is unchanged. The pregate MODULE + the RU audit_window.py wiring shipped first; the EN audit_window_en.py wiring followed same-day via an in-process per-sense adapter (see stage2_pregate_en_wiring_h405, now SHARED) — that edition audits in-process (audit_sense), not via the .raw.txt/.merged.md subprocess file-pair model this gate reuses for RU. Pinned by stage2_pregate.py's own pure-function --selftest (11 cases + a masker-sync assertion; no store file IO, runs in CI).",
     "tracking": "",
     "verified_sha256": {
       "src/stage2_pregate.py": "f801740067f981f66e480330a586e12d9e98f85f7f564e40520d7ff43af139e2",
@@ -752,18 +752,21 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
   },
   {
     "id": "stage2_pregate_en_wiring_h405",
-    "mechanism": "The Stage-2 mechanical pre-gate (stage2_pregate.py) is wired into the RU window auditor (src/pilot/audit_window.py) but NOT yet into the EN auditor (src/pilot/audit_window_en.py). The RU auditor runs deterministic gates as subprocess `--wf` shell-outs over IN/<stem>.raw.txt vs OUT/<stem>.merged.md file pairs; the EN auditor instead audits each wf card in-process (audit_card(res, tm, do_mw)) with no such file pairs, so the pre-gate cannot be dropped in by adding a command tuple — it needs an in-process adapter that hands audit_card's (source, translation) to pregate()",
+    "mechanism": "RESOLVED — the Stage-2 mechanical pre-gate is now wired into the EN auditor (src/pilot/audit_window_en.py) too. Because that edition audits in-process per-sense (audit_sense(german, english)) rather than via the RU auditor's .raw.txt/.merged.md subprocess file pairs, the wiring is an in-process adapter: audit_sense calls stage2_pregate.pregate(g, e) and folds in ONLY the NET-NEW hard flag types the EN auditor's own per-sense checks don't already produce — IS-LOSS (<is> spans; the EN AB regex omits <is>), STRANDED-ANCHOR (leftover {Tn}), ANCHOR-LEAK/-MISMATCH — while LS/SAN/AB loss stay owned by audit_sense at its own thresholds to avoid double-reporting. Those net-new types were added to the HARD tuple so --strict fails on them",
     "files": [
-      "src/pilot/audit_window_en.py"
+      "src/pilot/audit_window_en.py",
+      "src/stage2_pregate.py"
     ],
     "languages": [
+      "ru",
       "en"
     ],
-    "verdict": "GAP",
-    "note": "H405 (09-07-2026). The gate LOGIC is SHARED (see stage2_mechanical_pregate_h405); only the EN wiring is missing, and it is a real architectural adapter (in-process per-card), not a mechanical port. Deferred so the RU wiring ships without waiting on the EN refactor.",
-    "tracking": "H405 (Uprava/handoffs/H405-Opus_RussianTranslation_stage2-mechanical-pregate_09.07.26.md) — EN wiring follow-up",
+    "verdict": "SHARED",
+    "note": "H405 (09-07-2026, resolved same day). Both editions now run the same pregate() module for the mechanical invariants; the difference is only the adapter (RU: subprocess --wf over file pairs; EN: in-process per-sense), not the logic. The partial-adoption (net-new flag types only) is deliberate — the EN auditor already reimplemented LS/SAN/AB/MISSING per-sense with its own thresholds, so pregate contributes exactly the invariants it lacked (<is>, stranded/leaked anchors) rather than duplicating. Verified by a functional test (clean / is-dropped→IS-LOSS / stranded→STRANDED-ANCHOR / ls-dropped→single LS-LOSS not double-flagged) + window_selftest.py green.",
+    "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "850e51292b6885dc7786d92164b880118581fe67d26b0da3bacc93793c09d4d2"
+      "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a",
+      "src/stage2_pregate.py": "f801740067f981f66e480330a586e12d9e98f85f7f564e40520d7ff43af139e2"
     }
   },
   {

--- a/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md
+++ b/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md
@@ -735,10 +735,18 @@ requeue. The mechanical-criteria block was stripped from both judge prompts
 ([`2_qa_sudya_opus.txt`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru_prompts/2_qa_sudya_opus.txt)
 and its YandexGPT twin) — replaced with a note that the pre-gate guarantees
 anchor/markup integrity, so the judge rules only on semantics (`anchors` kept
-as an emergency backstop). The **EN** auditor
+as an emergency backstop).
+
+The **EN** auditor
 ([`audit_window_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window_en.py))
-audits in-process per-card, not via the file-pair subprocess model, so its
-wiring is a tracked GAP (`stage2_pregate_en_wiring_h405` in
+was wired same-day too. It audits in-process per-sense (`audit_sense(german,
+english)`), not via the file-pair subprocess model, so the adapter is an
+in-process `pregate(g, e)` call that folds in only the **net-new** hard flags
+its own checks lack — `IS-LOSS` (`<is>` spans; the EN `AB` regex omits `<is>`),
+`STRANDED-ANCHOR`, and the anchor-leak/mismatch backstops — while `LS/SAN/AB`
+loss stay owned by `audit_sense` at its own thresholds (no double-reporting).
+Both editions now run the same `pregate()` module; only the adapter differs.
+The parity GAP is closed (`stage2_pregate_en_wiring_h405` → SHARED in
 [LANG_PARITY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md)).
 
 ## LANG_PARITY

--- a/RussianTranslation/src/pilot/audit_window_en.py
+++ b/RussianTranslation/src/pilot/audit_window_en.py
@@ -17,6 +17,13 @@ Gates (per non-null card -> record -> sense, comparing `german` vs `english`):
     MISSING-EN english empty while german had gloss prose to translate [coverage]
     DUP        two senses in one record share identical english       [sense-duplicate]
 
+  shared mechanical pre-gate (H405, stage2_pregate.py — the same gate wired into the
+  RU audit_window.py; here it supplies only the invariants this auditor's own checks
+  above don't, to avoid double-reporting):
+    IS-LOSS         <is>..</is> italic-Sanskrit spans dropped (the AB regex omits <is>)
+    STRANDED-ANCHOR a {Tn} placeholder left unrestored in the final text
+    ANCHOR-LEAK/-MISMATCH  masked-pair anchor damage (defensive; restored EN rarely hits)
+
   markup-loss (pwg_ru/DharmaMitra crosswalk, FU1_PLAN.md; SOFT, never blocks --strict):
     MARKUP-LOSS {%..%} gloss-wrapper / <div> pairs dropped while the prose survives —
                 the dominant EN residual per FABLE_JUDGE_S7 (~47% of rows); tracked here so
@@ -31,7 +38,7 @@ Gates (per non-null card -> record -> sense, comparing `german` vs `english`):
                (soft cross-check against Monier-Williams, the gold MG chose)
 
 Report-only by default (exit 0). `--strict` exits non-zero if any HARD gate
-(LS/SAN/AB/MISSING-EN/DUP) fires, if any card came back null (missing EN), or if the
+(LS/SAN/AB/IS/STRANDED-ANCHOR/MISSING-EN/DUP) fires, if any card came back null (missing EN), or if the
 sense-dupe subgate crashed (a crash is NOT a clean pass); the soft semantic flags never
 fail the gate. Failure reasons are printed and written to `--report`.
 
@@ -58,7 +65,18 @@ DEFAULT_MW_TM = os.path.join(SRC, 'mw_en_tm.json')
 
 if HERE not in sys.path:
     sys.path.insert(0, HERE)
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
 from foreign_literal_guards import FRENCH_CONTEXT_WORDS, AMBIGUOUS_DE_FR_WORDS
+import stage2_pregate   # H405: the shared mechanical pre-gate (RU + EN)
+
+# Flag TYPES the pre-gate contributes to the EN path that this auditor's own
+# per-sense checks above do NOT already produce. LS/SAN/AB/LEX/LANG loss stay owned
+# by audit_sense (same thresholds), so pulling only these avoids double-reporting:
+#   IS-LOSS         <is>…</is> italic-Sanskrit spans dropped (EN's AB regex omits <is>)
+#   STRANDED-ANCHOR a {Tn} placeholder left unrestored in the final text
+#   ANCHOR-LEAK/-MISMATCH  masked-pair anchor damage (defensive; restored EN rarely hits)
+_PREGATE_NEW = {'IS-LOSS', 'STRANDED-ANCHOR', 'ANCHOR-LEAK', 'ANCHOR-MISMATCH'}
 
 LS = re.compile(r'<ls\b')
 SAN = re.compile(r'\{#.*?#\}', re.S)
@@ -162,6 +180,13 @@ def audit_sense(german, english):
             de_hits.add(tok.lower().strip('.,;:()'))
     if de_hits:
         soft.append('DE-RESIDUE(%s)' % ','.join(sorted(de_hits))[:40])
+
+    # H405: fold in the mechanical invariants stage2_pregate.py owns that this
+    # auditor doesn't — <is> preservation and stranded/leaked {Tn} anchors. Only the
+    # NET-NEW flag types (see _PREGATE_NEW) are taken; LS/SAN/AB loss stay owned above.
+    for fl in stage2_pregate.pregate(g, e)['flags']:
+        if fl.split('(')[0] in _PREGATE_NEW:
+            hard.append(fl)
     return hard, soft
 
 
@@ -255,7 +280,8 @@ def run_sense_dupes(mod, path):
     return {'returncode': rc, 'summary': line.strip()}
 
 
-HARD = ('MISSING-EN', 'LS-LOSS', 'SAN-LOSS', 'AB-LOSS', 'SENSE-DUPE', 'DUP')
+HARD = ('MISSING-EN', 'LS-LOSS', 'SAN-LOSS', 'AB-LOSS', 'IS-LOSS', 'STRANDED-ANCHOR',
+        'ANCHOR-LEAK', 'ANCHOR-MISMATCH', 'SENSE-DUPE', 'DUP')
 
 
 def is_hard(flag):
@@ -267,7 +293,7 @@ def main():
     ap.add_argument('wf_output', nargs='+',
                     help='one or more wf_output.en.<root>.json files (globs allowed)')
     ap.add_argument('--strict', action='store_true',
-                    help='exit non-zero on any HARD gate (LS/SAN/AB/MISSING-EN/DUP), '
+                    help='exit non-zero on any HARD gate (LS/SAN/AB/IS/STRANDED-ANCHOR/MISSING-EN/DUP), '
                          'any null card, or a crashed sense-dupe subgate')
     ap.add_argument('--mw-tm', default=DEFAULT_MW_TM,
                     help='MW translation-memory JSON for the soft cross-check (default: src/mw_en_tm.json)')


### PR DESCRIPTION
Closes the `stage2_pregate_en_wiring_h405` parity GAP — the last item of [H405](https://github.com/gasyoun/Uprava/blob/main/handoffs/H405-Opus_RussianTranslation_stage2-mechanical-pregate_09.07.26.md).

## Approach — in-process adapter, no double-reporting
The EN auditor ([`audit_window_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window_en.py)) audits **in-process per-sense** (`audit_sense(german, english)`), not via the RU auditor's `.raw.txt`/`.merged.md` subprocess file pairs — so the pre-gate can't be dropped in as a command tuple. Instead `audit_sense` now calls `stage2_pregate.pregate(g, e)` and folds in **only the net-new hard flag types** the EN checks don't already produce:
- **`IS-LOSS`** — `<is>…</is>` italic-Sanskrit spans (the EN `AB` regex is `<(?:ab|lex|lang)\b`, omitting `<is>`)
- **`STRANDED-ANCHOR`** — a `{Tn}` placeholder left unrestored
- **`ANCHOR-LEAK`/`-MISMATCH`** — masked-pair backstops (defensive)

`LS/SAN/AB` loss stay owned by `audit_sense` at its own thresholds, so nothing is double-flagged. These types were added to the `HARD` tuple so `--strict` fails on them.

## Parity
- `stage2_pregate_en_wiring_h405`: **GAP → SHARED**. Both editions now run the same `pregate()` module; only the adapter differs (RU: subprocess `--wf` over file pairs; EN: in-process per-sense).
- Re-verified `gate_fixes_20260703_ru_only` + `en_dup_hard_gate_20260704` still hold (additive change); hashes refreshed.

## Verification
- Functional test: `clean`→none, `is-dropped`→`IS-LOSS`, `stranded`→`STRANDED-ANCHOR`, `ls-dropped`→single `LS-LOSS` (not double-flagged)
- `window_selftest.py` green (incl. `test_lang_parity_ledger_complete`)
- `lang_parity_check.py` → 37 entries, no drift; `py_compile` clean

Built by Opus 4.8 (`claude-opus-4-8`), isolated worktree per the H214 protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)