### PR TITLE
H811: ≤N-wide staggered dispatch (boundedParallel) for degraded-API requeues

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,24 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### H811 — ≤N-wide staggered dispatch (boundedParallel) for degraded-API requeues
+- [`src/pilot/gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py) gains `--max-wide=N` +
+  `--stagger-ms=M`: the emitted top-level dispatch now runs through a
+  `boundedParallel(thunks, width, staggerMs)` worker-pool (≤N units in flight, first N starts
+  staggered) instead of the runtime `parallel()`. **Default 0 = unbounded (no regression).**
+- Root of the H255 w07 finding: the Workflow runtime caps width at ~10, and on a degraded
+  generation API a tiny card that completes in **~54 s alone** is inflated past the **180 s
+  kill CEIL** at ~10-wide (w07: 32/36 kill-timeouts on 128–500 B skeletons). A `--max-wide=3`
+  requeue keeps each card near its isolated latency. Requeue recipe:
+  `gen_opt_harness2.py <root>_rq1 --nominal --keys=<null-keys> --output-budget=1 --no-tm
+  --max-wide=3 --stagger-ms=2000`.
+- Verified: new [`src/pilot/boundedparallel_test.js`](src/pilot/boundedparallel_test.js)
+  behavioral test (against the REAL emitted fn — caps concurrency, staggers, order-preserving,
+  null-on-throw) wired into `window_selftest.test_lowwide_staggered_dispatch`; full
+  `window_selftest.py` + `lang_parity_check.py` green; new `lowwide_staggered_dispatch_h811`
+  SHARED LANG_PARITY entry (the width control is language-independent, emitted identically for
+  RU/EN).
+
 ### H809 — PWG→RU scale-readiness census (12-07-2026): NOT ready for nonstop; blocker is infra
 - [`SCALE_READINESS_CENSUS_2026-07-12.md`](SCALE_READINESS_CENSUS_2026-07-12.md) — a
   read-only 8-agent workflow (Opus 4.8 `claude-opus-4-8`, ~1.0 M tokens) verified the

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e"
     }
   },
   {
@@ -117,8 +117,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e",
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -136,8 +136,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e",
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -155,8 +155,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e",
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -173,7 +173,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e"
     }
   },
   {
@@ -224,7 +224,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e"
     }
   },
   {
@@ -241,7 +241,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e"
     }
   },
   {
@@ -257,7 +257,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The bare 'sonnet' alias resolved to Sonnet 4.6 (not 5.0) on a prior EN run — pinned explicitly there after that surprise. RU's alias was never observed to misresolve, so it was left alone rather than touching a stable production path for a problem it doesn't have. Re-evaluate if RU is ever caught on a stale alias too.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e"
     }
   },
   {
@@ -354,8 +354,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e",
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -374,7 +374,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -411,8 +411,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e",
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -449,7 +449,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e",
       "src/promote_final_cards.py": "f098ed7dc3009ec44aaf415b57d639a191ec0012ba53df776b34bf27efefd563"
     }
   },
@@ -469,9 +469,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -502,7 +502,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "1790c31d101d4247bcf3a6bcb29eb979be32bcf15649527f8ce3de8cfb9db597",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -521,7 +521,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -539,7 +539,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "95797986db7c21210a55c8a13f324514d17110ba07d2f804d000a77a003d5bf3",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "f098ed7dc3009ec44aaf415b57d639a191ec0012ba53df776b34bf27efefd563",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -623,7 +623,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "f2090d359ff49e798f474b26bb387f5a7309308442b4cfca01a11915d7c9192e",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -652,7 +652,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -672,7 +672,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -691,7 +691,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "5e257d130318be4e903bb55444d70c88544af8725c115253235e5daed716ec51",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -728,7 +728,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -786,7 +786,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -804,8 +804,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e",
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -823,8 +823,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e",
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -843,8 +843,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce",
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e",
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -865,8 +865,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "786bab98ce69837db2e44febaf5079e47ef34ca9cbd49f1f6c941507c54ace29",
-      "src/pilot/window_selftest.py": "8c45d8dc292d0eb2a8f70adcb80731b96d5369a9265354077bfaf9e0562f55ce"
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e",
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   },
   {
@@ -905,6 +905,27 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/store_path.py": "8b9d62c7c1fa463b9938c8b4a118b53a34bc4e0c22a146b487e88847fb7e583b",
       "src/promote_final_cards.py": "f098ed7dc3009ec44aaf415b57d639a191ec0012ba53df776b34bf27efefd563",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
+    }
+  },
+  {
+    "id": "lowwide_staggered_dispatch_h811",
+    "mechanism": "gen_opt_harness2.py --max-wide=N / --stagger-ms=M route the emitted top-level dispatch through a boundedParallel(thunks, width, staggerMs) worker-pool (at most N units in flight, first N starts staggered by M ms) instead of the runtime parallel(); 0 = unbounded (default, no regression). Degraded-API requeue lane: at ~10-wide a tiny card that completes in ~54s ALONE is inflated past the 180s kill CEIL (H255 w07: 32/36 kill-timeouts on 128-500B skeletons).",
+    "files": [
+      "src/pilot/gen_opt_harness2.py",
+      "src/pilot/boundedparallel_test.js",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "2e533c1b651f80e430b66360bbc01c9cb481ca83623138dfe18b012593ab434e",
+      "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
+      "src/pilot/window_selftest.py": "503624233456ba24e6c0c7db663f94c8fd30b34d801651ac5fd5044d5992f078"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/boundedparallel_test.js
+++ b/RussianTranslation/src/pilot/boundedparallel_test.js
@@ -1,0 +1,76 @@
+// Behavioral test for the H255/H811 boundedParallel low-width staggered dispatch.
+// Extracts the REAL boundedParallel emitted by gen_opt_harness2.py (so this can't drift from
+// the generator) and asserts: (A) concurrency is capped at `width`, (B) results stay index-
+// aligned, (C) a thrown thunk resolves to null without poisoning the batch, (D) width<=0 falls
+// back to parallel(), (E) the first `width` starts are staggered by staggerMs.
+//   node src/pilot/boundedparallel_test.js <path-to-a-generated-harness.js>
+const fs = require('fs')
+
+const harnessPath = process.argv[2] || 'src/pilot/lowwide_test.js'
+const src = fs.readFileSync(harnessPath, 'utf8')
+
+// Pull the function source out of the generated harness verbatim.
+const m = src.match(/async function boundedParallel\(thunks, width, staggerMs\) \{[\s\S]*?\n\}/)
+if (!m) { console.error('FAIL: boundedParallel not found in ' + harnessPath); process.exit(1) }
+
+// Provide the two runtime globals the harness gets for free: parallel() (all-concurrent, a
+// thrown thunk -> null) and setTimeout (real in Node). Then eval the extracted source.
+const parallel = thunks => Promise.all(thunks.map(t => Promise.resolve().then(t).catch(() => null)))
+// Direct eval (sees local `parallel`); wrap as an expression so the fn name doesn't collide.
+const boundedParallel = eval('(' + m[0] + ')')
+
+let failed = 0
+const check = (name, cond, extra) => { if (cond) { console.log('PASS: ' + name) } else { console.error('FAIL: ' + name + (extra ? ' -- ' + extra : '')); failed++ } }
+
+const sleep = ms => new Promise(r => setTimeout(r, ms))
+
+async function main() {
+  // (A) concurrency cap + (B) order: 8 thunks track a live counter; width 3 -> peak <= 3.
+  {
+    let live = 0, peak = 0
+    const thunks = Array.from({ length: 8 }, (_, i) => async () => {
+      live++; peak = Math.max(peak, live)
+      await sleep(20)
+      live--
+      return i
+    })
+    const res = await boundedParallel(thunks, 3, 0)
+    check('concurrency capped at width=3', peak <= 3, 'peak=' + peak)
+    check('all 8 ran', live === 0 && res.length === 8)
+    check('results index-aligned', res.every((v, i) => v === i), JSON.stringify(res))
+  }
+
+  // (C) a thrown thunk -> null, others unaffected.
+  {
+    const thunks = [async () => 'a', async () => { throw new Error('boom') }, async () => 'c']
+    const res = await boundedParallel(thunks, 2, 0)
+    check('thrown thunk -> null, batch survives', res[0] === 'a' && res[1] === null && res[2] === 'c', JSON.stringify(res))
+  }
+
+  // (D) width<=0 and width>=len fall back to parallel() (all results present).
+  {
+    const mk = () => [async () => 1, async () => 2]
+    const r0 = await boundedParallel(mk(), 0, 0)
+    const rBig = await boundedParallel(mk(), 99, 0)
+    check('width=0 falls back to parallel()', JSON.stringify(r0) === '[1,2]', JSON.stringify(r0))
+    check('width>=len falls back to parallel()', JSON.stringify(rBig) === '[1,2]', JSON.stringify(rBig))
+  }
+
+  // (E) stagger: width=3 over 6 thunks, staggerMs=60. Each initial worker starts ~w*60ms
+  // apart; thunks sleep 200ms (> width*stagger=180) so no worker races ahead and picks a 4th
+  // thunk during the stagger window. The 3 earliest starts are thus the 3 initial workers'
+  // first picks and must span >= ~2*stagger.
+  {
+    const t0 = Date.now()
+    const starts = []
+    const thunks = Array.from({ length: 6 }, () => async () => { starts.push(Date.now() - t0); await sleep(200) })
+    await boundedParallel(thunks, 3, 60)
+    const first3 = starts.slice(0, 3).sort((a, b) => a - b)
+    const span = first3[2] - first3[0]
+    check('first 3 starts staggered by ~2*60ms', span >= 100, 'first3=' + JSON.stringify(first3))
+  }
+
+  if (failed) { console.error('\nboundedparallel_test: ' + failed + ' FAILURE(S)'); process.exit(1) }
+  console.log('\nboundedparallel_test: all PASS')
+}
+main().catch(e => { console.error('FAIL: uncaught ' + (e && e.stack || e)); process.exit(1) })

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -193,6 +193,16 @@ MAX_AGENTS_HEADROOM = 10    # additive jitter allowance so a TINY window (expect
                             #  small/medium words (they never legitimately approach 40, so the
                             #  floor let their runaways run unchecked to 40). H189 follow-up.
 MAX_AGENTS_OVERRIDE = None  # --max-agents=N: combined ceiling allocated across both pools
+# --- low-width staggered dispatch (H255/H811, 2026-07-12) --------------------------
+# The top-level dispatch fans every batch into the Workflow runtime, which runs ~min(16,
+# cores-2) ~= 10 concurrently. H255 w07 proved that on a *degraded* generation API this
+# self-inflates: a tiny single-fragment card that completes in ~54s ALONE (measured, isolated
+# schema-carrying probe) blows past even the 180s kill CEIL at ~10-wide (32/36 kill-timeouts,
+# 128-500B skeletons). MAX_WIDE caps the concurrent dispatch units so a requeue keeps each
+# card near its isolated latency; STAGGER_MS spaces the first MAX_WIDE starts so the degraded
+# API isn't hit by a thundering herd. 0 = unbounded (default; uses the runtime parallel()).
+MAX_WIDE = 0                # --max-wide=N: at most N translateBatch/healOnly units in flight
+STAGGER_MS = 0              # --stagger-ms=M: delay between the first MAX_WIDE worker starts
 # --- per-card heal budget (H442, 2026-07-10) --------------------------------------
 # The window-level MAX_AGENTS switch above stops a runaway, but it is a SHARED pool: it
 # cannot stop ONE dense card from spending the WHOLE window budget before the other cards
@@ -415,6 +425,10 @@ def parse_args(argv):
             globals()['REFUSE_OVERSIZE'] = True
         elif a.startswith('--max-harness-bytes='):
             globals()['MAX_HARNESS_BYTES'] = int(a.split('=', 1)[1])
+        elif a.startswith('--max-wide='):                 # H255/H811: cap concurrent dispatch units (<=N-wide) for the degraded-API requeue lane
+            globals()['MAX_WIDE'] = int(a.split('=', 1)[1])
+        elif a.startswith('--stagger-ms='):               # H255/H811: delay between the first MAX_WIDE worker starts (thundering-herd guard)
+            globals()['STAGGER_MS'] = int(a.split('=', 1)[1])
     if budget_explicit and not output_explicit:
         # An explicit --budget=N with no --output-budget means the caller wants BYTE-mode
         # batching (backward compat: every pre-2026-07-02 documented invocation that tuned
@@ -1212,6 +1226,9 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         'heal_budget_cards': budget_plan.heal_cards,
         'max_agents_factor': MAX_AGENTS_FACTOR,
         'max_agents_headroom': MAX_AGENTS_HEADROOM,
+        # H255/H811 low-width staggered dispatch: <=MAX_WIDE concurrent units (0 = unbounded).
+        'max_wide': MAX_WIDE,
+        'stagger_ms': STAGGER_MS,
         # H442 per-card heal budget: caps the heal agent() calls ONE card may spend so a dense
         # card fails fast to partial instead of monopolizing the shared window MAX_AGENTS pool.
         'per_card_heal_budget': (PER_CARD_HEAL_BUDGET and SELFHEAL),
@@ -1295,6 +1312,11 @@ const KILL_SWITCH = %(kill_switch)s
 const MAX_AGENTS = %(max_agents)s
 const MAX_TRANSLATE_AGENTS = %(max_translate_agents)s
 const MAX_HEAL_AGENTS = %(max_heal_agents)s
+// H255/H811 low-width staggered dispatch: cap the concurrent translateBatch/healOnly units so
+// a degraded generation API isn't hit ~10-wide (the Workflow runtime cap) — a tiny card that
+// takes ~54s ALONE is inflated past the 180s kill CEIL under contention. 0 = unbounded.
+const MAX_WIDE = %(max_wide)s
+const STAGGER_MS = %(stagger_ms)s
 // H442 per-card heal budget: a per-card ceiling on heal agent() calls, threaded through
 // healGroup's bisection recursion. Unlike MAX_AGENTS (a shared window pool), this stops ONE
 // dense card from spending the whole window budget: once a card's own heal spend crosses
@@ -1795,11 +1817,34 @@ async function healOnly(k) {
   if (!row.card && FAIL[k]) row.error = FAIL[k]
   return [row]
 }
+// H255/H811 low-width staggered dispatch. Runs `thunks` with at most `width` in flight,
+// spacing the first `width` starts by `staggerMs` so a degraded generation API isn't hit by
+// a thundering herd. On a degraded API a tiny card that completes in ~54s ALONE is inflated
+// past the 180s kill CEIL at ~10-wide (the Workflow runtime cap); at <=3-wide it keeps its
+// isolated latency. width<=0 or >=len falls back to the runtime parallel(); a thrown thunk
+// resolves to null (parallel() parity), and results stay index-aligned with `thunks`.
+async function boundedParallel(thunks, width, staggerMs) {
+  if (!width || width >= thunks.length) return parallel(thunks)
+  const results = new Array(thunks.length).fill(null)
+  let next = 0
+  const worker = async () => {
+    for (let idx = next++; idx < thunks.length; idx = next++) {
+      try { results[idx] = await thunks[idx]() } catch (e) { results[idx] = null }
+    }
+  }
+  const workers = []
+  for (let w = 0; w < width; w++) {
+    if (staggerMs && w > 0) await new Promise(r => setTimeout(r, staggerMs))
+    workers.push(worker())
+  }
+  await Promise.all(workers)
+  return results
+}
 // UNITS pairs each parallel slot with the exact keys it owes rows for, so the accounting
 // backfill below stays index-correct with the presplit lane appended after the batches.
 const UNITS = BATCHES.map((b, i) => ({ keys: b, run: () => translateBatch(b, i) }))
   .concat(PRESPLIT.map(k => ({ keys: [k], run: () => healOnly(k) })))
-const grouped = await parallel(UNITS.map(u => u.run))
+const grouped = await boundedParallel(UNITS.map(u => u.run), MAX_WIDE, STAGGER_MS)
 // TOTAL ACCOUNTING INVARIANT: every selected key appears in `results` exactly once, no
 // matter what failed above. parallel() resolves a thrown thunk to null — flat() would
 // carry that null into results (crashing the summary below and silently dropping the
@@ -1876,6 +1921,7 @@ return { meta: META, summary, results: out }
         'kill_switch': json.dumps(KILL_SWITCH), 'max_agents': json.dumps(budget_plan.max_agents),
         'max_translate_agents': json.dumps(budget_plan.max_translate_agents),
         'max_heal_agents': json.dumps(budget_plan.max_heal_agents),
+        'max_wide': json.dumps(MAX_WIDE), 'stagger_ms': json.dumps(STAGGER_MS),
         'per_card_heal_budget': json.dumps(PER_CARD_HEAL_BUDGET and SELFHEAL),
         'per_card_heal_factor': json.dumps(PER_CARD_HEAL_FACTOR), 'per_card_heal_headroom': json.dumps(PER_CARD_HEAL_HEADROOM),
         'kill_timeout_no_bisect': json.dumps(bool(KILL_TIMEOUT_NO_BISECT and KILL and SELFHEAL)),

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3189,6 +3189,57 @@ def test_split_agent_pools_all_heal_runtime():
         shutil.rmtree(d, ignore_errors=True)
 
 
+def test_lowwide_staggered_dispatch():
+    """H255/H811: --max-wide=N routes the top-level dispatch through boundedParallel (<=N units
+    in flight, first N starts staggered by --stagger-ms) so a degraded generation API isn't hit
+    ~10-wide; the default (0) falls back to the runtime parallel() with no regression. The
+    behavioral half runs the REAL emitted boundedParallel (see boundedparallel_test.js)."""
+    import gen_opt_harness2 as gh
+    saved_ip, saved_kill = gh.input_paths, gh.KILL
+    saved_wide, saved_stag = gh.MAX_WIDE, gh.STAGGER_MS
+    d = tempfile.mkdtemp()
+    try:
+        keys = ['kk1~~h0_zz_pw', 'kk2~~h0_zz_pw']
+        paths = {}
+        for k in keys:
+            rp = os.path.join(d, k + '.raw.txt')
+            pp = os.path.join(d, k + '.portrait.json')
+            with open(rp, 'w', encoding='utf-8') as f:
+                f.write('=== LAYER: PW ===\n\n{#kk#} <lex>Adj.</lex> {%probe gloss%} <ls>Ref. 1,1</ls>.')
+            with open(pp, 'w', encoding='utf-8') as f:
+                f.write('[]')
+            paths[k] = (rp, pp)
+        gh.input_paths = lambda k, input_dir=None: paths[k]
+        gh.KILL = False
+        gh.MAX_WIDE, gh.STAGGER_MS = 3, 1500
+        js, _ = gh.build('zz_lowwide', keys, None, 12000,
+                         nominal=True, grammar_on=False, tm_path=None)
+        if 'const MAX_WIDE = 3' not in js or 'const STAGGER_MS = 1500' not in js:
+            fail('--max-wide/--stagger-ms did not emit the MAX_WIDE/STAGGER_MS constants')
+        if 'async function boundedParallel' not in js:
+            fail('boundedParallel helper not emitted')
+        if 'boundedParallel(UNITS.map(u => u.run), MAX_WIDE, STAGGER_MS)' not in js:
+            fail('top-level dispatch is not routed through boundedParallel')
+        gh.MAX_WIDE, gh.STAGGER_MS = 0, 0
+        js0, _ = gh.build('zz_default', keys, None, 12000,
+                          nominal=True, grammar_on=False, tm_path=None)
+        if 'const MAX_WIDE = 0' not in js0:
+            fail('default harness must emit MAX_WIDE=0 (unbounded, no regression)')
+        harness = os.path.join(d, 'lowwide_harness.js')
+        with open(harness, 'w', encoding='utf-8', newline='\n') as f:
+            f.write(js)
+        test_js = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               'boundedparallel_test.js')
+        p = subprocess.run(['node', test_js, harness],
+                           capture_output=True, text=True, encoding='utf-8', timeout=30)
+        if p.returncode:
+            fail('boundedParallel behavioral test failed:\n%s\n%s' % (p.stdout, p.stderr))
+    finally:
+        gh.input_paths, gh.KILL = saved_ip, saved_kill
+        gh.MAX_WIDE, gh.STAGGER_MS = saved_wide, saved_stag
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def test_budget_kill_switch_wired():
     """The generated Workflow must enforce independent translate/heal call ceilings."""
     import re as _re
@@ -4165,6 +4216,7 @@ def main():
         test_kill_gate_recalibrated_envelope,
         test_agent_budget_plan_separates_translate_and_heal_pools,
         test_split_agent_pools_all_heal_runtime,
+        test_lowwide_staggered_dispatch,
         test_budget_kill_switch_wired,
         test_harness_size_guard,
         test_perf_preflight_cost_gate,


### PR DESCRIPTION
Builds the fix identified in the [H255 w07 window](https://github.com/gasyoun/SanskritLexicography/pull/399): under the Workflow runtime's ~10-wide concurrency cap, a degraded generation API inflates a tiny card that completes in **~54 s alone** past the **180 s kill CEIL** (w07: 32/36 kill-timeouts on 128–500 B skeletons).

## What
- [`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py) gains **`--max-wide=N`** + **`--stagger-ms=M`**: the emitted top-level dispatch runs through a `boundedParallel(thunks, width, staggerMs)` worker-pool (≤N units in flight, first N starts staggered) instead of the runtime `parallel()`. **Default 0 = unbounded — no regression** for healthy full windows.
- **Requeue recipe** (degraded API): `gen_opt_harness2.py <root>_rq1 --nominal --keys=<null-keys> --output-budget=1 --no-tm --max-wide=3 --stagger-ms=2000` — each card keeps its isolated ~54 s latency instead of the contention-inflated >180 s.

## Verify
- New [`boundedparallel_test.js`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/boundedparallel_test.js) runs the **REAL emitted** `boundedParallel` and asserts: concurrency capped at width, staggered starts, index-aligned results, thrown-thunk→null, width≤0/≥len→parallel() fallback. Wired into `window_selftest.test_lowwide_staggered_dispatch` (generates a `--max-wide=3` harness, asserts the constants + dispatch, runs the node test).
- Full `window_selftest.py` green; `lang_parity_check.py` 44 entries no drift (new `lowwide_staggered_dispatch_h811` SHARED entry — the width control is language-independent, emitted identically for RU/EN).

Handoff: [H811](https://github.com/gasyoun/Uprava/blob/main/handoffs/H811-Opus_SanskritLexicography_pwg_ru_lowwide_staggered_requeue_dispatch_12.07.26.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)