### PR TITLE
docs: repoint dead H692 handoff links to archive/

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -143,7 +143,7 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   `renou_ls`/`renou_dcs`/`renou_enriched`) → **DO NOT DELETE**, `@DECIDE`
   raised on whether that regeneration was a correction or a regression.
   Zero data files touched this session — proposal only, per
-  [H692](https://github.com/gasyoun/Uprava/blob/main/handoffs/H692-Fable_RussianTranslation_assembled-cards-dedup-verify_11.07.26.md)'s
+  [H692](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H692-Fable_RussianTranslation_assembled-cards-dedup-verify_11.07.26.md)'s
   stop condition. Verification script:
   [`src/renou_stage_redundancy_check.py`](src/renou_stage_redundancy_check.py).
 

--- a/RussianTranslation/RENOU_STAGE_REDUNDANCY_AUDIT_12.07.26.md
+++ b/RussianTranslation/RENOU_STAGE_REDUNDANCY_AUDIT_12.07.26.md
@@ -2,7 +2,7 @@
 
 _Created: 12-07-2026 · Last updated: 12-07-2026_
 
-**Handoff:** [H692](https://github.com/gasyoun/Uprava/blob/main/handoffs/H692-Fable_RussianTranslation_assembled-cards-dedup-verify_11.07.26.md).
+**Handoff:** [H692](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H692-Fable_RussianTranslation_assembled-cards-dedup-verify_11.07.26.md).
 **Model:** Sonnet 5 (`claude-sonnet-5`), continuing an in-flight Fable 5
 (`claude-fable-5`) session that had written but not yet run
 [`src/renou_stage_redundancy_check.py`](src/renou_stage_redundancy_check.py)


### PR DESCRIPTION
H692 is already in `Uprava/handoffs/archive/`, but two references to it still pointed at the old `/handoffs/` root path (dead 404): the [stage-redundancy audit report](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU_STAGE_REDUNDANCY_AUDIT_12.07.26.md)'s `Handoff:` line and its `RussianTranslation/CHANGELOG.md` entry. Repointed both to `/handoffs/archive/`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)