### PR TITLE
H809 W2 (complete): relabel perf_preflight.py cost-gate to Sonnet 5

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -39,14 +39,20 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   runnable **14 → 701 / missing rootmap 687 → 0**; `verify_root_glue.py` **ALL GATES PASS**;
   0 tracked-file noise (all under gitignored `src/pilot/input/`). See
   [`src/pilot/RUN_LOG.md`](src/pilot/RUN_LOG.md) 2026-07-12.
-- **W2 (partial):** confirmed the Sonnet 5 (`claude-sonnet-5`) LIST rates via `/claude-api`
+- **W2 (done):** confirmed the Sonnet 5 (`claude-sonnet-5`) LIST rates via `/claude-api`
   ($3/$15; cache-write 5m $3.75, cache-read $0.30) and relabeled
   [`src/pilot/parse_workflow_cost.py`](src/pilot/parse_workflow_cost.py)'s `PRICE` comment.
   The numbers were **already correct** (Sonnet 4.6 and Sonnet 5 share $3/$15 list pricing), so
   the golden-window $79.83 / `PER_AGENT_USD=$0.347` are unchanged; a formula-pinning test lives
-  in [`src/pilot/h809_selftest.py`](src/pilot/h809_selftest.py). Refreshing the same label in
-  `perf_preflight.py` is **deferred** — it shares a `LANG_PARITY` key with H811's unresolved
-  `gen_opt_harness2.py` parity debt on `master`; its numbers are already Sonnet-5-correct.
+  in [`src/pilot/h809_selftest.py`](src/pilot/h809_selftest.py). Completing the previously
+  **deferred** half (H811's blocking parity debt was cleared the same day): the H189 cost-gate
+  comment and the live `rate_basis` string in
+  [`src/pilot/perf_preflight.py`](src/pilot/perf_preflight.py) are now Sonnet-5-labeled — **no
+  `Sonnet 4.x` remains in any live string** (only a historical as-run comment keeps it). The
+  relabel is a lang-agnostic label-only change (no RU/EN branching, no numeric value touched),
+  so its `LANG_PARITY` entry `presplit_lane_amortization_and_budget_guards_h189` was re-verified
+  **SHARED** and its `perf_preflight.py` hash refreshed; `lang_parity_check.py` (46 entries, no
+  drift) and `window_selftest.py` both green. W2 acceptance now fully met.
 - **W3-code (done):** [`src/pilot/no_pwg_scale_plan.py`](src/pilot/no_pwg_scale_plan.py) gains
   `used_window_indices()`/`next_free_index()` (scan `run_pilot_wf.<prefix>NN.js` +
   `wf_output.<prefix>NN.json`, `_rqN` requeues count as their base index); `--start-index`

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -471,7 +471,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H189",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "6f4ce071ddf02c4f9e7448f53497e78b9a8f4c2e296e3c98ca859e43fab11c14",
-      "src/pilot/perf_preflight.py": "a73a536d6f24e398faadd5507520e106a5d96c94c28e310c0e30366397b7d174",
+      "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
       "src/pilot/window_selftest.py": "22df5eca68b43c82ea7944f12e11c1f3fe941e872f1ebcdfad31a3686bebd8e1"
     }
   },

--- a/RussianTranslation/src/pilot/perf_preflight.py
+++ b/RussianTranslation/src/pilot/perf_preflight.py
@@ -29,13 +29,16 @@ from window_common import INP, input_paths, read_text
 
 # --- H189 cost gate ----------------------------------------------------------------
 # Empirical per-agent figures from the pril10_w1 blow-up (parse_workflow_cost.py over the
-# three sub-window transcripts: 230 agents, 42,316,604 tokens, $79.83 at Sonnet 4.x rates):
-#   184,000 tokens/agent (mean), $0.347/agent.
+# three sub-window transcripts: 230 agents, 42,316,604 tokens, $79.83): 184,000 tokens/agent
+# (mean), $0.347/agent. That $79.83 was the pril10_w1 as-run cost at Sonnet 4.x rates; Sonnet 5
+# shares the identical standard list pricing ($3 in / $15 out, cache-write $3.75 / cache-read
+# $0.30 — confirmed 12-07-2026 via the /claude-api skill, H809 W2), so both figures are
+# UNCHANGED under Sonnet 5.
 # agent_expected_after_tm is an optimistic FLOOR (one call per batch/fragment-group, no
 # retries) — the real run spent 230 vs a 174 estimate (1.32x) — so a realism multiplier is
-# applied before pricing. The $ figures inherit parse_workflow_cost.py's Sonnet 4.x rates
-# (order-of-magnitude for Sonnet 5); the TOKEN estimate and the per-card RATIO are the
-# model-independent, load-bearing parts of the gate.
+# applied before pricing. The $ figures inherit parse_workflow_cost.py's Sonnet 5 list rates;
+# the TOKEN estimate and the per-card RATIO are the model-independent, load-bearing parts
+# of the gate.
 PER_AGENT_TOKENS = 184000
 PER_AGENT_USD = 0.347
 REALISM_FACTOR = 1.35
@@ -74,7 +77,7 @@ def cost_estimate(report, per_card_ceiling=COST_CEIL_PER_CARD_USD,
         'window_ceiling_usd': window_ceiling,
         'over_ceiling': bool(over_card or over_window),
         'verdict': 'OVER-CEILING' if (over_card or over_window) else 'ok',
-        'rate_basis': 'Sonnet 4.x rates (order-of-magnitude); token estimate is model-independent',
+        'rate_basis': 'Sonnet 5 list rates; token estimate is model-independent',
     }
 
 


### PR DESCRIPTION
Completes the one remaining non-API-gated residual of [H809](https://github.com/gasyoun/Uprava/blob/main/handoffs/H809-Opus_RussianTranslation_pwg-ru-scale-unblock-fixes_12.07.26.md) W2, left deferred by [PR #413](https://github.com/gasyoun/SanskritLexicography/pull/413).

## What
[`RussianTranslation/src/pilot/perf_preflight.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/perf_preflight.py)'s H189 cost-gate carried the stale `Sonnet 4.x` rate label — including the **live** `rate_basis` string returned in `cost_estimate()`. PR #413 relabeled `parse_workflow_cost.py` but deferred this file because it shares a `LANG_PARITY` key with H811's parity debt (cleared the same day).

- H189 cost-gate comment + live `rate_basis` string → **Sonnet 5 list rates**; **no `Sonnet 4.x` left in any live string** (only a historical as-run $79.83 comment keeps it, matching `parse_workflow_cost.py`'s merged precedent).
- **No numeric value touched** — `PER_AGENT_USD=0.347`, `PRICE`, and the $2/card + $25/window ceilings are unchanged. Sonnet 5 and Sonnet 4.x share $3/$15 list pricing, so every figure holds.

## Parity + tests
- `LANG_PARITY` entry `presplit_lane_amortization_and_budget_guards_h189` re-verified **SHARED** (lang-agnostic, label-only — no RU/EN branching), `perf_preflight.py` hash refreshed via `--update-hash`.
- Green: `lang_parity_check.py` (46 entries, no drift), `h809_selftest.py`, `window_selftest.py`.

W2 acceptance ("no 'Sonnet 4.x' left in live strings") now fully met. **W0/W4 remain API-gated** — generation API still degraded ([SERVER_OUTAGES row 29](https://github.com/gasyoun/Uprava/blob/main/SERVER_OUTAGES.md)); no probe/canary fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)