### PR TITLE
H727: pwg_ru cards→MDF exporter + mapping design note

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1900,6 +1900,16 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H727 MDF exporter SHIPPED 11-07-2026 (Fable 5 `claude-fable-5`).** Read-only
+  cards→MDF exporter [src/pilot/export_mdf_pwg_ru.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/export_mdf_pwg_ru.py)
+  (2,350 records from the 11,383-row promoted store; `\de`=RU national /
+  `\ge`=EN gloss per Coward-Grimes §2.3; RANGE-SET §9.7 closed-vocab gate over
+  `<ab>`/`\ps` — 4 residual out-of-range tokens, visible not silent; selftest
+  17/17 incl. live csl-standards profile-schema cross-check). Design:
+  [docs/MDF_EXPORT_PWG_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/MDF_EXPORT_PWG_RU.md);
+  sample [docs/samples/pwg_ru_sample.mdf](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/samples/pwg_ru_sample.mdf);
+  LANG_PARITY entry `mdf_export` (SHARED). Harness/TMs/queues untouched.
+
 - **Partial-card clean-pass safeguards — DONE 11-07-2026 (Codex/GPT-5).**
   `audit_window.py` now places every explicit partial card on the transient/top-up requeue lane
   unless an independent gate makes it a defect; partial keys therefore cannot enter clean judge

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,6 +1,6 @@
 # LANG_PARITY.md — cross-language fix/feature parity ledger
 
-_Created: 04-07-2026 · Last updated: 07-07-2026_
+_Created: 04-07-2026 · Last updated: 11-07-2026_
 
 This repo runs the same PWG→Russian and PWG→English translation pipeline through
 shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
@@ -867,6 +867,23 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
       "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+    }
+  },
+  {
+    "id": "mdf_export",
+    "mechanism": "export_mdf_pwg_ru.py serializes promoted cards to MDF with \\de=RU national lane and \\ge=EN gloss lane in ONE code path (\\ge emitted only when promote_en.py attached en; never fabricated)",
+    "files": [
+      "src/pilot/export_mdf_pwg_ru.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "New mechanism 11-07-2026 (H727): both language lanes are handled by the same clean_prose/mdf_record path parameterized by lang; the RU <ab> Bucket-A display policy is the documented intentional per-language difference INSIDE the shared path (EN keeps the original token), per ABBREVIATIONS_RU.md. Design: docs/MDF_EXPORT_PWG_RU.md.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/export_mdf_pwg_ru.py": "1d32e10622d246295cc3b5f8300e166de76cb210e74719ca7d79ddc7170d2be4"
     }
   }
 ]

--- a/RussianTranslation/docs/MDF_EXPORT_PWG_RU.md
+++ b/RussianTranslation/docs/MDF_EXPORT_PWG_RU.md
@@ -1,0 +1,126 @@
+# pwg_ru cards → MDF/LIFT — mapping design and exporter (H727)
+
+_Created: 11-07-2026 · Last updated: 11-07-2026_
+
+Design note for [`src/pilot/export_mdf_pwg_ru.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/export_mdf_pwg_ru.py),
+the read-only exporter that turns already-promoted pwg_ru translation cards
+([`src/pwg_ru_translated.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_HISTORY.md),
+local-only store, 11,383 sense rows / 2,350 cards as of 11-07-2026) into
+SIL MDF standard-format records (Toolbox/FLEx lineage). Built for
+[H727](https://github.com/gasyoun/Uprava/blob/main/handoffs/H727-Fable_SanskritLexicography_pwg-kosha-mdf-integration_11.07.26.md)
+per the MG ruling of 11-07-2026 in the
+[SIL MDF ecosystem correlation map](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/SIL_MDF_ECOSYSTEM_CORRELATION.md) §4–5.
+Written by Fable 5 (`claude-fable-5`).
+
+## Why
+
+Coward & Grimes 2000 §4 of the correlation map: pwg_ru cards are already
+isomorphic to bilingual MDF records. Making the isomorphism explicit gives the
+RU translation an exchange format consumable by the language-documentation
+toolchain (Lexique Pro, Webonary, Dictionary App Builder) with none of our own
+tooling required on the consumer side. Distribution runs through the
+[kosha data-hub manifest](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json).
+
+## Record grain
+
+One MDF record per **card** = one `(key1, subcard)` group of store rows; each
+store row is one sense. Rows keep store (promotion) order inside a card; cards
+sort by IAST headword. 11,383 rows → 2,350 records on the current store.
+
+## Field mapping
+
+Profile alignment: the exporter's marker subset and field order are checked by
+`--selftest` against the csl-standards
+[`mdf-export-profile.json`](https://github.com/sanskrit-lexicon/csl-standards/blob/main/data/schema/mdf-export-profile.json)
+schema when the sibling clone is present (marker inventory ⊇ ours; field order
+must match verbatim), so the two exporters cannot drift silently.
+
+| Card element | MDF | Notes |
+|---|---|---|
+| `iast` headword | `\lx` | IAST display form (consumers are human-facing tools); SLP1 `key1` preserved in the meta note. The csl-standards MW profile uses SLP1 — an intentional divergence, documented here. |
+| homonym index (`~~hN_` in `subcard`, N>0) | `\hm` | `h0` = not a homonym, suppressed. |
+| first `<lex>` in the card (RU, then DE field) | `\ps` | Gender/POS folded in, PWG-style (`m.`, `adj.`, …). Absent for most verb roots — expected, not missing data. |
+| `sense_tag` | `\sn` | **PWG prints real sense numbers** (unlike MW's prose-inferred senses): when every row has a distinct numeric `sense_tag`, the printed numbering is kept as observed. Otherwise numbering is inferred 1..n and flagged with the same `\nt sense-numbering: inferred` convention csl-standards uses. Monosemous cards omit `\sn` per MDF convention. |
+| `en` (when present) | `\ge` | The secondary **English gloss lane**. Emitted only when [`promote_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_en.py) has attached an `en` field — never fabricated. The current store carries none yet (EN promotion pending), so current exports are `\de`-only; the lane is wired and tested. |
+| `ru` | `\de` | The primary **national/target-language definition** — exactly the book's §2.3 national-vs-English contrast, and the same ruling csl-standards H721 gives Sanskrit-Sanskrit koshas (SKD/VCP): the analysis language of the dictionary goes to `\de`, English to `\ge`. |
+| inline `<ls>` citations | `\bb` | Distinct citations per card, in order; `<ls n="M.">8,64.</ls>` continuation form expanded to a self-contained `M. 8,64.`. Also kept inline in `\de` prose (the citation is part of the printed definition). MDF has no evidence-class field — same `partial` adequacy call as the csl-standards mapping. |
+| store provenance | `\nt meta:` | profile version, national language, SLP1 key, subcard, PWG column/page pointer, `review_status`, generating model version. |
+
+**Not exported:** the German `de` field (PWG's own text — this dataset is the
+*translation*, recoverable via the meta pointer, not a PWG re-edition), the
+`evidence`/`evidence_summary` blocks and `differentia` (pipeline QA apparatus,
+not lexicography), `dcs_freq` (a kosha dataset in its own right).
+
+### `\ge`/`\de` in one sense block — bilingual deviation
+
+The csl-standards MW profile treats `\ge` and `\de` as alternates that never
+co-occur (English is MW's national language, so `\ge` alone is used). A
+bilingual RU+EN card legitimately carries both per sense (`\sn → \ge → \de`,
+in App. B relative order), and multi-sense cards repeat `\de` — which the
+MW-profile validator's order check would flag. The exporter's own structural
+validation therefore treats `\sn`/`\ge`/`\de` as one repeating sense block;
+everything else follows the shared App. B order table verbatim.
+
+## Markup resolution inside `\de` (one line per field, MDF is line-oriented)
+
+* `{%…%}` translation gloss — unwrapped.
+* `{#…#}` SLP1 Sanskrit — transliterated to IAST via the shared
+  `build_article_site.slp1_iast` (no transcoder #63).
+* `<ab>` abbreviations — the
+  [ABBREVIATIONS_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ABBREVIATIONS_RU.md)
+  tooltip policy applied as render-time text: Bucket A editorial tokens →
+  Russian via [`pwg_ab_ru.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_ab_ru.py)
+  (`vgl.` → `ср.`), Bucket B grammatical categories stay international Latin.
+  MDF has no tooltip channel, so the visible-text half of the policy is all
+  that applies.
+* `<is>` proper names — kept IAST. The site Cyrillicizes these, but
+  [`iast_to_cyrillic.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/iast_to_cyrillic.py)
+  is documented as not yet corpus-validated (ABBREVIATIONS_RU.md open item);
+  an exchange format should not bake in an unvalidated transliteration.
+* `[Page…]` print markers and the `¦` headword/body separator — stripped
+  (layout, not prose).
+
+## RANGE-SET gate (book §9.7) — closed vocabularies as a selftest
+
+Two field families are checked against **closed vocabularies**, the book's
+RANGE-SET discipline:
+
+1. **`<ab>` tokens** must resolve in PWG's own 791-entry `pwgab` table
+   ([`pwg_ab.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_ab.py);
+   lowercase-keyed, so sentence-initial capitals are folded first).
+2. **`\ps` values** must be in the exporter's `PS_RANGE` (the store's observed
+   `<lex>` inventory + standard PWG gender/POS values).
+
+Violations are counted and reported on every run; `--strict` makes them fatal;
+`--selftest` proves the gate trips on poisoned fixtures. Current full-store
+residue: **4 distinct out-of-range `<ab>` tokens** (`3.`, `Präs.`,
+`adv. Comp.`, `s. u. d.`) — the census's known "not in pwgab" tail (OCR noise /
+non-standard local abbreviations), left visible rather than silently passed.
+
+## LIFT
+
+The LIFT (XML) fourth serialization landed in csl-standards via H721
+([PR #107](https://github.com/sanskrit-lexicon/csl-standards/pull/107):
+[`export-lift.mjs`](https://github.com/sanskrit-lexicon/csl-standards/blob/main/scripts/export-lift.mjs),
+[`LIFT_EXPORT_MAPPING.md`](https://github.com/sanskrit-lexicon/csl-standards/blob/main/docs/LIFT_EXPORT_MAPPING.md)).
+The pwg_ru→LIFT mapping is the same table as above with the standard MDF↔LIFT
+correspondences (`\lx` → `lexical-unit`, `\ps` → `grammatical-info`, `\de` →
+`definition` with `lang="ru"`, `\ge` → `gloss` with `lang="en"`, `\bb` →
+`note type="source"`); a dedicated pwg_ru LIFT serializer is deferred until a
+consumer needs LIFT specifically (Lexique Pro, the first target consumer,
+reads MDF natively — see H722).
+
+## Running
+
+```
+python src/pilot/export_mdf_pwg_ru.py --selftest
+python src/pilot/export_mdf_pwg_ru.py --keys dah,gam --limit 30 --out docs/samples/pwg_ru_sample.mdf
+python src/pilot/export_mdf_pwg_ru.py --out src/pilot/output/pwg_ru_full.mdf
+```
+
+The committed 30-card sample lives at
+[`docs/samples/pwg_ru_sample.mdf`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/samples/pwg_ru_sample.mdf);
+the full export stays gitignored (`src/pilot/output/`) like the store it is
+derived from, and is distributed through the kosha manifest instead.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/samples/pwg_ru_sample.mdf
+++ b/RussianTranslation/docs/samples/pwg_ru_sample.mdf
@@ -1,0 +1,787 @@
+\lx dah
+\de dah , dahati DHĀTUP. 23,22. dadāha; adhākṣīt ( VOP. 8,80), ved. adhāk, dhāk (dhak относится к dagh), dhakṣi; partic. dhakṣat и dakṣat (ср. ṚV. PRĀT. 4,41); dhakṣyati (Kār. ṚV. PRĀT. 6 из SIDDH. K. к P. 7,2,10), dahiṣyati эп. MBH. 1,2120. BHĀG. P. 4,14,12; эп. также мед.; dagdhum, dagdhvā, dagdha; жечь, сжигать, гореть — основное значение корня: сжигать, пожирать огнём, гореть: mā māmedho daśatayaścito dhāk ṚV. 1,158,4. ṚV. 2,15,4. tṛṇā dahan ṚV. 3,29,6. dāru dhakṣat ṚV. 6,3,4. ṚV. 10,91,7. — ṚV. 1,130,8. ṚV. 4,4,4. ṚV. 4, 28,3. ṚV. 7,1,7. yadagnirāpo adahatpraviśya AV. 1,25,1. AV. 5,23,13. AV. 8,1,11. AV. 12,5,61. AV. 12,5, 62. yadyu miyate svaireva tamagnibhirdahati ŚAT. BR. 12,3,5,2. ŚAT. BR. 12, 5,1,15. ŚAT. BR. 12,5, 2,3. grāmyo 'gniḥ śālāṃ dahati KAUŚ. 133. ĀŚV. GṚHY. 4,4. KĀTY. ŚR. 25,13,28. ŚĀṄKH. ŚR. 18,24,14. nāgnirdadāha romāpi MBH. 8,116. MBH. 8, 115. janamejayasya vo yajñe dhakṣyati MBH. 1,1058. MBH. 1, 5834. MBH. 1, 8090. MBH. 1, 8329. kathamagnirna no dhakṣyet (pot. fut.) MBH. 8, 8383. gṛdhraṃ dagdhvā R. 1,1,53. R. 1,1, 75 taṃ hatvā kāṣṭhairadahat R. 1,1, 54. BHARTṚ. 2,47. RAGH. 12,63. anyaṃ kaṃcidadhākṣuśca — śavam KATHĀS. 15,99. uṣṇo dahati cāṅgāraḥ śītaḥ kṛṣṇāyate karam HIT. I,74. гореть (мед.) SUŚR. 1,32,5. SUŚR. 2,48,1. — мед.: dhakṣyate śāyakaiścemām — purīm R. 5,33,38. R. 5, 34,2. MBH. 1,8159. daheta naḥ MBH. 1, 5788. tvamevānyāndahase jātavedaḥ MBH. 14,245. atandrito dahate jātavedāḥ MBH. 5,818. сжигать, опалять, так преим. по образу огня совершенно уничтожать: ekameva dahatyagnirnaraṃ durupasarpiṇam . kulaṃ dahati rājāgniḥ M. 7,9. vṛkṣānaṅgārakārīva maināndhākṣīḥ samūlakān MBH. 2,2109. MBH. 5,7016. adhakṣaṃ (читай adhakṣyaṃ) tānahaṃ krūrāṃstadā sarvān MBH. 7,2541. dahat (imperf.) kṣatraṃ parasparam MBH. 1,138. lokāniva dhakṣyatī ruṣā BHĀG. P. 4,4,9. BHĀG. P. 4, 14,12. RĀJA-TAR. 5,478. adahata HARIV. 13993. MBH. 6,5070. mā tvāṃ dhakṣye cakṣuṣā dāruṇena MBH. 14,237. jagāma campāṃ prati dhakṣyamāṇastamaṅgarājaṃ sapuraṃ rāṣṭram MBH. 3,10084. tasya jñānāgninā pāpaṃ sarvaṃ dahati vedavit M. 11,246. M. 6,72. M. 12,101. ŚĀNTIŚ. 3,13. гореть, так преим. повергать в сильный жар —, приводить в возбуждение, волновать; терзать сердце: aṣṭau yasyāgnayo hyete na dahante manaḥ sadā MBH. 14,112. madanānalo dahati mama mānasam GĪT. 10,2. yanmāṃ tasyāḥ kapolau dahataḥ PAÑCAT. I,225. tapati tanugātri madanastvāmaniśaṃ māṃ punardahatyeva ŚĀK. 65. punardṛṣṭiṃ vāṣpaprakarakaluṣāmarpitavatī mayi krūre yattatsaviṣamiva śalyaṃ dahati mām ŚĀK. 136. itthamātmakṛtamaparihataṃ cāpalaṃ dahati ŚĀK. 69,12. yāvajjīvaṃ jaḍo (sutaḥ) dahet PAÑCAT. Pr. 4.
+\bb DHĀTUP. 23,22.
+\bb VOP. 8,80
+\bb ṚV. PRĀT. 4,41
+\bb ṚV. PRĀT. 6
+\bb SIDDH. K.
+\bb P. 7,2,10
+\bb MBH. 1,2120.
+\bb BHĀG. P. 4,14,12
+\bb ṚV. 1,158,4.
+\bb ṚV. 2,15,4.
+\bb ṚV. 3,29,6.
+\bb ṚV. 6,3,4.
+\bb ṚV. 10,91,7.
+\bb ṚV. 1,130,8.
+\bb ṚV. 4,4,4.
+\bb ṚV. 4, 28,3.
+\bb ṚV. 7,1,7.
+\bb AV. 1,25,1.
+\bb AV. 5,23,13.
+\bb AV. 8,1,11.
+\bb AV. 12,5,61.
+\bb AV. 12,5, 62.
+\bb ŚAT. BR. 12,3,5,2.
+\bb ŚAT. BR. 12, 5,1,15.
+\bb ŚAT. BR. 12,5, 2,3.
+\bb KAUŚ. 133.
+\bb ĀŚV. GṚHY. 4,4.
+\bb KĀTY. ŚR. 25,13,28.
+\bb ŚĀṄKH. ŚR. 18,24,14.
+\bb MBH. 8,116.
+\bb MBH. 8, 115.
+\bb MBH. 1,1058.
+\bb MBH. 1, 5834.
+\bb MBH. 1, 8090.
+\bb MBH. 1, 8329.
+\bb MBH. 8, 8383.
+\bb R. 1,1,53.
+\bb R. 1,1, 75
+\bb R. 1,1, 54.
+\bb BHARTṚ. 2,47.
+\bb RAGH. 12,63.
+\bb KATHĀS. 15,99.
+\bb HIT. I,74.
+\bb SUŚR. 1,32,5.
+\bb SUŚR. 2,48,1.
+\bb R. 5,33,38.
+\bb R. 5, 34,2.
+\bb MBH. 1,8159.
+\bb MBH. 1, 5788.
+\bb MBH. 14,245.
+\bb MBH. 5,818.
+\bb M. 7,9.
+\bb MBH. 2,2109.
+\bb MBH. 5,7016.
+\bb MBH. 7,2541.
+\bb MBH. 1,138.
+\bb BHĀG. P. 4,4,9.
+\bb BHĀG. P. 4, 14,12.
+\bb RĀJA-TAR. 5,478.
+\bb HARIV. 13993.
+\bb MBH. 6,5070.
+\bb MBH. 14,237.
+\bb MBH. 3,10084.
+\bb M. 11,246.
+\bb M. 6,72.
+\bb M. 12,101.
+\bb ŚĀNTIŚ. 3,13.
+\bb MBH. 14,112.
+\bb GĪT. 10,2.
+\bb PAÑCAT. I,225.
+\bb ŚĀK. 65.
+\bb ŚĀK. 136.
+\bb ŚĀK. 69,12.
+\bb PAÑCAT. Pr. 4.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_00_pwg00; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\sn 1
+\de — pass. «быть сожжённым, гореть, пылать, стоять в пламени»: tatra dahyeta pāpakṛt M. 8,372. MBH. 4,798. te dahyante sma vahninā MBH. 2,1140. MBH. 3,2935. dahyamānāmivārkeṇa MBH. 4, 2670. na ca dahyanti gacchantyaḥ sutaptairapi pāṃśubhiḥ MBH. 13,1468. bhṛgurbhṛjyamāno na dehe NIR. 3,17. dahyante gṛhāḥ AV. 12,4,3. diśaḥ ṢAḌV. BR. 5,9. tasminvane dahyamāne MBH. 1,8330. dahyatastasya — dāvasya MBH. 1, 8210. MBH. 3,2608. «быть устранённым огнём, быть уничтоженным» вообще: dahyante dhmāyamānānāṃ dhātūnāṃ hi yathā malāḥ . tathendriyāṇāṃ dahyante doṣāḥ prāṇasya nigrahāt .. M. 6,71. «гореть» (о ранах) SUŚR. 1,103,17. «быть снедаемым внутренним жаром, — томиться, изнывать»: viṣeṇa nāgarājasya dahyamāno divāniśam MBH. 3,2843. dahyamāna ivāgninā MBH. 2,1691. rājā svatejobhiradahyatāntarbhogīva mantrauṣadhiruddhavīryaḥ RAGH. 2,32. ādhibhirdahyamānasya MBH. 3,2754. kṣutpipāsābhyāṃ ca dahyamānāntarbahiḥśarīraḥ BHĀG. P. 5,26,14. dahyamānaḥ sa śokena MBH. 3,2647. śokena dehe janatātimātram BHAṬṬ. 3,11. dehe cātīva manyunā BHAṬṬ. 14,60. dahyamānāṃ bhṛśaṃ bālām MBH. 3,2731. MBH. 3, 2913. R. 1,58,12. mano hi me dūyate dahyate ca DRAUP. 6,4. amarṣavaśamāpanno dahyāmi MBH. 2,1690. dahyantyaṅgāni me MBH. 1,2061. tena me vyākulaṃ cittaṃ hṛdayaṃ dahyatīva ca MBH. 1, 5048. SĀV. 5,3. dahye 'haṃ madhuno lehairdāvairugrairyathā giriḥ «быть измученным —, изнурённым» BHAṬṬ. 6,82. С transit. знач. «сгорать»: (tām) sahānenādya dahyema MBH. 4,799. — partic. dagdha
+\sn 2
+\de 1) «сожжённый» AK. 3,2,48. H. 1486. MED. dh. 7. AV. 18,2,34. KĀTY. ŚR. 1,10,13. KĀTY. ŚR. 25,8,19. M. 8,189. MBH. 3,2400. HIḌ. 1,6. 43. PAÑCAT. 98,1. BHĀG. P. 5,14,4. «подгоревший» (о кушаньях): pattrāṇām (читай: pattriṇām) āmiṣaṃ parṇam . gorvarjyamāmiṣaṃ kṣīraṃ phale jambīramāmiṣam . āmiṣaṃ raktaśākaṃ ca sarvaṃ ca dagdhamāmiṣam KARMALOCANA в ŚKDR. неточно «приведённый в жар, снедаемый, измученный, истерзанный»: priyāviyogānaladagdhamānasa ṚT. 1,10. vyādhidagdhāntara RĀJA-TAR. 6,104. dagdhajaṭhara (BHARTṚ. 3,22), dagdhodara (HIT. I,62) «сожжённый огнём пищеварительной силы» (ср. jaṭharāgni, jāṭharo 'gniḥ) т.е. «голодный желудок»
+\sn 3
+\de — 2) «снедаемый скорбью, опечаленный»: ruddhāyāmapi vāci sasmitamidaṃ dagdhānanaṃ jāyate AMAR. 24. схол. : dagdhamiti dhikkāroktau .
+\sn 4
+\de — 3) «сожжённый», отсюда преим. «лишённый сока и силы»: (brahma) kutīrthādāgataṃ dagdhamapavarṇaṃ ca bhakṣitam ŚIKṢĀ 50 в Ind. St. 4,268.
+\sn 5
+\de — 4) «зловещий, несущий беду»: dagdhākṣara «некоторые буквы, которые в стихах считаются зловещими», SHAKESP. Hindust. Dict.; ср. dagdha 2,b.
+\sn 6
+\de — 5) = vidagdha «хитрый, лукавый» DAŚAK. в BENF. Chr. 193,15.
+\sn 7
+\de — ср. dagdha .
+\bb M. 8,372.
+\bb MBH. 4,798.
+\bb MBH. 2,1140.
+\bb MBH. 3,2935.
+\bb MBH. 4, 2670.
+\bb MBH. 13,1468.
+\bb NIR. 3,17.
+\bb AV. 12,4,3.
+\bb ṢAḌV. BR. 5,9.
+\bb MBH. 1,8330.
+\bb MBH. 1, 8210.
+\bb MBH. 3,2608.
+\bb M. 6,71.
+\bb SUŚR. 1,103,17.
+\bb MBH. 3,2843.
+\bb MBH. 2,1691.
+\bb RAGH. 2,32.
+\bb MBH. 3,2754.
+\bb BHĀG. P. 5,26,14.
+\bb MBH. 3,2647.
+\bb BHAṬṬ. 3,11.
+\bb BHAṬṬ. 14,60.
+\bb MBH. 3,2731.
+\bb MBH. 3, 2913.
+\bb R. 1,58,12.
+\bb DRAUP. 6,4.
+\bb MBH. 2,1690.
+\bb MBH. 1,2061.
+\bb MBH. 1, 5048.
+\bb SĀV. 5,3.
+\bb BHAṬṬ. 6,82.
+\bb MBH. 4,799.
+\bb AK. 3,2,48.
+\bb H. 1486.
+\bb MED. dh. 7.
+\bb AV. 18,2,34.
+\bb KĀTY. ŚR. 1,10,13.
+\bb KĀTY. ŚR. 25,8,19.
+\bb M. 8,189.
+\bb MBH. 3,2400.
+\bb HIḌ. 1,6. 43.
+\bb PAÑCAT. 98,1.
+\bb BHĀG. P. 5,14,4.
+\bb KARMALOCANA
+\bb ŚKDR.
+\bb ṚT. 1,10.
+\bb RĀJA-TAR. 6,104.
+\bb BHARTṚ. 3,22
+\bb HIT. I,62
+\bb AMAR. 24.
+\bb ŚIKṢĀ 50
+\bb Ind. St. 4,268.
+\bb SHAKESP.
+\bb DAŚAK.
+\bb BENF. Chr. 193,15.
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_01_sec_1; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\de — caus. dāhayati «давать сжечь —, велеть сжечь»: strīm — pūrvamāriṇīm . dāhayedagnihotreṇa yajñapātraiśca M. 5,167. pumāṃsaṃ dāhayetpāpaṃ śayane tapta āyase M. 8,372. YĀJÑ. 1,89. MBH. 1,588. MBH. 1, 5832. MBH. 1, 8309. MBH. 5,2418. MBH. 5, 3439. MBH. 11,798. HARIV. 9798. KATHĀS. 4,107. «велеть жарить»: vyādhairmāṃsānyadīdahan HARIV. 15523.
+\bb M. 5,167.
+\bb M. 8,372.
+\bb YĀJÑ. 1,89.
+\bb MBH. 1,588.
+\bb MBH. 1, 5832.
+\bb MBH. 1, 8309.
+\bb MBH. 5,2418.
+\bb MBH. 5, 3439.
+\bb MBH. 11,798.
+\bb HARIV. 9798.
+\bb KATHĀS. 4,107.
+\bb HARIV. 15523.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_02_sec_2; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\sn 1
+\de — desid. didhakṣati «собираться сжечь, погубить, уничтожить»: agne mā tvaṃ pravardhiṣṭhāḥ kvacinno na didhakṣasi MBH. 1,1244. didhakṣanniva MBH. 1, 8189. MBH. 1, 8325. MBH. 2,2. MBH. 3,468. MBH. 4,716. MBH. 4, 818. DAŚ. 1,35. R. 2,97,17. (tvām) didhakṣamāṇāṃ hṛdayaṃ sabandhanam R. 2, 12,106.
+\sn 2
+\de — ср. didhakṣā, didhakṣu . — caus. от desid. «побуждать кого-л. к тому, чтобы он собрался сжечь»: taṃ susthayantaḥ sacivā narendraṃ didhakṣayantaḥ BHAṬṬ. 3,33.
+\bb MBH. 1,1244.
+\bb MBH. 1, 8189.
+\bb MBH. 1, 8325.
+\bb MBH. 2,2.
+\bb MBH. 3,468.
+\bb MBH. 4,716.
+\bb MBH. 4, 818.
+\bb DAŚ. 1,35.
+\bb R. 2,97,17.
+\bb R. 2, 12,106.
+\bb BHAṬṬ. 3,33.
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_03_sec_3; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\sn 1
+\de — intens. dandahīti, dandahyate (bhāvagarhāyām) P. 7,4,86. P. 3,1,24. VOP. 20,2. VOP. 20, 8.
+\sn 2
+\de 1) trans. «полностью сжигать, испепелять, обращать в гибель»; act.: dāvāgnisadṛśo me 'dya dandahīti śubhāṃ tanum HARIV. 8726. dandagdhi (2. imperat.) dandagdhyarisainyamāśu kakṣaṃ yathā vātasakho hutāśaḥ BHĀG. P. 6,8,21. мед.: yattu dandahyate lokamado duḥkhākaroti mām ŚIŚ. 2,11.
+\sn 3
+\de — 2) мед. «полностью обращаться в огонь, исходить от жара»: atho anantasya mukhānalena dandahyamānaṃ sa nirīkṣya viśvam BHĀG. P. 2,2,26. brahmatejasātidurviṣaheṇa dandahyamānena vapuṣā BHĀG. P. 5,9,18. dandahyamānā jvalanena vardhatā serṣyāsamutthena HARIV. 7040. rājaprayojanavināśamavalokya dandahyamānahṛdayaḥ PAÑCAT. 58,2.
+\bb P. 7,4,86.
+\bb P. 3,1,24.
+\bb VOP. 20,2.
+\bb VOP. 20, 8.
+\bb HARIV. 8726.
+\bb BHĀG. P. 6,8,21.
+\bb ŚIŚ. 2,11.
+\bb BHĀG. P. 2,2,26.
+\bb BHĀG. P. 5,9,18.
+\bb HARIV. 7040.
+\bb PAÑCAT. 58,2.
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_04_sec_4; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx ati-dah
+\sn 1
+\de — ati
+\sn 2
+\de 1) «чрезмерно гореть»: atidagdha SUŚR. 2,47,19. «делать кому-л. чрезвычайно жарко»: eṣa cāti raṇe bhīṣmo dahate vai mahācamūm MBH. 6,5238.
+\sn 3
+\de — 2) «перекидываться пламенем через»: sa imā sarvā nadīratidadāha ŚAT. BR. 1,4,1,14. anatidagdha там же
+\bb SUŚR. 2,47,19.
+\bb MBH. 6,5238.
+\bb ŚAT. BR. 1,4,1,14.
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_05_ati; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx anu-dah
+\sn 1
+\de — anu
+\sn 2
+\de 1) «сжигать вслед, вдогонку»: dagdhamevānudahati (по-видимому, следует восполнить kālaḥ из предыдущего, так как anudahati едва ли может быть = anudahyeta) hatamevānuhanyate . naśyate naṣṭamevāgre MBH. 12,8107.
+\sn 3
+\de — 2) «выжигать дотла (от начала до конца)»: anu daha sahamūrānkravyādaḥ ṚV. 10,87,19. yatra kṛpīṭamanu taddahanti ṚV. 10, 28,8. AV. 2,25,4. na tvāmanudahetkruddho vanamagnirivaidhitaḥ R. 2,63,41.
+\bb MBH. 12,8107.
+\bb ṚV. 10,87,19.
+\bb ṚV. 10, 28,8.
+\bb AV. 2,25,4.
+\bb R. 2,63,41.
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_06_anu; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\de — apa «сжигать, выжигать (прочь)»: vījānyagnyapadagdhāni naro hanti yathā punaḥ MBH. 12,7705. «изгонять жаром»: viśvā agne 'pa daḥārātīḥ ṚV. 7,1,7.
+\bb MBH. 12,7705.
+\bb ṚV. 7,1,7.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_07_apa; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\de — api «поджигать, зажигать» (agniḥ) ṣoḍaśadhā vṛtrasya bhogānapyadahat TS. 2,1,4,6. pāpmānam TS. 2,1,4, 7. KĀṬH. 10,10. 21,8.
+\bb TS. 2,1,4,6.
+\bb TS. 2,1,4, 7.
+\bb KĀṬH. 10,10. 21,8.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_08_api; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\de — abhi «поджигать, сжигать»: sa yo vyasthādabhi dakṣadurvīm ṚV. 2,4,7. tamagnirvābhidahet ŚAT. BR. 3,6,2,20. yasya somamabhidahet KĀṬH. 35,16. abhidagdha ŚĀṄKH. ŚR. 13,6,8.
+\bb ṚV. 2,4,7.
+\bb ŚAT. BR. 3,6,2,20.
+\bb KĀṬH. 35,16.
+\bb ŚĀṄKH. ŚR. 13,6,8.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_09_a_bi; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\sn 1
+\de — ava «выгорать, сгорать дотла»: avādaho diva ā dasyumuccā ṚV. 1,33,7. kāṣṭhairbahubhiravadahya SUŚR. 2,35,19. vahninaivāvadahyate SUŚR. 313,15. avadagdha KAUŚ. 71.
+\sn 2
+\de — ср. avadāgha, avadāha .
+\bb ṚV. 1,33,7.
+\bb SUŚR. 2,35,19.
+\bb SUŚR. 313,15.
+\bb KAUŚ. 71.
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_10_ava; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\de — ā см. ādahana . Вместо prāṇānādagdhvā PAÑCAT. I,392 следует читать YĀJÑ. 1,340 prāṇānnādagdhvā . — caus. pass. «сжигаться, обжигаться»: sa yathā tatra nādāhyeta CHĀND. UP. 6,16,3. Ожидалось бы nādahyeta.
+\bb PAÑCAT. I,392
+\bb YĀJÑ. 1,340
+\bb CHĀND. UP. 6,16,3.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_11__a; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\de — upa «поджигать»: upa ha taddahedyadudantaṃ kuryādaprajajñi vai reta upadagdham ŚAT. BR. 2,3,1,14. yavamuṣṭiṃ bhṛjjatyanupadahan GOBH. 3,7,4. upadagdhena haviṣā ŚAT. BR. 11,4,4,2. bhūmerupadagdhaṃ samutkhāya KAUŚ. 69. «поднести огонь к» (acc.): suptānupādhākṣīdbālakān MBH. 3,546.
+\bb ŚAT. BR. 2,3,1,14.
+\bb GOBH. 3,7,4.
+\bb ŚAT. BR. 11,4,4,2.
+\bb KAUŚ. 69.
+\bb MBH. 3,546.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_12_upa; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\sn 1
+\de — ni «сжигать дотла, испепелять огнём»: rakṣo ni dhakṣi ṚV. 6,18,10. ni māyinastapuṣā rakṣaso daha ṚV. 8,23,14. ṚV. 1,99,1. KAUŚ. 52. 83. pass.: pāṇḍupāvakamāsādya nyadahyanta narādhipāḥ MBH. 1,4454.
+\sn 2
+\de — ср. nidāgha .
+\bb ṚV. 6,18,10.
+\bb ṚV. 8,23,14.
+\bb ṚV. 1,99,1.
+\bb KAUŚ. 52. 83.
+\bb MBH. 1,4454.
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_13_ni; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx nis-dah
+\sn 1
+\de — nis «выжигать, сжигать, уничтожать/поедать огнём, полностью уничтожать»: śītāḥ santo hṛdayaṃ nirdahanti ṚV. 10,34,9. agniradbhyo niradahajjarūtham ṚV. 10, 80,3. ṚV. 10, 103,12. AV. 7,108,2. AV. 9,2,4. AV. 9,2, 5. AV. 9,2, 31. TS. 2,2,5,2. tasyākṣiṇī nirdadāha ŚAT. BR. 1,7,4,6. idaṃ vā asāvāditya udyanneva yathāyamagnirnirdahedevamoṣadhīrannādyaṃ nirdahati ŚAT. BR. 5,3,4,16. ŚAT. BR. 1,1,1,17. ŚAT. BR. 3,1,2,6. nirdahaḥ infin. ŚAT. BR. 12,4,3,4. — KAUŚ. 90. 131. yathaidhastejasā vahniḥ prāptaṃ nirdahati kṣaṇāt M. 11,246. (agnivarṇayā surayā) kāye nirdagdhe M. 11, 90. BHĀG. P. 5,24,28. BHĀG. P. 6,4,6. na coṣarāṃ na nirdagdhāṃ mahīṃ dadyāt MBH. 13,3341. dhūmanirdagdhakūrca RĀJA-TAR. 5,461. nirdaheta ca yatkṛtsnaṃ trailokyam MBH. 13,856. kālāgnimiva bībhatsuṃ nirdahantamiva prajāḥ MBH. 4,1702. MBH. 1,241. bhittvā hṛdi śarāḥ pañca nirdahantīva me tanum HARIV. 4607. R. 1,54,22. R. 1, 55,21. R. 2,61,21. MBH. 4,1162. nāhaṃ janaṃ nirdaheyaṃ dṛṣṭvā ghoreṇa cakṣuṣā MBH. 2,2631. DAŚAK. в BENF. Chr. 186,1. vaidehīṃ rāvaṇaḥ kruddho nirdahanniva rākṣasaḥ R. 3,55,26. R. 5,33,37. PRAB. 82,10. VID. 145. (yasya cittam) na nirdahati kopakṛtānuśayaḥ BHARTṚ. 2,76. etattrayaṃ hi puruṣaṃ nirdahedavamāninam M. 4,136. (devāḥ) avajñātāvadhūtāśca nirdahantyadhamānnarān MBH. 13,4713. R. 1,55,6. durhṛdaḥ sādhu nirdahan . suhṛdastarpayankāmaiḥ R. 2,106,26. (enaḥ) tatsarvaṃ nirdahantāśu tapasaiva tapodhanāḥ M. 11,241. R. 2,36,29. BHĀG. P. 7,7,36.
+\sn 2
+\de — ср. nirdahana, nirdāha . — caus. «давать сгореть, велеть сжечь» RĀJA-TAR. 6,171.
+\bb ṚV. 10,34,9.
+\bb ṚV. 10, 80,3.
+\bb ṚV. 10, 103,12.
+\bb AV. 7,108,2.
+\bb AV. 9,2,4.
+\bb AV. 9,2, 5.
+\bb AV. 9,2, 31.
+\bb TS. 2,2,5,2.
+\bb ŚAT. BR. 1,7,4,6.
+\bb ŚAT. BR. 5,3,4,16.
+\bb ŚAT. BR. 1,1,1,17.
+\bb ŚAT. BR. 3,1,2,6.
+\bb ŚAT. BR. 12,4,3,4.
+\bb KAUŚ. 90. 131.
+\bb M. 11,246.
+\bb M. 11, 90.
+\bb BHĀG. P. 5,24,28.
+\bb BHĀG. P. 6,4,6.
+\bb MBH. 13,3341.
+\bb RĀJA-TAR. 5,461.
+\bb MBH. 13,856.
+\bb MBH. 4,1702.
+\bb MBH. 1,241.
+\bb HARIV. 4607.
+\bb R. 1,54,22.
+\bb R. 1, 55,21.
+\bb R. 2,61,21.
+\bb MBH. 4,1162.
+\bb MBH. 2,2631.
+\bb DAŚAK.
+\bb BENF. Chr. 186,1.
+\bb R. 3,55,26.
+\bb R. 5,33,37.
+\bb PRAB. 82,10.
+\bb VID. 145.
+\bb BHARTṚ. 2,76.
+\bb M. 4,136.
+\bb MBH. 13,4713.
+\bb R. 1,55,6.
+\bb R. 2,106,26.
+\bb M. 11,241.
+\bb R. 2,36,29.
+\bb BHĀG. P. 7,7,36.
+\bb RĀJA-TAR. 6,171.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_14_nis; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\de — anunis «сжигать одного за другим, по порядку»: teṣāṃ pannānāmadhamā tamāṃsyagne vāstūnyanunirdaha tvam AV. 9,2,9.
+\bb AV. 9,2,9.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_15_anunis; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\sn 1
+\de — vinis «сжигать, испепелять огнём, уничтожать полностью»: jagadvinirdahedetat (astram) MBH. 1,5307. ARJ. 3,52. eṣa senāḥ — agnivatsamare tāta cariṣyati vinirdahan MBH. 5,5769. cakrānalavinirdagdha HARIV. 5935. R. GORR. 1,29,11. R. GORR. 3,35,93. (enam) matprabhāvavinirdagdhaṃ pataṃgamiva vahninā MBH. 2,1492. brahmaśāpavinirdagdha MBH. 16,279. MBH. 3,14829. MĀRK. P. 39,61. tayājñānaṃ vinirdahan BHĀG. P. 9,7,24.
+\sn 2
+\de — ср. vinirdahana .
+\bb MBH. 1,5307.
+\bb ARJ. 3,52.
+\bb MBH. 5,5769.
+\bb HARIV. 5935.
+\bb R. GORR. 1,29,11.
+\bb R. GORR. 3,35,93.
+\bb MBH. 2,1492.
+\bb MBH. 16,279.
+\bb MBH. 3,14829.
+\bb MĀRK. P. 39,61.
+\bb BHĀG. P. 9,7,24.
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_16_vinis; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\sn 1
+\de — pari «обжигать вокруг, охватывать жаром, сжигать»: āgneyasvabhāvātparidahati kaṇṭhamuro hṛdayaṃ ceti SUŚR. 1,155,21. kāsetsa pāṇḍuḥ paridahyamānaḥ SUŚR. 2,503,1. dāvāgninā śucivane paridahyamāne BHĀG. P. 2,7,29. gāṇḍīvaṃ sraṃsate hastāttvakcaiva paridahyate «горит, пылает» BHAG. 1,30. diśi diśi paridagdhā bhūmayaḥ pāvakena ṚT. 1,24. saṃhārakāle paridagdhakāyā brahmāṇamāyānti sadā prajā hi MBH. 12,10076. HARIV. 548.
+\sn 2
+\de — ср. paridahana, paridāhin .
+\bb SUŚR. 1,155,21.
+\bb SUŚR. 2,503,1.
+\bb BHĀG. P. 2,7,29.
+\bb BHAG. 1,30.
+\bb ṚT. 1,24.
+\bb MBH. 12,10076.
+\bb HARIV. 548.
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_17_pari; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\de — saṃpari pass. «сжигать, погибать от жара»: gatena tenāsmi kṛto vicetā gātraṃ ca me saṃparidahyatīva MBH. 3,10067.
+\bb MBH. 3,10067.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_18_sa_mpari; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx pra-dah
+\sn 1
+\de — pra «сжигать, уничтожать»: pra su viśvānrakṣaso dhakṣyagne ṚV. 1,76,3. naiṣāṃ śiśnaṃ pra dahati jātavedāḥ AV. 4,34,2. AV. 4, 36,1. AV. 10,8,39. AV. 13,1,29. prajāṃ ca paśūṃśca pradahet ŚAT. BR. 14,2,2,45. ŚAT. BR. 14,2,2, 54. ŚAT. BR. 2,2,1,2. ŚAT. BR. 2, 6,3,15. ŚAT. BR. 11,4,2,16. sarvaṃ vai māyaṃ pradhakṣyati TBR. 2,3,7,1. TS. 2,2,8,6. īśvaraṃ vai vratamavisṛṣṭaṃ pradahaḥ TS. 1,7,6,6. tattvā mā pradhākṣīriti (после ŚAṂK. перестановки лиц; следует читать возможно ˚kṣīditi) CHĀND. UP. 4,1,2. prādahan śaraṇānyanye prajānāṃ jvalitolmukaiḥ BHĀG. P. 7,2,15. na pāvakastvāṃ pradahiṣyati MBH. 1,2120. MBH. 1, 8362. pāṇḍavāgnim — dīptaṃ pradahantamivāhitān MBH. 4,1520. bhīmasenadavāgnestu mama putrāṃstṛṇopamān . pradhakṣyataḥ (следует читать так: вместо pradhakṣataḥ) MBH. 7,5277. MBH. 1,1762. MBH. 5,678. MBH. 7,6092. MBH. 16,274. sarvāṇi mainyāni ca vāsudevaḥ pradhakṣyate sāyakavahnijālaiḥ MBH. 3,10274. — HARIV. 11601. HARIV. 13888. māṃ śokāgniḥ — pradhakṣyati R. 2,24,8. R. 2, 94,15. R. GORR. 2,25,6. tatkulaṃ pradahati BHĀG. P. 1,7,48. BHĀG. P. 1,7, 31. BHĀG. P. 4,4,2. BHĀG. P. 9,5,12. keliḥ pradahati majjāṃ (следует читать так) śṛṅgāro 'sthīni
+\sn 2
+\de PAÑCAT. I,191. — pass. «загораться, гореть, сгорать»: vṛkṣasyeva pradahyataḥ MBH. 2,2394. vastraṃ pradahyate VARĀH. BṚH. S. 72,6. tasyāḥ kṛpaṇacakṣurbhyāṃ pradahyetāpi medinī MBH. 2,2689. pradagdha «сожжённый» ŚAT. BR. 11,1,6,33. R. 3,42,53. VARĀH. BṚH. S. 72,2. yena pūrvaṃ pradagdhāni śatrusainyāni «уничтоженный» MBH. 16,275.
+\bb ṚV. 1,76,3.
+\bb AV. 4,34,2.
+\bb AV. 4, 36,1.
+\bb AV. 10,8,39.
+\bb AV. 13,1,29.
+\bb ŚAT. BR. 14,2,2,45.
+\bb ŚAT. BR. 14,2,2, 54.
+\bb ŚAT. BR. 2,2,1,2.
+\bb ŚAT. BR. 2, 6,3,15.
+\bb ŚAT. BR. 11,4,2,16.
+\bb TBR. 2,3,7,1.
+\bb TS. 2,2,8,6.
+\bb TS. 1,7,6,6.
+\bb ŚAṂK.
+\bb CHĀND. UP. 4,1,2.
+\bb BHĀG. P. 7,2,15.
+\bb MBH. 1,2120.
+\bb MBH. 1, 8362.
+\bb MBH. 4,1520.
+\bb MBH. 7,5277.
+\bb MBH. 1,1762.
+\bb MBH. 5,678.
+\bb MBH. 7,6092.
+\bb MBH. 16,274.
+\bb MBH. 3,10274.
+\bb HARIV. 11601.
+\bb HARIV. 13888.
+\bb R. 2,24,8.
+\bb R. 2, 94,15.
+\bb R. GORR. 2,25,6.
+\bb BHĀG. P. 1,7,48.
+\bb BHĀG. P. 1,7, 31.
+\bb BHĀG. P. 4,4,2.
+\bb BHĀG. P. 9,5,12.
+\bb PAÑCAT. I,191.
+\bb MBH. 2,2394.
+\bb VARĀH. BṚH. S. 72,6.
+\bb MBH. 2,2689.
+\bb ŚAT. BR. 11,1,6,33.
+\bb R. 3,42,53.
+\bb VARĀH. BṚH. S. 72,2.
+\bb MBH. 16,275.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_19_pra; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\de — saṃpra «сжигать»: na nastatra hutāśaḥ saṃpradhakṣyati MBH. 1,5796. MBH. 2,2256. «уничтожать»: putrapautrabadhaṃ śrutvā dhruvaṃ naḥ saṃpradhakṣyati MBH. 9,3526.
+\bb MBH. 1,5796.
+\bb MBH. 2,2256.
+\bb MBH. 9,3526.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_20_sa_mpra; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx prati-dah
+\sn 1
+\de — prati встречать огнём, отвечать пламенем на пламя: prati pratīcīrdahatādarātīḥ ṚV. 3,18,1. pratyagne mithunā daha ṚV. 10,87,24. ṚV. 10,87, 20. ṚV. 10,87, 23. ṚV. 1,12,5. ṚV. 1, 79,6. AV. 1,28,2. AV. 3,1,1. AV. 3,1, 3. agniṣṭapati pratidahati ŚAT. BR. 4,4,5,8. sa tvā pratidhakṣyati
+\sn 2
+\de CHĀND. UP. 2,22,4. — pass. сжигать (intrans.): vaiśvānaraṃ yathā prāpya pratidahyanti vai janāḥ MBH. 8,2750.
+\bb ṚV. 3,18,1.
+\bb ṚV. 10,87,24.
+\bb ṚV. 10,87, 20.
+\bb ṚV. 10,87, 23.
+\bb ṚV. 1,12,5.
+\bb ṚV. 1, 79,6.
+\bb AV. 1,28,2.
+\bb AV. 3,1,1.
+\bb AV. 3,1, 3.
+\bb ŚAT. BR. 4,4,5,8.
+\bb CHĀND. UP. 2,22,4.
+\bb MBH. 8,2750.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_21_prati; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx vi-dah
+\sn 1
+\de — vi «выжигать» (рану и т.д.) SUŚR. 1,100,21. «повредить огнём, обжигать»: mainamagne vi daho mābhi śocaḥ ṚV. 10,16,1. ṚV. 10,16, 7. «сжигать, уничтожать огнём»: śaranmadhyaṃdinābhārkatejasā vyadahadripūn MBH. 8,464. — pass.
+\sn 2
+\de 1) «сгорать» (intr.): pakṣābhyāṃ ca mayā gupto jaṭāyurna vyadahyata R. 4,60,20. vidahyamānaḥ pathi taptapāṃśubhiḥ ṚT. 1,13. «от внутреннего животного огня» SUŚR. 1,20,8. «страдать от внутреннего жара» SUŚR. 37,11. «жечь, гореть» (о ранах) SUŚR. 103,19.
+\sn 3
+\de — 2) «терзаться внутренне, изводить себя горем»: sakhyaṃ ca vāsudevena bālye gāṇḍīvadhanvanaḥ . prajānāmanurāgaṃ ca cintayāno vyadahyata MBH. 12,52.
+\sn 4
+\de — 3) «раздуваться от важности, важничать»: vṛthā saubhāgyamānena durbhage tvaṃ vidahyase . girinadyā iva srotastava saubhāgyamasthiram .. R. GORR. 2,6,12. Вместо этого: saubhāgyena vikatthase R. SCHL. 2,7,14. — partic. vidagdha
+\sn 5
+\de 1) «сожжённый»: tasyai ha (vṛkalāyai) vidagdhāyai sṛgālaḥ saṃbhavati ŚAT. BR. 12,5,2,5. a˚ KAUŚ. 60. 83. NIR. 9,26.
+\sn 6
+\de — 2) «воспалённый»: śophayorupanāhaṃ tu kuryādāmavidagdhayoḥ . avidagdhaḥ śamaṃ yāti vidagdhaḥ pākameti ca SUŚR. 2,5,21.
+\sn 7
+\de — 3) «переработанный внутренним огнём, желчью, которая варит пищу в желудке; сваренный»: ˚bhukta SUŚR. 2,110,14. rasa SUŚR. 545,10. śleṣman SUŚR. 1,79,8. pitta SUŚR. 78,18. āpo 'vidagdhāḥ SUŚR. 20,13. bhuktaṃ chardayatyavidagdhamatisāryate vā SUŚR. 118,15. 2,139,16. ср. pittavidagdhadṛṣṭi .
+\sn 8
+\de — 4) «разложившийся, испортившийся»: doṣāḥ SUŚR. 2,369,18. «прокисший» (как порча) SUŚR. 1,80,5. śālyodanapiṇḍamakuthitamavidagdham SUŚR. 170,4. mādhuryamannaṃ gatamāmasaṃjñaṃ vidagdhasaṃjñaṃ gatamamlabhāvam SUŚR. 245,11.
+\sn 9
+\de — 5) (тот, кто однажды обжёгся, поумнел на опыте) «умный, разумный, искушённый»: sparśaṃ vetsi vidagdhastvaṃ kāmadharmavicakṣaṇaḥ MBH. 4,745. ˚pariṣad BHARTṚ. 3,42. VIKR. 3,12. nāvidagdhaḥ priyaṃ brūyāt PAÑCAT. I,180. RĀJA-TAR. 5,79. neyaṃ gaṇanā vidagdhasya puruṣasya DAŚAK. в BENF. Chr. 188,9. vidagdhālāpānām — kavīnām BHARTṚ. 1,52. ˚vacana PAÑCAT. 112,25. «хитрый, лукавый», о девушках, искушённых в любовных искусствах, BHĀG. P. 6,18,28. BRAHMA-P. 55,15. DHŪRTAS. 78,4. ŚIŚ. 7,44. SĀH. D. 21,4. snigdhavidagdhamugdhamadhurairlolaiḥ kaṭākṣaiḥ BHARTṚ. 1,97. vidagdha = paṇḍita ŚABDAR. в ŚKDR. = kuśala и т.д. H. 343. = nāgara TRIK. 3,1,5. vidagdhā = vāṇinī TRIK. 3, 3,248. ср. durvidagdha, vidagdha имя собств., vidāha .
+\bb SUŚR. 1,100,21.
+\bb ṚV. 10,16,1.
+\bb ṚV. 10,16, 7.
+\bb MBH. 8,464.
+\bb R. 4,60,20.
+\bb ṚT. 1,13.
+\bb SUŚR. 1,20,8.
+\bb SUŚR. 37,11.
+\bb SUŚR. 103,19.
+\bb MBH. 12,52.
+\bb R. GORR. 2,6,12.
+\bb R. SCHL. 2,7,14.
+\bb ŚAT. BR. 12,5,2,5.
+\bb KAUŚ. 60. 83.
+\bb NIR. 9,26.
+\bb SUŚR. 2,5,21.
+\bb SUŚR. 2,110,14.
+\bb SUŚR. 545,10.
+\bb SUŚR. 1,79,8.
+\bb SUŚR. 78,18.
+\bb SUŚR. 20,13.
+\bb SUŚR. 118,15. 2,139,16.
+\bb SUŚR. 2,369,18.
+\bb SUŚR. 1,80,5.
+\bb SUŚR. 170,4.
+\bb SUŚR. 245,11.
+\bb MBH. 4,745.
+\bb BHARTṚ. 3,42.
+\bb VIKR. 3,12.
+\bb PAÑCAT. I,180.
+\bb RĀJA-TAR. 5,79.
+\bb DAŚAK.
+\bb BENF. Chr. 188,9.
+\bb BHARTṚ. 1,52.
+\bb PAÑCAT. 112,25.
+\bb BHĀG. P. 6,18,28.
+\bb BRAHMA-P. 55,15.
+\bb DHŪRTAS. 78,4.
+\bb ŚIŚ. 7,44.
+\bb SĀH. D. 21,4.
+\bb BHARTṚ. 1,97.
+\bb ŚABDAR.
+\bb ŚKDR.
+\bb H. 343.
+\bb TRIK. 3,1,5.
+\bb TRIK. 3, 3,248.
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_22_vi; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx sam-dah
+\de — sam «сжигаться вместе, сгорать дотла»: śocantaḥ saṃdahanto avratān ṚV. 9,73,5. druho dahāmi saṃ mahīranindrāḥ ṚV. 1,133,1. ṚV. 1, 36,14. ṚV. 1,36, 20. ṚV. 10,16,13. śarīramasya saṃ daha AV. 18,3,71. KĀTY. ŚR. 25,7,5. ŚAT. BR. 9,1,1,42. ŚAT. BR. 11,1,5,8. ŚAT. BR. 14,8,15,12. «уничтожать»: rāmaṃ putraṃ na me bālaṃ rāma saṃdagdhumarhasi R. GORR. 1,77,12. — pass. «сгорать, быть сожжённым»: abhijanaḥ saṃdahyatāṃ vahninā BHARTṚ. 2,32. saṃdagdhaṃ rakṣaḥ TS. 1,8,7,2. «гореть, пылать»: saṃdahyamānasarvāṅga eṣāmudvahanādhinā BHĀG. P. 3,30,8. «изнывать, терзаться»: pratyāgatāsuḥ samadahyatāntaḥ (v. l. samatapyata) RAGH. ed. Calc. 14,56. — caus. «давать сжечь, велеть сжечь» [Kaus.]: ghṛtāvasiktaṃ (pretaṃ) rājānam — vidhinā samadāhayat MBH. 1,4954. MBH. 11,793.
+\bb ṚV. 9,73,5.
+\bb ṚV. 1,133,1.
+\bb ṚV. 1, 36,14.
+\bb ṚV. 1,36, 20.
+\bb ṚV. 10,16,13.
+\bb AV. 18,3,71.
+\bb KĀTY. ŚR. 25,7,5.
+\bb ŚAT. BR. 9,1,1,42.
+\bb ŚAT. BR. 11,1,5,8.
+\bb ŚAT. BR. 14,8,15,12.
+\bb R. GORR. 1,77,12.
+\bb BHARTṚ. 2,32.
+\bb TS. 1,8,7,2.
+\bb BHĀG. P. 3,30,8.
+\bb RAGH. ed. Calc. 14,56.
+\bb MBH. 1,4954.
+\bb MBH. 11,793.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_23_sam; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx vyatisam-dah
+\de — vyatisam сжигать вперемешку, сжигать без разбора, целиком: atha yadyapyenānutkrāntaprāṇāñchūlena samāsaṃ vyatisaṃdahet CHĀND. UP. 7,15,3.
+\bb CHĀND. UP. 7,15,3.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_24_vyatisam; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx anusam-dah
+\de — anusam сгорать вдоль, сгорать по всей длине: brahmajyaṃ devyaghnya ā mūlādanusaṃdaha AV. 12,5,63.
+\bb AV. 12,5,63.
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_25_anusam; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\sn 1
+\de dah [Ved , unsp] сжигать (Acc), уничтожать огнём (Acc). [ часто в переносном смысле, что явствует из объектов. ] Graßmann 1873 (1996) : 586
+\sn 2
+\de [Ved , unsp] ( dáhati I ) гореть. Kaus: заставлять сжечь Hillebrandt 1885 : 92
+\sn 3
+\de [Ved , unsp] ( I ) гореть, сжигать. ṚV 4,4,4 Geldner 1907 : 80
+\sn 4
+\de [Ved , unsp] «причинять зло». Caland 1908, p. 100 Renou 1934 : 293
+\sn 5
+\de + ati : darüber - hinṭeg brennen, austrocknen. Śbh 1,4,1,14 . [Ved , unsp] + ánu : 1) воспламенять, полностью сжигать (Acc); 2) воспламеняться, разгораться, intr. Ved , unsp Graßmann 1873 (1996) : 586
+\sn 6
+\de + anunis : der ṇeihe nach verbrennen. āV 9,2,4 . [Ved , unsp] + apa ( apadagdha ): выгоревший ( duḥsvapnya ). AV(P) 7.7,8 . Ved , unsp ; Renou 1957 (1) : 76 (s.v. apadagdha )
+\sn 7
+\de + ápa : hinṭegbrennen, durch ghlut vertreiben (ākk). [Ved , unsp] + abhí : поджигать (Acc). Ved , unsp Graßmann 1873 (1996) : 586
+\sn 8
+\de + ava : ṝeuer herabṭerṛen auṛ. ṚV 1,33,7 . [Ved , unsp] + áva : выжигать вниз, вытеснять жаром (Acc) от (Abl). Ved , unsp Graßmann 1873 (1996) : 586
+\sn 9
+\de + ā , phass khaus: sich verbrennen. chhū Vī 16, 3 . [Ved , unsp] + ud ( uddahati ): сжигает дотла. Śikṣās 324.15 (vs) . Buddh , unsp ; BHSD : 130 (s.v. uddahati )
+\sn 10
+\de + ní : niederbrennen (ākk). [Ved , unsp] + nis , Caus ( nirdāhayati ): поджигать. RājTa . Gen , unsp ; MW : 555 (s.v. nirdah )
+\sn 11
+\de – aus-, verbrennen. ṚV 10,34,9 . [Ved , unsp] – выжигать, выкуривать; опалять, сжигать, также перен. ṚV 10,80,3 , ṚV 10,34,9 . Ved , unsp Geldner 1907 : 80
+\sn 12
+\de + nís : ganṣ verbrennen, vernichten (ākk). [Ved , unsp] + pari ( paridahyati , ° te , pass.) томится (страстью или желанием). Divyāv 420.6 . Buddh , unsp ; BHSD : 325 (s.v. paridahyati )
+\sn 13
+\de + prá : verbrennen, vernichten (ākk). [Ved , unsp] + prati : опалять. ṚV 3,18,1 . Ved , unsp Geldner 1907 : 80
+\sn 14
+\de + práti : entgegenbrennen, mit ghlut entgegengehen (ākk). [Ved , unsp] + vi : сжигать. ṚV 10,16,1 . Ved , unsp Geldner 1907 : 80
+\sn 15
+\de + ví : durch bhrennen beschädigen (ākk). [Ved , unsp] + vi ( vídagdha ): a) сожжённый, испепелённый; b) буро-желтоватый или красновато-коричневый (как нечистая кровь). ŚB , Lex(MW) . Gen , unsp ; MW : 965 (s.v. vídagdha )
+\sn 16
+\de + vyapa : see vyava °. [Buddh , unsp (s.v. vyapadahyati )] + vyava (° dahyati , pass.): сгорает, испепеляется [v.l. vyapa °]. Mvu i.18.13 . Buddh , unsp ; BHSD : 515 (s.v. vyavadahyati )
+\sn 17
+\de + sam : völlig verbrennen. ṚV 10,16,13 . [Ved , unsp] + sám : сжигать дотла, испепелять, уничтожать (Acc). Ved , unsp Graßmann 1873 (1996) : 586
+\sn 18
+\de [Buddh , unsp] [ dahāpaya - (Kaus)] заставлять сжечь. AbhisDh § 14.6.13A5 . BHS[Mvu]; ср. Pā. dahāpeti Karashima 2012 : 287 (s.v. dahāpaya -)
+\sn 19
+\de [dahiṣyant Ep , unsp] Adj mfn [PtzFut] пылающий, горящий (буд. время). R VII.21.42 . от dah . Sen 1951 : 57 (s.v. dah )
+\sn 20
+\de [didhakṣamāṇa Ep , unsp] Adj mfn [Des PtzPräs] желающий сжечь. R II.12.110 . от dah . Sen 1951 : 56 (s.v. dah )
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_zz_nws00; src=PWG pc=3-0559 page=3-p0280; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\ps Adj.
+\sn 1
+\de 1. √dah — 1〉 dahati (в эпосе также Med.)
+\sn 2
+\de — a〉 сжигать, испепелять огнём, жечь (также в мед. смысле). dhakṣyet Chr. 78,8.
+\sn 3
+\de — b〉 сжигать, опалять, отсюда преим. полностью уничтожать. adhākṣam {{MBH. 7,62,65->MBH. 7,72,65||20250606|Andhrabharati|https://github.com/sanskrit-lexicon/PWK/issues/84#issuecomment-2948415067|}}.
+\sn 4
+\de — c〉 жечь, отсюда преим. приводить в сильный жар —, в возбуждение, волновать (śrotraṃ putravṛttāntena DAŚAK. 78,9. 10), грызть сердце.
+\sn 5
+\de — 2〉 Pass. dahyate (в эпосе и MĀN. GṚHY. 2,15 также ˚ti) быть сжигаемым (MBH. 4,23,7), сгорать, гореть (также о ранах), стоять в пламени.
+\sn 6
+\de — b〉 быть устраняемым огнём, изглаживаться, обращаться в ничто вообще
+\sn 7
+\de — c〉 быть снедаемым внутренним жаром, — изнывать, быть удручаемым —, терзаемым, сокрушаться.
+\sn 8
+\de — 3〉 Partic. dagdha
+\sn 9
+\de — a) сожжённый, обожжённый.
+\sn 10
+\de — b〉 повергнутый в жар, испепелённый, измученный, истерзанный.
+\sn 11
+\de — d) сожжённый, отсюда преим. без сока и силы.
+\sn 12
+\de — e) зловещий, пагубный.
+\sn 13
+\de — f. 〉 негодный, жалкий, окаянный, проклятый KĀD. 187,12. 194,5. 2,22,19. 92,11. BENF. Chr. 193,15. — Caus. dāhayati
+\sn 14
+\de — 1) давать сжечь, приказывать сжечь.
+\sn 15
+\de — 2〉 давать жарить(ся).
+\sn 16
+\de — 3) гореть Spr. 339. — Desid. didhikṣiti, ˚te собираться (сделать что-л.), быть готовым (сделать что-л.).
+\sn 17
+\de — 1) жечь, сжигать.
+\sn 18
+\de — 2) губить, уничтожать. — Caus. От Desid. didhakṣayati побуждать кого-либо к тому, чтобы он приготовился сжечь. — Intens.
+\sn 19
+\de — 1) dandahīti (PRASANNAR. 118,14. 126,3), dandagdhi, dandahyate полностью сжигать, — опалять, — губить.
+\sn 20
+\de — 2) dandahyate полностью сгорать в огне, погибать в пламени. — С ati
+\sn 21
+\de — 1) чрезмерно жечь.
+\sn 22
+\de — 2) совсем иссушить, совершенно высушить ŚAT. BR. 1,4,1,14.
+\sn 23
+\de — 3〉 не достигать пламенем ĀPAST. ŚR. 1,25,9.
+\sn 24
+\de — 4〉 делать кого-л (Acc.) чрезвычайно горячим. — С anu
+\sn 25
+\de — 1〉 вспыхивать, сгорать дотла.
+\sn 26
+\de — 2〉 вспыхивать, воспламеняться (intrans.) ṚV. 2,1,10.
+\sn 27
+\de — 3〉 сгорать вслед, догорать (intrans.) MBH. 12,224,20. — С apa
+\sn 28
+\de — 1〉 изгонять жаром, вытеснять пламенем.
+\sn 29
+\de — 2〉 подгорать, начинать гореть. v. l. upadagdha вместо apadagdha. — С api подгорать. — С abhi
+\sn 30
+\de — 1〉 загораться, сгорать ĀPAST. 1,28,15.
+\sn 31
+\de — 2〉 нагревать, накалять ĀPAST. 1,17,10. — С ava сгорать, спекаться от огня. avadagdha также поврежденный огнем CARAKA. 5,12. — С ā в ādahana ādagdhvā PAÑCAT. 1,392 ошибочно вместо adagdhvā. — Caus. Pass. обжигаться, сгорать. — С abhyā в abhyādāhya (Nachtr. 2). — С upa подпаливать, поджигать {{MBH. 7,211,17->MBH. 12,211,17||20250606|Andhrabharati|https://github.com/sanskrit-lexicon/PWK/issues/84#issuecomment-2948415067|}}. поджигать, поднести огонь к (Acc.). — С ni сжигать дотла, испепелять огнём. Pass. быть сожжённым, сгорать. — С nis выгорать, сгорать, быть испепелённым огнём, уничтожаться полностью. Pass. также съёживаться, увядать. tuṣāreṇa padminī VIKRAMĀṄKAC. 16,14. — Caus. давать сжечь, велеть сжечь. — С anunis сжигать один за другим, по очереди. — С vinis сжигать, испепелять огнём, уничтожать полностью. — С pari обжигать вокруг, охватывать пламенем, сжигать. Pass. гореть, пылать. — С saṃpari Pass. (˚dahyati) сгорать, изнывать от зноя. — С pra сжигать, опалять, уничтожать. Pass. воспламеняться, гореть, сгорать. pradagadha сжигает, уничтожает. — Caus. давать сжечь, велеть сжечь. — С saṃpra сжигать, уничтожать. — С prati
+\sn 32
+\de — 1〉 гореть навстречу, встречать пламенем; с Acc.
+\sn 33
+\de — 2〉 Pass. (˚dahyati) сжигать, сгорать (intrans.). — С vi
+\sn 34
+\de — 1〉 Act.
+\sn 35
+\de — a〉 выжигать (рану и т.д.).
+\sn 36
+\de — b〉 повреждать огнём, подпаливать.
+\sn 37
+\de — в) жечь, спалять, уничтожать огнём.
+\sn 38
+\de — г) разлагать, портить CARAKA. 6,18.
+\sn 39
+\de — 2〉 Pass.
+\sn 40
+\de — а) жечь, сжигать (intrans.).
+\sn 41
+\de — б) жечь, гореть (о ранах).
+\sn 42
+\de — в) страдать от внутреннего жара.
+\sn 43
+\de — г) терзаться, изводить себя горем.
+\sn 44
+\de — д) важничать, кичиться. vikatthase v. l. вместо vidahyase.
+\sn 45
+\de — 3〉 Partic. vidagdha
+\sn 46
+\de — а) сожжённый.
+\sn 47
+\de — б) воспалённый.
+\sn 48
+\de — c) о внутреннем огне, о желчи, которая варит, перерабатывает, переваривает пищу в желудке.
+\sn 49
+\de — d) созревший (о нарыве) BHĀVAPR. 5,117.
+\sn 50
+\de — e) разложившийся, испорченный CARAKA. 6,10. скисший.
+\sn 51
+\de — f) поумневший от опыта, умный, разумный, хитрый, лукавый. — С sam
+\sn 52
+\de — 1) Act. сгорать, сжигать, уничтожать.
+\sn 53
+\de — 2〉 Pass.
+\sn 54
+\de — a) быть сожжённым.
+\sn 55
+\de — b) гореть, пылать.
+\sn 56
+\de — c) изнывать, томиться горем. — Caus. давать сжечь, велеть сжечь. — С vyatisam сжигать вперемешку, целиком, огулом. — С anusam сгорать вдоль, по длине. 2. ˚dah Adj. горящий.
+\bb Chr. 78,8
+\bb {{MBH. 7,62,65->MBH. 7,72,65||20250606|Andhrabharati|https://github.com/sanskrit-lexicon/PWK/issues/84#issuecomment-2948415067|}}
+\bb DAŚAK. 78,9. 10
+\bb MĀN. GṚHY. 2,15
+\bb MBH. 4,23,7
+\bb KĀD. 187,12. 194,5. 2,22,19. 92,11
+\bb BENF. Chr. 193,15
+\bb Spr. 339
+\bb PRASANNAR. 118,14. 126,3
+\bb ŚAT. BR. 1,4,1,14
+\bb ĀPAST. ŚR. 1,25,9
+\bb ṚV. 2,1,10
+\bb MBH. 12,224,20
+\bb ĀPAST. 1,28,15
+\bb ĀPAST. 1,17,10
+\bb CARAKA. 5,12
+\bb PAÑCAT. 1,392
+\bb Nachtr. 2
+\bb {{MBH. 7,211,17->MBH. 12,211,17||20250606|Andhrabharati|https://github.com/sanskrit-lexicon/PWK/issues/84#issuecomment-2948415067|}}
+\bb VIKRAMĀṄKAC. 16,14
+\bb CARAKA. 6,18
+\bb BHĀVAPR. 5,117
+\bb CARAKA. 6,10
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h0_zz_pw; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\hm 1
+\ps adj.
+\de dah (= 1. dah) adj. «пылающий, горящий», в конце comp.: dakṣiṇadhak (˚sad VS.) LĀṬY. 5,7,3; ср. uśadhak .
+\bb VS.
+\bb LĀṬY. 5,7,3
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h1_00_pwg00; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5
+
+\lx dah
+\hm 2
+\sn 1
+\de 1. dah стк. 3 dahiṣyati тоже PRASAṄGĀBH. 16,3. pass.: mithilāyāṃ pradīptāyāṃ na me dahyati kiṃ ca na у меня ничего не сгорает Spr. 3448. dagdha 4) ˚tithi Verz. d. Oxf. H. 86,a,38. Verz. d. Oxf. H. 333,b, No. 785. — caus.: na śudhyati yathā bhāṇḍaṃ surāyā dāhitaṃ sat было бы и это сожжено VṚDDHA-CĀṆ. 11,7.
+\sn 2
+\de — anu 1) NĪLAK. : dagdhaṃ kālātmanā īśvareṇa anuvahati (!) vahnyādiḥ.anudahati видимо, следует читать = anudahyate (так и нужно читать).
+\sn 3
+\de — ni, nyadahankāṣṭhaveṣṭitam (kalevaram) BHĀG. P. 10,6,33.
+\sn 4
+\de — pra caus. давать сжечь, велеть сжечь: yāvaccāgnau mṛte patyau strī nātmānaṃ pradāhayet Spr. 2479.
+\sn 5
+\de — vi сжигать, опалять: vidadāha tamaṅgeṣu śīto 'pi malayānilaḥ KATHĀS. 104,8. — partic. vidagdha
+\sn 6
+\de 5) хитрый, лукавый Spr. 586, v. l.
+\sn 7
+\de — sam сжигать, опалять: kugrāmavāsaḥ и т.д. vināgninā saṃdahate śarīram Spr. 690.
+\bb PRASAṄGĀBH. 16,3.
+\bb Spr. 3448.
+\bb Verz. d. Oxf. H. 86,a,38.
+\bb Verz. d. Oxf. H. 333,b, No. 785.
+\bb VṚDDHA-CĀṆ. 11,7.
+\bb NĪLAK.
+\bb BHĀG. P. 10,6,33.
+\bb Spr. 2479.
+\bb KATHĀS. 104,8.
+\bb Spr. 586
+\bb Spr. 690.
+\nt sense-numbering: inferred from row order, not observed in source
+\nt meta: profile=mdf-export-pwg-ru-v0.1; national=ru; slp1=dah; subcard=dah~~h2_00_pwg00; src=PWG pc=- page=-; review=ai_translated; model=claude-sonnet-5

--- a/RussianTranslation/src/pilot/export_mdf_pwg_ru.py
+++ b/RussianTranslation/src/pilot/export_mdf_pwg_ru.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python
+r"""export_mdf_pwg_ru.py — promoted pwg_ru cards -> MDF (SIL Multi-Dictionary Formatter) SFM.
+
+READ-ONLY consumer of the promoted store (src/pwg_ru_translated.jsonl). Never
+writes to the store, the TMs, the queues, or any harness artifact — it turns
+already-promoted de+ru(+en) sense rows into standard-format MDF records
+(Toolbox/FLEx lineage) so the RU translation has an exchange format consumable
+by the language-documentation toolchain (Lexique Pro, Webonary, Dictionary App
+Builder). Design note: RussianTranslation/docs/MDF_EXPORT_PWG_RU.md. Profile
+alignment: csl-standards data/schema/mdf-export-profile.json (marker inventory
+and Coward & Grimes 2000 App. B field order; checked by --selftest when the
+sibling csl-standards clone is present).
+
+Language lanes (the book's national-vs-English contrast, C&G 2000 §2.3):
+  \de  Russian   — the national/target-language definition (the primary lane;
+                   same ruling as csl-standards gives SKD/VCP their Sanskrit \de)
+  \ge  English   — the secondary gloss lane, emitted only when promote_en.py has
+                   attached an `en` field to the row (absent rows stay \de-only;
+                   never fabricated)
+The German source text is deliberately NOT exported: it is PWG's own material,
+recoverable from the store / csl-orig via the meta pointer, and this dataset is
+the *translation*, not a PWG re-edition.
+
+RANGE-SET gate (C&G 2000 §9.7): <ab> abbreviation tokens and \ps values are
+checked against closed vocabularies (PWG's own pwgab table for <ab>; PS_RANGE
+below for \ps). Violations are counted and reported; --strict makes them fatal.
+
+  python src/pilot/export_mdf_pwg_ru.py --selftest
+  python src/pilot/export_mdf_pwg_ru.py --keys Ap --out out.mdf      # sample
+  python src/pilot/export_mdf_pwg_ru.py --out full.mdf --strict      # everything
+"""
+import argparse
+import json
+import os
+import re
+import sys
+from collections import OrderedDict
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = os.path.dirname(HERE)
+for p in (HERE, SRC):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+import pwg_ab                     # noqa: E402  authoritative <ab> table (791 entries)
+import pwg_ab_ru                  # noqa: E402  RU display policy (Bucket A -> Russian)
+from build_article_site import slp1_iast  # noqa: E402  shared SLP1->IAST, no transcoder #63
+
+PROFILE_VERSION = 'mdf-export-pwg-ru-v0.1'
+NATIONAL_LANGUAGE = 'ru'
+
+DEFAULT_STORE = os.path.join(SRC, 'pwg_ru_translated.jsonl')
+
+# Marker subset used by this exporter — must stay inside the csl-standards
+# mdf-export-profile-v0.1 inventory (selftest cross-checks when the sibling
+# clone is present).
+MARKERS = ('lx', 'hm', 'ps', 'sn', 'ge', 'de', 'bb', 'nt')
+
+# Canonical relative field order, C&G 2000 App. B, as fixed by the csl-standards
+# profile schema. \sn/\ge/\de repeat as one sense block per sense (bilingual
+# deviation from the MW profile, where \de never repeats — documented in the
+# design note).
+FIELD_ORDER = ('lx', 'hm', 'lc', 'se', 'ps', 'sn', 'ge', 're', 'de', 'xv', 'xn',
+               'lf', 'le', 'cf', 'va', 'et', 'es', 'sd', 'bb', 'nt')
+SENSE_BLOCK = frozenset(('sn', 'ge', 'de'))
+
+# RANGE-SET (§9.7) closed vocabulary for \ps: every <lex> value observed in the
+# promoted store as of 11-07-2026 plus the standard PWG gender/POS inventory.
+# A value outside the set is a range violation, not a silent passthrough.
+PS_RANGE = frozenset((
+    'm.', 'f.', 'n.', 'mfn.', 'adj.', 'Adj.', 'adv.', 'Adv.', 'ind.',
+    'Indecl.', 'indecl.', 'interj.', 'Interj.', 'Pronomm.', 'pron.',
+    'm. f.', 'f. m.', 'm. n.', 'n. m.', 'f. n.', 'n. f.',
+))
+
+_LS = re.compile(r'<ls(?:\s+n="([^"]*)")?\s*>(.*?)</ls>', re.S)
+_AB = re.compile(r'<ab>(.*?)</ab>', re.S)
+_LEX = re.compile(r'<lex>(.*?)</lex>', re.S)
+_IS = re.compile(r'<is\b[^>]*>(.*?)</is>', re.S)
+_SK = re.compile(r'\{#(.*?)#\}', re.S)
+_GL = re.compile(r'\{%(.*?)%\}', re.S)
+_TAG = re.compile(r'<[^>]+>')
+_PAGE = re.compile(r'\[Page[^\]]*\]')
+_HM = re.compile(r'~~h(\d+)_')
+_WS = re.compile(r'\s+')
+
+
+def one_line(s):
+    return _WS.sub(' ', s or '').strip()
+
+
+def ab_tokens(text):
+    return [one_line(m.group(1)) for m in _AB.finditer(text or '')]
+
+
+def check_ab_range(tokens, violations):
+    """RANGE-SET gate: every <ab> token must resolve in PWG's own pwgab table.
+    The table is lowercase-keyed, so sentence-initial capitals (Pass., Act.)
+    are folded before being declared out-of-range."""
+    for tok in tokens:
+        if pwg_ab.resolve(tok) is None and pwg_ab.resolve(tok.lower()) is None:
+            violations.append(('ab', tok))
+
+
+def bb_citations(text):
+    """Distinct <ls> citations, in order. <ls n="M.">8,64.</ls> continuation
+    form is expanded to 'M. 8,64.' so every \\bb is self-contained."""
+    seen = OrderedDict()
+    for n, inner in _LS.findall(text or ''):
+        inner = one_line(inner)
+        value = one_line('%s %s' % (n, inner)) if n else inner
+        if value:
+            seen.setdefault(value, None)
+    return list(seen)
+
+
+def clean_prose(text, lang):
+    """One MDF field line from a store prose field.
+
+    <ls> kept inline as plain sigla (the citation is part of the printed
+    definition; \\bb additionally lists it for machines), <ab> rendered per the
+    tooltip policy (RU: pwg_ab_ru Bucket-A translation, Bucket-B Latin
+    fallback; EN: original token), {#..#} SLP1 -> IAST, {%..%} unwrapped,
+    <is> proper names kept IAST (site-level Cyrillicization is not yet
+    corpus-validated — ABBREVIATIONS_RU.md open item), leftover tags stripped.
+    """
+    t = text or ''
+    t = _LS.sub(lambda m: one_line('%s %s' % (m.group(1) or '', one_line(m.group(2)))), t)
+    if lang == 'ru':
+        t = _AB.sub(lambda m: pwg_ab_ru.display(one_line(m.group(1)))[0], t)
+    else:
+        t = _AB.sub(lambda m: one_line(m.group(1)), t)
+    t = _IS.sub(lambda m: one_line(m.group(1)), t)
+    t = _SK.sub(lambda m: slp1_iast(one_line(m.group(1))), t)
+    t = _GL.sub(lambda m: m.group(1), t)
+    t = _TAG.sub(' ', t)
+    t = _PAGE.sub(' ', t)          # print-page markers are layout, not prose
+    t = t.replace('¦', ' ')   # PWG's headword¦body separator
+    return one_line(t)
+
+
+def card_ps(rows, violations):
+    """First <lex> across the card's RU (then DE) fields -> \\ps, range-checked."""
+    for field in ('ru', 'de'):
+        for row in rows:
+            m = _LEX.search(row.get(field) or '')
+            if m:
+                value = one_line(_TAG.sub(' ', m.group(1)))
+                if value not in PS_RANGE:
+                    violations.append(('ps', value))
+                return value
+    return None
+
+
+def card_hm(subcard):
+    m = _HM.search(subcard or '')
+    return m.group(1) if m and m.group(1) != '0' else None
+
+
+def observed_sense_numbers(rows):
+    """PWG prints real sense numbers (unlike MW's prose senses). When every row
+    carries a distinct purely-numeric sense_tag, that printed numbering is used
+    as-is; otherwise numbering is inferred 1..n and flagged with the same
+    \\nt convention csl-standards uses."""
+    tags = [str(r.get('sense_tag') or '') for r in rows]
+    if all(re.fullmatch(r'\d+', t) for t in tags) and len(set(tags)) == len(tags):
+        return tags, True
+    return [str(i + 1) for i in range(len(rows))], False
+
+
+def mdf_record(key1, subcard, rows, violations):
+    lines = []
+    notes = []
+
+    lines.append('\\lx %s' % (one_line(rows[0].get('iast')) or slp1_iast(key1)))
+
+    hm = card_hm(subcard)
+    if hm:
+        lines.append('\\hm %s' % hm)
+
+    ps = card_ps(rows, violations)
+    if ps:
+        lines.append('\\ps %s' % ps)
+
+    for row in rows:
+        check_ab_range(ab_tokens(row.get('ru')), violations)
+
+    bb = OrderedDict()
+    numbers, observed = observed_sense_numbers(rows)
+    multi = len(rows) > 1
+    for number, row in zip(numbers, rows):
+        if multi:
+            lines.append('\\sn %s' % number)
+        en = row.get('en')
+        if en:
+            lines.append('\\ge %s' % clean_prose(en, 'en'))
+        lines.append('\\de %s' % clean_prose(row.get('ru'), 'ru'))
+        for cite in bb_citations(row.get('ru')):
+            bb.setdefault(cite, None)
+    for cite in bb:
+        lines.append('\\bb %s' % cite)
+
+    if multi and not observed:
+        notes.append('\\nt sense-numbering: inferred from row order, not observed in source')
+
+    prov = rows[0].get('provenance') or {}
+    meta = ('\\nt meta: profile=%s; national=%s; slp1=%s; subcard=%s; '
+            'src=PWG pc=%s page=%s; review=%s; model=%s' % (
+                PROFILE_VERSION, NATIONAL_LANGUAGE, key1, subcard,
+                rows[0].get('column') or '-', rows[0].get('page') or '-',
+                rows[0].get('review_status') or '-',
+                prov.get('model_version') or '-'))
+
+    return '\n'.join(lines + notes + [meta]) + '\n'
+
+
+def load_cards(store_path, keys=None, limit=None):
+    """Group store rows into cards by (key1, subcard), preserving store order
+    within a card. Yields (key1, subcard, rows) sorted by IAST headword."""
+    cards = OrderedDict()
+    with open(store_path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            if keys and row.get('key1') not in keys:
+                continue
+            cards.setdefault((row.get('key1'), row.get('subcard')), []).append(row)
+    items = sorted(cards.items(), key=lambda kv: (slp1_iast(kv[0][0] or '').lower(), kv[0][1] or ''))
+    if limit:
+        items = items[:limit]
+    return items
+
+
+def export(store_path, out_path, keys=None, limit=None):
+    violations = []
+    records = []
+    for (key1, subcard), rows in load_cards(store_path, keys, limit):
+        records.append(mdf_record(key1, subcard, rows, violations))
+    with open(out_path, 'w', encoding='utf-8', newline='\n') as f:
+        f.write('\n'.join(records))
+    return len(records), violations
+
+
+# ---------------------------------------------------------------- validation
+
+def parse_fields(text):
+    fields = []
+    for line in text.split('\n'):
+        if not line.strip():
+            continue
+        m = re.match(r'^\\(\w+)(?:\s+(.*))?$', line)
+        fields.append({'marker': m.group(1) if m else None,
+                       'value': (m.group(2) or '').strip() if m else line})
+    return fields
+
+
+def order_violations(markers):
+    """Field-order check mirroring csl-standards validate-mdf-profile.mjs,
+    with \\sn/\\ge/\\de sharing one sense-block key (the bilingual deviation)."""
+    sense_key = min(FIELD_ORDER.index(m) for m in SENSE_BLOCK)
+    bad = []
+    max_seen = -1
+    for marker in markers:
+        key = sense_key if marker in SENSE_BLOCK else (
+            FIELD_ORDER.index(marker) if marker in FIELD_ORDER else None)
+        if key is None:
+            continue
+        if key < max_seen:
+            bad.append(marker)
+        else:
+            max_seen = max(max_seen, key)
+    return bad
+
+
+def validate_records(text):
+    """Structural marker-profile validation of an exported .mdf text."""
+    problems = []
+    for i, block in enumerate(t for t in text.split('\n\n') if t.strip()):
+        where = 'record %d' % (i + 1)
+        fields = parse_fields(block)
+        markers = [f['marker'] for f in fields]
+        if markers[:1] != ['lx']:
+            problems.append('%s: must begin with \\lx' % where)
+        if any(m is None for m in markers):
+            problems.append('%s: non-marker line' % where)
+        unknown = sorted({m for m in markers if m and m not in MARKERS})
+        if unknown:
+            problems.append('%s: markers outside profile: %s' % (where, ', '.join(unknown)))
+        bad = order_violations([m for m in markers if m])
+        if bad:
+            problems.append('%s: field order violated at: %s' % (where, ', '.join(sorted(set(bad)))))
+        if not any(f['marker'] == 'nt' and f['value'].startswith('meta:') for f in fields):
+            problems.append('%s: missing meta note' % where)
+        if not any(f['marker'] == 'de' for f in fields):
+            problems.append('%s: no \\de definition' % where)
+    return problems
+
+
+def profile_schema_path():
+    return os.path.join(os.path.dirname(os.path.dirname(SRC)), '..',
+                        'csl-standards', 'data', 'schema', 'mdf-export-profile.json')
+
+
+# ------------------------------------------------------------------ selftest
+
+FIXTURE_ROWS = [
+    {'key1': 'Ap', 'subcard': '_ap~~h0_00_pwg01', 'iast': 'āp', 'sense_tag': '6',
+     'ru': '6) {%близкий, родственный%}; <lex>m.</lex> {%родственник%} '
+           '(<ab>vgl.</ab> {#Api#}) <ls>M. 2,109.</ls> <ls n="M.">8,64.</ls>',
+     'de': 'x', 'review_status': 'ai_translated',
+     'provenance': {'model_version': 'claude-sonnet-5'},
+     'column': '1-0649', 'page': '1-p0325'},
+    {'key1': 'Ap', 'subcard': '_ap~~h0_00_pwg01', 'iast': 'āp', 'sense_tag': '7',
+     'ru': '7) {%достигать%} {#Apnoti#} <ls>YĀJÑ. 1,28.</ls>', 'de': 'x',
+     'en': '7) {%to reach%} {#Apnoti#}',
+     'review_status': 'ai_translated', 'provenance': {'model_version': 'claude-sonnet-5'},
+     'column': '1-0649', 'page': '1-p0325'},
+]
+
+
+def selftest():
+    ok = True
+
+    def check(cond, name):
+        nonlocal ok
+        print('%s %s' % ('PASS' if cond else 'FAIL', name))
+        ok = ok and cond
+
+    violations = []
+    rec = mdf_record('Ap', '_ap~~h0_00_pwg01', FIXTURE_ROWS, violations)
+    fields = parse_fields(rec)
+    markers = [f['marker'] for f in fields]
+
+    check(markers[0] == 'lx' and fields[0]['value'] == 'āp', 'lx is IAST headword')
+    check('hm' not in markers, 'h0 homonym suppressed')
+    check(fields[markers.index('ps')]['value'] == 'm.', 'ps from <lex>')
+    check(markers.count('sn') == 2 and markers.count('de') == 2, 'per-sense sn+de')
+    check(markers.count('ge') == 1, 'ge only where en exists — never fabricated')
+    sn_vals = [f['value'] for f in fields if f['marker'] == 'sn']
+    check(sn_vals == ['6', '7'], 'observed PWG sense numbers kept')
+    de1 = [f['value'] for f in fields if f['marker'] == 'de'][0]
+    check('ср.' in de1 and 'vgl' not in de1, 'Bucket-A <ab> translated to RU (vgl.->ср.)')
+    check('āpi' in de1.lower(), 'SLP1 {#..#} -> IAST in prose')
+    bb_vals = [f['value'] for f in fields if f['marker'] == 'bb']
+    check(bb_vals == ['M. 2,109.', 'M. 8,64.', 'YĀJÑ. 1,28.'],
+          'bb citations incl. n= continuation expansion')
+    check(not violations, 'no range violations on clean fixture')
+    check(not validate_records(rec), 'record passes structural profile validation')
+
+    poisoned = [dict(FIXTURE_ROWS[0], ru='{%x%} <ab>zzz9.</ab> <lex>weird.</lex>')]
+    bad = []
+    mdf_record('Ap', '_ap~~h0_00_pwg01', poisoned, bad)
+    check(('ab', 'zzz9.') in bad, 'RANGE-SET gate trips on unknown <ab>')
+    check(('ps', 'weird.') in bad, 'RANGE-SET gate trips on out-of-range \\ps')
+
+    check(order_violations(['lx', 'ps', 'sn', 'ge', 'de', 'sn', 'de', 'bb', 'nt']) == [],
+          'sense block repeats legally')
+    check(order_violations(['lx', 'bb', 'ps']) == ['ps'], 'order check catches regression')
+
+    schema = profile_schema_path()
+    if os.path.exists(schema):
+        with open(schema, encoding='utf-8') as f:
+            prof = json.load(f)
+        inventory = {m.lstrip('\\') for m in prof['markers']}
+        check(set(MARKERS) <= inventory, 'marker subset within csl-standards inventory')
+        check(tuple(m.lstrip('\\') for m in prof['fieldOrder']) == FIELD_ORDER,
+              'field order matches csl-standards profile schema')
+    else:
+        print('SKIP csl-standards profile schema not present (%s)' % schema)
+
+    print('selftest %s' % ('PASS' if ok else 'FAIL'))
+    return 0 if ok else 1
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--store', default=DEFAULT_STORE)
+    ap.add_argument('--out', default=os.path.join(HERE, 'output', 'pwg_ru_full.mdf'))
+    ap.add_argument('--keys', help='comma-separated key1 filter (sample export)')
+    ap.add_argument('--limit', type=int, help='max cards')
+    ap.add_argument('--strict', action='store_true', help='range violations are fatal')
+    ap.add_argument('--selftest', action='store_true')
+    args = ap.parse_args()
+
+    if args.selftest:
+        sys.exit(selftest())
+
+    if not os.path.exists(args.store):
+        sys.exit('store not found: %s (local-only file; pass --store)' % args.store)
+
+    keys = set(args.keys.split(',')) if args.keys else None
+    count, violations = export(args.store, args.out, keys, args.limit)
+    with open(args.out, encoding='utf-8') as f:
+        problems = validate_records(f.read())
+    print('exported %d records -> %s' % (count, args.out))
+    if violations:
+        summary = {}
+        for kind, value in violations:
+            summary.setdefault(kind, set()).add(value)
+        for kind, values in sorted(summary.items()):
+            print('RANGE-SET violations (%s): %d distinct: %s' % (
+                kind, len(values), ', '.join(sorted(values)[:20])))
+    if problems:
+        print('structural validation problems:')
+        for p in problems[:20]:
+            print('- %s' % p)
+    if (violations and args.strict) or problems:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Executes [H727](https://github.com/gasyoun/Uprava/blob/main/handoffs/H727-Fable_SanskritLexicography_pwg-kosha-mdf-integration_11.07.26.md) (MDF/LIFT lens on the PWG-RU pipeline, per the [SIL MDF correlation map](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/SIL_MDF_ECOSYSTEM_CORRELATION.md) §4–5 MG ruling of 11-07-2026).

- **[RussianTranslation/src/pilot/export_mdf_pwg_ru.py](https://github.com/gasyoun/SanskritLexicography/blob/h727-mdf-export/RussianTranslation/src/pilot/export_mdf_pwg_ru.py)** — read-only cards→MDF exporter over the promoted store (11,383 sense rows → 2,350 records). `\de` = RU national-language definition, `\ge` = EN gloss lane (only when `promote_en.py` attached one — never fabricated), `\bb` from inline `<ls>` (with `n=` continuation expansion), observed PWG sense numbers kept in `\sn`. RANGE-SET (§9.7) closed-vocabulary gate over `<ab>` (pwgab table) and `\ps` (PS_RANGE); `--selftest` 17/17 incl. a live cross-check against the csl-standards [mdf-export-profile.json](https://github.com/sanskrit-lexicon/csl-standards/blob/main/data/schema/mdf-export-profile.json) schema.
- **[RussianTranslation/docs/MDF_EXPORT_PWG_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/h727-mdf-export/RussianTranslation/docs/MDF_EXPORT_PWG_RU.md)** — mapping design note (field table, bilingual `\ge`/`\de` sense-block deviation, markup-resolution rules, LIFT correspondence deferred to a real LIFT consumer).
- **[RussianTranslation/docs/samples/pwg_ru_sample.mdf](https://github.com/gasyoun/SanskritLexicography/blob/h727-mdf-export/RussianTranslation/docs/samples/pwg_ru_sample.mdf)** — committed 30-card sample (dah, gam); the full export stays gitignored and distributes via the kosha manifest.
- **[RussianTranslation/LANG_PARITY.md](https://github.com/gasyoun/SanskritLexicography/blob/h727-mdf-export/RussianTranslation/LANG_PARITY.md)** — new `mdf_export` SHARED entry (single code path for both lanes), hash-pinned; `lang_parity_check.py` + `window_selftest.py` PASS.

Harness/TMs/queues untouched (read-only consumer, built in a worktree per the handoff constraint). Model: Fable 5 (`claude-fable-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)