### PR TITLE
review sheet: add approve/reject/defer button legend

### DIFF
--- a/RussianTranslation/review/sanskritlexicography-renou-hypotheses_pilot_review.html
+++ b/RussianTranslation/review/sanskritlexicography-renou-hypotheses_pilot_review.html
@@ -2474,5 +2474,16 @@
   });
 })();
 </script>
+
+<div id="vote-legend" style="max-width:900px;margin:32px auto 100px auto;padding:18px 22px;border-radius:10px;background:rgba(128,128,128,0.08);border:1px solid rgba(128,128,128,0.25);font-family:-apple-system,Segoe UI,Roboto,sans-serif;font-size:13px;line-height:1.6;color:inherit;">
+  <b>What the buttons mean</b>
+  <ul style="margin:8px 0 0 0;padding-left:20px;">
+    <li><b>Approve</b> — accept the proposed change shown on the card. There is no separate "approve as-is" — approving means agreeing the correction should be made as written.</li>
+    <li><b>Reject</b> — keep the current entry unchanged, do not apply the correction.</li>
+    <li><b>Defer</b> — not sure yet, decide later.</li>
+  </ul>
+  <p style="margin:8px 0 0 0;">Use the free-text note field on a card to request a partial tweak instead of the exact wording proposed (e.g. "approve but keep X"), rather than rejecting outright. When done, use the Download decisions button — that file is what a future session reads to apply your votes.</p>
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
Adds a small legend footer explaining the Approve/Reject/Defer vote buttons to the renou-hypotheses review sheet, matching the H779 pattern applied org-wide.