### PR TITLE
test(pwg-ru): make no-PWG selftests hermetic

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -851,6 +851,14 @@ Two live tracks:
 
 ## ✅ Completed (Recent only)
 
+- **pwg_ru post-#311 hermetic selftest repair — DONE 10-07-2026 (Codex/GPT-5).**
+  Merged PR #311 made the full production-contract selftest a CI gate; its PR and `master` runs
+  exposed four pre-existing no-PWG tests that silently consumed the untracked sibling `csl-orig`
+  checkout locally. Branch `codex/pwg-selftest-hermetic` replaces those dependencies with isolated
+  synthetic PWG/PW/SCH indexes and redirects the older test's ignored live-input writes to a temp
+  directory. Acceptance passed from a fresh committed clone whose parent had no `csl-orig`: full
+  window suite, budget selftest, 41 parity entries, and 13 launch-ledger entries all green.
+
 - **pwg_ru production-spine split-pool refactor — DONE OFFLINE 10-07-2026 (Codex/GPT-5).**
   On isolated branch `codex/pwg-runtime-refactor`, split the generated Workflow runtime's
   translate and heal agent-call budgets through pure `src/pilot/agent_budget.py`; retained

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1855,6 +1855,17 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **Post-#311 no-PWG selftest hermeticity repair — DONE 10-07-2026 (Codex/GPT-5).**
+  PR #311 merged the split-pool runtime and added full `window_selftest.py` coverage to CI, but
+  both its PR run and the resulting `master` run failed at
+  `test_no_pwg_supplement_chain_cards_render`: four no-PWG render/worklist tests depended on the
+  untracked sibling `csl-orig` checkout, and the older render test also wrote ignored artifacts
+  into `src/pilot/input`. On `codex/pwg-selftest-hermetic`, one test-only fixture supplies
+  synthetic PWG `agni`, PW `Bagavat`, SCH `Akulita`, empty PWKVN/NWS, and an explicit true miss;
+  all caches/data paths and `pg.OUT` are restored. Four targeted tests, full window selftest,
+  41-entry parity ledger, 13-entry launch ledger, compile, and focused ruff are green. A fresh
+  committed clone with no sibling `csl-orig` also passed the complete production-contract suite.
+
 - **PWG runtime production-spine split-pool refactor — DONE OFFLINE 10-07-2026 (Codex/GPT-5).**
   On isolated branch/worktree `codex/pwg-runtime-refactor`, new pure
   [`src/pilot/agent_budget.py`](src/pilot/agent_budget.py) derives independent whole-card

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -471,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -502,7 +502,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "2a0478b0779e1aba2bf2e2a0e7d5b50807f7acccf44ae4b00a7dc3af3ff29005",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -521,7 +521,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "9ef1fd0e7c1d31760db187d16046b7dffbafa4fd6d11099ef61fb95094975b27",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
       "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -623,7 +623,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -652,7 +652,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -672,7 +672,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -691,7 +691,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "5e257d130318be4e903bb55444d70c88544af8725c115253235e5daed716ec51",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -728,7 +728,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -786,7 +786,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -805,7 +805,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -824,7 +824,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   },
   {
@@ -844,7 +844,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5",
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731",
       "src/pilot/classify_run.py": "868f9c76df11726d1872ac1c213f3f5b58aafcf090e302165d2ec52a2eddeecc"
     }
   },
@@ -866,7 +866,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "abf08e7b81ee664e9c20cc9e1bae62ca460a7312a67f53c5e117e18132720ce5"
+      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -191,6 +191,57 @@ def matrix_pilot_fixture():
                     f.write(old)
 
 
+@contextlib.contextmanager
+def no_pwg_dictionary_fixture():
+    """Provide a minimal isolated CDSL universe for no-PWG tests.
+
+    The real indexes live in an untracked sibling ``csl-orig`` checkout, which GitHub
+    runners do not have. Replace every local-data entry point used by these tests so
+    their result is identical with or without that sibling, then restore the process
+    caches and paths exactly as they were.
+    """
+    import corpus_gate as cg
+    import dict_merge as dm
+
+    def record(lid, key, body):
+        return ['<L>%s<pc>1<k1>%s<k2>%s<h>1<e>1' % (lid, key, key), body]
+
+    fixture_idx = {
+        'pwg': {
+            cg.form_key('agni'): [record('1', 'agni', '{#agni#}¦ {%Feuer%}.')],
+        },
+        'pw': {
+            cg.form_key('Bagavat'): [
+                record('2', 'Bagavat', '{#Bagavat#}¦ {%ehrwürdig, glückselig%}.'),
+            ],
+        },
+        'sch': {
+            cg.form_key('Akulita'): [
+                record('3', 'Akulita', '{#Akulita#}¦ {%nicht gekrümmt%}.'),
+            ],
+        },
+        'pwkvn': {},
+    }
+    old_idx = dm._IDX
+    old_ididx = dm._IDIDX
+    old_v02 = dm.V02
+    old_nws_dir = dm.NWS_DIR
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            dm._IDX = fixture_idx
+            dm._IDIDX = {}
+            dm.V02 = os.path.join(tmp, 'v02')
+            dm.NWS_DIR = os.path.join(tmp, 'nws')
+            os.makedirs(dm.V02)
+            os.makedirs(dm.NWS_DIR)
+            yield
+        finally:
+            dm._IDX = old_idx
+            dm._IDIDX = old_ididx
+            dm.V02 = old_v02
+            dm.NWS_DIR = old_nws_dir
+
+
 def manifest_files(edition_dir):
     files = {}
     for dirpath, _dirs, names in os.walk(edition_dir):
@@ -395,33 +446,39 @@ def test_no_pwg_supplement_card_renders_without_pwg():
     import _pilot_gen_merged as pg
     import gen_opt_harness2 as gh
     import dict_merge as dm
-    pwg_idx = dm.index('pwg')
-    if pg.gen_no_pwg_card('agni', pwg_idx, verbose=False) is not None:
-        fail('gen_no_pwg_card must return None for a PWG-present key (agni)')
-    for key, want_layer in (('Bagavat', 'pw'), ('Akulita', 'sch')):
-        n = pg.gen_no_pwg_card(key, pwg_idx, verbose=False)
-        if not n:
-            fail('gen_no_pwg_card(%s) produced no sub-cards' % key)
-        sub = '%s~~h0_zz_%s' % (pg.safe_name(key), want_layer)
-        rp = os.path.join(pg.OUT, sub + '.raw.txt')
-        pp = os.path.join(pg.OUT, sub + '.portrait.json')
-        if not (os.path.exists(rp) and os.path.exists(pp)):
-            fail('expected no-PWG sub-card files for %s (%s)' % (key, sub))
-        raw = open(rp, encoding='utf-8').read()
-        port = open(pp, encoding='utf-8').read()
-        if '=== LAYER: PWG' in raw:
-            fail('%s no-PWG card must NOT contain a PWG layer' % key)
-        if '=== LAYER:' not in raw:
-            fail('%s no-PWG card missing a LAYER marker' % key)
-        p0 = json.loads(port)[0]
-        if p0.get('portrait_kind') != 'no_pwg_supplement_chain' or p0.get('key1') != key:
-            fail('%s portrait must be a no_pwg_supplement_chain sidecar keyed to the headword' % key)
-        if p0.get('senses') != []:
-            fail('%s no-PWG portrait must not fabricate a sense tree' % key)
-        if gh.card_source_profile(raw, port) != 'no_pwg_supplement_chain':
-            fail('%s sub-card must classify as no_pwg_supplement_chain' % key)
-        if dm.layer_of(sub) != want_layer:
-            fail('%s sub-card id must encode layer %s' % (key, want_layer))
+    old_out = pg.OUT
+    with no_pwg_dictionary_fixture(), tempfile.TemporaryDirectory() as tmp:
+        pg.OUT = tmp
+        try:
+            pwg_idx = dm.index('pwg')
+            if pg.gen_no_pwg_card('agni', pwg_idx, verbose=False) is not None:
+                fail('gen_no_pwg_card must return None for a PWG-present key (agni)')
+            for key, want_layer in (('Bagavat', 'pw'), ('Akulita', 'sch')):
+                n = pg.gen_no_pwg_card(key, pwg_idx, verbose=False)
+                if not n:
+                    fail('gen_no_pwg_card(%s) produced no sub-cards' % key)
+                sub = '%s~~h0_zz_%s' % (pg.safe_name(key), want_layer)
+                rp = os.path.join(pg.OUT, sub + '.raw.txt')
+                pp = os.path.join(pg.OUT, sub + '.portrait.json')
+                if not (os.path.exists(rp) and os.path.exists(pp)):
+                    fail('expected no-PWG sub-card files for %s (%s)' % (key, sub))
+                raw = open(rp, encoding='utf-8').read()
+                port = open(pp, encoding='utf-8').read()
+                if '=== LAYER: PWG' in raw:
+                    fail('%s no-PWG card must NOT contain a PWG layer' % key)
+                if '=== LAYER:' not in raw:
+                    fail('%s no-PWG card missing a LAYER marker' % key)
+                p0 = json.loads(port)[0]
+                if p0.get('portrait_kind') != 'no_pwg_supplement_chain' or p0.get('key1') != key:
+                    fail('%s portrait must be a no_pwg_supplement_chain sidecar keyed to the headword' % key)
+                if p0.get('senses') != []:
+                    fail('%s no-PWG portrait must not fabricate a sense tree' % key)
+                if gh.card_source_profile(raw, port) != 'no_pwg_supplement_chain':
+                    fail('%s sub-card must classify as no_pwg_supplement_chain' % key)
+                if dm.layer_of(sub) != want_layer:
+                    fail('%s sub-card id must encode layer %s' % (key, want_layer))
+        finally:
+            pg.OUT = old_out
 
 
 def test_no_pwg_worklist_runnable_lane():
@@ -429,7 +486,7 @@ def test_no_pwg_worklist_runnable_lane():
     NOT reclassify a true miss (absent from every layer) as runnable, nor mix it into the
     PWG-rooted runnable count."""
     import nominals_worklist as nw
-    with tempfile.TemporaryDirectory() as tmp:
+    with no_pwg_dictionary_fixture(), tempfile.TemporaryDirectory() as tmp:
         path = os.path.join(tmp, 'sample.slp1.txt')
         manifest = os.path.join(tmp, 'scale_manifest.freq.json')
         store = os.path.join(tmp, 'store.jsonl')      # isolated empty store: the runnable/promoted
@@ -2364,15 +2421,15 @@ def test_generation_schema_carries_no_post_generation_field():
 
 
 def test_no_pwg_supplement_chain_cards_render():
-    """H214: PWG-missing lemmas with real PW/SCH/PWKVN/NWS records are runnable.
+    """H214: PWG-missing lemmas with PW/SCH/PWKVN/NWS records are runnable.
 
-    This uses real dictionary data but writes to a temp input directory, so it proves the
-    generator path without touching live pilot/input artifacts.
+    Synthetic indexes and a temp input directory prove the generator path without
+    requiring csl-orig or touching live pilot/input artifacts.
     """
     import _pilot_gen_merged as pg
     from safe_filename import safe_name
     old_out = pg.OUT
-    with tempfile.TemporaryDirectory() as tmp:
+    with no_pwg_dictionary_fixture(), tempfile.TemporaryDirectory() as tmp:
         pg.OUT = tmp
         try:
             bagavat_n = pg.gen_no_pwg_card('Bagavat', {}, verbose=False)
@@ -2408,7 +2465,7 @@ def test_no_pwg_supplement_chain_cards_render():
 
 def test_nominals_worklist_exposes_no_pwg_lane():
     import nominals_worklist as nw
-    with tempfile.TemporaryDirectory() as tmp:
+    with no_pwg_dictionary_fixture(), tempfile.TemporaryDirectory() as tmp:
         wordlist = os.path.join(tmp, 'sample.slp1.txt')
         manifest = os.path.join(tmp, 'scale_manifest.freq.json')
         store = os.path.join(tmp, 'store.jsonl')


### PR DESCRIPTION
## PR Type
- [ ] data
- [x] build
- [x] docs
- [ ] navigation

## Summary
- What changed: replaced four no-PWG tests' implicit `csl-orig` dependency with one isolated synthetic PWG/PW/SCH fixture, and redirected the older render test's output to a temporary directory.
- Why this change exists: [PR #311](https://github.com/gasyoun/SanskritLexicography/pull/311) enabled the full PWG production-contract suite in CI. Its PR run and the [merged `master` run](https://github.com/gasyoun/SanskritLexicography/actions/runs/29103348170/job/86397542473) then failed because GitHub runners do not have the untracked sibling `csl-orig` checkout that made those tests pass locally.

## Test Surface
- Automated checks: full `window_selftest.py`; `agent_budget.py`; 41-entry language-parity ledger; 13-entry launch-failure ledger; Python compilation; focused Ruff severe-error gate.
- Manual checks: ran the complete suite from a fresh committed clone whose parent had no `csl-orig`; all production-contract checks passed.
- Pure helpers / decision points covered: PWG-present `agni`, PW-only `Bagavat`, SCH-only `Akulita`, empty PWKVN/NWS, and a true miss.
- If build-related: import-safe verified? yes.

## Invariants
- Must stay true: the full selftest remains enabled in CI; no test skips or reduced CI subset were added; production dictionary/runtime behavior is unchanged.
- Counts / alignment / join rules: `Bagavat` yields a PW sub-card, `Akulita` yields a SCH sub-card, and the synthetic miss never enters the runnable lane.
- Source-of-truth assumptions: the fixture exercises the same `dict_merge` index and no-PWG generator interfaces as the real data, while replacing only test-process caches and paths.
- What would count as regression: any no-PWG test reads sibling data, writes `src/pilot/input`, leaks fixture caches/paths, or fails in a clone without `csl-orig`.

## Safety
- Fallback / failure mode: fixture state and `pg.OUT` are restored in `finally` blocks, including when an assertion fails.
- Observable marker or sanity check: the clean-clone run prints `NO-CSL-ORIG CLEAN-CLONE ACCEPTANCE OK` after all four production-contract commands pass.
- Rebuild / validate / verify command: `cd RussianTranslation && python src/pilot/agent_budget.py && python src/pilot/window_selftest.py && python src/pilot/lang_parity_check.py && python src/pilot/check_launch_ledger.py --since 2026-07-05`.

## Reader-Facing Done
- Navigation / entry point updated: N/A; CI continues using the entry point added by PR #311.
- Docs / changelog / handoff updated: root and `RussianTranslation` session journals record the post-merge failure, cause, and hermetic acceptance result.
- Known limits or caveats exposed: this repairs test isolation only; it does not alter or validate the live Workflow generation service.
- If not applicable, say why: no user-facing navigation change is needed.

## Type-Specific Notes
- If `data`: N/A; synthetic records are test-local and no dataset changes.
- If `build`: no production imports or generated artifacts changed; rollback is reverting this single commit.
- If `docs`: historical PR #311 claims remain intact and the CI follow-up is recorded separately.
- If `navigation`: N/A.
