### PR TITLE
docs: four audience manuals in docs/manuals/ (maintainer/researcher/student-RU/data-reuse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ Where to read what.
   plan, FAIR/standards gaps.
 - [changelog.md](changelog.md) — what changed, by dated snapshot.
 
+**Manuals (by audience)** — deep, standalone guides in
+[docs/manuals/](https://github.com/gasyoun/SanskritLexicography/tree/master/docs/manuals)
+([router](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/README.md)):
+
+- [MAINTAINER_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/MAINTAINER_MANUAL.md)
+  — operating/extending the repo (conventions, the pipelines, the epistemic
+  registries). English.
+- [RESEARCHER_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RESEARCHER_MANUAL.md)
+  — the evidence-graded thesis, paper pipeline, what's citable. English.
+- [STUDENT_MANUAL_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/STUDENT_MANUAL_RU.md)
+  — teaching material and what's usable today. Русский.
+- [DATA_REUSE_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/DATA_REUSE_MANUAL.md)
+  — dataset formats, encodings, traps, rights. English.
+
 **Contributors & agents**
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — how to contribute.

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,15 @@ then **cut a new version every time the changelog is updated** (promote
 
 ## [Unreleased]
 
+### Added — audience manuals
+- New [`docs/manuals/`](https://github.com/gasyoun/SanskritLexicography/tree/master/docs/manuals):
+  four deep, standalone manuals for distinct audiences — maintainer, researcher,
+  student (Russian), and data-reuser — plus a
+  [router README](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/README.md).
+  Linked from the root README documentation map. Language follows audience
+  (student = Russian; the rest English). Built under
+  [Uprava H529](https://github.com/gasyoun/Uprava/blob/main/handoffs/H529-Opus_SanskritLexicography_audience-manuals-quartet_10.07.26.md).
+
 ## [1.1.5] - 2026-07-03
 
 ### Added — Indische Sprüche dataset

--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,7 @@ then **cut a new version every time the changelog is updated** (promote
   [router README](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/README.md).
   Linked from the root README documentation map. Language follows audience
   (student = Russian; the rest English). Built under
-  [Uprava H529](https://github.com/gasyoun/Uprava/blob/main/handoffs/H529-Opus_SanskritLexicography_audience-manuals-quartet_10.07.26.md).
+  [Uprava H535](https://github.com/gasyoun/Uprava/blob/main/handoffs/H535-Opus_SanskritLexicography_audience-manuals-quartet_10.07.26.md).
 
 ## [1.1.5] - 2026-07-03
 

--- a/docs/manuals/DATA_REUSE_MANUAL.md
+++ b/docs/manuals/DATA_REUSE_MANUAL.md
@@ -1,0 +1,169 @@
+# Data-Reuse Manual — SanskritLexicography
+
+_Created: 10-07-2026 · Last updated: 10-07-2026_
+
+For the **programmer / data engineer / NLP researcher** who wants to *consume*
+the data here in scripts. This manual is about the committed, reusable datasets —
+their formats, encodings, traps, and rights. For the research framing see the
+[Researcher Manual](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RESEARCHER_MANUAL.md);
+to operate the pipelines see the
+[Maintainer Manual](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/MAINTAINER_MANUAL.md).
+
+---
+
+## 0. Read this first — rights and what is *not* in the repo
+
+- The repo is **public**, but it **mixes rights tiers**. The 19th-century source
+  dictionaries and Böhtlingk's German are public domain; the AI Russian
+  translations are **unpublished** and mostly **gitignored** (the `mw_ru`/`pwg_ru`
+  translation store, TM files, learner scores). If you clone this, you get the
+  *tooling and the FAIR-committed datasets*, **not** the full Russian dictionary
+  text. The TMX release is gated behind rights clearance.
+- Before redistributing anything from here, check
+  [REFERENCES.md](https://github.com/gasyoun/SanskritLexicography/blob/master/REFERENCES.md)
+  (asset provenance) and the per-dataset data statements (e.g.
+  [ReverseDictionary/DATA_STATEMENT.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/DATA_STATEMENT.md)).
+
+## 1. Encoding rules — get these right or your joins are garbage
+
+- **Default transliteration is SLP1** in the headword keys (`aMSa`, `a/MSa`).
+  Exceptions are explicitly named: the Huet/INRIA file is **Velthuis**
+  (`a.mza` = aṃśa); `SCH-accents-IAST-*` and the Catalan-Pujol spine are
+  **accented IAST**; `mw-apte-mcdonell-hk.txt` is **Harvard-Kyoto**.
+- **BOM is inconsistent.** Some `.txt` exports carry a UTF-8 BOM (`EF BB BF`),
+  some don't — even two files of the same dictionary differ. **Check
+  `head -c 3 file | xxd` before reading**, strip the BOM in-code, and preserve
+  the file's existing BOM state if you write it back. The org "no BOM" rule does
+  **not** hold here. All files are UTF-8.
+- **Filename counts are true counts, not `wc -l`.** In
+  `{DICT}-unique-{key}-{N}.txt`, `N` is the entry count; `wc -l` usually reports
+  `N − 1` because the last line has no trailing newline.
+- **Accented-IAST spines need normalizing before matching** — strip `√`,
+  accents, and editorial hyphens and transcode IAST→SLP1 first. Use the org's
+  canonical transcoder [`sanskrit-util`](https://github.com/sanskrit-lexicon/sanskrit-util),
+  not a hand-rolled one (there is a known `devanagari_to_slp1` `ळ→x` bug in one
+  copy — see org [SHARED_CODE.md](https://github.com/gasyoun/github-spine/blob/main/SHARED_CODE.md)).
+
+## 2. HeadwordLists — the core reusable data
+
+Full detail in
+[HeadwordLists/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/README.md).
+Naming: `{DICT}-unique-{key1|key2}-{N}.txt`, one headword per line, sorted.
+
+- **key1** = normalized computational key — may not match any printed form; use
+  for **matching, dedup, joins**.
+- **key2** = closer to the printed source (keeps `-`, `--`, `/` accent, `°`); use
+  for **display, citation, checking against the scan**. Not every dict ships both.
+- **`then-2014/` vs `now-2026/`:** the original lists were extracted in 2014 and
+  are frozen in
+  [then-2014/](https://github.com/gasyoun/SanskritLexicography/tree/master/HeadwordLists/then-2014);
+  the current regeneration is in
+  [now-2026/](https://github.com/gasyoun/SanskritLexicography/tree/master/HeadwordLists/now-2026).
+  They have **drifted** — e.g. AP 36,030 → 88,867 (+146.6%); across 9 comparable
+  lists 605,813 → 733,617 (+21.1%). See
+  [NOW_VS_THEN.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/NOW_VS_THEN.md).
+  Compare **by set**, not raw line-diff; the 2014 key2 is legacy numeric
+  transliteration (`am2s4a` = aṃśa), so key2 then-vs-now is a format migration.
+- **The union is the print target:**
+  [union/UNION.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/union/UNION.md)
+  — 323,425 headwords across 15 dicts with per-dict provenance + gender.
+- **Ready-made comparison:**
+  [mw-apte-mcdonell-hk.txt](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/then-2014/mw-apte-mcdonell-hk.txt)
+  (~202k lines, HK, MW ∪ Apte ∪ Macdonell).
+- **Variant patterns:** `{DICT}-fehlerhaft-{N}.txt` hold **full XML records, not
+  bare headwords**; `sanhw1.xlsx` is a 41 MB binary — load with a library, never
+  open in an editor.
+
+**Dictionary codes:** AP · BHS · BUR · CAE · CCS · GRA · INM · MD · MW · PD ·
+PWG · PWK · SCH · SKD · VCP · VEI (full titles in the HeadwordLists README).
+
+## 3. RussianTranslation — the FAIR-committed datasets
+
+These are committed and reusable (the *translation text* is not). Details in
+[RussianTranslation/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/README.md)
+§"Datasets".
+
+| Asset | What | Path |
+|---|---|---|
+| Headword index | 98,639 headwords: homonym no. · lexical category · accented form · inflection index · stem class · compound segmentation · irregularities | [src/headword_index.tsv](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/headword_index.tsv) |
+| Reverse paradigm index | Zaliznyak-style index token → every headword in that paradigm | [src/reverse_paradigm_index.json](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/reverse_paradigm_index.json) |
+| Paradigm statistics | stem-class / index-token distribution across the lexicon | [src/paradigm_stats.tsv](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/paradigm_stats.tsv) |
+| Frictionless descriptor | data-package metadata for the grammar dataset (CC-BY-SA-4.0) | [src/datapackage.json](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/datapackage.json) |
+| Addenda-relationship rollup | 5,603 supplement-layer senses classified vs the PWG base | [pwg_ru/relationships_rollup.tsv](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/relationships_rollup.tsv) |
+
+The Sa→Ru **translation memory** (1.09M verse-aligned pairs + a 10,132-pair
+precision-gated mined tier + a specialist glossary tier) is graded A/B/C and
+exportable as standard **TMX 1.4b**
+([src/build_tmx.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_tmx.py))
+— but the bulk TM files are gitignored pending the FAIR release; a CAT-tool user
+imports the TMX once the release clears.
+
+## 4. Other committed datasets
+
+- **Indische Sprüche** —
+  [IndischeSprueche/data/indische_sprueche.jsonl](https://github.com/gasyoun/SanskritLexicography/blob/master/IndischeSprueche/data/indische_sprueche.jsonl),
+  7,537 records, one JSON per line: `num`, `saying_id`, `page`, `deva`, `iast`,
+  `translation_de`, `source_attribution`, `notes`. **Use it as a bulk/derived
+  source, never as the citable edition** — it is 76 verses short of the verified
+  7,613 and comes from an unproofed Excel transcription. For anything
+  citation-facing, route to
+  [boesp2](https://github.com/sanskrit-lexicon-scans/boesp2) /
+  [boesp1](https://github.com/sanskrit-lexicon-scans/boesp1); `Spr. N` citation
+  resolution is **already shipped** in csl-orig, do not rebuild it. Only
+  `translation_de` exists (no RU/EN).
+- **Reverse dictionary master list** —
+  [ReverseDictionary/.doc.pdf/266820-reverse-Gasuns.txt](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/.doc.pdf/266820-reverse-Gasuns.txt),
+  266,819 lines, tab-separated `SOURCE_ABBREV<TAB>word`, reverse-sorted. Column
+  semantics + source-code→bibliography table in
+  [ReverseDictionary/SCHEMA.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/SCHEMA.md).
+  Three headword counts (250,026 / 255,882 / 266,820) exist as compilation
+  stages — the 266,820 file is canonical (see
+  [ReverseDictionary/CHANGELOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/CHANGELOG.md)).
+- **Catalan-Pujol spine** —
+  [HeadwordLists/Catalan-Pujol/](https://github.com/gasyoun/SanskritLexicography/tree/master/HeadwordLists/Catalan-Pujol),
+  an external Sanskrit–Catalan lemma list (61,266 lines, accented IAST **with
+  BOM**, `√`-roots + udātta + compound hyphens) plus its CDSL/DCS coverage
+  analysis. **Normalize heavily before matching.**
+
+## 5. What NOT to reuse (or reuse with care)
+
+- **The giant reference HTML/binary at the root** —
+  `DCS_statistical_evaluation.htm` (~75 MB), `DCS-Moniers-roots-w-references.html`
+  (~16 MB), `helpmorphids.html`, `sanhw1.xlsx` (41 MB): stream with CLI tools /
+  a library; **never** open in an editor or the Read tool. Provenance is in
+  [REFERENCES.md](https://github.com/gasyoun/SanskritLexicography/blob/master/REFERENCES.md).
+- **The gitignored translation store / TM / dashboards** — regenerable, local-only,
+  and (for the translations) unpublished. Not in a clone.
+- **`{DICT}-fehlerhaft-*.txt`** — these are flagged *problem* entries as XML, not
+  a clean wordlist.
+
+## 6. Findings that will bite a reuser
+
+From [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
+(cite by `§N`):
+
+- **§7 — DCS lemma data is keyed in two transliterations** (SLP1 vs IAST across
+  the two frequency files); pick the right one before joining.
+- **§8 — unaccented DCS cannot distinguish present class I from VI** (117
+  spurious corpus-derived class additions were reverted); don't infer verb class
+  from unaccented corpus data.
+- **§9 — DCS OccId and sent_id are not unique keys** (PK collisions silently
+  dropped tokens/sentences before synthetic keys were added).
+- **§67 — PWG article size confounds every per-entry statistic** — normalize for
+  entry length before comparing counts across entries.
+
+## 7. Reuse checklist
+
+1. `git remote -v` — confirm you're on `gasyoun/SanskritLexicography` (personal,
+   branch `master`), not an org mirror.
+2. `head -c 3 file | xxd` — BOM check on every `.txt` you read.
+3. Identify the transliteration (SLP1 default; IAST/Velthuis/HK exceptions are
+   named) and normalize with
+   [`sanskrit-util`](https://github.com/sanskrit-lexicon/sanskrit-util).
+4. Use the filename `N` as the true count; compare lists **by set**.
+5. Prefer `now-2026/` over `then-2014/` unless you specifically want the frozen
+   2014 snapshot.
+6. Check rights before redistributing; the Russian translation text is not
+   yours to republish.
+
+_Dr. Mārcis Gasūns_

--- a/docs/manuals/DATA_REUSE_MANUAL.md
+++ b/docs/manuals/DATA_REUSE_MANUAL.md
@@ -111,14 +111,17 @@ imports the TMX once the release clears.
   [boesp1](https://github.com/sanskrit-lexicon-scans/boesp1); `Spr. N` citation
   resolution is **already shipped** in csl-orig, do not rebuild it. Only
   `translation_de` exists (no RU/EN).
-- **Reverse dictionary master list** —
-  [ReverseDictionary/.doc.pdf/266820-reverse-Gasuns.txt](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/.doc.pdf/266820-reverse-Gasuns.txt),
-  266,819 lines, tab-separated `SOURCE_ABBREV<TAB>word`, reverse-sorted. Column
+- **Reverse dictionary master list** — the 266,819-line master word list
+  (`ReverseDictionary/.doc.pdf/266820-reverse-Gasuns.txt`, tab-separated
+  `SOURCE_ABBREV<TAB>word`, reverse-sorted) is **local-only / gitignored in the
+  public repo** — not in a clone. What *is* committed and reusable: its column
   semantics + source-code→bibliography table in
-  [ReverseDictionary/SCHEMA.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/SCHEMA.md).
-  Three headword counts (250,026 / 255,882 / 266,820) exist as compilation
-  stages — the 266,820 file is canonical (see
-  [ReverseDictionary/CHANGELOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/CHANGELOG.md)).
+  [ReverseDictionary/SCHEMA.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/SCHEMA.md),
+  the canonical-version declaration in
+  [ReverseDictionary/CHANGELOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/CHANGELOG.md)
+  (three counts 250,026 / 255,882 / 266,820 exist as compilation stages; the
+  266,820 file is canonical), and the full-folder inventory in
+  [ReverseDictionary/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/README.md).
 - **Catalan-Pujol spine** —
   [HeadwordLists/Catalan-Pujol/](https://github.com/gasyoun/SanskritLexicography/tree/master/HeadwordLists/Catalan-Pujol),
   an external Sanskrit–Catalan lemma list (61,266 lines, accented IAST **with

--- a/docs/manuals/MAINTAINER_MANUAL.md
+++ b/docs/manuals/MAINTAINER_MANUAL.md
@@ -1,0 +1,248 @@
+# Maintainer Manual — SanskritLexicography
+
+_Created: 10-07-2026 · Last updated: 10-07-2026_
+
+For the person (or agent) who **operates and extends** this repository. If you
+just want to *use* the data, read the
+[Data-Reuse Manual](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/DATA_REUSE_MANUAL.md)
+instead; if you want the *research programme*, read the
+[Researcher Manual](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RESEARCHER_MANUAL.md).
+
+---
+
+## 1. What this repository actually is
+
+A **personal research-and-data workspace** for Sanskrit digital lexicography —
+`gasyoun/SanskritLexicography`, default branch **`master`** (not `main`). It is
+*not* part of the `sanskrit-lexicon` GitHub org (it is gasyoun-personal; confirm
+with `git remote -v` before assuming org tooling applies). The unifying thesis
+is **evidence-graded lexicography**: treat a dictionary as a layered evidence
+graph where every claim carries source, evidence grade, corpus attestation, and
+review provenance (see the
+[Researcher Manual](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RESEARCHER_MANUAL.md)
+and
+[ROADMAP_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_2026_2027.md)).
+
+**Correction to the old framing.** The repo-level
+[CLAUDE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/CLAUDE.md)
+still says "no source code (no `.py`…)". That is **stale**: the *root* is data +
+Markdown, but several subprojects now carry substantial Python — the two
+translation pipelines in
+[RussianTranslation/src/](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation/src),
+the headword tooling in
+[HeadwordLists/](https://github.com/gasyoun/SanskritLexicography/tree/master/HeadwordLists),
+the site builder in
+[docs_site/build_site.py](https://github.com/gasyoun/SanskritLexicography/blob/master/docs_site/build_site.py),
+and the two dashboards. Treat the repo as **hybrid**: a data/docs workspace with
+live tooling embedded in the active subprojects.
+
+## 2. The subprojects — one map
+
+| Directory | What | State | Primary reader |
+|---|---|---|---|
+| [RussianTranslation/](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation) | Two LLM translation pipelines: `mw_ru` (Monier-Williams → RU, 287,358 cards, **done**) and `pwg_ru` (Petersburg Dict → RU/EN, **live production**, ~106k headwords) + grammar/TM assets. ~271k files. | Active | maintainer + researcher |
+| [HeadwordLists/](https://github.com/gasyoun/SanskritLexicography/tree/master/HeadwordLists) | Headword exports across ~16 CDSL dictionaries; key1/key2 semantics; comparison + union tooling | Active | data-reuser |
+| [Digital_Sanskrit_Lexicography-BOOK/](https://github.com/gasyoun/SanskritLexicography/tree/master/Digital_Sanskrit_Lexicography-BOOK) | Brill book draft (2 of ~10 chapters + plan/proposal/rights) | Early | researcher |
+| [papers/](https://github.com/gasyoun/SanskritLexicography/tree/master/papers) | Paper-pipeline notes/reviews/data (A33–A43) | Active | researcher |
+| [Syntax-Lectures/](https://github.com/gasyoun/SanskritLexicography/tree/master/Syntax-Lectures) | Russian particle-syntax lectures + interactive HTML explorer | Active | **student** |
+| [ReverseDictionary/](https://github.com/gasyoun/SanskritLexicography/tree/master/ReverseDictionary) | Working materials for an unpublished reverse dictionary (~266,820 headwords) | Active | researcher/student |
+| [IndischeSprueche/](https://github.com/gasyoun/SanskritLexicography/tree/master/IndischeSprueche) | Böhtlingk subhāṣita dataset (7,537 JSONL records) | Active (minimal) | data-reuser |
+| [article-comparison/](https://github.com/gasyoun/SanskritLexicography/tree/master/article-comparison) | Cross-dictionary single-article study (4 finalists) | Complete | researcher |
+| [literature/](https://github.com/gasyoun/SanskritLexicography/tree/master/literature) | Reference PDF/EPUB library + Markdown extractions + Lexicography-Manuals | Reference store | researcher |
+| [docs_site/](https://github.com/gasyoun/SanskritLexicography/tree/master/docs_site) | Static site built from research docs (zettelkasten), published to gasyoun.github.io | Active | maintainer |
+| [epistemic_dashboard/](https://github.com/gasyoun/SanskritLexicography/tree/master/epistemic_dashboard) · [findings_dashboard/](https://github.com/gasyoun/SanskritLexicography/tree/master/findings_dashboard) | Generated HTML dashboards over the governance registries below | Active | maintainer |
+
+## 3. The governance / epistemic layer — the load-bearing part
+
+This is what distinguishes the repo from a pile of exports, and the thing most
+likely to rot if you don't feed it. There are **nine registries at the root**,
+each append-only:
+
+- [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
+  — the empirical registry. **Schema per finding:** a `### §N` heading (the
+  number is the stable citation, never reused/shifted — append-only), the
+  **claim** in bold with a colour dot (🔴 important · 🟠 medium · 🟡 minor),
+  then `Evidence:` (a number / file+line), `Implication:` (what to do), and a
+  blockquoted `Source` line tagged `— repo · date`. **No HTML, ever** — use a
+  `> ` blockquote for muting. Only *measured* facts go here.
+- The **seven epistemic siblings** —
+  [ASSUMPTIONS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md),
+  [CONTRADICTIONS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md),
+  [GAPS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md),
+  [DEAD_ENDS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md),
+  [RECIPES.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md),
+  [STALENESS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/STALENESS.md),
+  [GLOSSARY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md)
+  — hold the acts FINDINGS can't: relying on an unproven premise, a source
+  disagreement, a not-yet-measured gap, an abandoned approach, a reproducible
+  recipe, a decaying fact, a defined term. Same 🔴🟠🟡 dots. Auto-seeded by
+  [sanskrit-util/tools/epistemic/](https://github.com/sanskrit-lexicon/sanskrit-util/tree/main/tools/epistemic).
+- [FEATURES_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md)
+  — capability inventory (dicts / interfaces / datasets / tools, each with a
+  real example + stable ID).
+
+**Two dashboards render these** and are regenerated, not hand-edited:
+
+```powershell
+python epistemic_dashboard\build_epistemic_dashboard.py   # -> epistemic_dashboard/index.html
+python findings_dashboard\build_findings_data.py          # -> findings_dashboard/data.json + index.html
+```
+
+The findings dashboard publishes to
+<https://gasyoun.github.io/SanskritLexicography/findings/> (importance/section
+breakdown, staleness flags, monthly time series, platform-liveness board;
+refreshed monthly via
+[findings_dashboard/monthly_refresh.py](https://github.com/gasyoun/SanskritLexicography/blob/master/findings_dashboard/monthly_refresh.py)).
+
+**The append reflex is the whole point.** If you spend >10 min measuring a
+non-obvious fact, it belongs in FINDINGS in the *same pass*; a caveat you relied
+on → ASSUMPTIONS; a fork you couldn't resolve → CONTRADICTIONS; an approach you
+killed → DEAD_ENDS. The registries are only as good as the last session that
+fed them. Route Sanskrit-data facts here; route infra/platform/process gotchas
+to [Uprava/FINDINGS.md](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)
+instead.
+
+## 4. The RussianTranslation pipelines — read before you touch
+
+This subproject is the largest and the easiest to break. Start at its own
+[README](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/README.md),
+then
+[PIPELINE_HISTORY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_HISTORY.md)
+(chronological "how did we get here" — it exists so you don't rediscover an
+already-fixed bug). The live operating procedure is
+[src/pilot/RUN_FREQ_MAX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_FREQ_MAX.md).
+
+**Hard guardrails — violating these is how the pipeline burns money or corrupts
+output:**
+
+- **Cost gate first, always:**
+  [src/pilot/perf_preflight.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/perf_preflight.py)
+  estimates agents/tokens/$ and refuses over-ceiling windows. Never launch a
+  window without it.
+- **≤3 concurrency.** The concurrency cliff (18-wide → 117 transient nulls) is
+  measured; the standing rule is ≤3-wide.
+- **Multi-agent fan-outs run *only* through
+  [src/synth_dispatch.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/synth_dispatch.py)**
+  (≤4 concurrency, 10-min output-file kill-guard, sealed single-owner outputs,
+  watcher-safe landing) — never bare async dispatches.
+- **Never bulk-run `kAla`-class monster windows.** Preflight partitions mixed
+  windows into `run_now` / `defer_monster`; keep the monster deferred. A single
+  expensive card can cost ~2M tokens/window (see the pwg_ru staged-run history in
+  [Uprava](https://github.com/gasyoun/Uprava) — gated, don't relaunch blind).
+- **Output is accepted only by
+  [audit_window.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window.py)**
+  (deterministic, zero-LLM gates: coverage, sense-dup, markup fidelity,
+  untranslated-residue, ownership). Human judgment enters only at defined gates
+  (HTML review sheets, gold-sample sessions) — never as silent post-editing.
+- **Markup is a checkable invariant.** Only English/German wrapper prose is
+  translated; Sanskrit (`<s>`/`{#…#}`), grammar labels (`<gram>`), and citations
+  (`<ls>`) are masked and restored mechanically. Do **not** "fix" untranslated
+  Sanskrit — that is correct behaviour.
+
+**Data policy:** the translation store, TM files, learner scores, review sheets,
+and re-glue outputs are **deliberately gitignored** — the repo is public, the
+unpublished Russian text is not. Do not commit them. The TMX release is gated
+behind rights clearance.
+
+## 5. Repo conventions you must follow
+
+Most are enforced by hooks in
+[claude-config/hooks/](https://github.com/gasyoun/claude-config/tree/main/hooks);
+the residue that isn't:
+
+- **Clickable links everywhere.** Every path/URL is a Markdown link. In
+  **committed** Markdown (this repo included) use **full `blob`/`tree` URLs**,
+  never relative — relative links don't resolve when a doc is pasted into chat,
+  an issue, or another repo, and a `check_md_full_urls.py` hook blocks relative
+  links on write. In chat, working-dir-relative links are fine.
+- **Dated header + byline** on every authored doc: `_Created: DD-MM-YYYY · Last
+  updated: DD-MM-YYYY_` (dashes, not ISO) and a `_Dr. Mārcis Gasūns_` byline.
+  When editing, find the real creation date
+  (`git log --follow --diff-filter=A --format=%ad --date=short -- <path> | tail
+  -1`) and bump only "Last updated".
+- **No HTML in `.md`** — use a `> ` blockquote for indent/muting. Enforced
+  (blocks on write).
+- **Language matches the material.** Russian-content directories get Russian
+  indexes ([Syntax-Lectures](https://github.com/gasyoun/SanskritLexicography/blob/master/Syntax-Lectures/README.md),
+  the `mw_ru`/`pwg_ru` prompt READMEs); the root README and CLAUDE.md are
+  English.
+- **BOM is inconsistent** in
+  [HeadwordLists/](https://github.com/gasyoun/SanskritLexicography/tree/master/HeadwordLists)
+  and the `.txt` corpora — check `head -c 3 file | xxd` before transforming and
+  preserve the file's existing BOM state. The org "no BOM" rule does **not** hold
+  here.
+- **Commits:** `ai-wip:` prefix, one logical change each. Never commit binary or
+  large data unless asked. Keep Markdown lint-clean (no trailing whitespace,
+  newline at EOF, valid YAML).
+- **Model attribution:** report the tier **and** exact version
+  (`Opus 4.8 (claude-opus-4-8)`), never the bare tier, in any provenance file.
+
+## 6. Concurrency safety — this tree is shared
+
+Concurrent sessions (Claude *and* Codex) have collided in this exact tree before
+(the H214 tree-intermix incident), and direct edits to the main checkout are
+**blocked by a hook**. Before starting a handoff-shaped task:
+
+1. **Isolate in a fresh `git worktree`** off `origin/master` and work there —
+   `git worktree add ../SanskritLexicography-<slug> origin/master -b <branch>` —
+   then deliver by PR. Do not edit the main checkout directly.
+2. Read the closest `.ai_state.md` fresh — the subsystem-local
+   [RussianTranslation/.ai_state.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md)
+   takes priority over the repo-root
+   [.ai_state.md](https://github.com/gasyoun/SanskritLexicography/blob/master/.ai_state.md)
+   when the work is under `RussianTranslation/`.
+3. Check [Uprava/GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md)
+   for a `🔒 CLAIMED` tag on the row.
+4. **Never `git add -A`** — `git status` / `git diff --cached` right before
+   committing so you commit only your own files, and reclaim finished worktrees
+   with [`/worktree-gc`](https://github.com/gasyoun/claude-config/blob/main/commands/worktree-gc.md).
+
+## 7. CI, pre-commit, releases
+
+- **CI** ([.github/workflows/ci.yml](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/workflows/ci.yml)):
+  Markdown lint + Markdown link-check + YAML lint. (Python/JS lint jobs are
+  conditional; they may now fire given the added `.py` — keep tooling importable.)
+- **Pre-commit** ([.pre-commit-config.yaml](https://github.com/gasyoun/SanskritLexicography/blob/master/.pre-commit-config.yaml)):
+  `check-yaml`, `end-of-file-fixer`, `trailing-whitespace` (markdown-aware),
+  `check-merge-conflict`.
+- **Releases:** promote [changelog.md](https://github.com/gasyoun/SanskritLexicography/blob/master/changelog.md)
+  `[Unreleased]` → `[X.Y.Z] - DATE`, annotated tag `vX.Y.Z`, `gh release create`.
+  Do **not** tag releases unprompted — a human drives release timing.
+
+## 8. The docs site
+
+[docs_site/](https://github.com/gasyoun/SanskritLexicography/tree/master/docs_site)
+is a real static site built by
+[build_site.py](https://github.com/gasyoun/SanskritLexicography/blob/master/docs_site/build_site.py)
+(via the `zettelkastenwiki` package, **not** Docusaurus/Observable) from
+[docs_site/wiki/research/](https://github.com/gasyoun/SanskritLexicography/tree/master/docs_site/wiki/research);
+built output in `_site/` publishes to
+gasyoun.github.io/SanskritLexicography/research. Rebuild and test:
+
+```powershell
+python docs_site\build_site.py
+python -m pytest docs_site\test_docs_site.py
+```
+
+Anything that becomes **public** (this site, the findings dashboard, any Pages
+flip) goes through a
+[publish-safety](https://github.com/gasyoun/claude-config/blob/main/commands/publish-safety-check.md)
+pass first — this repo mixes public exports with rights-gated and unpublished
+material.
+
+## 9. Where to look when you're lost
+
+- **"What changed"** → [changelog.md](https://github.com/gasyoun/SanskritLexicography/blob/master/changelog.md)
+  + the closest `.ai_state.md`.
+- **"Did someone already build this?"** → org
+  [SHARED_CODE.md](https://github.com/gasyoun/github-spine/blob/main/SHARED_CODE.md),
+  [Uprava/PROJECT_INTERLINKS.md](https://github.com/gasyoun/Uprava/blob/main/PROJECT_INTERLINKS.md),
+  and this repo's FINDINGS + FEATURES_INDEX before writing anything.
+- **"Who decides / what's next"** → [Uprava/GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md).
+- **Next-agent orientation for docs work** → [HANDOFF.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HANDOFF.md).
+- **Org-level conventions** (issue taxonomy, csl-orig workflow, `.ai_state.md`
+  protocol) → the org
+  [CLAUDE.md](https://github.com/gasyoun/github-spine/blob/main/CLAUDE.md), loaded
+  automatically.
+
+_Dr. Mārcis Gasūns_

--- a/docs/manuals/README.md
+++ b/docs/manuals/README.md
@@ -1,0 +1,37 @@
+# Manuals — SanskritLexicography
+
+_Created: 10-07-2026 · Last updated: 10-07-2026_
+
+Four audience-specific manuals for this repository. **Pick the one that matches
+why you're here** — each is a standalone deep reference; you don't need to read
+the others.
+
+| If you are… | Read | Language |
+|---|---|---|
+| **Operating or extending** the repo (maintainer / next agent) — conventions, the pipelines, the epistemic registries, "how not to break things" | [MAINTAINER_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/MAINTAINER_MANUAL.md) | English |
+| A **lexicographer / DH researcher / historian of dictionaries** — the evidence-graded thesis, the paper pipeline, what's citable | [RESEARCHER_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RESEARCHER_MANUAL.md) | English |
+| A **Sanskrit student / learner** — the teaching material and what's usable today | [STUDENT_MANUAL_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/STUDENT_MANUAL_RU.md) | Русский |
+| A **programmer / data engineer / NLP researcher** reusing the data — formats, encodings, traps, rights | [DATA_REUSE_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/DATA_REUSE_MANUAL.md) | English |
+
+## What this repository is, in one paragraph
+
+A **personal research-and-data workspace** for Sanskrit digital lexicography
+(`gasyoun/SanskritLexicography`, branch `master` — *not* part of the
+`sanskrit-lexicon` org). It has grown into ~12 subprojects — headword-list
+analytics, two large LLM dictionary-translation pipelines (`mw_ru`, `pwg_ru`), a
+Brill book draft, a paper pipeline, Russian syntax lectures, a reverse
+dictionary, and a governance layer of nine append-only epistemic registries —
+unified by one thesis: **evidence-graded lexicography** (a dictionary as a
+layered evidence graph). Fuller orientation:
+[README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/README.md) ·
+[ROADMAP_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_2026_2027.md).
+
+## Language convention
+
+Manuals follow the repo rule — **language matches the audience**: the student
+manual is in Russian (its readership); the maintainer, researcher, and
+data-reuse manuals are in English (their readership). See the
+[HANDOFF.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HANDOFF.md)
+documentation conventions.
+
+_Dr. Mārcis Gasūns_

--- a/docs/manuals/RESEARCHER_MANUAL.md
+++ b/docs/manuals/RESEARCHER_MANUAL.md
@@ -1,0 +1,157 @@
+# Researcher Manual — SanskritLexicography
+
+_Created: 10-07-2026 · Last updated: 10-07-2026_
+
+For the **lexicographer, digital-humanities researcher, or historian of
+dictionaries** who wants to understand the intellectual programme here, cite its
+data, or build on its method. To operate the repo, see the
+[Maintainer Manual](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/MAINTAINER_MANUAL.md);
+to reuse the raw data programmatically, see the
+[Data-Reuse Manual](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/DATA_REUSE_MANUAL.md).
+
+---
+
+## 1. The thesis: evidence-graded lexicography
+
+The programme's one sentence (from
+[ROADMAP_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_2026_2027.md),
+Part II):
+
+> A digital dictionary is not a text but a **layered evidence graph**. Every
+> lexicographic statement — headword, sense, gender, citation, cross-reference —
+> is a node carrying (a) its source dictionary and convention, (b) an explicit
+> evidence grade, (c) corpus attestation where available, and (d) review
+> provenance.
+
+What is genuinely new versus existing DH lexicography (ELEXIS, Lexonomy, TEI
+Lex-0 projects): they standardize *encoding*; this programme standardizes
+*epistemics* — graded, reviewable, corpus-anchored evidence per statement. The
+in-house evidence vocabulary is `observed | derived | inferred | reviewed`, with
+a chart-trust template (Evidence · Limitations · Validation · Owner · Next use).
+Publishing per-claim epistemic status is *ahead* of most published DH dictionary
+projects.
+
+**The two-civilizations axis** is the most original framing: Sanskrit has two
+parallel lexicographic traditions — the European (Petersburg/Monier-Williams/
+Apte, 1832–1957) and the indigenous (kośa + Pāṇinian: Śabdakalpadruma,
+Vācaspatyam, Amarakośa). The programme models them as **parallel evidence
+systems**, not flattened into one format. The **zero-meaning doctrine** — refusing
+to read marker-absence in SKD/VCP as content-absence, and recovering the
+indigenous apparatus on its own terms — is methodologically the centre of gravity.
+
+## 2. The spine (already exists in pieces)
+
+```
+Whitney roots (938)  ──┐
+DCS lemmas + freq    ──┼──►  Lemma spine (SLP1 + homonym key)
+28.5k lemma dossier  ──┘          │
+                                  ├── sense layer   (R2 alignments, evidence-graded)
+                                  ├── grammar layer (gaṇa/pada/transitivity, Whitney classes)
+                                  ├── citation layer (canonical sigla + aliases; <ls> + iti)
+                                  └── review layer  (community adjudication, κ-measured)
+```
+
+The learner's reading layer is then just one *view* over the graph: filter by
+DCS frequency band, rank senses by survival evidence, surface the paradigm cell.
+
+## 3. The paper pipeline (feeds the book chapter-for-chapter)
+
+The publication plan (roadmap Part III). Primary venue class = lexicography
+journals (IJL, Lexicographica, Lexikos, Dictionaries); the book is an
+English article-based monograph.
+
+| # | Working title | Venue | Submit |
+|---|---|---|---|
+| P1 | *The block economy of Monier-Williams: a data-grounded microanalysis of 286,561 entries* | IJL | Q3 2026 |
+| P2 | *Sense inheritance in the Sanskrit dictionary family: condensation, survival, and the citation advantage* | Lexicographica | Q4 2026 |
+| P3 | *Two citation registers: European source apparatus and indigenous* iti *quotation in nine Sanskrit dictionaries* | Dictionaries | Q1 2027 |
+| P4 | *When zero means nothing: recovering the indigenous microstructure of Śabdakalpadruma and Vācaspatya* | IJL / WSC 2027 | Q1–Q2 2027 |
+| P5 | *Fifty thousand corrections: an error typology of twelve years of collaborative dictionary maintenance* | Lexikos | Q2 2027 |
+| P6 | *A frequency-graded reading layer for Sanskrit learners: joining corpus, grammar, and seven dictionaries* | Lexikos (pedagogical) / eLex 2027 | Q2 2027 |
+
+**Book** (de Gruyter *Lexicographica Series Maior* or Brill): *Sanskrit
+Lexicography in the Digital Age: Evidence, Inheritance, and Two Traditions* —
+draft plan + first chapters in
+[Digital_Sanskrit_Lexicography-BOOK/](https://github.com/gasyoun/SanskritLexicography/tree/master/Digital_Sanskrit_Lexicography-BOOK)
+([BOOK_PLAN.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md),
+[BRILL_PROPOSAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BRILL_PROPOSAL.md);
+2 chapters drafted so far). Cross-repo paper status is tracked in
+[Uprava/ARTICLES.md](https://github.com/gasyoun/Uprava/blob/main/ARTICLES.md);
+working notes/reviews live in
+[papers/](https://github.com/gasyoun/SanskritLexicography/tree/master/papers).
+
+## 4. Research objects and datasets you can cite
+
+| Object | What it lets you study | Where |
+|---|---|---|
+| Petersburg layer model | How a PWG entry is assembled from up to 5 dictionary layers; ~36% of the headword union has *no* PWG record (PW-only is 24%, not an edge case) | [PWG_LAYER_COMBINATIONS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/PWG_LAYER_COMBINATIONS.md), [pwg-layers.md](https://github.com/gasyoun/SanskritLexicography/blob/master/pwg-layers.md) |
+| Cross-dictionary article study | Full microstructural comparison of one headword (agni, anya, akṣara, ananta) across dictionaries — verbatim / IAST / per-sense / corpus-RU views | [article-comparison/](https://github.com/gasyoun/SanskritLexicography/tree/master/article-comparison) |
+| Headword union | 323,425 headwords across 15 csl-orig dicts with per-dict provenance + gender; feminines folded | [HeadwordLists/union/UNION.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/union/UNION.md) |
+| Reverse dictionary | ~266,820-headword reverse index merging ~30 sources (1822–2005) — word-formation, verse endings, suffix study; a genuine Indological *desideratum* | [ReverseDictionary/](https://github.com/gasyoun/SanskritLexicography/tree/master/ReverseDictionary) |
+| Indische Sprüche | 7,537 Böhtlingk gnomic verses (Deva + IAST + German + source attribution) — a clean Sa→De gnomic parallel corpus | [IndischeSprueche/](https://github.com/gasyoun/SanskritLexicography/tree/master/IndischeSprueche) |
+| Sa→Ru translation memory | Graded (A/B/C) Sanskrit–Russian TM, TMX 1.4b exportable; FAIR release gated on rights | [RussianTranslation/](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/README.md) |
+| Particle syntax | Positional classification of 16 Sanskrit particles (Whitney–Speyer–Gonda–Apte line; Zaliznyak positional schema) | [Syntax-Lectures/](https://github.com/gasyoun/SanskritLexicography/tree/master/Syntax-Lectures) |
+| Reference literature map | 65 sources tagged by which dictionary/pipeline/paper they serve, with reverse lookup | [literature/md/INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/literature/md/INDEX.md) |
+
+## 5. The epistemic registries as a research method
+
+The nine root registries are not bookkeeping — they *are* the reproducibility
+apparatus a DSH/lexicography reviewer asks for and rarely gets. Cite findings by
+their stable `§N` number:
+
+- [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
+  — measured, evidence-backed facts (live dashboard at
+  <https://gasyoun.github.io/SanskritLexicography/findings/>). Examples relevant
+  to methodology: unaccented DCS cannot distinguish present class I from VI
+  (§8 — 117 spurious corpus-derived additions reverted); no printed frequency
+  dictionary of Sanskrit exists (§6 — DCS-frequency ordering is genuine
+  innovation); PWG article size confounds every per-entry statistic (§67).
+- [ASSUMPTIONS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) ·
+  [CONTRADICTIONS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) ·
+  [GAPS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) ·
+  [DEAD_ENDS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) ·
+  [RECIPES.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) ·
+  [STALENESS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/STALENESS.md) ·
+  [GLOSSARY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md)
+  — the acts FINDINGS can't hold: what the programme *relies on*, where sources
+  *disagree*, what is *not yet measured*, what was *abandoned* (and why), how to
+  *reproduce* a heavy result, what is *decaying*, and how terms are *defined*.
+
+For a reviewer or a co-author, DEAD_ENDS and CONTRADICTIONS are the most
+valuable: they record negative results (e.g. body/reverse-headword mining
+rejected at 38.6% precision; grammar-in-prompt does not improve DE→RU MT) so the
+next study doesn't repeat them.
+
+## 6. FAIR gaps — read before you cite
+
+The programme's own audit (roadmap Part I) is honest about what is *not* yet at
+the highest standard. The load-bearing caveats for a citing author:
+
+- **G1 — persistent identifiers.** No dataset DOIs yet, `CITATION.cff` being
+  rolled out, ORCID registered ([0000-0003-4513-884X](https://orcid.org/0000-0003-4513-884X)).
+  Data is *findable on GitHub* but full journal-grade citability (Zenodo DOI per
+  release) is in progress. Cite the exact commit until a DOI exists.
+- **G2 — standards exports deferred.** TEI Lex-0 / OntoLex-Lemon are planned in
+  csl-standards; a validated export does not exist yet. If your work needs TEI,
+  it isn't here today.
+- **G4 — single-reviewer bottleneck.** Reviewed claims were largely single-keyed;
+  inter-annotator agreement (κ) is being retrofitted via a community review pool.
+  Treat `reviewed`-graded claims as author-adjudicated unless a κ is reported.
+- **G5 — regex structure detection has no published gold standard yet** (a
+  200-entry double-annotated MW sample is planned as a P1 appendix).
+
+## 7. Provenance and how to reference
+
+- Large reference assets carry provenance in
+  [REFERENCES.md](https://github.com/gasyoun/SanskritLexicography/blob/master/REFERENCES.md)
+  (source, date, producer, size).
+- The canonical data-hub manifest for cross-repo derived datasets is
+  [kosha/data/manifest/datasets.json](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json);
+  the project dependency map is
+  [Uprava/PROJECT_INTERLINKS.md](https://github.com/gasyoun/Uprava/blob/main/PROJECT_INTERLINKS.md).
+- Author byline for citation: **Mārcis Gasūns**, ORCID
+  [0000-0003-4513-884X](https://orcid.org/0000-0003-4513-884X). Several
+  subprojects ship a `CITATION.cff` (e.g.
+  [ReverseDictionary/CITATION.cff](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/CITATION.cff)).
+
+_Dr. Mārcis Gasūns_

--- a/docs/manuals/RESEARCHER_MANUAL.md
+++ b/docs/manuals/RESEARCHER_MANUAL.md
@@ -84,7 +84,7 @@ working notes/reviews live in
 
 | Object | What it lets you study | Where |
 |---|---|---|
-| Petersburg layer model | How a PWG entry is assembled from up to 5 dictionary layers; ~36% of the headword union has *no* PWG record (PW-only is 24%, not an edge case) | [PWG_LAYER_COMBINATIONS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/PWG_LAYER_COMBINATIONS.md), [pwg-layers.md](https://github.com/gasyoun/SanskritLexicography/blob/master/pwg-layers.md) |
+| Petersburg layer model | How a PWG entry is assembled from up to 5 dictionary layers; ~36% of the headword union has *no* PWG record (PW-only is 24%, not an edge case) | [PWG_LAYER_COMBINATIONS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/PWG_LAYER_COMBINATIONS.md) |
 | Cross-dictionary article study | Full microstructural comparison of one headword (agni, anya, akṣara, ananta) across dictionaries — verbatim / IAST / per-sense / corpus-RU views | [article-comparison/](https://github.com/gasyoun/SanskritLexicography/tree/master/article-comparison) |
 | Headword union | 323,425 headwords across 15 csl-orig dicts with per-dict provenance + gender; feminines folded | [HeadwordLists/union/UNION.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/union/UNION.md) |
 | Reverse dictionary | ~266,820-headword reverse index merging ~30 sources (1822–2005) — word-formation, verse endings, suffix study; a genuine Indological *desideratum* | [ReverseDictionary/](https://github.com/gasyoun/SanskritLexicography/tree/master/ReverseDictionary) |

--- a/docs/manuals/STUDENT_MANUAL_RU.md
+++ b/docs/manuals/STUDENT_MANUAL_RU.md
@@ -1,0 +1,122 @@
+# Руководство для студента — SanskritLexicography
+
+_Created: 10-07-2026 · Last updated: 10-07-2026_
+
+Для **студента санскрита** (в первую очередь русскоязычного, из круга
+samskrte.ru / Общества ревнителей санскрита), который прошёл базовую морфологию и
+хочет понять, что в этом репозитории полезно лично ему. Технические подробности —
+в [руководстве для сопровождающего](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/MAINTAINER_MANUAL.md);
+научная рамка — в [руководстве для исследователя](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RESEARCHER_MANUAL.md).
+
+---
+
+## 0. Честно: это мастерская, а не учебник
+
+Здесь нет курса санскрита и нет готового онлайн-словаря. Это **рабочее
+пространство** — черновики, наборы данных, исследовательские заметки. Часть
+материалов уже готова к использованию прямо сейчас (открыть в браузере, читать),
+часть — технические инструменты (нужна командная строка и Python), а часть — пока
+**планы** (учебный веб-слой, публикация русских переводов). Ниже честно помечено,
+что к какой категории относится.
+
+За полноценным онлайн-словарём идите на
+[сайт CDSL](https://www.sanskrit-lexicon.uni-koeln.de/), а за курсами — на
+samskrte.ru.
+
+## 1. Готово сейчас — открыть в браузере, ничего не устанавливая
+
+### Санскритские частицы (главное для студента)
+
+[Syntax-Lectures/](https://github.com/gasyoun/SanskritLexicography/tree/master/Syntax-Lectures)
+— учебные материалы (на русском) по санскритским частицам и их синтаксису.
+Аудитория прямо ваша: первокурсник-индолог после базовой морфологии.
+
+- **Точка входа — конспект:**
+  [sanskrit_particles_lectures.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Syntax-Lectures/sanskrit_particles_lectures.md).
+  Две лекции по 60 минут: «Общая картина и позиционная классификация» и
+  «Семантика и прагматика». Линия Whitney — Speyer — Gonda — Apte; позиционная
+  классификация по А. А. Зализняку.
+- **Интерактивный разбор** (скачайте и откройте в браузере):
+  [sanskrit_particles_explorer.html](https://github.com/gasyoun/SanskritLexicography/blob/master/Syntax-Lectures/sanskrit_particles_explorer.html)
+  — кликабельная позиционная карта над 16 частицами; по каждой — функция,
+  примеры с глубокими ссылками на параллельный корпус (Гӣта/Ману), Whitney,
+  Speyer, DCS, цитаты Gonda/König/Hock, библиография и вложенные статьи Apte
+  (1957). Схема отдельно:
+  [sanskrit_particles_schema.html](https://github.com/gasyoun/SanskritLexicography/blob/master/Syntax-Lectures/sanskrit_particles_schema.html).
+- **Статьи Apte (1957) в русском переводе** — для семи частиц с отдельной
+  статьёй: api, eva, hi, iti, khalu, tu, vai (файлы
+  `Apte_1957-*_RU.md` в той же папке). Остальные девять из шестнадцати покрыты
+  только конспектом и схемой.
+
+### Субхашиты — короткие стихи для чтения
+
+[IndischeSprueche/](https://github.com/gasyoun/SanskritLexicography/tree/master/IndischeSprueche)
+— 7 537 гномических двустиший Бётлингка: каждое дано в деванагари, IAST и с
+немецким переводом. Отличный материал, чтобы читать целые (короткие,
+самодостаточные) шлоки: грамматически простые, с готовым переводом. Русского
+перевода в этом файле **нет** (только немецкий). Файл:
+[data/indische_sprueche.jsonl](https://github.com/gasyoun/SanskritLexicography/blob/master/IndischeSprueche/data/indische_sprueche.jsonl)
+(по одной записи на строку). Для точных ссылок «Spr. N» пользуйтесь живым сайтом
+[boesp2](https://github.com/sanskrit-lexicon-scans/boesp2), а не этим файлом.
+
+### Обратный словарь — по окончаниям слов
+
+[ReverseDictionary/](https://github.com/gasyoun/SanskritLexicography/tree/master/ReverseDictionary)
+— словарь, отсортированный по **последней** букве слова (для рифм, окончаний
+стиха, суффиксов). Что полезно студенту грамматики:
+
+- [249-types-of-pratyayas-MW.txt](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/249-types-of-pratyayas-MW.txt)
+  — частотность суффиксов по MW (`-ta` — 12 489 раз и далее вниз до редких).
+- [nounend.txt](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/nounend.txt)
+  и
+  [verbend-dev.txt](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/verbend-dev.txt)
+  — парадигмы именных и глагольных окончаний с пометами падежа/числа.
+
+Это «суффикс-ориентированный» взгляд на грамматику, которого не даёт обычный
+словарь по первой букве. Сам большой словарь пока **не издан** — это черновики к
+будущей книге.
+
+## 2. Для технического студента — нужен Python
+
+Если вы дружите с командной строкой, в
+[RussianTranslation/](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/README.md)
+есть учебный грамматический аппарат (данные готовы; это не перевод, а грамматика):
+
+```powershell
+python src\nominal_grammar.py --table agni m.    # таблица склонения одного слова
+python src\reverse_index.py --show "m·8n*"       # все слова с той же парадигмой
+```
+
+- **Learner-core** — подмножество из 22 772 заглавных слов (та ~21 % часть PWG,
+  которую реально удерживают студенческие словари).
+- **Зализняк-индекс** — компактная помета парадигмы `G·T S F` (например `m·8n*`),
+  знакомая по русской лексикографии:
+  [ZALIZNYAK_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ZALIZNYAK_INDEX.md).
+- **Обратный словарь по парадигме** — «покажи все слова, которые склоняются как
+  это» (`reverse_index.py --show`).
+
+## 3. Русские переводы великих словарей — статус
+
+Две отдельные работы (подробности —
+[RussianTranslation/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/README.md)):
+
+- **mw_ru** — русский перевод всего словаря Monier-Williams (287 358 карточек,
+  **готов**).
+- **pwg_ru** — Петербургский словарь (Бётлингк–Рот) → русский, **в производстве**.
+
+⚠️ **Текст переводов пока не опубликован** и в клоне репозитория его нет: файлы
+переводов намеренно исключены из git (репозиторий публичный, а неопубликованный
+русский текст — нет). Готовый учебный **веб-слой** (карточка слова: частотность
+по корпусу, лучшие значения, корень по Уитни, таблица парадигмы) — это **план**
+на конец 2026 года, а не готовая страница.
+
+## 4. Куда идти дальше
+
+- Полноценный онлайн-словарь: [сайт CDSL](https://www.sanskrit-lexicon.uni-koeln.de/).
+- Курсы санскрита: samskrte.ru.
+- Точные издания субхашит: [boesp1](https://github.com/sanskrit-lexicon-scans/boesp1) /
+  [boesp2](https://github.com/sanskrit-lexicon-scans/boesp2).
+- Общая карта репозитория: корневой
+  [README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/README.md).
+
+_Dr. Mārcis Gasūns_

--- a/docs/manuals/STUDENT_MANUAL_RU.md
+++ b/docs/manuals/STUDENT_MANUAL_RU.md
@@ -63,14 +63,15 @@ samskrte.ru.
 
 [ReverseDictionary/](https://github.com/gasyoun/SanskritLexicography/tree/master/ReverseDictionary)
 — словарь, отсортированный по **последней** букве слова (для рифм, окончаний
-стиха, суффиксов). Что полезно студенту грамматики:
+стиха, суффиксов). ⚠️ Сами файлы данных в публичный клон **не входят** (они
+локальные/gitignored) — обзор папки в
+[README](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/README.md).
+Что там полезно студенту грамматики:
 
-- [249-types-of-pratyayas-MW.txt](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/249-types-of-pratyayas-MW.txt)
-  — частотность суффиксов по MW (`-ta` — 12 489 раз и далее вниз до редких).
-- [nounend.txt](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/nounend.txt)
-  и
-  [verbend-dev.txt](https://github.com/gasyoun/SanskritLexicography/blob/master/ReverseDictionary/verbend-dev.txt)
-  — парадигмы именных и глагольных окончаний с пометами падежа/числа.
+- `249-types-of-pratyayas-MW.txt` — частотность суффиксов по MW (`-ta` — 12 489
+  раз и далее вниз до редких).
+- `nounend.txt` и `verbend-dev.txt` — парадигмы именных и глагольных окончаний
+  с пометами падежа/числа.
 
 Это «суффикс-ориентированный» взгляд на грамматику, которого не даёт обычный
 словарь по первой букве. Сам большой словарь пока **не издан** — это черновики к


### PR DESCRIPTION
Adds four deep, standalone manuals for distinct audiences, plus a router README, under [`docs/manuals/`](https://github.com/gasyoun/SanskritLexicography/tree/master/docs/manuals). Answers "what is going on in this repo?" from four different doors.

| Manual | Audience | Language |
|---|---|---|
| [MAINTAINER_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/docs/audience-manuals/docs/manuals/MAINTAINER_MANUAL.md) | operating/extending the repo | English |
| [RESEARCHER_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/docs/audience-manuals/docs/manuals/RESEARCHER_MANUAL.md) | lexicographer / DH researcher | English |
| [STUDENT_MANUAL_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/docs/audience-manuals/docs/manuals/STUDENT_MANUAL_RU.md) | Sanskrit student | Русский |
| [DATA_REUSE_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/docs/audience-manuals/docs/manuals/DATA_REUSE_MANUAL.md) | data reuser (formats/encodings/rights) | English |

- Language follows audience (student RU, rest EN) per the repo doc convention.
- Full `blob`/`tree` URLs, dated headers + byline, no HTML — authored-MD contract.
- Root README documentation map + changelog `[Unreleased]` updated.
- Notes and corrects the stale "no source code" claim in the repo CLAUDE.md.

Built under [Uprava H529](https://github.com/gasyoun/Uprava/blob/main/handoffs/H529-Opus_SanskritLexicography_audience-manuals-quartet_10.07.26.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)