### PR TITLE
H823: presplit cite-floor + single-card CEIL — fix the no-PWG presplit-cohort routing misfire

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -12,6 +12,21 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **H823 presplit cite-floor + single-card CEIL harness fix — ✅ SHIPPED, but live verify 0/6 (12-07-2026, Opus 4.8 `claude-opus-4-8`).**
+  Root-caused the H255 presplit-cohort loss: the CITATION presplit trigger `(1+<ls>) > OUTPUT_BUDGET`
+  degenerates under `--output-budget=1` (any citation card force-fragmented; heal groups die on the
+  slow host's ~60 s budgets). Fix: floor the cite trigger at `max(OUTPUT_BUDGET, PRESPLIT_SOLO_CITE_FLOOR=40)`
+  (`--presplit-solo-cite-floor`, no-op for the default 90) so tiny cards translate whole; + give ANY
+  single-card batch the CEIL (180 s), not just no-fallback singles (H220 generalization). Unit-tested
+  (`test_presplit_cite_floor_and_single_ceil`); suite + lang_parity green (new `presplit_cite_floor_h823`
+  SHARED). **Verified applied** (`no_pwg_presplitfix`: presplit_keys emptied; kills moved 60 s→180 s CEIL)
+  **but 0/6 recovered** on the *further-degraded* host — 4 exceed even 180 s (a 298 B card >180 s vs 54 s
+  ~3 h earlier; whole-card is a bigger prompt than a fragment), 2 are genuine content failures
+  (`avy_ahata` wrong key1, `avyagra` dropped 2/3 `{#…#}` spans). Cohort re-classed: 4 API-hard (land on a
+  healthy host), 2 content-hard (need a prompt/content fix). Shipped per MG. Full account:
+  [RUN_LOG.md 2026-07-12 H823 block](src/pilot/RUN_LOG.md). Handoff:
+  [H823](https://github.com/gasyoun/Uprava/blob/main/handoffs/H823-Opus_SanskritLexicography_pwg_ru_presplit_cite_floor_fix_12.07.26.md).
+
 - **H255 no-PWG — `no_pwg_w07_rq2` ≤2-wide pass on rq1's 8 residual kills; ✅ 5/8 recovered (12-07-2026, Opus 4.8 `claude-opus-4-8` orch / Sonnet 5 `claude-sonnet-5` gen).**
   Width sweep, final step: rq1's 8 non-presplit residual kills (all null at ≤3-wide) re-run at
   `--max-wide=2 --stagger-ms=3000` → **5/8 recovered** (still concurrency-sensitive down to 2-wide).

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,25 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### H823 — presplit cite-trigger floor + single-card CEIL kill budget (no-PWG lane fix)
+- [`gen_opt_harness2.py`](src/pilot/gen_opt_harness2.py): the CITATION presplit trigger now fires
+  only when `(1+<ls>) > max(OUTPUT_BUDGET, PRESPLIT_SOLO_CITE_FLOOR=40)` (new
+  `--presplit-solo-cite-floor=N`). Fixes a misfire under `--output-budget=1` (the no-PWG
+  single-card lane): there the batch budget is 1, so ANY citation-bearing card "exceeded" it and
+  was force-routed to the fragment heal lane, where its byte-scaled kill budgets (~60 s) died on a
+  slow host (the H255 presplit-cohort `selfheal-nothing-resolved` loss). Tiny cards translate whole
+  fine (`sam` is fine at 34 `<ls>`); only genuine 150-`<ls>` fail-solo giants presplit now. For
+  `OUTPUT_BUDGET ≥ 40` (default 90) it's a no-op.
+- `killBudgetForCur` now gives **ANY single-card batch** the CEIL kill budget (180 s), not just
+  no-fallback singles — a lone card has no batch-mates to starve and the heal lane is no better
+  budgeted on a slow host (clean H220 generalization).
+- Unit-tested (`window_selftest.test_presplit_cite_floor_and_single_ceil`); full suite +
+  `lang_parity_check.py` green (new `presplit_cite_floor_h823` SHARED entry). **Live verify
+  (`no_pwg_presplitfix`, 6 cards) recovered 0/6:** fix verified applied (presplit_keys emptied,
+  kills moved 60 s→180 s CEIL) but the cohort didn't recover on the *further-degraded* host today
+  (4 exceed even 180 s; 2 are genuine content-fidelity failures, tracked separately). Correct-by-
+  design; lands the cohort once the host returns to ~54 s.
+
 ### H818 — four-account Max headless orchestration
 - add a canonical generation manifest, `claude -p --json-schema` worker, coordinator-imported SQLite scheduler for four isolated Max profiles, immutable attempt logs/hashes, rate-limit parking, crash recovery, systemd deployment, and an audit/runbook. Live proof remains gated on four owner-authenticated foreign-host profiles.
 

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14"
     }
   },
   {
@@ -117,8 +117,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -136,8 +136,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -155,8 +155,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -173,7 +173,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14"
     }
   },
   {
@@ -224,7 +224,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14"
     }
   },
   {
@@ -241,7 +241,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14"
     }
   },
   {
@@ -258,7 +258,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 closes the former divergence: exact model provenance is required across four accounts, so both RU and EN now request and stamp claude-sonnet-5. This prevents account/profile alias resolution from making cross-window provenance incomparable.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14"
     }
   },
   {
@@ -355,8 +355,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -375,7 +375,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -412,8 +412,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
       "src/promote_final_cards.py": "f098ed7dc3009ec44aaf415b57d639a191ec0012ba53df776b34bf27efefd563"
     }
   },
@@ -470,9 +470,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
       "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -503,7 +503,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "1790c31d101d4247bcf3a6bcb29eb979be32bcf15649527f8ce3de8cfb9db597",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -522,7 +522,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -540,7 +540,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "95797986db7c21210a55c8a13f324514d17110ba07d2f804d000a77a003d5bf3",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -559,7 +559,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -599,7 +599,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "f098ed7dc3009ec44aaf415b57d639a191ec0012ba53df776b34bf27efefd563",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -624,7 +624,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "e1870c131b1a7138d75a14118ce4178b8075c968426a447ba62251ad28ca7708",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -653,7 +653,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "65b0cb16a8a1bd6ae5fde9c8e0b131a2ba9af8140ec954aa7c937f915ad8856c",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -673,7 +673,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -692,7 +692,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "3c51b49d2e45b23162d9331346b924f644addc9f32aaaef8f4e055fb819784fe",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -729,7 +729,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -787,7 +787,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -805,8 +805,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -824,8 +824,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -844,8 +844,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba",
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -866,8 +866,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -924,9 +924,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },
   {
@@ -948,7 +948,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 uses one language-parameterized manifest and worker contract. Production policy imports RU only for the initial scale proof, but the execution mechanism itself branches only on manifest.lang/field and preserves the EN schema rename. Presplit refusal is language-independent.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
       "src/pilot/headless_worker.py": "3f972e73ccb1ad25e447e958ce3677dc5a07e0e3108ddd827d34d1e5a875a8f3",
       "src/pilot/max_account_orchestrator.py": "ca4af4dacb161227bd40b1d67f8f9491e9ce8aff963e858d77c404f7a7737c1b",
       "src/pilot/coordinator.py": "3c51b49d2e45b23162d9331346b924f644addc9f32aaaef8f4e055fb819784fe",
@@ -973,10 +973,29 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H390 Phase 1 (12-07-2026, Opus 4.8 claude-opus-4-8), extended by H818. gen_model is written into language-agnostic run meta and flows through the shared ledger writer and harvester identically for RU/EN; both paths now stamp exact claude-sonnet-5. Pinned by test_ledger_stamps_gen_model in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "63312ce926ca8ba94316161a51b01d8f73a46454e1be88c7062edf89a273d39b",
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
       "src/pilot/window_reports.py": "e1870c131b1a7138d75a14118ce4178b8075c968426a447ba62251ad28ca7708",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "7440bd49aa0ace7ef335dc5ef1301e5c61b90c79bc507f283b70386df4568cba"
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
+    }
+  },
+  {
+    "id": "presplit_cite_floor_h823",
+    "mechanism": "gen_opt_harness2 floors the CITATION presplit trigger at PRESPLIT_SOLO_CITE_FLOOR (--presplit-solo-cite-floor, default 40) so --output-budget=1 (the no-PWG single-card lane) no longer force-routes every citation-bearing card into the fragment heal lane; and killBudgetForCur gives ANY single-card batch the CEIL kill budget (not just no-fallback singles), since a lone card has no batch-mates to starve and the heal lane is no better budgeted on a slow API.",
+    "files": [
+      "src/pilot/gen_opt_harness2.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "New mechanism 12-07-2026 (H823, fixes the H255 presplit-cohort loss). Both the citation presplit trigger (_presplit_hit) and the single-card kill budget (killBudgetForCur) are language-independent — they key on <ls>/fragment counts and FRAGS, never on --lang; the same floor + CEIL apply to RU and EN identically. Extends no_fallback_single_kill_budget_and_nominal_key_echo (H220) from no-fallback singles to all singles. Pinned by test_presplit_cite_floor_and_single_ceil.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
+      "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/RUN_LOG.md
+++ b/RussianTranslation/src/pilot/RUN_LOG.md
@@ -4,7 +4,7 @@ One block per Max run. **Record the model tier on every step** (Sonnet / Opus /
 Haiku / none), not just runtime and tokens. Failures are logged, not hidden.
 History of how the harness got here: [`EVOLUTION_TIMELINE.md`](EVOLUTION_TIMELINE.md).
 
-## 2026-07-12 — verb rootmap backfill (H809 W1) — gen **none (0-token, local)** / Opus 4.8 (`claude-opus-4-8`) — ✅ 687 rootmaps built, runnable 14→701
+## 2026-07-12 — verb rootmap backfill (H809 W1) — gen **none (0-token, local — no workflow)** / Opus 4.8 (`claude-opus-4-8`) — ✅ 687 rootmaps built, runnable 14→701
 
 Not a Max run — pure local `_pilot_gen_merged.py`, no Workflow/API. The verb drain was
 rootmap-gated: `verb_worklist.has_rootmap()` gates the runnable queue, and plain
@@ -699,3 +699,18 @@ So the 8 residual kills were still **concurrency-sensitive down to 2-wide** — 
 - `ativiz_a~~h0_zz_pw` — **fidelity-reject** (`{#…#}` markup 0/3 restored): a **content** failure, not concurrency — the model dropped the Sanskrit delimiters; needs a targeted rework, not a retry.
 
 **Net H255 over w07's 36 cards: 27 promoted** (5 w07 + 17 rq1 + 5 rq2), **9 residual** (6 structural presplit-cohort + these 3). `probe_log` outcome recorded for `wf_e670c54b-24b`. **Width-sweep conclusion: ≤2-wide is the effective floor for concurrency-recoverable cards on this degraded API; what's left is structural (presplit), API-hard (180 s CEIL), or content (fidelity) — none of which more width-tuning fixes.**
+
+---
+
+## 2026-07-12 — H823 presplit cite-floor + single-card CEIL harness fix (the H255 presplit-cohort); live verify 0/6 (host still degraded) — orchestration **Opus 4.8** (`claude-opus-4-8`)
+
+**The bug (root-caused from the fragments + the w07/rq1 logs).** The CITATION presplit trigger is `(1 + <ls>) > OUTPUT_BUDGET`, which correctly catches the 150-`<ls>` pwg00 heads at the default budget 90 — but **degenerates under `--output-budget=1`** (the no-PWG single-card lane): there the budget is 1, so ANY card with ≥1 citation "exceeds" it and is force-routed to the fragment heal lane. The H255 presplit cohort (`apr_apta`/`as_a_dya`/`asa_mskfta`/`avy_ahata`/`avyagra`/`b_ahlika`~~pw, 307–1131 B, 1–11 `<ls>`) are tiny cards that translate whole fine (`sam` is fine at 34 `<ls>`), yet got fragmented, and their heal groups' byte-scaled kill budgets (~60 s) died on the slow API → `selfheal-nothing-resolved`.
+
+**The fix (both changes, verified applied).**
+- **Cite floor** ([`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py) `_presplit_hit`): the citation trigger fires only when `(1+<ls>) > max(OUTPUT_BUDGET, PRESPLIT_SOLO_CITE_FLOOR=40)` — a genuine fail-solo giant, not merely a 1-card batch. For `OUTPUT_BUDGET ≥ 40` (default 90) it's a no-op. New `--presplit-solo-cite-floor=N`. **Verified: the cohort's `presplit_keys` is now empty** (they route to whole-card).
+- **Single-card CEIL** (`killBudgetForCur`): ANY single-card batch gets the CEIL (180 s), not just no-fallback singles — a lone card has no batch-mates to starve, and the heal lane is no better budgeted on a slow API. Clean H220 generalization. **Verified: the cohort's kills moved from the heal lane's 60–123 s to the whole-card 180 s CEIL.**
+- Unit-tested by `window_selftest.test_presplit_cite_floor_and_single_ceil` (routes low-`<ls>` cards whole under `--output-budget=1`, floor=1 reproduces the misfire, single→CEIL); full suite + `lang_parity_check.py` green (new `presplit_cite_floor_h823` SHARED entry).
+
+**Live verification (`no_pwg_presplitfix`, 6 cards, ≤2-wide): 🔴 0/6 — the fix is applied but the cards did NOT recover, for reasons ORTHOGONAL to the routing bug.** `wf_bb00c8a2-c4e`: **4 hit the 180 s CEIL** (`apr_apta` 755 B, `as_a_dya` 699 B, `asa_mskfta` 298 B, `b_ahlika` 975 B) — the API degraded *further* today (a 298 B card taking >180 s vs the 54 s an isolated probe read ~3 h earlier) and a whole card is a bigger prompt than one fragment, so it's slower per call on a slow API; **2 are genuine content failures** (`avy_ahata` wrong key1 echoed, `avyagra` dropped 2/3 `{#…#}` Sanskrit spans) that no budget/routing fix touches. 0 conn-errors.
+
+**Verdict:** the presplit routing misfire is genuinely fixed (correct + unit-tested, applied in the field) and is right for a healthy API (no wasteful fragmentation of tiny cards) — but **it does not recover these 6 on the current severely-degraded API**. The cohort re-classifies: **4 API-hard** (need a healthier API — the whole-card CEIL will land them once the API returns to ~54 s) + **2 content-hard** (`avy_ahata`/`avyagra` need a prompt/content fix, tracked separately). Store unchanged (0 promoted). Shipped per MG (the fix is correct-by-design; non-recovery is external). H823.

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -127,6 +127,18 @@ SENSE_PRESPLIT_BUDGET = 20  # --sense-presplit-budget=N (0/off to disable). SECO
                    #  below it (sam 6, pari 8). Senses are far heavier per unit than citations
                    #  (sam translates fine at 34 <ls>), so this budget is intentionally much
                    #  lower than OUTPUT_BUDGET and independent of byte/citation batching mode.
+PRESPLIT_SOLO_CITE_FLOOR = 40  # --presplit-solo-cite-floor=N. The CITATION presplit trigger
+                   #  compares (1 + <ls>) to the per-batch OUTPUT_BUDGET, which correctly catches
+                   #  the 150-<ls> pwg00 heads when the budget is the default 90 — but DEGENERATES
+                   #  under --output-budget=1 (the no-PWG single-card lane): there the budget is 1,
+                   #  so ANY card with >=1 citation "exceeds" it and is force-routed to the fragment
+                   #  heal lane. Those tiny cards (H255 presplit cohort: 1-11 <ls>, 307-1131 B) then
+                   #  die on the heal groups' byte-scaled kill budgets (~60 s) instead of getting a
+                   #  whole-card attempt — a misfire, since the SAME cards translate whole fine (sam
+                   #  is fine at 34 <ls>). So the cite trigger fires only when (1+<ls>) exceeds
+                   #  max(OUTPUT_BUDGET, this floor): a card genuinely fails-solo (>=40 citation-units,
+                   #  well above the whole-card-safe 34 and below the 150 giants), not merely because
+                   #  the batch holds one card. For OUTPUT_BUDGET >= 40 (default 90) nothing changes.
 # --- wall-clock kill gate (H155 follow-up, 2026-07-04) ----------------------------
 # The structural presplit triggers above catch the KNOWN whole-card failure drivers
 # (citation + sense density) BEFORE a run. The kill gate is the runtime BACKSTOP for
@@ -392,6 +404,8 @@ def parse_args(argv):
         elif a.startswith('--sense-presplit-budget='):
             v = a.split('=', 1)[1].strip().lower()
             globals()['SENSE_PRESPLIT_BUDGET'] = None if v in ('off', '0', 'none') else int(v)
+        elif a.startswith('--presplit-solo-cite-floor='):  # H255/H823: citation-presplit floor so --output-budget=1 doesn't force tiny cards into the heal lane
+            globals()['PRESPLIT_SOLO_CITE_FLOOR'] = int(a.split('=', 1)[1])
         elif a == '--no-kill':
             globals()['KILL'] = False
         elif a == '--kill':
@@ -506,7 +520,10 @@ def _presplit_hit(ls, nfrag, cite_budget):
     presplit-primary fragment lane? Returns (cite_hit, sense_hit). Kept in one place so
     the frags-loop grouping choice and the presplit-list construction can never drift
     (H189 — before this, the two sites replicated the condition independently)."""
-    cite_hit = cite_budget is not None and (1 + ls) > cite_budget
+    # Floor the citation trigger at PRESPLIT_SOLO_CITE_FLOOR so --output-budget=1 (no-PWG lane)
+    # doesn't force every citation-bearing card into the heal lane — only genuine fail-solo
+    # citation giants presplit. For OUTPUT_BUDGET >= the floor (default 90) this is a no-op.
+    cite_hit = cite_budget is not None and (1 + ls) > max(cite_budget, PRESPLIT_SOLO_CITE_FLOOR)
     sense_hit = SENSE_PRESPLIT_BUDGET is not None and nfrag > SENSE_PRESPLIT_BUDGET
     return cite_hit, sense_hit
 
@@ -1420,11 +1437,19 @@ const skelBytesOfKeys = keys => keys.reduce((n, k) => n + (INPUTS[k] ? INPUTS[k]
 // than a tiny skeleton's budget predicts: the fixed per-call StructuredOutput latency
 // (~55-105 s) dominates, independent of skeleton size. The no-PWG w1 run killed 6/6 nulls
 // this way (kill-timeout 53-104 s, all would have passed accept). Give a no-fallback single
-// the CEIL budget so it is only abandoned on a true >CEIL hang. Multi-card / splittable
-// batches keep the aggressive byte-scaled gate (there a kill routes to binary-split /
-// fragment heal — the gate's whole purpose). SHARED (keys on FRAGS, no RU/EN branching).
+// the CEIL budget so it is only abandoned on a true >CEIL hang.
+// H255/H823 extension: give ANY single-card batch the CEIL, not just no-fallback ones. The
+// original rule kept a SPLITTABLE single on the aggressive byte-scaled gate because "a kill
+// routes to fragment heal" — but the heal groups run on the SAME byte-scaled budgets, so on a
+// slow API BOTH the whole-card attempt AND the heal lane kill on the ~55-105 s fixed latency,
+// and the card is a permanent null anyway (the H255 presplit-cohort loss). A lone card has no
+// batch-mates to starve, so it should get the full CEIL on its ONE whole-card attempt (it
+// either lands within the fixed latency or genuinely hangs) instead of being abandoned into a
+// heal lane that is no better budgeted. Multi-card BATCHES keep the byte-scaled gate (there a
+// kill legitimately routes to binary-split, and one slow card must not hold up its mates).
+// SHARED (keys on FRAGS, no RU/EN branching).
 const hasFallback = k => Array.isArray(FRAGS[k]) && FRAGS[k].length > 0
-const killBudgetForCur = cur => (cur.length === 1 && !hasFallback(cur[0])) ? KILL_CEIL_MS : killBudgetMs(skelBytesOfKeys(cur))
+const killBudgetForCur = cur => (cur.length === 1) ? KILL_CEIL_MS : killBudgetMs(skelBytesOfKeys(cur))
 // Split-pool budget state. Labels beginning `heal:` are recovery; every other call is primary
 // translation (including resolveGroup binary splits). BudgetExceeded is deliberately NOT an
 // isKill(): a kill routes to recovery, whereas a pool stop must issue zero more calls in that

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -2957,6 +2957,57 @@ def test_no_fallback_single_gets_ceil_kill_budget():
         shutil.rmtree(d, ignore_errors=True)
 
 
+def test_presplit_cite_floor_and_single_ceil():
+    """H255/H823: the CITATION presplit trigger must not misfire under --output-budget=1.
+    With a 1-card batch budget, (1+<ls>) > budget fires on ANY citation-bearing card, force-
+    routing tiny cards into the fragment heal lane whose byte-scaled kill budgets die on a slow
+    API (the H255 presplit-cohort loss). PRESPLIT_SOLO_CITE_FLOOR gates the trigger so only
+    genuine fail-solo giants presplit; dropping the floor reproduces the misfire. Also: a
+    single-card batch now gets the CEIL kill budget regardless of a heal fallback (a lone card
+    has no batch-mates to starve, and the heal lane is no better budgeted on a slow API)."""
+    import re as _re
+    import gen_opt_harness2 as gh
+    raw = ('=== LAYER: PW — Böhtlingk kürzere Fassung ===\n\n'
+           '{#word#}¦ <lex>Adj.</lex>\n'
+           '— 1〉 {%Bedeutung eins%} <ls>Ref. 1</ls> <ls>Ref. 2</ls>.\n'
+           '— 2〉 {%Bedeutung zwei%} <ls>Ref. 3</ls> <ls>Ref. 4</ls>.\n'
+           '— 3〉 {%Bedeutung drei%} <ls>Ref. 5</ls>.\n')
+    key = 'zz~~h0_zz_pw'
+    d = tempfile.mkdtemp()
+    saved_ip, saved_ob = gh.input_paths, gh.OUTPUT_BUDGET
+    saved_floor = gh.PRESPLIT_SOLO_CITE_FLOOR
+    try:
+        rp = os.path.join(d, key + '.raw.txt')
+        pp = os.path.join(d, key + '.portrait.json')
+        with open(rp, 'w', encoding='utf-8') as f:
+            f.write(raw)
+        with open(pp, 'w', encoding='utf-8') as f:
+            f.write('[]')
+        gh.input_paths = lambda k, input_dir=None: (rp, pp) if k == key else saved_ip(k)
+        # no-PWG lane (--output-budget=1): with the default floor (40) a 5-<ls> card must NOT presplit.
+        gh.OUTPUT_BUDGET = 1
+        gh.PRESPLIT_SOLO_CITE_FLOOR = 40
+        js, _b = gh.build('zz', [key], None, 12000, nominal=True, grammar_on=False, tm_path=None)
+        presplit = json.loads(_re.search(r'^const PRESPLIT = (.*)$', js, _re.M).group(1))
+        if key in presplit:
+            fail('under --output-budget=1 with the cite floor, a low-<ls> card must NOT presplit '
+                 '(it should translate whole); got PRESPLIT=%r' % presplit)
+        if '(cur.length === 1) ? KILL_CEIL_MS' not in js:
+            fail('killBudgetForCur must give ANY single-card batch the CEIL budget (H255/H823)')
+        # dropping the floor (=1) reproduces the pre-fix misfire: the citation-bearing card presplits.
+        gh.PRESPLIT_SOLO_CITE_FLOOR = 1
+        js2, _b2 = gh.build('zz', [key], None, 12000, nominal=True, grammar_on=False, tm_path=None)
+        presplit2 = json.loads(_re.search(r'^const PRESPLIT = (.*)$', js2, _re.M).group(1))
+        if key not in presplit2:
+            fail('with the floor disabled (=1), --output-budget=1 must presplit the citation-'
+                 'bearing card — proves the floor is load-bearing; got PRESPLIT=%r' % presplit2)
+    finally:
+        gh.input_paths = saved_ip
+        gh.OUTPUT_BUDGET = saved_ob
+        gh.PRESPLIT_SOLO_CITE_FLOOR = saved_floor
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def test_nominal_key_echo_tolerance_scoped():
     """H220: nominal / no-PWG windows must tolerate the model echoing the CLEAN SLP1 headword
     (nominal_keymap[stem], e.g. 'CAyA') instead of the mangled sub-card stem
@@ -4247,6 +4298,7 @@ def main():
         test_sense_dense_card_presplit,
         test_kill_gate_wired,
         test_no_fallback_single_gets_ceil_kill_budget,
+        test_presplit_cite_floor_and_single_ceil,
         test_nominal_key_echo_tolerance_scoped,
         test_selfheal_no_fallback_preserves_upstream_reason,
         test_group_by_budget_count_cap,


### PR DESCRIPTION
Root-causes and fixes the H255 presplit-cohort `selfheal-nothing-resolved` loss.

## The bug
The CITATION presplit trigger `(1+<ls>) > OUTPUT_BUDGET` correctly catches the 150-`<ls>` pwg00 heads at the default budget 90 — but **degenerates under `--output-budget=1`** (the no-PWG single-card lane): there the budget is 1, so ANY citation-bearing card 'exceeds' it and is force-routed to the fragment heal lane, whose byte-scaled kill budgets (~60 s) die on a slow host. The cohort (307–1131 B, 1–11 `<ls>`) are tiny cards that translate whole fine (`sam` is fine at 34 `<ls>`).

## Fix (both changes, verified applied)
- **Cite floor** (`_presplit_hit`): trigger fires only when `(1+<ls>) > max(OUTPUT_BUDGET, PRESPLIT_SOLO_CITE_FLOOR=40)` (new `--presplit-solo-cite-floor=N`; no-op for OUTPUT_BUDGET ≥ 40). Verified: cohort `presplit_keys` now empty (routes whole).
- **Single-card CEIL** (`killBudgetForCur`): ANY single-card batch gets the CEIL (180 s), not just no-fallback singles (a lone card has no batch-mates to starve; clean H220 generalization). Verified: cohort kills moved 60 s→180 s.
- Unit-tested (`test_presplit_cite_floor_and_single_ceil`); full `window_selftest.py` + `lang_parity_check.py` green (new `presplit_cite_floor_h823` SHARED entry).

## Honest live result
`no_pwg_presplitfix` (6 cards, ≤2-wide): **0/6 recovered.** The fix is applied but the cohort didn't recover on the *further-degraded* host today: **4 exceed even the 180 s CEIL** (a 298 B card >180 s vs 54 s ~3 h earlier; a whole card is a bigger prompt than one fragment) and **2 are genuine content failures** (`avy_ahata` wrong key1, `avyagra` dropped 2/3 `{#…#}` spans). The routing misfire is genuinely fixed and right for a healthy host; the cohort re-classes to 4 host-hard + 2 content-hard. Store unchanged.

Handoff: [H823](https://github.com/gasyoun/Uprava/blob/main/handoffs/H823-Opus_SanskritLexicography_pwg_ru_presplit_cite_floor_fix_12.07.26.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)