### PR TITLE
H692: assembled_cards/renou stage-redundancy verify + deletion PROPOSAL

### DIFF
--- a/RussianTranslation/RENOU_STAGE_REDUNDANCY_AUDIT_12.07.26.md
+++ b/RussianTranslation/RENOU_STAGE_REDUNDANCY_AUDIT_12.07.26.md
@@ -1,0 +1,152 @@
+# RENOU stage-redundancy audit — verification + deletion PROPOSAL
+
+_Created: 12-07-2026 · Last updated: 12-07-2026_
+
+**Handoff:** [H692](https://github.com/gasyoun/Uprava/blob/main/handoffs/H692-Fable_RussianTranslation_assembled-cards-dedup-verify_11.07.26.md).
+**Model:** Sonnet 5 (`claude-sonnet-5`), continuing an in-flight Fable 5
+(`claude-fable-5`) session that had written but not yet run
+[`src/renou_stage_redundancy_check.py`](src/renou_stage_redundancy_check.py)
+in this same worktree. That script was run against the live data (all files
+gitignored, local-only, single-copy under `RussianTranslation/src/` in the
+main checkout) and its findings were cross-checked with an independent,
+homonym-aware (`key1`+`hom`) positional verifier for the two series named in
+the handoff (`assembled_cards`, `mw`) before any verdict below was written.
+**ZERO files were deleted, moved, or renamed by this session** — this is a
+proposal only, per the H692 stop condition.
+
+## Series A — `assembled_cards` chain: CLEAN, safe-to-delete candidate
+
+Chain: `assembled_cards.jsonl` → `.renou.jsonl` → `.renou.bhs.jsonl` →
+`.renou.bhs.wl.jsonl` (120,173 rows each, identical `key1` order throughout).
+
+Each stage strictly **adds** fields (`renou_dcs*`/`renou_enriched`/
+`renou_provenance` at stage 2, `renou_bhs` at stage 3, `renou_wl` at stage 4)
+and never mutates a substantive field already present. The only fields that
+change value between adjacent stages are the two tracking fields
+`renou_provenance` and `renou_enriched` — and every change there is a
+**monotonic** addition (e.g. `{"V": ["dcs"]}` → `{"V": ["dcs", "bhs"]}`,
+`renou_enriched: []` → `["V"]`), verified with zero exceptions across all
+120,173 rows for every adjacent pair. No substantive field (`renou_dcs`,
+`renou_dcs_oldest`, `renou_dcs_texts`, `renou_bhs`, `renou_wl`, `iast`,
+`key1`, `key2`, `records`, `attested_senses`, `quarantined_records`, `reuse`,
+`rights`) ever regresses between stages.
+
+**Verdict: `assembled_cards.jsonl`, `.renou.jsonl`, `.renou.bhs.jsonl` are
+fully content-contained in `.renou.bhs.wl.jsonl`** (mod. the intermediate
+provenance/enriched *snapshot*, which is reconstructable from the final
+file's provenance lists by dropping the `bhs`/`wl` source tags — see
+`enrich_renou_bhs.py`/`enrich_renou_wisdomlib.py` for the tag semantics).
+
+- **PROPOSE DELETE**: `assembled_cards.jsonl` (183 MB), `assembled_cards.renou.jsonl`
+  (198 MB), `assembled_cards.renou.bhs.jsonl` (199 MB) — **~607 MB recoverable**.
+- **KEEP**: `assembled_cards.renou.bhs.wl.jsonl` (201 MB) as the sole canonical
+  file for this series.
+- Out of scope (small, not part of this progressive chain — test/dev
+  fixtures written by `assemble.py`/`validate_assembled_export.py`, not
+  reused downstream the same way): `.chunk`, `.chunk.quarantine`, `.perf`,
+  `.perf.quarantine`, `.quarantine`, `.smoke`, `.smoke.quarantine`, `.test`,
+  `.test.quarantine` (all ≤14 MB, mostly KB-scale). Not audited here — no
+  redundancy claim either way.
+
+## Series B — per-dict `{code}_renou*` chain vs canonical `{code}.renou.jsonl`: NOT redundant, DO NOT DELETE
+
+The `.`-vs-`_` naming split flagged by the census is a real, **org-wide,
+systematic** pattern across 7 of 8 dictionary codes (`ap`, `ap90`, `ben`,
+`bhs`, `mw`, `pw`, `sch`; `pwg` has only the canonical dot-file, no
+underscore chain):
+
+- `{code}_renou.jsonl` [→ `{code}_renou.bhs.jsonl` → `{code}_renou.bhs.wl.jsonl`]
+  — the **old staged pipeline**, built 23/24‑06‑2026 by
+  [`tag_mw_from_source.py`](src/tag_mw_from_source.py) /
+  [`tag_dict_from_source.py`](src/tag_dict_from_source.py) →
+  [`enrich_renou_bhs.py`](src/enrich_renou_bhs.py) →
+  [`enrich_renou_wisdomlib.py`](src/enrich_renou_wisdomlib.py).
+- `{code}.renou.jsonl` — the **canonical consolidated file**
+  (`renou_bhs`+`renou_wl`+`renou_register`+`renou_register_provenance` all
+  present in one file), built ~25‑06‑2026, roughly one day later and ~53 min
+  after `dcs_lemma_renou.json` (the DCS attestation index) was itself
+  regenerated (`2026-06-25 13:17`).
+
+**Internally, the old underscore chain is clean** (same monotonic-addition
+pattern as Series A, verified for `ap` and `mw` with zero substantive-field
+regressions across every row of every adjacent pair).
+
+**But the old chain's final stage is NOT a strict subset of the canonical
+dot-file — real content diverges**, confirmed two ways:
+
+1. Homonym-aware (`key1`+`hom`) positional check, exact (not sampled), on
+   `mw`: of 286,560 rows, **13,836 (4.8%) differ in `renou_dcs`** and
+   **9,737 (3.4%) differ in `renou_dcs_oldest`** — always by the canonical
+   file having *fewer* register (I–V) attestations than the old chain (e.g.
+   `aMSuhasta`: old `["IV"]` → canonical `[]`; `aka`: old `["I","II","IV"]`
+   → canonical `["I","II"]`). Zero `key1` order mismatches; `mw.renou.jsonl`
+   itself lacks a `hom` field the underscore chain carries, so alignment
+   required matching by row position, not naive `key1` dict lookup (a naive
+   `key1`-keyed comparison over-reports divergence because ~26% of `mw`
+   `key1` values are shared across multiple homonyms).
+2. [`src/renou_stage_redundancy_check.py`](src/renou_stage_redundancy_check.py)'s
+   independent 1-in-25 `key1`-sampled check corroborates the same order of
+   magnitude and additionally surfaces **`renou_ls` divergence** (citation-derived
+   states, not just DCS-derived), which the exact `mw` check above did not
+   probe: `mw` sample disagreement `renou_ls` 2,596/11,396 (22.8%), `renou_dcs`
+   545/11,396 (4.8% — matches the exact count above), `renou_enriched`
+   1,171/11,396 (10.3%). The same qualitative pattern (`renou_ls`/`renou_dcs`/
+   `renou_enriched` disagreement, `renou_provenance`/order clean) recurs for
+   `ap`, `ap90`, `ben`, `bhs`, `pw`, `sch` — this is **not an `mw`-specific
+   anomaly**, it is systematic across the whole dictionary set.
+
+**Working hypothesis (not confirmed — needs a human call):** the canonical
+dot-files were regenerated a day after the old chain against a refreshed
+`dcs_lemma_renou.json` (and possibly a refreshed `ls_source_map_mw.json` for
+the `renou_ls` divergence), so the divergence may be a **correction**
+(old chain over-attested; canonical is right) rather than a **regression**
+(canonical is right for `renou_ls`/`renou_dcs` reduction but something else
+broke). Recent unrelated pipeline work in the same window fixed a
+"scale-plan OUT-path bug" (commit `f655bba`), which raises the prior that
+index/attestation regeneration bugs were actively being hunted around this
+date — but that commit is in a different subsystem (H255 no-PWG lane) and
+is not confirmed to be the same code path.
+
+**Verdict: KEEP BOTH old chain and canonical dot-file for every code until
+the divergence is adjudicated.** This is explicitly **not** a
+"row-counts-match → safe to delete" case — the row counts matching masked a
+real, systematic ~3–23% (field-dependent) content difference. Deleting the
+old chain now would be irreversible if the canonical regeneration turns out
+to have regressed rather than corrected.
+
+- **DO NOT DELETE**: `ap_renou.jsonl`, `ap_renou.bhs.jsonl`,
+  `ap_renou.bhs.wl.jsonl`, `ap90_renou.jsonl`, `ben_renou.jsonl`,
+  `bhs_renou.jsonl`, `mw_renou.jsonl`, `mw_renou.bhs.jsonl`,
+  `mw_renou.bhs.wl.jsonl`, `pw_renou.jsonl`, `sch_renou.jsonl`
+  (~379 MB total) — pending the `@DECIDE` below.
+- Naming-drift catalog (dot = canonical/newer, underscore = old
+  staged/older) — same table as above; no rename proposed here since the
+  two are not (yet proven) interchangeable.
+
+## Full run output
+
+Raw per-code numbers (rows, distinct `key1`, containment stats, sampled
+agreement) are in the script's own run — reproduce with:
+
+```
+python src/renou_stage_redundancy_check.py --out RENOU_STAGE_REDUNDANCY_RUN_12.07.26.md
+```
+
+(run from `RussianTranslation/src/` in the checkout that actually holds the
+gitignored data files — this repo's worktrees do not carry them).
+
+## GTD follow-up
+
+- `@DO` (human executes, no urgency): delete `assembled_cards.jsonl`,
+  `assembled_cards.renou.jsonl`, `assembled_cards.renou.bhs.jsonl`
+  (~607 MB) — proven safe above.
+- `@DECIDE` (human decides, blocks the ~379 MB underscore-chain deletion):
+  is the 25‑06 canonical `{code}.renou.jsonl` regeneration a correction
+  (old chain over-attested — safe to delete old chain once confirmed) or a
+  regression (canonical under-attests — investigate `enrich_renou_dcs.py`/
+  `tag_mw_from_source.py`/`ls_source_map_mw.json`/`dcs_lemma_renou.json`
+  provenance around 25‑06‑2026 before trusting the canonical files for
+  anything downstream)? Mirrored to
+  [Uprava/GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/RENOU_STAGE_REDUNDANCY_RUN_12.07.26.md
+++ b/RussianTranslation/RENOU_STAGE_REDUNDANCY_RUN_12.07.26.md
@@ -1,0 +1,51 @@
+## Series A — assembled_cards chain (full check, every row)
+
+- rows (all four stages zipped in lockstep): **120173** — equal lengths
+- assembled_cards.jsonl ⊂ assembled_cards.renou.jsonl: adds ['renou_dcs', 'renou_dcs_oldest', 'renou_dcs_texts', 'renou_enriched', 'renou_provenance']; key1 sequence mismatches **0**; modified-field violations **0**
+- assembled_cards.renou.jsonl ⊂ assembled_cards.renou.bhs.jsonl: adds ['renou_bhs']; key1 sequence mismatches **0**; modified-field violations **15383** (fields: {'renou_provenance': 9649, 'renou_enriched': 5734}; examples [('a', 'renou_provenance'), ('aMSa', 'renou_provenance'), ('aMSu', 'renou_provenance')])
+- assembled_cards.renou.bhs.jsonl ⊂ assembled_cards.renou.bhs.wl.jsonl: adds ['renou_wl']; key1 sequence mismatches **0**; modified-field violations **23** (fields: {'renou_provenance': 23}; examples [('akzoBya', 'renou_provenance'), ('amitABa', 'renou_provenance'), ('DarmaDAtuvAgISvara', 'renou_provenance')])
+
+## Series B — per-dict old underscore chain vs canonical `{code}.renou.jsonl`
+
+### AP
+- old chain `ap_renou.jsonl -> ap_renou.bhs.jsonl -> ap_renou.bhs.wl.jsonl`: 90654 rows zipped
+  - step ap_renou.jsonl ⊂ ap_renou.bhs.jsonl: adds ['renou_bhs']; key mismatches 0; modified-field violations 6014 (fields: {'renou_provenance': 3650, 'renou_enriched': 2364}; e.g. [('a', 'renou_provenance'), ('a', 'renou_provenance'), ('akaca', 'renou_enriched')])
+  - step ap_renou.bhs.jsonl ⊂ ap_renou.bhs.wl.jsonl: adds ['renou_wl']; key mismatches 0; modified-field violations 5 (fields: {'renou_provenance': 5}; e.g. [('akzoBya', 'renou_provenance'), ('amitABa', 'renou_provenance'), ('vajrAkAra', 'renou_provenance')])
+- old-final `ap_renou.bhs.wl.jsonl` (90654 rows, 88701 distinct key1) vs canonical `ap.renou.jsonl` (90654 rows, 88701 distinct key1): key1 only-in-old 0 rows / only-in-canonical 0 rows
+- sampled signal agreement on common key1 (1-in-25, n=3626): 3459 agree / 167 disagree (fields: {'renou_ls': 41, 'renou_enriched': 136, 'renou_dcs': 130})
+
+### AP90
+- old chain: only `ap90_renou.jsonl` (34882 rows)
+- old-final `ap90_renou.jsonl` (34882 rows, 34277 distinct key1) vs canonical `ap90.renou.jsonl` (34882 rows, 34277 distinct key1): key1 only-in-old 0 rows / only-in-canonical 0 rows
+- sampled signal agreement on common key1 (1-in-25, n=1396): 1285 agree / 111 disagree (fields: {'renou_enriched': 99, 'renou_dcs': 52, 'renou_ls': 7})
+
+### BEN
+- old chain: only `ben_renou.jsonl` (17310 rows)
+- old-final `ben_renou.jsonl` (17310 rows, 17036 distinct key1) vs canonical `ben.renou.jsonl` (17310 rows, 17036 distinct key1): key1 only-in-old 0 rows / only-in-canonical 0 rows
+- sampled signal agreement on common key1 (1-in-25, n=693): 609 agree / 84 disagree (fields: {'renou_enriched': 73, 'renou_dcs': 41, 'renou_ls': 7})
+
+### BHS
+- old chain: only `bhs_renou.jsonl` (17839 rows)
+- old-final `bhs_renou.jsonl` (17839 rows, 17777 distinct key1) vs canonical `bhs.renou.jsonl` (17839 rows, 17777 distinct key1): key1 only-in-old 0 rows / only-in-canonical 0 rows
+- sampled signal agreement on common key1 (1-in-25, n=714): 692 agree / 22 disagree (fields: {'renou_enriched': 22, 'renou_dcs': 21, 'renou_ls': 1})
+
+### MW
+- old chain `mw_renou.jsonl -> mw_renou.bhs.jsonl -> mw_renou.bhs.wl.jsonl`: 286560 rows zipped
+  - step mw_renou.jsonl ⊂ mw_renou.bhs.jsonl: adds ['renou_bhs']; key mismatches 0; modified-field violations 49188 (fields: {'renou_provenance': 33949, 'renou_enriched': 15239}; e.g. [('a', 'renou_provenance'), ('a', 'renou_provenance'), ('akAra', 'renou_provenance')])
+  - step mw_renou.bhs.jsonl ⊂ mw_renou.bhs.wl.jsonl: adds ['renou_wl']; key mismatches 0; modified-field violations 50 (fields: {'renou_provenance': 50}; e.g. [('akzoBya', 'renou_provenance'), ('akzoBya', 'renou_provenance'), ('akzoByA', 'renou_provenance')])
+- old-final `mw_renou.bhs.wl.jsonl` (286560 rows, 194084 distinct key1) vs canonical `mw.renou.jsonl` (286560 rows, 194084 distinct key1): key1 only-in-old 0 rows / only-in-canonical 0 rows
+- sampled signal agreement on common key1 (1-in-25, n=11396): 8416 agree / 2980 disagree (fields: {'renou_ls': 2596, 'renou_dcs': 545, 'renou_enriched': 1171})
+
+### PW
+- old chain: only `pw_renou.jsonl` (170556 rows)
+- old-final `pw_renou.jsonl` (170556 rows, 151349 distinct key1) vs canonical `pw.renou.jsonl` (170556 rows, 151349 distinct key1): key1 only-in-old 0 rows / only-in-canonical 0 rows
+- sampled signal agreement on common key1 (1-in-25, n=6799): 6012 agree / 787 disagree (fields: {'renou_enriched': 653, 'renou_dcs': 296, 'renou_ls': 237})
+
+### SCH
+- old chain: only `sch_renou.jsonl` (29125 rows)
+- old-final `sch_renou.jsonl` (29125 rows, 28455 distinct key1) vs canonical `sch.renou.jsonl` (29125 rows, 28455 distinct key1): key1 only-in-old 0 rows / only-in-canonical 0 rows
+- sampled signal agreement on common key1 (1-in-25, n=1165): 1040 agree / 125 disagree (fields: {'renou_enriched': 120, 'renou_ls': 8, 'renou_dcs': 48})
+
+### PWG
+- old underscore chain: **absent** (canonical `pwg.renou.jsonl` only — already clean)
+

--- a/RussianTranslation/src/renou_stage_redundancy_check.py
+++ b/RussianTranslation/src/renou_stage_redundancy_check.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""renou_stage_redundancy_check.py — H692: are the pipeline-stage files redundant?
+
+Two series of large local-only, gitignored, single-copy JSONL artifacts in
+``RussianTranslation/src/`` repeat a progressive-enrichment pattern, and the
+data-layer census flagged ~1.4 GB as possibly dead. This tool PROVES or REFUTES
+content-level redundancy — it never deletes, moves or rewrites anything.
+
+Series A — ``assembled_cards`` chain (full streaming verification, every row):
+    assembled_cards.jsonl -> .renou -> .renou.bhs -> .renou.bhs.wl
+  For each adjacent pair, every record is checked: same ``key1`` sequence, and
+  every field of the earlier stage must be present with a deeply-equal value in
+  the later stage (containment). Any modification, not just addition, is
+  counted and exemplified (keys only — no data rows are emitted).
+
+Series B — per-dict old stepwise chain vs the canonical pipeline artifact:
+    {code}_renou.jsonl [-> {code}_renou.bhs.jsonl -> {code}_renou.bhs.wl.jsonl]
+    vs {code}.renou.jsonl        (built by renou_pipeline.py, all four signals)
+  Checks: row counts, adjacent containment inside the old chain (full check),
+  then old-final vs canonical: key1 coverage both ways plus agreement of the
+  shared Renou signal fields on a deterministic 1-in-25 sample of common keys.
+
+Output: aggregates-only Markdown report (--out). Exit code 0 always (report
+tool, not a gate).
+
+Usage:
+    python renou_stage_redundancy_check.py [--src DIR] [--out REPORT.md]
+
+H692 (Lane B, Fable sprint). Run 11/12-07-2026 by Fable 5 (claude-fable-5).
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+
+ASSEMBLED = [
+    "assembled_cards.jsonl",
+    "assembled_cards.renou.jsonl",
+    "assembled_cards.renou.bhs.jsonl",
+    "assembled_cards.renou.bhs.wl.jsonl",
+]
+DICTS = ["ap", "ap90", "ben", "bhs", "mw", "pw", "sch", "pwg"]
+
+
+def jl(path):
+    with open(path, encoding="utf-8-sig") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                yield json.loads(line)
+
+
+def check_chain(paths):
+    """Full containment check along a chain of JSONL files (same row order).
+
+    Returns dict with rows per file, added-fields per step, and per-step
+    violation stats: {step: {"key_mismatch": n, "modified": Counter(field),
+    "examples": [(key, field)]}}.
+    """
+    gens = [jl(p) for p in paths]
+    rows = 0
+    added = [None] * (len(paths) - 1)
+    viol = [
+        {"key_mismatch": 0, "modified": Counter(), "examples": []}
+        for _ in range(len(paths) - 1)
+    ]
+    short = None
+    while True:
+        recs = []
+        for g in gens:
+            recs.append(next(g, None))
+        if all(r is None for r in recs):
+            break
+        if any(r is None for r in recs):
+            short = rows  # length mismatch — record and stop the zip
+            break
+        rows += 1
+        for i in range(len(recs) - 1):
+            a, b = recs[i], recs[i + 1]
+            if a.get("key1") != b.get("key1"):
+                viol[i]["key_mismatch"] += 1
+                continue
+            if added[i] is None:
+                added[i] = sorted(set(b) - set(a))
+            for f, v in a.items():
+                if f not in b or b[f] != v:
+                    viol[i]["modified"][f] += 1
+                    if len(viol[i]["examples"]) < 3:
+                        viol[i]["examples"].append((a.get("key1"), f))
+        if rows % 20000 == 0:
+            print(f"  …{rows} rows", file=sys.stderr)
+    return {"rows": rows, "added": added, "viol": viol, "short": short}
+
+
+def count_rows(path):
+    n = 0
+    with open(path, encoding="utf-8-sig") as fh:
+        for line in fh:
+            if line.strip():
+                n += 1
+    return n
+
+
+def series_b(src, code, out):
+    old = [f"{code}_renou.jsonl", f"{code}_renou.bhs.jsonl", f"{code}_renou.bhs.wl.jsonl"]
+    old = [f for f in old if os.path.exists(os.path.join(src, f))]
+    canon = f"{code}.renou.jsonl"
+    has_canon = os.path.exists(os.path.join(src, canon))
+    out.append(f"### {code.upper()}")
+    if not old:
+        out.append(f"- old underscore chain: **absent** (canonical `{canon}` only — already clean)\n")
+        return
+    paths = [os.path.join(src, f) for f in old]
+    if len(old) > 1:
+        r = check_chain(paths)
+        out.append(f"- old chain `{' -> '.join(old)}`: {r['rows']} rows zipped"
+                   + (f", LENGTH MISMATCH at {r['short']}" if r["short"] is not None else ""))
+        for i, v in enumerate(r["viol"]):
+            mods = sum(v["modified"].values())
+            out.append(
+                f"  - step {old[i]} ⊂ {old[i+1]}: adds {r['added'][i]}; key mismatches {v['key_mismatch']}; "
+                f"modified-field violations {mods}"
+                + (f" (fields: {dict(v['modified'])}; e.g. {v['examples']})" if mods else "")
+            )
+    else:
+        out.append(f"- old chain: only `{old[0]}` ({count_rows(paths[0])} rows)")
+    if not has_canon:
+        out.append(f"- canonical `{canon}`: **ABSENT** — old chain is the only artifact, keep\n")
+        return
+    # old-final vs canonical: key coverage + sampled signal agreement
+    old_final = paths[-1]
+    keys_old = Counter()
+    sample_old = {}
+    for i, rec in enumerate(jl(old_final)):
+        k = rec.get("key1")
+        keys_old[k] += 1
+        if i % 25 == 0:
+            sample_old[k] = rec
+    keys_can = Counter()
+    agree = disagree = 0
+    dis_fields = Counter()
+    sig_fields = ["renou_enriched", "renou_ls", "renou_dcs", "renou_bhs", "renou_wl"]
+    for rec in jl(os.path.join(src, canon)):
+        k = rec.get("key1")
+        keys_can[k] += 1
+        s = sample_old.get(k)
+        if s is not None:
+            if all(s.get(f) == rec.get(f) for f in sig_fields if f in s):
+                agree += 1
+            else:
+                disagree += 1
+                for f in sig_fields:
+                    if f in s and s.get(f) != rec.get(f):
+                        dis_fields[f] += 1
+            sample_old.pop(k, None)  # count each sampled key once
+    only_old = sum(c for k, c in keys_old.items() if k not in keys_can)
+    only_can = sum(c for k, c in keys_can.items() if k not in keys_old)
+    out.append(
+        f"- old-final `{old[-1]}` ({sum(keys_old.values())} rows, {len(keys_old)} distinct key1) vs canonical "
+        f"`{canon}` ({sum(keys_can.values())} rows, {len(keys_can)} distinct key1): "
+        f"key1 only-in-old {only_old} rows / only-in-canonical {only_can} rows"
+    )
+    tot = agree + disagree
+    out.append(
+        f"- sampled signal agreement on common key1 (1-in-25, n={tot}): "
+        f"{agree} agree / {disagree} disagree"
+        + (f" (fields: {dict(dis_fields)})" if disagree else "")
+        + "\n"
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--src", default=os.path.dirname(os.path.abspath(__file__)))
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    src = args.src
+
+    out = []
+    out.append("## Series A — assembled_cards chain (full check, every row)\n")
+    paths = [os.path.join(src, f) for f in ASSEMBLED]
+    print("Series A: zipping 4 assembled_cards stages …", file=sys.stderr)
+    r = check_chain(paths)
+    out.append(f"- rows (all four stages zipped in lockstep): **{r['rows']}**"
+               + (f" — LENGTH MISMATCH at row {r['short']}" if r["short"] is not None else " — equal lengths"))
+    for i, v in enumerate(r["viol"]):
+        mods = sum(v["modified"].values())
+        out.append(
+            f"- {ASSEMBLED[i]} ⊂ {ASSEMBLED[i+1]}: adds {r['added'][i]}; "
+            f"key1 sequence mismatches **{v['key_mismatch']}**; modified-field violations **{mods}**"
+            + (f" (fields: {dict(v['modified'])}; examples {v['examples']})" if mods else "")
+        )
+    out.append("")
+
+    out.append("## Series B — per-dict old underscore chain vs canonical `{code}.renou.jsonl`\n")
+    for code in DICTS:
+        print(f"Series B: {code} …", file=sys.stderr)
+        series_b(src, code, out)
+
+    text = "\n".join(out) + "\n"
+    if args.out:
+        with open(args.out, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(text)
+        print(f"written -> {args.out}", file=sys.stderr)
+    print(text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Series A (`assembled_cards` chain): CLEAN, ~607 MB safe-to-delete-proposal (early 3 stages fully content-contained in `.renou.bhs.wl.jsonl`, every row verified).
- Series B (per-dict `{code}_renou*` old chain vs canonical `{code}.renou.jsonl`): NOT redundant — real content divergence (`renou_ls`/`renou_dcs`/`renou_enriched`, 3–23% of rows depending on field/code) across ap/ap90/ben/bhs/mw/pw/sch. DO NOT DELETE pending a human `@DECIDE` on whether the canonical file's later DCS-index regeneration was a correction or a regression.
- Zero data files deleted, moved, or renamed — this PR adds only the audit report + the (now-run) verification script's output, per [H692](https://github.com/gasyoun/Uprava/blob/main/handoffs/H692-Fable_RussianTranslation_assembled-cards-dedup-verify_11.07.26.md)'s stop condition.

## Test plan
- [x] Independent homonym-aware (key1+hom) positional cross-check on `mw` and `ap` corroborates the script's sampled findings.
- [x] No `del`/`Remove-Item`/`git mv` run against any data file this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)