### PR TITLE
docs: metadoc template v2 backfill (H663) — 2 files

### DIFF
--- a/docs/manuals/README.meta.md
+++ b/docs/manuals/README.meta.md
@@ -53,6 +53,40 @@ index/hard-rules at root.
 - STUDENT_MANUAL_RU §1 depends on gitignored ReverseDictionary data files a
   clone does not contain — flagged inline.
 
+## Intended use / known misuse
+
+**Intended use:** the entry point an agent or human reads at session start (or when
+onboarding a new contributor) to pick the right depth for their role — maintainer,
+researcher, student, data-reuser, or agent — before touching the ~12-subproject
+workspace; the four manuals + [PROFILE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/PROFILE.md)
+route deep-dives, the root pair stays thin/index-only.
+
+**Known misuse:**
+- Trusting the dated state snapshots (AGENTS §4, HUMAN_RU §3–4) as currently accurate
+  without cross-checking `.ai_state.md` first — they are staleness-prone by design (see
+  Known limitations below and backlog item 2).
+- Using STUDENT_MANUAL_RU §1 without the gitignored ReverseDictionary data files present
+  in the clone — the section assumes data that a bare clone does not contain.
+- Treating a subsystem deep manual as a substitute for reading the actual subsystem code
+  or its own docs — the deep manuals summarize and post-mortem, they are not exhaustive
+  specs.
+- Using this set as an external-contributor "how to submit a correction upstream" guide —
+  that manual does not exist yet (backlog item 3); external submitters should be pointed
+  elsewhere until it ships.
+
+## Maintenance & sunset plan
+
+Regenerated via the [/workspace-manual](https://github.com/gasyoun/claude-config/blob/main/commands/workspace-manual.md)
+skill whenever a new subsystem deep manual is added or the router/PROFILE queue changes
+(as in H606/H607/H608 below). State snapshots (AGENTS §4, HUMAN_RU §3–4) are due a refresh
+on the next monthly pass against `.ai_state.md` (backlog item 2) — no automated staleness
+check exists yet. Owned by whichever session is actively driving workspace-manual work;
+no fixed cadence beyond "monthly-ish" for the snapshot refresh.
+
+## Deprecation status
+
+`active`
+
 ## Revision history
 
 | Date | Change | Session |
@@ -63,5 +97,6 @@ index/hard-rules at root.
 | 11-07-2026 | RUSSIANTRANSLATION_DEEP_MANUAL.md added (first subsystem deep manual: mw_ru post-mortem + pwg_ru operator depth); router row + PROFILE queue flip | H606 |
 | 11-07-2026 | [PUBLICATION_PIPELINE_DEEP_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/PUBLICATION_PIPELINE_DEEP_MANUAL.md) added (papers · M01 book · docs_site) + router row + PROFILE queue flip — Fable 5 (`claude-fable-5`) | H608 |
 | 11-07-2026 | HEADWORDLISTS_DEEP_MANUAL.md added (queue complete); router gains a "Subsystem deep manuals" table; PROFILE H607 row flipped done; backlog item 1 closed — Fable 5 `claude-fable-5` | H607 |
+| 11-07-2026 | template v2 backfill (H663) | Sonnet 5 (claude-sonnet-5) |
 
 _Dr. Mārcis Gasūns_

--- a/literature/md/Lexicography-Manuals/LEXICOGRAPHY_MANUALS.meta.md
+++ b/literature/md/Lexicography-Manuals/LEXICOGRAPHY_MANUALS.meta.md
@@ -146,6 +146,48 @@ carry no metadata — the identifications below are from internal evidence).
 7. **Systema-Sanscriticum teaching platform:** the applied/teaching shelf (DDL, learner
    corpora, young-learner pedagogy) if a corpus-informed Sanskrit teaching layer is built.
 
+## Intended use / known misuse
+
+**Intended use:** grounding literature for the M01 Brill/De Gruyter monograph and the
+A30/A31/A32 paper pipeline — consult the per-work tags table above to pick close-read vs.
+skim-only priority before citing, and read [LITERATURE_CROSSWALK.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/LITERATURE_CROSSWALK.md)
+for the full grounding map. Also serves the "beyond M01" backlog above (A30–A32, pwg_ru
+evidence grading, A39, methods sections, Systema teaching platform).
+
+**Known misuse:**
+- Citing Ryan (ed.) 2019 *Handbook of Corpus Linguistics* as an authoritative source — it
+  is a flagged low-authority reprint anthology of unrelated CC papers; trace and cite the
+  original papers instead (defect 4).
+- Citing page numbers from these Markdown conversions without spot-verifying against the
+  original — most carry no front-matter metadata, so identities/pagination above are
+  reconstructed from internal evidence, not publisher metadata (defect 5).
+- Redistributing or republishing full-text copies of these works externally. This is a
+  private research library of scanned/borrowed book PDFs and OA papers with mixed and
+  largely unaudited rights status per work; `making-dictionaries-mdf-coward-grimes-2000.md`
+  is explicitly flagged SIL all-rights-reserved (digest/paraphrase only, not full text) —
+  treat every other file as unverified-rights unless separately cleared, not as
+  cite-and-republish-safe.
+- Citing both the PDF and EPUB conversions of *The Routledge Handbook of Applied
+  Linguistics* (2024, 2nd ed.) as if independent sources — they are the same work
+  (defect 2); cite one edition.
+- Citing `Hints to the Study of Sanskrit Compounds.md` for content — the file is an empty
+  scan (Google-boilerplate only, no OCR'd body; defect 1).
+
+## Maintenance & sunset plan
+
+No active accession pipeline — the library was assembled in one pass (committed
+07-07-2026) and is not routinely expanded; new works are added ad hoc alongside M01
+chapter drafting, not on a schedule. The hygiene backlog (empty scan, PDF/EPUB duplicate,
+mangled filename, low-authority volume, missing front-matter) is triaged opportunistically
+by whichever session next touches the affected file, not swept on a cadence. Owned by
+whoever is actively driving M01 or the A30–A32 papers; re-run the identification/tagging
+audit (the H505 pattern) if the M01 outline changes enough to add or drop works, or if a
+work's rights status needs re-checking before wider reuse.
+
+## Deprecation status
+
+`active`
+
 ## Related documents
 
 - [LITERATURE_CROSSWALK.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/LITERATURE_CROSSWALK.md) — the full M01 crosswalk this metadoc indexes for
@@ -157,5 +199,6 @@ carry no metadata — the identifications below are from internal evidence).
 | Date | Change | Session |
 |---|---|---|
 | 10-07-2026 | Metadoc created: provenance, 37 per-work tags, defects, beyond-M01 backlog | H505, Fable 5 (`claude-fable-5`) |
+| 11-07-2026 | template v2 backfill (H663) | Sonnet 5 (claude-sonnet-5) |
 
 _Dr. Mārcis Gasūns_


### PR DESCRIPTION
## Summary
- Add three template-v2 sections (H663) to two metadocs: `Intended use / known misuse`, `Maintenance & sunset plan`, `Deprecation status` — inserted after Known limitations/Known defects and before Related documents/Revision history.
- `docs/manuals/README.meta.md` (audience-manual set metadoc) and `literature/md/Lexicography-Manuals/LEXICOGRAPHY_MANUALS.meta.md` (37-work collection metadoc, misuse section written at the library level).
- Content derived from reading each metadoc's own subject documents — no boilerplate.
- Revision-history row appended to each file (11-07-2026, "template v2 backfill (H663)", Sonnet 5).

## Test plan
- [ ] Human review of the new sections for accuracy
- [ ] Confirm blob URLs render correctly on GitHub

Not merged/auto-merged — left open for review per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)