### PR TITLE
docs: reviews-of-the-dictionaries bibliography (H731)

### DIFF
--- a/DICTIONARY_REVIEWS_BIBLIOGRAPHY.md
+++ b/DICTIONARY_REVIEWS_BIBLIOGRAPHY.md
@@ -1,0 +1,160 @@
+# Sanskrit dictionaries — published scholarly reviews (bibliography)
+
+_Created: 11-07-2026 · Last updated: 11-07-2026_
+
+A collected inventory of **published scholarly reviews** (English *review*, German
+*Rezension / Besprechung / Anzeige*, French *compte rendu*) **of** the major Sanskrit
+dictionaries — the Cologne-digitised set (see
+[FEATURES_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md))
+**plus the non-Cologne etymological dictionaries** (Mayrhofer's KEWA and EWA, Turner's
+CDIAL, Uhlenbeck) that the Cologne corpus does not carry.
+
+This is reviews **of** the dictionaries — the scholarly reception record — not reviews
+*by* the lexicographers, and not the referee reviews of our own papers under
+[papers/](https://github.com/gasyoun/SanskritLexicography/tree/master/papers).
+
+## How to read the confidence column
+
+- **HIGH** — a concrete bibliographic record (reviewer + venue + volume + year + pages, and
+  usually a DOI/JSTOR id) was opened directly on Cambridge Core, JSTOR, ProQuest, De Gruyter,
+  Springer, Persée or a library JPortal. Safe to cite after a final spot-check of pagination.
+- **LOW** — the review is *believed* to exist (a real reviewer, or a De Gruyter/ProQuest stub
+  that would not render its author), but no locatable record pinned the exact
+  volume/pages. **Do not cite a LOW row without independent confirmation.**
+- A blank / "gap" row is a genuine negative result for this web-search pass — it does **not**
+  mean no review was ever published (most 19th-c fascicles were noticed in ZDMG / GGA /
+  *Literarisches Centralblatt* in print), only that none was retrievable online here.
+
+No citation below was invented to fill a gap. Method: four parallel web-research passes
+(Opus 4.8 `claude-opus-4-8`, 11-07-2026), one per cluster.
+
+---
+
+## Cluster A — etymological / comparative dictionaries (non-Cologne)
+
+The richest review record, and the reason this inventory exists as more than a Cologne
+appendix. Mayrhofer holds written permission for KEWA/EWA content use
+(see the org GTD @DO — quote the email terms before publication-tier use).
+
+### KEWA — Manfred Mayrhofer, *Kurzgefaßtes etymologisches Wörterbuch des Altindischen* (Heidelberg: Winter, 1953–1980, 4 vols)
+
+Reviewed fascicle-by-fascicle over ~27 years; the list below is a start, not the complete record.
+
+| Reviewer | Venue, vol. (year), pp. | Reviewed | Lang. | Confidence |
+|---|---|---|---|---|
+| M. B. Emeneau | *Language* 35.2 (1959), 323–328 · [JSTOR 410543](https://doi.org/10.2307/410543) | Fasc. 11–12 | EN | **HIGH** |
+| Paul Tedesco | *JAOS* 80.4 (1960), 360–366 · "Notes to Mayrhofer's Etymological Sanskrit Dictionary" · [JSTOR 595886](https://www.jstor.org/stable/595886) | early fascicles | EN | **HIGH** (verify vol./p.) |
+| Robert Birwé | *Indogermanische Forschungen* 64 (1959), 108 | Bd. I (Anzeige) | DE | **HIGH** |
+| Robert Birwé | *Indogermanische Forschungen* 69 (1964), 148 | Lief. 15–17 | DE | **HIGH** |
+| T. Burrow | *Kratylos* 15 (1970 [1972]), 51–56 | later fasc. / Bd. III | EN | **LOW** — exact vol./pp. unverified |
+
+### EWA — Manfred Mayrhofer, *Etymologisches Wörterbuch des Altindoarischen* (Heidelberg: Winter, 1986–2001, 3 vols)
+
+| Reviewer | Venue, vol. (year), pp. | Reviewed | Lang. | Confidence |
+|---|---|---|---|---|
+| F. B. J. Kuiper | *Indo-Iranian Journal* 34 (1991), 105–120 · "The new 'Mayrhofer'" · [DOI 10.1007/BF00176055](https://doi.org/10.1007/BF00176055) | Bd. I, early fasc. | EN | **HIGH** |
+| J. C. Wright | *BSOAS* 53.3 (1990), 534–536 · [DOI 10.1017/S0041977X0015164X](https://doi.org/10.1017/S0041977X0015164X) | Bd. I, Lief. 1–6 | EN | **HIGH** |
+| Paul Thieme | *BSOAS* 57.2 (1994), 321–328 · review-article "On M. Mayrhofer's EWA" · [DOI 10.1017/S0041977X00024885](https://doi.org/10.1017/S0041977X00024885) | Bd. I | EN | **HIGH** |
+| Winfred P. Lehmann | *General Linguistics* 29.3 (1989), 206 | early fasc. (notice) | EN | **HIGH** |
+| Jaroslav Vacek | *Archív Orientální* 57 (1989), 280–281 | I. Band | EN | **HIGH** |
+| F. B. J. Kuiper | *Indo-Iranian Journal* 38.3 (1995), 239 ff. · "On a hunt for 'possible' objections" | rejoinder | EN | **LOW** — pages unverified |
+
+_Not found:_ no concrete Lubotsky / Werba / Hoffmann / Schlerath EWA review was confirmed this
+pass (a *Kratylos* record would not open) — flagged as not-found, not as non-existent.
+
+### CDIAL — Ralph L. Turner, *A Comparative Dictionary of the Indo-Aryan Languages* (London: OUP, 1962–1966; Indexes 1969; Addenda 1985)
+
+| Reviewer | Venue, vol. (year), pp. | Reviewed | Lang. | Confidence |
+|---|---|---|---|---|
+| T. Burrow | *JRAS* 95.3–4 (1963), 285–286 · [DOI 10.1017/S0035869X00122427](https://doi.org/10.1017/S0035869X00122427) | Fasc. I | EN | **HIGH** |
+| S. M. Katre | *BSOAS* 26.3 (1963), 662–664 | Fasc. I–II | EN | **HIGH** |
+| V. Miltner | *Archív Orientální* 32 (1964), 330–332 | early fasc. | EN | **HIGH** |
+| W. P. Schmid | *Indogermanische Forschungen* 70 (1965), 221 | Fasc. V–VI (notice) | DE | **HIGH** |
+| V. Miltner | *Archív Orientální* 34 (1966), 135–139 | further fasc. | EN | **HIGH** |
+| Henry M. Hoenigswald | *Journal of Asian Studies* 26.4 (1967), 747–748 · [DOI 10.2307/2051298](https://doi.org/10.2307/2051298) | complete work | EN | **HIGH** |
+
+_To pin:_ a *JRAS* review of the *Indexes* (1969) and a *BSOAS* notice of the *Addenda* (ed.
+J. C. Wright, 1985) both exist; citations not yet captured.
+
+### Uhlenbeck — C. C. Uhlenbeck, *Kurzgefasstes etymologisches Wörterbuch der altindischen Sprache* (Amsterdam, 1898–1899)
+
+| Reviewer | Venue, vol. (year), pp. | Lang. | Confidence |
+|---|---|---|---|
+| (not identified) | *Indogermanische Forschungen* — Anzeiger, Bd. 12 (1901) · [DOI 10.1515/if-1901-0109](https://doi.org/10.1515/if-1901-0109) | DE | **LOW** — existence HIGH, reviewer/pp. unverified |
+
+_Largely undocumented in this pass._ Best next source: the biographical study "C. C. Uhlenbeck's
+work on Sanskrit" (HAL `halshs-01917910`).
+
+---
+
+## Cluster B — the great 19th-century German-language dictionaries (Cologne)
+
+| Dict | Reviewer | Venue, vol. (year), pp. | Lang. | Confidence |
+|---|---|---|---|---|
+| **PW / PWG** — Böhtlingk & Roth, *Sanskrit-Wörterbuch* (Großes Petersburger Wb.), 7 vols, St. Petersburg 1855–1875 | Friedrich von Spiegel | *Jenaer Literaturzeitung* 2, Nr. 24 (1875), 413–415 (ThULB Jena JPortal `jparticle_00153600`) | DE | **HIGH** |
+| PW / PWG | W. D. Whitney | (venue unpinned) — Whitney's "spirited reply to Müller's criticisms on the Böhtlingk-Roth Dictionary" | EN | **LOW** — reviewer real, citation not located |
+| **GRA** — Hermann Grassmann, *Wörterbuch zum Rig-Veda*, Leipzig 1873 | Charles R. Lanman | *Jenaer Literaturzeitung* 2, Nr. 52 (1875), 915–917 (JPortal `jparticle_00217462`) | DE | **HIGH** |
+| **SCH** — Richard Schmidt, *Nachträge zum Sanskrit-Wörterbuch von Otto Böhtlingk*, Leipzig 1928 | L. D. Barnett | *JRAS* 61.3 (1929), 629 · "Indica" notice · [DOI 10.1017/S0035869X00151834](https://doi.org/10.1017/S0035869X00151834) | EN | **HIGH** |
+| **PWK** — Otto Böhtlingk, *Sanskrit-Wörterbuch in kürzerer Fassung*, St. Petersburg 1879–1889 | — | nothing verifiable found (JLZ had ceased; fascicles very likely noticed in ZDMG in print) | — | gap |
+| **CCS** — Carl Cappeller, *Sanskrit-Wörterbuch* (German), Straßburg 1887 | — | nothing verifiable found (expected: ZDMG / *Deutsche Litteraturzeitung* / *Lit. Centralblatt* / Bezzenberger's Beiträge) | — | gap |
+
+---
+
+## Cluster C — the Sanskrit–English / English–Sanskrit school dictionaries (Cologne)
+
+| Dict | Reviewer | Venue, vol. (year), pp. | Lang. | Confidence |
+|---|---|---|---|---|
+| **MW** — Monier-Williams, *A Sanskrit-English Dictionary*, new ed., Oxford 1899 | Maurice Bloomfield | *American Journal of Philology* 21.3 (1900), 323–327 · [JSTOR 287725](https://doi.org/10.2307/287725) | EN | **HIGH** |
+| MW (modern *study*, not a review) | R. Grünendahl et al. | *ZDMG* 170.1 (2020), 107–117 · "Woher hat er das? Zum Charakter des ‚Sanskrit-English Dictionary' von Monier-Williams" (MW's dependence on the Petersburg lexicons) | DE | **HIGH** (as study) |
+| **MD** — A. A. Macdonell, *A Practical Sanskrit Dictionary* (1924 OUP reissue) | R. L. Turner | *BSOS* 3.3 (1924), 594–595 · [DOI 10.1017/S0041977X00148839](https://doi.org/10.1017/S0041977X00148839) | EN | **HIGH** |
+| MD (1924 ed.) | R. Fick | *Orientalistische Literaturzeitung* 27 (1924), col. 670 | DE | **HIGH** |
+| **PD** — *Encyclopaedic Dictionary of Sanskrit on Historical Principles* (Deccan College), Poona 1976– | J. C. Wright | *BSOAS* 41.2 (1978), 388–389 · [DOI 10.1017/S0041977X00124826](https://doi.org/10.1017/S0041977X00124826) | EN | **HIGH** (Vol. 1 pts. i–ii) |
+| PD | O. von Hinüber (combined review art.) | *Indo-Iranian Journal* 23 (1981), 41–80 · [DOI 10.1007/BF00974793](https://doi.org/10.1007/BF00974793) | EN | **HIGH** |
+| PD | O. von Hinüber | *Indo-Iranian Journal* 42.2 (1999), 157–163 · [DOI 10.1023/A:1003264408418](https://doi.org/10.1023/A:1003264408418) | EN | **HIGH** (later vols.) |
+| **MW72** — Monier-Williams, 1st ed., Oxford 1872 | — | nothing verifiable found (likely *The Academy*, *Athenaeum*, ZDMG) | — | gap |
+| **WIL** — H. H. Wilson, *A Dictionary in Sanscrit and English*, 2nd ed. Calcutta 1832 | — | nothing verifiable found | — | gap |
+| **BEN** — Theodor Benfey, *A Sanskrit-English Dictionary*, London 1866 | — | nothing verifiable found | — | gap |
+| **CAE** — Carl Cappeller, *A Sanskrit-English Dictionary*, Strassburg/London 1891 | — | nothing verifiable found | — | gap |
+| **AP90 / AP** — V. S. Apte, *Practical Sanskrit-English Dictionary*, 1890; rev. Gode & Karve, Poona 1957–59 | — | nothing verifiable found (rev. ed. plausibly in ABORI / IIJ / JAOS) | — | gap |
+
+---
+
+## Cluster D — specialized and traditional lexica (Cologne)
+
+| Dict | Reviewer | Venue, vol. (year), pp. | Lang. | Confidence |
+|---|---|---|---|---|
+| **BHS** — Franklin Edgerton, *Buddhist Hybrid Sanskrit Grammar and Dictionary*, 2 vols, Yale 1953 | John Brough | *BSOAS* 16.2 (1954) — cf. his review-article "The language of the Buddhist Sanskrit texts", *BSOAS* 16.2 (1954), 351–375 | EN | **HIGH** (reviewer+venue+yr; confirm exact pp.) |
+| BHS | Alex Wayman | *JAOS* 85.1 (1965), 111–115 · review-article | EN | **HIGH** |
+| BHS | (author unconfirmed) | *Acta Linguistica Hafniensia* 9.1 (1966) · [DOI 10.1080/03740463.1966.10416017](https://doi.org/10.1080/03740463.1966.10416017) | EN? | **LOW** — review confirmed, author blocked (403) |
+| BHS | Renou / Gonda / de Jong / Lamotte / Shackleton Bailey / H. Smith / Simon / Regamey | — traditionally named as BHS reviewers; **no concrete citation located** — check a print bibliography before entry | — | **LOW** — unverified |
+| **STC** — Stchoupak, Nitti & Renou, *Dictionnaire sanscrit-français*, Paris 1932 | Maurice Leroy | *L'Antiquité classique* 28.2 (1959), 450 · (of a reprint; Persée) | FR | **HIGH** |
+| **BUR** — Burnouf & Leupol (rev. Renou), *Dict. classique sanscrit-français*, 1866 | — | nothing found | — | gap |
+| **SKD** — Rādhākānta Deva, *Śabdakalpadruma*, Calcutta 1886 | — | **cited, not reviewed** — no Western-style review (expected for a traditional Skt–Skt lexicon) | — | negative (expected) |
+| **VCP** — Tāranātha Tarkavācaspati, *Vācaspatyam*, Calcutta 1873–1884 | — | **cited, not reviewed** — same as SKD | — | negative (expected) |
+| **ACC** — Theodor Aufrecht, *Catalogus Catalogorum*, Leipzig 1891–1903 | — | nothing verifiable (likely ZDMG / GGA / OLZ 1890s–1900s in print) | — | gap |
+| **INM** — S. Sörensen, *Index to the Names in the Mahābhārata*, London 1904–1925 | — | nothing verifiable (widely praised later; contemporary JRAS/ZDMG notices likely in print) | — | gap |
+
+---
+
+## Where the gaps are, and how to close them
+
+Web search closes the modern record (post-~1950 journals with DOIs) well but is thin for the
+19th- and early-20th-century German fascicle notices, which is exactly where the Cologne
+dictionaries were reviewed. To complete the record:
+
+1. **Print review indices** — *Orientalische Bibliographie*, *Index Islamicus*, the ZDMG and
+   GGA cumulative registers — the only reliable source for 1855–1930 notices of PW, PWK, GRA,
+   CCS, MW72, WIL, BEN, CAE, ACC, INM.
+2. **Mayrhofer's obituary / Festschrift bibliographies** (e.g. the *JIES* 40 (2012) obituary;
+   *Encyclopaedia Iranica* s.v. "Mayrhofer") — the natural home of the complete
+   fascicle-by-fascicle KEWA/EWA review list; neither PDF would load this pass.
+3. **JSTOR / Persée / De Gruyter full-text back-runs** for the LOW rows above (Tedesco pagination,
+   Burrow *Kratylos*, Uhlenbeck IF-Anzeiger reviewer, the *Acta Linguistica Hafniensia* BHS author).
+
+---
+
+_Auto-generated from four parallel web-research passes (Opus 4.8 `claude-opus-4-8`,
+11-07-2026); every HIGH row corresponds to a bibliographic record opened directly. Verify LOW
+rows before citing._
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Adds `DICTIONARY_REVIEWS_BIBLIOGRAPHY.md` — a collected inventory of **published scholarly reviews of** the major Sanskrit dictionaries.

**Scope:** the Cologne-digitised set (PW/PWG, GRA, SCH, MW, MD, PD, BHS, STC, …) **plus the non-Cologne etymological dictionaries** the corpus does not carry — Mayrhofer's **KEWA** and **EWA**, Turner's **CDIAL**, Uhlenbeck.

**Method:** four parallel read-only web-research passes (Opus 4.8 `claude-opus-4-8`, 11-07-2026), one per cluster, synthesized into one table with a **HIGH/LOW confidence column**. Every HIGH row = a bibliographic record opened directly (Cambridge Core, JSTOR, ProQuest, De Gruyter, Springer, Persée, ThULB JPortal). No citation was invented to fill a gap.

**Highlights:** richest record is the etymological cluster (KEWA: Emeneau/Tedesco/Birwé; EWA: Kuiper/Wright/Thieme/Lehmann/Vacek; CDIAL: Burrow/Katre/Miltner/Schmid/Hoenigswald). Śabdakalpadruma & Vācaspatyam confirmed *cited, not reviewed* (expected for traditional Skt–Skt lexica). Pre-1950 German print notices (PWK, CCS, MW72, WIL, BEN, CAE, Apte, ACC, INM) flagged as gaps to close via print review indices.

Handoff: H731. Isolated worktree off `origin/master` per the repo's concurrency rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)