### PR TITLE
papers: cite Coward & Grimes 2000 in A33/A40 + M01 chapter plan (H724)

### DIFF
--- a/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md
@@ -125,7 +125,9 @@ testbed; the evidence-graph thesis stated; roadmap of the book. (~15–20 pp.)
 
 **Part II — Macrostructure: the shape of the dictionary**
 - Ch. 3 ← **A40** — coverage and growth of the headword inventory; the corpus-grounding
-  bridge (dictionary ↔ DCS).
+  bridge (dictionary ↔ DCS). _Documentary-lexicography baseline for the root- vs
+  lexeme-oriented headword contrast: Coward & Grimes 2000 §4.6/§6.1 (already wired into
+  A40 §1) — carry the citation into the chapter at conversion._
 - Ch. 4 ← **A06** — *Order is the dictionary*: the kośa macrostructural type — the book's
   most original European/indigenous contrast.
 
@@ -137,7 +139,9 @@ testbed; the evidence-graph thesis stated; roadmap of the book. (~15–20 pp.)
   sense-*ordering* material (genetic vs historical, PWG/MW vs Apte/Kochergina — reframed per
   the crosswalk as an empirical test of Apresjan's ordering principle against the European
   Sanskrit family, not a restatement of it) as the second half, "senses: inheritance and
-  order." Collapses the book to **14 chapters** — see §4/§9 below.
+  order." Collapses the book to **14 chapters** — see §4/§9 below. _Documentary-lexicography
+  baseline for the homonymy-vs-polysemy / sense-grouping contrast: Coward & Grimes 2000 §6.3
+  (already wired into A33 §1) — carry the citation into the chapter at conversion._
 - Ch. 7 ← **A04** — the indigenous entry: recovering the kośa/Pāṇinian apparatus on its own
   terms (the "zero means nothing" doctrine).
 - Ch. 8 ← **A35** — comparative derivation: Pāṇinian *vyutpatti* across ten lexica.

--- a/papers/A33_sense_ordering_note.md
+++ b/papers/A33_sense_ordering_note.md
@@ -50,7 +50,12 @@ largely settled on frequency/salience-first ordering for learner-facing works (A
 Rundell 2008) — exactly the split our Vedic-density discriminator recovers empirically
 between the philological and the pedagogical camps. The microstructure vocabulary is
 Hausmann and Wiegand's (1989); the Sanskrit lexicographic tradition the European
-dictionaries drew on is surveyed by Vogel (1979). That PWG and MW behave as "the same
+dictionaries drew on is surveyed by Vogel (1979). Field-lexicography practice converges
+on the same discipline from the other end: the SIL manual insists that sense structure —
+above all the homonymy-vs-polysemy split that governs how senses are grouped — be decided
+empirically from a natural-text corpus rather than by introspection (Coward & Grimes 2000,
+§6.3), the stance this note operationalizes at corpus scale for the ordering question.
+That PWG and MW behave as "the same
 animal" (§3.1) is expected rather than surprising: MW's dependence on the Petersburg
 lexicon is philologically established (Zgusta 1988; re-examined by Hanneder 2020), so
 their shared ordering regime is one more inherited convention — measured here for the
@@ -200,6 +205,9 @@ Apte, Vaman Shivram. 1890. *The Practical Sanskrit-English Dictionary.* Poona. �
 
 Atkins, B. T. Sue, and Michael Rundell. 2008. *The Oxford Guide to Practical
 Lexicography.* Oxford: Oxford University Press.
+
+Coward, David F., and Charles E. Grimes. 2000. *Making Dictionaries: A Guide to
+Lexicography and the Multi-Dictionary Formatter.* Waxhaw, NC: SIL International.
 
 Hanneder, Jürgen. 2020. "Woher hat er das? Zum Charakter des *Sanskrit-English
 Dictionary* von Monier-Williams." *Zeitschrift der Deutschen Morgenländischen

--- a/papers/A40_headword_inventory_note.md
+++ b/papers/A40_headword_inventory_note.md
@@ -73,8 +73,12 @@ A dictionary collection is usually described by a single number: "194,000 headwo
 "36,000 entries". That number is a snapshot of one edition at one moment, and it conflates
 two things a lexicographer actually cares about — how the inventory is *changing*, and how
 much of it is *grounded in attested language* rather than inherited from earlier lexica or
-generated as nonce compounds. The Cologne Digital Sanskrit Dictionaries are an unusually
-clean testbed for separating these. The same ~36 dictionaries are marked up in a uniform
+generated as nonce compounds. What even counts as a headword — whether a compound or
+derived form earns its own entry or is subordinated under a root — is itself a structural
+decision of documentary lexicography (Coward & Grimes 2000, §6.1 on headword-status
+criteria, §4.6 on root- vs lexeme-oriented database organization), and it silently
+conditions every inventory count compared here. The Cologne Digital Sanskrit Dictionaries
+are an unusually clean testbed for separating these. The same ~36 dictionaries are marked up in a uniform
 XML, each entry carrying a normalised computational key (`<k1>`) and a closer-to-print key
 (`<k2>`); and a frozen 2014 export of those keys has been preserved alongside the
 continuously-edited live source, giving a genuine twelve-year baseline rather than a
@@ -534,6 +538,10 @@ once minted.)*
 - Cologne Digital Sanskrit Dictionaries (CDSL), Universität zu Köln —
   [sanskrit-lexicon.uni-koeln.de](https://www.sanskrit-lexicon.uni-koeln.de/); source markup at
   [sanskrit-lexicon/csl-orig](https://github.com/sanskrit-lexicon/csl-orig).
+- Coward, D. F. & C. E. Grimes. 2000. *Making Dictionaries: A Guide to Lexicography and
+  the Multi-Dictionary Formatter.* Waxhaw, NC: SIL International.
+  ([sil.org/resources/archives/5741](https://www.sil.org/resources/archives/5741); §4.6
+  root- vs lexeme-oriented organization, §6.1 headword-status criteria.)
 - Hellwig, O. *Digital Corpus of Sanskrit (DCS)* — DCS-2021 attested-lemma list via
   [dcs_lemma_summary.json](https://github.com/gasyoun/VisualDCS/blob/main/dcs_lemma_summary.json)
   (CC BY); DCS-2026 release via the companion paper A38.


### PR DESCRIPTION
Part of **H724** — wire the [Coward & Grimes 2000 *Making Dictionaries*](https://www.sil.org/resources/archives/5741) primary-source citation into the surfaces where it is genuinely load-bearing.

- [`papers/A40_headword_inventory_note.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A40_headword_inventory_note.md) — §1 now names headword-status criteria (book §6.1) and root- vs lexeme-oriented organization (§4.6) as the documentary-lexicography baseline that conditions any headword count — A40's object — with the full reference added.
- [`papers/A33_sense_ordering_note.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A33_sense_ordering_note.md) — §1 "Relation to existing work" now cites the SIL manual's corpus-not-introspection stance on homonymy/polysemy grouping (§6.3) as the field-lexicography twin of A33's corpus-scale method, with the full reference added.
- [`Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md) — Ch.3 (← A40) and Ch.6 (← A02+A33) rows carry a baseline note so the not-yet-converted M01 chapters inherit the citation from their source articles.

One load-bearing sentence + reference per surface — no citation stuffing. Digest behind this: [`making-dictionaries-mdf-coward-grimes-2000.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/literature/md/Lexicography-Manuals/making-dictionaries-mdf-coward-grimes-2000.md) (H723).

**Surface verdicts:** csl-standards `docs/PAPER.md` already cited the book inline + in its bibliography → **not applicable, no change**. csl-atlas handled in [PR #255](https://github.com/sanskrit-lexicon/csl-atlas/pull/255).

🤖 Generated with [Claude Code](https://claude.com/claude-code)