### PR TITLE
Fix RussianTranslation gates: re-stamp government_census LANG_PARITY hash

### DIFF
--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -572,10 +572,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "H335 (08-07-2026). The census reads raw pwg.txt below any --lang branch and never touches RU/EN translation code; the government-marker regexes operate on the German source markup shared by both editions. Read-only over the source; selftest-gated.",
+    "note": "H335 (08-07-2026). The census reads raw pwg.txt below any --lang branch and never touches RU/EN translation code; the government-marker regexes operate on the German source markup shared by both editions. Read-only over the source; selftest-gated. Re-verified 12-07-2026 after H778 (#384) added a source_sha16-gated JSON sidecar freeze/cache layer (build_sidecar/write_sidecar/load_sidecar/census_or_load) plus a `freeze` CLI subcommand around the same run_census() function — still no --lang branch, verdict unchanged.",
     "tracking": "",
     "verified_sha256": {
-      "src/government_census.py": "501c21da829cf32555fa086274f5cd01578b7d8f88cd76f3402b5c16b124fd9b"
+      "src/government_census.py": "bf421d8fd743767c891ea1633f47e6526e88aef2c93d3a73437fc9ac749dafb1"
     }
   },
   {


### PR DESCRIPTION
## Summary
- `RussianTranslation gates` CI has been red on master since [#391](https://github.com/gasyoun/SanskritLexicography/pull/391) merged, but the actual cause is [#384](https://github.com/gasyoun/SanskritLexicography/pull/384) (H778): `government_census.py` grew a `source_sha16`-gated JSON sidecar freeze/cache layer (`build_sidecar`/`write_sidecar`/`load_sidecar`/`census_or_load`, a `freeze` CLI subcommand) around the existing `run_census()`, without re-running `lang_parity_check.py --update-hash`.
- Reviewed the diff since the last verified hash: the added code still has no `--lang` branch and still reads only the raw `pwg.txt` source shared by both RU/EN editions — the `SHARED` verdict holds. Re-stamped `verified_sha256` for `government_census.py` and noted the re-verification in the ledger entry.

## Test plan
- [x] `python src/pilot/lang_parity_check.py` → `LANG PARITY LEDGER: 42 entries, all verdicts complete, no drift`
- [x] `python src/government_census.py selftest` → `government_census selftest: OK` / `extract_government selftest: OK`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)