### PR TITLE
ai-wip: H425 re-audit Completed entry

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1799,6 +1799,20 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H425 — adversarial re-audit of W2/W3 provenance backfills — DONE 09-07-2026
+  (Opus 4.8 `claude-opus-4-8` executing the Sonnet-5 brief).** Re-ran every
+  offline check against the live store on `master`: **clean, no fabrication /
+  no status-conflation.** W2 rows-with-evidence 2,269/20.1% + all 12 per-source
+  tallies exact; koch/fri fabrication spot-checks (`seed(42)`, n=20) both 20/20;
+  W3 raw census 3,853/1,476/3,222 exact, backfill parses `de` never `ru`, zero
+  LLM; corpus-gate status markers + `#ИМЯ?` guard confirmed. Two consistent W3
+  notes: store-surface 510→508 (−2 drift), `government` field 0-populated (=
+  audit's own PARTIAL — backfill never run against the store; not a defect).
+  Verdict table appended to [PIPELINE_CAPABILITY_AUDIT_2026-07-08.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md),
+  merged [PR #294](https://github.com/gasyoun/SanskritLexicography/pull/294). No
+  fix PR needed. Open W3 delivery step (out of re-audit scope): decide whether to
+  populate the 508 `government` rows or keep recompute-on-demand.
+
 - **H429 — PWG page/column co-location index — DONE 09-07-2026 (Opus 4.8
   `claude-opus-4-8`).** [`src/pwg_page_index.py`](src/pwg_page_index.py) parses
   the `<pc>` volume-column marker on every PWG entry header (123,366 entries,


### PR DESCRIPTION
Adds the H425 re-audit Completed entry to [RussianTranslation/.ai_state.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md) — session-journal follow-through for [PR #294](https://github.com/gasyoun/SanskritLexicography/pull/294). Journal-only, no code or data change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)