### PR TITLE
docs(pwg_ru): H429 changelog + .ai_state entry

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1794,6 +1794,19 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H429 — PWG page/column co-location index — DONE 09-07-2026 (Opus 4.8
+  `claude-opus-4-8`).** [`src/pwg_page_index.py`](src/pwg_page_index.py) parses
+  the `<pc>` volume-column marker on every PWG entry header (123,366 entries,
+  100% coverage) → three views: [`pwg_columns.tsv`](src/pwg_columns.tsv)
+  (8,171 columns/Spalten), [`pwg_pages.tsv`](src/pwg_pages.tsv) (4,329 physical
+  pages, `page = ⌈col/2⌉`), [`pwg_entry_locations.tsv`](src/pwg_entry_locations.tsv)
+  (reverse lookup incl. cross-volume Nachtrag spans). `--annotate` adds
+  `volume`/`column`/`page`/`pc_all`/`page_all` to the gitignored
+  `pwg_ru_translated.jsonl` cards (11,239/11,261 matched). Served live from
+  kosha's DB as `/api/v1/page` + `/api/v1/neighbors` (kosha H434, PR #33).
+  [PR #286](https://github.com/gasyoun/SanskritLexicography/pull/286).
+  Page = `⌈col/2⌉` is derived (source stores columns only); 22 non-source
+  headword forms unmatched.
 - **H422 — `annotate_stats.py` card-count cache — DONE 09-07-2026 (Sonnet 5
   `claude-sonnet-5`).** Built the GRAMMAR_LAYER.md § "Counting grammar" design
   (PR #284): `src/annotate_stats.py` backfills a `stats` block per lemma

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,24 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### H429 — PWG page/column co-location index (`<pc>` → who shared a printed column/page)
+- New [`src/pwg_page_index.py`](src/pwg_page_index.py) parses the `<pc>`
+  volume-column marker on every entry header in
+  [`csl-orig/v02/pwg/pwg.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/pwg/pwg.txt)
+  (123,366 entries, 100% coverage) and emits three views:
+  [`pwg_columns.tsv`](src/pwg_columns.tsv) — column mode, 8,171 Böhtlingk-Roth
+  *Spalten* → entry IDs + headwords; [`pwg_pages.tsv`](src/pwg_pages.tsv) —
+  2-column page mode, 4,329 physical pages (`page = ⌈col/2⌉`, as printed);
+  [`pwg_entry_locations.tsv`](src/pwg_entry_locations.tsv) — reverse lookup,
+  entry → start column, page, all spanned columns (incl. cross-volume Nachträge).
+- `--annotate` adds `volume`/`column`/`page`/`pc_all`/`page_all` to the
+  gitignored `pwg_ru_translated.jsonl` cards (11,239/11,261 matched;
+  22 non-source-headword forms unmatched), idempotently.
+- Served from kosha's DB as the `/api/v1/page` + `/api/v1/neighbors` endpoints
+  (kosha H434, [PR #33](https://github.com/gasyoun/kosha/pull/33)); this is the
+  raw-source view of the same co-location concept.
+  ([PR #286](https://github.com/gasyoun/SanskritLexicography/pull/286)).
+
 ### H409 — `has_meaning()` short-token stemmer gap fixed, RATIO-scoring regression caught and reverted
 - New [`corpus_gate.ru_has_content()`](src/corpus_gate.py): relaxes the
   `>=3-char-after-stemming` floor for tokens already `<=3` letters before


### PR DESCRIPTION
Records the H429 PWG page/column co-location index ([PR #286](https://github.com/gasyoun/SanskritLexicography/pull/286)) in the pwg_ru changelog `[Unreleased]` and the RussianTranslation `.ai_state.md` Completed section — the state update that couldn't touch the guard-protected canonical checkout during the original session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)