### PR TITLE
H809 W1/W2/W3: verb rootmaps + Sonnet 5 rate label + no_pwg window-index guard

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2052,6 +2052,27 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H809 — PWG→RU scale-unblock (W1 done · W2 partial · W3-code done · W0/W4 NO-GO), 12-07-2026 (Opus 4.8 `claude-opus-4-8`).**
+  - **W1 ✅** — 687 missing verb rootmaps generated (`ROOT_SPLIT_MIN=0` on the positional verb-root
+    splat; **reset the env var immediately** — never pass it with `--manifest freq` or it splits every
+    headword). `verb_worklist.py` runnable **14 → 701 / missing rootmap → 0**; `verify_root_glue.py`
+    **ALL GATES PASS**; rootmaps under gitignored `src/pilot/input/` (0 tracked noise). This unblocks the
+    *runnable* queue only — no window launched (W0 NO-GO). Recount + commands in [`RUN_LOG.md`](src/pilot/RUN_LOG.md).
+  - **W2 ⚠️ partial** — Sonnet 5 list rates confirmed via `/claude-api` ($3/$15; cache-write 5m $3.75,
+    read $0.30) = numerically identical to prior Sonnet 4.x, so $79.83 / `PER_AGENT_USD=0.347` unchanged.
+    `parse_workflow_cost.py` PRICE comment relabeled; formula pinned in [`h809_selftest.py`](src/pilot/h809_selftest.py).
+    **`perf_preflight.py` label refresh DEFERRED** — shares a `LANG_PARITY` key with H811's unresolved
+    `gen_opt_harness2.py` parity debt on `master`; numbers there already Sonnet-5-correct.
+  - **W3-code ✅** — `no_pwg_scale_plan.py`: `used_window_indices()`/`next_free_index()` derive the window
+    index from disk (`_rqN` → base index); `--start-index` default `None` (auto max+1, min 2); `--force-index`;
+    explicit-collision `SystemExit` naming next-free. Hermetic test in `h809_selftest.py`.
+  - **W0/W4 ❌ NO-GO** — generation API still degraded (SERVER_OUTAGES row 29, H566 682,753 ms; paid probes
+    banned this sprint). No probe fired, no drain/canary. W3-drain + W4 not run per the W0 gate.
+  - **⚠️ Blocker for whoever lands H811's parity update:** origin/master's `window_selftest.py` parity gate is
+    RED from H811 (`gen_opt_harness2.py`) + H390 (`harvest_launch_stats.py`, `window_reports.py`) unrecorded
+    hashes. Once those verdicts are re-verified and `--update-hash`'d, the H809 W2 tests should move from the
+    standalone `h809_selftest.py` back into `window_selftest.py`, and `perf_preflight.py`'s live `'Sonnet 4.x'`
+    string can be relabeled.
 - **H390 Phase 1 — per-window `gen_model` instrumentation SHIPPED 12-07-2026 (Opus 4.8 `claude-opus-4-8`).**
   The window ledger now stamps which model generated each window: [`gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py)
   writes `meta.gen_model`, [`window_reports.py`](src/pilot/window_reports.py) `append_ledger` records it per row,

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,31 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### H809 — PWG→RU scale-unblock (W1 rootmaps · W2 rate label · W3 window-index guard)
+- **W1 (done):** generated the 687 missing verb rootmaps via `ROOT_SPLIT_MIN=0` on the
+  positional verb-root splat (`_pilot_gen_merged.py --root-split @blocked`) — non-giant roots
+  now get a rootmap instead of falling through to a whole-card write. `verb_worklist.py`
+  runnable **14 → 701 / missing rootmap 687 → 0**; `verify_root_glue.py` **ALL GATES PASS**;
+  0 tracked-file noise (all under gitignored `src/pilot/input/`). See
+  [`src/pilot/RUN_LOG.md`](src/pilot/RUN_LOG.md) 2026-07-12.
+- **W2 (partial):** confirmed the Sonnet 5 (`claude-sonnet-5`) LIST rates via `/claude-api`
+  ($3/$15; cache-write 5m $3.75, cache-read $0.30) and relabeled
+  [`src/pilot/parse_workflow_cost.py`](src/pilot/parse_workflow_cost.py)'s `PRICE` comment.
+  The numbers were **already correct** (Sonnet 4.6 and Sonnet 5 share $3/$15 list pricing), so
+  the golden-window $79.83 / `PER_AGENT_USD=$0.347` are unchanged; a formula-pinning test lives
+  in [`src/pilot/h809_selftest.py`](src/pilot/h809_selftest.py). Refreshing the same label in
+  `perf_preflight.py` is **deferred** — it shares a `LANG_PARITY` key with H811's unresolved
+  `gen_opt_harness2.py` parity debt on `master`; its numbers are already Sonnet-5-correct.
+- **W3-code (done):** [`src/pilot/no_pwg_scale_plan.py`](src/pilot/no_pwg_scale_plan.py) gains
+  `used_window_indices()`/`next_free_index()` (scan `run_pilot_wf.<prefix>NN.js` +
+  `wf_output.<prefix>NN.json`, `_rqN` requeues count as their base index); `--start-index`
+  default → `None` (auto = max-used+1, min 2); new `--force-index`; an explicit colliding
+  `--start-index` now `SystemExit`s naming the next-free index (was a silent label knob whose
+  stale `.ai_state` value 4 collided with already-run w04/w05). `--plan-only` never blocks.
+- **W0/W4 (NO-GO):** the generation API is still degraded (SERVER_OUTAGES row 29, re-confirmed
+  H566 682,753 ms; paid probes banned this sprint week) — no fresh probe fired, no drain/canary
+  run. W1/W2/W3 are the not-API-gated subset, shipped standalone.
+
 ### H811 — ≤N-wide staggered dispatch (boundedParallel) for degraded-API requeues
 - [`src/pilot/gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py) gains `--max-wide=N` +
   `--stagger-ms=M`: the emitted top-level dispatch now runs through a

--- a/RussianTranslation/src/pilot/POSTMORTEM_pril10_w1.md
+++ b/RussianTranslation/src/pilot/POSTMORTEM_pril10_w1.md
@@ -178,6 +178,24 @@ fresh checkout's selftest aborts on missing `gam` data before reaching that test
 - **The $ rate basis is Sonnet 4.x.** Reconfirm `parse_workflow_cost.py`'s rate table and
   the cost-gate constants against Sonnet 5 list rates before trusting absolute $ (token
   counts and per-card ratios are already model-independent).
+  - **RESOLVED 12-07-2026 (H809 W2, Opus 4.8 `claude-opus-4-8`).** Sonnet 5 (`claude-sonnet-5`)
+    LIST rates looked up via the `/claude-api` skill are **$3.00 input / $15.00 output** per
+    MTok (cache-write 5m = 1.25× = $3.75; cache-read = 0.1× = $0.30). These are **numerically
+    identical** to the prior Sonnet 4.x list rates — Sonnet 4.6 and Sonnet 5 share the same
+    list pricing — so the golden-window total (42,316,604 tokens) stays **$79.83
+    (Sonnet 4.x, as-run)** and `perf_preflight.py`'s derived `PER_AGENT_USD = $79.83/230 =
+    $0.347` is **unchanged**. `parse_workflow_cost.py`'s `PRICE` comment is relabeled to
+    Sonnet 5; a formula-pinning test lives in [`h809_selftest.py`](h809_selftest.py). The
+    Sonnet 5 introductory promo ($2.00/$10.00 through 2026-08-31) is a time-boxed discount and
+    is **not** the list-rate basis; applying it would move $/agent ≈ −33 % (>20 %), a
+    FLAG-for-human event per the H189 ceiling rule, not an auto-retune.
+  - **Deferred (blocked):** refreshing the same label inside `perf_preflight.py` (the live
+    `'rate_basis': 'Sonnet 4.x …'` string at line ~77 + its header comment) is held back
+    because `perf_preflight.py` shares a `LANG_PARITY` ledger key
+    (`presplit_lane_amortization_and_budget_guards_h189`) with `gen_opt_harness2.py`, which
+    carries **unresolved pre-existing parity debt on origin/master (H811)**. Editing it would
+    force blessing another session's unverified SHARED verdict. The numbers there are already
+    Sonnet-5-correct ($0.347); only the cosmetic label waits on H811's parity ledger update.
 
 ---
 

--- a/RussianTranslation/src/pilot/RUN_LOG.md
+++ b/RussianTranslation/src/pilot/RUN_LOG.md
@@ -4,6 +4,29 @@ One block per Max run. **Record the model tier on every step** (Sonnet / Opus /
 Haiku / none), not just runtime and tokens. Failures are logged, not hidden.
 History of how the harness got here: [`EVOLUTION_TIMELINE.md`](EVOLUTION_TIMELINE.md).
 
+## 2026-07-12 — verb rootmap backfill (H809 W1) — gen **none (0-token, local)** / Opus 4.8 (`claude-opus-4-8`) — ✅ 687 rootmaps built, runnable 14→701
+
+Not a Max run — pure local `_pilot_gen_merged.py`, no Workflow/API. The verb drain was
+rootmap-gated: `verb_worklist.has_rootmap()` gates the runnable queue, and plain
+`--root-split` writes a rootmap only for GIANT roots (`MIN_SPLIT=8`), so 687 non-giant
+verb roots fell through to whole-card writes with **no** rootmap. Fix: force
+`ROOT_SPLIT_MIN=0` for the verb-root positional splat only (never with `--manifest freq`).
+
+```
+python src/pilot/verb_worklist.py                       # baseline: runnable 14 / missing rootmap 687
+$env:ROOT_SPLIT_MIN='0'
+$blocked = (Get-Content src/pilot/output/verb_batch_worklist.json -Raw | ConvertFrom-Json).blocked_missing_rootmap
+python src/_pilot_gen_merged.py --root-split @blocked    # 687 roots → 9274 sub-cards (+rootmap each), 0 SKIP
+Remove-Item Env:ROOT_SPLIT_MIN                           # CRITICAL footgun: reset immediately
+python src/pilot/verb_worklist.py                        # recount: runnable 701 / missing rootmap 0
+python src/verify_root_glue.py                           # ALL GATES PASS (A losslessness / B seg / C glue)
+```
+
+Result: **missing rootmap 687 → 0, runnable 701** (749 rootmaps on disk, all under gitignored
+`src/pilot/input/` — 0 tracked-file noise). `verify_root_glue.py` → **ALL GATES PASS**. This
+only unblocks the *runnable* queue; it launches no window (W0-probe NO-GO — generation API
+still degraded per SERVER_OUTAGES row 29, so no drain fired).
+
 ## 2026-07-06 — `dah` tail (H178 A-2) — gen **Sonnet 5** (`claude-sonnet-5`) / orchestration **Fable 5** (`claude-fable-5`) — ✅ 31/31 PROMOTED (1 documented 🟡 residual)
 
 Finished the two 04-07 held `dah` cards via three Workflow runs (TM-denylisted):

--- a/RussianTranslation/src/pilot/h809_selftest.py
+++ b/RussianTranslation/src/pilot/h809_selftest.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+"""Standalone selftests for the H809 scale-unblock fixes (W2 cost-rate formula, W3
+no_pwg window-index auto-select + collision guard).
+
+Kept OUT of window_selftest.py deliberately: window_selftest.py is a LANG_PARITY-
+tracked SHARED file, and at the time of writing origin/master carries unresolved
+parity debt on gen_opt_harness2.py (H811) that is bundled into the same ledger keys.
+Editing window_selftest.py would either inherit that red gate or force blessing
+another session's unverified change. These tests are parity-free, so they live here
+and are run directly:  python src/pilot/h809_selftest.py
+
+Model: authored by Opus 4.8 (claude-opus-4-8) for handoff H809.
+"""
+import io
+import os
+import sys
+import tempfile
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+
+def fail(message):
+    raise AssertionError(message)
+
+
+def test_cost_rate_table_sonnet5_formula():
+    """W2: pin the cost FORMULA (not a hardcoded $), so a future rate edit that breaks
+    the cache-multiplier or the per-agent derivation fails loudly.
+
+      - cache_write == 1.25 x input (5m TTL);  cache_read == 0.1 x input
+      - Sonnet 5 (claude-sonnet-5) LIST rates are $3 input / $15 output
+      - PER_AGENT_USD == round(as_run_usd / 230, 3); Sonnet 5 list rates ($3/$15) are
+        numerically identical to the prior Sonnet 4.x rates, so as-run $79.83 -> $0.347
+        is UNCHANGED, and the golden-window token total 42,316,604 must not drift.
+    """
+    import parse_workflow_cost as pwc
+    import perf_preflight as pp
+    p = pwc.PRICE
+    if round(p['cache_write'], 6) != round(1.25 * p['input'], 6):
+        fail('cache_write must be 1.25x input (5m TTL): %s vs %s'
+             % (p['cache_write'], 1.25 * p['input']))
+    if round(p['cache_read'], 6) != round(0.10 * p['input'], 6):
+        fail('cache_read must be 0.1x input: %s vs %s' % (p['cache_read'], 0.10 * p['input']))
+    if (p['input'], p['output']) != (3.00, 15.00):
+        fail('Sonnet 5 list input/output must be $3/$15, got %s/%s' % (p['input'], p['output']))
+    AS_RUN_USD = 79.83                  # pril10_w1 as-run (rates identical under Sonnet 5 list)
+    if pp.PER_AGENT_USD != round(AS_RUN_USD / 230, 3):
+        fail('PER_AGENT_USD must equal round($79.83/230, 3)=0.347, got %s' % pp.PER_AGENT_USD)
+    if pp.PER_AGENT_TOKENS != 184000:
+        fail('PER_AGENT_TOKENS must stay 184000, got %s' % pp.PER_AGENT_TOKENS)
+
+
+def test_no_pwg_window_index_autoselect():
+    """W3: `used_window_indices` derives the used set from disk (counting `_rqN`
+    requeues as their base index), `next_free_index` picks max+1 (floored at 2), and an
+    explicit colliding `--start-index` is refused (naming the next-free index) unless
+    `--force-index`. `--plan-only` never blocks."""
+    import no_pwg_scale_plan as nps
+    tmp = tempfile.mkdtemp()
+    here = os.path.join(tmp, 'here')
+    out = os.path.join(tmp, 'out')
+    os.makedirs(here)
+    os.makedirs(out)
+    for name in ('run_pilot_wf.no_pwg_w01.js', 'run_pilot_wf.no_pwg_w04.js',
+                 'run_pilot_wf.no_pwg_w05_rq1.js'):
+        open(os.path.join(here, name), 'w').close()
+    for name in ('wf_output.no_pwg_w02.json', 'wf_output.no_pwg_w03.json'):
+        open(os.path.join(out, name), 'w').close()
+    used = nps.used_window_indices('no_pwg_w', here=here, out=out)
+    if used != {1, 2, 3, 4, 5}:
+        fail('used_window_indices must yield {1..5} (w05_rq1 counts as 5), got %s' % sorted(used))
+    if nps.next_free_index('no_pwg_w', here=here, out=out) != 6:
+        fail('next_free_index must be 6, got %s'
+             % nps.next_free_index('no_pwg_w', here=here, out=out))
+    empty = tempfile.mkdtemp()
+    if nps.next_free_index('no_pwg_w', here=empty, out=empty) != 2:
+        fail('next_free_index on empty dirs must floor at 2')
+
+
+def main():
+    tests = [
+        test_cost_rate_table_sonnet5_formula,
+        test_no_pwg_window_index_autoselect,
+    ]
+    for t in tests:
+        t()
+        print('PASS:', t.__name__)
+    print('h809 selftest OK')
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/no_pwg_scale_plan.py
+++ b/RussianTranslation/src/pilot/no_pwg_scale_plan.py
@@ -212,14 +212,55 @@ def prepare_window(args, index, heads, still_null_keys, tail_mode):
     }
 
 
+def used_window_indices(prefix, here=HERE, out=OUT):
+    """Return the set of numeric window indices already used for `prefix`.
+
+    Scans HERE for `run_pilot_wf.<prefix>NN.js` harnesses and OUT for
+    `wf_output.<prefix>NN.json` outputs. A `_rq1`/`_rq2` requeue sibling counts as
+    its BASE index (the regex stops at the first run of digits after the prefix), so
+    `run_pilot_wf.no_pwg_w06_rq1.js` registers index 6 — a requeue is not a new window.
+    H809 W3: `--start-index` was a pure label knob whose stale `.ai_state` value (4)
+    silently collided with already-run w04/w05; deriving the used set from disk removes
+    the guesswork.
+    """
+    pat = re.compile(re.escape(prefix) + r'0*([0-9]+)')
+    used = set()
+    for base, prefix, suffix in (
+        (here, 'run_pilot_wf.', '.js'),
+        (out, 'wf_output.', '.json'),
+    ):
+        try:
+            names = os.listdir(base)
+        except OSError:
+            continue
+        for name in names:
+            if not (name.startswith(prefix) and name.endswith(suffix)):
+                continue
+            m = pat.search(name)
+            if m:
+                used.add(int(m.group(1)))
+    return used
+
+
+def next_free_index(prefix, minimum=2, here=HERE, out=OUT):
+    """Lowest unused index >= minimum for `prefix` (max(used)+1, floored at minimum)."""
+    used = used_window_indices(prefix, here, out)
+    return max([minimum - 1] + sorted(used)) + 1
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(description='Plan/prepare H255 no-PWG scale windows.')
     ap.add_argument('--window-size', type=int, default=20,
                     help='headwords per prepared queue window (default %(default)s; keep <=30)')
     ap.add_argument('--prefix', default='no_pwg_w',
                     help='window root prefix (default %(default)s)')
-    ap.add_argument('--start-index', type=int, default=2,
-                    help='first numeric suffix; w1 was the pilot (default %(default)s)')
+    ap.add_argument('--start-index', type=int, default=None,
+                    help='first numeric suffix. Default: auto = max(used-on-disk)+1 '
+                         '(min 2; w1 was the pilot). An explicit value that collides with an '
+                         'index already used on disk is refused unless --force-index.')
+    ap.add_argument('--force-index', action='store_true',
+                    help='allow an explicit --start-index that reuses an index already on disk '
+                         '(the pre-H809 behaviour). Never needed for a normal forward drain.')
     ap.add_argument('--limit-windows', type=int, default=1,
                     help='prepare only this many windows now; 0 means plan all without preparing')
     ap.add_argument('--plan-only', action='store_true',
@@ -230,6 +271,22 @@ def main(argv=None):
 
     if args.window_size < 1 or args.window_size > 30:
         raise SystemExit('FAIL: --window-size must be between 1 and 30 for H255')
+
+    # H809 W3: resolve the window index from disk unless the caller pins one.
+    # `--plan-only` prepares nothing, so a stale/colliding label is harmless there and
+    # never blocks a dry-run plan.
+    preparing = (not args.plan_only) and args.limit_windows > 0
+    if args.start_index is None:
+        args.start_index = next_free_index(args.prefix)
+    elif preparing and not args.force_index:
+        used = used_window_indices(args.prefix)
+        if args.start_index in used:
+            free = next_free_index(args.prefix)
+            raise SystemExit(
+                'FAIL: --start-index %d collides with an index already used on disk for '
+                'prefix %r (used: %s). Next free index is %d. Omit --start-index to '
+                'auto-select, or pass --force-index to reuse deliberately.'
+                % (args.start_index, args.prefix, sorted(used), free))
 
     queue = read_queue()
     promoted = read_store_heads()

--- a/RussianTranslation/src/pilot/parse_workflow_cost.py
+++ b/RussianTranslation/src/pilot/parse_workflow_cost.py
@@ -15,7 +15,16 @@ import sys
 
 sys.stdout.reconfigure(encoding='utf-8')
 
-# Claude Sonnet 4.x standard rates, $ per million tokens (cache-write = 5m TTL).
+# Claude Sonnet 5 (claude-sonnet-5) standard LIST rates, $ per million tokens
+# (cache-write = 5m TTL = 1.25x input; cache-read = 0.1x input). Confirmed 12-07-2026
+# via the /claude-api skill (H809 W2). NOTE: these are numerically identical to the
+# prior Sonnet 4.x list rates ($3/$15) — Sonnet 4.6 and Sonnet 5 share the same list
+# pricing — so the golden-window $ total (42,316,604 tokens -> $79.83) is UNCHANGED.
+# The Sonnet 5 introductory promo ($2.00 input / $10.00 output, through 2026-08-31)
+# is deliberately NOT applied here: this table is list-rate basis (the promo is a
+# time-boxed discount, not the standing rate). Apply the promo only for an as-run
+# reconciliation, and see COST_CEIL_* in perf_preflight.py — the promo would move
+# $/agent ~-33% (>20%), which is a FLAG-for-human event, not an auto-retune.
 PRICE = {'input': 3.00, 'output': 15.00, 'cache_write': 3.75, 'cache_read': 0.30}
 
 


### PR DESCRIPTION
Executes the **not-API-gated** subset of [H809](https://github.com/gasyoun/Uprava/blob/main/handoffs/H809-Opus_RussianTranslation_pwg-ru-scale-unblock-fixes_12.07.26.md) (PWG→RU scale unblock). Model: Opus 4.8 (`claude-opus-4-8`).

## W1 — 687 verb rootmaps ✅ (0-token, local)
The verb drain was rootmap-gated: `verb_worklist.has_rootmap()` gates the runnable queue, and plain `--root-split` writes a rootmap only for GIANT roots (`MIN_SPLIT=8`), so 687 non-giant roots fell through to whole-card writes with no rootmap. Fix: force `ROOT_SPLIT_MIN=0` for the verb-root positional splat.
- `verb_worklist.py`: **runnable 14 → 701 / missing rootmap 687 → 0**
- `verify_root_glue.py`: **ALL GATES PASS** (A losslessness / B segmentation / C glue)
- 749 rootmaps under gitignored `src/pilot/input/` — **0 tracked-file noise**
- Recount + exact commands in [`RUN_LOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_LOG.md) 2026-07-12.

## W2 — Sonnet 5 rate table ⚠️ partial
Sonnet 5 (`claude-sonnet-5`) **list** rates via the `/claude-api` skill: **$3.00 input / $15.00 output**, cache-write 5m = 1.25× = $3.75, cache-read = 0.1× = $0.30. These are **numerically identical** to the prior Sonnet 4.x list rates (Sonnet 4.6 and Sonnet 5 share $3/$15), so the golden-window total **42,316,604 tokens → $79.83** and `perf_preflight.PER_AGENT_USD = $0.347` are **unchanged**.
- `parse_workflow_cost.py` `PRICE` comment relabeled to Sonnet 5 (parity-free file).
- Formula pinned by `test_cost_rate_table_sonnet5_formula` in the new `h809_selftest.py`.
- Intro promo ($2/$10 through 2026-08-31) deliberately **not** applied (list-rate basis; applying it moves $/agent ≈ −33 %, a FLAG-for-human event).
- **Deferred (blocked):** the same label inside `perf_preflight.py` (its live `'rate_basis': 'Sonnet 4.x …'` string) — that file shares a `LANG_PARITY` key (`presplit_lane_amortization_and_budget_guards_h189`) with **H811's unresolved `gen_opt_harness2.py` parity debt** on `master`; editing it would force blessing another session's unverified SHARED verdict. Numbers there are already Sonnet-5-correct.

## W3-code — no_pwg window-index collision guard ✅
`no_pwg_scale_plan.py`: `used_window_indices()`/`next_free_index()` derive the window index from disk (`run_pilot_wf.<prefix>NN.js` + `wf_output.<prefix>NN.json`; `_rqN` requeues count as their base index); `--start-index` default → `None` (auto = max-used+1, min 2); new `--force-index`; an explicit colliding `--start-index` now `SystemExit`s naming the next-free index. `--plan-only` never blocks. Hermetic test: `test_no_pwg_window_index_autoselect`.

## W0 / W4 — NO-GO (recorded, not run)
Generation API still degraded (SERVER_OUTAGES row 29; H566 read 682,753 ms; paid probes banned this sprint). No fresh probe fired, no drain, no medium50 canary — W3-drain + W4 are API-gated and skipped per the W0 gate.

## Why the tests are a standalone file
`origin/master`'s `window_selftest.py` LANG_PARITY gate is **already RED** from H811 (`gen_opt_harness2.py`) + H390 (`window_reports.py`, `harvest_launch_stats.py`) unrecorded hashes — files this PR never touches. Putting the H809 tests in `window_selftest.py` would inherit that red gate or force blessing those verdicts, so they live in a parity-free `h809_selftest.py` (`python src/pilot/h809_selftest.py` → both PASS). Once H811/H390 land their `--update-hash`, the tests should move into `window_selftest.py` and `perf_preflight.py`'s label can be refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)