### PR TITLE
Clean up uncommitted artifacts: H685 RU-gloss gap-stats + A33 checklist

### DIFF
--- a/RussianTranslation/glossary/ru_gloss_gap_stats.json
+++ b/RussianTranslation/glossary/ru_gloss_gap_stats.json
@@ -1,0 +1,313 @@
+{
+  "corpus_rows": 1093391,
+  "corpus_distinct_keys": 191436,
+  "rows_empty_ru": 0,
+  "kinds": {
+    "translation": 992265,
+    "commentary": 101126
+  },
+  "hapax_keys": 112782,
+  "hapax_rate_pct": 58.91,
+  "surface_keys_with_ru": 191436,
+  "lemma_layer_keys": 40370,
+  "root_layer_keys": 2021,
+  "token_coverage_pct": {
+    "dcs_only": 79.12,
+    "plus_vidyut": 86.53,
+    "plus_marker": 87.07
+  },
+  "dcs_freq_lemmas_slp1": 90349,
+  "dcs_freq_meta": {
+    "source": "VisualDCS dcs_full.sqlite token table",
+    "total_tokens": 5688416,
+    "distinct_lemmas": 90349
+  },
+  "per_dict_coverage": {
+    "AP": {
+      "headwords": 88867,
+      "surface": 18727,
+      "lemma": 13359,
+      "root": 734,
+      "any": 21386,
+      "any_pct": 24.07
+    },
+    "GRA": {
+      "headwords": 11108,
+      "surface": 6620,
+      "lemma": 7931,
+      "root": 649,
+      "any": 8526,
+      "any_pct": 76.76
+    },
+    "MW": {
+      "headwords": 194084,
+      "surface": 35388,
+      "lemma": 36220,
+      "root": 897,
+      "any": 43287,
+      "any_pct": 22.3
+    },
+    "PWG": {
+      "headwords": 106082,
+      "surface": 23595,
+      "lemma": 24150,
+      "root": 886,
+      "any": 27780,
+      "any_pct": 26.19
+    },
+    "PWK": {
+      "headwords": 151349,
+      "surface": 27546,
+      "lemma": 27795,
+      "root": 928,
+      "any": 32430,
+      "any_pct": 21.43
+    },
+    "SKD": {
+      "headwords": 40817,
+      "surface": 6469,
+      "lemma": 2238,
+      "root": 140,
+      "any": 6713,
+      "any_pct": 16.45
+    },
+    "VCP": {
+      "headwords": 48636,
+      "surface": 13954,
+      "lemma": 12892,
+      "root": 190,
+      "any": 15313,
+      "any_pct": 31.48
+    },
+    "VEI": {
+      "headwords": 3704,
+      "surface": 2130,
+      "lemma": 2214,
+      "root": 29,
+      "any": 2346,
+      "any_pct": 63.34
+    }
+  },
+  "gap_keys_total": 242726,
+  "gap_keys_in_dcs": 36974,
+  "gap_list_file": "glossary/ru_gloss_gaps.tsv",
+  "gap_head_top20": [
+    {
+      "key": "tEla",
+      "dicts": [
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP",
+        "VEI"
+      ],
+      "dcs_count": 2109
+    },
+    {
+      "key": "sEnya",
+      "dicts": [
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP"
+      ],
+      "dcs_count": 1494
+    },
+    {
+      "key": "vESampAyana",
+      "dicts": [
+        "MW",
+        "VCP"
+      ],
+      "dcs_count": 1326
+    },
+    {
+      "key": "dEtya",
+      "dicts": [
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP"
+      ],
+      "dcs_count": 1258
+    },
+    {
+      "key": "dEva",
+      "dicts": [
+        "AP",
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP",
+        "VEI"
+      ],
+      "dcs_count": 1226
+    },
+    {
+      "key": "ganDaka",
+      "dicts": [
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP"
+      ],
+      "dcs_count": 1192
+    },
+    {
+      "key": "aNgula",
+      "dicts": [
+        "GRA",
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP"
+      ],
+      "dcs_count": 1054
+    },
+    {
+      "key": "SEla",
+      "dicts": [
+        "AP",
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP"
+      ],
+      "dcs_count": 1036
+    },
+    {
+      "key": "mUzA",
+      "dicts": [
+        "AP",
+        "MW",
+        "SKD"
+      ],
+      "dcs_count": 946
+    },
+    {
+      "key": "vESya",
+      "dicts": [
+        "GRA",
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP",
+        "VEI"
+      ],
+      "dcs_count": 931
+    },
+    {
+      "key": "ekEka",
+      "dicts": [
+        "AP",
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP"
+      ],
+      "dcs_count": 925
+    },
+    {
+      "key": "sEnDava",
+      "dicts": [
+        "AP",
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP",
+        "VEI"
+      ],
+      "dcs_count": 918
+    },
+    {
+      "key": "sOmya",
+      "dicts": [
+        "AP",
+        "GRA",
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP",
+        "VEI"
+      ],
+      "dcs_count": 917
+    },
+    {
+      "key": "OzaDa",
+      "dicts": [
+        "AP",
+        "MW",
+        "PWG",
+        "PWK"
+      ],
+      "dcs_count": 905
+    },
+    {
+      "key": "prajYApAramitA",
+      "dicts": [
+        "AP",
+        "MW",
+        "PWG",
+        "PWK"
+      ],
+      "dcs_count": 881
+    },
+    {
+      "key": "SanEs",
+      "dicts": [
+        "AP",
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP"
+      ],
+      "dcs_count": 837
+    },
+    {
+      "key": "Endra",
+      "dicts": [
+        "AP",
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP"
+      ],
+      "dcs_count": 818
+    },
+    {
+      "key": "mAkzika",
+      "dicts": [
+        "AP",
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP"
+      ],
+      "dcs_count": 793
+    },
+    {
+      "key": "vESvAnara",
+      "dicts": [
+        "AP",
+        "GRA",
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP"
+      ],
+      "dcs_count": 783
+    },
+    {
+      "key": "kOrava",
+      "dicts": [
+        "AP",
+        "MW",
+        "PWG",
+        "PWK",
+        "VCP",
+        "VEI"
+      ],
+      "dcs_count": 736
+    }
+  ]
+}

--- a/RussianTranslation/src/build_ru_gloss_gap_stats.py
+++ b/RussianTranslation/src/build_ru_gloss_gap_stats.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python
+r"""H685 — corpus_lexicon RU-gloss statistics: per-dict coverage, hapax rate, gap-list.
+
+Reads the live aligned corpus (src/corpus_lexicon.jsonl) plus the three glossary
+layers (surface = derived here from the live corpus; lemma + root = the committed
+rollups in the sibling gasyoun/SanskritRussian repo) and answers the
+DATA_LAYERS_CENSUS.md §3 questions for this asset:
+
+  1. per-dict coverage % — which Cologne dictionary headwords (HeadwordLists/
+     now-2026 key1 lists, SLP1) have >=1 corpus-attested RU gloss in any layer;
+  2. hapax rate — surface keys attested exactly once in the corpus;
+  3. the "keys with no RU gloss" gap-list — dictionary headwords with no RU gloss
+     in any layer, ranked by DCS corpus frequency (src/dcs_freq.json, IAST ->
+     SLP1), so the top of the list = highest-value targets for the next
+     translation window.
+
+It also re-runs the resolution-tier token-coverage measurement (DCS -> +Vidyut ->
++marker) against the LIVE corpus so the glossary README's 79.1 / 86.6 / 87.1 %
+figures can be reconciled with the current row count.
+
+Outputs (paths relative to RussianTranslation/):
+  glossary/ru_gloss_gaps.tsv        the full gap-list (gitignored via glossary/*.tsv)
+  glossary/ru_gloss_gap_stats.json  small committed stats snapshot (tables source)
+
+Only key1 dictionaries are joined (key1 = the normalized computational key; key2
+keeps print accents/marks that never match SLP1 joins). Key2-only dictionaries
+(BHS, BUR, CAE, CCS, INM, MD, SCH) are out of scope here.
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+
+SRC_DIR = Path(__file__).resolve().parent          # RussianTranslation/src
+RT_DIR = SRC_DIR.parent                            # RussianTranslation
+GITHUB_DIR = RT_DIR.parent.parent                  # GitHub/
+
+MARKER_SPLIT = re.compile(r"[+-]")
+
+
+def norm_key(k: str) -> str:
+    """Join-key normalization used across the glossary pipeline."""
+    return k.lstrip("'’")
+
+
+def load_tsv_col(path: Path, col: int = 0, skip_header: bool = True) -> set:
+    out = set()
+    with path.open(encoding="utf-8") as fh:
+        if skip_header:
+            next(fh, None)
+        for line in fh:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) > col and parts[col]:
+                out.add(norm_key(parts[col]))
+    return out
+
+
+def load_tsv_pairs(path: Path, kcol: int = 0, vcol: int = 1) -> dict:
+    out = {}
+    with path.open(encoding="utf-8") as fh:
+        next(fh, None)
+        for line in fh:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) > max(kcol, vcol):
+                out.setdefault(norm_key(parts[kcol]), parts[vcol])
+    return out
+
+
+def load_jsonl_keys(path: Path, field: str) -> set:
+    out = set()
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            if line.strip():
+                out.add(norm_key(json.loads(line)[field]))
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--corpus", type=Path, default=SRC_DIR / "corpus_lexicon.jsonl")
+    ap.add_argument("--sanskrit-russian", type=Path,
+                    default=GITHUB_DIR / "SanskritRussian")
+    ap.add_argument("--headword-dir", type=Path,
+                    default=GITHUB_DIR / "SanskritLexicography" / "HeadwordLists" / "now-2026")
+    ap.add_argument("--dcs-freq", type=Path, default=SRC_DIR / "dcs_freq.json")
+    ap.add_argument("--out-dir", type=Path, default=RT_DIR / "glossary")
+    args = ap.parse_args()
+
+    sr = args.sanskrit_russian
+
+    # --- resolution maps (for the README token-coverage reconciliation) -------
+    dcs_form2lemma = load_tsv_pairs(sr / "dcs_form2lemma.tsv")
+    vidyut_form2lemma = load_tsv_pairs(sr / "vidyut_form2lemma.tsv")
+    known_lemmas = set(dcs_form2lemma.values()) | set(vidyut_form2lemma.values())
+    known_lemmas |= load_tsv_col(sr / "dcs_lemma2root.tsv", col=1)
+
+    # --- glossary layers with RU glosses --------------------------------------
+    lemma_keys = load_jsonl_keys(sr / "lemma_glossary.jsonl", "lemma_slp1")
+    root_keys = load_jsonl_keys(sr / "root_glossary.jsonl", "root_slp1")
+
+    # --- stream the live corpus ------------------------------------------------
+    key_count = Counter()          # per normalized surface key: total rows
+    key_ru_count = Counter()       # per key: rows with a nonempty RU gloss
+    kinds = Counter()
+    rows = rows_empty_ru = 0
+    tok_dcs = tok_vidyut = tok_marker = 0
+    with args.corpus.open(encoding="utf-8") as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            rec = json.loads(line)
+            rows += 1
+            key = norm_key(rec["slp1"])
+            key_count[key] += 1
+            kinds[rec.get("kind", "?")] += 1
+            if rec.get("ru", "").strip():
+                key_ru_count[key] += 1
+            else:
+                rows_empty_ru += 1
+            # resolution tiers, mirroring build_rollup_glossaries.py
+            if key in dcs_form2lemma:
+                tok_dcs += 1
+            elif key in vidyut_form2lemma:
+                tok_vidyut += 1
+            elif "+" in key or "-" in key:
+                joined = key.replace("+", "").replace("-", "")
+                tail = MARKER_SPLIT.split(key)[-1]
+                if (joined in dcs_form2lemma or joined in vidyut_form2lemma
+                        or tail in known_lemmas):
+                    tok_marker += 1
+
+    surface_ru_keys = {k for k, n in key_ru_count.items() if n > 0}
+    glossed_any = surface_ru_keys | lemma_keys | root_keys
+    hapax = sum(1 for n in key_count.values() if n == 1)
+    distinct = len(key_count)
+
+    # --- DCS frequency, transcoded IAST -> SLP1 -------------------------------
+    from indic_transliteration import sanscript
+    dcs_freq_slp1 = {}
+    dcs_meta = {}
+    if args.dcs_freq.exists():
+        freq = json.loads(args.dcs_freq.read_text(encoding="utf-8"))
+        dcs_meta = freq.get("meta", {})
+        for lemma_iast, rec in freq.get("by_lemma", {}).items():
+            slp1 = sanscript.transliterate(lemma_iast, sanscript.IAST, sanscript.SLP1)
+            prev = dcs_freq_slp1.get(slp1)
+            if prev is None or rec["count"] > prev["count"]:
+                dcs_freq_slp1[slp1] = rec
+
+    # --- per-dict coverage ------------------------------------------------------
+    dict_files = sorted(args.headword_dir.glob("*-unique-key1-*.txt"))
+    per_dict = {}
+    gap_membership = {}            # gap key -> [dict codes]
+    for path in dict_files:
+        code = path.name.split("-")[0]
+        raw = path.read_text(encoding="utf-8-sig").splitlines()
+        heads = {norm_key(h.strip()) for h in raw if h.strip()}
+        m_surface = len(heads & surface_ru_keys)
+        m_lemma = len(heads & lemma_keys)
+        m_root = len(heads & root_keys)
+        matched_any = heads & glossed_any
+        for h in heads - glossed_any:
+            gap_membership.setdefault(h, []).append(code)
+        per_dict[code] = {
+            "headwords": len(heads),
+            "surface": m_surface,
+            "lemma": m_lemma,
+            "root": m_root,
+            "any": len(matched_any),
+            "any_pct": round(100.0 * len(matched_any) / len(heads), 2),
+        }
+
+    # --- gap-list ranked by DCS frequency --------------------------------------
+    def rank(item):
+        rec = dcs_freq_slp1.get(item[0])
+        return (-(rec["count"] if rec else 0), item[0])
+
+    gaps = sorted(gap_membership.items(), key=rank)
+    gaps_in_dcs = sum(1 for k, _ in gaps if k in dcs_freq_slp1)
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    gap_path = args.out_dir / "ru_gloss_gaps.tsv"
+    with gap_path.open("w", encoding="utf-8", newline="\n") as fh:
+        fh.write("key_slp1\tdicts\tdcs_count\tdcs_band\n")
+        for key, codes in gaps:
+            rec = dcs_freq_slp1.get(key)
+            fh.write(f"{key}\t{','.join(codes)}\t"
+                     f"{rec['count'] if rec else 0}\t{rec['band'] if rec else 0}\n")
+
+    stats = {
+        "corpus_rows": rows,
+        "corpus_distinct_keys": distinct,
+        "rows_empty_ru": rows_empty_ru,
+        "kinds": dict(kinds),
+        "hapax_keys": hapax,
+        "hapax_rate_pct": round(100.0 * hapax / distinct, 2),
+        "surface_keys_with_ru": len(surface_ru_keys),
+        "lemma_layer_keys": len(lemma_keys),
+        "root_layer_keys": len(root_keys),
+        "token_coverage_pct": {
+            "dcs_only": round(100.0 * tok_dcs / rows, 2),
+            "plus_vidyut": round(100.0 * (tok_dcs + tok_vidyut) / rows, 2),
+            "plus_marker": round(100.0 * (tok_dcs + tok_vidyut + tok_marker) / rows, 2),
+        },
+        "dcs_freq_lemmas_slp1": len(dcs_freq_slp1),
+        "dcs_freq_meta": {k: dcs_meta.get(k) for k in ("source", "total_tokens", "distinct_lemmas")},
+        "per_dict_coverage": per_dict,
+        "gap_keys_total": len(gaps),
+        "gap_keys_in_dcs": gaps_in_dcs,
+        "gap_list_file": str(gap_path.relative_to(RT_DIR)).replace("\\", "/"),
+        "gap_head_top20": [
+            {"key": k, "dicts": c, "dcs_count": dcs_freq_slp1[k]["count"]}
+            for k, c in gaps[:20] if k in dcs_freq_slp1
+        ],
+    }
+    stats_path = args.out_dir / "ru_gloss_gap_stats.json"
+    stats_path.write_text(json.dumps(stats, ensure_ascii=False, indent=2) + "\n",
+                          encoding="utf-8", newline="\n")
+    print(json.dumps(stats, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/papers/A33_checklist.md
+++ b/papers/A33_checklist.md
@@ -1,0 +1,66 @@
+# A33 — ARR Responsible NLP + reproducibility checklist (dry run)
+
+_Created: 11-07-2026 · Last updated: 11-07-2026_
+
+Filled per the checklist gate added to
+[`/paper-submission-pack`](https://github.com/gasyoun/claude-config/blob/main/commands/paper-submission-pack.md)
+Phase 3.5 and [`/paper-referee`](https://github.com/gasyoun/claude-config/blob/main/commands/paper-referee.md)
+Phase 2 (H666, 11-07-2026). Checklist source:
+[aclrollingreview.org/responsibleNLPresearch](http://aclrollingreview.org/responsibleNLPresearch/),
+fetched 11-07-2026, page marked "Updated for ARR October 2024 cycle". Subject:
+[A33_sense_ordering_note.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A33_sense_ordering_note.md)
+("Genetic, not historical...", readiness 4/5, target Lexikos / IJL / eLex — none ARR-governed,
+so this is a dry run/internal quality check, not a required submission artifact per the
+venue-calibration rule below).
+
+## A. General
+
+| Item | Status | Pointer |
+|---|---|---|
+| A1. Limitations discussion | **no** | The note has no dedicated Limitations section. §5 states one methodological caveat (the fixed sense-delimiter regex bug) but doesn't discuss scope-of-claims limits (single-language-family sample, PWG/MW-only for the quantitative core, AP90 Vedic-siglum recall explicitly flagged as unverified in "To do before submission"). |
+| A2. Risk discussion | n/a (partial) | No human/societal-harm surface — this is corpus philology, not deployed NLP. Dual-use / fairness / privacy are not applicable to 19th-century dictionary text. |
+
+## B. Scientific artifacts
+
+| Item | Status | Pointer |
+|---|---|---|
+| B1. Citation of creators | **yes** | §"References" cites PWG, PW, MW, GRA, AP90, Kochergina with full bibliographic detail; CDSL cited as primary digital source with URL. |
+| B2. Licenses/terms | **no** | No license statement for the CDSL editions (`csl-orig`) or the citation-dating map (`ls_source_map.json`) used as inputs. Gap — should cite CDSL's stated terms of use. |
+| B3. Intended-use compatibility | n/a | Research/scholarly use of public-domain 19th–20th-c. dictionary text; no derivative-license conflict apparent. |
+| B4. Personal info / offensive content | n/a | No personal data or human-subject content — historical lexicographic text only. |
+| B5. Artifact documentation | **partial** | Domain (Sanskrit lexicography) and source editions are named; no formal data-statement/datasheet exists for the citation-dating map itself. |
+| B6. Dataset statistics | **yes** | §3.1/§3.3 report exact entry/citation counts (11,882 PWG entries, 13,822 MW entries, 113,012/99,716/19,163/29,177 cited senses per dictionary). |
+
+## C. Computational experiments
+
+| Item | Status | Pointer |
+|---|---|---|
+| C1. Model/infra details | n/a | No ML model — this is a corpus-statistics study (counting, Kendall τ), not a trained model. |
+| C2. Experimental setup | **yes** | §2 Method fully specifies the extraction and computation procedure (sense segmentation per dictionary format, dated-citation extraction, the three measured statistics). |
+| C3. Descriptive statistics | **partial** | Point estimates given throughout with explicit chance-floor/ceiling framing (§3.1); no confidence intervals or error bars are reported for the percentages/τ values — a reproducibility gap worth flagging for a full submission. |
+| C4. Package/tool versions | n/a | No third-party NLP toolkits used (regex/counting scripts only); scripts are self-contained and linked. |
+
+## D. Human annotators/participants
+
+| Item | Status | Pointer |
+|---|---|---|
+| D1–D5 | **n/a** | No human annotation or participant study — all data is derived mechanically from digitized dictionary markup. |
+
+## E. AI assistant usage
+
+| Item | Status | Pointer |
+|---|---|---|
+| E1. Disclosure of AI assistants | **yes** (should be stated in-paper) | The note's own status line credits "Fable 5 (`claude-fable-5`)" for the hostile referee pass (03-07-2026); the analysis scripts and this note were produced with heavy AI-agent assistance throughout the `pwg_ru`/RussianTranslation pipeline. **Gap:** the manuscript itself has no explicit AI-assistant disclosure statement in a Methods/Acknowledgements section — currently only inferable from the repo's provenance conventions, not stated for a reader outside this org. Recommend adding one line before submission. |
+
+## Verdict
+
+Not blocking for the current non-ARR target venues (Lexikos / IJL / eLex — none require
+the formal checklist artifact per the venue-calibration rule), but two items are worth
+fixing before submission regardless: **A1** (add a real Limitations paragraph — scope of
+claims, single-language-family/only-2-dictionaries-quantitative-core caveat, the flagged
+AP90 recall gap) and **E1** (add an explicit AI-assistant disclosure line). B2/B5 are minor
+polish (a one-line CDSL terms-of-use citation). This is a report only — fixes are not
+applied here; see [A33_review_fable5.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A33_review_fable5.md)
+for the existing hostile-review memo, which this checklist supplements rather than replaces.
+
+_Sonnet 5 (`claude-sonnet-5`), 11-07-2026, H666 dry run._


### PR DESCRIPTION
Sweeps two finished-but-unshipped artifacts out of the shared working tree.

## H685 — corpus_lexicon RU-gloss gap-stats
- [`RussianTranslation/src/build_ru_gloss_gap_stats.py`](https://github.com/gasyoun/SanskritLexicography/blob/cleanup-h685-a33/RussianTranslation/src/build_ru_gloss_gap_stats.py) — builder for per-dict coverage %, hapax rate, and the DCS-freq-ranked no-RU-gloss gap-list over the 1.09M-row aligned corpus.
- [`RussianTranslation/glossary/ru_gloss_gap_stats.json`](https://github.com/gasyoun/SanskritLexicography/blob/cleanup-h685-a33/RussianTranslation/glossary/ru_gloss_gap_stats.json) — committed stats snapshot (hapax 58.9%; token coverage 79.1/86.5/87.1%). The 5.3 MB `ru_gloss_gaps.tsv` stays gitignored per handoff.
- Handoff: H685 (Fable 5).

## A33 — ARR Responsible NLP checklist dry run
- [`papers/A33_checklist.md`](https://github.com/gasyoun/SanskritLexicography/blob/cleanup-h685-a33/papers/A33_checklist.md) — reproducibility-checklist dry run for the A33 sense-ordering note (H666, Sonnet 5). Report only.

Script byte-compiles clean. Committed via worktree (H214 shared-tree guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)