### PR TITLE
docs: FEATURES_INDEX — register the three census-named uncounted assets (H694)

### DIFF
--- a/FEATURES_INDEX.md
+++ b/FEATURES_INDEX.md
@@ -23,7 +23,7 @@ carries a **real example** and its **first-introduced month/year**.
 > Some linked repos are private ([`github-spine`](https://github.com/gasyoun/github-spine),
 > [`Uprava`](https://github.com/gasyoun/Uprava)).
 
-**At a glance:** 44 dictionaries · 21 interfaces (17 live) · 39 data assets · 14 tools · 4 external stacks.
+**At a glance:** 44 dictionaries · 21 interfaces (17 live) · 42 data assets · 14 tools · 4 external stacks.
 
 **IDs & tiers.** Every asset has a **stable ID** — a **running number within its category**
 (1–N; it does *not* restart at each sub-section) prefixed by a **section letter** (`A`–`F` data ·
@@ -105,6 +105,8 @@ actual files (⚪-tier / *schema*-marked = gitignored / binary / too large, so t
 | 🟡 E38 | `<ls>` citation-frequency graph | Which classical texts each dict quotes via `<ls>`, canonicalized to shared nodes across 11 dicts; 828,505 resolved citations, 912 texts. MW non-text markers filtered | 912 texts · 1,707 edges · ~150 KB | `pwg   Mahābhārata   39130` (edge) · `Mahābhārata   56818   8   MAHĀBHĀRATA; MBh; …` (node) | 07/26 | [csl-atlas/data/citations](https://github.com/sanskrit-lexicon/csl-atlas/tree/main/data/citations) |
 | ⚪ E39 | markup-tag census | Markup-tag frequency census over all 44 csl-orig/v02 dicts: tag × dict counts + per-1,000-entry rates, 96 distinct tags, 17.5M tag hits, with under-marking verdicts ([report](https://github.com/gasyoun/SanskritLexicography/blob/master/data/MARKUP_TAG_CENSUS_CSLORIG_2026.md)) | 671 rows · 18 KB | `sch   29125   <ab>   2   0.07` (an abbreviation-tagging start that never happened) | 07/26 | [data/markup_tag_census.tsv](https://github.com/gasyoun/SanskritLexicography/blob/master/data/markup_tag_census.tsv) |
 | ⚪ E40 | headword overlap matrix + unique counts | Pairwise headword overlap over the 15-dict union (C13): 105 dict pairs with shared/union/Jaccard + per-dict unique inventories ([findings](https://github.com/gasyoun/SanskritLexicography/blob/master/data/HEADWORD_OVERLAP_UNION15_2026.md); MW∩PWG=94,753 — the figure once mislabeled as "the union"; BHS 58.7% unique, CCS 0.6%) | 105 pairs + 15 dicts · 3 KB | `CAE   CCS   27008   40211   0.6717` (the max-Jaccard pair) | 07/26 | [data/headword_overlap_matrix.tsv](https://github.com/gasyoun/SanskritLexicography/blob/master/data/headword_overlap_matrix.tsv) |
+| 🟢 E41 | `correction_events_{all,typed,final}.csv` | Full correction-event log behind E32: 52,498 events (git-mined 28,057 + release diffs), one row per correction with old/new IAST, edit-op trace, corrector, latency; `_typed` adds the empirical error typology, `_final` is the canonical enriched view | 52,498 × 3 views · 178.0 MB | `1a1bd21d909e0bb0, 2014-03-18, form, apes, pain, ghad → ghaṭ (ट् instead of द्)` | 06/26 | [csl-observatory data/](https://github.com/sanskrit-lexicon/csl-observatory/tree/main/observatory/site/src/data) |
+| 🟢 E42 | Kompozity `names.csv` | DCS proper-name compound (samāsa) splits with frequency vectors: surface form; constituent-stem split; part count; total corpus frequency; per-period/text tail | 168,880 · 90.7 MB | `rājendra; rājan indra;2;863;596;14;…` | 07/26 | [VisualDCS Kompozity](https://github.com/gasyoun/VisualDCS/blob/main/derived-data/Kompozity/README.md) |
 
 ### F · Text collections & other
 
@@ -115,6 +117,7 @@ actual files (⚪-tier / *schema*-marked = gitignored / binary / too large, so t
 | ⚪ F35 | do-not-file corpus | 2,297 deliberately non-standard headword spellings across 33 dicts | 2,297 · 25 KB | `ABasvara` (deliberately non-standard — do not "correct") | 06/26 | [do_not_file_suppress.txt](https://github.com/drdhaval2785/SanskritSpellCheck/blob/master/nochange/do_not_file_suppress.txt) |
 | 🟢 F36 | csl-santam Tamil SQLite | MW + Cappeller + Cologne Online Tamil Lexicon combined | 321,620 · 29.9 MB | `source(mwd·cap·otl) · headword · body` (schema; Harvard-Kyoto keys) | 06/15 | [csl-santam](https://github.com/sanskrit-lexicon/csl-santam) |
 | ⚪ F37 | OCR'd dictionary front-matter | Faithful Markdown + EN/RU editions of title pages, prefaces, abbreviations | multi-dict | per dict: title-page + preface + abbreviations as Markdown (schema) | 06/26 | [csl-guides](https://github.com/gasyoun/csl-guides) |
+| 🟢 F43 | `allngramtxt.txt` char-n-gram oracle | Every distinct character n-gram (all lengths, sorted by length) of the pan-CDSL headword list `sanhw1.txt` — the membership oracle of the n-gram spell-check method (a headword containing a chunk attested nowhere else is suspect; generator [listngrams.py](https://github.com/sanskrit-lexicon/CORRECTIONS/blob/master/ngram/listngrams.py)) | 6,656,616 n-grams · 82.3 MB | `aBisaMboD` (one SLP1 n-gram per line) | 06/26 | [CORRECTIONS/ngram](https://github.com/sanskrit-lexicon/CORRECTIONS/tree/master/ngram) |
 
 ---
 
@@ -297,6 +300,7 @@ is rendered on the interactive artifact._
 
 | When | Change |
 |---|---|
+| 07/26 | **E41 · E42 · F43** — the census-named tracked-but-uncounted trio registered (H694): csl-observatory correction-event log (52,498 × 3 views, 178 MB), Kompozity `names.csv` compound splits (168,880, 90.7 MB), CORRECTIONS `allngramtxt.txt` n-gram oracle (6,656,616, 82.3 MB). |
 | 07/26 | **E40** — headword pairwise-overlap matrix + unique counts over the 15-dict union (H684): 105 pairs, Jaccard, per-dict unique inventories; resolves the stale "union 94,753" figure (= MW∩PWG). |
 | 07/26 | **E39** — markup-tag frequency census over all 44 csl-orig/v02 dicts (H683): 96 distinct tags, per-1,000-entry rates, under-marking verdicts ([TSV](https://github.com/gasyoun/SanskritLexicography/blob/master/data/markup_tag_census.tsv) + [report](https://github.com/gasyoun/SanskritLexicography/blob/master/data/MARKUP_TAG_CENSUS_CSLORIG_2026.md)). |
 | 07/26 | **E38** — `<ls>` citation-frequency graph (csl-atlas, [PR #220](https://github.com/sanskrit-lexicon/csl-atlas/pull/220)): 828,505 canonicalized citations → 912 texts across 11 dicts. |


### PR DESCRIPTION
Executes [H694](https://github.com/gasyoun/Uprava/blob/main/handoffs/H694-Fable_SanskritLexicography_features-index-register-uncounted_11.07.26.md) (Fable 48h sprint Lane B): the three tracked-but-uncounted assets named by [DATA_LAYERS_CENSUS.md §4](https://github.com/gasyoun/Uprava/blob/main/DATA_LAYERS_CENSUS.md) get proper [FEATURES_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md) rows. Fable 5 (`claude-fable-5`).

Live counts re-verified on disk this session (all match the census within header off-by-one):

| ID | Asset | Verified count | Size |
|---|---|--:|--:|
| E41 | [correction_events_{all,typed,final}.csv](https://github.com/sanskrit-lexicon/csl-observatory/tree/main/observatory/site/src/data) | 52,498 data rows each (census's 52,499 = with header) | 178.0 MB |
| E42 | [Kompozity names.csv](https://github.com/gasyoun/VisualDCS/blob/main/derived-data/Kompozity/README.md) | 168,880 rows | 90.7 MB |
| F43 | [CORRECTIONS/ngram/allngramtxt.txt](https://github.com/sanskrit-lexicon/CORRECTIONS/tree/master/ngram) | 6,656,616 n-grams | 82.3 MB |

Also: at-a-glance dataset count 39 → 42; changelog entry added. kosha manifest rows and the census §4 tick ship separately (kosha PR + Uprava push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)