### PR TITLE
docs: dated headers for 2 RussianTranslation roadmaps (H697)

### DIFF
--- a/RussianTranslation/RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md
+++ b/RussianTranslation/RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md
@@ -1,6 +1,6 @@
 # PWG->RU research-grade capability roadmap: 30 additive layers
 
-_Created: 09-07-2026_
+_Created: 09-07-2026 · Last updated: 09-07-2026_
 
 This roadmap turns the four H335 capability questions into a wider, ranked
 research programme for `pwg_ru`. It is additive: the baseline remains the
@@ -391,3 +391,4 @@ Each card has the same contract:
 - Use explicit `unknown`/`unmapped` outcomes. Do not collapse absent evidence
   into negative evidence.
 
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/REVIEW_AND_ROADMAP.md
+++ b/RussianTranslation/REVIEW_AND_ROADMAP.md
@@ -1,5 +1,7 @@
 # pwg_ru — full review and roadmap (2026-06-16)
 
+_Created: 09-07-2026 · Last updated: 09-07-2026_
+
 A candid retrospective of the corpus-first build and a phased plan forward.
 Companion docs: [METHODOLOGY_REVIEW.md](METHODOLOGY_REVIEW.md) (5-lens external
 review), [APRESJAN.md](APRESJAN.md) (theory), [HARVEST.md](HARVEST.md) (the harvest
@@ -150,3 +152,5 @@ machine; frequency-first is how the bulk should actually run.
 Then per card: **harvest → translate (Sonnet) → F12 gate + Opus judge → collect +
 provenance-stamp → review queue**, drawing from the freq manifest. Review the core
 tranche together; decide the tail strategy at the reassess checkpoint.
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Completes/inserts the standard dated header + byline on the two RussianTranslation roadmaps showing — in [ROADMAP_INDEX.md](https://github.com/gasyoun/Uprava/blob/main/ROADMAP_INDEX.md) §Tier-1. Content untouched. Part of [H697](https://github.com/gasyoun/Uprava/blob/main/handoffs/H697-Fable_Uprava_roadmap-dated-headers-tier01_11.07.26.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)