### PR TITLE
SIL MDF map: flip Lexique Pro smoke-test ruling to executed (H722)

### DIFF
--- a/papers/SIL_MDF_ECOSYSTEM_CORRELATION.md
+++ b/papers/SIL_MDF_ECOSYSTEM_CORRELATION.md
@@ -142,7 +142,7 @@ transformation's adequacy against it.
    **plus** implementation in the PWG translation pipeline + kosha, and an explicit
    account of how it changes dictionary treatment at Cologne (§4 above).
 2. **LIFT**: add now (not parked) — fourth serialization beside TEI/OntoLex/MDF.
-3. **Lexique Pro smoke test**: run it.
+3. **Lexique Pro smoke test**: run it. ✅ executed 12-07-2026 (H722, Fable 5 `claude-fable-5`): 250/250 records parsed, per-marker render table + 3 findings in [MDF_EXPORT_MAPPING.md](https://github.com/sanskrit-lexicon/csl-standards/blob/main/docs/MDF_EXPORT_MAPPING.md#real-consumer-smoke-test--lexique-pro-36-h722), [PR #109](https://github.com/sanskrit-lexicon/csl-standards/pull/109) merged.
 4. **SIL reach**: all four — semdom ↔ kosha crosswalk, Webonary channel, Dictionary App
    Builder, community outreach (drafts only; nothing auto-sends).
 


### PR DESCRIPTION
One-line status flip in [papers/SIL_MDF_ECOSYSTEM_CORRELATION.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/SIL_MDF_ECOSYSTEM_CORRELATION.md) §5: the Lexique Pro real-consumer smoke test ruled there was executed under [H722](https://github.com/gasyoun/Uprava/blob/main/handoffs/H722-Fable_csl-standards_lexique-pro-mdf-smoke-test_11.07.26.md) — 250/250 pilot records parsed, per-marker render table + 3 findings, [csl-standards PR #109](https://github.com/sanskrit-lexicon/csl-standards/pull/109) merged, v1.1.0 cut. Fable 5 (`claude-fable-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)