### PR TITLE
Episteme: Sundara apparatus residue (GAPS/ASSUMPTIONS/DEAD_ENDS)

### DIFF
--- a/ASSUMPTIONS.md
+++ b/ASSUMPTIONS.md
@@ -1,6 +1,6 @@
 # ASSUMPTIONS — unverified premises the Sanskrit-data pipelines rely on
 
-_Created: 08-07-2026 · Last updated: 08-07-2026_
+_Created: 08-07-2026 · Last updated: 11-07-2026_
 
 **Epistemic sibling of [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).** FINDINGS holds *measured, past-tense* facts. This file holds the act FINDINGS structurally cannot: **relying** on an unproven premise. An assumption is *depended-upon but unverified* — the moment its **Test** passes, it **graduates** to a FINDINGS row (delete it here, cite the finding there). One of the seven episteme registries minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md); the full set is on the [episteme dashboard](https://gasyoun.github.io/SanskritLexicography/episteme/). Its infra twin is [`Uprava/ASSUMPTIONS.md`](https://github.com/gasyoun/Uprava/blob/main/ASSUMPTIONS.md).
 
@@ -84,6 +84,13 @@ Test to confirm: re-verify every row against current `csl-orig` immediately befo
 - **The 🔴 blast-radius rows §1–§4 are the dangerous ones** — they sit under the frequency and translation pipelines, so a silent violation drops ~1/5 to ~1/3 of the data with no error.
 - **None has graduated yet** (all ⚠️ spot-checked, none ✅): each needs a *full* verification, not a sample, before it becomes a FINDINGS fact. §6 is the one that decays continuously — treat it as perishable.
 - **Where they point:** the assumptions feed forward into [RECIPES](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (how to check them), sideways into [CONTRADICTIONS](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) and [DEAD_ENDS](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) (what breaks when they fail), and their unmeasured residue into [GAPS](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md).
+
+### §7. «Рамаяна. Книга 5. Сундараканда 2026.html» — финальная редакция перевода
+🔴 ✍️ **Весь двухъярусный аппарат считает этот файл финальной редакцией перевода Леонова.**
+Relied on by: все 1058 якорей яруса-1, dedup 897 нот яруса-2, цель плотности ~37%, печатный мастер, kosha-манифест `sundarakanda-two-tier-apparatus` — при более свежей редакции якоря и dedup частично инвалидируются.
+Verified?: ❌ никогда — подтверждение запрошено у Леонова (задача 2 [issue №58](https://github.com/gasyoun/CommentaryStrategies/issues/58)), ждём с 10-07-2026.
+Test to confirm: одно письмо Леонова «да, финал» — или присланная новая редакция → diff по стихам → пере-якорение затронутых нот.
+> **Source:** ✍️ H497/H533, 10-07-2026; registered via /artifact-propagate epistemic pass 11-07-2026 (Fable 5 `claude-fable-5`).
 
 ---
 

--- a/DEAD_ENDS.md
+++ b/DEAD_ENDS.md
@@ -1,6 +1,6 @@
 # DEAD_ENDS — the Sanskrit-data negative-results graveyard
 
-_Created: 08-07-2026 · Last updated: 10-07-2026_
+_Created: 08-07-2026 · Last updated: 11-07-2026_
 
 **Epistemic sibling of [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).** FINDINGS is *confirmed-true*. This file holds the act FINDINGS cannot: **abandoning** an approach — a whole method that was tried and does not work, so the next session does not pay to rediscover the failure. Distinct from a single refuted hypothesis (that lives per-row in [`Uprava/QUESTIONS_LOG.md`](https://github.com/gasyoun/Uprava/blob/main/QUESTIONS_LOG.md)); a dead end is per-*approach*. One of the seven epistemic registries minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md). Its infra twin is [`Uprava/DEAD_ENDS.md`](https://github.com/gasyoun/Uprava/blob/main/DEAD_ENDS.md).
 
@@ -123,6 +123,13 @@ Don't retry unless: you adjudicate the citation against **the vulgate itself**, 
 - **The 🔴 rows are 🔴 precisely because a naive re-attempt looks plausible and fails silently** — 38.6% precision that reads like success (§1), a class pass that writes 117 spurious rows before revert (§2), an NFD key that manufactures false matches with no error (§5), ids that drop tokens before anyone notices (§6). The expensive part is always the *silence*, not the failure.
 - **The standing escape hatch is a better witness or a better key, not more effort.** §1 wants a corpus inflected-form index (DCS); §2 wants a grammar/Zaliznyak cross-check; §5/§6 want a length-preserving `form_key` / a stable `LemmaId` — each dead end names the concrete different-signal condition that would reopen it.
 - **Where they point:** the abandoned keys are the mirror of [RECIPES](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (the paths that *do* reproduce), the violated premises live in [ASSUMPTIONS](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md), and §7's corpus-scale reversal is already a [CONTRADICTIONS](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) row.
+
+### §8. Gemini-OCR санскритских комментариев Сундараканды — вытеснен скрейпом
+🟠 ✍️ **Маршрут «OCR сканов комментариев через Gemini» (H370) для слоя комментаторского диалога — оставлен, не провален.**
+What was tried: план OCR-ингеста печатных изданий Тилаки/Бхушаны/Широмани для Фазы-2.
+Why abandoned: лицензированный цифровой источник (Gita Supersite, CC BY 4.0) закрыл потребность раньше и чище — H370 закрыт как superseded 08-07-2026, Opus 4.8 (`claude-opus-4-8`); диспозиция: [SUNDARA_OCR_PHASE2_SUPERSEDED.md](https://github.com/gasyoun/CommentaryStrategies/blob/main/docs/SUNDARA_OCR_PHASE2_SUPERSEDED.md).
+Lesson: перед OCR-проектом проверять существование лицензированного цифрового текста (частный случай /prior-art §4 «даже код/данные не мои»).
+> **Source:** ✍️ registered via /artifact-propagate epistemic pass 11-07-2026 (Fable 5 `claude-fable-5`).
 
 ---
 

--- a/GAPS.md
+++ b/GAPS.md
@@ -1,6 +1,6 @@
 # GAPS — the Sanskrit-data known-unknowns frontier
 
-_Created: 08-07-2026 · Last updated: 08-07-2026_
+_Created: 08-07-2026 · Last updated: 11-07-2026_
 
 **Epistemic sibling of [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).** FINDINGS is what is *known*. This file is its **negative space** — the act FINDINGS cannot hold: **not-yet-knowing**, the frontier of things we have explicitly NOT measured. The moment a gap is measured, it **graduates** to a FINDINGS row (delete it here, cite the finding there). One of the seven episteme registries minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md); the full set is on the [episteme dashboard](https://gasyoun.github.io/SanskritLexicography/episteme/). Its infra twin is [`Uprava/GAPS.md`](https://github.com/gasyoun/Uprava/blob/main/GAPS.md).
 
@@ -123,6 +123,13 @@ How to close: identify the preliminary caveat, finalise or document why it can't
 - **The 🟠 rows are the pipeline-unblockers.** §2 (error population), §3 (Heritage morphology), §6 (Cyrillic name keys), §10 (routing κ) each free a whole downstream — and Heritage as a third morphology witness (§3) is the single biggest unlock, gated only on a browser download + a licence @DECIDE.
 - **The ⚙️ auto-seeded §7–§11 are candidates, not confirmed gaps** — each is a manifest dataset with no FINDINGS row, awaiting a human confirm-or-delete. Several (§7, §8, §9) need only a statistics pass over data already in hand, not new acquisition.
 - **Where they point:** a measured gap graduates to a [FINDINGS](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) row; several here would also settle a live [CONTRADICTIONS](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) row (§1→§1, §8→§2) or ride a method already sketched in [RECIPES](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md).
+
+### §12. Сундараканда: стихи песней 2 и 28 — пропуск оцифровки или воля переводчика?
+🔴 ✍️ **Мы НЕ знаем, почему в оцифрованном переводе Леонова песнь 2 содержит 55/58 стихов, а песнь 28 — 19/20.**
+Why it matters: блокирует полный печатный мастер тома ЛП ([BOOK_BUILD_REPORT.md](https://github.com/gasyoun/CommentaryStrategies/blob/main/data/book/BOOK_BUILD_REPORT.md) флагует обе песни); от ответа зависит, чинить оцифровку или фиксировать лакуну в аппарате.
+Blocker: ответить может только М. Леонов — задача 1 его [issue №58](https://github.com/gasyoun/CommentaryStrategies/issues/58); руководство доставлено 10-07-2026, эскалация с 17-07-2026 (GTD @WAITING).
+How to close: письмо Леонова → либо влить присланные стихи (агентная сессия), либо пометить «сознательное решение» в аппарате — и строка градуирует в FINDINGS/BOOK_BUILD_REPORT.
+> **Source:** ✍️ H497 role-guide session, 10-07-2026 (Fable 5 `claude-fable-5`); registered via /artifact-propagate epistemic pass 11-07-2026.
 
 ---
 


### PR DESCRIPTION
Первый эпистемический проход /artifact-propagate по двухъярусному аппарату Сундараканды: во всех семи реестрах не было ни одной строки про Сундару. Добавлены три: [GAPS §12](https://github.com/gasyoun/SanskritLexicography/blob/sundara-episteme/GAPS.md) — стихи песней 2/28 (пропуск оцифровки vs воля переводчика, блокер — ответ Леонова, эскалация 17-07); [ASSUMPTIONS §7](https://github.com/gasyoun/SanskritLexicography/blob/sundara-episteme/ASSUMPTIONS.md) — недоказанная посылка «2026.html = финальная редакция», на которой стоят все 1058 якорей и dedup; [DEAD_ENDS §8](https://github.com/gasyoun/SanskritLexicography/blob/sundara-episteme/DEAD_ENDS.md) — OCR-маршрут H370, вытесненный лицензированным скрейпом Gita Supersite. CONTRADICTIONS/RECIPES/STALENESS/GLOSSARY — осознанно пусто: противоречий источников аппарат не вскрыл, конвейер уже задокументирован каноном PHASE2_METHOD (не re-derive рецептом), decay-даты нет, новых терминов не чеканил.

🤖 Generated with [Claude Code](https://claude.com/claude-code)