### PR TITLE
STALENESS: regenerate for 12-07-2026 — zero due rows (H701)

### DIFF
--- a/STALENESS.md
+++ b/STALENESS.md
@@ -1,6 +1,6 @@
 # STALENESS — confidence-decay table over [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
 
-_Created: 08-07-2026 · Last updated: 11-07-2026_
+_Created: 12-07-2026 · Last updated: 12-07-2026_
 
 **⚙️ FULLY AUTO-GENERATED — do not hand-edit the table below.** Regenerate with [`sanskrit-util/tools/epistemic/derive_staleness.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/derive_staleness.py). This is the STALENESS epistemic sibling of [`FINDINGS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) (Sanskrit-data side) — one of the seven registries minted under [H356](https://github.com/gasyoun/Uprava/blob/main/handoffs/H356-Opus_csl-corrections_epistemic-sibling-registries_08.07.26.md). It answers the one question FINDINGS structurally cannot: *when was each fact last re-checked, and which are decaying?*
 
@@ -12,77 +12,88 @@ Every FINDINGS finding measures a fact **at a moment**. A count true in June may
 - 🟡 **3–6 months** — verify if the underlying source may have moved.
 - 🟢 **fresh** (<3 months) — trust as-is.
 
-**Snapshot (08-07-2026):** 66 findings — 🔴 0 · 🟡 0 · 🟢 66.
+**Snapshot (12-07-2026):** 77 findings — 🔴 0 · 🟡 0 · 🟢 77.
 
 > **Discovered** = earliest date in the finding's block · **Last re-verified** = latest date if the block carries more than one (a re-check leaves a second date) · **Age** = days from the newest dated activity to the regeneration date · **Re-check recipe** = the RECIPES row that reproduces this finding (Wave 2 fills the numbers; `§TBD` until then).
 
 | FINDINGS § | Discovered | Last re-verified | Age | Flag | Re-check recipe |
 |------------|-----------|------------------|-----|------|-----------------|
-| [§8](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#8-unaccented-dcs-cannot-distinguish-present-class-i-from-vi) | 01-06-2026 | — | 37d | 🟢 | RECIPES §TBD |
-| [§19](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#19-skd-and-vcp-carry-essentially-zero-western-markup) | 01-06-2026 | — | 37d | 🟢 | RECIPES §TBD |
-| [§23](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#23-apte-is-three-dictionaries-keys-differ-stem-vs-nominative) | 01-06-2026 | — | 37d | 🟢 | RECIPES §TBD |
-| [§36](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily) | 01-06-2026 | — | 37d | 🟢 | RECIPES §TBD |
-| [§37](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#37-bom-state-is-inconsistent-across-exports) | 01-06-2026 | — | 37d | 🟢 | RECIPES §TBD |
-| [§39](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#39-devanagaritoslp1-mis-routes-retroflex-la) | 01-06-2026 | — | 37d | 🟢 | RECIPES §TBD |
-| [§28](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#28-mw-inherited-the-pwg-apparatus-skeleton-not-its-prose) | 03-06-2026 | — | 35d | 🟢 | RECIPES §TBD |
-| [§9](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#9-dcs-occid-and-sentid-are-not-unique-keys) | 06-06-2026 | — | 32d | 🟢 | RECIPES §TBD |
-| [§10](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#10-dcs-ud-tense-marking-conflates-aorist-and-perfect) | 06-06-2026 | — | 32d | 🟢 | RECIPES §TBD |
-| [§11](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#11-dcs-2021-and-2026-vintages-are-not-directly-comparable) | 06-06-2026 | — | 32d | 🟢 | RECIPES §TBD |
-| [§12](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword) | 11-06-2026 | — | 27d | 🟢 | RECIPES §TBD |
-| [§3](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#3-the-warnemyr-scrape-union-smears-homonym-classes) | 13-06-2026 | — | 25d | 🟢 | RECIPES §TBD |
-| [§2](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling) | 14-06-2026 | — | 24d | 🟢 | RECIPES §TBD |
-| [§27](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#27-sense-granularity-is-a-family-trait-not-a-diachronic-trend) | 15-06-2026 | — | 23d | 🟢 | RECIPES §TBD |
-| [§30](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#30-body-text-headword-mining-is-a-dead-end-386-percent-precision) | 15-06-2026 | — | 23d | 🟢 | RECIPES §TBD |
-| [§32](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#32-correction-events-concentrate-in-sense-text) | 17-06-2026 | — | 21d | 🟢 | RECIPES §TBD |
-| [§5](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#5-the-parallel-corpus-rarely-attests-prefixed-verb-forms) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
-| [§6](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#6-no-printed-frequency-dictionary-of-sanskrit-exists) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
-| [§7](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
-| [§15](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#15-pwg-encodes-secondary-stems-inline-not-in-div-markup) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
-| [§16](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
-| [§17](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#17-pwg-orders-senses-genetically-not-historically) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
-| [§18](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#18-vedic-citation-density-separates-the-dictionary-traditions) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
-| [§20](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#20-the-ls-source-map-recognises-724-percent-of-pwg-citations) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
-| [§31](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#31-detector-precision-stratifies-by-digitization-quality) | 24-06-2026 | — | 14d | 🟢 | RECIPES §TBD |
-| [§22](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#22-mw-has-no-sense-level-div-markup) | 26-06-2026 | — | 12d | 🟢 | RECIPES §TBD |
-| [§29](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index) | 26-06-2026 | — | 12d | 🟢 | RECIPES §TBD |
-| [§33](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#33-indigenous-dictionaries-agree-on-derivation-wilson-is-the-outlier) | 26-06-2026 | — | 12d | 🟢 | RECIPES §TBD |
-| [§34](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#34-the-e-abbreviation-tag-is-polysemous-across-dicts) | 26-06-2026 | — | 12d | 🟢 | RECIPES §TBD |
-| [§35](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#35-root-recovery-tiers-err-on-root-form-not-identity) | 26-06-2026 | — | 12d | 🟢 | RECIPES §TBD |
-| [§40](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#40-gloss-language-spelling-drift-tracks-reform-type-not-age) | 26-06-2026 | — | 12d | 🟢 | RECIPES §TBD |
-| [§38](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#38-injected-boms-crash-the-hw-record-parser) | 27-06-2026 | — | 11d | 🟢 | RECIPES §TBD |
-| [§4](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#4-pwg-nominal-grammar-compresses-into-335-paradigm-tokens) | 29-06-2026 | — | 9d | 🟢 | RECIPES §TBD |
-| [§13](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#13-sa-ru-glossary-token-coverage-plateaus-at-866-percent) | 01-07-2026 | — | 7d | 🟢 | RECIPES §TBD |
-| [§14](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#14-renou-period-state-tagging-covers-770k-entries-in-8-dicts) | 01-07-2026 | — | 7d | 🟢 | RECIPES §TBD |
-| [§42](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#42-whitney-self-contradicts-on-derivative-ī-stem-genpl-accent) | 02-07-2026 | — | 6d | 🟢 | RECIPES §TBD |
-| [§21](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#21-pwg-citation-occurrences-track-distinct-references) | 02-07-2026 | — | 6d | 🟢 | RECIPES §TBD |
-| [§24](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#24-about-9-percent-of-typo-corrections-are-collisions) | 01-07-2026 | 02-07-2026 | 6d | 🟢 | RECIPES §TBD |
-| [§25](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#25-a-verified-correction-queue-decays-against-live-csl-orig) | 01-07-2026 | 02-07-2026 | 6d | 🟢 | RECIPES §TBD |
-| [§26](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#26-citation-density-is-register-bound-not-comparable-raw) | 13-06-2026 | 02-07-2026 | 6d | 🟢 | RECIPES §TBD |
-| [§41](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#41-the-sanskrit-dictionary-platform-landscape-probed-live) | 16-02-2026 | 02-07-2026 | 6d | 🟢 | RECIPES §TBD |
-| [§43](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#43-skdvcp-sensecitation-fusion-is-a-record-type-effect-not-a-dictionary-level-one) | 02-07-2026 | — | 6d | 🟢 | RECIPES §TBD |
-| [§44](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#44-raw-latin-string-tallies-over-gloss-text-include-etymological-false-positives-bopp-lacks-yabh) | 02-07-2026 | — | 6d | 🟢 | RECIPES §TBD |
-| [§45](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#45-siglum-prefix-families-routinely-bundle-several-distinct-works-the-diacritic-stripping-fold-has-poisoned-keys) | 02-07-2026 | — | 6d | 🟢 | RECIPES §TBD |
-| [§1](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#1-whitney-accent-mobility-rules-are-machine-encodable) | 29-06-2026 | 03-07-2026 | 5d | 🟢 | RECIPES §TBD |
-| [§46](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#46-twelve-years-of-corrections-cover-only-1014--of-the-estimated-error-population) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
-| [§47](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#47-heritage-data-is-acquirable-despite-the-anubis-wall--via-a-github-mirror-the-morphology-xml-is-not-in-it) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
-| [§48](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#48-vedaweb-20s-resource-export-is-an-async-task-behind-a-pickup-key-not-a-direct-get--and-the-server-went-unresponsive-mid-attempt) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
-| [§49](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#49-mwheritage-coverage-highlighting-is-a-duplicate-anchor-pattern-not-a-css-class--and-the-mirrors-current-dictionary-is-a-different-scope-asset-than-the-2014-reader-stem-list) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
-| [§50](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#50-cdsl-display-paths-are-not-uniformly-2020web--and-two-new-digitizations-landed-in-june-2026) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
-| [§51](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#51-huet-correspondence-predates-this-session-2021--the-morphology-xml-gate-was-already-resolved-in-writing-direct-download-urls-recovered) | 30-03-2021 | 03-07-2026 | 5d | 🟢 | RECIPES §TBD |
-| [§52](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#52-heritage-vs-kosha-forms-diff-the-small-raw-overlap-is-mostly-convention--model-difference-and-disagreements-are-two-thirds-lemmatization-policy-not-error) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
-| [§53](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#53-the-wil-etymology-extractions-affix-field-is-half-noise--wilson-outlier-figures-are-substantially-a-measurement-artifact) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
-| [§56](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#56-dicos-entry-anchors-nest-three-structural-roles-under-one-html-class--only-one-is-a-true-entry-boundary) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
-| [§55](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#55-genoptharness2py-output-budget-coarser-wins-on-both-knobs-in-opposite-directions) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
-| [§57](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#57-samskrtamruz-is-id-addressed-with-no-name-lookup--deep-linking-needs-a-scraped-rootid-table-8-primer-basic-roots-are-absent) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
-| [§58](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#58-pwg-ru-promoted-store-has-input-level-provenance-but-old-ru-rows-lacked-exact-model-versions) | 03-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
-| [§59](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#59-böhtlingks-indische-sprüche-both-editions-already-fully-digitized-in-sanskrit-lexicon-scans-not-just-sanskrit-lexicon) | 06-05-2026 | 03-07-2026 | 5d | 🟢 | RECIPES §TBD |
-| [§54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) | 03-07-2026 | 05-07-2026 | 3d | 🟢 | RECIPES §TBD |
-| [§64](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1--pwg-is-not-the-sole-spine-of-the-local-layer-universe) | 05-07-2026 | — | 3d | 🟢 | RECIPES §TBD |
-| [§60](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-practical-russian-transcription-of-sanskrit-names-has-no-safe-reverse-transliteration) | 05-07-2026 | — | 3d | 🟢 | RECIPES §TBD |
-| [§70](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#70-pwg_ru-tm-composite-grade-a-is-consensus-gated-57-and-a-reference-free-surface-qe-cannot-detect-wrong-sense) | 03-07-2026 | 06-07-2026 | 2d | 🟢 | RECIPES §TBD |
-| [§63](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian) | 07-07-2026 | — | 1d | 🟢 | RECIPES §TBD |
-| [§62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) | 05-03-2026 | 07-07-2026 | 1d | 🟢 | RECIPES §TBD |
-| [§65](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse) | 07-07-2026 | — | 1d | 🟢 | RECIPES §TBD |
-| [§61](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#61-the-reverse-dictionarys-30-sources-split-18-pd-vs-10-in-copyright--the-merged-headword-list-is-not-automatically-publishable) | 26-06-2026 | 07-07-2026 | 1d | 🟢 | RECIPES §TBD |
+| [§8](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#8-unaccented-dcs-cannot-distinguish-present-class-i-from-vi) | 01-06-2026 | — | 41d | 🟢 | RECIPES §TBD |
+| [§19](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#19-skd-and-vcp-carry-essentially-zero-western-markup) | 01-06-2026 | — | 41d | 🟢 | RECIPES §TBD |
+| [§23](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#23-apte-is-three-dictionaries-keys-differ-stem-vs-nominative) | 01-06-2026 | — | 41d | 🟢 | RECIPES §TBD |
+| [§36](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily) | 01-06-2026 | — | 41d | 🟢 | RECIPES §TBD |
+| [§37](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#37-bom-state-is-inconsistent-across-exports) | 01-06-2026 | — | 41d | 🟢 | RECIPES §TBD |
+| [§39](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#39-devanagaritoslp1-mis-routes-retroflex-la) | 01-06-2026 | — | 41d | 🟢 | RECIPES §TBD |
+| [§28](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#28-mw-inherited-the-pwg-apparatus-skeleton-not-its-prose) | 03-06-2026 | — | 39d | 🟢 | RECIPES §TBD |
+| [§9](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#9-dcs-occid-and-sentid-are-not-unique-keys) | 06-06-2026 | — | 36d | 🟢 | RECIPES §TBD |
+| [§10](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#10-dcs-ud-tense-marking-conflates-aorist-and-perfect) | 06-06-2026 | — | 36d | 🟢 | RECIPES §TBD |
+| [§11](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#11-dcs-2021-and-2026-vintages-are-not-directly-comparable) | 06-06-2026 | — | 36d | 🟢 | RECIPES §TBD |
+| [§12](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword) | 11-06-2026 | — | 31d | 🟢 | RECIPES §TBD |
+| [§3](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#3-the-warnemyr-scrape-union-smears-homonym-classes) | 13-06-2026 | — | 29d | 🟢 | RECIPES §TBD |
+| [§2](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling) | 14-06-2026 | — | 28d | 🟢 | RECIPES §TBD |
+| [§27](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#27-sense-granularity-is-a-family-trait-not-a-diachronic-trend) | 15-06-2026 | — | 27d | 🟢 | RECIPES §TBD |
+| [§30](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#30-body-text-headword-mining-is-a-dead-end-386-percent-precision) | 15-06-2026 | — | 27d | 🟢 | RECIPES §TBD |
+| [§32](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#32-correction-events-concentrate-in-sense-text) | 17-06-2026 | — | 25d | 🟢 | RECIPES §TBD |
+| [§5](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#5-the-parallel-corpus-rarely-attests-prefixed-verb-forms) | 24-06-2026 | — | 18d | 🟢 | RECIPES §TBD |
+| [§6](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#6-no-printed-frequency-dictionary-of-sanskrit-exists) | 24-06-2026 | — | 18d | 🟢 | RECIPES §TBD |
+| [§7](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations) | 24-06-2026 | — | 18d | 🟢 | RECIPES §TBD |
+| [§15](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#15-pwg-encodes-secondary-stems-inline-not-in-div-markup) | 24-06-2026 | — | 18d | 🟢 | RECIPES §TBD |
+| [§16](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes) | 24-06-2026 | — | 18d | 🟢 | RECIPES §TBD |
+| [§17](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#17-pwg-orders-senses-genetically-not-historically) | 24-06-2026 | — | 18d | 🟢 | RECIPES §TBD |
+| [§18](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#18-vedic-citation-density-separates-the-dictionary-traditions) | 24-06-2026 | — | 18d | 🟢 | RECIPES §TBD |
+| [§20](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#20-the-ls-source-map-recognises-724-percent-of-pwg-citations) | 24-06-2026 | — | 18d | 🟢 | RECIPES §TBD |
+| [§31](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#31-detector-precision-stratifies-by-digitization-quality) | 24-06-2026 | — | 18d | 🟢 | RECIPES §TBD |
+| [§22](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#22-mw-has-no-sense-level-div-markup) | 26-06-2026 | — | 16d | 🟢 | RECIPES §TBD |
+| [§29](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index) | 26-06-2026 | — | 16d | 🟢 | RECIPES §TBD |
+| [§33](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#33-indigenous-dictionaries-agree-on-derivation-wilson-is-the-outlier) | 26-06-2026 | — | 16d | 🟢 | RECIPES §TBD |
+| [§34](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#34-the-e-abbreviation-tag-is-polysemous-across-dicts) | 26-06-2026 | — | 16d | 🟢 | RECIPES §TBD |
+| [§35](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#35-root-recovery-tiers-err-on-root-form-not-identity) | 26-06-2026 | — | 16d | 🟢 | RECIPES §TBD |
+| [§40](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#40-gloss-language-spelling-drift-tracks-reform-type-not-age) | 26-06-2026 | — | 16d | 🟢 | RECIPES §TBD |
+| [§38](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#38-injected-boms-crash-the-hw-record-parser) | 27-06-2026 | — | 15d | 🟢 | RECIPES §TBD |
+| [§4](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#4-pwg-nominal-grammar-compresses-into-335-paradigm-tokens) | 29-06-2026 | — | 13d | 🟢 | RECIPES §TBD |
+| [§13](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#13-sa-ru-glossary-token-coverage-plateaus-at-866-percent) | 01-07-2026 | — | 11d | 🟢 | RECIPES §TBD |
+| [§14](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#14-renou-period-state-tagging-covers-770k-entries-in-8-dicts) | 01-07-2026 | — | 11d | 🟢 | RECIPES §TBD |
+| [§42](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#42-whitney-self-contradicts-on-derivative-ī-stem-genpl-accent) | 02-07-2026 | — | 10d | 🟢 | RECIPES §TBD |
+| [§21](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#21-pwg-citation-occurrences-track-distinct-references) | 02-07-2026 | — | 10d | 🟢 | RECIPES §TBD |
+| [§24](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#24-about-9-percent-of-typo-corrections-are-collisions) | 01-07-2026 | 02-07-2026 | 10d | 🟢 | RECIPES §TBD |
+| [§25](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#25-a-verified-correction-queue-decays-against-live-csl-orig) | 01-07-2026 | 02-07-2026 | 10d | 🟢 | RECIPES §TBD |
+| [§26](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#26-citation-density-is-register-bound-not-comparable-raw) | 13-06-2026 | 02-07-2026 | 10d | 🟢 | RECIPES §TBD |
+| [§41](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#41-the-sanskrit-dictionary-platform-landscape-probed-live) | 16-02-2026 | 02-07-2026 | 10d | 🟢 | RECIPES §TBD |
+| [§43](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#43-skdvcp-sensecitation-fusion-is-a-record-type-effect-not-a-dictionary-level-one) | 02-07-2026 | — | 10d | 🟢 | RECIPES §TBD |
+| [§44](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#44-raw-latin-string-tallies-over-gloss-text-include-etymological-false-positives-bopp-lacks-yabh) | 02-07-2026 | — | 10d | 🟢 | RECIPES §TBD |
+| [§45](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#45-siglum-prefix-families-routinely-bundle-several-distinct-works-the-diacritic-stripping-fold-has-poisoned-keys) | 02-07-2026 | — | 10d | 🟢 | RECIPES §TBD |
+| [§1](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#1-whitney-accent-mobility-rules-are-machine-encodable) | 29-06-2026 | 03-07-2026 | 9d | 🟢 | RECIPES §TBD |
+| [§46](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#46-twelve-years-of-corrections-cover-only-1014--of-the-estimated-error-population) | 03-07-2026 | — | 9d | 🟢 | RECIPES §TBD |
+| [§47](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#47-heritage-data-is-acquirable-despite-the-anubis-wall--via-a-github-mirror-the-morphology-xml-is-not-in-it) | 03-07-2026 | — | 9d | 🟢 | RECIPES §TBD |
+| [§49](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#49-mwheritage-coverage-highlighting-is-a-duplicate-anchor-pattern-not-a-css-class--and-the-mirrors-current-dictionary-is-a-different-scope-asset-than-the-2014-reader-stem-list) | 03-07-2026 | — | 9d | 🟢 | RECIPES §TBD |
+| [§50](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#50-cdsl-display-paths-are-not-uniformly-2020web--and-two-new-digitizations-landed-in-june-2026) | 03-07-2026 | — | 9d | 🟢 | RECIPES §TBD |
+| [§51](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#51-huet-correspondence-predates-this-session-2021--the-morphology-xml-gate-was-already-resolved-in-writing-direct-download-urls-recovered) | 30-03-2021 | 03-07-2026 | 9d | 🟢 | RECIPES §TBD |
+| [§52](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#52-heritage-vs-kosha-forms-diff-the-small-raw-overlap-is-mostly-convention--model-difference-and-disagreements-are-two-thirds-lemmatization-policy-not-error) | 03-07-2026 | — | 9d | 🟢 | RECIPES §TBD |
+| [§53](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#53-the-wil-etymology-extractions-affix-field-is-half-noise--wilson-outlier-figures-are-substantially-a-measurement-artifact) | 03-07-2026 | — | 9d | 🟢 | RECIPES §TBD |
+| [§56](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#56-dicos-entry-anchors-nest-three-structural-roles-under-one-html-class--only-one-is-a-true-entry-boundary) | 03-07-2026 | — | 9d | 🟢 | RECIPES §TBD |
+| [§55](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#55-genoptharness2py-output-budget-coarser-wins-on-both-knobs-in-opposite-directions) | 03-07-2026 | — | 9d | 🟢 | RECIPES §TBD |
+| [§57](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#57-samskrtamruz-is-id-addressed-with-no-name-lookup--deep-linking-needs-a-scraped-rootid-table-8-primer-basic-roots-are-absent) | 03-07-2026 | — | 9d | 🟢 | RECIPES §TBD |
+| [§58](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#58-pwg-ru-promoted-store-has-input-level-provenance-but-old-ru-rows-lacked-exact-model-versions) | 03-07-2026 | — | 9d | 🟢 | RECIPES §TBD |
+| [§59](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#59-böhtlingks-indische-sprüche-both-editions-already-fully-digitized-in-sanskrit-lexicon-scans-not-just-sanskrit-lexicon) | 06-05-2026 | 03-07-2026 | 9d | 🟢 | RECIPES §TBD |
+| [§54](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents) | 03-07-2026 | 05-07-2026 | 7d | 🟢 | RECIPES §TBD |
+| [§64](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1--pwg-is-not-the-sole-spine-of-the-local-layer-universe) | 05-07-2026 | — | 7d | 🟢 | RECIPES §TBD |
+| [§60](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-practical-russian-transcription-of-sanskrit-names-has-no-safe-reverse-transliteration) | 05-07-2026 | — | 7d | 🟢 | RECIPES §TBD |
+| [§63](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian) | 07-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) | 05-03-2026 | 07-07-2026 | 5d | 🟢 | RECIPES §TBD |
+| [§65](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse) | 07-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§61](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#61-the-reverse-dictionarys-30-sources-split-18-pd-vs-10-in-copyright--the-merged-headword-list-is-not-automatically-publishable) | 07-07-2026 | — | 5d | 🟢 | RECIPES §TBD |
+| [§48](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#48-vedaweb-20s-resource-export-is-an-async-task-behind-a-pickup-key-not-a-direct-get--and-the-server-went-unresponsive-mid-attempt) | 03-07-2026 | 08-07-2026 | 4d | 🟢 | RECIPES §TBD |
+| [§66](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#66-the-dcs-ql-frequency-workbooks-slp1-and-length-columns-are-truncated-at-ṣṭhḍh-clusters) | 10-07-2026 | — | 2d | 🟢 | RECIPES §TBD |
+| [§67](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#67-in-pwg-article-size-dwarfs-every-parametric-statistic-you-can-extract-from-the-entry) | 10-07-2026 | — | 2d | 🟢 | RECIPES §TBD |
+| [§69](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#69-hand-transcribed-telemetry-cannot-adjudicate-code-vs-infra--and-a-local-only-ledger-silently-swaps-your-denominator) | 10-07-2026 | — | 2d | 🟢 | RECIPES §TBD |
+| [§76](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#76-the-mwwordnetsemdom-bridge-is-a-candidate-generator-not-a-classifier) | 11-07-2026 | — | 1d | 🟢 | RECIPES §TBD |
+| [§70](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#70-pwgru-tm-composite-grade-a-is-consensus-gated-57-and-a-reference-free-surface-qe-cannot-detect-wrong-sense) | 03-07-2026 | 11-07-2026 | 1d | 🟢 | RECIPES §TBD |
+| [§71](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#71-pwg-marks-case-government-explicitly-3853-times-across-3222-senses--a-deterministic-census-not-an-estimate) | 08-07-2026 | 11-07-2026 | 1d | 🟢 | RECIPES §TBD |
+| [§72](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#72-vedawebs-idgra-token-field-is-the-grassmann-l-entry-number--no-fuzzy-text-matching-needed-for-a-gravedaweb-crosswalk) | 08-07-2026 | 11-07-2026 | 1d | 🟢 | RECIPES §TBD |
+| [§73](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#73-vedaweb-20s-cc-by-40-for-everything-claim-is-not-machine-confirmed--only-236-catalog-resources-carry-an-explicit-license-field) | 08-07-2026 | 11-07-2026 | 1d | 🟢 | RECIPES §TBD |
+| [§74](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#74-the-ls-graph-citation-matrix-is-degenerate-for-mw--its-top-abbreviations-sit-unresolved-use-the-citation-apparatus-siglum-matrix-for-cross-dict-citation-profiles) | 08-07-2026 | 11-07-2026 | 1d | 🟢 | RECIPES §TBD |
+| [§68](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#68-the-sanskrit-spellchecker-landscape-one-dormant-demo-one-license-unsettled-543k-wordlist-no-occupant) | 10-01-2025 | 11-07-2026 | 1d | 🟢 | RECIPES §TBD |
+| [§75](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#75-the-full-devībhāgavata-purāṇa-sanskrit-is-not-on-gretil--only-the-devigita-fragment-the-complete-mūla-lives-on-sanskritdocumentsorg-without-dbhp-markers) | 10-07-2026 | 11-07-2026 | 1d | 🟢 | RECIPES §TBD |
+| [§76](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#76-dcs-2026-sqlite-carries-531747-sense-annotated-tokens-mwordsem-but-no-local-idgloss-inventory--gold-scored-wsd-against-mw-senses-is-blocked-until-the-inventory-is-recovered) | 26-06-2026 | 11-07-2026 | 1d | 🟢 | RECIPES §TBD |
 
 _Auto-generated by [`derive_staleness.py`](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/derive_staleness.py); regenerate on FINDINGS change, do not edit by hand._


### PR DESCRIPTION
H701 re-check sweep: regenerated via [derive_staleness.py](https://github.com/sanskrit-lexicon/sanskrit-util/blob/main/tools/epistemic/derive_staleness.py); 77 rows, all 🟢, none undated — no decayed fact due under the registry's own 3/6-month cadence. Part of [H701](https://github.com/gasyoun/Uprava/blob/main/handoffs/H701-Fable_Uprava_staleness-recheck-sweep_11.07.26.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)