### PR TITLE
docs: repoint H771 handoff links to archive/ (handoff archived)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -28,7 +28,7 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   was a homonym‑misalignment artifact of key1‑keyed sampling; the LS source maps
   never changed (23‑06). **The ~379 MB old underscore chain is safe to delete**
   (deletion stays a human `@DO`). Zero data files touched — read‑only, per
-  [H771](https://github.com/gasyoun/Uprava/blob/main/handoffs/H771-Opus_RussianTranslation_renou-dcs-index-regression-investigation_12.07.26.md).
+  [H771](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H771-Opus_RussianTranslation_renou-dcs-index-regression-investigation_12.07.26.md).
 
 ### H805 — canonical shared store path so worktree drain windows don't silently drop promotions
 - New [`src/store_path.py`](src/store_path.py) `canonical_store()` resolves the ONE logical

--- a/RussianTranslation/RENOU_DCS_INDEX_REGRESSION_INVESTIGATION_12.07.26.md
+++ b/RussianTranslation/RENOU_DCS_INDEX_REGRESSION_INVESTIGATION_12.07.26.md
@@ -2,7 +2,7 @@
 
 _Created: 12-07-2026 · Last updated: 12-07-2026_
 
-**Handoff:** [H771](https://github.com/gasyoun/Uprava/blob/main/handoffs/H771-Opus_RussianTranslation_renou-dcs-index-regression-investigation_12.07.26.md).
+**Handoff:** [H771](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H771-Opus_RussianTranslation_renou-dcs-index-regression-investigation_12.07.26.md).
 **Model:** Opus 4.8 (`claude-opus-4-8`). Read-only against all data files
 (`.jsonl`, `dcs_lemma_renou.json`, `ls_source_map*.json`) — **zero files
 deleted, moved, renamed, or regenerated this session.** Adjudicates the


### PR DESCRIPTION
Follow-up to [PR #394](https://github.com/gasyoun/SanskritLexicography/pull/394): the H771 handoff was archived to `Uprava/handoffs/archive/` today, so the two blob-URL references to it (the [RENOU investigation report](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU_DCS_INDEX_REGRESSION_INVESTIGATION_12.07.26.md) + its `RussianTranslation/CHANGELOG.md` entry) are repointed from `/handoffs/` to `/handoffs/archive/` to keep the links live. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)