### PR TITLE
H861: Ch.13 (A34 Renou's registers) journal→book conversion

### DIFF
--- a/Digital_Sanskrit_Lexicography-BOOK/.ai_state.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/.ai_state.md
@@ -10,24 +10,24 @@ _Created: 07-07-2026 · Last updated: 13-07-2026_
   (Hellwig CC-BY sign-off). DOI *minting* = human/credentials @DO; the mechanical
   **CITATION.cff** add to kosha / SanskritLexicography / SanskritRussian is a
   Fable/Sonnet follow-on (those 3 lack a `.cff`).
-- **Remaining chapter conversions** — **6 of 14** chapters still need journal→book
-  conversion (ch01, ch02, ch04, ch05, ch08, ch09, ch10, ch12 now exist). Next most-mature,
-  self-contained one-to-one conversions: Ch. 13 (A34 Renou registers), Ch. 14 (A12 fifty
-  thousand corrections), Ch. 7 (A04 indigenous verbal-root microstructure). Two special cases:
-  the merged **Ch. 6 (A02+A33)** needs the two source articles' prose genuinely *interleaved*,
-  not concatenated; **Ch. 3 (A40)** and **Ch. 11 (A50)** are data-ready but prose-thin (write
-  ~1 chapter of prose atop committed data), not straight conversions.
+- **Remaining chapter conversions** — **5 of 14** chapters still need journal→book
+  conversion (ch01, ch02, ch04, ch05, ch08, ch09, ch10, ch12, ch13 now exist). Next
+  self-contained one-to-one conversion: Ch. 14 (A12 fifty thousand corrections), Ch. 7 (A04
+  indigenous verbal-root microstructure). Two special cases: the merged **Ch. 6 (A02+A33)**
+  needs the two source articles' prose genuinely *interleaved*, not concatenated; **Ch. 3
+  (A40)** and **Ch. 11 (A50)** are data-ready but prose-thin (write ~1 chapter of prose atop
+  committed data), not straight conversions.
 - **Goal-loop active (13-07-2026):** converting all remaining chapters one at a time, each a
   full book chapter shipped via its own PR+merge+handoff; stop when all 14 `chapters/ch*.md`
-  exist in book form. Order: Ch. 8 ✓ → Ch. 12 ✓ → Ch. 13 → Ch. 14 → Ch. 7 → then Ch. 3 /
+  exist in book form. Order: Ch. 8 ✓ → Ch. 12 ✓ → Ch. 13 ✓ → Ch. 14 → Ch. 7 → then Ch. 3 /
   Ch. 11 (prose-thin) → Ch. 6 (interleave).
 - **Ch. 2 corpus-methods section** — write the ~6–8 pp. "The corpus as a bounded witness"
   section into ch02 at its next revision (MG ruled (b) on 13-07-2026; see Completed).
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- Goal-loop: converting remaining chapters one at a time. H860 (Ch. 12) landed; 8 of 14 now in
-  book form. Next: Ch. 13 (A34 Renou registers).
+- Goal-loop: converting remaining chapters one at a time. H861 (Ch. 13) landed; 9 of 14 now in
+  book form. Next: Ch. 14 (A12 fifty thousand corrections).
 
 ## 🧠 Dev Notes & Hypotheses (Bugs, ideas, context)
 
@@ -44,6 +44,13 @@ _Created: 07-07-2026 · Last updated: 13-07-2026_
 
 ## ✅ Completed (Recent only)
 
+- 13-07-2026 ([H861](https://github.com/gasyoun/Uprava/blob/main/handoffs/H861-Opus_SanskritLexicography_ch13_a34_renou_registers_book_conversion_13.07.26.md),
+  Opus 4.8 `claude-opus-4-8[1m]`): **Ch. 13 converted journal→book** —
+  [chapters/ch13_renou_registers.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch13_renou_registers.md)
+  from A34 (*Register, Not Just Period*, local papers). Abstract stripped, A08→Ch. 10 remap,
+  the **mandatory reframe** (68.3% corpus-absent → DCS-coverage statement, McEnery & Brezina
+  caveat) applied, grounding woven in (Ferri/Maltby Servius; Dickey Atticist; Geyken &
+  Lemnitzer; Partridge); all counts and tables carried over unchanged. 9 of 14 in book form.
 - 13-07-2026 ([H860](https://github.com/gasyoun/Uprava/blob/main/handoffs/H860-Opus_SanskritLexicography_ch12_a10_apparatus_not_errors_book_conversion_13.07.26.md),
   Opus 4.8 `claude-opus-4-8[1m]`): **Ch. 12 converted journal→book** —
   [chapters/ch12_apparatus_not_errors.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch12_apparatus_not_errors.md)

--- a/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md
@@ -468,6 +468,18 @@ at its next revision. Both `@DECIDE` forks from H505 are now closed.
   fingerprinting). Every count and table carried over unchanged. **8 of 14 chapters now in
   book form** (ch01, ch02, ch04, ch05, ch08, ch09, ch10, ch12).
 
+**Done 13-07-2026 (H861 execution, Opus 4.8 `claude-opus-4-8[1m]`):**
+- ✅ **Ch. 13 converted journal→book** →
+  [chapters/ch13_renou_registers.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch13_renou_registers.md)
+  (from A34, *Register, Not Just Period*, local papers source). Abstract/status stripped, the
+  A08 companion remapped to **Ch. 10**, and — the **mandatory crosswalk reframe applied** — the
+  "68.3% corpus-absent" headline recast as an explicit **DCS-corpus-coverage** statement under
+  the McEnery & Brezina corpus-absence caveat (not an absolute absence claim). Grounding woven
+  in: Ferri/Maltby (Servius' three-register system, tying back to Ch. 1), Dickey (Atticist
+  register-marking), Geyken & Lemnitzer (diasystematic labelling as current practice), Partridge
+  (register scales). Every count and table carried over unchanged. **9 of 14 chapters now in
+  book form** (ch01, ch02, ch04, ch05, ch08, ch09, ch10, ch12, ch13).
+
 **Still to do:**
 1. Run the **FAIR/DOI sprint** (Zenodo deposits + re-mint the false correction-dataset DOI
    + Hellwig DCS sign-off) — the DOI *minting* is a human/credentials @DO; the mechanical

--- a/Digital_Sanskrit_Lexicography-BOOK/CHANGELOG.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/CHANGELOG.md
@@ -7,6 +7,28 @@ folder. Registry ID **M01** in [Uprava/ARTICLES.md](https://github.com/gasyoun/U
 
 ## [Unreleased]
 
+### Added — 13-07-2026 (H861, Ch. 13 conversion)
+
+- **Ch. 13 converted journal→book** →
+  [chapters/ch13_renou_registers.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch13_renou_registers.md),
+  the book-form version of A34 *Register, Not Just Period: Renou's Subsections as an Orthogonal
+  Axis* (local papers source
+  [A34_renou_register_note.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A34_renou_register_note.md)).
+  Abstract + status apparatus stripped, provenance headnote added (A34 stays citable at Lexikos
+  / IJL / eLex), the A08 citation-register companion remapped to **Ch. 10**. **Mandatory
+  crosswalk reframe applied:** the headline "68.3% corpus-absent" recast as an explicit
+  statement about **DCS-corpus coverage** (the DCS is a literary corpus containing no
+  inscriptions), under the **McEnery & Brezina** corpus-absence caveat — not a claim of absence
+  from the language. Further grounding woven in — **Ferri/Maltby** (Servius' three-register
+  *grandiloquus/medius/humilis* system, tying back to Ch. 1's decorum), **Dickey** (Atticist
+  normative register-marking), **Geyken & Lemnitzer** (diasystematic labelling from corpus
+  metadata as current practice), **Partridge** (graded register scales). Every count and table
+  (770,292 entries / 8 dicts; 709 épigraphique / 484 = 68.3% corpus-absent, strict 518/73.1%;
+  bhāṣya 14,498 / kāvya 26,973 / bauddha 25,740 / jaina 286 at 0%; cross-axis slices 6,895 /
+  20,758 / 25,220; finite-verb density 14.4%→6.7%, bhāṣya 6.25% vs kāvya 7.48%) carried over
+  unchanged. **9 of 14 chapters now in book form** (ch01, ch02, ch04, ch05, ch08, ch09, ch10,
+  ch12, ch13).
+
 ### Added — 13-07-2026 (H860, Ch. 12 conversion)
 
 - **Ch. 12 converted journal→book** →

--- a/Digital_Sanskrit_Lexicography-BOOK/chapters/ch13_renou_registers.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/chapters/ch13_renou_registers.md
@@ -1,0 +1,244 @@
+# Chapter 13 — Register, Not Just Period: Renou's Subsections as an Orthogonal Axis
+
+_Created: 13-07-2026 · Last updated: 13-07-2026_
+
+> **Provenance.** This chapter is the book-form version of the research note *Register, Not
+> Just Period: Renou's Subsections as an Orthogonal Axis for Evidence-Graded Sanskrit
+> Lexicography* (source draft:
+> [A34_renou_register_note.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A34_renou_register_note.md)),
+> which is being published separately in a journal version (target: *Lexikos* / *IJL* / *eLex*);
+> where the article must remain independently citable, cite that version. Every count and table
+> below is carried over from the article unchanged. Only the framing has been converted from
+> journal to book form — the abstract and status apparatus removed, the companion-paper label
+> remapped to this book's chapters, the headline "68.3 % corpus-absent" figure reframed as an
+> explicit statement about *DCS-corpus coverage* per the corpus-absence caveat, and the
+> comparative register literature engaged at the monograph's depth. Section numbering is
+> chapter-internal (§1–§5).
+
+The book's final movement turns from descent to the *living* dictionary — the labels by which
+an entry marks what kind of Sanskrit a word belongs to. This chapter adds a second, orthogonal
+badge to the evidence graph. Digital work routinely reduces Louis Renou's *Histoire de la
+langue sanskrite* to five language-states — Vedic, Pāṇinian, Epic, Classical, Buddhist/Jaina —
+and treats them as a period scale. But Renou's chapters are themselves divided into
+subsections that are **registers, not periods**: the commentarial *bhāṣya* opens the Classical
+chapter and is given its own grammar; *le sanskrit épigraphique* is filed inside the
+Pāṇinian-norm chapter as a witness to real attested usage against the grammarians' ideal. A flat
+I–V period tag cannot express either. This chapter operationalises both axes — a diachronic
+*state* axis and an orthogonal, multi-label *register* axis — as two independent per-sense
+badges, each carrying its evidential provenance.
+
+The chapter is the direct heir of Chapter 10. There the citation *register* was a property of
+the dictionary's evidential practice (the European `<ls>` apparatus versus the indigenous
+*iti*-quotation); here Renou's *language* registers become a per-sense annotation axis on the
+same evidence graph. And its headline result rhymes with the book's recurring theme that the
+instrument shapes what is seen — but with a crucial reframing that this chapter is careful to
+make: of 709 headwords tagged *épigraphique*, 484 have **no attestation in the DCS literary
+corpus**. Read naively that is a claim about the words; read correctly it is a statement about
+the *corpus's coverage* — and the register axis exists precisely to make that coverage boundary
+measurable rather than invisible.
+
+## 1. The problem: register cross-cuts period
+
+Diachronic tagging of Sanskrit lexicon entries has converged on Renou's five states, treated as
+a period scale. This is useful but lossy in a specific way: register cross-cuts period. A
+commentary (*bhāṣya*) can gloss a Vedic, epic, or classical base text; its language — terse,
+formulaic, meta-textual — is a register of its own that does not reduce to "Classical."
+Inscriptional Sanskrit is, for Renou, not a period at all but a documentary *witness*,
+deliberately placed beside the discussion of the spoken norm. The Classical chapter alone holds
+four distinct registers (*bhāṣya*, *kathā* narrative, the *théâtre* dialogue, *kāvya* poetry),
+and the Pāṇinian-norm chapter hosts the épigraphique witness. None of these is a fifth, sixth, or
+seventh *state*; they are an orthogonal dimension.
+
+Register labelling is not a Sanskrit novelty but a lexicographic universal, and naming its
+precedents places this chapter's contribution precisely. The classical grammarians already
+sorted usage by register: Servius' scholia grade diction as *grandiloquus / medius / humilis*
+(Ferri 2019, essay by Maltby) — the same three-register decorum system whose *sexual* extreme
+opened this book in Chapter 1 — and the Atticist lexica of Greek marked usage normatively,
+admitting or proscribing words by register (Dickey 2007). The modern counterpart is
+*diasystematic* labelling — the temporal, regional, and stylistic marks a dictionary attaches to
+a sense — now increasingly derived from corpus metadata rather than editorial intuition (Geyken
+and Lemnitzer 2009), and its informal end has a lexicographic pedigree in Partridge's graded
+slang/colloquial/vulgarism scales (Partridge 1963). What is new here is the operationalisation of
+Renou's *subsections* — as opposed to his five chapter-states — as a multi-label tagging scheme
+over a dictionary corpus, each tag provenance-graded.
+
+## 2. Method: two independent axes, each provenance-graded
+
+I tag every dictionary sense on **two independent axes**, each multi-label (a word can carry
+several values) and each value carrying a provenance set:
+
+- **State (I–V)** — Renou's five chapters, from three deterministic signals plus a tertiary one:
+  the entry's own `<ls>` citation resolved through a curated siglum→state map; DCS-corpus
+  attestation (each text typed to a state by genre/name/date); Edgerton's BHS set membership for
+  state V; and a partial tradition tag.
+- **Register** — a 20-code lattice of Renou's subsections, built from the same two primary
+  signals plus dedicated detectors: a genre/name→register map over the corpus texts (commentary
+  caught by name-stems `*bhāṣya/ṭīkā/vṛtti/vārttika`, since the corpus has no commentary
+  *genre*); the `<ls>` siglum's source genre (the only route to *jaina*); and a dedicated
+  **épigraphique detector** — an inscription marker (PWG German `Inschr.`, MW/Apte `Inscr.`)
+  inside any citation, the sole route to a register the corpus contains none of.
+
+Both axes share one noise-control policy. The corpus index is *lossless* — it stores, per lemma,
+the per-state and per-register evidence depth — and a min-support filter is applied at tagging
+time: a corpus state is kept only if attested in ≥2 texts *or* in one authoritatively-typed
+text, pruning the thin date-fallback tail (9.9 % of corpus state-assignments). The two axes are
+kept in disjoint vocabularies and separate fields; an independent data-integrity audit confirmed
+entry-count invariance, provenance coherence, and zero leakage between axes. This is the
+per-sense operationalisation of the book's evidence-grade discipline (Chapter 2): every tag
+carries whether it rests on a lexicographer's citation, a corpus attestation, or a register
+membership. The substrate is eight machine-readable Cologne dictionaries (PWG, MW, PW, AP, AP90,
+BEN, SCH, BHS) — **770,292 entries** — and the DCS 2026 corpus snapshot.
+
+## 3. Results
+
+### 3.1 Coverage
+
+The register axis is populated across all eight dictionaries (~38–41 % of all entries carry ≥1
+register; 100 % for BHS, every entry being Buddhist by construction). The commentary register is
+large and robust — *bhāṣya* tags **14,498 distinct headwords** (10,320 attested in ≥2
+dictionaries); the poetic and Buddhist lexica reach 26,973 (*kāvya*) and 25,740 (*bauddha*).
+Nineteen of the twenty lattice registers are populated; only *hors-de-l'Inde* (Sanskrit abroad)
+is empty, having no source in either signal.
+
+### 3.2 The headline: épigraphique is largely invisible *to this corpus*
+
+Of **709 headwords tagged épigraphique, 484 (68.3 %) have no attestation in the DCS literary
+corpus** (the conservative reading; the strict corpus-only reading gives 518, 73.1 %). The
+figure must be read for exactly what it is — a statement about **corpus coverage**, not about the
+language. It does not say these words are absent from Sanskrit; it says they are absent from *the
+DCS as it currently stands*, which is a curated corpus of *literary* texts and contains, by
+construction, no inscriptions. The corpus-absence caveat of corpus linguistics applies at full
+strength: absence of a form from a bounded corpus is not evidence of its absence from the
+language, because low frequency and true non-occurrence are indistinguishable in a finite sample
+(McEnery and Brezina 2022). For the épigraphique register that caveat is not a weakness to be
+apologised for but the very point being measured: these are words the *literary* corpus
+structurally cannot contain, recoverable only because the lexicographers preserved the
+inscription citation.
+
+| Register | Distinct headwords | Corpus-absent (no DCS attestation) |
+|---|--:|--:|
+| **épigraphique** | **709** | **484 (68.3 %)** |
+| jaina | 286 | 0 |
+| bhāṣya | 14,498 | (corpus-rich) |
+
+These are the words a corpus-only diachronic method never sees: donative and administrative
+terms (*akṣayanīvī* "perpetual, non-confiscable endowment"), monastery names
+(*abhayagirivihāra*), and above all the dynastic onomasticon engraved in stone (*ajayavarman*,
+*akkādevī*, *akabara* = Akbar). The contrast with *jaina* (0 % corpus-absent — Jaina-tagged words
+are literary words MW happens to cite from Jaina sources) sharpens the point: épigraphique is the
+one register whose vocabulary lies *outside the literary timeline*, and a word attested only in an
+undated inscription has no well-defined Renou state yet a perfectly definite register. The state
+axis, by construction, cannot see it; the register axis can.
+
+### 3.3 Composing the two axes
+
+Because state and register are orthogonal, their intersection and difference define editorially
+meaningful strata that neither axis alone can name:
+
+| Slice | Definition | Headwords | What it is |
+|---|---|--:|---|
+| Vedic-in-commentary | register `bhāṣya` ∩ state I | 6,895 | Vedic vocabulary the commentarial tradition kept alive |
+| born-in-kāvya | register `kāvya` ∖ state I | 20,758 | poetic words with no Vedic attestation (*abdhi* "ocean", III·IV only, vs Vedic *samudra* I–V) |
+| pure archaisms | state I only | 25,220 | words dropped after the Saṃhitās |
+
+The full coordinate per sense is `(state, register, provenance)` — e.g. *akṣobhya* = `III·V` /
+`purāṇa·tantra·bauddha` / all-signals — an evidence-graded position, not a single label. The
+*bhāṣya* register works as a Vedic reservoir, *kāvya* as a coinage engine (≈¼ of the
+born-in-kāvya slice is dictionary-specific), and the inscription-only onomasticon (*vākāṭaka*,
+*humāuṃ* = Humāyūn) is register in the *absence* of period.
+
+### 3.4 Register quality rides on provenance, not on a frequency gate
+
+The min-support filter that prunes the state axis is, on the register axis, a no-op by
+construction: a register only ever derives from a *typed* source (a corpus genre, a curated
+siglum, an inscription marker), so no register rests on the low-confidence date-fallback texts
+that produce state-axis noise. Register quality therefore rides on the genre/name confidence
+floor, not on a frequency gate — a result of the audit, not an assumption, and the reason the
+épigraphique figure is a coverage statement rather than a noise artefact.
+
+### 3.5 Further register findings
+
+Beyond épigraphique, four register-metric results follow. (i) *bhāṣya* is a cross-disciplinary
+*syntactic* register — Renou's own thesis (the nominal doctrinal style applied across all
+disciplines) corroborated by its low 8.8 % dictionary-specificity, a standardised not
+idiosyncratic vocabulary. (ii) *bauddha* is a second self-contained lexical world — 44.5 %
+single-dictionary, 92 % of that recorded only by Edgerton's BHS, 12.4 % corpus-absent — a
+parallel to épigraphique by a different mechanism. (iii) The doctrinal registers carry the
+perennial lexicon (kārikā/tantra/upaniṣad, 56.7–65.0 % of headwords spanning ≥4 states) while
+narrative/poetic/documentary registers are period-bound (épig/epic/kāvya, 10.0–22.2 %). (iv)
+*nāṭya* and *kāvya* are the coinage registers among the literary ones (dictionary-specificity
+23.8 % and 19.8 %), the śāstric ones the standardising — conservation vs invention, read
+straight off the register metrics.
+
+A fifth result steps off the headword axis onto running text: Renou's nominal-style thesis is
+confirmed on the DCS corpus — finite-verb density more than halves across the states (Vedic
+14.4 % → Classical 6.7 %) as participles and nominals rise, and **bhāṣya (6.25 %) is more nominal
+than kāvya (7.48 %)**, the exact wording of *Histoire* p. 139 — corroborating the *bhāṣya*
+finding from a second, syntactic direction.
+
+## 4. Consequence
+
+For an evidence-graded digital dictionary the register is a second per-sense badge, independent
+of the period badge, and the two compose into a queryable coordinate rather than a flat label —
+the same "language of the gloss encodes the editor's stance toward the reader" axis this book
+opened with in Chapter 1, now generalised from candour to the full diasystem. Two concrete
+payoffs follow. First, **reusable register lexica**: eight deduplicated, provenance-tagged
+glossaries ship with the study, the épigraphique list positioned as a *derived,
+provenance-tagged complement* to Sircar's corpus-curated *Indian Epigraphical Glossary* (1966) —
+where Sircar curated inscriptional vocabulary from the epigraphic corpus directly, this list
+recovers it from the lexicographers' citation apparatus, so the two can validate each other.
+Second, **honest negative coverage**: the 68.3 % corpus-absent figure is itself a finding about
+the limits of corpus-driven lexicography, and the register tagging makes that gap *measurable*
+instead of invisible — the épigraphique stratum is exactly the material Chapter 3's
+corpus-grounding of the headword inventory cannot reach, named here rather than silently dropped.
+
+## 5. Reproducibility
+
+The tagger, resolvers, audit, glossary extractor, and the eight shipped glossaries are committed
+alongside the study; the derived per-dictionary indices are regenerated by the pipeline, and the
+headline 68.3 % corpus-absent figure reproduces exactly from the committed indices (superseding an
+earlier stale 63.0 % hand-copy in one findings table). Every reported number is walkable to its
+generator under the discipline of Chapter 2.
+
+## References
+
+Dickey, Eleanor. 2007. *Ancient Greek Scholarship.* Oxford and New York: Oxford University
+Press. [Atticist lexica and normative register-marking.]
+
+Edgerton, Franklin. 1953. *Buddhist Hybrid Sanskrit Grammar and Dictionary.* 2 vols. New Haven:
+Yale University Press.
+
+Ferri, Rolando (ed. contributions). 2019. In Robert Maltby et al. (eds.), *Studies on Late
+Antique and Medieval Latin Glossaries and Dictionaries.* [Maltby on Servius' three-register
+(*grandiloquus/medius/humilis*) system.]
+
+Geyken, Alexander, and Lothar Lemnitzer. 2009. "Diasystematic Labelling from Corpus Metadata."
+In *Internet Lexicography.* [Corpus-derived register/temporal/regional labelling as current
+practice.]
+
+Hellwig, Oliver. 2010–. *DCS — The Digital Corpus of Sanskrit.*
+[www.sanskrit-linguistics.org/dcs/](https://www.sanskrit-linguistics.org/dcs/) (2026 snapshot).
+
+McEnery, Tony, and Vaclav Brezina. 2022. *Fundamental Principles of Corpus Linguistics.*
+Cambridge: Cambridge University Press. [The corpus-absence caveat: non-occurrence in a bounded
+corpus is not absence from the language.]
+
+Partridge, Eric. 1963. *The Gentle Art of Lexicography.* London: Deutsch. [Graded
+slang/colloquial/vulgarism register scales.]
+
+Renou, Louis. 1956. *Histoire de la langue sanskrite.* Lyon–Paris: Éditions IAC.
+
+Salomon, Richard. 1998. *Indian Epigraphy: A Guide to the Study of Inscriptions in Sanskrit,
+Prakrit, and the Other Indo-Aryan Languages.* New York: Oxford University Press.
+
+Sircar, Dineschandra. 1966. *Indian Epigraphical Glossary.* Delhi: Motilal Banarsidass.
+
+Vogel, Claus. 1979. *Indian Lexicography.* (A History of Indian Literature V.4.) Wiesbaden:
+Harrassowitz.
+
+**Primary digital source.** Cologne Digital Sanskrit Dictionaries (CDSL). Universität zu Köln,
+[`www.sanskrit-lexicon.uni-koeln.de`](https://www.sanskrit-lexicon.uni-koeln.de/) — the eight
+machine-readable dictionaries (PWG, MW, PW, AP, AP90, BEN, SCH, BHS) tagged here, with the DCS
+2026 corpus snapshot as the state/attestation substrate.
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Converts **Ch. 13 ← A34** (*Register, Not Just Period: Renou's Subsections as an Orthogonal Axis*) from journal-article to book form for the Brill monograph *Digital Sanskrit Lexicography* (registry **M01**), the ninth chapter conversion.

## What changed
- **New chapter** [`chapters/ch13_renou_registers.md`](https://github.com/gasyoun/SanskritLexicography/blob/ch13-a34-conversion/Digital_Sanskrit_Lexicography-BOOK/chapters/ch13_renou_registers.md) from the local source [`papers/A34_renou_register_note.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A34_renou_register_note.md). Abstract + status apparatus removed; provenance headnote added; the A08 citation-register companion remapped to **Ch. 10**.
- **Mandatory crosswalk reframe applied:** the headline "68.3% corpus-absent" recast as an explicit **DCS-corpus-coverage** statement (the DCS is a literary corpus with no inscriptions), under the **McEnery & Brezina** corpus-absence caveat — not a claim of absence from the language. Further grounding from [LITERATURE_CROSSWALK.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/LITERATURE_CROSSWALK.md) — **Ferri/Maltby** (Servius' three-register system, tying back to Ch. 1), **Dickey** (Atticist register-marking), **Geyken & Lemnitzer** (diasystematic labelling), **Partridge** (register scales). **Every count and table carried over unchanged** (770,292 entries / 8 dicts; 709 épigraphique, 484 = 68.3% corpus-absent; the cross-axis slices; finite-verb density 14.4%→6.7%).
- **Records swept:** `BOOK_PLAN.md` §11 (9/14 in book form), `CHANGELOG.md`, `.ai_state.md` (5 of 14 remain).

Handoff: [H861](https://github.com/gasyoun/Uprava/blob/main/handoffs/H861-Opus_SanskritLexicography_ch13_a34_renou_registers_book_conversion_13.07.26.md). Goal-loop, one chapter at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)