### PR TITLE
ai-state: journal H604 + deep-manual queue H606-H608

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -20,6 +20,25 @@ Two live tracks:
 
 ## ➡️ Next Steps (Queue)
 
+- [ ] **Subsystem deep-manual queue (H604 fan-out, 2026-07-11, Fable 5 `claude-fable-5`)** —
+      three launchable Fable handoffs per
+      [docs/manuals/PROFILE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/PROFILE.md):
+      H606 RussianTranslation pipelines · H607 HeadwordLists analytics · H608 papers/book/docs_site.
+      Start the first with:
+      `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H606-Fable_SanskritLexicography_russiantranslation-pipeline-deep-manual_11.07.26.md and execute it.`
+
+- [x] **H604 manual-set consolidation + /workspace-manual skill (2026-07-11, Fable 5 `claude-fable-5`).**
+      [PR #333](https://github.com/gasyoun/SanskritLexicography/pull/333) merged:
+      docs/manuals/ ruled canonical, root MANUAL_* pair thinned + cross-wired (multi-account
+      protocol now lives only in AGENTS §5), fact-check fixes (NOW_VS_THEN figures, CI job list,
+      Catalan-Pujol/ReverseDictionary counts, store 11,317), new
+      [PROFILE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/PROFILE.md) +
+      [README.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/README.meta.md).
+      Manual regeneration procedure now encoded in the global
+      [/workspace-manual](https://github.com/gasyoun/claude-config/blob/main/commands/workspace-manual.md)
+      skill (SKILLS_INDEX 118→119). Known defect spun off: FINDINGS.md has seven duplicated
+      §N pairs (§56/§60/§62–65/§69) — repair task chipped.
+
 - [x] **H479 workspace manual pair shipped (2026-07-10, Fable 5 `claude-fable-5`).**
       Two repo-root manuals: [MANUAL_LEXICON_WORKSPACE_HUMAN_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/MANUAL_LEXICON_WORKSPACE_HUMAN_RU.md)
       (Russian, human-facing: repo map, 10-06→10-07 delta, human gates, H442 hypotheses,


### PR DESCRIPTION
Journal-only follow-up to [PR #333](https://github.com/gasyoun/SanskritLexicography/pull/333): records the H604 consolidation in the root [.ai_state.md](https://github.com/gasyoun/SanskritLexicography/blob/master/.ai_state.md) Queue and adds the launchable H606–H608 deep-manual queue entry with its starter line. Model: Fable 5 (`claude-fable-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)