### PR TITLE
feat(progress): public PWG→RU translation progress dashboard

### DIFF
--- a/.github/workflows/findings-dashboard.yml
+++ b/.github/workflows/findings-dashboard.yml
@@ -49,17 +49,23 @@ jobs:
           ref: gh-pages
           path: pages
 
-      - name: Publish to gh-pages/findings/ and gh-pages/episteme/
+      - name: Publish to gh-pages/findings/, /episteme/ and /progress/
         run: |
-          mkdir -p pages/findings pages/episteme
+          mkdir -p pages/findings pages/episteme pages/progress
           cp findings_dashboard/index.html findings_dashboard/data.json findings_dashboard/timeseries.json pages/findings/
           [ -f findings_dashboard/platform_status.json ] && cp findings_dashboard/platform_status.json pages/findings/ || true
           cp epistemic_dashboard/index.html epistemic_dashboard/epistemic.json pages/episteme/
+          # PWG->RU progress dashboard: its data is built LOCALLY (from gitignored
+          # pipeline artifacts CI cannot see) and committed to master, so here we
+          # only COPY the already-committed HTML+JSON — there is no build step.
+          cp progress_dashboard/index.html pages/progress/
+          [ -f progress_dashboard/progress_data.json ] && cp progress_dashboard/progress_data.json pages/progress/ || true
+          [ -f progress_dashboard/progress_timeseries.json ] && cp progress_dashboard/progress_timeseries.json pages/progress/ || true
           cd pages
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # the dashboard published at /epistemic/ before the 08-07-2026 rename to /episteme/ — drop the stale copy
           git rm -r --quiet --ignore-unmatch epistemic
-          git add findings episteme
+          git add findings episteme progress
           git diff --cached --quiet || git commit -m "chore(dashboards): publish monthly refresh"
           git push

--- a/progress_dashboard/README.md
+++ b/progress_dashboard/README.md
@@ -1,0 +1,61 @@
+# PWG→RU progress dashboard
+
+_Created: 10-07-2026 · Last updated: 10-07-2026_
+
+Public companion to the [article site](https://gasyoun.github.io/SanskritLexicography/).
+Where the article site shows the **finished** PWG→Russian translations, this shows
+**how far along the work is** — the honest denominators for each lane.
+
+Published at **`/progress/`** on gh-pages once the workflow runs (see below).
+
+## What it shows
+
+- **Verb lane funnel** (H151) — vetted PWG verb roots → DCS-attested (in scope) →
+  promoted → runnable / blocked-on-rootmap.
+- **Store depth** — sense-rows translated into the RU spine, split by AI-first-pass
+  vs human-reviewed.
+- **Frequency coverage** — what share of PWG is DCS-attested (the first-pass ceiling).
+- **Nominal lane** + the corpus-lexicon / TM asset.
+- **Trend** — one point per rebuild (append-only timeseries).
+
+## Files
+
+| File | Role |
+|---|---|
+| [`build_progress_data.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/build_progress_data.py) | reads local-only pipeline artifacts, emits the two JSONs below |
+| [`progress_data.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/progress_data.json) | one snapshot of every lane/metric (committed) |
+| [`progress_timeseries.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/progress_timeseries.json) | append-only, one row per build date, for trend lines |
+| [`index.html`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/index.html) | self-contained page; fetches the two JSONs |
+
+## Refresh
+
+**Runs locally, not in CI.** The numbers come from gitignored / local-only artifacts
+(`RussianTranslation/src/pwg_ru_translated.jsonl`, the `*_batch_worklist.json`
+snapshots, the frequency manifest) that GitHub Actions never checks out — exactly
+like [`build_article_site.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/build_article_site.py).
+
+```
+python progress_dashboard/build_progress_data.py
+```
+
+Then commit the refreshed `progress_data.json` + `progress_timeseries.json`. The
+[`findings-dashboard.yml`](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/workflows/findings-dashboard.yml)
+workflow **copies** the committed HTML+JSON onto gh-pages `/progress/` on its monthly
+run (or `workflow_dispatch`); it does **not** rebuild them.
+
+Building from an isolated worktree that lacks the gitignored data? Point the script
+at the checkout that has it:
+
+```
+PWG_DATA_ROOT=/path/to/main/checkout python progress_dashboard/build_progress_data.py
+```
+
+## Provenance
+
+Most numbers are counted live from the pipeline's own files. Two are documented
+constants (marked `*` in the trust block): the frequency **denominator** (106,082
+total PWG headwords, from `RussianTranslation/.ai_state.md`) and the **95.4% corpus
+recall** (measured in H309). "Promoted" means passed the mechanical + review gate and
+written to the shipped store — not merely generated.
+
+_Dr. Mārcis Gasūns_

--- a/progress_dashboard/build_progress_data.py
+++ b/progress_dashboard/build_progress_data.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Build the PWG->RU/EN *progress* dashboard data.
+
+Companion to the public article browser (article_site/, served at the repo
+root of https://gasyoun.github.io/SanskritLexicography/). Where the article
+site shows the *finished* translations, this shows *how far along the work is*
+— the honest denominators for the verb lane, the nominal lane, store depth,
+frequency coverage, and the corpus/TM asset.
+
+WHY THIS RUNS LOCALLY, NOT IN CI: the numbers are derived from local-only /
+gitignored artifacts (`RussianTranslation/src/pwg_ru_translated.jsonl`, the
+`verb_batch_worklist.json` / `nominal_batch_worklist.json` snapshots, the
+frequency manifest). GitHub Actions never checks those out, so — exactly like
+`build_article_site.py` — this is run on the residential machine and only the
+tiny aggregate `progress_data.json` (+ the append-only `progress_timeseries.json`)
+is committed. The `findings-dashboard.yml` workflow then merely *copies* the
+committed HTML+JSON onto the gh-pages `/progress/` subdir; it does not rebuild.
+
+Emits, next to this script:
+  - progress_data.json        one snapshot of every lane/metric, with a per-metric
+                              `measured` flag so the trust block can say whether a
+                              number was counted live or is a documented fallback.
+  - progress_timeseries.json  append-only; one row per build date, for trend lines.
+
+Run: python progress_dashboard/build_progress_data.py
+     (from the repo root; paths below are resolved relative to it.)
+
+When the data lives in a different checkout than this script (e.g. building on an
+isolated worktree that lacks the gitignored artifacts), point it at the checkout
+that has them:  PWG_DATA_ROOT=/path/to/main/checkout python .../build_progress_data.py
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+
+OUT = Path(__file__).resolve().parent
+REPO = OUT.parent
+# The data root defaults to this checkout, but can be overridden when the
+# gitignored artifacts live elsewhere (isolated worktree build).
+DATA_REPO = Path(os.environ.get("PWG_DATA_ROOT", REPO)).resolve()
+RT = DATA_REPO / "RussianTranslation"
+
+# --- documented fallback constants (numbers that live in prose, not a machine file) ---
+# Total PWG headwords, from RussianTranslation/.ai_state.md ("43,968 / 106,082
+# DCS-attested PWG headwords (41%)").
+TOTAL_HEADWORDS_FALLBACK = 106082
+# corpus_lexicon recall, measured in H309 (overall 95.4%). No machine file exposes
+# it, so it is carried as a documented constant until a metrics file does.
+CORPUS_RECALL_PCT = 95.4
+
+
+def _load_json(rel):
+    p = RT / rel
+    try:
+        with p.open(encoding="utf-8-sig") as fh:
+            return json.load(fh)
+    except Exception as e:  # noqa: BLE001 — a missing local artifact must not crash the build
+        print(f"  ! could not read {rel}: {e}")
+        return None
+
+
+def verb_lane():
+    v = _load_json("src/pilot/output/verb_batch_worklist.json")
+    if not v:
+        return {"measured": False}
+
+    def n(key):
+        val = v.get(key)
+        return len(val) if isinstance(val, list) else (val if isinstance(val, int) else None)
+
+    return {
+        "measured": True,
+        "universe": n("universe_verbs01"),
+        "dcs_attested": n("dcs_attested"),
+        "promoted": n("done_promoted"),
+        "runnable": n("runnable_remaining"),
+        "blocked": n("blocked_missing_rootmap"),
+    }
+
+
+def nominal_lane():
+    nm = _load_json("src/pilot/output/nominal_batch_worklist.json")
+    out = {"measured": bool(nm)}
+    if nm:
+        out.update(
+            {
+                "candidates": nm.get("nominal_candidates"),
+                "promoted": nm.get("already_promoted_count"),
+                "runnable": nm.get("runnable_count"),
+                "pwg_hits": nm.get("pwg_hits"),
+            }
+        )
+    # The medium-50 band-4 relaunch arc (H317 -> H389 -> H437): 2/50 promoted,
+    # lane paused on kill-gate miscalibration (H442). Documented, not in this file.
+    out["medium50_promoted"] = 2
+    out["medium50_total"] = 50
+    out["medium50_status"] = "paused (kill-gate recalibration, H442/H462)"
+    return out
+
+
+def store_depth():
+    p = RT / "src" / "pwg_ru_translated.jsonl"
+    if not p.exists():
+        return {"measured": False}
+    senses = 0
+    roots = set()
+    review = {}
+    with p.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+            except Exception:  # noqa: BLE001
+                continue
+            senses += 1
+            k = d.get("key1") or d.get("h") or d.get("root")
+            if k:
+                roots.add(k)
+            rs = d.get("review_status", "unknown")
+            review[rs] = review.get(rs, 0) + 1
+    return {
+        "measured": True,
+        "senses": senses,
+        "roots": len(roots),
+        "review": review,
+        "human_reviewed": review.get("human_reviewed", 0),
+    }
+
+
+def coverage():
+    f = _load_json("src/pilot/output/scale_manifest.freq.json")
+    attested = len(f) if isinstance(f, list) else None
+    total = TOTAL_HEADWORDS_FALLBACK
+    pct = round(attested / total * 100, 1) if attested else None
+    return {
+        "measured": attested is not None,
+        "dcs_attested_headwords": attested,
+        "total_headwords": total,
+        "total_measured": False,  # denominator is a documented constant
+        "pct": pct,
+    }
+
+
+def corpus():
+    p = RT / "src" / "corpus_lexicon.jsonl"
+    pairs = None
+    if p.exists():
+        # 1M+ lines; count cheaply without JSON-parsing each row.
+        with p.open(encoding="utf-8") as fh:
+            pairs = sum(1 for _ in fh)
+    return {
+        "measured": pairs is not None,
+        "pairs": pairs if pairs is not None else 1093391,
+        "pairs_measured": pairs is not None,
+        "recall_pct": CORPUS_RECALL_PCT,
+        "recall_measured": False,
+    }
+
+
+def main():
+    today = datetime.now(timezone.utc).date().isoformat()
+    verb = verb_lane()
+    nom = nominal_lane()
+    st = store_depth()
+    cov = coverage()
+    cor = corpus()
+
+    data = {
+        "generated_at": today,
+        "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
+        "site_url": "https://gasyoun.github.io/SanskritLexicography/",
+        "lanes": {"verb": verb, "nominal": nom},
+        "store": st,
+        "coverage": cov,
+        "corpus": cor,
+    }
+
+    (OUT / "progress_data.json").write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"progress_data.json written ({today}).")
+
+    # append-only timeseries: one row per build date (last write per date wins)
+    ts_path = OUT / "progress_timeseries.json"
+    ts = {"snapshots": []}
+    if ts_path.exists():
+        try:
+            ts = json.loads(ts_path.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            ts = {"snapshots": []}
+    row = {
+        "date": today,
+        "verb_promoted": verb.get("promoted"),
+        "verb_dcs_attested": verb.get("dcs_attested"),
+        "senses": st.get("senses"),
+        "roots": st.get("roots"),
+        "coverage_pct": cov.get("pct"),
+    }
+    ts["snapshots"] = [s for s in ts.get("snapshots", []) if s.get("date") != today] + [row]
+    ts["snapshots"].sort(key=lambda s: s["date"])
+    ts_path.write_text(json.dumps(ts, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"progress_timeseries.json: {len(ts['snapshots'])} snapshot(s).")
+
+    # console summary
+    print(
+        f"  verb lane:   {verb.get('promoted')}/{verb.get('dcs_attested')} promoted "
+        f"({verb.get('runnable')} runnable, {verb.get('blocked')} blocked)"
+    )
+    print(f"  store:       {st.get('senses')} senses across {st.get('roots')} roots")
+    print(f"  coverage:    {cov.get('pct')}% DCS-attested ({cov.get('dcs_attested_headwords')}/{cov.get('total_headwords')})")
+    print(f"  corpus/TM:   {cor.get('pairs')} pairs, {cor.get('recall_pct')}% recall")
+
+
+if __name__ == "__main__":
+    main()

--- a/progress_dashboard/index.html
+++ b/progress_dashboard/index.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PWG→RU progress — SanskritLexicography</title>
+<style>
+  :root { --fg:#1f2328; --mut:#59636e; --bg:#fff; --card:#f6f8fa; --line:#d1d9e0;
+          --accent:#0969da; --done:#1a7f37; --run:#9a6700; --block:#d1242f; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg:#e6edf3; --mut:#9198a1; --bg:#0d1117; --card:#161b22; --line:#30363d;
+            --accent:#4493f8; --done:#3fb950; --run:#d29922; --block:#f85149; }
+  }
+  body { font: 15px/1.5 system-ui, sans-serif; color:var(--fg); background:var(--bg);
+         max-width: 1080px; margin: 0 auto; padding: 1.5rem; }
+  h1 { font-size: 1.5rem; margin-bottom:.2rem; } h2 { font-size: 1.15rem; margin-top: 2.2rem; }
+  .mut { color: var(--mut); font-size: .85rem; }
+  a { color: var(--accent); }
+  .cards { display: flex; gap: .8rem; flex-wrap: wrap; margin: 1rem 0; }
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+          padding: .7rem 1.1rem; min-width: 8.5rem; }
+  .card b { font-size: 1.7rem; display: block; line-height:1.1; }
+  .card .sub { color: var(--mut); font-size: .8rem; }
+  table { border-collapse: collapse; width: 100%; font-size: .9rem; }
+  th, td { text-align: left; padding: .35rem .6rem; border-bottom: 1px solid var(--line); }
+  th { color: var(--mut); font-weight: 600; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  /* funnel + bars */
+  .bar-wrap { background: var(--card); border:1px solid var(--line); border-radius:8px;
+              padding:.9rem 1.1rem; margin:.6rem 0; }
+  .bar-row { display:flex; align-items:center; gap:.7rem; margin:.35rem 0; }
+  .bar-row .lbl { flex: 0 0 12.5rem; }
+  .bar-row .lbl small { color:var(--mut); }
+  .track { flex:1; background:rgba(127,127,127,.14); border-radius:5px; height:1.5rem; position:relative; overflow:hidden; }
+  .fill { height:100%; border-radius:5px 0 0 5px; }
+  .bar-row .val { flex:0 0 8.5rem; text-align:right; font-variant-numeric:tabular-nums; }
+  .c-done{ background:var(--done);} .c-run{ background:var(--run);} .c-block{ background:var(--block);}
+  .c-att{ background:var(--accent);} .c-univ{ background:rgba(127,127,127,.45);}
+  .legend { font-size:.8rem; color:var(--mut); margin-top:.5rem; }
+  .legend span { margin-right:1rem; white-space:nowrap; }
+  .sw { display:inline-block; width:.7rem; height:.7rem; border-radius:2px; vertical-align:middle; margin-right:.25rem; }
+  .trust { background:var(--card); border:1px solid var(--line); border-left:3px solid var(--accent);
+           border-radius:6px; padding:.7rem 1rem; font-size:.83rem; color:var(--mut); margin:1rem 0; }
+  .trust b { color:var(--fg); }
+  .chart { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding:.6rem; }
+  .flags { font-size:.8rem; }
+  .est { color:var(--run); cursor:help; }
+  footer { margin-top:2.5rem; color:var(--mut); font-size:.8rem; }
+</style>
+</head>
+<body>
+<h1>PWG → Russian — translation progress</h1>
+<p class="mut">How the machine-assisted translation of the <b>Petersburg Dictionary</b>
+  (Böhtlingk–Roth, PWG) into Russian is progressing. The finished articles are browsable at the
+  <a id="sitelink" href="https://gasyoun.github.io/SanskritLexicography/">article site</a>;
+  this page is the <em>backlog-and-coverage</em> companion. <span id="stamp"></span></p>
+
+<div class="cards" id="cards"></div>
+
+<h2>Verb lane — the priority workstream (H151)</h2>
+<p class="mut">The dictionary is topped by verbal roots (<code>sTA</code> 379 senses, <code>i</code> 272,
+  <code>gam</code> 213…). They are translated root-by-root through the Claude Workflow harness. Funnel
+  from every vetted PWG verb root down to what is actually promoted:</p>
+<div class="bar-wrap" id="verbfunnel"></div>
+<div class="legend">
+  <span><i class="sw c-univ"></i>vetted universe</span>
+  <span><i class="sw c-att"></i>DCS-attested (in scope)</span>
+  <span><i class="sw c-done"></i>promoted</span>
+  <span><i class="sw c-run"></i>runnable now</span>
+  <span><i class="sw c-block"></i>blocked (needs rootmap)</span>
+</div>
+
+<h2>Store depth — what is translated so far</h2>
+<p class="mut">Sense-rows written into the RU spine (<code>pwg_ru_translated.jsonl</code>), and how many
+  have passed <em>human</em> review versus still carrying only the AI first pass.</p>
+<div class="bar-wrap" id="reviewbar"></div>
+
+<h2>Frequency coverage — how much of PWG is even in scope</h2>
+<p class="mut">Only DCS-attested headwords are targeted first (corpus-frequency route). This is the
+  ceiling the lanes above are working toward, not a translated count.</p>
+<div class="bar-wrap" id="covbar"></div>
+
+<h2>Nominal lane &amp; supporting assets</h2>
+<table id="misc"></table>
+
+<h2>Trend</h2>
+<p class="mut">One point per dashboard rebuild. A single point shows the current value; the line
+  appears once a second snapshot exists.</p>
+<div class="cards" id="charts"></div>
+
+<div class="trust" id="trust"></div>
+
+<footer>
+  Built by <code>progress_dashboard/build_progress_data.py</code> from local-only pipeline artifacts;
+  published to <code>/progress/</code> on gh-pages. Source:
+  <a href="https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/">progress_dashboard/</a>.
+</footer>
+
+<script>
+'use strict';
+const esc = s => String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const fmt = n => (n == null ? '—' : n.toLocaleString('en-US'));
+
+function barRow(label, sub, value, total, cls, valText) {
+  const pct = total ? Math.max(1.5, value / total * 100) : 0;
+  return `<div class="bar-row">
+    <div class="lbl">${esc(label)}${sub ? ` <small>${esc(sub)}</small>` : ''}</div>
+    <div class="track"><div class="fill ${cls}" style="width:${pct.toFixed(1)}%"></div></div>
+    <div class="val">${valText != null ? valText : fmt(value)}</div>
+  </div>`;
+}
+
+function line(el, series, label, suffix) {
+  suffix = suffix || '';
+  const last = series[series.length - 1];
+  if (series.length === 1) {
+    el.insertAdjacentHTML('beforeend',
+      `<div class="chart"><b>${esc(label)}</b>
+       <div style="font-size:2rem;font-weight:650;margin:.35rem 0 .1rem">${fmt(last[1])}${suffix}</div>
+       <span class="mut">first snapshot · ${esc(last[0])} — trend line appears next rebuild</span></div>`);
+    return;
+  }
+  const w = 300, h = 120, px = 44, py = 20;
+  const vals = series.map(p => p[1]);
+  const lo = Math.min(...vals), hi = Math.max(...vals);
+  const span = (hi - lo) || 1;
+  const x = i => px + i * (w - 2 * px) / (series.length - 1);
+  const y = v => h - py - (v - lo) / span * (h - 2 * py);
+  const pts = series.map((p, i) => `${x(i)},${y(p[1])}`).join(' ');
+  const dots = series.map((p, i) =>
+    `<circle cx="${x(i)}" cy="${y(p[1])}" r="2.6" fill="currentColor"><title>${esc(p[0])}: ${fmt(p[1])}${suffix}</title></circle>`).join('');
+  el.insertAdjacentHTML('beforeend',
+    `<div class="chart"><b>${esc(label)}</b> <span class="mut">${fmt(last[1])}${suffix} · ${esc(last[0])}</span><br>
+     <svg viewBox="0 0 ${w} ${h}" width="100%" height="${h}">
+       <text x="${px - 6}" y="${y(hi) + 4}" text-anchor="end" font-size="9" fill="currentColor" fill-opacity=".6">${fmt(hi)}</text>
+       <text x="${px - 6}" y="${y(lo) + 4}" text-anchor="end" font-size="9" fill="currentColor" fill-opacity=".6">${fmt(lo)}</text>
+       <polyline points="${pts}" fill="none" stroke="currentColor" stroke-width="1.5"/>${dots}
+       <circle cx="${x(series.length - 1)}" cy="${y(last[1])}" r="4" fill="none" stroke="currentColor"/>
+     </svg></div>`);
+}
+
+async function j(f) { try { const r = await fetch(f); return r.ok ? r.json() : null; } catch { return null; } }
+
+(async () => {
+  const d = await j('progress_data.json');
+  if (!d) {
+    document.getElementById('cards').innerHTML = '<p class="bad">progress_data.json not found.</p>';
+    return;
+  }
+  const v = d.lanes.verb, nm = d.lanes.nominal, st = d.store, cov = d.coverage, cor = d.corpus;
+  document.getElementById('stamp').textContent = 'Snapshot ' + d.generated_at + '.';
+  if (d.site_url) document.getElementById('sitelink').href = d.site_url;
+
+  // headline cards
+  document.getElementById('cards').innerHTML = [
+    `<div class="card"><b>${fmt(st.senses)}</b><span class="sub">sense-rows translated (RU)</span></div>`,
+    `<div class="card"><b>${fmt(st.roots)}</b><span class="sub">roots with translations</span></div>`,
+    `<div class="card"><b>${fmt(v.promoted)}<span class="sub" style="display:inline;font-size:1rem"> / ${fmt(v.dcs_attested)}</span></b><span class="sub">verb roots promoted</span></div>`,
+    `<div class="card"><b>${cov.pct}%</b><span class="sub">of PWG is DCS-attested</span></div>`,
+  ].join('');
+
+  // verb funnel
+  const vf = document.getElementById('verbfunnel');
+  const U = v.universe || 0;
+  vf.innerHTML =
+    barRow('Vetted PWG verb roots', 'universe_verbs01', v.universe, U, 'c-univ') +
+    barRow('DCS-attested (in scope)', 'first-pass target', v.dcs_attested, U, 'c-att') +
+    barRow('Promoted', 'shipped to store', v.promoted, U, 'c-done',
+           `${fmt(v.promoted)} <span class="mut">(${(v.promoted / v.dcs_attested * 100).toFixed(1)}% of scope)</span>`) +
+    barRow('Runnable now', 'has rootmap', v.runnable, U, 'c-run') +
+    barRow('Blocked', 'missing rootmap', v.blocked, U, 'c-block');
+
+  // store review split
+  const rb = document.getElementById('reviewbar');
+  const human = st.human_reviewed || 0;
+  const ai = (st.senses || 0) - human;
+  rb.innerHTML =
+    barRow('AI first pass', 'awaiting human QA', ai, st.senses, 'c-run',
+           `${fmt(ai)} <span class="mut">(${(ai / st.senses * 100).toFixed(1)}%)</span>`) +
+    barRow('Human-reviewed', 'signed off', human, st.senses, 'c-done',
+           `${fmt(human)} <span class="mut">(${(human / st.senses * 100).toFixed(1)}%)</span>`);
+
+  // coverage bar
+  const cb = document.getElementById('covbar');
+  cb.innerHTML =
+    barRow('DCS-attested headwords', 'in first-pass scope', cov.dcs_attested_headwords, cov.total_headwords, 'c-att',
+           `${fmt(cov.dcs_attested_headwords)} <span class="mut">(${cov.pct}%)</span>`) +
+    barRow('Total PWG headwords', 'whole dictionary', cov.total_headwords, cov.total_headwords, 'c-univ');
+
+  // misc table
+  const est = t => `<span class="est" title="documented constant, not counted live">${esc(t)} *</span>`;
+  document.getElementById('misc').innerHTML =
+    '<tr><th>Item</th><th class="num">Value</th><th>Note</th></tr>' +
+    `<tr><td>Nominal lane — promoted</td><td class="num">${fmt(nm.promoted)} / ${fmt(nm.candidates)}</td><td class="mut">pril10 core nominal candidates</td></tr>` +
+    `<tr><td>Nominal medium-50 band</td><td class="num">${fmt(nm.medium50_promoted)} / ${fmt(nm.medium50_total)}</td><td class="mut">${esc(nm.medium50_status || '')}</td></tr>` +
+    `<tr><td>Corpus lexicon (TM source)</td><td class="num">${cor.pairs_measured ? fmt(cor.pairs) : est(fmt(cor.pairs))}</td><td class="mut">Sa→Ru alignment pairs</td></tr>` +
+    `<tr><td>Alignment recall</td><td class="num">${est(cor.recall_pct + '%')}</td><td class="mut">measured H309</td></tr>`;
+
+  // trend charts
+  const ts = await j('progress_timeseries.json');
+  if (ts && ts.snapshots && ts.snapshots.length) {
+    const el = document.getElementById('charts');
+    const pick = key => ts.snapshots.filter(s => s[key] != null).map(s => [s.date, s[key]]);
+    let s;
+    if ((s = pick('senses')).length) line(el, s, 'Sense-rows translated');
+    if ((s = pick('verb_promoted')).length) line(el, s, 'Verb roots promoted');
+    if ((s = pick('coverage_pct')).length) line(el, s, 'DCS coverage', '%');
+  }
+
+  // trust block
+  const flag = ok => ok ? '<b style="color:var(--done)">measured live</b>' : '<span class="est">documented constant *</span>';
+  document.getElementById('trust').innerHTML =
+    `<b>Provenance.</b> Snapshot <b>${esc(d.generated_at)}</b>. ` +
+    `Verb/nominal lanes and store depth are counted live from the pipeline's own worklist + store files; ` +
+    `the frequency denominator (${fmt(cov.total_headwords)} headwords) and the ${cor.recall_pct}% recall are ` +
+    `documented constants (marked <span class="est">*</span>). ` +
+    `Store: ${flag(st.measured)}. Verb lane: ${flag(v.measured)}. Coverage numerator: ${flag(cov.measured)}. ` +
+    `“Promoted” = passed the mechanical + review gate and written to the shipped store, not merely generated.`;
+})();
+</script>
+</body>
+</html>

--- a/progress_dashboard/progress_data.json
+++ b/progress_dashboard/progress_data.json
@@ -1,0 +1,48 @@
+{
+  "generated_at": "2026-07-10",
+  "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
+  "site_url": "https://gasyoun.github.io/SanskritLexicography/",
+  "lanes": {
+    "verb": {
+      "measured": true,
+      "universe": 1882,
+      "dcs_attested": 749,
+      "promoted": 48,
+      "runnable": 11,
+      "blocked": 690
+    },
+    "nominal": {
+      "measured": true,
+      "candidates": 304,
+      "promoted": 3,
+      "runnable": 283,
+      "pwg_hits": 286,
+      "medium50_promoted": 2,
+      "medium50_total": 50,
+      "medium50_status": "paused (kill-gate recalibration, H442/H462)"
+    }
+  },
+  "store": {
+    "measured": true,
+    "senses": 11275,
+    "roots": 147,
+    "review": {
+      "ai_translated": 11275
+    },
+    "human_reviewed": 0
+  },
+  "coverage": {
+    "measured": true,
+    "dcs_attested_headwords": 43968,
+    "total_headwords": 106082,
+    "total_measured": false,
+    "pct": 41.4
+  },
+  "corpus": {
+    "measured": true,
+    "pairs": 1093391,
+    "pairs_measured": true,
+    "recall_pct": 95.4,
+    "recall_measured": false
+  }
+}

--- a/progress_dashboard/progress_timeseries.json
+++ b/progress_dashboard/progress_timeseries.json
@@ -1,0 +1,12 @@
+{
+  "snapshots": [
+    {
+      "date": "2026-07-10",
+      "verb_promoted": 48,
+      "verb_dcs_attested": 749,
+      "senses": 11275,
+      "roots": 147,
+      "coverage_pct": 41.4
+    }
+  ]
+}


### PR DESCRIPTION
## What & why

Answers *"the article site shows what's **done** — where's the dashboard of **how the work is going**?"* — MG, 10-07-2026.

Adds [`progress_dashboard/`](https://github.com/gasyoun/SanskritLexicography/tree/progress-dashboard/progress_dashboard), a **public** GitHub Pages companion to the [article site](https://gasyoun.github.io/SanskritLexicography/). Where the article site shows finished PWG→Russian translations, this shows the **backlog-and-coverage** picture.

Published at [`/progress/`](https://gasyoun.github.io/SanskritLexicography/progress/) on gh-pages, next to `/findings/` and `/episteme/`.

## What it shows (first snapshot, 10-07-2026)

- **Verb-lane funnel** (H151): 1,882 vetted → 749 DCS-attested → **48 promoted** (11 runnable, 690 blocked on missing rootmap).
- **Store depth**: 11,275 sense-rows / 147 roots — **100% AI first pass, 0% human-reviewed** (surfaces the QA gap honestly).
- **Frequency coverage**: 41.4% of PWG is DCS-attested (43,968 / 106,082).
- **Nominal lane** + corpus/TM asset (1.09M pairs, 95.4% recall), and an append-only **trend** series.

## How it's wired

- [`build_progress_data.py`](https://github.com/gasyoun/SanskritLexicography/blob/progress-dashboard/progress_dashboard/build_progress_data.py) reads local-only pipeline artifacts (`pwg_ru_translated.jsonl`, `*_batch_worklist.json`, freq manifest) → tiny aggregate JSON. Honors `PWG_DATA_ROOT` for isolated-worktree builds.
- **Runs locally, not in CI** (same reason as the article site — the data is gitignored). [`findings-dashboard.yml`](https://github.com/gasyoun/SanskritLexicography/blob/progress-dashboard/.github/workflows/findings-dashboard.yml) gains a **copy-only** step to publish the committed HTML+JSON to gh-pages `/progress/`.
- Provenance/trust block distinguishes live-counted numbers from two documented constants (the 106,082 denominator, the 95.4% H309 recall).

## Verification

- Rendered via local http server: accessibility snapshot confirms every metric, funnel bar, review split, coverage bar, and trust block; **zero console errors**.
- `py_compile`, JSON-valid, YAML-valid all green.

Handoff: [H495](https://github.com/gasyoun/Uprava/blob/main/handoffs/H495-Sonnet_SanskritLexicography_pwg_ru_progress_dashboard_10.07.26.md) (refresh runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)