### PR TITLE
refactor(pwg-ru): split translation and recovery budgets

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -645,6 +645,13 @@ Two live tracks:
 
 ## 🚧 Current Work-In-Progress (WIP)
 
+- [ ] **pwg_ru production-spine refactor IN PROGRESS (10-07-2026, Codex/GPT-5).**
+      Isolated `codex/pwg-runtime-refactor` worktree. First green milestone separates the
+      generated Workflow's translate and heal agent-call pools through a pure budget planner,
+      so the H442/H462 per-card heal caps can bind instead of losing first to one shared window
+      counter. Scholarly prompts, translation schema, gates, and store semantics are untouched.
+      Full detail and verification live in `RussianTranslation/.ai_state.md`.
+
 - [ ] **FREQUENCY-FIRST validated + the GIANT-ROOT finding (2026-06-23).** `freq_route.py`
       built → `scale_manifest.freq.json` (43,968/106,083 = 41% DCS-attested; band 5=641,
       4=3170 → ~3.8k core). **Top of the dictionary = verbal roots** (sTA 379 senses, i 272,

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -645,13 +645,6 @@ Two live tracks:
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- [ ] **pwg_ru production-spine refactor IN PROGRESS (10-07-2026, Codex/GPT-5).**
-      Isolated `codex/pwg-runtime-refactor` worktree. First green milestone separates the
-      generated Workflow's translate and heal agent-call pools through a pure budget planner,
-      so the H442/H462 per-card heal caps can bind instead of losing first to one shared window
-      counter. Scholarly prompts, translation schema, gates, and store semantics are untouched.
-      Full detail and verification live in `RussianTranslation/.ai_state.md`.
-
 - [ ] **FREQUENCY-FIRST validated + the GIANT-ROOT finding (2026-06-23).** `freq_route.py`
       built → `scale_manifest.freq.json` (43,968/106,083 = 41% DCS-attested; band 5=641,
       4=3170 → ~3.8k core). **Top of the dictionary = verbal roots** (sTA 379 senses, i 272,
@@ -857,6 +850,16 @@ Two live tracks:
   demote to plain text with "(не входит в этот репозиторий)", do not link.
 
 ## ✅ Completed (Recent only)
+
+- **pwg_ru production-spine split-pool refactor — DONE OFFLINE 10-07-2026 (Codex/GPT-5).**
+  On isolated branch `codex/pwg-runtime-refactor`, split the generated Workflow runtime's
+  translate and heal agent-call budgets through pure `src/pilot/agent_budget.py`; retained
+  backwards-compatible total telemetry and added per-lane classification signals. A generated-JS
+  Node test proves an all-heal window reaches its per-card ceilings without the window pool firing
+  first. Full production-contract selftest, parity ledger (41 entries), launch ledger, compilation,
+  and severe-error ruff gate pass; CI now runs those contracts. Scholarly prompts, schema, gates,
+  and store semantics are unchanged. Live medium50 remains paused pending a healthy >=5 KB probe
+  and `h317_w1b` canary; this commit does not assert field success.
 
 - **RussianTranslation coordinator orchestration hardening — DONE 09-07-2026 (Codex/GPT-5).**
   In `RussianTranslation`, hardened `src/pilot/coordinator.py`: abandoned pre-prepare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,13 @@ jobs:
         run: |
           pip install rdflib pyshacl
           python src/lod_acceptance.py --cards /nonexistent
+      - name: Validate PWG production runtime and failure contracts
+        working-directory: RussianTranslation
+        run: |
+          python src/pilot/agent_budget.py
+          python src/pilot/window_selftest.py
+          python src/pilot/lang_parity_check.py
+          python src/pilot/check_launch_ledger.py --since 2026-07-05
       - name: Validate roadmap
         working-directory: RussianTranslation
         run: python src/roadmap_check.py

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1610,6 +1610,17 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## 🚧 Current Work-In-Progress (WIP)
 
+- **PWG runtime production-spine refactor — IN PROGRESS 10-07-2026 (Codex/GPT-5).**
+  Isolated branch/worktree `codex/pwg-runtime-refactor` from current `origin/master`.
+  First milestone green: new pure `src/pilot/agent_budget.py` derives independent
+  whole-card translate and fragment-heal call pools; the heal ceiling equals the sum of
+  per-card ceilings, eliminating the H442/H462 shared-counter condition that made those
+  card caps unreachable on all-heal windows. `gen_opt_harness2.py` emits/enforces both
+  pools and returns per-lane spend/trip telemetry while retaining total fields. Added
+  executable plan tests + generated-runtime wiring checks; `agent_budget.py` selftest,
+  full `window_selftest.py`, focused ruff, and LANG_PARITY (41 entries) pass. Next:
+  behavioral mock-runtime characterization, CI wiring, operator docs, then full verification.
+
 - **FIX_PLAN_2026-07-09 P0 safety patch — PR READY 09-07-2026 (Codex/GPT-5).**
   P0 requeue/TM safeguards are present and now testable without old ignored runtime fixtures:
   `requeue_from_audit.py` forces `--no-tm` for defect/all requeues, appends card + fragment

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -42,9 +42,12 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   [`LAUNCH_LEDGER_AUDIT_2026-07.md`](LAUNCH_LEDGER_AUDIT_2026-07.md) (2 of 13 classifications
   overturned → `concurrency/api`, corrections appended not rewritten), and the honest
   `LAUNCH_STATS.md` (450-window population + provenance stamp + refused-launch side-denominator).
-  Remaining structural lever (behavioural, out of H462 scope): **separate the heal pool from the
-  translate pool** — until then the per-card heal cap cannot bind on an all-heal window by
-  construction. Verb drain (H151) unaffected.
+  The remaining H462 structural lever is now **implemented offline** on
+  `codex/pwg-runtime-refactor` (Codex/GPT-5, 10-07-2026): the generated runtime has independent
+  translate/heal pools, the heal ceiling is derived from the sum of per-card ceilings, and a Node
+  all-heal behavioral test proves the shared window counter no longer fires first. This is not a
+  live-lane closeout: medium50 stays paused until a healthy >=5 KB probe and `h317_w1b` canary
+  validate the change under load. Verb drain (H151) unaffected.
 
 - **H405 Stage-2 mechanical pre-gate — FULLY DONE 09-07-2026 (Opus 4.8 `claude-opus-4-8`), RU + EN.**
   [`src/stage2_pregate.py`](src/stage2_pregate.py) built + selftest-green; measured 99.72% CLEAN / 0.10% hard-FAIL over the 11,261-row store (13 real defects surfaced). `--wf` window-gate mode wired into [`src/pilot/audit_window.py`](src/pilot/audit_window.py) as `stage2_mechanical`; mechanical criteria stripped from both judge prompts ([`2_qa_sudya_opus.txt`](pwg_ru_prompts/2_qa_sudya_opus.txt) + YandexGPT twin). EN auditor [`src/pilot/audit_window_en.py`](src/pilot/audit_window_en.py) wired via in-process `audit_sense`→`pregate(g,e)` adapter contributing only net-new hard flags (IS-LOSS, STRANDED-ANCHOR, anchor backstops); LS/SAN/AB stay owned by `audit_sense`. Parity GAP closed → `stage2_pregate_en_wiring_h405` SHARED; LANG_PARITY 37 entries no drift; `window_selftest.py` green. No follow-ups.
@@ -1610,17 +1613,6 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- **PWG runtime production-spine refactor — IN PROGRESS 10-07-2026 (Codex/GPT-5).**
-  Isolated branch/worktree `codex/pwg-runtime-refactor` from current `origin/master`.
-  First milestone green: new pure `src/pilot/agent_budget.py` derives independent
-  whole-card translate and fragment-heal call pools; the heal ceiling equals the sum of
-  per-card ceilings, eliminating the H442/H462 shared-counter condition that made those
-  card caps unreachable on all-heal windows. `gen_opt_harness2.py` emits/enforces both
-  pools and returns per-lane spend/trip telemetry while retaining total fields. Added
-  executable plan tests + generated-runtime wiring checks; `agent_budget.py` selftest,
-  full `window_selftest.py`, focused ruff, and LANG_PARITY (41 entries) pass. Next:
-  behavioral mock-runtime characterization, CI wiring, operator docs, then full verification.
-
 - **FIX_PLAN_2026-07-09 P0 safety patch — PR READY 09-07-2026 (Codex/GPT-5).**
   P0 requeue/TM safeguards are present and now testable without old ignored runtime fixtures:
   `requeue_from_audit.py` forces `--no-tm` for defect/all requeues, appends card + fragment
@@ -1862,6 +1854,20 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   ([SamudraManthanam #16](https://github.com/gasyoun/SamudraManthanam/issues/16)).
 
 ## ✅ Completed (Recent only)
+
+- **PWG runtime production-spine split-pool refactor — DONE OFFLINE 10-07-2026 (Codex/GPT-5).**
+  On isolated branch/worktree `codex/pwg-runtime-refactor`, new pure
+  [`src/pilot/agent_budget.py`](src/pilot/agent_budget.py) derives independent whole-card
+  translate and fragment-heal call pools. The heal ceiling equals the sum of per-card ceilings,
+  eliminating the H442/H462 shared-counter condition that made those caps unreachable on
+  all-heal windows. `gen_opt_harness2.py` enforces both pools and returns per-lane spend/trip
+  telemetry while retaining H462's total fields; `classify_run.py` surfaces the new fields but
+  remains compatible with old payloads. A generated-JS Node test executes two all-heal cards and
+  proves each stops at its own cap without the window pool firing first. CI now runs
+  `agent_budget.py`, full `window_selftest.py`, LANG_PARITY, and the launch-ledger audit.
+  Verification green: compilation, full selftest, 41-entry parity ledger, 13-entry launch ledger,
+  focused ruff, and `git diff --check`. This closes the offline structural defect only: medium50
+  remains paused pending a healthy >=5 KB probe and `h317_w1b` live canary.
 
 - **H462 — launch-telemetry ledger code-vs-docs audit — DONE 10-07-2026 (Fable 5
   `claude-fable-5`).** Counters-only telemetry patch (summary now returns

--- a/RussianTranslation/FIX_PLAN_H442_2026-07-10.md
+++ b/RussianTranslation/FIX_PLAN_H442_2026-07-10.md
@@ -97,8 +97,13 @@ as infra-confounded, not as a code failure.
 
 Only consider these after a clean-environment P0 measurement fails.
 
-- Raise or uncouple `MAX_AGENTS` for nominal-heal windows so the shared window
-  pool does not trip before cards finish.
+- **Implemented offline 10-07-2026:** uncouple the translate and heal agent pools. The
+  generated runtime now enforces `MAX_TRANSLATE_AGENTS` and `MAX_HEAL_AGENTS`
+  independently; the heal pool equals the sum of per-card ceilings, so those card caps are
+  reachable on an all-heal window. `agent_budget.py` makes the derivation pure, and a Node
+  mock-runtime test proves two all-heal cards stop at their card caps without tripping the
+  window pool. This is a guardrail implementation, not an H442 closeout: the live
+  `h317_w1b` stop condition below remains unmeasured in a healthy generation environment.
 - Right-size presplit/sense budgets for medium50 cards so dense cards enter
   smaller clean fragments before runtime heal begins.
 - Re-measure h317_w1b after each parameter change; stop after three measured

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -455,7 +455,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
   },
   {
     "id": "presplit_lane_amortization_and_budget_guards_h189",
-    "mechanism": "Presplit-PRIMARY cards are grouped at PRESPLIT_GROUP_CITE_BUDGET(60)/PRESPLIT_GROUP_SENSE_CAP(18) instead of the conservative SELFHEAL_GROUP_BUDGET(12), amortizing the ~27k framework across many fragments per agent() call; the wall-clock kill gate is recalibrated (floor 120s->45s, ceil 480s->180s) per MG's >60s-suspicious/>3min-unacceptable rule; a window-level budget kill-switch aborts+requeues once agent() calls exceed MAX_AGENTS=ceil(expected*3)+10); the generator warns + suggests a key-disjoint split when the harness exceeds MAX_HARNESS_BYTES(480k); perf_preflight adds a per-card / per-window cost gate that flags a window dominated by expensive cards",
+    "mechanism": "Presplit-PRIMARY cards are grouped at PRESPLIT_GROUP_CITE_BUDGET(60)/PRESPLIT_GROUP_SENSE_CAP(18) instead of the conservative SELFHEAL_GROUP_BUDGET(12), amortizing the ~27k framework across many fragments per agent() call; the wall-clock kill gate is recalibrated (floor 120s->45s, ceil 480s->180s) per MG's >60s-suspicious/>3min-unacceptable rule; the original window-level shared MAX_AGENTS kill-switch is retained as backwards-compatible total telemetry but superseded operationally by the independent translate/heal ceilings in split_agent_budget_pools_20260710; the generator warns + suggests a key-disjoint split when the harness exceeds MAX_HARNESS_BYTES(480k); perf_preflight adds a per-card / per-window cost gate that flags a window dominated by expensive cards",
     "files": [
       "src/pilot/gen_opt_harness2.py",
       "src/pilot/perf_preflight.py",
@@ -471,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -502,7 +502,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "2a0478b0779e1aba2bf2e2a0e7d5b50807f7acccf44ae4b00a7dc3af3ff29005",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -521,7 +521,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "9ef1fd0e7c1d31760db187d16046b7dffbafa4fd6d11099ef61fb95094975b27",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
       "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -623,7 +623,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -652,7 +652,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -672,7 +672,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -691,7 +691,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "5e257d130318be4e903bb55444d70c88544af8725c115253235e5daed716ec51",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -728,7 +728,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -786,7 +786,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -805,7 +805,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -824,7 +824,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   },
   {
@@ -844,8 +844,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672",
-      "src/pilot/classify_run.py": "4da13f241aa3dcfc4d0670e9ff5ffc8bba7cacf848bbf1c51006aa15d49ff9fe"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5",
+      "src/pilot/classify_run.py": "868f9c76df11726d1872ac1c213f3f5b58aafcf090e302165d2ec52a2eddeecc"
     }
   },
   {
@@ -861,12 +861,12 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "10-07-2026, Codex/GPT-5. Budget planning and generated agentKill lane selection are language-agnostic: both RU and EN use the same batches, FRAGS, healGroup/selfHeal, label prefixes, and counters. The change does not touch prompt text, output fields, or model selection. Pinned by agent_budget.selftest, test_agent_budget_plan_separates_translate_and_heal_pools, and test_budget_kill_switch_wired.",
+    "note": "10-07-2026, Codex/GPT-5. Budget planning and generated agentKill lane selection are language-agnostic: both RU and EN use the same batches, FRAGS, healGroup/selfHeal, label prefixes, and counters. The change does not touch prompt text, output fields, or model selection. Pinned by agent_budget.selftest, test_agent_budget_plan_separates_translate_and_heal_pools, test_split_agent_pools_all_heal_runtime (executes generated JS under Node with a null-returning mock agent), and test_budget_kill_switch_wired.",
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
+      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
     }
   }
 ]

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29"
     }
   },
   {
@@ -117,8 +117,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -136,8 +136,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -155,8 +155,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -173,7 +173,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29"
     }
   },
   {
@@ -224,7 +224,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29"
     }
   },
   {
@@ -241,7 +241,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29"
     }
   },
   {
@@ -257,7 +257,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The bare 'sonnet' alias resolved to Sonnet 4.6 (not 5.0) on a prior EN run — pinned explicitly there after that surprise. RU's alias was never observed to misresolve, so it was left alone rather than touching a stable production path for a problem it doesn't have. Re-evaluate if RU is ever caught on a stale alias too.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29"
     }
   },
   {
@@ -354,8 +354,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -411,8 +411,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -449,7 +449,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b",
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d"
     }
   },
@@ -469,9 +469,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b",
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -502,7 +502,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "2a0478b0779e1aba2bf2e2a0e7d5b50807f7acccf44ae4b00a7dc3af3ff29005",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -521,7 +521,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "9ef1fd0e7c1d31760db187d16046b7dffbafa4fd6d11099ef61fb95094975b27",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
       "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -623,7 +623,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -652,7 +652,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -672,7 +672,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -691,7 +691,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "5e257d130318be4e903bb55444d70c88544af8725c115253235e5daed716ec51",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -728,7 +728,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -786,12 +786,12 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
     "id": "per_card_heal_budget_h442",
-    "mechanism": "Per-card heal-call ceiling from the H442 kill-gate recalibration. PER_CARD_HEAL_BUDGET (default on) makes selfHeal derive one shared {spent,max} per card sized ceil(nGroups*PER_CARD_HEAL_FACTOR)+PER_CARD_HEAL_HEADROOM and thread it through healGroup + its bisection recursion; once a card's own heal spend crosses max, healGroup returns a PARTIAL card (missing_fragments requeue-able) instead of draining the shared window MAX_AGENTS pool. --no-per-card-heal-budget tunes only this ceiling; kill-timeout bisection waste is tracked separately in heal_kill_timeout_no_bisect_h442.",
+    "mechanism": "Per-card heal-call ceiling from the H442 kill-gate recalibration. PER_CARD_HEAL_BUDGET (default on) makes selfHeal derive one shared {spent,max} per card sized ceil(nGroups*PER_CARD_HEAL_FACTOR)+PER_CARD_HEAL_HEADROOM and thread it through healGroup + its bisection recursion; once a card's own heal spend crosses max, healGroup returns a PARTIAL card (missing_fragments requeue-able). The follow-up split_agent_budget_pools_20260710 mechanism removes the shared-window ceiling that previously fired before these card caps on all-heal windows. --no-per-card-heal-budget tunes only this ceiling; kill-timeout bisection waste is tracked separately in heal_kill_timeout_no_bisect_h442.",
     "files": [
       "src/pilot/gen_opt_harness2.py",
       "src/pilot/window_selftest.py"
@@ -804,8 +804,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -823,8 +823,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4"
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   },
   {
@@ -843,9 +843,30 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "8c1f45349d5cde2870171eecca9b4e4a437eaa855a205803d57afce4c51d840b",
-      "src/pilot/window_selftest.py": "17406bc8be6ce8772e14b01557eac8636f0a3066aa284042e2b66c973e9567b4",
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672",
       "src/pilot/classify_run.py": "4da13f241aa3dcfc4d0670e9ff5ffc8bba7cacf848bbf1c51006aa15d49ff9fe"
+    }
+  },
+  {
+    "id": "split_agent_budget_pools_20260710",
+    "mechanism": "The generated Workflow runtime enforces independent translate and heal agent-call pools. Whole-card batches and resolveGroup binary splits spend MAX_TRANSLATE_AGENTS; fragment recovery and presplit cards spend MAX_HEAL_AGENTS. agent_budget.py derives the plan as pure Python: the heal ceiling equals the sum of per-card heal ceilings, so the window pool cannot fire before the per-card guards merely because many cards recover concurrently. The legacy --max-agents override remains one combined hard ceiling allocated across active pools. Summary/meta return both pool ceilings, spend, and trip flags while retaining backwards-compatible total fields.",
+    "files": [
+      "src/pilot/agent_budget.py",
+      "src/pilot/gen_opt_harness2.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "10-07-2026, Codex/GPT-5. Budget planning and generated agentKill lane selection are language-agnostic: both RU and EN use the same batches, FRAGS, healGroup/selfHeal, label prefixes, and counters. The change does not touch prompt text, output fields, or model selection. Pinned by agent_budget.selftest, test_agent_budget_plan_separates_translate_and_heal_pools, and test_budget_kill_switch_wired.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
+      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
+      "src/pilot/window_selftest.py": "70c7119ccb890f04369fd8c416b1694c7fada1c71f7144e8e2ee1fbd8f286672"
     }
   }
 ]

--- a/RussianTranslation/LAUNCH_LEDGER_AUDIT_2026-07.md
+++ b/RussianTranslation/LAUNCH_LEDGER_AUDIT_2026-07.md
@@ -134,6 +134,14 @@ bind on all-heal windows â€” uncoupling the heal pool from the translate pool â€
 behavioural, and therefore **out of H462's counters-only scope**; it stays recorded in
 entry 13's `residual_risk` as the next structural move.
 
+> **Follow-up implemented offline 10-07-2026 (Codex/GPT-5):** the current refactor removes
+> that shared-counter design. `agent_budget.py` derives independent translate and heal
+> ceilings; `agentKill` charges by lane; the heal ceiling is the sum of per-card caps; and
+> summary/meta return both pools' spend and trip state. A generated-JS Node test with two
+> all-heal, always-null cards reaches both per-card caps without tripping the window heal
+> pool. The historical finding above remains the correct reading of H437/H442 artifacts;
+> the new behavior is not production-validated until a healthy `h317_w1b` canary runs.
+
 **Ruling on the handoff's open question 2 (per-card vs per-window `heal_calls`):**
 per-window. The summary's new `heal_calls` counts heal-lane `agent()` calls window-wide
 (labels `heal:*`); the per-card view already exists inside the run as `cardBudget.spent`

--- a/RussianTranslation/MEASUREMENT_2026-07-08_H317.md
+++ b/RussianTranslation/MEASUREMENT_2026-07-08_H317.md
@@ -377,4 +377,19 @@ The FIX_PLAN's audit command is also wrong and was corrected in this pass: it sa
 `--root nominal_h317_w1b`, but the harness root is `h317_w1b`; the stale-artifact guard correctly
 refused the mismatched run.
 
+## Update — 10-07-2026: shared-counter design removed offline; live stop condition still pending
+
+The disposition's structural item (c) is implemented on `codex/pwg-runtime-refactor`:
+`agent_budget.py` derives independent translate and heal pools, and the generated runtime
+charges whole-card/binary-split calls to `MAX_TRANSLATE_AGENTS` while fragment recovery and
+presplit calls use `MAX_HEAL_AGENTS`. The heal ceiling is the sum of the per-card ceilings,
+so the window cannot fire before those card caps solely because many cards heal at once.
+
+Offline verification executes generated JavaScript under Node with two sense-dense presplit
+cards and a null-returning mock `agent()`: both cards reach their own caps, all keys remain
+explicitly requeueable, `heal_agents_spent == max_heal_agents`, and
+`heal_budget_tripped=false`. This closes the construction defect, not the production result.
+The medium50 lane remains paused until a load-representative probe passes and one healthy
+`h317_w1b` canary measures the existing `>=6/12`, no-trip, zero-connection-error stop condition.
+
 _Dr. Mārcis Gasūns_

--- a/RussianTranslation/pwg_ru/REPRODUCIBILITY.md
+++ b/RussianTranslation/pwg_ru/REPRODUCIBILITY.md
@@ -44,8 +44,10 @@ All defined in [gen_opt_harness2.py](https://github.com/gasyoun/SanskritLexicogr
 | `KILL_SLOPE_MS` | 45 | ms per masked-skeleton byte (above the 44 ms/byte observed ceiling) |
 | `KILL_FLOOR_MS` | 45,000 | never kill before 45 s (H189; was 120,000) |
 | `KILL_CEIL_MS` | 180,000 | hard 3-min ceiling (H189; was 480,000). H220 exception: a single card with no selfheal fallback gets the CEIL budget directly |
-| `MAX_AGENTS` | `⌈expected × 3.0⌉ + 10` | live budget kill-switch (`MAX_AGENTS_FACTOR=3.0`, `MAX_AGENTS_HEADROOM=10`, `--max-agents=N` override) |
-| `PER_CARD_HEAL_BUDGET` | on; `⌈groups × 1.5⌉ + 3` | H442 per-card heal-call ceiling (`--no-per-card-heal-budget`, `--per-card-heal-factor=N`, `--per-card-heal-headroom=N`) so one dense card cannot consume the shared window `MAX_AGENTS` pool |
+| `MAX_TRANSLATE_AGENTS` | `⌈batch_count × 3.0⌉ + 10` | whole-card translation + binary-split pool; independent from fragment recovery |
+| `MAX_HEAL_AGENTS` | sum of every active card's heal cap | fragment-recovery/presplit pool; cannot fire before the per-card caps merely because many cards heal concurrently |
+| `MAX_AGENTS` | translate pool + heal pool | backwards-compatible total telemetry; `--max-agents=N` remains a combined hard override allocated across active pools |
+| `PER_CARD_HEAL_BUDGET` | on; `⌈groups × 1.5⌉ + 3` | H442 per-card heal-call ceiling (`--no-per-card-heal-budget`, `--per-card-heal-factor=N`, `--per-card-heal-headroom=N`); pure derivation lives in `src/pilot/agent_budget.py` |
 | retries | 1 per card/stage | plus the runtime's internal StructuredOutput retry cap (~5) |
 | TM | `--tm=auto` default | card + fragment translation memory; **requeue denylists TM** — [requeue_from_audit.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/requeue_from_audit.py) auto-appends `--no-tm` on anything but `--transient` (fixed 04-07-2026) |
 | concurrency | ≤3 root harnesses | Slice-D 18-wide collapse (117 transient nulls) is the standing counter-example |

--- a/RussianTranslation/src/pilot/agent_budget.py
+++ b/RussianTranslation/src/pilot/agent_budget.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Pure agent-budget planning for the generated PWG Workflow runtime.
+
+The production harness has two materially different call lanes:
+
+* ``translate`` — whole-card batches and their binary-split retries;
+* ``heal`` — fragment recovery, including cards routed directly to presplit.
+
+Before this module existed both lanes spent one ``MAX_AGENTS`` counter.  On an
+all-heal window the shared ceiling necessarily fired before the sum of the
+per-card heal ceilings, making the per-card guard unreachable.  Keeping the
+plan pure makes that invariant executable without launching the external
+Workflow runtime.
+"""
+
+import math
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True)
+class AgentBudgetPlan:
+    """Derived call ceilings for one generated Workflow window."""
+
+    translate_expected: int
+    heal_groups: int
+    heal_cards: int
+    max_translate_agents: int | None
+    max_heal_agents: int | None
+    max_agents: int | None
+    strategy: str
+
+    def meta(self):
+        return asdict(self)
+
+
+def _scaled(expected, factor, headroom):
+    if expected <= 0:
+        return 0
+    return int(math.ceil(expected * factor)) + headroom
+
+
+def _per_card_heal_cap(groups, factor, headroom):
+    if groups <= 0:
+        return 0
+    return int(math.ceil(groups * factor)) + headroom
+
+
+def _allocate_total(total, translate_default, heal_default):
+    """Allocate an explicit legacy ``--max-agents`` ceiling across both pools.
+
+    The override remains a hard *combined* ceiling.  Defaults are used only as
+    weights; translate gets the odd/last slot because primary work must be able
+    to reach recovery rather than being pre-empted by recovery already in
+    flight.  A ceiling below the number of active pools necessarily leaves one
+    pool disabled, which is honest and deterministic.
+    """
+    if total < 0:
+        raise ValueError('max_agents_override must be >= 0')
+    if not translate_default:
+        return 0, total
+    if not heal_default:
+        return total, 0
+    if total == 0:
+        return 0, 0
+    if total == 1:
+        return 1, 0
+    combined = translate_default + heal_default
+    translate = max(1, int(round(total * translate_default / combined)))
+    translate = min(total - 1, translate)
+    return translate, total - translate
+
+
+def derive_agent_budget(
+        batch_count,
+        heal_groups_by_key,
+        *,
+        enabled=True,
+        translate_factor=3.0,
+        translate_headroom=10,
+        per_card_heal_budget=True,
+        per_card_heal_factor=1.5,
+        per_card_heal_headroom=3,
+        max_agents_override=None):
+    """Return independent translate/heal ceilings for one window.
+
+    With per-card heal budgeting enabled, the window heal ceiling is exactly
+    the sum of every card's ceiling.  Therefore the window pool cannot fire
+    before a card-level ceiling merely because several cards recover at once.
+    With per-card budgeting disabled, a conservative scaled group count keeps
+    a finite global recovery backstop.
+    """
+    if batch_count < 0:
+        raise ValueError('batch_count must be >= 0')
+    raw_groups = {str(k): int(v) for k, v in dict(heal_groups_by_key or {}).items()}
+    if any(v < 0 for v in raw_groups.values()):
+        raise ValueError('heal group counts must be >= 0')
+    groups = {k: v for k, v in raw_groups.items() if v > 0}
+    if not enabled:
+        return AgentBudgetPlan(
+            translate_expected=batch_count,
+            heal_groups=sum(groups.values()),
+            heal_cards=len(groups),
+            max_translate_agents=None,
+            max_heal_agents=None,
+            max_agents=None,
+            strategy='disabled',
+        )
+
+    translate_default = _scaled(batch_count, translate_factor, translate_headroom)
+    if per_card_heal_budget:
+        heal_default = sum(
+            _per_card_heal_cap(n, per_card_heal_factor, per_card_heal_headroom)
+            for n in groups.values())
+    else:
+        heal_default = _scaled(sum(groups.values()), translate_factor, translate_headroom)
+
+    if max_agents_override is None:
+        max_translate, max_heal = translate_default, heal_default
+        strategy = 'split-pools-per-card-heal'
+    else:
+        max_translate, max_heal = _allocate_total(
+            int(max_agents_override), translate_default, heal_default)
+        strategy = 'split-pools-total-override'
+
+    return AgentBudgetPlan(
+        translate_expected=batch_count,
+        heal_groups=sum(groups.values()),
+        heal_cards=len(groups),
+        max_translate_agents=max_translate,
+        max_heal_agents=max_heal,
+        max_agents=max_translate + max_heal,
+        strategy=strategy,
+    )
+
+
+def selftest():
+    plan = derive_agent_budget(8, {'a': 2, 'b': 5})
+    assert plan.max_translate_agents == 34
+    assert plan.max_heal_agents == 6 + 11
+    assert plan.max_agents == 51
+    assert plan.max_heal_agents == sum(
+        _per_card_heal_cap(n, 1.5, 3) for n in (2, 5))
+
+    overridden = derive_agent_budget(8, {'a': 2, 'b': 5}, max_agents_override=20)
+    assert overridden.max_agents == 20
+    assert overridden.max_translate_agents > 0
+    assert overridden.max_heal_agents > 0
+
+    disabled = derive_agent_budget(8, {'a': 2}, enabled=False)
+    assert disabled.max_agents is None
+    assert disabled.strategy == 'disabled'
+    print('agent_budget selftest OK')
+
+
+if __name__ == '__main__':
+    selftest()

--- a/RussianTranslation/src/pilot/classify_run.py
+++ b/RussianTranslation/src/pilot/classify_run.py
@@ -69,6 +69,14 @@ def classify(summary):
     kill_ceiling = max(INFRA_KILL_MIN, int(math.ceil(INFRA_KILL_FRAC * agents)))
     signals = {
         'agents_spent': agents,
+        # H462 payloads predate the split-pool refactor, so these remain optional.
+        # Echo them when present without making historical payloads unclassifiable.
+        'translate_agents_spent': summary.get('translate_agents_spent'),
+        'max_translate_agents': summary.get('max_translate_agents'),
+        'translate_budget_tripped': summary.get('translate_budget_tripped'),
+        'heal_agents_spent': summary.get('heal_agents_spent'),
+        'max_heal_agents': summary.get('max_heal_agents'),
+        'heal_budget_tripped': summary.get('heal_budget_tripped'),
         'kill_timeouts': kills,
         'conn_errors': conns,
         'heal_calls': summary.get('heal_calls'),

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -41,6 +41,7 @@ sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
 from window_common import INP, REPO, SRC, input_paths, load_json, read_text, rootmap_path, sha256_file, write_text
+from agent_budget import derive_agent_budget
 import pwg_mask
 from autosplit_requeue import plan as split_plan     # deterministic per-card sense/citation split
 sys.path.insert(0, SRC)
@@ -174,23 +175,15 @@ KILL_CEIL_MS = 180000       # hard ceiling — NOTHING runs past 3 min (MG). Was
 # --- live budget kill-switch (H189, 2026-07-05) -----------------------------------
 # The per-call kill gate above bounds ANY SINGLE agent() call, but nothing bounded the
 # WHOLE WINDOW: pril10_w1 spawned 230 agents (est. 174) and burned 42 M tokens before MG
-# killed it by hand. This is an absolute, window-level backstop: the harness counts every
-# agent() call it makes and, once the count crosses MAX_AGENTS, refuses to start further
-# calls (the remaining cards are nulled with a `budget-kill-switch` reason and REQUEUED,
-# not silently dropped) so a runaway retry/binary-split cascade self-terminates instead of
-# running to a manual kill. Tokens aren't observable inside the runtime (agent() returns
-# structured output, not a usage record), so the mechanical proxy is agent-CALL count —
-# which is exactly what blew up (230 vs 174). The ceiling is derived per window and must
-# SCALE WITH WORD SIZE, not be a one-size-fits-all floor: a `gam`-class word legitimately
-# needs dozens of calls, but a 3-card stub must never be allowed 40 — a flat floor would let
-# a small-word runaway burn 40 agents before the switch ever fired, defeating it for exactly
-# the words that need it. So the ceiling is proportional to the preflight estimate plus a
-# small fixed headroom for one hard card's heal/binary-split jitter:
-#   MAX_AGENTS = ceil(expected * MAX_AGENTS_FACTOR) + MAX_AGENTS_HEADROOM
-# e.g. expected 2 -> 16, 6 -> 28, 20 -> 70, 60 -> 190 — a continuous small/medium/large
-# typology, no cliff at a tier boundary and no "what counts as medium" to pin down.
-KILL_SWITCH = True          # --no-kill-switch disables; --max-agents=N sets an absolute override
-MAX_AGENTS_FACTOR = 3.0     # abort once actual agent() calls exceed 3x the preflight estimate
+# killed it by hand. H189 added one shared MAX_AGENTS counter; H442/H462 then proved that
+# sharing it between whole-card translation and fragment recovery makes the per-card heal
+# cap unreachable on an all-heal window. The generated runtime now has two independently
+# derived pools: translate calls (including binary-split retries) and heal calls. The
+# translate ceiling remains proportional to its preflight batch count; the heal ceiling is
+# the sum of the already-bounded per-card heal ceilings, so a window cannot starve recovery
+# before those card-level guards can bind. ``agent_budget.py`` owns the pure derivation.
+KILL_SWITCH = True          # --no-kill-switch disables; --max-agents=N overrides the combined total
+MAX_AGENTS_FACTOR = 3.0     # translate pool: abort past 3x the whole-card batch estimate
                             #  (pril10_w1 was 230/174 = 1.3x before the manual kill — 3x leaves
                             #  ample room for legitimate binary-split/heal while still catching a
                             #  true runaway well before a $80 outcome).
@@ -199,7 +192,7 @@ MAX_AGENTS_HEADROOM = 10    # additive jitter allowance so a TINY window (expect
                             #  replaces the old flat floor of 40, which was far too loose for
                             #  small/medium words (they never legitimately approach 40, so the
                             #  floor let their runaways run unchecked to 40). H189 follow-up.
-MAX_AGENTS_OVERRIDE = None  # --max-agents=N: pin an absolute ceiling, bypassing the derivation
+MAX_AGENTS_OVERRIDE = None  # --max-agents=N: combined ceiling allocated across both pools
 # --- per-card heal budget (H442, 2026-07-10) --------------------------------------
 # The window-level MAX_AGENTS switch above stops a runaway, but it is a SHARED pool: it
 # cannot stop ONE dense card from spending the WHOLE window budget before the other cards
@@ -1149,17 +1142,26 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     if lang == 'en':                                    # inject MW TM once per root (root mode)
         single_grammar = mw_tm_block(root, mw_tm_path) + single_grammar
 
-    # Preflight-parity agent estimate (one call per batch + one per presplit fragment group)
-    # and the H189 live budget kill-switch ceiling derived from it.
+    # Preflight-parity agent estimate (one call per batch + one per presplit fragment group).
+    # The runtime budget is planned separately: whole-card translation/binary-split calls use
+    # the translate pool; every selfheal-capable card contributes its own bounded ceiling to
+    # the recovery pool. This removes the H442/H462 shared-counter starvation class.
     agent_expected = len(batches) + sum(len(frags.get(k, [None])) for k in presplit)
     runtime_keys = set(batch_keys) | set(presplit)
     runtime_inputs = {k: inputs[k] for k in keys if k in runtime_keys}
     runtime_phmaps = {k: phmaps[k] for k in keys if k in runtime_keys}
     runtime_suggest_tm = {k: v for k, v in suggest_tm.items() if k in runtime_keys}
-    if MAX_AGENTS_OVERRIDE:
-        max_agents = MAX_AGENTS_OVERRIDE
-    else:   # proportional to word size + small jitter headroom (NOT a flat floor)
-        max_agents = int(math.ceil(agent_expected * MAX_AGENTS_FACTOR)) + MAX_AGENTS_HEADROOM
+    budget_plan = derive_agent_budget(
+        len(batches),
+        {k: len(v) for k, v in frags.items() if v},
+        enabled=KILL_SWITCH,
+        translate_factor=MAX_AGENTS_FACTOR,
+        translate_headroom=MAX_AGENTS_HEADROOM,
+        per_card_heal_budget=bool(PER_CARD_HEAL_BUDGET and SELFHEAL),
+        per_card_heal_factor=PER_CARD_HEAL_FACTOR,
+        per_card_heal_headroom=PER_CARD_HEAL_HEADROOM,
+        max_agents_override=MAX_AGENTS_OVERRIDE,
+    )
 
     # H214: per-card source-material profile, stamped on promoted rows via
     # meta.source_profiles (promote_final_cards.provenance reads it per sub-card). Window-level
@@ -1198,11 +1200,16 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         'kill': KILL,
         'kill_gate': ({'factor': KILL_FACTOR, 'base_ms': KILL_BASE_MS, 'slope_ms': KILL_SLOPE_MS,
                        'floor_ms': KILL_FLOOR_MS, 'ceil_ms': KILL_CEIL_MS} if KILL else None),
-        # H189 live budget kill-switch: the harness aborts (and requeues remaining cards) once
-        # it makes more than max_agents agent() calls — a window-level backstop against the
-        # runaway that spent 230/174 agents on pril10_w1 before a manual kill.
+        # Split agent pools: translate/binary-split cannot be starved by recovery already in
+        # flight, and recovery cannot hit a shared ceiling before the per-card caps can bind.
         'kill_switch': KILL_SWITCH,
-        'max_agents': max_agents if KILL_SWITCH else None,
+        'agent_budget_strategy': budget_plan.strategy,
+        'max_agents': budget_plan.max_agents,
+        'max_translate_agents': budget_plan.max_translate_agents,
+        'max_heal_agents': budget_plan.max_heal_agents,
+        'translate_agent_expected': budget_plan.translate_expected,
+        'heal_budget_groups': budget_plan.heal_groups,
+        'heal_budget_cards': budget_plan.heal_cards,
         'max_agents_factor': MAX_AGENTS_FACTOR,
         'max_agents_headroom': MAX_AGENTS_HEADROOM,
         # H442 per-card heal budget: caps the heal agent() calls ONE card may spend so a dense
@@ -1280,13 +1287,14 @@ const KILL_BASE_MS = %(kill_base_ms)s
 const KILL_SLOPE_MS = %(kill_slope_ms)s
 const KILL_FLOOR_MS = %(kill_floor_ms)s
 const KILL_CEIL_MS = %(kill_ceil_ms)s
-// H189 live budget kill-switch: abort the whole window once it has made more than
-// MAX_AGENTS agent() calls (a runaway retry/binary-split cascade), instead of running to a
-// manual kill. Tokens aren't observable in-runtime, so agent-CALL count is the proxy (230
-// vs 174 estimate on pril10_w1). Remaining cards are nulled with a budget-kill-switch reason
-// and requeued by the normal audit path — nothing is silently dropped.
+// H189 live budget kill-switch, split after H442/H462: whole-card translation/binary-split
+// and fragment recovery spend independent pools. One runaway recovery cascade can no longer
+// consume the capacity required to attempt the remaining primary batches; the recovery pool
+// is the sum of the per-card heal ceilings, so those card-level guards are reachable.
 const KILL_SWITCH = %(kill_switch)s
 const MAX_AGENTS = %(max_agents)s
+const MAX_TRANSLATE_AGENTS = %(max_translate_agents)s
+const MAX_HEAL_AGENTS = %(max_heal_agents)s
 // H442 per-card heal budget: a per-card ceiling on heal agent() calls, threaded through
 // healGroup's bisection recursion. Unlike MAX_AGENTS (a shared window pool), this stops ONE
 // dense card from spending the whole window budget: once a card's own heal spend crosses
@@ -1352,15 +1360,17 @@ const skelBytesOfKeys = keys => keys.reduce((n, k) => n + (INPUTS[k] ? INPUTS[k]
 // fragment heal — the gate's whole purpose). SHARED (keys on FRAGS, no RU/EN branching).
 const hasFallback = k => Array.isArray(FRAGS[k]) && FRAGS[k].length > 0
 const killBudgetForCur = cur => (cur.length === 1 && !hasFallback(cur[0])) ? KILL_CEIL_MS : killBudgetMs(skelBytesOfKeys(cur))
-// H189 live budget kill-switch state. AGENTS_SPENT counts real agent() calls; once it
-// reaches MAX_AGENTS every further agentKill() throws BudgetExceeded WITHOUT calling agent()
-// (0 tokens), so retry/binary-split cascades short-circuit to instant no-ops and the window
-// winds down at ~MAX_AGENTS calls. BudgetExceeded is deliberately NOT an isKill() (a kill
-// routes to MORE fragment calls — the opposite of what a budget stop wants); the caller's
-// generic catch nulls the card with a budget-kill-switch reason for the normal requeue path.
+// Split-pool budget state. Labels beginning `heal:` are recovery; every other call is primary
+// translation (including resolveGroup binary splits). BudgetExceeded is deliberately NOT an
+// isKill(): a kill routes to recovery, whereas a pool stop must issue zero more calls in that
+// lane. AGENTS_SPENT remains the backwards-compatible total telemetry counter.
 class BudgetExceeded extends Error {}
 let AGENTS_SPENT = 0
 let BUDGET_TRIPPED = false
+let TRANSLATE_AGENTS_SPENT = 0
+let HEAL_AGENTS_SPENT = 0
+let TRANSLATE_BUDGET_TRIPPED = false
+let HEAL_BUDGET_TRIPPED = false
 // H462 telemetry: COUNTERS ONLY, no behavioural change. The two decisive numbers of every
 // launch post-mortem — the kill-timeout count and the 'Connection closed mid-response'
 // count — previously existed only as console.log strings and were hand-counted from
@@ -1375,15 +1385,23 @@ let HEAL_CALLS = 0
 let KILL_BISECT_BLOCKED = 0
 const isConn = e => !!(e && !(e instanceof KillTimeout) && /connection closed|connection error|econnreset|econnrefused|socket hang up|fetch failed|network error/i.test(String(e && e.message)))
 async function agentKill(prompt, opts, skelBytes, budgetMsOverride) {
-  if (KILL_SWITCH && MAX_AGENTS != null && AGENTS_SPENT >= MAX_AGENTS) {
+  const healLane = !!(opts && opts.label && /^heal:/.test(String(opts.label)))
+  const lane = healLane ? 'heal' : 'translate'
+  const spent = healLane ? HEAL_AGENTS_SPENT : TRANSLATE_AGENTS_SPENT
+  const ceiling = healLane ? MAX_HEAL_AGENTS : MAX_TRANSLATE_AGENTS
+  if (KILL_SWITCH && ceiling != null && spent >= ceiling) {
     BUDGET_TRIPPED = true
-    throw new BudgetExceeded('budget-kill-switch: window hit MAX_AGENTS=' + MAX_AGENTS + ' agent() calls; remaining cards requeued')
+    if (healLane) HEAL_BUDGET_TRIPPED = true
+    else TRANSLATE_BUDGET_TRIPPED = true
+    throw new BudgetExceeded('budget-kill-switch[' + lane + ']: hit ' + ceiling + ' agent() calls; lane remainder requeued')
   }
   AGENTS_SPENT++
+  if (healLane) HEAL_AGENTS_SPENT++
+  else TRANSLATE_AGENTS_SPENT++
   // heal-lane spend: every healGroup label starts 'heal:' (bisection halves inherit the
   // prefix), so this counts real heal agent() calls against the whole window — the
   // per-card view stays on selfHeal's cardBudget.spent.
-  if (opts && opts.label && /^heal:/.test(String(opts.label))) HEAL_CALLS++
+  if (healLane) HEAL_CALLS++
   if (!KILL) return agent(prompt, opts)   // kill gate off = counters best-effort (never in production)
   const ms = (budgetMsOverride != null) ? budgetMsOverride : killBudgetMs(skelBytes)
   let timer
@@ -1815,11 +1833,16 @@ const summary = { root: META.root, lang: META.lang, cards: out.length, ok: _ok,
                   presplit: PRESPLIT.length, tm: out.filter(r => r.tm).length,
                   degenerate_passthrough: out.filter(r => r.degenerate_passthrough).length,
                   frag_tm_fragments: META.frag_tm_fragments || 0,
-                  // H189: agents_spent surfaces the real call count vs META.max_agents;
-                  // budget_kill_switch_tripped=true means the window self-aborted and its
-                  // null_keys must be requeued (they were not translated, not defective).
+                  // Total counters stay backwards-compatible; lane counters make starvation
+                  // and the binding pool directly observable.
                   agents_spent: AGENTS_SPENT, max_agents: (KILL_SWITCH ? MAX_AGENTS : null),
                   budget_kill_switch_tripped: BUDGET_TRIPPED,
+                  translate_agents_spent: TRANSLATE_AGENTS_SPENT,
+                  max_translate_agents: (KILL_SWITCH ? MAX_TRANSLATE_AGENTS : null),
+                  translate_budget_tripped: TRANSLATE_BUDGET_TRIPPED,
+                  heal_agents_spent: HEAL_AGENTS_SPENT,
+                  max_heal_agents: (KILL_SWITCH ? MAX_HEAL_AGENTS : null),
+                  heal_budget_tripped: HEAL_BUDGET_TRIPPED,
                   // H462: returned telemetry (previously log-only, hand-counted from
                   // transcripts). kill_bisect_blocked counts heal groups whose kill-timeout
                   // was routed to requeue instead of bisection (KILL_TIMEOUT_NO_BISECT).
@@ -1850,7 +1873,9 @@ return { meta: META, summary, results: out }
         'kill': json.dumps(KILL), 'kill_factor': json.dumps(KILL_FACTOR),
         'kill_base_ms': json.dumps(KILL_BASE_MS), 'kill_slope_ms': json.dumps(KILL_SLOPE_MS),
         'kill_floor_ms': json.dumps(KILL_FLOOR_MS), 'kill_ceil_ms': json.dumps(KILL_CEIL_MS),
-        'kill_switch': json.dumps(KILL_SWITCH), 'max_agents': json.dumps(max_agents if KILL_SWITCH else None),
+        'kill_switch': json.dumps(KILL_SWITCH), 'max_agents': json.dumps(budget_plan.max_agents),
+        'max_translate_agents': json.dumps(budget_plan.max_translate_agents),
+        'max_heal_agents': json.dumps(budget_plan.max_heal_agents),
         'per_card_heal_budget': json.dumps(PER_CARD_HEAL_BUDGET and SELFHEAL),
         'per_card_heal_factor': json.dumps(PER_CARD_HEAL_FACTOR), 'per_card_heal_headroom': json.dumps(PER_CARD_HEAL_HEADROOM),
         'kill_timeout_no_bisect': json.dumps(bool(KILL_TIMEOUT_NO_BISECT and KILL and SELFHEAL)),

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3064,6 +3064,74 @@ def test_agent_budget_plan_separates_translate_and_heal_pools():
         fail('--no-kill-switch must disable both budget pools')
 
 
+def test_split_agent_pools_all_heal_runtime():
+    """Execute the generated JS with a null-returning mock agent.
+
+    Two sense-dense cards route directly to recovery. Every call fails, so each card must
+    stop at its own cap. The window heal pool is exactly the sum of those caps and therefore
+    must *not* trip first — the production invariant H442 could not previously satisfy.
+    """
+    import gen_opt_harness2 as gh
+    senses = '\n'.join('<div n="1">— %d〉 {%%Bedeutung %d%%}.' % (i, i)
+                       for i in range(1, 31))
+    raw = ('=== LAYER: PW — Böhtlingk kürzere Fassung ===\n\n'
+           '<hom>1.</hom> √{#gam#}¦ <ls>X. 1</ls>.\n' + senses + '\n')
+    keys = ['zz~~runtime_pool_a', 'zz~~runtime_pool_b']
+    d = tempfile.mkdtemp()
+    saved_ip = gh.input_paths
+    saved_kill = gh.KILL
+    try:
+        paths = {}
+        for key in keys:
+            rp = os.path.join(d, key + '.raw.txt')
+            pp = os.path.join(d, key + '.portrait.json')
+            with open(rp, 'w', encoding='utf-8') as f:
+                f.write(raw)
+            with open(pp, 'w', encoding='utf-8') as f:
+                f.write('[]')
+            paths[key] = (rp, pp)
+        gh.input_paths = lambda k, input_dir=None: paths[k]
+        gh.KILL = False  # mock calls are immediate; exercise budgets, not wall time
+        js, batches = gh.build(
+            'zz_runtime_pool', keys, None, 12000,
+            nominal=True, grammar_on=False, tm_path=None)
+        if batches:
+            fail('sense-dense runtime fixture must be presplit-only; got batches=%r' % batches)
+        marker = 'return { meta: META, summary, results: out }'
+        if marker not in js:
+            fail('generated runtime return marker changed; update behavioral harness deliberately')
+        runnable = (
+            "const phase = () => {};\n"
+            "const log = () => {};\n"
+            "const agent = async () => null;\n"
+            "const parallel = async thunks => Promise.all(thunks.map(async fn => { "
+            "try { return await fn() } catch (_) { return null } }));\n" +
+            js.replace(marker, 'console.log(JSON.stringify({ meta: META, summary, results: out }))'))
+        script = os.path.join(d, 'runtime_pool_test.mjs')
+        with open(script, 'w', encoding='utf-8', newline='\n') as f:
+            f.write(runnable)
+        p = subprocess.run(
+            ['node', script], capture_output=True, text=True, encoding='utf-8', timeout=30)
+        if p.returncode:
+            fail('mock generated runtime failed:\n%s\n%s' % (p.stdout, p.stderr))
+        payload = json.loads(p.stdout.strip().splitlines()[-1])
+        summary = payload['summary']
+        if summary['translate_agents_spent'] != 0:
+            fail('presplit-only fixture must spend zero translate calls')
+        if summary['heal_agents_spent'] != summary['max_heal_agents']:
+            fail('all-heal fixture must stop exactly at the sum of per-card caps; got %r' % summary)
+        if summary['heal_budget_tripped']:
+            fail('window heal pool fired before/at a per-card cap — shared-counter bug returned')
+        if summary['budget_kill_switch_tripped']:
+            fail('no window pool should trip when each card stops at its own ceiling')
+        if summary['null'] != len(keys):
+            fail('null mock must leave every card explicitly requeueable')
+    finally:
+        gh.input_paths = saved_ip
+        gh.KILL = saved_kill
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def test_budget_kill_switch_wired():
     """The generated Workflow must enforce independent translate/heal call ceilings."""
     import re as _re
@@ -3184,11 +3252,21 @@ def test_classify_run_verdicts():
     H442 launch-3 signature), code-failure (nulls with a quiet network), and the honest
     refusal on a pre-H462 payload that carries no counters."""
     import classify_run as cr
-    base = {'agents_spent': 58, 'kill_timeouts': 0, 'conn_errors': 0, 'heal_calls': 40,
+    base = {'agents_spent': 58,
+            'translate_agents_spent': 18, 'max_translate_agents': 28,
+            'translate_budget_tripped': False,
+            'heal_agents_spent': 40, 'max_heal_agents': 55,
+            'heal_budget_tripped': False,
+            'kill_timeouts': 0, 'conn_errors': 0, 'heal_calls': 40,
             'kill_bisect_blocked': 0, 'null_keys': [], 'budget_kill_switch_tripped': False}
-    v, _, _ = cr.classify(dict(base))
+    v, _, sig = cr.classify(dict(base))
     if v != 'clean':
         fail('all-ok summary must classify clean; got %r' % v)
+    for field in ('translate_agents_spent', 'max_translate_agents',
+                  'translate_budget_tripped', 'heal_agents_spent',
+                  'max_heal_agents', 'heal_budget_tripped'):
+        if sig[field] != base[field]:
+            fail('classifier must preserve split-pool signal %s' % field)
     # H442 launch 3: 58/58 agents, 7 kill-timeouts, 2 conn-errors, 12 nulls, tripped
     infra = dict(base, kill_timeouts=7, conn_errors=2,
                  null_keys=['k%d' % i for i in range(12)], budget_kill_switch_tripped=True)
@@ -3985,6 +4063,7 @@ def main():
         test_presplit_card_uses_amortized_grouping,
         test_kill_gate_recalibrated_envelope,
         test_agent_budget_plan_separates_translate_and_heal_pools,
+        test_split_agent_pools_all_heal_runtime,
         test_budget_kill_switch_wired,
         test_harness_size_guard,
         test_perf_preflight_cost_gate,

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3043,12 +3043,29 @@ def test_kill_gate_recalibrated_envelope():
              % gh.KILL_CEIL_MS)
 
 
+def test_agent_budget_plan_separates_translate_and_heal_pools():
+    """H442/H462: the heal pool must let every per-card cap become reachable."""
+    import agent_budget as ab
+    groups = {'a': 2, 'b': 5, 'c': 1}
+    plan = ab.derive_agent_budget(8, groups)
+    expected_translate = int(math.ceil(8 * 3.0)) + 10
+    expected_heal = sum(int(math.ceil(n * 1.5)) + 3 for n in groups.values())
+    if plan.max_translate_agents != expected_translate:
+        fail('translate pool must scale only from whole-card batches')
+    if plan.max_heal_agents != expected_heal:
+        fail('heal pool must equal the sum of per-card ceilings so the window cannot bind first')
+    if plan.max_agents != expected_translate + expected_heal:
+        fail('combined max_agents must be the sum of the two independently enforced pools')
+    overridden = ab.derive_agent_budget(8, groups, max_agents_override=20)
+    if overridden.max_agents != 20 or not overridden.max_translate_agents or not overridden.max_heal_agents:
+        fail('--max-agents must remain a hard combined override allocated across active pools')
+    disabled = ab.derive_agent_budget(8, groups, enabled=False)
+    if disabled.max_agents is not None:
+        fail('--no-kill-switch must disable both budget pools')
+
+
 def test_budget_kill_switch_wired():
-    """H189: the harness must carry a window-level budget kill-switch — count agent()
-    calls and abort (requeue remaining) once past MAX_AGENTS — so a runaway retry/binary-
-    split cascade self-terminates instead of running to a manual kill (pril10_w1: 230
-    agents, 42M tokens, $80 before MG stopped it). MAX_AGENTS is derived from the preflight
-    estimate: max(floor, ceil(expected * factor))."""
+    """The generated Workflow must enforce independent translate/heal call ceilings."""
     import re as _re
     import gen_opt_harness2 as gh
     raw = ('=== LAYER: PW — Böhtlingk kürzere Fassung ===\n\n'
@@ -3068,7 +3085,10 @@ def test_budget_kill_switch_wired():
         try:
             js, _b = gh.build('zz', [key], None, 12000, nominal=True, grammar_on=False, tm_path=None)
             for tok in ('const KILL_SWITCH = true', 'const MAX_AGENTS =',
-                        'class BudgetExceeded', 'AGENTS_SPENT++', 'BUDGET_TRIPPED'):
+                        'const MAX_TRANSLATE_AGENTS =', 'const MAX_HEAL_AGENTS =',
+                        'class BudgetExceeded', 'AGENTS_SPENT++',
+                        'TRANSLATE_AGENTS_SPENT++', 'HEAL_AGENTS_SPENT++',
+                        'TRANSLATE_BUDGET_TRIPPED', 'HEAL_BUDGET_TRIPPED'):
                 if tok not in js:
                     fail('budget kill-switch token %r missing from the harness' % tok)
             # BudgetExceeded must NOT be treated as a kill (a kill routes to MORE fragment
@@ -3076,20 +3096,24 @@ def test_budget_kill_switch_wired():
             if _re.search(r'isKill\s*=.*BudgetExceeded', js):
                 fail('BudgetExceeded must not be classified as a kill (would spawn more agents)')
             meta = json.loads(_re.search(r'^const META = (\{.*\})\n', js, _re.M).group(1))
-            expected = meta.get('agent_expected_after_tm', 0)
-            # H189 follow-up: the ceiling SCALES with word size (ceil(expected*factor)+headroom),
-            # NOT a flat floor — a flat floor let a small-word runaway burn 40 agents unchecked.
-            want = int(math.ceil(expected * gh.MAX_AGENTS_FACTOR)) + gh.MAX_AGENTS_HEADROOM
-            if meta.get('max_agents') != want:
-                fail('meta.max_agents must be ceil(expected*factor)+headroom=%d; got %r'
-                     % (want, meta.get('max_agents')))
+            expected_translate = meta.get('batch_count', 0)
+            want_translate = (int(math.ceil(expected_translate * gh.MAX_AGENTS_FACTOR))
+                              + gh.MAX_AGENTS_HEADROOM)
+            if meta.get('max_translate_agents') != want_translate:
+                fail('translate ceiling must be ceil(batch_count*factor)+headroom=%d; got %r'
+                     % (want_translate, meta.get('max_translate_agents')))
+            if meta.get('max_agents') != (meta.get('max_translate_agents', 0)
+                                          + meta.get('max_heal_agents', 0)):
+                fail('meta.max_agents must be the sum of the split pool ceilings')
+            if meta.get('agent_budget_strategy') != 'split-pools-per-card-heal':
+                fail('default generated runtime must declare the split-pool strategy')
             if hasattr(gh, 'MAX_AGENTS_FLOOR'):
                 fail('the flat one-size-fits-all MAX_AGENTS_FLOOR must be gone — the ceiling '
                      'must scale with word size so a small-word runaway is caught, not clamped to 40')
-            # summary must expose the trip flag for the requeue path
-            if 'budget_kill_switch_tripped' not in js:
-                fail('run summary must expose budget_kill_switch_tripped so a self-aborted '
-                     'window\'s null cards are requeued, not read as defective')
+            for field in ('budget_kill_switch_tripped', 'translate_budget_tripped',
+                          'heal_budget_tripped', 'translate_agents_spent', 'heal_agents_spent'):
+                if field not in js:
+                    fail('run summary must expose %s' % field)
         finally:
             gh.input_paths = saved_ip
     finally:
@@ -3138,9 +3162,12 @@ def test_run_telemetry_counters_returned():
                               r'else if \(isConn\(e\)\) CONN_ERRORS\+\+; throw e \}', js):
                 fail('agentKill must count kills/conn-errors in its catch and RE-THROW — '
                      'telemetry must not change control flow')
-            # heal-lane spend keyed on the heal: label prefix (bisections inherit it)
-            if not _re.search(r"/\^heal:/\.test\(String\(opts\.label\)\)\) HEAL_CALLS\+\+", js):
-                fail('agentKill must count heal-lane calls via the heal: label prefix')
+            # heal-lane spend is derived once from the heal: label prefix; both the dedicated
+            # pool and telemetry must use that exact lane decision.
+            if "const healLane = !!(opts && opts.label && /^heal:/.test(String(opts.label)))" not in js:
+                fail('agentKill must classify heal calls via the heal: label prefix')
+            if 'if (healLane) HEAL_CALLS++' not in js:
+                fail('agentKill must count heal-lane calls from the shared lane decision')
             # a KillTimeout must never double-count as a connection error
             if 'e instanceof KillTimeout' not in js.split('const isConn =', 1)[1].split('\n', 1)[0]:
                 fail('isConn must exclude KillTimeout so a kill is never double-counted as a conn error')
@@ -3957,6 +3984,7 @@ def main():
         test_group_by_budget_count_cap,
         test_presplit_card_uses_amortized_grouping,
         test_kill_gate_recalibrated_envelope,
+        test_agent_budget_plan_separates_translate_and_heal_pools,
         test_budget_kill_switch_wired,
         test_harness_size_guard,
         test_perf_preflight_cost_gate,


### PR DESCRIPTION
## PR Type
- [ ] data
- [x] build
- [x] docs
- [ ] navigation

## Summary
- What changed: split generated Workflow agent-call accounting into independent translation and fragment-recovery pools, added per-lane telemetry/classification, an executed generated-JavaScript regression test, and CI coverage for the PWG production contracts.
- Why this change exists: H442/H462 established that one shared `MAX_AGENTS` counter made the per-card recovery caps unreachable on all-heal windows. The window counter fired first by construction, so dense cards could starve their batch-mates and the intended guardrail could not govern recovery.

## Test Surface
- Automated checks: full `src/pilot/window_selftest.py`; `agent_budget.py` selftest; 41-entry `LANG_PARITY.md` ledger; 13-entry launch-failure ledger; Python compilation; focused Ruff severe-error gate; CI YAML parse.
- Manual checks: inspected generated runtime constants, spend counters, trip flags, summary fields, and legacy-total compatibility.
- Pure helpers / decision points covered: `derive_agent_budget()` covers translate-only, heal-only, combined, disabled, and legacy `--max-agents` allocation behavior.
- If build-related: import-safe verified? yes.

## Invariants
- Must stay true: scholarly prompts, translation schema, downstream gates, and store semantics do not change; pre-H462 payloads remain classifiable under the old required telemetry contract.
- Counts / alignment / join rules: `MAX_HEAL_AGENTS` equals the sum of active per-card heal ceilings; total spend remains the sum of translation and heal spend.
- Source-of-truth assumptions: `agent_budget.py` is the single budget planner; generated JavaScript consumes its emitted plan rather than independently recomputing ceilings.
- What would count as regression: an all-heal window trips the window pool before individual card caps, either lane spends past its ceiling, old payloads become unclassifiable, or RU/EN parity drifts.

## Safety
- Fallback / failure mode: exhausted cards remain explicit null/requeue results; legacy total telemetry remains available; `--no-kill-switch` disables both pools.
- Observable marker or sanity check: summaries now expose `translate_agents_spent`, `max_translate_agents`, `translate_budget_tripped`, `heal_agents_spent`, `max_heal_agents`, and `heal_budget_tripped`.
- Rebuild / validate / verify command: `cd RussianTranslation && python src/pilot/window_selftest.py && python src/pilot/lang_parity_check.py && python src/pilot/check_launch_ledger.py --since 2026-07-05`.

## Reader-Facing Done
- Navigation / entry point updated: CI now runs the PWG production runtime and failure-contract checks.
- Docs / changelog / handoff updated: H442 fix plan, H317 measurement, launch-ledger audit, reproducibility guide, language-parity ledger, and both session journals are updated.
- Known limits or caveats exposed: this closes the offline structural defect only. Medium50 remains paused until a healthy load-representative ≥5 KB probe and an `h317_w1b` live canary pass. Existing generation-service connection instability is a separate failure mode.
- If not applicable, say why: N/A.

## Type-Specific Notes
- If `data`: N/A; no source or derived data changed.
- If `build`: generated artifacts are not committed; the change is confined to planner/runtime generation, telemetry, tests, and CI. Rollback is reverting the two commits.
- If `docs`: historical failure findings remain intact; follow-up notes distinguish offline repair from live validation.
- If `navigation`: N/A.
