### PR TITLE
H255: no-PWG lane drain w05+w05_rq1

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,7 +12,30 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
-- **H255 no-PWG lane scale drain — first genuine queue-mode window `no_pwg_w04` (20 headwords) + `no_pwg_w04_rq1` requeue, 🟡 PARTIAL, residual documented (11-07-2026, Sonnet 5 `claude-sonnet-5`).**
+- **H255 no-PWG lane scale drain — window `no_pwg_w05` (20 headwords) + `no_pwg_w05_rq1` requeue, 🟡 PARTIAL, residual documented (11-07-2026, Sonnet 5 `claude-sonnet-5`).**
+  Prepared cleanly with the `w04` OUT-path fix already live (`no_pwg_scale_plan.py --start-index 5`):
+  20 headwords / 44 subcards, cost gate GO (~$20.61, under $25 ceiling).
+  Generation: 23/44 non-null, 21 null (18 kill-timeouts, 3 selfheal-nothing-resolved);
+  `audit_window.py` flagged 7/23 as content defects → 16/44 truly clean. Requeue (the one
+  permitted, `--no-tm`, the 21 null keys only): 17/21 non-null, 4 null (`_u_das~~h0_zz_pw` same
+  kill-timeout again; `_sibi~~h0_zz_pw`/`a_sud_da~~h0_zz_pw`/`aklizwa~~h0_zz_pw` same
+  selfheal-nothing-resolved again — documented residual, not requeued a 3rd time); 4/17 flagged
+  defect (1 high-confidence: `ajagan_d_a~~h0_zz_pw` untranslated braced German gloss) →
+  13/21 truly clean.
+  **Promoted 40 non-null sub-cards (69 sense rows) across 20 headwords.** Store 11,436→**11,505
+  rows**; TM rebuilt (2,371→**2,411 cards**). 232-lemma queue remaining: 190→**170**. Full account:
+  [RUN_LOG.md 2026-07-11 `no_pwg_w05` block](src/pilot/RUN_LOG.md).
+  **Documented residual:** `_u_das~~h0_zz_pw` (2× kill-timeout, infra), 3 sub-cards with 2×
+  selfheal-nothing-resolved, + 11 content-defect-flagged sub-cards across both windows (all
+  promoted but flagged for G5 review — `ajagan_d_a~~h0_zz_pw` specifically needs a manual German-
+  gloss translation pass, see RUN_LOG for the full key list).
+  **Next:** continue the 232-lemma queue via
+  `no_pwg_scale_plan.py --window-size 20 --limit-windows 1 --start-index 6`. Re-run
+  `probe_log.py gate` before any future window. Handoff:
+  [H255](https://github.com/gasyoun/Uprava/blob/main/handoffs/H255-Sonnet_RussianTranslation_pwg_ru_no_pwg_lane_scale_06.07.26.md)
+  (row stays 🟡 queued — 138 of 232 headwords now drained/attempted, lane not yet complete).
+
+- **H255 no-PWG lane scale drain — prior session's first genuine queue-mode window `no_pwg_w04` (20 headwords) + `no_pwg_w04_rq1` requeue, 🟡 PARTIAL, residual documented (11-07-2026, Sonnet 5 `claude-sonnet-5`).**
   **Fixed first:** `no_pwg_scale_plan.py`'s `existing_subcards()` scanned `src/pilot/output/` for
   the `<head>~~h0_zz_*.raw.txt` sidecars `_pilot_gen_merged.py` actually writes to
   `src/pilot/input/` — a directory mismatch that only surfaces in **queue mode** (the still-null

--- a/RussianTranslation/src/pilot/RUN_LOG.md
+++ b/RussianTranslation/src/pilot/RUN_LOG.md
@@ -562,3 +562,19 @@ Requeued `no_pwg_w02`'s 27 transient keys (pulled from `audit_window.report.json
 **Documented residual (not requeued further):** `_gawik_a~~h0_zz_nws00` (2× kill-timeout — infra, not content), `_kowa~~h0_zz_pw` (selfheal-nothing-resolved), plus the 10 content-defect-flagged sub-cards across both windows (`_b_azita~~h0_zz_nws00`, `_badr_a~~h0_zz_nws00`, `_badr_a~~h0_zz_sch`, `_dar_a~~h0_zz_sch`, `_gawik_a~~h0_zz_nws00`(defect+transient), `_kecar_i~~h0_zz_nws00`, `_kecar_i~~h0_zz_sch`, `_kowa~~h0_zz_nws00`, `_kowa~~h0_zz_pw`(defect+transient), `_s_alyodana~~h0_zz_nws00`) — all already promoted as `ai_translated` per the guardrail above, but flagged in `audit_window.report.json`/`window_status.json` for the G5 human review pass, not silently clean.
 
 **Next:** continue the 232-lemma queue via `no_pwg_scale_plan.py --window-size 20 --limit-windows 1 --start-index 5` (the planner's own "next window" hint after this run reused a stale `no_pwg_w02` name — a residual instance of the `w03` naming-collision gotcha noted above; always pass an explicit `--start-index` past every root already logged in this file, don't trust the hint blindly). Re-run `probe_log.py gate` before any future window.
+
+---
+
+## 2026-07-11 — no-PWG lane window `no_pwg_w05` (H255 scale drain, `no_pwg_scale_plan.py --start-index 5`) — gen **Sonnet 5** (`claude-sonnet-5`) / orchestration **Sonnet 5** (`claude-sonnet-5`) — 🟡 40/65 candidate sub-cards PROMOTED, residual documented
+
+Prepared cleanly with the `w04` OUT-path fix already live: 20 headwords / 44 sub-cards, cost gate GO (~$20.61 est., under the $25 ceiling).
+
+**Generation (`no_pwg_w05`, 44 cards/41 batches, `--output-budget=1`):** **Result: 23/44 non-null, 21 null** (18 kill-timeout, 3 `selfheal-nothing-resolved`). `audit_window.py` flagged 7 of the 23 non-null as content defects → **16/44 truly clean this pass.**
+
+**Requeue (`no_pwg_w05_rq1`, the one permitted requeue, `--no-tm`):** the 21 null keys only (not the 7 defects, per the drain-loop rule). **Result: 17/21 non-null, 4 null** (`_u_das~~h0_zz_pw`: SAME kill-timeout again, `_sibi~~h0_zz_pw`/`a_sud_da~~h0_zz_pw`/`aklizwa~~h0_zz_pw`: SAME `selfheal-nothing-resolved` again). `audit_window.py` flagged 4 of the 17 as content defects (one high-confidence: `ajagan_d_a~~h0_zz_pw` untranslated braced German gloss) → **13/21 truly clean this pass.**
+
+**Promotion:** same explicit-glob discipline as `w04` — `--glob "src/pilot/output/wf_output.no_pwg_w05*.json"` (real `*` wildcard). **Promoted 40 non-null sub-cards** (16 audit-clean + 7 defect-flagged from `w05`, 13 audit-clean + 4 defect-flagged from `w05_rq1`; 69 sense rows across 20 headwords). Store `src/pwg_ru_translated.jsonl`: 11,436 → **11,505 rows**. TM rebuilt (`translation_memory.ru.json build --lang ru`): 2,371 → **2,411 cards**. `no_pwg_scale_plan.py`'s own remaining-headword count (232-lemma queue): 190 → **170**.
+
+**Documented residual (not requeued further):** `_u_das~~h0_zz_pw` (2× kill-timeout — infra, not content), `_sibi~~h0_zz_pw`/`a_sud_da~~h0_zz_pw`/`aklizwa~~h0_zz_pw` (2× `selfheal-nothing-resolved` each), plus the 11 content-defect-flagged sub-cards across both windows (`a_smar_i~~h0_zz_nws00`, `_sy_am_a~~h0_zz_nws00`, `a_b_uta~~h0_zz_nws00`, `_sibi~~h0_zz_nws00`, `_su_r_w_i~~h0_zz_nws00`, `_su_r_w_i~~h0_zz_sch`, `_sy_am_a~~h0_zz_sch`, `a_sakta~~h0_zz_sch`, `ajagan_d_a~~h0_zz_pw`(high-confidence untranslated-gloss), `aklizwa~~h0_zz_sch`, `ambaz_w_a~~h0_zz_sch`) — all already promoted as `ai_translated` per the `w04` guardrail, flagged for the eventual G5 human review, not silently clean. `ajagan_d_a~~h0_zz_pw` in particular needs a manual German-gloss translation pass, not blind retry.
+
+**Next:** continue the 232-lemma queue via `no_pwg_scale_plan.py --window-size 20 --limit-windows 1 --start-index 6`. Re-run `probe_log.py gate` before any future window.


### PR DESCRIPTION
## Summary
- Drains no-PWG supplement-chain window `no_pwg_w05` (20 headwords / 44 sub-cards) + its `no_pwg_w05_rq1` requeue (21 transient nulls, `--no-tm`): 40 sub-cards promoted (69 sense rows), store `pwg_ru_translated.jsonl` 11,436 → 11,505 rows, TM rebuilt to 2,411 cards, 232-lemma backfill queue remaining 190 → 170.
- Uses the `existing_subcards()` OUT-path fix from [PR #362](https://github.com/gasyoun/SanskritLexicography/pull/362) — no code changes in this PR, drain output only.
- Full account + documented residual (1 recurring kill-timeout, 3 recurring `selfheal-nothing-resolved`, 11 content-defect-flagged sub-cards including one high-confidence untranslated-German-gloss flag on `ajagan_d_a~~h0_zz_pw`, all held for the eventual G5 human review) in `RussianTranslation/src/pilot/RUN_LOG.md` and `RussianTranslation/.ai_state.md`.
- Handoff: [H255](https://github.com/gasyoun/Uprava/blob/main/handoffs/H255-Sonnet_RussianTranslation_pwg_ru_no_pwg_lane_scale_06.07.26.md) (stays 🟡 queued — 138/232 headwords now drained/attempted, lane not yet complete).

## Test plan
- [x] `audit_window.py` run on both `no_pwg_w05` and `no_pwg_w05_rq1` outputs
- [x] `promote_final_cards.py --merge` verified via `--dry-run` before the real run
- [x] `python src/pilot/window_selftest.py`, `agent_budget.py`, `lang_parity_check.py`, `check_launch_ledger.py --since 2026-07-05` all pass locally
- Store (`pwg_ru_translated.jsonl`) and TM (`translation_memory.ru.json`) are gitignored runtime artifacts — not part of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)