### PR TITLE
A58 annex-finding propagation: FEATURES_INDEX C19 asset + M01 Ch.2 comparative-taxonomy aside (H782)

### DIFF
--- a/Digital_Sanskrit_Lexicography-BOOK/CHANGELOG.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/CHANGELOG.md
@@ -1,11 +1,21 @@
 # Digital Sanskrit Lexicography (Brill monograph) — changelog
 
-_Created: 07-07-2026 · Last updated: 10-07-2026_
+_Created: 07-07-2026 · Last updated: 12-07-2026_
 
 Tracks changes to the book build plan and any future manuscript/front-matter drafts in this
 folder. Registry ID **M01** in [Uprava/ARTICLES.md](https://github.com/gasyoun/Uprava/blob/main/ARTICLES.md).
 
 ## [Unreleased]
+
+### Added — 12-07-2026 (H782, A58 comparative-taxonomy aside)
+
+- **Ch. 2 §3.10** gains a one-paragraph comparative aside on the varga scaffold itself:
+  the A58 semdom ↔ Amarakosha crosswalk's structure agreement (67%) and the counted
+  grammatical-annex symmetry (AK kāṇḍa 3 46.4% of synsets vs semdom top-9 9.4% of
+  domains, converging 10.7% vs 9.4% without nānārtha —
+  [SL FINDINGS §77](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)),
+  as validation that the indigenous taxonomy works as a cross-epoch measurement frame.
+  Citation-level only; A58 stays outside M01's 15-article glue list.
 
 ### Changed — 10-07-2026 (MG ruling on H505's Ch. 7 `@DECIDE`)
 

--- a/Digital_Sanskrit_Lexicography-BOOK/chapters/ch02_measurement_framework.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/chapters/ch02_measurement_framework.md
@@ -1,6 +1,6 @@
 # Chapter 2 — The Measurement Framework: Measuring the Dictionary Family
 
-_Created: 09-07-2026 · Last updated: 09-07-2026_
+_Created: 09-07-2026 · Last updated: 12-07-2026_
 
 > **Provenance.** This chapter is the book-form version of the article *Measuring the
 > Dictionary Family: A Traceable Measurement Framework for Computational Lexicography*
@@ -235,6 +235,21 @@ anchors from the committed data, not the chapters' full results.
   [`data/lexico/h4_semantic_field_review_packet.json`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/lexico/h4_semantic_field_review_packet.json).
 - **Limits.** Headword coverage is not sense, corpus, or citation coverage; rows need
   source review before topical claims.
+
+A comparative aside on the scaffold itself. Using the varga taxonomy as a measurement
+frame is not an antiquarian convenience: the first crosswalk of SIL's 1,792
+field-lexicography semantic domains to the Amarakośa
+([SEMDOM_AK_CROSSWALK_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/data/SEMDOM_AK_CROSSWALK_2026.md);
+paper A58) finds the two organizations agreeing on 67% of synset placements at the
+section level — and, more telling for method, both taxonomies bolt a formal annex onto
+their semantic scheme for the words meaning cannot organize. The Amarakośa's kāṇḍa 3
+holds 46.4% of its synsets, but 35.7 points of that is nānārtha, a polysemy register
+SIL absorbs structurally by listing a word under several domains; the form-class
+residue proper is 10.7% against semdom's 9.4%
+([FINDINGS §77](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)).
+A sixth-century verse thesaurus and a twentieth-century elicitation taxonomy converge
+on both the semantic partition and the size of its formal remainder — which is
+precisely the property a cross-epoch measurement scaffold needs.
 
 The point of stating these together is that they are **independent estimators of
 relatedness and structure**, not facets of one similarity score. §6 shows why that

--- a/FEATURES_INDEX.md
+++ b/FEATURES_INDEX.md
@@ -1,6 +1,6 @@
 # FEATURES_INDEX.md — what the Sanskrit Lexicon project actually has
 
-_Created: 04-07-2026 · Last updated: 11-07-2026_
+_Created: 04-07-2026 · Last updated: 12-07-2026_
 
 **Purpose.** A clickable, capability-first map of the working assets across the ~85
 repositories: the **dictionaries** digitised, the **interfaces** that serve them, the
@@ -78,7 +78,7 @@ actual files (⚪-tier / *schema*-marked = gitignored / binary / too large, so t
 | ⚪ C16 | union `coverage_additions.tsv` | Headwords found beyond the core CDSL dictionaries | union · 711 KB | `5   nominal   enad   enad` | 06/26 | [HeadwordLists/union](https://github.com/gasyoun/SanskritLexicography/tree/master/HeadwordLists/union) |
 | 🟢 C17 | csl-atlas `alignment-confidence.json` | Per-pair cross-dict headword alignment confidence, sharded | 164 shards · 43.0 MB | `{ "code":"mw", "label":"MW", "grammarReliable": true }` | 05/26 | [csl-atlas](https://github.com/sanskrit-lexicon/csl-atlas) |
 | 🟢 C18 | csl-atlas low-confidence review set | Alignments flagged below threshold for a human pass | review set · 31.3 MB | the below-threshold subset of `alignment-confidence.json` (schema) | 05/26 | [csl-atlas](https://github.com/sanskrit-lexicon/csl-atlas) |
-| 🟢 C19 | semdom ↔ Amarakosha crosswalk | First SIL semantic-domains ↔ classical-thesaurus map (H742): Level A varga↔domain ID pairs (108, hand-authored) + top-6 machine candidates for all 5,590 AK synsets + 200-synset adjudicated gold (κ 0.677; bridge top-1 17.5% — a shortlist, not labels, [FINDINGS §76](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)); CC BY-SA 4.0, feeds the H721 MDF/LIFT `\sd` layer | 108 + 5,590 + 200 rows · ~400 KB | `AK-1.4,kAlavargaH,…,8.4,…,Time,close` | 07/26 | [data/SEMDOM_AK_CROSSWALK_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/data/SEMDOM_AK_CROSSWALK_2026.md) |
+| 🟢 C19 | semdom ↔ Amarakosha crosswalk | First SIL semantic-domains ↔ classical-thesaurus map (H742): Level A varga↔domain ID pairs (108, hand-authored) + top-6 machine candidates for all 5,590 AK synsets + 200-synset adjudicated gold (κ 0.677; bridge top-1 17.5% — a shortlist, not labels, [FINDINGS §76](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)); + the grammatical-annex symmetry counted by [semdom_ak_annex_table.py](https://github.com/gasyoun/SanskritLexicography/blob/master/data/semdom_ak_annex_table.py) (H774: AK kāṇḍa 3 46.4% of synsets vs semdom top-9 9.4% of domains, converging 10.7% vs 9.4% sans nānārtha, [FINDINGS §77](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)); CC BY-SA 4.0, feeds the H721 MDF/LIFT `\sd` layer | 108 + 5,590 + 200 rows · ~400 KB | `AK-1.4,kAlavargaH,…,8.4,…,Time,close` | 07/26 | [data/SEMDOM_AK_CROSSWALK_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/data/SEMDOM_AK_CROSSWALK_2026.md) |
 
 ### D · Heritage & morphology oracles
 


### PR DESCRIPTION
Two of the four H782 propagation targets (the batch green-lit 12-07-2026):

- **FEATURES_INDEX C19** now registers the H774 annex-table asset ([semdom_ak_annex_table.py](https://github.com/gasyoun/SanskritLexicography/blob/master/data/semdom_ak_annex_table.py)) and its headline: AK kāṇḍa 3 = 46.4% of synsets vs semdom top-9 = 9.4% of domains, converging **10.7% vs 9.4%** sans nānārtha ([FINDINGS §77](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)).
- **M01 Ch. 2 §3.10** ([ch02_measurement_framework.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch02_measurement_framework.md)) gains a one-paragraph comparative aside: the crosswalk's 67% structure agreement + the annex symmetry as validation of the varga taxonomy as a cross-epoch measurement scaffold. Citation-level; A58 stays outside M01's glue list. Book [CHANGELOG](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/CHANGELOG.md) [Unreleased] entry added.

Companion PRs: csl-standards `\sd` coverage boundary (same batch); INDOLOGY list post drafted in [H782](https://github.com/gasyoun/Uprava/blob/main/handoffs/H782-Fable_SanskritLexicography_a58-annex-finding-propagation-batch_12.07.26.md) (MG sends). Fable 5 (`claude-fable-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)