### PR TITLE
fix(FINDINGS): repair seven duplicated §N citation keys (H616)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -39,6 +39,20 @@ Two live tracks:
       skill (SKILLS_INDEX 118→119). Known defect spun off: FINDINGS.md has seven duplicated
       §N pairs (§56/§60/§62–65/§69) — repair task chipped.
 
+- [x] **H616 FINDINGS duplicate-§N key repair (2026-07-11, Fable 5 `claude-fable-5`).**
+      The seven duplicated pairs from the H604 fact-check repaired in
+      [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md):
+      later twins renumbered with tombstones — §60→§70, §62→§71, §63→§72, §64→§73,
+      §65→§74, §69→§75; the second "§56" was a verbatim double-append of §68
+      (spellchecker landscape, PRs #305/#307) and was removed with a tombstone under §68.
+      Header max marker §65→§75; stale later-twin citations repointed
+      (STALENESS §60-row, ROADMAP_VEDAWEB_REUSE §63/§64, PIPELINE_HISTORY/USE_CASES/
+      RussianTranslation `.ai_state.md` §60); manuals caveats dropped
+      (MAINTAINER §3, RESEARCHER §5), metadoc backlog item 4 closed. Uprava hub
+      citations (PROJECT_INTERLINKS, GTD, handoffs registry/archive) repointed in the
+      same pass. Handoff:
+      [H616](https://github.com/gasyoun/Uprava/blob/main/handoffs/H616-Fable_SanskritLexicography_findings-duplicate-section-key-repair_11.07.26.md).
+
 - [x] **H479 workspace manual pair shipped (2026-07-10, Fable 5 `claude-fable-5`).**
       Two repo-root manuals: [MANUAL_LEXICON_WORKSPACE_HUMAN_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/MANUAL_LEXICON_WORKSPACE_HUMAN_RU.md)
       (Russian, human-facing: repo map, 10-06→10-07 delta, human gates, H442 hypotheses,

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,6 +1,6 @@
 # FINDINGS — cross-repo empirical registry
 
-_Created: 26-06-2026 · Last updated: 10-07-2026_
+_Created: 26-06-2026 · Last updated: 11-07-2026_
 
 📊 **Live dashboard:** <https://gasyoun.github.io/SanskritLexicography/findings/> —
 importance/section breakdown, staleness flags, monthly time series (§12/§13/§21/§25) and the
@@ -28,7 +28,7 @@ do), and a blockquoted (`> `) **Source** paragraph linking the exact statement a
 with a `— repo · date` tag — the `>` gives the Source line its left indent and muted rendering
 in plain Markdown; no HTML in this file, ever. Keep findings grounded (a number, a file, a
 probe), never a hunch. **Importance label:** every finding carries a colour dot at the start of its claim line and its index entry — 🔴 3 important · 🟠 2 medium · 🟡 1 not that important — assign one when appending. **Numbers are append-only:** a new finding takes the next free number
-(currently §65) whatever its section, so existing numbers never shift; when a finding is later
+(currently §75) whatever its section, so existing numbers never shift; when a finding is later
 refuted or superseded, strike it and say why — never reuse its number.
 
 ## Index
@@ -82,9 +82,9 @@ refuted or superseded, strike it and say why — never reuse its number.
 - 🟠 [§44. Raw Latin-string tallies over gloss text include etymological false positives; Bopp lacks √yabh](#44-raw-latin-string-tallies-over-gloss-text-include-etymological-false-positives-bopp-lacks-yabh) — MW72's lone *cunnus* glosses a Lithuanian cognate, not a headword; BOP has no √*yabh* entry (all *futu-* hits are *futurum*); trust A36's curated CSV, not the raw sweep.
 - 🟠 [§45. Siglum prefix-families routinely bundle several distinct works; the diacritic-stripping fold has poisoned keys](#45-siglum-prefix-families-routinely-bundle-several-distinct-works-the-diacritic-stripping-fold-has-poisoned-keys) — 26/50 top families mix 2–6 works (Bhag./BhP., Rajan./Rajat., 5 Śabda-kośas); `samk` fold merges Śaṃk°+Sāṃk°; ~120 pseudo-variants are just unstripped roman numerals; MW unknown-layer tail = only 6.5% of citation weight.
 - 🔴 [§61. The reverse dictionary's 30 sources split ~18 PD vs ~10 in-copyright — the merged headword list is not automatically publishable](#61-the-reverse-dictionarys-30-sources-split-18-pd-vs-10-in-copyright--the-merged-headword-list-is-not-automatically-publishable) — rights table + 3 decision options in the H265 analysis; ruling is a human @DECIDE.
-- 🟠 [§62. PWG marks case government explicitly ≈3,853 times across ≈3,222 senses — a deterministic census, not an estimate](#62-pwg-marks-case-government-explicitly-3853-times-across-3222-senses--a-deterministic-census-not-an-estimate) — 2,309 single-case parens + 40 variation groups + 1,504 mit-phrases; verbs only 417 of 1,476 marker-bearing entries; the store slot `government` is empty (0/11,261).
+- 🟠 [§71. PWG marks case government explicitly ≈3,853 times across ≈3,222 senses — a deterministic census, not an estimate](#71-pwg-marks-case-government-explicitly-3853-times-across-3222-senses--a-deterministic-census-not-an-estimate) — 2,309 single-case parens + 40 variation groups + 1,504 mit-phrases; verbs only 417 of 1,476 marker-bearing entries; the store slot `government` is empty (0/11,261).
 - 🔴 [§64. PW-only headwords outnumber PWG-only ones 6-to-1 — PWG is not the sole spine of the local layer universe](#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1-pwg-is-not-the-sole-spine-of-the-local-layer-universe) — 40,338 headwords (24%) exist in PW/SCH/PWKVN with no PWG record at all; any worklist built by iterating PWG keys silently drops ~36% of the local-layer universe; NWS adds net-new content to 20.3% of headwords.
-- 🟠 [§65. The ls-graph citation matrix is degenerate for MW](#65-the-ls-graph-citation-matrix-is-degenerate-for-mw--its-top-abbreviations-sit-unresolved-use-the-citation-apparatus-siglum-matrix-for-cross-dict-citation-profiles) — MW resolves to 5 texts, top keys unresolved; BEN~MW=0.0 artifact; use the citation-apparatus siglum matrix; only 7/14 L0-edge dicts have `<ls>` adapters.
+- 🟠 [§74. The ls-graph citation matrix is degenerate for MW](#74-the-ls-graph-citation-matrix-is-degenerate-for-mw--its-top-abbreviations-sit-unresolved-use-the-citation-apparatus-siglum-matrix-for-cross-dict-citation-profiles) — MW resolves to 5 texts, top keys unresolved; BEN~MW=0.0 artifact; use the citation-apparatus siglum matrix; only 7/14 L0-edge dicts have `<ls>` adapters.
 
 **Etymology & derivation**
 
@@ -1518,7 +1518,9 @@ citation crosswalk must also run `gh repo list funderburkjim` and
 `gh repo list sanskrit-lexicon-scans`, and grep the actual `csl-orig` source
 text for existing `<ls>` markup, before assuming nothing exists.
 
-### §60. pwg_ru TM composite grade: A is consensus-gated (5.7%), and a reference-free surface QE cannot detect wrong-sense
+### §70. pwg_ru TM composite grade: A is consensus-gated (5.7%), and a reference-free surface QE cannot detect wrong-sense
+
+> _Was §60 until 11-07-2026, renumbered — duplicate key (§60 was already taken by the Russian-transcription finding)._
 
 🟡 **Grading the 1.09M-unit Sa→Ru translation memory
 ([`tm_grade.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_grade.py),
@@ -1576,7 +1578,9 @@ A descriptive *paper* about the resource is NOT gated by the ruling — only the
 
 ---
 
-### §62. PWG marks case government explicitly ≈3,853 times across ≈3,222 senses — a deterministic census, not an estimate
+### §71. PWG marks case government explicitly ≈3,853 times across ≈3,222 senses — a deterministic census, not an estimate
+
+> _Was §62 until 11-07-2026, renumbered — duplicate key (§62 was already taken by the varga-distribution finding)._
 
 🟠 **Böhtlingk-Roth state case government (управление; the `snih` + loc. class) explicitly
 ≈3,853 times in the German sense text — 2,309 parenthesized single-case markers
@@ -1605,7 +1609,9 @@ build handoff [H338](https://github.com/gasyoun/Uprava/blob/main/handoffs/H338-S
 
 ---
 
-### §63. VedaWeb's `id_gra` token field IS the Grassmann `<L>` entry number — no fuzzy text-matching needed for a GRA↔VedaWeb crosswalk
+### §72. VedaWeb's `id_gra` token field IS the Grassmann `<L>` entry number — no fuzzy text-matching needed for a GRA↔VedaWeb crosswalk
+
+> _Was §63 until 11-07-2026, renumbered — duplicate key (§63 was already taken by the vidyut dhātupāṭha finding)._
 
 🟢 **VedaWeb 2.0's `lemmatization.json` export (H096) already carries a per-token
 `id_gra` array resolved via its own `kosh.uni-koeln.de/cdsd/gra/restful/ids` API — and
@@ -1636,7 +1642,9 @@ check the analogous `<L>`-number identity first rather than re-deriving a text m
 
 ---
 
-### §64. VedaWeb 2.0's "CC BY 4.0 for everything" claim is not machine-confirmed — only 2/36 catalog resources carry an explicit license field
+### §73. VedaWeb 2.0's "CC BY 4.0 for everything" claim is not machine-confirmed — only 2/36 catalog resources carry an explicit license field
+
+> _Was §64 until 11-07-2026, renumbered — duplicate key (§64 was already taken by the PW-only-headwords finding)._
 
 🟠 **Re-checking the VedaWeb 2.0 catalog's own `license`/`licenseUrl` fields (not the
 `ROADMAP_VEDAWEB_REUSE.md` summary) found `license: null` on 34 of 36 resources.** Only
@@ -1684,7 +1692,9 @@ assume, and here asking took one email and about a day's turnaround.
 
 ---
 
-### §65. The ls-graph citation matrix is degenerate for MW — its top abbreviations sit unresolved; use the citation-apparatus siglum matrix for cross-dict citation profiles
+### §74. The ls-graph citation matrix is degenerate for MW — its top abbreviations sit unresolved; use the citation-apparatus siglum matrix for cross-dict citation profiles
+
+> _Was §65 until 11-07-2026, renumbered — duplicate key (§65 was already taken by the DeepSeek word-alignment grounding finding)._
 
 **Claim.** [`csl-atlas/data/citations/ls_citation_edges.tsv`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/citations/ls_citation_edges.tsv)
 (the H213 canonicalized dict×text citation graph) resolves **MW to only 5 texts**
@@ -1707,34 +1717,6 @@ MW72/BOP have none, so any per-edge citation statistic shrinks to n=5 edges. Ful
 
 > **Source:** H342 PH2 CITE-4AXIS ([csl-atlas PR #233](https://github.com/sanskrit-lexicon/csl-atlas/pull/233)),
 > Fable 5 `claude-fable-5` · 2026-07-08
-
-### §56. The Sanskrit spellchecker landscape: one dormant demo, one license-unsettled 543k wordlist, no occupant
-
-🟠 **No maintained flag-and-suggest Sanskrit spellchecker exists (verified 10-07-2026), and the
-two nearest things both carry traps.** (1) The sanskrit-spellchecker.netlify.app demo M.G. named
-in the 02-07 interview is the online interface of **Prasanna S., "Spellchecker for Sanskrit: The
-Road Less Taken", ICON 2022** ([2022.icon-main.35](https://aclanthology.org/2022.icon-main.35/))
-— identified via the paper's own footnote 14; 37,058-entry Paninian word-and-paradigm Hunspell
-dictionary, **source never published, no license, dormant since ~2022** (all 117 of the author's
-public repos enumerated; the announced Firefox/LibreOffice add-ons never appeared). (2)
-**LibreOffice bundles a 543,758-entry `sa_IN` Hunspell pair since 10-01-2025**
-([LibreOffice/dictionaries `sa_IN/`](https://github.com/LibreOffice/dictionaries/tree/master/sa_IN),
-Shantanu Oak, wikipedia/wikisource-derived flat wordlist + `BREAK` stripping) whose **in-tree
-license is formally unsettled** — a GPL-2 `COPYING` was added 05-05-2025 and reverted three days
-later by a LibreOffice maintainer as contradicting per-file copyright; do NOT ingest that
-wordlist, use it only as an evaluation baseline. Also verified absent: any `sa` pack in
-wooorm/dictionaries or GNU aspell; any spellcheck component in sanscript/indic-transliteration
-(transliteration-only, MIT); any suggestion surface in SCL (its old analyser-based web
-spellchecker is defunct per the ICON paper) or the Heritage Platform (grey-rectangle flag only,
-LGPLLR databanks). A44's related-work citation "contextual spell-checker, ISCLS 2024" was a
-mis-attribution — that volume contains no spellchecking paper; corrected to Prasanna 2022.
-[COLOGNE #91](https://github.com/sanskrit-lexicon/COLOGNE/issues/91) ("Hunspell for Sanskrit?")
-has been open since 2016 — the demand signal for the planned SanskritSpellCheck web app, whose
-niche (suggestion generation against a validated, provenance-carrying lexicon) is unoccupied.
-
-> **Source:** [SanskritSpellCheck docs/PRIOR_ART.md](https://github.com/drdhaval2785/SanskritSpellCheck/blob/master/docs/PRIOR_ART.md)
-> (H452, [PR #27](https://github.com/drdhaval2785/SanskritSpellCheck/pull/27), 3 parallel
-> research agents, every claim fetch-backed), Fable 5 `claude-fable-5` · 2026-07-10
 
 ### §66. The DCS `QL` frequency workbook's `SLP1` and length columns are truncated at ṣṭh/ḍh clusters
 
@@ -1778,6 +1760,8 @@ itself a function of corpus frequency.
 > Opus 4.8 `claude-opus-4-8` · 2026-07-10
 
 ### §68. The Sanskrit spellchecker landscape: one dormant demo, one license-unsettled 543k wordlist, no occupant
+
+> _A verbatim copy of this finding also sat earlier in the file under a duplicate "§56" heading until 11-07-2026 (double-appended by two 10-07 sessions, PRs #305/#307); the copy was removed — cite §68._
 
 🟠 **No maintained flag-and-suggest Sanskrit spellchecker exists (verified 10-07-2026), and the
 two nearest things both carry traps.** (1) The sanskrit-spellchecker.netlify.app demo M.G. named
@@ -1838,7 +1822,9 @@ the probe log's JSONL), never only in a worktree-local gitignored file.
 
 ---
 
-### §69. The full Devībhāgavata-purāṇa Sanskrit is NOT on GRETIL — only the Devigita fragment; the complete mūla lives on sanskritdocuments.org without `DbhP_` markers
+### §75. The full Devībhāgavata-purāṇa Sanskrit is NOT on GRETIL — only the Devigita fragment; the complete mūla lives on sanskritdocuments.org without `DbhP_` markers
+
+> _Was §69 until 11-07-2026, renumbered — duplicate key (§69 was already taken by the launch-telemetry finding)._
 
 Verified 2026-07-10 (H534, three-way check): GRETIL's own update history
 ([`hist.html`](http://gretil.sub.uni-goettingen.de/hist.html) #370) and TEI

--- a/ROADMAP_VEDAWEB_REUSE.md
+++ b/ROADMAP_VEDAWEB_REUSE.md
@@ -1,6 +1,6 @@
 # ROADMAP — VedaWeb 2.0 data reuse across the Sanskrit Lexicon repos
 
-_Created: 03-07-2026 · Last updated: 03-07-2026_
+_Created: 03-07-2026 · Last updated: 11-07-2026_
 
 Scope ruled by M.G. 03-07-2026 (4 decisions, elicited in-session): **full breadth**
 (validation + persistent feed + GRA crosswalk + meter/translation layers) · feed home =
@@ -79,7 +79,8 @@ Sonnet-tier chat in `GitHub\WhitneyRoots`.
   GRA entries (77.8%), 9,475/11,108 unique headwords (85.3%) attested ≥1× in RV. Issue open:
   [sanskrit-lexicon/GRA#52](https://github.com/sanskrit-lexicon/GRA/issues/52)
   (`content-enhancement`, Major Enhancements milestone). Finding logged:
-  [FINDINGS.md §63](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).
+  [FINDINGS.md §72](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
+  (renumbered from §63 on 11-07-2026).
   Handoff: [H097](https://github.com/gasyoun/Uprava/blob/main/handoffs/H097-Sonnet_VisualDCS_gra_vedaweb_crosswalk_03.07.26.md).
 
 ```
@@ -96,7 +97,8 @@ Sonnet-tier chat in `GitHub\VisualDCS`.
   finding: only 2/36 catalog resources carry an explicit `license` field** — the blanket
   "CC BY 4.0 for everything" framing above (Standing constraints) was an unverified
   assumption at triage time; see
-  [FINDINGS.md §64](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).
+  [FINDINGS.md §73](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
+  (renumbered from §64 on 11-07-2026).
   Triage originally parked all 4 meter/translation candidates DECIDE pending confirmation
   (Elizarenkova RU explicitly in-copyright to ~2078, Renou to ~2036). Full table + per-
   consumer effort estimates:

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -276,7 +276,8 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   A 5.7% / B 94.0% / C 0.3%**, all 62,503 A units consensus-gated (0 violations). Calibration on the
   320-row `gold/gold_set.jsonl`: 0 defective rows reach A, but proxy QE separates acceptable/defective
   at only AUC ≈ 0.58 (a surface heuristic can't detect wrong-sense → semantic lift is consensus +
-  A-gate; `--qe comet` / Slice 3 aligner are the next steps — [FINDINGS §60](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)).
+  A-gate; `--qe comet` / Slice 3 aligner are the next steps — [FINDINGS §70](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md),
+  renumbered from §60 on 11-07-2026, duplicate-key repair).
   Grades sidecar + TMX stay gitignored (rights). Docs: [`src/BUILD_TMX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/BUILD_TMX.md).
   **Next:** Slice 3 (L0 segment layer + real SimAlign/awesome-align word-align cross-check → real
   `alignment_confidence`), Slice 4 (oral ingest, coordinate H174), Slice 5 (FAIR release — the real

--- a/RussianTranslation/PIPELINE_HISTORY.md
+++ b/RussianTranslation/PIPELINE_HISTORY.md
@@ -1,6 +1,6 @@
 # PWG→RU/EN pipeline — history: solutions, failures, current state
 
-_Created: 04-07-2026 · Last updated: 07-07-2026_
+_Created: 04-07-2026 · Last updated: 11-07-2026_
 
 This is the orientation document for anyone (human or session) who needs the
 **shape** of how this pipeline got here, without reading the full
@@ -349,7 +349,7 @@ TM **publication-grade**: a TMX 1.4b exporter
 so the asset is consumable by standard CAT tooling, and a composite A/B/C
 quality grader ([`src/tm_grade.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_grade.py))
 so every TM row carries an evidence grade instead of implicit trust (grade
-distribution logged as FINDINGS §60). H215's remaining slices (L0 segment
+distribution logged as FINDINGS §70, renumbered from §60 on 11-07-2026). H215's remaining slices (L0 segment
 layer, oral-corpus ingest, FAIR release clearance) are open — the release
 clearance is the real blocker.
 

--- a/RussianTranslation/USE_CASES.md
+++ b/RussianTranslation/USE_CASES.md
@@ -1,6 +1,6 @@
 # RussianTranslation Use Cases
 
-_Created: 28-06-2026 · Last updated: 07-07-2026_
+_Created: 28-06-2026 · Last updated: 11-07-2026_
 
 Operational scenarios for the PWG -> Russian production pipeline. The canonical
 runbook remains [src/pilot/RUN_FREQ_MAX.md](src/pilot/RUN_FREQ_MAX.md); this
@@ -230,7 +230,7 @@ python src\build_tmx.py build --sample 1000       # small export for inspection
 ```
 
 Grades: A = strong direct-equivalence evidence · B = plausible gloss · C =
-usage/citation-only co-occurrence. Distribution is logged as FINDINGS §60.
+usage/citation-only co-occurrence. Distribution is logged as FINDINGS §70.
 Public release of the export waits on the H215 rights clearance.
 
 ---

--- a/STALENESS.md
+++ b/STALENESS.md
@@ -1,6 +1,6 @@
 # STALENESS — confidence-decay table over [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
 
-_Created: 08-07-2026 · Last updated: 08-07-2026_
+_Created: 08-07-2026 · Last updated: 11-07-2026_
 
 **⚙️ FULLY AUTO-GENERATED — do not hand-edit the table below.** Regenerate with [`sanskrit-util/tools/epistemic/derive_staleness.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/derive_staleness.py). This is the STALENESS epistemic sibling of [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) (Sanskrit-data side) — one of the seven registries minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md). It answers the one question FINDINGS structurally cannot: *when was each fact last re-checked, and which are decaying?*
 
@@ -79,7 +79,7 @@ Every FINDINGS finding measures a fact **at a moment**. A count true in June may
 | [§54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) | 03-07-2026 | 05-07-2026 | 3d | 🟢 | RECIPES §TBD |
 | [§64](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1--pwg-is-not-the-sole-spine-of-the-local-layer-universe) | 05-07-2026 | — | 3d | 🟢 | RECIPES §TBD |
 | [§60](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-practical-russian-transcription-of-sanskrit-names-has-no-safe-reverse-transliteration) | 05-07-2026 | — | 3d | 🟢 | RECIPES §TBD |
-| [§60](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-pwgru-tm-composite-grade-a-is-consensus-gated-57-and-a-reference-free-surface-qe-cannot-detect-wrong-sense) | 03-07-2026 | 06-07-2026 | 2d | 🟢 | RECIPES §TBD |
+| [§70](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#70-pwg_ru-tm-composite-grade-a-is-consensus-gated-57-and-a-reference-free-surface-qe-cannot-detect-wrong-sense) | 03-07-2026 | 06-07-2026 | 2d | 🟢 | RECIPES §TBD |
 | [§63](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian) | 07-07-2026 | — | 1d | 🟢 | RECIPES §TBD |
 | [§62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) | 05-03-2026 | 07-07-2026 | 1d | 🟢 | RECIPES §TBD |
 | [§65](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse) | 07-07-2026 | — | 1d | 🟢 | RECIPES §TBD |

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,27 @@ then **cut a new version every time the changelog is updated** (promote
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-07-11
+
+### Fixed — FINDINGS.md duplicate section keys (H616)
+- Repaired the seven accidentally duplicated `§N` citation keys found by the
+  H604 fact-check: the later twin of each pair renumbered to a fresh key with a
+  one-line tombstone under the renamed heading — §60→§70 (pwg_ru TM composite
+  grade), §62→§71 (PWG case-government census), §63→§72 (VedaWeb `id_gra` =
+  GRA `<L>`), §64→§73 (VedaWeb license fields), §65→§74 (ls-graph degeneracy
+  for MW), §69→§75 (Devībhāgavata not on GRETIL). The second "§56" was a
+  verbatim double-append of §68 (spellchecker landscape, PRs #305/#307) and was
+  removed with a tombstone under §68. Header max-number marker corrected
+  (§65→§75); stale citations of the renamed twins repointed in
+  [`STALENESS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/STALENESS.md),
+  [`ROADMAP_VEDAWEB_REUSE.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_VEDAWEB_REUSE.md),
+  [`RussianTranslation/PIPELINE_HISTORY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_HISTORY.md),
+  [`RussianTranslation/USE_CASES.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/USE_CASES.md)
+  and `RussianTranslation/.ai_state.md`; duplication caveats dropped from
+  [`docs/manuals/MAINTAINER_MANUAL.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/MAINTAINER_MANUAL.md) §3
+  and [`docs/manuals/RESEARCHER_MANUAL.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RESEARCHER_MANUAL.md) §5;
+  metadoc backlog item 4 closed.
+
 ## [1.5.0] - 2026-07-11
 
 ### Added — audience manuals

--- a/docs/manuals/MAINTAINER_MANUAL.md
+++ b/docs/manuals/MAINTAINER_MANUAL.md
@@ -60,10 +60,7 @@ each append-only:
 
 - [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
   — the empirical registry. **Schema per finding:** a `### §N` heading (the
-  number is the stable citation, never deliberately reused/shifted —
-  append-only; caveat: a 11-07-2026 audit found seven accidentally duplicated
-  §N pairs (§56/§60/§62–65/§69), pending repair — when citing, quote the claim
-  text alongside the §N), the
+  number is the stable citation, never reused/shifted — append-only), the
   **claim** in bold with a colour dot (🔴 important · 🟠 medium · 🟡 minor),
   then `Evidence:` (a number / file+line), `Implication:` (what to do), and a
   blockquoted `Source` line tagged `— repo · date`. **No HTML, ever** — use a

--- a/docs/manuals/README.meta.md
+++ b/docs/manuals/README.meta.md
@@ -36,10 +36,11 @@ index/hard-rules at root.
    `.ai_state.md` first.
 3. ⬜ Consider an external-contributor manual (how to submit corrections
    upstream) once the Cologne batched-PR cadence stabilizes.
-4. ⬜ FINDINGS.md carries seven accidentally duplicated `§N` pairs
-   (§56, §60, §62–65, §69 — H604 fact-check, 11-07-2026): repair by renaming
-   the *later* twin of each pair to a fresh number and leaving a tombstone
-   note, then drop the caveat lines from MAINTAINER §3 / RESEARCHER §5.
+4. ✅ FINDINGS.md carried seven accidentally duplicated `§N` pairs
+   (§56, §60, §62–65, §69 — H604 fact-check, 11-07-2026). Repaired 11-07-2026
+   (H616): later twins renumbered §70–§75 with tombstone notes (the later
+   "§56" was a verbatim copy of §68 and was removed), stale citations
+   repointed, caveat lines dropped from MAINTAINER §3 / RESEARCHER §5.
 
 ## Known limitations
 
@@ -54,5 +55,6 @@ index/hard-rules at root.
 |---|---|---|
 | 10-07-2026 | Set created (4 manuals + router + root pair) | H479/H535 |
 | 11-07-2026 | H604 consolidation (see Provenance) | H604 |
+| 11-07-2026 | FINDINGS duplicate-§N caveat dropped from MAINTAINER §3 / RESEARCHER §5 after the H616 key repair; backlog item 4 closed | H616 |
 
 _Dr. Mārcis Gasūns_

--- a/docs/manuals/RESEARCHER_MANUAL.md
+++ b/docs/manuals/RESEARCHER_MANUAL.md
@@ -97,9 +97,7 @@ working notes/reviews live in
 
 The nine root registries are not bookkeeping — they *are* the reproducibility
 apparatus a DSH/lexicography reviewer asks for and rarely gets. Cite findings by
-their stable `§N` number (caveat: an 11-07-2026 audit found seven accidentally
-duplicated `§N` pairs pending repair — quote the claim text alongside the `§N`;
-the sections cited below are unique):
+their stable `§N` number:
 
 - [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
   — measured, evidence-backed facts (live dashboard at

--- a/epistemic_dashboard/epistemic.json
+++ b/epistemic_dashboard/epistemic.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-10T16:35:32Z",
+ "generated_at": "2026-07-11T07:58:45Z",
  "side": "Sanskrit-data",
  "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
  "core": {
@@ -9,7 +9,7 @@
   "total": 75,
   "by_importance": {
    "3": 14,
-   "2": 43,
+   "2": 42,
    "1": 11
   },
   "by_origin": {
@@ -22,15 +22,15 @@
    "key": "ASSUMPTIONS",
    "act": "relying on an unproven premise",
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md",
-   "total": 6,
+   "total": 7,
    "by_importance": {
-    "3": 4,
+    "3": 5,
     "2": 2,
     "1": 0
    },
    "by_origin": {
     "auto": 0,
-    "human": 6
+    "human": 7
    },
    "categories": 3,
    "interlinks": 6,
@@ -70,6 +70,12 @@
      "importance": 2,
      "origin": "human",
      "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#6-a-verified-correction-queue-stays-valid-until-filed"
+    },
+    {
+     "title": "§7. «Рамаяна. Книга 5. Сундараканда 2026.html» — финальная редакция перевода",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#7-рамаяна-книга-5-сундараканда-2026html--финальная-редакция-перевода"
     }
    ]
   },
@@ -126,15 +132,15 @@
    "key": "GAPS",
    "act": "not-yet-knowing (the frontier)",
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md",
-   "total": 11,
+   "total": 12,
    "by_importance": {
-    "3": 0,
+    "3": 1,
     "2": 4,
     "1": 7
    },
    "by_origin": {
     "auto": 5,
-    "human": 6
+    "human": 7
    },
    "categories": 3,
    "interlinks": 11,
@@ -204,6 +210,12 @@
      "importance": 1,
      "origin": "auto",
      "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#11-dcs-verb-form-frequency-prelim-is-flagged-preliminary-never-finalised"
+    },
+    {
+     "title": "§12. Сундараканда: стихи песней 2 и 28 — пропуск оцифровки или воля переводчика?",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#12-сундараканда-стихи-песней-2-и-28--пропуск-оцифровки-или-воля-переводчика"
     }
    ]
   },
@@ -211,15 +223,15 @@
    "key": "DEAD_ENDS",
    "act": "abandoning an approach",
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md",
-   "total": 9,
+   "total": 10,
    "by_importance": {
     "3": 7,
-    "2": 2,
+    "2": 3,
     "1": 0
    },
    "by_origin": {
     "auto": 1,
-    "human": 8
+    "human": 9
    },
    "categories": 4,
    "interlinks": 9,
@@ -277,6 +289,12 @@
      "importance": 3,
      "origin": "human",
      "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#8-resolving-pwgmw-hariv-citations-against-dcs-to-find-shared-erroneous-citations--abandoned"
+    },
+    {
+     "title": "§8. Gemini-OCR санскритских комментариев Сундараканды — вытеснен скрейпом",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#8-gemini-ocr-санскритских-комментариев-сундараканды--вытеснен-скрейпом"
     }
    ]
   },
@@ -453,16 +471,16 @@
   "unknown": 0
  },
  "totals": {
-  "rows": 115,
+  "rows": 118,
   "auto": 72,
-  "human": 43,
+  "human": 46,
   "by_importance": {
-   "3": 17,
-   "2": 24,
+   "3": 19,
+   "2": 25,
    "1": 8
   },
   "layers": 7,
-  "entry_rows": 49,
+  "entry_rows": 52,
   "candidates": 6,
   "categories": 20,
   "interlinks": 49,

--- a/findings_dashboard/data.json
+++ b/findings_dashboard/data.json
@@ -1,12 +1,12 @@
 {
- "generated_at": "2026-07-10T16:35:32Z",
+ "generated_at": "2026-07-11T07:58:14Z",
  "stale_days_threshold": 180,
  "counts": {
   "total": 75,
   "by_importance": {
-   "2": 43,
-   "1": 11,
-   "None": 7,
+   "2": 39,
+   "1": 10,
+   "None": 12,
    "3": 14
   },
   "stale": 0
@@ -18,7 +18,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-29",
-   "age_days": 11,
+   "age_days": 12,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#1-whitney-accent-mobility-rules-are-machine-encodable"
   },
   {
@@ -27,7 +27,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-14",
-   "age_days": 26,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling"
   },
   {
@@ -36,7 +36,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-13",
-   "age_days": 27,
+   "age_days": 28,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#3-the-warnemyr-scrape-union-smears-homonym-classes"
   },
   {
@@ -45,7 +45,7 @@
    "section": "Grammar & morphology data",
    "importance": 1,
    "evidence_date": "2026-06-29",
-   "age_days": 11,
+   "age_days": 12,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#4-pwg-nominal-grammar-compresses-into-335-paradigm-tokens"
   },
   {
@@ -54,7 +54,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 8,
+   "age_days": 9,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#42-whitney-self-contradicts-on-derivative-ī-stem-genpl-accent"
   },
   {
@@ -63,7 +63,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-07-05",
-   "age_days": 5,
+   "age_days": 6,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents"
   },
   {
@@ -72,7 +72,7 @@
    "section": "Grammar & morphology data",
    "importance": null,
    "evidence_date": "2026-07-07",
-   "age_days": 3,
+   "age_days": 4,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian"
   },
   {
@@ -81,7 +81,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 16,
+   "age_days": 17,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#5-the-parallel-corpus-rarely-attests-prefixed-verb-forms"
   },
   {
@@ -90,7 +90,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 16,
+   "age_days": 17,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#6-no-printed-frequency-dictionary-of-sanskrit-exists"
   },
   {
@@ -99,7 +99,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 16,
+   "age_days": 17,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations"
   },
   {
@@ -108,7 +108,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 25,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#8-unaccented-dcs-cannot-distinguish-present-class-i-from-vi"
   },
   {
@@ -117,7 +117,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06-06",
-   "age_days": 34,
+   "age_days": 35,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#9-dcs-occid-and-sent_id-are-not-unique-keys"
   },
   {
@@ -126,7 +126,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-06",
-   "age_days": 34,
+   "age_days": 35,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#10-dcs-ud-tense-marking-conflates-aorist-and-perfect"
   },
   {
@@ -135,7 +135,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-06",
-   "age_days": 34,
+   "age_days": 35,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#11-dcs-2021-and-2026-vintages-are-not-directly-comparable"
   },
   {
@@ -144,7 +144,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-11",
-   "age_days": 29,
+   "age_days": 30,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword"
   },
   {
@@ -153,7 +153,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 1,
    "evidence_date": "2026-07-01",
-   "age_days": 9,
+   "age_days": 10,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#13-sa-ru-glossary-token-coverage-plateaus-at-866-percent"
   },
   {
@@ -162,7 +162,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-01",
-   "age_days": 9,
+   "age_days": 10,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#14-renou-period-state-tagging-covers-770k-entries-in-8-dicts"
   },
   {
@@ -171,7 +171,7 @@
    "section": "Corpus & parallel-text data",
    "importance": null,
    "evidence_date": "2026-07-07",
-   "age_days": 3,
+   "age_days": 4,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards"
   },
   {
@@ -180,7 +180,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-07",
-   "age_days": 3,
+   "age_days": 4,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse"
   },
   {
@@ -189,7 +189,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 16,
+   "age_days": 17,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#15-pwg-encodes-secondary-stems-inline-not-in-div-markup"
   },
   {
@@ -198,7 +198,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 16,
+   "age_days": 17,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes"
   },
   {
@@ -207,7 +207,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 16,
+   "age_days": 17,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#17-pwg-orders-senses-genetically-not-historically"
   },
   {
@@ -216,7 +216,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 16,
+   "age_days": 17,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#18-vedic-citation-density-separates-the-dictionary-traditions"
   },
   {
@@ -225,7 +225,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 25,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#19-skd-and-vcp-carry-essentially-zero-western-markup"
   },
   {
@@ -234,7 +234,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 16,
+   "age_days": 17,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#20-the-ls-source-map-recognises-724-percent-of-pwg-citations"
   },
   {
@@ -243,7 +243,7 @@
    "section": "Dictionary structure & markup",
    "importance": 1,
    "evidence_date": "2026-07-02",
-   "age_days": 8,
+   "age_days": 9,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#21-pwg-citation-occurrences-track-distinct-references"
   },
   {
@@ -252,7 +252,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 14,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#22-mw-has-no-sense-level-div-markup"
   },
   {
@@ -261,7 +261,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 25,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#23-apte-is-three-dictionaries-keys-differ-stem-vs-nominative"
   },
   {
@@ -270,7 +270,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-07",
-   "age_days": -5,
+   "age_days": -4,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#24-about-9-percent-of-typo-corrections-are-collisions"
   },
   {
@@ -279,7 +279,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07",
-   "age_days": -5,
+   "age_days": -4,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#25-a-verified-correction-queue-decays-against-live-csl-orig"
   },
   {
@@ -288,7 +288,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-13",
-   "age_days": 27,
+   "age_days": 28,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#26-citation-density-is-register-bound-not-comparable-raw"
   },
   {
@@ -297,7 +297,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-15",
-   "age_days": 25,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#27-sense-granularity-is-a-family-trait-not-a-diachronic-trend"
   },
   {
@@ -306,7 +306,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-03",
-   "age_days": 37,
+   "age_days": 38,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#28-mw-inherited-the-pwg-apparatus-skeleton-not-its-prose"
   },
   {
@@ -315,7 +315,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 14,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index"
   },
   {
@@ -324,7 +324,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-15",
-   "age_days": 25,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#30-body-text-headword-mining-is-a-dead-end-386-percent-precision"
   },
   {
@@ -333,7 +333,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 16,
+   "age_days": 17,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#31-detector-precision-stratifies-by-digitization-quality"
   },
   {
@@ -342,7 +342,7 @@
    "section": "Dictionary structure & markup",
    "importance": 1,
    "evidence_date": "2026-06-17",
-   "age_days": 23,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#32-correction-events-concentrate-in-sense-text"
   },
   {
@@ -351,7 +351,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#46-twelve-years-of-corrections-cover-only-1014--of-the-estimated-error-population"
   },
   {
@@ -360,7 +360,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-07-05",
-   "age_days": 5,
+   "age_days": 6,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1--pwg-is-not-the-sole-spine-of-the-local-layer-universe"
   },
   {
@@ -369,7 +369,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 14,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#33-indigenous-dictionaries-agree-on-derivation-wilson-is-the-outlier"
   },
   {
@@ -378,7 +378,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 14,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#34-the-e-abbreviation-tag-is-polysemous-across-dicts"
   },
   {
@@ -387,7 +387,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 14,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#35-root-recovery-tiers-err-on-root-form-not-identity"
   },
   {
@@ -396,7 +396,7 @@
    "section": "Encoding & normalization",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 25,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily"
   },
   {
@@ -405,7 +405,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06",
-   "age_days": 25,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#37-bom-state-is-inconsistent-across-exports"
   },
   {
@@ -414,7 +414,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06-27",
-   "age_days": 13,
+   "age_days": 14,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#38-injected-boms-crash-the-hw-record-parser"
   },
   {
@@ -423,7 +423,7 @@
    "section": "Encoding & normalization",
    "importance": 1,
    "evidence_date": "2026-06",
-   "age_days": 25,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#39-devanagari_to_slp1-mis-routes-retroflex-la"
   },
   {
@@ -432,7 +432,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 14,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#40-gloss-language-spelling-drift-tracks-reform-type-not-age"
   },
   {
@@ -441,7 +441,7 @@
    "section": "Encoding & normalization",
    "importance": 1,
    "evidence_date": "2026-07-05",
-   "age_days": 5,
+   "age_days": 6,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-practical-russian-transcription-of-sanskrit-names-has-no-safe-reverse-transliteration"
   },
   {
@@ -450,7 +450,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 8,
+   "age_days": 9,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#41-the-sanskrit-dictionary-platform-landscape-probed-live"
   },
   {
@@ -459,7 +459,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#47-heritage-data-is-acquirable-despite-the-anubis-wall--via-a-github-mirror-the-morphology-xml-is-not-in-it"
   },
   {
@@ -468,7 +468,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 8,
+   "age_days": 9,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#43-skdvcp-sensecitation-fusion-is-a-record-type-effect-not-a-dictionary-level-one"
   },
   {
@@ -477,7 +477,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 8,
+   "age_days": 9,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#44-raw-latin-string-tallies-over-gloss-text-include-etymological-false-positives-bopp-lacks-yabh"
   },
   {
@@ -486,7 +486,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 8,
+   "age_days": 9,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#45-siglum-prefix-families-routinely-bundle-several-distinct-works-the-diacritic-stripping-fold-has-poisoned-keys"
   },
   {
@@ -495,7 +495,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#48-vedaweb-20s-resource-export-is-an-async-task-behind-a-pickup-key-not-a-direct-get--and-the-server-went-unresponsive-mid-attempt"
   },
   {
@@ -504,7 +504,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#49-mwheritage-coverage-highlighting-is-a-duplicate-anchor-pattern-not-a-css-class--and-the-mirrors-current-dictionary-is-a-different-scope-asset-than-the-2014-reader-stem-list"
   },
   {
@@ -513,7 +513,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#50-cdsl-display-paths-are-not-uniformly-2020web--and-two-new-digitizations-landed-in-june-2026"
   },
   {
@@ -522,7 +522,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#51-huet-correspondence-predates-this-session-2021--the-morphology-xml-gate-was-already-resolved-in-writing-direct-download-urls-recovered"
   },
   {
@@ -531,7 +531,7 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#52-heritage-vs-kosha-forms-diff-the-small-raw-overlap-is-mostly-convention--model-difference-and-disagreements-are-two-thirds-lemmatization-policy-not-error"
   },
   {
@@ -540,7 +540,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#53-the-wil-etymology-extractions-affix-field-is-half-noise--wilson-outlier-figures-are-substantially-a-measurement-artifact"
   },
   {
@@ -549,7 +549,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#56-dicos-entry-anchors-nest-three-structural-roles-under-one-html-class--only-one-is-a-true-entry-boundary"
   },
   {
@@ -558,7 +558,7 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#55-gen_opt_harness2py-output-budget-coarser-wins-on-both-knobs-in-opposite-directions"
   },
   {
@@ -567,7 +567,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#57-samskrtamruz-is-id-addressed-with-no-name-lookup--deep-linking-needs-a-scraped-rootid-table-8-primer-basic-roots-are-absent"
   },
   {
@@ -576,7 +576,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#58-pwg-ru-promoted-store-has-input-level-provenance-but-old-ru-rows-lacked-exact-model-versions"
   },
   {
@@ -589,13 +589,13 @@
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#59-böhtlingks-indische-sprüche-both-editions-already-fully-digitized-in-sanskrit-lexicon-scans-not-just-sanskrit-lexicon"
   },
   {
-   "n": 60,
+   "n": 70,
    "title": "pwg_ru TM composite grade: A is consensus-gated (5.7%), and a reference-free surface QE cannot detect wrong-sense",
    "section": "External platforms & services",
-   "importance": 1,
+   "importance": null,
    "evidence_date": "2026-07-03",
-   "age_days": 7,
-   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-pwg_ru-tm-composite-grade-a-is-consensus-gated-57-and-a-reference-free-surface-qe-cannot-detect-wrong-sense"
+   "age_days": 8,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#70-pwg_ru-tm-composite-grade-a-is-consensus-gated-57-and-a-reference-free-surface-qe-cannot-detect-wrong-sense"
   },
   {
    "n": 61,
@@ -603,53 +603,44 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-07",
-   "age_days": 3,
+   "age_days": 4,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#61-the-reverse-dictionarys-30-sources-split-18-pd-vs-10-in-copyright--the-merged-headword-list-is-not-automatically-publishable"
   },
   {
-   "n": 62,
+   "n": 71,
    "title": "PWG marks case government explicitly ≈3,853 times across ≈3,222 senses — a deterministic census, not an estimate",
    "section": "External platforms & services",
-   "importance": 2,
+   "importance": null,
    "evidence_date": "2026-07-08",
-   "age_days": 2,
-   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-pwg-marks-case-government-explicitly-3853-times-across-3222-senses--a-deterministic-census-not-an-estimate"
+   "age_days": 3,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#71-pwg-marks-case-government-explicitly-3853-times-across-3222-senses--a-deterministic-census-not-an-estimate"
   },
   {
-   "n": 63,
+   "n": 72,
    "title": "VedaWeb's `id_gra` token field IS the Grassmann `<L>` entry number — no fuzzy text-matching needed for a GRA↔VedaWeb crosswalk",
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-08",
-   "age_days": 2,
-   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vedawebs-id_gra-token-field-is-the-grassmann-l-entry-number--no-fuzzy-text-matching-needed-for-a-gravedaweb-crosswalk"
+   "age_days": 3,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#72-vedawebs-id_gra-token-field-is-the-grassmann-l-entry-number--no-fuzzy-text-matching-needed-for-a-gravedaweb-crosswalk"
   },
   {
-   "n": 64,
+   "n": 73,
    "title": "VedaWeb 2.0's \"CC BY 4.0 for everything\" claim is not machine-confirmed — only 2/36 catalog resources carry an explicit license field",
    "section": "External platforms & services",
-   "importance": 2,
+   "importance": null,
    "evidence_date": "2026-07-08",
-   "age_days": 2,
-   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-vedaweb-20s-cc-by-40-for-everything-claim-is-not-machine-confirmed--only-236-catalog-resources-carry-an-explicit-license-field"
+   "age_days": 3,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#73-vedaweb-20s-cc-by-40-for-everything-claim-is-not-machine-confirmed--only-236-catalog-resources-carry-an-explicit-license-field"
   },
   {
-   "n": 65,
+   "n": 74,
    "title": "The ls-graph citation matrix is degenerate for MW — its top abbreviations sit unresolved; use the citation-apparatus siglum matrix for cross-dict citation profiles",
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-08",
-   "age_days": 2,
-   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-the-ls-graph-citation-matrix-is-degenerate-for-mw--its-top-abbreviations-sit-unresolved-use-the-citation-apparatus-siglum-matrix-for-cross-dict-citation-profiles"
-  },
-  {
-   "n": 56,
-   "title": "The Sanskrit spellchecker landscape: one dormant demo, one license-unsettled 543k wordlist, no occupant",
-   "section": "External platforms & services",
-   "importance": 2,
-   "evidence_date": "2026-07-10",
-   "age_days": 0,
-   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#56-the-sanskrit-spellchecker-landscape-one-dormant-demo-one-license-unsettled-543k-wordlist-no-occupant"
+   "age_days": 3,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#74-the-ls-graph-citation-matrix-is-degenerate-for-mw--its-top-abbreviations-sit-unresolved-use-the-citation-apparatus-siglum-matrix-for-cross-dict-citation-profiles"
   },
   {
    "n": 66,
@@ -657,7 +648,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-10",
-   "age_days": 0,
+   "age_days": 1,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#66-the-dcs-ql-frequency-workbooks-slp1-and-length-columns-are-truncated-at-ṣṭhḍh-clusters"
   },
   {
@@ -666,16 +657,16 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-10",
-   "age_days": 0,
+   "age_days": 1,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#67-in-pwg-article-size-dwarfs-every-parametric-statistic-you-can-extract-from-the-entry"
   },
   {
    "n": 68,
    "title": "The Sanskrit spellchecker landscape: one dormant demo, one license-unsettled 543k wordlist, no occupant",
    "section": "External platforms & services",
-   "importance": 2,
+   "importance": null,
    "evidence_date": "2026-07-10",
-   "age_days": 0,
+   "age_days": 1,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#68-the-sanskrit-spellchecker-landscape-one-dormant-demo-one-license-unsettled-543k-wordlist-no-occupant"
   },
   {
@@ -684,8 +675,17 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-10",
-   "age_days": 0,
+   "age_days": 1,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#69-hand-transcribed-telemetry-cannot-adjudicate-code-vs-infra--and-a-local-only-ledger-silently-swaps-your-denominator"
+  },
+  {
+   "n": 75,
+   "title": "The full Devībhāgavata-purāṇa Sanskrit is NOT on GRETIL — only the Devigita fragment; the complete mūla lives on sanskritdocuments.org without `DbhP_` markers",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": "2026-07-10",
+   "age_days": 1,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#75-the-full-devībhāgavata-purāṇa-sanskrit-is-not-on-gretil--only-the-devigita-fragment-the-complete-mūla-lives-on-sanskritdocumentsorg-without-dbhp_-markers"
   }
  ]
 }

--- a/findings_dashboard/timeseries.json
+++ b/findings_dashboard/timeseries.json
@@ -1,7 +1,7 @@
 {
  "snapshots": [
   {
-   "date": "2026-07-10",
+   "date": "2026-07-11",
    "source": "build",
    "metrics": {
     "dcs_cdsl_linkage_pct": null,
@@ -31,9 +31,9 @@
    "registry": {
     "total": 75,
     "by_importance": {
-     "2": 43,
-     "1": 11,
-     "None": 7,
+     "2": 39,
+     "1": 10,
+     "None": 12,
      "3": 14
     },
     "stale": 0


### PR DESCRIPTION
Repairs the seven accidentally duplicated `### §N` citation keys in [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) found by the H604 fact-check (11-07-2026), per the registry contract in [docs/manuals/MAINTAINER_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/MAINTAINER_MANUAL.md) §3 (§N is a stable, never-reused key).

## What changed

**Renumbered later twins** (earlier twin of each pair keeps its number; each renamed heading carries a one-line tombstone "was §N until 11-07-2026, renumbered — duplicate key"):

| Old | New | Finding (later twin) | Earlier twin keeps |
|---|---|---|---|
| §60 | **§70** | pwg_ru TM composite grade (H215 Slice 2) | Russian transcription, 05-07 |
| §62 | **§71** | PWG case-government census (H335) | varga distribution, 07-07 |
| §63 | **§72** | VedaWeb `id_gra` = GRA `<L>` (H097) | vidyut dhātupāṭha, 07-07 |
| §64 | **§73** | VedaWeb license fields (H098/H359) | PW-only headwords, 05-07 |
| §65 | **§74** | ls-graph degeneracy for MW (H342) | DeepSeek grounding, 07-07 |
| §69 | **§75** | DBhP not on GRETIL (H534, PR #322) | launch telemetry (H462, PR #309, earlier merge) |

**§56 special case:** the later "§56" (spellchecker landscape) is a **byte-identical double-append of §68** — the same H452 finding was committed twice ([PR #305](https://github.com/gasyoun/SanskritLexicography/pull/305) as §56, [PR #307](https://github.com/gasyoun/SanskritLexicography/pull/307) as §68). Renumbering it would have minted a third number for one finding, so the copy is removed and a tombstone under §68 records it. §56 stays the DICO-anchors finding (03-07).

**Citation sweep** (checked repo + the seven sibling registries + docs/manuals/ + Uprava hubs): repointed the stale later-twin citations in [STALENESS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/STALENESS.md) (§60 tm-grade row), [ROADMAP_VEDAWEB_REUSE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_VEDAWEB_REUSE.md) (§63/§64), [RussianTranslation/PIPELINE_HISTORY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_HISTORY.md), [RussianTranslation/USE_CASES.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/USE_CASES.md), `RussianTranslation/.ai_state.md`, and the FINDINGS index anchors. All other citations (ASSUMPTIONS, CONTRADICTIONS, GAPS, GLOSSARY, RECIPES) point at the earlier twins and are untouched. Uprava-side citations (PROJECT_INTERLINKS, GTD, handoffs registry) are repointed in a follow-up push to that private repo.

**Follow-through:** header max-number marker corrected (§65→§75, was already stale); duplication caveat sentences dropped from MAINTAINER_MANUAL §3 and RESEARCHER_MANUAL §5; backlog item 4 in [docs/manuals/README.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/README.meta.md) closed; both dashboards regenerated (`findings_dashboard/data.json`: 75 findings, unique keys verified 1..75 with no gaps; `epistemic_dashboard/epistemic.json`); changelog [1.5.1].

Handoff: [H616](https://github.com/gasyoun/Uprava/blob/main/handoffs/H616-Fable_SanskritLexicography_findings-duplicate-section-key-repair_11.07.26.md). Noted in passing, NOT fixed here (out of scope): §70''s Source block appears mis-pasted from §59 (Indische Sprüche verification text on a TM-grading finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)