### PR TITLE
H255: fix no_pwg_scale_plan.py STORE path (dedup was silently broken)

### DIFF
--- a/RussianTranslation/src/pilot/no_pwg_scale_plan.py
+++ b/RussianTranslation/src/pilot/no_pwg_scale_plan.py
@@ -27,7 +27,7 @@ RT = os.path.dirname(os.path.dirname(HERE))
 SRC = os.path.join(RT, 'src')
 OUT = os.path.join(HERE, 'output')
 QUEUE = os.path.join(HERE, 'lexical_cores', 'pwg_miss_backfill_queue.md')
-STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+STORE = os.path.join(SRC, 'pwg_ru_translated.jsonl')
 STILL_NULL = os.path.join(OUT, 'no_pwg_w1.still_null.txt')
 
 if SRC not in sys.path:


### PR DESCRIPTION
## Summary
- `no_pwg_scale_plan.py`'s `STORE` constant pointed at `src/pilot/pwg_ru_translated.jsonl`, but the real translated store lives at `src/pwg_ru_translated.jsonl` (one directory up) — `promoted_headwords_seen` was silently always 0.
- Effect: the planner's freshly-prepared `no_pwg_w03` "still-null tail" window (this session, H255) included 19/29 subcards that were **already promoted** in the store from prior H255 w02/w03 drain sessions (Bagavat/CAyA/GaRwA/SAKA/...). Generating/promoting that window as-is would have wasted tokens re-translating done work and risked duplicate/conflicting store rows.
- Fix: `STORE = os.path.join(SRC, 'pwg_ru_translated.jsonl')`, matching where `promote_final_cards.py` actually writes.

## Test plan
- [x] `python -m py_compile src/pilot/no_pwg_scale_plan.py`
- [x] Verified with a throwaway copy of the real store: `read_store_heads()` now returns 159 promoted heads instead of 0