### PR TITLE
pwg_ru: slim opt2 generation schema to unblock agent() safety classifier (H428)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -15,23 +15,28 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 - **H405 Stage-2 mechanical pre-gate — FULLY DONE 09-07-2026 (Opus 4.8 `claude-opus-4-8`), RU + EN.**
   [`src/stage2_pregate.py`](src/stage2_pregate.py) built + selftest-green; measured 99.72% CLEAN / 0.10% hard-FAIL over the 11,261-row store (13 real defects surfaced). `--wf` window-gate mode wired into [`src/pilot/audit_window.py`](src/pilot/audit_window.py) as `stage2_mechanical`; mechanical criteria stripped from both judge prompts ([`2_qa_sudya_opus.txt`](pwg_ru_prompts/2_qa_sudya_opus.txt) + YandexGPT twin). EN auditor [`src/pilot/audit_window_en.py`](src/pilot/audit_window_en.py) wired via in-process `audit_sense`→`pregate(g,e)` adapter contributing only net-new hard flags (IS-LOSS, STRANDED-ANCHOR, anchor backstops); LS/SAN/AB stay owned by `audit_sense`. Parity GAP closed → `stage2_pregate_en_wiring_h405` SHARED; LANG_PARITY 37 entries no drift; `window_selftest.py` green. No follow-ups.
 
-- **H317/H389 pwg-ru medium50 test — BLOCKED on the opt2 schema classifier; gated behind H428.**
-  H389 ran the ONE solo diagnostic window (`h317_w1a`, 13 keys) on 09-07-2026 (Opus 4.8
-  `claude-opus-4-8` driving Workflow): **0/13, 0 subagent tokens, 83 ms — all 67 agent() calls
-  errored `blocked by safety classifier: output schema too large to classify safely`.** This is
-  NOT the transient instability or nominal kill-gate H317 hypothesized — it is the same
-  deterministic agent()-schema-size block as the H388 B-arm ([Uprava/FINDINGS.md §30](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md);
-  the ~8,202-char opt2 `CARDS_SCHEMA` grew past the classifier threshold after H335 government +
-  H405 evidence fields; §30's orphan-`$def` prune is necessary but no longer sufficient). Full
-  account appended to [`MEASUREMENT_2026-07-08_H317.md`](MEASUREMENT_2026-07-08_H317.md) +
-  [`LAUNCH_FUCKUPS.md`](LAUNCH_FUCKUPS.md) (`H389_MEDIUM50_SCHEMA_CLASSIFIER_BLOCK_2026-07-09`).
-  **Do NOT launch any opt2 window** (w1b/w2a/w2b/H151/H388-B) until the schema is slimmed —
-  escalated to
-  [H428](https://github.com/gasyoun/Uprava/blob/main/handoffs/H428-Sonnet_RussianTranslation_opt2-schema-slim-classifier-unblock_09.07.26.md):
-  ```
-  Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H428-Sonnet_RussianTranslation_opt2-schema-slim-classifier-unblock_09.07.26.md and execute it.
-  ```
-  After H428 lands, resume from `src/pilot/output/requeue.h317_w1a/w1b/w2a.keys.txt` (h317_w2b
+- **H428 opt2 schema-slim classifier unblock — ✅ DONE 09-07-2026 (Sonnet 5 `claude-sonnet-5`).**
+  Isolated worktree `SanskritLexicography-h428` (branch `h428-opt2-schema-slim`). Measured the
+  reachable opt2 `CARDS_SCHEMA` at 10,940 chars (grown past the 03-07 H130 orphan-`$def` prune
+  after H335 `government` + H405 `evidence`/`evidence_summary` + H422 `stats` each added a
+  legitimately-`$ref`'d field) — the exact [Uprava/FINDINGS.md §30](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)
+  block, 67/67 `agent()` calls rejected pre-generation at 0 tokens in H389. New
+  `_strip_post_generation_fields()` in [`src/pilot/gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py)
+  drops every field a downstream deterministic annotator adds post-generation
+  (`government`/`labels`/`renou`/`renou_oldest`/`evidence` on sense, `renou_oldest_sense` on
+  record, `evidence_summary`/`stats` on card) from the *generation* schema only — the
+  promote/annotate scripts still add them back from the unmodified schema file on disk.
+  Reachable schema: 10,940 → 1,698 chars (84%); `$defs` collapse from 6 entries to
+  `{card,record,sense}`. New `--dump-schema` CLI flag for future measurement without a
+  Workflow-tool probe. **Verified live:** one diagnostic `agent()` call (nominal window,
+  root=vinasa) returned a valid card, 75,774 subagent tokens spent (vs 0 pre-fix) — the
+  classifier now accepts the call. Pinned by new
+  `window_selftest.py:test_generation_schema_carries_no_post_generation_field`; full
+  `window_selftest.py` (107 tests) + `lang_parity_check.py` (37 entries, `cards_schema_defs_pruning`
+  verdict extended) both green. `Uprava/FINDINGS.md §30` + `LAUNCH_FUCKUPS.md` updated with the
+  second-order lesson (reachability-prune alone doesn't bound growth; slim to
+  reachable-AND-model-generated). **Unblocks H389 (medium50 w1a/w1b/w2a/w2b), H388 B-arm,
+  H151 verb drain** — resume from `src/pilot/output/requeue.h317_w1a/w1b/w2a.keys.txt` (h317_w2b
   still needs its first launch), promote clean rows, finish the n=50 metrics table.
 
 - **H309 corpus-lexicon commentary-tail + adverb recall fix — ✅ DONE 08-07-2026 (Sonnet 5 `claude-sonnet-5`).**

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,33 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### H428 — opt2 generation schema slimmed to reachable-AND-model-generated fields, unblocking the classifier
+- The Workflow tool's `agent()` safety classifier was blocking 100% of opt2
+  translation calls (67/67 in [H389](https://github.com/gasyoun/Uprava/blob/main/handoffs/H389-Sonnet_RussianTranslation_pwg-ru-medium50-resume_08.07.26.md),
+  52/52 in H388's B-arm) with `output schema too large to classify safely`, at
+  0 subagent tokens — the reachable `CARDS_SCHEMA` had grown to 10,940 chars
+  after H335 (`government`)/H405 (`evidence`/`evidence_summary`)/H422 (`stats`)
+  each added a legitimately-`$ref`'d field. See [Uprava/FINDINGS.md §30](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md).
+- New `_strip_post_generation_fields()` in
+  [`src/pilot/gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py) drops every
+  field a *downstream deterministic annotator* adds after generation —
+  `government`/`labels`/`renou`/`renou_oldest`/`evidence` (sense),
+  `renou_oldest_sense` (record), `evidence_summary`/`stats` (card) — from the
+  per-call generation schema only; `promote_final_cards.py` + the annotator
+  scripts still add them back from the unmodified schema file on disk.
+  Reachable schema: 10,940 → 1,698 chars (84% reduction); `$defs` collapse
+  from `{card,record,sense,evidence_item,evidence_summary,stats}` to
+  `{card,record,sense}`.
+- New `--dump-schema` CLI flag prints the live generation schema + char length
+  without needing a Workflow-tool probe.
+- Verification: a single diagnostic `agent()` call (nominal window, root
+  `vinasa`) returned a valid card with 75,774 subagent tokens spent (vs 0
+  tokens / classifier-blocked pre-fix). Pinned by new
+  `window_selftest.py:test_generation_schema_carries_no_post_generation_field`.
+  Full `window_selftest.py` (107 tests) and `lang_parity_check.py` (37
+  entries) both green.
+- Unblocks H389 (medium50 windows), H388 B-arm, and the H151 verb-root drain.
+
 ### H409 — `has_meaning()` short-token stemmer gap fixed, RATIO-scoring regression caught and reverted
 - New [`corpus_gate.ru_has_content()`](src/corpus_gate.py): relaxes the
   `>=3-char-after-stemming` floor for tokens already `<=3` letters before

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18"
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7"
     }
   },
   {
@@ -117,8 +117,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7",
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -136,8 +136,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7",
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -155,8 +155,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7",
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -173,7 +173,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18"
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18"
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7"
     }
   },
   {
@@ -212,7 +212,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
   },
   {
     "id": "cards_schema_defs_pruning",
-    "mechanism": "H130 fix: CARDS_SCHEMA only carries $defs reachable from 'card', not the whole shared schema file's judge/judge_issue defs",
+    "mechanism": "H130 fix: CARDS_SCHEMA only carries $defs reachable from 'card', not the whole shared schema file's judge/judge_issue defs. H428 extension: _strip_post_generation_fields() additionally drops every field a deterministic annotator adds AFTER generation (government/labels/renou/renou_oldest/evidence on sense, renou_oldest_sense on record, evidence_summary/stats on card) BEFORE the reachable-defs walk, so evidence_item/evidence_summary/stats become unreachable too. Reachable schema: 10,940 -> 1,698 chars.",
     "files": [
       "src/pilot/gen_opt_harness2.py"
     ],
@@ -221,10 +221,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "_reachable_defs() walks $ref pointers regardless of lang.",
+    "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18"
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7"
     }
   },
   {
@@ -241,7 +241,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18"
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7"
     }
   },
   {
@@ -257,7 +257,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The bare 'sonnet' alias resolved to Sonnet 4.6 (not 5.0) on a prior EN run — pinned explicitly there after that surprise. RU's alias was never observed to misresolve, so it was left alone rather than touching a stable production path for a problem it doesn't have. Re-evaluate if RU is ever caught on a stale alias too.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18"
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7"
     }
   },
   {
@@ -354,8 +354,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7",
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -411,8 +411,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7",
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -449,7 +449,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d"
     }
   },
@@ -469,9 +469,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "700665baa30b550c59ca9f1dfc00adc2569bb3d5b91fe1eb0bddb922e7742a18",
+      "src/pilot/gen_opt_harness2.py": "28b76d25214dc9f8d0a5fa6e96032bae198682900e644731e89ba530fa0fe7d7",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -502,7 +502,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "2a0478b0779e1aba2bf2e2a0e7d5b50807f7acccf44ae4b00a7dc3af3ff29005",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -521,7 +521,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "9ef1fd0e7c1d31760db187d16046b7dffbafa4fd6d11099ef61fb95094975b27",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
       "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -623,7 +623,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -652,7 +652,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -672,7 +672,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -691,7 +691,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "5e257d130318be4e903bb55444d70c88544af8725c115253235e5daed716ec51",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -728,7 +728,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   },
   {
@@ -786,7 +786,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "91cc1b2c8423bd33f6a00fe8ad0a7d50dbecec46bc504391358fc11d679a3e73"
+      "src/pilot/window_selftest.py": "535ffe2c9d3675d135b1c59c0f466ff5523022ac82fc7fb240a3421b19cdc28e"
     }
   }
 ]

--- a/RussianTranslation/LAUNCH_FUCKUPS.md
+++ b/RussianTranslation/LAUNCH_FUCKUPS.md
@@ -288,7 +288,7 @@ classes, expected-vs-actual metrics, residual status, and unknown recurrence.
     "classification": "concurrency/api",
     "root_cause": "Two overlapping causes measured, not one: (1) RUN_FREQ_MAX.md's <=3-wide concurrency ceiling is not a safe floor -- 3 concurrent Workflow launches alone was enough to saturate throughput and trigger cascading kill-timeouts across all three windows simultaneously; (2) a session-wide transient API instability ('Connection closed mid-response') was ALSO present even at 1-wide, so concurrency width did not fully explain the failure -- pass 2's solo run had the same symptom class as pass 1's 3-wide run, just fewer simultaneous casualties.",
     "guardrail": "Do not keep burning agent budget retrying into a live transient-API window. Pause further H317 window launches until a subsequent solo launch comes back mostly clean (confirming the outage has cleared), then resume sequential (1-wide) retries per window. Revise the standing <=3-wide guidance in RUN_FREQ_MAX.md to require a clean 1-wide reference launch before any concurrent width is trusted again in a session showing these symptoms.",
-    "residual_status": "superseded",
+    "residual_status": "accepted-as-proven-residual",
     "residual_risk": "SUPERSEDED by H389_MEDIUM50_SCHEMA_CLASSIFIER_BLOCK_2026-07-09: the clean-environment solo retry did NOT recur as a kill-gate miscalibration NOR as transient infra -- the actual, deterministic block is the agent() output-schema safety classifier (see next entry). The 08-07 'Connection closed mid-response' symptoms predate the classifier rollout; the operative blocker today is schema size, not concurrency or transient outage."
   },
   {
@@ -309,11 +309,35 @@ classes, expected-vs-actual metrics, residual status, and unknown recurrence.
     },
     "passes": 1,
     "symptoms": "Every batch agent (b0-b9), every binary-split heal group, and every retry returned 'blocked by safety classifier: output schema too large to classify safely' at subagent_tokens:0. Binary-splitting did NOT help (a single-item call still carries the full constant schema). 0/13 cards, 0 tokens. This is a DETERMINISTIC pre-generation block, not the transient/kill cascade of the 08-07 H317 attempts.",
-    "classification": "schema/tooling",
-    "root_cause": "The Workflow-tool agent() safety classifier refuses the opt2 CARDS_SCHEMA (~8,202 chars: nested $defs for card/record/sense carrying government/evidence/evidence_summary objects, many enums, long descriptions) as too large to classify, pre-execution. FINDINGS.md §30's orphan-$def prune (_ref_names/_reachable_defs, landed 03-07 H130) is necessary but NO LONGER SUFFICIENT: H335 (government) + H405 (evidence/stage-2) grew the REACHABLE schema past the classifier threshold after that fix. Identical block hit the H388 SkillOpt B-arm the same day (52/52). Supersedes H317's 'transient API instability + kill-gate' hypothesis.",
-    "guardrail": "Escalated to H428 (Uprava/handoffs/H428-Sonnet_RussianTranslation_opt2-schema-slim-classifier-unblock_09.07.26.md): slim the GENERATION schema to reachable-AND-model-generated fields only -- drop government/evidence/evidence_summary/labels/renou* (all added deterministically post-generation by government_census.py / annotate_evidence.py / annotate_renou.py), trim descriptions, flatten $defs; pin with a window_selftest.py test so a later field addition cannot silently re-cross the threshold. Do NOT retry any opt2 window until H428 lands -- it is a deterministic 0-token 0-progress block.",
-    "residual_status": "routed-to-bug-hunt",
-    "residual_risk": "The ENTIRE pwg_ru opt2 production path is blocked until H428 slims the schema: H389 (medium50 windows w1a/w1b/w2a/w2b), H388 B-arm live gate, and the H151 verb-root drain all use gen_opt_harness2.py and will hit the identical block. 0 tokens are wasted per attempt, but 0 progress is possible."
+    "classification": "structured-output-limit",
+    "root_cause": "The Workflow-tool agent() safety classifier refuses the opt2 CARDS_SCHEMA (~8,202 chars measured H388/H389; re-measured 10,940 chars at H428 after further $defs growth: nested $defs for card/record/sense carrying government/evidence/evidence_summary/stats objects, many enums, long descriptions) as too large to classify, pre-execution. FINDINGS.md §30's orphan-$def prune (_ref_names/_reachable_defs, landed 03-07 H130) is necessary but NO LONGER SUFFICIENT: H335 (government) + H405 (evidence/stage-2) + H422 (stats) grew the REACHABLE schema past the classifier threshold after that fix. Identical block hit the H388 SkillOpt B-arm the same day (52/52). Supersedes H317's 'transient API instability + kill-gate' hypothesis.",
+    "guardrail": "FIXED by H428 (Uprava/handoffs/H428-Sonnet_RussianTranslation_opt2-schema-slim-classifier-unblock_09.07.26.md, 09-07-2026, Sonnet 5 claude-sonnet-5): new `_strip_post_generation_fields()` in gen_opt_harness2.py drops government/labels/renou/renou_oldest/evidence (sense), renou_oldest_sense (record), evidence_summary/stats (card) -- all added deterministically post-generation by government_census.py/annotate_government.py/annotate_renou.py/annotate_evidence.py/annotate_stats.py, never by the translating model -- from the GENERATION schema only (the promote/annotate scripts still add them back from the untouched schema file on disk). Reachable schema: 10,940 -> 1,698 chars (84% reduction); $defs collapse from {card,record,sense,evidence_item,evidence_summary,stats} to {card,record,sense}. Pinned by new window_selftest.py test_generation_schema_carries_no_post_generation_field so a future annotator field addition cannot silently re-cross the threshold. New `--dump-schema` CLI flag prints the live generation schema + char length for future measurement without a Workflow-tool probe.",
+    "residual_status": "fixed",
+    "residual_risk": "None outstanding for schema size. Verification: a single diagnostic agent() call (nominal window, root=vinasa, 1 card, generated via `gen_opt_harness2.py vinasa --nominal --keys=vinasa --no-tm`) returned a valid card with 75,774 subagent tokens spent (vs 0 tokens / classifier-blocked on the pre-fix 10,940-char schema) -- confirms the classifier now accepts the call. Unblocks H389 (medium50 windows w1a/w1b/w2a/w2b), H388 B-arm live gate, and the H151 verb-root drain, all of which use gen_opt_harness2.py."
+  },
+  {
+    "id": "H428_OPT2_SCHEMA_SLIM_FIX_2026-07-09",
+    "handoff": "H428",
+    "date": "2026-07-09",
+    "title": "Slimmed the opt2 generation schema (drop post-generation-only fields) -- classifier now accepts the per-call schema",
+    "lane": "nominal medium (band-4) / all opt2 lanes",
+    "model": "claude-sonnet-5",
+    "orchestrator": "Sonnet 5 Claude Code session, isolated worktree SanskritLexicography-h428, ONE solo diagnostic Workflow launch (1 card, root=vinasa)",
+    "expected": {
+      "agents": "1 (single-card nominal diagnostic window)",
+      "tokens": "order of tens of thousands (a single tiny nominal card)"
+    },
+    "actual": {
+      "agents": "1 agent() call, returned a valid card, 0 errors",
+      "tokens": "75,774 subagent tokens"
+    },
+    "passes": 1,
+    "symptoms": "N/A -- this is the fix-confirmation entry, not a failure. Prior state: H389_MEDIUM50_SCHEMA_CLASSIFIER_BLOCK_2026-07-09 (67/67 agent() calls blocked pre-generation, 0 tokens).",
+    "classification": "structured-output-limit",
+    "root_cause": "See H389_MEDIUM50_SCHEMA_CLASSIFIER_BLOCK_2026-07-09 -- the reachable generation schema (10,940 chars) crossed the Workflow tool safety-classifier's size threshold.",
+    "guardrail": "gen_opt_harness2.py:_strip_post_generation_fields() + _POST_GENERATION_{CARD,RECORD,SENSE}_FIELDS strip government/labels/renou/renou_oldest/evidence/evidence_summary/stats/renou_oldest_sense from the per-call StructuredOutput schema (kept on the full schema file for promote/annotate). window_selftest.py:test_generation_schema_carries_no_post_generation_field pins the reachable-defs shape and a <=5,000-char ceiling.",
+    "residual_status": "fixed",
+    "residual_risk": "None. If a future annotator field is added to schemas/pwg_ru_final_card.schema.json and it is post-generation-only, it must be added to the relevant _POST_GENERATION_*_FIELDS tuple or the new selftest will not catch its omission (only re-measures size, not the specific field list beyond the banned set already known)."
   }
 ]
 ```

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -595,6 +595,53 @@ def _reachable_defs(defs, start):
     return {k: v for k, v in defs.items() if k in seen}
 
 
+# Fields present on the final card/sense/record schema but added AFTER generation, by a
+# deterministic annotator script — never by the translating model. Keeping them in the
+# per-call StructuredOutput schema only adds dead weight: H428 measured the full reachable
+# schema (post-H335/H405/H422 growth) at 10,940 chars, over the Workflow tool's safety-
+# classifier size threshold (every agent() call blocked pre-generation, 0 tokens, H388/H389).
+# Stripping these from the *generation* schema only — the promote/annotate scripts below
+# still add them back onto the promoted card from the unmodified schema file on disk.
+_POST_GENERATION_SENSE_FIELDS = (
+    'government',       # annotate_government.py / government_census.py (H335 W3)
+    'labels',            # planned diasystem-label annotator (Dimension 2); no generation-time
+                         # prompt or annotator currently populates it either, but it is not
+                         # model-generated, so it does not belong in the generation schema
+    'renou', 'renou_oldest',  # annotate_renou.py
+    'evidence',          # annotate_evidence.py
+)
+_POST_GENERATION_RECORD_FIELDS = (
+    'renou_oldest_sense',  # annotate_renou.py
+)
+_POST_GENERATION_CARD_FIELDS = (
+    'evidence_summary',  # annotate_evidence.py
+    'stats',             # annotate_stats.py
+)
+
+
+def _strip_post_generation_fields(defs):
+    """Deep-copy `defs` with every post-generation-added field removed from `properties`
+    (and `required`, though none of them are required today). See H428 /
+    Uprava/FINDINGS.md §30."""
+    import copy
+    defs = copy.deepcopy(defs)
+    for def_name, fields in (
+        ('card', _POST_GENERATION_CARD_FIELDS),
+        ('record', _POST_GENERATION_RECORD_FIELDS),
+        ('sense', _POST_GENERATION_SENSE_FIELDS),
+    ):
+        node = defs.get(def_name)
+        if not node:
+            continue
+        props = node.get('properties', {})
+        for f in fields:
+            props.pop(f, None)
+        req = node.get('required')
+        if isinstance(req, list):
+            node['required'] = [r for r in req if r not in fields]
+    return defs
+
+
 def mw_tm_block(root, mw_tm_path):
     """The MW English translation-memory block injected once per root (en pilot). '' if none."""
     if not mw_tm_path or not os.path.exists(mw_tm_path):
@@ -805,7 +852,8 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     # cards; they are re-derivable downstream). validate_final_card_schema.py was
     # relaxed to match, so RU cards with a missing annotator field still validate.
     schema['$defs']['sense']['required'] = ['tag', 'german', field]
-    defs = _reachable_defs(schema['$defs'], 'card')
+    defs = _strip_post_generation_fields(schema['$defs'])
+    defs = _reachable_defs(defs, 'card')
     card_ref = {'$ref': '#/$defs/card'}
     batch_schema = {
         'type': 'object', 'additionalProperties': False, 'required': ['cards'],
@@ -1724,7 +1772,37 @@ def harness_size_report(root, keys, nominal, js_len, max_bytes):
     return True, lines
 
 
+def dump_schema(lang='ru'):
+    """H428 diagnostic: print the per-call generation StructuredOutput schema's reachable
+    $defs and char length, so a schema-size regression is visible without a Workflow-tool
+    probe. Mirrors the schema build() actually sends (field-rename + required-narrowing +
+    post-generation-field strip + reachable-defs prune)."""
+    field = 'english' if lang == 'en' else 'russian'
+    schema = load_json(os.path.join(REPO, 'schemas', 'pwg_ru_final_card.schema.json'))
+    if field != 'russian':
+        schema = _rename_sense_field(schema, 'russian', field)
+    schema['$defs']['sense']['required'] = ['tag', 'german', field]
+    defs = _strip_post_generation_fields(schema['$defs'])
+    defs = _reachable_defs(defs, 'card')
+    batch_schema = {
+        'type': 'object', 'additionalProperties': False, 'required': ['cards'],
+        'properties': {'cards': {'type': 'array', 'minItems': 1, 'items': {'$ref': '#/$defs/card'}}},
+        '$defs': defs,
+    }
+    s = json.dumps(batch_schema)
+    print('lang=%s reachable $defs: %s' % (lang, sorted(defs.keys())))
+    print('char length: %d' % len(s))
+    print(s)
+
+
 def main():
+    if '--dump-schema' in sys.argv[1:]:
+        lang = 'ru'
+        for a in sys.argv[1:]:
+            if a.startswith('--lang='):
+                lang = a.split('=', 1)[1].strip().lower()
+        dump_schema(lang)
+        return
     root, keyfilter, keylist, budget, lean, nws_gate, nominal, grammar_on, out_path, lang, mw_tm, tm, tm_auto, suggest_tm, suggest_profile = parse_args(sys.argv[1:])
     if nominal:
         # No rootmap: the headword keys ARE the cards, in the order given.

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -2326,6 +2326,43 @@ def test_build_emits_nominal_keymap():
         fail('batched (non-nominal) build must leave meta.nominal_keymap null')
 
 
+def test_generation_schema_carries_no_post_generation_field():
+    """H428: the per-call StructuredOutput schema (build()'s batch_schema) must never carry
+    a field that a deterministic annotator adds AFTER generation (government, labels, renou,
+    renou_oldest, evidence, evidence_summary, stats, renou_oldest_sense) -- those fields
+    pushed the full reachable schema to 10,940 chars, over the Workflow tool's safety-
+    classifier size threshold, blocking every agent() call pre-generation at 0 tokens
+    (Uprava/FINDINGS.md §30). Pins the fix so a future annotator field added to
+    schemas/pwg_ru_final_card.schema.json cannot silently regress this without also being
+    added to _POST_GENERATION_*_FIELDS."""
+    import gen_opt_harness2 as gh
+    schema = gh.load_json(os.path.join(gh.REPO, 'schemas', 'pwg_ru_final_card.schema.json'))
+    schema['$defs']['sense']['required'] = ['tag', 'german', 'russian']
+    defs = gh._strip_post_generation_fields(schema['$defs'])
+    reachable = gh._reachable_defs(defs, 'card')
+    banned = (gh._POST_GENERATION_CARD_FIELDS + gh._POST_GENERATION_RECORD_FIELDS
+              + gh._POST_GENERATION_SENSE_FIELDS)
+    for def_name in ('card', 'record', 'sense'):
+        props = reachable.get(def_name, {}).get('properties', {})
+        for f in banned:
+            if f in props:
+                fail('generation schema $defs[%r] still carries post-generation field %r' % (def_name, f))
+    # evidence_item/evidence_summary/stats become unreachable once sense.evidence and
+    # card.evidence_summary/stats are stripped -- pin that they actually drop out, since a
+    # dangling $defs entry is exactly the H130 orphan-defs dead weight this fix removes.
+    for orphan in ('evidence_item', 'evidence_summary', 'stats'):
+        if orphan in reachable:
+            fail('%r should be unreachable from card once post-generation fields are stripped' % orphan)
+    size = len(json.dumps({
+        'type': 'object', 'additionalProperties': False, 'required': ['cards'],
+        'properties': {'cards': {'type': 'array', 'minItems': 1, 'items': {'$ref': '#/$defs/card'}}},
+        '$defs': reachable,
+    }))
+    if size > 5000:
+        fail('slimmed generation schema grew to %d chars (was 1,698 at H428) -- '
+             're-measure against the Workflow tool safety-classifier threshold' % size)
+
+
 def test_no_pwg_supplement_chain_cards_render():
     """H214: PWG-missing lemmas with real PW/SCH/PWKVN/NWS records are runnable.
 
@@ -3698,6 +3735,7 @@ def main():
         test_coordinator_defect_requeue_uses_no_tm_and_out,
         test_promote_nominal_key1,
         test_build_emits_nominal_keymap,
+        test_generation_schema_carries_no_post_generation_field,
         test_no_pwg_supplement_chain_cards_render,
         test_nominals_worklist_exposes_no_pwg_lane,
         test_no_pwg_source_profile_promotes,


### PR DESCRIPTION
## Summary
- The reachable opt2 `CARDS_SCHEMA` grew to 10,940 chars after H335/H405/H422 each added a legitimately-`$ref`'d field, crossing the Workflow tool's `agent()` safety-classifier size threshold and blocking every call pre-generation at 0 tokens ([H389](https://github.com/gasyoun/Uprava/blob/main/handoffs/H389-Sonnet_RussianTranslation_pwg-ru-medium50-resume_08.07.26.md): 67/67; H388 B-arm: 52/52).
- New `_strip_post_generation_fields()` in `src/pilot/gen_opt_harness2.py` drops every field a downstream deterministic annotator adds post-generation (`government`/`labels`/`renou`/`renou_oldest`/`evidence`, `renou_oldest_sense`, `evidence_summary`/`stats`) from the generation-time schema only — the promote/annotate scripts still add them back from the schema file on disk. Reachable schema: 10,940 → 1,698 chars (84% smaller).
- New `--dump-schema` CLI flag for future measurement without a Workflow-tool probe.
- Second-order lesson logged in [Uprava/FINDINGS.md §30](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md).

## Verification
- One diagnostic `agent()` call (nominal window, root `vinasa`) returned a valid card, 75,774 subagent tokens spent (vs 0 tokens / classifier-blocked pre-fix).
- New `window_selftest.py:test_generation_schema_carries_no_post_generation_field` pins the fix.
- Full `window_selftest.py` (107 tests) and `lang_parity_check.py` (37 entries, `cards_schema_defs_pruning` verdict extended) both green.

## Test plan
- [x] `python src/pilot/window_selftest.py` — 107/107 PASS
- [x] `python src/pilot/lang_parity_check.py` — 37 entries, no drift
- [x] Live diagnostic `agent()` probe via the Workflow tool — returned a valid card

Executes [H428](https://github.com/gasyoun/Uprava/blob/main/handoffs/H428-Sonnet_RussianTranslation_opt2-schema-slim-classifier-unblock_09.07.26.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)