### PR TITLE
FINDINGS §83: PWG/PW/MW non-independence + Stache-Weiske notes (H796)

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2058,6 +2058,50 @@ and counting "MW entries" by raw `<L>` records overcounts printed entries.
 
 > Source: EntryAnatomy specimen-page build (H780) · SanskritLexicography · 12-07-2026, Fable 5 (`claude-fable-5`).
 
+### §83. MW and the Petersburg dictionaries are NOT independent witnesses on inventory or apparatus — do not count their agreement as corroboration; but no shared *error* has ever been found
+
+Monier-Williams inherited Böhtlingk's **apparatus** — which words to enter, which
+texts to cite and in what order, how to divide homonyms — measured six ways in
+A10 ([`article_21_apparatus_not_errors.md`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/docs/articles/article_21_apparatus_not_errors.md)).
+The new **shared-omission** cut (F9, A10 §3.5) settles the negative-space side:
+on 6,941 real words attested in both indigenous kośas (SKD ∩ VCP), whether MW
+enters a word is **≈8× more predicted by PWG's decision** than by an independent
+compiler's (gap-sensitivity 12.3× vs Apte 1.5×). **Consequence for any downstream
+analysis:** PWG/PW ↔ MW agreement — shared headwords, shared citations, shared
+sense structure, "the tradition agrees" tallies (cf. the etymology-extraction
+90–100% agreement, [`project_cologne_etymology_extraction`]) — is **inheritance,
+not independent confirmation.** When counting how many *independent* authorities
+back a reading, PWG, PW **and** MW collapse to roughly **one** European witness;
+the genuinely independent European-tradition control is **Apte**, and the indigenous
+kośas (SKD, VCP, Amarakośa) are the independent non-European anchor.
+
+The **positive counter-fact**, equally load-bearing: MW carries over **none** of
+Böhtlingk's mechanical errors (F4b Ahlborn ≈0%, F4a 0 shared print errors) and
+recomposed its English prose (F3/F6), and it independently supplies **54.6%** of the
+real indigenous words PWG omits — *more* than Apte. So the non-independence is of
+**scholarship/inventory**, not of typesetting or prose. Documentary basis: Böhtlingk's
+1883 *pw* preface (35 cited passages) and the Böhtlingk↔Max-Müller correspondence,
+Stache-Weiske 2015 ([`papers/Stache-Weiske_Bö-MW.notes.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/Stache-Weiske_Bö-MW.notes.md)).
+
+**On the shared-*erroneous-citation* avenue — a measured null, not a closed door.**
+The Lachmann-style airtight proof (a citation *wrong* against the text, present in
+both dicts) returned measured nulls on the corpora tested: 1/587 resolvable against
+DCS (edition-mismatch block), and 0 shared errors against the Kinjawadekar Harivaṃśa
+vulgate. That is a **recorded negative result on those candidate sets**, not evidence
+of independence and not proof the avenue is exhausted — a Nilakantha-**vulgate** full
+Mahābhārata e-text would reopen it (see [`DEAD_ENDS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) §8/§8b). The
+untested shared-error surfaces remain **shared headword/gloss misprints and copied
+sense-order** (F5 citation-order 0.811 is suggestive but not the meaning-order Müller
+named).
+
+> **Source:** csl-atlas A10 §3.5 / F9
+> ([`f9_shared_omission.py`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/scripts/forensic/f9_shared_omission.py),
+> [`SHARED_OMISSION_TEST.md`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/forensic/SHARED_OMISSION_TEST.md),
+> [csl-atlas PR #263](https://github.com/sanskrit-lexicon/csl-atlas/pull/263)) ·
+> [H796](https://github.com/gasyoun/Uprava/blob/main/handoffs/H796-Opus_csl-atlas_boehtlingk_mw_shared_omission_test_12.07.26.md) ·
+> 12-07-2026, Opus 4.8 (`claude-opus-4-8`).
+> ↔ [ASSUMPTIONS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md) (independence premise for tradition-agreement counts) · [DEAD_ENDS.md §8](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md) (shared-erroneous-citation null).
+
 ---
 
 _Started 2026-06-26 (relocated from `Uprava/FINDINGS.md`, which now holds **non-Sanskrit**

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,23 @@ lane then dropped to 0.0.1–0.0.42 snapshot tags (18-06 … 02-07) before resum
 at 1.1.4 on 03-07 — the dip is baked into the published tags and is intentional,
 not an error.
 
+## [Unreleased]
+
+## [1.9.1] - 2026-07-12
+
+### Added — Böhtlingk item-#1 shared-omission finding + Stache-Weiske notes (H796)
+- [FINDINGS §83](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md):
+  MW and the Petersburg dictionaries are **not** independent witnesses on inventory/apparatus
+  (do not count their agreement as corroboration) — but no shared *error* has ever been found.
+  Grounded in the new csl-atlas shared-omission test (A10 §3.5 / F9,
+  [csl-atlas PR #263](https://github.com/sanskrit-lexicon/csl-atlas/pull/263)): on 6,941 real
+  indigenous-attested words, MW's omissions track PWG's ≈8× more than the independent Apte's, yet
+  MW independently supplies 54.6% of PWG's gaps.
+- Reading notes on the source paper:
+  [`papers/Stache-Weiske_Bö-MW.notes.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/Stache-Weiske_Bö-MW.notes.md)
+  — the itemised 1881–83 charge (omission/error/sense-order) mapped to each A10 test, with the
+  remaining open clause (sense-order) and the 35-Stellen gold-set flagged as actionable.
+
 ## [1.9.0] - 2026-07-12
 
 ### Added — Duden-style entry-anatomy specimen pages for PWG, MW and the CDSL record (H780)

--- a/papers/Stache-Weiske_Bö-MW.notes.md
+++ b/papers/Stache-Weiske_Bö-MW.notes.md
@@ -1,0 +1,98 @@
+# Reading notes — Stache-Weiske (2015) on the Böhtlingk–Monier-Williams plagiarism dispute
+
+_Created: 12-07-2026 · Last updated: 12-07-2026_
+
+Companion notes to [`Stache-Weiske_Bö-MW.pdf`](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/Stache-Weiske_Bö-MW.pdf).
+
+> Agnes Stache-Weiske. 2015. „Man muß zuweilen Insekten mit Kanonen schießen." Max Müllers Rolle
+> im Streit zwischen Böhtlingk und Monier-Williams. In: *„In ihrer rechten Hand hielt sie ein
+> silbernes Messer mit Glöckchen…" — Studies in Indian Culture and Literature* (Festschrift Heidrun
+> Brückner), eds. A. A. Esposito, H. Oberlin, B. A. Viveka Rai & K. J. Steiner, 323–336. Wiesbaden:
+> Harrassowitz. ISBN 978-3-447-10548-4.
+
+## Why this paper matters to us
+
+It is the **primary-source documentation of the founding accusation of Sanskrit computational
+lexicography-forensics**: Otto Böhtlingk's 1883 charge that Monier-Williams's *Sanskrit-English
+Dictionary* (MW) is an unselbständige "Ausbeutung" (exploitation) of the Petersburg dictionaries
+(PW/pw). Reconstructed from the newly-surfaced Böhtlingk↔Max-Müller correspondence (22 Müller letters
+in the Leipzig Streitberg Nachlass + Böhtlingk's replies in the Oxford Bodleian), it hands us the
+**exact terms** of the charge — which is precisely what our A10 forensic suite (csl-atlas) measures on
+the digitised editions. The paper turns A10 from "an interesting quantitative exercise" into "the
+computational adjudication of a named, dated, 140-year-old scholarly accusation." That framing is the
+enrichment.
+
+## The dispute in one paragraph
+
+MW appeared 1872; Böhtlingk largely **ignored** it for eleven years ("keine Citate … dann brauche ich
+es nicht"). In 1881 Max Müller — a Clarendon Press curator with a long personal animus against MW,
+dating to his 1860 defeat for the Boden Chair — reopened it when MW sought a 2nd edition, feeding
+Böhtlingk the plagiarism framing and the English legal theory that reprinting another's misprints is
+"piracy." Böhtlingk went public in the 1883 preface to *pw* vol. 4, citing **35 passages**. The
+Clarendon Press first declined, then (with a £900 India-Council subsidy) published MW² anyway. Müller's
+verdict on the whole affair — the title quote — was that shooting Böhtlingk's cannon at the MW "insect"
+was an unpleasant business. Zgusta (1988) later judged it a failure of *acknowledgement*, not theft.
+
+## The charge, itemised — and what each clause maps onto
+
+Müller's letter of 11 June 1881 (Stache-Weiske p. 328) states it most precisely: MW reproduces PW's
+**omissions**, its **errors**, and its **sense-order** —
+> „Was in Ihrem Werk ausgelaßen u[nd] versehen ist, ist bei ihm ausgelaßen und versehen u[nd] die
+> Reihenfolge der Bedeutungen einfach abgeschrieben."
+
+Böhtlingk to the Clarendon Press, 28 Nov 1881 (p. 330): MW carries "Versehen mannigfacher Art,
+Druckfehler und falsche Citate, die wiederholt werden." Böhtlingk's own evidential bar (25 March 1882,
+p. 332): a **single** demonstrable copied case suffices. Müller's legal test (30 June 1881): under
+English law "Wiederabdruck von Druckfehlern" = piracy — i.e. the **common-error principle**, exactly
+the Lachmann criterion our A10 uses.
+
+| Historical clause (1881–83) | Our computational test | Status now |
+|---|---|---|
+| Shared **omissions** — "was ausgelaßen ist, ist ausgelaßen" | A10 §3.5 / **F9** shared-omission (this session) | **Measured.** MW's omissions track PWG's ≈8× more than independent Apte (gap-sensitivity 12.3× vs 1.5×) → inventory descent confirmed; **but** MW independently fills 54.6% of PWG's gaps → *not* a carbon copy. Descent, not blindness. |
+| Shared **errors** — misprints | A10 §4.1 F4b (Ahlborn), §4.3 F4a print errors | **Null.** MW carries ≈0% of PWG's misspellings; 0 shared print errors. |
+| Shared **false citations** | A10 §6 F7 (Harivaṃśa vulgate) | **Measured null** on tested corpora (1/587 via DCS; 0 shared errors vs Kinjawadekar vulgate). A recorded negative, not a closed avenue — a Nilakantha-vulgate MBH text would reopen it. |
+| Copied **sense-order** — "Reihenfolge der Bedeutungen" | A10 §3.4 F5 (citation-order 0.811) — **proxy only** | **Partially tested.** F5 measures *citation* order, not *meaning* order. The literal Müller claim (order of senses) is **untested** — see actionable #1. |
+| Shared apparatus (which words / which texts) | A10 §3.1–3.3 (containment, F1 citation Jaccard, F2 homonym) | **Strongly positive** — the paper's core. |
+
+Net verdict (ours, matching Zgusta's historical one): **MW is heir to Böhtlingk's scholarship —
+inventory, citation apparatus, entry order — and author of its own English prose and typesetting.**
+Böhtlingk's "shared errors" charge does **not** hold on the digitised evidence; his "shared apparatus /
+inventory" charge holds overwhelmingly. The dispute was, in modern terms, about un-credited *derived*
+work, not fabricated errors.
+
+## What this session did (H796)
+
+- **Ran the shared-omission test (F9)** — the one clause of the charge A10 had never tested. Result and
+  method: [`csl-atlas/.../SHARED_OMISSION_TEST.md`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/forensic/SHARED_OMISSION_TEST.md),
+  script [`f9_shared_omission.py`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/scripts/forensic/f9_shared_omission.py).
+- **Integrated the documentary history into A10** (not a new paper, per instruction): §1 grounding (the
+  35 Stellen, the correspondence, Müller's legal test, Zgusta's verdict), §3.5 result, F9 in the method
+  table, abstract + references (Stache-Weiske 2015, Zgusta 1988). [csl-atlas PR #263](https://github.com/sanskrit-lexicon/csl-atlas/pull/263).
+- **Logged the non-independence caveat** as [FINDINGS §82](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md): PWG/PW/MW collapse to ≈one European
+  witness; do not count their agreement as independent corroboration.
+
+## Actionable items — "pure statement then, verifiable now"
+
+1. **Sense-order test (Müller's literal item, still untested).** F5 measured *citation* order; the
+   charge was *"die Reihenfolge der Bedeutungen"* — the order of glosses/senses within an entry. A
+   cross-lingual sense-sequence alignment (MW English senses ↔ PWG German senses, per shared headword)
+   would close the last open clause. Harder than F5 (needs sense segmentation + DE↔EN sense matching),
+   but the data (parsed MW + PWG entries) is in hand. **This is the one remaining "asserted but not
+   measured" clause.**
+2. **Locate Böhtlingk's actual 35 Stellen** (1883 *pw* vol. 4 preface, pp. II–III) and resolve each on
+   the digitised editions — a small, high-value gold set for *directly* re-adjudicating the specific
+   cases Böhtlingk chose, rather than corpus-wide aggregates. The preface text is a scan; OCR + manual
+   extraction of ~35 items is cheap.
+3. **Widen the shared-omission anchor** (F9 used SKD ∩ VCP = 6,941; SKD ∪ VCP or + Amarakośa/Apte-cross
+   would test robustness) — an enhancement, not a gate.
+
+## Bibliographic leads surfaced by the paper (for our lit library)
+
+- Zgusta, L. 1988. "Copying in lexicography: Monier-Williams … (Dvaikośyam)." *Lexicographica* 4,
+  145–164. — the scholarly analysis of exactly our question; **should be acquired** for M01/A10.
+- Zgusta, L. 1986. "Eine Kontroverse zwischen der deutschen und englischen Sanskrit-Lexikographie."
+- Stache-Weiske, A. 2007. *Otto Böhtlingk an Rudolf Roth. Briefe zum Petersburger Wörterbuch 1852–1885.*
+  Wiesbaden: Harrassowitz. — the full Böhtlingk–Roth correspondence; the source behind most of the paper.
+- Stache-Weiske, A. 2012. "…Verhältnis von Otto Böhtlingk und Max Müller." In *200 Jahre Indienforschung*.
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Companion to [csl-atlas PR #263](https://github.com/sanskrit-lexicon/csl-atlas/pull/263) (the shared-omission test, **merged**). Rebased onto master (resolved against the concurrent H780 §82 / 1.9.0 — my finding renumbered **§83**, changelog **[1.9.1]**).

- **[FINDINGS §83](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)** — MW and the Petersburg dictionaries are **not** independent witnesses on inventory/apparatus; agreement is inheritance, not corroboration (they collapse to ≈one European witness; Apte + indigenous kośas are the independent anchors). No shared *error* ever found. The shared-erroneous-citation avenue is a **measured null on tested corpora, not a closed door**.
- **[`papers/Stache-Weiske_Bö-MW.notes.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/Stache-Weiske_Bö-MW.notes.md)** — the 1881–83 charge (omission/error/sense-order) mapped onto each A10 test; remaining actionables: the sense-**order** clause (only proxied by F5) and Böhtlingk's **35 Stellen** gold set.

Handoff [H796](https://github.com/gasyoun/Uprava/blob/main/handoffs/H796-Opus_csl-atlas_boehtlingk_mw_shared_omission_test_12.07.26.md). Opus 4.8 (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)