### PR TITLE
pwg_ru: expand card stats + grammar-block join (H777) + freeze government census sidecar (H778)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,39 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### H777 — expand per-card stats (layer/markup/QA/xref + dcs_freq + grammar join), 3 grains
+- [`src/annotate_stats.py`](src/annotate_stats.py) extended from the H422 lemma block to the
+  full accepted count menu (MG ruling 12-07-2026) at **three granularities** —
+  `sense_stats` (per row), `record_stats` (per homonym), `stats` (per lemma): layer/5-merge
+  provenance (`n_layers`, `layers_present`, `n_senses_supplement`), markup density (`n_ls`,
+  `n_lex`, `n_ab`, `n_xref`, `n_labels`), translation/QA (`equivalence_types`, `source_types`,
+  `review_statuses`, `n_differentia`, `n_null`), frequency (`dcs_freq_max`, exact-iast DCS
+  join), and the **grammar-block join** (`grammar_join`, `n_whitney_homonyms`,
+  `n_irregularities`, `root_class`, `stem_final`).
+- **`n_irregularities` no longer stuck at 0** — joined from `whitney_grammar.grammar_for`
+  for single-Whitney-homonym roots (32/205 lemmas, 46 irregularities on the current store);
+  ambiguous-homonym roots (17) are left `null`, not guessed (hand PWG-h ↔ Whitney alignment
+  owed). `dcs_freq_max` is exact-iast-or-null (170/205 matched) — prefixed forms DCS doesn't
+  lemmatise stay null rather than force-matched (the Renou-classifier lesson).
+- Schema `stats` block + `sense_stats`/`record_stats` documented in
+  [`schemas/pwg_ru_final_card.schema.json`](schemas/pwg_ru_final_card.schema.json); every
+  grammar-join state validates. `pipeline_versions.json` `script` bumped 1.0.0 → 1.1.0
+  (re-froze SHA; `annotate_stats.py` added to the tracked set) so cached blocks
+  self-invalidate. Extended fixture selftest.
+
+### H778 — freeze the PWG government census to a committed sidecar (no re-scan)
+- [`src/government_census.py`](src/government_census.py) gains a `freeze` command +
+  `build_sidecar`/`load_sidecar`/`census_or_load`: the corpus-level marker census over the
+  whole raw `pwg.txt` is frozen to the committed [`src/census_stats.json`](src/census_stats.json)
+  (**3,853 markers over 123,366 entries**), validated by the source SHA — `government_census.py
+  census` now prints `census source: cached` and skips the end-to-end re-scan when `pwg.txt`
+  is unchanged. [`src/government_queries.py`](src/government_queries.py) gains `--summary` for
+  the store-free corpus answer. Per-row listing queries still stream the store (rows not
+  frozen). Sidecar round-trip covered by the selftest.
+- Both are language-neutral analysis layers (operate on `de`/store structure) — no
+  LANG_PARITY entry required. Store fields are materialised locally by re-running the
+  annotator chain; the store is gitignored, so the code + sidecar are what ship.
+
 ### H775 — capability roadmap cards 5 + 23: MFS baseline + government sidecar (local-only)
 - New [`src/mfs_baseline.py`](src/mfs_baseline.py) (roadmap card 5): groups the
   store by `key1` and emits a deterministic most-frequent-sense candidate per

--- a/RussianTranslation/GRAMMAR_LAYER.md
+++ b/RussianTranslation/GRAMMAR_LAYER.md
@@ -1,6 +1,6 @@
 # Grammar layer — the 3rd axis (Whitney) for pwg_ru
 
-_Created: 07-07-2026 · Last updated: 09-07-2026 (H422)_
+_Created: 07-07-2026 · Last updated: 12-07-2026 (H777/H778)_
 
 pwg_ru already carries two evidence axes per headword: **lexicon** (corpus_lexicon Sa→Ru
 candidates) and **corpus** (parallel verse + Renou register). This adds the **grammar** axis,
@@ -136,27 +136,37 @@ per-case accent rules are already ingested (`whitney_sections.json` §§315–31
 
 ## Counting grammar — what's countable in a card, and caching the counts
 
-Case-government is now backfilled (`sense.government[]`, deterministically extracted by
-[`government_census.py`](src/government_census.py):`extract_government`, D4 ruling). But the
-**counts** derived from grammar are still recomputed on every question:
-[`government_census.py`](src/government_census.py) re-scans raw `pwg.txt` end-to-end each run,
-and [`government_queries.py`](src/government_queries.py) reloads the whole
-`pwg_ru_translated.jsonl` store and re-aggregates every query. Nothing on the card records
-"this lemma has N senses, M government markers, governs {loc, gen}, spans Renou I–IV." The
-census/query cost is paid again each time.
+Case-government is backfilled (`sense.government[]`, deterministically extracted by
+[`government_census.py`](src/government_census.py):`extract_government`, D4 ruling). The
+per-card counts are cached by [`annotate_stats.py`](src/annotate_stats.py) (H422, expanded
+H777) at three grains — `sense_stats` (per row), `record_stats` (per homonym), `stats` (per
+lemma) — and the corpus-level `pwg.txt` scan is frozen to the committed
+[`src/census_stats.json`](src/census_stats.json) sidecar (H778), so neither the census nor the
+per-card aggregation is recomputed on every question:
+[`government_census.py`](src/government_census.py) reads the sidecar when the source SHA is
+unchanged (`government_census.py census` prints `census source: cached`), and the corpus
+answer is available store-free via `government_queries.py --summary`. The per-row *listing*
+queries still stream the store (the individual rows are not frozen — only the aggregates).
 
 ### What is countable in a card
 
-All derivable from fields **already stored** — no new source parsing:
+All derivable from fields **already stored** — no new source parsing. Shipped families (H777),
+each computed at lemma / record / sense grain:
 
-| Scope | Countable |
+| Scope | Countable (shipped) |
 |---|---|
-| Structural | `n_records` (homonyms), `n_senses` (total + per record), max sense depth |
-| Grammar | `n_government` markers, `cases_governed` (union set), `has_variation`, `n_domain_labels`, stem-class present?, root class(es), `n_irregularities` |
-| Chronology (Renou) | `strata_span` (min–max), `n_strata`, oldest-sense index |
-| Evidence | `n_provides` / `n_supports` / `n_contradicts` / `n_silent`, `evidence_status` |
-| QA | `severity`, `n_issues`, `coverage_ok` |
-| Source markup | `n_ls` citations, `n_compound_members`, `has_accent` |
+| Structural | `n_records` (homonyms), `n_senses` |
+| Government | `n_government`, `cases_governed` (union), `has_variation` |
+| Layer / 5-merge | `n_layers`, `layers_present` ⊆ {pwg,pw,sch,pwkvn,nws}, `n_senses_supplement` |
+| Source markup | `n_ls` citations, `n_lex`, `n_ab`, `n_xref` (vgl.), `n_labels` |
+| Translation / QA | `equivalence_types`, `source_types`, `review_statuses`, `n_differentia`, `n_null` |
+| Frequency | `dcs_freq_max` {iast, count, band} (exact-iast DCS join) |
+| Grammar | `grammar_join`, `n_whitney_homonyms`, `n_irregularities`, `root_class`, `stem_final` |
+| Chronology (Renou) | `strata_span` (min–max), `n_strata` |
+| Evidence | `evidence.{provides,supports,contradicts,silent}` |
+
+Deferred (need a source not yet on the row): `n_compound_members`, `has_accent` (both live in
+the nominal-grammar / Zaliznyak blocks, not the flat store), max sense depth.
 
 ### Store them: a derived, self-invalidating `stats` block
 
@@ -175,19 +185,36 @@ card). Two rules keep a cached count safe rather than a stale-data trap:
    model tier (persist-tables reflex), so nobody re-scans `pwg.txt` to re-answer a settled
    count.
 
-Additive shape (`additionalProperties:false`-compatible, sits on `card`):
+Expanded lemma-block shape (H777 — all count families accepted 12-07-2026, finest grain):
 
 ```json
 "stats": {
   "n_records": 2, "n_senses": 7,
-  "n_government": 3, "cases_governed": ["loc","gen"], "has_variation": true,
-  "n_irregularities": 1, "strata_span": ["I","IV"], "n_strata": 3,
+  "n_government": 3, "cases_governed": ["gen","loc"], "has_variation": true,
+  "n_layers": 3, "layers_present": ["nws","pw","pwg"], "n_senses_supplement": 4,
+  "n_ls": 41, "n_lex": 3, "n_ab": 6, "n_xref": 2, "n_labels": 0,
+  "equivalence_types": {"equivalent": 5, "explanatory": 2},
+  "source_types": {"attested": 6, "mixed": 1}, "review_statuses": {"ai_translated": 7},
+  "n_differentia": 3, "n_null": 0,
+  "dcs_freq_max": {"iast": "prāp", "count": 6022, "band": 5},
+  "grammar_join": "single", "n_whitney_homonyms": 1, "n_irregularities": 1,
+  "root_class": "V", "stem_final": "p",
+  "strata_span": ["Vedic","Classical"], "n_strata": 3,
   "evidence": {"provides": 2, "supports": 4, "contradicts": 0, "silent": 3},
-  "computed_by": "annotate_stats.py", "pipeline_version": "…"
+  "computed_by": "annotate_stats.py", "pipeline_version": "1.1.0"
 }
 ```
 
-Status: **built** (H422, 09-07-2026) — [`src/annotate_stats.py`](src/annotate_stats.py) +
-the schema `stats` block ([`schemas/pwg_ru_final_card.schema.json`](schemas/pwg_ru_final_card.schema.json))
-are in place; validated against all 145 lemmas on the live store. `n_irregularities` stays 0
-until the grammar block is joined onto card rows (not yet a stored field).
+Status: **built + expanded** ([`src/annotate_stats.py`](src/annotate_stats.py), H422 →
+**H777**). The grammar block is now joined: `grammar_join` ∈ {`single`, `ambiguous-homonym`,
+`none`} — `n_irregularities`/`root_class` populate for single-Whitney-homonym roots (32 of
+205 lemmas, 46 irregularities on the current store), and are left `null` (not guessed) for
+the 17 ambiguous-homonym roots that still owe the hand PWG-h ↔ Whitney-homonym alignment. The
+`dcs_freq_max` join is exact-iast (170/205 matched); prefixed forms DCS doesn't lemmatise stay
+`null` rather than being force-matched. Schema `stats` block +
+`sense_stats`/`record_stats` siblings documented in
+[`schemas/pwg_ru_final_card.schema.json`](schemas/pwg_ru_final_card.schema.json); every
+grammar-join state validates. `script` component bumped 1.0.0 → 1.1.0 so cached blocks
+self-invalidate. **Local materialisation** (the store is gitignored): re-run
+`annotate_government.py` then `annotate_stats.py` on `pwg_ru_translated.jsonl` to write the
+fields onto the working copy — the code + census sidecar are what ship.

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -1,6 +1,6 @@
 # RussianTranslation — results log
 
-_Created: 09-07-2026 · Last updated: 09-07-2026_
+_Created: 09-07-2026 · Last updated: 12-07-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
@@ -40,4 +40,47 @@ Script v1.0.0 · Sonnet 5 (claude-sonnet-5)
 | lemmas with case variation | 0 |
 | evidence: provides | 1734 |
 | evidence: supports | 1935 |
+
+## 12-07-2026 — pwg_ru card stats rollup (annotate_stats.py)
+
+Script v1.1.0 · Opus 4.8 (claude-opus-4-8)
+
+| metric | value |
+|---|---|
+| lemmas | 205 |
+| records (homonym groups) | 635 |
+| senses | 11505 |
+| government markers | 508 |
+| lemmas with case variation | 2 |
+| grammar-joined lemmas (single homonym) | 32 |
+| … whitney irregularities counted | 46 |
+| grammar ambiguous-homonym (alignment owed) | 17 |
+| dcs-matched lemmas | 170 |
+| <ls> citations (total) | 41031 |
+| evidence: provides | 1699 |
+| evidence: supports | 1893 |
+
+Numbers are over the current 205-lemma pwg_ru_translated store (the gitignored working
+copy); the fields (`government`, `stats`, `sense_stats`, `record_stats`) are materialised
+locally by re-running the annotator chain — the store itself is not committed. Contrast the
+09-07 v1.0.0 row above (0 government markers, no grammar counts) with this v1.1.0 row: H777
+joined the grammar block (`n_irregularities` no longer stuck at 0) and added the layer /
+markup / QA / frequency families.
+
+## 12-07-2026 — PWG case-government census, frozen (H778, government_census.py freeze)
+
+Script v1.1.0 · Opus 4.8 (`claude-opus-4-8`). Corpus-level marker census over the **whole
+raw** [`csl-orig/v02/pwg/pwg.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/pwg/pwg.txt)
+(sha `430c910f8b0c9229`), frozen to the committed [`src/census_stats.json`](src/census_stats.json)
+sidecar so the scan is not re-run on every question. This is the corpus answer to "сколько
+таких помет в PWG"; the per-205-lemma store rollup above is the pwg_ru subset.
+
+| metric | value |
+|---|---|
+| PWG entries scanned | 123366 |
+| sense units scanned | 288991 |
+| government markers (total) | 3853 |
+| … paren-single / variation / mit-phrase | 2309 / 40 / 1504 |
+| entries with ≥1 marker | 1476 |
+| sense units with ≥1 marker | 3222 |
 

--- a/RussianTranslation/schemas/pwg_ru_final_card.schema.json
+++ b/RussianTranslation/schemas/pwg_ru_final_card.schema.json
@@ -296,7 +296,7 @@
     "stats": {
       "type": "object",
       "additionalProperties": false,
-      "description": "OPTIONAL. Derived, self-invalidating per-lemma counts (GRAMMAR_LAYER.md § 'Counting grammar', H422) — cached from fields already on the card so government_census.py / government_queries.py-style aggregation is not re-run on every question. Added by annotate_stats.py, run last in the annotator chain; attached identically to every flat store row sharing key1 (the flat store has no lemma object), mirroring evidence_summary.",
+      "description": "OPTIONAL. Derived, self-invalidating per-lemma counts (GRAMMAR_LAYER.md § 'Counting grammar', H422; expanded H777). Cached from fields already on the card so government_census.py / government_queries.py-style aggregation is not re-run on every question. Added by annotate_stats.py, run last in the annotator chain; attached identically to every flat store row sharing key1 (the flat store has no lemma object), mirroring evidence_summary. Finer-grained sibling blocks `record_stats` (per homonym group) and `sense_stats` (per row) carry the same families at their own grain — see annotate_stats.py.",
       "required": [
         "n_records",
         "n_senses",
@@ -331,10 +331,65 @@
           "type": "boolean",
           "description": "True when >=1 government marker lists more than one case."
         },
-        "n_irregularities": {
+        "n_layers": {
           "type": "integer",
           "minimum": 0,
-          "description": "Whitney-grammar exception count for this lemma. 0 until the grammar block (whitney_grammar.py) is joined onto card rows -- see GRAMMAR_LAYER.md."
+          "description": "Distinct source layers of the 5-layer merge (pwg/pw/sch/pwkvn/nws) contributing senses to this lemma."
+        },
+        "layers_present": {
+          "type": "array",
+          "items": { "enum": ["pwg", "pw", "sch", "pwkvn", "nws"] },
+          "uniqueItems": true,
+          "description": "Which merge layers contributed a sense (sorted)."
+        },
+        "n_senses_supplement": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Senses from a non-PWG supplement layer (layer != 'pwg'); PWG is the grammatical backbone."
+        },
+        "n_ls": { "type": "integer", "minimum": 0, "description": "Total <ls> citation markers across this lemma's German source (attestation density)." },
+        "n_lex": { "type": "integer", "minimum": 0, "description": "Total <lex> POS/gender markers across the German source." },
+        "n_ab": { "type": "integer", "minimum": 0, "description": "Total <ab> grammatical-abbreviation markers across the German source." },
+        "n_xref": { "type": "integer", "minimum": 0, "description": "Cross-reference markers (deterministic floor: 'vgl.'/vergleiche only; 's.'/siehe omitted as ambiguous)." },
+        "n_labels": { "type": "integer", "minimum": 0, "description": "Total Kochergina-style domain labels (грам./миф./бот. …) across senses." },
+        "equivalence_types": {
+          "type": "object",
+          "additionalProperties": { "type": "integer", "minimum": 0 },
+          "description": "Distribution of `equivalence_type` across this lemma's senses (equivalent/explanatory/…)."
+        },
+        "source_types": {
+          "type": "object",
+          "additionalProperties": { "type": "integer", "minimum": 0 },
+          "description": "Distribution of `source_type` across senses (attested/lexicographic/mixed)."
+        },
+        "review_statuses": {
+          "type": "object",
+          "additionalProperties": { "type": "integer", "minimum": 0 },
+          "description": "Distribution of `review_status` across senses (ai_translated/reviewed/…)."
+        },
+        "n_differentia": { "type": "integer", "minimum": 0, "description": "Senses carrying a non-empty `differentia` note." },
+        "n_null": { "type": "integer", "minimum": 0, "description": "Senses with an empty Russian translation (untranslated)." },
+        "dcs_freq_max": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "iast": { "type": ["string", "null"] },
+            "count": { "type": "integer", "minimum": 0 },
+            "band": { "type": ["integer", "null"] }
+          },
+          "description": "DCS corpus attestation for this lemma's most-attested matched form (exact-iast join against dcs_freq.json by_lemma). null when no sense's form exact-matches DCS."
+        },
+        "grammar_join": {
+          "enum": ["single", "ambiguous-homonym", "none"],
+          "description": "whitney_grammar join status: 'single' = one Whitney homonym, fully joined; 'ambiguous-homonym' = >1 homonym, PWG-h↔Whitney alignment owed (counts null, not guessed); 'none' = not a Whitney root."
+        },
+        "n_whitney_homonyms": { "type": "integer", "minimum": 0, "description": "Number of Whitney homonym records for this SLP1 root (0 = not a Whitney root)." },
+        "root_class": { "type": ["string", "null"], "description": "Whitney gaṇa/class (e.g. 'I|II'); null unless grammar_join=='single'." },
+        "stem_final": { "type": ["string", "null"], "description": "Final SLP1 phoneme of key1 (coarse stem hint; correct-by-construction, not a declension-class claim)." },
+        "n_irregularities": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Whitney-grammar exception count for this lemma (irregularities[] length). Populated when grammar_join=='single'; null when 'ambiguous-homonym' (alignment owed) or 'none' (not a Whitney root). H777 joined the grammar block — no longer stuck at 0."
         },
         "strata_span": {
           "type": "array",

--- a/RussianTranslation/src/annotate_stats.py
+++ b/RussianTranslation/src/annotate_stats.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""annotate_stats.py — cache per-card derived counts onto the pwg_ru store (H422).
+"""annotate_stats.py — cache per-card derived counts onto the pwg_ru store (H422, H777).
 
 GRAMMAR_LAYER.md § "Counting grammar" design (merged, PR #284): nothing on a card
 records "N senses, M government markers, governs {loc, gen}, spans Renou I-IV" —
@@ -7,20 +7,47 @@ government_census.py / government_queries.py re-scan/re-aggregate the whole stor
 on every question. This is the backfill that fixes that, run **last** in the
 annotator chain (after annotate_government.py / annotate_renou.py /
 annotate_evidence.py) — it reads only fields already on the store row, no new
-source parsing:
+source parsing.
 
-  row['stats']  {n_records, n_senses, n_government, cases_governed, has_variation,
-                 n_irregularities, strata_span, n_strata, evidence, computed_by,
-                 pipeline_version}
+Three granularities are attached (H777 — MG ruling 12-07-2026, all count families,
+finest grain):
 
-Grouped and attached per lemma (`key1`), identically to every store row sharing
-that key1 — the same convention `evidence_summary` already uses (the flat store
-has no lemma object to hang a lemma-level block off of).
+  row['sense_stats']   per-row (one sense) — markup density + this sense's own
+                       government/QA fields + dcs_freq for this sense's exact form
+  row['record_stats']  per homonym group (key1 + subcard ~~h<N>_) — aggregate of
+                       its senses; replicated across the record's rows
+  row['stats']         per lemma (key1) — the full rollup; replicated across every
+                       row sharing that key1 (the flat store has no lemma object to
+                       hang a lemma-level block off of, the same convention
+                       evidence_summary already uses)
+
+Count families on the lemma block (H777 accepted menu):
+  structural   n_records, n_senses
+  government   n_government, cases_governed, has_variation          (annotate_government.py)
+  chronology   strata_span, n_strata                                (stratum free-text)
+  evidence     evidence{provides,supports,contradicts,silent}
+  layer/merge  n_layers, layers_present, n_senses_supplement        (5-layer merge: pwg/pw/sch/pwkvn/nws)
+  markup       n_ls, n_lex, n_ab, n_xref, n_labels                  (inline <ls>/<lex>/<ab>/vgl. in `de`)
+  translation  equivalence_types, source_types, review_statuses, n_differentia, n_null
+  frequency    dcs_freq_max {iast, count, band}                     (DCS corpus attestation, exact-iast join)
+  grammar      grammar_join, n_whitney_homonyms, n_irregularities, root_class, stem_final
+                                                                    (whitney_grammar.py — single-homonym only)
 
 Self-invalidation: `stats.pipeline_version` is the manifest `script` component
 version (pipeline_version.py) at compute time. A stats block whose stamped
 version is older than the current script version is stale -> recompute;
 otherwise trust it without a rescan (mirrors `evidence_summary.evidence_status`).
+Bump the `script` component when this file's output shape changes so every lemma
+recomputes (H777 bumped script 1.0.0 -> 1.1.0 for the expanded block).
+
+Correct-by-construction joins (never a fuzzy guess — the Renou-classifier lesson):
+  * dcs_freq  — EXACT match of a form's `iast` against dcs_freq.json by_lemma, else
+                null. Prefixed forms (`nis+vā`) that DCS does not lemmatise stay null
+                rather than being force-matched to a different simple lemma.
+  * grammar   — whitney_grammar.grammar_for(key1) is joined ONLY when the root has
+                exactly ONE Whitney homonym record. Multi-homonym roots need the
+                hand PWG-h <-> Whitney-homonym alignment (flagged in GRAMMAR_LAYER.md,
+                not guessed here): grammar_join='ambiguous-homonym', counts left null.
 
   python annotate_stats.py [--store PATH] [--dry-run] [--no-backup] [--limit N]
   python annotate_stats.py --selftest
@@ -38,8 +65,22 @@ if HERE not in sys.path:
 import pipeline_version as pv
 
 STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+DCS_FREQ = os.path.join(HERE, 'dcs_freq.json')
 
 _SUBCARD_H_RE = re.compile(r'~~h(\d+)_')
+
+# Markup-density counters over a sense's `de` (German — the canonical layer text, the
+# same field government/dcs key off). Cross-reference marker: `vgl.` (vergleiche) only —
+# a deterministic floor; `s.`/`siehe` are omitted deliberately (too ambiguous to count
+# without false positives — the same discipline government_census.py applies).
+_TAG_LS = re.compile(r'<ls\b')
+_TAG_LEX = re.compile(r'<lex>')
+_TAG_AB = re.compile(r'<ab>')
+_XREF = re.compile(r'\bvgl\.')
+
+# The 5-layer merge chain (pwg_ru_prompts/6_merged_translate.md). PWG is the
+# grammatical backbone; the other four are supplements folded in with attribution.
+BACKBONE_LAYER = 'pwg'
 
 # Canonical Renou-style era vocabulary, oldest -> youngest. `stratum` is a free-text
 # field (not the structured `renou[]` enum) — a row's stratum string is scanned for
@@ -55,30 +96,167 @@ def strata_in(text):
     return [s for s in STRATA_ORDER if s in text]
 
 
+def homonym_of(row, idx=0):
+    """The homonym-group token for a row, from `subcard`'s `~~h<N>_`. A row with no
+    parseable subcard is its own group (via a per-row fallback), so it never silently
+    merges into h0."""
+    m = _SUBCARD_H_RE.search(row.get('subcard') or '')
+    return m.group(1) if m else ('_row%d' % idx)
+
+
 def n_records_for(rows):
-    """Distinct homonym groups for a lemma, from `subcard`'s `~~h<N>_` token.
-    A row with no parseable subcard counts as its own (unknown) group of one,
-    via a per-row fallback key so it never silently merges into h0."""
-    groups = set()
-    for i, r in enumerate(rows):
-        m = _SUBCARD_H_RE.search(r.get('subcard') or '')
-        groups.add(m.group(1) if m else ('_row%d' % i))
-    return len(groups)
+    """Distinct homonym groups for a lemma."""
+    return len({homonym_of(r, i) for i, r in enumerate(rows)})
 
 
-def compute_stats(rows, script_version):
-    """Derive the `stats` block for one lemma's (key1-grouped) rows."""
-    n_government = 0
-    cases_governed = set()
-    has_variation = False
+# --- dcs_freq join (exact-iast, lazy, tolerant of a missing gitignored file) --------
+_DCS_CACHE = None
+
+
+def _dcs_by_lemma(path=DCS_FREQ):
+    """Load dcs_freq.json's by_lemma once. dcs_freq.json is gitignored bulk data —
+    absent in a fresh worktree — so a missing file yields an empty map (no join, no
+    crash), logged once."""
+    global _DCS_CACHE
+    if _DCS_CACHE is None:
+        if os.path.exists(path):
+            _DCS_CACHE = json.load(open(path, encoding='utf-8')).get('by_lemma', {})
+        else:
+            print('annotate_stats: %s absent — dcs_freq join skipped (fields left null)'
+                  % os.path.basename(path), file=sys.stderr)
+            _DCS_CACHE = {}
+    return _DCS_CACHE
+
+
+def dcs_lookup(iast, by_lemma=None):
+    """Exact-match dcs frequency for one form's IAST, else None. Never a fuzzy join."""
+    if not iast:
+        return None
+    d = (by_lemma if by_lemma is not None else _dcs_by_lemma()).get(iast)
+    if not d:
+        return None
+    return {'count': d.get('count'), 'band': d.get('band'),
+            'hapax': d.get('hapax'), 'core80': d.get('core80')}
+
+
+# --- grammar join (whitney_grammar, single-homonym only) ----------------------------
+_GRAMMAR_FN = None
+
+
+def _grammar_for():
+    """Lazily import whitney_grammar.grammar_for; tolerate its absence (returns a
+    stub that yields []) so the annotator still runs where the module/data is missing."""
+    global _GRAMMAR_FN
+    if _GRAMMAR_FN is None:
+        try:
+            from whitney_grammar import grammar_for
+            _GRAMMAR_FN = grammar_for
+        except Exception as e:               # pragma: no cover - defensive
+            print('annotate_stats: whitney_grammar unavailable (%s) — grammar join skipped' % e,
+                  file=sys.stderr)
+            _GRAMMAR_FN = lambda slp1, homonym=None: []
+    return _GRAMMAR_FN
+
+
+def grammar_join(key1, grammar_for=None):
+    """Join whitney_grammar for one lemma's SLP1 key. Single Whitney homonym -> full
+    join; multiple -> flagged ambiguous, counts null (hand alignment owed, not guessed);
+    none -> not a Whitney root (nominal/other). Returns a dict merged into the lemma block."""
+    gf = grammar_for or _grammar_for()
+    recs = gf(key1) or []
+    stem_final = key1[-1] if key1 else None
+    if len(recs) == 1:
+        r = recs[0]
+        return {'grammar_join': 'single', 'n_whitney_homonyms': 1,
+                'n_irregularities': len(r.get('irregularities') or []),
+                'root_class': r.get('class') or None, 'stem_final': stem_final}
+    if len(recs) > 1:
+        return {'grammar_join': 'ambiguous-homonym', 'n_whitney_homonyms': len(recs),
+                'n_irregularities': None, 'root_class': None, 'stem_final': stem_final}
+    return {'grammar_join': 'none', 'n_whitney_homonyms': 0,
+            'n_irregularities': None, 'root_class': None, 'stem_final': stem_final}
+
+
+# --- per-sense (row) block ----------------------------------------------------------
+def sense_stats(row, by_lemma=None):
+    """Derived counts for ONE sense (row) — markup density + this sense's own
+    government / QA fields + dcs_freq for this sense's exact form."""
+    de = row.get('de') or ''
+    gov = row.get('government') or []
+    cases = sorted({c for h in gov for c in (h.get('cases') or [])})
+    return {
+        'n_ls': len(_TAG_LS.findall(de)),
+        'n_lex': len(_TAG_LEX.findall(de)),
+        'n_ab': len(_TAG_AB.findall(de)),
+        'n_xref': len(_XREF.findall(de)),
+        'n_labels': len(row.get('labels') or []),
+        'n_government': len(gov),
+        'cases': cases,
+        'has_differentia': bool((row.get('differentia') or '').strip()),
+        'is_null': not (row.get('ru') or '').strip(),
+        'layer': row.get('layer'),
+        'equivalence_type': row.get('equivalence_type'),
+        'source_type': row.get('source_type'),
+        'dcs_freq': dcs_lookup(row.get('iast'), by_lemma),
+    }
+
+
+def _aggregate_senses(senses):
+    """Shared roll-up used by both record and lemma blocks. `senses` are dicts from
+    sense_stats() carrying two extra private keys: `review_status`, `_iast`."""
+    agg = {
+        'n_senses': len(senses),
+        'n_government': sum(1 for s in senses if s['n_government']),
+        'cases_governed': sorted({c for s in senses for c in s['cases']}),
+        'n_ls': sum(s['n_ls'] for s in senses),
+        'n_lex': sum(s['n_lex'] for s in senses),
+        'n_ab': sum(s['n_ab'] for s in senses),
+        'n_xref': sum(s['n_xref'] for s in senses),
+        'n_labels': sum(s['n_labels'] for s in senses),
+        'n_differentia': sum(1 for s in senses if s['has_differentia']),
+        'n_null': sum(1 for s in senses if s['is_null']),
+        'layers_present': sorted({s['layer'] for s in senses if s['layer']}),
+        'n_senses_supplement': sum(1 for s in senses
+                                   if s['layer'] and s['layer'] != BACKBONE_LAYER),
+        'equivalence_types': dict(Counter(s['equivalence_type'] for s in senses
+                                          if s['equivalence_type'])),
+        'source_types': dict(Counter(s['source_type'] for s in senses if s['source_type'])),
+        'review_statuses': dict(Counter(s.get('review_status') for s in senses
+                                        if s.get('review_status'))),
+    }
+    agg['n_layers'] = len(agg['layers_present'])
+    # most-attested form for the group (max dcs count over matched senses)
+    freqs = [(s['dcs_freq']['count'], s) for s in senses
+             if s['dcs_freq'] and s['dcs_freq'].get('count') is not None]
+    if freqs:
+        cnt, s = max(freqs, key=lambda x: x[0])
+        agg['dcs_freq_max'] = {'iast': s.get('_iast'), 'count': cnt,
+                               'band': s['dcs_freq'].get('band')}
+    else:
+        agg['dcs_freq_max'] = None
+    return agg
+
+
+def _senses_of(rows, by_lemma):
+    senses = []
     for r in rows:
-        hits = r.get('government') or []
-        if hits:
-            n_government += 1
-        for hit in hits:
-            cases_governed.update(hit.get('cases') or [])
-            if hit.get('variation'):
-                has_variation = True
+        s = sense_stats(r, by_lemma)
+        s['review_status'] = r.get('review_status')
+        s['_iast'] = r.get('iast')
+        senses.append(s)
+    return senses
+
+
+def record_stats(rows, by_lemma=None):
+    """Per-homonym-record aggregate. `rows` are the raw store rows of ONE record."""
+    return _aggregate_senses(_senses_of(rows, by_lemma))
+
+
+def compute_stats(rows, script_version, key1=None, by_lemma=None, grammar_for=None):
+    """Derive the `stats` block for one lemma's (key1-grouped) rows."""
+    has_variation = any(h.get('variation') for r in rows for h in (r.get('government') or []))
+
+    agg = _aggregate_senses(_senses_of(rows, by_lemma))
 
     strata = set()
     for r in rows:
@@ -99,15 +277,39 @@ def compute_stats(rows, script_version):
     n_contradicts = len(summary.get('contradicts', [])) if summary else 0
     n_silent = len(summary.get('silent', [])) if summary else 0
 
+    gj = grammar_join(key1 or (rows[0].get('key1') if rows else ''), grammar_for)
+
     return {
         'n_records': n_records_for(rows),
         'n_senses': len(rows),
-        'n_government': n_government,
-        'cases_governed': sorted(cases_governed),
+        'n_government': agg['n_government'],
+        'cases_governed': agg['cases_governed'],
         'has_variation': has_variation,
-        'n_irregularities': 0,     # not yet joined onto card rows — see GRAMMAR_LAYER.md
+        # layer / 5-merge provenance
+        'n_layers': agg['n_layers'],
+        'layers_present': agg['layers_present'],
+        'n_senses_supplement': agg['n_senses_supplement'],
+        # markup density
+        'n_ls': agg['n_ls'], 'n_lex': agg['n_lex'], 'n_ab': agg['n_ab'],
+        'n_xref': agg['n_xref'], 'n_labels': agg['n_labels'],
+        # translation / QA
+        'equivalence_types': agg['equivalence_types'],
+        'source_types': agg['source_types'],
+        'review_statuses': agg['review_statuses'],
+        'n_differentia': agg['n_differentia'],
+        'n_null': agg['n_null'],
+        # frequency
+        'dcs_freq_max': agg['dcs_freq_max'],
+        # grammar (whitney_grammar join)
+        'grammar_join': gj['grammar_join'],
+        'n_whitney_homonyms': gj['n_whitney_homonyms'],
+        'n_irregularities': gj['n_irregularities'],
+        'root_class': gj['root_class'],
+        'stem_final': gj['stem_final'],
+        # chronology
         'strata_span': strata_span,
         'n_strata': len(strata),
+        # evidence
         'evidence': {'provides': n_provides, 'supports': n_supports,
                      'contradicts': n_contradicts, 'silent': n_silent},
         'computed_by': 'annotate_stats.py',
@@ -123,9 +325,13 @@ def is_stale(stats, current_version):
     return pv.semver_lt(stats.get('pipeline_version'), current_version)
 
 
-def annotate_rows(rows, script_version, force=False):
-    """Mutate store rows in place, attaching `stats` per lemma. Returns a
-    Counter of corpus-level rollup totals."""
+def annotate_rows(rows, script_version, force=False, by_lemma=None, grammar_for=None):
+    """Mutate store rows in place, attaching `sense_stats` (per row), `record_stats`
+    (per homonym group) and `stats` (per lemma). Returns a Counter of corpus-level
+    rollup totals."""
+    if by_lemma is None:
+        by_lemma = _dcs_by_lemma()
+
     by_key = defaultdict(list)
     for i, r in enumerate(rows):
         by_key[r.get('key1') or ''].append(i)
@@ -138,11 +344,27 @@ def annotate_rows(rows, script_version, force=False):
         if not force and not is_stale(existing, script_version):
             stats = existing
             lemmas_cached += 1
+            recompute = False
         else:
-            stats = compute_stats(group, script_version)
+            stats = compute_stats(group, script_version, key1=key1,
+                                  by_lemma=by_lemma, grammar_for=grammar_for)
             lemmas_recomputed += 1
+            recompute = True
         for i in idxs:
             rows[i]['stats'] = stats
+
+        # per-sense / per-record blocks follow the lemma block's freshness — recompute
+        # them exactly when the lemma block is recomputed, skip when the lemma is cached.
+        if recompute:
+            by_h = defaultdict(list)
+            for i in idxs:
+                by_h[homonym_of(rows[i], i)].append(i)
+            for hidxs in by_h.values():
+                rec = record_stats([rows[i] for i in hidxs], by_lemma)
+                for i in hidxs:
+                    rows[i]['record_stats'] = rec
+            for i in idxs:
+                rows[i]['sense_stats'] = sense_stats(rows[i], by_lemma)
 
         totals['lemmas'] += 1
         totals['records'] += stats['n_records']
@@ -150,6 +372,14 @@ def annotate_rows(rows, script_version, force=False):
         totals['government_markers'] += stats['n_government']
         if stats['has_variation']:
             totals['lemmas_with_variation'] += 1
+        if stats.get('grammar_join') == 'single':
+            totals['lemmas_grammar_joined'] += 1
+            totals['irregularities'] += stats.get('n_irregularities') or 0
+        elif stats.get('grammar_join') == 'ambiguous-homonym':
+            totals['lemmas_grammar_ambiguous'] += 1
+        if stats.get('dcs_freq_max'):
+            totals['lemmas_dcs_matched'] += 1
+        totals['ls_citations'] += stats['n_ls']
         totals['evidence_provides'] += stats['evidence']['provides']
         totals['evidence_supports'] += stats['evidence']['supports']
 
@@ -168,6 +398,11 @@ def report(totals):
     print('total senses            : %d' % totals['senses'])
     print('government markers      : %d  (lemmas with case variation: %d)'
           % (totals['government_markers'], totals['lemmas_with_variation']))
+    print('grammar-joined lemmas   : %d single (%d irregularities), %d ambiguous-homonym'
+          % (totals['lemmas_grammar_joined'], totals['irregularities'],
+             totals['lemmas_grammar_ambiguous']))
+    print('dcs-matched lemmas      : %d' % totals['lemmas_dcs_matched'])
+    print('<ls> citations (total)  : %d' % totals['ls_citations'])
     print('evidence: provides=%d supports=%d'
           % (totals['evidence_provides'], totals['evidence_supports']))
 
@@ -192,6 +427,11 @@ def write_rollup(totals, script_version, model_version, path):
         f.write('| senses | %d |\n' % totals['senses'])
         f.write('| government markers | %d |\n' % totals['government_markers'])
         f.write('| lemmas with case variation | %d |\n' % totals['lemmas_with_variation'])
+        f.write('| grammar-joined lemmas (single homonym) | %d |\n' % totals['lemmas_grammar_joined'])
+        f.write('| … whitney irregularities counted | %d |\n' % totals['irregularities'])
+        f.write('| grammar ambiguous-homonym (alignment owed) | %d |\n' % totals['lemmas_grammar_ambiguous'])
+        f.write('| dcs-matched lemmas | %d |\n' % totals['lemmas_dcs_matched'])
+        f.write('| <ls> citations (total) | %d |\n' % totals['ls_citations'])
         f.write('| evidence: provides | %d |\n' % totals['evidence_provides'])
         f.write('| evidence: supports | %d |\n' % totals['evidence_supports'])
         f.write('\n')
@@ -203,54 +443,99 @@ def selftest():
     assert strata_in('general') == []
     assert strata_in('') == [] and strata_in(None) == []
 
+    # dcs join is exact-or-null, never fuzzy
+    fake_dcs = {'agni': {'count': 900, 'band': 4, 'hapax': False, 'core80': True}}
+    assert dcs_lookup('agni', fake_dcs) == {'count': 900, 'band': 4, 'hapax': False, 'core80': True}
+    assert dcs_lookup('nis+vā', fake_dcs) is None      # prefixed form not force-matched
+    assert dcs_lookup('', fake_dcs) is None and dcs_lookup(None, fake_dcs) is None
+
+    # grammar join: single -> counts; multi -> ambiguous, null; none -> not a root
+    def fake_grammar(slp1, homonym=None):
+        table = {
+            'gam': [{'class': 'I|II', 'irregularities': ['multi_class', 'root_final_nasal_loss(gam→gatá)']}],
+            'as': [{'class': 'II', 'irregularities': []}, {'class': 'IV', 'irregularities': []}],
+        }
+        return table.get(slp1, [])
+    gj = grammar_join('gam', fake_grammar)
+    assert gj == {'grammar_join': 'single', 'n_whitney_homonyms': 1, 'n_irregularities': 2,
+                  'root_class': 'I|II', 'stem_final': 'm'}, gj
+    gj2 = grammar_join('as', fake_grammar)
+    assert gj2['grammar_join'] == 'ambiguous-homonym' and gj2['n_irregularities'] is None, gj2
+    gj3 = grammar_join('deva', fake_grammar)
+    assert gj3 == {'grammar_join': 'none', 'n_whitney_homonyms': 0, 'n_irregularities': None,
+                   'root_class': None, 'stem_final': 'a'}, gj3
+
     rows = [
-        {'key1': 'agni', 'subcard': '_agni~~h0_00_pwg01', 'sense_tag': '1',
-         'stratum': 'Vedic', 'government': [], 'evidence': [{'relation': 'provides'}],
+        {'key1': 'gam', 'subcard': '_gam~~h0_00_pwg01', 'sense_tag': '1', 'layer': 'pwg',
+         'iast': 'gam', 'stratum': 'Vedic', 'government': [], 'differentia': 'x',
+         'equivalence_type': 'equivalent', 'source_type': 'attested', 'review_status': 'ai_translated',
+         'ru': 'идти', 'de': '{%gehen%} <ls>RV. 1,1</ls> <ls>MBH.</ls> vgl. {#i#}.',
+         'evidence': [{'relation': 'provides'}],
          'evidence_summary': {'silent': ['smirnov'], 'contradicts': []}},
-        {'key1': 'agni', 'subcard': '_agni~~h0_01_pwg01', 'sense_tag': '2',
-         'stratum': 'Classical',
+        {'key1': 'gam', 'subcard': '_gam~~h0_01_pw01', 'sense_tag': '2', 'layer': 'pw',
+         'iast': 'gam', 'stratum': 'Classical',
          'government': [{'cases': ['loc', 'gen'], 'variation': True}],
+         'equivalence_type': 'explanatory', 'source_type': 'attested', 'review_status': 'ai_translated',
+         'ru': '', 'de': '{%treffen%} (<ab>loc.</ab> und <ab>gen.</ab>) <ls>ŚĀK.</ls> <lex>m.</lex>',
          'evidence': [{'relation': 'supports'}],
          'evidence_summary': {'silent': ['smirnov'], 'contradicts': []}},
-        {'key1': 'agni', 'subcard': '_agni~~h1_00_pwg01', 'sense_tag': '1',
-         'stratum': '', 'government': [], 'evidence': [], 'evidence_summary': None},
-        {'key1': 'deva', 'subcard': '_deva~~h0_00_pwg01', 'sense_tag': '1',
-         'stratum': '', 'government': [], 'evidence': [], 'evidence_summary': None},
+        {'key1': 'gam', 'subcard': '_gam~~h1_00_nws01', 'sense_tag': '1', 'layer': 'nws',
+         'iast': 'saMgam', 'stratum': '', 'government': [],
+         'equivalence_type': 'equivalent', 'source_type': 'mixed', 'review_status': 'ai_translated',
+         'ru': 'сходиться', 'de': '{%zusammenkommen%}', 'evidence': [], 'evidence_summary': None},
     ]
+    dcs = {'gam': {'count': 5000, 'band': 5, 'hapax': False, 'core80': True}}
     rows_copy = [dict(r) for r in rows]
-    totals = annotate_rows(rows_copy, '1.0.0')
-    assert totals['lemmas'] == 2, totals
-    assert totals['lemmas_recomputed'] == 2 and totals['lemmas_cached'] == 0, totals
+    totals = annotate_rows(rows_copy, '1.1.0', by_lemma=dcs, grammar_for=fake_grammar)
+    assert totals['lemmas'] == 1, totals
+    assert totals['lemmas_recomputed'] == 1 and totals['lemmas_cached'] == 0, totals
 
-    agni_stats = rows_copy[0]['stats']
-    assert agni_stats is rows_copy[1]['stats'] is rows_copy[2]['stats'], 'stats is lemma-scoped'
-    assert agni_stats['n_records'] == 2, agni_stats            # h0, h1
-    assert agni_stats['n_senses'] == 3, agni_stats
-    assert agni_stats['n_government'] == 1, agni_stats
-    assert agni_stats['cases_governed'] == ['gen', 'loc'], agni_stats
-    assert agni_stats['has_variation'] is True, agni_stats
-    assert agni_stats['strata_span'] == ['Vedic', 'Classical'], agni_stats
-    assert agni_stats['n_strata'] == 2, agni_stats
-    assert agni_stats['evidence'] == {'provides': 1, 'supports': 1, 'contradicts': 0, 'silent': 1}, agni_stats
-    assert agni_stats['computed_by'] == 'annotate_stats.py'
-    assert agni_stats['pipeline_version'] == '1.0.0'
+    st = rows_copy[0]['stats']
+    assert rows_copy[0]['stats'] is rows_copy[2]['stats'], 'stats is lemma-scoped'
+    assert st['n_records'] == 2 and st['n_senses'] == 3, st          # h0, h1
+    assert st['n_government'] == 1 and st['cases_governed'] == ['gen', 'loc'], st
+    assert st['has_variation'] is True, st
+    # layer / merge
+    assert st['n_layers'] == 3 and st['layers_present'] == ['nws', 'pw', 'pwg'], st
+    assert st['n_senses_supplement'] == 2, st                        # pw + nws (non-pwg)
+    # markup density (summed over senses)
+    assert st['n_ls'] == 3 and st['n_lex'] == 1 and st['n_ab'] == 2 and st['n_xref'] == 1, st
+    # QA
+    assert st['equivalence_types'] == {'equivalent': 2, 'explanatory': 1}, st
+    assert st['source_types'] == {'attested': 2, 'mixed': 1}, st
+    assert st['n_differentia'] == 1 and st['n_null'] == 1, st
+    # frequency (exact iast join; 'saMgam' unmatched)
+    assert st['dcs_freq_max'] == {'iast': 'gam', 'count': 5000, 'band': 5}, st
+    # grammar join
+    assert st['grammar_join'] == 'single' and st['n_irregularities'] == 2, st
+    assert st['root_class'] == 'I|II' and st['stem_final'] == 'm', st
+    # chronology + evidence
+    assert st['strata_span'] == ['Vedic', 'Classical'] and st['n_strata'] == 2, st
+    assert st['evidence'] == {'provides': 1, 'supports': 1, 'contradicts': 0, 'silent': 1}, st
 
-    deva_stats = rows_copy[3]['stats']
-    assert deva_stats['n_records'] == 1 and deva_stats['n_senses'] == 1, deva_stats
-    assert deva_stats['strata_span'] == [] and deva_stats['n_strata'] == 0, deva_stats
+    # per-sense block
+    ss0 = rows_copy[0]['sense_stats']
+    assert ss0['n_ls'] == 2 and ss0['n_xref'] == 1 and ss0['is_null'] is False, ss0
+    ss1 = rows_copy[1]['sense_stats']
+    assert ss1['n_ab'] == 2 and ss1['is_null'] is True and ss1['cases'] == ['gen', 'loc'], ss1
+    # per-record block: h0 = senses 0+1, h1 = sense 2
+    rec0 = rows_copy[0]['record_stats']
+    assert rows_copy[0]['record_stats'] is rows_copy[1]['record_stats'], 'record-scoped'
+    assert rec0['n_senses'] == 2 and rec0['n_null'] == 1, rec0
+    rec1 = rows_copy[2]['record_stats']
+    assert rec1['n_senses'] == 1 and rec1['dcs_freq_max'] is None, rec1  # saMgam unmatched
 
-    # self-invalidation: a stale-versioned cached block is recomputed; a fresh one is trusted
-    assert is_stale(None, '1.0.0') is True
-    assert is_stale({'pipeline_version': '0.9.0'}, '1.0.0') is True
-    assert is_stale({'pipeline_version': '1.0.0'}, '1.0.0') is False
-    assert is_stale({'pipeline_version': '1.1.0'}, '1.0.0') is False
+    # self-invalidation
+    assert is_stale(None, '1.1.0') is True
+    assert is_stale({'pipeline_version': '1.0.0'}, '1.1.0') is True
+    assert is_stale({'pipeline_version': '1.1.0'}, '1.1.0') is False
 
     rows_copy2 = [dict(r) for r in rows]
-    annotate_rows(rows_copy2, '1.0.0')
-    totals2 = annotate_rows(rows_copy2, '1.0.0')     # re-run at the same version: no recompute
-    assert totals2['lemmas_recomputed'] == 0 and totals2['lemmas_cached'] == 2, totals2
-    totals3 = annotate_rows(rows_copy2, '2.0.0')     # bump: every lemma recomputes
-    assert totals3['lemmas_recomputed'] == 2, totals3
+    annotate_rows(rows_copy2, '1.1.0', by_lemma=dcs, grammar_for=fake_grammar)
+    totals2 = annotate_rows(rows_copy2, '1.1.0', by_lemma=dcs, grammar_for=fake_grammar)
+    assert totals2['lemmas_recomputed'] == 0 and totals2['lemmas_cached'] == 1, totals2
+    totals3 = annotate_rows(rows_copy2, '2.0.0', by_lemma=dcs, grammar_for=fake_grammar)
+    assert totals3['lemmas_recomputed'] == 1, totals3
 
     print('annotate_stats selftest OK')
 

--- a/RussianTranslation/src/census_stats.json
+++ b/RussianTranslation/src/census_stats.json
@@ -1,0 +1,258 @@
+{
+  "schema": "pwg_ru.government_census.v1",
+  "generated": "12-07-2026",
+  "pipeline_version": "1.1.0",
+  "source": "pwg.txt",
+  "source_sha16": "430c910f8b0c9229",
+  "census": {
+    "n_entries": 123366,
+    "n_units": 288991,
+    "entries_with": 1476,
+    "units_with": 3222,
+    "kinds": {
+      "mit-phrase": 1504,
+      "paren-single": 2309,
+      "paren-nongov": 68,
+      "paren-variation": 40
+    },
+    "cases": {
+      "mit-phrase": {
+        "gen": 318,
+        "acc": 635,
+        "loc": 197,
+        "abl": 120,
+        "dat": 108,
+        "instr": 125,
+        "nom": 1
+      },
+      "paren-single": {
+        "acc": 1102,
+        "loc": 385,
+        "instr": 270,
+        "gen": 245,
+        "abl": 190,
+        "dat": 117
+      },
+      "paren-nongov": {
+        "voc": 47,
+        "nom": 21
+      },
+      "paren-variation": {
+        "gen+dat": 1,
+        "loc+acc": 4,
+        "dat+loc": 4,
+        "dat+gen": 1,
+        "acc+loc": 8,
+        "instr+gen": 3,
+        "acc+dat+gen": 1,
+        "acc+dat": 2,
+        "acc+gen": 1,
+        "loc+dat": 2,
+        "instr+acc": 1,
+        "nom+acc": 1,
+        "acc+instr": 1,
+        "abl+instr": 1,
+        "gen+instr": 1,
+        "gen+loc": 1,
+        "loc+gen": 2,
+        "instr+loc": 2,
+        "abl+gen": 1,
+        "instr+loc+abl": 1,
+        "loc+instr": 1
+      }
+    },
+    "pos_gov_entries": {
+      "unknown": 427,
+      "adj": 327,
+      "nominal": 241,
+      "indecl": 64,
+      "verb": 417
+    },
+    "pos_entries_all": {
+      "unknown": 29492,
+      "nominal": 62103,
+      "adj": 26918,
+      "verb": 2971,
+      "indecl": 1877,
+      "other(ind)": 5
+    },
+    "top_entries": [
+      [
+        [
+          "113928",
+          "sTA"
+        ],
+        113
+      ],
+      [
+        [
+          "82186",
+          "yuj"
+        ],
+        88
+      ],
+      [
+        [
+          "88503",
+          "vart"
+        ],
+        68
+      ],
+      [
+        [
+          "9940",
+          "i"
+        ],
+        58
+      ],
+      [
+        [
+          "21814",
+          "gam"
+        ],
+        42
+      ],
+      [
+        [
+          "55166",
+          "BU"
+        ],
+        42
+      ],
+      [
+        [
+          "93196",
+          "viS"
+        ],
+        39
+      ],
+      [
+        [
+          "15071",
+          "kar"
+        ],
+        38
+      ],
+      [
+        [
+          "42000",
+          "pad"
+        ],
+        37
+      ],
+      [
+        [
+          "81815",
+          "yA"
+        ],
+        34
+      ],
+      [
+        [
+          "27838",
+          "jYA"
+        ],
+        30
+      ],
+      [
+        [
+          "36484",
+          "DA"
+        ],
+        29
+      ],
+      [
+        [
+          "101574",
+          "Sri"
+        ],
+        29
+      ],
+      [
+        [
+          "114561",
+          "smar"
+        ],
+        28
+      ],
+      [
+        [
+          "104247",
+          "sad"
+        ],
+        27
+      ],
+      [
+        [
+          "103843",
+          "saYj"
+        ],
+        26
+      ],
+      [
+        [
+          "106410",
+          "sar"
+        ],
+        26
+      ],
+      [
+        [
+          "106569",
+          "sarj"
+        ],
+        26
+      ],
+      [
+        [
+          "24902",
+          "car"
+        ],
+        25
+      ],
+      [
+        [
+          "15749",
+          "kalp"
+        ],
+        24
+      ],
+      [
+        [
+          "19764",
+          "kram"
+        ],
+        22
+      ],
+      [
+        [
+          "57252",
+          "man"
+        ],
+        22
+      ],
+      [
+        [
+          "101797",
+          "Sru"
+        ],
+        22
+      ],
+      [
+        [
+          "32399",
+          "dA"
+        ],
+        21
+      ],
+      [
+        [
+          "54756",
+          "BAz"
+        ],
+        20
+      ]
+    ],
+    "n_hits": 3921
+  }
+}

--- a/RussianTranslation/src/government_census.py
+++ b/RussianTranslation/src/government_census.py
@@ -225,6 +225,90 @@ def run_census(source, tsv=None, top=10):
     }
 
 
+SIDECAR_SCHEMA = "pwg_ru.government_census.v1"
+DEFAULT_SIDECAR = os.path.join(HERE, "census_stats.json")
+
+
+def source_sha16(path):
+    """16-hex content hash of the raw source. The census is a pure function of this
+    file, so an unchanged SHA means the frozen sidecar is still valid."""
+    import hashlib
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()[:16]
+
+
+def _script_version():
+    """The pipeline_version.py manifest 'script' component version, or 'n/a' if the
+    manifest is unreadable (keeps the census standalone)."""
+    try:
+        import pipeline_version as pv
+        return pv.load_manifest()["components"]["script"]["version"]
+    except Exception:
+        return "n/a"
+
+
+def build_sidecar(source, top=25, generated=None):
+    """Run the census once and wrap it with provenance for freezing. `generated` is
+    an injectable date string (callers stamp it; no implicit clock in library code)."""
+    import datetime
+    census = run_census(source, top=top)
+    return {
+        "schema": SIDECAR_SCHEMA,
+        "generated": generated or datetime.date.today().strftime("%d-%m-%Y"),
+        "pipeline_version": _script_version(),
+        "source": os.path.basename(source),
+        "source_sha16": source_sha16(source),
+        "census": census,
+    }
+
+
+def write_sidecar(source, out_path=DEFAULT_SIDECAR, top=25, generated=None):
+    """Freeze the census to a committed JSON sidecar (H778) — the corpus-level rollup
+    is a committed artifact, not a live re-scan target (GRAMMAR_LAYER.md rule 2)."""
+    data = build_sidecar(source, top=top, generated=generated)
+    tmp = out_path + ".tmp"
+    with open(tmp, "w", encoding="utf-8", newline="\n") as f:
+        import json
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    os.replace(tmp, out_path)
+    return data
+
+
+def load_sidecar(sidecar_path=DEFAULT_SIDECAR, source=DEFAULT_SOURCE):
+    """Return (census_dict, 'cached') when the frozen sidecar is still valid — i.e. the
+    raw source's SHA matches what was frozen — else (None, reason). Callers use this to
+    skip re-scanning pwg.txt end-to-end when nothing changed."""
+    import json
+    if not os.path.exists(sidecar_path):
+        return None, "no sidecar"
+    try:
+        data = json.load(open(sidecar_path, encoding="utf-8"))
+    except Exception as e:
+        return None, "unreadable sidecar (%s)" % e
+    if data.get("schema") != SIDECAR_SCHEMA:
+        return None, "schema mismatch"
+    if not os.path.exists(source):
+        # source gone (e.g. running where csl-orig isn't cloned): trust the frozen copy.
+        return data.get("census"), "cached (source absent — trusting frozen)"
+    if data.get("source_sha16") != source_sha16(source):
+        return None, "source changed since freeze"
+    return data.get("census"), "cached"
+
+
+def census_or_load(source=DEFAULT_SOURCE, sidecar=DEFAULT_SIDECAR, top=10, prefer_sidecar=True):
+    """The read path callers should use instead of run_census() directly: return the
+    frozen census if fresh, else scan the source live. Returns (census_dict, origin)."""
+    if prefer_sidecar:
+        census, why = load_sidecar(sidecar, source)
+        if census is not None:
+            return census, why
+    return run_census(source, top=top), "live scan"
+
+
 def print_report(r):
     gov_total = sum(n for k, n in r["kinds"].items() if k != "paren-nongov")
     print("# PWG case-government census (deterministic, raw source)")
@@ -301,6 +385,23 @@ def selftest():
         # sTA: no root sign, DHĀTUP head line, body <lex>adj.</lex> must NOT win
         assert r["pos_gov_entries"] == {"verb": 2}, r
         assert r["units_with"] == 3, r  # snih div2.s1 (both parens) + snih div3 (mit) + sTA div1.s1
+
+        # H778 sidecar round-trip: freeze -> fresh read -> stale on source change
+        sc = path + ".census.json"
+        data = write_sidecar(path, sc, generated="01-01-2026")
+        assert data["schema"] == SIDECAR_SCHEMA and data["source_sha16"] == source_sha16(path)
+        cached, why = load_sidecar(sc, path)
+        assert why == "cached" and cached["n_entries"] == 3, (why, cached)
+        got, origin = census_or_load(path, sc)
+        assert origin == "cached" and got["kinds"].get("mit-phrase") == 1, (origin, got)
+        # mutate the source -> SHA differs -> sidecar rejected, live scan instead
+        with open(path, "a", encoding="utf-8") as f:
+            f.write("\n<L>9<pc>9-9<k1>x\n{#x#} etwas.\n<LEND>\n")
+        none_c, why2 = load_sidecar(sc, path)
+        assert none_c is None and why2 == "source changed since freeze", why2
+        _, origin2 = census_or_load(path, sc)
+        assert origin2 == "live scan", origin2
+        os.unlink(sc)
         print("government_census selftest: OK")
     finally:
         os.unlink(path)
@@ -337,18 +438,41 @@ def selftest_extract_government():
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("cmd", nargs="?", default="census",
-                    choices=["census", "selftest"])
+                    choices=["census", "freeze", "selftest"],
+                    help="census = report (uses the frozen sidecar if fresh); "
+                         "freeze = (re)write the committed census_stats.json sidecar")
     ap.add_argument("--source", default=DEFAULT_SOURCE)
     ap.add_argument("--tsv", default=None,
                     help="write per-hit rows to this TSV (gitignored path)")
     ap.add_argument("--top", type=int, default=10)
+    ap.add_argument("--sidecar", default=DEFAULT_SIDECAR,
+                    help="frozen census JSON (H778); census reads it when fresh, freeze writes it")
+    ap.add_argument("--no-sidecar", action="store_true",
+                    help="ignore the frozen sidecar and scan the source live")
     args = ap.parse_args()
     if args.cmd == "selftest":
         selftest()
         return
-    if not os.path.exists(args.source):
-        sys.exit("source not found: %s" % args.source)
-    print_report(run_census(args.source, tsv=args.tsv, top=args.top))
+    if args.cmd == "freeze":
+        if not os.path.exists(args.source):
+            sys.exit("source not found: %s" % args.source)
+        data = write_sidecar(args.source, args.sidecar, top=max(args.top, 25))
+        print("froze census -> %s  (source %s sha=%s, %d markers, %d entries)"
+              % (args.sidecar, data["source"], data["source_sha16"],
+                 sum(n for k, n in data["census"]["kinds"].items() if k != "paren-nongov"),
+                 data["census"]["n_entries"]))
+        return
+    # census report — prefer the frozen sidecar unless it's stale or --no-sidecar
+    if args.tsv:
+        # a per-hit TSV needs the live per-entry scan; the sidecar holds only aggregates
+        if not os.path.exists(args.source):
+            sys.exit("source not found: %s" % args.source)
+        print_report(run_census(args.source, tsv=args.tsv, top=args.top))
+        return
+    census, origin = census_or_load(args.source, args.sidecar, top=args.top,
+                                    prefer_sidecar=not args.no_sidecar)
+    print("<!-- census source: %s -->" % origin)
+    print_report(census)
 
 
 if __name__ == "__main__":

--- a/RussianTranslation/src/government_queries.py
+++ b/RussianTranslation/src/government_queries.py
@@ -114,10 +114,30 @@ def main():
     ap.add_argument('--variation', action='store_true')
     ap.add_argument('--never-gen', action='store_true')
     ap.add_argument('--limit', type=int, default=15)
+    ap.add_argument('--summary', action='store_true',
+                    help='corpus-level marker totals from the frozen census sidecar '
+                         '(H778) — no store reload, no pwg.txt re-scan')
     ap.add_argument('--selftest', action='store_true')
     args = ap.parse_args()
     if args.selftest:
         return selftest()
+
+    if args.summary:
+        # The corpus-level "how many such markers in PWG" answer is a settled count —
+        # read it from the committed census_stats.json rather than re-scanning (H778).
+        import government_census as gc
+        census, origin = gc.census_or_load()
+        gov_total = sum(n for k, n in census['kinds'].items() if k != 'paren-nongov')
+        print('census source: %s' % origin)
+        print('government markers (total)       : %d' % gov_total)
+        print('  paren-single / variation / mit : %d / %d / %d' % (
+            census['kinds'].get('paren-single', 0),
+            census['kinds'].get('paren-variation', 0),
+            census['kinds'].get('mit-phrase', 0)))
+        print('entries with >=1 marker          : %d' % census['entries_with'])
+        print('sense units with >=1 marker      : %d' % census['units_with'])
+        print('(per-row listing queries still stream the store — the rows are not frozen)')
+        return
 
     rows = load_store(args.store)
     run_all = not (args.loc_required or args.variation or args.never_gen)

--- a/RussianTranslation/src/pipeline_versions.json
+++ b/RussianTranslation/src/pipeline_versions.json
@@ -23,17 +23,18 @@
       "note": "domain vocab (kavya/bauddha/jaina/vedic/epigraphic) + de-ru translation aids"
     },
     "script": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "min_valid": "1.0.0",
-      "sha": "0ac4d57a230ec6f2",
+      "sha": "144e83f802c72828",
       "files": [
         "src/run_batch.py",
         "src/pwg_mask.py",
         "src/corpus_gate.py",
         "src/assemble.py",
-        "src/promote_final_cards.py"
+        "src/promote_final_cards.py",
+        "src/annotate_stats.py"
       ],
-      "note": "deterministic mask / harvest / restore / corpus-gate + card promotion"
+      "note": "deterministic mask / harvest / restore / corpus-gate + card promotion + derived-stats backfill (annotate_stats.py; 1.1.0 = H777 expanded stats block, forces stats recompute)"
     }
   }
 }


### PR DESCRIPTION
Completes the two open gaps in [GRAMMAR_LAYER.md § "Counting grammar"](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/GRAMMAR_LAYER.md) (MG ruling 12-07-2026 — all count families, finest granularity, JSON sidecar, dcs_freq on every card).

## H777 — expand per-card stats + join the grammar block
[`annotate_stats.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/annotate_stats.py) now attaches three grains — `sense_stats` (per row), `record_stats` (per homonym), `stats` (per lemma) — carrying the full accepted menu:
- **layer / 5-merge** `n_layers`, `layers_present ⊆ {pwg,pw,sch,pwkvn,nws}`, `n_senses_supplement`
- **markup density** `n_ls`, `n_lex`, `n_ab`, `n_xref` (vgl.), `n_labels`
- **translation / QA** `equivalence_types`, `source_types`, `review_statuses`, `n_differentia`, `n_null`
- **frequency** `dcs_freq_max` — exact-iast DCS join (170/205 matched); prefixed forms DCS doesn't lemmatise stay `null`, never force-matched
- **grammar** `grammar_join` ∈ {single, ambiguous-homonym, none}, `n_whitney_homonyms`, `n_irregularities`, `root_class`, `stem_final`

**`n_irregularities` no longer stuck at 0** — joined from `whitney_grammar.grammar_for` for single-Whitney-homonym roots (32/205 lemmas, 46 irregularities on the current store); the 17 ambiguous-homonym roots are left `null` (hand PWG-h ↔ Whitney alignment owed, not guessed).

Schema `stats` block expanded + `sense_stats`/`record_stats` documented; every grammar-join state validates. `pipeline_versions.json` `script` 1.0.0 → 1.1.0 (re-frozen) so cached blocks self-invalidate.

## H778 — freeze the government census to a committed sidecar
[`government_census.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/government_census.py) gains `freeze` + `build_sidecar`/`load_sidecar`/`census_or_load`: the raw-`pwg.txt` marker census (**3,853 markers / 123,366 entries**) is frozen to the committed [`src/census_stats.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/census_stats.json), source-SHA validated. `census` prints `census source: cached` and skips the re-scan when `pwg.txt` is unchanged; `government_queries.py --summary` gives the store-free corpus answer. Per-row listing queries still stream the store (rows not frozen).

## Notes
- Stores (`pwg_ru_translated.jsonl`, `dcs_freq.json`) are **gitignored** — the code + census sidecar ship; the per-card fields are materialised locally by re-running `annotate_government.py` then `annotate_stats.py`. Verified end-to-end on a faithful store copy: **508 government markers, 46 irregularities, 170 dcs-matched** (logged in [RESULTS_LOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md)).
- Language-neutral analysis layers — no LANG_PARITY entry.
- Selftests green: `annotate_stats`, `government_census`, `government_queries`, `pipeline_version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)