### PR TITLE
research: add INTERVIEWS.md living log, register Sebastian Nehrdich conversation

### DIFF
--- a/RussianTranslation/research/INTERVIEWS.md
+++ b/RussianTranslation/research/INTERVIEWS.md
@@ -1,0 +1,32 @@
+# Interviews — recorded conversations relevant to research direction
+
+_Created: 11-07-2026 · Last updated: 11-07-2026_
+
+Append-only log of recorded conversations (own channel or third-party) with
+researchers/practitioners whose work bears on the lexicographic and Sanskrit-NLP
+direction tracked in [`research/README.md`](README.md). Distinct from
+[`ACL_ANTHOLOGY_MONITOR.md`](ACL_ANTHOLOGY_MONITOR.md), which tracks *papers*;
+this tracks *conversations*. Each entry: video, date, participant, topic,
+actionability for this project, transcript (when available).
+
+## Sebastian Nehrdich
+
+- **Video:** [Беседа с Sebastian Nehrdich](https://www.youtube.com/watch?v=5-UDOPEGLuA)
+  (Mārcis Gasūns channel)
+- **Date added:** 11-07-2026
+- **Transcript:** not yet available — YouTube blocked automated caption/transcript
+  fetch (yt-dlp and `youtube_transcript_api` both hit the bot-check gate from this
+  network on 11-07-2026). Add the transcript text here once exported manually
+  (e.g. from YouTube Studio) or fetched from a network that isn't rate-limited.
+- **Actionable for us?** Not yet assessed — pending transcript/notes to extract
+  concrete takeaways for `pwg_ru` / Sanskrit-NLP direction.
+
+<!-- Next entry template:
+## <Name>
+- **Video:** [<title>](<url>)
+- **Date added:** DD-MM-YYYY
+- **Transcript:** <inline text, or link to a committed transcript file>
+- **Actionable for us?** <verdict + why>
+-->
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/research/README.md
+++ b/RussianTranslation/research/README.md
@@ -30,6 +30,7 @@ classifications/method-maps so they never get stranded in an ephemeral handoff:
 | Doc | What it holds |
 |---|---|
 | [ACL_ANTHOLOGY_MONITOR.md](ACL_ANTHOLOGY_MONITOR.md) | Monthly ACL-Anthology / NLP-for-DH monitor mapped onto the pwg_ru subsystems (judge · TM · terminology · structured-output · Sanskrit-NLP · data-docs · **word/sentence alignment** · **speech-translation alignment**), each entry with an `Actionable for us?` verdict. Includes the **"three publication-grade TM gaps → NLP directions"** map (verse→word alignment, per-segment QE grading, retrieval-TM). Codex automation `monthly-acl-anthology-sanskrit-nlp-monitor` appends to it. |
+| [INTERVIEWS.md](INTERVIEWS.md) | Recorded conversations with researchers/practitioners relevant to this direction (video + transcript + `Actionable for us?` verdict) — the conversation-shaped twin of the paper-shaped ACL monitor above. |
 
 
 ## Spawned as handoff chats (2026-06-23)


### PR DESCRIPTION
## Summary
- New append-only `research/INTERVIEWS.md` log for recorded conversations relevant to research direction — the conversation-shaped twin of `ACL_ANTHOLOGY_MONITOR.md`'s paper tracking.
- First entry: [Беседа с Sebastian Nehrdich](https://www.youtube.com/watch?v=5-UDOPEGLuA) (Mārcis Gasūns channel). Transcript not yet included — YouTube's bot-check blocked automated fetch (yt-dlp + youtube_transcript_api) from this network; template left for manual transcript addition.
- Registered the new doc in `research/README.md`'s living-monitors table.

## Test plan
- [x] Doc-only change, no code paths affected — markdown lint/link-check CI covers it.