### PR TITLE
fix(pwg_ru): reconcile edition licence to CC BY-SA 4.0 + ORCID byline; refresh DH-roadmap status (H455)

### DIFF
--- a/RussianTranslation/CITATION.cff
+++ b/RussianTranslation/CITATION.cff
@@ -1,9 +1,36 @@
 cff-version: 1.2.0
 message: "If you use this Sanskrit-Russian lexicography dataset, please cite the edition manifest and repository."
-title: "PWG Russian Translation Lexicography Release"
+title: "pwg_ru: a Russian edition of the Sanskrit-German Petersburg Dictionary (PWG, Böhtlingk-Roth)"
+abstract: >-
+  A Russian edition of the Petersburg Dictionary (PWG, Böhtlingk-Roth), produced
+  by corpus-attested sense harvesting over a parallel Sanskrit-Russian corpus
+  combined with LLM translation of the German wrapper prose. Every sense carries
+  source and role provenance; the edition exports to OntoLex-Lemon and TEI Lex-0.
 type: dataset
 authors:
-  - name: "Sanskrit Lexicography Project"
-repository-code: "https://github.com/"
-license: "CC-BY-4.0"
+  - family-names: "Gasūns"
+    given-names: "Mārcis"
+    alias: "gasyoun"
+    orcid: "https://orcid.org/0000-0003-4513-884X"
+    email: "gasyoun@ya.ru"
+    affiliation: "Институт лингвистических исследований РАН (ИЛИ РАН)"
+repository-code: "https://github.com/gasyoun/SanskritLexicography"
+license: "CC-BY-SA-4.0"
 version: "unreleased"
+keywords:
+  - sanskrit
+  - russian
+  - lexicography
+  - petersburg-dictionary
+  - ontolex
+  - tei-lex-0
+preferred-citation:
+  type: book
+  title: "Sanskrit-Wörterbuch"
+  year: 1875
+  authors:
+    - family-names: "Böhtlingk"
+      given-names: "Otto"
+    - family-names: "Roth"
+      given-names: "Rudolph"
+  notes: "The German source dictionary (PWG), public domain."

--- a/RussianTranslation/DATA_LICENSE.md
+++ b/RussianTranslation/DATA_LICENSE.md
@@ -48,5 +48,7 @@ top-level `LICENSE`.
 > Böhtlingk–Roth), produced with corpus-attested sense harvesting.* Sanskrit
 > Lexicon / Cologne Digital Sanskrit Dictionaries. CC BY-SA 4.0.
 
-A machine-readable `CITATION.cff` is planned (see
-[METHODOLOGY_REVIEW.md](METHODOLOGY_REVIEW.md), rec 8).
+A machine-readable [CITATION.cff](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/CITATION.cff)
+sits beside this file and declares the same `CC-BY-SA-4.0` licence. It stays at
+`version: unreleased` until the immutable edition cut is archived and a DOI is
+registered against it — see [DOI_PLAN.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/DOI_PLAN.md).

--- a/RussianTranslation/METHODOLOGY_REVIEW.md
+++ b/RussianTranslation/METHODOLOGY_REVIEW.md
@@ -1,5 +1,13 @@
 # pwg_ru methodology review (2026-06-16)
 
+_Created: 07-07-2026 · Last updated: 10-07-2026_
+
+> **Status refreshed 10-07-2026** (H455) against the code on `origin/master`.
+> Priority 3 has substantially landed since this review was written; Priority 2
+> is split — the gold-set scaffold shipped, human labelling and the
+> lexicographic microstructure are still open. Each recommendation now carries a
+> verified marker.
+
 A five-lens expert review of the pwg_ru process against best **Digital Humanities**
 and **bilingual ("dual") lexicography** practice. Each lens read the actual repo;
 every proposed gap was then *grounded against the code* (REAL / PARTIAL /
@@ -73,14 +81,24 @@ standards & interoperability · editorial & print production.
 
 ### Priority 2 — next (the scholarly core)
 
-4. **Held-out human-checked gold set + fix the fidelity probe** — *Och & Ney AER;
-   Wilson CIs.* The harvest ships senses with *unmeasured* precision, and the surface-
+4. **Held-out human-checked gold set + fix the fidelity probe** — 🟡 *PARTIAL:
+   the stratified n=320 sample is frozen ([gold/gold_set.jsonl](gold/gold_set.jsonl)) and
+   precision is reported with a Wilson CI (84.4%, 95% CI 80.0–87.9,
+   [gold/precision_report.md](gold/precision_report.md)) — but the labels are **LLM-judged**,
+   not human. [gold/HUMAN_GOLD_PROTOCOL.md](gold/HUMAN_GOLD_PROTOCOL.md) is the written,
+   un-executed human pass; until it runs, the number must not be cited as print-grade
+   precision. The κ figure additionally needs a second annotator, which is deferred
+   through 2026.* — *Och & Ney AER; Wilson CIs.* The harvest ships senses with *unmeasured* precision, and the surface-
    overlap probe conflates correct lemmatisation (rājan→царь scored a miss because
    the verse has genitive rājño) with hallucination. Draw a stratified 300–500 sample,
    human-label correct/wrong-sense/hallucinated/lemma-only, report precision + 95%
    Wilson CI, freeze a checked-in gold set; make the probe lemma-aware. *(effort M)*
 
-5. **Gate stratum-preference on real per-stratum coverage** — *corpus
+5. **Gate stratum-preference on real per-stratum coverage** — 🟡 *PARTIAL: the
+   coverage-by-stratum report shipped (`corpus_harvest.py coverage`), but nothing in
+   [src/corpus_harvest.py](src/corpus_harvest.py) labels a thin stratum as **fell-back**,
+   so a Rigvedic sense still silently inherits Epic Russian. The disclosure exists; the
+   gate does not.* — *corpus
    representativeness (Biber); honest disclosure.* Era-correct Russian is the headline
    feature, yet the lexicon currently covers ~9 of 121 texts (Epic + one AV book; **zero
    Rigvedic rows**), while [build_ls_map.py](src/build_ls_map.py) marks Rigveda/kāvya
@@ -88,7 +106,12 @@ standards & interoperability · editorial & print production.
    Russian. Report coverage by stratum, label thin strata as fell-back, and assemble no
    Vedic-citation cards for print until those builds land. *(effort M — partly shipped, see below)*
 
-6. **Build the lexicographic microstructure** — *Atkins & Rundell; Zgusta;
+6. **Build the lexicographic microstructure** — 🔴 *OPEN — the largest remaining gap
+   between this pipeline and a publishable scholarly edition. Verified 10-07-2026:
+   `HEAD_SENSE_ONLY = True` is still hard-coded at [src/corpus_gate.py:40](src/corpus_gate.py),
+   and the `h` homonym number is still not threaded through [src/pwg_mask.py](src/pwg_mask.py)
+   `parse()`, so 6,424 homograph records continue to pool into one card.* —
+   *Atkins & Rundell; Zgusta;
    Adamska-Sałaciak; Hausmann marker typology.* [assemble.py](src/assemble.py) emits a
    flat sense-bag; the gate hard-codes `HEAD_SENSE_ONLY`; [pwg_mask.py](src/pwg_mask.py)
    `parse()` drops the `h` homonym number so 6,424 homograph records pool into one card;
@@ -97,7 +120,11 @@ standards & interoperability · editorial & print production.
    `(key1, h)`, add a per-sense `equivalence_type` + diasystem label (Vedic/Classical/
    domain/register) from the `<ls>` stratum + PWG `ved./ep.` markers. *(effort L)*
 
-7. **Translation-store auditor + cross-card terminology-consistency auditor** —
+7. **Translation-store auditor + cross-card terminology-consistency auditor** — 🟡
+   *PARTIAL: [src/audit_translation.py](src/audit_translation.py) and
+   [src/audit_translation_provenance.py](src/audit_translation_provenance.py) now guard the
+   translation store. The **cross-card German-term concordance** — flagging a glossary key
+   rendered more than one way across cards — has no implementation.* —
    *deterministic fail-closed build-gate; controlled-metalanguage enforcement.*
    [_audit.py](src/_audit.py) guards only the corpus lexicon; nothing guards
    `pwg_ru_translated.jsonl`. Add `_audit_translations.py` (no residual German outside
@@ -105,16 +132,27 @@ standards & interoperability · editorial & print production.
    unaltered; unique ords; exit non-zero) and a German-term concordance flagging a
    glossary key rendered more than one way across cards. *(effort M)*
 
-### Priority 3 — later (interoperability & citability)
+### Priority 3 — later (interoperability & citability) — 🟢 SUBSTANTIALLY SHIPPED
 
-8. **Export to TEI Lex-0 / OntoLex; make the edition citable and reversible** —
-   *TEI Lex-0; OntoLex-Lemon + vartrans + FrAC; CITATION.cff; Zenodo DOI; PROV-O.*
-   Output is bespoke gitignored JSONL — no TEI, no OntoLex, no JSON Schema, no PID, no
-   reverse (Russian→Sanskrit) index, no edition freeze. The sibling **csl-standards**
-   repo already has `export-tei-lex0.mjs` / `export-ontolex.mjs` over the same SLP1
-   keys, so this is an adapter + a Russian sense path. Commit a versioned card JSON
-   Schema now; add `CITATION.cff`; define an immutable `edition_vN.jsonl` cut; seed a
-   reverse index from the pymorphy3 lemmas. *(effort L)*
+8. **Export to TEI Lex-0 / OntoLex; make the edition citable and reversible** — 🟢
+   *SHIPPED, verified 10-07-2026.* The original text below described a state that no
+   longer holds. What exists now: TEI Lex-0 export
+   ([src/export_interop.py](src/export_interop.py) → `tei_lex0.xml`), OntoLex-Lemon
+   ([release/ontolex.ttl](release/ontolex.ttl), 726k lines) with a SHACL
+   [release/shapes.ttl](release/shapes.ttl), three versioned JSON Schemas under
+   [schemas/](schemas/), a Russian→Sanskrit [release/reverse_index.jsonl](release/reverse_index.jsonl),
+   an immutable edition cut ([src/make_edition_cut.py](src/make_edition_cut.py)), and a
+   [CITATION.cff](CITATION.cff) — corrected under H455 to `CC-BY-SA-4.0` (matching
+   [DATA_LICENSE.md](DATA_LICENSE.md)) with the ORCID byline. **Remaining:** the Zenodo
+   DOI itself is unregistered and `CITATION.cff` stays at `version: unreleased` until the
+   archival upload happens — see [DOI_PLAN.md](DOI_PLAN.md).
+   *— TEI Lex-0; OntoLex-Lemon + vartrans + FrAC; CITATION.cff; Zenodo DOI; PROV-O.*
+
+   > *Original 2026-06-16 text, kept for the record:* Output is bespoke gitignored
+   > JSONL — no TEI, no OntoLex, no JSON Schema, no PID, no reverse (Russian→Sanskrit)
+   > index, no edition freeze. The sibling **csl-standards** repo already has
+   > `export-tei-lex0.mjs` / `export-ontolex.mjs` over the same SLP1 keys, so this is an
+   > adapter + a Russian sense path. *(effort L)*
 
 ## Quick wins (small, independent)
 
@@ -125,11 +163,16 @@ standards & interoperability · editorial & print production.
 - **Print a coverage-by-stratum table** — exposes the empty Rigvedic/kāvya strata (rec 5). ✅ *shipped this session — `corpus_harvest.py coverage`.*
 - Keep `publishable`/rights metadata per sense, with approved modern sources
   marked publishable and cited by source (rec 3).
-- Commit a versioned JSON Schema for the assembled card (rec 8).
-- Thread the `h` homonym number through [pwg_mask.py](src/pwg_mask.py) `parse()` (rec 6).
-- Add a `CITATION.cff` and list pwg_ru/mw_ru in the ROADMAP Zenodo/DOI plan (rec 8).
+- Commit a versioned JSON Schema for the assembled card (rec 8). ✅ *shipped — [schemas/](schemas/).*
+- Thread the `h` homonym number through [pwg_mask.py](src/pwg_mask.py) `parse()` (rec 6). 🔴 *still open.*
+- Add a `CITATION.cff` and list pwg_ru/mw_ru in the ROADMAP Zenodo/DOI plan (rec 8). ✅ *shipped; DOI registration still pending.*
 
 ---
 *Method: 5 expert-lens agents + per-gap repo grounding + synthesis (34 agents).
 Re-run by editing the workflow and re-invoking. This document is the canonical
 to-do; check items off as they land.*
+
+*Status markers refreshed 10-07-2026 under H455 by Opus 4.8 (`claude-opus-4-8`),
+each verified against the code on `origin/master` rather than assumed.*
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Closes the citability defects surfaced while answering "does the PWG→RU pipeline follow DH best practice, and is it documented?"

It is documented — [METHODOLOGY_REVIEW.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/METHODOLOGY_REVIEW.md) is a five-lens review against FAIR/DH and bilingual-lexicography practice. Verifying it against the code found three defects and one stale doc.

## Fixed

**Licence contradiction (would have shipped a wrong-licence DOI).** [DATA_LICENSE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/DATA_LICENSE.md) declared `CC-BY-SA-4.0`; [CITATION.cff](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/CITATION.cff) declared `CC-BY-4.0`. Ruling 10-07-2026: **CC-BY-SA-4.0** governs the edition.

**`repository-code` was the literal placeholder** `https://github.com/`.

**Anonymous author, no ORCID.** Replaced with the canonical byline from [CommentaryStrategies/CITATION.cff](https://github.com/gasyoun/CommentaryStrategies/blob/main/CITATION.cff) — Mārcis Gasūns, ORCID [0000-0003-4513-884X](https://orcid.org/0000-0003-4513-884X), ИЛИ РАН. Added `abstract`, `keywords`, and a `preferred-citation` to Böhtlingk–Roth.

**Stale roadmap status.** Priority 3 was still listed as "later" though most of it shipped.

## Verified status (against code on `master`, not assumed)

| Rec | Status | Evidence |
|---|---|---|
| 4 gold set | 🟡 partial | n=320 frozen, 84.4% precision (95% CI 80.0–87.9) — but **LLM-judged**; `HUMAN_GOLD_PROTOCOL.md` un-executed |
| 5 stratum gate | 🟡 partial | coverage reports; no `fell-back` labelling |
| 6 microstructure | 🔴 open | `HEAD_SENSE_ONLY = True` at `corpus_gate.py:40`; `h` not threaded through `pwg_mask.py parse()` → 6,424 homographs pool into one card |
| 7 translation auditor | 🟡 partial | auditors exist; no cross-card German-term concordance |
| 8 TEI/OntoLex/citability | 🟢 shipped | `tei_lex0.xml` export, `ontolex.ttl` (726k lines), `shapes.ttl`, 3 schemas, reverse index, edition cut, CITATION.cff |

Docs only — no code paths touched. `CITATION.cff` re-validated as YAML; no BOM.

Handoff: H455. Authored in an isolated worktree because concurrent Codex sessions hold WIP in the shared tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)