### PR TITLE
Prevent partial cards from passing clean

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1889,6 +1889,14 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **Partial-card clean-pass safeguards — DONE 11-07-2026 (Codex/GPT-5).**
+  `audit_window.py` now places every explicit partial card on the transient/top-up requeue lane
+  unless an independent gate makes it a defect; partial keys therefore cannot enter clean judge
+  sampling. `classify_run.py` now treats `summary.partial_keys` as incomplete output, returning
+  code-failure or infra-confounded under the existing signal rules while preserving historical
+  payload compatibility. Focused regressions, Python compilation, the 41-entry parity ledger,
+  and the full `window_selftest.py` suite are green; partial-row promotion remains unchanged.
+
 - **Post-#311 no-PWG selftest hermeticity repair — DONE 10-07-2026 (Codex/GPT-5).**
   PR #311 merged the split-pool runtime and added full `window_selftest.py` coverage to CI, but
   both its PR run and the resulting `master` run failed at

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -279,7 +279,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
       "src/pilot/prompt_rule_audit.py": "d2c578eb62a1919c5c22c0726940df952dee7ead0791bf61d1a1bc7c83f26fdf",
-      "src/pilot/audit_window.py": "2a0478b0779e1aba2bf2e2a0e7d5b50807f7acccf44ae4b00a7dc3af3ff29005",
+      "src/pilot/audit_window.py": "1790c31d101d4247bcf3a6bcb29eb979be32bcf15649527f8ce3de8cfb9db597",
       "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a"
     }
   },
@@ -298,7 +298,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The denylist append and load_frag_tm filtering are lang-agnostic (fsha encodes lang; requeue_from_audit takes --lang), but the fshas EMITTER lives only in the RU auditor: audit_window_en.py reimplements its gates and does not compute requeue_defect_fshas or write the file, so an EN defect requeue does not auto-denylist its fragments.",
     "tracking": "Uprava/handoffs/H304-Fable_RussianTranslation_coordinator-driver-remake_07.07.26.md (EN-emitter port is the recorded follow-up)",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "2a0478b0779e1aba2bf2e2a0e7d5b50807f7acccf44ae4b00a7dc3af3ff29005",
+      "src/pilot/audit_window.py": "1790c31d101d4247bcf3a6bcb29eb979be32bcf15649527f8ce3de8cfb9db597",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878"
     }
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -471,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -500,9 +500,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/preflight_remaining_gates.py": "00386c837b97986c9702abfceed9c29534736c3df3063af202ddfaae6b078b8f",
       "src/release_readiness.py": "db38a870bbc8b5dbe694e706e4a7b9089ba41211a3881ad9a1bd4eb02950c8a9",
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
-      "src/pilot/audit_window.py": "2a0478b0779e1aba2bf2e2a0e7d5b50807f7acccf44ae4b00a7dc3af3ff29005",
+      "src/pilot/audit_window.py": "1790c31d101d4247bcf3a6bcb29eb979be32bcf15649527f8ce3de8cfb9db597",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -521,7 +521,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "9ef1fd0e7c1d31760db187d16046b7dffbafa4fd6d11099ef61fb95094975b27",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "863b8e1a5ce294233dea1346dd3e139bac8c3f4d9b0a35f00102196f1b63369d",
       "src/promote_en.py": "84b79476e9a82df2e6dc08b3be29a3b798eef04fce6416155afb3dd0e9fac81b",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -619,11 +619,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H336 (08-07-2026). window_reports.write_reports/write_window_status already took an out_dir parameter (pre-existing --out-dir escape hatch); --window-tag is a thin, lang-agnostic sugar layer over that same parameter computed once in audit_window.py and threaded through unchanged to requeue_from_audit.py/root_window_status.py. Neither RU nor EN branch differently. Pinned by test_audit_window_tag_routing.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "2a0478b0779e1aba2bf2e2a0e7d5b50807f7acccf44ae4b00a7dc3af3ff29005",
+      "src/pilot/audit_window.py": "1790c31d101d4247bcf3a6bcb29eb979be32bcf15649527f8ce3de8cfb9db597",
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -652,7 +652,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -672,7 +672,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -691,7 +691,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "5e257d130318be4e903bb55444d70c88544af8725c115253235e5daed716ec51",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -728,7 +728,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -747,7 +747,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/stage2_pregate.py": "f801740067f981f66e480330a586e12d9e98f85f7f564e40520d7ff43af139e2",
-      "src/pilot/audit_window.py": "2a0478b0779e1aba2bf2e2a0e7d5b50807f7acccf44ae4b00a7dc3af3ff29005"
+      "src/pilot/audit_window.py": "1790c31d101d4247bcf3a6bcb29eb979be32bcf15649527f8ce3de8cfb9db597"
     }
   },
   {
@@ -786,7 +786,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -805,7 +805,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -824,7 +824,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   },
   {
@@ -844,8 +844,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731",
-      "src/pilot/classify_run.py": "868f9c76df11726d1872ac1c213f3f5b58aafcf090e302165d2ec52a2eddeecc"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce",
+      "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
   {
@@ -866,7 +866,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "9fc7e83e5885100948a1da65e6ea8e0a82c9ee0e31b0af6a6bfb780c7927d731"
+      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -252,6 +252,40 @@ def emit_audit_event(event_type, level='info', root=None, state=None, summary=''
             pass
 
 
+def classify_harness_requeues(null_cards, partial_cards, gate_requeue, failure_reasons):
+    """Split incomplete harness output from independently gate-flagged defects."""
+    null_set = set(null_cards or [])
+    partial_set = set(partial_cards or [])
+    gate_set = set(gate_requeue or [])
+    fidelity_nulls = {
+        k for k, e in (failure_reasons or {}).items()
+        if e.startswith('fidelity-reject') or e.startswith('stitched-fidelity')
+    }
+    defect = (gate_set - null_set) | fidelity_nulls
+    transient = (null_set | partial_set) - defect
+    return transient, defect, fidelity_nulls
+
+
+def collect_harness_quality(results):
+    """Extract explicit partial-card and null-failure metadata from harness rows."""
+    partial_cards, failure_reasons = {}, {}
+    for row in results or []:
+        key = row.get('key')
+        if not key:
+            continue
+        card = row.get('card')
+        if card and (card.get('partial') or row.get('partial')):
+            partial_cards[key] = {
+                name: (card.get(name) if card.get(name) is not None else row.get(name))
+                for name in ('missing_fragments', 'missing_groups', 'total_groups',
+                             'missing_senses', 'total_senses')
+                if card.get(name) is not None or row.get(name) is not None
+            }
+        if not card and row.get('error'):
+            failure_reasons[key] = row['error']
+    return partial_cards, failure_reasons
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('wf_output')
@@ -481,19 +515,13 @@ def main():
     # Harness-side quality markers (post-#63/#64 wf files): per-row failure reasons on null
     # cards, and partial:true cards (usable but incomplete — selfheal/autosplit partial
     # credit). Older wf files carry neither; everything below degrades to empty.
-    partial_cards, failure_reasons = {}, {}
-    for r in results or []:
-        k = r.get('key')
-        if not k:
-            continue
-        c = r.get('card')
-        if c and (c.get('partial') or r.get('partial')):
-            partial_cards[k] = {m: (c.get(m) if c.get(m) is not None else r.get(m))
-                                for m in ('missing_fragments', 'missing_groups', 'total_groups',
-                                          'missing_senses', 'total_senses')
-                                if c.get(m) is not None or r.get(m) is not None}
-        if not c and r.get('error'):
-            failure_reasons[k] = r['error']
+    partial_cards, failure_reasons = collect_harness_quality(results)
+
+    # Partial output remains promotable as useful intermediate data, but it is never a clean
+    # window result. Requeue it for targeted top-up even when percentage gates miss a small
+    # omission.
+    partial_set = set(partial_cards)
+    requeue.update(partial_set)
 
     report = {'workflow': wf, 'root': args.root, 'keys': keys, 'null_cards': null_cards,
               'workflow_meta': wf_meta, 'stale_check': stale,
@@ -508,10 +536,10 @@ def main():
     # construction (the model answered; the deterministic guard refused it — observed live
     # as the Sam/Buj/naS 'stubborn null' loop) -> classify as defect, not transient, so the
     # cheap-re-run lane stops burning quota on it.
-    fidelity_nulls = {k for k, e in failure_reasons.items()
-                      if e.startswith('fidelity-reject') or e.startswith('stitched-fidelity')}
-    report['requeue_transient'] = sorted(set(null_cards) - fidelity_nulls)
-    report['requeue_defect'] = sorted((gate_requeue - set(null_cards)) | fidelity_nulls)
+    transient, defect, fidelity_nulls = classify_harness_requeues(
+        null_cards, partial_set, gate_requeue, failure_reasons)
+    report['requeue_transient'] = sorted(transient)
+    report['requeue_defect'] = sorted(defect)
     # H304 gate-outcome memory: the fragment TM is harvested from raw wf_output BEFORE any
     # gate runs, so a defect card's fragments would otherwise stay silently reusable
     # (frag_address keys on the input SHA, not on whether the output passed). Surface every

--- a/RussianTranslation/src/pilot/classify_run.py
+++ b/RussianTranslation/src/pilot/classify_run.py
@@ -11,7 +11,7 @@ hand-counted from transcript log lines. Since H462 the harness summary RETURNS
 kill_timeouts / conn_errors / heal_calls / kill_bisect_blocked, so the whole adjudication
 is computable from the payload:
 
-  clean            null_keys empty AND budget_kill_switch not tripped.
+  clean            null_keys and partial_keys empty AND budget_kill_switch not tripped.
   infra-confounded conn_errors >= 1, OR kill_timeouts >= max(3, 25%% of agents_spent) —
                    the recurring-transport / mass-kill-timeout signature of a degraded
                    generation environment (H442 launches 1-3). An infra-confounded window
@@ -65,6 +65,7 @@ def classify(summary):
     nulls = summary.get('null_keys')
     if nulls is None:
         nulls = [None] * (summary.get('null') or 0)
+    partials = summary.get('partial_keys') or []
     tripped = bool(summary.get('budget_kill_switch_tripped'))
     kill_ceiling = max(INFRA_KILL_MIN, int(math.ceil(INFRA_KILL_FRAC * agents)))
     signals = {
@@ -82,11 +83,13 @@ def classify(summary):
         'heal_calls': summary.get('heal_calls'),
         'kill_bisect_blocked': summary.get('kill_bisect_blocked'),
         'null_cards': len(nulls),
+        'partial_cards': len(partials),
+        'partial_keys': list(partials),
         'budget_kill_switch_tripped': tripped,
         'infra_kill_threshold': kill_ceiling,
     }
     reasons = []
-    if not nulls and not tripped:
+    if not nulls and not partials and not tripped:
         reasons.append('all cards returned, budget switch untripped')
         if conns or kills:
             reasons.append('non-blocking infra noise: %d conn-error(s), %d kill-timeout(s)'
@@ -103,8 +106,9 @@ def classify(summary):
         reasons.append('degraded generation environment — result says nothing about the '
                        'harness code; do not tune budgets on this run (H442 rule)')
         return 'infra-confounded', reasons, signals
-    reasons.append('%d null card(s), tripped=%s, with NO infra signal (%d conn-errors, '
-                   '%d kill-timeouts < %d)' % (len(nulls), tripped, conns, kills, kill_ceiling))
+    reasons.append('%d null card(s), %d partial card(s), tripped=%s, with NO infra signal '
+                   '(%d conn-errors, %d kill-timeouts < %d)' %
+                   (len(nulls), len(partials), tripped, conns, kills, kill_ceiling))
     reasons.append('suspect the harness itself: kill gate, heal budget, schema, or key matching')
     return 'code-failure', reasons, signals
 

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3302,6 +3302,37 @@ def test_run_telemetry_counters_returned():
         shutil.rmtree(d, ignore_errors=True)
 
 
+def test_partial_cards_requeue_and_stay_out_of_clean_sample():
+    """Partial-only output is transient; an independent content defect wins."""
+    import audit_window as aw
+    import window_reports as wr
+
+    fixture = [
+        {'key': 'partial_only', 'card': {'partial': True,
+                                         'missing_fragments': ['g1:f9']}},
+        {'key': 'partial_defect', 'card': {'partial': True,
+                                           'missing_fragments': ['g2:f3']}},
+    ]
+    partial_cards, failure_reasons = aw.collect_harness_quality(fixture)
+    transient, defect, _ = aw.classify_harness_requeues(
+        [], partial_cards, {'partial_defect'}, failure_reasons)
+    if transient != {'partial_only'} or defect != {'partial_defect'}:
+        fail('partial requeue precedence drifted: transient=%r defect=%r' %
+             (transient, defect))
+
+    report = {'root': 'zz', 'keys': ['clean', 'partial_only', 'partial_defect'],
+              'null_cards': [], 'requeue': sorted(transient | defect)}
+    saved_merged_exists = wr.merged_exists
+    try:
+        wr.merged_exists = lambda key: True
+        sample = wr.build_judge_sample(report, rate=1.0, minimum=0, seed='partial-test')
+    finally:
+        wr.merged_exists = saved_merged_exists
+    if sample['clean_sample_keys'] != ['clean']:
+        fail('partial keys leaked into clean judge candidates: %r' %
+             sample['clean_sample_keys'])
+
+
 def test_classify_run_verdicts():
     """H462: classify_run.py mechanizes the code-vs-infra rule H442 applied by hand
     ('if connection errors recur, record as infra-confounded, not a code failure') from
@@ -3319,6 +3350,8 @@ def test_classify_run_verdicts():
     v, _, sig = cr.classify(dict(base))
     if v != 'clean':
         fail('all-ok summary must classify clean; got %r' % v)
+    if sig['partial_cards'] != 0 or sig['partial_keys']:
+        fail('historical summary without partial_keys must remain compatible')
     for field in ('translate_agents_spent', 'max_translate_agents',
                   'translate_budget_tripped', 'heal_agents_spent',
                   'max_heal_agents', 'heal_budget_tripped'):
@@ -3337,6 +3370,17 @@ def test_classify_run_verdicts():
     v, _, _ = cr.classify(code)
     if v != 'code-failure':
         fail('nulls with no infra signal must classify code-failure; got %r' % v)
+    partial = dict(base, partial_keys=['p1'])
+    v, reasons, sig = cr.classify(partial)
+    if v != 'code-failure' or sig['partial_cards'] != 1 or sig['partial_keys'] != ['p1']:
+        fail('partial-only output must classify code-failure with partial signals; got %r %r' %
+             (v, sig))
+    if '1 partial card(s)' not in ' '.join(reasons):
+        fail('partial-only code-failure reason must name the incomplete card count')
+    partial_infra = dict(base, partial_keys=['p1'], conn_errors=1)
+    v, _, _ = cr.classify(partial_infra)
+    if v != 'infra-confounded':
+        fail('partial output plus an infra signal must classify infra-confounded; got %r' % v)
     # kill-timeouts alone (no conn errors) past the 25%% ceiling are ALSO infra
     kills = dict(base, kill_timeouts=58, null_keys=['a'], budget_kill_switch_tripped=True)
     v, _, _ = cr.classify(kills)
@@ -4189,6 +4233,7 @@ def main():
         test_per_card_heal_budget_wired,
         test_heal_group_kill_timeout_does_not_bisect,
         test_run_telemetry_counters_returned,
+        test_partial_cards_requeue_and_stay_out_of_clean_sample,
         test_classify_run_verdicts,
     ]
     for test in tests:


### PR DESCRIPTION
## Summary
- requeue explicit partial cards through the transient/top-up lane unless a content defect wins
- keep partial keys out of clean judge sampling
- classify partial payloads as code-failure or infra-confounded while preserving historical compatibility

## Verification
- focused partial-card regressions
- Python compilation
- 41-entry language-parity ledger
- full RussianTranslation window_selftest.py