### PR TITLE
H813: Sanskrit-in-Numbers Wave 0 + Wave 1 - 5 new module datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ HeadwordLists/heritage_mirror/
 # semdom.json fetch cache (semdom_varga_crosswalk.py / semdom_ak_annex_table.py) — CC BY-SA input, fetched on demand, never committed
 /data/semdom.json
 /data/wn-links-semdom-words-all.tsv
+
+# H813 Sanskrit-in-Numbers module8 fetch cache (zaliznyak-grammar-index TSV,
+# already published as a kosha release asset — fetched on demand, never committed)
+papers/sanskrit_in_numbers/.cache/

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,21 @@ not an error.
 
 ## [Unreleased]
 
+## [1.9.7] - 2026-07-13
+
+### Added
+- **H813 — «Санскрит в цифрах» Wave 0 + Wave 1 (Sanskrit-in-Numbers, the Duden
+  *Sprache in Zahlen* analog).** New `papers/sanskrit_in_numbers/`: Wave 0 assembles
+  the already-owned modules (vocab size → A40/A55, POS → A56, lemma/token +
+  a new Zipf coverage curve → VisualDCS) into `MODULES_OWNED.md`; Wave 1 ships
+  the five NEW modules with reproducible generator scripts + committed JSON
+  datasets — akṣara/phoneme frequency (Module 5), longest compounds with a
+  ≥5-occurrence honesty floor (Module 6), gender distribution (Module 8),
+  samāsa types best-effort via DCS's UD-style `compound:coord` tag (Module 9,
+  explicitly flagged — no fabricated tatpuruṣa/bahuvrīhi split), and verb
+  classes + parasmaipada/ātmanepada/ubhayapada voice from WhitneyRoots (Module
+  10). See `WAVE1_SUMMARY.md` for headline numbers + trust blocks.
+
 ## [1.9.6] - 2026-07-13
 
 ### Fixed

--- a/papers/ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md
+++ b/papers/ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md
@@ -2,7 +2,7 @@
 
 ## Roadmap 2026–2027 · public portrait + book/monograph appendix
 
-_Created: 12-07-2026 · Last updated: 12-07-2026_
+_Created: 12-07-2026 · Last updated: 13-07-2026_
 
 > **What this is.** A plan to build the Sanskrit analog of Duden's *Sprache in Zahlen* — the
 > quantitative "language in numbers" appendix that closes the [Duden Universalwörterbuch](https://www.duden.de/)
@@ -108,34 +108,49 @@ from DCS is unattested-in-our-corpus, not a ghost word.
 Each wave states what unblocks it. Waves 0–1 are agent-doable now; waves 2–4 gate on human/rights
 inputs.
 
-### Wave 0 — Assemble the "already-owned" modules (agent-doable, now)
+### Wave 0 — Assemble the "already-owned" modules (agent-doable, now) — ✅ DONE 13-07-2026
+
 *Unblocked by:* nothing — all inputs are committed.
 
 - Pull modules **2** (vocab size → A40 census + A55 union), **7** (POS distribution → A56
   grammar-token index), **1** (lemma/token → VisualDCS), and a first cut of **3/4** (frequency →
   `dcs_lemma_summary.json`) into a single **`papers/sanskrit_in_numbers/` data table**, RU-labelled.
-- Deliverable: [`papers/sanskrit_in_numbers/MODULES_OWNED.md`](https://github.com/gasyoun/SanskritLexicography/tree/master/papers) — one row per module, each citing its source artifact with n + date (the house trust-block discipline).
+- Deliverable: [`papers/sanskrit_in_numbers/MODULES_OWNED.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/sanskrit_in_numbers/MODULES_OWNED.md) — one row per module, each citing its source artifact with n + date (the house trust-block discipline). Shipped under [H813](https://github.com/gasyoun/Uprava/blob/main/handoffs/H813-Sonnet_SanskritLexicography_sanskrit_in_numbers_wave1_new_modules_12.07.26.md) (Sonnet 5 `claude-sonnet-5`): Petersburg-family de-duplicated union 167,904 vs. naive sum 285,799 (+70.2% double-count inflation, the D2/D6 caveat now quantified); the new Zipf coverage curve shows DCS's top-100 lemmas cover 36.1% of the corpus (vs. Duden's ~50% for German).
 
-### Wave 1 — Build the five NEW modules (agent-doable, now — **the core measurement**)
+### Wave 1 — Build the five NEW modules (agent-doable, now — **the core measurement**) — ✅ DONE 13-07-2026
+
 *Unblocked by:* wave 0's basis lock; PWG/PWK/SCH markup already present in the org dict repos.
 
-A committed dataset + one figure per module, computed reproducibly from the family markup + DCS:
+A committed dataset + one figure per module, computed reproducibly from the family markup + DCS.
+Shipped under [H813](https://github.com/gasyoun/Uprava/blob/main/handoffs/H813-Sonnet_SanskritLexicography_sanskrit_in_numbers_wave1_new_modules_12.07.26.md) (Sonnet 5 `claude-sonnet-5`) — headline numbers + trust blocks in
+[`papers/sanskrit_in_numbers/WAVE1_SUMMARY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/sanskrit_in_numbers/WAVE1_SUMMARY.md):
 
 - **Module 5 — akṣara / phoneme frequency.** Phoneme histogram over family headwords (SLP1/key1)
   and over DCS tokens; report both *graphemic* (Devanagari akṣara) and *phonemic* counts, since
-  sandhi makes them diverge — the Sanskrit-specific twist on Duden's letter chart.
+  sandhi makes them diverge — the Sanskrit-specific twist on Duden's letter chart. Shipped:
+  family (285,950 headwords) + DCS corpus (5,688,416 tokens) histograms both computed; the two
+  layers genuinely diverge (e.g. phonemic `a` at 21–24% vs. no single akṣara exceeding 5.5%).
 - **Module 6 — longest compounds.** Longest samāsa in DCS (with a ≥5-occurrence honesty floor, as
-  Duden does), plus the length distribution; the show-stopper module.
+  Duden does), plus the length distribution; the show-stopper module. Shipped: 39-char/16-akṣara
+  record at the floor (*sāgaravaradharabuddhivikrīḍitābhijñasya*, n=5) vs. a 50-char hapax without
+  the floor — demonstrating why the floor matters.
 - **Module 8 — gender distribution.** m / f / n shares from family gender markers; the
-  multi-gender headword set (the analog of Duden's *der/die/das Joghurt*).
+  multi-gender headword set (the analog of Duden's *der/die/das Joghurt*). Shipped from the
+  already-released A56 zaliznyak-grammar-index `lex` column (98,639 headwords): masc 54.6% / neut
+  23.4% / fem 22.0% (of 64,488 gendered nouns); 482 multi-gender headwords.
 - **Module 10 — verb classes + voice.** gaṇa (10-class) distribution and
-  parasmaipada/ātmanepada/ubhayapada shares, from family `cl.`/`<ab>P.</ab>` markup joined to
-  [WhitneyRoots](https://github.com/gasyoun/WhitneyRoots) (85.5 % gaṇa agreement already measured);
-  the direct *haben/sein* analog.
+  parasmaipada/ātmanepada/ubhayapada shares, from [WhitneyRoots](https://github.com/gasyoun/WhitneyRoots)'
+  own digitized Whitney (1885) classification (857 roots) + vidyut-prakriya-generated paradigms
+  (419 roots corroborated) — not re-parsed from raw PWG prose, per the honest-method note in
+  WAVE1_SUMMARY.md; the direct *haben/sein* analog. Shipped: gaṇa I dominates at 72.0%; pada split
+  parasmaipada 61.1% / ātmanepada 20.5% / ubhayapada 18.4%.
 - **Module 9 — samāsa types (best-effort).** Distribution of tatpuruṣa / bahuvrīhi / dvandva /
   … over a DCS-segmented sample (vidyut / DCS analyses); flagged best-effort because full
   compound typing needs segmentation, not markup. The *Fugenzeichen* analog: sandhi transformation
-  at the juncture.
+  at the juncture. Shipped: DCS's own UD-style `compound:coord` tag gives a reliable dvandva count
+  (2,044 relations, 92.3% of tagged compound relations) — genuinely new, not heuristic; the
+  tatpuruṣa/bahuvrīhi split is explicitly NOT auto-classified (would risk fabricated percentages)
+  and is left as a flagged follow-up with a hand-typing sample included.
 
 ### Wave 2 — The RU portrait (gates on wave 1 + Manual home)
 *Unblocked by:* all 10 module datasets; confirmation of the Manual repo/build (see §8).

--- a/papers/sanskrit_in_numbers/MODULES_OWNED.md
+++ b/papers/sanskrit_in_numbers/MODULES_OWNED.md
@@ -1,0 +1,126 @@
+# «Санскрит в цифрах» — Wave 0: owned modules assembled
+
+_Created: 13-07-2026 · Last updated: 13-07-2026_
+
+> Assembles the modules already **owned** by sibling papers/datasets (modules 2 and 7 —
+> cited, never recomputed here) plus modules 1/3/4 (owned data, one new computation: the
+> Zipf coverage curve the roadmap flagged as "partial"). Executes Wave 0 of
+> [ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md)
+> under handoff [H813](https://github.com/gasyoun/Uprava/blob/main/handoffs/H813-Sonnet_SanskritLexicography_sanskrit_in_numbers_wave1_new_modules_12.07.26.md).
+> Generator: [module0_wave0_assembly.py](module0_wave0_assembly.py) → [module0_wave0_owned_modules.json](module0_wave0_owned_modules.json).
+
+## Module 1 — lemma vs token
+
+**Owner:** [VisualDCS](https://github.com/gasyoun/VisualDCS) (DCS-2026 release). Cited, not recomputed.
+
+| Metric | n | Source |
+|---|---|---|
+| Texts | 270 | VisualDCS DCS-2026 |
+| Tokens | 5,688,416 | `DCS-data-2026/dcs_full.sqlite` |
+| Sentences | 754,726 | same |
+| Distinct lemmas attested | 90,349 | same, exact per-token join (see Module 3/4 caveat below re: the coarser published summary) |
+
+## Module 2 — vocabulary size (union ≠ naive sum)
+
+**Owner:** [A40 headword census](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A40_headword_inventory_note.md)
++ [A55 union index](https://github.com/gasyoun/kosha/blob/main/papers/A55_UNION_HEADWORDS_DATA_PAPER_JOHD.md)
++ [HEADWORD_OVERLAP_UNION15_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/data/HEADWORD_OVERLAP_UNION15_2026.md).
+Cited, not recomputed — the family-only figures below are a **filter** of the
+already-published 15-dict [union_headwords.tsv](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/union/union_headwords.tsv)
+down to the Petersburg family (PWG+PWK+SCH, D6 basis), not a new census.
+
+| Metric | n |
+|---|---|
+| Full 15-dict de-duplicated union | 323,425 |
+| Petersburg family (PWG+PWK+SCH) headwords, naive sum | 285,799 |
+| Petersburg family, de-duplicated union | 167,904 |
+| **Naive-sum double-count inflation** | **+70.2%** |
+| Headwords attested in all three (PWG ∩ PWK ∩ SCH) | 7,605 |
+| PWG rows in the union | 106,054 |
+| PWK rows in the union | 151,314 |
+| SCH rows in the union | 28,431 |
+
+**The caveat the portrait must state on its face (D2+D6):** PWK abridges PWG (finer
+splitting inflates its own headword count even as it summarizes PWG), and SCH is an
+addenda layer — summing `PWG + PWK + SCH` overstates true vocabulary size by **70%**. The
+honest number is the de-duplicated union (167,904), not the naive sum (285,799).
+
+## Module 3/4 — frequency, POS, and the Zipf coverage curve
+
+**Owner:** [VisualDCS](https://github.com/gasyoun/VisualDCS) (DCS-2026 release) for the raw
+frequencies; the coverage curve itself is **NEW this wave** (flagged "partial" in the
+roadmap, not owned by a sibling paper) — computed once from the already-committed DCS-2026
+corpus (`token.lemma_id` exact per-token counts, not the coarser `freqBand` (1–5) in
+[dcs_lemma_summary.json](https://github.com/gasyoun/VisualDCS/blob/main/dcs_lemma_summary.json),
+which cannot support a precise coverage curve).
+
+**Duden's own headline stat:** "100 words cover about half the [running] text." Sanskrit's
+answer, from DCS:
+
+| Top-N lemmas | Cumulative tokens | % of corpus |
+|---|---|---|
+| 1 | 197,087 | 3.46% |
+| 10 | 852,064 | 14.98% |
+| 50 | 1,673,921 | 29.43% |
+| **100** | **2,054,399** | **36.12%** |
+| 200 | 2,485,217 | 43.69% |
+| 500 | 3,190,620 | 56.09% |
+| 1,000 | 3,776,049 | 66.38% |
+| 2,000 | 4,361,773 | 76.68% |
+| 5,000 | 5,002,905 | 87.95% |
+| 10,000 | 5,333,485 | 93.76% |
+| 20,000 | 5,525,765 | 97.14% |
+| 50,000 | 5,645,261 | 99.24% |
+
+Sanskrit's top 100 lemmas cover **36.1%** of the corpus versus German's ~50% for the
+Dudenkorpus — a genuinely lower concentration, plausibly reflecting DCS's much smaller,
+more genre-skewed (Vedic/śāstra/kāvya-heavy) corpus versus a balanced 5.2-billion-word
+modern reference corpus. See [module0_wave0_owned_modules.json](module0_wave0_owned_modules.json)
+for the top-20 lemma list and full curve.
+
+**Honest scale caveat (repeat of the roadmap's own framing):** the Dudenkorpus is 5.2
+**billion** word forms; DCS is 5.7 **million** — roughly a thousandfold smaller. Sanskrit has
+no billion-word balanced contemporary corpus and never will, being a classical language.
+Corpus-unattested ≠ non-existent (the A40 caveat carries over): a lemma absent from this
+curve is unattested-in-DCS, not a ghost word.
+
+## Module 7 — grammar-category (POS) distribution
+
+**Owner:** [A56 Zaliznyak grammar-token index](https://github.com/gasyoun/kosha/blob/main/papers/A56_ZALIZNYAK_GRAMMAR_INDEX_DATA_PAPER_JOHD.md)
+(kosha, release [data-v0.1.0](https://github.com/gasyoun/kosha/releases/tag/data-v0.1.0)).
+Cited, not recomputed.
+
+| Metric | n |
+|---|---|
+| PWG headwords classified | 98,639 |
+| Distinct paradigm tokens (closed inventory) | 335 |
+
+Module 8 of this wave (gender distribution) reuses the SAME already-released dataset's
+`lex` column for a different cut (gender, not paradigm token) — legitimate reuse of a
+committed asset, not duplication of A56's own novelty (the paradigm-token inventory
+itself).
+
+---
+
+## Anti-salami boundary (restated)
+
+Modules 2 and 7 are **cited, never re-derived** here, per the roadmap's §5. The
+self-layering of the Petersburg family (why PWK's headword count exceeds PWG's) is
+[A49](https://github.com/gasyoun/Uprava/blob/main/ARTICLES.md)'s territory, not this
+wave's. This file's only new computation is the Module 3/4 Zipf coverage curve.
+
+## Wave 1 — the five NEW modules
+
+Built separately, each with its own generator + dataset + trust block:
+
+| # | Module | Generator | Dataset |
+|---|---|---|---|
+| 5 | akṣara / phoneme frequency | [module5_akshara_phoneme_freq.py](module5_akshara_phoneme_freq.py) | [module5_akshara_phoneme_freq.json](module5_akshara_phoneme_freq.json) |
+| 6 | longest compounds | [module6_longest_compounds.py](module6_longest_compounds.py) | [module6_longest_compounds.json](module6_longest_compounds.json) |
+| 8 | gender distribution | [module8_gender_distribution.py](module8_gender_distribution.py) | [module8_gender_distribution.json](module8_gender_distribution.json) |
+| 9 | samāsa types (best-effort) | [module9_samasa_types.py](module9_samasa_types.py) | [module9_samasa_types.json](module9_samasa_types.json) |
+| 10 | verb classes + voice | [module10_verb_class_voice.py](module10_verb_class_voice.py) | [module10_verb_class_voice.json](module10_verb_class_voice.json) |
+
+See [WAVE1_SUMMARY.md](WAVE1_SUMMARY.md) for the headline numbers and trust blocks.
+
+_Dr. Mārcis Gasūns_

--- a/papers/sanskrit_in_numbers/WAVE1_SUMMARY.md
+++ b/papers/sanskrit_in_numbers/WAVE1_SUMMARY.md
@@ -1,0 +1,142 @@
+# «Санскрит в цифрах» — Wave 1: five NEW module datasets
+
+_Created: 13-07-2026 · Last updated: 13-07-2026_
+
+> Executes Wave 1 of [ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md)
+> under handoff [H813](https://github.com/gasyoun/Uprava/blob/main/handoffs/H813-Sonnet_SanskritLexicography_sanskrit_in_numbers_wave1_new_modules_12.07.26.md).
+> Five modules, each with a reproducible generator script and a committed dataset. This is
+> the portrait's own scholarly novelty (§5 anti-salami: modules 2/7 are cited elsewhere, see
+> [MODULES_OWNED.md](MODULES_OWNED.md)).
+
+## Module 5 — akṣara / phoneme frequency
+
+**Source · n · date:** Petersburg family (PWG+PWK+SCH) headwords, `HeadwordLists/now-2026/`
+key1/key2 SLP1, n=285,950 headwords · DCS-2026 corpus tokens, n=5,688,416 · 13-07-2026 ·
+Sonnet 5 (`claude-sonnet-5`). Generator: [module5_akshara_phoneme_freq.py](module5_akshara_phoneme_freq.py).
+
+Reports BOTH layers because sandhi makes them diverge — the module's core finding, with no
+German counterpart:
+
+| Layer | Family top-5 | DCS-corpus top-5 |
+|---|---|---|
+| **Phonemic** (SLP1 char = 1 phoneme) | a (24.2%), r (6.7%), A (6.4%), i (5.2%), t (4.9%) | a (21.2%), A (7.2%), t (7.0%), r (5.3%), i (5.0%) |
+| **Graphemic** (Devanagari akṣara) | न (3.8%), र (3.6%), क (3.6%), अ (2.9%), म (2.7%) | म (5.5%), त (4.4%), अ (3.6%), न (3.0%), व (2.6%) |
+
+Totals: family = 2,572,557 phonemes / 1,187,061 akṣaras; DCS corpus = 32,067,704 phonemes /
+15,084,217 akṣaras. The phonemic and graphemic rankings genuinely diverge (e.g. `a` dominates
+phonemically but no single akṣara dominates as heavily graphemically) — a direct, quantified
+demonstration of sandhi's effect on the written vs. spoken/phonemic layer that Duden's German
+letter-chart has no equivalent for. Full histograms (top-40 each): [module5_akshara_phoneme_freq.json](module5_akshara_phoneme_freq.json).
+
+## Module 6 — longest compounds (samāsa)
+
+**Source · n · date:** DCS-2026 corpus, `token.form` surface forms, n=381,413 distinct forms
+(91,726 meeting the ≥5-occurrence honesty floor) · 13-07-2026 · Sonnet 5 (`claude-sonnet-5`).
+Generator: [module6_longest_compounds.py](module6_longest_compounds.py).
+
+| | Form | Occurrences | Char length | Akṣara length |
+|---|---|---|---|---|
+| **Record (≥5-occurrence floor)** | *sāgaravaradharabuddhivikrīḍitābhijñasya* | 5 | 39 | 16 |
+| No-floor "record" (hapax) | *vyādhavākyopadeśakathanapūrvakadānādiphalavarṇanaṃ* | 1 | 50 | — |
+
+The floor matters exactly the way Duden's own methodology intends: without it, a one-off
+colophon-title string sets an unrepresentative 50-character "record"; with the same
+≥5-occurrence discipline Duden applies to German's 79-character *Bandwurmwort*, Sanskrit's
+honest record is 39 characters / 16 akṣaras. Full top-50 + length distribution:
+[module6_longest_compounds.json](module6_longest_compounds.json).
+
+**Method note:** "compound" here = longest attested single orthographic word (Duden's own
+unit for the *Bandwurmwort* record), not a formally verified samāsa parse — see Module 9 for
+why full samāsa segmentation is a separate, harder problem.
+
+## Module 8 — gender distribution
+
+**Source · n · date:** [zaliznyak-grammar-index](https://github.com/gasyoun/kosha/releases/tag/data-v0.1.0)
+(A56, kosha), `lex` column, n=98,639 PWG headwords · 13-07-2026 · Sonnet 5 (`claude-sonnet-5`).
+Generator: [module8_gender_distribution.py](module8_gender_distribution.py). Reuses an
+already-released committed asset (not re-derived from raw PWG markup) — see anti-salami note
+in [MODULES_OWNED.md](MODULES_OWNED.md).
+
+| Gender | n | % (of 64,488 gendered nouns) |
+|---|---|---|
+| Masculine | 35,184 | 54.56% |
+| Neuter | 15,112 | 23.43% |
+| Feminine | 14,192 | 22.01% |
+
+**Multi-gender headwords** (the Sanskrit *der/die/das Joghurt* analog): **482** headwords
+(0.74% of gendered nouns) attested with more than one gender — m./n. 459, m./f./n. (tri-gender)
+12, m./f. 7, f./n. 4. Non-gendered categories (adj./adv./indecl./interj., 33,662 headwords)
+are excluded from the percentage base, since Sanskrit adjectives take the gender of the noun
+they modify rather than carrying a fixed dictionary gender — the structural reason Sanskrit's
+multi-gender set is dominated by substantivized adjectives, not ordinary nouns, unlike German.
+Full breakdown: [module8_gender_distribution.json](module8_gender_distribution.json).
+
+## Module 9 — samāsa types (best-effort, flagged)
+
+**Source · n · date:** DCS-2026 corpus, `token.deprel` UD-style compound relations, n=5,688,416
+tokens total (2,214 carrying an explicit compound-member relation) · 13-07-2026 · Sonnet 5
+(`claude-sonnet-5`). Generator: [module9_samasa_types.py](module9_samasa_types.py).
+
+| deprel | n | Type |
+|---|---|---|
+| `compound:coord` | 2,044 | **dvandva (coordinate)** — reliably tagged, not heuristic |
+| `compound` | 119 | tatpuruṣa / karmadhāraya / bahuvrīhi, **undifferentiated** |
+| `compound:name` | 51 | proper-name compound |
+
+**Explicitly flagged best-effort, per the roadmap.** DCS's own UD-style tagging gives a
+reliable, corpus-native **dvandva** count (`compound:coord`) — this is not a guess. But the
+much larger tatpuruṣa/bahuvrīhi distinction is **not** auto-classified: the UD `compound`
+relation used by DCS does not carry that distinction, and inventing percentages for it via
+unverified heuristics would risk fabricating data. A random 15-item sample per bucket is
+included in the dataset for a future dedicated segmentation pass (vidyut `cheda` + hand
+adjudication) to type — that full typing pass is a follow-up, not delivered here. **Scale
+caveat:** only 0.039% of all DCS tokens carry an explicit compound-member deprel at all — most
+Sanskrit compounds in this corpus remain single, undecomposed orthographic words (see Module
+6), so this module describes the tagged minority, not the full compound population. Full
+detail: [module9_samasa_types.json](module9_samasa_types.json).
+
+## Module 10 — verb classes (gaṇa) + voice
+
+**Source · n · date:** [WhitneyRoots](https://github.com/gasyoun/WhitneyRoots)
+`Whitney_roots_class-PP.txt` (Whitney 1885 digitized classification), n=857 roots, for gaṇa;
+`src/paradigms.json` (vidyut-prakriya 0.4.0 generated paradigms), n=419 roots corroborated,
+for voice · 13-07-2026 · Sonnet 5 (`claude-sonnet-5`). Generator:
+[module10_verb_class_voice.py](module10_verb_class_voice.py).
+
+**Gaṇa (primary class, 689 classified roots; 168 unclassified/no attested class):**
+
+| Gaṇa | I | II | IV | VI | III/V/VII/VIII/IX (each) |
+|---|---|---|---|---|---|
+| % | 71.99% | 7.11% | 8.85% | 6.53% | 1.89% / 1.31% / 0.73% / 0.29% / 0.73% |
+
+Class I dominates at **72%** — the direct Sanskrit analog of Duden's "weak verbs 76.7%",
+structurally similar in magnitude though for a different reason (thematic-vowel regularity
+vs. German's weak/strong conjugation split). 244 roots (35.4% of classified roots) belong to
+more than one gaṇa (see `gana_membership_pct` in the dataset for the full multi-class
+picture).
+
+**Voice (pada), 419 vidyut-corroborated roots (NOT extrapolated to all 857):**
+
+| Pada | n | % |
+|---|---|---|
+| Parasmaipada | 256 | 61.10% |
+| Ātmanepada | 86 | 20.53% |
+| Ubhayapada | 77 | 18.38% |
+
+A cleaner structural analog of German's *haben/sein* auxiliary split than German's own
+(irregular, historically accreted) list — Sanskrit's P/A/U split is a live grammatical
+category assigned to every verb root, not a lexical residue. **Cross-reference, cited not
+re-measured:** WhitneyRoots' own corpus-vs-Whitney gaṇa agreement measurement (857
+DCS-attested roots, 85.5% agreement) lives in that repo's `corpus_verdict_summary.txt`.
+Full detail: [module10_verb_class_voice.json](module10_verb_class_voice.json).
+
+---
+
+## Reproducibility
+
+Every script reads only already-committed sibling-repo data (VisualDCS, WhitneyRoots, kosha
+release, this repo's HeadwordLists) — no manual/uncommitted inputs. Re-run any module with
+`python module<N>_<name>.py` from this directory; each writes its own `.json` and prints its
+headline numbers to stdout.
+
+_Dr. Mārcis Gasūns_

--- a/papers/sanskrit_in_numbers/module0_wave0_assembly.py
+++ b/papers/sanskrit_in_numbers/module0_wave0_assembly.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Wave 0 assembly (Sanskrit-in-Numbers, H813): pull the already-OWNED modules
+(2, 7, 1, partial 3/4) into one data table, and build the Zipf coverage curve
+that Module 3/4 lacked ("100 words ~ 1/2 of text", Duden's own framing).
+
+Anti-salami: modules 2 and 7 are CITED here, never recomputed -- this script
+only filters the already-published union_headwords.tsv down to the
+Petersburg-family subset (a read, not a re-derivation) and reads off already-
+published totals from A40/A55/A56/VisualDCS. The Zipf coverage curve IS new
+computation (module 3/4 was flagged "partial" in the roadmap, not owned), but
+uses only the ALREADY-committed VisualDCS DCS-2026 corpus (real lemma
+frequencies from token.lemma_id joins, not the coarse frequency BANDS in
+dcs_lemma_summary.json, which are too coarse for a coverage curve).
+"""
+import csv
+import json
+import sqlite3
+import sys
+from datetime import date
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GITHUB_ROOT = REPO_ROOT.parent
+UNION_TSV = REPO_ROOT / "HeadwordLists" / "union" / "union_headwords.tsv"
+DCS_DB = GITHUB_ROOT / "VisualDCS" / "src" / "DCS-data-2026" / "dcs_full.sqlite"
+
+FAMILY = {"PWG", "PWK", "SCH"}
+
+
+def family_union():
+    """Filter the already-published 15-dict union down to the Petersburg
+    family (PWG+PWK+SCH), reading dict-membership per headword. This is a
+    read/filter of already-published data (A40/A55), not a re-derivation."""
+    n_family_union = 0
+    n_all_three = 0
+    n_pwg = n_pwk = n_sch = 0
+    with open(UNION_TSV, encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            dicts = set(row["dicts"].split())
+            fam_dicts = dicts & FAMILY
+            if fam_dicts:
+                n_family_union += 1
+                if fam_dicts == FAMILY:
+                    n_all_three += 1
+                if "PWG" in fam_dicts:
+                    n_pwg += 1
+                if "PWK" in fam_dicts:
+                    n_pwk += 1
+                if "SCH" in fam_dicts:
+                    n_sch += 1
+    return {
+        "family_union_dedup": n_family_union,
+        "in_all_three": n_all_three,
+        "pwg_rows": n_pwg,
+        "pwk_rows": n_pwk,
+        "sch_rows": n_sch,
+        "naive_sum": n_pwg + n_pwk + n_sch,
+    }
+
+
+def zipf_coverage_curve():
+    """Real lemma-frequency Zipf coverage curve from DCS-2026: what % of all
+    tokens do the top-N lemmas cover. Uses exact counts from token.lemma_id,
+    not dcs_lemma_summary.json's coarse freqBand (1..5), which cannot support
+    a precise coverage curve."""
+    con = sqlite3.connect(str(DCS_DB))
+    cur = con.cursor()
+    cur.execute(
+        "SELECT lemma, COUNT(*) AS n FROM token WHERE lemma IS NOT NULL "
+        "AND lemma != '' GROUP BY lemma ORDER BY n DESC"
+    )
+    rows = cur.fetchall()
+    con.close()
+
+    total_tokens = sum(n for _, n in rows)
+    n_distinct_lemmas = len(rows)
+
+    checkpoints = [1, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000]
+    curve = []
+    running = 0
+    idx = 0
+    for cp in checkpoints:
+        while idx < cp and idx < len(rows):
+            running += rows[idx][1]
+            idx += 1
+        curve.append({
+            "top_n": cp,
+            "cumulative_tokens": running,
+            "pct_of_corpus": round(100 * running / total_tokens, 2),
+        })
+
+    top20 = [{"lemma": l, "n": n, "pct": round(100 * n / total_tokens, 3)} for l, n in rows[:20]]
+
+    return {
+        "total_tokens": total_tokens,
+        "n_distinct_lemmas": n_distinct_lemmas,
+        "coverage_curve": curve,
+        "top20_lemmas": top20,
+    }
+
+
+def main():
+    fam = family_union()
+    zipf = zipf_coverage_curve()
+
+    out = {
+        "wave": 0,
+        "generated": str(date.today()),
+        "model": "Sonnet 5 (claude-sonnet-5)",
+        "modules_owned": {
+            "module_2_vocabulary_size": {
+                "owner": "A40 (headword census) + A55 (union index, kosha)",
+                "source": [
+                    "papers/A40_headword_inventory_note.md",
+                    "https://github.com/gasyoun/kosha/blob/main/papers/A55_UNION_HEADWORDS_DATA_PAPER_JOHD.md",
+                    "data/HEADWORD_OVERLAP_UNION15_2026.md",
+                ],
+                "headline_n": {
+                    "full_15_dict_union": 323425,
+                    "petersburg_family_union_dedup": fam["family_union_dedup"],
+                    "petersburg_family_naive_sum": fam["naive_sum"],
+                    "petersburg_family_double_count_inflation_pct": round(
+                        100 * (fam["naive_sum"] - fam["family_union_dedup"]) / fam["family_union_dedup"], 1
+                    ),
+                    "in_all_three_pwg_pwk_sch": fam["in_all_three"],
+                    "pwg_headwords": fam["pwg_rows"],
+                    "pwk_headwords": fam["pwk_rows"],
+                    "sch_headwords": fam["sch_rows"],
+                },
+                "caveat": "PWK abridges PWG, PW abridges further, SCH is addenda -- naive "
+                          "summing double-counts massively (D2/D6 caveat, roadmap SS2). "
+                          "The honest 'vocabulary size' number is the de-duplicated union, "
+                          "computed here by filtering the already-published 15-dict union "
+                          "(union_headwords.tsv) to the family, NOT recomputed from scratch.",
+            },
+            "module_7_pos_distribution": {
+                "owner": "A56 (Zaliznyak grammar-token index, kosha)",
+                "source": "https://github.com/gasyoun/kosha/blob/main/papers/A56_ZALIZNYAK_GRAMMAR_INDEX_DATA_PAPER_JOHD.md",
+                "headline_n": {"headwords_classified": 98639, "paradigm_tokens": 335},
+                "caveat": "Cited, not recomputed here.",
+            },
+            "module_1_lemma_vs_token": {
+                "owner": "VisualDCS (DCS-2026 release)",
+                "source": "https://github.com/gasyoun/VisualDCS",
+                "headline_n": {
+                    "texts": 270,
+                    "tokens": zipf["total_tokens"],
+                    "sentences": 754726,
+                    "distinct_lemmas_attested": zipf["n_distinct_lemmas"],
+                },
+            },
+            "module_3_4_frequency_and_zipf": {
+                "owner": "VisualDCS (DCS-2026 release); coverage curve NEW this wave",
+                "source": "VisualDCS/src/DCS-data-2026/dcs_full.sqlite (real per-token lemma "
+                          "counts, not the coarse freqBand in dcs_lemma_summary.json)",
+                "coverage_curve": zipf["coverage_curve"],
+                "top20_lemmas": zipf["top20_lemmas"],
+                "caveat": "Duden's own headline stat is '100 words cover ~half the text'; "
+                          "DCS's top-100 lemmas cover "
+                          f"{next(c['pct_of_corpus'] for c in zipf['coverage_curve'] if c['top_n']==100)}% "
+                          "of tokens -- see the curve for the full comparison. Scale caveat: "
+                          "DCS (5.7M tokens) is ~1000x smaller than the Dudenkorpus (5.2B); "
+                          "corpus-unattested does not mean non-existent (A40 caveat).",
+            },
+        },
+        "anti_salami_note": "This file CITES modules 2 and 7 (A40/A55/A56 own their novelty); "
+                             "it does not re-derive their headline results. The family-union "
+                             "figure above is a FILTER of already-published per-headword "
+                             "dict-membership data, not a new census. The Zipf coverage curve "
+                             "is genuinely new (module 3/4 was 'partial' in the roadmap), "
+                             "computed once here from the already-committed DCS-2026 corpus.",
+    }
+
+    out_path = Path(__file__).parent / "module0_wave0_owned_modules.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(out, f, ensure_ascii=False, indent=2)
+
+    print(f"family union dedup: {fam}")
+    print(f"zipf total_tokens: {zipf['total_tokens']}, distinct lemmas: {zipf['n_distinct_lemmas']}")
+    print(f"coverage curve: {zipf['coverage_curve']}")
+    print(f"wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/papers/sanskrit_in_numbers/module0_wave0_owned_modules.json
+++ b/papers/sanskrit_in_numbers/module0_wave0_owned_modules.json
@@ -1,0 +1,215 @@
+{
+  "wave": 0,
+  "generated": "2026-07-13",
+  "model": "Sonnet 5 (claude-sonnet-5)",
+  "modules_owned": {
+    "module_2_vocabulary_size": {
+      "owner": "A40 (headword census) + A55 (union index, kosha)",
+      "source": [
+        "papers/A40_headword_inventory_note.md",
+        "https://github.com/gasyoun/kosha/blob/main/papers/A55_UNION_HEADWORDS_DATA_PAPER_JOHD.md",
+        "data/HEADWORD_OVERLAP_UNION15_2026.md"
+      ],
+      "headline_n": {
+        "full_15_dict_union": 323425,
+        "petersburg_family_union_dedup": 167904,
+        "petersburg_family_naive_sum": 285799,
+        "petersburg_family_double_count_inflation_pct": 70.2,
+        "in_all_three_pwg_pwk_sch": 7605,
+        "pwg_headwords": 106054,
+        "pwk_headwords": 151314,
+        "sch_headwords": 28431
+      },
+      "caveat": "PWK abridges PWG, PW abridges further, SCH is addenda -- naive summing double-counts massively (D2/D6 caveat, roadmap SS2). The honest 'vocabulary size' number is the de-duplicated union, computed here by filtering the already-published 15-dict union (union_headwords.tsv) to the family, NOT recomputed from scratch."
+    },
+    "module_7_pos_distribution": {
+      "owner": "A56 (Zaliznyak grammar-token index, kosha)",
+      "source": "https://github.com/gasyoun/kosha/blob/main/papers/A56_ZALIZNYAK_GRAMMAR_INDEX_DATA_PAPER_JOHD.md",
+      "headline_n": {
+        "headwords_classified": 98639,
+        "paradigm_tokens": 335
+      },
+      "caveat": "Cited, not recomputed here."
+    },
+    "module_1_lemma_vs_token": {
+      "owner": "VisualDCS (DCS-2026 release)",
+      "source": "https://github.com/gasyoun/VisualDCS",
+      "headline_n": {
+        "texts": 270,
+        "tokens": 5688416,
+        "sentences": 754726,
+        "distinct_lemmas_attested": 90349
+      }
+    },
+    "module_3_4_frequency_and_zipf": {
+      "owner": "VisualDCS (DCS-2026 release); coverage curve NEW this wave",
+      "source": "VisualDCS/src/DCS-data-2026/dcs_full.sqlite (real per-token lemma counts, not the coarse freqBand in dcs_lemma_summary.json)",
+      "coverage_curve": [
+        {
+          "top_n": 1,
+          "cumulative_tokens": 197087,
+          "pct_of_corpus": 3.46
+        },
+        {
+          "top_n": 10,
+          "cumulative_tokens": 852064,
+          "pct_of_corpus": 14.98
+        },
+        {
+          "top_n": 50,
+          "cumulative_tokens": 1673921,
+          "pct_of_corpus": 29.43
+        },
+        {
+          "top_n": 100,
+          "cumulative_tokens": 2054399,
+          "pct_of_corpus": 36.12
+        },
+        {
+          "top_n": 200,
+          "cumulative_tokens": 2485217,
+          "pct_of_corpus": 43.69
+        },
+        {
+          "top_n": 500,
+          "cumulative_tokens": 3190620,
+          "pct_of_corpus": 56.09
+        },
+        {
+          "top_n": 1000,
+          "cumulative_tokens": 3776049,
+          "pct_of_corpus": 66.38
+        },
+        {
+          "top_n": 2000,
+          "cumulative_tokens": 4361773,
+          "pct_of_corpus": 76.68
+        },
+        {
+          "top_n": 5000,
+          "cumulative_tokens": 5002905,
+          "pct_of_corpus": 87.95
+        },
+        {
+          "top_n": 10000,
+          "cumulative_tokens": 5333485,
+          "pct_of_corpus": 93.76
+        },
+        {
+          "top_n": 20000,
+          "cumulative_tokens": 5525765,
+          "pct_of_corpus": 97.14
+        },
+        {
+          "top_n": 50000,
+          "cumulative_tokens": 5645261,
+          "pct_of_corpus": 99.24
+        }
+      ],
+      "top20_lemmas": [
+        {
+          "lemma": "tad",
+          "n": 197087,
+          "pct": 3.465
+        },
+        {
+          "lemma": "ca",
+          "n": 174415,
+          "pct": 3.066
+        },
+        {
+          "lemma": "iti",
+          "n": 78511,
+          "pct": 1.38
+        },
+        {
+          "lemma": "eva",
+          "n": 65472,
+          "pct": 1.151
+        },
+        {
+          "lemma": "mad",
+          "n": 63834,
+          "pct": 1.122
+        },
+        {
+          "lemma": "na",
+          "n": 63741,
+          "pct": 1.121
+        },
+        {
+          "lemma": "yad",
+          "n": 62099,
+          "pct": 1.092
+        },
+        {
+          "lemma": "idam",
+          "n": 52529,
+          "pct": 0.923
+        },
+        {
+          "lemma": "tvad",
+          "n": 51156,
+          "pct": 0.899
+        },
+        {
+          "lemma": "bhū",
+          "n": 43220,
+          "pct": 0.76
+        },
+        {
+          "lemma": "etad",
+          "n": 41421,
+          "pct": 0.728
+        },
+        {
+          "lemma": "kṛ",
+          "n": 40808,
+          "pct": 0.717
+        },
+        {
+          "lemma": "api",
+          "n": 37474,
+          "pct": 0.659
+        },
+        {
+          "lemma": "sarva",
+          "n": 37191,
+          "pct": 0.654
+        },
+        {
+          "lemma": "tu",
+          "n": 37081,
+          "pct": 0.652
+        },
+        {
+          "lemma": "as",
+          "n": 35763,
+          "pct": 0.629
+        },
+        {
+          "lemma": "vac",
+          "n": 33950,
+          "pct": 0.597
+        },
+        {
+          "lemma": "mahat",
+          "n": 26986,
+          "pct": 0.474
+        },
+        {
+          "lemma": "vā",
+          "n": 25488,
+          "pct": 0.448
+        },
+        {
+          "lemma": "tathā",
+          "n": 24787,
+          "pct": 0.436
+        }
+      ],
+      "caveat": "Duden's own headline stat is '100 words cover ~half the text'; DCS's top-100 lemmas cover 36.12% of tokens -- see the curve for the full comparison. Scale caveat: DCS (5.7M tokens) is ~1000x smaller than the Dudenkorpus (5.2B); corpus-unattested does not mean non-existent (A40 caveat)."
+    }
+  },
+  "anti_salami_note": "This file CITES modules 2 and 7 (A40/A55/A56 own their novelty); it does not re-derive their headline results. The family-union figure above is a FILTER of already-published per-headword dict-membership data, not a new census. The Zipf coverage curve is genuinely new (module 3/4 was 'partial' in the roadmap), computed once here from the already-committed DCS-2026 corpus."
+}

--- a/papers/sanskrit_in_numbers/module10_verb_class_voice.json
+++ b/papers/sanskrit_in_numbers/module10_verb_class_voice.json
@@ -1,0 +1,115 @@
+{
+  "module": 10,
+  "title": "verb classes (gana) + voice (parasmaipada/atmanepada/ubhayapada)",
+  "trust_block": {
+    "source": "WhitneyRoots Whitney_roots_class-PP.txt (938 roots, Whitney 1885 digitized classification) for gana; WhitneyRoots src/paradigms.json (vidyut-prakriya 0.4.0 generated, 454/938 roots corroborated) for pada",
+    "n": {
+      "roots_total_whitney": 857,
+      "roots_gana_classified": 689,
+      "roots_gana_unclassified": 168,
+      "roots_multi_class": 244,
+      "roots_pada_corroborated": 419
+    },
+    "date": "2026-07-13",
+    "model": "Sonnet 5 (claude-sonnet-5)"
+  },
+  "gana_primary_pct": {
+    "I": {
+      "n": 496,
+      "pct": 71.99
+    },
+    "II": {
+      "n": 49,
+      "pct": 7.11
+    },
+    "III": {
+      "n": 9,
+      "pct": 1.31
+    },
+    "IV": {
+      "n": 61,
+      "pct": 8.85
+    },
+    "V": {
+      "n": 13,
+      "pct": 1.89
+    },
+    "VI": {
+      "n": 45,
+      "pct": 6.53
+    },
+    "VII": {
+      "n": 5,
+      "pct": 0.73
+    },
+    "VIII": {
+      "n": 2,
+      "pct": 0.29
+    },
+    "IX": {
+      "n": 5,
+      "pct": 0.73
+    },
+    "X": {
+      "n": 0,
+      "pct": 0.0
+    }
+  },
+  "gana_membership_pct": {
+    "I": {
+      "n": 496,
+      "pct": 71.99
+    },
+    "II": {
+      "n": 120,
+      "pct": 17.42
+    },
+    "III": {
+      "n": 44,
+      "pct": 6.39
+    },
+    "IV": {
+      "n": 133,
+      "pct": 19.3
+    },
+    "V": {
+      "n": 44,
+      "pct": 6.39
+    },
+    "VI": {
+      "n": 121,
+      "pct": 17.56
+    },
+    "VII": {
+      "n": 28,
+      "pct": 4.06
+    },
+    "VIII": {
+      "n": 7,
+      "pct": 1.02
+    },
+    "IX": {
+      "n": 49,
+      "pct": 7.11
+    },
+    "X": {
+      "n": 0,
+      "pct": 0.0
+    }
+  },
+  "pada_pct": {
+    "parasmaipada": {
+      "n": 256,
+      "pct": 61.1
+    },
+    "ubhayapada": {
+      "n": 77,
+      "pct": 18.38
+    },
+    "atmanepada": {
+      "n": 86,
+      "pct": 20.53
+    }
+  },
+  "note": "gana 'primary' = first-listed class per root (the dictionary/grammar's own citation order); 'membership' = every class a multi-class root belongs to, so membership percentages sum to >100%. Voice (pada) is reported only over the 454-root vidyut-corroborated subset, NOT extrapolated to all 938 -- the smaller, cleaner denominator is stated explicitly rather than silently assumed representative of the full root inventory. Cross-reference: WhitneyRoots' own corpus-vs-Whitney gana agreement measurement (857 DCS-attested roots, 85.5%) is cited, not re-run, here (see corpus_verdict_summary.txt in that repo)."
+}

--- a/papers/sanskrit_in_numbers/module10_verb_class_voice.py
+++ b/papers/sanskrit_in_numbers/module10_verb_class_voice.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Module 10 - verb classes + voice (Sanskrit-in-Numbers Wave 1, H813).
+
+Duden's *Sprache in Zahlen* reports German verb-class shares (weak 76.7% /
+strong 17.2%) and the haben/sein auxiliary split. Sanskrit's direct analogs:
+the 10 gana (verb class) distribution, and the parasmaipada / atmanepada /
+ubhayapada (P/A/U, "for others" / "for oneself" / both) voice split -- a
+cleaner structural analog of haben/sein than German's own irregular-verb list.
+
+Source (WhitneyRoots, a sibling repo -- reused per org convention, not
+re-derived from raw PWG prose):
+  - GANA: Whitney_roots_class-PP.txt -- 938 roots digitized from Whitney's
+    "Roots, Verb-forms and Primary Derivatives" (1885), the standard
+    philological reference (Whitney's own classification, cross-checked
+    against the corpus elsewhere in that repo at 85.5% agreement -- cited,
+    not re-measured, here).
+  - PADA (voice): src/paradigms.json -- vidyut-prakriya-generated paradigms
+    for 454/938 roots (the subset where a Pāṇinian-gaṇa-consistent, either
+    corpus- or Dhātupātha-attested paradigm could be generated/corroborated).
+    Multi-pada roots (attested with more than one pada across paradigm
+    entries) are classified ubhayapada.
+
+Honesty note: gana coverage is 938 roots (full Whitney inventory, ~14% with
+no attested/classifiable class, shown as "unclassified"); voice coverage is
+the smaller 454-root corroborated subset -- reported as its own denominator,
+not silently extrapolated to all 938.
+"""
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import date
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GITHUB_ROOT = REPO_ROOT.parent
+WHITNEY_ROOT = GITHUB_ROOT / "WhitneyRoots"
+CLASS_PP_PATH = WHITNEY_ROOT / "Whitney_roots_class-PP.txt"
+PARADIGMS_PATH = WHITNEY_ROOT / "src" / "paradigms.json"
+
+LINE_RE = re.compile(
+    r"^\s*\d+\.\s+(?:\d\s+)?√?\s*(?P<root>\S+)\s+(?P<classes>\S+)\s+"
+)
+
+
+def parse_gana():
+    """Return dict root -> set of gana roman numerals (or empty set if '-')."""
+    roots = {}
+    with open(CLASS_PP_PATH, encoding="utf-8") as f:
+        for line in f:
+            m = LINE_RE.match(line)
+            if not m:
+                continue
+            root = m.group("root")
+            classes_raw = m.group("classes")
+            if classes_raw in ("—", "-", "—"):
+                classes = set()
+            else:
+                classes = set(c for c in classes_raw.split("/") if c)
+            # multiple homonyms of the same root spelling: keep the union of
+            # classes under one key (root spelling is what Module 10 counts,
+            # matching how the dictionary family cites class per root-spelling)
+            roots.setdefault(root, set()).update(classes)
+    return roots
+
+
+def parse_pada():
+    """Return dict root -> set of padas attested across generated paradigms."""
+    with open(PARADIGMS_PATH, encoding="utf-8") as f:
+        data = json.load(f)
+    roots = defaultdict(set)
+    meta = data["_meta"]
+    for _key, entry in data["roots"].items():
+        root = entry["root"]
+        for p in entry.get("paradigms", []):
+            pada = p.get("pada")
+            if not pada:
+                continue
+            # vidyut labels ubhayapada roots with a single combined string
+            # "parasmaipada+atmanepada" rather than two separate paradigm
+            # entries -- split it so it lands in both/ubhayapada correctly.
+            for part in pada.split("+"):
+                if part:
+                    roots[root].add(part)
+    return dict(roots), meta
+
+
+GANA_ROMAN = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
+
+
+def main():
+    gana_by_root = parse_gana()
+    n_roots_total = len(gana_by_root)
+    n_unclassified = sum(1 for v in gana_by_root.values() if not v)
+    n_classified = n_roots_total - n_unclassified
+
+    # gana distribution: a root with multiple classes contributes to each
+    # (matching Duden's own practice of not double-counting whole-word tokens,
+    # but here a multi-class root genuinely belongs to more than one gana --
+    # report both a "primary gana" (first-listed) share and a "multi-class
+    # membership" share, so neither reading is silently hidden)
+    primary_gana = Counter()
+    membership_gana = Counter()
+    n_multi_class = 0
+    for root, classes in gana_by_root.items():
+        if not classes:
+            continue
+        ordered = [g for g in GANA_ROMAN if g in classes]
+        if ordered:
+            primary_gana[ordered[0]] += 1
+        if len(classes) > 1:
+            n_multi_class += 1
+        for g in classes:
+            membership_gana[g] += 1
+
+    primary_gana_pct = {
+        g: {"n": primary_gana.get(g, 0), "pct": round(100 * primary_gana.get(g, 0) / n_classified, 2)}
+        for g in GANA_ROMAN
+    }
+    membership_gana_pct = {
+        g: {"n": membership_gana.get(g, 0), "pct": round(100 * membership_gana.get(g, 0) / n_classified, 2)}
+        for g in GANA_ROMAN
+    }
+
+    pada_by_root, paradigms_meta = parse_pada()
+    n_pada_roots = len(pada_by_root)
+    pada_class = Counter()
+    for root, padas in pada_by_root.items():
+        if len(padas) > 1:
+            pada_class["ubhayapada"] += 1
+        elif padas == {"parasmaipada"}:
+            pada_class["parasmaipada"] += 1
+        elif padas == {"atmanepada"}:
+            pada_class["atmanepada"] += 1
+        else:
+            pada_class["other/" + ",".join(sorted(padas))] += 1
+
+    pada_pct = {
+        k: {"n": v, "pct": round(100 * v / n_pada_roots, 2)}
+        for k, v in pada_class.items()
+    }
+
+    out = {
+        "module": 10,
+        "title": "verb classes (gana) + voice (parasmaipada/atmanepada/ubhayapada)",
+        "trust_block": {
+            "source": "WhitneyRoots Whitney_roots_class-PP.txt (938 roots, Whitney 1885 "
+                       "digitized classification) for gana; WhitneyRoots src/paradigms.json "
+                       "(vidyut-prakriya 0.4.0 generated, 454/938 roots corroborated) for pada",
+            "n": {
+                "roots_total_whitney": n_roots_total,
+                "roots_gana_classified": n_classified,
+                "roots_gana_unclassified": n_unclassified,
+                "roots_multi_class": n_multi_class,
+                "roots_pada_corroborated": n_pada_roots,
+            },
+            "date": str(date.today()),
+            "model": "Sonnet 5 (claude-sonnet-5)",
+        },
+        "gana_primary_pct": primary_gana_pct,
+        "gana_membership_pct": membership_gana_pct,
+        "pada_pct": pada_pct,
+        "note": "gana 'primary' = first-listed class per root (the dictionary/grammar's "
+                "own citation order); 'membership' = every class a multi-class root "
+                "belongs to, so membership percentages sum to >100%. Voice (pada) is "
+                "reported only over the 454-root vidyut-corroborated subset, NOT "
+                "extrapolated to all 938 -- the smaller, cleaner denominator is stated "
+                "explicitly rather than silently assumed representative of the full "
+                "root inventory. Cross-reference: WhitneyRoots' own corpus-vs-Whitney "
+                "gana agreement measurement (857 DCS-attested roots, 85.5%) is cited, "
+                "not re-run, here (see corpus_verdict_summary.txt in that repo).",
+    }
+
+    out_path = Path(__file__).parent / "module10_verb_class_voice.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(out, f, ensure_ascii=False, indent=2)
+
+    print(f"roots total: {n_roots_total}, classified: {n_classified}, unclassified: {n_unclassified}")
+    print(f"primary gana pct: {primary_gana_pct}")
+    print(f"pada roots: {n_pada_roots}, pada pct: {pada_pct}")
+    print(f"wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/papers/sanskrit_in_numbers/module5_akshara_phoneme_freq.json
+++ b/papers/sanskrit_in_numbers/module5_akshara_phoneme_freq.json
@@ -1,0 +1,843 @@
+{
+  "module": 5,
+  "title": "akshara / phoneme frequency",
+  "trust_block": {
+    "source": "Petersburg family (PWG+PWK+SCH) headwords, HeadwordLists/now-2026/ key1(key2 for SCH); DCS corpus tokens, VisualDCS DCS-data-2026/dcs_full.sqlite (DCS-2026 release)",
+    "n": {
+      "family_headwords": 285950,
+      "family_by_dict": {
+        "PWG": 106082,
+        "PWK": 151349,
+        "SCH": 28519
+      },
+      "dcs_tokens": 5688416
+    },
+    "date": "2026-07-13",
+    "model": "Sonnet 5 (claude-sonnet-5)"
+  },
+  "family": {
+    "phonemic": {
+      "total_phonemes": 2572557,
+      "top": [
+        {
+          "unit": "a",
+          "count": 622153,
+          "pct": 24.184
+        },
+        {
+          "unit": "r",
+          "count": 171579,
+          "pct": 6.67
+        },
+        {
+          "unit": "A",
+          "count": 165284,
+          "pct": 6.425
+        },
+        {
+          "unit": "i",
+          "count": 133184,
+          "pct": 5.177
+        },
+        {
+          "unit": "t",
+          "count": 126127,
+          "pct": 4.903
+        },
+        {
+          "unit": "n",
+          "count": 108908,
+          "pct": 4.233
+        },
+        {
+          "unit": "k",
+          "count": 106763,
+          "pct": 4.15
+        },
+        {
+          "unit": "v",
+          "count": 100650,
+          "pct": 3.912
+        },
+        {
+          "unit": "s",
+          "count": 79480,
+          "pct": 3.09
+        },
+        {
+          "unit": "p",
+          "count": 78340,
+          "pct": 3.045
+        },
+        {
+          "unit": "u",
+          "count": 75637,
+          "pct": 2.94
+        },
+        {
+          "unit": "m",
+          "count": 74472,
+          "pct": 2.895
+        },
+        {
+          "unit": "y",
+          "count": 73335,
+          "pct": 2.851
+        },
+        {
+          "unit": "d",
+          "count": 61369,
+          "pct": 2.386
+        },
+        {
+          "unit": "l",
+          "count": 48521,
+          "pct": 1.886
+        },
+        {
+          "unit": "S",
+          "count": 43503,
+          "pct": 1.691
+        },
+        {
+          "unit": "I",
+          "count": 39974,
+          "pct": 1.554
+        },
+        {
+          "unit": "z",
+          "count": 39619,
+          "pct": 1.54
+        },
+        {
+          "unit": "g",
+          "count": 35106,
+          "pct": 1.365
+        },
+        {
+          "unit": "R",
+          "count": 33908,
+          "pct": 1.318
+        },
+        {
+          "unit": "h",
+          "count": 32407,
+          "pct": 1.26
+        },
+        {
+          "unit": "D",
+          "count": 29231,
+          "pct": 1.136
+        },
+        {
+          "unit": "e",
+          "count": 28174,
+          "pct": 1.095
+        },
+        {
+          "unit": "j",
+          "count": 27700,
+          "pct": 1.077
+        },
+        {
+          "unit": "o",
+          "count": 25853,
+          "pct": 1.005
+        },
+        {
+          "unit": "B",
+          "count": 25730,
+          "pct": 1.0
+        },
+        {
+          "unit": "c",
+          "count": 23873,
+          "pct": 0.928
+        },
+        {
+          "unit": "f",
+          "count": 19643,
+          "pct": 0.764
+        },
+        {
+          "unit": "U",
+          "count": 19066,
+          "pct": 0.741
+        },
+        {
+          "unit": "w",
+          "count": 15874,
+          "pct": 0.617
+        },
+        {
+          "unit": "M",
+          "count": 15081,
+          "pct": 0.586
+        },
+        {
+          "unit": "b",
+          "count": 13584,
+          "pct": 0.528
+        },
+        {
+          "unit": "T",
+          "count": 12685,
+          "pct": 0.493
+        },
+        {
+          "unit": "q",
+          "count": 10051,
+          "pct": 0.391
+        },
+        {
+          "unit": "K",
+          "count": 7977,
+          "pct": 0.31
+        },
+        {
+          "unit": "N",
+          "count": 7873,
+          "pct": 0.306
+        },
+        {
+          "unit": "E",
+          "count": 6939,
+          "pct": 0.27
+        },
+        {
+          "unit": "Y",
+          "count": 6759,
+          "pct": 0.263
+        },
+        {
+          "unit": "O",
+          "count": 6629,
+          "pct": 0.258
+        },
+        {
+          "unit": "G",
+          "count": 5677,
+          "pct": 0.221
+        }
+      ]
+    },
+    "graphemic": {
+      "total_aksharas": 1187061,
+      "top": [
+        {
+          "unit": "न",
+          "count": 44801,
+          "pct": 3.774
+        },
+        {
+          "unit": "र",
+          "count": 42539,
+          "pct": 3.584
+        },
+        {
+          "unit": "क",
+          "count": 42221,
+          "pct": 3.557
+        },
+        {
+          "unit": "अ",
+          "count": 34762,
+          "pct": 2.928
+        },
+        {
+          "unit": "म",
+          "count": 31780,
+          "pct": 2.677
+        },
+        {
+          "unit": "व",
+          "count": 31722,
+          "pct": 2.672
+        },
+        {
+          "unit": "त",
+          "count": 30263,
+          "pct": 2.549
+        },
+        {
+          "unit": "प",
+          "count": 27472,
+          "pct": 2.314
+        },
+        {
+          "unit": "स",
+          "count": 25483,
+          "pct": 2.147
+        },
+        {
+          "unit": "य",
+          "count": 24962,
+          "pct": 2.103
+        },
+        {
+          "unit": "ल",
+          "count": 20719,
+          "pct": 1.745
+        },
+        {
+          "unit": "द",
+          "count": 16482,
+          "pct": 1.388
+        },
+        {
+          "unit": "वि",
+          "count": 16475,
+          "pct": 1.388
+        },
+        {
+          "unit": "का",
+          "count": 16036,
+          "pct": 1.351
+        },
+        {
+          "unit": "ति",
+          "count": 14463,
+          "pct": 1.218
+        },
+        {
+          "unit": "श",
+          "count": 14173,
+          "pct": 1.194
+        },
+        {
+          "unit": "ह",
+          "count": 13539,
+          "pct": 1.141
+        },
+        {
+          "unit": "प्र",
+          "count": 12391,
+          "pct": 1.044
+        },
+        {
+          "unit": "ण",
+          "count": 11971,
+          "pct": 1.008
+        },
+        {
+          "unit": "ज",
+          "count": 11606,
+          "pct": 0.978
+        },
+        {
+          "unit": "ग",
+          "count": 11458,
+          "pct": 0.965
+        },
+        {
+          "unit": "नि",
+          "count": 10048,
+          "pct": 0.846
+        },
+        {
+          "unit": "रा",
+          "count": 9898,
+          "pct": 0.834
+        },
+        {
+          "unit": "रि",
+          "count": 9817,
+          "pct": 0.827
+        },
+        {
+          "unit": "वा",
+          "count": 9665,
+          "pct": 0.814
+        },
+        {
+          "unit": "मा",
+          "count": 8902,
+          "pct": 0.75
+        },
+        {
+          "unit": "च",
+          "count": 8465,
+          "pct": 0.713
+        },
+        {
+          "unit": "न्त",
+          "count": 8246,
+          "pct": 0.695
+        },
+        {
+          "unit": "पा",
+          "count": 8174,
+          "pct": 0.689
+        },
+        {
+          "unit": "ता",
+          "count": 7941,
+          "pct": 0.669
+        },
+        {
+          "unit": "आ",
+          "count": 7926,
+          "pct": 0.668
+        },
+        {
+          "unit": "उ",
+          "count": 7830,
+          "pct": 0.66
+        },
+        {
+          "unit": "सु",
+          "count": 7654,
+          "pct": 0.645
+        },
+        {
+          "unit": "ष",
+          "count": 7087,
+          "pct": 0.597
+        },
+        {
+          "unit": "ना",
+          "count": 7009,
+          "pct": 0.59
+        },
+        {
+          "unit": "सं",
+          "count": 6985,
+          "pct": 0.588
+        },
+        {
+          "unit": "भ",
+          "count": 6429,
+          "pct": 0.542
+        },
+        {
+          "unit": "ध",
+          "count": 6171,
+          "pct": 0.52
+        },
+        {
+          "unit": "पु",
+          "count": 5929,
+          "pct": 0.499
+        },
+        {
+          "unit": "सा",
+          "count": 5890,
+          "pct": 0.496
+        }
+      ]
+    }
+  },
+  "dcs_corpus": {
+    "phonemic": {
+      "total_phonemes": 32067704,
+      "top": [
+        {
+          "unit": "a",
+          "count": 6804958,
+          "pct": 21.221
+        },
+        {
+          "unit": "A",
+          "count": 2304408,
+          "pct": 7.186
+        },
+        {
+          "unit": "t",
+          "count": 2232726,
+          "pct": 6.963
+        },
+        {
+          "unit": "r",
+          "count": 1701357,
+          "pct": 5.306
+        },
+        {
+          "unit": "i",
+          "count": 1601195,
+          "pct": 4.993
+        },
+        {
+          "unit": "m",
+          "count": 1384230,
+          "pct": 4.317
+        },
+        {
+          "unit": "v",
+          "count": 1316546,
+          "pct": 4.106
+        },
+        {
+          "unit": "n",
+          "count": 1278606,
+          "pct": 3.987
+        },
+        {
+          "unit": "y",
+          "count": 1267483,
+          "pct": 3.953
+        },
+        {
+          "unit": "s",
+          "count": 1065852,
+          "pct": 3.324
+        },
+        {
+          "unit": "e",
+          "count": 907307,
+          "pct": 2.829
+        },
+        {
+          "unit": "u",
+          "count": 869417,
+          "pct": 2.711
+        },
+        {
+          "unit": "p",
+          "count": 847829,
+          "pct": 2.644
+        },
+        {
+          "unit": "k",
+          "count": 743129,
+          "pct": 2.317
+        },
+        {
+          "unit": "d",
+          "count": 741926,
+          "pct": 2.314
+        },
+        {
+          "unit": "H",
+          "count": 701434,
+          "pct": 2.187
+        },
+        {
+          "unit": "M",
+          "count": 551429,
+          "pct": 1.72
+        },
+        {
+          "unit": "z",
+          "count": 465370,
+          "pct": 1.451
+        },
+        {
+          "unit": "S",
+          "count": 430612,
+          "pct": 1.343
+        },
+        {
+          "unit": "c",
+          "count": 419130,
+          "pct": 1.307
+        },
+        {
+          "unit": "h",
+          "count": 407770,
+          "pct": 1.272
+        },
+        {
+          "unit": "o",
+          "count": 391589,
+          "pct": 1.221
+        },
+        {
+          "unit": "B",
+          "count": 342157,
+          "pct": 1.067
+        },
+        {
+          "unit": "g",
+          "count": 319567,
+          "pct": 0.997
+        },
+        {
+          "unit": "R",
+          "count": 317378,
+          "pct": 0.99
+        },
+        {
+          "unit": "I",
+          "count": 311272,
+          "pct": 0.971
+        },
+        {
+          "unit": "j",
+          "count": 307884,
+          "pct": 0.96
+        },
+        {
+          "unit": "D",
+          "count": 304128,
+          "pct": 0.948
+        },
+        {
+          "unit": "l",
+          "count": 284383,
+          "pct": 0.887
+        },
+        {
+          "unit": "f",
+          "count": 247047,
+          "pct": 0.77
+        },
+        {
+          "unit": "T",
+          "count": 198824,
+          "pct": 0.62
+        },
+        {
+          "unit": "U",
+          "count": 178859,
+          "pct": 0.558
+        },
+        {
+          "unit": "E",
+          "count": 150494,
+          "pct": 0.469
+        },
+        {
+          "unit": "b",
+          "count": 136973,
+          "pct": 0.427
+        },
+        {
+          "unit": "w",
+          "count": 95456,
+          "pct": 0.298
+        },
+        {
+          "unit": "O",
+          "count": 79273,
+          "pct": 0.247
+        },
+        {
+          "unit": "Y",
+          "count": 71177,
+          "pct": 0.222
+        },
+        {
+          "unit": "K",
+          "count": 55508,
+          "pct": 0.173
+        },
+        {
+          "unit": "q",
+          "count": 46086,
+          "pct": 0.144
+        },
+        {
+          "unit": "N",
+          "count": 43486,
+          "pct": 0.136
+        }
+      ]
+    },
+    "graphemic": {
+      "total_aksharas": 15084217,
+      "top": [
+        {
+          "unit": "म",
+          "count": 828542,
+          "pct": 5.493
+        },
+        {
+          "unit": "त",
+          "count": 666101,
+          "pct": 4.416
+        },
+        {
+          "unit": "अ",
+          "count": 546056,
+          "pct": 3.62
+        },
+        {
+          "unit": "न",
+          "count": 451042,
+          "pct": 2.99
+        },
+        {
+          "unit": "व",
+          "count": 387866,
+          "pct": 2.571
+        },
+        {
+          "unit": "स",
+          "count": 343273,
+          "pct": 2.276
+        },
+        {
+          "unit": "र",
+          "count": 324743,
+          "pct": 2.153
+        },
+        {
+          "unit": "य",
+          "count": 293664,
+          "pct": 1.947
+        },
+        {
+          "unit": "च",
+          "count": 265186,
+          "pct": 1.758
+        },
+        {
+          "unit": "प",
+          "count": 249201,
+          "pct": 1.652
+        },
+        {
+          "unit": "द",
+          "count": 231965,
+          "pct": 1.538
+        },
+        {
+          "unit": "ति",
+          "count": 222663,
+          "pct": 1.476
+        },
+        {
+          "unit": "आ",
+          "count": 186602,
+          "pct": 1.237
+        },
+        {
+          "unit": "वि",
+          "count": 178147,
+          "pct": 1.181
+        },
+        {
+          "unit": "क",
+          "count": 175596,
+          "pct": 1.164
+        },
+        {
+          "unit": "इ",
+          "count": 165965,
+          "pct": 1.1
+        },
+        {
+          "unit": "ए",
+          "count": 162922,
+          "pct": 1.08
+        },
+        {
+          "unit": "उ",
+          "count": 153310,
+          "pct": 1.016
+        },
+        {
+          "unit": "वा",
+          "count": 145592,
+          "pct": 0.965
+        },
+        {
+          "unit": "ह",
+          "count": 141281,
+          "pct": 0.937
+        },
+        {
+          "unit": "श",
+          "count": 135836,
+          "pct": 0.901
+        },
+        {
+          "unit": "प्र",
+          "count": 134161,
+          "pct": 0.889
+        },
+        {
+          "unit": "ते",
+          "count": 132418,
+          "pct": 0.878
+        },
+        {
+          "unit": "नि",
+          "count": 121022,
+          "pct": 0.802
+        },
+        {
+          "unit": "ता",
+          "count": 118193,
+          "pct": 0.784
+        },
+        {
+          "unit": "मा",
+          "count": 116740,
+          "pct": 0.774
+        },
+        {
+          "unit": "ग",
+          "count": 108403,
+          "pct": 0.719
+        },
+        {
+          "unit": "रा",
+          "count": 108031,
+          "pct": 0.716
+        },
+        {
+          "unit": "ज",
+          "count": 106414,
+          "pct": 0.705
+        },
+        {
+          "unit": "ना",
+          "count": 103696,
+          "pct": 0.687
+        },
+        {
+          "unit": "स्य",
+          "count": 101662,
+          "pct": 0.674
+        },
+        {
+          "unit": "ल",
+          "count": 96805,
+          "pct": 0.642
+        },
+        {
+          "unit": "या",
+          "count": 96553,
+          "pct": 0.64
+        },
+        {
+          "unit": "भ",
+          "count": 91480,
+          "pct": 0.606
+        },
+        {
+          "unit": "का",
+          "count": 91466,
+          "pct": 0.606
+        },
+        {
+          "unit": "ण",
+          "count": 80430,
+          "pct": 0.533
+        },
+        {
+          "unit": "पा",
+          "count": 79589,
+          "pct": 0.528
+        },
+        {
+          "unit": "सं",
+          "count": 72560,
+          "pct": 0.481
+        },
+        {
+          "unit": "तु",
+          "count": 70785,
+          "pct": 0.469
+        },
+        {
+          "unit": "पु",
+          "count": 69907,
+          "pct": 0.463
+        }
+      ]
+    }
+  },
+  "note": "Phonemic = SLP1 character count (1 char = 1 phoneme, no digraphs). Graphemic = Devanagari akshara (orthographic syllable) count after SLP1/IAST -> Devanagari transliteration. The two diverge because of sandhi (e.g. a word-final consonant assimilating/eliding at a word boundary is a phonemic event with no single-word graphemic trace, and conversely visarga/anusvara alternations are graphemically stable but phonetically variable) -- this divergence has no German analog and is the module's main finding."
+}

--- a/papers/sanskrit_in_numbers/module5_akshara_phoneme_freq.py
+++ b/papers/sanskrit_in_numbers/module5_akshara_phoneme_freq.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Module 5 - aksara / phoneme frequency (Sanskrit-in-Numbers Wave 1, H813).
+
+Duden's *Sprache in Zahlen* reports letter frequency over German headwords.
+Sanskrit's analog must report BOTH layers, because sandhi makes them diverge:
+  - phonemic  : SLP1 character frequency (1 SLP1 char == 1 phoneme, no digraphs)
+  - graphemic : Devanagari akshara (orthographic syllable) frequency, after
+                SLP1 -> Devanagari transliteration
+
+Two corpora, computed independently:
+  (a) Petersburg-family headwords (PWG + PWK + SCH), key1 (SLP1) forms,
+      from HeadwordLists/now-2026/ (this repo).
+  (b) DCS corpus tokens (surface forms), from VisualDCS's real DCS sqlite
+      (DCS-data-2026/dcs_full.sqlite -- NOT src/dcs_full.sqlite, which is a
+      0-byte decoy; see SanskritLexicography memory
+      dcs-full-db-path-and-gita-gap.md).
+
+Output: module5_akshara_phoneme_freq.json with both histograms for both
+corpora, normalized to percent, plus n and date for the trust block.
+"""
+import csv
+import json
+import re
+import sqlite3
+import sys
+from collections import Counter
+from datetime import date
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.path.insert(0, str(Path(__file__).parent))
+
+from indic_transliteration import sanscript
+from indic_transliteration.sanscript import transliterate
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GITHUB_ROOT = REPO_ROOT.parent
+HW_DIR = REPO_ROOT / "HeadwordLists" / "now-2026"
+DCS_DB = GITHUB_ROOT / "VisualDCS" / "src" / "DCS-data-2026" / "dcs_full.sqlite"
+
+FAMILY_FILES = {
+    "PWG": HW_DIR / "PWG-unique-key1-106082.txt",
+    "PWK": HW_DIR / "PWK-unique-key1-151349.txt",
+    "SCH": HW_DIR / "SCH-unique-key2-28519.txt",  # SCH has no key1 export; key2 used, SLP1-compatible
+}
+
+# SLP1 phoneme inventory (single ASCII char == single phoneme; no digraphs).
+SLP1_VOWELS = set("aAiIuUfFxXeEoO")
+SLP1_CONS = set("kKgGNcCjJYwWqQRtTdDnpPbBmyrlvSzsh")
+SLP1_MARKS = set("MH~")  # anusvara, visarga, avagraha
+SLP1_ALPHABET = SLP1_VOWELS | SLP1_CONS | SLP1_MARKS
+
+# Devanagari akshara segmentation: an akshara is
+#   (consonant + virama)* consonant (vowel-sign | anusvara/visarga)?
+# or a single independent vowel (+ anusvara/visarga)?
+DEVANAGARI_CONS = "क-हक़-य़"
+DEVANAGARI_INDEP_VOWEL = "ऄ-औॠॡॲ-ॷ"
+DEVANAGARI_VOWEL_SIGN = "ा-ौॕ-ॗॢॣ"
+DEVANAGARI_VIRAMA = "्"
+DEVANAGARI_ANUSVARA_VISARGA = "ंःँ"
+
+AKSHARA_RE = re.compile(
+    rf"(?:[{DEVANAGARI_CONS}]{DEVANAGARI_VIRAMA})*[{DEVANAGARI_CONS}]"
+    rf"(?:[{DEVANAGARI_VOWEL_SIGN}])?(?:[{DEVANAGARI_ANUSVARA_VISARGA}])?"
+    rf"|[{DEVANAGARI_INDEP_VOWEL}](?:[{DEVANAGARI_ANUSVARA_VISARGA}])?"
+)
+
+
+def phoneme_tokens(slp1_text: str):
+    """Yield SLP1 phoneme characters, skipping non-alphabet chars (digits, '-', '/')."""
+    for ch in slp1_text:
+        if ch in SLP1_ALPHABET:
+            yield ch
+
+
+def akshara_tokens(devanagari_text: str):
+    for m in AKSHARA_RE.finditer(devanagari_text):
+        if m.group(0):
+            yield m.group(0)
+
+
+def load_family_keys():
+    """Return list of SLP1 key strings across the Petersburg family (PWG+PWK+SCH)."""
+    keys = []
+    counts = {}
+    for dict_name, path in FAMILY_FILES.items():
+        if not path.exists():
+            raise FileNotFoundError(path)
+        n = 0
+        with open(path, encoding="utf-8-sig") as f:
+            for line in f:
+                key = line.strip().split("\t")[0]
+                if not key:
+                    continue
+                keys.append(key)
+                n += 1
+        counts[dict_name] = n
+    return keys, counts
+
+
+def family_histograms():
+    keys, counts = load_family_keys()
+    phon = Counter()
+    aksh = Counter()
+    for key in keys:
+        phon.update(phoneme_tokens(key))
+        deva = transliterate(key, sanscript.SLP1, sanscript.DEVANAGARI)
+        aksh.update(akshara_tokens(deva))
+    return phon, aksh, counts, len(keys)
+
+
+def dcs_token_sample():
+    """Pull all DCS token surface forms (IAST). Returns list[str]."""
+    con = sqlite3.connect(str(DCS_DB))
+    cur = con.cursor()
+    cur.execute("SELECT form FROM token")
+    forms = [row[0] for row in cur.fetchall() if row[0]]
+    con.close()
+    return forms
+
+
+IAST_TO_SLP1_DIGRAPH_SAFE = True
+
+
+def dcs_histograms(forms):
+    phon = Counter()
+    aksh = Counter()
+    for form in forms:
+        # IAST -> SLP1 for phonemic count (indic_transliteration handles digraphs kh/gh/... correctly)
+        slp1 = transliterate(form, sanscript.IAST, sanscript.SLP1)
+        phon.update(phoneme_tokens(slp1))
+        deva = transliterate(form, sanscript.IAST, sanscript.DEVANAGARI)
+        aksh.update(akshara_tokens(deva))
+    return phon, aksh, len(forms)
+
+
+def top_percent(counter: Counter, total_chars: int, limit=40):
+    return [
+        {"unit": k, "count": v, "pct": round(100 * v / total_chars, 3)}
+        for k, v in counter.most_common(limit)
+    ]
+
+
+def main():
+    fam_phon, fam_aksh, fam_counts, fam_n = family_histograms()
+    dcs_forms = dcs_token_sample()
+    dcs_phon, dcs_aksh, dcs_n_tokens = dcs_histograms(dcs_forms)
+
+    fam_phon_total = sum(fam_phon.values())
+    fam_aksh_total = sum(fam_aksh.values())
+    dcs_phon_total = sum(dcs_phon.values())
+    dcs_aksh_total = sum(dcs_aksh.values())
+
+    out = {
+        "module": 5,
+        "title": "akshara / phoneme frequency",
+        "trust_block": {
+            "source": "Petersburg family (PWG+PWK+SCH) headwords, HeadwordLists/now-2026/ key1(key2 for SCH); "
+                       "DCS corpus tokens, VisualDCS DCS-data-2026/dcs_full.sqlite (DCS-2026 release)",
+            "n": {
+                "family_headwords": fam_n,
+                "family_by_dict": fam_counts,
+                "dcs_tokens": dcs_n_tokens,
+            },
+            "date": str(date.today()),
+            "model": "Sonnet 5 (claude-sonnet-5)",
+        },
+        "family": {
+            "phonemic": {
+                "total_phonemes": fam_phon_total,
+                "top": top_percent(fam_phon, fam_phon_total),
+            },
+            "graphemic": {
+                "total_aksharas": fam_aksh_total,
+                "top": top_percent(fam_aksh, fam_aksh_total),
+            },
+        },
+        "dcs_corpus": {
+            "phonemic": {
+                "total_phonemes": dcs_phon_total,
+                "top": top_percent(dcs_phon, dcs_phon_total),
+            },
+            "graphemic": {
+                "total_aksharas": dcs_aksh_total,
+                "top": top_percent(dcs_aksh, dcs_aksh_total),
+            },
+        },
+        "note": "Phonemic = SLP1 character count (1 char = 1 phoneme, no digraphs). "
+                "Graphemic = Devanagari akshara (orthographic syllable) count after "
+                "SLP1/IAST -> Devanagari transliteration. The two diverge because of "
+                "sandhi (e.g. a word-final consonant assimilating/eliding at a word "
+                "boundary is a phonemic event with no single-word graphemic trace, and "
+                "conversely visarga/anusvara alternations are graphemically stable but "
+                "phonetically variable) -- this divergence has no German analog and is "
+                "the module's main finding.",
+    }
+
+    out_path = Path(__file__).parent / "module5_akshara_phoneme_freq.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(out, f, ensure_ascii=False, indent=2)
+
+    print(f"family headwords: {fam_n} ({fam_counts})")
+    print(f"family phonemes: {fam_phon_total}, aksharas: {fam_aksh_total}")
+    print(f"DCS tokens: {dcs_n_tokens}")
+    print(f"DCS phonemes: {dcs_phon_total}, aksharas: {dcs_aksh_total}")
+    print(f"top-5 family phonemes: {fam_phon.most_common(5)}")
+    print(f"top-5 family aksharas: {fam_aksh.most_common(5)}")
+    print(f"top-5 DCS phonemes: {dcs_phon.most_common(5)}")
+    print(f"top-5 DCS aksharas: {dcs_aksh.most_common(5)}")
+    print(f"wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/papers/sanskrit_in_numbers/module6_longest_compounds.json
+++ b/papers/sanskrit_in_numbers/module6_longest_compounds.json
@@ -1,0 +1,427 @@
+{
+  "module": 6,
+  "title": "longest compounds (samasa)",
+  "trust_block": {
+    "source": "VisualDCS DCS-data-2026/dcs_full.sqlite (DCS-2026 release), token.form surface forms",
+    "n": {
+      "total_tokens": null,
+      "distinct_forms": 381413,
+      "distinct_forms_meeting_floor": 91726,
+      "occurrence_floor": 5
+    },
+    "date": "2026-07-13",
+    "model": "Sonnet 5 (claude-sonnet-5)"
+  },
+  "record_with_floor": {
+    "form": "sāgaravaradharabuddhivikrīḍitābhijñasya",
+    "occurrences": 5,
+    "char_length": 39,
+    "akshara_length": 16
+  },
+  "top50_with_floor": [
+    {
+      "form": "sāgaravaradharabuddhivikrīḍitābhijñasya",
+      "occurrences": 5,
+      "char_length": 39,
+      "akshara_length": 16
+    },
+    {
+      "form": "aniṣṭapratigrahādayo'bhipretāḥ",
+      "occurrences": 6,
+      "char_length": 30,
+      "akshara_length": 12
+    },
+    {
+      "form": "mahābhijñājñānābhibhuvaṃ",
+      "occurrences": 12,
+      "char_length": 24,
+      "akshara_length": 9
+    },
+    {
+      "form": "mahābhijñājñānābhibhūḥ",
+      "occurrences": 11,
+      "char_length": 22,
+      "akshara_length": 8
+    },
+    {
+      "form": "paranirmitavaśavartino",
+      "occurrences": 17,
+      "char_length": 22,
+      "akshara_length": 10
+    },
+    {
+      "form": "nirūḍhapaśubandhasya",
+      "occurrences": 5,
+      "char_length": 20,
+      "akshara_length": 8
+    },
+    {
+      "form": "pratisaṃskartṛsūtram",
+      "occurrences": 5,
+      "char_length": 20,
+      "akshara_length": 8
+    },
+    {
+      "form": "sahasrasaṃvatsarasya",
+      "occurrences": 9,
+      "char_length": 20,
+      "akshara_length": 8
+    },
+    {
+      "form": "satatasamitābhiyukta",
+      "occurrences": 5,
+      "char_length": 20,
+      "akshara_length": 9
+    },
+    {
+      "form": "vātavyādhicikitsitaṃ",
+      "occurrences": 5,
+      "char_length": 20,
+      "akshara_length": 8
+    },
+    {
+      "form": "yāvadābhūtasamplavam",
+      "occurrences": 7,
+      "char_length": 20,
+      "akshara_length": 9
+    },
+    {
+      "form": "śrīmālinīvijayottare",
+      "occurrences": 5,
+      "char_length": 20,
+      "akshara_length": 9
+    },
+    {
+      "form": "ūrdhvapātanayantreṇa",
+      "occurrences": 5,
+      "char_length": 20,
+      "akshara_length": 8
+    },
+    {
+      "form": "darśapūrṇamāsābhyām",
+      "occurrences": 5,
+      "char_length": 19,
+      "akshara_length": 8
+    },
+    {
+      "form": "mahāmaudgalyāyanena",
+      "occurrences": 5,
+      "char_length": 19,
+      "akshara_length": 8
+    },
+    {
+      "form": "saddharmapuṇḍarīkaṃ",
+      "occurrences": 19,
+      "char_length": 19,
+      "akshara_length": 7
+    },
+    {
+      "form": "sahasrasaṃvatsareṇa",
+      "occurrences": 7,
+      "char_length": 19,
+      "akshara_length": 8
+    },
+    {
+      "form": "siddhayogīśvarīmate",
+      "occurrences": 5,
+      "char_length": 19,
+      "akshara_length": 8
+    },
+    {
+      "form": "śuśumāragirīyakānāṃ",
+      "occurrences": 7,
+      "char_length": 19,
+      "akshara_length": 9
+    },
+    {
+      "form": "abhiśraddadhāsyasi",
+      "occurrences": 5,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "adhaḥpātanayantraṃ",
+      "occurrences": 5,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "aindrābārhaspatyam",
+      "occurrences": 10,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "aindrābārhaspatyaṃ",
+      "occurrences": 15,
+      "char_length": 18,
+      "akshara_length": 6
+    },
+    {
+      "form": "aṣṭottarasahasreṇa",
+      "occurrences": 5,
+      "char_length": 18,
+      "akshara_length": 8
+    },
+    {
+      "form": "brāhmaṇācchaṃsinam",
+      "occurrences": 6,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "brāhmaṇācchaṃsinaś",
+      "occurrences": 7,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "brāhmaṇācchaṃsinaḥ",
+      "occurrences": 24,
+      "char_length": 18,
+      "akshara_length": 6
+    },
+    {
+      "form": "kṛṣṇadvaipāyanasya",
+      "occurrences": 11,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "mahāmaudgalyāyanaḥ",
+      "occurrences": 5,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "naravāhanadattasya",
+      "occurrences": 17,
+      "char_length": 18,
+      "akshara_length": 8
+    },
+    {
+      "form": "pratiprasrabhyante",
+      "occurrences": 16,
+      "char_length": 18,
+      "akshara_length": 6
+    },
+    {
+      "form": "pratyabhighārayati",
+      "occurrences": 10,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "pratyanubhaviṣyati",
+      "occurrences": 25,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "pravartyamānābhyām",
+      "occurrences": 6,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "rasendracintāmaṇau",
+      "occurrences": 7,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "saddharmapuṇḍarīko",
+      "occurrences": 6,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "samyaksambuddhasya",
+      "occurrences": 38,
+      "char_length": 18,
+      "akshara_length": 6
+    },
+    {
+      "form": "samyaksaṃbuddhasya",
+      "occurrences": 45,
+      "char_length": 18,
+      "akshara_length": 6
+    },
+    {
+      "form": "samyaksaṃbuddhānām",
+      "occurrences": 22,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "samyaksaṃbuddhānāṃ",
+      "occurrences": 12,
+      "char_length": 18,
+      "akshara_length": 6
+    },
+    {
+      "form": "saṃpraharṣayiṣyati",
+      "occurrences": 5,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "saṃprakāśayitavyaḥ",
+      "occurrences": 6,
+      "char_length": 18,
+      "akshara_length": 7
+    },
+    {
+      "form": "upakaniṣṭhikābhyām",
+      "occurrences": 5,
+      "char_length": 18,
+      "akshara_length": 8
+    },
+    {
+      "form": "abhinirvartayanti",
+      "occurrences": 9,
+      "char_length": 17,
+      "akshara_length": 7
+    },
+    {
+      "form": "abhiniṣkramiṣyati",
+      "occurrences": 11,
+      "char_length": 17,
+      "akshara_length": 7
+    },
+    {
+      "form": "abhisaṃbhotsyante",
+      "occurrences": 11,
+      "char_length": 17,
+      "akshara_length": 6
+    },
+    {
+      "form": "abhisaṃprasthitāḥ",
+      "occurrences": 5,
+      "char_length": 17,
+      "akshara_length": 6
+    },
+    {
+      "form": "agnihotrahavaṇyām",
+      "occurrences": 6,
+      "char_length": 17,
+      "akshara_length": 8
+    },
+    {
+      "form": "agnihotrahavaṇyāṃ",
+      "occurrences": 5,
+      "char_length": 17,
+      "akshara_length": 7
+    },
+    {
+      "form": "aindrābārhaspatyā",
+      "occurrences": 6,
+      "char_length": 17,
+      "akshara_length": 6
+    }
+  ],
+  "record_no_floor": {
+    "form": "vyādhavākyopadeśakathanapūrvakadānādiphalavarṇanaṃ",
+    "occurrences": 1,
+    "char_length": 50
+  },
+  "length_distribution_char": [
+    [
+      1,
+      26
+    ],
+    [
+      2,
+      136
+    ],
+    [
+      3,
+      622
+    ],
+    [
+      4,
+      3063
+    ],
+    [
+      5,
+      7968
+    ],
+    [
+      6,
+      14055
+    ],
+    [
+      7,
+      17501
+    ],
+    [
+      8,
+      16473
+    ],
+    [
+      9,
+      13017
+    ],
+    [
+      10,
+      9007
+    ],
+    [
+      11,
+      5199
+    ],
+    [
+      12,
+      2512
+    ],
+    [
+      13,
+      1243
+    ],
+    [
+      14,
+      481
+    ],
+    [
+      15,
+      225
+    ],
+    [
+      16,
+      115
+    ],
+    [
+      17,
+      40
+    ],
+    [
+      18,
+      24
+    ],
+    [
+      19,
+      6
+    ],
+    [
+      20,
+      8
+    ],
+    [
+      22,
+      2
+    ],
+    [
+      24,
+      1
+    ],
+    [
+      30,
+      1
+    ],
+    [
+      39,
+      1
+    ]
+  ],
+  "note": "'Compound' here means the longest attested single orthographic word in the DCS corpus (Duden's own unit for the Bandwurmwort record), not a formally verified samasa parse -- DCS does not corpus-wide segment every long noun into its samasa members, so a handful of top entries could in principle be non-compound single stems (rare at this length in Sanskrit) or proper-name/colophon strings. The record_no_floor entry shows why the floor matters: without it, a hapax colophon title sets an unrepresentative 'record', exactly the failure mode Duden's own floor avoids."
+}

--- a/papers/sanskrit_in_numbers/module6_longest_compounds.py
+++ b/papers/sanskrit_in_numbers/module6_longest_compounds.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Module 6 - longest compounds / samasa (Sanskrit-in-Numbers Wave 1, H813).
+
+Duden's *Sprache in Zahlen* reports German's longest attested word (the
+79-character Bandwurmwort record) with an occurrence-count honesty floor.
+Sanskrit's compounding is unbounded and far more productive than German's, so
+this is the show-stopper module: longest attested compound-shaped surface
+forms in the DCS corpus, subject to the SAME >=5-occurrence honesty floor
+(so a one-off philosophical run-on doesn't set the "record"), plus the full
+length distribution.
+
+Source: VisualDCS's real DCS sqlite, DCS-data-2026/dcs_full.sqlite (5,688,416
+tokens; NOT src/dcs_full.sqlite, a 0-byte decoy -- see SanskritLexicography
+memory dcs-full-db-path-and-gita-gap.md).
+
+Method: rank token.form (surface form, sandhi-joined -- the orthographic
+"word" as printed, matching Duden's own unit of measurement) by character
+length among forms occurring >=5 times in the corpus. Reported in BOTH
+Sanskrit's natural prosodic unit (akshara / orthographic syllable count,
+after Devanagari transliteration) and raw IAST character count (the direct
+Duden-comparable unit).
+"""
+import json
+import re
+import sqlite3
+import sys
+from collections import Counter
+from datetime import date
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+from indic_transliteration import sanscript
+from indic_transliteration.sanscript import transliterate
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GITHUB_ROOT = REPO_ROOT.parent
+DCS_DB = GITHUB_ROOT / "VisualDCS" / "src" / "DCS-data-2026" / "dcs_full.sqlite"
+
+MIN_OCCURRENCES = 5
+
+DEVANAGARI_CONS = "क-ह"  # standard 33 consonants; nukta letters (क़ etc.) never occur in transliterated Sanskrit
+DEVANAGARI_INDEP_VOWEL = "ऄ-औॠॡॲ-ॷ"
+DEVANAGARI_VOWEL_SIGN = "ा-ौॕ-ॗॢॣ"
+DEVANAGARI_VIRAMA = "्"
+DEVANAGARI_ANUSVARA_VISARGA = "ंःँ"
+AKSHARA_RE = re.compile(
+    rf"(?:[{DEVANAGARI_CONS}]{DEVANAGARI_VIRAMA})*[{DEVANAGARI_CONS}]"
+    rf"(?:[{DEVANAGARI_VOWEL_SIGN}])?(?:[{DEVANAGARI_ANUSVARA_VISARGA}])?"
+    rf"|[{DEVANAGARI_INDEP_VOWEL}](?:[{DEVANAGARI_ANUSVARA_VISARGA}])?"
+)
+
+
+def akshara_count(iast_text: str) -> int:
+    deva = transliterate(iast_text, sanscript.IAST, sanscript.DEVANAGARI)
+    return len(AKSHARA_RE.findall(deva))
+
+
+def main():
+    con = sqlite3.connect(str(DCS_DB))
+    cur = con.cursor()
+    cur.execute("SELECT form, COUNT(*) AS n FROM token GROUP BY form")
+    rows = cur.fetchall()
+    con.close()
+
+    total_distinct_forms = len(rows)
+    floor_rows = [(form, n) for form, n in rows if n >= MIN_OCCURRENCES and form]
+    print(f"distinct forms: {total_distinct_forms}, >= {MIN_OCCURRENCES} occ: {len(floor_rows)}")
+
+    # rank by IAST character length
+    floor_rows.sort(key=lambda r: len(r[0]), reverse=True)
+    top50 = floor_rows[:50]
+
+    records = []
+    for form, n in top50:
+        records.append({
+            "form": form,
+            "occurrences": n,
+            "char_length": len(form),
+            "akshara_length": akshara_count(form),
+        })
+
+    # length distribution (character length) over the floor-passing set
+    length_hist = Counter(len(form) for form, _ in floor_rows)
+    length_hist_sorted = sorted(length_hist.items())
+
+    # also the ALL-forms record (no floor) for the honesty-floor comparison Duden itself makes
+    all_forms_sorted = sorted(rows, key=lambda r: len(r[0]), reverse=True)
+    no_floor_record = all_forms_sorted[0] if all_forms_sorted else None
+
+    out = {
+        "module": 6,
+        "title": "longest compounds (samasa)",
+        "trust_block": {
+            "source": "VisualDCS DCS-data-2026/dcs_full.sqlite (DCS-2026 release), token.form surface forms",
+            "n": {
+                "total_tokens": sum(n for _, n in rows) if False else None,
+                "distinct_forms": total_distinct_forms,
+                "distinct_forms_meeting_floor": len(floor_rows),
+                "occurrence_floor": MIN_OCCURRENCES,
+            },
+            "date": str(date.today()),
+            "model": "Sonnet 5 (claude-sonnet-5)",
+        },
+        "record_with_floor": records[0] if records else None,
+        "top50_with_floor": records,
+        "record_no_floor": {
+            "form": no_floor_record[0],
+            "occurrences": no_floor_record[1],
+            "char_length": len(no_floor_record[0]),
+        } if no_floor_record else None,
+        "length_distribution_char": length_hist_sorted,
+        "note": "'Compound' here means the longest attested single orthographic word "
+                "in the DCS corpus (Duden's own unit for the Bandwurmwort record), not "
+                "a formally verified samasa parse -- DCS does not corpus-wide segment "
+                "every long noun into its samasa members, so a handful of top entries "
+                "could in principle be non-compound single stems (rare at this length "
+                "in Sanskrit) or proper-name/colophon strings. The record_no_floor entry "
+                "shows why the floor matters: without it, a hapax colophon title sets "
+                "an unrepresentative 'record', exactly the failure mode Duden's own "
+                "floor avoids.",
+    }
+
+    out_path = Path(__file__).parent / "module6_longest_compounds.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(out, f, ensure_ascii=False, indent=2)
+
+    print(f"record (floor>={MIN_OCCURRENCES}): {records[0] if records else None}")
+    print(f"record (no floor): form={no_floor_record[0] if no_floor_record else None}, n={no_floor_record[1] if no_floor_record else None}")
+    print(f"wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/papers/sanskrit_in_numbers/module8_gender_distribution.json
+++ b/papers/sanskrit_in_numbers/module8_gender_distribution.json
@@ -1,0 +1,187 @@
+{
+  "module": 8,
+  "title": "gender distribution",
+  "trust_block": {
+    "source": "zaliznyak-grammar-index (A56, kosha release https://github.com/gasyoun/kosha/releases/tag/data-v0.1.0), `lex` column over all PWG headwords",
+    "n": 98639,
+    "date": "2026-07-13",
+    "model": "Sonnet 5 (claude-sonnet-5)"
+  },
+  "gender_shares_simple_pct": {
+    "feminine": {
+      "n": 14192,
+      "pct": 22.01
+    },
+    "masculine": {
+      "n": 35184,
+      "pct": 54.56
+    },
+    "neuter": {
+      "n": 15112,
+      "pct": 23.43
+    }
+  },
+  "n_gendered_simple": 64488,
+  "n_multi_gender": 482,
+  "multi_gender_breakdown": {
+    "multi: m./n.": 459,
+    "multi: m./f./n. (tri-gender)": 12,
+    "multi: m./f.": 7,
+    "multi: f./n.": 4
+  },
+  "n_non_gendered_categories": 33669,
+  "n_unmapped_lex_values": {},
+  "multi_gender_sample": [
+    {
+      "k1": "aMSa",
+      "hom": "2",
+      "lex": "m.n."
+    },
+    {
+      "k1": "aMsa",
+      "hom": "2",
+      "lex": "m.n."
+    },
+    {
+      "k1": "agaru",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "aGamarzaRa",
+      "hom": "",
+      "lex": "m.f.n."
+    },
+    {
+      "k1": "aNkuSa",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "aNkUza",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "aNgAra",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "aNgurIya",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "aNgurIyaka",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "aNgulIya",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "aRi",
+      "hom": "",
+      "lex": "m.f."
+    },
+    {
+      "k1": "anUka",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "anDakAra",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "anvaya",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "aBiDAna",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "amftaPala",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "ayuta",
+      "hom": "2",
+      "lex": "m.n."
+    },
+    {
+      "k1": "araRya",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "arari",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "arcis",
+      "hom": "",
+      "lex": "f.n."
+    },
+    {
+      "k1": "arRavaja",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "arDarca",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "arbuda",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "arma",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "alaka",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "avataMsa",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "avAra",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "avityaja",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "aSmIra",
+      "hom": "",
+      "lex": "m.n."
+    },
+    {
+      "k1": "azWIvant",
+      "hom": "",
+      "lex": "m.n."
+    }
+  ],
+  "note": "Shares computed over gendered NOUN headwords only (m./f./n. and their multi-gender combinations); adj./adv./indecl./interj. are excluded from the percentage base since Sanskrit adjectives take the gender of the noun they modify rather than carrying a fixed dictionary gender -- the direct structural reason Sanskrit's 'multi-gender' set is a distinct, much smaller class from German's (where any noun can in principle be multi-gender, e.g. der/die/das Joghurt): in Sanskrit the tri-gender class is dominated by adjectives used substantively, not ordinary nouns."
+}

--- a/papers/sanskrit_in_numbers/module8_gender_distribution.py
+++ b/papers/sanskrit_in_numbers/module8_gender_distribution.py
@@ -143,13 +143,15 @@ def main():
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(out, f, ensure_ascii=False, indent=2)
 
+    # Console summary kept deliberately terse: CodeQL's clear-text-logging-sensitive-data
+    # query pattern-matches on the word "gender" and flags verbose dumps of the
+    # gender-labeled dicts as if they were personal data (they are grammatical-gender
+    # dictionary statistics, not PII) -- avoided here by printing only counts, with the
+    # full per-gender breakdown left to the committed JSON output instead.
     print(f"n_total rows: {n_total}")
-    print(f"lex counts: {lex_counts.most_common(20)}")
-    # lgtm[py/clear-text-logging-sensitive-data] -- false positive: "gender" here is
-    # grammatical gender (PWG dictionary m./f./n. classification), not personal data.
-    print(f"n_gendered_simple: {n_gendered_simple}, shares: {simple_shares}")  # lgtm[py/clear-text-logging-sensitive-data]
-    print(f"n_multi_gender: {n_multi}, breakdown: {dict(gendered)}")  # lgtm[py/clear-text-logging-sensitive-data]
-    print(f"unmapped: {dict(unmapped)}")
+    print(f"n_gendered_simple: {n_gendered_simple}")
+    print(f"n_multi_gender: {n_multi}")
+    print(f"n_unmapped_lex_values: {len(unmapped)}")
     print(f"wrote {out_path}")
 
 

--- a/papers/sanskrit_in_numbers/module8_gender_distribution.py
+++ b/papers/sanskrit_in_numbers/module8_gender_distribution.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Module 8 - gender distribution (Sanskrit-in-Numbers Wave 1, H813).
+
+Duden's *Sprache in Zahlen* reports German gender shares (fem 46 / masc 34 /
+neut 20) plus multi-gender headwords (der/die/das Joghurt). Sanskrit's analog:
+m./f./n. shares over the Petersburg family, plus the multi-gender headword set
+(m.n., m.f.n., m.f., f.n. -- words attested with more than one grammatical
+gender across dictionary entries).
+
+Source: the already-public zaliznyak-grammar-index dataset (A56, kosha
+release data-v0.1.0) -- a per-headword classification of all 98,639 PWG
+headwords into a lexical-category token (`lex` column), built for the
+Zaliznyak-style paradigm-token retrofit. This module reuses that `lex` column
+directly (per org convention: reuse a committed derived asset rather than
+re-deriving gender from raw PWG markup from scratch). Anti-salami note: A56
+itself is Module 7's owner (POS distribution) and is cited, not re-derived,
+there -- Module 8 is a NEW module that draws on the SAME already-released
+column for a different cut (gender, not POS), which is legitimate reuse, not
+duplication of A56's own novelty (paradigm-token inventory).
+
+This script downloads the release TSV on first run (cached locally,
+gitignored) and computes the gender-share table.
+"""
+import csv
+import json
+import subprocess
+import sys
+from collections import Counter
+from datetime import date
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+CACHE_DIR = Path(__file__).parent / ".cache"
+CACHE_DIR.mkdir(exist_ok=True)
+TSV_PATH = CACHE_DIR / "zaliznyak_grammar_index.tsv"
+RELEASE_URL = "https://github.com/gasyoun/kosha/releases/tag/data-v0.1.0"
+
+GENDER_MAP = {
+    "m.": ("masculine", 1),
+    "f.": ("feminine", 1),
+    "n.": ("neuter", 1),
+    "fem.": ("feminine", 1),  # spelling variant, folded
+    "neutr.": ("neuter", 1),  # spelling variant, folded
+    "m.n.": ("multi: m./n.", 2),
+    "m.f.": ("multi: m./f.", 2),
+    "f.n.": ("multi: f./n.", 2),
+    "m.f.n.": ("multi: m./f./n. (tri-gender)", 3),
+    "mm.": ("masculine", 1),  # "always-plural masculine" notation (index_token still m·N), folded to m.
+    "ff.": ("feminine", 1),  # "always-plural feminine" notation (index_token still f·N; verified against source rows), folded to f.
+}
+NON_GENDERED = {"adj.", "adv.", "indecl.", "ind.", "interj."}
+
+
+def ensure_tsv():
+    if TSV_PATH.exists() and TSV_PATH.stat().st_size > 0:
+        return
+    subprocess.run(
+        [
+            "gh", "release", "download", "data-v0.1.0",
+            "--repo", "gasyoun/kosha",
+            "--dir", str(CACHE_DIR),
+            "--pattern", "*.tsv",
+            "--clobber",
+        ],
+        check=True,
+    )
+
+
+def main():
+    ensure_tsv()
+
+    lex_counts = Counter()
+    with open(TSV_PATH, encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        rows = list(reader)
+    for row in rows:
+        lex_counts[row["lex"]] += 1
+
+    n_total = len(rows)
+    gendered = Counter()
+    multi_gender_rows = []
+    non_gendered_n = 0
+    unmapped = Counter()
+
+    for row in rows:
+        lex = row["lex"]
+        if lex in GENDER_MAP:
+            label, arity = GENDER_MAP[lex]
+            gendered[label] += 1
+            if arity > 1:
+                multi_gender_rows.append(
+                    {"k1": row["k1"], "hom": row["hom"], "lex": lex}
+                )
+        elif lex in NON_GENDERED:
+            non_gendered_n += 1
+        else:
+            unmapped[lex] += 1
+
+    n_gendered_simple = sum(
+        v for k, v in gendered.items() if not k.startswith("multi")
+    )
+    n_multi = sum(v for k, v in gendered.items() if k.startswith("multi"))
+    n_gendered_total = n_gendered_simple + n_multi
+
+    simple_shares = {
+        k: {"n": v, "pct": round(100 * v / n_gendered_simple, 2)}
+        for k, v in gendered.items()
+        if not k.startswith("multi")
+    }
+
+    out = {
+        "module": 8,
+        "title": "gender distribution",
+        "trust_block": {
+            "source": f"zaliznyak-grammar-index (A56, kosha release {RELEASE_URL}), "
+                      "`lex` column over all PWG headwords",
+            "n": n_total,
+            "date": str(date.today()),
+            "model": "Sonnet 5 (claude-sonnet-5)",
+        },
+        "gender_shares_simple_pct": simple_shares,
+        "n_gendered_simple": n_gendered_simple,
+        "n_multi_gender": n_multi,
+        "multi_gender_breakdown": {
+            k: v for k, v in gendered.items() if k.startswith("multi")
+        },
+        "n_non_gendered_categories": non_gendered_n,
+        "n_unmapped_lex_values": dict(unmapped),
+        "multi_gender_sample": multi_gender_rows[:30],
+        "note": "Shares computed over gendered NOUN headwords only (m./f./n. and "
+                "their multi-gender combinations); adj./adv./indecl./interj. are "
+                "excluded from the percentage base since Sanskrit adjectives take "
+                "the gender of the noun they modify rather than carrying a fixed "
+                "dictionary gender -- the direct structural reason Sanskrit's "
+                "'multi-gender' set is a distinct, much smaller class from German's "
+                "(where any noun can in principle be multi-gender, e.g. der/die/das "
+                "Joghurt): in Sanskrit the tri-gender class is dominated by adjectives "
+                "used substantively, not ordinary nouns.",
+    }
+
+    out_path = Path(__file__).parent / "module8_gender_distribution.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(out, f, ensure_ascii=False, indent=2)
+
+    print(f"n_total rows: {n_total}")
+    print(f"lex counts: {lex_counts.most_common(20)}")
+    print(f"n_gendered_simple: {n_gendered_simple}, shares: {simple_shares}")
+    print(f"n_multi_gender: {n_multi}, breakdown: {dict(gendered)}")
+    print(f"unmapped: {dict(unmapped)}")
+    print(f"wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/papers/sanskrit_in_numbers/module8_gender_distribution.py
+++ b/papers/sanskrit_in_numbers/module8_gender_distribution.py
@@ -145,8 +145,10 @@ def main():
 
     print(f"n_total rows: {n_total}")
     print(f"lex counts: {lex_counts.most_common(20)}")
-    print(f"n_gendered_simple: {n_gendered_simple}, shares: {simple_shares}")
-    print(f"n_multi_gender: {n_multi}, breakdown: {dict(gendered)}")
+    # lgtm[py/clear-text-logging-sensitive-data] -- false positive: "gender" here is
+    # grammatical gender (PWG dictionary m./f./n. classification), not personal data.
+    print(f"n_gendered_simple: {n_gendered_simple}, shares: {simple_shares}")  # lgtm[py/clear-text-logging-sensitive-data]
+    print(f"n_multi_gender: {n_multi}, breakdown: {dict(gendered)}")  # lgtm[py/clear-text-logging-sensitive-data]
     print(f"unmapped: {dict(unmapped)}")
     print(f"wrote {out_path}")
 

--- a/papers/sanskrit_in_numbers/module9_samasa_types.json
+++ b/papers/sanskrit_in_numbers/module9_samasa_types.json
@@ -1,0 +1,357 @@
+{
+  "module": 9,
+  "title": "samasa types (best-effort)",
+  "trust_block": {
+    "source": "VisualDCS DCS-data-2026/dcs_full.sqlite (DCS-2026 release), token.deprel Universal-Dependencies-style compound relations",
+    "n": {
+      "total_tokens": 5688416,
+      "total_compound_relations": 2214,
+      "compound": 119,
+      "compound:coord": 2044,
+      "compound:name": 51
+    },
+    "date": "2026-07-13",
+    "model": "Sonnet 5 (claude-sonnet-5)"
+  },
+  "counts": {
+    "compound": 119,
+    "compound:coord": 2044,
+    "compound:name": 51
+  },
+  "pct_of_compound_relations": {
+    "compound": 5.37,
+    "compound:coord": 92.32,
+    "compound:name": 2.3
+  },
+  "reliable_typed_bucket": {
+    "dvandva (compound:coord)": 2044,
+    "proper-name compound (compound:name)": 51
+  },
+  "undifferentiated_bucket": {
+    "tatpurusa/karmadharaya/bahuvrihi, undifferentiated (compound)": 119
+  },
+  "sample_for_manual_typing": {
+    "compound": [
+      {
+        "form": "abhimarśana",
+        "lemma": "abhimarśana",
+        "upos": "NOUN",
+        "sentence_id": 202134,
+        "head_id": 7
+      },
+      {
+        "form": "kākṣi",
+        "lemma": "kākṣi",
+        "upos": "NOUN",
+        "sentence_id": 11956,
+        "head_id": 5
+      },
+      {
+        "form": "araṇya",
+        "lemma": "araṇya",
+        "upos": "NOUN",
+        "sentence_id": 11571,
+        "head_id": 12
+      },
+      {
+        "form": "madhu",
+        "lemma": "madhu",
+        "upos": "NOUN",
+        "sentence_id": 495890,
+        "head_id": 12
+      },
+      {
+        "form": "śakuna",
+        "lemma": "śakuna",
+        "upos": "NOUN",
+        "sentence_id": 11989,
+        "head_id": 15
+      },
+      {
+        "form": "tinduka",
+        "lemma": "tinduka",
+        "upos": "NOUN",
+        "sentence_id": 11982,
+        "head_id": 3
+      },
+      {
+        "form": "mūla",
+        "lemma": "mūla",
+        "upos": "NOUN",
+        "sentence_id": 11974,
+        "head_id": 6
+      },
+      {
+        "form": "śirīṣa",
+        "lemma": "śirīṣa",
+        "upos": "NOUN",
+        "sentence_id": 11973,
+        "head_id": 4
+      },
+      {
+        "form": "elā",
+        "lemma": "elā",
+        "upos": "NOUN",
+        "sentence_id": 11956,
+        "head_id": 5
+      },
+      {
+        "form": "madhu",
+        "lemma": "madhu",
+        "upos": "NOUN",
+        "sentence_id": 208423,
+        "head_id": 5
+      },
+      {
+        "form": "ava",
+        "lemma": "ava",
+        "upos": "ADP",
+        "sentence_id": 731431,
+        "head_id": 14
+      },
+      {
+        "form": "udāna",
+        "lemma": "udāna",
+        "upos": "NOUN",
+        "sentence_id": 177601,
+        "head_id": 7
+      },
+      {
+        "form": "mūka",
+        "lemma": "mūka",
+        "upos": "ADJ",
+        "sentence_id": 11950,
+        "head_id": 10
+      },
+      {
+        "form": "vrīhi",
+        "lemma": "vrīhi",
+        "upos": "NOUN",
+        "sentence_id": 200959,
+        "head_id": 6
+      },
+      {
+        "form": "caturtha",
+        "lemma": "caturtha",
+        "upos": "ADJ",
+        "sentence_id": 56124,
+        "head_id": 2
+      }
+    ],
+    "compound:coord": [
+      {
+        "form": "aśva",
+        "lemma": "aśva",
+        "upos": "NOUN",
+        "sentence_id": 351120,
+        "head_id": 12
+      },
+      {
+        "form": "plavaka",
+        "lemma": "plavaka",
+        "upos": "NOUN",
+        "sentence_id": 11938,
+        "head_id": 3
+      },
+      {
+        "form": "brahma",
+        "lemma": "brahman",
+        "upos": "NOUN",
+        "sentence_id": 7296,
+        "head_id": 2
+      },
+      {
+        "form": "darśa",
+        "lemma": "darśa",
+        "upos": "NOUN",
+        "sentence_id": 634782,
+        "head_id": 10
+      },
+      {
+        "form": "kṣauma",
+        "lemma": "kṣauma",
+        "upos": "ADJ",
+        "sentence_id": 138085,
+        "head_id": 5
+      },
+      {
+        "form": "anāmikā",
+        "lemma": "anāmikā",
+        "upos": "NOUN",
+        "sentence_id": 95710,
+        "head_id": 2
+      },
+      {
+        "form": "aśva",
+        "lemma": "aśva",
+        "upos": "NOUN",
+        "sentence_id": 91279,
+        "head_id": 16
+      },
+      {
+        "form": "nakula",
+        "lemma": "nakula",
+        "upos": "NOUN",
+        "sentence_id": 11950,
+        "head_id": 4
+      },
+      {
+        "form": "svādhyāya",
+        "lemma": "svādhyāya",
+        "upos": "NOUN",
+        "sentence_id": 633888,
+        "head_id": 2
+      },
+      {
+        "form": "karavīra",
+        "lemma": "karavīra",
+        "upos": "NOUN",
+        "sentence_id": 11934,
+        "head_id": 7
+      },
+      {
+        "form": "śubha",
+        "lemma": "śubha",
+        "upos": "NOUN",
+        "sentence_id": 451386,
+        "head_id": 7
+      },
+      {
+        "form": "iṣu",
+        "lemma": "iṣu",
+        "upos": "NOUN",
+        "sentence_id": 634520,
+        "head_id": 3
+      },
+      {
+        "form": "iṣu",
+        "lemma": "iṣu",
+        "upos": "NOUN",
+        "sentence_id": 702784,
+        "head_id": 4
+      },
+      {
+        "form": "oṣadhi",
+        "lemma": "oṣadhi",
+        "upos": "NOUN",
+        "sentence_id": 208298,
+        "head_id": 8
+      },
+      {
+        "form": "paśu",
+        "lemma": "paśu",
+        "upos": "NOUN",
+        "sentence_id": 11583,
+        "head_id": 6
+      }
+    ],
+    "compound:name": [
+      {
+        "form": "viśve",
+        "lemma": "viśva",
+        "upos": "ADJ",
+        "sentence_id": 714333,
+        "head_id": 21
+      },
+      {
+        "form": "gārhapatyaḥ",
+        "lemma": "gārhapatya",
+        "upos": "NOUN",
+        "sentence_id": 15278,
+        "head_id": 9
+      },
+      {
+        "form": "viśvaiḥ",
+        "lemma": "viśva",
+        "upos": "ADJ",
+        "sentence_id": 13778,
+        "head_id": 9
+      },
+      {
+        "form": "lakṣmaṇyasya",
+        "lemma": "lakṣmaṇya",
+        "upos": "NOUN",
+        "sentence_id": 738722,
+        "head_id": 4
+      },
+      {
+        "form": "viśvāḥ",
+        "lemma": "viśva",
+        "upos": "ADJ",
+        "sentence_id": 94254,
+        "head_id": 6
+      },
+      {
+        "form": "viśvebhyaḥ",
+        "lemma": "viśva",
+        "upos": "ADJ",
+        "sentence_id": 25263,
+        "head_id": 11
+      },
+      {
+        "form": "viśve",
+        "lemma": "viśva",
+        "upos": "ADJ",
+        "sentence_id": 25262,
+        "head_id": 10
+      },
+      {
+        "form": "devāḥ",
+        "lemma": "deva",
+        "upos": "NOUN",
+        "sentence_id": 15279,
+        "head_id": 10
+      },
+      {
+        "form": "viśve",
+        "lemma": "viśva",
+        "upos": "ADJ",
+        "sentence_id": 14103,
+        "head_id": 12
+      },
+      {
+        "form": "viśve",
+        "lemma": "viśva",
+        "upos": "ADJ",
+        "sentence_id": 670063,
+        "head_id": 3
+      },
+      {
+        "form": "viśve",
+        "lemma": "viśva",
+        "upos": "ADJ",
+        "sentence_id": 14038,
+        "head_id": 11
+      },
+      {
+        "form": "viśvebhyaḥ",
+        "lemma": "viśva",
+        "upos": "ADJ",
+        "sentence_id": 701396,
+        "head_id": 2
+      },
+      {
+        "form": "svāyambhuvasya",
+        "lemma": "svāyambhuva",
+        "upos": "NOUN",
+        "sentence_id": 446415,
+        "head_id": 3
+      },
+      {
+        "form": "viśve",
+        "lemma": "viśva",
+        "upos": "ADJ",
+        "sentence_id": 13947,
+        "head_id": 3
+      },
+      {
+        "form": "viśve",
+        "lemma": "viśva",
+        "upos": "ADJ",
+        "sentence_id": 747340,
+        "head_id": 2
+      }
+    ]
+  },
+  "note": "BEST-EFFORT, per roadmap ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md Wave 1 module 9 spec. DCS's own UD-style `deprel` tagging gives a reliable, corpus-native dvandva count (compound:coord) and a proper-name-compound count (compound:name) -- these are NOT heuristic. The much larger remaining question -- tatpurusa vs karmadharaya vs bahuvrihi -- is NOT auto-classified here: the UD compound relation used by DCS does not carry that distinction, and guessing it algorithmically without a real semantic/syntactic samasa parser would risk reporting fabricated percentages. A random 15-item sample per bucket is included for a human or a future dedicated-segmentation pass (vidyut cheda + hand adjudication) to type; that full typing pass is flagged as a follow-up, not delivered here. Absolute scale caveat: only 0.039% of all DCS tokens carry an explicit compound-member deprel at all -- most Sanskrit compounds in this corpus are NOT syntactically decomposed into member tokens (they remain single orthographic words, see Module 6); this module's counts describe the tagged MINORITY, not the full compound population."
+}

--- a/papers/sanskrit_in_numbers/module9_samasa_types.py
+++ b/papers/sanskrit_in_numbers/module9_samasa_types.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Module 9 - samasa types, best-effort (Sanskrit-in-Numbers Wave 1, H813).
+
+Duden's *Sprache in Zahlen* reports German Fugenzeichen (linking-element)
+types in compounds. Sanskrit's structural analog is samasa TYPE (tatpurusa /
+bahuvrihi / dvandva / karmadharaya / avyayibhava ...), which the roadmap
+flags explicitly as **best-effort** because full compound typing needs
+semantic/syntactic segmentation, not markup -- there is no dictionary-markup
+shortcut the way there is for gender or verb class.
+
+This module reports what the DCS Universal-Dependencies-style treebank
+ALREADY tags reliably, and is explicit about what it cannot distinguish:
+
+  - `compound:coord` (UD "coordinating compound") IS a direct, corpus-native
+    tag for dvandva (coordinate) compounds -- reliable, not a heuristic.
+  - `compound:name` tags proper-name compounds (a distinct, smaller bucket).
+  - plain `compound` covers everything else the treebank marks as an
+    internal compound-member relation -- this bucket mixes tatpurusa,
+    karmadharaya, AND bahuvrihi, because the UD scheme does not distinguish
+    them. This script does NOT attempt to auto-classify that bucket by
+    semantic guesswork (that would risk fabricating a typed number); instead
+    it draws a small, explicitly-labeled illustrative sample for a human/future
+    session to hand-read, and reports the honest undifferentiated count.
+
+Source: VisualDCS DCS-data-2026/dcs_full.sqlite, token.deprel.
+"""
+import json
+import random
+import sqlite3
+import sys
+from collections import Counter
+from datetime import date
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GITHUB_ROOT = REPO_ROOT.parent
+DCS_DB = GITHUB_ROOT / "VisualDCS" / "src" / "DCS-data-2026" / "dcs_full.sqlite"
+
+COMPOUND_DEPRELS = ("compound", "compound:coord", "compound:name")
+
+
+def main():
+    con = sqlite3.connect(str(DCS_DB))
+    cur = con.cursor()
+
+    cur.execute("SELECT COUNT(*) FROM token")
+    total_tokens = cur.fetchone()[0]
+
+    counts = {}
+    samples = {}
+    for deprel in COMPOUND_DEPRELS:
+        cur.execute("SELECT COUNT(*) FROM token WHERE deprel=?", (deprel,))
+        counts[deprel] = cur.fetchone()[0]
+        cur.execute(
+            "SELECT form, lemma, upos, sentence_id, head FROM token WHERE deprel=?",
+            (deprel,),
+        )
+        rows = cur.fetchall()
+        random.seed(42)
+        sample = random.sample(rows, min(15, len(rows)))
+        samples[deprel] = [
+            {"form": r[0], "lemma": r[1], "upos": r[2], "sentence_id": r[3], "head_id": r[4]}
+            for r in sample
+        ]
+
+    con.close()
+
+    n_total_compound_relations = sum(counts.values())
+
+    out = {
+        "module": 9,
+        "title": "samasa types (best-effort)",
+        "trust_block": {
+            "source": "VisualDCS DCS-data-2026/dcs_full.sqlite (DCS-2026 release), "
+                       "token.deprel Universal-Dependencies-style compound relations",
+            "n": {
+                "total_tokens": total_tokens,
+                "total_compound_relations": n_total_compound_relations,
+                **counts,
+            },
+            "date": str(date.today()),
+            "model": "Sonnet 5 (claude-sonnet-5)",
+        },
+        "counts": counts,
+        "pct_of_compound_relations": {
+            k: round(100 * v / n_total_compound_relations, 2) for k, v in counts.items()
+        },
+        "reliable_typed_bucket": {
+            "dvandva (compound:coord)": counts["compound:coord"],
+            "proper-name compound (compound:name)": counts["compound:name"],
+        },
+        "undifferentiated_bucket": {
+            "tatpurusa/karmadharaya/bahuvrihi, undifferentiated (compound)": counts["compound"],
+        },
+        "sample_for_manual_typing": samples,
+        "note": "BEST-EFFORT, per roadmap ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md Wave 1 "
+                "module 9 spec. DCS's own UD-style `deprel` tagging gives a reliable, "
+                "corpus-native dvandva count (compound:coord) and a proper-name-compound "
+                "count (compound:name) -- these are NOT heuristic. The much larger "
+                "remaining question -- tatpurusa vs karmadharaya vs bahuvrihi -- is "
+                "NOT auto-classified here: the UD compound relation used by DCS does not "
+                "carry that distinction, and guessing it algorithmically without a real "
+                "semantic/syntactic samasa parser would risk reporting fabricated "
+                "percentages. A random 15-item sample per bucket is included for a human "
+                "or a future dedicated-segmentation pass (vidyut cheda + hand adjudication) "
+                "to type; that full typing pass is flagged as a follow-up, not delivered "
+                "here. Absolute scale caveat: only "
+                f"{round(100 * n_total_compound_relations / total_tokens, 3)}% of all "
+                "DCS tokens carry an explicit compound-member deprel at all -- most "
+                "Sanskrit compounds in this corpus are NOT syntactically decomposed into "
+                "member tokens (they remain single orthographic words, see Module 6); "
+                "this module's counts describe the tagged MINORITY, not the full "
+                "compound population.",
+    }
+
+    out_path = Path(__file__).parent / "module9_samasa_types.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(out, f, ensure_ascii=False, indent=2)
+
+    print(f"total tokens: {total_tokens}")
+    print(f"compound relation counts: {counts}")
+    print(f"wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Executes Wave 0 + Wave 1 of [ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md) under handoff [H813](https://github.com/gasyoun/Uprava/blob/main/handoffs/H813-Sonnet_SanskritLexicography_sanskrit_in_numbers_wave1_new_modules_12.07.26.md).
- New `papers/sanskrit_in_numbers/`: `MODULES_OWNED.md` (Wave 0 assembly, citing A40/A55/A56, plus a new DCS Zipf coverage curve) + `WAVE1_SUMMARY.md` (Wave 1 headline numbers/trust blocks) + 6 generator scripts + 6 committed JSON datasets.
- Five NEW modules per the roadmap: akshara/phoneme frequency (5), longest compounds with a >=5-occurrence honesty floor (6), gender distribution (8), samasa types best-effort (9, explicitly flagged - no fabricated tatpurusa/bahuvrihi split), verb classes + voice (10, from WhitneyRoots).
- Anti-salami respected: modules 2 (vocab size) and 7 (POS distribution) are cited from A40/A55/A56, never recomputed.
- `changelog.md` [1.9.7] entry added; `ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md` Wave 0/1 marked done with headline results.

## Test plan
- [x] All 6 generator scripts run standalone and produce valid JSON (verified: `python -c "import json,glob; [json.load(open(f,encoding='utf-8')) for f in glob.glob('*.json')]"`).
- [x] Spot-checked headline percentages in `WAVE1_SUMMARY.md`/`MODULES_OWNED.md` against the actual JSON output (caught and fixed two transcription errors: 50-char not 51-char hapax record; 244 not 123 multi-class roots).
- [x] No uncommitted cache/vendor artifacts leaked (`.cache/` gitignored).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>