### PR TITLE
H389: medium50 diagnostic — opt2 schema classifier block, escalate to H428

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -15,12 +15,24 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 - **H405 Stage-2 mechanical pre-gate — FULLY DONE 09-07-2026 (Opus 4.8 `claude-opus-4-8`), RU + EN.**
   [`src/stage2_pregate.py`](src/stage2_pregate.py) built + selftest-green; measured 99.72% CLEAN / 0.10% hard-FAIL over the 11,261-row store (13 real defects surfaced). `--wf` window-gate mode wired into [`src/pilot/audit_window.py`](src/pilot/audit_window.py) as `stage2_mechanical`; mechanical criteria stripped from both judge prompts ([`2_qa_sudya_opus.txt`](pwg_ru_prompts/2_qa_sudya_opus.txt) + YandexGPT twin). EN auditor [`src/pilot/audit_window_en.py`](src/pilot/audit_window_en.py) wired via in-process `audit_sense`→`pregate(g,e)` adapter contributing only net-new hard flags (IS-LOSS, STRANDED-ANCHOR, anchor backstops); LS/SAN/AB stay owned by `audit_sense`. Parity GAP closed → `stage2_pregate_en_wiring_h405` SHARED; LANG_PARITY 37 entries no drift; `window_selftest.py` green. No follow-ups.
 
-- **H317 pwg-ru medium50 test — resume once a clean environment is confirmed.** Closed this
-  session at 0/50 promoted (transient API instability + kill-gate cascade, see the Completed
-  entry below and [`MEASUREMENT_2026-07-08_H317.md`](MEASUREMENT_2026-07-08_H317.md)). A future
-  session should first launch ONE solo diagnostic Workflow window; if it comes back mostly/fully
-  clean, resume from `src/pilot/output/requeue.h317_w1a/w1b/w2a.keys.txt` (h317_w2b still needs
-  its first launch), promote clean rows, and finish the n=50 metrics table.
+- **H317/H389 pwg-ru medium50 test — BLOCKED on the opt2 schema classifier; gated behind H428.**
+  H389 ran the ONE solo diagnostic window (`h317_w1a`, 13 keys) on 09-07-2026 (Opus 4.8
+  `claude-opus-4-8` driving Workflow): **0/13, 0 subagent tokens, 83 ms — all 67 agent() calls
+  errored `blocked by safety classifier: output schema too large to classify safely`.** This is
+  NOT the transient instability or nominal kill-gate H317 hypothesized — it is the same
+  deterministic agent()-schema-size block as the H388 B-arm ([Uprava/FINDINGS.md §30](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md);
+  the ~8,202-char opt2 `CARDS_SCHEMA` grew past the classifier threshold after H335 government +
+  H405 evidence fields; §30's orphan-`$def` prune is necessary but no longer sufficient). Full
+  account appended to [`MEASUREMENT_2026-07-08_H317.md`](MEASUREMENT_2026-07-08_H317.md) +
+  [`LAUNCH_FUCKUPS.md`](LAUNCH_FUCKUPS.md) (`H389_MEDIUM50_SCHEMA_CLASSIFIER_BLOCK_2026-07-09`).
+  **Do NOT launch any opt2 window** (w1b/w2a/w2b/H151/H388-B) until the schema is slimmed —
+  escalated to
+  [H428](https://github.com/gasyoun/Uprava/blob/main/handoffs/H428-Sonnet_RussianTranslation_opt2-schema-slim-classifier-unblock_09.07.26.md):
+  ```
+  Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H428-Sonnet_RussianTranslation_opt2-schema-slim-classifier-unblock_09.07.26.md and execute it.
+  ```
+  After H428 lands, resume from `src/pilot/output/requeue.h317_w1a/w1b/w2a.keys.txt` (h317_w2b
+  still needs its first launch), promote clean rows, finish the n=50 metrics table.
 
 - **H309 corpus-lexicon commentary-tail + adverb recall fix — ✅ DONE 08-07-2026 (Sonnet 5 `claude-sonnet-5`).**
   Fixed the two H136-measured recall failure classes ([recall_report.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/gold/recall_report.md)):

--- a/RussianTranslation/LAUNCH_FUCKUPS.md
+++ b/RussianTranslation/LAUNCH_FUCKUPS.md
@@ -288,8 +288,32 @@ classes, expected-vs-actual metrics, residual status, and unknown recurrence.
     "classification": "concurrency/api",
     "root_cause": "Two overlapping causes measured, not one: (1) RUN_FREQ_MAX.md's <=3-wide concurrency ceiling is not a safe floor -- 3 concurrent Workflow launches alone was enough to saturate throughput and trigger cascading kill-timeouts across all three windows simultaneously; (2) a session-wide transient API instability ('Connection closed mid-response') was ALSO present even at 1-wide, so concurrency width did not fully explain the failure -- pass 2's solo run had the same symptom class as pass 1's 3-wide run, just fewer simultaneous casualties.",
     "guardrail": "Do not keep burning agent budget retrying into a live transient-API window. Pause further H317 window launches until a subsequent solo launch comes back mostly clean (confirming the outage has cleared), then resume sequential (1-wide) retries per window. Revise the standing <=3-wide guidance in RUN_FREQ_MAX.md to require a clean 1-wide reference launch before any concurrent width is trusted again in a session showing these symptoms.",
-    "residual_status": "open-paused",
-    "residual_risk": "If this recurs on a later clean-environment retry, escalate as a genuine kill-gate miscalibration for nominal single-card windows rather than assuming transient infra every time; if it does NOT recur, this entry is the transient-outage case per the NOMINAL_W1_100SMALL_2026-07-06 precedent."
+    "residual_status": "superseded",
+    "residual_risk": "SUPERSEDED by H389_MEDIUM50_SCHEMA_CLASSIFIER_BLOCK_2026-07-09: the clean-environment solo retry did NOT recur as a kill-gate miscalibration NOR as transient infra -- the actual, deterministic block is the agent() output-schema safety classifier (see next entry). The 08-07 'Connection closed mid-response' symptoms predate the classifier rollout; the operative blocker today is schema size, not concurrency or transient outage."
+  },
+  {
+    "id": "H389_MEDIUM50_SCHEMA_CLASSIFIER_BLOCK_2026-07-09",
+    "handoff": "H389",
+    "date": "2026-07-09",
+    "title": "opt2 CARDS_SCHEMA too large for agent() safety classifier -> 67/67 blocked pre-generation, 0 tokens",
+    "lane": "nominal medium (band-4, 3-30 citation size)",
+    "model": "claude-sonnet-5 (generation, hardcoded in harness)",
+    "orchestrator": "Opus 4.8 (claude-opus-4-8) Claude Code session driving the Workflow tool; ONE solo diagnostic window h317_w1a (13 keys), no concurrency",
+    "expected": {
+      "agents": "19 (agent_expected_after_tm)",
+      "tokens": "~4.7M subagent tokens / ~$8.90 (preflight cost gate)"
+    },
+    "actual": {
+      "agents": "67 agent() calls, ALL errored identically 'blocked by safety classifier: output schema too large to classify safely'; window hit MAX_AGENTS=67 budget-kill-switch",
+      "tokens": "0 subagent tokens (rejected before any model invocation), 83 ms total wall-clock"
+    },
+    "passes": 1,
+    "symptoms": "Every batch agent (b0-b9), every binary-split heal group, and every retry returned 'blocked by safety classifier: output schema too large to classify safely' at subagent_tokens:0. Binary-splitting did NOT help (a single-item call still carries the full constant schema). 0/13 cards, 0 tokens. This is a DETERMINISTIC pre-generation block, not the transient/kill cascade of the 08-07 H317 attempts.",
+    "classification": "schema/tooling",
+    "root_cause": "The Workflow-tool agent() safety classifier refuses the opt2 CARDS_SCHEMA (~8,202 chars: nested $defs for card/record/sense carrying government/evidence/evidence_summary objects, many enums, long descriptions) as too large to classify, pre-execution. FINDINGS.md §30's orphan-$def prune (_ref_names/_reachable_defs, landed 03-07 H130) is necessary but NO LONGER SUFFICIENT: H335 (government) + H405 (evidence/stage-2) grew the REACHABLE schema past the classifier threshold after that fix. Identical block hit the H388 SkillOpt B-arm the same day (52/52). Supersedes H317's 'transient API instability + kill-gate' hypothesis.",
+    "guardrail": "Escalated to H428 (Uprava/handoffs/H428-Sonnet_RussianTranslation_opt2-schema-slim-classifier-unblock_09.07.26.md): slim the GENERATION schema to reachable-AND-model-generated fields only -- drop government/evidence/evidence_summary/labels/renou* (all added deterministically post-generation by government_census.py / annotate_evidence.py / annotate_renou.py), trim descriptions, flatten $defs; pin with a window_selftest.py test so a later field addition cannot silently re-cross the threshold. Do NOT retry any opt2 window until H428 lands -- it is a deterministic 0-token 0-progress block.",
+    "residual_status": "routed-to-bug-hunt",
+    "residual_risk": "The ENTIRE pwg_ru opt2 production path is blocked until H428 slims the schema: H389 (medium50 windows w1a/w1b/w2a/w2b), H388 B-arm live gate, and the H151 verb-root drain all use gen_opt_harness2.py and will hit the identical block. 0 tokens are wasted per attempt, but 0 progress is possible."
   }
 ]
 ```

--- a/RussianTranslation/MEASUREMENT_2026-07-08_H317.md
+++ b/RussianTranslation/MEASUREMENT_2026-07-08_H317.md
@@ -97,4 +97,61 @@ retry *still* shows this failure pattern, escalate as a genuine kill-gate
 miscalibration for nominal medium-band cards (parallel to the `DAH_TAIL`
 no-fallback-singleton finding) rather than assuming transient infra again.
 
+## Update — 09-07-2026 diagnostic (H389): the real blocker is the agent() schema classifier, not transient infra
+
+[H389](https://github.com/gasyoun/Uprava/blob/main/handoffs/H389-Sonnet_RussianTranslation_pwg-ru-medium50-resume_08.07.26.md)
+launched the single solo diagnostic window this measurement recommended
+(`h317_w1a`, 13 keys, no concurrency), on 09-07-2026, Opus 4.8
+(`claude-opus-4-8`) driving the Workflow tool; generation model unchanged
+(Sonnet 5, hardcoded in the harness).
+
+**Result: 0/13, 0 subagent tokens, 83 ms.** All 67 `agent()` calls — every
+batch (b0–b9), every binary-split heal group, every retry — errored identically:
+
+> `blocked by safety classifier: output schema too large to classify safely`
+
+The budget kill-switch (`MAX_AGENTS=67`) tripped because every errored call
+counts against the window budget. No model was ever invoked (0 tokens).
+
+### This supersedes the "transient API instability" reading above
+
+The recommended-next-action test ("resume once a solo diagnostic comes back
+mostly clean, else escalate as a kill-gate miscalibration") returned a **third,
+decisive** answer neither branch anticipated: a **deterministic, pre-generation
+platform block**. It is not concurrency (the run was 1-wide), not transient
+latency (`Connection closed mid-response` did not appear — the agents never ran),
+and not the nominal kill-gate (the kill-gate never engaged; the classifier
+refused the schema first).
+
+Root cause = the same one measured for the H388 SkillOpt B-arm the same day:
+the opt2 `CARDS_SCHEMA` handed to every `agent({schema})` call is **too large
+for the Workflow-tool safety classifier** (~8,202 chars: nested `$defs` for
+card/record/sense carrying `government`/`evidence`/`evidence_summary` objects,
+many enums, long descriptions). [Uprava/FINDINGS.md §30](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)
+🔴 first recorded this class; its orphan-`$def` prune fix (`_ref_names` /
+`_reachable_defs`, landed 03-07, H130) is **necessary but no longer sufficient**
+— H335 (government) and H405 (evidence/stage-2) grew the *reachable* schema past
+the classifier threshold after that fix landed.
+
+### Consequence — the whole opt2 path is blocked, not just this window
+
+Every pwg_ru opt2 window uses `gen_opt_harness2.py` and hits the identical block:
+the H317/H389 medium50 windows, the H388 B-arm live gate, and the H151 verb-root
+drain. The block wastes **0 tokens per attempt but yields 0 progress**, so
+retrying is pointless.
+
+**Decision: STOP the H317/H389 window resume.** Do not launch `h317_w1b`,
+`h317_w2a`, or `h317_w2b` — they would each hit the same deterministic refusal.
+Escalated to
+[H428](https://github.com/gasyoun/Uprava/blob/main/handoffs/H428-Sonnet_RussianTranslation_opt2-schema-slim-classifier-unblock_09.07.26.md):
+slim the *generation* schema to reachable-AND-model-generated fields only (drop
+the post-generation-added `government`/`evidence`/`evidence_summary`/`labels`/
+`renou*`, trim descriptions, flatten `$defs`), pinned by a `window_selftest.py`
+test so a future field addition cannot silently re-cross the threshold. Once
+H428 lands, H389's medium50 windows become launchable again.
+
+Classified in [`LAUNCH_FUCKUPS.md`](LAUNCH_FUCKUPS.md) as
+`H389_MEDIUM50_SCHEMA_CLASSIFIER_BLOCK_2026-07-09` (and the prior
+`H317_MEDIUM50_3WIDE_KILL_CASCADE_2026-07-08` entry marked `superseded`).
+
 _Dr. Mārcis Gasūns_


### PR DESCRIPTION
## What H389 did

Executed the H389 handoff's single scoped step: launch ONE solo diagnostic Workflow window (`h317_w1a`, 13 keys) to test whether the 08-07 transient API instability had cleared.

## Result — a decisive, different root cause

**0/13 cards, 0 subagent tokens, 83 ms.** All 67 `agent()` calls errored identically:

> `blocked by safety classifier: output schema too large to classify safely`

This **supersedes** H317's "transient API instability + kill-gate cascade" hypothesis. The block is:
- **deterministic** (not transient — no `Connection closed mid-response`),
- **pre-generation** (0 tokens; no model ever ran),
- **not concurrency** (1-wide run),
- **not the nominal kill-gate** (the classifier refused the schema before the kill-gate could engage).

Root cause = the same one measured for the [H388](https://github.com/gasyoun/Uprava/blob/main/handoffs/H388-Opus_Uprava_skillopt_skill_optimizer_pwg_pilot_08.07.26.md) SkillOpt B-arm the same day: the opt2 `CARDS_SCHEMA` (~8,202 chars) handed to every `agent({schema})` call is too large for the Workflow-tool safety classifier. [Uprava/FINDINGS.md §30](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)'s orphan-`$def` prune (03-07, H130) is necessary but no longer sufficient — H335 (government) + H405 (evidence) grew the *reachable* schema past the threshold after that fix.

## Consequence

The **entire pwg_ru opt2 path** is blocked (H389 windows, H388 B-arm, H151 verb drain) — every window uses `gen_opt_harness2.py`. 0 tokens wasted per attempt but 0 progress possible.

**Decision: STOP** the H317/H389 resume; do not launch w1b/w2a/w2b. Escalated to [H428](https://github.com/gasyoun/Uprava/blob/main/handoffs/H428-Sonnet_RussianTranslation_opt2-schema-slim-classifier-unblock_09.07.26.md) — slim the generation schema to reachable-AND-model-generated fields.

## Files

- [`MEASUREMENT_2026-07-08_H317.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/MEASUREMENT_2026-07-08_H317.md) — 09-07 diagnostic section appended
- [`LAUNCH_FUCKUPS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LAUNCH_FUCKUPS.md) — `H389_MEDIUM50_SCHEMA_CLASSIFIER_BLOCK_2026-07-09`; H317 entry → superseded
- [`.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md) — H317/H389 BLOCKED, gated behind H428

🤖 Generated with [Claude Code](https://claude.com/claude-code)