### PR TITLE
ai-wip: tidy sweep -- LaukikaNyaya OCR + sol.md + research-layers append

### DIFF
--- a/LaukikaNyaya/raw_jacob_1907-1911_ocr.txt
+++ b/LaukikaNyaya/raw_jacob_1907-1911_ocr.txt
@@ -1,0 +1,17375 @@
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+Digitized By Siddhanta eGangotri Gyaan 
+
+
+za 
+
+
+—————— 
+
+
+Te UND a 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha S 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+~A 
+ठोकिकन्यायाञ्ञलिः ॥ 
+प्रथमो भाग: ॥ 
+A HANDFUL OF POPULAR MAXIMS 
+
+
+CURRENT IN SANSKRIT LITERATURE. 
+
+
+f OLLECTED BY 
+
+
+Colonel G. A. Jacob, 
+
+
+“INDIAN STAFF CORPS. 
+
+
+Author of “Concordance to the Principal. Upanishads,” ५ Manual 
+of Hindu Pantheism” dc, de. 
+
+
+SECOND EDITION—REVISED AND ENLARGED. 
+—S HOS 
+
+PRINTED AND PUBLISHED 
+
+BY 
+TUKARAM JÀVAJI, 
+PROPRIETOR or JAVAJ! 10503708 NIRNAYA-SAGARA" Press, 
+gni. 
+1907. 
+
+
+Price 6 Annus. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Mr gue iig a Le SRE 
+
+
+SES 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+[AH rights reserved by the Publisher.]  - | 
+
+
+Registered under Act XXV of 1867. 
+
+
+* 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+EXTRACT FROM PREFACE JO FIRST EDITION. 
+
+
+Ix Dr. Bühler's well-known Kashmir Report of 1877, we read 
+the following:—^A curious and very useful though modern 
+treatise is the Laukikanydyasangraha of Raghunath, a Raj- 
+put. This worthy has collected the nydyas or ‘inferences from 
+familiar instances,’ which occur in the S’dstvas, especially those 
+from the Vedámtas'ástra e. g. Danddpipikdnydya, Dehali- 
+dipanydya ke. The collection is not complete, but contains a 
+good deal more than that Professor Balasastri has given in his 
+article in the Pandit.* P. Vamanicharya Jhalkikar is at pre- 
+sent engaged on a still more extensive work on this subject, 
+which will comprise about 900 such nydyas.” Page 76. 
+
+
+The information given in the concluding sentence raised our 
+hopes to a high pitch, for the need of such a work was great, 
+and Dálas'ástri had explained only nine of those nyfyas. But 
+alas! ^ there's many a slip between the cup and lip, and though 
+wo have waited for this “more extensive work” for 22 long 
+years, there are still no signs of its appearing. 
+
+
+I have therefore determined to lay before the publie the 
+‘handful’ of popular maxims which I have collected durirg many 
+years of reading, in the hope that they may become the nucleus 
+of a very much larger collection. In Táránáth Tarkavachas- 
+patis Vdcaspatyam we have a list of 151 nyáyas, popular and 
+technical ; but references to works where they are to be found 
+are few and far between, and this considerably lessens their value. 
+Thirty of these were reproduced in V. S. Apte’s dictionary, in 
+1890, but with the same defect. Again, in 1875, Pandit Satya- 
+vrata Sümas'rami published a small pamphlet of 36 popular 
+
+
+maxims together with a larger number of purely technical ones, 
+
+
+and professed to give à reference for each of them. But à man 
+who refers you to the * Bhigavata Purana,’ to “A commentary 
+on the Vedàntabháshya," or to “A commentary on the Kivya- 
+
+
+“October RBBB SAVY vrat Shastri Collection. 
+
+
+ai Digitized By Siddhanta eGangott yaan Kosha 
+
+prakás'a," and vouchsafes no further information whatever, is 
+a worthless guide ; and such mere semblance of guidance deserves 
+nothing but reprobation. One can tolerate ambiguity of this 
+kind in the ancient writings ; but in modern times, when printed 
+books of reference abound, such vagueness is inexcusable. 
+
+
+My list comprises only ‘ popular’ maxims, and therefore such 
+purely technical ones as Adhydropanydya, haimutikanydya, 
+guaopasamhárangája, and others of a similar nature, which 
+abound in the philosophical and grammatical works, will not be 
+found here. Moreover, I have rigorously excluded even popular 
+maxims which I have been unable to find in actual use in the 
+literature, deeming an unverified maxim with a mere diction- 
+ary-existence as of very little value. 
+
+
+* * * * + + * 
+
+
+Imay add that about 22 illustrative sayings, which are praeti- 
+cally nydyas, might be gathered from the fourth Book of the 
+Sdnkhyasttras; such as, for example, the well-known ““ अहिनि- 
+चैयनीवत्‌ > and others more or less useful. Some of them were 
+published in the Pandit for December 1876, under the title 
+of “Stories illustrative of the Sánkhya doctrine;” but the 
+whole will be found translated in the volume of “Sankhya 
+Aphorisms” published in Trübners Oriental Series. 
+
+* * * * * * 
+
+
+In concluding this preface I must apologize to the reader for 
+not giving him a bigger *handful' of maxims, and one of 
+better quality. But what there is has been put together in 
+defiance of the warnings of the skilful oculist in whose hands 
+I have been for the last five years, and therefore at some risk 
+to failing sight. May some younger scholar be provoked to the 
+good work of giving us something fuller and better. 
+
+
+Redhill, Surrey. } 
+
+
+July 1909. G. A.J. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+PREFACE TO SECOND EDITION. 
+
+
+Seven years have elapsed since the publication of this book- 
+
+
+let, and, as my researches have been continued during tho 
+
+
+whole of the interval, I have naturally collected much ad- 
+ditional material. Part of this was published as a “Second 
+Tlandful” in 1902, and that was succeeded by a “Third” in 1904 
+During my reading I frequently came upon older references to 
+many of the nyayas first published, and these have now been 
+utilized; whilst other changes, some of them of a radical nature, 
+have been made, and a few new nyáyas added. , The discovery 
+of MSS. of Raghunáthavarman's works, as recorded in tke pre- 
+face to the “Second Handful”, was of the utmost importance to 
+me; but the student will find in my three small volumes some 
+nytyas which even he did not explain, —amongst which are 
+the कृत्वाचिन्तान्याय and मणिमन्नन्याय here incorporated for the first 
+time. 1 make no distinction now between what may be really 
+called a ‘popular’ maxim, and one of a technical nature. Both 
+need to be explained and illustrated, so both are freely admitted. 
+I have thoroughly revised, and considerably enlarged, the “Se- 
+cond Handful” also, and hope soon to see it reprinted. It will 
+contain, amongst much new matter, the story connected with 
+the वधूमाषमापनन्याय which so long eluded me, and for which, as 
+well as for several other valuable items of information, I am in- 
+debted to Mr. Govind Das, an Honorary magistrate of Benares. 
+Another lover of Sanskrit has come to my help in the person 
+of Mr. M. R. Telang, Head Shirastedar of the Bombay High 
+Court, who has kindly supplied what was to me, at any rate, ® 
+novel interpretation of the लोष्टप्रस्तारन्याय- lam anxious to revise 
+
+
+as soon as possible the whole of the nyàyas which I have en- - 1 
+
+
+deavoured to elucidate, before increasing infirmities compel the 
+
+
+abandonment of the studies which have been my delight for | 
+
+
+forty-six years. 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+II Digitized By Siddhantd ®Gdny6t, Gyaan Kosha 
+
+
+prakas'a,” and vouchsafes no further information whatever, is 
+a worthless guide ; and such mere semblance of guidance deserves 
+nothing but reprobation. One can tolerate ambiguity of this 
+kind in the ancient writings; but in modern times, when printed 
+books of reference abound, such vagueness is inexcusable. 
+
+
+My list comprises only ' popular” maxims, and therefore such 
+purely technical ones as Adhydropanydya, haimutikanydya, 
+gunopaswmhdranydya, and others of a similar nature, which 
+abound in the philosophical and grammatical works, will not be 
+found here. Moreover, I have rigorously excluded even popular 
+maxims which I have been unable to find in actual use in the 
+literature, deeming an unverified maxim with a mere diction- 
+ary-existence as of very little value. 
+
+
+* + * * * * * 
+
+
+I may add that about 22 illustrative sayings, which are practi- 
+cally nydyas, might be gathered from the fourth Book of the 
+Sánkhyasütras ; such as, for example, the well-known ** अहिनि- 
+चेयनीवतू and others more or less useful. Some of them were 
+published in the Pandit for December 1876, under the title 
+of “Stories illustrative of the Sánkhya doctrine; but the 
+whole will be found translated in the volume of ५ Sankhya 
+Aphorisms” published in Trübner's Oriental Series. 
+
+
+* * * * * * 4 
+
+
+In concluding this preface I must apologize to the reader for 
+not giving him a bigger ‘handful’ of maxims, and one of 
+better quality, But what there is has been put together in 
+defiance of the wainings of the skilful oculist in whose hands 
+I have been for tho last five years, and therefore at some risk 
+to failing sight. May some younger scholar be provoked to the 
+good work of giving us something fuller and better, 
+
+
+Redhill, Surrey. } 
+
+
+July 1909. G A. J, 
+
+
+— मा 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+PREFACE TO SECOND EDITION. 
+
+
+Seven years have elapsed since the publication of this bock- 
+
+
+Jet, and, as my researches have been continued during the 
+
+
+whole of the interval, I have naturally collected much ad- 
+ditional material. Part of this was published as a “Second 
+Handful” in 1902, and that was succeeded by a “Third” in 1904 
+During my reading I frequently came upon older references to 
+many of the nyayas first published, and these have now been 
+utilized; whilst other changes, some of them of a radical nature, 
+have been made, and a few new nyáyas added. , The discovery 
+of MSS. of Raghunáthavarman's works, as recorded in tke pre- 
+face to the “Second Handful”, was of the utmost importance to 
+me; but the student will find in my three small volumes some 
+nyáyas which even he did not explain,—amongst which are 
+the कृत्वाचिन्तान्याय and मणिमत्रन्याय here incorporated for the first 
+time. I make no distinction now between what may be really 
+called a ‘popular’ maxim, and one of a technical nature. Both 
+need to be explained and illustrated, so both are freely admitted. 
+I have thoroughly revised, and considerably enlarged, the “Se- 
+cond Handful” also, and hope soon to see it reprinted. Tt will 
+contain, amongst much new matter, the story connected with 
+the वधूमाषमापनन्याय which so long eluded me, and for which, as 
+well as for several other valuable items of information, I am in- 
+debted to Mr. Govind Dás, an Honorary magistrate of Benares. 
+Another lover of Sanskrit has come to my help in the person 
+of Mr. M. R. Telang, Head Shirastedar of the Bombay High 
+Court, who has kindly supplied what was to me, at any rate, a 
+novel interpretation of the लोष्टप्रस्तारन्याय. Tam anxious to revise 
+as soon as possible the whole of the ny&yas which I have en- 
+deavoured to elucidate, before increasing infirmities compel the 
+
+
+abandonment of the studies which haye been my delight for 
+
+
+forty-six years, 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Iv Digitized By Siddhanta dal iE Gyaan Kosha 
+
+
+I wish I could impart to some of my fellow count ymen resid 
+ent in India, something of the enthusiasm which its or md 
+literature awakened within mein the early part of my carcer 
+and which has never waned during this long intervening period, 
+
+
+Such a hobby not only provides delightful mental exercise, but, 
+
+
+better still, it draws one into sympathetic touch with the people 
+amongst whom one’s lot is cast. 
+
+
+Redhill, Survey, Y 
+Oclober, 1907. - | G. A. JACOB, 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+WA S I 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+hist of Works quoted in the ` 
+following pages. 
+GE 
+
+Aldvaitabrahimasiddhi, of Sadánanda Yati; Bib. Ind., 1890. 
+
+Alankdrasarvasva of Ràjânaka Ruyyaka; Nirnaya-sigar 
+Press, Bombay, 1898, ँ 
+
+Apastamba-Grihyasütra, with the Com. of. Sudars'anarya ; 
+edited by Dr. Winternitz, Vienna, 1887. 
+
+Atmatativaviveka of Udayana, edited by Pandit Jivananda 
+Vidyáságara; Calcutta, 1873. 
+
+bháinalt of Vácaspatimisra; Bib. Ind., 1880. e 
+
+Bhartriharis S’atakatraya, with Com. Nirnaya-ságar Press, 
+Bombay, S'aka 1813. 
+
+Bháshápariccheda, with Com.; edited by L. N. Vasáka, 
+Calcutta, 1871. 
+
+Dhedadhikkára of Nrisimhüsrama Muni; Benares Sanskrit 
+Series, 1904. 
+
+Bralimasátrabhásya of S'ankarücàrya, with Anandagiri's Com. ; 
+Anandásrama Press, 2 vols, 1890-1. Translation by Dr. 
+G. Thibaut in Sacred Books of East Series; 2 vols, 1890:6. 
+A fine edition of the Bhásya, with the Bhamati, and two 
+other Commentaries, was issued from the Nimaya-ságar 
+Press, in one volume, in 1904. : 9 
+
+Brahmasitratdtparyavivarana, published in The Pandit 
+for 1882. 
+
+Brihaddranyakopunisadbhdsyavartika of  Sures’varacdrya, 
+with Anandagivi’s tika, and full Index to verses; Anandá- 
+srama 1२0055, 2 vols, 1892-4. This is sometimes quoted as 
+the large Vartika ; 
+
+Citsukht of Citsukhamuni, with his own vritü; published in 
+the Pandit for 1882-3 
+
+
+Divanydloka of Anandavardhana, with Abhinavaguptws tiki; 
+
+
+Nirnaya-ságar Press, 189 
+'CC-0. Prof. Satya Vrat Shastri Collection 
+
+
+VI Digitized By Siddha EAF AA Ban Kosha 
+
+
+Ganaratnamahodadhi of Vardhamána; edited by Prof, Egge- 
+ling, 1879-81. Index much needed. 
+
+Huthayogapradipikd of Svatmarim, with Brahmananda's 
+tik; Nirnaya-sagar Press, S'aka 1811. 
+
+History of Indian Literature, by Prof. Dr. Weber; Trübners 
+Oriental Series, 1878. 
+
+History of Sanskrit Literature, by Prof. A. A. Macdonell, 
+London, 1900. 
+
+Jaiminis Mimémsdsitra, with S'abara's Bhásya; 2 vols. Bib, 
+Ind., 1873-89. 
+
+Jivanmuktiviveka of Vidyaranya; Anandasrama Series, S'aka 
+1811, 
+
+Kàmasütra, of Vàtsyáyana; Nirnaya-sigar Press, 1891. 
+
+Kathdsaritsigavra of Somadevabhatta; Nirnaya-sagar Press, 
+1887. Translation by Prof. C. H. Tawney, 2 vols., Bib. Ind, 
+1880-4. 
+
+Kdvyddars'a of Dandin ; Bib. Ind., 1863. 
+
+Kávyálankàra of Rudrata, with Namisádhu's tika ; Nirnaya- 
+sagar Press, 1886. 
+
+Kávyapradipa of Govinda, with Vaidyanatha’s ka; Nirnaya- 
+sagar Press, 1891. 
+
+Kivyaprakas'a of Mammata and Allata; edited by Mahes‘a- 
+candra Nyáyaratna, Calcutta, 1866. 
+
+Khandanuthandakhddya of S'viharsa, with S'ankaramis'ra's 
+tika; Medical Hall Press, Benares, 1888. A new edition 
+of this work, with the Com. entitled Vidydsdgart, is now 
+appearing in the Chaukhambá Sanskrit Series, Benares, 
+edited by Prof. Gangánátha Jhá who is also issuing à 
+translation in the new Magazine Indian Thought. 
+
+
+Jit uen on 
+
+
+Khandanoddhdra, a criticism of the above, by Vácaspati (not : y 
+celebrated philosopher, but a modern writer of about three 
+centuries ago-so the learned Pandit Govind Das of Bena- 
+res tells me); Medical Hall Press, Benares. 
+
+Kusumånjali of Udayana, with his own vritti, 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Incomplete. 
+and two tikas; 
+
+
+CIENT Ae Lui. 
+
+
+Digitized By Siddhanta E ER: Gyaan Kosha 
+LIST OF BOOKS. VII 
+
+
+2 vols, Bib. Ind., 1890-95. The kárikás of the same, with 
+Haridasa’s tika, edited and translated by Prof. Cowell; 
+Calcutta, 1864. 
+
+Kuvalaydnanda of Appaidiksita, with Vaidyanátha's tika, edi- 
+ted by Pandit J. Vidyáságara; Calcutta, S'aka 1796. A very 
+faulty edition. But an excellent one of the same two 
+works, was published at the Nimaya-sagar Press, in 1903. 
+
+Laukikanydyasangraha of Raghunáthavarman; India office 
+MS. 700. An inaccurate edition was published at the 
+Medical Hall Press, Benares, in 1902. है 
+
+Mágha's S'is'upâlavadha with Mallinatha’s comment, edited by 
+Táránáth Tarkavacaspati; Calcutta, S'aka 1769. 
+
+Mahábhárata, 4 vols, Calcutta 1834-39. Also an oblong edition 
+with Nilkantha Govind's tika; Ganpat Krishnájí's Press, 
+Bombay, S’aka 1799. 
+
+Mahdbhdsya of Patanjali, edited by Dr. Kielhorn; 3 vols, Bom- 
+bay Sanskrit Series, 1880-85. A new edition is now in 
+course of publication; and let us hope that the learned edi- 
+tor will add a complete index. 
+
+Manusmriti with 7 Commentaries; edited by Rio Sahib V. N. 
+Mandlik, Bombay, 1886. 
+
+Manual of Hindu Pantheism, by Colonel Jacob; Triibner’s 
+Oriental Series, 3rd edition, 1891. This edition was 
+reprinted by the publishers, about two years ago, with- 
+out the authors knowledge, and therefore without the 
+revision necessary to bring it up to date. 
+
+Molesworth's Mardthi-English Dictionary; 2nd. edition, 
+Bombay, 1857. " 
+
+Mrrechakatikandtaka, edited by N. B. Godbole; Bombay, 
+1896. "Translation by Dr. Ryder; Harvard Oriental 
+Series, 1905. . 1 
+
+Mudrdrdksasandtaka with Dhundhirája's tika, edited by K. 
+T. Telang; Bombay Sanskrit Series, 1884. - 
+
+Naiskarmyasiddhi of Sures' vara, with the comment of Jn&not- 
+
+
+tama; edited by Colonel Jacob, 2nd. edition, Bombay, 1900. Si 
+b Big cuore 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+* 
+
+
+PT WA | 
+
+
+viil LIST OF BOOKS. 
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+Nitisdra of Kamandaki, with tik&; Bib. Ind., 1884. | 
+
+Nydyabindutikd of Dharmottara, edited by Prof. P. Peterson p 
+Bib. Ind., 1889. 
+
+Nydyakandalé of S'ridhara, with the test of Pras'astapadas | 
+Vaisestkabhdsya; Vizianagram Sanskrit Series, 1895, It 
+is a lamentable thing that this fine series has come toa 
+premature end. A translation of both works is now | 
+appearing in the Pandit. 
+
+
+Nydyakanikd, a Commentary by Vácaspatimisra on Manda- 
+namis'ras Vidhiviveka, with which it is now being pub- - 
+lished in the Pandit. 
+
+Nydyomakaranda of Anandabodha, with comment by Cit- 
+
+: sukha Muni; Chaukhambá Sanskrit Series, Benares. 
+Incomplete. न 
+
+Nydyamanjart of Jayanta Bhatta; Vizianagram Sanskrit 
+Series, 1895. 
+
+Nydyasiddhdntadipa of S'egadharücárya, with of 
+S‘esAnanta; in course of publication in Pandit. 
+
+Nydyavdrtika of Uddyotakara; Bib. Ind. 1907. The first 
+fasciculus was issued in 1887; the title page, this year! 
+
+AN'yáyavártikatátparyattká of Vàcaspatimisra; Vizianagram 
+Sanskrit Series, 1895. Often quoted as Tátparyatiká. 
+When are we going to have an edition of Udayanas , 
+Paris'úddhi? 
+
+Padamanjart, a Commentary on Cds'ikdvritti; published in 
+the Pandit, 2 vols. : 
+
+Pamcadasi of Vidyaranya, with Rámkrishna's comment; 
+edited by Pandit J. Vidyás&gara, Calcutta, 1882. 5 
+
+Pancapádiká of Padmapáda; Vizianagram Sanskrit Series, 
+1891. Said to be the oldest comment on S'ankara's bhasya 
+(stitras 1-4 only ). 
+
+A translation of the first 14 pages of this work, by Mr. Arthu 
+
+
+Venis, was published in the Pandit, but then, alas! i 
+ceased ! 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By SIAAKMNAREIGRE Gyaan Kosha IX 
+
+
+Pancatantra, edited by Professors Bühler and Kielhorn; Bom- 
+bay Sanskrit Series, 1885. 
+
+
+Paris'istaparvan, of Hemacandra, edited by Prof, H. Jacobi; 
+Bib. Ind., 1891. 
+
+Practical Sanskrit Dictionary by V. S. Apte; Poona, 1890. 
+
+Prasannardghava Nataka of Jayadeva; Nimaya-ságar Press, 
+1893. 
+
+Rájatarangint of Kalhana, edited by Pandit Durgáprasád ; 
+Bombay Sanskrit Series, 1892-96. 
+
+Ramayana of Valmiki; Nirnaya-sàgar Press, 2 vols, 1888. 
+
+Rasagangddhara of Jagannath Pandit, with Náges' Bhatta’s 
+tika; Nirnaya-ságar Press, 1888. 
+
+Rational Refutation of Hindu Philosophical Systems, by N. 
+98507 Goreh, translated from the Hindi by Dr. Fitzed- 
+ward Hall; Calcutta, 1862. 
+
+Saddars'‘anacintanikd of Mahádeo Moreshwar Kunte, in San- 
+skrit, Marathi and English; Poona, 1877-82. Incomplete. 
+
+Saddars'anasamuccaya of Haribhadrasüri, with the comment 
+of Manibhadra; Chaukhamba Sanskrit Series, Benares, 
+1905. About half of the chapter on Jainism is found, 
+word for word, in the Syddvédamanjart! Which was 
+the plagiarist, this man or Mallisena ? 
+
+S'ankaravijaya of Anandagiri; Bib. Ind., 1868. 
+
+Sdnkhyasttravritti of Aniruddha, with Extracts from Vedantin 
+Mahádeva's Commentary, edited and translated by Dr. R. 
+Garbe; Bib. Ind., 1888 and 1892. 
+
+Stinkhyatattuakawmudi of Vàcaspatimisra, edited by Pandit 
+Taranath Tarkavácaspati ; Calcutta, 1871. 
+
+Sankshepas'áriraka, of Sarvajnütma Muni; The Pandit, vols., 
+IV-X. New Series. 
+
+Saptapadartht of S'iváditya, with comment by Madhava Sara- 
+svati; Vizianagram Sanskrit Series, 1893. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+É 3 
+x LIST OF BOOKS, 3 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+Sarvadars'anasungraha of Madhava; Bib. Ind., 1858, An edi- 
+tion by Jivánanda Vidyáságara, Calcutta, 1871. Trans- 
+lation by Professors Cowell and Gough, in Trübner’s Ori- ; 
+ental Series, 1882. This, too, was reprinted by the publi. — 
+shers, without the much-needed revision. An edition of the 
+Text, with an additional chapter on S'ankara's System, | 
+and the text of Madhusüdana Sarasvati's Prasthdnabheda, 
+was published at the Anandas'rama Press in 1906. | 
+
+S'éstradtpikà of Parthasfrathi Misra; Medical Hall Press, | 
+Benares, 1891. 
+
+Satyavrata Sámas'rami's Nyáyávali ; Caleutta, 1875. | 
+
+Siddhántales'a of Appaidiksita; Vizianagram Sanskrit Series, i 
+1890. A translation by Mr. Arthur Venis is being pub- | 
+lished in the Pandit. So far, it extends to page 47 only 
+
+of the text. I hope my learned friend will carry this on to 
+
+completion; for his renderings and critical notes are al- 
+ways of the highest value, 
+
+
+a 
+
+
+Syddvddamanjart, a Commentary by Mallisena on Hemacand- 
+785 verses entitled Vitarágastuti; Chaukhambá Sanskrit 
+Series, Benares, 1900. This work is wrongly described by 
+Rájendralàl Mitra, in his Notices of Sanskrit Mss. vol. iv, 
+page 87, as “A Commentary in verse,” and ascribed to 
+Gaganadinamani. See the remarks, above, on : 
+anusamuccaya. 
+
+
+Luittiriyopanisadbhdsyavdrtika of Sures'varücárya, with 
+Anandajnana’s tika; Ánandás'rama Press, S'aka 1811. 
+Lantravartika of Kumárila ; Benares Sanskrit Series, 1903. 
+
+Prof. Gangán&tha Jha is bringing out a translation of | 
+this important work in the Bibliotheca Indica Series. He - 
+has already, through the same channel, published a com- | 
+plete translation of the first volume of Kumarila’s work, — 
+the S'lokavártika. 3 
+Tirkikaraksd of Varadarája, with the Commentary (in part) 
+of Mallinátha; Medical Hall Press, Benares, 1903. : 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+LIST OF BOOKS. XI 
+
+
+Tuttvamuktikaldpa of Venkatnatha, with his own comment; 
+Medicai Hall Press, Benares, 1900. In the Sarvadars'ana- 
+sangraha it is quoted as Tattvamuhtdvali. 
+
+Udánam, a Buddhist work, published by Páli Text Society, 
+1885. 
+
+Upamitibhavaprapancá Kathd of Siddharsi, edited by Profess- 
+ors Peterson and Jacobi; Bib. Ind., 1899-1907. Incomplete. 
+
+Upades'asálasré of S'ankarácürya, with Ramatirtha's tika; 
+edited by Krishna S'ástri Navare, Bombay, 1886. 
+
+Vacaspatyam, a Sanskrit Lexicon, of 5442 pages, by Pandit 
+Tarfinitha Tarkavácaspati, Calcutta. It is very full up to 
+the end of q (page 4550), whilst the rest of the alphabet 
+is squeezed into 900 pages! It is said that the Bengal 
+Govt, which largely subsidized the undertaking, ordered 
+it to be curtailed. Jf that is so, it did a very unwise thing! 
+We ought to store up the knowledge of these old Pandits 
+who are fast dying out! 
+
+Vedántakalpataru of Amalananda, a commentary on the 
+Bhámati; Vizianagram Sanskrit Series, 1895-7. 
+
+Vedantakalpatarwparimala of Appaidiksita; Vizianagram 
+Sanskrit Series, 1895-8. Sometimes quoted as Parimala. 
+
+
+Vedántasára of Sadánanda, with the commentaries of Nrisimha- 
+‘sarasvati and Rámatirtha; edited by Colonel Jacob, and 
+published at Nimaya-sigar Press, 1894. For the transla- 
+tion of the same, see Manual of Hindu Panthersm. 
+
+Vedántasiddhántamauktávali of Prakás'ánanda, edited and 
+translated by Prof. Arthur Venis; Benares, 1890. 
+
+Vidvanmandana of Vitthala Upadhaya, edited by Ratnago- 
+pala; Victoria Press, Benares, 1904. In Halls Index this 
+is described as * Stricbures on the expositions of several 
+expositors of the Vedanta doctrine.” It ascribes to the same 
+author a work entitled Bhaktihetunirnaya. 
+
+Viraranaprameyasangraha of Vidyaranya; Vizianagram 
+
+Sanskrit Series, 1893. A translation by Dr. Thibaut is now 
+
+
+appearing 800%४४०)३४५३७४॥४/४॥१५४॥९४४४ 
+Cc = 
+
+
+XIL Digitized By Siddhdnl& 8089१ Gan Kosha 
+
+
+Yas'astilaka of Somadeva, with S'ris'rutasigara’s tika; Nip. 
+naya-ságar Press, 2 vols. 1901-3. 
+Yogasdtrs with Vyásas bháshya and Vacaspatimis’ra’s tik 
+— edited by Rajaram 98801 Bodas; Bombay Sanskrit Se: 
+1892. 
+Yogavártika of Vijnina Bhiksu; Medical Hall Press, Benai 
+1884. 3 
+Yogavásistha with the Commentary of Anandabodhend 
+Saraswati; Ganpat Krishnáji's Press, Bombay, This ough 
+to be printed in modern style. The huge oblong tomes are 
+most difficult to handle, 4 
+
+
+ERRATA 
+
+
+Page 30, line 7 from bottom, For “vir bully” say “virtu 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+A HANDFUL OF POPULAR MAXIMS, - 
+
+
+<0 
+
+
+अजाकृपाणीयन्यायः ॥ 
+
+
+The maxim of the she-goat and the sword. It is founded on 
+some story of a goat's being suddenly killed by accidental con- 
+tact with a sword, and is used to illustrate any surprising event 
+happening altogether by chance. It therefore belongs to the 
+same class aS काकतालीय, खल्वाटबिल्वीय and others of a similar 
+kind. An excellent illustration of its use is found on page 229 of 
+S'riharsha's Khandanakhan dakhddya:—“qrait पञ्च वराटकार्पिधाय 
+कश्चित्पृच्छति कति वराटका इति | पृष्टश्चाजाकृपाणीयन्यायेन ब्रवीति पञ्चेति” ॥ 
+In a footnote the maxim is thus explained :—‘ 'कृष्डूयनार्थे स्तंभादौ 
+शिथिलबन्धखज्जे छागी औवां ग्रसारयति यदृच्छया च ग्रीवा छिद्यते तथाभूतोऽजाङ्क- 
+पाणीयन्यायः काकतालीयन्यायसमः? ॥ Vardhamána puts it differ- 
+ently in his comment on Ganaratnamahodadhi iii. 196 :— 
+““य॒थाजया भूमि खनन्त्यात्मचधाय कृपाणो दर्शितस्तत्तुल्यं qd केनचिदात्मवि- 
+नाशाय कृतमजाकृपाणीयम्‌? For another variety, see Padamaü- 
+jar? on Kasika 5. 3. 106. 
+
+The nyaya, with the same illustration,is found also in the 
+Khandanoddhára, page 52; and the illustration, without the 
+nyaya, in Siddhántalesa, page 95. 'Then on page 96, ib is 
+again referred to in the expression “काकतालीयसंवादिवराटकसंख्या- 
+mamaaa ” 
+
+
+It is interesting to note that the Maráthi-speaking folk of 
+Western India have adopted the maxim, but with a changed 
+meaning. Molesworth defines it as “The maxim of the sword 
+
+
+upon the neck of the goat. Expressive of meekness and abso- - 
+
+
+lute helplessness.” 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGargotri Gyaan Kosha 
+
+
+अन्तदींपिकान्यायः ॥ 
+
+
+The maxim of a lamp in a central position. Applied to 
+something which fulfils a double purpose. It occurs in S'anka- 
+788 bháshya on the Mundaka Upanishad 3.1. 5. (“सस्येन लभ्यरत- 
+पसा ह्येप आत्मा सम्यज्ज्ञानेन ब्रह्मचर्येण नित्यम्‌ 7 1) on which he says:— | 
+“नित्यं सवेदा । नित्यं सत्येन नित्यं तपसा नित्यं सम्यग्ज्ञानेनेति सर्वत्र नित्यशब्दो | 
+ऽन्तरदीपिकान्यायेनानुपक्तव्यः ” ॥ It isakin to देहली दीपन्याय and मध्य- | 
+दीपन्याय. Jivánanda's edition of the NMundakabhishya reads 
+अन्त्यदीपकल्यायेन. The reading given above is from the Ânand- _ 
+ds‘rama edition. 
+
+
+अन्धकवर्तकीयन्यायः॥ 
+The maxim of the blind man and the quail. Like अजाः 
+कृपाणीय and many others, it is used to express a wholly fortu- 
+itous occurrence. Vardhamana, on Ganaratnamahodadh iii. 
+195, explains it thus:—“ अन्धकश्न वतेका च अन्धकवतकस्‌ | अन्धकस्य 
+बर्तकाय उपर्यतर्कितः पादन्यास उच्यते | तत्तुल्यमन्धकवर्तकीयम्‌ ? ॥ - 5 
+authority brings the quail under the blind man’s foot; bub the 
+commentator S'ris'rutaságara, who expounded ihe work Yas'as- 
+lalaka and who in the colophon is described as“ तकेव्याकरण- 
+उन्दोलूकारसिद्धान्तसाहित्यादिशाखनिषुणमतिः T 
+aga ”. brings the bird into the man’s hands. And, surely, 
+such a prodigy of learning must be right! The verse in which 
+the expression अन्धकवर्वकीय occurs is Yas'astilaka ii. 153. “संसार- 
+सागरमिमं saat नितान्तं जीवेन मानवभवः समवापि दैवात्‌ । तत्रापि यद्भुवन- 
+मान्यकुले प्रसूतिः सत्सङ्गतिश्च तदिहान्धकवतेकीयम्‌?? ॥ “Tt is altogether 
+by chance that a soul wandering about in this ocean of repeated 
+births is born as a man; and that he should be born into a - 
+family of repute in the world, and enjoy the society of the good, : 
+i8 likewise as accidental as in the case of the blind m 
+
+
+an and the | 
+* This important work, described by Dr. Peterson at ‘by Dr. Peterson at considerable lenat length 
+rH 
+
+
+in his Second Report, was published in tho Kdvyamáld, ७ valuable periodical 
+issued by the Proprietor of the Nirnayaságar Press, 
+
+
+1 
+3 
+3 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddha nta. eGangotri Gyaan Kosha 
+(3) 
+
+
+quail" Srisrutasagara's explanation of the last term is as 
+follows :— अन्धकवतेकीयो दृष्टान्त: | यथा कश्चिदन्धक: पुमान्‌ करतलेन करे 
+ताडयल्वतेते तस्य करद्वयमध्ये वर्तकः पक्षिविशेषः समायाति स तु हुर्ूभस्तथा 
+Maana सत्सज्ञतिहुरूभा quu ॥ 
+
+
+अन्धगजन्यायः ॥ 
+
+
+The maxim of the blind men and the elephant. A number 
+of blind men desired to form an idea of the shape of an 
+elephant. One touched his trunk and thought he must be like 
+a snake; another took hold of a leg and supposed that he was 
+like a post, and so on. "Táránátha tells us that it is used to illus- 
+trate the divergence of views held by the ignorant in regard to 
+Ts' vara. 
+
+The story is found in the Buddhist work Udómam (vi 4, 
+pages 66-69) published by the Pali Text Society in 1885. 
+
+
+It is referred to in Sures'vara’s large Vártika 4. 4. 566 ( page 
+1813) as follows:— एकमेवैकरूप॑ सद्द RATS निरञ्जनस्‌। जात्यन्धगजदष्टयेव 
+कोटिशः करूप्यते war” Also in his Naisharmyasiddhi ii. 98 :— 
+‘age ब्रह्म निर्विकारं कुवुद्धिसिः | जात्यस्घगजदृष्ट्येव कोटिशः परि 
+maai” U I have met with the nyaya again on pages 107 
+and 160 of Syddvddamanjart. It occurs also in the Jainadar- 
+s'ana of Saddars'anasamuccaya (page 46); but the passage in 
+which it is found was taken verbatim from Mallisena’s work, 
+without any acknowledgment. 
+
+
+अन्धगोलाङ्कुन्यायः T 
+
+
+The maxim of the blind man and the cows tail. The story is 
+that an evil-disposed fellow found a blind man who, having lost 
+his way, was wandering about helplessly. Expressing great sym- 
+pathy for him, and promising to help him, the man led him to 
+a young and frisky cow, and putting her tail into his hand told 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta deem Gyaan Kosha 
+
+
+him to hold on, and that she would certainly lead him to the 
+village to which he wished to go. The result was, of course, 
+most disastrous. i 
+
+
+S'ankara, in his bháshya on Veddntastitra 1. 1, 7, applies tho 
+maxim to the case of a teacher who wrongly instructs 
+his pupil in regard to emancipation and so leads him to destruc- 
+tion! These are his words:— “ यदि चाज्ञस्य सतो सुसुक्षोरचेतनमा- 
+त्मानमात्मेत्युपदिशेत्ममाणभूतं We स॒ श्रद्दघानतयान्धगो लाङ्गछन्यायेन | 
+तदात्मदृष्टिं न Raa RRE चात्मानं न प्रतिपद्येत तथा सति पुरुपाथी- | 
+द्विहन्येतानर्थ च ऋच्छेत्‌? ॥ The nyaya is found, too, in Panem: | 
+pádákàvivavano, page 170. 
+
+
+अन्धपरम्परान्यायः ॥ 
+The maxim of a continuous series of blind men. It would — 
+seem to be in this sense that S'ankaráchárya uses it in his 
+Brahmasttrabhdshya 2. 2. 30,87. The passages stand thus:— 
+“अनादित्वे$प्यन्धपरम्परान्यायेनाप्रतिष्ठेवानवस्था व्यवहारलोपिनी स्यान्नाभिप्राः | 
+यसिद्धिः!“वतमानकालवदतीतेष्वपि काछेष्वितरेतराश्रयदोपाविरेषादन्धपरम्पः | 
+रान्यायापत्तेः? y In his rendering of the former passage, Dr. Thibaut 
+has overlooked the mazim, but the latter he translates as fol- 
+lows:—“For in past time as well as in the present, mutual 
+interdependence of the two took place, so that the 1 
+series is like an endless chain of blind men leading other blind 
+men.” I should add that, in the former case, Sankara is argt | 
+
+ing against the Buddhist theory of a beginningless series of 
+mental impressions, and, in the latter, against the Sankhya 
+notion of a similar chain of human actions and divine interposk 
+tions. Dr. Thibaut’s explanation of the maxim is quite in 
+accord with that of Dr. Garbe in his rendering of ७९५00 
+Sutra ii 81 “इतरथान्धपरस्परा? “Else there would bo a tradition | 
+[ comparable to a row ] of blind men [ leading each other n 3 
+; A vary apt quotation from one of Coleridge's Lay Sermons ; 
+18 given in that useful work A Rational Refutation of Hindu 
+Phalosophical Systems (now quite out of print), from which 4 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By यावया याच eGangotri Gyaan Kosha 
+
+
+extract the following:—“The old man talked much and vehe- - 
+
+
+mently concerning an infinite series of causes and effects, which 
+he explained to be a string of blind men, the last of whom 
+caught hold of the skirt of the one before him, he of the next, 
+and so on till they were all out of sight; and that they all 
+walked infallibly straight, without making one false step, 
+though all were alike blind. Methought I borrowed courage 
+from surprise, and asked him, ‘Who, then, is at the head to 
+guide them? He looked at me with ineffable contempt, not 
+unmixed with an angry suspicion and then replied, “No one; 
+the string of blind men goes on for ever without any beginning, 
+for although one blind man’ cannot move without stumbling, 
+yet infinite blindness supplies the want of sight.” 
+
+In the opening part of the Pudamaijart ( Pandit x. 248 ) 
+we find the expression अन्धपरस्पराप्रसक्ञ used with reference to 
+testimony received through a series of blind men, and therefore 
+of doubtful value. It is part of an interesting discussion 
+regarding different forms of a word, why some are considered 
+correct and others not. “तत्र ये साधवस्ते शाखेणानुशिष्यन्तेञ्साधुभ्यो 
+विविक्ताः प्रकृतिप्र्ययविभागेन ज्ञाप्यन्त इमे साधव इति । कथं पुनरिदमा- 
+चार्येण पाणिनिनावगतमेते साधव इति | आपिशलेन पूर्वव्याकरणेन | आपिः 
+शलिना तर्हि केनावगतम्‌ | ततः पूर्वेण व्याकरणेन | यद्चेवमन्धपरस्पराप्रसङ्गः | 
+तद्यथा Te क्षीरमिलन्धेनोक्ते केनेदमवगतमिति YA यदान्धरान्तरं मूलं निदि- 
+शाति सोऽप्यन्धान्तरं तदा नैतद्वचः Ma प्रमाणं भवति ताइगेतत्‌? d 
+
+That the nyaya is in very general use will be apparent from 
+the following additional references. Taniravdrtika, pages 
+11, 72, 75, 232, 799, 877. Pancapddild, page 98. Bhdmatt, 
+pages 254, 464, Nydyamanjart pages 234, 249, 251, 425, 492. 
+
+
+अरुन्धतीप्रदशनन्यायः ॥ 
+
+
+The maxim of the pointing out of the star Arundhati. - 
+The idea here is that of gradual instruction, on the principle of — 
+
+
+the अध्यारोपापवादुन्याय for which see the Second Handful. Its 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+usage is explained by S'ankara in Brahmasdtrabhdshya 1.1, | 3 
+as follows.—' यथारून्धतीं दिदशयिपुस्तत्समीपस्थां स्थूलां तारामसुख्यां ` 
+प्रथममरुन्धतीति ग्राहयित्वा तां प्रत्याख्याय पश्चादरुन्धतीसेव ग्राहयति aga 
+मात्मेति ब्रूयात्‌? u Similarly, too, in 1. 1. 12, we read :—* 'यथारुन्धती- | 
+निदर्शने बह्ीष्वपि तारास्वसुख्यास्वरुन्धतीपु TAA यान्त्या प्रदरयेते सा सुख्ये- 
+वारुन्धती भवत्येवमिहाप्यानन्द्मय्रस्य सवोन्तरत्वान्मुख्यमात्मत्वम्‌?? The | 
+maxim is sometimes styled स्थूलारन्वतीन्याय, and it appears 
+
+under this name in Nrisimhasarasvati's commentary on section 
+20 of the Veddntasdra—that section which gives the views of 
+Chárvákas and others as to the átman. 
+
+
+अके चेन्मधु विन्देत किमथ पर्वतं asta ॥ 
+
+
+Lf one can find honey on the Arka-tree | close at band ] then 
+why go to the mountain for it? That is, if an object can be 
+accomplished by simple means, don’t adopt a more complicated 
+method. ‘This is well illustrated by S’ankara in his Veddnta- 
+sitrabhdshya 3. 4. 3, as’ follows:—“ केवलाचेज्ज्ञानात्पुरुपार्थसाद्धि 
+स्याल्किमर्थमनेक्ायाससमन्वितानि कर्माणि ते PA: | अर्के चेन्म॒ विन्देत Gur 
+पवेत ब्रजेदिति न्यायात? ॥ 
+
+
+Its source, however, is S'abara on Jaimini 1. 2, 4. Here, tho 
+pirvapakshin, after taking exception to certain Vedic injunc- — 
+tions as useless says.—'* तद्यथा पथि smash apaa तेनेव पथा a 
+मध्वर्थिनः पर्वत न गच्छेयुस्ताइशं हि तत्‌ । अपि चाहुः । अकै Wag निन्देत 
+faa पर्वतं नजेत्‌ । aa संसिद्धौ को विद्वान्यत्माचरेत्‌”” ॥ 
+The same couplet is quoted by Aniruddha in his comment on E 
+Sdnkhyasttra i. 1; also by Váchaspati Mis/ra in his Sénkhya- : 
+talivakawmudi 1., and again in his Nydyavdrtikatdtparyagthd, — 
+page 220. Instead of अ, however, we have in the former 
+instance s and in the latter sgg. Raghunath reads अक्के and 
+oxplains it by yeast. One more example of the application of 
+this nyaya may be found in Kumérila’s Lantravirtike 1,2,17 :-- 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+fi 
+
+
+“ य॒द्यल्पान्महतश्व FAN: समं फलं जायेत duis चेन्मधु विन्देतेत्यनेनैव 
+न्यायेनास्पेन सिद्धे महति न कश्चित्मरवत्तेत”॥ ` 
+
+
+अर्धजरतीयन्यायः ॥ 
+
+
+The maxim of the semi-senile woman. It is very difficult to 
+fix on the exact force of this saying. Authorities differ so much 
+as to make it almost an instance of quot homines tot sententie. 
+As expounded by Vardhamána (iii. 195 ) it seems to imply in- 
+definiteness, half-and-half-ness, the being neither one thing 
+nor the other. He says +—** यथा edt न तरुणी SIMA कृणकेश- 
+WA जरती वकुं शक्यते तद्वस्सिद्वासिद्धं प्रयोजनम्‌? ॥ This seems to accord 
+with the meaning assigned to it by Maráthas, as shown by 
+Molesworth in his Marathi dictionary where he defines it as 
+" Action of indeterminate character; speech vague and indefinite; 
+à proceeding void of decided leaning or bearing." 
+
+
+The maxim is cited by S'ankara in Brahm astilrabhdshya 
+1. 1. 19, and againin 1. 2. 8 In the former, after quoting 
+Taittirtya-upanishad ii. 1-4 in regard to अन्नरसमय, प्राणमय UO. 
+he 80098 :-- इति विकारार्थे azarae सत्यानन्दमय एवाकस्मादधजरतीय- 
+न्यायेन कथसिव सयटः म्राचुयॉर्थस्वं zawa वाश्रीयत इति” ॥ The com- 
+mentators Anandagiri and Ramanand (erroneously styled 
+Govindánanda*) ignore the maxim entirely, and so does Dr, 
+Thibaut in his translation. In the second instance, S'ankara 
+says :-- यथाशास्थं afe शास्त्रीयो थे: प्रतिपत्तव्यो न तत्राधेजरतीयं Bray,” 
+which is rendered by Dr. Thibaut, “Very well, then, it appears 
+that the truth about scriptural matters is to be ascertained from 
+scripture, and that scripture is not sometimes to be appealed, to 
+and on other occasionstobe disregarded.” Anandagiri’s comment 
+isa हि ङुक्कुटादेरेकदेशो भोगाय पच्यत एकदेशस्तु प्रसवाय FAA विरो- 
+un, “You cannot take one part of a fowl for cooking and 
+
+
+leave the other part to lay eggs” that is, you must take a 
+
+
+* Sco Dr, Fitzedward Halls Index, pace 0) i 
+i CC-0. Prof. Satya Vr k zs Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+thing in its entirety, or else leave it altogether. Rámánanda, 
+on the other hand, says:— aÑ सुखमात्रं जरत्या वृद्धायाः कामयते | 
+नाङ्गानीति सोअ्यमर्धजरतीयन्यायः स चात्र न gT: ," which seems to he | 
+based on Patanjalis words न चेदानीमर्धजरतीयं BT । तद्यथा | | 
+sr जरत्याः कामयते$धे नेति”, as found in Mahdbhdshya 4. 1. 18.5 H 
+Again we find the maxim in the Bauddha section of Sarva 
+davs'anasangrala (page 14 of Bib. Ind., and 17 of Jivananda’s 
+edn.), which reads thus :--“'न चार्धजरतीयमुचितम्‌ । न हि Geet | 
+एको भागः पाकायापरों भागः प्रसवाय कल्प्यतामिति कलप्यत?', and which | 
+is identical with Anandagiri’s exposition. Prof. Gough, who | 
+translated this chapter, rendered the maxim by “ semi-effete’— 
+« Nor is a semi-effete existence admissible.” 
+
+
+Another excellent illustration of the usage of this nyáyais | 
+given in the following passage of the Brahmasttratdiparye — 
+७४५५११७११७ 3. 4. 26. (The Pandit vol. vi. page 220 y—' ब्रह्मविद्या | 
+aque afr नापेक्षते तथा स्वोत्पत्तावषि नापेक्षते p अन्यथा कचिदपेक्षा | 
+कचिन्नेत्यधजरतीयत्वापत्तिरिति ma आह सवोपेक्षेति । नाधजरतीयन्यायों o 
+योग्यतावशादेवैकस्थैच कार्यविशेपेष्वपेक्षानपेक्षयोरुपपत्तेः | यथा लाङ्गलवहनेऽनः | 
+पेक्षितोऽश्वो रथवहनेऽपेक्ष्यते तद्वत्स्वोत्पत्तो तु विद्या कर्मापेक्षते N 
+
+
+Other references are the following :—Saptapaddrihi, page 
+26. Vivaranaprameyasangraha, page 21. Nyayamanjuri, 
+pages 248, 249. Advaitabrahmasiddhi, page 340. 
+
+
+uu | 
+
+
+अझाक्तोऽहं शृहारम्भे शक्तोऽहं Janga ॥ 
+
+
+I am too weak to construct a house, but I am well able | 
+destroy one. This is found in Dhundhirájas commentary on 
+Mudrârâkshasa iii. 11. Chánakya says— Fù स्पर्धते मया सह 
+दुरात्मा राक्षसः'? | and then follows the verse “कृतागाः कौटिल्यो Jot 
+
+a 
+
+
+most kindly gave me the reference, 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Sidhani eGangotri Gyaan Kosha 
+
+
+इव निर्याय नगरात्‌ &९.,” on which Dhundhirája remarks:-—“aaa 
+नास्य बुद्धिबलं परंतु मत्सरमात्रेण अशक्तोऽहं गृहारम्भे शक्तोऽहं गृहमञ्जन इति 
+न्यायेन मोर्यापकारमाच्राय प्रयतमानः सन्केवलं पौरुपवलमवष्ट्य WZz: प्रकप- 
+मतिशयितुं व्यवसित इत्यहो राक्षसस्य दुव्येवसितमिति’' ॥ Iam indebted 
+for this passage to the late learned Librarian at the India 
+Office, C. H. Tawney Esqr, who has also pointed out to me 
+Pancatantra i. 363 as illustrating the nyaya. 
+
+
+The verse reads thus :— 
+
+
+“‹ घातयितुमेव नीचः परकार्य वेत्ति न प्रसाधयितुम्‌ । 
+पातयितुमेव शक्तिना खोरुद्धतुंमन्नपिटम्‌ ” ॥ 
+
+
+अशोकवनिकान्यायः ॥ 
+
+
+The maxim of the grove of As'oka trees. Apte says “Ravana 
+kept Sita in the grove of Asoka trees, but it is not easy to 
+account for his preference of that particular grove to any other 
+one; so when a man finds several ways of doing a thing, any 
+one of them may be considered as good as another, and the pre- 
+ference of any particular one cannot be accounted for.” For the 
+As'oka-grove see ltémdyana 1. 1. 73. The only example 
+of this nyaya that I have met with is in S’esananta’s tika on 
+S'as'adhara's Nydyasiddhéniadipa, page 11. "This work was 
+commenced in the Pandit for April 1903, but is still incomplete. 
+
+
+अश्मलोष्टन्याय; ॥ 
+
+
+The maxim of the stone and clod of earth. Apte, following 
+the Vdcaspatyam, explains it thus:—“A clod may be consi- 
+dered to be hard when compared with cotton, but is soft as 
+compared with a stone. So a person may ‘be considered to be 
+very important as compared with his inferiors, but sinks into 
+insignificance when compared with his betters.” TAranatha 
+adds that when it is intended to indicate that there is very little 
+difference between two things or persons compared, the kindred 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGahgbtri Gyaan Kosha 
+
+
+maxim पापाणेष्कान्याय is used. With these Apte compares 1 
+Maráthi proverb “'दगडापेक्षां चीट मऊ? “Brick is softer than 
+stone" ‘The sense, however, is not quite the same; for, accor 
+
+ding to Molesworth, the Marathi saying is used “in ivonical | 
+softening of a difficulty or hardship but barely surmountable ou 
+sufferable, by comparing it with a matter utterly impracticable | 
+or intolerable. | 
+
+
+Is it not much more likely however that the maxim is based F 
+on Brihadâranyaka Upanishad 1. 3.7, “यथाइमानसूखा लोष्ट्र 
+विध्वंसेत” which Sankara expounds thUs:—‘यथा लोकेऽइमानं पाषा | 
+TAT गत्वा प्राप्य Sg: AA पाएाणचूणनायाइमान TAJ: स्वय E 
+विध्वंसेत विस्र॑सेत बिचूणीभवेत्‌ १ This is referred to in Brahma- 
+sitrabhdshya 3. 8. 6, as the “'अञ्मलोष्टनिद्दांन” and it seems to - 
+remind one of the Scripture saying “Whosover shall fall upon J 
+that stone shall be broken; but on whomsoever it shall fall, it 
+will grind him to powder." 
+
+
+अस्त्रमस्त्रेण शास्यति ॥ 
+
+
+A weapon is silenced by « weapon. Perhaps analogous to 
+the saying “Diamond cuts diamond,” or, “Set a thief to catch a 
+thief.” It occurs in Jnánottama's commentary on Suresvaras 
+Naiskarmyasiddhi i. 81, where he says :— eas शाम्यतीति ; 
+न्याथेन काम्यः काम्यानां निषिद्धेनिपिद्धानां निवृत्तिरस्त्वित्यिते आह नच 
+PARR” ॥ | 
+
+
+Compare with this Vitisdra viii, 67 :— 
+“विष विषेण व्यथते ast वज्रेण भिद्यते । 
+गजेन्द्रो दृष्टसारेण गजेन्द्रेणेव बध्यत्ते” ॥ 
+
+
+अस्तेहृदीपन्यायः ॥ 1 
+
+The simile of 4 Lamp without oil [ that is, from which th J 
+
+oil has burnt out],  Raghunáthavarma explains it thus: 
+
+“ आस्मश्चाध्यासेऽज्ञानं कारणम्‌ | तत्त्वज्ञानेन वातदीपन्यायेन तन्निव्रत्तावसे 
+
+दीपन्यायेन तदध्यासोऽपि निवतेते । न च ज्ञानेनेवोभयनिवृत्तिः gat d 
+CC-0. Prof. Satya Vrat Shastri Collection d 
+
+
+Digitized By SI Gyaan Kosha 
+
+
+स्यात्‌ । ज्ञानमज्ञानस्यैव निवर्तकमिति न्यायविरोधात्‌ । द्विविधा हि निवृत्ति- 
+विरोधिना सामग्रीनिवृत्त्या च । यथा वातादिना दीपनाशो यथा च तलवत्यादि- 
+fae दीपनिवृत्तिः । तत्राद्या निवृत्तिरज्ञानस्य द्वितीया कार्यवर्गस्येति 
+बोध्यम्‌ Uu 
+
+
+I have met with the following example of the nyaya in 
+Vogavdsistha 2. 1, 44, a chapter entitled शुकनियौणम्‌ — 
+
+
+“aq वषेसहस्राणि निर्विकस्पसमाधिना । 
+war स्थित्वा शशामासावात्मन्येहृदीपवत्‌ ” ॥ 
+
+
+For the nyaya ज्ञानमज्ञानस्यैव निवर्तकम्‌ see the Third Hand- 
+ful of Popular Maxims; and for निर्विकतपसमाधि see Vedómta- 
+867७, pp. 55, 57 &e, and Manuul of Hindu Pantheism, pages 
+109, 110. 
+
+
+अहिकुण्डठन्यायः ॥ 
+
+The maxim of the snake and its coils. The expression occurs 
+in Brahmaséitva 3. 2. 27, and is explained in the bhashya. 
+They read ४108 :--“ उभयव्यपदेद्यात्वहिकुण्डलवत्‌ ॥ -.-अत उभयव्यपदेः 
+शदर्शनादहिकुण्डलवदत्र तत्त्व भवितुमर्हति | यथाहिरित्यभेदः कुण्डलाभोग- 
+प्रांुत्वादीनीति च भेद एवसिहापीति” ॥ Dr. Thibauts translation is 
+as follows:—“But on account of twofold designation, ( the rela- 
+tion of the highest Self to the individual soul has to be viewed) 
+like that of the snake to its coils...... We therefore look on the 
+relation of the highest Self and the soul as analogous to that of 
+the snake and its coils. Viewed as a whole the snake is one, 
+non-different, while an element of difference appears if we view 
+it with regard to its coils, hood, erect posture and so on.” It is 
+akin therefore to the expressions “a forest and its trees,” “a 
+lake and its waters," so often used by the Vedantists as illustra- 
+tions of identity. The explanation given by Taranatha in the 
+Vdchaspatyam does not coincide with the above: He says:— 
+“ae: सर्पस्य यथा कुण्डलाकृतिवेष्टन स्वाभाविकं तथा यस्य स्वाभाविकधर्मा 
+व्यपदिश्यते तन्नास्य प्रवृत्तिः? ॥ 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+आकाशमुष्टिहननन्याय: ॥ 
+
+
+The maxim of striking the sky with ones fist. A vain 
+attempt at an impossibility. It occurs in the Jaimini chapter of 
+Sarvadars'anasangraha (page 133 of Bib. Ind. edition, and 
+p. 151 of Jivánanda's) as follows :—'* तस्माहुस्पत्तौ aay च qv 
+प्रमाणसंभवात्स्वतःसिद्धं प्रामाण्यमित्येतत्पूतिकूष्माण्डायत इति चेत्तदेतदाकाश- 
+सुष्टिहननायते” u Prof. Cowell has rendered it thus:—“Therefore, 
+as we can prove that authoritativeness is both produced and 
+recognized by means of something external, the Miminist tenet 
+
+
+‘authoritativeness is self-proved' is like a gourd over-ripe and | 
+
+
+rotten. This long harangue of our opponent, however, is but a 
+vain attempt to strike the sky with his fist.” 
+
+Much older instances of the employment of the nyaya are 
+the following :—Tantravdrtika, page 170, * 'यस्तन्तूननुपादाय तुरीमा- 
+त्रपरिग्रहात्‌। पटं कु समीहेत स हन्याङ््योम सुष्टिभिः” ॥ [ With this com- 
+pare the words of a great modern preacher-Dr. Maclaren- 
+“Logic without Revelation is like a spinning-machine without 
+cotton, busy drawing out nothing” |. Pancapddikd page 4४, 
+line 19, “तद्यदि नाम ज्ञानं लोके सिद्धं तथापि निरस्तप्रपञ्चात्मविषयमसिद्धमा- 
+काशसुष्टिहननवन्न विधातुं शक्यम्‌.” Then, in Vydyakandalt, page 
+56, line 6, we find the cognate expression “यथा कश्चनिन्निशितं कृपाणः 
+
+
+मच्छेद्यमाकाशं प्रति व्यापारयन्‌ "7, and again in Nydyakanthd, 
+page 219, 
+
+
+उपयन्नपयन्धमो विकरोति हि धर्मिणम्‌ ॥ 
+
+
+Th, ip 2 . |oc 
+he appearance or disappearance of ७ quality (or chat 
+
+
+acteristic ) produces « corresponding change in the subject of 
+at. This nyaya is the second line of Naiskarmyasiddhi ii. 35, 
+
+
+the first being “ “आगमापायिनिष्टत्वादनित्यत्वामियादुशिः” ॥ Although ib | 
+
+
+is included in Raghunâtha’s list, it ought not, strictly speaking: 
+to find a place amongst popular maxims; but I insert ib in 
+order to make a necessary correction in the printed text of the 
+Sarvadursanasangraha where ib is quoted. On page 161 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+13 
+
+
+of the Bibliotheca Indica edition, and on page 182 of that 
+prepared by Jivánanda Vidyáságara, we read ९ ततश्रोपपन्नस्त्वयन्धर्मों 
+विकरोति हि धर्मिणमिति न्यायेन” and this bad reading of course 
+affects the translation as it appears on page 244 of the volume 
+prepared for Trübner's Oriental Series by Professors Cowell 
+and Gough. The explication given in Véchaspatyum is as 
+follows:— यथा पूर्वस्य रूपरसादिरूपधर्मृपरात्रृत्तौ रूपरसाद्यन्तरोत्पत्तो च 
+घटादेधोर्मिणो विकृतिरेवं यस्य धर्मिणः पूर्वधर्मस्यापगमेऽन्यधर्मस्योत्पत्तिस्तत्रायं 
+न्यायो$वतरति?? ॥ 
+
+
+उष्ट्कण्टकभक्षणन्यायः 
+
+
+The maxim of 4 camels eating thorns. This is not in Raghu- 
+nátha's list, but in the Vdcaspatyam it is explained thus:— 
+Caga शमीकण्टकवेधजातढुःखकालेऽपि शमीपत्रभक्षणसुखलेशों यथा तथा- 
+भीष्टविषयोपार्जनदुःखकाले तडुपाजितद्रव्यजसुखलेशो यत्रोपदिञ्यते तत्रास्य 
+्तरृत्तिः/॥ I regard this, however, as quite beside the mark. 
+In Brahmasdtrabhdshya 2. 9. 1. S'ankara, after combating at 
+length the Sankhya theory, that objects are in themselues 
+सुखदुःखमोहात्सक, 5098:--शब्दाद्यविशेषेष्पि च भावनाविशेषात्सुखादिवि- 
+शेषोपलब्धेः,? which Dr, Thibaut renders—“ And, further, 
+although the sense-object, such as sound and so on, is one, yet 
+we observe that owing to the difference of the mental impres- 
+sions (produced by it) differences exist in the effects it produces, 
+one person being affected by it pleasantly, another painfully, 
+and so 01.” On which Anandagiri says: शब्दादीति | भावना 
+तत्तज्जातियोग्या वासना तद्विशेषादुष्टादीनां कण्टकादौ सुखादिदर्शनात्‌ &e.” 
+Vacaspatimis'ra, esplains the same passage in the Bhámat, 
+(pp. 380-1), pointing out that things are not in themselves essen- 
+tially pleasant or unpleasant, and that what causes pleasure to 
+one may be painful to another, and that even the same thing 
+which at one time is agreeable may at another time be the re- 
+verse. Otherwise thorns would be as acceptable to men as they are 
+
+
+toa camel Here are his words: यदि पुनरेत एव सुखदुःखस्वभावा _ 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta cio Gyaan Kosha “ ; 
+
+
+P] 
+ji 
+भवेयुस्ततः स्वरूपस्वाद्धेमन्तेपि चन्दनः सुख; स्यात्‌ A हि चन्दनः कदाचिद | 
+चन्दन: | तथा निदाधेप्वपि कुंकुमपंकः सुखो भवेत्‌। न ह्यसौ कदाचिदङुंङुमपंक;| | 
+एवं कण्टकः PATEA सुख इति सनुष्यादीनामपि प्राणभ्गृतां सुखः स्यात्‌ | | 
+न हासो कांश्चित्प्रयेवाकण्टक* इति । तस्मादसुखादिस्वभावा अपि चन्दनकुंकु- । 
+मादयो जातिकालावस्थाद्यपेक्षया सुखदुःखादिहेतवो न तु स्वयं सुखादिस्वभावा _ 
+इति रमणीयम्‌”. A camel, then, eats thorns because it likes thom | 
+a man does not eat them because he does not like thom. May | 
+not the maxim, therefore, be the equivalent of our “ Whats one | 
+man’s food is another man’s poison?” Mr. M. R. Telang has | 
+kindly pointed out Vikramdnkadevacarita i. 29. as illustrating , 
+a camel's love of thorns. | 
+
+
+एकमनुसन्धित्सतोऽपरं प्रच्यवते ॥ | 
+
+
+Whilst seeking for one thing he loses unother. The saying 
+appears twice, in this form, in the Savvadars'anasangralus 
+The first instance is in the Arhata Section (p. 27 of Bib. Ind. 
+and 33 of Jivananda’s edn. ), translated by Professor Cowell:— 
+““एतद्दोषपरिजिहीपया ज्ञानं जडतां नानुकरोतीति मुपे हन्त तर्हि तस्या ग्रहणं 
+न स्यादित्येकमनुसन्धित्सतोऽपरं प्रच्यवत इति emn. ^ Tf in your 
+wish to escape this difficulty, you assert that ‘the perception 
+does not follow the object in being insentient, then there would 
+be no perception that the object is insentient, and so ib is 9 | 
+case of the proverb, While he looks for one thing which he has — 
+lost, another drops.” 
+
+
+a 
+
+
+The second example, from the Akshapáda section (PP: 118 
+and 184 ), is as follows:— “नन्वेकमनुसन्धिस्सत्तोऽपरं प्रच्यवत इति स्याः 
+येन ढुःखवत्सुखमित्युच्छिद्यत इत्यकास्योअ्य पक्ष इति edd मंस्थाः” | F 
+
+“Nor may you retort on us that we have fulfilled the por 
+verb of ‘seeking one thing and dropping another in the search, 
+since we have abolished happiness as being ever tainted with 
+some incidental pain &e." ] 
+
+
+* The printed text wrongly reads कण्टक for अकण्डक, 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Sadhena eGangotri Gyaan Kosha 
+5 
+
+
+In the Khandanakhandakhadya (page 441) and in Malli- 
+nátha on Tárkikeraksá, pp. 7 and 25, we meet with the nyaya 
+in another form, namely “'एकं सन्थित्सतो5परं प्रच्यवते? which 
+means “ Whilst trying to reunite one [ piece of a broken vessel] 
+another falls off.” 
+
+
+एकवृन्तगतफलट्कयन्यायः ॥ 
+
+
+The maxim of two fruits attached to one stalk. Used by 
+writers on Alankára to illustrate a particular kind of Parono- 
+masia, namely the coalescence of two meanings under one 
+word. It was first pointed out to me by Mr. F. W. Thomas, 
+Assistant Librarian to the India Office, he having met with it 
+in the commentary on Kåvyådars'a ii. 310. I have since found 
+it in use in the Alankérasarvasva, Kdvyapradipa, Sáhitya- 
+darpana, Rasagangddhara, Alankdrakaustubha, and Sahitya- 
+kaumudi, in each case under the figure gy. The maxim finds 
+a place in Marathi literature also, and is regarded by Moles- 
+worth as equivalent to our proverb “Killing two birds with one 
+stone,” 
+
+
+कदस्बकोरकन्यायः ॥ 
+
+
+The maxim of the buds of the Kadamba tree. They are said 
+to burst forth simultaneously. As, for example, in Hema- 
+eandra's Paris‘ishtaparvan i. 241 :— 
+
+
+“fart स्वपाणिप्ेन स्पुदयमानो5$वनीपति: । 
+उस्कोरककदम्बाभो बभूव पुलकांकुरेः? d 
+
+
+In the Nyéyamanjart, pages 214 and 228, and in the 
+Bhashdparichehheda (verse 166) this nyaya is given as an 
+illustration of the way in which sound is produced, The last- 
+mentioned reads thus:— 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta edShgotri Gyaan Kosha 
+
+
+वीचीतरज्जन्यायेन तदुत्पत्तिस्तु कीतिता । 
+कदुस्बकोरकन्यायादुत्पत्तिः कस्यचिन्मते ॥ 
+
+
+The commentary, Siddhdntamuhtdvalz, however, explains gz- 
+म्बगोलकल्यायात्‌ and this is the form given to the maxim in the 
+Vdchaspatyam which explains it as follows :-- 'कद॒म्बगोलकस्य 
+गोलाकारकदस्बस्य सवीवयवेषु यथा युगपत्पुष्पोद्रम एवं सवेप्रदेशेपु युगपद्यत्र 
+प्रसरस्तन्रास्य प्रवृत्ति? ॥ In Vedantin Mahadeva's comment on 
+Sdnkhyasdtra V. 108, we have a third form, namely qara- 
+मुकुलन्याय. 
+
+
+कफोणिगुडन्यायः ॥ 
+
+
+The maxim of treacle on the elbow, Used of something 
+tantalizingly inaccessible. It is found in Udayana’s Atmatattva- 
+viveka, page 26 :--अस्तु तहिं भावस्वरूपातिरिक्ता निद्वृत्तिर्नास्तीत्यस्य सोपा- 
+ख्येति शेपः । नन्वयमपि क्षणभंगस्योद्धारः स च कफोणिगुडायितो वर्तते भवतु 
+वा निवृत्तिरसमर्था तथाप्यहेतुकत्वे तस्याः किमायातम्‌? u Then in the 
+Akshapida chapter of Sarvadars'anasangraha (page 116 of 
+
+Bib Indica, and 132 of Jivananda’s edition) we read:— 
+“ag दुःखात्यन्तोच्छेदो$पवर्ग इत्येतदद्यापि कफोणिगुडायितं वर्तते तत्कथं 
+सिद्धवत्कृत्य व्यवहियत इति चेन्मैवम्‌? which Prof. Cowell trans- 
+lates as follows :—“But is not your definition of the summum 
+bonum, liberation, that is, the absolute abolition of pain, after 
+all as much beyond our reach as treacle on the elbow 4s to the 
+tongue; why then is this continually put forth as if it were 
+established beyond all dispute £” In a footnote he says, “Com- 
+pare the English proverb ‘As soon as the cat can lick her ear 
+In the Vdchaspatyam, however, the nyaya is explained as mean 
+ing the absence of a thing, not its inaccessibility. It saysi— 
+“कफोणौ गुडाभावे$पि तदाशया यथा लेहनमेवं यत्र वस्त्वसद्भावे5पि तत्प्रद्या 
+
+
+शया व्यापारभेदस्तत्रास्ग्र प्रवृत्ति? ॥ The St. Petersburg Lexicon | 
+
+
+(8. v. कफोणिगुडायू) renders it "like & ball on the elbow.” 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+| 
+| 
+
+
+Digitized By Siddhantg CSE Gyaan Kosha 
+
+
+काकतालीयन्यायः ॥ 
+
+
+The maxim of the crow and the Palmyra fruit. A crow 
+alighted on a Palmyra tree, and at the same moment some of - 
+the fruit fell on its head and killed it. The maxim is therefore 
+used to illustrate a startling and purely accidental, occurrence. 
+It is well explained in the Kdsikdvritti on Pdnine 5. 3. 106 
+(as quoted by Dr. Eggeling in a footnote to Ganaratnamaho- 
+dadhi iii. 195):--'काकतालीयम्‌ | अजाकृपाणीयस्‌ । अन्धकवतेकीयम्‌ d 
+अतर्कितोपनतं चित्रीकरणमुच्यते | तत्कथम्‌ | काकस्यागसनं यारच्छिकं तालस्य 
+पतनं च | तेन तालेन पतता काकस्य AA: कृतः | एवभेव देवदत्तस्य TAMAA 
+दस्यूनां चोपनिपातः । तेश्च तस्य वधः कृतः | तत्र यो देवदत्तस्य दस्यूनां च 
+समागमः स काकतालसमागमसदरा: N 
+
+
+We find the saying in Pafichadas’t ix. 12 as. follows taz- 
+थावस्तुविज्ञानात्फलं लभ्यत ईप्सितम्‌ | काकतालीयतः सोऽयं «atf 
+उच्यते? ॥ And again in Anandavardhana’s Dhvanyaloka ii. 16, 
+and in Nydyavartikatdtparyattkd, page 401. There isa capital 
+example of it, too, in the following verses of the Nydyamanjart 
+(page 106):—“ अपि चानागतं ज्ञानमस्मदादेरपि क्वचित्‌ ॥ प्रमाणं प्रातिभं 
+इवो मे आतागन्तेति इयते ॥ नानर्थजं न सन्दिग्धं न बाधविधुरीकृतम्‌ । न 
+दुष्टकारणं चेति प्रमाणमिदमिष्यताम्‌ ॥ कचिद्ठाधकयोगश्वेदस्तु तस्याप्रसाणता | 
+यन्नापरेदुरश्येति आता तन्न किमुच्यताम्‌ ॥ काकतालीयभिति चेन्न प्रमाणप्रद- 
+सितम्‌ । वस्तु तत्काकतालीयमिति भवितुमर्हति” ॥ In his commentary 
+on S'antiparva elxxvii. 11, Nilakantha Govind gives another, 
+and less probable, definition of the maxim. He says :-- ताल: 
+« करतल्योः शब्दुजनकः संयोगस्तस्मिन्‌ क्रियमाणे उत्पतन्काको San ताला- 
+भ्यामाक्रान्तो$भूत्तदेतत्काकतालीयमित्युच्यते । काकस्पदीसमकालं तालफलस्य 
+ताएब्ृक्षस्य वा पतनं तदित्यन्ये” Molesworth explains it thus:— 
+* Said when any occurrence synchronizing with, or immediately 
+following, some other seems, however in truth independent of 
+E to have been occasioned, by it;Ó—as the fruit of a Palmyra 
+
+alling at the alighting upon it of a crow, may appear to fall in 
+consequence,” 
+
+
+3 CC-0. Prof-Satya Vrat Shastri Collection. 
+
+
+dl 8 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha | 
+
+
+काकदन्तपरीक्षान्यायः ॥ 
+
+
+The maxim of the examination of a crows teeth. Used of 
+any useless and manifestly fruitless enquiry. It occurs in the 
+Buddhist treatise Vydyabindutikd, page 1, and again on page 
+8, line 8. Also in S'ankara's bháshya on Katha- Upanishad i, 25 
+[“नचिकेतो मरणं मानुप्राक्षीः ?]:~“नचिकेतो मरणं मरणसंबद प्रश्नं प्रेयास्त | 
+नास्तीति काकदन्तपरीक्षारूपं माजुप्राक्षीमेंवं agai We find it too | 
+in Abhinavagupta on Dhvanydloka iii. 19 (page 163 of Pandit | 
+Durgápras&da's edition) as follows :---““ब्यंग्योष्था भवतु मा वाभूत्‌ | 
+कस्तत्राभिनिवेशः । काकदन्तपरीक्षाप्रायमेव तत्स्यादिति भावः? qp It appears | 
+also in Pancapddikd, pages 53 and 68, and in many works | 
+besides. In Nydywmanjaré, page 7, line 5, it takes the form of | 
+वायसददानविमशोन्याय. 
+
+
+काकाक्षिगोठकन्यायः ॥ 
+
+
+The maxim of the crows eyeball. Crows are popularly sup- 
+posed to have only one eye, which, as occasion requires, moves 
+from the cavity on one side into that on the other. The maxim 
+is used of a word which appears only once in a sentence but 
+which applies to two portions of ib; or of persons or things ful- 
+filling a double purpose. I have met with ib in the former 
+sense in Svátmáràm's Hathayogupradépika iv. 10, “Raua: 
+FAAA: करणेरापे,” on which the commentator, Brahmánanda, 
+says “ARARA काकाक्षिगोलकन्यायेनोभयत्र संबध्यते.” Also in Abhi- 
+navagupta's comment on Dhwanydloka iii. 1, “qarat स्मारकव्वेऽपि 
+पदमात्रावभासिनः”, where he remarks 6 “अपिशब्दः काकाक्षिन्यायेनो- 
+भयत्रापि Aaaa ॥ Of its use in the second sense, we have an 
+interesting example in Kámandaki's Nitisdra, a work ascribed 
+to the third century before Christ, Chapter xi. 24 reads thus:— 
+हक वाचात्मानं समर्पयन्‌ । द्वैधीभावेन qua E 
+क्षितः, Y 
+
+
+RE 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+19 
+
+
+काराकुरावळम्बचच्यायः ॥ 
+
+
+The maxim of catching at straws. The being driven from 
+one argument or position to another equally untenable, Tara- 
+nâtha 5978: नद्यादौ पतितस्य संतरणानभिज्ञस्य यथा कुशकाशावल्त्रनं 
+निरथकमेवं प्रबळयुक्तिषु निराकृतासु दुबेलयुक्त्यवलम्बनं निर्थकमित्येवः 
+सवलस्त्रनस्य निरर्थकस्वविवक्षायामस्य प्रवृत्ति? The expression aa- 
+कुशावलम्बनकल्प॑? occurs in the Arhata chapter ( p. 25 of Bib. 
+Ind. and p. 31 of Jivánanda's edition) of the Sarvadars'ana- 
+sangraka, and again in the Panini chapter (pp. 142 and 161 y 
+and in both places Prof. Cowell has rendered it “like a drow- 
+ning man’s catching at a straw.” We have the same, though 
+not as a compound, in Naishkarmyasiddht i. 16,— 5e निरा- 
+कृतोऽपि काश Hat वावळम्व्याह.” It appears also in Nydyamanjart 
+page 183; and again, as follows, on page 551 :--“'तस्सात्प्रमाणतो5- 
+झाक्ये शक्ये वा वस्तुनिर्णये | एवं प्रायमयुक्तं यत्कुशकाशावलंवनस” ॥ In 
+Tantravartika 1. 3. 18 (page 213) we have the maxim in the 
+following couplet:— ‘aiai न चेजातं स्ुख्यैर्यस्य ग्रयोजनः | तस्यानुषः 
+ज्ञिकेष्वाशा कुशकाशावलंबिनी ॥ 
+
+
+In expounding Brakmastitrabhdshya 3. 3. 29, Anandagiri 
+quotes Amarakos’a 2. 4 166 (weft Hat कुशो qui: पवित्रमथ कत्तणम्‌) 
+as follows:—“‘stq wart कुशमित्यमरसिहेनानुरिष्टम्‌.” Does this 
+throw any new light on the date of Amara? In his History 
+of Indian Literature ( page 230), Professor Weber tells us 
+that the Amarakos'a cannot be widely separated from those 
+dictionaries which we know to belong to the eleventh, twelfth, 
+and following centuries; whils& Professor Macdonell, in his 
+recently issued History of Sanskrit Literature ( page 433) 
+assigns that work to about 500 A. D. 
+
+
+कूपमण्डूकन्यायः ॥ 
+The maxim of c frog ina well. It is applied to an inex: | 
+
+
+perienced person brought u R in the narrow circle of home, and 
+sgl CC-9. Prof. Satya Vrat Shastri Eddie. D j 
+
+
+ignorant of publie life and mankind. “Home-keeping youth 
+have over homely wits” ( Two Gentlemen of Verona i 1), 
+The following passage from Prasannardghava-Ndtaka i (page | 
+18) illustrates the use of the term :—''a मामपि दशदिग्विलासिनी- । 
+कर्णपूरीकृतकीर्तिपछ्ववं त्रिशुवनवीरनामधेय कूपमंडूक इव सागरमविख्यातमप- | 
+fama ॥ So, too, Upamitibhavaprapancå, page 828:— 
+
+
+Digitized By Siddhanta &éhngotri Gyaan Kosha 1 | 
+x 
+
+| 
+
+| 
+
+| 
+
+
+“यो न निर्गत्य निःशेषां विलोकयति मेदिनीम्‌ । 
+अनेकाडुतवृत्तान्तां स नरः कूपददुरः?? ॥ 
+
+
+कूपयन्त्रघटिकान्यांयः ॥ | 
+
+
+The maxim of the pots attached to the water-wheel of a well. 
+As the wheel revolves, some of the pots are going up and others 
+are going down; some are full whilst others are empty; and 80 
+it is applied to illustrate the changes and chances of this mortal 
+life, This is well put in Mrichchhakatika x. 60:— 
+
+
+“कांश्रित्तुच्छयति प्रपूरयति वा कांश्रिन्नयत्युन्नति | 
+कांश्रित्पातविधो करोति च पुनः कांश्रिक्नयत्याकुलानू । | 
+अन्योन्यं प्रतिपक्षसंहतिमिमां लोकस्थिति बोधय- i 
+at कीडति कृपयत्रघटिकान्यायग्रसक्तो विधिः” ॥ 
+Tarandtha’s explanation of this maxim is extremely tame, not 
+to say nonsensical! According to him, it is intended to teach 
+that as a pot is raised by the water-wheel from a deep well, 
+so, by means of instruction, the essence of the S’Astras is drawn 
+up, deep though they are by reason of their complexity! See 
+the cognate घटीयन्नन्याय in Second and Third Handful. 
+
+
+Rabe पी के कल ee ee 
+
+
+कूमाङ्गम्यायः ॥ 
+
+
+The maxim of the limbs of the tortoise. Its meaning : 1 
+application will be apparent from the following passage taken . 
+from the Sánkhya section of Sarvadars‘anasangraha (page 
+
+
+150 Bib. Ind. and 17 nn A 
+१0 Bib dnd d गत 580 08000 edition ):-- यथा हि कूर्म" 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+21 
+
+
+स्याङ्गानि कूर्मशरीरे निविशमानानि तिरोभवन्ति निःसरन्ति चाविभेवन्लेव 
+कारणस्य तन्त्वादे: पटादयो विशेषा निःसरन्त आविभैवन्त उत्पद्यन्त इत्युच्यन्ते 
+निविशमानास्तिरोभवन्तो विनञ्यन्तीत्युच्यन्ते | न पुनरसतासुत्पत्तिः सतां वा 
+fas" u Prof. Cowell renders it thus:—* As the limbs of a 
+tortoise, when they retire within its shell, are concealed, and, 
+when they come forth, are revealed, so the particular effects, as 
+cloth &e., of a cause, as threads &e, when they come forth and | 
+are revealed, are said to be produced; and when they retire and 
+
+are concealed, they are said to be destroyed; but there is no 
+
+such thing as the production of the non-existent, or the destrue- 
+
+tion of the existent.” Very similar language is used by Vachas- 
+
+pati Mis’ra, too, in his Sénkhyatativakaumudt 9 and 15. See 
+
+also, Kshurikd-Upanishad 3, and ४८४७ ii. 58. 
+
+
+कृत्वाचिन्तान्यायः ॥ 
+
+
+The nyaya stands thus in Zantravdrtika 3. 4. 1 र्या यस्तु 
+भाष्यकारेणोपन्यासः कृतः स कृत्वाचिन्तान्यायेनेति द्रष्टव्यस्‌. On applying 
+to my friend Mr. Arthur Venis for an elucidation of the nyaya 
+he replied as follows:—“I have always understood it as the 
+method of granting to your adversary what later you mean to 
+refute, for which another common expression 19 अभ्युपगमवाद. 
+The word कृत्वा is elliptical for इति कृत्वा, that is, having admit- 
+ted your adversary’s point, you proceed to the चिन्ता 07 discus- 
+sion of it.” This view seems to be confirmed by the fact that 
+in S'dstradtpikd, pages 615, 666, 707, 710, and 739, it takes 
+the form of ““इति कृत्वा चिन्त्यते, and that. in S'abara on Jaimini 
+ll. 3.16. and 12, 9. 11, we read at the close of each “gaa 
+कुस्वा चिन्त्यते | कृत्वाचिन्तेयम्‌. 
+
+
+In his Saddars'anacintanikd, Mr. M. M. Kunte gives 
+three different renderings of the expression. On page 650 
+( where it is attached to the title of the adhikarang ) its 
+meaning is said to be “a point already discussed,” and he 
+
+
+hs Soc ithe 5 Mádhava; then, on page 1999; it 
+claims for it th athorit YA पुश वन s ) 
+
+
+Digitized By Siddhanta B@angotri Gyaan Kosha 
+
+
+is rendered “an adjustment not founded on fact;” and, finally, on 
+page 2040, “the examination of a subject after merely grant 
+ing an opponent's statement.” This third rendering coincides 
+with that of Mr. Venis. 
+
+
+I may add that Prof. Ganganatha Jha tells me that a pandit 
+would explain the term thus;—' gear (यद्यप्य्रेतद्रिपयकसंदायो नोदेति 
+तथापि तद्विषयगतसकळविचारस्थोपन्यासाथे कल्पनां कृत्वा) चिन्ता (Pan). 
+Or, as the Professor himself puts it, “the bhasya has introduced 
+certain points of discussion simply for the sake of argument, 
+in order to exhaust all possible alternatives with regard to the 
+subject matter of the adhikarana.” I have not met with the 
+ny&ya anywhere but in works on Mimamsa. 
+
+
+क्षीरं विहायारोचकम्रस्तस्य सौवीररुचिमनुभवति ॥ 
+
+
+“Leaving the milk suitable to the dyspeptic, he enjoys the 
+sour gruel.” The nyaya is found in this farm in the Akshapada 
+section of Sarvadurs’anasangraha (P. 318 of Bib. Ind. 
+edition and p. 184 of Jivananda’s ed.) as follows:—“‘ag garth 
+व्यक्तिसुक्तिरिति पक्षं परित्यज्य दुःखनिवृत्तिरव मुक्तिरिति स्वीकारः धिर AT 
+यारोचकग्रस्तस्य सैौवीररुचिमनुभवतीति चेत्तदेतज्ञाटकपक्षपतितं AZA 
+gum ॥ 
+
+
+Prof. Cowell translates it thus:—“But if you give up the view 
+that liberation is the manifestation of hdppiness, and then 
+accept such a view as that which holds it to be only the cessa- 
+tion of pain, does not your conduct resemble that of the dys- 
+peptic patient who refused sweet milk and preferred sour rice- 
+gruel? Your satire, however, falls powerless, as fitter for some 
+speech in a play [rather than for a grave philosophical argu- 
+ment]|" There can be little doubt however that Madhava took 
+the nyaya from Udayanus Atmatattvaviveka where it appears 
+(on Bus 0 no 3) as ale Rey कहग सोर” 
+
+nstance of ib, and it is not in Raghunatha’s 
+Laukikanydyasangraha. d 
+CC-0. Prof. Satya-Vrat-Shastri-Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+3% 
+~) 
+
+
+खल्वाटविस्वीयन्यायः ॥ 
+
+
+The maxim of the bald (or bare-headed) man, and the 
+woodapple. Vardhamána (iii 195) explains it बा यथा 
+खल्वाटः पर्यटन्नतर्कितं श्रीफलतरोरधस्तादागतो देववद्याच विल्वसुपरि पतितं 
+तद्व दन्योऽप्युभश्रवस्तुसंयोग waagwa” u Bhartrihari, in his Nifi 
+sataka 90, brings the bald man under a palm tree:— 
+
+“खल्वाटो दिवसेश्वरस्य किरणेः संतापितो मस्तके 
+वाब्छन्देशमनातपं विधिवदात्तारुस्य मूलं रातः 
+JAMAA सहाफळलन पतता भस सशब्द शिरः 
+प्रायो गच्छति यन्न भाग्यरहितस्तत्रैव यान्त्यापदः” ॥ 
+
+This maxim belongs to the same class as अजाकृपाणीय and काकः 
+asta, which see. 
+
+
+_ गगनरोमन्थन्यायः ॥ 
+
+
+The maxim of ruminating on ether. Equivalent to beating 
+the air. It is found twice in the Sarvadars'anasangraka. First, 
+
+
+in the Ramanuja section (page 57 of JivAnanda’s edition, and E 
+47 of Bib. एत. ):--“तदेतद्गनरोमन्थायितम्‌, which Prof Gough E 
+renders “All this is about as profitable as it would be for a ru- 3 
+minant animal to ruminate on ether" Secondly, in the Panini ड 
+Ds 
+
+
+section ( pages 162 and 143 respectively ):-- तदेतद्भगनरोसच्थ- 
+कल्पस्‌”, rendered by Prof Cowell by “All this is only the a 
+ruminating of empty ether.” In the Nyáyamanjari page 453, Jaa 
+it appears in a slightly different form, in the expression “nfa 
+रोमन्थकेलिवतू;” and in 86606 p. 154, and Nyéyamakaranda, 
+page 129, we meet with गगनम्रासकटप. 
+
+
+गडुरिकाप्रवाहन्यायः ॥ 
+
+
+The maxim of « continuous rush of sheep. It is used to — 
+indicate the blind following of others like a flock of sheep. 
+
+
+So the Váchaspatyam, which say s— गाइ कानासवीनां संघादेका fi 
+
+
+0. Prof. Satya Vrat Shastri Collection 
+
+
+24 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+चेन्नद्यादौ पतति तदा तत्संघान्तर्गताः सर्वेऽपि वार्यमाणा अपि qu Aa | 
+लोकप्रसिद्ध्या यत्न वार्यमाणानामपि अनिष्टमार्गे धावनं तत्रास्य प्रवृत्ति? | ' 
+The expression occurs in Chap. viii. (page 214) of the Kavya. 
+prakds'a where a very helpful note of Mahes'achandra's will be 
+found; and also in Chap. vi, page 188, of the Sdhityadarpang | 
+which however, Mr. Pramadádása Mitra has rendered, “in 
+pursuance of established custom.” | 
+It is found, also, on pages 86 and 125 of Abhinavaguptos | 
+commentary on the Dhvanydloka, and in the opening part of | 
+Kéavyapradipa viii (p. 327). There seems to be much difference | 
+of opinion as to the correct form of the first word of the | 
+maxim, since it appears in the four varieties of गडुरिका, | 
+गडुलिका, गड्डारिका and गड्डालिका. | 
+
+
+शुडजिह्निकान्यायः ॥ q 
+
+
+The maxim ofthe tongue [smeared] with treacle [in order to dis- 
+guise an unpalatable draught]. The Váchaspatyam thus explains - 
+its प्र8७:-- यथा तिक्तताभिया निस्वपानमकुवौणस्य वारस्य जिह्वायां गुडलेपं | 
+qa पित्रादिस्तं fara पाययति एवमर्थवादवाक्यानि बह्मायाससाध्ये कर्मण्यप्रव- 
+त्तमान पुरुष स्वर्गाक्षय्यादिकं श्रावयित्वा प्रवत्तेयन्ति । फलश्रुतिरपि रोचनाथो”!॥ 
+
+An excellent example of this is found in Kdvyapradipa, p. T:- 
+“ये सुकुमारमतयो$तिसुखिस्वभावा राजकुमारादयो नीरसे नीतिशास््रे प्रवर्त- 
+यितुमराक्यास्तान्काव्ये कान्तेव सरसतापादनेनाभिसुखीकृत्योपदेशं आहयति 
+गुडजिहिकया शिशूनिवोषधम्‌ । यथाहुः | 
+
+
+OER 
+
+
+स्राटुकाव्यरसोन्मिश्रं वाक्यार्थसुप भुञ्जते | : | 
+प्रथमाळीढमधवः: पिबन्ति mz HAFA 
+
+
+It is employed in a similar manner by Abhinavagupta in his 
+comment on Dhvanydloka iii. 30, and by the author of Pada- | 
+manjart in the early part of his work (the Pandit x. 254); i 
+somewhat less clearly, in Bhdmutt, pages 342, 534, and Nyaya- 
+viriikulitparyatika, pages 438, 441. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+25 
+
+
+'गोबलीवर्दन्यायः ॥ 
+
+
+The maxim of the cattle and the bull. In the Pandit for 
+October 1867, Rajarama S'astri expounded it thus;—'*ga m: 
+कार्य बलीवदे चेत्युच्यते तत्र गोपदेनेव बलीवर्दपदसिद्धौ बलीवदपदं gi 
+स्यत्वज्ञापनपरत्वेन सफलमिति Hewa ॥ That given in the Y'áchas- 
+patyam is somewhat fuller—''qsfrager गोविशेषत्वेऽपि adaga 
+झटिति गोत्वेन बोधनार्थ यथा प्रयोगस्तथान्ययोः सामान्यविशेषरूपयोझेटिति 
+बोधनार्थं यत्न प्रथोगस्तत्रास्य प्रवृत्ति ॥ In his exposition of Manu 
+viii. 28, where six classes of women are enumerated as having 
+a claim to the King's protection, Kullika says:—“‘sq चानेक- 
+शब्दोपादाने गोबलीवर्दन्यायेन पुनरुक्तिपरीहारः” ॥ The commentators 
+Raghavananda and Govindarája also quote the maxim in the 
+same connection, and we have it in Kdvyapradipa vii. 11 
+(page 300) Vacaspatimis’ra, too, makes frequent use of it 
+It occurs in Bhdmati, pages 518, 536; and in Nyayavdrtika- 
+tátparyatiká, pages 11, 118, 119 and 404. It belongs to the 
+same class as ब्राह्मणवसिष्ठन्याय and ब्राह्मणपरित्राजकन्याय. | 
+
+
+गोमयपायसीयन्यायः ॥ 
+
+
+The maxim of cowdung as a milky preparation. Some stupid 
+person is supposed to argue that cowdung is made of milk, be- 
+cause it comes frorn the cow; hence it is used to denote an utterly 
+absurd argument or statement. It occurs in Vyáüsa's bháshya 
+on Yogasütra i. 32. He says: “कथंचित्समाधीयमानमप्येतद्वो मय- 
+पायसीयन्यायमाक्षिपति? ॥ On which the Yogavdrtika remarks:— 
+“गोमयं पायलं गव्यत्वादित्यादिन्यायमतदूपणं समाधीयमानमप्याक्षिपति 
+तिरस्करोति?? ॥ See, too, Nyayaviriikatatparyatiki, p. 435. 
+
+It is found also in the Bauddha section of the Suruadars'a- 
+nusangrahka (page 18 of Bib. Ind. and 22 of Jivànanda's'edi- 
+tion ) in the following sentencei— पुवं चायसभेद्साधको हेतुर्गामय- 
+पायसीयन्यायवदाभासतां भजेत्‌”, which Professor Gough renders 
+“Thus oe argument which you. adduce to proye-that there is J 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhant>Wangotri Gyaan Kosha 3 
+
+
+difference between subject and object, turns out a mere absurd- 
+ity, like milky food made of cowdwng.” 
+
+
+The compound गोमयपायसीय is included in Ganaratnamaho- 
+dadhi iii, 196, but Vardhamána did not explain it, 
+
+
+घट्टकुटीप्रभातन्यायः ॥ 
+
+
+The maxim of day-break in the vicinity of the toll-col- 
+lectors hut. A man, anxious to avoid paying toll, takes 
+another road, but losing his way in the dark, finds himself, at 
+day-break, in the vicinity of that very toll-gate! "The saying 
+is employed to illustrate yzgqrf@fz, as Prof. Cowell puts it; 
+that is, failure to accomplish a desired object. It occurs in the 
+Panini section of Sarvadars'anasangraha as follows:—“q 
+स्फोटवाचकतापक्षे$पि प्रागुक्तविकल्पप्रसरेण घट्टकुटीप्रभातायितमिति चेत्तदेत- 
+न्मनोराउप्रविज्ञृम्भणं qued Wat, which is thus rendered by Prof. 
+Cowell:—“But even on your own hypothesis that there is a 
+certain thing called sphota which expresses the meaning, tho 
+same untenable alternative will recur which we discussed 
+before ; and therefore it will only be a ease of the proverb that 
+‘the dawn finds the smuggler with the revenwe-officer’s house 
+close by’. This, however, is only the inflation of the world of 
+faney from the wide difference between the two cases.” 
+
+
+S'riharsha, too, used the simile in his Khandanakhanda- 
+khddya ( page 35 ):--“'तहिं' कारणस्प्र सत्तामभ्युपगतवानसीति घद्टकुव्यां 
+प्रभातमिति चन्न” ॥ See also Siddhántales'a, pages 40 and 116 
+Vivaranaprameyasangraha, page 62; Advaitabrahmasiddhi, 
+pages 03, 146, 219, 871; Cilsukh, i. 12; ii, 24 ( Pandit iv, 
+518; v, 510 ), and Kusumdnjali iii. 19 ( page 496 ). | 
+
+
+घुणाक्षरन्याय; ॥ 
+
+
+The maxim of the letter made by the wood-worm ghuna. — 
+This worm 00708 holes in wood and in books which sometimes 
+assume the shape of a letter of the alphabet; hence its use to 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+कंसा 2८ 
+
+
+L> e mrm 
+Y 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+27 
+
+
+intimate the occurrence of something quite accidental. Here is 
+Vardhamána's ( iii. 195 ) description of it :--घुणोत्किरणात्कथंचि- 
+ज़िष्पन्नमक्षरं gma | तदिव यदकुशलेन देवान्निष्प्यते gem ॥ 
+The simile is found in the opening part of Prasanna- 
+raghava ( page 9 ) as follows:—“ अहो घुणाक्षरन्यायो यदिदं असर्व 
+प्रति मयोक्तं akazi प्रति फलितं वचः? ॥ Also in Rájatavamgi iv. 
+107: त्रीन्वारान्समरे far जितं मेने स सुम्सुनिम्‌ । सक्कज्जयमरेवीरा 
+मन्यन्ते हि घुणाक्षरम्‌? ॥ 2700८ iii. 58 may also be referred to. 
+
+
+चन्द्रचन्द्रिकान्यायः ॥ 
+
+
+The maxim of the moon and its light. Used of two insepar- 
+able things. It is found in Anandagivi’s S’ankaravijaya, page 
+194:— f अतः सर्वदेवकारणस्य रुद्रस्य या शक्तिश्चन्द्र चन्द्रिकान्यायेन तदुद्दो- 
+धरूपिणी स्वाधीनवलभेति प्रसिद्धा सेव भवानी” ॥ 
+
+
+नौरापराधान्साण्डव्यनियहन्यायः ॥ 
+
+
+The maxim of the punishment of Mándavya for the erime 
+committed by robbers. The story of the Rishi Ani-Mándavya is 
+told at length in Adiparva evii, cvii. Whilst he was practising 
+severe austerities, in conjunction with the mauna-vrata, some 
+robbers concealed themselves and their plunder in his As'rama. 
+The king’s guard found them there, and, believing the sage to 
+be implicated in the affair, carried him off together with them 
+and impaled them all together! Mándavya was eventually ro- 
+moved from the stake, but its point (जणी ) remained in him; 
+hence the name, given him by the people, of Ani-Mándavya. 
+Tife maxim is found in the Pürnaprajna chapter of Sarva- : 
+dars‘anasungraha (page 78 of Jivànanda's edition, and 62 of 
+Bib. Ind. ):--« तस्माज्ञ भेदप्रत्यक्ष सुप्रसरमिति चेत्कि वस्तुस्वरूपभेद्वादिन 
+प्रति इसानि दूषणान्युद्धुष्यन्ते किंवा धर्मिभेदवादिन प्रति । प्रथमे चौरापरा 
+चान्माण्डव्यनिग्रहन्यायापातः? Wu But its earliest occurrence is in Atma- E 
+tattvaviveka, page 70, line 15, where we read (एवं हि चोरापर घेन 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Er g 
+Digitized By Siddhanta eGarigotri Gyaan Kosha 
+
+
+वयक्तमयं माण्डव्यनिग्रहः स्यात्‌ ??॥ and it was from this source that 
+the Khandanakâra, too, derived the nyâya together with several 
+pages of context! Compare pages 633-636 of S'riharsa's work 
+with pages 70 and 71 of-Udayana’s. 
+
+
+छत्रिन्यायः ॥ 
+
+The maxim of the men with umbrellas. The thought here 
+is of a crowd of men, many of them with umbrellas up, and so 
+all seeming to have them. Its application will be apparent 
+from the examples which follow. We have one in S'ankara's 
+bháshya on Katha-Upanishad ii. 1 ( “ogg पिबन्तो? &e. ):— 
+“एकस्तत्र कर्मफलं पिबति ys नेतरस्तथापि पातृसंबन्धात्पिवन्ताविव्युच्यते छत्ति- 
+न्यायेन? Again, in his bháshya on Veddntasttra 3. 3. 34, 
+where the same text is expounded :--“ऋत पिबन्तावित्यत्र तु _जीवे | 
+पिबत्यशनायाद्यतीतः परमात्मापि साहचर्याच्छत्तिन्यायेन पिबतीव्युपचर्यत ? ॥ | 
+On the former of these two passages, the commentator Gopála 
+Yatindra 88098:--«“छक्षिन्यायेनेति | यथा लोके छत्तिणो गच्छन्तीति प्रयोगे 
+सपरिवारे राज्ञि गच्छति छत्यछत्तिससुदाये छक्षिशब्दो वत्तेत एकसमूहवाहित्वे 
+नेव पिबदपिवत्समुदाये पिबतिवत्तेत इत्यर्थः ॥ 
+
+
+DIR NON PS ee 
+
+
+I have met with the maxim in the Kuvalaydnanda also 
+under the figure zgra, and in Anandagiri on. Brahmastitra- 
+bhdshya 1. 2. 11; 1. 4. 12. 
+
+
+But the nyaya is found long before S'ankara's time, and 
+perhaps originated with S'abara, in whose bhashya on Jaimini 
+1. 4. 28 we read “gar gir गच्छन्तीत्येकेन छन्तिणा aa लक्ष्यन्ते??} and 
+in Lantravdrtika 1.4.19 ५८ तस्मादेकदे शास्थैरपि विश्रेदेवेरूपलक्षितानां 
+छत्तिन्यायेन तत्प्रख्यतयेव सर्वेपां नामधेयत्वम्‌” ॥ A 
+
+
+—€— 
+
+
+तमोदीपन्यायः ॥ 
+
+
+. The maxim of durkness and the lamp. This ig found in the 
+Vedántasiddhámtamulktávali (page 125 ) where we read :— 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By. Siddhanta eGangotri Gyaan Kosha 
+29 
+
+
+८ तदयं तमोदीपन्यायः | तथाहि । अज्ञानं ज्ञातुमिच्छेद्यो सानेनात्यन्तमूढधीः 1 
+ख़ तु नूनं तमः पद्येदीपेनोत्तमतेजसा?? ॥ ^ Hence the well-known illus- 
+tration of darkness and the lamp:—Thus that dullest of dull- 
+heads who would cognize Nescience by means of a pramana, 
+would forsooth go looking for darkness with a brilliant lamp.” 
+
+This verse is most probably based on that of Sures vara in 
+Tuittiviyavdrtika 2. 1. 177 :— 
+
+८४ प्रमाणोत्पन्नया इष्ट्या यो$विद्यां द्ष्ट्मिच्छति । 
+दीपेनासी za प्येद्दुहाकुक्षिगत तमः” ॥ 
+
+
+: दग्धपटन्यायः ॥ 
+
+
+Tke maxim of the burnt cloth. When a piece of cloth, or a 
+leaf, is thrown into the fire and consumed, its outline is still 
+visible in the charred remains; and this the Vedantists use to 
+illustrate the unreality and unsubstantiality of all phenomena. 
+It occurs twice in Nrisiriihasarasvatis commentary on the 
+Vedántasára, namely on pages 55 and 66, as follows:—‘‘agt 
+aj afar ब्रह्मेतदातम्यमिदं सर्वमित्यादिश्वुतिबलात्सवमहमिति गिरिलदी- 
+समुद्वात्मके सर्व जगत्स्वाभिन्नसञ्चिदानन्द्ब्रह्मत्वेना्ुभूय तस्य दग्धपटन्यायेन 
+प्रपञ्चभानेऽप्यद्वैतं सचिदानन्दलक्षणं वस्तु भासत एवेत्यर्थः? ॥ ( Page 55 ). 
+
+“न्वेतादशस्य जीवन्मुक्तस्य देहेन्द्रियादिभानमस्ति न वेत्याशङ्कय दग्धपट- 
+भ्यायेनेन्द्रजालनिर्मितसो धसमुद्गादिवच्च॒बाधिताजुबत्त्या मिथ्यात्वेन भानेऽपि 
+परमार्थतया भानं नेत्याह अयमित्यादिना न पञ्यतीत्यन्तेन” ॥ ( Page 66 ). 
+
+
+दण्डापूपिकान्यायः ॥ 
+
+| The maxim of the stick and the cakes. Ifa number of cakes 
+| ( chapátis) are attached to a stick, and the stick is carried off 
+or eaten by mice, the inference is that the cakes have shared 
+the same fate. The application of the maxim is obyious, In 
+the Sdhityakawmudé ( xi. 8 ); and in the Kuvalaydnanda 
+( page 244 ), ib is used to illustrate the figure अर्थापत्ति and 
+काव्याथांपात्ति respectively. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+2 
+
+Digitized By Siddhanta oe Gyaan Kosha 
+
+“ दण्डापूपिकयान्याथोगसो5थोपत्तिरिष्यत ॥ ८ ॥ सूपिकेण दण्डो ata. | 
+
+दिहस्थः पूपोऽपि तेन भक्षित इति न्यायो दण्डापूपिका । तयान्याथीगमोडथीन्तर- i 
+मत्ययोऽथोपत्तिरिव्यर्थः” ॥ (Sah. ) 
+
+
+“केमुत्येनार्थसंसिद्धिः काव्याथीपत्तिरिष्यत्ते* | स जितस्त्वन्युखेनेन्दु: का वाक्त | | 
+सरसीरुहाम्‌॥ अन्न स इत्यनेन पद्मानि येन जितानीति विवक्षितं तथा च सोऽपि 
+येन जितस्तेन पदानि जितानीति feg वक्तव्यसिति दण्डापूपिकान्यायेन पद्मजब- 
+रूपस्यार्थस्य संसिद्धिः काव्यार्थीपत्तिः | तात्रिकाभिमतार्थापत्तिव्य़ावर्तनाय का- 
+व्येति विशेषणम्‌ ” N ( Kum, » 
+
+See also Brihaddvanyakopanishad-bhashyavdrtika, page 
+909, verse 135. 
+
+
+देहलीदीपन्यायः ॥ 
+
+
+The maxim of a lamp on the threshold. A lamp so placed 
+gives light both inside and outside the house, and is therefore 
+used as an illustration of anything which fulfills a double 
+purpose. S'abara refers to such a lamp in his bháshya on 
+Jaimini 12.1. 8 :—6 gay प्रासादे कृतः प्रदीपः सज्ञिधानाद्राजमार्गेषप्यु- 
+पकरोति”. There is a similar expression, too, in Kuvalayd- 
+nanda, page 97. Another good example of the nyaya is | | 
+found in the commentary on Saptapaddrtht, page 52. The 
+text stands thus: —« द्रव्यानारंभकं कायेद्रव्यमल्त्यावयचि ॥ प्रागभाव- 
+KAIA ॥ भोगायतनमन्त्यावयावे aT on which Madhava Sara- 
+svati remarks :— ““दारीरलक्षणेष्न्त्यावयविपदज्ञानाय तल्लक्षणमाह द्रब्येति। 
+यद्यप्यु देशान्तरं लक्षणस्य दक्तव्यत्वाच्छरीरळक्षणानन्तरं भोगादिवदन्त्यावयवी 
+लक्षयितु्ुचितस्तथाप्यत्र दव्यपदव्यवच्छेयत्वेन ग्रापव्वाद्देहळीम्रदीपन्यायेनो- 
+भयत्रोपकार्यैतयात्रैव क्षित इत्यदोषः” ॥ 5 
+
+My friend Professor Cowell pointed out another instance 3 
+of the use of the nyaya in Anandagiri's S'ankaravijaya, xi, page is 
+82. The maxim is akin to काकाक्षिगो लकन्याय and जामात्नर्थे श्रपितस्य 
+सूपादेरतिथ्युपकारकरवम्‌ ॥ 
+
+
+* The author of Rasagangddhara finds fault With this definition, See 
+page 487 of Durgáprasáda's edition, Bombay 1888, 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+T 
+i 
+| 
+i 
+1 ] 
+| 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+31 
+
+
+नष्टाश्वदग्धरथन्यायः Ul 
+
+The maxim of /he lost horses and burnt chariot. This is 
+based on the story of two men travelling in their respective 
+chariots, and one of them losing his horses and the other having 
+his chariot burnt, through the outbreak of a fire in the village 
+in which they were putting up for the night. The horses that 
+were left were harnessed to the remaining chariot, and the two 
+men pursued their journey together. Its teaching is—union 
+for mutual advantage. That the story is very old is clear from 
+the fact that the saying is quoted in the 16th vdrtika (“' संप्रयोगो 
+वा नष्टाश्चदग्चरथवत्‌??) to 70१७८ 1. 1. 50, and again in S'abara's 
+bháshya 2.1. 1. It appears also in Sures'vara's Brihadárawja- 
+bhdshyavdrtika 2. 1. 38, which reads thus:—< नष्टाश्वदग्धरथवन्यायं 
+चाश्रित्य भूमिपम्‌ । प्राह सानुपवित्ताढ्य॑ देववित्तसमन्वितः?? ॥ On which 
+Anandagiri says :— “अधिकारिणे विद्यां वक्तं गाग्येश्रदुपचक्रमे ताहि योग्यं 
+ब्राह्मणं हित्वा किमिति राजानसुपेत्य व्रवीति | तत्राह नष्टेति | यथाहुर्युक्तः संयो- 
+गोऽधिकारार्थेन हेतुना नष्टाश्वदग्घरथवदिति? ॥ 
+
+
+Ramtirtha, too, quotes the maxim in his comment on the 
+
+
+‘Vedantusdrw’ ( page 93, line 3) :— ¢ नष्टाश्वदग्धरथन्यायेत FAN 
+
+
+पितृलोक ? इति श्रुतिरुपपद्यते??› of which the following translation is 
+found in The Pandit for May 1872:—*The Vedic text ‘The 
+world of progenitors is attained by works, can be explained 
+according to the analogy of two men, of whom the horses of 
+ihe one are lost and the chariot of the other burnt [ for the 
+horses of the latter may be yoked to the car of the former, and 
+they may travel together; and in like manner, constant and 
+occasional works, though no special result has been recorded 
+of them, may supply a cause for the attainment of the world of 
+the progenitors, which requires some special works as a condi- 
+tion ].” See also Tantravdrtika, pp. 15, 709, 882, and Bhématt, 
+page 81. 
+
+
+नहि कठोरकण्ठीरवस्य कुरङ्गशावः प्रतिभटो भवति ॥ 
+
+
+A young fawn cannot stand wp against e full-grown lion. 
+
+
+Ea 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+This is found in the Akshapáda chapter of Survadavs'ana. | 
+sangraha ( page 136 of Jivánanda's, and 119 of Bib, Ind. )— - 
+“'नेतस्परीक्षाक्षममीक्ष्यते नहि कठोरकण्ठीरवस्य ङुरङ्गशावः प्रतिभटो भवतिः, 
+which Prof. Cowell renders, “ This pretented inference will no 
+more stand examination than the young fawn can stand the 
+attack of the full-grown lion.” Compare “'नाट्पीयसा महतोऽभिभवः | 
+संभवति? ॥ of Slik, page 94, and sce the nydya “नहि भवति . 
+तरक्षुः &e.” in Second Handful. | 
+
+
+नहि खदिरगोचरे परशो पलाशे द्वेधीभावो भवति ॥ 
+
+
+The Palás'a tree is not cleft when the axe is applied to the 
+Khadiva tree. The saying is used to indicate that two objects — 
+are essentially distinct. I have met with it in three of Vacas- |. 
+patimis'ra’s works. P 
+
+It occurs in Bhdmat! 2. 2. 28 ( page 438 ) in the 
+connection. “स्वरूपं विज्ञानस्यासत्याकारयुक्त प्रमेयम्‌ | प्रमेयप्रकाशनं TANT 
+फलं, तत्प्रकाशनशक्तिः प्रमाणम्‌ । बाह्यवादिनोरपि वेभापिकसोत्रान्तिकयोः d 
+काल्पनिक एव प्रमाणफलव्यवहारो$भिमत इत्याह “सत्यपि urs इति | 
+भिन्नाधिकरणत्वे हि प्रमाणफलयोस्तद्गावो न स्यात्‌ । नहि खदिरगोचरे परशौ 
+पलाशे द्वेंथीभावो भवति | तस्मादनयोरेकाधिकरण्यं ATAR ॥ 
+
+
+Then in Yogabhdsyatihd i. 7 we read :--ननु पुरुषवर्ती बोधः कथं | 
+चित्तगताया qt फलम्‌ । नहि खदिरगोचरव्यापारेण परशुना पलाशे छिदा 
+क्रियत इति” ॥ 
+
+And very similarly in Vydyavdrtikatdtparyatika, page 01:- 
+“अथ प्रमाणफल्योभिन्नविषयत्वेन विप्रतिपत्त्या प्रमाणफलभावायोगात्‌ | ale 
+AKATAA परशुना खदिरे द्वेधीभावो Kaa ॥ But he is not the only. 
+writer who makes use of it; for in Ad»aitabralumasiddlü, 
+page 93, we read — तयोभिन्नाधिकरणबृत्तिस्वे खदिरगोचरे परशौ पालाशे 
+KUA wad? ॥ For earlier references to this nyaya, see the 
+Superaddenda to the Third Handful. i 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+33 
+
+
+A A 
+
+न हि वरविघाताय कन्योद्वाहः ॥ 
+
+The bride is not married for the destruction of the bride- 
+groom. This is found in Brahmasdirabhdshya 4. 1. 2, and in 
+the Pürnaprajna chapter of Sarvadars'anasangraha ( page 68 
+of Bib. Ind, and 75 of Jivananda’s edn. ), It occurs also in 
+Jivanmuktiviveka, page 101 (line 4 from bottom). In the 
+Vdchaspatyam and in the Laukikanydyasangraha, the max- 
+im is given in the positive form, viz. “araa meum 
+with the other as a possible variant, Taranatha explains 16 
+thus:—“agenat gaat यत्र वरस्य घातः संभाव्यते तन्न तां नोह्वहे देवं 
+विवक्षायामस्य प्रवृत्तिः । तथा चानिष्टान्तरपातादिसंभावनायासभीष्टहेतुरपि 
+बस्तु न वरणीयमित्येवं तज््यायतात्पर्यम्‌ | अयमेव न्यायः कचिन्न हि वरघाताय 
+कन्यासुद्वाहयतीति न्यायतया yeaa” We have a reference to “poi- 
+son-damsels” in Kathásaritságara xix. 82, which reads thus:— 
+“Bey विषकन्याश्व सेन्ये पण्यविलासिनीः | प्राहिणोत्पुरुषांश्रेव frag 
+च्छद्यघातिनः? ॥ In a foot-note to his translation of the passage, 
+Mr. Tawney says, “One of these poison-damsels is represented 
+as having been employed against Chandragupta in the Mudra- 
+Rakshasa. Compare the xith tale in the Gesta Romanorum, 
+where an Indian queen sends one to Alexander the Great, 
+Aristotle frustrates the stratagem.” 
+
+
+पङ्कप्रक्षारूनन्यायः ul 
+The maxim of the washing off of mud. It is evidently de- 
+duced from Pañchatantra ii. 157, verse intended to strengthen 
+an argument against the possession of riches under any circum- 
+stances, and which reads thus—'' ani यस्य वित्तेहा तस्यापि न 
+शुभाबहा । प्रक्षारनाद्धि पङ्कस्य दूरादस्पशैन mau “Tf a man desires | 
+wealth for charitable purposes, even to him it will bring no —— 
+good; for, better than the washing off of mud is the keeping p 
+away from it altogether" The nyaya is therefore the equiva- | 
+lent of our “Prevention is better than cure.” In his bháshya _ 
+on Brahmasétra 9. 2. 22. Sankara twice quotes the second line 
+of the above couplet; and, in commenting thereon, Anandagini 
+uses the maxim three times. It is again applied twice by 
+5 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+3) 4 
+Digitized By Siddhanta eGargotri Gyaan Kosha 
+
+
+on Brahmasdlrabhdshya 4. 1. 16. as follows:—t “अभिहोत्रा दीनामपि 
+पुण्यान्तरवद्विनाइयव्वास्पङ्गक्षारनन्यायापातादास्स्क्ुणापि तानि नाजुष्टेयानि”; 
+^ धीनाइयानामपि कर्मणामचुष्टानस्य विद्योत्पत्त्यथतया पड्प्रक्षालनन्यायान- 
+वकाशात्पूवे ज्ञानादनुष्टेयान्यभिहोत्रादीनीति सिद्धान्तप्रतिज्ञां विवृणोति. 
+See also Bhdmati and Bhdshyaratnaprabhd on the same, and 
+Vwaranaprameyasangraha, page 97, line 14, 
+
+
+पज्चन्चन्यायः n 
+
+The maxim of the lame man and the blind man. The con 
+ception is that of a lame man mounted on the shoulders of one 
+who is blind, so that the former is furnished with the power of 
+locomotion and the latter with sight. It is intended to illu 
+strate mutual dependence for mutual advantage, as exemplified 
+in Sdnkhyakdrikd 21, the text of which, with Colebrookes 
+translation, is as follows:—t “पुरुपस्य़ SAAT केवल्यांथे तथा प्रधानस्य। 
+पङ्कन्धवहु भयोरपि संयोगस्तत्कृतः सर्गः? ॥ “For the soul’s contempla- 
+tion of Nature, and for its abstraction, the union of both takes 
+place, as of the halt and blind. By that union a creation is 
+framed.” Váchaspati Mis'ra ignores the illustration, but Pandit 
+Táránátha has a helpful note on it. He saye:— “saidi zara: 
+ageaatata । यथा गतिशक्तिरहितस्थ पङ्गोगेतिसाधनाय गतिमतोऽन्धस्याः 
+पेक्षा, makaka चान्धस्य गतिशक्तिसच्वे$पि स्वाभीष्टदेशगमन दरक 
+मन्तरेण न संभवति तथा च यथा स्वस्वकायीय तयोरन्योन्यापेक्षा तथा 
+क्रियारहितस्य पुरुषस्य सक्रियप्रधानस्यापेक्षा रष्टिशक्तिरहितस्य च प्रधानस्य 
+इष्टिशक्तिथुक्तपुरुषस्यापेक्षेत्यत उभाभ्यामन्योन्यभपेक्ष्य स्वस्वकार्य निष्पाद्यत ई 
+व्यर्थः? ॥ The above kérikd is quoted on the last page of the 
+Sankhya section of Sarvadars'anasangraha, and is preceded 
+by a very clear explanation of the maxim. 
+
+
+VT VN WERT 
+
+
+ABMS cC Cid 
+
+
+4 
+] 
+
+
+पज्ञरचाठनन्याय! ॥ 
+
+
+The maxim of the moving of the bird-caye. An zi t 
+of the power of united effort. Ina discussion on prdna, under 
+
+
+Vedámtasüiva 2. 4. 9, S'ankara introduces thi i il 
+Mra 2, 4. a ) es thi xim ant 
+CC-O. Prof. Satya Vrat Shastri Collection. his maxir 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+OU 
+29 
+
+
+explains it thus:—“agq पञ्जरचाळनन्यायेनेतद्भविष्यति | ययैकपञ्षरवर्तिन 
+एकादशपक्षिणः प्रत्येक प्रतिनियतव्यापाराः सन्तः संभूयेक पञ्जरं चालयन्ति | 
+एवमेकशरीरवतिन wea: प्रत्येकं प्रतिनियतव्रृत्तयः सन्तः संभूयेकां 
+ग्राणाख्याँ Atha प्रतिळप्स्यन्त इति” ॥ Dr. Thibaut translates the pas- 
+sage as follows :—“ But, an objection may be raised, the thing 
+may take place in the manner of the moving [of the? ] bird- 
+cage. ` Just as.eleven birds shut up in one cage, may, ‘although | 
+each makes a separate effort, move the cage by the combination 
+of their efforts, so the eleven pránas which abide in one body 
+may, although each has its own special function, by the com- 
+bination of these functions, produce one common function called 
+prána." 
+
+
+SS =~ = 
+पाटञ्चरळुण्ठिते KMA यासेकजागरणम्‌ ॥ 
+
+The vigilance of the watchman after the house has been 
+plundered by thieves. Equivalent to our proverb “ Shutting 
+the stable door after the horse is gone.” It occurs in Khanda- 
+nakhandakhddya, page 45 :—“ प्रयोजनानुपयुक्ते काले तस्य स्वरूपतो- 
+ऽवस्थानं पाटचरळुण्ठिते ufa यामिकजागरणवृत्तान्तम चुहरति” ॥ 
+
+
+s > 
+
+पिण्याकयाचनाथे गतस्य खारिकातेलदातृत्वाभ्युपगसः u 
+
+He went to crave the leavings of the oil-seed, and had in- 
+stead to agree to give 16 measures of oil. Used of one com- 
+pletely worsted in argument. I render पिण्याक in accordance 
+with its meaning in Pañchatantra iii. 99 (४ श्रेयस्तेल च पिण्याकात?). 
+The maxim is found in the Pürnaprajna section of the Sarva- 
+dars'anasangraha ( page 63 of Bib. Ind, and 75 of Jivà- 
+nanda ):—“ “सोऽयं पिण्याकयाचनार्थ गतस्य खारिकातेलदातृत्वाभ्युपगम इव > 
+which Prof, Gough renders:—“ And thus it must be allowed 
+that, in raising the objection, you have begged for a little oil- 
+cake, and have had to give us gallons of oil.” 
+
+
+पिष्टपेषणन्यायः ॥ 
+The maxim of the grinding of that which is already ground, 
+Fruitless reiteration, unproductive repetition. eThe oldest in- 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta egangotri Gyaan Kosha 
+
+
+stance, known to me, of the employment of the nyáya, is i 4 
+S'abara on Jaimini 9. 2. 3:—“A हि (eraer sud — पिष्टस्य 
+
+चा पेषणम्‌, It occurs again in 12. 2. 1 6, and in Tantravdrtika, 
+pp. 54 and 477. We find it likewise in S'ankara's bháshya on 
+Kena-Upanishad 32:— यादि तावच्छूतस्यार्थस्य प्रश्नः कृतस्ततः पिष्टः 
+पेपणवत्पुनरुक्तोऽनर्थकः प्रश्नः स्यात्‌?? d, and in Sudars'anárya's com. 
+ment on Âpastamba-Grihyasûtra xiv. 9 (“gaat व्यक्ते at 
+तिष्येण??)) where he says “ इदमपि सीमन्तवत्परथम एव न तु प्रतिगर्भ 
+Reana ॥ Compare तुपकण्डनन्याय in Second Handful. 
+
+
+1 
+| 
+
+
+E 
+
+
+प्रदीपे प्रदीपं प्रज्वाल्य तमोनाशाय यतमानः॥ | 
+
+
+Trying to remove the dimness of a lamp by lighting 
+another. Used of foolishly superfluous and misdirected effort, — 
+It occurs in Khandanakhandakhadya, page 294:--““रूघोरुपाया- — 
+त्साध्यसिद्धो भवन्त्यां***गुराघुपाये प्रवर्तमानस्य तवैवेदं दोषोद्भावनं प्रदीपे 
+प्रदीपं प्रज्वाल्य तमोनाशाय यतमानस्येव ga: ॥ Ina footnote, the editor 
+says—''gdid प्रज्वाल्य प्रदीपे तमोनाशाय यतमानस्य एस इवेत्यन्वय:, | 
+
+In Upades'asdhasri xvii. 41 ( page 218 ), we read:—“न हि — | 
+दीपान्तरापेक्षा यद्वहीपप्रकाशने | बोधस्यात्मस्वरूपत्वान्न बोघान्यस्तथेष्यते | 
+and, in Sures'vara's Brihaddranyakavartika 4, 8. 501;— ननु 
+दीपः स्वमात्मानं स्वात्मनेवावभासयन्‌ | दृष्टो दीपप्रकाशार्थ न हि diem 
+हृतिः? u Sce also Nyâyamanjart, page 625, on Nydyasts | 
+tra 8, 1, 10. 
+
+
+N 
+
+
+प्रधानमल्लनिबहेणन्यायः ॥ र 
+
+The maxim of the destruction of the chief antagonist The 
+principle that when the most formidable enemy has been. 
+defeated, the less formidable are already virtully overcome. In 
+the bhishya on Vedántasütra 1. 4. 28 (“uta सर्वे व्याख्याता 
+व्याझ्याताः??) we read:— aa: प्रधानमछनिबईणन्यायेनातिदिशति | एवं 
+न प्रधानकारणवाद्प्रतिपेधन्यायकलापेन सवेऽण्वादिकारणवादा अपि प्रतिषिद्धः 
+
+
+on the word mara, the Sánkhya theory of the Pradhána being! 
+
+
+the chief antagonist met and overcome in the forecoi (bras. 
+COO. Prof. Satya Vrat Shastri Collection. oregoing 80079 
+
+
+Digitized By Siddha "à $° angotri Gyaan Kosha « 
+
+
+and bhàshya. The same expression appears again in the 
+bháshya on Sétra 2. 1. 12, and the maxim is found, too, in the 
+Rámánuja chapter of Sarradars'anasangraha ( page 54 of, 
+Tivananda’s edition, and p. 45 of Bib. Ind. edition ). 
+
+
+बीजाङ्करन्यायः ॥ 
+~ 
+
+The maxim of an eternal series of seed and shoot. As the 
+seed produces the shoot, so the latter in turn reproduces the 
+former, Each therefore is a cause and an effect. The maxim 
+ig mot with very frequently in the literature. We find it in 
+Brahmasdtrabhashya 2. 1. 86 (on the eternity of the world) as 
+follows:—‘a च कर्मान्तरेण शरीरं संभवति । न च शरीरमन्तरेण कम संभव 
+तीदीतरेतराश्रयःवप्रसङ्गः | अनादित्वे तु बीजाङकुरन्यायेनोपपत्ेनै कश्चिद्दोपो 
+भवति??, which is rendered thus by Dr. Thibaut:—" Without 
+merit and demerit no body can enter into existence, and again, 
+without a body merit and demerit cannot be formed ; so that— 
+on the doctrine-of the world having a beginning—we are led 
+into a logical see-saw. The opposite doctrine, on the other 
+hand, explains all matters in à manner analogous to the case of 
+the seed and sprout, so that no difficulty remains.” 16 occurs 
+again at the end of the bhdshya on 3. 2. 9. Also in the Arhata 
+section of Sarvadars'anasangraha ( page 31 of Bib. Ind., and 
+37 of Jivünanda), in Rámatirtha's commentary on Vedámta- 
+sdra ( page 110 ), and in Pancapádiká, page 12, line 12. 
+
+
+ब्राह्मणपरित्राजकन्यायः ॥ 
+
+The maxim of the Brahmans and the mendicants. In such 
+a sentence as ब्राह्मणा भोजयितव्याः परित्राजकाश्च the separate men- 
+tion of the latter, who are really included in the former term, 
+merely emphasizes their position as 8 special part of the general 
+body. 1018 thus the exact parallel of the गोबलीवदेन्याय and of 
+the ब्राह्मणवसिष्ठन्याय. It is used by Sankara three times in his 
+exposition of the Vedántasütras, namely under 1. 4. 16, 2.3. _ 
+15, and 3. 1. 11; but I forbear to quote his words, for without a 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+je: 
+=a 
+“ 
+
+3 
+
+
+ry 
+E 
+
+
+; 
+
+
+3 
+
+ji 
+lengthy portion of context they would be unintelligible Tt 1 
+appears also in Tuntravartika, pages 423, 590. | 
+
+
+Digitized By Siddhanta eGungotri Gyaan Kosha 
+
+
+व्राह्मणवसिष्ठन्याय। ॥ 
+
+
+The maxim of the Brdhmans and Vasishiha, This is of . 
+the same type as ब्राह्मणपरित्राजकन्याय, which sec. Satyavrata | 
+gives as a reference ‘ “हलन्त्य-सूत्रभाष्यं,” 4. e. Patanjali on Pánini 
+1.3.8, But the reference is à pure delusion; and I thinkI 
+may safely say that the maxim is not to be found in any part 
+of the Mahdbhdshya. It would not be unreasonable, however, 
+to infer that the author of the Padamanjart had this nyaya in 
+view when he penned the following:—ai@erat लौकिकत्वेऽपि 
+प्राधान्यख्यापनार्थ एथग्ग्रहणं यथा ब्राह्मणा आगता वसिष्ठोऽप्यागत इति? N 
+(The Pundit, vol. x, page 282), Compare तक्रकोण्डिन्यन्याय in 
+Second Handful. 
+
+
+्राह्मणश्नमणन्यायः ॥ 
+
+
+The maxim of the Brdhman-ascetic. The श्रमण is a 
+ascetic, and therefore not a Brahman,—but the expression 
+ब्राह्मणश्रमण implies that though now a Buddhist he was formerly 
+a Brahman, The maxim is used by the authors of the Kdvyd- 
+prakds'a ( page 68 ) and the Séhityadarpana (article 257 ) in 
+exactly the same connexion. After giving an example of ‘sug- 
+gested meaning’ in the form of ‘semblance of contradiction’ 
+(विरोधाभास), the author of the latter work says:-—' अन्नामित 
+इत्यादावपिशब्दाभावाद्विरो धाभासो व्यङ्गयः | व्यज्ञयस्यालूंकार्यत्वे5पि sU 
+श्रमणन्यायादलंकारत्वसुपचर्यते ”, which Mr. Pramadâdâsa Mitra 
+renders thus:—“ Here, from the absence of the particle आपि. 
+after the words अमित &c., the semblance of the ornament-named — 
+contradiction’ is suggested. The suggested meaning, though | 
+strictly what is ornamented, is figuratively spoken of here a 
+the ornament, with reference to its being an ornament in ano- 
+ther condition [ 4. e. when it is expressed, not suggested ], just 3 
+
+
+as we use the word Bráhman-mendicant, which, t it 
+CC-0. Prof. Satya Vrat Shastri Collection. hich, though 1b 
+
+
+Digitized By sanaa Gyaan Kosha 
+9 
+
+
+clymologically means an absurdity, viz. a mendicant, or one 
+not a Bráhman, who is a Brahman, tropically signifies one who 
+was a Brahman.” 
+
+
+भक्षितेऽपि लशुने न शान्तो व्याधिः ॥ 
+
+Although the garlic has been caten the disease is not cured. 
+This proverb is applied as follows by Nrisimhasarasvati in his 
+comment on the opening verse of the Vedámtasáreu:— ag 
+भक्षितेऽपि लशुने न शान्तो व्याधिरिति न्यायेन ग्रपश्नस्याधिष्टानव्य तिरिक्त- 
+तया प्रतीयमानस्वात्कथमद्वैतसिद्धिरित्याशाङ्कां तृणीकुवेन्नाह अखण्डमिति N 
+It is found also in Veddéntakalpataruparimala, page 37. 
+
+
+भिक्चुपादप्रसारणन्यायः॥ 
+
+
+The maxim of a beggar’s obtaining a firm footing [in a pat- 
+ron's house]. Perhaps approaching our “Give him an inch and he 
+will take an ell.” Táránátha explains it thus:—*' यथा कश्चिद्विक्ष॒यः 
+भे्भोजनाच्छादनवासगृहादिलाभार्थ कस्यचिद्धनिनो गृहे atest युगपस्सवा- 
+sereni मन्यमानः प्रथमं धनिगृहे मे पादप्रसारणसस्तु पश्चादनेन परिचयमु- 
+wa सर्वमभीष्टं संपादयिष्यामीति धिया स्वल्पामपि भिक्षां बहुमन्यमानः 
+पश्चाव्क्रमेण स्वाभीष्टं संपादयत्येवं यत्र विवक्षा तत्रास्य प्रबरृत्तिः” d 
+
+
+It occurs in the Bauddha chapter of Sarvudars'anasangraha 
+( page 14 of Bib. Ind. edn. ) as follows :--“माध्यमिकास्तावदुत्तमप्रज्ञा 
+इत्थमचीकथन्भिक्षुपादप्रसारणन्यायेन क्षणभङ्काद्यभिधानसुखेन स्थायित्वानुकूल- 
+चेदनीयत्वाचुगतसर्वसत्यत्वभ्रमव्यावतनेन सवेशून्यतायामेव पर्यवसानम्‌” ॥ 
+Here is Prof. Gough's rendering:—“The Madhyamikas, ex- 
+cellently wise, explain as follows, namely that the doctrine of 
+Buddha terminates in that of a total void ( universal baseless- 
+ness or nihilism ) by a slow progression like the intrusive steps 
+of 4 mendicant, through the position of a momentary flux, 
+and through the ( gradual ) negation of the illusory assurances 
+of pleasurable sensibility, of universality, and of reality.” 
+
+
+I have met with one other example only, namely in Venkata< 
+
+
+nithe’s Tattvamuktákalápa, page 254 :--“'अस्त्वेवामिति चेन्न Ng: 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGdr(yotri Gyaan Kosha 
+
+
+पादप्रसारणन्यायेन निरीश्वरवादावतारादतः कोधाव्यम्भावादीश्वरस्यापि gue | 
+azania: ॥ The subject under discussion here is आगमिकेश्वर i 
+सिद्धि. For the cognate expression पादप्रसारिका ४९७ the Second 
+Handful. 
+
+
+मणिमन्त्रादिन्यायः ॥ 
+
+
+The nyaya of a gem or charm &e. [ as an obstructer or ox- | 
+citer of fire &c., by its presence or absence]. This obscure | 
+nyaya is not in Raghunáthavarma's collection, but is defined as. .— 
+follows in the Vdcaspatyam, page 4166 :—“‘aftiaardtat ai ' 
+प्रति यथा स्वातच्येण प्रतिबन्धकत्वं लोकसिद्धं न च तत्र युक्तयपेक्षा एवं 
+कामिनीजिज्ञासाया अपि ज्ञानमात्रं प्रति ग्रतिबन्धकत्वमि्येवं यत्र पृथक | 
+प्रतिबन्धकत्वं तत्रास्य प्रवृत्तिः” ॥ 3 
+
+
+Iam much indebted to Mr. Arthur Venis for the following | 
+note elucidating the nyâya :—“ In their analysis of the notion | 
+of cause and effect many Indian writers distinguish between 
+those cases in which the processes that intervene ( avdntara 
+wy&pára ) between the cause and its final product ( kdrya ) 
+are known by ordinary experience ( lokasiddha ), and those 
+other cases in which the intermediate stages are not thus 
+known. Of the latter cases, while we know as a fact ( say 
+these writers ) that, for example, a mani or a mantra will pro 
+duce a certain effect or prevent it from coming into existene 
+we are quite unable to explain the rationale of the process in 
+terms of ordinary experience. All that can be said in 8767 
+cases is that the mani or the mantra has the power ( s'akti ) 
+to produce this or hinder that result. This postulate of a power 
+transcending ordinary experience is the मणिमत्रादिन्याय, and x 
+proper application ( pravritti ) is to the class of causes thus 
+roughly described. If I remember rightly, another, and to । 
+westerns a more interesting, example of this nyáya is the dou 
+ble fact of attention to something and attention away PA 
+‘something else. ‘The lover, intent on discovering his anis! 
+
+
+Chami 4 ४६१० ५/ SREY PR GREG WBS to all that does 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+41 
+
+
+concern her. But how should his attention fo her cause atten- 
+tion away from all the world beside? - Here, says the Indian 
+psychologist, analysis of the how can proceed no further. ‘The 
+postulate of the ama must be applied here; or, in other 
+words, we can only say that attention to a thing has the power 
+to cause (s‘akti) attention away from something else.” This 
+question is discussed in Kusumdnjali i. 10, and Prof. Cowell’s 
+translation of the karika and Haridasa's comment will be 
+found helpful. I have met with the nyaya in the Samks'epa- 
+s'driraka iii. 87, 88, 91; in Zattvamuktákalápa iv. 103, and 
+better still, in v. 99; and in Vidvanmandana, page 59. 
+
+
+भण्डूकछतिन्यायः ॥ 
+
+
+The maxim of a frog’s leap. Used by grammarians and 
+others to express the passing from one rule to another over in- 
+tervening ones. I noted it in the following portions of the 
+Mahdabhdshya:—1. 1. 3 (vart. 2); 5.2. 4 (2); 6.1. 17 and 3. 49; and 
+7, 9. 117. I have met with it also in Jayaratha's commentary on 
+Alankérasarvasva 20 (““विषयस्यापहृवेऽपह्णतिः), where he says :— 
+“केचन मण्डूकछुतिन्याेनाचुवर्तनस्याचुचितस्वा्रान्तिमदनन्तरमपह्ुतिअन्थक्कता 
+रक्षिता उछेखश्चातिशयोत्तयनन्तरमिति sed विपयासितवन्तः | न चेतत्‌? ॥ , 
+See, too, Bhdmatt 1, 3. 39, and Ballantyne's Aphorisms of the 
+Nydya, ii. 80. 
+
+
+मध्यदीपिकान्यायः ॥ 
+
+
+The maxim of the central lump. The idea is of a lamp in a 
+central position shedding its light on all sides. I6 occurs in the 
+Mundaka-bhdshya 1. 1. 3 (MATA महाशालोऽङ्गिरसं विघिवदुपसक्षः 
+
+= q EN : संबर गेवघिव > zq नविधे rq. 
+पप्रच्छ ):--“शोनकाह्विरसोः न्धादवाग्विधिवद्विशिषणादुपसदुनविधे: YA 
+पामनियम इति गम्यते | मयोदाकरणाथे मध्यदीपिकान्यायाथै वा विशेषणम्‌? ॥ 
+Also in Rámatirtha on Veddatasdra (page 129) :-- मध्यप्रदीप- 
+
+
+न्यायेनोत्तरन्रापि जाग्रद्वासनेस्यत्र कोशन्नयपदं संबध्यते?) which is thus ren; 
+6 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+du. 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+dered by Prof. Gough ( in the Pandit for Feb. 1873, p. 219)— 
+“The term triad of sheaths has a double connection [ with both ! 
+the preceding and following clauses], after the manner ofa Í 
+lamp placed in the middle of a door [ and throwing light both — 
+inwards and outwards.)” The following from Nydyamanjant, 
+page 212, further illustrates the ny&ya :--'ग्रृहे दघिघटी द्रष्टमानीतो 
+गृहमेधिना । अपूपानपि तहेशान्प्रकाशयति दीपकः” ॥ Akin to this is | 
+मध्यमणिन्याय, which is explained in the Pandit for Dec. 1867 as 
+referring to the central ruby of a nose-ring which casts a lustre 
+on the pearl on each side of it. 
+
+
+भानाधीना मेयसिद्धिः ॥ 
+
+
+To know the thing to be measured you must know the measure, 
+This is quoted in the opening part of the Akshapáda section of 
+Sarvadars'anasangraha:—“ मानाधीना मेयसिद्धिरिति न्यायेन sam 
+स्य प्रथममुद्देशे तदनुसारेण लक्षणस्य कथनीयतया प्रथमो दिष्टस्य प्रमाणस्य प्रथमं 
+लक्षणं कथ्यते? Prof Cowell’s translation is as follows:—“In 
+accordance with the principle that ‘to know the thing to be 
+measured you must first know the measure, proof ( pramána ) is 
+first enunciated, and as this must be done by defining it, we 
+have first a definition of proof.” We find it too, in Tattvapra- 
+
+dipikd (or Cttsukhé) ii. 18, as follows: ‘मानाधीना मेयसिद्विर्मानसिद्िश्र 
+लक्षणात्‌ | तच्चाध्यक्षादिमानेषु गीर्वाणेरपि दुर्भणम्‌” ॥ Compare also the | 
+following from #Sankshepas'driraka (i. 487):—“ मानेन drama ४ 
+युक्ता धर्मस्य जाड्याद्विधिनिष्टकाण्डे । मेयेन मानावगतिस्तु युक्ता वेदान्तः 
+चाक्येष्वजडं हि Fay’ ॥ See, too, Vvaranaprameyasangralt, — 
+page 86, and Sénkhyakdrikd 4 (¢ प्रमेयसिद्धिः प्रमाणाद्धि). 
+
+
+भुञ्जादिषीकोद्वरणन्यायः ॥ 
+
+
+The maxim of the extraction of the interior spike of the टॅ 3 
+
+
+* Its author, Sarvajnitmamuni, was a pupil of Bures'varácürya. S९0 
+B. PA RO e 
+Mr. K. B, Páthal's valuable paper Dhartrihari and Kumárila ( 1892.) 
+
+
+page 21. 
+pae CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+43 
+
+
+Munja grass. The following verse from the Pajicadas’ ( 1. 
+42), with an extract from Rámakrishna's comment thereon 
+will fully explain the meaning and application of the saying:— 
+«यथा स्ुञ्जादिपीकैवमात्मा युत्तया समुद्धतः । शरीरत्रितयाद्धीरे : परं रह्मैव 
+जायते” ॥ “थथा येन प्रकारेण सुञ्जादेतन्नामकात्तृणविशेपादिषीका गर्भस्थं 
+कोमलं तृणे युक्त्या बहिरावरकस्वेन स्थितानां equa विभजनलक्षणेनो- 
+पायेन समुद्रियत एवमात्मापि...शरीरत्रितयात.. .धीरेः...ससुद्धतः प्रथक्‌ 
+कृतश्चेत्स परं ब्रह्मेव जायते” ॥ The illustration is 8 very ancient one, 
+since it is employed in S'atapatha Bråhmana 4. 8. 3. 16, and in 
+Katha Upanisad vi. 17. The latter instance is as follows:— 
+“ तं स्वाच्छरीरात्प्रवृहेन्मु आादिवेषीकां iiw.» For the former, see this 
+nyaya in the Superaddenda to Third Handful. It is found 
+also in Brihaddranyakavdrtika 4. 4. 1277. 
+
+
+याचितकमण्डनन्यायः ॥ 
+
+
+The maxim of borrowed ornaments. Appearing in borrowed 
+plumes. It is well illustrated by Naisadhacarita vi, 56:— 
+“अस्या मुखश्रीप्रतिबिस्बमेव जलाच्च तातान्सुकुराच मित्रात्‌ । अभ्यथ्ये धत्तः 
+खलु पद्मचन्द्री विभूषणं याचितकं कदाचित्‌? ॥ On which Mallinatha 
+comments thus:—‘arfras याच्चानिवृत्तम्‌। AAAS याचितकमित्यमरः | 
+अपमित्ययाचिताभ्यां कक्कनाविति कन्प्रत्ययः (Pan. 4 4 21 ) । विभूषणं 
+कदाचिदभ्यर्थ्ये धत्तो दधाते खळु p एतदीयमेव सुहछब्धमनयोयाचितं मण्डनं ` 
+न स्वाभाविकमित्युत्े क्षा??. In the above form the nyaya is found in 
+Tarkikaraksd, page 46:--'तेनायथार्थस्यापे यथार्थानुभवजनितत्बेन यथाः 
+haaa इति याचितकमण्डनकमनीयमेव स््तेर्याथाथ्यंम्‌.” As याचितः 
+मण्डन 1 have met with it in Khandanoddhdra, page 62, and in 
+Kéwyapradipatikd of Vaidyanátha Tatsat, page 17 3. ` 
+
+
+लोष्टप्रस्तारन्यायः ॥ ; ; 
+
+
+| | E 
+| This occurs in Abhinavagupta's comment on Dhwanydloka — - 
+| iii, 16 (page 159) in the following sentence:— ‘तेन छोष्टप्रस्तार- 
+
+
+्यायेानस्तवैचिनयुक्तम » and in the first edition T said that ib — 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eoddoui Gyaan Kosha 
+
+
+could only mean the maxim of an expanse of clods of carth [as 
+in a roughly ploughed field] Regarding however प्रस्तार as ' 
+mislection for प्रस्तर it would mean the maxim of a stone and | 
+a clod of earth, and would be synonymous with अइमलोष्टन्याय 0 
+the dictionaries. Mr. M. R. T'elang ( of the Bombay Hig 
+Court) has however kindly suggested the following, with which 
+I was quite unfamiliar, He says :—“ gs means a pebble | 
+and प्रस्तार a table showing the varieties of metres &e 
+formed by different arrangements of the short and long sy 
+lables in prosody, music &e. The Indians make use of this | 
+process to find out the number of varieties of any number of J | 
+given things. So the meaning of the nyaya can be better ex- 
+plained by the expression the maxim of the process of per 
+mutations and combinations. 
+
+
+It may be asked what लोष्ट (७ pebble) has to do with permuta- 
+tions and combinations. In finding out the number of varieties 
+of any number of given things, a pebble is used for marking 
+certain figures according to the Indian process with the help J 
+of प्रस्तार, खण्डमेरु, agites &७. These processes are well known to | 
+any one conversant with books on Indian music or prosody. — 
+The following references to books on the subject will support 
+my statement. Vide संगीतरल्लाकर Chap. i verses 61 to 69 (pages - 
+51-60 ); संगीतदुर्पण Chap. i ver. 144 to 154.” 
+
+
+at सांशयिकान्निष्कादसांशयिकः कार्षापणः N 
+
+
+Better is a certain káürvshápama than an uncertain mishka 
+This and the proverb immediately following are found in the 
+second chapter of Vatsyayana's Kámasútra ( page 19 ), and 
+are the equivalents of our saying “A bird in the hand is wortl 
+two in the bush,” 
+
+
+वरमद्य कपोतः श्वो मयूरात्‌ di 
+Better is a pigeon to-day than « peacock tomorrow, Se 
+
+
+above, 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+45 
+
+
+विपुलकदलीफललिप्सया जिह्वाच्छेदनम्‌ ॥ 
+
+
+> Cutting off the tongue while trying to get a fine plan: 
+This is found in the Pürnaprajna section of Sarvadarsian 
+samgraha (page 64 of Bib. Ind., and 75 of Jivánanda's ed 
+as follows:—“‘ug च परमेश्वराभेदतृष्णया विष्णोगुणोस्कर्पस्थ स्रातृष्णिकासम- 
+त्वाभिधानं विपुलळकदलीफललिप्सया जिह्याच्छेदनमनहरत्येतादश विष्णुविद्वेषणा- 
+दन्धतमप्तप्रवेशप्रसड्ञात्‌ uq Prof. Gough renders it thus:—“ Thus 
+the statement of those (Advaita-vidins) in their thirst to be — 
+one with the Supreme Lord, that the supreme excellence of 
+Vishnu is like a mirage, is as if they were to cut off them 
+tongues in trying to get a fine plantain, since it results that 
+through offending this supreme Vishnu they must enter into the — 
+hell of blind darkness.” 
+
+
+विषकृमिन्यायः ॥ 
+
+
+| Ápte's Dictionary alone gives us this nyaya which he descr: 
+as follows:—“It is used to denote a state of things 
+though fatal to others, is not so to those who, being bred i si 
+are inured or naturalized to it.” In this case it might represe 
+
+
+| gives no reference to a passage where the maxim 
+I am indebted for one to that veritable raindkara, 
+
+
+tion from Vriddha-Canakhya, a work which appears. 
+in MS. only. It runs thus:— 
+
+
+विप्रास्मिन्नगरे महान्कथय कस्ताळद्रुमाणां गण 
+को दाता रजको ददाति वसनं प्रातगृह्दीत्वा निशि । 
+को दक्षः परदारवित्तहरणे udis दक्षो जनः 
+कस्माजीवसि हे सखे विषकृमिन्यायेन MAKATA ॥ 
+
+
+Digitized By Siddhanta eGafk iri Gyaan Kosha 
+
+
+Freund? Ich lebe nach Art des Mistkáfers ( d. i. Ich suche l | 
+Beste heraus )" If this is correct, the nyaya must be eX. 
+pressive of “living in clover,” or, amidst “marrow and fat- | 
+ness!” | 
+
+
+4 
+
+
+i 
+हे Ü 
+विषवृक्षन्यायः ॥ | 
+
+| 
+
+
+The maxim of the poisonous tree. This appears to be based | 
+on the second half of Kumdrasambhava ii 55 ( or Pancas 
+tantra i, 245), which runs thus:—''fawgensft संवर्ध्ध ey 
+छेत्तुमसाम्प्रतम्‌. /? “It would be improper to cut down even a | | 
+poisonous tree, after cultivating it oneself.” This is usedasa | 
+maxim by the author of Khandanakhandakhddya ( page 727). 
+in the following sentence :— एते सर्वे तर्काः...अस्माभिरेव तर्कपदव्यामः | 
+भिपिक्तास्ततो न प्रबन्धेन निरस्यन्ते “ विपवृक्षो5पि संवध्ये स्वयं छेतुमसास्मत- । 
+मिति? १? There is another capital instance of it in Upamiti: — 
+bhowaprapaned Kathé, page 715:—“ हा हा भयेद॑ नो चारु कृतं 5 
+यत्सुतभत्सनम्‌ | विपत्रृक्षोऽपि HA स्वयं छेत्तुमसाम्प्रतम्‌ ” ॥ 
+
+
+वीचीतरङ्गन्यायः ॥ 
+
+
+The maxim of wave-undulation. This is used by the author । 
+of the Bhdshdpariccheda ( verses 165, 166 ) to account for ' 
+the production of sound. He says—‘ सर्वः शब्दो नभोवृत्तिः aa 
+त्पन्नस्तु Tad । वीचीतरङ्गन्यायेन तदुत्पत्तिस्तु कीर्तिता | कदम्बको रकन्याया 
+पत्तिः कस्प्रचिन्मते ?? ॥ Almost the same words are used by Vedánti 
+
+
+Mahadeva (latter part of 17th century ) in his comment on 
+Sdnkhyasiira V. 108:- किंतु शब्द एव वीचीतरङ्गन्यायेन कदस्बसुकुलन्या 
+
+
+येन वा maa गतः paupe». “But sound comes to the seab 
+of hearing in the same manner as the undulating waves [of 
+water], or as the anthers of a [globulous] Kadamba-flowe ; 
+and is thus apprehended by the ear.” ‘The translation, is Di 
+R. Garbe's, 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha . 
+
+
+47 
+
+
+वृद्धकुमारीवाक्यन्यायः ॥ 
+
+
+The maxim of the request of the aged spinster. This ts re- 
+corded in Mahdbhdsya 8. 2.. 8 as follows:—‘‘ayzar बृद्धकेमारी- 
+वाक्यवदिदं द्रष्टव्यम्‌ AAA बृद्धकुमारीन्द्रेणोक्ता वरं ब्रणीप्वेति सा वरमव्रणीत 
+पुत्रा मे बहुक्षीरथ्वृतमोदनं कांस्यपात्र्यां शुञ्जीरन्निति। न च तावदस्याः पतिर्भवति 
+कुतः पुत्राः कुतो गावः कुतो धान्यम्‌ | तत्रानयैकेन वाक्येन पतिः पुत्रा गावो 
+धान्यमिति स्व संगृहीतं भवतिः ॥ This would be applied to a 
+sentence having a variety of meanings. In Tantravartiku 2 
+2 (page 452) we meet with it as वृद्धकुमारीचरप्रार्थनः. and in the 
+Pandit for December 1867 ( page 156 ) we find exactly the 
+same kind of thing under the heading वृद्धबाह्मणवरन्यायः. This 
+worthy was not only old but blind, and his request was “zatia 
+राजसिंहासनस्थितमीक्षितुमिच्छामीति.? 
+
+
+वृद्धिमिष्टवतो मूलमपि ते WE ॥ 
+
+
+Wishing to grow, you have destroyed your root. This is Prof. 
+Cowell’s rendering of the saying as it appears in the Sarva- 
+dars‘anasangraha ( page 27 Bib. Ind. p. 33 Jivananda ):— 
+“तथा च वृद्धिमिष्टवतो मूलमपि ते नष्टं स्यादिति महत्कष्टमापन्नमू'? । [1 | 
+the Vdcaspatyam, however, we haye the literal and more usu- 
+al meaning of the nyaya, namely “Whilst seeking to obtain; 
+interest, the creditor loses [that and] the capital too.” 
+“afgfieadt मूछमपि विनष्टमिति न्यायः । वृद्धिधनप्रयोगे$धमणोत्म़ाप्यांदा- 
+भेदलाभः। तामिष्टवत उत्तमणेस्याधमणंदोष्ट्यायथा मूलं नऱ्यत्येवं यत्राभीष्टान्त- 
+रसंपादनाय प्रयतमानस्य मूल नश्याति तत्रास्य Tata”? See also Khanda- 
+makhandakhâdya, p. 31; Pancadas’t, vii. 81; Vedantakalpa- 
+taru, page 821; aud Syddvddamanjart, page 19. An amu- 
+sing illustration of this saying is found in Kuvalaydnanda, 
+under the figure विषमः ` इष्टाथसुदिरय किचित्कमोरड्यवतो न केवलसिष्ट- 
+wale: किन्तु ततो5निष्टस्यापि प्रतिलुंभश्वेत्तदपि विषसम्‌ । यथा सक्ष्यप्रे 
+
+
+प्सया सपैपेदिकां qut प्रविष्टस्य मूपकस्य न केवलं सक्ष्यालाभः किन्तु स्वरूपः 
+CC-0. Prof. Satya Vrat Shastri Collection 
+
+
+Digitized By Siddhanta ci bti Gyaan Kosha 
+
+
+तन्ता महिषीं हन्ति.” 
+
+
+शरपुरुषीयन्यायः ॥ 
+
+
+The maxim of the man and the arrow. Vardhamina ex- 
+plains this, as follows, in his comment on Ganaratnamaho 
+dadhi ii. 196:-—“ रश्च ea: aaa पुरुष उत्थितः स तेन हतः। ' 
+aga शरपुरुपीयस्‌ ?? ॥ An arrow is discharged from a bow, and | 
+at the same moment a man rises up from behind a wall and is | 
+killed by it. It illustrates, therefore, a purely accidental and | 
+unforeseen occurrence, and must be classed with the AMAA, ५ 
+खल्वाटबिल्वीय, and others of a like nature. 
+
+
+शर्करोन्मज्जनीयन्यायः ॥ 
+
+
+The maxim of the pebble and the [man’s] emerging [from 
+the water ] This, like that immediately preceding, is found in 
+Vardhamana’s work, and on the same page. He explains it 
+thus :— शर्करा च क्षिप्ता पुरुषस्य चोन्मजनं तत्तुल्ये शकंरोन्मजञनीयम्‌ d 
+At the moment that the pebble is thrown, a man who has been 
+
+
+cabegory. 
+
+
+शिरइछेदे$पि शतं न ददाति विंशतिपश्चक॑ तु प्रयच्छती 
+शाकटिकन्यायः ॥ j 
+
+
+The maxim of the carter who would be beheaded ratl 
+
+
+than pay a hundred; but will at once give Ri 
+i 
+CC-0. Prof. Satya Vrat Shastri Collection: five 2५०१८ 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+49 
+
+
+occurs in the Pürnaprajna section of Sarvadars' anasangraha, 
+( page 71 of Bib. Ind. and page 88 of Jivánanda's) as follows:— 
+“ag प्रपञ्चस्य मिथ्यात्वमभ्युपेयते नासत्त्वमिति चेत्तदेतत्सोड्य शिरइछदेडपि 
+शतं न दंदाति विशातिपञ्चकं तु प्रयच्छतीति शाकटिकवृत्तान्तमनु हरेन्मिथ्यात्वा- 
+aan: पर्यायत्वादित्यलमतिप्रपक्ञेन?? ॥ “If you say that you accept 
+the falsity of the universe, but not its unreality, you are 
+simply acting like the carter who would lose his head rather 
+than pay a hundred pieces of money, but at once gives five 
+score! For falsity and unreality are Synonymous, But enough 
+of prolixity." 
+
+
+It is found also in Atmatattvaviveka ( page 31 ), from which 
+Madhava probably took it. In Tattvamuktákalápa ii. 71 (page 
+244) ib takes the form of ** शतमदित्सतः आातार्धेद्वयदानस्‌??, and there 
+is still another variety of it in Khandanoddhéra, page 74, 
+namely «“शिरइछेदेडपि काकणीं न ददाति पञ्चगण्डकांस्तु ददाति.?* Compare 
+with this the following from Nydyamanjari, page 432:—« अथो- 
+च्यते न प्रत्यक्ष आत्मा किंत्वपरोक्ष इति नेदमर्थान्तरवचनं शिशव एवं प्रतार्यते 
+न प्रामाणिकाः” ॥ 
+
+
+ANN Sor. zq A च 
+शाष सपा दशान्तर वच्यः ॥ 
+A snake in the head, and the doctor in another country ! 
+This occurs, in Prákrit, in Kurpiramanjart iv. ( page 100 ). 
+It is found in somewhat similar form in Mudvdrdkshasa i. 21, 
+
+
+also in Prákrit. The chhdyd is as follows. “उपरि घनं घनररितं 
+दूरे दयिता किमेतदापतितम्‌ | हिमवति दिव्योषधयः शीर्षे ad: समाविष्ट:” ॥ 
+
+
+शुकनलिकान्यायः ॥ 
+
+
+The maxim of the parrot and the Nalikd-tree, Illustra- 
+tive of causeless fear. In Udyoga-Parva xevi. 42 we read 
+“ काकुदीकं झुकं नाकमक्षिसंतर्जनं तथाः? । on which the commentator 
+Nilakantha says —  काकुदीकमित्यादयो5टावखजातय: ।...येच शुकन- 
+
+
+डिकान्यायेन sr was IR MARU शिष्यन्ति qum 
+7 = 
+
+
+Digitized By Siddhanta fe Gyaan Kosha 
+मोहनं नाम”? ॥ Ihave met with it also in a MS. (No. 288 
+1882-83 in Deccan College, Poona ) of Navayana’s commentary । 
+on Gopdlottaratapanitya-Upanishad 8 ( corresponding with 9] | 
+and 22 of Bib. Imd. edition ), where, expounding the words - 
+“ यो हि वे कामेन कामान्कामयते &८.” he says:— “ वास्तव aid | 
+बन्धमोक्षादिकमात्मनो नास्ति किंतु स्वकामपरिकल्पितं झुकनलिकान्यायेन ” E 
+
+
+झङ्गम्ाहिकान्यायः ॥ 
+
+
+The maxim of seizing oven by their horns, That is, by way - 
+of specification, and not in the sense of our proverb ‘Taking | 
+the bull by the horns! This is very clearly put in Rama 
+krishna’s commentary on S'ankaránanda's Átmapwrána, iv. 
+561-2. The text runs thus :—“ are चान्न प्रवृत्त. सत्प्रवृत्ति कुरुते 
+द्विधा । विधानेन निषेधेन लोकदृष्टिसमाश्रयात्‌ ॥ ५६१ ॥ RREA यदि 
+बोधयेत्तद्धिधायकम्‌ | यथा लोके करे तेऽस्ति फलमित्यादिभाषणम्‌ ॥ ५६२॥ › 
+On the latter verse, Ramakrishna says :—“za विधायकशास्रस्य 
+लक्षणं लौकिकसुदाहरणं चाह wee । शृङ्गस्य म्हणं यस्यां क्रियायां सा इङ्गः 
+ग्राहिका | संज्ञायामिति ण्वुल्‌ । Pan. 3. 3. 108-9 ) । यथा गोव्रजे का मदीया 
+गौरिति गोपः ge: शृङ्गं गृहीत्वा गां ग्रदर्कयेत्तथाबोधर्कं शास्त्र विधायकसुच्यः | 
+ते” ॥ So too, in Sures'vara's vartika on Brihadaranyakopam- — 
+shadbhdshya 1. 4, 866:—“ शाड़ग्राहिकया श्रुत्या ब्रह्मतापोदिता स्फुटम्‌ 5, 
+on which Anandagiri says:— यथा गोमण्डलस्थां गां ae गृहीत्वा 
+विशेषतो दर्दायत्येषा बहुक्षारेति &c" The same sense is attached to the 
+maxim in Nilakantha on Udyoga-Parva xv. 9 (f “मदो 5ष्टादशदों 
+a स्यारपुरा योऽप्रकीर्तितः?) where we read :--““अप्रकीर्तित इति दमविरो 
+धिन एव प्रातिकूल्यादयो मददोपत्वेन सूचिता अपि झज्ञग्नाहिकया sau 
+विधिमुखेन न प्रोक्ता इत्यर्थ:?॥ A fourth instance of the employment 
+of this maxim in the same sense is found in the metrical com- 
+ment on S'ándálya-sütra, 87:—“a तावत्समवायेन भेद्संबन्धगोरवात्‌ | 
+शब्दानां समयोऽप्येवं झज्ञम्राहिकया eus" The passage is translate 
+by Prof. Cowell as follows:—* It will not do to hold that 
+
+
+the connexion between tl its eff that 
+ee 3200 950 ve afe. addis effect may be th: 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+51 
+
+
+called ‘Intimate relation,” and not that called « Identity, — 
+because it is a much more cumbrous assumption than ours and 
+involves the connexion of ‘difference ; and by our own we easi- 
+ly get at the true meaning of the various S'ruti passages,— 
+seizing them one by one, as oxen by their horns" In a foot- 
+note he adds :—* That is, such passages as * Uktha is Brahman, 
+'Prána is Brahman’ &c. S'ringagrahikdnydya is a proverb 
+sometimes explained as 'catching an unruly bull first by secur- 
+ing one horn and then the Second, and sometimes, “driving 
+many oxen into a stall, by seizing them one by one by their 
+horns, In Bhdmaté 3. 2. 22 ( page 566 ) we have the phrase 
+again :— यथा यवादृयो विषयाः साक्षाच्छक्ग्राहिकया प्रतिपाद्यन्ते प्रती- 
+यन्ते च नेवं ब्रह्म” ॥ Mr. F. W. Thomas has pointed out to me the 
+शीर्षग्रहणन्याय which is quoted in the commentary on Dandin's 
+Kdvyddars'a ii. 368. I think its usage must be similar to that 
+of the above. 
+
+
+३येनकपोतीयन्यायः ॥. 
+
+
+The maxim of the hawk and the pigeon. Vardhamana, in 
+Ganavatnamahodadhi iii. 195, explains it in the following 
+way —“ इयेनकपोतयोरिव इयेनकपोतीयो gata: | यथा कपोतो5तर्कितमाग- 
+तेन इयेनेन ग्रहीतस्तथाकस्मिको यो gui: स एवमुच्यते?? ॥ This must be 
+classed therefore with शरपुरुषीय and others of a similar kind. 
+We have a इयेनकपोतीयमुपाख्यान given in the table of contents 
+which forms the opening part of the Mahábhórata, and the 
+story will be found in Vanaparva excyi. "There is another in 
+chapter exxxi. 
+
+
+श्वथ्ूनिगच्छोक्तिस्यायः ॥ 
+
+
+The maxim of the mother-in-law who said, “Be of This 
+quaint illustration appears day Sueesnaaw Solvertshkarmyasiddhs 
+
+
+59 
+
+Digitized By Siddhanta ee Gyaan Kosha 
+
+i, 98, as follows :--“अभ्युपगताभ्युपगमाच्य खश्रूनिर्गच्छोक्तिवळधवतो f 
+योजनः WaT ॥ “And since you now express 
+that which we also acknowledge, your protracted discussion 
+was as unreasonable as was the mother-in-law’s Saying | to the 
+mendicant] ‘Be oft" The commentator, Jnanottama, ey- 
+plains this in the following manner :-—< 'सिक्षामठते माणवकाय भिक्षां | 
+प्रत्याचक्षाणासात्मनः स्नुपां भर्त्सयित्वा "IT: पुनस्तमाहूय समागते तस्मित्रास | 
+भिक्षा निर्गच्छेति तथैव प्रत्याचरे? ॥ “After 
+law for refusing to give alms to 
+
+
+E 
+agreement with 1 
+= 
+
+
+abusing her daughterin- 
+a wandering mendicant, the 
+
+
+mother-in-law called him back, and, when he had come, said to I 
+
+him, “There are no alms, be off? thus refusing also herself!’ | 
+
+1 
+
+Á | 
+सिहावलोकनन्यायः ॥ 
+
+
+The maxim of & lion’s glance. This is based on a lions 
+habit of looking in front and behind, after killing its proy, to ji 
+see if there is any rival to dispute possession! It is | | 
+says "láránátha, where a word in a sentence is connected with | 
+what precedes and with that which follows it. It is’ not, how- 
+ever, restricted to this. The expression occurs four times in the — 
+Lwittiriya-Pratis'ékhya, namely in ii. 51, iv. 4, xiii, 3 and 15. 
+Prof. Whitney remarks as follows on the first instance of its 
+occurrence :—“ The ‘and’ of this rule [ वर्गवच्चेषु ], the commenta- ही 
+tor says, brings forward, on the principle of the lion’s look’ (a 
+distant glance backward ) the already defined organs of pro- 
+duction of the various mute Series" It is found also in Nila- 
+kantha’s comment on Vanaparva cexxi. 1 ( गुरुभिनियमेजीतो भरतो 
+नास पावकः) :— सिंहावलोकनन्यायेन stat: पोन्नमूजपुत्र॑ भरतं स्तौति सा” 
+YA गुरूमिरितिः? ॥ It was a favourite maxim of Vácaspatimis as 
+and I have met with it eight times in 
+occurs in Bhdmatti 2. 3. 6 
+mudi, 7 ( page 36 ) and in 
+97, 199, 230, 322, 403, 405. 
+found in Hemach andra’s Par 
+न्यायेनालीढः 
+
+
+three of his writings. n 
+( Page 473 ); in Sankhyatativaka- 
+Nydyavdrtika-tétparyatthé, pages | 
+An example of a different kind is 
+is ishtaparvan, i. G3:—< “स्िहावलोकनः 
+क्षत्रतेजसा | प्रत्यक्षानिव सोऽद्राक्षीत्तानमात्यान्ुल द्विपः (E 
+CC-0. Prof. Satya-Vrat Shastri Collection. § 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+53 
+
+
+सूचीकटाहन्यांयः ॥ 
+The maxim of the needle and the boiler. Ib is explained as 
+follows in Molesworth’s Marathi dictionary :—“ A phrase used 
+as an illustration upon the occasion of two matters of which the 
+one is superlatively simple and easy, or altogether insignificant, 
+and the other indefinitely greater, more difficult, or more im- 
+portant, arising at once to be done ; and of which it is intended 
+to intimate that the trifling one should be despatched first.” Tt 
+occurs in the opening part of chapter iv of Kdvyapraditpa, and 
+again on page 70. Also in the commentary on Sthityakawmudt 
+iv. 1, where the same kdrikd is expounded. The following is 
+from the Saptapaddrthi, page 21. The text runs thus:— 
+८“ अनुभवोडपि द्विविधः । म्रमाऽप्रमा च । अप्रमापि संशयो विपर्ययश्च । प्रमा 
+प्रसक्षमचुमितिश्च ” ॥ On which the commentator remarks :— s- 
+मानिरूप्यत्वात्परस्ताद्विभक्तामप्यप्रमां सूचीकटाहन्यायेन प्राग्विभजतेञप्रमापी- 
+f n There is another good example of the maxim, witha 
+lucid translation by Dr. Ballantyne, in the introduction to Book 
+ii of his Aphorisms of the Nydya. 
+
+
+स्थालीपुलाकन्यायः ॥ 
+
+
+The maxim of the rice in the cooking-pot. * In a cooking-pot 
+all the grains being equally moistened by the heated water, when 
+one grain is found to be well cooked the same may be inferred 
+with regard to the other grains. So the maxim is used when the 
+condition of the whole class is inferred from that of a part.” 
+(Aptes Sanskrit Dictionary). It is therefore equivalent to * Ez 
+uno disce ommes.” Patanjali seems to have laid the foundation 
+of the nyaya in the following words, in Mahdbhdsya 1. 4. 23 
+( vart. 15 ):—“ qaidi aa: पुलाकः स्थाल्या निदशेनाय-? Then we 
+find it in Jaimini 7. 4. 12, the stéra with a portion of S'abara's 
+bhásya being as follows — “ छिङ्गस्य पूवेचत्वाचोदनाराऽद्सासात्यादेके- 
+नापि निरूप्येत यथा स्थालीपुलाकेन ॥ ...... एतन््यायपूर्वकं लिङ्गमेकत्रापि T- 
+इयमान तुल्यन्यायानां सवेषां धर्मवत्तां ज्ञापयति | यथा स्थाल्यां जुल्यपाकानां 
+
+
+` ` Ta - 2 
+पुळाकानामेकसुपस्य़ान्यपामुपि, सि ASA f cdhection. पु 
+
+
+* 50; Nydyamakarandatikd, pp. 201, 215; and Khandanoddhara, — 
+pages 58, 62. WE 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+Other instances of its occurrence are Tantravdrtika 3. 5, 19; | 
+Vedántakalpataru, page 446; Kalpataruparimala, pages 115, | 
+468, 667, 685 ; and Tuttvamuktdkaltpu, 293. Of similar im: . 
+port is the following line from Hemachandra’s Parisistaparva 
+vii, 94:--“सिक्‍थेनापि द्रोणपाकं जानन्ति हि मनीपिणः” ॥ 
+
+
+स्थूणानिखननन्यायः ॥ 
+
+
+The maxim of the driving in of a post. Asa post is driven 
+into the ground by repeated efforts, so a position is strengthened |. 
+by the bringing forward of a succession of facts or arguments, It 
+occurs three times in S’ankara’s bháshya on the Vedantasdétras, 
+as follows:—“daa जगजन्मादिहेतुत्वमीश्वरस्याक्षिप्यते स्थूणानिखननन्या- 
+येन प्रतिज्ञातस्यार्थस्य इढीकरणाय” 2, 1, 84. “आक्षेपपूर्विका हि परिहारो- 
+क्तिविवक्षितेऽथे स्थूणानिखननन्यायेन eet बुद्धिसुत्पादयति?8, 3. 58. “सलं 
+प्रसाधितं तस्यैव तु स्थूणानिखननवत्फलद्वारेणाक्षेपसमाधाने क्रियेते दाढ्याय ” 
+
+
+3.4.2, But S'abara seems to have originated it in his bhashya 
+on Jaimini 7, 2. 1. 
+
+
+हळ sical 
+
+
+स्वाङ्गं स्वव्यवधायंक न भवति ॥ 
+
+
+One's own body does not hinder one. It is found at the end | 
+of the Akshapáda section of the Sarvadars‘anasangraha, 88 | 
+follows :—“a च स्वातश्यभङ्गः शङ्कनीयः स्वाङ्गं स्व्यवधायकं न भवतीति s 
+न्यायेन प्रत्युत तन्निवीहात्‌ ” “Nor need you object that this would | 
+interfere with God's own independence [as He would thus seem — 
+to depend on others’ actions ] since there is the well-known 
+saying, ‘One’s own body does not hinder one; nay rather it 
+helps to carry out one’s aims.” This is Professor Cowell’s trans: 
+lation. 
+
+
+Other instances of its employment are Bhamats 3. 4 20. 
+(page 682); Pdtparyatikd, pp. 72. 90; Larkikaraksdtika, page 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+————— 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+लोकिकन्यायाञ्जलिः ॥ 
+
+
+हितीयो भागः ॥ 
+A SECOND HANDFUL OF POPULAR MAXIMS 
+
+
+CURRENT IN SANSKRIT LITERATURE, 
+
+
+fOLLECTED BY 
+Colonel G. A. Jacob, 
+INDIAN ARMY. 
+Author of “ Concordance to the Principal Upanishads,” “ Manual 
+
+
+of Hindu Pantheism,” &e., dc, 
+
+
+SECOND EDITION—REVISED AND ENLARGED. 
+
+
+PUBLISHED BY 
+
+
+TUKARAM JAVAJI, 
+PROPRIETOR “NIRNAYA-SAGAR” PRESS. 
+
+
+only: 
+
+
+1909. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+B 
+
+
+[All rights reserved by the Publisher. ] 
+
+
+Registered under the Act X XV of 1867, 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+PREFACE TO THE SECOND EDITION. 
+
+
+The issue, in Benares seven years ago, of an' edition of 
+Raghunathavarma’s Laukikanydyasangraha, has made ib un- 
+necessary to reprint the Preface to the former edition of the 
+present Handful, seeing that a good part of it was devoted to a 
+description of that then-unpublished treatise. For the same 
+reason I have omitted the appended list of nyayas contained 
+in Raghunatha’s work, and which, at no small expenditure of 
+time and toil, I compiled from the two MSS. in the India 
+Office Library. 
+
+
+The whole of the explanatory matter attached to the 
+nyayas has been thoroughly revised for this edition, and, in 
+some cases, has been re-written. In addition to this the book 
+will be found to contain thirty-two new nyayas, some of them 
+of considerable importance, and all of them more or less interest- 
+ing. The six Systems seem to be the most attractive part 
+of the field for the study of similes of the class which predomi- 
+nates in these pages; but grammatical commentaries also, 
+appear likely to prove a not unfruitful field to the painstaking 
+explorer. 
+
+For the reasons given in the preface to the Third Handful 
+I would gladly have seized this opportunity of eliminating the 
+word ‘Maxims’ from the titlepage; but it was not politic to 
+
+
+change the name adopted ten years ago and repeated in each 
+new issue. 
+
+
+It is not probable that this will pass into a third edition 
+during my lifetime; but I trust that in its present form it may 
+prove helpful to young students whose reading has not bene 
+quite so wide as my own. 
+
+
+REDHILL, SURREY, 6 A JACOB. — x 
+23 Sept. 1909. D AU E. 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+ee क, TIT वात 
+
+
+21५ -२« ET ae तरच. 6 ५. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+hist of additional authors quoted in the 
+following pages. 
+
+
+— 94,00 —= ^ 
+
+
+Ayamapramanya of Yamunacarya Swamin (Ramanuja's Para- 
+maguru =guru’s guru); Medical Hall Press, Benares 1900. ° 
+
+Atmabodha of S'ankarücarya, edited, with Commentary, by 
+Fitzedward Hall; Mirzapur, 1852. 
+
+Atmatalivaviveka of Udayana, with four Commentaries; Bib. 
+Ind. Series, Part i, 1907. See also First Handful. 
+
+Bodhicarjavatüra of S'antideva, with the Com. of Prajna- 
+karamati, edited by Prof. L. de la Vallée Poussin; Bib. Ind. 
+Series, 1901-1907. Incomplete. 
+
+Gaudapada's karikas on Mandukya-Upanisad ; Anandás'rama 
+Sanskrit Series, Poona, 1890. 
+
+Indiam Thought, a quarterly Magazine edited by Dr. G. Thi- 
+baut and Prof. Ganganatha Jhà ; Allahabad, 1907. 
+
+Kirandvali ot Udayana, on Prasastapadas bhasya; Benares 
+Sanskrit Series, 1885 and 1897. A mere fragment. 
+
+Kirtikaumudi of Somes'varadeva, edited by Abaji Vishnu 
+Kathavate ; Bombay, 1883. E 
+
+Laukikanydyaratnakare of Raghunathavarman; India Office 
+MS. 582. - 
+
+
+Madhyamakavrilti of Candrakirti on Naganjunas karikas, — 
+
+
+edited by Prof L. dela Vallée Poussin; Bibliotheca Bud- 
+
+dhica, St. Petersburg, 1903-1907. Incomplete. 
+Mahabhdsyo with the Pradipa of Kaiyata, and Nagesas 
+
+Uddyota; edited by Mahamahopadhyaya Pandit Sivadatta 
+
+
+D. Kudala; vol. i (Navahnika) Nirnayasagar Press 
+
+
+1908. A fine edition. 
+Mahabhisyapradipoddyota of Nāgesa Bhatta, in cours 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddharta Béahgdif fai Kosha 
+
+
+publication in Bib. Ind. Series, Calcutta; Vols. i and ii; 7 E 
+part of iii, already issued. | 
+
+Medini, a dictionary of homonymous words, edited by Soma. | 
+nath Mukhopadhyaya ; Calcutta, 1869. 
+
+Nitis‘ataka of Bhartrihari; Nirnayasigar Press, Bombay, 
+Samvat 1947. 
+
+Nyayadipavali of Anandabodbacarya, published together with 
+Nyayamakaranda in Chaukhamba Sanskrit Series, Be- 
+nares, 1907. 
+
+
+| 
+
+
+| 
+| 
+i 
+Nydyamalavistara of Mādhavācārya; Anandas'rama Sanskrit | 
+Series, 1892. i i 
+Nyayamanjarisara, a Commentary on Nydyasiddhantaman- | 
+jari; The Pandit, 1907. | 
+Nydyasiddhanjana of Venkantanath (of Ramanuja’s School); । 
+Medical Hall Press, Benares, 1 901, 
+Pancapadikévivarana of Prakis'itma Yati ; Vizianagram San- 
+skrit Series, Samvat 1948. र 
+Paramarthasdra of S'esha; Lucknow, 1876. 
+Paribhasendws'ekhara, Text and translation; Bombay San: 
+skrit Series, 1868— 74. 
+Prabandhacintamani of Merutunga ; Bombay, 1888. Transla- 
+tion by Mr. C. H. Tawney; Bib. Ind. Series, 1901. 
+Pramanamala of Anandabodhacirya, published with Nyaya- 
+dipavali, as above. 
+
+
+Sahityadarpana of Vis vanatha Kavirüja, edited by Dr. Roer; - 
+Bib. Ind. 1851. Translation by Dr, Ballantyne and Mr | 
+Pramadadasa Mitra; Bib. Ind. 1875, B 
+
+Salikd, or Prakaranupancikd, a treatise on Mimamsa accord- 
+ing to the school of Prabhakara, by S‘alikanatha ; Chau- - 
+khamba Sanskrit Series, 1903. Originally published in 
+the Pandit, 1866—7. Portions of the work are missing, 
+
+
+Sambandhavartika of Sures varücarya, translated by S. Venka- 
+
+
+Se o eA Medical, य्यक, 1905. - 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+LIST OF BOOKS. VIL 
+
+
+Sarvarthasiddhi, Venkatanütha's vritti on his own work Tat- 
+tvamuktaikalapa, for which see First Handful of Maxims. 
+
+S'lokavaviika of Kumirila, with Parthasarathis tika; 
+Chaukhamba Sanskrit Series, Benares, 1898. Translation 
+by Prof. Gangünath Jha; Bib. Ind. Series, 1907. 
+
+S’ribhdsya of Rümünuja, with Sudars'anücürya's tika, reprinted 
+from the Pandit, 3 vols. 1889-91. An edition of the text 
+only, edited by Rev, J. J. Johnson of Benares, is now 
+nearing completion in the Pandit. Translation by Dr. G. 
+Thibaut in Sacred Books of East Series, 1904. 
+
+Tarkabhdsa of Kes'ava Misra, with the tika entitled Nyaya- 
+pradipa of Vis'vakarman ; Medical Hall “Press, Benares, 
+1901. : 
+
+Tattvabindu, a treatise on Mimimsa, by Vacaspati Misra; 
+Medical Hall Press, Benares, 1892. 
+
+
+Tativadīpana of Akhandananda Muni, a commentary on Pan- 
+capadikivivarana ; Benares Sanskrit Series, 1902. 
+
+Vaiydsikanydyamala on the Vedantasutras; Anandas‘rama 
+Sanskrit Series, Poona, 1891. 
+
+Vakyapadiya of Bhartrihari, kandas i and ii, Benares Sanskrit 
+Series. 1887. An edition of kanda iii, otherwise styled 
+Prakirnaka, has been commenced jn the same Series. 
+
+Vedantaparibhasa, with the Stikhamant and the tika of 
+Amaradiisa; Venkates'vara Press, Bombay, 1 901. Trans- 
+lation of the Paribhas& by Mr. A. Venis in the. Pandit, 
+1882—85. 
+
+Vidhirasiyana, a work on Mimamsa, by Appai Diksita ; Chau- 
+khamba Sanskrit Series, 1901. 
+
+Vishnu Purdna, with Sriratnagarbha Bhatta's Candrika en- 
+titled Vaisnavākūta ; Krishna Sastri Gurjara’s Press, Bom- 
+bay. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+CORRIGENDA. 
+
+
+Page 26, line 8. For “ts” say “as”. Thisunsightly error crept 
+in after the corrected proof had left my hands ! 
+
+Page 28, line 16. For दुग्धा read great. 
+
+Page 30, line 11 from bottom, After ay insert INTIR. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+A SECOND HANDFUL OF POPULAR MAXIMS. 
+
+
+CoU EL y 
+
+
+अजातपुत्रनामोत्कीतनन्यायः ॥ 
+
+
+Proclaiming the name of a son before he is born. That is, 
+counting your chickens before they are hatched. The nyaya, 
+in a negative form, is found in the Vydyamanjari, page 345:— 
+Caa व्यापारः क्रियते चाभिधीयते च स किं पूवेमभिधीयते ततः क्रियते 
+पूर्वं वा क्रियते पश्चादभिधीयते युगपदेव वास्य करणामिधाने इति । न ताव- 
+पूर्वम भिधीयतेऽनुत्पन्नस्याभिधानाजुपपत्तेः | न ह्यजाते पुत्रे नामधेयकरणम्‌ di 
+
+
+अणुरपि विरोषोऽध्यवसायकरः ॥ 
+
+
+Even a slight diference [ between two or more things 
+or expressions] establishes the fact [that they do differ, 
+and enables us to discriminate between them]. After ex- 
+plaining the पुष्टलगुडन्याय and nine others of similar purport, 
+Raghunatha 889७:--“पुष्टलगुडन्यायादारभ्येतत्पर्यन्तानां न्यायानां साम्येऽपि 
+यत्किचिद्रिशेषमादायाणुरापे विशोषोऽध्यवसायकर इति न्यायेन भदसिद्धि- 
+भिन्नोदाहरणत्वसिद्धिश्च केषांचिदिति बोध्यम्‌? The nyaya occurs in 
+Mathuranatha’s commentary on the opening paragraph of 
+Atmatattvaviveka (page 19), where, after stating that, accord- 
+ing to the Buddhists, moksa is brought about by the know- 
+ledge of the non-existence of soul, he says :-+ तदुक्तम्‌ । नेरास्म्यरष्टि 
+भोक्षस्य हेतु केचन मन्वते | आत्मतत्त्वाधियं त्वन्ये न्यायतत्त्वानुसारिणः ॥ इति। 
+न च तत्र नैरात्म्यदृष्टिपदं शारीरात्मभिन्नतत्वज्ञानपरसिति वाच्यम्‌ । निरः संसर्गा- 
+भावबोधकतया ताइशज्ञानस्य तदर्थत्वासंसवात्‌ | न्यायमते च मोक्षाश्रयसुख्य- 
+विशेष्यकतया अणुरपि विशेषोऽध्यवसायकर इति ऱ्यायेनात्मविशेष्यकशरीरादिः 
+भिन्नत्वज्ञानस्यैव मोक्षहेतुत्वादिति ध्येयम्‌ .?? 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+39 
+Digitized By Siddhanta eGangotri Gyaan Kosha 2 
+
+
+अत्यन्तपराजयाद्वर संशयोऽपि ॥ | 
+
+
+Better even a doubtful condition of things than a crushing | 
+defeat. This occurs in the Nydyavartekatatparyatika 5. 1, 49 | 
+(page 491 ):- यदि स्वस्य कदाचित्सम्यक्साधनवादिनोऽपि प्रतिभाक्षया. ' 
+स्समाधानं न स्फुरति ततोऽतन्तपराजयाद्वरं संशयो5पीति न्यायेन ama 
+आासेनापि प्रत्यवस्थेयमेवेत्याशयवानाह तेपां साध्वसाथुतायामिति ?॥ On page 
+473 of the same, and in Nydyamanjari, page 620, it appears 
+aS एकान्तपराजयाद्वरं सन्देहः ॥ Tt is not in any of the lists of nyayas | 
+to which I have had access, but Raghunithavarman has two of | 
+the same purport, namely “ मारणाय गृहीतोऽङ्गच्छेदं स्वीकरोति” । 
+( which see below ), and “ मरणाद्वरं व्याधिः 2; and, in Nydyamala- 
+vistara 6. 2. 7. Madhava gives us “प्रधानलोपाद्वरमङ्गलोपः” ॥ All of 
+these seem akin to our “ Half a loaf is better than no bread.” 
+
+
+` अध्यारोपापवादन्यायः ॥ | 
+
+
+The method of illusory attribution followed by its with- 
+drawal. This nyaya belongs entirely to the Vedantists, but I | 
+follow Raghunatha in admitting it here. The two terms are | 
+explained as follows in the Vedamtasara:—"lllusory attribu- | 
+tion is the attributing to the real of that which is unreal; asa | 
+snake is imagined in a rope which is not a snake." “The with- | 
+drawal is the assertion that the whole of the unreal, beginning | 
+with Ignorance, which is an illusory effect of the Real, 1810- | 
+thing but the Real; just as a snake, which is the illusory effect | 
+of a rope is nothing whatsoever but the rope.” This 3 
+is from my Manual of Hindu Pantheism, pages 44 and 88 
+On page 42, there is the following note which includes a quota 
+tion from page 209 of that valuable book A Rational Refut- i 
+tion of Hindu Philosophical Systems:— 
+
+
+“12. Illusory attribution &e. ( adhyiropapanadu ). 
+
+
+In order to describe th i È 
+e pur X x t e 
+CC-0. Prof. Satya ot uabstraetion Brahma, ho teaches 
+
+
+* 
+
+
+Digitized By Siddhanta — | Gyaan Kosha 
+
+
+D 
+
+
+attributes to him, or superimposes on him, certain qualities 
+which in reality do not belong to him, and then afterwards 
+withdrawing them, teaches that the residuum is the undiffer- 
+
+. enced Absolute. When the Vedintins speak of the origin of 
+the world, they do not believe its origin to be true. "This mode 
+of expression they call false imputation ( adhyd@ropa ). Tt con- 
+sists in holding for true that which is false, in accommodation 
+to the intelligence of the uninitiated. At a further stage of 
+instruction, when the time has arrived for propounding the 
+esoteric view, the false imputation is gainsaid, and this gainsay- 
+ing is termed rescission ( apavada ).” 
+
+
+See also a long note on page 172 of the text of the Vedanta- 
+sara. The verse in the Vivekactidamant, there referred to, 
+should be 140 instead of 170. 
+
+
+c 
+अन्धदपणन्यायः ॥ 
+
+
+The maxim of a looking-glass for a blind man. Ti is found 
+in Upamitibhavaprapancé Katha, page 836, as follows:— 
+^ केवलं ज्ञातशास्रोऽपि स्वावस्थां यो न बुध्यते | तस्याकिञ्चित्करं ज्ञानमन्धस्येव 
+सुदर्षणः ” ॥ See also S'esinantacarya on Nyayasiddhantadipa, 
+page 22, line 2. The Laukikanyayaratnakara gives the fol- 
+lowing example-—‘ तदुक्तं वासिष्ठे। यस्य नास्ति स्वयं प्रज्ञा We तस्य 
+करोति किम्‌ । लोचनाभ्यां विहीनस्य दर्पणः किं करिष्यति 2॥ T have no 
+doubt that the reference is to the Yogavasishiha, but the verse 
+is also found in the Hitopades’a (iii, 115). See, too, under 
+अरण्यरोदनन्याय. 
+
+
+अन्धस्येवान्धलय़स्य विनिपातः पदे पदे ॥ 
+One who leans on a blind man will fall with him at every 
+step. This is akin to the saying “Ifthe blind lead the blind, 
+
+
+both will fall into the ditch.” It occurs in Bhamatt ( page 20 ) 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+त On 7१ 
+
+
+4 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+1 M 
+
+
+as follows:—“ योऽयमर्थप्रकाशः फलं यस्सन्नर्थश्वात्मा च प्रथेते स कि जइ ` 
+स्वयंप्रकाशो वा । जडश्चेद्विपयात्मानावपि जडाविति कस्मिन्‌ किं प्रकाशेताविशे. 
+पादिति प्राप्तमान्ध्यमशेषस्य शेषस्य जगतः । तथा चाभाणकः | अन्धस्येवान्धलम्च् 
+
+विनिपातः पढे पदे” ॥ Compare the following expression in Venkata. 
+nitha’s vritti on his Tattvamuktākalāpa iii. 50:— इति चान्स 
+जात्यन्धयष्टिदानोपसं विदुः 7॥ Though not exactly parallel with the 
+nyaya, the following verse of Jayanta's ( page 120 ) will not 
+be out of place here:-— “gerqaifearaa विषमे gf धावता । 
+अनुमानप्रधानेनं विनिपातो न goa: ” 
+
+
+अपराद्धेषोरिव धानुष्कस्य कण्ठाडम्बरः ॥ 
+
+
+Noisy boasting like that of an | unskilful ] archer whose | 
+arrows always miss the mark, This simile occurs in the - 
+
+
+Atmatatteavivelka ( page 49), but was no doubt borrowed | 
+from Magha ii, 27:— 
+^ अनिर्लोडितकार्यस्य वाग्जालं वाग्मिनो वृथा | 
+।नासत्तादपराद्धपां पो MG PAT वाल्गतम्‌ 
+
+
+“The chatter of a talkative man who has no knowledge of | 
+affairs, is as useless as the swaggering of an archer whose i 
+arrows always miss the mark." 
+
+
+अरण्यरोदनन्यायः ॥ 
+
+
+The simile of crying im the wilderness. Used to 
+wasted effort. Molesworth defines it as “A term for unregard-- 
+ed or unavailing complaint or supplication.” The following 
+verse from Namisüdhu's comment on Rudrata’s Kavyalankare 
+viii. 37 includes not only this nyaya but also Raghunatha’s 
+
+
+दवोढतेनन्याय, ऊषरवृष्टिन्याय, श्वुच्छोन्ञामनन्याय, बधिरकणैजपन्याय, and 
+CC-0. Prof. Satya Vrat Shastri Collection 
+
+
+Digitized By Pond eGangotri a Kosha 
+
+
+probably his अन्धदर्पणन्याय; for Dr. Bühtlingk, who quotes the 
+verse as from Pancatantra, gives 'घतो$न्धमुखदर्पेणः as a variant 
+for कृतान्धमुखमण्डना. 
+
+
+अरण्यरुदितं कृतं शवशरीरसुद्गरतितं 
+स्थले कमलरोपणं सुचिरमूपरे वर्षितम्‌ । 
+श्रपुच्छमवनामितं बघिरकणेजापः कृतः 
+कृतान्धमुखमण्डना यदबुधो जनः सेवितः ॥ 
+See also Pancatantra i. 393; Kiranīvali page 5; and Kusu- 
+manjali, vol ii, page 176, 
+
+
+e^ wA em. CS N 
+अथा समथा विद्ानांधाक्रेयत ॥ 
+
+He has the right who has the want, the power, and the wit. 
+This nyaya is found in the Jaimini section of Sarvadars anu- 
+sangraha as follows :--अर्थी समर्थो विद्वानधिक्रियत इति न्यायेन दरः 
+पू्णसासादिविषयावबोधरमेवक्षमाणास्तत्वबोधे स्वाध्याये विनियुञ्जते? ॥ 110- 
+fessor Cowell translated it thus:—“According to the old rule 
+“He has the right who has the want, the power, and the wit; 
+those who are aiming to understand certain things, as the new 
+and full-moon sacrifices, use their daily reading to learn the 
+truth about them.” 
+
+
+The saying is found in a more complete form in Vaiyasika- 
+nyãyamālā 1.3.9, namely, “अर्थी समर्था विह्वाञ्शाख्नणापयुदस्तोऽधि- 
+Bea," which is itself a reproduction of the following passage 
+in S'ankarabhasya 1. 3. 25:—“are ह्यविशेषम्रवृत्तम पे मनुष्यानेवा- 
+घिकरोति शक्तत्वादर्भित्वादपरयुदस्तत्वादुपनयनादिशास्त्राचोते वर्णितमेतद्धि- 
+कारलक्षणे.? Dr. Thibaut renders it thus:—“Lhe Sastra, al- 
+though propounded without distinction (४. e. although not itself 
+specifying what class of beings is to proceed according to its 
+
+
+precepts), does in reality entitle men only ( to act according to — ^ | 
+
+
+its precepts); for men only ( of the three higher castes ) are, 
+firstly, capable ( of complying with the precepts of the S'astra y. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+$ 
+
+
+AT 
+
+
+6 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+are, secondly, desirous ( of the results of actions enjoined by the 
+S'astra'); are, thirdly, not excluded by prohibitions; and are, 
+fourthly, subject to the precepts about the Upanayana cere. 
+mony and so On. This point has been explained in the section 
+treating of the definition of adhikdra ( Pūrva Mimanisi vi. 1) 
+For the last-mentioned, see under अधिकारन्याय in the third 
+Handful This question of अर्थिस्व ७७. will be found also in 
+S'ankarabhasya 1. 1. 4 ( page 54 ); 1. 3. 20, 33, 84; and 2, 2, 10, 
+
+
+अधेवेशसन्याय: ॥ 
+
+
+The similo of the slaying of one half [of a body, whilst 
+the other half is kept alive! ) Raghunàthavarman defines it 
+as follows—" असंभवविवक्षायासर्धवेशसन्यायः | यथा कुक्कुटीमांस भोजन- 
+कामस्तत्सन्ततिकामश्च कश्चिद्यवनस्तङ्वीवादिकं four bm उदरं च aami 
+स्थापयतीति तस्यार्थः” ॥ The nyaya is therefore expressive of absur- 
+dity, contradiction, or incongruity; and so, in some respects, 
+resembles the अर्धजरतीयन्याय. The earliest example, known to 
+me, of the use of the term isin Kumarasambhava iv. 31, where 
+Rati complains that, by destroying Kama, Fate had slain half of 
+herself, The verse stands thus:—“ विधिना कृतमर्धवेशसं ननु मां 
+कामवधे gaat । अनपायिनि संश्रयद्रमे Waa पतनाय agit” N 
+Mallinatha points out that as the slaying of a part involves that 
+of the whole, Rati here announces her own destruction also, as 
+is clearly implied in the second half of the verse. Its employ- 
+ment here by Kalidasa, however, is in a literal sense, whilst 
+the philosophical writers apply it figuratively, 
+
+In the latter part of S’ankar 
+
+
+as bhasya on Brahmasitra 3.3. 
+18 we find the expression “ 
+
+
+न ह्यधेवैशसं संभवाति”, and I have 
+noted it in Tantravartika, pages 84, 89, 97 and 202, The first 
+
+
+of the four passages is the following:—" r&y श्रुतिमूलं न मूला- 
+
+
+न्तरसँभवः | विरोधे त्वन्यमूळ्त्वमिति स्यादर्धवेशसम्‌ ?॥ In this passage, - 
+
+
+as well as in the other three, contradiction o 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+x inconsistency | 
+
+
+i 
+i 
+y 
+
+
+Digitized By Siddhanta =) Gyaan Kosha 
+
+
+> 
+
+7 
+is clearly implicd. So, too, in a passage in Nydyakandals, 
+page 6, line 3; and in Khandanakhandakhadya, page 685. 
+One more example will suffice, namely Brihaddaranyavartika 
+
+न 4 - 6: ¢ $A D : ^ ADA ® ~ > 
+1, 4, 1276:—“ न चाधेवेशसं युक्त तच्वज्ञाने विवक्षिते | संशयो हि तथा श्रोतुः 
+स्यादनिश्चितवाक्यतः ”॥ Anandagiri explains this in the manner 
+stated above by Raghunatha, viz. “ कुक्करादेरेको देवाः प्रसवाय कल्पते 
+NM das A : ESO ; : 
+
+पच्यत देशान्तरमि्र्धवेर तदिहायुक्तं नाह वस्तु ब्रह्म चात्रह्म च तच्वञ्ञानस्य 
+
+विवक्षितव्वाद्विरुद्वस्यातथात्वादित्यर्थः ? ॥ 
+
+
+अलाभे मत्तकाशिन्या दृष्टा तिर्यक्षु कामिता ॥ 
+
+
+Failing to obtain a lovely woman, affection is seen | to 
+have been lavished ] on animals. This very stupid nyaya is 
+expounded by Raghunatha as follows: यत्राधिकाथोलाभे$ल्पार्थ 
+प्रवृत्तिने दोषायेति विवक्षायां तत्रालाभे मत्तकाशिन्या दृष्टा fag कामितोति 
+न्यायः | मत्तकाशिनी umm I have met with it only in the 
+Atmatattvaviveka (page 130) and in Anandabodhücarya's 
+Pramanamala, page 2. 
+
+
+अश्वतरीगर्भन्यायः ॥ 
+
+
+The simile of 6 she-mules being in foal. Raghunatha ex- 
+plains it thus:-—“ नन्वज्ञानकार्यान्तःकरणवृत्त्यात्मकं ज्ञानं कथं स्वकारणी- 
+भूताज्ञाननाशाय स्यादुपजीव्यविरोधादिति चेदश्वतरीगर्भेन्यायादित्यवेहि । बः 
+डवायां गर्दैभादुत्पन्नाश्चतरी तस्या गर्भो यथा तन्नाशाय भवति तथा भवतु 
+ज्ञानमपि स्वहेत्वज्ञाननाद्रायेत्यनवद्यम्‌ ?॥ The following verse, bear- 
+ing on this subject, is found in Hifopadesa, ii. 135, Panca- 
+tantra, ii. 32 and iv. 14:—“ ASEE तु यन्मित्रं पुनः सन्धातुमिच्छति | 
+akata गृह्णाति गर्भमश्वतरी war? As Dr. Peterson points out 
+in his Note on the verse from Hitopades'a, the second line is 
+found in Adiparva (Bombay edn.) os. 83 (not 75, as wrongly 
+printed), and in S’antipurve CXL. 30 (nob 347 as stated). 
+
+
+In a footnote to Indische Sprüche 58, Dr. Bohtlingk quotes - 
+
+
+Nilakantha’s comment on the verse from S‘antiparva—_ 
+CC-0. Prof. Satya Vrat Shastri Collection. - 
+
+
+Digitized By Siddhanta eGahgotri Gyaan Kosha 
+
+
+^ अश्वतरी गर्दैभजाश्वा उदरभेदेनेव प्रसूत इति प्रसिद्धम्‌.” Ol like import 
+are two other nyàyas quoted by Raghunatha, namely कदली- 
+फलबन्याय and वृश्चिकीगर्भन्याय. As to the former of these, compare 
+the following, Vanaparva ccnxvim. 9 ( Bombay edn, = 
+“ यथा च वेणुः कदली नलो वा फलत्यभावाय न भूतयेत्मनः | तथेव मां ते: 
+परिरक्ष्यमाणामादास्यसे कर्कटकीव Tiu" This verse is quoted by 
+Johnson in his Notes on Hitopades'a 11. 147, and he adds, “Tn | 
+the Gulistiin, the Persian poet Saadi declares that the young | 
+of the scorpion eats its way out through the mother's entrails’; , 
+
+| 
+
+| 
+
+| 
+
+
+and in Vedantakalpataru, page 354, line 2, we are told “वृश्रिका- 
+
+
+दिर्मातुरुदरं निर्मिद्य uan. Udayana (in Atmatattvaviveka, 
+page 67, line 9 ) seems to assert the same thing of the crab— 
+" कुछीरस्येव सप्रसूतयुक्त्यापतयेनैव प्रतिहतस्वात्‌ .? 
+(NN 
+आहभुकवतेन्यायः ॥ 
+
+The simile of the opiwm-cater and the fisherman, I haye 
+not met with this in actual use in the literature, but include it 
+on the authority of Raghunathavarmav, whose interpretation 
+of it, however, seems most improbable. The word आहि is said 
+by him to mean “an intoxicating plant, known in the language 
+of the West as Post” E उन्मादकर ओपधिविदोपः पोस्तेति पाश्चात्त्यः 
+भाषायाम्‌”? ). This meaning of अहि is unknown to the lexicogra- 
+phers; but, in Bate’s Hindi dictionary, पोस्त is said to mean 
+“the poppy-plant; an infusion of the poppy formerly much 
+used as a slow poison;” whilst Fallon defines it as “Poppy- 
+head or capsule; an intoxicating drug.” We must take अहि 
+therefore in the sense of अहिफेन which is the original | 
+of the modern अफीम, opium. The story on which the - 
+maxim is said to be based is as follows: अहिभुक्तेवर्तन्यायस्तु | 
+तादात्म्याध्यास एव ज्ञेयः । श्रूयते हि लोके काश्चिदहिभुझावमारुरोह स च तत्र 
+बहुजनसञुदायं दृष्टा केनचिन्मे विनिमयो न स्यादिति धिया स्वपादे रज्जं बद्धा | 
+तन्द्रां ग्राप। केवर्तश्रोपहासार्थ तत्पादात्तां मोचयित्वा स्वपादे बबन्ध । नावि 3 
+पारं गतायामवरोहणसमये5हिभुक्स्वपादे रज्जुमदृष्टा कैवतेपादे च तां दष्टाह | 
+
+स्वहृदि iret केवर्त त्वमहमहं च त्वामिति तेन विवादं ` 
+
+क्तवान्‌ ?॥ This nonsense is meant to teach the identity of 
+the individual with the one Self! ] 
+CC-0. Prof. Satya-Vrat-Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri 3| Kosha 
+9 ine: 
+
+
+आदावन्ते च यन्नास्ति वर्तमानेऽपि तत्तथा ॥ 
+
+
+That which at the beginning and the end has no [ real ] 
+existence, has mone either during the antervening period. The 
+Vedantists of S'ankara's school hold that existence is of three 
+kinds, namely, paramarthika ( true ), of which Brahma is the 
+sole representative, —tyāvahārika (practical ), to which all 
+phenomena belong, —and pratibhasika ( apparent), which in- 
+cludes such things as a snake surmised in a rope, or nacre mis- 
+taken for silver. The second and third kind, therefore, have 
+no real existence from the beginning to the end of their sup- 
+posed existence. 
+
+
+Raghunatha says regarding 1: नस्वादावन्ते च यज्ञास्ति वर्त- 
+सानेऽपि तत्तथेति न्यायाद्ये तुच्छमेव द्वैतं मन्यन्ते तेषां ब्रह्मपोघेन सविकृत्यविद्या- 
+बाधो न स्यात्तस्य ब्रह्मस्वरूपनित्यबोधमहिञ्ना सदैव वाधितत्वात्‌ ?॥ He may 
+have taken the nyaya, like so many others in his book, from 
+the Yogaväsistha where it is found as the first line of 4. 45. 45; 
+but its real source is Gaudapada’s kārikās on the Mandakya 
+Upanisad. It occurs twice there, namely in ii. 6 and 1v. 31. 
+
+
+आम्रसेकपितृतपंणन्यायः ॥ 
+
+
+Watering a mango-tree, and, at the same time, satisfying 
+the Manes with ७ libation. Bringing about two results by 
+one operation. Its earliest occurrence is in the Mahabhasya, 
+where it appears twice. In 1. 1. 1 ( page 14) it stands thus:— 
+“ani पुनरेकेन यल्लेनोभयं लभ्यम्‌ | लभ्यमित्याह | कथस्‌ p द्विगता अपि हेतवो 
+भवन्ति | तद्यथा | आम्राश्च सिक्ताः पितरश्च प्रीणिता इति The, second 
+instance is in 8. 2. 8. 2 
+
+The nyaya in its consolidated form is found in the following 
+passage of the Nyayamamnjar ( 8. 1. 39), page 634. “तदेवमनेन 
+चतुविशतिजात्युदाहरणप्रतिसमाधानोपदेशवत्मना शब्दानित्यत्वसाधने परकीयसु- 
+पाळम्भजातमेवंप्रायमखिलमपाकृतमाञ्रसेकपिठृतर्पणन्यायेन भवति भगवता Ga 
+qur? ॥ It is not in any of the dictionaries or lists of nyaya. —— 
+
+32 CC-0. Prof-Satye-Vrat Shastri Collection. ` 
+
+
+Digitized By Siddhanta eGanbbkri Gyaan Kosha 
+
+
+आम्रान्पृष्टः कोविदारानाचष्टे ॥ | 
+
+
+Questioned as to mango trees, he speaks of Kovidara trees | 
+This is nyaya 223 of the second part of Raghunathavarman | 
+large work, the Laukikanydyaratnakara, and is applied by 
+him as follows (page 4194 of India office MS. 589 ):--“तधा 
+हि लोके प्रकृष्टपरकाशश्वन्द इत्यत्र अक्रष्टपदेनाप्रकृछखद्योतादेः प्रकाइापदेनागरका- | 
+
+
+झात्मकास्धकारादेश्व व्यवच्छेदेन जिज्ञासितश्रन्द्रआतिपदिकमात्रार्थ: प्रतिपाद्यः | 
+ते। इतरथा आश्रान्पष्ट कोविदारानाचष्ट इति न्यायेन वक्तरजिज्ञासितमर्ध । 
+प्रतिपादयतोऽश्रद्वेयवचनव्वप्रसङ्गात्‌ ^w It is found in Bhamati 1. 1, - 
+22 (page 145 ):-- य॒द्यप्याकाशपदं प्रधानार्थं तथापि यत्पृष्टं तदेव प्रतिव 
+
+क्तव्यम्‌ । न खल्वनुन्सत्त आञ्रान्षृष्टः कोविदारानाचष्टे ?॥ In Vedanta 
+kalpataru 1. 4. 1 (page 201 ):--“ जीवे we तं दुर्दशीमिति aes 
+क्तपरसात्मप्रतिवचनमाम्रग्रश्ने कोविदारप्रतिवचनवदसङ्गतम्‌ ” ॥ There is 
+also an excellent example in the Nydyavirtikatatparyatika, 
+page 187, line 16, and another on page 545 of the comment on 
+Tattoamvuktakalapa. Its source, however, is Mahabhasya 1. 2. 
+
+
+45 (vart. 8 ):--“ अन्यद्धवान्पष्टोबन्यदाचप्टे । आम्रान्पृष्टः कोविदारानाचष्टे.” 
+
+
+आयुर्घृतम्‌ ॥ 
+
+Butter is life. This scarcely deserves a place amongst 
+maxims, but I follow Raghunitha in admitting it. It is one of | 
+the x stock illustrations of writers on Alanküra, and is found - 
+in Namisüdhu's comment on Rudrata's Kavyalankara, vii. 83; 
+as follows:— | 
+
+
+MA पुण्यं भयं चोरः सुखं प्रिया । 
+वरं चूतं युरुञ्ञानं श्रेयो बाह्मणपूजनम्‌ ॥ 
+
+I have traced it, however, as far back as Tait -SaMhitä 2. 
+2.2, and have met with it again in Mahabhasya 1. 1. 59 
+(vart. 6), and 6. 1, 82 (vārt. G). For the last passage 500 
+“ दघित्रपुसं प्रत्यक्षो ज्वरः ” in the Third Handful. Sures'vara too 
+furnishes an excellent example of it in his large variika 1. 5. 
+1848: परीक्ष्य चक्षुपा यस्मालभते गोधनादिकम्‌। ag: स्यान्मानुषं वित्तं. 
+
+
+यथायुश्रतसुच्यते ” ॥ »1 
+CC-0. Prof. Satya-Vrat-Shastri-Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan - 
+
+
+1i 
+
+
+आशामोदकतृघ्तन्यायः ॥ 
+
+
+The illustration of one who is satisfied with sweetmeats 
+in prospect. Itis found in a verse quoted in Nygyakandala, 
+page 130:— 
+
+
+^ आशामोदकतृप्ता ये ये चोपाजितमोदकाः | 
+रसवीग्रेविपाकादि तुल्यं तेषां प्रसज्यते”? ॥ 
+
+
+The same verse is quoted on page 37 of Khandanakhanda- 
+khadya, and is translated by Prof. Ganganatha Jha (in the new 
+periodical, Indian Thought) as follows:—“But, says an objector, 
+from your theory it would follow that those who enjoy merely 
+imaginary sweets, and those who eat real sweets, would have 
+exactly the same experiences of flavour, strength, nutritive 
+effects, and so on. He, we reply, who fatters himself with the 
+hope of this objection invalidating our view, truly himself feeds 
+upon imaginary sweets ( इत्यस्यापि बाधकत्वमाशासोदकायते ). In 
+Nydyadipavali, p. 7, we read “आद्यामोदकोपाजितमोदकयोरस्त्येव 
+स्वभे$पि कियद्वेलक्षण्यम्‌.” 
+
+
+इषुकारन्यायः ॥ 
+
+
+The illustration of the arrow-maker, Used of one wholly 
+engrossed in his work, and unconscious of his surroundings. 
+Tt is based on the following verse of S'antiparva, chapter 178:- 
+“ डूपुकारो नरः कश्चिदिषावासक्तमानसः | समीपेनापि गच्छन्तं राजानं नाववुद्ध- 
+am” u Sankara makes use of it in his exposition of Vedanta- 
+sūtra 3. 2. 10 [“मुग्धे$ धैसंपत्तिः परिशेषात्‌.” In the case of one in 
+a swoon ( there is not entrance into either of the states of sleep 
+&c.) so, by the only remaining alternative, there is a semi- 
+entrance (into sound sleep and another state ) ] He says—— 
+इपुकारन्यायेन सुग्धो भविष्यति | यथेषुकारो जाग्रदपीष्वासक्तमनस्तया नान्या- 
+न्विषयानीक्षत एवं मुग्धो सुसलसंघातादिजनितदुःखाचुभवव्यमसनस्तया जाग्रः 
+
+
+दपि नान्यान्विपयानीक्षत इति । न । अचेतयमानत्वात्‌” Anandagiri 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+॥ 1 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+refers to the same nyàya in his comment on Sures'vara/g lange | 
+Vartika 1.5. 106 (page 816). See, too, Nyayamakaranda. i 
+tika, page 78. Compare with this the picture drawn by John | 
+Bunyan of “a man who could look no way but downwards | 
+with a muck-rake in his hand. There stooda Iso one over his . 
+head with a celestial crown in his hand, and proffered him that 
+crown for his muck-rake; but the man did neither look up nor 
+
+
+regard, but raked to himself the Straws, the small sticks, and 
+the dust of the floor". 
+
+
+इषुवेगक्षयन्यायः ॥ | 
+
+
+The simile of the gradual diminution of the speed of an | 
+arrow. 16 13 found in Brahmasiitrabhdsya 3. 3. 32— ८ प्रवृत्तः | 
+फलस्य कर्साशयस्य सुक्तेपोरिव वेगक्षयात्रिवृत्ति:?॥ Then, in Brihadi | 
+ranyavartika 1, 4. 1529 (page 736 ) we read as follows— | 
+“ आरब्धफरुरोपेकहेतुत्वादेहसं स्थितेः | रागादिग्रत्ययोद्भूतिरिपुचक्रादिवेगवत्‌ ?॥ 
+“ The experience of passion and other mental conditions, owing 
+to the continuance of the body caused by the remnant of frue- - 
+tescent works, is like the [ diminishing ] speed of a [ potter's] - 
+wheel or of an arrow.” 
+
+
+Upon which Anandagiri remarks:— 
+H इघुचक्रेति॥ यथा भ्रवृत्तवेगस्थेप्वादेवेंगक्षयादेव क्षयस्तथारव्धक्षयो ] D | 
+भोगेन at क्षपयित्वा संपद्यत? इति न्यायान्न ज्ञानादित्यर्थः” ॥ The quo: - 
+tation is Vedamtasütra, 4, 1. 19, In S'ankara/s most interesting 
+exposition of sütra 4. l, 15, we moet with the expression. 
+कुलालचक्रवतू in the same connection. ; 
+
+
+उत्कृष्टटृष्टिनिकृष्टेड्ध्यसितव्या ॥ 
+
+
+The idea of something higher ८७ to be superimposed UPON 
+something lower. This is Dr. Thibaut's rendering of the nyaya 
+as it occurs in Brahmasitrabhasya 4,1. 5 (the sūtra being 
+
+
+्रहमदष्टि््कर्षात्‌ ):--“ एवं श्राप्ते बूमः । ब्रह्मदृष्टिवादित्यादिषु स्थादिति । ; 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+13 
+
+
+कस्मात्‌ | seni | एबमुल्कपेंणादिद्यादयो दृष्टा भवन्ति । seeders 
+ध्यासात्‌। तथा च लौकिको न्यायोऽचुमतो भवति | उत्कृष्टडष्टिदि निकृष्टेऽध्य- 
+सितब्येति लोकिको न्यायः। यथा राजदृष्टिः aay”? q "To this we make 
+the following reply. The contemplation on Brahman is exclu- 
+sively to be superimposed on Aditya and go on. Why ? ‘On ac- 
+count of exaltation” For thus Aditya and so on are viewed in 
+an exalted way, the contemplation of something higher than 
+they being superimposed on them. Thereby we also comply 
+with a secular rule, namely the one enjoining that the idea of 
+something higher is to be superimposed upon something lower, 
+as when we view—and speak of—the king’s charioteer as a 
+king.” Vücaspatimisra, in his comment on the above in the 
+Bhāmatī, changes the form of the expression to “ Mazoea 
+इति लौकिको न्यायः,? and perhaps Ramanuja had this in mind 
+when, in his very short comment on the sūtra, he wrote 
+
+
+* उत्कृष्टे हि राजाने was: प्रत्यवायकरी, YA तु राजदष्टिरभ्युदयाय. 
+
+
+उत्खातदंष्ट्रोरगन्यायः ॥ 
+
+
+The simile of the snake whose fangs have been extracted. 
+The illustration is used by Suresvara in his vartika on 
+Brihadaranyakopanishadbhashya 1. 4 1746 (page 776 ):— 
+“उत्खातरदंश्रोरगवदविद्या किं करिष्यति | विद्यमानापि विध्वस्ततीज्ञानर्थपरस्परा!॥ 
+
+
+उपजीव्यविरोधस्यायुक्तत्वस्‌ ॥ 
+
+
+It is wrong to quarrel with that on which one’s livelihood 
+depends, It is found in Paribhashendus'ekhara 85, as follows: - 
+८ संनिपातो द्वयोः संबन्घस्तन्निंमित्तो विधिस्तं संनिपातं यो विहन्ति तस्यानिसि- 
+त्तम्‌ ॥ उपजीन्यविरोधस्यायुक्तत्वमिति न्यायमूलैषा ?॥ Professor Kielhorn 
+has rendered it thus:—“ सन्निपात “2 combination ? is the junction - 
+of two (things; that which is taught in ) & rule (the applica 
+tion of) which is caused by such (a combination ), does not 
+
+CC-0. Prof. Satya Vrat Shastri Collection. iu 
+
+
+Digitized By Siddhanta eGanghih Gyaan Kosha | 
+cause (the application of ) another (rule) which would destro 
+
+that combination. This ( Paribhāshā ) is founded on the marin ; 
+that one must not be hostile to that to which one owes one's | 
+existence,” 
+
+
+| 
+| 
+
+
+There are references to the nyaya in the following works— 
+Khandanakhandakhadya, page 128;  Vedantakalpatam, | 
+pages 231, and 556 (especially the latter); Pavima 
+
+
+* la, pages 
+10, 11, 12, 451; Nydyamakarandatika, page 149. 
+
+
+उष्टलगुडन्यायः ॥ 
+
+
+The illustration of the camel and the stick, The equivalent 
+apparently, of “ Hoist with his own petard” (Hamlet, Act i, | 
+pee iv): The following is Raghunātha’s exposition of iti— | 
+
+स्वमते परेणोड्भाव्यमानानां दूपणानां तन्मते पातने डष्टलगुडन्यायावतारः । | 
+यथोष्रेणोह्ममानेनेव लगुडेन SEHEN: क्रियते तथा तार्किकोत्थापितदूपणेसन्म- | 
+तमेव वेदान्तिभिनिराकरियते | तथाहि । अद्वेतवादे यद्धोगसांकर्यादिरूपं quio 
+तैरुच्यते तदीपनिषंदैविभ्वनेकात्मवादिनां तेपामेव मते पात्यते?॥ Tt occurs in 
+the following passage of the Atmatattvaviveka (page 54, line 
+16 | तज्जातीयस्य तु वाह्यवद्विज्ञानस्यापि विवेचनमेवेति स्वसंवेदनबाधि- । 
+तोऽयं विसुद्धधर्माध्यासो न भेदसाधक इत्युष्टलगुडकं संवेदनेनेवास्य साधि | 
+तत्वात्‌? There is another instance of it in Vedantakalpa f 
+C page 118 ( where it appears as the उष्टलकुटन्याय ), and l 
+again in Nyayadvpavalà page 6, line 11. ‘ | 
+
+
+) 
+
+
+——— ~ 
+
+
+ऊषरवृष्टिन्यायः ॥ 
+
+
+The simi ह 
+The simile of rain on a saline barren waste. Tis application 
+ig similar to that of अरण्यरोदन, which see above. Hemacandra 
+has & good example of it in his Parisis' taparvan viii, 417:— 
+
+
+¢ ` 
+` कपायपक्षिृक्षेषु कतप्लेष दुरात्मसु | 
+एतेषु निष्फलं दानसपरेप्वस्वव्रृ्िवित q” 
+CC-0. Prof. Satya Vrat Shastri Collection. i 
+* 
+
+
+Digitized By P RE eGangotri J Kosha 
+ei 
+
+
+In Anus dsunaparva xc. line 4314, we read:— यथोषरे बीजमुप्त 
+
+
+> 
+
+
+न रोहेन्न वा Ag प्रा्॒या्ठीजभाराम्‌। एवं श्राद्धं भुक्तमनहंमाणैन चेह नामुत्र 
+me ददाति” ॥ 
+
+
+=r c Q N 
+ऋजुमार्गेण सिध्यतो5थस्य वक्रेण साधनायोगः ॥ 
+
+
+No one tries to accomplish in a round-about way a thing 
+which can be effected by direct means. This nyaya is the 
+counterpart of अके चेन्मधु विन्देत Ge, and is used twice by 
+Vacaspatimisra in his Nyayavartikatatparyatika. On page 
+195, we read:— न॒ च कार्येणेव कारणमनुमीयतां जीवच्छरीरे कि व्यतिरे- 
+किणा ऋजुमार्गेण सिध्यन्तं को नु वक्रेण साधयेदिति वाच्यम्‌। कारणमात्रस्य 
+ततः सिद्धेरित्युक्तस्‌ ? ॥ Again, on page 203:—“ अन्वयव्यतिरेकिणि 
+हेतो सत्यपि quei साधर्म्यांदाहरणमेवोचितं तत्र तत्पूर्वकत्वाद्वैधम्येम्रतीतेः 
+ऋजुमार्गेण सिध्यतोऽ्थस्य वक्रेण साधनायोगात्‌? ॥ 
+
+A still older example is found in S’alika, page 86:— 
+
+८ asp Rio RTT न वक्रमार्गसाश्रयेत.? 
+
+
+See, also, Tarkabhāsā, page 48, line 5. 
+
+
+एकाकिनी प्रतिज्ञा हि प्रतिज्ञातं न साधयेत्‌ ॥ 
+
+
+Bare assertion is no proof of the matter asserted. This is 
+Professor Gough's rendering of the saying as found in the 
+Bauddha chapter of the Sarvadars anasangraha ( page 10 of 
+Jivünanda's edn.):—“aty कश्चित्मामाण्यमजुमानस्थ नाड्वीकुर्यात्त प्रति 
+ब्ूयादनुमानं प्रमाणं न भवतीत्येतावन्मात्रसुच्यते तत्र न किञ्चन साधनसुपन्य- 
+स्यत उपन्यस्यते वा। न प्रथमः । एकाकिनी प्रतिज्ञा हि प्रतिज्ञातं न साधये- 
+दिति न्यायात्‌? ॥ The following is from the Laukikanyaya- 
+sangraha:—* नन्वेकाकिनी प्रतिज्ञा हि प्रतिज्ञातं न साधयेदिति न्यायेन 
+प्रतज्ञयार्थसिद्धयभावान्नाद्वैतं साधयितुं पारयते | भेदवादिनो हि जीवेशाभेदमपि 
+न क्षमन्तेऽन्यस्य का कथा । तद्भेदेऽपि किं मानमिति चेन्नाहमीश्वर इति प्रत्य- 
+क्षमित्यवेहि The nyaya “aR प्रतिज्ञामात्रेणाथैसिद्धिः? is given 
+in Raghunatha’s list as one of similar import. Compare 
+
+
+Nydyavartika, page 345, line 11:--*न च प्रतिज्ञा प्रतिज्ञां uos _ 
+
+
+CC-0. Prof-Satya Vrat Shastri Collection. 
+
+
+16. 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+एकामसिद्धिं परिहरतो ह्वितीयापद्यते ॥ 
+
+Whalst avoiding one kind of fallacy, ८७०४७ 
+pears! This is explained by Raghunatha as follows: m 
+बौद्धाधिकारे उदयनाचार्योक्तिः । Tipe शरीर्यजन्यत्वा दित्यत्र शरीः | 
+रीतिविशेषणेन स्वरूपासिद्धि परिहरतो dizer व्याप्यत्वासिद्धिरापद्यते ” | 
+The work here entitled Bauddhadhikara is styled Bauddhg. | 
+dhikkdra in Hall's Indes ( pp. 81, 82). 
+known as Atmatattvaviveka 5 
+found on page 108 
+
+
+$ 
+| 
+er kind dp. | 
+Í 
+| 
+| 
+| 
+
+
+| 
+1 
+E | 
+It is more generally | 
+and the passage in question jg | 
+, as follows:— अस्तु Me सत्मतिपक्षत्वं शरीराजन्य- | 
+तुल्यवलूत्वात्‌ । असिद्धिपरिहा: | 
+RA LII T 
+{तायापत्तः Ig ne 
+
+
+त्वादिति चेन्न अससर्थविशेषणत्वेनासिद्ध भेदस्यातुल्यः 
+रेण विशेषणं समर्थमिति चेन्न एकाम सिद्धि परिहरतो 
+same passage is clearly referred to in 0८८5000707 1, 24 (Pandit, vol. 
+v. page 110 ):—“ क्षिय्ादिकसकर्दृकं शरीयंजन्यत्वादाकाशवदित्यादाविव 
+व्याप्यत्वासिद्धिरिति चेन्मैवम्‌ । तत्राकर्ठत्वे साध्ये तदेकदेशस्याजन्यत्वस्थेवोपाधि- 
+तया fee व्याप्यत्वासिद्धेः। उक्तं हि । एकामसिद्धि परिहरतो द्वितीयाः 
+सिद्विरापद्यत इति ??॥ So, too, Venkatanatha in the comment on 
+his Tattvumuktākalāpa iii. 22 (p. 289), and again in his 
+Nyayasiddhanjana, page 100. For a clear and concise 
+definition of the three terms आश्रयासिद्ध, स्वरूपासिद्ध and व्याप्यता- 
+सिद्ध, sce Apte’s Practical Sanskrit Dictionary, s. v. असिद्धः 
+
+
+कटकगवोदाहरणम्‌ ॥ 
+
+
+The illustration of æ cow [tied] in an enclosure. This occurs 
+in Khandanakhandakhadya, page 632:—“ यत्त सत्तेवेत्युक्त तत्कः 
+त्तु | 
+
+टकगवोदाहरणमनुहरति यतः सत्ताप्यसुना दूषणेनास्मासिः खण्डनीया. ” 
+The commentator explains as follows:—€ यथा कटके बद्धा गोबैन्धनः 
+रज्जुमादाय विद्रवति Raa: सह तथाझुना खण्डनेन विद्गभवता भेदेन | 
+
+सत्तापि विद्रविष्यतीत्यर्थः । यद्वा यथा कटके गोरपसार्यमाणापि पुनस्तथैवाः 
+याति तथा बहुशः खण्डितापि सत्ता एनरुदाहरणत्वेनायातीत्यर्थः” Ima 
+add that the long Passage beginning with the words “के भेदज्ञानं | 
+नास्ति,” on page 652, down to the words “इत्येषा Rag” on page 
+: . T 3 A 
+687, is taken verbatim from Udayana’s Atmatativaviveka, pages 
+70 to 72, It includes another, and probably the earliest, 
+example of the use of the nyày. 
+
+
+: a “चोरापराधेन माण्डव्यनिग्रहः??, for 
+Which, see the first Handful of maxims, Y kN E. 
+
+
+CC-0. Prof. Satya Vrat Stiastri Collection m xi 
+
+
+S LTEM 
+
+
+Digitized By Siddhanta eGangotri Gyaan «| 
+
+
+17 
+
+
+कण्ठचामीकरन्यायः ॥ 
+
+
+The simile of the golden ornament on the neck. A person 
+is supposed to have a golden ornament round the neck and yet 
+to be unaware of it until some one points it out; a kind of 
+illustration greatly in vogue amongst Vedantists, who tell us 
+that although we are already Brahma, and free, we are not 
+aware of the fact until instructed by a competent teacher! For 
+the translation of a passage of the Vedantaparibhasha bearing 
+on this, see pages 180 and 131 of my Manual of Hindu 
+Panthcism. The above nyaya is found at the top of page 180 
+of Atmatattvaviveka. 
+
+
+कदलीफटन्यायः ॥ 
+
+
+The simile of the fruit of the pluntuin tree. For explanation 
+of this see अश्वतरीगर्भन्याय. Another instance of it is found in 
+CVM 
+
+
+Naiskarmyasiddhi iv. 11:--“बुद्धिमेवापरूद्गाति कदली तत्फलं यथा.” 
+See, also, Bodlvicaryavatara i. 12. 
+
+
+करविन्यस्तबिल्वन्यायः ॥ 
+
+
+The simile of the woodapple on the [open palm of the ] 
+hand. Said of something unmistakably clear—"as plain asa 
+pike-staff”! It occurs in Sures vara's large Vartika 2. 1. 95:— 
+“अतोऽनुपेतमेव त्वां करविन्यस्तबिल्ववत्‌ | Fa विज्ञापयिष्यामि यज्ज्ञाने 
+
+
+‘> 
+
+
+adaa” ॥ Again in 2. 5. 136 of the same:—“निःशषोपनिषत्सा- 
+रस्तदेतदिति साम्प्रतम्‌ | उतत्याविष्क्रियते साक्षात्करविन्यस्तबिल्ववत्‌  ॥ A 
+third instance is found in 4. 3. 1334, and there is another in the 
+vartika on the Yaittirtyopanishadbhashya, page 200. 0 
+exactly the same import is the करस्थासरकच्याय) for which see the 
+former Vartika 3. 1. 14. 
+
+
+3 . 4, CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+K 1 
+
+
+9 A 
+Digitized By Siddhanta eGangotri Gyaan Kosha ^ ; 
+
+@) i 
+कमंभ्रूयस्त्वात्फंलभूयस्त्वम्‌ ॥ | 
+
+
+Abundance of labor produces abundance of fruit; from 
+great pains come great gains. It occurs in the followin 
+passage of Vidyaranya’s Vivaranaprameyasangraha, page | 
+4$7:--“बह्मोपासनानां सर्वेषामपि यद्येकरूपं फलं तदा गुणो | 
+पासनोपचयापचयो व्यथों स्याताम्‌ । तथा च कर्मभूयस्त्वात्फलभूयस्त्वरमिति | 
+न्यायविरोधः”॥ Compare S'abara's “अङ्गभूयस्त्वे फलभूयस्त्वम्‌ in 
+10. 6. 62. and 11, 1, 15. It is quoted in Parimala, page 000, 
+
+
+कांस्यभोजिन्यायः ॥ 
+
+
+The simile of the man who euts from ८ brazen ‘vessel, 
+Raghunatha explains it thus:—* सया नित्यं गुरुशिष्ट भोक्तव्यं ae | 
+पात्रे च भोक्तव्यमिति नियमवतो विनेयस्य नियमाभङ्गाय गुरुनित्यं कांस्यपात्रे | 
+
+
+YA इति । यद्यप्ययं शास्त्रीयस्तथाप्येतब्यवहारस्य लौकिकत्वात्सुन्दोपसुन्दः 
+न्यायवल्ौकिकेषु परिगाणितः ? ॥ 
+
+
+The nyaya is taken from Jaiminis sütra 12. 2, 34, where 
+S‘abara interprets it as 10110098:--क्ांस्रभोजिवत्‌ । तद्यथा । शिष्यस्य 
+काँस्यपात्रभोजित्वनियम उपाध्यायस्यानियमः | यदि तयोरेकस्सिन्पात्रे भोजनमाः | 
+पद्यते5मुख्यस्यापि शिष्यस्थ धर्मा नियम्येत । मा भूड़मेलोप इति” ॥ The | 
+principle here laid down is that of some one’s doing something 
+
+
+which he is not bound to do, in order that I 
+
+
+he may not hinder Í 
+another who 4s required to do it, The converse, that is, of & | 
+
+
+& 
+man's abstaining from doing something, possibly harmless in. | 
+his case, lest another should do the same and suffer 1 
+“ If meat make my brother to offend, I will eat no flesh 
+while the world standeth, lest I make my brother to offend.” - 
+
+
+Examples of the nyaya are found in Lantravirtika, pages 
+898, 577, and 907 3 in Vidhirasdyana, page 50; in Bhamatt, - 
+page 478; in Vedamtakalpataru, pages 314, 425, 502, 517; and 
+in Parimala, pages 462, 572, 666. I 
+
+
+——————— 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. j 
+
+
+Digitized By Siddhanta eGangotri : Kosha 
+19 | 
+
+
+काकोळूकनिशावत्‌ ॥ 
+
+
+The simile of the crows and owls night-time. What is day 
+to the former is night to the latter, and vice versa. This 
+characteristic of the owl is often referred to by the poets, as, 
+for instance, in Bhartrihari's Nitis‘ataka 93:— 
+
+
+te AC S NON ct 
+YA नव यदा करीरविटपे दोषो वसन्तस्य कि 
+नोलूकोऽप्यवलोकते यदि दिवा सूर्यस्य कि quum | 
+
+
+The nyaya is found is Sures'vara's large vartika 1. 4. 313:— 
+
+
+“काकोलक़निशेवायं संसारोऽज्ञात्मवेदिनोः | 
+या निशा सर्व॑भूतानामित्यवोचत्स्वयं हरिः? ॥ 
+
+
+Anandagiri comments on this as follows:— refer | या काकाः 
+दीनां प्रसिद्धा निशा तस्यासुलूको जागतीति TEST सापलप्यते | यदा च काका- 
+दयो जाग्रति तदा नक्तंशो निशेति काकादिइष्टया सापहूयते यथेत्यर्थः | एवमज्ञ- 
+स्यायं मात्रादिः संसारो यदा विवतेते तदा तदृष्टया तत्त्वस्यासत्कल्पना | यदा 
+विदुपस्तत्त्वानुभवस्तदा तददष्ट्या मात्रादेरसत्त्वामिति  ॥ The quotation in 
+the second line of Sures'vara’s verse is from Gita 11-69 which 
+
+
+reads thus:—“ar निशा सर्वभूतानां तस्यां जागति संयमी | यस्यां जाग्रति 
+भूतानि सा निशा पझ्यतो सुनेः”॥ In Naiskarmyasiddhi ii. 111 
+the nyaya is quoted as उलूकनिद्यावत्‌ू. The passage stands thus:— 
+“अनुदितानस्तमितकूटस्थबोधमात्रस्वाभाव्यादात्मनो दुःसम्भाव्यो5विद्यासः्वाव 
+इति चेन्न । अविद्याप्रसिद्धेव तत्सञ्गावसिद्धेरुलूकनिशावदित्यत इदसुच्यते | 
+
+
+अहो धाष्ट्येमविद्याया न कश्चिदातिवतेते | 
+प्रमाणं वस्त्वनाइत्य परमात्मेव तिष्ठति? ॥ 
+
+
+कारणगुणप्रक्रमन्यायः ॥ 
+
+
+The principle of the reproduction, im the effect, of certain 
+. qualities, in the proportion in which they exist in the produc- 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+phg क्षीरावसेकादस्लत्वं 5 
+process:—“srs77 स्लत्वं परिहृत्य माझर्यमपादायानुवतैमानामलकी 
+* ollection. E 
+
+
+9 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+ing cause. In the Veddntasdra, section 12, we read.—« तदान 4 
+सत्त्वरजस्तमांसि कारणगुणप्रक्रमेण तेप्वाकाशादिपूत्पद्चन्ते? On which, the 
+
+commentator Nrisimhasarasvati ama तदानी मुत्पत्तिवेलायों 
+सत्वादयस्रयोडपि गुणास्तारतम्येन कारणगुणप्रक्रमन्यायेन तेप्वाकाशादियु प. 
+भूतेषूततरोत्तराधिक्येन जायन्त इत्यर्थः?॥ For full notes on कारणगुण, see 
+page 176 of the Vedantasara referred to above. 
+
+
+कार्पासरक्ततादृष्टान्तः ॥ 
+
+
+The illustration of the redness of cotton [ produced by | 
+smearing the cotton-seeds with red lae] One of the stock | 
+illustrations of the Buddhist when seeking to establish the | 
+doctrine that all existence is momentary ( क्षणभड़वाद ). For 
+the examination and refutation of the tenet, see S'ankara on 
+Brahmastitras 2. 1. 18, 2. 2, 20 &८.; and the opening part of 
+the Arhata chapter of Sarvadars'anasangraha. The nyaya 
+18 contained in the following verse:— 
+
+
+“यस्मिन्नेव हि सन्तान आहिता कर्भवासना | 
+फलं तत्रैव वञ्नाति कार्पासे रक्तता यथा”? u 
+
+
+This is quoted in Syadvadamamjani, pages 155 and 193; 
+
+
+in Manibhadra’s comment on kürikü 5 of Saddavs ama- 
+
+
+samuccaya; in a slightly altered form, on page 1501 of 
+Brihadiranyakavartika; in ANyayamanjar 
+
+
+abico un pie dua Petr etas ja ee eec ccu 
+
+
+7, page 443; in the 
+vritti on Tattvamulktakalapa i. 29; and in the Arhata section J 
+of Sarvadars'anasangraha, where Pr 
+
+
+ofessor Cowell renders - 
+it:—“In whatever 
+
+
+series of successive states the original 
+impression of the action was produced, there verily accrues the j| 
+result, just like the redness produced in cotton". We find the 
+कार्पासरागसंक्रान्तिदृष्टान्त in Vydyamanjart page 465, in the con: | 
+cluding portion of the author's क्षणभद्गनिरास, and the following 
+extract from the Atmatattvaviveka (page 102) explains the 
+
+
+i 
+
+
+CC-0. Prof. Satya Vrat Shastri Coll 
+
+
+Digitized By ST eGangotri Gyaan Kosha 
+
+
+कालान्तरेऽपि माधुर्यसुन्मीलयति; लाक्षारसावसेकाद्वा E रक्तता- 
+मुपादायानुवतैसाने कार्पासबीजं कुसुमेषु cary.” In the closing verses 
+of the निरालम्बनवाद (Slokavartika, page 267) Kumarila deals 
+with this Buddhist illustration in connection with a citron 
+(न्रीजपूर) instead of the cotton plant; and we meet with it 
+again in Bhamati 1. 1, 4 (page 95). 
+
+
+ex (१ Cx ON 
+किमाद्रेकषणिजो वहित्रचिन्तया ॥ 
+
+
+What has & seller of ginger to do with ships? Possibly the 
+equivalent of “No cobbler beyond his last.” It occurs in the fol- 
+lowing passage of Atmatativaviveka, page 62, line 10:--अविद्येव 
+हि तथा तथा विवतेते यथा यथालुभाव्यतया व्यवहियते तत्तन्मायोपनीतोपा- 
+धिभेदाचब्वाजुभूतिरपि Bea व्यवहारपथसवतरति गगनमिव स्वप्नद्घटकटाह- 
+
+
+` S S CS e 
+
+
+कोटरकुटीकोटिभिः | तदास्तां तावत्‌ । किमाट्रेकवणिजो वहित्रचिन्तयेति ॥ 
+
+
+कुठारच्छेद्यतां कुयीन्नखच्छेद्यं न पण्डितः ॥ 
+
+
+A wise man should not imagine that he can remove with a 
+finger-nail that which can only be cut down with an axe. A 
+caution against under-rating the strength of an enemy. Tt 
+occurs in Upamitibhavaprapance: Kathd, page 1034;— 
+
+
+ES 
+
+
+“नोपेक्षणीयं देवेन तस्मादेतत्प्रयोजनस्‌ | 
+
+
+कुठारच्छेद्यतां कुयोन्नखच्छेय न पण्डितः ॥ 
+
+
+Compare Udayana’s saying in Kiranārali, page 14:—" खलु 
+नखरञ्जनिका परझुच्छेद्यं छिनत्ति.” 
+
+
+५ 6५ ; ` 
+कुड्यं विना चित्रकर्मव ॥ 
+Like ७ decoration without a wall | to be decorated; or, like à 
+; CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+22 
+painting without a canvas]. An unreality, like a hare's hom 
+
+
+&c. Ibis found in the Nyayamanjari, page 108, ina disquisi | 
+tion on योगिम्रयक्षसाधनम्‌. 
+“agarat नाम नास्त्येव परमार्थतः | 
+A A > A ` ` 
+तद्धि कुड्यं विना तत्र चित्रकर्मेव लक्ष्यते ॥ 
+नहि नभःकुसुसस्य सोरभासौरभविचारो युक्तः?” ॥ 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha | 
+1 
+| 
+| 
+|] 
+
+
+A much older example is contained in Sankhyakarika 41... | 
+“चित्रं rarae स्थाण्वादिभ्यो विना यथा छाया । तद्वद्विना विशेपेन Roe | 
+निराश्रयं Rag” ॥ | 
+
+
+There is a similar 
+
+
+thought in Aniruddha's comment on | 
+Sdnkhyasitra iii, 12. 
+
+
+| 
+He 8898:---यद्यात्मना विना देहेऽहमिति प्र. 
+त्ययस्तदा HASEN प्रत्ययः स्यात। न चेवस्‌ | यथावरकेण विना न 
+
+
+छाया भित्ति विना न चित्रं तथात्रापि” See also Mallinatha on | 
+Lavktharaksd, page 111 and 176. 
+
+
+क्षीरनीरन्यायः ॥ 
+
+
+The simile of milk and water. Used to illustrate the most 
+intimate union of two or more things. The oldest example of i 
+it known to me is in Mahabhasya 1. 9, 82:--क्षीरोदके समपृक्त | 
+आमिश्रीभूतत्वान्न ज्ञायते कियत्क्षीरं कियदुदक॑ कर्मिज्ञवकाशे क्षीरं aie 
+वकाश उदकमिति.” Writers on Alankara employ it to exemplify 
+the figure called Sankara (Commixture) in which there is a 
+combination of other figures. It differs from 2 3 
+(Collocation) which is compared to the union between rice and 
+sesamum, which is less intimate and e 
+The author of the Alanlar 
+“अधुनेषां सर्वेपामलंकाराणां संश्छेषससुर 
+संयोगन्यायेन समवायऱ्यायेन च Bd 
+स्थितिः | समवायन्यायो यन्न 
+'तिळतण्डुलन 
+
+
+asily distinguishable 
+asarvasua (page 192) says: 
+व्थापितमलंकारद्वयसुच्यते | तत्र Uu 
+विधः | संयोगन्यायो यत्र भेदस्योत्कटतयां | 
+तस्यैवानुत्कटत्वेनावस्थानम्‌ | तन्रोस्कटत्येन स्थितौ 
+YA इतरत्र तु क्षीरनीरसाइश्यम्‌ । क्रमेणेतदुच्यते । एषां fred 
+ण्ड्ळन्यायेन मिश्रत्वं संसृष्टिः po क्षीरनीरन्यायेन तु संकरः ll 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+123 
+Similarly too in Sarasvatikanthabharana (page 262 ):— 
+
+
+“संसृष्टिरिति विज्ञेया सर्वालंकारसंकर: | 
+सा तु व्यक्ता तथाव्यक्ता व्यक्ताव्यक्तेति च त्रिधा ॥ 
+'तिलतण्डुवव्यक्ता छायादशेवदेव च । 
+अव्यक्ता क्षीरजलवत्पांशुपानीयवच्च सा ॥ 
+व्यक्ताव्यक्ता च संसृष्टिनेरसिहवदिष्यते । 
+चित्रवर्णवदन्यस्मिन्नानारुकारसंकरे ” ॥ 
+
+
+It will be noticed that here there is mention of a third kind 
+of combination which is likened to that of man and lion. The 
+three kinds are noticed in Kuvalaydnanda, also (page 337), 
+as follows:—“ अथैतेषामलङ्काराणां यथासंभवं कचिन्मेलने लोकिकालंका- 
+राणां मेलन इव चारुत्वातिशयोपलंभान्नरसिंहन्यायेन प्थणलूकारावस्थितों तः 
+न्निर्णयः क्रियते । तत्र तिलतण्डुलन्यायेन स्फुटावगम्यभेदालंकारमेलने संसाष्टिः । 
+नीरक्षीरन्यायेनास्फुटभेदाळंकारमेळने संकरः? ॥ 
+
+
+खले supe ॥ 
+
+
+The simile of pigeons alighting on œ threshing-floor. Used 
+by writers on Alankara to illustrate the production of a certain 
+effect by the simultaneous action of numerous causes. In Sahi- 
+tyadarpana (739) we yai समुञ्चयोऽयमेकस्मिन्सति कायस्य 
+साधके । खले कपोतिकान्यायात्तत्करः स्यात्परोऽपि चेत्‌? ॥ “The conjunc 
+tion is when notwithstanding the existence of one cause sufi- 
+cient to bring about an effect, there are represented others pro- | 
+ducing the same, according to the maxim of the Threshing-floor 
+and the pigeons See this, also, very concisely put, in 
+Alankdrasarvasya, page 161, and in Kuvalayananda, p. 240. 
+There is further reference to this nyaya in Mallinatha on 
+Magha x. 16, and in Nyayamdlavistara 11. 1. 3. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangdhi Gyaan Kosha 
+
+
+गन्धाइमरजसा स्पृष्टो नष्टो दीपः पुनज्वैलेत्‌ ॥ 
+
+
+A lamp which has gone out will burn wp again if | 
+
+
+with sulphur-powder. The use of this illustration will be seen j 
+from the following passage of the vritti on Ta tevamultakalipn | 
+ii, 65—" ननु संस्रत्यवस्थालिद्धं निरयाणां ग्रातिकूल्यं स्वानुभूतं च ad मुक्त: | 
+पश्यति वा न वा। आद्ये गन्धाइमरजसा À नष्टो ढीपः पुनज्वेलेदिति ps 
+पुनरपि दुःखसन्ततिरुदियात्‌” ॥ | 
+
+
+गतंवर्तिगोधामांसविभजनन्यायः ॥ 
+
+
+The simile of the partition of the jlesh of an Iguana whilst | 
+at is still in its hole! Used to illustrate an impossibility. Ra | 
+ghunütha says of ४--“अनवबुद्धार्थ प्रद्नत्तिबिलवर्तिगोधाविभजनन्यायेः 
+नाइाक्येति ziada.” It occurs, in the form given above, in | 
+Khandanakhandakhadya page 640:--“यदपि तथापि क zee 
+तिर्यक्‌ Weed तदपि गर्तेवर्तिगोधामांसविभजनन्यायमनुहराति TATA 
+क्तयुक्तवा आच्छादितस्य दर्शयितुमशकयत्वेन तद्विभागब्यवस्थितेरनवसरतिर 
+SERI ॥ 
+
+
+गले पादुकान्यायः ॥ 
+
+
+The simile of the shoes on the neck. This quaint nyaya 
+appears to be used when an Opponent is compelled to accept 
+certain conclusions or else adopt an utterly absurd alternative 
+It occurs three times in Citsukhr. The first instance is in i, 11 
+(Pandit, vol. 1v, page 484), as 10]|0५४:--सर्वपासपि भावानांमाश्रय 
+SET संमते । प्रतियोगित्वमत्यन्ताभावं sr RT ॥ १५ ॥ तथाहि प 
+घटादीनां भावानां स्त्ाश्रयत्वेनाभिमतास्तन्त्वादयो ये तन्निष्ठात्यल्ताभावश्रतिः 
+VA तेषां सिथ्यात्वम्‌ । नहि तेपामन्यत्रसत्ता संभविनी । तत्रापि चेत्सा 
+"सदा गले पादुकान्यायेन रूपात्वमेव qa? ॥ This verse is quo | 
+
+
+ted in the second cha ji j ibl da 
+; chapter of the Tedantaparibhasha, und à 
+CC-0. Prof. Satya Vrat De er ceci arebhashd, and 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+25 YA 
+
+
+translation of it, and of the comment on it, by Professor Venis 
+will be found in the Pandit for 1888, page 660. I subjoin : 
+that portion which contains the simile, *For the existence of 
+these things cannot be surmised anywhere but in their sub- 
+strates......, and if the existence of these things, in their sub- 
+strates, cannot be surmised..., then the unreality of things is 
+the only conclusion (forced upon us), much in the same way 
+that 2 man must hang his shoes round his neck if he will nob 
+wear them on his feet.” The other two examples are in i. 26, 
+and ii, 16 (Pandit, vol v, pages 112 and 435). It is found also 
+in Atmatattvaviveka, page 45, in Khandanoddhara, pages 7 
+and 124, and in Upamitibhavaprapanca Katha, page 284, in 
+the erroneous form “गले पादिका.” 
+
+The explanation given by Raghundthavarman differs en- 
+tirely from the above, and is extremely far-fetched and unsatis- 
+factory. He says:—“ सदसतोरुत्पत्तिनिवृत्यसंभवेन परस्परविरोधे न प्रः 
+कारान्तरस्थितिरिति न्यायसिद्धस्य सच्वस्यासत्त्वस्य वानुपपत्तेगले पाढुकान्यायेः 
+नाज्ञानकार्यस्य बाधानुपपत्त्या चाज्ञानस्यानिवेचनीयत्वं बलात्खीकार्यस्‌ | यथा 
+कस्यचिङ्गहस्थस्य गृहेऽन्नाद्यार्थत्वछलेनागतो निषण्णश्च कश्चिद्वितेन तत्वतो 
+` ज्ञात्वा गच्छ गच्छेति पुनःपुनरुच्यमानोऽपि यदा धौतेन स्वेच्छया गमनं न 
+स्वीकरोति तदा पाहुकासाहितं पढं गले निधाय नोदयित्वा च बलान्निस्सायैते 
+तथा प्रकृते$पि बोध्यम्‌” ॥ 
+
+
+‘© : A x ee 
+गृहीत्वार्थ गताश्चोराः कस्तानाच्छत्तुमहातं ॥ 
+
+
+The robbers have got away with the booty; who is able to 
+intercept them? This saying is quoted by Vacaspatimisra in 
+his comment (on page 59) on Nyayavartika 1, 1.2. “ अपायो- 
+ऽपि तत्त्वज्ञानान्मिथ्याज्ञानस्थ स्वरूपतो वा विषयतो वा फलतो वा स्यात्‌ | न 
+तावत्स्वरूपतः । -.-नापि विषयतः । नहि झुक्तिकाज्ञानं रजतज्ञानस्य रजत- 
+विषयतामपहरसुत्सहते जातं हि dae विषयीकृत्य । यथाहुः | गुहीत्वाथै 
+गताश्चौराः कस्तानाच्छेत्तमहेतीति 7 10 is found also in Khandanod- 
+dhara, page 119." 
+
+
+4 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+26. 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+घटप्रदीपन्यायः ॥ 
+
+
+The simile of æ lighted lamp inside a vessel, Raghunath, 
+points out that a lamp so placed illuminates only the interior ot 
+the vessel, and he applies it to one whose knowledge of Brah. 
+man is of a low order. The maxim is used very differently, 
+however, by Anandavardhana in his Dhvanydloka iii. 33 (page | 
+190), ts the following extract will show:—“q त्वेष वाच्यव्य॑ग्ययोः | 
+न्यायः । नहि व्यंग्ये प्रतीयमाने वाच्यबुद्धिदूरीभवाति | वाच्यावभासाविनाभावे | 
+तस्य प्रकाशनात्‌ | तस्माद्वटप्रदीपन्यायस्तयोः । यथैव हि प्रदीपद्वारेण घरप. | 
+तीताबुत्पन्नायां न प्रदीपप्रकाशो निवर्तते तद्वब्यंग्यप्रतीतो वाच्यावभासः ”॥ ` 
+Abhinavagupta, when explaining Dhwanyaloka i. 12, refers to 
+this passage in the following words:—“aq एव तृतीयोह्योते we 
+्रदीपदष्टान्तबलाद्य॑ग्यग्रतीतिकालेऽपि वाच्यग्रतीतिरन विघटत इति यद्वक्ष्यति | 
+तेन सहास्य ग्रन्थस्य न विरोधः”? ॥ According to these great author | 
+ities on Alankara, therefore, the nyaya teaches that as the lamp 
+continues to burn after it has lighted up the interior of the | 
+vessel, and is indeed essential to the continuance of that illumi- | 
+nation, so the expressed meaning of a sentence is absolutely | 
+
+
+essential as a basis for the figurative meaning which it also 
+conveys, j 
+
+
+घटीयत्रन्यायः ॥ 
+
+
+This has the same meaning and application as the paa: 
+घटिकान्याय, for which see the first series of maxims. It occurs | 3 
+Sures'vara's large Vartika 4. 4. 248, and 6. 2. 155, as follows:— 
+“ अनिरज्ञातात्मतत्त्वः सन्कामबन्धनबन्धनः | घटीयञ्रवदश्रान्तो बंश्रमीत्यनिशं 
+नरः” ॥ “ घदीयन्रवदश्रान्ता एवमेव पुनः पुनः । परिवर्तन्ति संसारे कर्मः 
+वायुसमीरिता: ? ॥ Similarly, in his vartika on the Taittiriya- 
+bhashya 2. 1, 221 (page 86 ):—“aiteist भवेजन्म जन्मबीज तथा 
+सृतिः | घटीयच्रवदश्रान्तो बंश्रमीत्यनिज्ञं नर: ?॥ 16 is found too in पी 
+third work of his, namely Naiskarmyasiddhi i. 42. Also in. 
+
+
+the Jain treatise Prabamdhacintamani, page 62, as follows 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Fe 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+27 
+
+
+“आपट्गतं हससि कि द्वविणान्धमूढ 
+लक्ष्मीः स्थिरा न भवतीति किमत्र चित्रम्‌ । . 
+कि त्वं न पदयसि घटीजेलयत्रचक्रे 
+रिक्ता भवन्ति भरिता भरिताश्च रिक्ताः? ॥ 
+
+
+In Upamitibhavaprapanca Katha, pages 52, and 418, it 
+appears as अरघट्टघटीयच्रन्यायः In Kirtikauwmuds vi. 48, we have 
+the compound अमद्वटीसंघटितारघट्टखाद्वारशव्देः: The word अरघट्ट has 
+become राहाट in Marathi, as in राहाटगाडगें. 
+
+
+चक्रभ्नमणन्यायः ॥ 
+
+
+The simile of the [continued] revolving of the potter's 
+wheel. Followers of both Sankhya and Vedanta have asked 
+why, on attaining to right knowledge, a man is not immediately 
+liberated. Kapila's answer is contained in Sutra iH, 82. 
+* चक्रश्रमणवद्धुतशरीरः 7 ॥ On which Aniruddha says:—“ यथा 
+दण्डापगमे संस्कारवशाञ्चक्रं अमति तथा विवेकिनामपि देहधारणकर्मणोऽक्षी- 
+णत्वान्न तरक्षणान्सुक्तिः किन्तूपभोगादिना कसैक्षयादिति ॥ तथा च श्रुतिः । 
+fata नरो सुच्येत्त्टेन्सुक्तोऽपि विग्रहे । कुलाळचक्रमध्यस्थो विच्छिन्नोऽपि 
+Haz” ॥ Brahmasitrabhashya 4. 1. 15 teaches the same 
+thing from the Vedantist's standpoint, and propounds the very 
+important doctrine that whilst accumulated and current works 
+are destroyed by true knowledge, fructescent works, which 
+brought about the present existence, are not. ‘Therefore the 
+Jivanmukta has to continue here until death—just as the 
+potters wheel continues to revolve until the impetus given to: 
+it exhausts itself. 
+
+
+चिन्तामणिं परित्यज्य काचमंणिग्रहणन्यायः ॥ 
+The maxim of giving up the fabulous gem Cintamanr, and 
+tubing instead ७ mere piece of quartz! Tts application is 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+र Digitized By Siddhanta ०७६6 Gyaan Kosha 
+
+
+obvious. Raghunitha applies it to the man who abandons the i 
+search for the knowledge of Brahma in order to enjoy the. 
+pleasures of this life. S'antis'ataka 12, in Haeberlin’s Antho. 
+logy, bears on ऐ॥158:--“जन्मेदं वन्ध्यतां नीतं भवभोगोपलिप्सया | काच. 
+मूल्येन विक्रीतो हन्त चिन्तामणिर्मया” ॥ So, too, ZLitopades'a ii. 60:— 
+“ मणिर्छुठति पादेषु काचः शिरसि धार्यते । adang तथैवास्तु काचः काचो 
+मणिर्मणिः” y 
+
+There is an additional example in Upamitibhavaprapones 
+
+Katha, page 420:—“ निर्वाणसुखसंसारसुखयोश्च परस्परम्‌ । frena | 
+काचेन यावत्तावद्गणान्तरम्‌.”” Then, lower down on the same page, * 
+this and eight other figures are employed to illustrate the folly | 
+of one who, though acquainted with the Jaina creed, still clings J 
+to evil. The whole passage is reproduced for the benefit of 
+those who have not the book to refer to, “यो जैनमपि सम्प्राप्य 
+शासन कर्मनाशनम्‌ । हिंसाक्रोधादिपापेषु रज्यते मूढमानसः dp ET 
+काचेन चिन्तामणिमजुत्तमस्‌ । करोत्यङ्गारवाणिञ्यं दग्धा गोशीर्षचन्दनम्‌ ॥ 
+
+भिनत्ति नावं मूढात्मा लोहार्थे स महोदधौ | सूत्रार्थ दारयत्युचेवेंडूर्य रलमुत्तमम्‌॥ 
+
+प्रदीपयति set देवद्रोणी महत्तमाम्‌ । रत्रस्थाल्यां पचत्याम्लखलकं मोहदो 
+पतः ॥ सौवर्णराङ्गाम्रेण लिखित्वा वसुधां तथा । अकंबीजं वपत्येप तूलाथे | 
+मूढमानसः ॥ छित्वा कपूरखण्डानि कोद्रवाणां समन्ततः । दृति विधत्त सूढोऽयमहं 
+agha: किल ?॥ On page 170 there is yet another word of 
+
+Siddharsi’s in regard to the Cintémani, namely “ निर्ळक्षणतरो 
+
+नैव चिन्तामाणिमवामुते.? 
+
+
+| 
+
+
+ESI PEM सर ८६ 
+
+
+चेतनस्य यलहीनस्योध्वगतिश्चेतनान्तराधीना ॥ 
+
+
+Movement upward on the part of a quiescent | 
+being is dependent on [ the action of ] some other being of ४४ — 
+telligence. I should call this an axiom rather than a maxim; 
+but as Anandagiri terms it a laukika-nydya I include it here. 
+16 occurs in his comment on Brahmasitrabhashya, 4. 9, 5, a5 — 
+follows :--“चेतनस्य यलहीनस्योध्वंगतिश्रेतनान्तराधीनोति लोकिकन्यायेन | 
+यलहीनानां गन्दरणां गमयितारोऽचिरादयश्चेतनाः स्युरिति सूत्रयोजनया ब्रूते” ॥ 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+29 
+
+
+7 
+
+
+जलकतकरेणुन्यायः ॥ 
+
+
+The simile of particles of the Kataka nut [placed] in water 
+[in order to clear it]. Manu refers to it in vi 67 thus:— 
+
+
+[1 a ~ 
+
+‘ae कतकवृक्षस्य यद्यप्यस्बुप्रसादकस्‌ | न नामग्रहणादेव तस्य वारि 
+प्रसीदति? ॥ In the Laukikanydyasangraha the nyaya is 
+explained as follows:— यथा हि सपङ्कजरे निक्षिप्तः कतकस्योपधिवि- 
+शेषस्य रेणवो रजांसि तस्माज्लात्पङ्कं विलाप्य स्वयमेव विलीयन्ते तथा 
+तच्वज्ञानं सविलासाज्ञानं fad स्वयमेव Fada” The larger work, 
+the Laukikanyayaraindkara, adds the following quotation in 
+support of the definition: “qe भगवत्पादैः । अज्ञानकलुषं जीव 
+ज्ञानाभ्यासाद्विनिमेलम्‌ | कृत्वा ज्ञानं स्वयं नस्येजळं कतकरेणुवत्‌ u^ The 
+“worshipful feet” are those of S'ankaracharya, and the verse is 
+Atmabodha 5. 
+
+Sures'vara has given a capital illustration of the application 
+of this in his large Vartika 4. 3. 975-6 (page 1553):— 
+
+“अपां कतकसंपर्काद्यथास्न्तप्रसन्नता | 
+अपास्ताशेपसंसारभावनस्यैवमात्मनः ॥ 
+स्वास्थ्यं प्रसन्नतेतस्मिन्सुपु्ते भवतीत्यतः | 
+सम्प्रसादामंम आहुः सुषु West जनाः ॥ 
+
+There is an interesting example, too, in Hemachandra’s 
+Parisistaparvan ii, 4:— 
+
+“गुरुवाक्कतकक्षो दसंसक्तमभवत्सदा | 
+TUPAC AAAS तन्मनोवारि AAS” 
+
+Venkatanatha, however, does not altogether hold with this 
+simile; for in the vritti to his Zattvamuktakalapa i. 50 (page 
+215), he says:— 
+
+“न तु क्कचिदपि द्रव्यनाशः | अवस्थान्तरापत्त्या चादशनम्‌ | कतकरजोनि 
+
+
+दर्शनं च बालप्रलो भनम्‌ | न हि पयसि पंकः कतकरजसा शाम्यते विश्लेषमात्रदष्ट:। 
+न च स्वयं तत्र नऱ्यत्यसंशेषमान्नसिद्धेः' ॥ 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+£2 x20 IOS EL Se? 
+
+
+9 
+Digitized By Siddhanta edi otri Gyaan Kosha 
+
+
+जामात्रर्थ श्रपितस्य सूपादेरतिथ्युपकारकत्वम्‌ ॥ 
+
+
+xac क 
+
+
+Broth cooked for the son-in-law is also useful for the umer. 
+pected guest. This, like the देहलीदीपन्याय aud many others. 
+resembles our proverb “killing two birds with one stone,” I 
+have met with it only in Kwvalayananda (page 98) under the 
+figure दीपक. The passage is as follows: ef दीपस्य termat 
+
+दयोर्युगपढुपकारकत्वेन ` Es A A H 
+योरयुंगपदुपकारकत्वेन जामात्रर्थं श्रपितस्य सूपस्यातिथिक्ष्यः प्रथमपरिवेषणेन ` 
+च प्रासङ्गिकस्वं हीयते ७०.” This passage also illustrates another of _ 
+Ragunatha's nyayas, namely ग्रहार्थमारोपितस्थ दीपस्य रथ्योपकारकत्वमू. „ 
+
+
+ज्वरहरतक्षकचूडारलालंकारोपदेशवत्‌ ॥ | 
+
+
+Like instructions for obtaining Takshaka's crest jewel as a 
+Jebrifuge! An illustration of utter impossibility. It occurs in 
+the Nyayabindutika, page 3, line 9, in a passage regarding the 
+anubandhas, It runs thus" संशयो युक्तः | अनुक्तेपु तु | 
+अतिपत्तृमिनिष्पयोजनमभिधेयं संभाव्येतास्य प्रकरणस्य काकदन्तपरीक्षाया _ 
+इव । अशक्याजुष्ठानं वा । ज्वरहरतक्षकचूडारत्रारुंकारोपदेशवत्‌ | अनभिमतं ' 
+वा | मातृविवाहक्रमोपदेशवत्‌ W? I am indebted to Professor C. - 
+Bendall for pointing out this passage tome. It is applied by | 
+Vücaspatimis'a, in the same sense, in his Tütparyatika, page 3 
+and in the Nyayakanika, pages 338 and 417. 
+
+
+re 
+
+
+टिट्टिभन्यायः ॥ 
+
+
+.. The simile of the bird named Tittibha | Parra Jacana]. Tt 
+
+is based on the story of this bird as given in the Hitopadesa, 
+
+and is used 88 an illustration of ridiculous conceit. The verse 
+which paves the way for the story is ii. 137:— 
+“अङ्गाङ्गिभावमज्ञात्वा कथं सामर्थ्यैनिणय: | 
+
+पञ्य टिट्टिभमात्रेण समुद्धो व्याकुलीकृतः ॥ 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+व By Siddhanta eGangotri Gyaan Kosha 
+31 PES. 
+
+
+तक्रकोण्डिन्यन्यायः ॥ 
+
+
+The maxim of buttermilk for Kaundinya. This is one of 
+Raghunitha’s grammatical nyayas, taken from Mahabhasya, 
+and is intended to indicate a special exception to a general rule 
+as in the sentence ब्राह्मणेभ्यो दधि दीयतां तक्रं कौण्डिन्याय, where an 
+exception is made in the case of Kaundinya though included 
+amongst the Brahmans. It occurs in Brihadaranyavartika 
+1. 6. 71 ( page 881 ):— 
+
+
+“तक्रकोण्डिन्यवडय़ायो न चेहाप्यवसीयते । 
+उत्सर्गानवकाशत्वाच्छून्यतैवात आपतेत्‌” ॥ 
+
+
+On which Anandagiri comments as follows:— “अभिन्नराव्द्स्य 
+सेदनिषेधित्वेऽपि न भेदस्य शून्यता सवंत्र प्राप्तस्य कारणे निषेधादार्यभ्यो द॒धि 
+ढीयतामित्यायोपाधौ प्राप्तस्थ दश्षस्तक्रं कौण्डिन्यायेति कौण्डिन्ये निषेधेऽप्यञ्चन्यः 
+तावदित्यारांक्याह तक्रेति? ॥ 
+
+
+I have noted down seven instances of the occurrence of this 
+illustration in the Mahabhasya, namely, 1. 1. 47; 6. 1. 2 (4); 6. 2- 
+1; 6. 4. 163 (2); 7. 1. 72 (8); 7. 2. 117 (2); and 7. 4. 61 (4). It 
+will suffice to quote the first, as the other six are practically the 
+5.m९:—“लौकिकोऽयं cera: | लोके हि सत्यपि संभवे बाधनं भवति d 
+तद्यथा | दधि ब्राह्मणेभ्यो दीयतां तक्रं कौण्डिन्यायेति सत्यापि सम्भवे दधि- 
+दानस्य तक्रदानं fads भवति.” See, also, Nagoji Bhatta's pari- 
+bhasa LVI], and Professor Kielhorn’s translation of the same. 
+Other instances of it will be found in Vakyapadiya, ii. 352; 
+S'lokavartika, page 617 (verse 15); Tantravartika, page 262 
+(last 2 verses); and Bhamati, 3. 3. 26 ( page 628), 
+
+
+तपनीयमपनीय वाससि अ्रन्थिकतारमुपहससि स्वयं च 
+कनकमुपादाय गगनाञ्चले मन्थि करोषि ॥ 
+
+
+Thou ridiculest the man who taking his gold ties it wp in 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+i 
+
+
+‘on page 181 of the Taittiriyavārtika:— rezi पर्य gaa fg 
+
+
+32 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+a corner of his garment, and then thyself taking the gold J ! 
+it up in the skirt of the sky! It is found in A imatattravivelg, P4 
+(page 58, line 3 from bottom ), as follows:— तस्मान्नीलादीनां " 
+काशसानत्वं परिपालयता ग्राह्यछक्षणे यलः कर्तव्यः परिहतंव्यं वा प्रकाशमानः 
+aq | अन्यथा तपनीयमपनीय वाससि अन्थिकर्तारसुपहससि ag कनक. 
+सुपादाय गगनाञ्जले ríe करोषीति । सेयं सर्वग्रकारमसिद्धिः aaa 
+चानेकान्तिकमिति ” ॥ 
+
+
+तस्करकन्दुन्यायः ॥ 
+
+
+The simile of « thief [who engaged himself] as « cook, 
+His inability to perform the duties, however, led to his discovery 
+and arrest. This is intended to teach the folly of undertaking | | 
+to do something quite beyond our powers! Sures'vara is the 
+only author in whose works I have met with it. The following | 
+verse, which contains it, appears in his large Vartika ( page 
+610), and also in that on the Taittirtyopanishadbhashya - 
+(page 169), the preceding context, too, being identical in both । 
+cases:—“ अशक्ये विनियुक्तोऽपि कृष्णलान्‌ श्रपयेदिति । सर्वात्मनाप्यसौ । 
+कर्वन्कुयांत्तस्करकन्दुवत्‌.” The following is an extract from Anan: 
+dagiri’s comment on the former passage:-—“aq यद्यपि सन्तापमात्रं 
+कृप्णलेप्वपि शक्यं ag तथापि विक्लित्तिप्रधानः used इति न्यायेन सन्तापः 
+wat तामेव तेषु कुवंन्नायासमात्रभागी स्याद्यथा लोके तस्करः सन्कन्दुरपूपाः | 
+Rg स््यमपि sf तत्कर्म कुर्वन्नरक्यकारित्वादायासमात्रभागभवत्ेः 
+वमशक्यत्वाउज्ञानेऽपि न वेधी spends" ॥ The same commenta- 
+1078 explanation of the nyaya as it appears in the latter work - 
+is somewhat different. He 8098:--कश्रिच्चोय कृत्वा स्वकीयचौर्यः d 
+संवरणार्थ सन्निहितं कन्दुृहं प्रविष्टः गृहस्वामिना कन्दुना कन्दुकमौणि नियुः | 
+क्तसतत्कर्मण्यशक्ये विनियुक्तत्वात्तव्कुर्वन्‌ राजपुरुपैस्तस्करमन्वेषमाणैस्तत्र झटिति | 
+समागतेरुक्ते कर्मण्यकुशलतां समालोच्य तस्करोऽयमिति ज्ञात्वा गृहीतो 
+व्यथक्रेशभागी यथा तस्करकन्दुः संवृत्तस्तथा ब्रह्मज्ञाने नियुक्तोऽपि तस्य mds 
+मशक्यव्वातततकु्वन्व्यर्थक्लेशभागी भवेदित्यर्थः? ॥ The nyaya occurs again | 
+
+
+मो N TAA TRS 
+क्तोऽपि न erp | शक्रुयात्सज्नियोगाज्ेल्कुर्यात्तस्करकन्दुव॒त्‌ ॥ 
+CC-0. Prof. Satya Vrat Strastri Collection. 
+
+
+aaa By Siddhanta eGangotri Gyaan Kosha 
+
+
+33 
+
+
+तस्करस्य पुरस्तात्कक्षे सुवणमुपेत्य सर्वाङ्गोद्धाटनम्‌ ॥ 
+
+
+A. thief’s offer of his limbs for examination when the gold 
+has been found under his armpit! This occurs in the Jai- 
+mini chapter of Sarvadars'anasangraha (page 134 of Bib. Ind, 
+edition, and page 152 of Jivananda’s) of which the following is 
+on extracti—“qeaq कुसुमाञ्जलाबुदयनेन झटिति प्रचुरभवृत्तेः प्रामाण्यनि- 
+श्वयाधीनत्वाभावमापादयता woe wur तस्करस्य पुरस्तात्‌ कक्षे 
+सुवणेमुपेत्य सवोङ्गोद्वाटनमिव प्रतिभाति” ॥ Professor Cowell's render- 
+ing of the passage is as follows:—“As for the argument urged 
+by Udayana in the Kusumanjali, when he tries to establish that 
+immediate and vehement action does not depend on the agent's 
+certainty as to the authoritativeness of the speech which sets 
+him acting......all this appears to us simple bluster, like that of 
+the thief who ostentatiously throws open all his limbs before 
+me, when I had actually found the gold under his armpit.” 
+
+
+तिलतण्डुलन्यायः ॥ 
+
+The simile of «ice and sesamum seeds, Used to illustrate 
+an easily distinguishable union of two or more things, in con- 
+tradistinction to the more intimate and indistinguishable union 
+exemplified by the commingling of milk and water. For 
+examples, see क्षीरनीरन्याय, Also Rudrata’s Kavydlankare x. 25, 
+
+
+तुलोन्नमनन्यायः ॥ 
+
+
+The simile of the raising [with the hand, one scale] ofa 
+balance. That, of course, causes the other scale to go down; 
+and so the simile is used to illustrate the bringing about of 
+two or more results by one operation. It occurs in the follow- 
+ing passage of Pancapadika ( page 38 ):— pk रजतामेति यन्नः 
+
+
+kaama निरस्यते न वस्तुतत्त्वमवबोध्यत तत्र तथा भवतु । इह Gale 
+5 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+DE. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+ज्ञानमेव तादरासुत्पत्न॑ यद्विरोधिनिराकरणमन्तरेण न स्वार्थ साधयितुमल za | 
+ज्षमनव्यापार इवानमननान्तंरीयक्रः । तथाह्यन्नमनव्यापारः स््रविपयस्य P | 
+द्रव्यस्थोध्वेदेशसंबन्धं न साधयितुमलं तत्कालमेव तस्याधोदेशसंबन्धमनापराद् | 
+न वोन्नमनकारकस्य हस्तप्रयलादेरानमनेऽपि कारकत्वम्‌? ॥ In commenting 
+on this, Prakas‘atman says: अन्यविषयव्यापारादन्यविषयस्य नान्तरी 
+यकसिद्धि साधयति तथाह्यु्नमनव्यापार इति? ॥ 
+
+
+Other good examples of it will be found in Nyayavirtika ` 
+3, 2, 12 (top of page 412), the substance of which is reproduced 
+in Vydyamanjari, page 456 ; in S'lokavartikatika, page 311 | 
+(where it is seen in conjunction with the पक्मपत्रशतव्य़तिभेदन्याय); | 
+and in Vivaranaprameya, page 99, line 4, 4 
+
+
+तुषकण्डनन्यायः ॥ 
+
+
+The simile of #he grinding of chaf. Used, like पिष्टपेषण- ' 
+न्याय, of any unnecessary and useless effort. It occurs in | 
+Padmapida’s Pancapadika, page 68, as follows:—“@q gar |! 
+थैरूपताऽनन्यसिद्वता तत्मतिपाद्यता चेति भिद्यन्ते विपयसंबन्धप्रयोजनानि तानि | 
+च त्रीण्यपि पत्रृतयङ्गम्‌ । नापुरुपार्थे काकदन्तपरीक्षायां तुषकण्डने वा प्रवते 
+अक्षावान्‌ u Also in the Hitopades'a iv. jr T यु- i 
+क्तिकथनं तुषकण्डनम्‌ | नीचेपूपकृतं राजन्वालुकास्विव a eeu ॥ ë 
+
+Sures'vara too makes very frequent use of it. We find it on 
+pages 676, 1036, 1334, 1505, and 1572 of his large Vartika; 1 
+and on page 176 of his Taittirīiyavārtika. r 
+
+
+.The nyüya is not in Raghunatha’s book, but he has others ~ 
+of the same meaning which I have not met with in the litera- 
+Ure ; namely जलमन्थनन्याय, and गदैभरोमगणनन्याय. The same | 
+एफ 1S expressed in the following sentence of the Wyayamani 4 
+B pe Os नार किसयं दग्धो दह्यते स्तो वा मार्यते अनेकान्तिकहेत: | 
+CC नम गाना टात किं हेत्वन्तराख्यनिग्रः | 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+E By Siddhanta eGangotri Gyaan Kosha 
+35 
+
+
+e 
+तुष्यतु दुजनन्यायः ॥ 
+
+This saying is explained by Taranatha as follows: —“qurgq 
+दुर्जन इति न्यायो यत्र प्रतिवादयुक्तपक्षं दुष्टमपि वादिना प्रौढिवादेनाङ्गीकृत्यापि 
+दूषणान्तरस्य दानं तत्रास्य प्रवृत्तिः ॥ 16 would therefore seem to 
+mean “Let this evil fellow, my opponent, chuckle over his ap- 
+parent success in this argument, but what about so-and so?” 
+I have met with it in Advaitubrahmasiddht, page 14, in the 
+following sentence :—“ यथास्वरूपं किमधिकरणस्ुताधेयम्‌ | यद्वा प्रती- 
+तिकालः किं वा प्रतीतिरेव । उतावच्छेदकदेशो वेत्यत्र विनिगमनाविरहात्तुष्यलु 
+दुर्जनन्यायेन स्त्रीकारेऽपि न निर्वाहः? ॥ I6 occurs again on page 16. 
+In the Bhdmati, page 243, we have it in the form “तुष्यतु परः?? 
+as 10|1095:--“यद्येष परस्याग्रहो धर्मिण्यग्रह्ममाणे तद्धर्मा न शक्या ग्रहीतुः 
+मिति । एवं नामास्तु तथा तुष्यतु परस्तथाप्यदोष इत्यर्थः ॥” This is de- 
+cidedly the clearest example. In his translation of Haridasa’s 
+comment on Kusumanjali i. 3, Prof. Cowell's rendering of the 
+nyaya is * the principle of satisfying an opponent.” 
+
+
+तृणंजलायुकान्यायः ॥ 
+
+
+The illustration of the caterpillar. This illustration is used and 
+explained in Brihadaranyakopanishad 4.4. 3 as follows:— 
+“ तद्यथा तृणजलायुका तृणस्यान्तं गत्वान्यमाक्रममाक्रम्यात्मानमुपसंहरत्येवमे- 
+वायमात्मेद॑ शरीरं निहत्याविद्यां गमयिस्ान्यमाक्रममाक्रम्यात्मानसुपसं- 
+हरति” ॥ I include it because it is found in Raghunatha's 
+list; but it is of no practical value. 
+
+
+तृणारणिमणिन्यायः॥ 
+
+
+The simile of straw, arani wood, and the burning gem | as 
+means of producing fire]. The kind of fire produced by each 
+Varies ( just as that of a lighted lamp differs from that of burn- 
+
+
+ing wood or cowdung); and the method of production, too, is 
+. CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+36 E | 
+Digitized By Siddhanta eGahgotri Gyaan Kosha र 
+
+
+different; that being in one case blowing, in another attrition 
+and in the third the rays of the sun. The application of the 
+
+
+= | 
+
+
+nyaya will be seen from the following passage of Nyayamanja. | 
+risdra, page 3, line 5 :--“अन्न नव्या: तृणारणिमणिन्यायेन विप्नध्व॑सविशेष 
+एव मङ्गलस्य फलं विप्नध्व॑सविशेषान्तरं च विनायकस्तवपाठादेः फलम्‌ | 
+विक्रसंसर्गाभावादिकारणकलापजन्या”?. For an interesting discussion 
+as to the ‘capacity’ (शक्ति) residing in straw &c., see Kusuman- 
+jali pages 58-72, and Prof. Cowell’s translation, pages 6 and 7, — 
+The nyaya is not included in Raghunatha’s collection, but is 
+explained in the Vacaspatyam ( s. v. न्याय) as follows — anaig | 
+अति तृणस्य, आरणेयवहि प्रत्यरणेः, मणिजन्यवाहि प्रति मणेश्र कारणत्वं, न तु 
+बह्लित्वावच्छिन्नं प्रति तृणादेः कारणत्वं परस्परव्यभिचारात्‌ | एवं यत्र कार्यकारण 
+भावबाहुल्यं कार्यतावच्छेदकं कारणतावच्छेदकं च नाना तत्रास्य HAA” d 
+
+
+4] 
+
+
+तैल्पात्रधरन्यायः ॥ 
+
+
+The simile of a man carrying a, vessel full of oil [and who is | 
+to be put to death if he spills a drop of it!]. This curious | 
+illustration is given in Bodhicurydvatara vii-70, and applied | 
+to one who has adopted the ascetic ॥11९:--“तेलपात्रधरो यद्वदसिहस्तेः i T 
+रभिष्टितः। स्खलिते मरणत्रासात्तत्परः स्यात्तथा ब्रती.?? 
+
+
+त्यजेदेकं कुलस्यार्थे ॥ 
+
+
+One should abandon an individual for the sake of a whole 
+Jamily. This is the first pada of Hetopades’a i. 115 which | 
+reads ॥108:--“लजेदेक॑ कुलस्यार्थे ग्रामस्यार्थे कुळं त्यजेत्‌ | मामं जनपदस्यार्थे 
+आत्मार्थे प्रथिवी त्यजेत्‌? is quoted by Anandagiri, in his com- 
+ment on Brakmastitrabhashya 1, 1. 22, as follows:—"erstas: 
+कुलस्पार्थ इति न्यायाद्भ्यसीनां नह्मलिङ्गश्रुतीनामनुग्रहायाकाशाश्चुतेरेकस्या बाध 
+gue” ॥ Raghunatha expounds it thus in the Laukikanyaye 
+500700 यत्रो भयको दिकसंये एकत्र बह्वर्थहानिद्वितीयस्वीकारे ले 
+कार्थेहानिस्तन्र Tate: स्वीकतेव्य Gp विवक्षायांतझञजेदेकं send इति 
+
+
+e By Siddhanta eGangotri Gyaan Kosha 
+
+
+37 
+
+
+न्यायः प्रसरति?॥ Further on he says, “aeg त्यजेदेकमिति न्यायं 
+नानुसराति सोऽस्पस्य हेतोर्बहु हातुमिच्छन्विचारमूढः प्रतिभासि मे स्वमिति 
+न्यायविपयतां नातिवर्तते” ॥ A nyaya ‘of similar import to the one 
+under consideration is “ सर्वनाञ्चे समुत्पन्ने अधे त्यजति पण्डित:;” 
+which see below. 
+
+
+द्ग्धेन्धनवह्लिन्यायः ॥ 
+
+
+The simile of the fire which has consumed the fuel [and 
+therefore goes out]. This immediately follows the semas- 
+रेणुन्याय in Raghunütha's list, and is meant to teach much the 
+same thing. He says:—‘eradizaala येन aisha स्वयमेव 
+शास्याति तथेति qaaa ॥ We have an instance of the employ- 
+ment of the figure in S’vetds'vatara Upanisad vi. 19; and again 
+in S'ankara's bhashya on .-Dralimasütra i.i 4 (page 76), and 
+Sures'vara/s large Vartika pages 1593 and 1840. The follow- 
+lng is Paramarthasara 17:— reat कमविकल्पानात्मस्थे सनः केवलं 
+कृत्वा | दग्धेन्वन इव afa: सवंत्रात्सा भवेच्छान्तः d 
+
+
+A 
+दाण्डन्यायः ॥ 
+
+The simile of « man with a stick | or, men with sticks]. The 
+first instance, which I know of, of the employment of this 
+nyaya is in a curious passage of Patanjali’s on Panini 8. 2. 83, 
+for reference to which I am indebted to Professor Kielhorn. It 
+occurs also in the Nydyavartika on sūtra i. 37. In this, and 
+in the preceding sūtra, there is a definition of udaéharana, 
+in the course of which the term तदधर्मभावी occurs. In regard to 
+this the Vartikakara remarks:—“a तु तद्धमेभावीत्येतत्पदमच्यथा 
+निराकुर्वन्ति तद्धम॑भावी भवन्नुष्णभोजिन्यायेन वा भवेहण्डिन्यायेन वा भवेत्‌ । 
+तद्यदि ताव्रदुष्णभोजिन्यायेन उष्णं wr शीलमस्येत्युष्णभोजी quo वा 
+भावयिठुं शीलमस्येति तद्ध्म॑भावी । अत्रापि भावयितुं गमयितुं यावदुक्तं 
+स्यादिति । नायं सूत्रार्थं इति न किञ्चिदेतत्‌। दण्डिन्यायस्तु द॒ण्डो यस्यास्तीति 
+
+
+स दण्डी TEAM यस्यास्ति स भवति तदुर्मभावी d 
+-0. Prof. Satya Vrat Shastri Collection 
+
+
+38 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+The following from Vachaspatimisra’s Lattvabindy closely 
+resembles the explanation given of the FU ees 
+गच्छन्तीत्यत्र तु दण्ड्यदण्डिपु RI लक्ष्यमाणेपु तदन्तर्गतस्थाविशेषाह- 
+ण्डिशब्दार्थस्थ परिग्रहः?॥ 
+
+
+दामव्यालकटन्यायः ॥ 
+
+
+The maxim of the Asuras, Dama, Vydla, and Kata. This 
+is expounded by Raghunatha in the following manner— 
+“दामव्यालकरन्यायो न तव स्यात्कदाचन | भीसभासरढन्यायः सर्वदा तेऽस्तु 
+qaa” इत्यादिना वासिष्ट इदं न्यायद्वयं सम्रपञ्चसुपन्यस्तस्‌ | तन्रादयस्योच्चतरां 
+दशामापन्नस्याप्यज्ञस्यातिनीचदराप्रासिरवइग्रं कालेन भवतीति तत्त्वबोधो- 
+saa संपाद्य इति विवक्षायां प्रवृत्तिः | दामव्यालकराख्यास्रयोऽसुराः शंबरेण 
+स्वमायया निमितास्ते च तलम्रहारादिना मेर्वादिचूर्णीकरणे झक्ता अप्यज्ञान- 
+प्रभावात्कालेन मशकादियोनिं प्रापुरिति प्रसिद्धं तत्र ॥ तत्त्वविन्न कदापि 
+स्वपदात्पततीति विवक्षायां द्वितीयस्यावतारः । तेऽप्यसुरास्तेनेव तथा निः 
+fate जीवन्मुक्तिसुखमनुभूय निर्वाणपदं प्राप्ता इति संक्षेपः । प्रपञ्जसतु 
+तत्रैव द्रष्टव्यः? ॥ “Vasishtha,” means the Yogavasistha, in Book 4 
+(chapters xxv—xxxiv ) of which, we have a detailed account 
+of these six Asuras. The verse quoted by Raghunatha is not 
+
+
+found in the printed edition exactly in that form, but 4. 34. 30 
+reads thus :— 
+
+
+“दामव्यालकटन्यायस्तस्पान्मा तेऽस्तुं राघव | 
+भीमभासदढन्यायो नित्यमस्तु तवानघ ” ॥ 
+
+
+ip Y " . . ` - i 
+
+WA 18 one of similar import in the opening part of thelt 
+
+istory, and Mr, M. R. Telang has pointed out a third in the 
+closing part of chapter xxiv, 
+
+
+mm 
+
+
+धनंजयन्यायः || 
+
+
+Th टा f n l ; 
+TON me ot Arjuna. Used to show that something; 
+one, may be done again, as in t 1j i 
+who defeat gain, as in the case of Arjun 
+
+cleatedélyp Rica Setyac\yrat hes qon pe हा defeated 
+
+
+Bag 
+
+
+NE Aa Aa 
+
+
+> 
+
+
+Digitized By Siddhanta efigngotri Gyaan Kosha 
+
+
+them. Rachunatha Says — नित्रबोधमहिस्ना बाधितेऽपि zà वाक्य- 
+जबोधस्य धनंजयन्यायेन बाधकत्वोपपत्तः । यथाहुः । "नित्यबोधपरिपीडितं . 
+जरद्विञ्रमं नुदति वाक्यज्ञा मतिः | वासुदेवनिहतं धनञ्जयो हन्ति कौरवकुळं 
+यथा पुनः’ ॥ “Knowledge effected through Vedic sentences de- 
+stroys that error termed the world, which had already been 
+destroyed by eternal knowledge (Self, Brahman): jusb 88 
+Arjuna slays again the Kuru race already slain by Vasudeva.” 
+The verse is Sankshepas'ariraka ii. 38, and the translation 
+is that of Mr. Arthur Venisin the Vedantasiddhantamuktavalt 
+(page 174) where the verse is quoted. 
+
+
+घान्यपरारच्यायः ॥ 
+
+
+The simile of grain and its husk. The earliest example of 
+this figure is in the Brahmabindwu Upanishad, verse 18:— 
+“ग्रन्थमभ्यस्य मेधावी ज्ञानविज्ञानतत्त्वतः | पलालमिव धान्याथी ल्जेड़- 
+न्थसहोषतः?॥ This verse, with others of similar import, is 
+quoted in Pancadas7 iv. The following, from 0060066, page 
+54, appears also, without any acknowledgement, in the first 
+chapter of Survadars'anasangraha :— अवर्जनीयतया दुःखमागत- 
+मपि परिहत्य सुखमात्रं भोक्ष्यते । तद्यथा । मत्स्याथी सशल्कान्‌ सकण्टकान्म- 
+व्स्यानुपादत्ते स यावदादेयं तावदादाय विनिवर्तते । यथा वा west 
+सपलालानि धान्यान्याहरति स यावदादेयं ताबढुपादाय निवतंते?? 
+
+
+Vüeaspatimisra, however, was not the originator of the 
+illustration. It occurs four times in the Mahabhasya, namely, 
+1, 2. 39; 3. 3. 18; 3. 4. 21 (vart. 2); and 4. 1, 92, The following 
+is the passage, the substance of which is reproduced in the 
+Bhamati and Sarvadars'anasangraha — कश्चिदन्नाथी शालिकलापं 
+सपलालं सतुपमाहरति नान्तरीयकस्वात्‌। स यावदादेयं तावदादाय तुषपलाला- 
+न्युत्सृजाते | तथा कश्रिन्मांसार्थी मत्स्यान्सकण्टकान्सशकलानाहरति नान्तरी- 
+यकत्वात्‌। स यावदादेयं तावदादाय शकलकण्टकानुस्सृजाति.? See, also, 
+Nagoji Bhatta's paribkasa 73. The nyaya seems to have a 
+different application in Marathi literature. Molesworth's defini- 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta कळी Gyaan Kosha 
+tion is as Tollows:—“The law of the corn and its straw. Conquer 
+. the king and you conquer his subjects; accomplish or acquire a 
+matter and you attain all it sustains or involves.” 
+
+
+Tag शालग्रामे किरातशतसङ्कीर्णे प्रतिवसन्नपि ब्राः 
+झणः किरातो भवति ॥ 
+
+
+A Brahman does not become a Kirdta by living on the 
+S'dlagrama mountain filled with hundreds of those barbari- 
+ans! This is equivalent to our saying, “A horse does not bo- 
+come an ass by being born in the stable of the latter,” Compare, 
+too, S'ankara’s “न ह्यश्वस्थाने गां पइ्यन्नश्वोऽय्रमित्यमूढोऽध्यवस्यति in 
+Brahmasiitrabhdsya 1. 4. 1. The saying as given above is 
+found in Vacaspatimis'ra's comment on Yogabhashya i. 5; and 
+he makes use of it again in his Bhamatii 1, 5 ( page 126) in 
+the sentence “ अन्यथा किरातशतसंकीणदेशनिवासिनों ब्राह्मणायनस्थापि कि- 
+रातत्वरापत्तेः” ॥ 
+
+
+न यहिरिशक्धमारुद्म शृह्यते तदप्रत्यक्षम्‌॥ 
+
+
+A thing does not become imperceptible because perceived by 
+one who has ascended & mountain peak—This saying, quoted 
+from Tantravartika 1, 9 
+
+
+anjarī (page 422) in the course of a discussion on the sadhutua 
+and asadhuta of words, 
+
+
+नेप दोपः । वे पिप ` i i 
+aT St चयाकरणोपदेशसाहायको स [पक्ततश्रोत्रेन्ट्रिय़ाह्यत्वाभ्युपगमात्‌ । यथा 
+यथाह Do KA न प्ल्यक्षगस्यतामपोज्ञति । | 
+REFARI गृह्यते तदप्रत्यक्षसिति ? ॥? it 
+on pages 06 and 299, ale उमत्यक्षसिति ) ॥१? Jayanta quotes i r 
+
+
+eo सम डा, 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+SII क्य 
+
+
+Digitized By Siddhanta faac Gyaan Kosha 
+
+
+~N सिंहर 
+नरासहन्यायः il 
+The simile of the union of man and lion. Used to illustrate 
+a particular kind of Alankara consisting of ७ combination of 
+figures. See the quotations from Sarasvatikanthdbharana and 
+Kuvalayananda, under क्षीरनीरन्याय. 
+
+
+न हि निन्दा fed निन्दितुं प्रयुज्यते किं तहिं निन्दिता- 
+Rara प्रशंसितुम्‌ ॥ 
+
+Blame 4s mot employed in order to blame something that 
+is blameworthy, but rather to praise something other than 
+that.. This is the form taken by the nyaya in S'abara on Jai- 
+mini 2, 4. 20. In Tantravārtika, page 16, it appears as “न हि 
+निन्दा निन्द्यं निन्दितुं sada अपि तु विघेयं स्तोतुम्‌)? and Anandagiri 
+quotes this reading of it in his comment on Brihadaranyak- 
+opanisadbhasya 2. 5. 16. 
+
+The following passage from Agamapramanya, page 51, ad- 
+mirably illustrates the meaning of the nyaya-——“ag 34 वेदमूलत्वे 
+पञ्नरात्रतनज्नाणामजुपपन्नं वेदनिन्दादशनात्‌ | उक्तं हि चतुर्षु वेदेषु पुरुषार्थमल- 
+भमानः शाण्डिल्य इदं शास्रमधीतवानिति | अनवगतवचनव्यक्तेरयं पर्यनुयोगः । 
+न हि निन्दा निन्द्यं निन्दितुं प्रवर्तते अपि तु निन्दितादितरत्मरांसितुम्‌ । यथैतरे- 
+THM प्रातः प्रातरनृतं ते वदान्ति’ इत्यनुदितहोमानिन्दा उदितहोमम्रशंसा- 
+थेति गम्यते । यथा सानवे (iv. 124) | 
+
+* ऋग्वेदो देवदैवत्यो यजुर्वेदस्तु मानुपः । 
+सामवेदस्तु पित्र्यः '्यात्तस्मात्तस्याछुचिध्वेनिः? ॥ 
+इति सामवेदनिन्दा इतरवेदप्रशंसा्थां | यथा वा UTA | 
+* चत्वार एकतो वेदा भारतं चेकसेकतः। 
+समागतेस्तु ऋपिभिस्तुर्यारोपितं पुरा ॥ 
+महत्त्वे च गुरुत्वे च Gat यतोऽधिकम्‌ । 
+Haa गुरुत्वाच महाभारतझुच्यते' ॥ 
+
+इति महाभारतग्रंसाथेति' गृह्यते न वेढनिन्देति | एवं पन्चरात्रत्रशसेतिं 
+
+Tae” ॥ 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+d 9 
+Digitized By Siddhanta eGáhgotri Gyaan Kosha 
+
+
+Another reference to the vyaya will be found in Vyayjamep, 
+
+
+jari page 273, 
+
+
+नहि भवति तरक्षुः प्रतिपक्षो हरिणशावकस्य ॥ 
+
+
+A hyena does not finda suitable opponent in a young 
+fawn. This may be contrasted with the saying “न हि कठोर- 
+कण्ठीरवस्य ङुरङ्गश्ावः प्रतिभटो भवति.” 1 is found in the Nyiya- 
+vartikatdtparyatika, page 38:--“तुल्यबलो हि मिथः प्रतिपक्षो भवतो 
+न तु दुर्बलोत्तमबली । न हि भवति तरक्षुः प्रतिपक्षो हरिणशावकस्य किन्तु 
+समरकण्डूनिप्राविपाणकोटिससझ्चुललिखितगण्डशेळस्य विपिनमहि पस्य”? y 
+
+
+न हि भिक्षुकाः सन्तीति स्थाल्यो नाधिश्रीयन्ते न च 
+मृगाः सन्तीति यवा नोप्यन्ते ॥ 
+
+
+Men do not refrain from setting the cooking-pots on the 
+Jire because there are beggars | who may come to ask for some 
+of the contents ], nor do they abstain from sowing barley be- 
+cause there are wild animals [ which may devour it ] This 
+oft-quoted saying appears three times in the Mahabhasya, 
+namely in 1. 1. 39 ( vart. 16), 4. 1. 1 ( vart. 15), and 6. 1. 18 
+(vart. 18), and this is probably the original source of it. I have 
+met with it in two of Vacaspatimisra’s works, as follows, In 
+the Nyayawartika tatparyatike, page 62:— FA खल्वयं प्रेक्षावतां 
+समाचारों यहुःखभिया सुखपरित्याग इति अपि तु सुखं दुःखाद्विभिद्योपाददते दुःखं 
+च वर्जयन्ति | न हि खगाः सन्तीति शालयो नोप्यन्ते भिक्षुकाः सन्तीति स्थाल्यो 
+नाधिश्रीयन्त इति’ ॥ Similarly, on page 441 of the same. In Bha- 
+mati, page 54, we 7680:--“तस्माहु:खभयाज्नानुकूलवेदनीयमै हिकं वामु 
+ष्मिकं वा सुखं परियक्तुसुचितम्‌। न हि झगा: सन्तीति meat नोप्यन्ते fr 
+Ba: सन्तीति स्थाल्यो नाधिश्रीयन्ते q The same passage, with a 
+good deal of the preceding context, reappears, without acknow- 
+ledgment, in the Chàrvüka chapter of the Sarvadars‘anasan- 
+
+
+gue We find the Saying in a modified form in the Lanca- 
+| aS 3 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+* 
+
+
+Digitized By Siddhanta mgoni Gyaan Kosha 
+
+
+padika, page 63:—"अतोऽजीर्णभयान्नाहारपरित्यागो भिक्षुकभयान्न स्थाल्या 
+अनधिश्रयणं दोपेषु प्रतिविधातब्यामिति न्यायः ॥” It appears in this 
+form in Jivanmuktiviveka, (page 8) also, and is there ascribed 
+to Anandabodhicirya. See his ग्रमाणसाला page 21. Then we 
+have the well-known verse, Hitopades'a ii. 50:— 
+
+
+“दोषभीतेरनारम्भः कापुरुषस्य लक्षणम्‌ | 
+Redi ` NC रिही NM. 
+PANAMA IAA परिहीयते ॥ 
+
+
+न हि इयामाकवीजं परिकमंसहस्रेणापि कलमाङ्कराय 
+कल्पत Ul 
+
+
+Not even by the employment of a thousand different. pros 
+cesses can S'yamaka grain be made to germinate as rice. 
+Vacaspatimis’ra was fond of this kind of saying. That above 
+is from his Nya@yavartikatatparyatika, page 55, and another 
+of the same class occurs twice in the Bhémati. On page 180 
+(1.2.18) “ नहि जातु वटाडुरः कुटजबीजाज्ञायते)' and on page 704 
+(4. 1. 1.) “न खलु कुटजबीजाद्वटाडुुरो जायते? ॥ Compare, too, Manu 
+
+
+ix, 40:-- अन्यदुप्तं जातमन्यदित्येतन्नोपपद्यते | उप्यते यद्धि Agi तत्तदेव 
+प्ररोहति” They all remind us of those sayings from another 
+
+
+part of the Orient:—“ Do men gather grapes of thorns, or figs 
+of thistles?” and again, “ Whatsoever a man soweth that shall 
+he also reap.” 
+
+
+न हि सहस्रेणाप्यन्धैः पाटचरेभ्यो TE रक्ष्यते ॥ 
+
+Not even a thousand blind men can protect a house from 
+robbers, This is another of the sayings of Vacaspatimis'ra, and 
+is found in his tika on Nyayavdrtika 1. 2, (the definition of 
+जल्प ). To see the aptness of the saying it would be necessary 
+to transcribe a lengthy passage of the bhashya and vartika ; 
+but the scholar can easily refer to them himself. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta Ed Eon Gyaan Kosha | 
+
+A Cs T हि | 
+
+न हि सुतीक्ष्णाप्यसिधारा स्व॑ छेन्माहितव्यापारा t | 
+
+| 
+
+The edge of a sword, even though very keen, is not employed 
+
+to cut itself. The nyaya is found in this form in Syadvadaman- | 
+
+jarī, page 89, in combination with that which immediately 
+
+follows ; and Mr. Thomas, the Librarian at the India Office, tells | 
+
+me that he has met with the two together in Nagarjuna’s ईश्वरक- | 
+
+तृत्वनिराकरण, but there the sword-nyaya takes the form of ET | 
+
+हि खरतरकरवालधारा स्वमात्मानं छेत्तं सस्था भवतिः? In Madhyamaka- | 
+
+०१०८७, page 62, it again occurs in conjunction with another | 
+
+sintile—"'erarf नाम तयेवासिधारया सेवासिधारा न शक्यते छेत्तं न तेनेवा- 
+
+gemi तदेवाझुल्यग्रं शाक्यते ag &e” For the latter, seo Third 
+
+Handful. Further instances will be found in Tatparyatika, 
+
+page 255; Nydyamakaranda, page 131 ; and others of a like 
+nature in Venkatanatha’s Sarvarthasiddhi, page 891, 
+
+
+न हि सुशिक्षितोऽपि नटबडुः स्वस्कन्धमघिरोहुं qe: ॥ 
+
+
+No yowng actor, however well-trained, is clever enough to get | 
+on his own shoulder, This is Mallisena’s version of the nyäya, 
+as cited in conjunction with the cognate one above. In Brah- 
+masūirabhäsya 3. 3. 54, S'ankara quotes it as “q हि नटः [दिः 
+Taa: सन्स्वस्कन्धमघिरोद्ष्यति.?? In the vartika on Taittiviyabhasya, । 
+page 108, Sures'vara puts it thus— "er स्वस्कन्धमारोढुं निएुणोऽपीह | 
+साधकः? ॥ Other varieties are the following. “a हि सुशिक्षितोऽपिबि- | 
+ज्ञानी स्वेन स्कन्ध्रेनास्मानं वोहुसुत्सहते, Dhamati 1. 3. 41 ( page 277 ); 
+“नहि सुशिक्षितोडपि नटबटुः स्वस्कन्धमारुह्य quf" Khandanakhan- 
+dakhadya, page 592; and, finally, “न हि पडुतरो5पि' NEU: स्वस्क- 
+न्धमारुह्य नरीनति?, Vidyasaqart on Khandana, page 57. It 
+
+
+will thus be seen that no two authors agree as to the form of 
+the maxim ! : 
+
+
+To 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By SCS टा GyaanKosha , 
+
+
+न ह्यप्राप्य प्रदीपः प्रकाश्यं प्रकाशयति ॥ 
+
+
+A lamp does not illuminate until it [ à. e. its light ] reaches 
+the object to be illuminated. It therefore comes under the head 
+of आप्यकारी, for which, and its opposite, see Nydyakandali, 
+page 23. It occurs in the Nyāyamanjarī on 5. 1. 7 (page 624): 
+“सोऽयं हेलुः प्राप्य चा साध्यं साधयेदप्राप्य वा । प्राप्य चेद्‌. द्र्योलूब्धस््ररूप- 
+यारप्रासिसवतीति 1क कस्य साध्य साधनं वेत्यविशेषः। अप्राप्य तु साधकत्वमनु- 
+पपन्नमतिम्रसङ्गात्‌ । न ह्यप्राप्य ्रदीपः ग्रकाइयं प्रकाशयतीति!? 4150 in 
+Tirkikaraksa page 271:—“a हि दाह्ममप्राप्तो दहनो दहति प्रकाइयम प्राप्य 
+अदीपः maaa.” Then in Sarvdrthasiddhi (on 7८0७७॥०१॥४०- 
+kalāpa i. 32) we ०९90:--"अप्राप्तोत्पादने सर्वस्मास्सर्वसुत्प्येत ग्रकाइयम- 
+याप्य वा दीपः अकाशयेद्ाह्ममग्राप्य वा दहनो दहेत्‌.” Compare Nagar- 
+juna's karika vii. 11:--“अप्राप्येव प्रदीपेन यदि वा निहतं तमः । इहस्थः 
+सर्वलोकस्थं स तसो निहनिष्यति” ॥ 
+
+
+MATE स्सरत्यन्यः ॥ 
+One person does not remember what another has seen. This 
+is the first pada of Kusumanjali 1. 15, the whole verse being 
+as follows:— 
+
+
+“ARIES स्मरत्यन्यों नेकं भूतमपक्रमात्‌ । 
+वासनासंक्रमो नास्ति न च गत्यन्तरं Pent" ॥ 
+
+Professor Cowell translates thus:—“ One does not remember 
+what another has seen; the body remains not one and the 88110 
+from decay; there cannot be transference of impressions, and 
+if you accept a non-momentary existence there is no other 
+means.” The karika, however, is hardly intelligible apart from 
+the preceding context of which it is a sort of summing up. The 
+nyaya did not, however, orginate with Udayana, since it is quoted 
+in Vyasa’s Yogabhasya iii. 14, and in Nyayabhasya 1. 1. 10. It 
+is found, too, in Syaduddamanjari, pages 61 and 154; also in 
+Nyäyamanjarı, page 437, line 10. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eA Gotri Gyaan Kosha 
+
+
+नो खल्वन्धाः सहस्रमपि पान्थाः पन्थानं विदन्ति ॥ 
+
+
+Not even a thousand blind travellers can discover the road] 
+[to be taken]. This is contained in Bhamati 1. 1. 5 (page 124), 
+in the following passage:—“ हि प्राधानिकान्यन्तबाहिष्करणानि त्रयोदश 
+सत्वप्रधानान्यपि स्वयमेवाचेतनानि agra स्त्रं वा परं वा वेदितुसुतसहन्ते | 
+नो खल्वन्धाः सहस्रमपि पान्थाः पन्थानं विदन्ति। चञ्नुप्मता चैकेन Ulud स 
+एव तह मार्गदशीं Baa: कर्ता नेता qur du 
+
+
+TUSHAR मुग्धायाः JAMAA ॥ 
+
+It is better to leave this untranslated. The पण्डकोपाख्यान 
+is found in Vyasa's Yogabháshya ii. 24, as follows: rar कश्चिः 
+त्पण्डकोपाख्यानेनोद्घाटयति । सुरधया भार्यायाभिधीयते । पण्डक MIJA 
+अपत्यवती मे भगिनी किमर्थं नाम नाहमिति । स तामाह ख्रतस्तेऽहमपत्यसु- 
+त्पादयिष्यामीति ” ॥ On this Vacaspatimis'ra remarks: अन्न 
+कश्चिन्नास्तिकः कैवल्यं पण्डकोपाख्यानेनोपहसति The nyaya, as given 
+above, is found in the Nyāyavärtikatātparyatīkā, page 29:— 
+“ यादि हि पक्षं विहाय बहिरेव सपक्षासपक्षयोरविनाभावो गम्येत तदा aa 
+सिमात्रबलेन पक्षधमोंऽपि हेतुर्न पक्षे साध्यं साधयेत्‌ | असिद्धा हि तत्र स्वसाध्येन 
+ane: | तदेतत्पण्डकमुद्गाह्म सुर्धायाः पुत्रप्राथनमिव'” ॥ See, too, Citsu. 
+kha ii. 26 ( Pandit, vol. v, page 514 ) where reference is made to 
+Vacaspati's use of the nyaya; and the same objection is taken 
+
+
+to it by S'riharsha in the Khandanakhandakhadya, page 354. 
+
+
+—— 
+
+
+पादप्रसारिका ॥ 
+
+
+Professor Venis tells me that the Benares pandits regard | 
+asa shortened form of the भिक्चुपादम्रसारणन्याय (for which, see the 
+First Handful of maxims ), and that 16 means « unduly exten- 
+ding one’s claim or one’s Position generally.” Its equivalent in 
+: Marathi is पाय पसरणे, which, Molesworth tells us, means “to 
+
+
+establish Gia 8 self freely and fully: to extend one’s power far 
+and wide.” He gives, as 
+CC-0. Prof. Satya Vrat Shad ri Collection. 
+
+
+an example of its use, the Marathi 3 
+
+
+Digitized By Siddha is) se angotri Gyaan Kosha 
+
+
+proverb “aza दिली ओसरी भट्ट पाय पसरी,” which is the equi- 
+valent of our * Give him an inch and he'll take an ell.” Inthe 
+passages, however, in which I have met with the expression, it 
+seems to imply a dogged adherenceto a position in spite of pre- 
+vious failure, and when there is little prospect of future success, 
+Two passages in Upamitibhavaprapanca Katha pages 798 and 
+907, seem to confirm ४॥15:--“एतत्सर्वमनालोच्य कृत्वा पादप्रसारिकाम्‌ | 
+विवेकचक्षुः सम्मील्य स्वपन्ति ननु जन्तवः” ॥ “ ततो विषादमापन्नः सर्वकर्म- 
+पराड्यखः | स्थितोऽहं मौनमालम्ब्य कृत्वा पादप्रसारिकाम्‌??॥ There are 
+two other instances of it on pages 656, 657 of the same, and it 
+occurs three times in the Nydyamanjari, as follows. On page 
+118:-- एवं हि द्विविधं प्रतिबन्धमनुमेयाव्यभिचारनिबन्धनमनुक्तवा केवलसा- 
+हचर्यनियममात्रवर्णनं यत्प्रसारिका सैवेति। उच्यते | पादप्रसाईकेव साधीयसी 
+स्थूलदृष्टिभिरवलंबिता वरं न. सूक्ष्मदष्टिभिर्त्रेक्षितास्तादात्स्यादिप्रतिवन्धा:? ॥ 
+On page 121:— यं कंचिदर्थमालोक्य यः कश्चिन्नावगम्यते। कंचिदेवाक्षिपत्य- 
+Ja: कश्चिदिति स्थितिः ॥ तत्र वस्तुस्वभावोऽयमिति पादप्रसारिका । दृह्यते 
+ह्यविनाभूतादर्थादर्थान्तरे मतिः On page 504:--“न च न कदाचिदनी- 
+इशं जगदिति पादप्रसारिकामात्रं कर्तुसुचितं सरंम्रबन्धप्रलयम्रबन्धस्य quiu 
+तत्वादिति ॥ अतश्च पक्षान्तरदुर्वलत्वाद्यथोदितः सिध्यति भूतवर्गः | तं यस्तु 
+पश्यन्नपि निहुवीत तस्मै नमः पण्डितशेखराय”” ॥ There is one instance 
+of it in Khandanakhandakhādya (page 31) a50:_-न च 
+सत्ताभेदानन्त्यमस्सेवेत्यपि पादग्रसारिका निस्ताराय,” which is rendered by 
+Prof. Ganganatha Jha:—‘Nor will you escape from this predi- 
+cament by taking the long step of assuming an infinity of 
+different kinds of real existence.” Indiun Thought, page 17, 
+
+
+पिण्डमुत्सज्य करं लेढि ॥ 
+
+Leaving the sweet morsel he licks his hand! Tt is found in 
+Pateupadika, page 49, as follows :--“अथ वेदाधिकरणे वेदांश्रेके 
+सन्निकर्षमिति विश्ेषाभिधानाह्वेदिकत्वसिद्धिरिति | सोऽयमाभाणको लोके पिण्डः 
+सुस्सूज्य करं लेढीति सूत्रकारस्याप्यकोशलं प्रदर्शित स्यात? ॥ In Raghu- 
+natha's list it appears as पिण्डं Rar करं लेढि. We may compare 
+it with the saying “क्षीरं विहायारोचकग्रस्तः सोवीररुचिमनुभवाति”. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+— M 
+
+
+48 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+पित्रनुस्‌तस्तनंधयन्यायः ॥ | 
+The similc of æ father’s conforming to [the ways of] his Littl, 
+
+child. This is set forth as a model for the knower of Brahma, | 
+that, by a lowly and humble demeanour, he may attract 
+the ignorant. It is thus explained in the Laukikanyaya. 
+sangraha :— "egere तत्त्वविदो5तत्त्वविदुद्धारातिरिक्तकर्तव्याभावाद्यथा 
+तदुद्धारः स्यात्तथैव कर्तव्यम्‌ | सुरेन्द्रादिपूज्येनापि विदुपा पित्रनुस्‌तस्तनंधयन्या- 
+येनाज्ञोऽनुसर्तव्यः | तेर्निन्द्यमानो5पि देहस्य निन्दत्वमात्मनो5वाळूमनसगस्यत्व 
+च जानन्नोद्रिजेत्‌ । किन्तु प्रत्युत तच्चेष्टानुसारेण स्वयमप्याचरेत्‌, ॥ In the 
+larger work the following passage is quoted by way of illustra. ` 
+lon:—" तदुक्तं quei ...... अविद्वदनुसारेण stagger युञ्यते | स्तनंधया- 
+चुसारेण वत्तेते तत्पिता यतः ॥ अधिक्षिप्तस्ताडितो चा बालेन स्वपिता तदा | 
+न झिश्चाति न कुप्येच्च वालं AJA लालयेत्‌ ॥ निन्दितः स्तूयमानो वा विद्ठानज्ञेन 
+निन्दति । न स्तौति किन्तु तेपां स्याद्यथा बोधस्तथाचरेत्‌ ? ॥ The “elder? 
+is Vidyaranya, and the verses are Pancadas'; Vit. 986-988, 
+
+
+पिशाचानां पिशाचभाषयैवोत्तरं देयम्‌ ॥ 
+
+
+Pis'cas should be answered in the Pis'ūca language, 
+This nyaya is found on Pages 214 and 410 of Sarvarthasiddhi 
+(on Tatwamuktakalipa ii. 49 and iv. 13 ), in the first instance 
+in conjunction with “यक्षानुरूपो बलिः ”, with which it is clearly 
+Synonymous. See “यादो यक्षस्तादशो बलिः ?, 
+
+न 
+
+
+पुष्टछगुडन्यायः ॥ 
+
+
+T LA 4 
+The simile of c stout cudgel. Such a stick, hurled at a 
+yelping cur, may at the same time Strike and silence other dogs 
+
+
+near 15; and so the nyaya seems to be used Somewhat in the 
+sense of “Killing tw 
+
+
+O birds with one Stone." Tt is thus de- 
+fined by Raghunatha:—« एकता त्रिकसतानिरासायर अयुक्तया युक्त्या तत्स- 
+
+क्ष्यते तदा उष्रुगुडन्यायमरत्रत्तिः । यथा वहूनां 
+हाराथ प्रक्षिप्त: अष्टछगुडस्त अहत्यान्यानपि प्रहरात 
+R य aa 
+
+
+Digitized By E S Gyaan Kosha 
+
+
+युक्तयस्तं निरस्य योगाभिसतप्रधानकारणवादमपि साम्यानिराकुर्वन्तीति Re ॥ 
+The simile is employed in this sense in Advaitabraluma- 
+siddhi, page 100:- न चेदं दोषत्रयं वैशेषिकेपूक्त तदेव विज्ञानवादिपु 
+किमर्थमापद्यत इति वाच्यम्‌ | पुष्टलगुडन्यायेन वेशेपिकमत इव “अन्तः सत 
+इतिवादिनो “बहिः सत्‌? इतिवादिनश्च बोद्धस्य मतेऽपि ग्रसरतीत्याभिप्रायात॥ 
+It is akin to ग्रधानमछनिवहेणन्याय; which see in First Handful. 
+
+
+ग्रदीपचतू ॥ 
+
+
+The simile of « lamp. We have here another of the many 
+lamp-illustrations. In Mahabhasya 1. 1. 49 ( vart. 4) an adhi- 
+kara is said to be of three kinds, and in the first it is likened 
+to a lamp in the following ७०॥१७:--"किश्चिदेकदेरास्थः सर्वे शाखमसि- 
+उवळयाति यथा प्रदीपः सुप्रज्वालित एकदेशस्थः सर्व वेइमाभिज्वल्यति.? In 
+the opening part of 2, 1. 1, where the question is asked “क: पुन- 
+रघिकारपरिभापरयार्विशेषः,?” the paribhasa, and not the adhikara, is 
+likened to a lamp, in the same words as above. 
+
+Nügesa (in vol. iii page 8 of the Uddyota) quotes the 
+following verse:— 
+
+“ एकदेशस्थिता meray याति दीपताम्‌ | 
+परितो व्याएतां भाषां परिभाषां प्रचक्षते ? ॥ 
+
+We find the same figure in Jaimini’s sūtra 11. 1. 60, which 
+S'abara explains thus:—“qgiq एकस्सिन्प्रदेशे झुञ्जानानां ब्राह्मणानासे- 
+कस्य सन्निधो प्रज्वलितः सर्वेपाझुपकारं करोति.” In dealing with this 
+adhikarana Madhava substitutes the figure of a single dancer 
+amusing a number of spectators. See the नर्वकन्याय in Third 
+Handful. 
+
+
+प्रसक्तं हि प्रतिषिध्यत इति न्यायः ॥ 
+
+This nyaya, which is quoted by Amaradisa in his tiki on 
+Vedantasikhamani, page 262, is apparently another form of 
+the more concise प्रसज्यप्रतिषेध which, as it occurs in the Yoga 
+Section of Sarvadars'anasangraha, is rendered by Prof. Cowell 
+
+í CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+EN 
+
+
+Digitized By Siddhanta ed hgoti Gyaan Kosha 
+
+
+"Express negation.” In a footnote (on page 250 ) he explains it * 
+thus :—“ Where the negation is prominent it is called frasajya- | 
+pratishedha ; but where it is not prominent we have the pary- | 
+१८७८७ negation. In the former, the negative is connected with | 
+the verb: in the latter, it is generally compounded with some | 
+other word; as, for example, (a) ‘Not a drum was heard, not a । 
+funeral note'. (0) “Unwatched the garden bough shall sway, | 
+The former corresponds to the logicians’ atyantabhiva, the | 
+
+| 
+
+
+, 
+
+
+latter to anyonyabhdva ov bheda”, 
+
+
+In the Vacaspatyam the nyaya is quoted under ग्रसज्यम्रतिषेध 
+as follows :--“प्रसज्य असक्ति सम्पाद्यारोप्येति यावत्प्रतिपेधः | अत्यन्ताभावे | 
+“प्रसक्तं हि प्रतिपिध्यत ' इति न्यायेन आरोपितग्रसंगस्येव निषेधः । तेन वायो 
+रूपं नास्तीत्यादावपि वायो रूपारोपं कृत्वेव निपेधो नजा बोध्यत इति विवेकः॥? | 
+According to this, then, the meaning of the nyaya is “that | 
+which has been applied or asserted is subsequently withdrawn | 
+or denied,” 
+
+
+Both the forms of negation are contained in Mahabhasya 
+1. 4. 50 &, in Vakyapadiya ii. 86, and in Sures'vara's large | 
+vartika 3.9.73. Verses defining the two are quoted on page 
+214 (Chap. vii.) of the Sahityadarpana, and renderings will be 
+found on page 254 of Mr. Pramadadiisa’s translation, Compare 
+Molesworth’s definitions of the terms. 
+
+
+फलवत्सन्निधावफर्ल TAR ॥ 
+
+
+The principle that whatever has no result of its own, but | 
+mentioned in connection with something else which has such 
+6 result, is subordinate to the latter. This is Dr. Thibaut’s 
+
+
+rendering of the nyaya as ib occurs in Bralkimasiitrabhashya 
+2. 1, 14 (page 443 ), and he explains it thus in a footnote;— 
+“A Mimamsa principle. A sacrificial act, for ins 
+dependent when a special result is assigned to it by the sacred 
+texts; an act which is enjoined without such 2 specification is 
+merely auxiliary to another act.” The & Bree of. the nyaya is R 
+
+
+tance, 18 in- 
+
+
+CC-0. Prof. Satya Vrat Shastri DN E 
+
+
+Digitized By Siddha rt i angotri Gyaan Kosha 
+
+
+S'abara 4.4.19, and Madhava applies it in Nyāyamālāvis- 
+iura, 4. 3, 16 (sūtra 37). I have met with it also in Nyaya- 
+võrtikatätparyatīkā, page 178, line 2; and in Vvorana- 
+prameyasungraha, page 117, line 11; and. page 147, line 9 
+from bottom. 
+
+
+वंकवन्धनन्यायः ॥ 
+
+
+The simile of the capture of a crane. Raghunath explains 
+it thus:—A man wishing to secure a crane puts butter on its 
+head, which, when melted by the sun, goes into its eyes and 
+blinds it, so that he can then take hold of it! He clearly took 
+this explanation from the Zativadipana, a commentary on the 
+Pancapadikavivarana (itself a commentary), and I subjoin a 
+portion of each. Vivarana, page 283, line 4:— 
+
+
+^ ननु स्वर्गकामिनो यागकर्तव्यता स्वर्गसाधनमन्तरेणानुपपन्ना । तच साधनत्वं 
+क्षणभंगिनः कर्मणो मध्यवातिकार्यसन्तरेणानुपपन्नमिति श्रुतार्थापत्त्याप्पून गम्यते 
+तत्र शब्दस्य सामर्थ्ये गृह्यत इति सोऽयं anaes) On this the Dipana, 
+page 779, bottom line :—“ बकवन्ध इति । बकबन्धसमानन्याय geni: 
+बकग्रहणे क उपाय इति SARIS खरतरदिनकरसंपकीत्तन्मस्तकानेहितनवनीत- 
+बिन्ुभिर्नेयनयोः wart ase सुकरमिति कश्चित्तुच्छमतिः प्रातैबाक्ते। न च 
+तडुपपद्यते | बकग्रहणमन्तरेण तन्मस्तके नवनीतम्रक्षेपा्ुपपत्तः । तस्मिश्च परि- 
+गृहीते तत्म्रक्षेपोऽपि सुधा? Then follows his application of the 
+nyaya. Both writers evidently regard it as an illustration of 
+Something ridiculous; and to me it recalls the nursery tradition 
+that the way to catch a sparrow is to put salt on its tail! 
+Raghunatha, however, classes it with nyayas deprecating a 
+roundabout way of doing a thing. Amongst these he gives the 
+दण्डसपेमारणन्याय, where a man whilst looking for a stick with 
+which to kill a snake, comes upon an axe; but, instead of 
+using that against the enemy, he goes out to cut a stick with it. 
+
+
+In Vivaranaprameyasangraka, page 262, lino 9, we 
+again find the बकबन्धप्रयास- 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta edifigori Gyaan Kosha 
+
+
+वघिरकणजपन्यायः ॥ 
+
+
+The illustration of whispering in the car of a deaf mam, A 
+good example is found in Upamitibhavaprapanca Katha, pago 
+1062:— 
+
+“Stat कर्णजापोध्यमन्धे नृत्तप्रददीनस्‌ । 
+ऊपरे बीजनिक्षेपस्तस्य या धर्मदेशना ^ ॥ 
+
+Comparc the following from Nydyamanjari, page 405:— 
+“तदेतद्वधिरस्थ रामायणं वर्णितमस्माभिर्य एवमपि za वेदार्थपरिगमाभ्युपायं 
+aaa.” Also the expression “बघिरेष्विव maaa” in Vaiskarmya- 
+siddhi iv. 21. For similes of a like kind, see अरण्यरोदनल्याय. 
+
+
+वहुछिद्रघटप्रदीपन्यायः ॥ 
+
+
+The simile of a lamp in a vessel with muny holes. Raghu: 
+nütha explains ib as follows:—“aererferzter बहिर्निंगत्येव जीवोपा- 
+धिभूता धीवांह्यविषयान्ब्या्ञोति तद्योगाच्च चिदाभासोऽपि निःसृत इव sd 
+यत इति विवक्षायां बहुच्छिद्रघरमरदीपन्यायोऽवतरति। अयं भगवत्पादैः संक्षे- 
+पेण भाष्यतात्पर्यप्रकाशके श्रीदक्षिणामूतिस्तोत्रे सोदाहरणसुक्तः । ` नानाछिट्र- 
+बदोदरस्थितमहादीपप्रभाभास्तरं ज्ञानं यस्य तु चक्षुरादिकरणद्वारा बहिः स्यन्दते d 
+जानामीति तमेव भान्तमनुभासेतत्समस्तं surat श्रीगुरुमूर्तये नम इदं 
+श्री दक्षिणामूर्तये? इति? ॥ The above is verse 4 of S'ankara's poem, to 
+the exposition of which Sures'vara devotes 37 verses in his 
+AMónasollasa. 
+
+
+भारेकदेशावतरणल्यायः ॥ 
+
+
+The illustration of the lowering of one part of a load [and 
+80 casing one’s burden ] This is found under Lantravartike 
+1.3. 22 (pago 222 )“इढविपर्ययज्ञानानन्तर॑ सहसैव च सम्यग्ज्ञानो- 
+त्पादातिभाराद्भारेकदेशावतरणाथ संशयोत्थापनामात्रमेव तावद्युक्तस्‌.?? Prof. 
+Gangünàtha Jha renders the passage thus:— “When a certain 
+
+
+conclusion to the contrary has been lai E § 
+s been laid an ex 
+CC-0. Prof. eee Vrat Shastri chaa exceptionally 
+
+
+4 
+
+
+Digitized By Sinaga oa Gyaan Kosha 
+
+
+strong manner, if one proceeds to immediately point out the 
+true theory, it involves a very hard work ;and hence with a 
+view to lighten this burden, the present sūtra proceeds only to 
+weaken the contrary view by throwing it open to doubt,” 
+
+
+Jayanta Bhatta reproduced this on page 419 of the Nyaya- 
+manjarī as ii uu reg ragen RRRA aaa 
+समनन्तरं सहसेव सम्यग्ज्ञानोत्पादनातिभाराद्वारेकदेशावतरणन्यायेन संशय- 
+स्तावठुपपद्यते.?? 
+
+
+भीमभासहृढन्यायः ॥ 
+
+
+The illustration of the three Asuras, Bhima, Bhisa, and 
+Dridhe. See this explained under दासब्यालकटन्याय. 
+
+
+सूलिङ्गन्यायः ॥ 
+
+
+The simile of ihe bird Bholinga. It is supposed to say “mā 
+sGhasum,’ “don’t do anything desperate”, and then does 
+desperate deeds itself! The purport of the nyaya would 
+therefore seem to be, “Practise what you preach.” There are 
+two references to this bird in Subhdparva. The first is in 
+XLL 18 (Bombay edition ):-- न गाथागाथिनं शास्ति बहु चेदपि 
+गायति प्रक्ृति यान्ति भूतानि भूलि्ठशकुनिर्यथा?॥ This is explained by 
+the second passage ( X1४. 27-32. )— "epp Sat न ते बुद्धिः प्रकृति 
+याति भारत। मयेव कथितं पूर्वं भूलिङ्गशङुनिर्यथा ॥ २७ ॥ भूलिज्जशकुनिर्नाम 
+WU हिमवतः परे । भीष्म तस्याः सदा वाचः श्रूयस्तेड्थविगर्हिताः ॥ Re ॥ सा 
+साहसमितीदं सा सततं वाशते किल । साहसं चात्मनातीव चरन्ती नावबुध्यते 
+॥ २९॥ सा हि मांसार्गलं भीष्म मुखात्सिहस्य खादतः। दन्तान्तरविलं 
+यत्तदादत्तेऽल्पचेतना ॥ ३० ॥ इच्छतः सा हि सिंहस्य भीष्म जीवत्यसंशयस्‌ | 
+AKWA सदा वाचः प्रभाषसे ॥ ३१॥ इच्छतां भूमिपालानां भीष्स 
+जीवस्यसंशयम्‌ | छोकविद्विष्टकर्मा हि नान्योऽस्ति भवता समः? ॥ ३२॥ dn 
+the Calcutta edition of 183%, the chapters are XL and XLII res- 
+Pecüvely. Raghunatha’s remark on the simile is as follows :— 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGahdotri Gyaan Kosha 
+
+
+“ यो भूलिहन्यायेन परोपदेशमात्रकुशलः खयं च यथेशचरणझीलः सोऽपि 
+दांभिकत्वात्त्यक्तव्यः । भूलिङ्गाख्यः पक्षी मा साहसं कुर्विति पुनः पुनरूचेवंदान्स. 
+हदेष्रान्तलंझं मांसलवं जिशृक्षतीति meaa m’ For the following 
+interesting example of the application of this nyaya (though 
+the bird is not mentioned by name) I am indebted to my 
+friend Mr. C. H. Tawney, C. I. E. It is found on pages 138-9 
+of the Parisistapurvan:— ततः कमलवत्यूचे हे नाथ कमलानन | 
+मासाहसराकुनिवन्मा त्वं साहसिको भव ॥ १४१ ॥ तथा ह्येकः पुभान्देशान्तरे 
+दुभिक्षपीडितः | चचाल aad हित्वा सार्थेन महता सह ॥ १४२ ॥ एकस्यां च 
+महाटव्यां सार्थ आवासिते सति । आहत तृणकाष्टादि a एकोऽपि विनिर्ययौ 
+॥ १४३ ॥ तदा च सुपतन्याध्ास्यातपक्ष्येको वनगव्हरे | दन्तलझामिपखण्डान्यादा- 
+यारोहदंहिपम्‌ ॥१४४॥ मा साहसमिति Sg: स भणन्मांसखादकः | शकुनिस्तेन 
+जगदे पुरुपेण सविस्मयम्‌ ॥ १४५ ॥ रोपि मा साहसमिति व्याघ्रास्यान्मांसमस्सि 
+च । मुग्धस्त्वं ae वाचोऽनुरूपं कुरुपे न च ॥ ५४६ ॥ हित्वा साक्षाद्भवः 
+सुखं तददृष्टसुखेच्छया | तपश्चिकी्धुस्त्वमसि मासाहसखगोपमः” ॥ १४७ ॥ 
+An interesting conversation on the inconsistency of not practis- 
+ing what one preaches (though not in connection with this 
+nyaya ) is found also in the Bhagavata Purana x. 33. 27-40, 
+
+
+भोतविचारन्यायः ॥ 
+
+
+The simile of the reflections of a madman. The story coi- 
+nected with this is told in the following passage of : 
+vweka, page 64:—" तचचेद्विचारासहं किं तेन भौतविचारकल्पेन । तथाहि 
+केनचिद्धोतेन राजद्वारि द्विरदमालोक्य विकहिपतं किमयसन्धकारो HERRAT- 
+होस्विजलवाहो बलाकान्वषाति गर्जेति च । यद्वा बान्धवो यं “राजद्वारे स्मशाने 
+च यस्तिष्ठति स बान्धवः? इति परमाचार्यवचनात्‌? । अथवा योऽयं भूमो द्यते 
+तस्य छायेति दूपितं च । तत्र नाद्यस्तस्य सूर्पयुगल्प्रस्फोटनाभावात्‌ | न द्वितीयः 
+स्तस्य स्तंभचतुष्टयाभावात्‌ | न तृतीयस्तस्य रूगुडञ्रामणाभावात्‌ | न चतुर्थस्तस्य 
+नरशिरःशतोद्विरणाभावात्‌ । ततो न क्रिञ्चिदिदस्ित्रि । किमेतावता द्विरदरूपं 
+Misano p 
+
+
+a क T A 
+१ Pancatantra V. 41 ( Indische Sprüche 1221] 5 
+z CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+me, 
+
+
+| 
+
+
+m 
+
+
+Digitized By Siddha us eGangotri Gyaan Kosha 
+D 
+
+
+मणिप्रभामणिमतिन्यायः ॥ 
+
+
+The swpposition that the light of a gem is itself the gem. 
+This follows Mr. A. E. Gough’s explanation of 8 slightly 
+varied form of the nyaya which is found inthe Bauddha 
+section of Sarvadarsamasangraha. He adds that, in this case, 
+“we may yet handle the gem, because it underlies the light, 
+while, if we were to take nacré for silver, we could not lay 
+hold of amy silver." The correctness of this view is established 
+by an important passage at the beginning of Pancadas Ix, 
+which treats of ध्यान as ameans of arriving at a right know- 
+ledge of Brahman. Such meditation, being directed towards 
+Brahman with qualities, is of course erroneous, inasmuch as. 
+that Impersonality has no qualities; but it nevertheless leads to 
+the underlying nirguna Brahman, just as the mistaken notion 
+regarding the sparkle of the gem leads to the discovery of the 
+gem itself. This is styled संवादिभ्रम, an error which hasa 
+corresponding reality underlying it. To mistake the distant 
+shining of a lamp through the keyhole of a door for a gem, is 
+an illustration of विसंवादिश्रम, an error entirely devoid of an 
+underlying reality. The passage is as f0]]0ws:—“सणिम्रदीपम्रभयो- 
+मेणिबुद्याभिधावतो: । मिथ्याज्ञानाविरेषेऽपि विरेषोऽथक्रियां प्रति ॥ २॥ दी- 
+पो5पवरकस्थान्तर्वत्तेते तत्मभा बहिः | इञ्यते द्वाय्य॑थान्यत्र AZA मणेः प्रभा 
+॥ ३ ॥ दूरे प्रभाद्वयं दृष्टा मणिबुड्याभिधावतोः । प्रभायां मणिबुद्धिस्तु मिथ्या 
+शानं द्वयोरपि ॥४॥ न लभ्यते मणिर्दीपप्रभां प्रत्यमिधावता । प्रभायां 
+ammam लभ्येतेव a ॥ ५॥ दीपम्रभासणिञ्जा न्तिरविसंवादिञ्रमः 
+स्तः । मणिप्रभामणिश्जान्तिः संवादिभ्रम उच्यते ॥ ६॥ The commentator, 
+Ramakrishna, ascribes verses 2-5 to a vartika; whilst Citsukha 
+Muni, in his comment on verse 2 which is quoted in the 
+Nyayamakaranda (page 148), names Dharmakirti as its 
+author, This is not improbable; for Dharmakirti is known to 
+have composed wartikas on the works of Dignaga, a famous 
+Buddhist writer of the sixth century (See Mr. K. B. Pathak's 
+Paper “On the authorship of the Nyayabindu”). In Nyaya- 
+manjart, pages 24 (line 1), 33 (line 4 from bottom ), and 158 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGaRdbtri Gyaan Kosha | 
+
+
+(line 10), the nyaya is found: as मणिप्रभामणिबुद्धिवत. Then on | 
+page 308 (line 9 from bottom ) there is the following Passage | 
+which corresponds with the extract from 7002000687, namely:— 
+अर्थ हि मूळवर्तिनसुपलभ्य प्रवतेमानस्तमाप्तोति अपवरकनिहितमणिप्रसृतायां 
+कुञ्जिकाविवरनिर्यतायामिव प्रभायां मणिवुच्या ग्रवतेसानः । यत्न तु aesa | 
+नास्ति तत्र व्यामोहास्वतेमानो विप्रलभ्यते दीपप्रभायाम्रिव qq मणिबुद्या | 
+प्रवर्तमानः ॥ The nyaya occurs again on page 317, | 
+Other references to it are S'alika, page 22, line 4; Nyiya- 
+kandali, page 190; Aimatatlvavivehka, page 45; and Taykika- 
+raksa, page 16. 
+
+
+मणिविक्रयदृष्टान्तः ॥ 
+
+
+The illustration afforded by the sale of gems. It is intended 
+to teach that, in disposing of precious stones, one who under- 
+stands their value will derive greater advantage than one who 
+is without that knowledge. This would undoubtedly be tho 
+case if the seller were a S'abara and the buyer a dealer in 
+gems! The illustration is S‘ankara’s, and is used by him in 
+his exposition of Chhándogya 1. 1. 10, which sets forth the | 
+value of an intelligent use of the syllable Om. The passage | 
+is as follows :— तेनोभौ कुरुतो यश्नेतदेव वेद यश्च न वेद । नाना तु विद्या | 
+चाविद्या च । यदेव विद्यया करोति.. “तदेव वीर्यवत्तरं अवति.” An objector 
+here urges that the result of an action does not depend 
+the intelligence of the performer of it, but on the due perfor- 
+ance of the act itself, and he supports his view with the follow- 
+aoe illustration «gy हि लोके हरीतकीं भक्षयतोस्तद्रसाभिज्ञेतर- 
+योदि मू.” The Sidhintin disallows this, and gives another 
+illustration :--“ eg हि लोके वणिक्शवरयोः प्मरागादिमणिविक्रये _वणिजों 
+
+विज्ञानाधिक्यात्फल्ाधि RIE । तस्माद्यदेव विद्यया विज्ञानेन aq: ,सन्करोति 
+कम. ..तदेव कर्म दत्कमणो$घिकफलं vafa. ॥ ` 
+_ The nyaya is quoted, in a slightly different form, by | 
+Anandagiri in his comment on Brakmasutrabhasya 3. 3, 42; E E. 
+
+
+and again, by Amalananda, in the same connection, in company 
+With the drug-illustration, ST 
+
+
+CC-0. Prof. Satya-Vrat-Shasiri Collection. 
+
+
+* ^w 
+
+
+Digitized By Siddhant? cenis Gyaan Kosha 
+मण्डूकवसाक्ताक्षाणां वंशषूरगभ्वमः ॥ 
+
+
+Mistaking bamboos for snakes on the part of those whose 
+eyes have been smeared with the fat of frogs. This curious 
+illustration, taken from STokavartika, page 520, is found in the 
+following passage of Tatparyatika, page 314 :—“a च मण्डूकव- 
+साक्ताक्षाणामिवानवगतास्ट्रतोरगाणामपि प्रथमाक्षसन्निपाता द्रंशेपूरगारोप इति 
+साम्प्रतम्‌ । सवोसामेव आन्तीनां प्रमाणगृहीतारोप्यारोपविषयग्रहणपुरःसरत्व- 
+यमात्‌ | तदनुसारंण मण्डूकवसाक्ताक्षाणामपि वंरोपूरगञ्जमो व्याख्येयः । 
+वंशानां तावदस्ति भूयः सारूप्यसुरगेण तेन चेते तन्मात्रेण रुपेण शक्कवन्ति 
+गृहीताः स्मारयितुसुरगम्‌ | एवमपि यदन्येषां अमो न भवति तत्र सर्पाकारच्या- 
+बृत्तवंशगहो हेतुः मण्डूकवसाञ्जनं च वंशाकारपिधानमात्रहेतुः” ॥ 
+
+
+The S‘lokavdrtika passage containing the nyaya forms the 
+second quotation in the following excerpt from Sarvarthasiddhi 
+on Tattvamuktakalapa ii. 64 :—“ संकोचकानां निर्शेषक्षीणत्वान्न चान्न 
+“ काणतां जनयेद्दीपो निस्बब्न्दाकरेणुमान्‌ * इतिवल्किल्निन्निमित्तमन्तरेण ea: 
+आपतम्रकाशैकदेशभङ्गः स्यात्‌ | “मण्डूकवसयाक्ताक्षा वंशाचुरगबुद्धिभिः? इतिवद्वा 
+केनचिद्धेतुना प्रागनुकूलेपु प्रतिकूल्बुद्धियुक्ता q^ Another instance of 
+
+
+the nyaya is to be found in Parimala, page 43, line 9. 
+
+
+मात्स्यन्यायः ॥ 
+
+
+The simile drawn from fish. Tt is used to illustrate the 
+oppression of the weak by the strong. In Raghunàthavarman's 
+list, it follows the सुन्दोपसुन्दन्याय, and he explains it thus— 
+“अयं [ सुन्दोपसुन्दन्यायः ] तुल्यबल्योविरोधे प्रसरति । प्रबलनिबळविरोधे स- ` ` 
+बलेन निर्बळबाधविवक्षायां तु मात्स्यन्यायावतारः | अयं प्राय इतिहासपुराणा- 
+दिषु इश्यते । तथाहि वासिष्ठे प्रह्मादाख्याने तत्समाधि प्रस्तुत्योक्तम्‌ p ` एताव- 
+ताथ ` कालेन तद्रसातलमण्डलस्‌ | बभूवाराजकं det मात्स्न्यायकद्थि- 
+तम्‌ ' ॥ यथा प्रबला मत्स्या निबेलांस्तान्नाशयन्ति तथाराजकेऽसुकदेशे प्रबला 
+जना निवेछान्नराज्ञाशयन्तीति न्‍्यायार्थ: u The verse quoted here is 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+58 
+
+Yogavasist 78 RRB NEO re of the usage of 
+this nyaya in Kamandakiya-Nitrstra ii. 40 which reads 
+६०8:—“परस्परामिपतया जगतो भिन्नवर्त्मनः | दण्डाभावे परिध्वंसी मात्स्यो 
+न्यायः ada? n My friend Mr. Tawney has given me a reference 
+to the commentary on i. 13 of the same work, and also to 
+Kathasaritsagara cii. 63 which I here subjoin together with 
+his translation ( vol. ii, page 890) :--“ नास्त्यवाराजकं कि्चिद्वत कोऽपि 
+प्रजास्वहो | राजशब्दः सुरैः सृष्टो मात्स्यन्यायभयादयम्‌ ?? “There is no 
+race in the world without a king; I do believe the gods 
+introduced the magical name among men in their alarm, 
+fearing that otherwise the strong would devour the weak, as 
+great fishes eat the little.” Kullüka gives “जले मत्स्यानिवाहैंस्युः” 
+as 8 various reading in the second line of Manu vii. 20, and 
+adds “aq बलवन्तो दुवेलान्हिस्युरिति मत्स्यन्याय एव स्यादित्युक्तम्‌ ? ॥ 
+For this, also, I am indebted to Mr. Tawney. 
+
+
+मारणाय गृहीतोऽङ्गच्छेदं स्वीकरोति ॥ 
+
+
+One who has been seized in order to be put to death, 
+[gladly] agrees to the amputation of a limb [as an alternative} 
+The nearest approach to this nyaya of Raghunatha’s is ] 
+in the following verse of Bodhicaryavatara (vi. 72) :— 
+
+
+** मारणीयः करं छित्त्वा सुक्तश्चेत्किम भद्रकम्‌ | 
+मलुप्यदुःखैनेरकान्सुक्तश्चेत्किमभद्गकम्‌ ?W 
+
+On the former part of this, the commentator says —"q हि 
+
+मारणमहैति स यदि हस्तमात्रं छित्वा सुच्यते तदा न काचित्क्षतिरस्ति प्रत्युत 
+
+CMSA मन्यते | अत्यल्पमिदं मरणदुःखात्करच्छेदनढुःखमिति ”। 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+| 
+
+
+| 
+| 
+| 
+| 
+| 
+| 
+i 
+i 
+| 
+1 
+| 
+) 
+| 
+| 
+| 
+| 
+| 
+। 
+
+
+Digitized By Siddhant5 $Gangotri Gyaan Kosha 
+
+
+मारतीगन्धगुणविदर्भ न रमते ह्यलिः ॥ 
+
+
+The bee that knows the excellence of the perfume of jasmine 
+cares not for darbha grass. This is found in the following 
+passage of Upamitibhavaprapanca Katha, page 1081 :— 
+
+
+“ अत एवागमज्ञस्य या क्रिया सा क्रियोच्यते | 
+आगमज्ञो5पि यस्तस्यां यथाशक्त्या प्रववते di 
+चिन्तामणिस्वख्पज्ञो दोगत्योपहतो नहि i 
+तद्राघ्युपायवैचित्ये सत्यन्यत्न प्रवर्तते ॥ 
+
+न चासौ तत्खरूपज्ञों योऽन्यत्रापि प्रवर्तते । 
+मालतीगन्धयुणविद्दर्भ न रमते ges ॥ 
+
+
+माषरारिप्रविष्टमषीन्यायः |) 
+
+
+The simile of a grain of soot in a heap of spotted beams. 
+Perhaps akin to a needle in a haystack. It seems to have 
+originated in that very ancient drama the Mriechakatika where 
+it is found (on page 40) in the following Prakrit passage :— 
+“ शकारः ॥ भावे भावे बलिए क्खु was माशलाशिपविश fer 
+मशीगुडिआ दीइान्ती dat जेव पणष्टा वशन्तशेणिआ” ॥ (=m 
+बळवत्यन्धकारे मापराझिप्रविष्टेव मशीगुडिका EZTHÜD प्रनष्टा वसन्तसेना y: 
+In vol. ix of the Harvard Oriental Series, Dr. A. W. Ryder (in 
+imitation of the शकार ) renders it thus:—“But mashter, it's 
+pitch dark and it/s like hunting for a grain of soot in a pile 
+of shpotted beans, Now you shee Vasantasenà and now 
+you don’t, ” 
+
+
+The nyaya is quoted in Udayana's Kirandvali, page 79 :— 
+“स लु साषराशिम्रविष्टमशीवन्महाम्रकाशसमाहाराब्नेक्ष्यते”, and again on 
+Pages 208 and 451 of Venkatanatha's Sarvarthasiddhi, the 
+latter being as follows :--/यथा सापराशौ मषी यथा वा नीळोत्पळवने 
+कादुस्बस्तद्धे दाअहात्तदृप्थरभावेनाभिमन्यते व्यवहियते च. ” 
+
+
+> 
+
+
+4 
+YA 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+60 
+
+
+Digitized By Siddhanta eGangotri ee ANA 
+मिथिलायां प्रदीप्तायां न मे दह्यति किञ्चन ॥ 
+
+
+If Mithila should be in flames nothing of mine would be 
+
+
+burnt up. This is the second line of a verse in SGntiparya, 
+
+
+chapter 178, the first line being “अनन्तं बत मे वित्त यस्य मे नास्ति 
+raa”. It is used to indicate the freedom from anxiety of one 
+who has nothing to lose; like Juvenal’s “Cantabit vacuus coram 
+latrone viator.  S'ankara quotes the phrase in his exposition 
+of the words “न हास्य कर्म क्षीयते ।?? in Brihadaranyakopanishad 
+L 4. 16:--“न हास्य कर्म क्षीयते । कर्माभावादेवेति निल्यानुवादः । यथावि- 
+gu कर्मक्षयलक्षणं संसारदुःखं सन्ततमेव न तथा ager बिद्यत इत्यर्थः | 
+मिथिलायां प्रदीप्तायां न मे दह्यति किञ्चनेति यद्वत्‌”? u It appears also 
+in the following verse of the Khandanakhandakhddya, page 
+278 ;-- 
+
+
+“ तथाहि मिथिलानाथो सुसुक्चनिर्ममः पुरा । 
+are? मिथिलादाहे न से क्रिञ्जन दह्यते ” ॥ 
+
+
+मुण्डितशिरोनक्षत्रान्वेषणम्‌ ॥ 
+
+
+Lnquiring as to a suitable date for the shaving of one's 
+head when one has already performed that ceremony ! It 
+occurs in the following passage of tho Nydyamanjari, page 
+171 :--“यत्पुनः कालान्तरे तन्निश्चयकरणे दूपणमितरेतराश्रयत्व वा ; 
+रोनक्षत्रान्वेषणवद्देयर्थ्ये चेति वर्णितं Taree विपये प्रामाण्य निश्चयपूर्विकायाः 
+अबृत्तेरभ्युपगमान्नेतरेतराश्रयं चक्रकं वा? This saying was explained 
+to me by my learned friend the Principal of the Government 
+Sanskrit College at Benares. It is similar to two given by 
+Raghunathavarman, namely, “कृते कार्ये किं सुहूतंप्रश्ेन,?” and “न हि 
+
+
+विवाहानन्तरं वरपरीक्षा क्रियते.” Sce also कृतक्षोरस्य नक्षत्रपरीक्षा in the 
+Third Hand ful. 
+
+
+Sd 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+| 
+| 
+| 
+| 
+| 
+) 
+
+
+| 
+| 
+| 
+j 
+| 
+| 
+| 
+j 
+| 
+| 
+| 
+| 
+| 
+| 
+| 
+| 
+| 
+| 
+| 
+J 
+| 
+
+
+Digitized By Siddha ID eGangotri Gyaan Kosha 
+मूषासिक्तताम्नन्यायः ॥ 
+
+
+The simile of [ molten] copper poured into a mould | and 
+assuming its shape J. Raghunathavarman expounds it thus:— 
+“चक्षुरादिद्वारा बहिर्निःसृतस्यान्तःकरणस्य मूपषासिक्तताम्रन्यायेन विषयाकारता 
+भवति । तदुक्तं भगवत्पादैः । 'मूपासिक्त यथा ताम्रं तन्निभं जायते तथा । 
+रूपादीन्व्यामुवच्चित्तं तन्निभं दृश्यते श्रुवमिति”. This verse is S'ankar- 
+acarya’s Upades'aschasrt xiv. 3, on which Ramatirtha com- 
+ments as follows :--मूपान्तःसुषिरा gender | यथास्निसंपकांद्रवी भूतं 
+ast मूपाय़ां निपिक्त निक्षिप्तं सत्तन्निभं जायते तत्समानाकृति भवति तथा 
+चित्तमपि रूपादीन्विषयान्व्यामु वत्तन्निभ इश्यते तदाकारं जायत इत्यर्थः” d 
+
+
+I may add that the nyaya which immediately follows this 
+in Raghunatha's list, namely व्यज्भकव्यंग्यन्याय, is based on the 
+very next verse of the Upadesasahasri KAFA वा यथा लोकः 
+&e.”], and his explanatory remarks are taken verbatim from 
+Ramatirtha’s comment. The nyaya we are now examining ap- 
+pears also in Brahmasutrabhashya 1. 1. 12 in the expres- 
+sion “मूपानिपिक्तदुततास्रादिप्रतिमावत??, and in Tortiriyavartike 
+(p. 94):—* विद्यादन्नमयेनेव मूषायां दुततास्रवत्‌ | सवोन्प्राणमयादीस्तान्र- 
+चितान्पुरुषाकृतीन्‌.'? 
+
+
+fas les A e 
+मूषिकभक्षितबीजादावड्डूरादिजननप्राथेना ॥ 
+
+
+Looking for the production of germs when the seed has been 
+eaten by ७ mouse! This seems to belong to the same category 
+as the काकदन्तपरीक्षा. 16 occurs in the Bauddha chapter of 
+Sarvadars'anasangraha (page 14 of Jivananda's edn, ). The 
+whole passage is too long for quotation, but the nyaya-por- 
+tion is as follows:—“@dta स्थायित्ववृत्याशा मूषिकभाक्षितबीजादावडु- 
+रादिजननम्रार्थनामनुहरेत? ॥ 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+62 
+; i ha 
+D que itized By Siddhanta क angotri Gyaan Kos! E d 
+सत इण्डुभमांसाद्य काकोऽपि गरुडायते ॥ . | 
+Liven a [ cowardly ] crow can assume the bearing of an | 
+eagle, when it comes upon 6 dead lizard! This ig the firs | 
+line of Bodhicurydvatara vii. 72, the second being 
+
+
+“ झापदाबाधते$ल्पापि मनो मे यदि दुर्बलम्‌ ” ॥ ; | 
+How true to nature this is! | 
+
+
+यः कारयति स करोत्येव ॥ 
+
+
+He who causes a thing to be done by another १७ himself the 
+real doer of it, “Facit per alium facit per se”, 
+is of common occurrence, There is a good instance of it in 
+
+
+Anandagiri’s comment on Brakmastitrabhashya l. 2. 11, Ex- 
+plaining Mundaka Upanishad 3. 1. 1, S'ankara 8098 :--/ए वमे- 
+
+
+केनापि पिबता द्वौ पिबन्ताङुच्येते । यद्वा जीवस्तावत्पिबतीश्वरस्तु पाययति 
+
+
+| 
+| 
+पाययन्नपि पिवतीत्युच्यते | पाचयितर्यपि पक्तत्वग्रसिद्विदरानात्‌? ॥ ०० | 
+| 
+
+
+This nyaya 
+
+
+which Anandagiri remarks :--“पायय ्निति । 
+TAHAR कथमित्याशंक्याह पाचयितरीति । यः 
+दित्यर्थः”? See also Latparyatika, p 
+
+
+प्रधानकतैरि प्रयोगो 
+कारयति स PUANA न्याया- 
+age 187, line 1. 
+
+
+—M 
+
+
+यत्कृतकं तदनित्यम्‌ ॥ 
+
+
+Anything that has b 
+
+
+cen made is :non-eternal, In | 
+words, that which has a beginning has also an end; except of 
+course, the Naiyayika’s अध्वंसाभाव, which hag a beginning but no 
+end! The nyaya is found in the Nyäyabindu, page 108, and 
+its converse, rear TATIFY, On page 116, The following are 
+
+
+additional examples of its use, Viwaranaprameyasangrahu, 
+Page 240, line 3:—. 
+
+
+cm 3 “अतो यत्कृतर्क तदनित्यसित्यादिन्यायानुसारेणानिय- 
+E मोक्षस्य TAA” ॥ Nyayavartikatatparyajika page 187 
+
+
+; i बुभुत्समानाया p 
+line 8 from bottom :--“पुवमनित्य des oe 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+63 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+इत्यनुक्त्वा यदेव किंचिदुच्यते कृतकत्वादिति वा यत्कृतक तदनित्यमिति वा. 
+
+
+कृतकश्च शब्द इति वा तत्सर्वमस्यानपेक्षितमापाततो5संबद्धाभिधानं तथा 
+चानवहितो न बोद्युमहँतीति | यत्कृतकं तत्सर्वमनित्य यथा धटः कृतकश्च शब्द 
+इति वचनमर्थसामथ्यनवापेक्षितशब्दानित्यत्वनिश्चायकमित्यवधानमत्रेति चेन्न 
+परस्पराश्रयत्वप्रसंगात्‌?॥ Part of this latter passage is quoted in 
+Citsukht i. 23 ( Pandit, vol. V. page 27). 
+
+
+यदश्वेन हृतं पुरा तत्पश्चाहदभः Mea केनोपायेन शक्तुयात्‌ ॥ 
+
+
+By what means can a donkey overtake [80 as to bring back) 
+that which has been carried off long before by [one mounted on] 
+a horse? This phrase, borrowed from Tantravartika ( page 
+730 ), is introduced into the Vydyamanjari ( page 262 ) in the 
+course of a discussion on the relative value and authority of 
+S'rutà and Smriti, in the following verse :-- 
+
+
+“सोऽयमाभाणको लोके यदश्वेन हृतं पुरा । 
+तत्पश्चाद्गदेसः TS केनोपायेन MATT” ॥ 
+
+
+According to Kumarila, a man who has accepted the teach- 
+ing of sruti will not allow it to be upset by a contradictory 
+smriti, and vice versa. This is expressed, as follows, in two 
+passages of Tantravartika 1. 8. 8. (as pointed out by the editor 
+of Nydyamanjari. )—'« च श्रुतिजनितप्रद्ययस्य स्मृतिजनितो बाधकत्वं 
+प्रतिपद्यते ॥ स्मास्य बाधकः श्रौतो बलवत्त्वात्रतीयते । प्रत्यक्षे चानुमाने च 
+प्रागेतद्यवधारितम्‌ ॥ ...... न च शीघ्रहतेऽथेऽस्ति चिरादागच्छतो गतिः | 
+अश्वैरपहृतं को हि aio maada ॥ Page 92. Again on page 
+94 :--“यो हि श्राति प्रथमसश्रत्वा Raat पश्यति तस्याग्रतिहतश्चुत्यनुमाने 
+TANA पश्चाच्छूयसाणापि af: स्यात्प्रतिबन्धिका । गर्दभेनापनीतं हि EX 
+श्रश्चिराद्गतः?? ॥ 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+ae 
+
+
+not be the causes of shoots in general" The following is the 
+
+
+64 
+नो 
+
+
+i ha 
+igiti By Siddhanta eGang Gyaan Kos 
+afaa अयाः y Sidel 
+
+
+TERT कायकारणभावाऽसातं वाधके तत्सामान्यः 
+योरपि ॥ 
+
+
+This nyaya, is found in Raghunitha’s larger work, the 
+Laukikanydyaratnakar (India Office MS. 582, page 185 a) 
+and on page 6 of S“ikhdimanitika. Prof. Cowell, however, 
+quoted and explained it in a footnote to his translation of 
+Haridasa’s comment on Kusumanjali ए. 4, I quote a portion 
+of the comment to elucidate the note. “You may not say 
+that ‘the volition of the conscious agent is the cause in effort 
+only, and not in all action generally,’ because even though a 
+particular kind of volition may be the cause in the case of 
+effort, this does not preclude volition generally; otherwise, 
+because a particular seed is the cause of a particular shoot, it 
+would follow that seeds in general [ 4. e, the class, seed ] could 
+
+
+footnote. "This argument depends on two principles-a. The 
+same relation of cause and effect which exists between parti- 
+culars, exists likewise between their respective classes, “यद्विशेषयोः 
+
+T न्ययोरपि? and b. the general causes only 
+their effects when conjoined with the particular causes, 'सामान्य- 
+सामग्री विशेषसामग्रीसहितेव कार्य जनयति.” Thus Archbishop Whately 
+has made a book on Logic,—man can therefore make logical 
+
+
+books; only in each particular case we require the concurrents, 
+education, leisure ७८.” 
+
+
+STE यक्षस्ताहशो बलिः ॥ 
+
+
+As is the Yaksha, 80 should be the ofering, This is included 
+in Raghunatha’s list, but without any definitio 
+
+
+n of its meaning. | 
+Tt is embedded, however, 
+
+
+in the philosophica] part of his | 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By SiddhantaeGangotti Gyaan Kosha 
+
+
+treatise, as follows—" यस्त्वनेकजन्मार्जितपापपुञजन्यदुरागहादेकभाक्ति- 
+च्छलेनान्यं निन्दति असकृद्दोध्यमानो5पि चर्जुमार्गणासेद॑ नोपैति आमयति च 
+मन्दान्स यादशो यक्षस्ताइशो बलिरिति न्यायात्तत्मतिपादितोत्कर्षांपकर्षविपरीतो- 
+त्कर्षापकर्पोपपादनेन विजित्य पश्चात्पर्वोक्तरीत्यास्न्ताभेदोपपादनेन बोधनीयः | 
+एवं हि स मारणाय गृहीतोऽङ्गच्छेदं स्वीकरोतीति न्यायेनाभेदं स्वीकरिष्यति” ॥ 
+
+I have found the nyaya in use in the following works of 
+Vacaspatimisra’s and of Jayanta Bhatta. In the Nyayavartika- 
+tatparyatika, page 115 :-- अह्ृद्यवाचामह्ृदया पुव प्रतिवाचो ya 
+न्ति । यक्षानुरूपो बलिरिति हि लौकिकानामाभाणकः 11? Also in the Bhi- 
+matt 4. 1. 15 (page 723) :—“a च कार्यसपि भयकम्पादि वस्तुसत्‌ | 
+तस्यापि विचारासहत्वेनानिवाच्यत्वात्‌ | अनिर्वाच्याच्चानि्वाच्योत्पत्तो नानुपपत्तिः । 
+Weal यक्षस्तारशो बलिरिति सर्वमवदातम्‌? The two which follow 
+are from the Nyayamanjari, Page 54 :-- 
+
+
+“ अभावश्च क्चिल्िज्ञमिष्यते भावसंविदः | 
+वृष्ट्यभावो$पि वाय्वभ्रसंयोगस्यानुमापकः ॥ 
+
+
+तस्मायुक्तमभावस्य नाभावेनेव वेदनम्‌ | 
+न नाम याइशों यक्षो बलिरप्यस्य ताइशः di 
+
+
+On page 637 :— 
+८ याव्ग्यक्षो बलिरपि तथेत्येवमाधाय gel 
+यस्तु ब्रुयात्कलुषमफलस्तस्य gts हेतुः ” | 
+
+
+It occurs also in S'ridhara's Nyayakandali, page 144, line 13, 
+and, finally, in the vritti on Zattvamuktakalapa ii. 49, where 
+it is immediately followed by “पिशाचानां पिशाचभाषयैवोत्तर देयमिति 
+ITI." The general sense of the nyaya would seem to be 
+that of “ tit-for-tat”, “a Roland for an Oliver.” 
+
+
+9 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+66 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+' यावद्वचनं वाचनिकम्‌ ॥ 
+
+
+Conveying the meaning actually expressed | and therefore 
+needing nothing to supplement it J. Kumarila puts it thus in 
+Lantravartika 8. 5. 19 :- “कश्चात्र विशेष: । स॒ यदि वाचनिकस्ततो 
+यावद्वचनमेव peer: ॥ Compare, too, the latter part of S'abara 
+on 2.3.2. It occurs twice in Bhamati. On 4. 1. 4 ( page 710 ) 
+
+
+c. 
+
+
+We 1९90 :--"यस्माद्यस्थ यन्मात्राव्मतयोपासनं विहितं wer तन्मात्रात्मतयेव 
+मतिपत्तब्यं यावद्वचनं वाचनिकमिति न्यायान्नाधिकमध्याहतेव्यमतिम्रसङ्गात्‌? i 
+Again on 4, 3, 4 (page 742) as follows “न चामानवस्य पुरुपस्य 
+विद्युदादिपु वोढ्त्वदर्शनादर्चिरादीनामपि वोढ्त्वसुन्नेयं यावद्गवचन हि वाचनिकं न 
+
+
+तदवाच्ये सञ्चारयितुसुचितम्‌?” T Anandagiri , too, quotes the nyaya in 
+his comment on 4. 3. 4, He says :“ अमानवपुरुषस्य विद्युदादाबातिवा- 
+हिकत्वद््टेरचिंरादी नामपि तदुन्नेयमित्यर्थः । यावद्वचनं वाचनिकमिति enum 
+तेपामातिवाहिकस्वसाधकमेतदिति शंकते तदिति” ॥ It is found also in 
+the philosophical portion of Laukikanydyasangraha (7, 0, 
+
+
+MS. 1081, page 45 ७. )--“या तु पिशाचसोचनाख्याने पिशाचस्यापि 
+
+
+तत्खानात्प A 'निपादस्थपती KA A ~ 
+' पत्खानात्पशाच्यनाशोक्ति: सा टस्थपती श्‍विद्यावद्ठचनं तावद्वाचनिकमिति 
+
+
+न्यायात्तन्मात्रविषयेव । न च लिङ्गस्य काशीम्रवेात्पापनारे वचोऽस्ति तस्मा- 
+व्काइयुत्पन्नविषयाणि तत्तहिङ्गदर्रीनादिनैकब्या दिजन्मपापक्षयबोधकानि qui 
+सीत्याहुः” ॥ See, too, Nages’a’s Uddyota, vol, i. p. 574. 
+
+
+———— 
+राजपुत्रव्याधन्यायः ॥ 
+
+
+The illustration of the king's son | who was brought up ] | a 
+hunier. The story is that a young prince, abandoned by his 
+parents at his birth, was adopted by a hunter and brought up 
+as his own son. The boy remained in ignorance of his real 
+
+
+origin until he was discovered by a kindly person and restored 
+
+
+to his rightful position. S'ankarücarya seems to have been the 
+first to utilize the tale, and he gives it as follo 
+
+
+on Brihadār E S 
+: : Sd RE lection. 
+
+
+Digitized By Sidhe AR Gyaan Kosha 
+
+
+“अन्न च संप्रदायविद आख्यायिकां संप्रचक्षते । कश्चित्किल राजपुत्रो जात- 
+मात्र एव सातापितृभ्यामपविद्धो व्याधगृहे संवर्धित: | सोऽसुष्य वंशतामज्ान- 
+न्व्याधजातिप्रत्ययो व्याधजातिकर्माण्येवानुवर्तते न राजास्मीति राजजातिकमौ- 
+` ण्यनुवर्तेते | यदा पुनः कश्चित्परमकारुणिको राजपुत्रस्य राजश्रीप्राप्रियोग्यतां 
+maaga पुत्रतां बोधयति न त्वं व्याधोऽसुष्य राज्ञः ya कर्थचिब्याधगृहमचु- 
+प्रविष्ट इति स एवं बोधितस्तक्स्वा व्याधजातिप्रय्यकर्माणि पिठृपेतामहीमात्मनः 
+पदवीमलुवर्तते राजाहमस्मीति. 
+
+
+Sure'svara refers to this several times in his large Vürtika, 
+On page 71 we 1'९80:--“तच्चाविद्यानिरास्येव व्याधभावनयाज़ितः । राज- 
+सूनोः स्म्रतिग्राप्तो व्याधभावो निवर्वते.'? Then, on pages 970-2, he 
+devotes ten verses to the nyaya, and returns to it once more on 
+page 1845. 
+
+
+The author of the Siddhantales'a (on page 20) cites i& as 
+the “व्याधकुलूसंवर्धितराजकुमारदृष्टान्त, ” and it is reproduced, in a 
+slightly different form, in the comments of Aniruddha and 
+Vedantin Mahadeo on Samkhyasitra iv. 1. See also Bhamati 
+1. 4. 22. Raghunüthavarman links with the above the NERT- 
+न्याय Which tells of a lion’s cub being brought up as a ram; but 
+T have not yet met with it elsewhere. 
+
+
+— 
+
+
+राजपुरप्रवेशन्यायः ॥ 
+
+
+The simile of the manner of entering œ royal city. Th is, 
+found in both of Raghuniithavarma’s treatises, but the following 
+explanation of it is taken from the Vacaspatyam:—'" Hasa 
+राजपुरप्रवेशे राजपुररक्षकैस्ताडनादिक॑ क्रियेतेति भिया श्रेणीभूततया यथा 
+TAIT एवं aa यत्र कार्यकरणस्य विवक्षा तन्नास्य प्रवृत्तिः? ॥ 
+Raghunātha points out that we do not grasp the meaning of a 
+long sentence as a whole, but that the sense of each word 
+enters the mind singly, on the principle of राजपुरप्रवेश,-- “तत्र हि 
+कमेणेव बहूनां पुरुषाणां प्रवेशों भवति न युगपत्‌.” 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+I have met with the nyaya in Nages'a Bhatta's comment on 
+Kaiyata. In Mahabhasya 1. 1. 58 (under vartika 1 ) we read 
+“अनाजुपूर््यणापि संनिविष्टानां यथेष्टमभिसंबन्धो' भवति । तद्यथा । me | 
+सुदहारि या त्वं हरसि शिरसा कुम्भं भगिनि साचीनमभिधावन्तमद्राक्षी | | 
+तस्य .यथेष्टमभिसंवन्धो भवति । उदहारि भगिनि या त्वं कुम्भ हरसि शिरसा. | 
+नद्धाहं साचीनमभिधावन्तमद्राक्षीरिति?॥ Kaiyata remarks on this E 
+“पाठक्रमादार्थक्रमो बलीयानिति यथेष्टमत्राभिसंबन्धः!?, and on these words 
+Nagesa says “आर्थक्रमो नाम राजपुरग्रवेशन्यायेन स्वस्याकांक्षितार्थान्वयः | 
+कमः । एवं च कल्पितासन्नवाक्याद्वोधविषये तात्पर्ये नियामकमिति भावः? T 
+The passages here quoted will be found on pages 389 and 390 
+of vol. i. of the edition of Mahàbhasya with the Prada and 
+Uddyota, published at the Nirnayasügar Press in 1908, 
+
+
+68 | 
+
+Digitized By Siddhanta eGangotri Gyaan Kosha | 
+| 
+
+| 
+
+
+राजाथोंपयिकं ferr वहति कुंकुमम्‌ ॥ 
+
+
+This is the second line of a verse on page 372 of the Tantra- | 
+variika. To make it intelligible I quote a portion of the con- | 
+text as interpreted by Professor Ganginatha Jha in his trans- | 
+lation ( page 511, last line ):- “It has been urged aboye that, | 
+if the Apūrva inhere in the Soul, then it becomes only an end 
+in itself desirable by men. But this does not affect our position; 
+because one thing becomes subservient to another only when its 
+sole use lies in the serving of some purpose of this latter, and 
+not merely when it rests in this ; for instance, though the Red 
+Dye is carried by the camel (and as such rests upon its back), 
+yet it serves the purposes of the king ( for whom it is carried ie 
+
+
+रुधिरसम्पर्कवतो विषस्य शरीरे प्रसपणम्‌ ॥ 
+
+
+The circulation within th 
+
+
+€ body of poison which has 
+entered the blood. Used as a warning against the beginnings of 
+evil in however small a de 
+
+
+i greo. The figure is found in | j 
+Bodhicaryavataya, Yaa vrat Shastri Collection. 
+
+
+Digitized By Siddha हुं eGangotri Gyaan Kosha 
+
+
+‘faq रुधिरमासाद्य प्रसपति यथा तनौ । 
+तथैव छिद्रमासाद्य दोपश्रित्ते प्रसपेति ” ॥ 
+
+
+The commentary runs thus:—“ अणुमात्रस्यापि दोषस्यावकाशो न 
+दातव्यः | अन्यथा तन्मात्रस्याप्यचुम्रवेरो चित्ते तत्मसरावरोधस्य कतुमराक्यत्वात्‌ | 
+यथा हि स्वल्पत्रणेऽपि रुधिरसम्पर्कवतो विषस्य शारीरे | तस्मादणुमात्रक्केराप्रहार- 
+निवारणेऽपि तात्पर्यं कुर्यात. Compare “The beginning of strife is as 
+when one letteth out water; therefore leave off contention be- 
+fore there be quarrelling.” 
+
+
+सरुमाक्षिप्तकाषन्यायः ॥ 
+
+
+The illustration of wood thrown «nto the salt-lake [or mine] 
+Ruma. The Medin 17098 explains Ruma as * fatfzreeaumes ^; 
+and it is said to be situated near Ajmere. The tradition is that 
+anything thrown in there becomes saline itself. The earliest 
+mention of Rumi, with which I am acquainted, is in the 
+following verse of Tantravartika ( page 182 ) :-- 
+
+
+“ यथा रुमायां SANE मेरो यथा वोज्वलरुक्मभूमों । 
+यज्ञायते तन्मयमेव तत्स्यात्तथा भवेद्वेदविदात्मतुष्टिः ? ॥ 
+
+
+Kumürila seems here to regard Ruma as the region in which 
+the salt mines are situated, rather than as the mine itself; and 
+this may give some ground for the footnote by the editor of the 
+Medini, ( Calcutta, 1869) where he defines विशिष्टलवणाकरः 88 
+“लवणखनि भूयिष्टदेशविशेषः- » Tn his translation of the above verse, 
+Prof. Ganganatha Jha omits Ruma altogether. He says :— 
+“Just as in the case of salt mines, and in that of Meru the land 
+of bright gold, whatever is produced in them, becomes salt and 
+gold (respectively),—so also in the case of the inner satisfaction 
+
+
+of one who knows the Veda (which imparts Vedic authority - 
+
+
+to all that it touches). 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+70 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha | 
+
+We have an example of the nyaya in Vücaspati 019७१ , | 
+comment on Vogasütrabhasya iv. 14. The sütra is “परिणामेकत्वा- । 
+auawa” on which he says 7 बहूनामप्येकः परिणामों इष्ट: । तद्यथा। | 
+गवाश्वमहिपसातङ्गानां रुमानिक्षिप्तानामेको लवणत्वजातीयलक्षणः परिणामो | 
+वर्तितेलानलानां च प्रदीप इति.” Then Ven katanatha uses the illus. | 
+tration in Tattvamuktakalapa v. 28, and in his vritti thereon, | 
+as follows :— | 
+i “ स्थादुप्णः कृष्णवर्त्मा सलिलसापि तथा शीतमस्तु Suum | 
+स्पर्शा$न्यो5प्यत्न दृष्टस्स तु भवतु स्माक्षिप्तलावण्यव्ञेत्‌ Hn | 
+
+“so: कृणावत्मा aa जलमपि शीतमिव्युपलभ्यते ग्रक्ृत्या । अन्न कश्चिदाह | 
+अन्योऽपि स्पशो दहने सलिले च कदाचिटुपलभ्यते स तु रुमाक्षिप्रकाष्टादिल्वण- | 
+न्यायेन तस्यैव परिणतिविशेष इति.” | 
+same, the author s | 
+काष्टन्यायः?? ॥ | 
+l 
+
+| 
+
+] 
+
+
+In the vritti on ii, 1 of the 
+ayS:— गुणसंक्रमो न क्कचिदपि | न चात्र रूमाक्षिप्तः 
+
+
+——— —— 
+
+
+रूढियोगमपहरति ॥ 
+
+
+Popular usage overpowers etymologica 
+2 capital illustration of this in the Viwaranaprameyasangraha 
+
+-3 ( pages 134, 135 ) where Badarayana’s first sutra is under 
+discussion “न॒ जिज्ञासाशाब्दो विचारे रूढः । 
+बिचारविवक्षया प्रयुक्तत्वात्‌ । अतो रूढिर्योगमपहरतीति 
+कारो न युक्तस्ततोऽर्थरव्दोऽप्यधिकाराशोः 
+शक्यत्वादिति चेन्मैवम्‌ । रूढियोंगमपहरती ति न्यायस्थात्राम्रसरात् ।.. 9००6? 
+तत्र यः शब्द एकत्रार्थ रूढो5परत्र योगिको यथा च्छागे रूढो5जशन्द आत्मनि 
+योगिकस्तत्राजं ii रूढिये पोंगमपहरतीति न्यायः असरति । इह तु जि- 
+TAREA न विचारे रूढः” ॥ The following verse is quoted in the 
+Nyayapradipa, a commentary on Tarkabhasa, page 5:— 
+“लब्धात्मिका सती रूढिभ॑वेद्योगापहारिणी । कल्पनीया तु लभते नात्मानं 
+
+योराबाधतः?? ॥ ‘The editor cites 8 very modern author who as- - 
+
+
+cribes the verse to Ku marila, See also Pancapadikavivarana, E 
+PP: 182-3; Vedamtakalpataru, P. 207; and Anandagiri on - 
+Brakmasitrabhashya, 1 8, 42, E 
+
+
+i meaning. There is 
+
+
+भाष्यकारादिभिस्तत्र 
+
+` Fe i 
+न्यायेनावयवार्थस्वी- 
+भविष्यतीति विचारस्य "Ned 
+
+
+CC-0. Prof. SatyaVrat Shastri Collection. 
+
+
+Digitized By eel CN Gyaan Kosha 
+
+
+रेखागवयन्यायः ॥ 
+
+
+The illustration of the sketch of the Bos Gavacus ( Gayal ). 
+Raghunathavarma explains and applies it as follows :--कीह शो 
+गवय इति ग्रामीणेन set बन्यो लिखित्वा alae स चर्जबुद्धित्वादेखाग- 
+वयमेव गवयं मेने । पश्चाइने गवयं दृष्टा रेखायां wate तत्याजेति लौकिकी 
+गाथा । तथैष पुरुष इत्यादिश्रुतेः पू्वोक्ततात्पयौनभिजञोऽनात्मानमेवात्मतया 
+जानीते | गुरुशास्रोपदेशेनात्मनि ज्ञाते तदात्मडुद्धिमपवदति.” It is found 
+on page 457 of Vacaspatimis'ra's Tatparyatikd, and again on 
+page 363 of Veddntakalpataruparimala. The latter passage 
+reads thus :--“यथा तात्विकारुन्धतीम्रतिपत्त्युपायतया नानापुरुषः कल्प्य- 
+मानायां तत्माच्योदीच्यादिनक्षत्ररूपायां स्थूलारुन्धत्या यथा वा रेखागवयल्याथेन 
+नित्यशव्दप्रतिपत्त्युपायतया नानाग्याकरणेः परस्परभिन्नप्रकृतिप्रत्ययविभागेन 
+HAASE इति भावः” ॥ 
+
+
+A third example is found in the following extract from 
+Kaiyata on Mahabhasya 1. 1. 46 :-“असत्य्रक्ृतिम्र्योपदेशेन सत्यस्य 
+पदस्थ व्युत्पादनं क्रियते रेखागवयेनेव सत्यगवयस्य.” See also 57१४१७७४७० 
+Page 322, and page 77 of Dr. Thibaut's translation. 
+
+
+लक्षणप्रमाणाभ्यां वस्तुसिद्धिः ॥ 
+
+
+[ The existence, or nature, 01] an object is established by 
+means of some distinguishing characteristic, and bya 
+recognized form of proof | such as sense-perception, scripture 
+2०. | “यथा गन्धवत्त्वादिलक्षणेन प्रत्यक्षप्रमाणेन च एथिब्यादिसिदिः?॥ Or, 
+Just as the wonders of creation establish the “eternal power 
+and Godhead” of the invisible Deity, to which Scripture also 
+bears testimony, 
+
+
+Raghunithavarms, quotes the nyaya in the following passage 
+on page 28 of the Benares edition of his work :--“एवससीन्द्रा- ^ 
+
+
+दित्येश्वरवादा अपि तन्माहात्म्योपपादकश्रुतीतिहासपुराणवचनाल्याश्रित्य तत्रैव 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+9 
+Digitized By Siddhanta eGand/t Gyaan Kosha 
+
+
+प्रपञ्चिता ज्ञेयाः । तत्तद्धक्ता अपि सगोदिहेतुत्वरूपेश्वरलक्षणं श्रुत्यादिप्रमाण : 
+तत्र तत्र दर्शयन्तो लक्षणप्रमाणाभ्यां वस्तुसिद्धिरिति न्याथेनेश्वरत्वं साधयन्ति.” | 
+Commenting on the opening verse of the Vedantaparibhaa, | 
+the author of the S'ikhàmani says:i—“ag ब्रह्मणि लक्षणप्रमाणाभावेन 
+तस्यैवासिद्धेः कथं जीवत्रह्माभेदः mai इति चेन्न तावत्ममाणाभावो भूतभौति- 
+कोत्पत्तेरेव प्रमाणत्वात्‌.” Amaradasa’s tika on this begins ay 
+follows :—“लक्षणप्रमाणाभ्यां वस्तुसिद्विरिति न्यायमाश्रित्यादांकते नन्विति.” 
+
+
+लाङ्गलं जीवनम्‌ ॥ 
+
+
+A plough is existence. That is, it is a means of existence; | 
+cause and effect being here identified as in आयुर्घृतम्‌, The nyaya 
+is found in Sures'vara's Sambandhavārtika, page 9, as fol. | 
+lows “--“यथोक्तविद्याबोधित्वाडून्थो5पि तदभेदतः । भवेदुपनिषन्नामा छाङ्गछं 
+जीवनं यथा.” On which Anandagiri remarks:—“साध्यसाधनयोरभेः 
+दोपचारेण साध्यशब्दस्य साधने प्रयोगे दष्टान्तमाह लाङ्गलमिति.” We may | 
+compare with this the phrase “The plough supports the bullocks’, 
+which occurs in Brahmasitrabhashya 3. 2. 4 :--“यथा erg गवा. | 
+दीचुद्वहतीति निमित्तमात्रत्वादेवसुच्यते न तु प्रत्यक्षमेव enge गवादीचुः | 
+
+
+zeta 29 RU 
+
+
+वधूसाषमापनन्यायः ॥ 
+
+
+The simile of the measuring out [ or distribution ] of beans 
+by the daughter-in-law. I am much indebted to Mr. Govind | 
+Das, Honorary Magistrate of Benares, for giving me what 
+Seems to be the rea] meaning of this hitherto-puzzling nyaya. j 
+He believes i& to be the adaptation of a Maithila proverb with J 
+which the following Story is connected. 
+
+
+ü “A very miserly old 
+Brahman used to have a Jistful of grain given daily by his wife 
+
+
+to every b ; i 
+: : room to dhe, Joetiectbhe old man having 
+
+
+Digitized By Sidhe Gyaan Kosha 
+
+
+married his son, the idea struck him that if he got his daughter- 
+in-law to do the distribution instead of his old and ugly wife, 
+the smaller fist would measure out 8 smaller quantity of grain ! 
+But, unluckily for him, the girl was very beautiful, so even 
+persons who were not in need began to drop in, disguised as 
+beggars, in order to admire her! The result was that, while 
+each measure was less, the total amount given away was very 
+much more.” 
+
+
+It occurs in the Atmatattvaviveka, page 87, line 12, as follows:- 
+YA चानवस्था अवद्यवेद्यत्वानभ्युपगमा्निश्रचयवदन्यथा त्वानेश्चितनिश्चयस्य नाद्यः | 
+निश्चयोऽपि सिध्येत न चासावात्मन्यनिश्चय इति तदिदं वधूमापसापनवृत्ता- 
+न्तमचुहरति’? ॥ 
+
+
+वध्यघातकन्यायः d 
+
+
+The maxim. of the destroyer and its prey. Used of two 
+things which cannot exist together. It occurs in Taittirzya- 
+värtika 2. 1. 66 ( page 53 ):— प्रतिपद्य पदार्थे हि विरोधात्तद्विरोधिनः | 
+पश्चादभाव॑ जानाति वध्यघातकवत्पदात्‌.” Anandagiri explains it 
+thus :--यथावच्छचेनमूपकादिना दूपितां भूमिसुपलभ्य तद्विरोधिनो घातः 
+कस्य॒ सार्जारादेरभावोऽ्थादवगस्यते तथा सत्यादिपदात्पदार्थं परमार्थत्वादिकं 
+मतीत्य प्रतीतपरसार्थत्वादिविरोधिनोऽसयत्वादेरभावोऽर्थापत्या ज्ञायते न हि 
+सल्यादेरसत्यादेश्रेकाधिकरणत्वं घरते??. See also Pras‘astapada’s V'aís'e- 
+shikabhashya, pages 112, 113; and the latter part of Citsukht 
+iv. 4. ( Pandit vi, 390 ). Compare the बाध्यबाधकभाव of Nais- 
+harmyasiddht i 55 (पञ्चास्योरणय़ोः), and iii, 85 (आखुनकुल्योः). 
+
+
+वनसिंहन्यायः ॥ 
+
+
+The illustration of « Lion im ७ forest. Used of things which 
+mutually aid or protect each other. This, and the हृदनक्रस्याय * 
+Which is of similar import, occur together in the following - a 
+CC-0. Prof. Satya Vrat Shastri Collection. है 
+
+
+74 है 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+passage of the Vedāntakalpataruparimala ( page 100). 
+“सोऽयं वनसिंहङ्ृदनक्रन्यायः | feed राक्योऽपि सिंहो महन शरणं 
+प्रविश्य दुराधर्पस्तेभ्यो न विभेति वनं च तत्सिहाधिष्ठानानुगृहीतं agora 
+भवति ”॥ Similarly, the lake shelters the alligator, and the 
+alligator protects the lake. There is another reference to the 
+वनसिंहन्याय on page 627 of the same work I" m च वनसिंहन्या 
+येन श्रमाणतर्कन्यायेन वोभयोरप्यंशभेदेन परस्परापेक्षायामपि न परस्परा श्रय- 
+ata: The source of the nyaya is doubtless Udyogaparva 
+xxxvii. 46, for the reference to which I am indebted to Professor 
+Dr. R. Pischel. The verse is as follows :— 
+
+
+“न स्थाइनस्ते व्याघ्ा्च्याम्रा न end "I 
+वनं हि रक्ष्यते व्याप्रैव्याप्रान्‌ रक्षति काननम्‌” ॥ 
+Compare also verse 64 of the same, 
+
+
+वरगोष्ठीन्यायः ॥ 
+
+
+The maxim of the discussion of matters with ७ view to 
+obtaining ७ husband [ for one’s daughter ] It is thus explain- 
+ed by Raghunüthavarman :--“गोष्टिरन्योन्यवार्ता वरलाभाय गोष्टिवर- 
+गोष्ठिस्तया यथा वरवधूबन्धूनामैकमत्ये सति विवाहरूपमेकं कार्यं निष्पाद्यते 
+तथेत्यर्थः? ॥ Ihave met with the expression twice in the l 
+2५८८६७८ ( pages 72, 73 ),ina description of the erroneous views 
+of common people ( such as the Laukayatikas &e, ) in regard to 
+
+
+the aiman. The passages are ag 011098:--“एवसिन्द्रियाण्येव चेतनानि 
+आत्मेत्यपरे । इन्द्रियाणां चक्षरादिमनःपर्यन्तानामेकेक समि असत्येव शरीरे रूपा- 
+
+
+व्यस्तानां चेतनत्वमहंमरत्ययविषयत्वं च मन्यन्ते ऋसेः 
+ण च वरगोष्टीवदितरेतरगुणभावं च? ॥ ४ :--“यदि तावद्चस्तानां 
+युगपत्परिकल्प्येत ततः स्वार्थ्रयुक्तत्वात्यवृत्तेरड़ाज्लिभावो नावकल्पेत | न चाङ्गा- 
+
+
+संघात उपपद्यते । Tent व्यस्तेषु TURN: । अस्तु ताहे 
+कमेण विरोधाद्वरगोष्ठीवादिति | नेतदेवं युक्तम्‌? ॥ 
+
+
+Tt needs a more intimate acquaintance with वरगोष्ठी than we 
+Westerns possess in order t; 
+
+
+nyaya, and I must confess to a, Certain amo 
+
+
+o i to 
+CC-0. Prof. Satya Vrat Shastri Colo Of haziness as | 
+
+
+o grasp the full Significance of the | 
+
+
+Digitized By Siddhaptg eGangotri Gyaan Kosha 
+
+
+its exact sense in the passages here cited. In a later part of 
+his treatise Raghunatha gives us the maxim ५ 39 
+appended to which is the remark “केचित्तु प्रागुदाहृतं वरगोष्ठिन्याय- 
+मेतदर्थकत्वेन व्याचक्षते.” The way in which he applies the latter 
+will be apparent from the following excerpt from the philoso- 
+phical portion of his work :--“एवं हि वादिनो यद्विवाहस्तद्गीतगानसिः 
+तिन्यायाजुसारीणि स्वसवेष्टदेवमाहात्म्यवाक्यानि परयन्तोऽन्यानि तु पञ्यन्तोऽपि 
+दुरामहपिनद्धषृ्टित्वादपञ्यन्त इव तदेकवाक्यतादिकं 'चाजानन्तो5न्धगजन्याये- 
+नान्योन्यं विवदतेऽुद्गैव च मतान्तरं कूपमण्डूकन्यायान्निराकुर्न्तो बुदधैरुपहस- | 
+नीयतां यान्ति” ॥ Compare Kumarila’s “कन्यावरणार्थागतमूर्खवरगोव्र- 
+प्रश्नोत्तवत्‌ । यदेव भवतां गोत्रं तदस्माकमपीतिवत्‌”॥ Taniravartika, 
+page 169-70. Prof. Ganganatha Jha points out that if the 
+would-be bridegroom was really of the same gotra, it would 
+make the marriage impossible ! 
+
+
+विक्रीतगवीरक्षणम्‌ ॥ 
+Retaining possession of a cow after it has been sold to 
+some one else. This illegality is dealt with by Narada and 
+Yajnavalkya in the « विव्हीयासम्प्रदानमकरणम्‌ 7, "The non-delivery- 
+of a sold chattel.” In chapter viii, 1, the former defines it 
+thus ;— 
+“ विक्रीय पण्यं मूल्येन क्रेतुर्यज्न प्रदीयते । 
+विक्रीयासम्प्रदानं तद्विवादपदसुच्यते ” ॥ 
+The latter lays down the Jaw on the subject in chapter ii. 
+254-8. Udayana's application of the above in Atmatattvavivela, 
+page 58, is as follows :— : 
+© यदनात्मान एवैताश्चतस्रः कोटयो भासन्ते न वा प्रतिभान्तीति । तत्राप्रतिभान- 
+मबुत्तरम्‌। प्रतिभाने तु राह्मलक्षणायोगेऽपि ग्राह्मभाव इति चेदेवमेतत्‌।..-प्रकाश- 
+सानत्वं तु नीलादीनामशक्यापह्ुवम्‌। तावन्मात्रं चास्माकमभिमतसिति चेत्तदेत- 
+ह्विकीतगवीरक्षणम्‌ ? ॥ 
+The drift of this is not very clear. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta WA Gyaan Kosha 
+वृक्षप्रकंपनन्यायः ॥ 
+
+The illustration of the shaking of & tree. A man is supposed 
+to be up a tree whilst others are standing below it. One of the 
+latter points to a particular branch which he wishes to he 
+shaken, and the others point out other branches for the same 
+purpose; so the man shakes the whole tree at once and thus 
+satisfies every body by the one effort! Raghunatha applies this 
+in the following way :—“ यत्रेकस्य वस्तुनो मतभेदेन वहूनि रूपाणि 
+WERTE ्रतिपा्यमानान्युपरभ्य क्रिया हि Bees न वस्त्विति न्याया- 
+aa विकल्पासंभवं भत्वा विरुद्धानां ससुञ्चयस्याप्यसंभवेन तेष्वेकमतप्रति- 
+पादितं सर्वाविरुद्धं वस्तु स्रीक्रियते तत्र ब्रक्षमरक॑पनन्यायः प्रवर्तते? ॥ In his 
+larger work, Raghunatha Says that the simile is also found as 
+बरक्षमचळनन्याय, and in this form I have met with it in Mahā- 
+
+
+bhasya, vol. 1. page 23 (bottom ) “zai प्रचलन्सहावयवेः mah. 
+Also in 6, 1, 1 ( vàrt, 13), l 
+
+
+वृश्चिकभिया पलायमान आशीविषमुखे निपतितः ॥ 
+
+
+Running away through fear of a scorpion, he falls into the 
+jaws of 6 poisonous snake! Avoiding Scylla, he falls into 
+Charybdis! The nyaya occurs in the following passage of the ' 
+Ny dyavartikatatparyatika, page 53:— यद्यपि रागादिनिवृत्तिहेतु- 
+नेरात्म्यदर्शनं तथापि नास्ति कर्म नास्ति कर्सफळमिति इष्टेः परमं निदानम्‌। 
+ga प्रेत्यभावाभावज्ञानस्य च । तथा च दुःखहेतोहेयवर्गस्याभावाच तद्धानाया- | 
+नेन घटितव्यम्‌ । न चाघरमानो ह्य हातुमहति सोऽयं दृश्चिकमिया quur | 
+मान आशीविषसुखे निपतितः?” u tis found also in Kusumānjali | 
+ii. 3 ( page 328 ), in Vidvanmandana, page 4, and in Nyaya- | 
+makaranda, Page 223. Of sémewhat similar import is the | 
+yaya “एकामासोादें परिहरतो द्वितीयापद्यते??, which see, 
+
+
+A Q 
+बाश्चकीगभन्यायः d 
+For this see the अश्वतरीगर्भन्याय. 
+
+
+—— 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+व्याठनकुलन्याय* i 
+
+
+The maxim of the snake and the mungoose. The well- 
+known innate antipathy of these two for one another ( Panini 
+2, 4. 9.) is a commonly-used illustration of inherent opposition 
+between two things. Mr. Tawney has reminded me of the 
+story in Panchatantra V. 2. which speaks of the enmity 
+between them in the following words :--“अत्रान्तरे देववशात्कृष्णसर्पा 
+Renaa: । नकुछोडपि तं स्वभाववेरिणं मत्वा भ्नातू रक्षणार्थ सर्पेण सह 
+युद्धा सपे aves: Jaag u The nyaya is employed by Udayana 
+in Atmatattvaviveka, page 53, as follows :— स्वसंविदि तद्रूपस्वादि- 
+ति चेत्तत्किमङ्गपरिणतशान्तेराश्रमपदामिव विज्ञानमासाद्य व्यालनकुछादेरिव 
+नीळधवळादेः शाश्वतिकविरोधत्यागो निम््तवैराणां तत्फलत्यायो वा। न ताव- 
+awm: परस्परानिपेधविधिनान्तरीयकविधिनिपेधयोरविरोधे जगति विरोधोच्छेदः 
+असज्ञत्‌” ॥ It is more commonly known as अहिनङुळन्याय. 
+
+
+झतपत्रपत्रशंतभेदन्यायः ॥ 
+
+
+The simile of the | apparently simultaneous ] piercing [ with 
+a needle] of one hundred lotus leaves. It is found under 
+the figure agaa in Kuvalaydnanda, in connection with the 
+following example :— 
+
+
+“ बिआणा हृदये त्वया विनिहितं प्रेमाभिधानं नवं 
+शल्य यद्विदधाति सा विधुरिता साधो तदाकण्यैतास्‌। 
+शेते Baa तास्याति प्रलपति अस्लायति प्रेंखति 
+आम्यत्युछ्ुठति प्रणश्यति गलत्युन्सूच्छीते JAA ॥ 
+अन्न कासांचित्कियाणां किश्वित्कालभेदसंभवेडपि शतपत्रपत्रशतभेद्न्यायेन 
+aire विरहातिशयद्योतनाय विवक्षितमिति छक्षणानुगतिः”” ॥ 
+
+In the Sahityadarpana, also, we have the same ides some- 
+what differently expressed in the description of असंलक्ष्यक्रसव्यंग्य. 
+The following is the passage (on page 102) with Mr. Pramada- 
+dase Mitra’s translation:— - 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+78 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+“अन्न व्यंग्यप्रतीतेविंभावादिग्नतीतिकारणकत्वात्कमो 5वश्यमस्ति किन्तूत्पलपत्र 
+शतव्यतिभेदवल्लाघवान्न संलक्ष्यते ” q “ Now, the perception of the 
+suggested, caused as it is by, and hence succeeding, the percep. 
+tion of the Accessories &c., has necessarily a process, but from 
+its quickness ib is not perceived, like the process of the appa. 
+rently simultaneous piercing through of a hundred lotus leaves 
+placed one upon another.” The expression “ उत्पलद्वातपश्रव्यतिभे- 
+gaq” is used by Aniruddha in his comment on Sänkhyasūtra 
+ii, 32; and Dr. Garbe thinks that he took it from the Sahitya. 
+darpana. See his Preface to the Sénkhyastitravritti, There 
+are two examples of this nyaya in S’ridhara’s Nydyakandali, 
+On page 23 :--“यद्गच्छति तत्सन्रिहितव्यवहिताथों क्रमेण ्रामोति तत्कथं 
+गाखाचन्द्रमसोस्तुल्यकालोपलब्धिरिति चेदिन्द्वियवृत्तेराझुसज्ञा रित्वात्पलाशश- 
+तव्यतिभेदवत्क्रमाम्रहणनिमित्तोष्यं मो न छु वास्तवं dhag.” The 
+other is on page 158, 
+
+A much older example is found in S'lokavartika, page 811 
+( verse 157 ), to which I append Mr. Ganganatha Jha’s transla- 
+tion :--“यत्मदीपम्रभायुक्त सूक्ष्मकालोउस्ति तत्र नः । दुर्लक्षस्तु यथा वेध! 
+UNT तथा.” “You have brought forward the case of the 
+
+
+hundred petals of the lotus.” Professor Jacobi has | 
+Pointed out an instance of it in Nydyavartika, page 87, in the 
+form उत्पलदलशतव्यतिभेदवत्‌, from which, perhaps, Aniruddha 
+took the nyaya rather than from the very modern Sahitya 
+darpana, The same expression 
+In the Jaina work Syddvadamanjart ( page 92 ). Besides these, 
+Latparyatika, Page 334, line 2 
+ad form म तरवाणहेतकशतपत्शतन्यतिभेदवत्‌ ); in Nyaya- 
+
+४००७, page 498 (ag सूच्यमभिद्यमानकोकनददलकद्म्बकवत्‌ केदस्बकवत्‌ ); in 
+Tarkabhasatika, Page 24; in Tarkikaraksatika,. page > as 
+SEN and in Citsukht ii 9 (झतपत्रपत्रशतव्यतिभेदाजु- 
+
+
+NC Er त 
+.CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+उत्पलपत्रशतव्याति भे is found | 
+
+
+RRR rg RNR NRO 
+
+
+Digitized By Siddhapta eGangotri Gyaan Kosha 
+
+
+शते पञ्चाशत्‌ ॥ 
+
+
+Fifty [is contained] in a hundred. The greater includes 
+the less. In the Vacaspatyam the nyaya is thus defined :— 
+“ब्यापकशतसंख्यायां यथा व्याप्यपश्चाशत्संस्या निविष्टा एवं WW व्यापके 
+व्याप्यस्य निवेशस्तत्रास्य प्रवृत्ति? ॥ I have met with it only in the Ve- 
+dantakalpataru, page 121, line 12, where a highly technical pas- 
+sage from S'abara 6, 1. 48 is discussed, regarding the pronounce- 
+ment of the names of Prayaras at new and full moon sacrifices. 
+
+
+A reference to Kunte's पड्दर्शनचिन्तनिका, page 1776, would 
+throw light on this dark passage, 
+
+
+झवोद्व्तनन्यायः ॥ 
+
+
+The simile of perfuming a dead body. For the application 
+and illustration see अरण्यरोदनन्याय. 
+
+
+शाखाचन्द्रन्यायः ॥ 
+
+
+The simile of the moon upon 6 bough. Molesworth defines 
+it thus:—“A Sanskrit phrase adduced as a simile or an illustra- 
+tion when an object seen or a matter debated has its position or 
+' relation assigned to it as at, on, in consistency with &e. a parti- 
+cular object or matter, simply from the appearance of conti- 
+guity or connection which, under one line of view or one train 
+of reasoning, it ordinarily presents; whilst actually and truly 
+it is remote from it so widely as to preclude altogether affirma- 
+tion of connection. We say the sun sinks in the ocean by 
+the same law as we say the moon is upon a bough of a tree, 
+Speaking in both cases from the appearance presented.” It is 
+thus akin to the अरुन्धतीप्रदर्शनन्याय. The following example is 
+found in Laitiriyabhashyavartika 2. 1. 282 (page 88) :-- 
+
+यैव सोमं «qon । निष्कोश कोशदृष्टयैव प्रतीचि au 
+दश्यते ॥ And in Vivaranaprameyasangraüha, page 202, we 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+80 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+read :--“नन्वन्न सूत्रे त्रह्मस्वरूपलक्षणं नोक्तं न च तदन्तरेण aT 
+प्रकृष्टपरकाशात्मत्वसनुक्त्वा शाखाग्रे चन्द्र इत्येवोक्ते चन्द्स्त्ररूपानवगमात्‌” ॥ ` 
+
+
+c 
+सकृत्कृते कृतः WANA: ॥ 
+To do a thing once is sufficient to satisfy the demands of 
+the S’astra. The nyaya is found in AMahabhasya, 6. 1, 8 
+(vart, 4), 108 ( vārt. 3), and in 6, 4. 104 (vart, 3 ) Also in | 
+S'abara 11. 1, 28, 35; and 12, 8,10. It seems to resemblo the 
+Marathi phrase शास्त्रापुरता, which Molesworth thus defines —"To 
+be enough indeed for the Supplying, serving, or fulfilling of any 
+matter or point required by the S'üstra, but without excess 
+beyond; to exist in just sufficient quantit y, or to be performed 
+with just sufficient definiteness of action, as to warrant the 
+name or designation borne, and to preclude disallowal of its 
+existence or its performance 3 to be enough to swear by." Tho, 
+Sanskri& phrase occurs also in Vivaranaprameyasangrala, | 
+Page 154 (line 2 from bottom ) :--* TTE AREA कृतः mani इति | 
+न्यायेन सकृदध्ययनादेव नित्याध्ययनविधिसिद्धेरावृत्ति्न लभ्येतेति चेन्न” ॥ 
+See too Bhümatiz 4, 1. 12, and compare कपिञ्ज रन्याय- 
+
+
+| 
+| 
+| 
+| 
+| 
+| 
+
+
+सकृत्मवृत्तायाः किमवगुण्ठनेन ॥ 
+
+
+4 woman who has fallen once need veil her face no more. 
+This occurs in Lantravartika, pages 703, 704, in the course of j 
+the discussion (under 3. 1. 12) of the meaning of the expression | 
+“ अरुणया पिज्ञाक्ष्यैकहायन्या सोमं miofa”. On page 703 we read:— | 
+“ अरुणाव्वाव्दस्तावदवऱ्यमेव केनचिद्वाणिना सम्बन्धनीयः । एकहायनीशब्दस्थापि 1 
+क्रियासस्वन्धात्सातऽयमपनीतम्‌ | तत्र पदान्तरसस्बन्ध्षेऽपि सक्त्मब्वत्तायाः कि- 
+सवयण्ठनेनेतिवत्तस्य तावत्येव alee.” The nyaya 2 quoted by 
+Parthasarathi in S'astradapika 1. 4, 4 (Page 177, line 6 from | 
+bottom), whilo discussing the subject of Words like Agnihotra | - 
+&0., as the names of sacrifices, : i 
+
+
+LVI em c ere 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddha ४१ eGangotri Gyaan Kosha 
+
+
+सहृशात्सहशोञ्गवः ॥ 
+
+
+Like produces like, Jayanta Bhatta denies that this is a 
+fixed principle, on the ground that scorpions are produced from 
+cowdung. He puts it thus (page 466 ):— 
+
+
+“न चेष नियमो लोके AAKA: | 
+वृश्चिकादेः ससुत्पादो गोमयादपि cet? ॥ 
+
+
+This “old wives’ fable” regarding the scorpion was deeply 
+rooted in the Indian mind! It is found in Mahabhasya 1, 4. 30, 
+and is used as an illustration by S'ankaracarya in his bhisya 
+on Brahmasutra 2. 1. 6. Ramanuja followed suit. Udayana, 
+too, has it in his vritti on Kusumanjali ii. 2, and the com- 
+mentator Haridasa remarks that a scorpion can be produced 
+from cowdung as well as from a scorpion. 
+
+
+Thanks, however, to the now well-established Law of 
+Biogenesis, we are better informed at the present time. To 
+quote Henry Drummond:—*It is now recognized on every 
+hand that Life can only come from the touch of Life. Huxley 
+categorically announces that the doctrine of Biogenesis, or life 
+only from life, is ‘victorious along the whole line at the present 
+day.” And even whilst confessing that he wishes the evidence 
+were the other way, Tyndall is compelled to say, ‘I affirm that 
+no shred of trustworthy experimental testimony exists to 
+Prove that life in our day has ever appeared independently of 
+antecedent life.” 
+
+
+सन्दिग्धे न्यायः qada इति न्यायः ॥ 
+
+
+When there is doubt reason comes into play. This is found in 
+Jnànottama's comment on Naiskarmyasiddiv iv. 3. He says :— 
+“सन्दिग्धे न्याय: cata इति न्यायात्सस्दिग्धस्थेच विचायेत्वात्तत्परिशाधयितुस- 
+
+11 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+TRIER S (2 MRT 20०४ EEN MEN TOM 
+
+
+2 
+Digitized By Siddhanta Gyaan Kosha 
+विप्रति cat atazaa.” Akin to this is the Nyaya aa 
+सप्रयोजनं च विचारसह॑ति, ? which is found in the earlier part of 
+the same work (namely in the comment on 7. 29), and which 
+Raghunatha expounds thus in his smaller work :—“s विचारपारेन 
+यावद्यावद्विवेकदाव्य भवति तावत्तावद्भमञचेथिल्यं जायते तरतमभावापन्नसाधना- 
+यत्तं फळं तरतमभावापन्नमिति न्यायात्‌ | विचारविपयत्वं च नाज्ञातस्य नापि 
+निश्चितस्य किंतु सन्दिग्धस्य सन्दिग्धं सप्रयोजनं च विचारमहेतीति न्यायात्‌? 
+
+
+सवेनाशे समुत्पन्ने अर्ध त्यजति पण्डितः l 
+
+
+When the loss of all is impending, a wise man will give 
+up half [ if by so doing he can save the other half | It occurs 
+twice in tho Pancatantra, namely iu iv, 27, and v. 42, as 
+follows :— 
+
+
+“सर्वनाश ayes अर्ध त्यजति पण्डितः | 
+अर्धेन कुरुते कार्य सर्वनाशो हि दुस्तरः ap" 
+
+
+In tho second Passage, the final word is दुःसहः. See Dr. 
+B n र S t Aa E Y > " " H > 
+ühler's note on agua अर्ध. The first half of this couplet is 
+quoted in Kuniirila’s Lantravartika, page 91, but there tho 
+reading is arf 
+
+
+© è ^ D N 
+सव ज्ञान धर्मिण्यश्ान्तं प्रकारे तु व्यत्ययः ॥ 
+
+
+No cognition is erroneous in respect of & thing as d | 
+of certain Properties; but there May be error in regard to the 
+५८८८४ form of the thing. For example, a man secs a glittering 1 
+object on the ground, and Supposes it to be silver 2 but it burns 
+out © be nacre and not silver. There is no mistake in his 
+oo eas object, but his Conception of the nature 
+
+Oneous, The nyäya is found in Çitsukhi 
+CC-0. Prof. Satya Vrat Shastri Collection. 1 
+
+
+Digitized By Siddhapte eGangotri Gyaan Kosha 
+
+
+ji 18 (The Pandit, vol. v. page 496 ) :--“सर्थे ज्ञानं धर्मिण्यभ्रान्त 
+
+प्रकारे तु व्यत्यय इति वदद्विरिदं रजतमिति विश्रमज्ञानमिदमंरो प्रमाणमग्रमाणं 
+^ NA 
+
+रजतांदो$भ्युपगम्ग्रते परीक्षकः” ॥ 
+
+
+Underlying the words “सविकर्पकनिर्विकल्पकयोस्तु प्रमायामप्रमायां 
+azania” on page 25 of the Saptapadārthī, we find the 
+following comment :--"रजते wad रजतमिति सविकल्पकं प्रमा | अरजते 
+रजतज्ञानं भ्रम इत्यर्थः । निर्विकल्पकं तु प्रमायामेवान्तर्भवति । तस्य प्रथमाक्षः 
+सन्निपातजस्य चस्तुस्वरूपमात्रविषयस्य क्राप्यवाधात्‌ | सवे ज्ञानं धर्मिण्यआन्त 
+प्रकारे तु व्यत्यय इति न्यायात्‌ | निर्विकल्पकस्य च ग्रकाराभावात्‌” ॥ 
+
+
+Another interesting example is to be found in Tattvamvukta- 
+kalapa iv. 104. I subjoin the second half of the verse and 
+a portion of the author's own vritti on it :— 
+
+
+“आत्मस्वात्मांशयोश्र क्चिदपि न भवेद्धान्तिरंशान्तरेईपि स्यादेपा न स्वरूपे 
+कचन परमसौ द्विप्रकारे प्रकारे” ॥ “अंशान्तरेऽपि विपयांेऽप्येपा आन्तिः । 
+स्वरूपे कचन न स्थात्सवे ज्ञानं धर्मिण्यभ्रान्तमिति वचनात्‌ । तथा च विषयेडपि 
+AST सर्वज्ञानसाधारण्यास्मामाण्यस्य स्वाभाविकत्वमेव युक्तमित्यर्थः । तहिं 
+कुत्र श्रान्तिरित्यत आह परमिति | असौ आन्तिद्विम्रकारे प्रकारे । द्विप्रकारे 
+ स्वरूपनिरूपकध्मे निरूपितस्वरूपविशेषकधमें चेत्यर्थः | इदं रजतसित्यत्र स्वरूपः 
+निरूपकधमिवेपरीत्यम्‌ | पीतः शंख इत्यत्र निरूपितखरूपविशेषकघम वैपरी- 
+त्यमिति विभागः? ॥ 
+
+
+On page 408 of Vidyasagara's tika on Khandanakhandakha- 
+dya the nyaya is ascribed to लीलावतीकार. 1 would commend to 
+students a helpful note ( No 84 ) at the end of Professor M. N. 
+Dvivedi's edition of the Zurkakawmudi, as bearing on the 
+Principle enunciated in this nyaya. 
+
+
+सविशेषणे हीति न्यायः ॥ 
+
+
+In this contracted form the nyaya is quoted by the author of 
+the Vedantaparibhasa (chapter vii, page 411 ); in its entirety 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+84 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+it reads thus :--सविशेषणे हि विधिनिषेधो विशेष्ये वाधे सति विशेषण- 
+सुपसंक्रामतः”॥ The following is Mr. Arthur Vonig rendering । 
+it (in The Pandit, vol. vii. page 460 ):—“An affirmation Ora | 
+negation, when made of a subject together with its Predicate | 
+applies to the predicate if a bar exisis to the affirmation or | 
+negation .being attached to the subject". An extract from | 
+Rational Refutation of Hindu philosophical Systems (page | 
+282 ) may tend to elucidate the above. “When the Vedanting | 
+give to intelligence appropriated to the internal organ the name | 
+of subject of right notion, we are to understand, that the | 
+character which they ascribe to intelligence associated with the | 
+
+| 
+
+] 
+
+| 
+
+i 
+
+| 
+
+
+internal organ, really belongs to that organ. They have a 
+maxim, -which all the other Systems subscribe to,-that ‘An 
+affirmation, or a negation, when predicated of anything together 
+with its associate, if debarred from the object substantive, is 
+to be referred to the object adjective. In their opinion, the 
+quality of being a cognizer cannot be assigned to the soul, and, 
+consequently, is debarred from it,” 
+
+
+The nyaya is found in Tatparyatia, page 31, line 5, and in | 
+Almatatinariveka, page 72, line 3 from bottom ; but, in both 
+
+
+cases, without the words “विशेष्ये arp सति.” 1४ is quoted, (00, 
+in Laulikanyayasangraha, page 69, line 15. 
+
+
+uu 
+
+
+सहेव दशभिः पुत्रैभारं बहति गदंभी ॥ 
+
+
+Though possessing ten sons the mother 
+
+
+-donkey carries | 
+load! This evidently well-known Saying, taken from Tantra- 
+
+
+virile, page 807, is found in Bhamati 8. 4, 33 ( page 691) 
+in the following connection :-“सहकारित्वं च कमणां न कार्ये विद्यायाः 
+किं TAM कोऽर्थो च्िद्यासहकारीणि कमोणीत्ययमर्थः | सत्सु mig विद्येव 
+Sart व्याप्रियते । यथा सहेव aah: Sait वहति गर्दृभीति सत्स्वेव | 
+CC-0. Prof. Satya Vrat Shastri Collection. E 
+
+
+Digitized By Siddha nja eGangotri Gyaan Kosha 
+
+
+NA 
+
+
+ददापुत्रेपु सेव भारस्य वाहिकेति? ॥ The saying is quoted by Ananda- 
+giri also, in his comment on the same portion of the bhashya. 
+See, too, Vedantasikhamani, p. 168. 
+
+
+Co 
+
+
+सुन्दोपसुन्दन्यायः ॥ 
+
+
+The simile of Sunda and Upasunda. Used of conflicting 
+and mutually destructive things. It is thus explained by Raghu- 
+nithavarma in his Laukikanydyasangraha :-“अन्योन्यनाऱ्यनादक- 
+भावविवक्षायां सुन्दोपसुन्दन्यायः | यथा हि सुन्दोपसुन्दसञ््ञौ सहोदरावसुरो 
+तिलोत्तमार्थ वध्यघातकभावेनोभावपि नष्टाविति भारते प्रसिद्धम्‌ । तथा ˆ 
+वीचीतरङ्गन्यायेनोत्पन्नानां कार्यशाव्दनाइ्यानामन्योपान्त्यशाब्दो परस्परेण नाइया« 
+बन्य उपान्त्येनोपान्त्यश्चान्त्येनेति केचित्ता्किकाः” ॥ 
+
+
+The story of Sunda and Upasunda is told at great length in 
+Adiparva ceix-cexii, but is condensed into six verses in Ka- 
+thasarisagara xv., of which the following is Mr. Tawney's 
+translation :—“There were two brothers, Asuras by race, Sunda 
+and Upasunda, hard to overcome, in as much as they surpassed 
+the three worlds in valour. And Brahma, wishing to destroy 
+them, gave an order to Vis'vakarman, and had constructed a 
+heavenly woman named Tilottama, in order to behold whose 
+beauty even S'iva truly became four-faced, so as to look four 
+ways at once, while she was devoutly circumambulating him. 
+She, by the order of Brahma, went to Sunda and Upasunda, while 
+they were in the garden of Kailüsa, in order to seduce them. 
+And both those two Asuras distracted with love, seized the fair 
+One at the same time by both her arms, the moment they saw 
+her near them. And as they were dragging her off in mutual 
+Opposition, they soon came to blows, and both of them were 
+destroyed.” The simile is met with in Sénkhyutattakawumuds 
+13, as follows:—“aq परस्परविरोधशीला गुणाः सुन्दोपसुन्दवत्परस्परं 
+ध्वेसन्त gala युक्त प्रागेव तेषामेकक्रियाकरतृतायाः?? ॥ See also Kamanda,” 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+“is Raghuniitha’s ex planation of it: 
+planation of it:— rpa विरुद्धानेकधर्मसमावे शासं- 
+
+
+8 
+
+Digitized By Siddhanta Es Gyaan Kosha 
+kiya Nütisava,ix.01. In Sarvarthasiddhi (on Tattvomukiz | 
+kalapa ii. 88) we have the expression “ सुन्दोपसुन्दाविपनाशकविप न्दा Né ^ 
+न्यायेन. This nyaya is used, says Raghunatha, when the thi 
+in opposition are of equal strength ; but when they e 
+unequal Strength, and the weaker go to the wall, the Mats ४ 
+nyaya is employed, ni 
+
+
+——————— 
+
+
+` सुभगाभिक्षुकन्यायः ॥ 
+
+
+m ~ 
+The simile of Subhaga and the mendicant, The following 
+5 
+
+
+ee a R 
+E तु सुभगाभिक्षुकन्यायः प्रवर्तते। यथा सुभगत्वं भिक्षुकत्वं efti des 
+2 E. नपदद्धयसामानाधिकरण्यात्यतीयमानमसपि विरुद्वतवा देकस्मिन्युगपन्न 
+" iuh 
+
+Per remet मामाण्याप्रामाण्यलक्षणविरूद्धं धर्मद्वयं न 
+=. केचित्‌ । अन्ये तु यथा सुभगाभिक्षुको प्रबलघातकभयात्कंचि- 
+m T a च शरणायतत्यागदोपश्रवणात्सर्वप्रयल्लेनो भयो रक्षणे प्रबलाः 
+त LS ~ . 1 
+AMA ANT वा प्राप्तेऽपि सुभगां रक्षति भिक्षुक त्यजतीति यत्तन्न 
+तस्यच्छेव नियामिका न तु किंचिद्धिनि a 
+Teer न तु दानेगमकमस्ति तथा प्रकृते$पीदावचनत्वा- 
+
+हुभयो: प्रामाण्ये पौरुषेयर a i 
+_ ` ` Reame धर्मादौ तदभावादप्रामाण्ये 
+चा प्ासेऽपयुक्तविभागे तार्केकेच्छैव नियामिकेत्यर्थम his se 
+or WA नियामिकेत्यर्थमाहु:?? ॥ This seems {0 
+moo प s actory, but I can suggest nothing better - 
+pum ; in which I have met with the nyàya is the 
+Es Ta a ( e 54), where it is wrongly printed as 
+न्याय. would ne xt it intelli 
+eee चा need a long extract to make it intelli- 
+gible, 85 reter the reader to the work itself. 
+
+
+SOUS ae 
+सोपानारोहणन्यायः ॥ 
+The simi 
+Simile of the ascent of « staircase. Used of knowled 
+
+
+arrived at erad 
+Sradual] à 
+y by easy Steps. “Line upon line precep 
+CC-0. Prof. Satya Vrat Shastri Collection. decem 
+
+
+Digitized By Soho eGangotri Gyaan Kosha 
+
+
+upon precept, here a little and there a little” There is an 
+instance of its use in Bhamati 1. 3. 8 ( page 201 ):--“एवं चानात्म- 
+विद आत्मानं विविदिषोनारदस्य प्रश्ने परमात्मानमेवास्मे व्याख्यास्यामीत्यभि- 
+सन्थिमान्सनत्कुमारः सोपानारोहणन्यायेन स्थूलादारभ्य तत्तद्भूमव्युत्पादनऋमेण 
+
+
+ç 
+
+
+भूमानमतिदुज्ञानतया परमसूक्ष्मं व्युत्पादयामास” ॥ 
+
+
+सौभरिन्यायः ॥ 
+
+
+The illustration afforded by Saubhari. The story of this 
+sage is told in Book 4, chapter 2, of the Vishnu Purana, and, 
+with less detail, in Book 9, chapter 6, of the Bhagavata 
+Purdna, We there learn that, after remaining immersed in à 
+piece of water for twelve years, the Muni was so much im- 
+pressed by the happiness of the little fish which disported them- 
+selves around their great progenitor named Sammada, that 
+he determined to marry and raise up progeny himself: He 
+accordingly went to king Mandhata, the father of fifty 
+charming daughters, and asked for one of them in marriage, 
+Taken somewhat aback by the appearance of this old and 
+emaciated suitor, but fearing to displease him, the king replied 
+that it was the custom for princesses to select their own husband, 
+but that if any one of them chose him as such, he could take 
+her to wife. He was accordingly conducted to the ladies’ 
+apartments; but, on the way there, he transformed his 
+repelling person into one of handsome and youthful appearance, 
+and the consequence was that each of the fifty maidens fell 
+Violently in love with him and demanded him as a husband, 
+and so he married them all! Each of them lived in a beautiful 
+mansion by herself, surrounded by every luxury. After a 
+time, the king went on a visit to them to see how they fared, 
+The first one pointed to her lovely surroundings and told of her 
+husband’s goodness to her, but added that there was one thing 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+1 8 8 
+
+
+| Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+which troubled her very much, namely, that her husband was 
+always with her, and therefore her sisters could never enjoy 
+his society at all. The king then visited cach of the others in 
+turn, and heard exactly the same thing from each ; and 50 the 
+necessary inference is that the sage entered into fifty bodies at 
+one and the same time, and this is the sole point of the nyaya! 
+It occurs in Bhamati 4. 4, 11 as follows :-- सोभरेरभिविनिरित- 
+विविधदेहस्यापर्यायेण मान्धाठृकन्याभिः पञ्चा्ता विहारः पौराणिकैः स्मर्यते. 
+Venkatanatha is the only other writer in whose works I haye 
+met with it. On page 65 of the Nydyasiddhanjana we read.— 
+“भास्करमते तु नित्यसर्वज्ञस्योपाधियोग एव परिहास्यः | उपाधिभिर्छेदनाद्य- 
+योगेन ब्रमण एव संसारित्वानपायः । उपाधिसञ्चारे प्रतिक्षणं बन्धमोक्षप्रसङ्गः 
+सौभर्यादिवदुपाधिमेदेऽपि प्रतिसन्धानस्य दुस्त्यजत्वात्‌ | छेदाभ्युपगमे चाच्छेद्यत्व- 
+वादविरोधः”॥ In his vritti on Tativamultakalapa iii. 22, where 
+the same subject is discussed, we find the following:— 
+
+
+“न च स्वेनान्यदेहादेरधिष्ठानादिसस्भव: | 
+सौभरिन्यायतसत्तमतिबन्दिग्रसङ्गत 8S 
+It occurs again in the text and comment of vorse 31, 
+
+
+स्फटिकलोहित्यन्यायः ॥ 
+
+
+The simile of the redness of the crystal. Such redness is 
+owing to the proximity of a red object, such as a rose &c. The 
+illustration is much used by writers on Vedanta ७८. For exam- 
+ple, we read in Paramdrthasara, verses 1 6 and 61:— 
+
+“ नानाविधवस्तूनां वर्णान्धत्ते यथामल: स्फटिक: । 
+तहढुपाधेगुणभावितस्य भावं विभुधत्ते ॥ १६ ॥ 
+बिरातोपाधिः स्फटिक: स्वप्नभया भाति निर्मलो यद्वत्‌ । 
+चिद्दीपः स्वप्रभया तथा विभातीह निरुपाधिः ॥ &3 nN” 
+
+So, too, Aniruddha on Sankhyasiitra ii, 35:—“gor जपा A 
+सर्गात्स्फटिके wee तदपगमात्स्फाटेक: स्वरूपेणावतिष्टते?”॥ See also At- 
+
+
+mabodha, 14; and a, verse, by some unknown author, quoted in 
+i CC-0. Prof. Satya Vrat Shastri Collection. ? E. 
+
+
+Digitized By SiddharggyeGangotri Gyaan Kosha 
+
+
+the Panini gen of Sarvadars anasangraha ( page 144 Bib, 
+Ind,and 163 in Jivananda’s edn.) In the Kuvalayananda 
+(page 289) under the figure अतद्वुण, we read:—é 
+हणाग्रहणे च रक्तस्फटिकवस््रमालिन्यादिन्यायेनान्यदीयगुणनेवानुर्षनाननुर्ञने 
+विवक्षिते” ॥ See also Vivaranaprameya, page 214. 
+
+
+स्वभावो दुरतिक्रमः ॥ 
+
+
+Nature is hard to overcome. This is no doubt based on 
+Hitopades'a iii. 56:— 
+“यः स्वभावो हि यस्य स्यात्तस्यासो दुरतिक्रमः | 
+श्वा यदि क्रियते राजा तत्कि नाश्नात्युपानहम्‌ d" 
+Raghunatha applies it in the following manner:— “qg 
+संविलासाज्ञानवाधकस्वभावत्वं चेद्गोधस्य तदा स्वभावो दुरतिक्रम इति न्याया- 
+TALIA ज्ञानो दयानन्तरं सविलासाज्ञानबाधनादेहपातस्तात्कालिकः स्यात्तथा 
+- चच्छिन्नसंग्रदायकत्वाहुपनिषदामवोधत्वलक्षणाम्रासाण्यम्रसङ्ग इति शंकानिराः 
+साय यदाज्ञानस्य नाशेऽप्यारव्धकेणा ग्रतिबन्धान्न देहादिक्षय आरब्धकर्मेणश्र 
+=~ ~ A >> ALS 
+भोगलक्षणकार्यक्षयादेव क्षय इति समाधीयते तदेषुवेगक्षयन्यायप्रवृत्ति:। धनुषः 
+सकाशान्सुक्तस्येपोर्बाणस्य कर्मणः आरब्धवेगक्षयादेव क्षय इति प्रसिद्धम्‌” ॥ 
+k The expression occurs also in the following verse of the 
+Kusumanjali (1. 7 .— 
+““एकस्य न क्रम: क्कापि वैचित्र्यं च समस्य न । 
+शक्तिभेदो न चासिन्नः स्वभावो दुरतिक्रमः? ॥ 
+
+
+स्वविषमूर्च्छितो भुजङ्ग आत्मानमेव दशति ॥ 
+
+The snake stwpified by its own poison bites its own body! 
+This Saying is found in Udayana’s Atmatattvaviveka, page 67, 
+lino 6.-- यादे हि न ज्ञातं किद्चिदस्तीत्यादिग्रतिज्ञार्थः प्रतिज्ञा स्प्रशेत्कथम- 
+TH: प्रत्येतव्यः । नचेत्कर्थ साजुपपन्ना | तहुपपन्नत्वे च कथं पुनः प्रतिज्ञा 
+SMUG | तदिद्‌मायातं स्वविपमूरच्छितो सुजङ्ग आत्मानमेव sata” ॥ 
+
+12 न 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+90 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+स्वामिभृत्यन्यायः di 
+
+
+The simile of the relation as master and Servant, “Tp + 
+used to mark the relation of the feeder and the fed, or the B 4 
+porter and the supported, subsisting between any two E 
+Apte's Sanskrit Dictionary, It is of very common occurrene 
+F or instance, in S'ankara's bhashya on Brahmasitra 9 1 i 
+in a discussion as to the relation between Brahma and the won 
+he says:—“afe साम्ये सत्युपकार्योपकारकभावो भवति । नहि ग्रतीपौ पर्‌ 
+स्परस्योपकुरुतः । ननु चेतनमपि कार्यकारणं स्वासिश्टत्यन्यायेन भोक्तरुपक- 
+ag । न । स्वामिथ्ट्त्ययोरप्यचेतनांशस्येव चेतन प्रत्युपकारकत्वात्‌” ॥ 
+
+so in 2. 3. 43, we read :—é. जीवेः 
+
+ya ; :— aaa AT - 
+वाभ्युपगमात्कि स्वामिभ्वत्यवत्संवन्ध meee य 
+कित्सायामनियमो वा प्रासोति” See, too, Ramatirtha on Vedanta- 
+sara, 19 ( page 141, last line ) 
+
+
+हदनक्रन्यायः ॥ 
+
+
+ne simile of an alligator in a lake. Used of things which 
+mutually aid or protect each other. See वनसिंहन्याय i 
+
+
+नस न — ———. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+SOME OPINIONS OF THE PRESS ON THE FIRST HANDFUL. 
+
+
+— NA 
+
+
+“There are few books which give the results of so much reading in 
+30 small a compass as this little pamphlet of some fifty pages. As its 
+name indicates, it is a collection of those popular maxims, or, as Dr. 
+Bühler calls them, “inferences from familiar instances,” which one 
+hears so frequently in conversation with Pandits.........Similiar collec- 
+tions have been frequently put together...but we very rarely find in 
+these any reference to the use of nyayas in actual literature. The 
+great value of Colonel Jacob's work is that at least one such reference 
+is given for every maxim quoted. He has drawn principally from 
+works on philosophy and on rhetoric, branches of Sanskrit literature 
+which he has made peculiarly his own, and the modestly styled 
+‘Handful’ is only one more example of the labourious care and love of 
+accuracy for which its author is distinguished. 
+
+
+The book is useful to other than Sanskrit scholars.........-.-.«Dhe 
+student of Tulasi Dasa, or of Malik Muhmmad, will find many an 
+obscure passage illumined by this true dehali-dipaka, throwing light, 
+A8 it does, both upon the past and on the present.” 
+
+Journal of Royal Asiatic Society ( July 1901). 
+
+
+“Under the title ‘Laukikanyayaijali,’ or ‘ A handful of Popular 
+Maxims’, Colonel G. A. Jacob has published and explained a number 
+of those allusions to popular and, at the time, no doubt, well-known 
+Proverbs or stories which abound in Sanskrit literature. These 
+nyayus find their parallels from our own language in such enis 
+Sayings as ‘like the pot and the kettle’, ‘Jike the hare and the tortoise 
+ete, The proverbs or stories to which they allude are perfectly well- 
+known and need no explanation. In the case of their Sanskrit 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+2 
+Digitized By Siddhanta eGangotri Gyaan Kosha k 
+counterparts, the memory of their origin has not always been pr 3 ry 
+ed or has become obscured. The list now published Consists of those 
+examples which Colonel Jacob has been able either to trace to the 
+
+
+source or to partly explain. Let us hope that this useful little n 
+the result of many years of reading may, in his own words, ‘become | 
+
+
+the nucleus of a very much larger collection’.” 
+
+
+“From what we have written above, we think our readers will ३९७ | 
+what a useful little book Colonel Jacob’s is, especially for those who. | 
+
+
+wish to address the people of this land in forms of speech and with | 
+thoughts that are familiar to them. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+Digitized By Siddhanta eGangotri Gya: 
+क्र 
+
+
+3m : 
+किकन्यायाञ्जलिः ॥ 
+
+तृतीयो भागः ॥ 
+| A THIRD HANDFUL OF POPULAR MAXI 
+
+
+CURRENT IN SANSKRIT LITERATURE, 
+
+
+f OLLECTED BY 
+
+
+Colonel G. A. Jacob, 
+
+
+INDIAN ARMY. 
+
+
+Author of * Concordance to the Principal Upanishads,” “ 
+of Hindu Pantheism,” de. de. 
+
+
+SECOND EDITION REVISED AND ENLARGED. 
+
+
+PUBLISHED BY 
+
+
+TUKARAM JA! 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+(Registered according to Act XX V of 1867.) 
+All rights reserved by the publisher. 
+
+
+Published by Tukarm Javaji, Proprietor N, 5. Press, 
+23, Kolbhat Lane, Bombay, 
+ee 
+Printed by B. R. Ghanekar at the Nirnaya-Sagar Press, 
+23, Kolbhat Lane, Bombay, 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+————————yOgD 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+Preface to First Edition. 
+
+
+Ir is with somewhat of a feeling of regret that I launch this 
+third instalment of nyàyas; for I had hoped that they mightbe 
+embodied in & revised re-issue of the first and second, so as to 
+have the whole alphabetically arranged in one volume. There _ 
+are not many, however, amongst India’s two hundred and ninety _ 
+millions, who take much interest in an effort of this kind, so we 
+were compelled to follow a less ambitious course. To facilitate 
+reference, I have prepared an index to the whole of the 430 
+nyàyas explained in the three volumes, and have written addi- 
+tional notes on several of those contained in the first and 
+second. The latter will be found in the Superaddenda. 
+
+
+The present ‘handful’ differs materially from the two which 
+preceded it in that it contains a goodly number of technical 
+nyayas; to wit, most of those representing important adhi- 
+karanas in the Mimaisa system, as well as certain parabhasas 
+from Patanjali and Nagoji Bhatta. All of these appear to be 
+quoted as nyayas by writers on the various schools of philo- 
+sophy; and I hope that such explanations of them as 4 hay 
+been able to give will prove of service to young students of - 
+these interesting works, and that the numerous references to 
+the Mahabhasya will not be considered superfluous That work, 
+28 presented in Benares editions, used to have a most forbidding 
+aspect; for sūtra, vartika, and bhagya, were crowded ec : 
+like sardines in à box, without numbers or any distinguishing - 
+marks to facilitate reference, and then this conglomerate y 
+requently (as in my own copy) sandwiched betwee 
+equally compressed portions of Kaiysta! Dr. Kielho 
+ever, has turned the impenetrable jungle into a well- 
+park in which one can roam about with ease and 0 
+
+
+ii PREFACE. 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+Now for a word regarding the title of these pamphlets. T an | 
+by no means satisfied with ‘maxim’ as the equivalent of nyaya, 
+but adopted it because many great scholars had already done 
+so. As to the naturalness of such a course on my part let two 
+Indian poets speak :— यद्यदाचरति श्रेष्ठस्तत्तदेवेतरो जन: | स यत्ममाणं 
+कुरुते छोकस्तदनुवर्तते.”” “ एकस्य कर्म संवीक्ष्य करोत्यन्योऽपि रहितम्‌ | 
+गतानुगतिको लोको न लोकः rens" ॥ The nyayas dealt with 
+by me come under three distinct heads, and are either (1) 
+Illustrations [ dristanta ], (2) Rules, or principles [as in the case 
+of paribhasas &c.], or (8) Topies [ adhikaranas, as in the case of 
+the kapinjalanydya and others from the same Source]. It 
+would, therefore, be better, in My opinion, to adopt the term 
+nyaya itself, without translating it into English, 
+
+
+This would seem to be the most suitable place for a note on 
+the Khandanoddhara, & work now in course of publication in 
+Lhe Pandit, and from which I have occasionally quoted in the 
+following pages. It has been stated by some Indian scholars 
+of repute ( beginning with Pandit Taranatha Tarkavacaspati, in 
+1871, in the preface to his edition of Sankhyatattvakawmudi), 
+and the statement is now stereotyped in the Descriptive Cata- 
+
+
+for the year 1900, that the Vacaspati who wrote the above work 
+in refutation of Sri Harsha’s Khandanakhandakhadya, 18 
+identical with the celebrated philosopher Vacaspati Misra. No 
+reasons have been given for this assertion, and no evidence in 
+its favour seems to be forthcoming from the work: itself, 
+
+
+RR ae ser AA 
+
+
+Digitized By Sigghanta eCangotri Gyaan Kosha i 
+Hká; and he may be supposed to have lived as late as 
+1050 A. 1).” Now, on page 13, the authorof Khandanoddhara 
+quotes Kuswmàanjalà i. 19, prefaced with the words ५ तदुक्तमा- 
+ai: and, on the next page, cites i. 10 of the same, with the 
+words “ आचार्या अप्याहु:.? On page 45, herefers to Atmatattuu- 
+viveka in the same way. Is it in the least likely that a re- 
+nowned Acarya like Vacaspati Mis'ra would quote a very 
+junior contemporary in such language as that, even if he con- 
+descended to notice him at all ? Again, on page 25, the author of 
+the Uddhara says “ विस्तरस्तु तत्त्वालोके मयेवोक्त इतीहोपरस्यते,”? 
+but the author of the Bhamati has never been credited with a 
+treatise of that name, though we know of his Tuttvasamoksd. 
+Lastly, on page 35, there is a reference to विवरणमत, and, on 
+page 40, to नरसिंहहरिशम मत, which could hardly carry us back 
+to the tenth century. 
+
+
+It has been suggested by some that S’ri Harsha, too, was a 
+contemporary of Vacaspati Misra and Udayana,—but, since he 
+quotes the former on page 354 of the Khandana (as I pointed 
+out on page 29 of the Second Handful), and cites Udayana 
+four times at least ( see, especially, pages 633-637 ), this posi- 
+tion can hardly be maintained. In 1871, Dr. Bühler, on the 
+authority of a Jain writer named Rijas'ekhara, placed Sti 
+Harsha in the twelfth century; and, if that is correct, the ques- 
+tion of the authorship of the Uddhara is finally settled as 
+far as Vücaspati Misra is concerned. There was a prolonged 
+discussion as to S'ri Harsha’s date in the first three volumes 
+(1872-4 ) of the Indian Antiquary, but nothing was 
+conclusively established as against Dr. Biihler’s view which is 
+recorded on page 80 of the first volume. 
+
+
+On page 49 of Khandanoddha@ra we read :—“ अथ खण्डनकृतू 
+पोडशपदाथी खण्ड यिष्यंस्तत्र मूर्धन्यं प्रमाणं खण्डयितु तदुपधायिकां प्रमामादा 
+खण्डयति स्म ` arava भूतिः प्रमेत्ययुक्तम. ” The passage in question 
+
+
+will be found on page 148 of Khandamakhandakhád;ya, and 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+Ae PREFACE. 
+the commentator S'ankara Misra ascribes this definition of 
+pramā to the Laksanamald, a work which the editor, in a foot- 
+note, attributes to S'ivaditya, the author of the Saptapadartha, 
+The latter was published in the Vizianagram Sanskrit Series 
+in 1893, and in the Preface we have the same authorship of the 
+Laksanamala asserted on the authority of a Citsukhivyakhya, 
+the date of which is not stated. In opposition to this, however, 
+I would point out that Varadaraja quotes the Laksanamala 
+on pages 179 and 225 of his Tarkikaraksa, and, in both cases, 
+the famous commentator Mallinatha ascribes it to Udayana. 
+The doubt expressed by Fitzedward Hall, on page 27 of his Indew 
+as to this being “the well-known commentator on the poems of 
+Kalidasa and others,” is set aside by Mallinatha’s quoting, on 
+page 39, a portion of his commentary on Raghuvams'a ii. 34, 
+and adding “ इति स्फुटीकृतं चैतदस्माभिः पञ्चकाव्यादिटीकासु ` अळं महीः 
+पाळ तव श्रमेणेत्यादो.? ^ 
+
+
+७, A.J. 
+
+
+REDHILL, SURREY. 
+October 1904. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+Preface to Second Edition. 
+
+
+With the re-issue of this ‘Handful’ the revision of the three 
+is complete but by no means perfect; for I have been sore let 
+and hindered by the presence of that powerful ‘limiting 
+adjunct’ (upüdhi) Avidya. Many a struggle have I had with 
+it over some of the nyayas; but it is for scholars to say with 
+whom the victory rests. Had it been possible to borrow Indra's 
+Vimana for a week-end visit to Poona, a quiet talk with old 
+friends there would have speedily dispelled many doubts and 
+dificulties. Especially helpful would it have been to have got 
+their opinion regarding the nyaya “ ग्रकृतिप्रत्ययो प्रत्ययाथ सह qa" 
+to which Kumarila and other writers on Mimamsa appear to 
+assign a meaning at variance with that of Patanjali as inter- 
+preted for me by Dr. Kielhorn,—an interpretation which seems 
+to me to be the only reasonable one. 
+
+A comparison of this edition with the previous one will show 
+that considerable changes have been made, especially in some 
+of the technical nyayas, and that twenty-two new ones have 
+been added. Ihave abstained on the present occasion from 
+appending supplementary notes, but will take advantage of 
+
+
+this opportunity for making an interesting addition to the 
+तेलपात्रधरन्याय in the Second Handful, by giving two important 
+Book 6, chap 1 
+
+
+references to it. They are Rathasarttsagar% : 
+Verses 43-52; and S'antipartt 11696 ( chap. 311 VOY? WA 
+Bombay edition). For the former I am indebted to Mr. C. H. 
+Tawney, and, for the latter, (0 Professor Washburn. Hopkins. 
+
+
+An alphabetical list of the ४०११७ contained in the three 
+
+
+pam i 
+phlets is appendedras अ Shastri Collection. 
+
+
+Digitized By Siddhanta ती Gyaan Kosha 
+
+
+a “Mrs PF AA 20... va 
+
+
+Land of Bharata, as एकमेवा द्वितीयम्‌, 
+
+
+REDHILL, SURREY, 
+October 1910, 
+
+
+U^ MM T 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+A THIRD HANDFUL OF POPULAR MAXIMS. 
+— RI 
+
+
+अकाले कृतमकृतं स्यात्‌ ॥ 
+
+
+A thing done at & wrong time [might as well be left undone, 
+for it] would be regarded as not done. Tt occurs in the follow- 
+ing passage of Madhava's Nyayamalavistara 10. 1. 1:--“किंचतुर्धा- 
+करणादूध्वैमावाह्यते किंवा प्रयाजेभ्यः पुरा । नाद्यः | अकारे कृतमझते स्यादिति 
+न्यायेनावाहनस्य निरर्थकत्वात्‌. 
+
+Again, in G'abara on Jaimini 6. 2. 25, with reference to the 
+times prescribed for the Agnihotra, and New and Full Moon 
+
+
+` 
+
+
+sacrifices, we read “ तस्मादन्येपु कालेपु अविहितत्वात्कृतमप्यकृतं स्यात 
+
+
+Compare the following which is guoted on page 984 of 
+Nyayalandali :— 
+
+
+“कारे यदकुवेस्तत्करोत्यन्यदचेतन: | 
+्रत्यवायोऽस्य तेनैव नाभावेन स जन्यते" ॥ 
+
+
+And somewhat similarly we have Patanjali 1. 2. 64 ( vart. 
+43)— "reri क्रियमाणे विगुणं कमे भवति विगुणे च कर्मणि फलान- 
+
+
+m? ॥ 
+
+
+ee 
+
+
+अक्षिपात्रन्यायः d 
+
+
+The simile of the eyeball. An illustration of extreme sensi- 
+tivencss—in persons or things The following from Yogabha- 
+sya ii. 15 (page 78) is an example of its application to a per- 
+501:-*एवाभिदमनादिदुःखखोतो विप्नसत॑योगिनमेव अतिकूलात्मकल्वाडु- 
+ढवेजयति । कस्मात्‌ | अक्षिपात्रकल्पो हि विद्ठानिति। यथोणीतस्तुरक्षिपात्र न्यस्तः 
+स्पेन दुःखयति न चान्येषु गात्रावयवेष्वेवसेताने zi नि हुःखान्यक्षिपात्रकल्प योगिनः 
+मेव क्लिश्नन्ति नेतरं प्रतिपत्तारम्‌ This is very well put, also, m the 
+Mantprabha on the same sutra. See, too, Tatparyattke, page 
+442, line S, It looks as if this nyaya, like many others found 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+relating to tl A री लिकिी3 Vrat Shastri Collectio: i 
+
+
+Digitized By Siddhanta E Gyaan Kosha 
+
+
+in orthodox works, came from a Buddhist source. Prof, L, de la 
+Vallée Poussin has kindly pointed out the following verses on 
+page 476 of the Madhyamakavritti:—‘sutqen wa हि aug. 
+संस्थं न विद्यते पुंभिः | अक्षिगतं तु तदेव हि जनयत्यरति च पीडां च॥ करतल. 
+सदृशो बालो न वेत्ति संस्कारटुःखतापक्ष्म | अक्षिसदशस्तु विद्वान्‌ तेनैवोद्वेजते 
+गाढम्‌. u The word आक्षिपात्र 8 not in any of our dictionaries 
+In the Yogavartika it is defined thus:—“ago: पात्रेणाधारेण गोलकेन 
+तुल्यो विठ्ठानिति.? 
+
+
+अग्निहोत्रन्याथः ॥ 
+
+
+The rule as to the Agnihotra sacrifice [consisting of morning 
+and evening libations}. It forms the subject of Jaimini 6. 2 
+23-26, where the injunction यावजीवम मिहोत्र जुहोति’? is discussed 
+The interpretation put upon these words by the pürvapaksin is 
+that the householder is to do nothing else but offer the Aenihotra 
+during his whole life! Kunte thus summarizes his areument;— 
+“From the time of the establishment of a sacred fire to the time 
+of death the Agnihotra is to be performed continuously, without 
+the remission of a moment. This is the duty of an Arya. He 
+cannot rest fora moment. The Agnihotra is not a constituent 
+part of any other sacrifice. It is an independent sacrifice by 
+itself. It therefore accomplishes the purpose.of a person; and | 
+must therefore be unremittingly adhered to; and it does not 
+matter if, in performing a principal act, minor acts are neglected 
+It is therefore reasonable to perform the Agnihotra-sacrifice 
+alone continuously for life.” The reply to all this is that the 
+meaning of the vidhi is simply that it is to be offered every 
+morning at daybreak, and every evening, according to tho - 
+injunction "प्रदोषमभिहोत्रं होतव्यं व्युष्टायां प्रातः. For a description 
+of the Agnihotra, see S’atapatha Brahmana, Kanda 2, 
+Adhyüyas 3 and 4; also a very useful excursus of Kuntes on 
+pages 410-420 of his Suddars'anacintanika. Brahmasitr 
+bhasya 3. 4. 32 shows how Vedantists apply the injunction. 
+
+
+t 
+
+
+Digitized By Siddhagta eGangotri Gyaan Kosha 
+
+
+अङ्कुलिदीपिकया ध्वान्तध्वंसविधिः ॥ 
+
+
+Attempting to dispel the darkness with a lump no bigger than 
+your finger ! Endeavouring to bring about a great result by 
+the use of manifestly inadequate means. It occurs in the follow- 
+ing passage of Atmatativaviveka, page 52. —“q चास्माकामेव 
+तवाप्यत्र मूकतैव शरणं सर्वथा वचनविरोधे ह्युदासीनस्य सा शोभते । न चात्र 
+विधौ विरोधः eer | न च त्वमुदासीनः प्रयोजने प्रवृत्तत्वात्‌ । तस्मादलमछु- 
+लिदीपिकया 'वान्तध्वंसविधिमनुष्ठाय.” Iam indebted to Mr. Arthur 
+Venis for an explanation of this nyaya. 
+
+
+Aga न तेनैवाहुस्यग्रेण स्पृश्यते ॥ 
+
+
+The tip of a finger cannot be touched by itself. Akin to tbe 
+sayings “ A man cannot mount on his own shoulder,” and “The 
+edge of a sword cannot cut itself” Jb occurs in Nydyavartike- 
+tdtpuryatika page 466, line 10 from bottom:—“qage न 
+तेनैवाङ्कुल्यम्रेण स्प्रश्यत एवं ज्ञानं न तेनेव ज्ञानेन अहीतु शक्यते”? Then in 
+Madhyamakevritti, page 62, we have the double similo.— 'य- 
+थापि नाम तस्यैवासिधारया सैवासिधारा न शक्यते छे न तेनेवांगुल्यग्रेण तदे” 
+aga शक्यते giaa न तेनैव चित्तेन तदेव चित्तं शक्यं FER” Il 
+We meet with it again in Parthasarathis comment on the 
+S'ünyavada section of the Slokavartike (page 988 ):—“a हि 
+पाकः पच्यते छिदा वा छिद्यते। नापि करणकमेत्वं क्क्व वा प संसवति। 
+न हाङ्कुल्यग्रेणेवाङ्कुल्यग्र स्परश्यते नाप्यडुल्यम्रमात्मानं CERT । तेनासां विधाना 
+षटाम्ते कचिदप्यदर्षनाज्जञाने$पि नास्ति संभवः- ' 
+
+I do not understand the double statement hero about the 
+finger-tip, Parthasarathi could not mean that the tip of one 
+finger cannot be touched by the tip of another finger ! The 
+Second part of the statement looks like a marginal gloss which 
+
+has got into the text. 
+
+
+* ka 
+The following verse 18 found 10 Prokaranapancue, page 
+
+
+68, and in Nyayakaniki, p. 268:— 
+C-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta SUM Gyaan Kosha 
+
+
+अङ्कुल्यग्रं यथात्मानं नात्मना स्प्रष्टमहति | 
+स्वांरोन ज्ञानमप्येवं नात्मानं ज्ञातुमर्हति ॥ 
+
+
+See also Nydyamakaranda, pages 131, 183; S‘ribhisya 
+page 169; and Sarvarthasiddhi, page 391. 
+
+
+AFIT हस्तियूथशतमास्ते ॥ 
+
+
+There are a hundred herds of elephanis on the tip of my 
+Jinger! This illustration of an absurdity occurs frequently. In 
+Vinuronaprameyasangraha, page 232 ४, we read: —“ary केचिच्चो- 
+दयन्ति । व्यर्थोऽयं व्युत्पत्तिनिरूपणप्रयासः । शब्दस्थाथीसंस्पर्शित्वात्‌ | a 
+TI हस्तियूथशतमास्त इत्यादिशब्देः कश्चिदर्थः प्रमीयते । ama 
+भ्रमीयते तत्रापि मानान्तरनिवन्धना सा प्रमितिन शब्दनिबन्धनेति.” Then 
+in (४8७॥/४ ii. 82:--“आप्तोदीरितवाक्येघु मालतीमाधवादिपु | व्यभिचारान्न 
+तदयुक्तमासत्वस्यानिरुक्तित: ॥ ३२ ॥ स्वकपोछूकल्पितमालतीमाधवादिवाक्येपु 
+प्रामाण्याभावादतिव्याप्ति: । न हि gua एव सन्नाटकनाटिकादिप्रबन्धविरचन- 
+भात्रेणानाप्तो भवति भवभूतिः | उक्त चेतदुम्बकेन “यदाप्तोडपि कस्मैचिदुपदिशति 
+न स्वयाननुभूतार्थविषयं वाक्यं प्रयोक्तव्यं यथाडुल्यम्रे हस्तियूथशतमास्त इति' | 
+तत्रार्थव्यभिचारः स्फुटः.” Compare S'alika p. 13, verse 4. 
+
+In the commentary on Khandanakhandakhadya, page 104, 
+the saying is modified to “अङ्कुल्यम्रे करिशतं विहरति,?? and another 
+of a like kind is added, namely “मम कर्णकुहरं प्रविइ्य सिंहः क्रीडाति;” 
+and in Âimatattvaviveka, page 65, Udayana gives us “मम कर्ण 
+AAA राजो गर्जति भेषजसुच्यताम्‌.” The Umbaka quoted above is 
+perhaps the Umbeka* referred to by Hall ( on page 166 of his 
+
+
+* Hall found this name (together with those of Prabhakara, 
+Vümana, and Revana ) ina verse of the eritti by Charitra Sinha 
+Gani on the Saddars'anasamuccaya. What is manifestly the same 
+verse is found also in the ९7४८७ ascribed to Manibhadra; but there J 
+the name Utpala is substituted for Umbeka. The verso is 28 | 
+follows:— उत्पलः कारिकां वेत्ति ast वेत्ति प्रभाकर: । वामनस्तूभयं वेत्ति व | 
+fira für रवणः ” ॥ From the fact that all the other authors and works 
+mentioned in Gani’s vritti are found in the latter also, T am inclined | 
+
+
+to think that Gre yo RA NANA Nastri Collection. 
+
+
+| 
+| 
+| 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+2 
+
+
+Jude») as an authority on Mimámsa Iu the Catalogus 
+Catalogorum, the latter is identified with Mandanamisra, 
+which is one of the names by which Sures varacarya is known. 
+
+
+~ US Salt 
+अत्यन्तबलवन्तोडपि पोरजानपदा जना! | दुब 
+ES A 
+बाध्यन्ते yat; पार्थिवाश्रितः ॥ 
+
+Even very powerful men from town and country are held im 
+check by weaker men who have the king's support. This verse 
+from the Lantravartika (page 863 ), found also, as à quotation, 
+in Mimamsdnyayaprakasa, page 35, is thus applied by 
+Raghunatha:—“qa निबेलेनापि प्रबळसहायेन प्रबलो बाध्यते तत्र अत्यन्तः 
+बळवन्तोऽपि पौरजानपदा जनाः । दुबेलेरपि बाध्यन्ते पुरपः पार्थिवाश्रितेः इति 
+न्यायोऽवतरति । स्पष्टार्थोऽयम्‌ | उदाहरणं तु seam दुबेलाया अपि 
+स्मृतेराचमनरूपप्रबळपदाथोश्रितत्वेन TATA, । अतः शऔरौतक्रमत्यागेन वेदः 
+
+
+करणानन्तरं क्षुते आचमनमेव कार्यमिति Ga.” We may compare with 
+this the following from Sures’vara's large vartika, page 198 :— 
+
+
+८ आाञ्ञंसते बलीयांसमबलीयानपि स्वयम्‌। 
+ud बलं समाश्रित्य जेतु लोके तथा यथा ॥ 
+राज्ञा बलेनाल्पबलो बलीयांसं कुटुस्बिनम्‌। 
+जेतुमाशंसते ques: स्याद्दलळवत्तमः ॥ 
+
+
+अदित्सोवेणिजः प्रतिदिनं पत्रलिखितश्वस्तनदिनभणनः 
+न्यायः ॥ 
+
+
+The simile of the merchant who was unwilling to give, and 
+who wrote every day say ing that he would give on the morrow! 
+Tt occurs in the following passage of Mallisena’s Syadvadaman- 
+juri ( page 128) :--“सोगताः किलेत्थं प्रमाणयान्ति सवै सव्क्षणिकं यतः सब 
+तावद्धरादिक वस्तु spec ant नाशं qucd । तत्र येन स्बरूपेणान्त्यावस्थाया 
+घटादिकं विनइयति तञ्चैतत्स्वरूपसुरप्मात्रस्य वेद्यत । तदानीसुत्पादानन्तरमेव 
+तेन नष्टव्यसिति ACHA क्षणिकत्वम्‌ | अश्रेदश एवं स्वभावस्तस्य हेतुतो जातो 
+यस्कियन्तसपि काले, स्थित्वा ब्रिनइयाति । एवं ale सुदरादिसश्निधानेऽपि एष 
+
+
+f Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta Ce Gyaan Kosha 
+) 
+
+
+Ns 
+
+
+एव तस्य स्वभाव इति पुनरप्यनेन तावन्तमेव कारं स्थातव्यामेति नेवं faye 
+
+
+RR सोऽयमदित्सोरवणिजः प्रतिदिनं पत्रलिखितश्चस्तनदिनभणनन्यायः” | 
+
+
+Those who, in an Indian cantonment, have ever undertaken | 
+the thankless task of the collection of promised subscriptions 
+
+
+to a fund, are very familiar with the “kal Go,” or “parson, ke 
+din Go,’ with which their messenger is often greeted, with per. 
+haps stronger language superadded! Human nature is much 
+the same everywhere. Compare Proverbs iii, 28, 
+
+
+अधिकरणसिद्वान्तन्यायः ॥ 
+
+
+A truth or conclusion which implies another truth or 
+
+
+conclusion. This is the third of four kinds of सिद्धान्त defined 
+
+
+in Nydyasiitras 1. 1, 28-31, the others being (1) सर्वतन्रसिद्धान्त, 
+
+
+(2) प्रतितत्रासिद्धान्त, and (4) अभ्युपगमसिद्धान्त. Dallantyne's render 
+ing of the four is (1) a dogma of all the schools, (2) a dogma 
+peculiar to some school, (8) a hypothetical dogma, and (4) a 
+dogmatic corollary. In Tarkikaraks i. 29 (page 126) we 
+have the following description of manas --““युगपदूज्ज्ञानानुत्पात्िम 
+
+
+नसो छिङ्गमिति। | एवं चाणुतयेव मनसः सिद्विः । अन्यथा युगपदनेकेन्द्रियाधिः d 
+
+
+छानाद्युगपद्जज्ञानोदयम्रसंगात्‌?। On this, Mallinatha comments thus— 
+
+
+एवं चेति । जगत्कर्तुः सर्वज्ञत्वादिवन्मनसोऽणुतवमधिकरणसिद्धान्तन्यायाद्वर्मः | 
+आहकादेव सिद्धमित्यर्थः” ॥ There is another example in Atmatat- 
+८०८४८०८४६८, page 83, line 9; and a third in Yamunacarya’s 
+
+
+Agamapramanya, page 17, line 1 
+
+
+For an example of the three other kinds of siddhanta, 
+Nydyavartibkatatparyatiia, page 36, lines 16-97 
+
+
+अधिकारब्यायः ॥ 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+principal thing here is the desire for heaven, whilst the sacrificial 
+act is subordinate. The remainder of the pada deals with the 
+physical and social fitness demanded. See under आख्यातानामर्थ 
+gaat ४९, below. For a full description of the four kinds of 
+injunction, of which adhika@ravidhi is the third, see Laugaksi- > 
+phaskara’s Arthasangraha, page 4, with Dr, Thibaut's transla- 
+tion, page 7 Sc. 
+
+
+अनधीते महाभाष्ये व्यथा स्यात्पदमज्ञरी | अधीतेऽपि 
+महाभाष्ये व्यथा सा पदमञ्जरी ॥ 
+
+
+The Padamanjart would be of no use to one who had not 
+read the Mahabhasya, and would be equally useless [ because 
+unnecessary ] if the latter had been read! This saying is used by 
+| Raghunatha to illustrate the position of the Ganapatas who 
+regard the worship of Ganapati as essential and all-inclusive. 
+A portion of the argument is as follows: —“sta: भ्रेयःकामेः स्वैरपि 
+स एवाराध्यः । तत्पूजां विनान्यपूजाया वेयर्थ्यस्मरणेन फलजनकत्वायोगातू | 
+अवश्यापे क्षितानपेक्षितयोरपेक्षितं स्मरणीयमिति न्यायेन कृताकृतम्रसङ्गी यो बिधिः 
+स नित्य इति न्यायेन च तदाराधनस्यावश्यकत्वात्‌ | कृते च तस्मिन्विदयार्थी 
+लभते विद्यां धनार्थी लभते धनम्‌ । wa लभते पुत्रान्मोक्षार्थी परमं पदमित्या- 
+दिवचनेभ्यः सर्वेष्टाभसंभवेनानधीते महाभाष्ये व्यर्था स्यात्पदमञ्जरी | अधी- 
+तेऽपि महाभाष्ये व्यर्था सा पदमञ्जरीति न्यायेनान्याराधने योजनाभावात्‌. 
+The second nyaya quoted here is a slight modification of 
+Nagoji’s paribhasa xri, “कृताकृतप्रसज्ि नित्यं तद्विपरीतमनित्यम्‌. 
+In the Preface to vol, 2 of his edition of the Mababhasya Dr. 
+Kielhorn, referring to the above dictum of the Pandits, says;— 
+“ Whatever truth there be in this remark, I can say for myself 
+that I have been much assisted by Haradatta's learned work, 
+
+
+| evon though it is based to a great extent on the Mahabhisya 
+
+
+itself and on Kaiyata’s commentary ". and he points out that, 
+; a commentary on the 
+
+
+though the Padamanjari is primarily 
+length, most of 
+
+
+pas ad t 6 डौ Yi 
+Kasika, ye its author discusses, often at great 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGanggjri Gyaan Kosha 
+
+
+the arguments advanced in the Mahübhisya. Jayanta 
+
+has several verses of the same type as that regarding tho 
+
+Padamanjari. They will be found on pages 29, 39, 55, 61, 189, 
+
+447, and 448 of his Vydyamanjurt, I quote that on page 189 
+. as a sample:— 
+
+
+कार्य चेदवगम्येत कि कारणपरीक्षया | 
+कार्य चेन्नावगम्येत किं कारणपरीक्षया ॥ 
+
+
+अनन्तरस्य विधिर्वा भवति प्रतिषेधो वा ॥ 
+
+
+[A rule containing] an injunction or a prohibition [enjoins — 
+or forbids only ] that which is nearest [to it in some other rue] - 
+Here is one of Raghunütha's grammatical nyàyas, included in 
+both of his works. My translation is based on that of Dr, 
+Kielhorn in his well-known edition and translation of the Pari- 
+bhäsendus'elhara, where it appears as Paribhasi usi. Nagoji- 
+Bhatta took it, of course, from the Mahabhasyu, and J have 
+noted the following ten instances of its oecurrence:—1, 1. 43 
+(vart. 3); 1, 2, 48 (vart. 7); 1. 3. 19 (vart. 7); 1. 3. 14 (vart. 3); 
+1.8. 58 (vart.3); 1. 4. 17; 3. 1. 67 (vàrt. 5 ) 7, 1. 21 (vat, 1); 
+7. 2, 8 (vart. 2); and 7. 3, 85 (vart. 4). 
+
+
+अनन्यलभ्यः शब्दार्थः ॥ 
+
+
+The meaning of 6 word is that which cannot be j f 
+from any other source [ such as implication &८. J. This is Mx - 
+Venis’ rendering (in the Pandit, vol. vi, page 97 ) of the maxim _ 
+in the Veddntaparibhasa ( chap. iv. page 280). It occurs in 
+Tamtravartika (page 340 )in a more extended form, namely 
+“यावानेव हि अनन्यलभ्योऽर्थः शब्दाद्वम्यते स सः शब्दार्थ:? ॥ Proh | 
+Ganganatha Jha (on page 474, line 10 of his translation) 
+‘translates thus:— In the case of any word, all that is not 
+cognizable by means of any other word is held to be the mean- 
+ing of that ward, ProfTSdiyalvos Spastriseelagion, overlook the wo: 
+
+
+| 
+| 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+e AC SETS d The nyaya is found in its usual form in Agama- 
+pramany%, page 35, line 10. In the Parnaprojna section of 
+Survadars anasangrala (page 85 of Jivananda’s edition) we 
+have the cognate nyaya “अनन्यलभ्यः simi, “the rule that the 
+gense of the sacred institutes is not to be taken from other ` 
+sources than these” ( Prof. Gough’s translation, page 101). 
+
+
+A remark of Udayana’s, as to word-meanings, may be of 
+interest. It is found in Kusumédnjali, vol. 2,page 182:—"q: 
+शब्दों यत्र बृद्धेरसति वृत्त्यन्तरे प्रयुज्यते स तस्य वाचको यथा wes: सुखावि- 
+
+
+2 
+
+
+~ 
+
+
+शेपे प्रयु्यमानस्तस्य वाचकः” ॥ 
+
+
+अनिषिद्वमनुमतम्‌ ॥ 
+
+
+That which is not objected to 18 agreed to. “Silence gives 
+consent.” It occurs in Hemacandra's Parisistaparven vii. 36:— 
+
+
+एतस्याः संप्रदानं च श्रुत्वा संसोढवानसि । 
+अनिषिद्ध द्यनुसतमिति न्यायोऽपि वतैते ॥ 
+
+The nyaya is found in & slightly different form ‘in Nyaya- 
+vārtika, page 41:--“तत्नान्तरे मन इन्द्रियमिति पढ्यते | तच्चेह न प्रति- 
+fread । अग्रतिपेधाहुपात्तं तदिति। न। शषाभिधानवैयथ्यौत्‌। शेषाण्यपीन्द्ि- 
+याणि तैः परिपडितानि तस्मात्तान्यपि न वक्तव्यानि यद्यप्रतिपेधाहुपादानं स्या- 
+दिति । न। तत्रयुत्त्यनवबोधात्‌। न भवता तत्रयुक्तिः परिज्ञायते | परमतमम्रतिः 
+षि्मनुमतमिति हि तज्ञयुक्तिः ॥ i 
+
+In his comment on this passage, Vücaspatimisra (on page 
+97 of Tatparyatika) quotes à line of Digniga's:—“ GEIRG 
+दिग्नागेन 'अनिषेधादुपात्त चेदन्येन्द्रियरुत वृथा?-” There is another 
+example in Prabundhacintamant, page 205. 
+
+
+2 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+another example of it in the following passage of the 5 ह 
+
+
+सोपवा व translatica 1 
+
+
+i 
+Digitized By Siddhanta cand Gyaan Kosha d 
+
+
+अन्तरङ्गवहिरङ्गयोरन्तरङ्गं वलीयः ॥ 
+
+
+Of the prowimate [ or, closely related ] and the remote 
+[ or, distantly related], the former is the stronger. I find i 
+most difficult to give a rendering of this nyaya. Itseems to be. 
+long primarily to the grammarians, though found also in philo. 
+sophical works. It is included in Siradeva’s list of paribhasig, 
+but not in that of Nagoji Bhatta. The terms अन्तरङ्ग and बहिरङ्ग c 
+are, however, explained by the latter, under his paribhaga 
+“असिद्धं बहिरङ्गमन्तरङ्गे)? in the following manner, and I subjoin 
+Dr. Kielhorn's translation. As this eminent scholar gives no 
+English equivalent of the two terms here described, it may - 
+fairly be assumed that no satisfactory one is to be found, “ अन्त- | 
+ret बहिरङ्गशास्रीयनिमित्तससुदायमध्येऽन्तर्भूतान्यङ्गानि निमित्ताने यस्य तव- | 
+न्तरङ्गम्‌ | एवं तदीयनिमित्तससुदायाद्ृहि भूताङ्गकं बहिरङ्गम्‌,” “Antaranga — 
+is (a rule ) the causes (of the application ) of which lie within 
+(or before ) the sum of the causes of a bahiranga rule; in like 
+manner (that rule) the causes (of the application) of which 
+lie without (or beyond) the sum of the causes of that (antararga 
+rule) is bahiranga. The Professor adds the following in a 
+footnote:— arare: and बहिरङ्ग are. two Bahuvrihi-compounds 
+and denote a rule, or an operation, or that which is taught in a 
+rule. The word अङ्क here neither denotes a member of the body, — 
+nor is it the grammatical term अङ्क as defined in P. 1. 4, 18; bub ` 
+it is equivalent to उपकारक ‘that which assists (an operation ) 
+
+
+or, in other words, it denotes the निमित्त, that is, ‘the cause’ of 
+an operation." i 
+
+
+The nyaya is employed by S'abara on Jaimini 12. 2. 27, and 
+by Anandagiri on Brahmasutrabhasya 2. 1. 4 ; and there is — 
+
+
+सुत्पद्यते पश्चाद्विरोधिसंसगीभावापेक्षा तथा चान्तरङ्गबहिरङ्गयोरन्तरङ्ग बरूवदिति 
+JOE Yea mbere Dr. Thibaut (in 
+
+
+D ught, vol, i, page 80) renders it 
+
+
+| 
+d 
+
+
+| 
+
+
+E] 
+4 
+
+
+Digitized By E qon Gyaan Kosha 
+
+
+«the principle that what is intimately connected has greater 
+force than what 18 remotely connected." 
+
+
+It is quoted also by Anandagiri in his comment on verse 867 
+of Sures' vara's Sambamdhavartika— seque हि विज्ञानं प्रत्यड्या- 
+Squad | बहिरङ्गं तु कमे स्यादवामद्रव्याश्रयत्वतः” ॥ Mr. S.B. Aiyars 
+rendering of the terms antoranga and bahiranga in this verse 
+is “subjective” and ‘objective, respectively. 
+
+
+अन्यवेश्‍मस्थिताद्धमान्न वेसमान्तरमग्निमत्‌ ॥ 
+
+
+From seeing smoke rising from one house we do not infer 
+that there is a fire im another house. This is from Tantra- 
+vartika (page 180, line 9) on Jaiminis sūtra “अनुमानब्यवस्था- 
+नात्तत्संयुक्त प्रमाणं स्यात्‌?” (1. 3. 15 X 
+
+
+अन्यार्थमपि प्रकृतमन्यार्थं भवति ॥ 
+
+A thing, though made for one purpose, may also serve for 
+another. This is found in Mahabhasya 1. 1. 23 (vart. 4), 1.3. 
+12 ( vart. 5), and 6. 1. 50, as follows—“qurag=aa न ID 
+प्रकृतमन्यार्थ भवतीत्यन्यार्थमपि प्रकृतमल्याथे भवति | तद्यथा | शल्य कुल्याः 
+प्रणीयन्ते ताभ्यश्च पानीयं पीयत उपस्पृश्यते च शालयश्च were." It is 
+quoted by S’abara on Jaimini 3. 1. 12 (page 220), and is re- 
+ferred to by Kumarila in his long and interesting discussion of 
+शेष (an accessory—that which serves the purpose of something 
+else) in the opening part of the third chapter of the Tantra- 
+००४६८. On page 668, line 13, we read.— “a हि कश्चिदपि शालि- 
+झुल्यास्थमुदकं पिबन्मदर्थमताः प्रणीता इत्यध्यवस्थति । तस्मादन्यत्तादश्यैः 
+सन्यश्चोपकार इति विज्ञायते.” Patanjali’s illustration is found in 
+Pancapadika, page 45, and is employed by Vidyaranya m 
+Vivaranaprameyasangraha (page 118; line 9), where ib is 
+styled कुल्याप्रणयनन्याय. Compare the nyaya “जामात्रथे अपितस्य 
+सूपादेरतिथ्युपक्रारकत्वम्‌'? in the Second Handful. ; 
+
+
+रह 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangbffi Gyaan Kosha 
+
+
+अपच्छेदन्यायः ॥ 
+The law regarding the interruption [of a procession of ! 
+It is thus explained by Goldstiicker:—“ Used in the liturgical - 
+writings of the interruption of a procession of priests, caused by - 
+the inadvertence of one or several amongst them; thus, it being — 
+the rule that at the first Savana of the Jyotishtoma the priests — 
+must proceed one after the other ‘in the black-ant fashion, the | 
+one that comes after holding his preceder by the hem of his | 
+1 garment, an interruption caused by the dropping of the hem, on 
+the part of one priest would be एककतृकोष्पच्छेदः &७” This | 
+curious ceremony is discussed in Jaimini 6. 5. 49-56, where 
+certain penalties are prescribed for letting go the garment (कच्छ: 
+विमोचन). The matter is well and concisely put in the Nyàya- - 
+malàvistara on the above portion of Jaimini, and much informa- — 
+tion is contained in Kunte’s notes on the same 81788, 
+
+
+The nyaya is employed by writers on Vedanta. It is found, ; 
+for example, in Vedantakalpataruparimala, page 10, line 8— | 
+| “अयेष्टस्यापीति। अपच्छेदन्यायेन पूर्वस्य परेण ATARI तदपेक्षस्येति विशेषितं _ 
+if तेनोत्तरस्य पूर्वापेक्षायामुपक्रमाधिकरणन्याय एव प्रवतत इति सूचितमित्यर्थः”॥ c 
+ji The passage of the Vedantakalpataru here explained is found — 
+| on page 6, line 8:--'्यिष्टस्यापि पौर्वापर्यन्यायेन बाघमाशंक्याह तदपेक्षः 
+स्येति.” The पौवीपथेन्याय is a part of the अपच्छेदन्याय, and derives | 
+its name from sütra 54, namely “पौर्वापर्ये पूर्वदोर्बल्यं प्रकृतिवत? | 
+the subject of the adhikarana being that when the priests, walk: - 
+ing in procession, let go their hold one after another, the one who 
+does so last is liable to a penalty. This same sūtra is quoted i : 
+full in Bhamati, page 5, last line, and. is immediately follow: 
+by a verse from Kumaàxrila/s Tantravartika, page 819; where, 
+however, the reading of the first line is पोवोपर्यबलीयस्त्व॑ instead ` 
+of the पूबोत्परबलीयरूव of the Bhamati. The same ver 
+d by Vaácaspatimis'ra at the bottom of page 59. 
+
+tikatdtparyatika, where the reading agrees w 
+
+
+Digitized By Siddhark® eGangotri Gyaan Kosha 
+
+
+sya, page 143, where Dr. Thibaut (on page 26 of his transla- 
+tion) renders it “ As in the case of the Udgatri and Pratihartri 
+breaking the chain in succession.” The whole ceremony is 
+very clearly explained on page 156 of the Tattuadipana, and 
+the passage will repay perusal. 
+
+
+अपवादेरुत्सर्गा बाध्यन्ते ॥ 
+
+General rules are set aside by special ones. This well-known 
+grammatical rule, found thus in Mahabhasya 2. 1. 24 ( vart. 5) 
+and in a variety of forms in paribhasüs, is admitted to these 
+pages chiefly because, in two of his poems, Kalidasa has adopted 
+it asa sort of सात्स्यन्याय to illustrate a phase of human affairs, 
+namely the subordination of the weak to the strong. 
+
+One instance is in Kwmarasambhava ii. 21:-- 
+
+« लब्धप्रतिष्ठाः प्रथमं यूयं किं बलवत्तरैः | 
+अपवादैरिवोत्सर्गा: कृतव्यावृत्तयः de dd 
+
+The other is in Raghuvams'a xv. T— 
+
+“gq: कश्चन रघूणां हि परमेकः परंतपः | 
+अपवाद gaat व्यावतेयितुमीश्वरः' ॥ 
+
+In a note on this latter passage Mr. Shankar ए, Pandit says 
+“Whatever may be the value of the simile as regards the 
+similitude, it certainly cannot be said to be very poetical, being 
+derived altogethér from a pedant's life” At the end of his 
+comment on the former verse, Mallinatha adds “इत्यरमतिगहनाव- 
+TR; hich may possibly indicate some feeling of disapprove 
+al on his part also. It is on the principle enunciated in this 
+nyaya that the law forbidding the taking of life is superseded 
+by the Vedie ritual which demands animal sacrifices; and it 1s 
+interesting to note the famous Jaina Hemacandra's denunciation 
+of the whole argument in the eleventh verse of his Vitaraga- 
+siuti, the first half of which stands thus:— 
+
+
+* = धमेहेतुविहितापि हिंसा 
+नोत्सूष्टमन्या्थमपोद्चते च? | 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotii fyaan Kosha 
+
+
+In his vritti on the verse Mallisena states the case from the 
+Mimamsaka’s standpoint as follows:—“qsq न हिस्यात्सर्वभूतागी. 
+त्यादिना हिंसानिषेधः स ओव्सर्गिको मार्गः सामान्यतो विधिरित्यर्थः | Suam. 
+वादेनोत्सगंस्य बाधितत्वान्न श्रौतो हिंसाविधिदोपायोत्सगापवादयोरपवादो B. 
+घिबेळीयानिति न्यायात्‌.” (Syadvidumanjari, page 84). 
+
+In connection with the above guotation from Hemacandra, 
+see the डमरुकमणिल्याय. 
+
+
+अप्राप्ते शास्त्रमथेवत्‌ ॥ 
+
+
+Scripiwre attaches a meaning [to an act &e.] when such 
+[a meaning] has not been established [and could not be estab- 
+lished in any other way J. I take this to be the drift of this 
+somewhat difficult nyaya which forms part of Jaimini’s sūtra 
+6.2.18. In Brahmasutrabhasya 3. 3. 18 there is a discussion 
+as to the aim of certain Srutis which prescribe the rinsing of 
+the mouth, before and after eating, in connection with the 
+prānavidyā. Were they intended to enforce आचमन 8 an ad 
+of cleanliness, and also as an act of ritual directed to prana? 
+The decision is that the former was already provided for by 
+smriti, and that s‘ruti merely attached to it its significance as 8 
+religious ceremonial. Bharatitirtha sums up the case in Adhi- 
+karanamalé 3. 3. 9, as follows:—“sf& mÀ TA: 'अग्रासे amend. 
+वत्‌? इति न्यायेन मानान्तराप्रासमनझताचिन्तनमेव विधेयम्‌---आचमनं पं 
+आुड्यथेतया स्ट्रतिबलादेव meee न विधीयते... तस्मादाचमनस्य प्रापत्वादः 
+नझतावुद्धिरेव प्राणोपासकं प्रति विधेया.” The nyaya is found also Ya 
+Tantravartika, page 145, line 3, and again on page 282; 10 
+S'ribhasya, page 554 (where it is rendered by Dr. Thibaut, WA 
+page 133 of his translation, “Scripture has a purport with | 
+regard to what is not established by other means”); 3 ip 
+Nydyakandali, page 5 (where Prof Ganganatha Jha’s inter - 
+pretation of it is “ An injunction has its use only in a Case 
+where its object has nob been accomplished by other means") 
+Other refeteneesrob Sbtwrürat'Gfsaspry collection. Pandit, vol. iv. pag 
+
+
+TAN cd i) 
+
+
+AA 
+
+
+Digitized By SiddhanfaseGangotri Gyaan Kosha 
+
+
+475 ); the Ramanuja section of Sarvadars‘anasangraha (page 
+69, line 12, of Jivananda’s edition); and Sarvarthasiddht 
+pages 98, 263. In Tattvadipana, page 544, the nyaya is quoted 
+as “अनधिगते शाख्रमर्थवत्‌.” 
+
+
+ore Q 
+अभ्याहत पूवम्‌ ॥ 
+
+The more worthy should come first. These words form part 
+of Patanjali’s comment on a vartika on Panini's rule 2. 2. 34 in 
+regard to the position of words in a dvandva compound, The 
+whole sentence is as £0]10wऽ:—“अभ्याहितं पूव निपततीति वक्तव्यम्‌ | 
+मातापितरो श्रद्धामेधे ॥ Its use is not restricted to grammar, how- 
+ever, as the following extract from the first paragraph of 
+Sayana’s introduction to his commentary on the Rigveda shows: 
+kaa प्राथम्येन स्ंत्राञ्नातत्वादभ्यहितं पूर्वमिति न्‍्यायेनाभ्यहितत्वात्तह्या- 
+ख्यानमादौ युक्तम्‌? ॥ Again, at the commencement of the twelfth 
+chapter of the Jaiminiyanyayamalavistara, we read as 
+follows—srearéd पूर्वमिति न्यायमाश्रित्य तन्रप्रसङ्गप्रतिपादकयोरेकादः 
+शद्वादशाध्याययोः पूर्वोत्तरभाव उपपादितः? ॥ And in Anandagiri on 
+Brahmasūtrabhāşya 1. 4. 28:--“प्रधानवादस्यैव प्राधान्येन निरासे 
+हेत्वन्तरमाह स चेति। न केवलमभ्यार्हैतव्वात्तस्य प्राधान्य स्स्रतिमूलत्वादपी- 
+त्याह- 93 
+
+
+अभ्युपगमसिद्धान्तन्यायः ॥ 
+
+The principle of an implied axiom Lor, dogmatic corollary |, 
+This is taken from Nyayasutra 1. 1. 31 which Dr. Ballantyne 
+rendered as follows:—“A ‘dogmatic corollary’ is the mention of 
+a particular fact in regard to anything, not expressly aan 
+in an aphorism, [our knowlege of the fact coming 80 immedi- 
+ately ] from what is recognized [by the maker of the aphorisms, 
+as to render a demonstration superfiuous—the fact being thus 
+entitled to rank not as a deduction but as a dogma |” The 
+nyaya is applied by Udayana in Kiranduali, page 20, line 4 
+from hottom, See also under अधिकरणासेंद्वान्तन्याय 
+
+CC-0. Prof. Satya Vrat-Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+16 
+
+
+अम्बुनि मजन्त्यलावूनि ग्रावाणः TAT . 
+E 
+Gourds sink in water, but stones float! This is often quoted as 
+
+an illustration of an absurdity. Itis as old as the Mahābhārata - 
+
+and appears at the end of chapter LXIV of the Sabhàparvan— | 
+
+“मजन्तयलावूनि शिलाः छवन्ते yaka नावा5म्भासे शश्रदेव.” I have met 
+
+with it twice in S'abara's bhashya. In 1, 1. 5 (page 11 jia 
+
+जातीयकं प्रमाणविरुद्धं वचनमप्रमाणम्‌ | अम्बुनि मजन्त्यलावूनि ग्रावाणः इवन्त | 
+इति यथा.” In 4. 3 10:—“q चैवंजातीयकं ग्रत्यक्षविरूद्धं वचनं प्रमाणं ` 
+भवति | यथाम्डुनि मजन्त्यलावूनि शिलाः aed पावकः शीत इति.” | 
+
+Other references are Sanksepas'artraka ii. 2 (Pandit, vol, vii, 
+page 169); and, in Prakrita, just after verse viii, 31 of 
+
+Balaramayana. 
+
+1 
+
+
+अयमपरो गण्डस्योपरि स्फोटः ॥ 
+
+
+p 
+
+Here is another boil on the top of a previous one! An illustra. 
+tion of difficulty upon difficulty; trouble upon trouble. It occurs 
+in Bhamati 2. 2. 87 as follows:—“a हीश्वराधीना जनाः MIAE 
+कर्म कतुमहोन्ति । तदनधिष्टितं वा कपूयं कर्म फळं प्रसोतुसुत्सहते । TA 
+तत्रोऽपीश्वरः कर्मभिः प्रवत्येत इति दृष्टविपरीतं कल्पनीयम्‌ | तथा चायमपरो 
+गण्डस्योपरि स्फोट इतरेतराश्रयः प्रसज्येत कर्मणेश्वरः प्रवर्तनीय इश्वरेण च. 
+कर्मेति” In the same form it is put into the mouth of Rik 
+sasa in Mudrarakshasa v (page 220 ) The oldest example 
+however, are in Prikrit. In the opening part of S'akumtala ü 
+we find it as “FA गण्डस्स उर्वारे पिण्डिआ aga” (or, in Dr. Pische 
+edition ,“जदों गण्डस्स sate विष्फोडओ संबुत्तो”); and in Viddhasae 
+bhamjika i. ( page 12), as “अवरो गण्डस्स उवरि पिण्ठओ संबुत्तो.” 
+
+
+Digitized By Siddhartd eGangotri Gyaan Kosha 
+
+
+(line 4), is the आरुणिन्याय of Jaimini 3,1. 12, and is based on 
+the following wor ds connected with the ritual of the Jyotistoma 
+sacrifice “arent पिङ्गाक्ष्येकहायन्या सोमं क्रीणाति,' “he buys Soma 
+with a red-coloured, yellow-eyed [cow] of a year old” The 
+Mimàamsaka delights in hair-splitting, and in trifling with lang- 
+uage; and we have a typical instance of this idiosyncrasy in the 
+way in w hich this simple sentence is dealt with. Because the 
+cow is not actually mentioned, and the word अरुणा denotes a 
+quality (redness), an objector says “how can one buy Soma 
+with a mere quality ?” S'abara's reply to this occupies ten octavo 
+pages, whilst that of Kumarila fills twenty-nine ! The objection 
+is concisely put in the Nyayamalavistara, part of which is as 
+follows:— 
+
+
+अरुणाशब्दो 5रुणिमान॑ गुणसाचष्टे | गुणिविषयतया प्रयुज्यमानस्यापं नाः 
+गृहीतविशेषणा विशिष्टे बुद्धिः? इति न्यायेन गुणबोधकत्वात्‌ | अन्वयच्यतिरकाः 
+भ्यां गुणमात्रे AGATA | तस्य चारुणिमयुणस्य तृतीयाश्चत्या सामक्रयसाधनत्व 
+KAMA तञ्चाचुपपन्नम्‌ | AKA गुणस्य वासो हिरण्यादिवत्क्रयसाधनत्वासभः 
+बात”! ॥ The reply to this 5:—“यद्यप्यमूतां गुणस्तथापे हायनवदक्षिव च 
+गोद्रव्यमवच्छिनत्ति | तञ्च zai साधनमिति तद्वारा गुणस्य ऋयेणान्वयो भवति | 
+एवं सति वाक्यभेदो न भविष्यति’? ॥ 
+
+
+There is a long discussion on the nyaya in Ramanujas 
+S'ribhdsya 1. 1. 13, commencing on page 813 of the Benares 
+edition. See Dr, Thibaut’s translation, page 222 
+
+
+`A A 
+अवतप्तेनंकुलास्थतस्‌ U 
+
+A mungoose’s standing on hot ground. Used of a fickle, 
+changeable person who never sticks to a thing. It is found in 
+Mahabhasya 2. 1. 47, as follows: यथाबत्षे नकुला न चिरं स्थातारो 
+wed कार्याण्यारभ्य यो न चिरं तिष्ठति स उच्यते$वतसेनकुलस्थित त 
+एतदिति.” It occurs a second time in 6. 2. 49 (var 6), 
+company with the expression उदकेविशीर्ण The compound तीथेकाक 
+Which is found in 2. 1. 42, has much the same meaning Patanjali 
+
+
+SAYS. "mr तीर्थे काका न चिरं स्थातारो भवन्ेवे यो गुरुकुरानि गत्वा न 
+C-0. Prof. Satya Vrat Shastri Collection 
+
+
+za 
+
+
+Digitized By Siddhanta eGangojri.Gyaan Kosha 
+i 3 
+
+
+चिरं तिष्टति स उच्यते तीथकाक zia." In Marathi, however, the name 
+is applied to “a person ever watchful after some booty or spoil’ 
+a meaning which seems more in accord with the character 0 
+the crow than that assigned to it by Patanjali 
+
+
+| अवयवप्रसिद्धेः समुदायग्रसि द्विर्बळीयसी ॥ 
+
+For this paribhasa sec under रथकारन्याय, It is quoted by 
+Kumarila in Tantravartika 1. 4, 11, more than once, but one 
+example will ४प्री७७--/लूव्धात्मिका हि ससुदायप्रसिद्धिरवयवग्रसिदि 
+बाधत तस्यास्त्वात्मलाभा यत्र ग्रसाणान्तरंण पूवानुसूताचयवाथराहतऽथ राब्दः 
+म्रयोगो दृश्यते | यथाश्वत्वकणंत्वरहि ते JASER.” As a parallel 
+| to this, we might take our word cockroach, which is neither a 
+
+
+ji cock nor a roach! For other examples of the paribhüs see 
+4 Lantravdrlika pages 538, 1002, 1048, and 1149 
+
+
+I have met with another reference in Tatparyatika, page 
+fi 150, line 12:—“aq च घ्राणादिशव्दाः पंकजादिपदवदवयवार्थ निमित्तीकृल | 
+h ep rape ente ran रेषे वर्तन्ते अवयवार्थस्य प्रतीयमानस्यासतति बाधके परि 
+
+
+H त्यागायोगात्‌ | अश्वकर्णादी द्रक्षाविशेषवाचके वाजिकणीयोगेन बाधकेनावयवार्थ 
+| परित्यागात्‌.” See also Vydyamanjari, page 385, lino 10; an 
+page 534, line 15, 
+
+
+अविरविकन्यायः ॥ 
+
+
+The principle of the words avi and avika. Though both 
+mean “a sheep, yet a derivative in the sense of the. flesh fa 
+sheep (आविक) can be formed only from the latter. It occurs in 
+Mahabhasya 4, 1. 88 (virt. 2) as follows “तत्र gat: शब्दाः 
+समानार्थयोरेकेन विद्रहोंऽपरस्माहुत्पत्तिर्भविष्यत्यविरविकन्यायेन । तद्यथा | 
+अवेमासमिति Pye अविकशव्दादुत्पत्तिभवति आविकमिति?॥ S 
+
+8. 1. 89 (च, 6); 4. 2. 60; 4. 3. 131; 5.1.7; 5, 1. 28; and 6 
+
+
+Digitized By Siddharjta eGangotri Gyaan Kosha 
+
+
+In Nyayamanjart, pages 413 and 414, Jayanta Bhatta joins 
+in the attack on this irregular compound; and on grammatical 
+deformities found in the works of such writers as Manu, 
+As valiyana, Valmiki, and Dvaipayana. The following is a 
+portion of his ००॥॥॥७॥८-- भाष्यकारोडपि अविरविकन्यायेनेति दन्द्रगर्भ 
+ager प्रयुशुक्षिते सुपो घातुप्रातिपादिकयोः' इति प्राप्तमपि लोपं न कृतवान्‌। 
+धअन्यथाकृत्वा चोद्यमन्यथाकृत्वा परिहार? इत्यत्र च “अन्यथेवंकथमित्थंसु सिद्धाप्र- 
+योगश्रेत? इति प्राप्तमपि णसुलमुपेक्ष्य TAMA UIS N 
+
+
+The quotation “अन्यथाकृत्वा ८७ is from Patanjali on Panini 
+4. 1. 7 (vart. 3), and the sūtra quoted is 3. 4. 27. See 
+Kumiarila’s remarks on this expression in Tuntravartika page 
+201. They would apply equally to “aigat चोदितं ७0०.” in T. 
+1.3 (vart. 5). 
+
+
+अश्वारूढाः कथं चाश्वान्विस्मरेयुः सचेतनाः ॥ 
+
+
+How could, men of intelligence be moumted on horses und yet 
+forget their horses! Yet grammarians and others sometimes. 
+ignore their own rules! In Tantravartika 1. 3. 18 ( according 
+to the numbering of the Benares edition }, Kumarila com- 
+ments at great length on the corrupt forms of words 
+employed by even learned writers. On page 200, he says 
+“अन्तो नास्त्यपदाव्दानासितिहासएुराणयोः? and then instances the 
+curious word zama which is made to mean «a blow given by 
+an elephant with both tusks” (युगपदुभाभ्यां दन्ताभ्यां प्रहारः).. On 
+the following page he 895:-“येडपि व्याकरणस्येव परे पारे प्रतिष्ठिताः । 
+सुतरां तेऽपि गाव्यादितुल्यानेव प्रयुञ्जते ॥ सूत्रवातिकभाप्येषु दश्यते चापशब्दाः 
+नम्‌। अश्वारूढाः कथं चाश्चान्विस्मरेयुः सचेतनाः ॥ 
+
+A variant of this is found in S'alika, page 16, verse 41;— 
+
+* नन्वेवं हुरगारुढस्तुरङ्गं REGES भवान्‌। 
+वेदप्रामाण्यसिदधर्थुस्थितस्तत्महीणवान्‌' u 
+Mallinàtha probably had this in mind when, in his comment 
+
+
+on Varadaraia? Tg "e vergl sj 9 Lau. 
+* aracaraja COBDS Ba wiles s 
+
+
+Digitized By Siddhanta ee yaan Kosha 
+4 
+
+
+तत्तरगाधिरूढस्य तुरगविस्मरणं यद्वेदप्रामाण्यसाधने प्रवृत्तस्य 3 7 
+स्तखमाद इति सोपहासं परिहरति.? 
+It is very clear, however, that the nyaya came from a 
+ti Buddhist source, since it is found in the following karika of J 
+1 Nügürjuna's, on page 502 of the Madhyamahkavritti ( for | 
+] y reference to which I am indebted to Prof, Poussin = 
+
+
+| “a दोपानाव्सनीयानस्मासु परिपातयन्‌ | 
+अश्वमेवाधिरूढः सन्नश्वमेवासि विस्मृतः? ॥ 
+In a footnote, the Professor gives a variant from another 
+
+
+| Buddhist work, namely, “घोटामेवाभिरूढ: सन्‌ Se 
+
+
+असाधारण्येन व्यपदेशा भवन्ति ॥ 
+
+
+Names wre given in consideration of some speciality. This 
+was perhaps taken from Sénkhyasitra V. 112:--"सवपु पथिः 
+व्युपादानमसाधारण्यात्तब्यपदेशः पूर्ववत्‌. ? “In all [bodies] earth is the 
+material: in consideration [however] of some speciality, there is 
+designation as this [or that other clement than earth, as entering 
+| into the constitution of some given body], as in the preceding 
+| case.” This is Dr. Ballantyne's rendering, The nyaya is found 
+in the carly part of the Aksapida section of Sarvadars'ant- 
+sangraha, and I append Prof. Cowell's translation: —“aq 
+प्रमाणादिपदार्थपोडराके प्रतिपाद्यमाने कथमिदं न्यायशास्रसिति व्यपदिश्यते 
+सत्यम्‌ । तथाप्यसाधारण्येन व्यपदेशा भवन्तीति न्यायेन न्यायस्य qut 
+बुमानापरपर्यायस्य सकलविद्यानुग्राहकतया सवेकर्मानुष्टानसाधनतया प्रधानत 
+तथा व्यपदेशो युञ्यते.?? 
+
+
+Fy 
+
+
+“But here an objector may say, ‘If these sixteen topics, 
+. . &e,are all thus fully discussed, how is it that it has rec 
+the name of the Nyaya S‘astra [as reasoning, 4, e. JV: 
+logie, properly forms only a small part of the topic 
+
+
+of W : ree of bjeetion; st 
+
+
+Digitized By Siddhama eGangotri Gyaan Kosha 
+
+
+System, since ‘reasoning’, or inference for the sake of another, is 
+justly held to be a predominant feature from its usefulness in 
+all kinds of knowledge, and from its being a necessary means 
+for every kind of pursuit.” See also S'alika, page 98, line 8; 
+and Bhamati 1-3-14 ( page 208 ). 
+
+
+असिधारामधुलेहनन्यायः ॥ 
+
+The simile of licking honey from the edge of a sword! This 
+is found in the Jaina chapter of Survadars‘anasangraha ( page 
+45 of Jivünanda's edn, ), as 101005:--“सदसद्वे दनीयस्य सुखदुःखो- 
+व्पादकत्वमसिधारामुलेहनवत्‌, ˆ which Prof. Cowell renders, “An 
+object recognized as simultaneously existing or non-existing 
+produces mingled pleasure and pain, as licking honey from a 
+sword's edge—this is vedantya.” Compare Bodhicaryavatara 
+०1-04:--“कामैन तृप्तिः संसारे क्षरधारामधूपमेः॥ 
+
+
+हृदयवचसामहूदयसुत्तरम्‌ ॥ 
+
+Heartless words get heartless answer. Like receives like 
+This occurs in Vedaántatattvaviveka, (The Pandit for May 1903), 
+page 14, line 4 from bottom:—"qa चाहृदयवचसामहृदयमुत्तरसिति 
+न्यायेन सदन्यत्वं प्रपज्ञस्थोक्त न तु तत्वामित्रायेण.” In the Tatparya- 
+kika it takes the form of “अहृदयवाचामहृदया एव प्रतिवाचो Kaa,” 
+and is combined with rex यक्षस्ताइो बलिः”. The passage 
+will be found under that nyaya in the second Handful. 
+
+In his Nyayadipanali, page 2, Anandabodhacarya quotes the 
+Nyaya in accordance with VàcaspatimisTa. 
+
+
+आख्यातानामर्थ gaat शक्तिः सहकारिणी ॥ 
+
+
+Power [of understanding on the part of the hearer] co-operates 
+
+
+with the verbs expressing ७ certain sense. Thisis Dr. Thibaut’s 
+rendering of thecnyüys as it appears in Laugakshibhüskara s. 
+ni OT. 
+
+
+atya Vrat Shastri Collection. 
+
+
+sg so 
+
+
+Digitized By Siddhanta eGangoty Gyaan Kosha 
+
+
+Arthasangraha (page 16) ina passage explanatory of z 9 
+vidhi. The portion connected with the nyaya, and the transla. 
+tion, are as follows:— ud सामर्थ्यमपि | आख्यातानामर्थ gaat शक्ति 
+सहकारिणीति न्यायात्समर्थे प्रत्येव विधिप्रवरत्तेः?॥ "In the same manner, 
+capability ( to perform the duty is an understood = 
+for the injunction applies only to those who are capable (by 
+bodily strength and health, mental power &e. ) to carry it out, 
+L4 according to the principle expressed in the words ‘power (of 
+(s understanding on the part of the hearer ) co-operates with the | 
+। verbs expressing a certain sense’ (the verbs although possessing 
+E à certain sense have no effect on a person not able to understand 
+| it)” The commentator, Ràmes' vara S'ivayogibhikshu, explains 
+that blind, deaf, and lame persons are excluded as being incap- 
+able of performing various parts of the sacrificial ritual, 
+
+
+p 
+
+
+A much earlier instance of the employment of the nyaya is 
+met with in Sures’vara’s Sumbandhavartilka, verse 75, which I 
+
+
+here subjoin, together with Anandagiri's comment. 
+
+
+“सहकत्री भवेच्छक्तिरिति न्यायाद्भवेद्यादि | 
+
+मनुष्यगोचरोऽपीति नाख्यातासंभवात्तथा ॥ ७५॥ | 
+
+आख्यातानामर्थ बोधयतामधिकारिशक्तिः सहकारिणीति न्यायाद्विधेयाथी 
+
+चुष्टानशक्तमधिकारिणं विना विधेविंधित्वायोगात्कास्यादि सुसक्षर्वंजयेदि 
+ANT RJA प्रति स्व्राथ बोधयतो मनुप्यशक्तिसापेक्षत्वादेवमात्रगोचर 
+
+स्यासिद्धमिति शकते | सहकत्रोति | यत्राख्यातमस्ति तत्र तत्सहकर्त्री कर्तृशक्ति 
+
+रिष्टा न च मोक्षकामी काम्यादि बजैयेदित्याख्यातं ead न मनुष्यः 
+
+चरतोक्तहेतोरिति समाधत्ते नाख्यातेति?? ॥ 
+
+The verse immediately ‘preceding is the following 
+यादाच्छिकी सिद्धिवंक्तव्येह विपश्चिता । देवगोचर एवेष न g मानुषगोः 
+The two are rendered as follows in 8 translation (by Mi 
+
+iyar) which appeared in The Pandit:—*.A wise m: 
+z z 
+
+
+ot t 
+
+
+Le 1 13, 
+Digitized By Siddhant#?eGangotri Gyaan Kosha 
+
+
+of human effort, on the principle that injunction implies 
+endeavour; for there is no injunction ( akhydta ) to that effect.” 
+
+The nyaya probably originated with S'abara who makes use 
+of ib in his bhasya on Jaimini 1. 4, 30, where the reading is 
+आख्यातशब्दानामर्थ &e. The expression “सवोख्यातसहकारिदक्तयनुसा- 
+रण? in Tantravartikea 2. 2. 27, page 558, line 9, incorporates 
+the same nyaya, 
+
+
+aà फठार्थे निमिते छाया गन्ध इल्यनूत्पद्येते ॥ 
+
+
+Though a mamgo-tree is planted for the sake of its fruit, 
+yet shade and fragrance are also incidentally produced. 
+This illustration is employed by Apastamba in his Dharma- 
+sübra 1, T. 20. 8 which I quote together with Dr. Biihler's 
+translation (in Sacred Books of the East, vol. 1i);— तदथास्रे 
+war निमिते छाया गन्ध इत्यनूत्पचेते। एवं धमै चर्यमाणमथो sepa." 
+
+* Worldly benefits are produced as accessories to the fulfil- 
+ment of the law, just as in the case of a mango-tree, which is 
+planted in order to obtain fruit, shade and fragrance are 
+accessory advantages.” Plain and intelligible as this is, it is 
+invariably misquoted, and instead. of निमिते (from the root सि 
+प्रक्षेपण ) we find निमिते, or the clearly impossible निमित्ते. The 
+nyaya is found in S'ankara's bhasya on Brahmasütva 4. 3. 14, 
+and in every edition known to me the text and comment stand 
+thus “aq नित्यनेसित्तिकानु्ठानातत्यवायाचुत्पत्तिमात्रं न पुनः फलान्तरोत्प- 
+त्तिरिति प्रसाणमस्ति फलान्तरस्याप्यनुनिष्पादिनः सम्भवात्‌। स्मरति द्यापस्तम्बः | 
+Wu फलार्थे निमिते छायारान्धावनूतपद्चते एवं धर्म चर्यमाणसथा अनूत्पद्यन्त 
+इवि.” Then the tikakara is made to say “ निमित्त आरोपिते सतीति 
+
+
+"Hn." We find it again in Sures'vara's Saumbandhavariike, 
+' verses 96 and 97:— 
+
+
+८ फल नित्यस्य नापीह ठुरितक्षयमात्रकस्‌ | 
+
+
+फळान्तरश्रुतेः साक्षात्तद्रथाम्रस्मतेस्तथा ॥ 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+1 ; 
+A j 
+d 
+$ 
+
+
+Digitized By Siddhanta eGangofti4syaan Kosha 
+
+
+“आम्रे निमित्त? इत्यादि ह्यापस्तस्वस्मृत्तेवेच: | 
+
+फलवत्त्वं समाचष्टे नित्यानामपि कर्मणाम्‌ ॥ ?? 
+
+Here, again, the unfortunate commentator is -made | à 
+misquote the Sütra, with निमित्ते for निमिते, and to 
+
+meaning belonging to the latter, namely 
+
+
+"3 
+
+
+give it the | 
+“ निहिते रोपिते. ” The 
+translator of the vartika was apparently satisfied with the 
+
+reading in verse 97, which he rendered * Tho mango being the 
+cause &c." But did Sures’vara really put it thus ? É 
+
+
+Apastamba’s simile is found also in Ramatirtha/s comment 
+on the Vedantasara, page 90 of my edition. 
+
+
+A 
+I may add that the verb निमि occurs frequently in Vedic 
+literature, and means to set up, erect, or fix. The root TE in 
+combination with the two prepositions अनु and gq has no place 
+in the dictionaries, and may be peculiar to Apastamba. 
+
+
+आदे वस्रं समन्ताद्वातानीतं रेणुजातमुपादत्ते ॥ 
+
+
+A wet garment collects the dust brought to it from every sule 
+by the wind. This illustration is taken from the Jaina secti 
+of Survadarsanasangraha (page 44 of Jivinanda’s edn). A he 
+text, and Professor Cowell's translation, are as 1011098:--यथाई 
+
+
+Tel समन्ताद्वातानीतं रेणुजातमुपादत्ते तथा कषायजलाद्रे आत्मा योगानीतं 
+
+
+सर्वश्रदेशेगृह्ञाति । यथा 
+
+
+” Ina 
+he natu 
+
+
+Digitized By Siddhant# BGangotri Gyaan Kosha 
+
+
+आषाढवाते चलति द्विपेन्द्रे चक्रीवतो वारिधिरेव काष्ठा ॥ 
+
+
+When the wind is blowing in the month Ashadha [ 4. e. in 
+the rainy season, when strong winds prevail] and the lordly 
+elephant as being driven about, nothing but the sea can 
+be the final resting place of the donkey. That is to say, if 
+the mighty elephant can with difficulty withstand the force 
+of the wind, the puny donkey must inevitably be blown 
+into the sea! I am greatly indebted to Mr. D. Sundara 
+Rajasarma of Madras for giving me a reference to this 
+nyaya in the Vedantas'ikhamani (a work which I bad nob 
+then read). It appears in a passage on page 393, and I 
+append an extract from Amaradasa’s comment on it:— 
+s बामदेवादीनासुत्पन्नत्रह्मसाक्षात्काराणामप्यसुक्ताववोचीनानामाषाढवाते चलति 
+ek चक्रीवतो वारिधिरेव काष्टेति न्यायेन सुक्तिदूरोत्सारिता स्यात्‌.” 
+८ आपाढवाते इति आपाढवायुसम्बड़े हिपेन्द्रे गजेन्द्रे चलति इतस्ततो दोलाय- 
+माने सति चक्रीवतो रासभस्य वारिधिरेव समुद्ग एव काष्टा विश्रामावधि- 
+रित्यर्थः” ॥ 
+
+
+Raghunatha’s application of the simile is somewhat different, 
+and makes it the equivalent of the ग्रधानमछनिबर्ईणन्यायः He 
+ee याभि्युक्तिभिरतिग्रबछुष्कतकेक्केशत्वेन प्रसिद्धोऽपि द्वैतसयत्ववादी 
+वैशेषिकादिजैय्यस्ताभिरितरे ganas दूरतो निरस्ता अवन्तीति 
+बिवक्षायामापाढवाते चलति द्विपेन्दे चक्रीवतो वारिधिरेव काति न्यायः 
+प्रवृत्ति: । चलतीति सप्तम्यन्तं पदं देहलीदीपन्यायेनोभयत्न सम्बध्यते | चक्री- 
+वानू गदभः । स्पष्टमन्यत्‌?’ d ; 
+
+Tn a manuscript of the Sikhamani copied for me in Poona 
+the nyaya, stands ४॥॥६:--“आपषाढमासे वलद्विपेन्दे चक्रिवतोऽरे भवति 
+खुकाष्ठावधिरेव काष्टा.” Though partly inaccurate this clearly 
+furnishes a variant of the simile. The reading of the India 
+Office manuscript (No. 568, page 78 b) differs materially from 
+above and seems hopelessly corrupt. Tt puis ib as followers 
+“आपाठमासे चलति द्विपेन्द्र चक्रिवतो धावतो धावति काष्ठवाहोरिति न्यायेन! 
+Does this, in spite of its inaccuracy, indicate the existence 
+of another variant ? 
+
+5 —— 
+
+
+4 CC-0: Prof. Satya Vrat Shastri Collection. 
+
+
+की ne cc 
+
+
+dars'anasangraha, page 69 ( Jivananda’s edn), 
+
+
+Digitized By Siddhanta eGangaki;Gyaan Kosha 1 
+
+
+इतो व्याघ्र इतस्तटी ॥ 
+
+
+On one side a tiger, on the other a precipice! A Serious 
+dilemma! There is a good example in Hemacandra’s Paris. 
+staparvan iii. 166:—“कुटुस्बम्पि मे प्रेयः मेयांस्त्वमपि हे सखे । कि करोमि 
+द्विधाचित्त इतो व्याघ्र gaad.” Another is found in Sydduada. 
+manjari, page 151:—“अवास्तवत्वग्राहकं प्रमाणं सांबूतमसांबृतं वा स्यात्‌। 
+यदि aad कथं तस्मादवास्तवाद्वास्तवस्य शून्यवादस्य सिद्धिः प्राप्ता । तथा 
+च वास्तव एव समस्तोऽपि प्रसात्रादिव्यवहारः । अथ [SENEC प्रमाणं स्वयम- 
+सांदृतं तर्हिं क्षीणाः प्रमात्रादिव्यवहारा वास्तवत्वप्रतिज्ञातेनेव व्यभिचारात्‌ | 
+तदेवं पक्षद्वयेऽपीतो व्याघ्र इतस्तटीति न्यायेन व्यक्त एव परमार्थतः खाभिमत- 
+सिद्धिविरोधः”?॥ In the following verse on page 896 of Upamiti. 
+bhavaprapanca Katha we have the nyaya as a compound:— 
+
+
+“इतो हि मेथुनस्याज्ञा इतः सागरवारणम्‌ | 
+a च्याघ्रदुस्तटीन्यायः संजातो मे सुदुस्तरः” ॥ 
+
+
+इष्यमाणस्यैव प्राधान्यं न त्विच्छायाः ॥ 
+
+
+The thing wished for is of more importance than the wish. 
+This occurs in Vedantakalpataruparimala, page 56, as 
+
+
+follows-—* ननु विध्यन्वयित्वेनाविवक्षितमपि प्रैपानुवचनमजुवाद्यतया यथाः 
+विधेयदण्डान्वयि एवमिच्छापि प्रारयमाणब्रह्मज्ञानान्वयिनी सती ब्रह्मज्ञानस्य 
+
+
+प्रयोजनत्वं बरह्मणः सन्दिग्धत्व॑ च गमयेत्‌ | इच्छेष्यमाणसमभिव्याहारे चेष्यमाः 
+णप्राधान्यं यजेत खर्गकाम इत्यादौ कुतम्‌ | अत इहापीच्छाग्राधान्यं विहायेः 
+व्यमाणग्राधान्यमभ्युपगन्ठुं युक्तम्‌  ॥ Again, on page 62, of the 
+
+
+Same" अल्ययार्थ: प्रधानमिति सामान्यन्यायादिच्छेष्यमाणसमभिव्याहता 
+
+
+विष्यमाण प्रधानमिति स्वगकामपदादिपु set विशेषन्यायो बळवानिति 
+< 
+
+भाबः” ॥ So too, in Ramanuja’s Sribhdsya, page 81:--“ज्ञातुमिच्छा 
+
+जिज्ञासा । इच्छाया इष्यमाणप्रधानत्वादिष्यमाणं ज्ञानमिह विधीयते” ॥ 
+
+This is repeated verbatim in the Ramanuja section of Sarva 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhan BGangotri Gyaan Kosha 
+
+
+उदरे Wa कोशो Wa? ॥ 
+
+
+When his stomach is full his coffers are full. Used of a 
+lazy fellow who has no ambition beyond his daily food. “Whose 
+god is his belly.” It occurs in Hemaeandra's Parisistaparvan 
+ai, 113:—“ दारिद्येण सदीयेन बिभष्युदरमप्यदः | उदरे च अते कोशो 
+wt zaa मन्यसे. n 
+
+
+उपवासाद्वरं भिक्षा ॥ 
+
+It is better to beg than to starve. This is one of Raghu- 
+nütha's nyayas and he applies it thus:— 
+
+“येषां तु धीमान्याहूयो भूयः श्र्यमाणो$प्यभेदो न बुद्धिमारोहति तेस्तूपवा- 
+सादर भिक्षेति न्यायेन भेदबुद्यापि खम्रेमास्पदविग्रहावच्छिन्नशाराधनं काये 
+तत्मसादान्मेधोदये AVA कोद्रवाशनत्यागन्यायेन त्याज्या भेदधीः ॥ 
+
+It is found in Pancadas’s ix. 119, 120:— 
+
+“ अस्त्येवोपासकस्यापि वास्तवी ब्रह्मतेति चेत्‌ । 
+पामराणां तिरश्चां च वास्तवी ब्रह्मता न किस्‌ ॥ 
+अज्ञानादपुसर्थत्वसुभयत्रापि तत्समम्‌ d 
+उपवासाद्यथा भिक्षा वरं ध्यानं तथान्यतः” d 
+
+
+उपसंजनिष्यमाणनिमित्तोऽप्यपवाद उपसंजातनिमिः 
+त्तमप्युत्सग बाधते ॥ 
+
+
+This is another of Raghunathas grammatical nyayas. It is 
+not met with in the Mahabhasya, but forms one of Nagoji- 
+bhatta’s paribhasas. The following is Prof. Kielhorn’s rendering 
+of it:—* An apavada, even though the causes of its Conley 
+are still to present themselves, supersedes 4 general tule? the 
+causes (of the application) of which are already present.” In 
+connection with this paribhasà we have the देवदत्तहन्वृहतन्या्‌य 
+Which see below. 
+
+
+et 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta २७०१९३ Gyaan Kosha 
+
+
+उभयतः्पाशा रज्जुः ॥ “WA 
+
+
+A rope which binds at both ends. i An embarrassing position ; 13 
+a dilemma. The following is from the Jaimini section of 
+Sarvadars'anasangraha (page 133, Bib. Ind., or 180 of Jivana- 
+nda’s edition), with Professor Cowell's translation (page 198):— 
+“अभावः कारणमेव न भवतीति चेत्तदा वक्तव्यमभावस्थ कार्यत्वमस्ति न | 
+यदि नास्ति तदा पटप्रध्वंसानुपपत््वा नित्यताग्रसज्ञ: । अथास्ति किमपराद्धं 
+कारणव्वेनेति | सेयसुभयतःपाशा रजुः” ॥ 
+
+
+“Tf you object that non-existence ( or absence ) cannot be a 
+cause, we reply by asking you whether non-existence can be an 
+effect or nob? If it cannot, then we should have to allow that 
+cloth is eternal, as its ' emergent non-existence’ or destruction 
+would be impossible. If it can be an effect, then why should it 
+not be a cause also? So this rope binds you at both ends.” ; 
+
+The earliest occurrence of the nyaya isin Patanjali 6. 1. 68 
+(vart. 2 and 5); and it is found in Lantravartika 8. 6. 42 (page 
+1118) as 10095“ यद्यापि न वाधस्तथापि विकल्पस्तावत्माझोति न हि 
+तुल्यार्थानां क्चित्समुच्चयों ce: सेयसुभयतःपाशा रज्जुः” Mandanamisra 
+used it in Vidhiviveka, page 83; and we find instances of it in 
+Nyayamanjart, page 436, line 16; in Kusumanjali iti, 6 4 
+(page 374); in the same authors Laksandvali, page 56; in 
+Khandana, page 580; and in the opening part of Oitsukhi - 
+( Pandit, vol iv. page 466 ). i: 
+
+
+v 
+T 
+
+
+एकदेशविकृतमनन्यवत्‌ ॥ 
+A thing that is changed in one part does not thereby become _ 
+something else (literally, like something else) For exampl 
+as Patanjali says under 1. 1. 56 (vart. 10), the cutting, 
+
+
+ears or tail does not turn it into a horse or a (0756! 
+
+
+Digitized By Siddha219 eGangotri Gyaan Kosha 
+
+
+(wart. 3); 6, 4. 149 ( vàrt. 2); and 8 8. 85. The paribhasa is 
+No 37 in Dr. Kielhorn’s edition of the Paribhasendus ekhara, 
+and my rendering of it is based upon his. It is included in 
+Raghunatha’s list of nyáyas, and is quoted as such by Jayanta 
+Bhatte in Nydyamanjart, page 989, line 6. For further 
+illustrations of the paribhasa, see under श्वा कणे वा ४०. 
+
+
+एकसस्बन्धिदरीनेऽन्यसम्बधिस्मरणम्‌ ॥ 
+
+On seeing one thang we are reminded of others connected 
+with it. The nyaya is found in this form in the Nyayapradipa 
+on Tarkabhadsa, page 44, where the presence of smoke is said to 
+remind the spectator of the invariably connected fire. In 
+Amaradasa’s tika on S'ikhamani, page 93, it is quoted as 
+८ एकसम्बन्धिज्ञानमपरसम्बन्धिस्मारकस्‌  - In both of Raghunatha- 
+varman's books it appears as एकसस्बन्धिद्शनमस्यसम्बन्धिस्मारकम| 
+and, in the larger of the two, he illustrates it thus:—“aat 
+हस्तिपकद॒शन हस्तिस्मारकं तथा नद्यादिज्ञानस्य कुशकाशजलतुंबिकाजलकानां 
+तत्सम्बन्धिनां स्मरणहेतुत्वम. Taranatha (S. V. न्याय ) guotes the 
+saying in the form एकसम्बन्धिज्ञानम्‌ &c. He reverses the above 
+illustration by saying that the elephant reminds one of the 
+driver; and adds that a word reminds one of its meaning, 4 
+statement which, in these degenerate times, is not universally 
+true! See, too, Tatparyateka, page 167, line 1S. 
+
+
+SSS 
+
+
+~ 
+कापञ्जलन्यायः ॥ 
+
+The rule as to the Kapinjalas [2 kind of partridge], 5e 
+Vajasaneyi-Sarihitü xxiv. 20, we read वसन्ताय “` ५ 
+ल्मेत,? and the question arises, how many of the birds are to 
+be sacrificed? Jaimini devotes eight sutras [11 1. 3845] to 
+the discussion of this point, and finally decides that three, ‘the 
+lowest figure representing plurality (two being merely duality), 
+will satisfy the requirements of the sruti. S'abars's lengthy 
+argument is very concisely summed up in the Nyayamala- 
+visiara, as follows:— à 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+aaa 
+
+
+; 
+Digitized By Siddhanta eGangots (yaan Kosha | 
+
+
+“ कपिअलेपु त्रित्वायया ऐच्छिकाखित्वमेव वा । 
+arent बहुत्वसाम्यान्न त्नित्वेनेव कृतत्वतः ॥ 
+
+
+अश्वमेघ “वसन्ताय कपिञ्जलानालभत’ इति त्रित्वचलुषठादि संख्यानां बहुल: 
+साम्यादिच्छया या काचिद्दहुत्वसंख्या स्वीकार्यति चेत्‌ । न । त्रित्वेनेव शास्र 
+कृतत्वात्‌ | यो हि चतुष्टरादिसंख्यासुपादत्ते तेन न तदन्तभूत frd वजयितु शक्यं 
+त्रिस्वसुपाददानेन त्वनन्तभूत॑ agentes वर्जयितुं शाक्यते अतो$5वऱ्यंभावित्वेन 
+प्रथमभाविस्वेन लाघवेन च त्रित्व उपात्ते शाखाथेसिद्धो ततो$धिकपक्षिहिसायां 
+प्रत्यवायात्‌ । तस्सात्रित्वमेवोपादेयम्‌?? ॥ 
+
+
+There is an admirable example in Nyayakandali, page 50, 
+where, in commenting on Pras'astapada's “इहेदानीं agi 
+महाभूतानां सृष्टिसंहारावेधिरुच्यते,'? Sridhara 525: महाभूता नामित्युक्ते 
+त्रयाणामेव परिग्रहः कपिञ्जलानाळमेतेतिवद्वहुत्वसंख्यायास्तावत्येच चरितार्थः 
+स्वात्‌ | अतश्चतुणोमि त्युक्तम्‌.” 
+
+
+It is found also in Taniravartika 2. 1, 19 ( page 394), and 
+8. 5. 26 ( page 1049); in Parimala, page 550, line 3; and in 
+Sikhémani, page 303. Commenting on Manu viii. 105, 
+Where certain offerings are directed to be made to Sarasvali, 
+Kullüka decides that, in accordance with the kapinjala-nydaye 
+three are sufficient. The nyaya is clearly of the type of सकृत्कृते 
+कृतः शास्त्रार्थ; and in accord with the Marathi phrase शास्त्रापुरता, 
+
+
+कंबलनिर्णजनन्यायः ॥ 
+
+
+The simile of the cleansing of a course blanket [by beating it 
+on the feet, and so dusting them at the same time]! One of the 
+numerous examples of the accomplishment of two objects by 
+one operation:—" killing two birds with one stone.” Tt is found 
+in S'abara 2. 9. 25. —tt. 
+होमं च । ननु कंबलनिर्णजनवदेतद्भविष्यति | निर्णेजनं हि उभयं करोति! | 
+tasa पादयोश्च fea?) T a 
+Marathas) Gomoeler ४१७9०४0891 
+
+
+3 
+
+
+अपि च दधि उभयमसमर्थ a} फलं साधयितुं | 
+
+
+Digitized By Siddhantd eGangotri Gyaan Kosha 
+
+
+generally black or black and grey. In the case of the very 
+poor, it is often their sole garment by day as well as their 
+
+
+only covering ab night. 
+
+
+akakaa: ॥ 
+
+The nyaya of the trumpeting of an elephant. The word 
+करि is really redundant, since the whole meaning is conveyed 
+by aka alone—afea करिगर्जितमित्यमर:--00 the addition, in this 
+and similiar cases, is made for some special purpose. Raghu- 
+natha defines it thus :--/विशिष्टवाचकानामपि पदानां सति प्रथग्विशिषण- 
+वाचकपदसमवधाने विदोष्यमात्रपरतायां करिबृंहितन्यायः sade.” This 
+principle may be exemplified by the following verse from 
+Kivyaprakdas'a vii. 10:— 
+
+८ सौन्द्र्यसम्पत्तारुण्यं यस्यासे ते च विश्रमाः | 
+पट्पदान्पुष्पमालेव कान्नाकपेति सा सखे” ॥ 
+
+Here the author of the Kavyapradtpa remarks (page 295):— 
+“मालाशब्दो यद्यपि grea खजि शक्तस्तथापि न पुष्पपदमपुष्टार्थमू | 
+लक्षणयोत्क्ृष्टत्वप्रतिपादकत्वात. । अयमेव करिब्रंहितन्याय:..' So too, the 
+Udaharanacandrika:—“ अत्र निरुपपदान्मालाराव्दादव ुष्पल्मतीतेः 
+पुष्पपदमुत्कृष्टपुष्पत्वे संक्रमितवाच्यम्‌ | एवमेव करिब्रृहितादिष्वपि बोध्यम्‌ 
+
+The following additional nyayas are cited by Raghunātha 
+as belonging to tho same 0888:--गजघटान्याय? नीलेन्दीवरन्याय) 
+
+
+, In 
+पर्वताधित्यकान्याय, पर्वतोपत्यकान्याय; वाजिमन्दुरान्याय) स m 
+each case the first word might be omitted without affecting 
+
+
+meaning. 
+
+
+कळञ्जच्यायः ॥ , killed 
+
+The law of [ abstention from] the flesh of am e. the 
+
+with a, poisoned arrow. “Some hold the Kalanja to ae 
+
+flesh of a deer killed by & poisoned arrow; others, hemp of 5 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotrjXSyaan Kosha 
+
+
+others, a kind of garlic.” (Cowell’s note on page 81 of his 
+translation of Kusumanjali). But this can hardly be Correct 
+as the garlic and bhang are mentioned in addition, Ii; may be 
+noticed, however, that ताम्रकूट is given as an equivalent of s, 
+the meaning of which is the tobacco plant. It is deduced from 
+Jaimini 6. 2. 19, 20,—an adhikarana designed to teach the 
+evil result of doing forbidden things. The words “न करङ्ग 
+भक्षयितव्यं न छशुन agat च” are discussed, and the question 
+arises as to whether this is an instance of पर्युदास or ० प्रतिषेध,-- 
+whether it means अभक्षणं wee or भक्षणं न कर्तव्यम्‌. The subtle 
+intellect of the Mimanisaka sees a great difference between 
+these two, the former being something to be done, and the 
+latter being something to be avoided! The siddhantin decides 
+
+` in favour of the latter. I would advise my readers to study 
+pages 39-41 of Dr. Thibaut’s excellent translation of Arthasan- 
+graha, in order to get, if possible, a clear understanding of 
+this peculiar tenet. Many years ago, when in India, I heard 
+a statement made by a Brahman, to the effect that the words 
+“put no oil in the lamp,” did not mean “ don't put oil in the 
+lamp,” but rather “put in the lamp” some “no-oil”; in other 
+words, it was not a prohibition of an act but an injunction to 
+do something! This is just the position of the Mimamisaka, 
+who, in regard to the rule that a Snataka must not look at the > 
+rising or setting sun, says that « not-looking is something to 
+be done.” The above nyáya is quoted by Anandagiri on Bral- _ 
+mastitrabhasya 3. 4. 28, and 4. 1. 18, and is found in Sanksep- 
+saraka, i. 417-420, and in S'ribhdsya 1. 1. 4 (page 687). 
+
+
+Ic 
+
+
+ç 
+कलशपुरःसरप्रासादनिमाणतुल्यम्‌ ॥ 
+Like the erection of a temple including the pot-shaped fiia / 
+. [which is placed on the summit at its completion ], Use 
+ironically of one who considers that he is doing somethi 
+meritoriousas. thet aliwa aa temple, 
+
+
+PDA D pec 
+
+
+Digitized By SiddhaBt8 eGangotri Gyaan Kosha 
+
+
+In a footnote to page 73 of his translation of Prabandha- 
+cintamant, Mr. Tawney says :—Dr. Burgess informs me that 
+kalas'a is really the finial of the spire, which is shaped like a 
+vase or urn.” Then, on page 135, there is the following foot- 
+note:—“Mr. Cousens writes in a letter, which Dr. Burgess has 
+kindly shown me, ‘J understand that the term kalas‘adanda- 
+pratistha refers solely to the setting up of the kalasa or 
+pot-finial, the danda being the pole or stick which supports the 
+finial and upon which it is set up. With a small kalas'a made 
+solid, 16 would not be required, the neck of the same taking its 
+place, but it is always required with the larger and more com- 
+plex kalas’as, especially those made of hollow metal.” Fre- 
+quent mention is made by Merutunga of the erection of 8 कलश 
+and ध्वज as the completion of a temple. The two are mentioned 
+on pages 119 and 211, whilst on pages 219 and 222 we have 
+the कलरादण्डप्रतिष्ठा referred to above. On pages 120 and 224, 
+the कलश is mentioned alone. In Hemacandra’s Parisistapar- 
+van i. 14, we find ga for poai तत्र elg सोवर्णध्वजकुम्भमरीचयः !. 
+The illustration occurs in S'ürngadhara's tika on Udayana’s 
+definition of dravya in his Laksandvali (page 4 ). The 
+definition is— “ तत्र गुणात्यन्ताभावानधिकरणं द्रव्यम्‌ a and, whilst 
+explaining it, the commentator attacks the views of Citsukha 
+Muni as follows:—“qrqa तत्त्वप्रदीपिकाकारेणोत्पत्त्यनन्तरक्षणे अब्यापि- 
+HATA गुणवत्त्वात्यन्ताभावानधिकरणत्वे aq परिहारमाशंक्योत्पत्त्यनस्तरक्षण- 
+विशिष्टे कदाचिदपि गुणाजुदयात्पुनरव्यासेस्तदवस्थत्वान्रैवमिति परिहृतम्‌ d 
+तत्कलशपुरःसरप्रासादनिमाणतुल्यम्‌/? 1 ॐ 76099 here to bear 
+in mind the tenet of the logicians—* उत्पन्न za क्षणमगुणं तिष्ठति. i 
+The Tattvapradipikā, better known as Citsukhi, is described by 
+Hall as “a confutation of the Nyaya philosophy, on the basis 
+of the Vedanta” The wrath of the logicians would of course, 
+therefore, be kindled against it The passage complained of 
+above is the soka ii. 4 with the vri The former stands 
+
+
+५५७ :--अब्यासेरप्यतिन्यापेईरव्यं नैव गुणाश्रयः । आये क्षणे eism 
+
+
+वीक्षणात्‌.*? : 
+pl ER 
+5 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangomnyaan Kosha 1 
+
+
+काकदधिघातकन्यायः ॥ 
+
+The simile of a crow as a destroyer of curds. An example 
+of upalaksana, where one represents many, or a part stands for 
+the whole. So if any one were warned to keep the crows off 
+the curds, it would imply that all other possible raiders were 
+also to be warded off. It is thus put by Bhartrihari in Valya- 
+padiya ii. 314 :— 
+
+“ काकेभ्यो रक्ष्यतां सर्पिरिति बालोऽपि चोदितः | 
+उपघातपरे वाक्ये न श्वादिभ्यो न रक्षति ?॥ 
+
+This is reproduced, with slight variations, in Tantravartika, 
+page 731, and is quoted in the same form in Bhāmatī 1. 4 8 
+(page 287). Raghunatha’s application of it is as follows:— 
+“ तहुक्तमीश्वरगीतायाम्‌। ' ये स्विमं विष्णुमव्यक्त मां च देवं महेश्वरम्‌। एकी" 
+भावेन पश्यन्ति न तेपां पुनरुद्भवः? इति। अत्र हरिहरयोग्रहणं काकदधिघातः 
+कन्यायेन विधेरप्युपलक्षणम्‌ ?. The Ts'varagita forms part of the 
+uttarabhiga of the Karma Purdna, and the verse here quoted 
+is xi, 8. In the fourth chapter of Vedantaparibhasa (page 
+285) this is given as an example of Jahadajahallaksana. 
+“ जहदजहल्यक्षणोदाहरणं तु काकेभ्यो दधि रक्ष्यतामित्यादिकमेव । तत्र 
+शक्यकाकपरित्यांगेनाशक्यदध्युपघातकत्वपुरस्कारेणाकाके काके च काकशब्दस 
+प्रवृत्ते: ?॥ This kind of laksana is termed bhagalaksana m 
+Vedantasara 93; and bhagatyagalaksandé in Vivaranapre J 
+meya, page 229. In the अहेकत्वन्याय, too, a part represents the — 
+whole, 
+
+
+काकाधिकरणत्वन्यायः ॥ 
+
+
+The being something on which a crow is perched. This 
+illustration seems to have originated with Patanjali, and 
+found in Mahabhasya 1. 1. 26 ( vartikas 3 and 4 ):—“ अनुबन्धों 
+उन्यत्वकर इति चेत्तन्न । किं कारणम्‌ । छोपात्‌ । लप्यते5त्रानुबन्धः | छे 
+उन्नानुवन्ये नीय RAE Mee ua गृहम्‌। अदो 
+
+
+Digitized By Siddha eGangotri Gyaan Kosha 
+
+
+काक इति । उत्पतिते काके WE dé भवति | एवमिहापि लसेऽनुबन्धे नष्टः 
+^ > न्धकस्येयं * 
+
+प्र्ययो भवति । यद्यपि छुप्यते जानाति त्वसो सानुवन संज्ञा कृतेति । 
+
+तद्यथा | इतरत्रापि कतरददेवदत्तस्य शृहम्‌ | अदो यत्रासो काक इति । उत्पतिते 
+
+काके यद्यपि as age भवत्यन्ततस्तमुद्देश जानाति.” 
+
+
+It occurs in Vivaranaprameyasongrahe (page 198 ) in the 
+course of a discussion on Badarayana’s second sttra:—“qq: 
+
+कारणसंबन्धिनो जन्मादेरलक्षणत्त्वमिति चेन्मेवम्‌ | काकाधिकरणत्ववहुपपत्तेः । 
+` काकाधिकरणत्वं हि न sada । तथा च सति काकविगमे ग्रहेकदेश- 
+भङ्गवुद्धप्रसङ्गात्‌ | अतो गृहस्याधिकरणत्वं नामौपाधिको ध्मः स च परिः 
+शेपालक्षणे एवान्तभैवति | तन्निरूपकस्य काकस्य यथा लक्षणत्वं तथा ब्रह्मणोऽपि 
+कारणत्वमोपाधिको धर्मा लक्षणान्तःपाती.? Similarly in Sanksepa- 
+sarwaka उ. 206:—“ यत्रैप काक इदमेव तु देवदत्तवेइमोति लाक्षणिकवृत्ति- 
+रिहाभ्युपेता | काकास्पदत्वमवधीर्यं तथापि चेश्ममात्राकृतिभवति लाक्षणिकी तु 
+बुद्धिः? ॥ With slight modifications it is found also in Tantra- 
+virtika, page 277, line 8:--“यथानमिधीयमानमपि काकनिल्यनं देवः 
+दत्तणूहरव्दस्य स्वार्थभभिद्धतश्चिह्नभूततां प्रतिपद्यते तद्वदाक्ृतिश्चिह्णं व्यक्तय- 
+भिधाने भविष्याति.?? See, also, Khandana., page 502. 
+
+
+a > NO 
+काचिन्निषादी पुत्र प्रसूते कश्चिन्निषादस्तु कषायपायी ॥ 
+A Nisadi gives birth to a son, and a Nisada drinks the 
+decoction of herbs | prepared for her]! For the context of this 
+आभाणक see under “ सुनिर्मनुते spei सुच्यते. 
+
+
+काण्डानुसमयन्यायः |l 
+
+
+The law relating to “the performance of all prescribed acts of 
+ritual in orderly succession for a particular object peiora ee 
+forming the same acts in the same order for a second object. 
+This is Sir Monier-Williams’ definition based on the commen- 
+tary on Ás'valayana's Grihyasūtra 1. 94, Y which prescribes 
+Certain gifts commencing with fee and ending with गो. The 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri ७881 Kosha 
+
+
+commentator says “ऋत्विजां म'धुपर्कदाने द्वे गती संभवत: | : 
+काण्डानुसमय इति । तत्र पदार्थानुसमयों नाम सर्वेपां वरणक्रमेण विष्टर र 
+ततः पाद्य ततोऽष्यमिति | काण्डानुसमयो नाम एकस्यैव विष्टरादिगोनिवेदना॑ त 
+समाप्य ततोऽन्यस्य सरवै ततोऽन्यस्येति. ” In a case of this kind, whey 
+| there is merely a bestowal of gifts, and not the performance of 
+pus sacrificial ritual, the definition given by Molesworth is more 
+suitable:—“The order, when a suit or set of things is to be 
+given to each individual of a multitude, of giving at once ali 
+d the articles composing the suit or set, as distinguished fror 
+| पदार्थानुसमय.?” 7 
+| The nyaya represents the purport of Jaimini 5. 2, 3, Kunte 
+| 8998 that the word araa used in the sūtra means kändānu 
+samaya. His notes on sūtras 1-3 contain some very interest- 
+| ing items of information, of especial value to us of the West 
+i See पदार्थानुसमयन्याय, below. i. 
+
+
+कुल्याप्रणयनन्यायः ॥ : 
+
+The figure of the laying down of a, water-cowrse for गग 
+
+tion, An example of a thing made for one purpose subserving 
+
+other purposes also. It is found in Vévaranaprameyasangral h 
+
+page 118, line 9:-.“अतो न विधेयप्रत्यये तात्पर्यमिति कुल्याग्रणयनन्यायेतो- 
+
+भयार्थत्वाविधेयत्वात्‌ । यथा शाल्यर्थ कुल्याः अणीयन्ते ताभ्य एव प is 
+पीयते तद्वत्‌ ॥” | s 
+
+
+For the source of this nyaya, see अन्यार्थे प्रकृतमन्याथ walt. i 
+
+
+d 
+
+
+कूटकाषांपणन्यायः ॥ 
+The simile of [tho unwitting employment of] base n 
+_ [in one’s business]. It is used by Kumarila (in T 
+. 3. 8, page 95) in the course 
+
+
+Digitized By SiddhaMA eGangotri Gyaan Kosha 
+
+
+using counterfeit coins must at once abstain from so doing. 
+The portion containing the nyaya is as follows—“ay हि कूटकार्षा- 
+पणेन कंचिस्कालमज्ञों लोकमध्ये व्यवहरति न तेन विवेकज्ञानजनितव्युत्पत्ति- 
+नापि तथैव व्यवहतेव्यम्‌-” 
+
+In Tantravartike 1. 3. 8 (page 149, line 3 from bottom), 
+Kumarila compares words to coins which can be tested by in- 
+telligent people. He -says :--“शब्दापअंशवदेंव गोणभ्रान्यादिप्रयोग- 
+निमित्ता अर्थापअंशा भवन्ति ते शास्र्ैरवाद्रिुतार्थक्रियानिमित्पु्यार्थिभिः 
+शक्यन्ते साध्वसाधुकार्पापणमध्यादिव तत्परीक्षिभिविवेक्तुम्‌-” 
+
+The nyaya is found in Nyayamanjari, page 162, as 
+follows :--“ नापि बाधकाभावपरिच्छेदात्मामाण्यनिश्रयः सं हि तात्कालिको वा 
+स्यात्कालान्तरभावी वा । तात्कालिको न पर्याप्तः प्रामाण्यपरिनिश्रये । कूटकाषो- 
+
+
+पणादौ किंचित्काळमनुत्पन्नवाधकेपि कालान्तरे तहुत्पाददर्शनात्‌-” Tt occurs 
+again on page 169, line 3, on page 187, line 4 from bottom, and 
+on page 531, line 1. 
+
+
+कूपखानकन्यायः u 
+
+The simile of the well-digger. Tt is applied by Raghunatha 
+as follows:—' यथा कूपखानके पतितं पंकादि कूपान्निःसतेनाम्भसा प्रक्षाल्यते 
+तथा तत्तद्विग्रहावच्छिन्नेशभेदवुद्धिजो दोपखुपासनाजन्यसुकृतमहिश्ोयन्ेना, 
+द्वैतबोधेन समूलं निवल्येत इति ज्ञेयम्‌॥ » The illustration is as ol 
+as Patanjali who made use of it in the introductory chapter 
+of the Mahabhasya (vol. i page 11 ) when discoursing i 
+the importance of the study of grammar, and on the mer 
+Which accrues to the user of correct ' words. He ec 
+“अथवाभ्युपाय एवापशब्दज्ञानं शब्दज्ञाने । योडपशब्दाज्ञानाति Ue 
+जानाति | तदेवं ज्ञाने धमं इति ब्रुवतो3र्थादापन्न भवल्यपश्व्दश्ञानपूवैके शब्द 
+जाने धर्म इति | अथवा कूपखानकवदेतद्भविष्यति । तथया कूपखानक ह. 
+खनन्यद्यपि सदा पांसुभिश्रावकीणो भवति asg Soa T m 
+सादयति येन a च दोषो निहेण्यते भूयसा egens s e 
+यद्यप्यपदव्दज्ञाने$धमस्तथापि TCA शब्दज्ञाने थमेस्तेन स च 
+लिष्यते भूयसा चाभ्युदयेन योगो भविष्यति. 
+
+
+ois अर 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+aM Digitized By Siddhanta eGangotri Sgaan Kosha 
+
+
+A 
+कृतक्षोरस्य नक्षत्रपरीक्षा ॥ 
+This is identical in meaning with alsa: WAFIWA RS 
+
+
+for which see the Second Handful 1६ occurs in Nyayaman. 
+
+
+| jart, page 164:— अनिश्चितप्रामाण्यस्य तु प्रवृत्तो पश्चात्तत्रिर्णयो भवन्नपि 
+कृतक्षौरस्य नक्षत्रपरीक्षावदफल एवेत्युक्तम्‌.” Lower down on the same | 
+| page, there is another nyàya of similar import, in the following 
+verse :— 
+“समर्थकारणज्ञानाद्यो5पि ग्रामाण्यनिश्वयम्‌ | 
+
+
+बूते सोऽपि कृतोद्वाहस्तत्र wa परीक्षते.” ॥ | 
+
+
+| कृत्रिमाकृत्रिमयोः कृत्रिमे कार्यसम्प्रत्ययः ॥ 
+
+i The rule that “whenever it may appear doubtful whether 
+an operation has reference to that which is expressed by the 
+technical or to that which is expressed by the ordinary mean. 
+ing of a particular term, the operation refers (only) to that 
+which is expressed by the technical meaning of the term in | 
+question.” This is Professor Kielhorn’s rendering of the nyaya 
+as quoted in Nigojibhatta’s vritti to Paribhasa ix:—“ag_ 
+संख्याग्रहणे बह्वादीनामेव अहर्ण स्थात्मकरणस्याभिधानियामकत्वसिद्धात्क्त्रिमाह ` 
+Fart: इत्रिसे कार्यसम्प्रत्यय इति न्यायात्‌ ? I6 is taken from the 
+
+| Mahabhasya where it appears several times. In 1. 1, 48 _ 
+
+(vart. 3), it is followed by the example “ लोके गोपालकमानय _ 
+
+कटजकमानयेति Tea संज्ञा भवति स आनीयते न यो गाः पालयति यो दा 
+
+कटे जातः ”. Siradeva includes it in his collection of paribhasis J 
+
+
+NC Aes 
+कॅवळवचनानधनाधमर्णिक इव साधून्‌ भामयन्‌ ॥ 
+Like an impecunious debtor deceiving the money-lenders 
+with empty promises, This occurs in Atmatattvaviveka, pa 
+
+
+20, as follows:—« अवस्तुत्वादिति चेन्नन्वेतदपि कुतः सिद्धम्‌ aaa 
+विरहादिति चेत्सोऽयमितस्ततः केवलेवचनेर्नि धनाधमर्णिक =e R 
+
+
+रस्पराश्रयदोषमपि न quaft. 
+कक CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+TT 
+
+
+Digitized By Siddha 189 eGan gotri Gyaan Kosha 
+
+
+क्रिया हि विकल्प्यते न वस्तु ॥ 
+
+
+Action may vary, but substance cannot. This is plainly 
+set forth in S'ankarabhasya, 1. 1. 2 (page 37) as follows:— 
+॥कर्हुमकघुमन्यथा वा कहुँ शक्यं लोकिकं वेदिकं च कमे । यथाश्चेन गच्छति 
+पद्यामन्यथा वा न वा गच्छतीति । ......न तु TRA नेवमस्ति नास्तीति वा 
+
+
+विकल्प्यते ^. Similarly in 2. 1. 27 (page ४॥1):-- किय़ाविषये हि-....- 
+विकल्पाश्रयणं ...- इह तु विकल्पाश्रयणेनापि न विरोधपरिहारः संभवलपुरुप- 
+
+
+तन्त्रत्वाहस्तुनः 
+
+
+Then, in Anandagiri's comment on 1. 4, 1 (page 325), we 
+find the expression क्रियायामिव वस्तुनि-विकल्पाभावात्‌, ˆ and on 
+page 359, “न हि qu विकल्पो$स्ति.? It occurs also on the 
+first page of the Rāmānuja chapter of Sarvadars'anasang- 
+raha:—“q च सदसत्त्वयोः परस्परविरुद्धदयोः समुच्चयासंभवे विकल्पः किं न 
+स्यादिति वादितव्यं क्रिया हि विकल्प्यते न वस्त्विति ama.” “Nor 
+should any one say: Granting the impossibility of the co- 
+existence of existence and non-existence, which are reciprocally 
+contradictory, why should there not be an alternation between 
+existence and non-existence, there being the rule that it is 
+action, not Ens, that alternates ?” This rendering is Professor 
+Gough’s, The nyaya is found, too, in S'astradupika 1. 8. 8 
+(page 154, line 6 ), and Naiskarmyasiddht iii. 82. 
+
+
+SE: mou नीराजना ॥ 
+e lustration of arms? 
+
+
+What connection has ७ camel with th 
+
+None at all; and the phrase is used to indicate that certain 
+things are not connected. The नीराजनाविधि (28 described 1n 
+Chapter 267 of the Agni Purina) was 4 ceremony performed 
+by kings or generals before going forth to battle, and consisted. 
+
+
+of the purification of the component parts of the army, in- 
+Jephants, and the weapons 
+
+
+cluding that of the horses, the 0 र 
+Raghuvams'a iy. 25, on 
+
+
+T Jj E - 
+he चाजिनीराजनाविधि is mentioned in 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+which Mallinatha remarks:—‘ वाजिग्रहणं = ; 
+सपि नीराजनाविधानात्‌.? The illustration appears in Upami. 
+bhavaprapancé Katha, page 522:-- नद्यादिवस्त॒ भेदाश्च कथितं मे 
+
+
+| | Digitized By Siddhanta eGangotri fgypan Kosha 
+| 
+| pu ~ ~ ` » 
+कथाचकमू | त्वयेद तत्र म भाति mig नीराजना gw tl 
+
+
+| क्षते क्षारमिव ॥ 
+
+
+डा Like salt on a wound. “क्षार क्षते क्षिप्‌ has become ndi j 
+
+| and means ‘to aggravate the pain which is already unbearable! 
+‘to make bad worse, ‘to add insult to injury" (Apte’s Dic - 
+i tionary). He cites Utiararamacarita iv. 7 :-+“य एव मे जनः 
+| पूर्वमासीन्‍्मूत्तों महोत्सवः । क्षते क्षारमिवासह्यं जातं ada दनम्‌.” Also 
+i Mricchakatika V. 18. I have met with it again in Upamiti- 
+bhavaprapanca Katha, page 5, verse 42 “कथां कामार्थयोस- 
+| सान्न कुर्वीत कदाचन | कः क्षते क्षारनिक्षेपं विदधीत विचक्षणः” y There is 
+ग्या another example on page 993 of the same. 
+
+
+£| गर्गशतदण्डनन्यायः ॥ E 
+i The figure of the infliction of a fine of one hundred on the 
+| Gargas. There are two paribhasis which are freguently found 
+| together in the Mahabhisya, viz. “प्रत्येकं वाक्यपरिससास्तिः” a a j 
+i “समुदाये वाक्यपरिसमाप्तिः” Professor Kielhorn (in his transi 
+tion of Nagojibhatta ) renders them (the latter slightly modi 
+fied) thus:—“What is stated (in grammar of several things) + 
+must be understood (to have been stated ) of each of 
+separately,” And “sometimes (it) also (happens that wha bi & 
+stated in grammar of several things) must be understood | 
+
+
+have been stated) of all of them collectively.” Patanjali’s 
+illustration of the former is 
+
+
+“देवदत्तयज्ञदत्तविष्णुमित्रा भोऽ 
+ate person is to be fed; 
+“गर्गोः शतं दण्ड्यन्ताम्‌?” W 
+fined a hundred, The 
+
+
+LER 
+
+
+Digitized By Siddhafith eGangotri Gyaan Kosha 
+
+
+The two paribhasas and examples are quoted by S'abara on 
+Jaimini 3. 1. 12 ( page 223), and the second one is referred to 
+as follows by Kumarila in his vartika on the same passage 
+(page 712):—“ gx: पुनराह सत्यमेष न दोष इति। क्रियाप्राधान्ये तु तह 
+शीकृतबिशेषणसमुदाये वाक्यपरिसमाप्तिः । गर्गेशतदण्डनहोमाभिपवभक्षवदिति 
+परिहारः | न तु दण्डस्य दण्ड्यसंस्कारत्वाज्ञोजनादिवटतिगर्गमावृत्ति: प्राप्नोति । 
+न्नेष दोपः | 
+
+शारीरो निग्रहो यत्र तत्र प्रत्येकभिन्नता | 
+हिरण्यादानदण्डस्तु समुदाये समाप्यते” ॥ 
+
+This paribhisi occurs also in Taméravartika 1. 4, 3 
+(page 294, line 15), and in 1, 4 8 (page 300); whilst the 
+former one is quoted in 1. 4. 18 (page 314). 
+
+
+गतेस्थमृतसर्पन्यायः ॥ 
+
+
+The simile of 6 snake lying dead in a hole. It is employed 
+by Vijnina Bhiksu (in his Brahmasitrabhasya 1. 1. 2, page 
+36) when explaining the line “प्राक्सृष्टेः प्रल्यादूध्वे नासीत्किचि- 
+द्विजोत्तम ? from the Narasimha Purana. He says “ नासीदिति 
+विरतव्यापारतया कारणरूपेण गर्वस्थरूतसपैवद्विलीनमासीदित्य्थः us 
+on page 96 of the same—^ एवं aaa at च End गुणत्रयरूपिणीं 
+निसामपि निव्यापारतया गर्तस्थर्टतसर्पवत्करणकारणविविक्ते चिन्मात्रे विलापः 
+
+
+यन्ति.” On the next page we have it again, in 8 similar con- 
+nection, as ख़तसपेचत्‌- 
+
+
+oo ——्FE 
+
+
+गाहपत्यन्यायः ॥ 
+
+The rule as to the [application to the] Garhapatya-fire [of a 
+mantra in which reference is made to Indra) This represents 
+Mimàmsasütras 3. 2. 3, 4 where the Vedie Du. ८ निवेशनः 
+सङ्गमनो वसूनामिलेन्द्रया गाईपत्यमुपतिष्ठते i5 discussed. ‘The question 
+is raised whether, since the mantra makes mention of Indra 
+
+
+JU es Misi arhapatya (one 
+the adoration is addressed to him or to the Garhapatya ( 
+6 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri gaan Kosha 
+
+
+of the three sacred fires perpetually maintained by ७ hong 
+holder, and from which fires for sacrificial purposes are li * 
+ed). Jaimini's decision is in favour of the latter on the d 
+that direct enunciation (s'rufi) is stronger than ह. 
+power (linga). The following extract from Arthasangraha 
+page 6, with Dr. Thibaut’s translation ( page 11), will explain 
+this:—“ सेयं श्रुतिलिज्ञादिभ्यः मबला।..-अत एव ten Rea: 
+त्वम्‌ | किंतु ten mirage इत्यत्र गाईपत्यमिति दवितीयाश्रुस्ा 
+गाह॑पत्योपस्थानार्थत्वम्‌.?? “Direct enuniciation is stronger than 
+suggestive power and the other proofs (by which one thing is 
+shown to be subsidiary to another ); ...for this reason we do not 
+conclude at once on the ground of suggestive power that 8 
+verse (apparently) addressed to Indra (that is, a verse con- 
+taining 2 mention of Indra’s name, or one of his attributes &,) 
+18 really to be used for addressing Indra; but rather decide if 
+we find at the same time a direct enunciation as, for instance, 
+“with a verse bearing Indra's mark he addresses the Girt, 
+patys, that in consequence of the direct enunciation of the 
+second case termination (Garhapatyam ) the verse is subsi 
+gay to the act of addressing the Garhapatya-fire.” The words 
+निवेदन: सङ्गमनो quen, which, amongst other places, are 
+found in the Atharvasamhita x. 8, 42, are rendered by Pro- 
+fessor Whitney “The reposer, the assembler of good things” 
+and by Mr. Griffith, “Luller to rest, and gatherer up of 
+treasures,” As quoted in S'atapatha Brakmana 7. 2. 1, 20 
+Prof. Eggeling translates it “The harbourer and gatherer of 
+ae Who shall decide between these learned doctors? 
+The Garhapatyanyaya is explained and applied in Bhamatt 
+3. 8, 25 ( page 613), and in other works on Vedanta. Owing 
+to the word G1 in sūtra 3, the adhikarana is sometimes 
+styled एन्द्री न्याय. 
+
+
+RE eres IMG 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+lus ELT 
+
+
+Digitized By Siddhagig eGangotri Gyaan Kosha 
+
+
+गोदोहनन्यायः ॥ 
+
+
+The simile of the milk-patl. Tt is laid down that a sacri- 
+ficer who wishes for cattle must bring the water for his sacri- 
+fice in a milk-pail. But that is not done in other cases. The 
+godohama, is therefore used as an illustration of something 
+which is occasionally, and not universally, connected with 
+an act or performance as an essential part of it, It occurs 
+in S'ankarabhasya 3. 3. 42, as follows—“‘gta क्मोङ्कव्यपाश्रः 
+याणि विज्ञानानि 'ओमिल्येतदक्षरसुद्दीथसुपासीत' इत्यवमादीनि । कि तानि निः 
+द्यान्येव स्युः कमैसु पर्णमयीत्वादिवहुतानित्यानि गोदोहनादिवदिति विचारयामः? 
+Then, at the close of the same: तस्माद्यथा कऋत्वाश्रयाण्यपि गोंदोहनाः 
+दीनि फलसंयोगादनित्यान्येवसुट्रीथाद्युपासनानीत्यपि द्रष्टव्यम्‌” It appears 
+again in 8. 3. 65; 3. 4, 45, and in 4 1. 6. Sures'vara quotes it 
+also in his vartika on the Brihadaranyakopanisad 8. 3. 5l:— 
+“न च गोदोहनन्यायः काम्यकर्मसु युज्यते । तेपां सुक्तिफलत्वे हि न मानं 
+विद्यते यतः” ॥ 
+
+
+For the mantra regarding the use of this pail, see S'abara 
+and Nyayamdlavistara on Jaimini 4, 1. 2. Other references 
+to the nyaya are Tantravartika 3. 6. 43 (page 1118) n and 
+ANyayamamnjari, page 166, line 4, in connection with which a 
+verse is quoted from S'lokavartilta (page 63 ) where mention 
+is made of the godohama. Kunte’s long note on the sutra of 
+Jaimini referred to above will be found useful. 
+
+
+it मुख्ये K E £ 
+गोणमुख्ययोमुख्ये कार्यसम्प्रत्ययः ॥ : 
+When a word has both a primary and a secondary es i 
+ing, ०७ operation takes effect (only) when the word coat 
+JA Primary meaning. This is an abridgment of E St 
+Kielhorn’s rendering of Nagojibhatta’s fifteenth paribhasa ; 
+and the following extracts from the vritti may help to explain 
+is hich à in a secondary sense 18 SO J 
+A word which is employed in : 
+
+
+rat Shastri Collection. 
+
+
+| E 
+| 
+| 1 
+
+
+Digitized By Siddhanta eGangotri £ aan Kosha q 
+
+
+employed ( only ) because (the character of that which it de. 
+notes in) its primary sense is ascribed (to that which if denotes 
+in a secondary sense)" “For example, the word गो Ox" con. 
+veys the secondary meaning ‘one who is only flt for bearing 
+burdens, an unintelligent person; because (such a. person has) 
+certain qualities such as stupidity &e, (in common with 
+an ox Y’. 
+
+
+The nyaya appears in the above form in Mahabhasya 1.1, 
+15, and 6. 3. 46; but in 1. 4. 108, and in 8. 3. 82, the word apt 
+is omitted. In this shortened form it is quoted by Anandagiri 
+on Brahmasitrabhasya 1. 2. 18 (page 185), and 1. 8. 14 
+(page 246) Then in 4. 3, 12, S'ankara says “परं हि ब्रह्म ब्रह्म 
+शब्दस्य सुख्यमालंबनं गोणमपरम्‌ | मुख्यगौणयोश्र get संग्रत्ययो भवति” 
+In Vedantakalpataru, page 346, line 3, we read —“ag aleani 
+वस्तु प्रायदशनान्निर्णीयत्ते गाणसुख्यग्रहणविपये' च HA सम्प्रत्ययः”. 
+
+
+In S'abara's bhisya on Jamini 8. 2. 1 ( which deals with the 
+Barhirnyaya ) we have a very interesting discussion on गोण 
+and मुख्य, in the course of which he says “नह्यनाभिधाय मुख्य गोण- 
+मभिवदति शब्दः”. The conclusion arrived at is thus espressed:— 
+“ तस्मान्मुख्यगौणयोर्सुख्ये कार्यसम्प्रत्यय इति eq.” 
+
+
+अहेकत्वन्यायः ॥ 
+
+
+; The illustration furnished by [the mention of the washing of 
+
+1 one cup only. This is the title of the adhikarana comprising - 
+Mimamsastitras 3. 1. 13-15 in which the passage relating to the > 
+cleansing of the Soma-cups is discussed. The direction given - 
+is “दद्यापवित्नेण अहं dane’, “he cleanses the cup with a fringed | 
+filtering-cloth.” But there are many such grahas in use; I | 
+only one of them to be washed ? The decision is that all 3 
+
+
+be cleansed; and this, according to MM (who is closely 
+followed KR fete Yet Shasit Col imamsaparibhash), ` 
+
+
+Digitized By Siddhantg eGangotri Gyaan Kosha 
+
+
+because one represents the whole, and also on the ground of 
+the rule that “a subordinate act is to be repeated in the case 
+of each principal thing.” The cup is here the ‘principal? and 
+the act of cleansing is ‘subordinate, and is therefore to be 
+repeated until each one has been cleansed. The passage stands 
+thus in the Nydyamaldvistora:—* ग्रहमिति द्वितीयया ग्रहस्योद्देश्यतया' 
+प्रयोजनवत्तया च प्राधान्यं end । अहं प्रति गुणः dum । ति प्रधानं च 
+गुण आवर्तनीय इति" न्यायेन यावन्तो ग्रहाः सन्ति ते संमाजनीयाः” ॥ 
+
+Kumárila explains this in the following karika of Tanira- 
+vartika 8. 1. 14:— 
+
+““व्यक्तीरुदिइ्य यत्कर्म खजात्याद्युपरक्षिताः । 
+Bet गुणभावेन qaa प्रतीयते” 
+
+For further applications of the nyaya by him, see pages 339 
+(line 4 from bottom ) and 551 (line 13). For its use outside 
+the Mimamsa, see Nyāyamanjarī, page 287, lime 4; and 
+Vedantasikhamani, page 120. The grammarian Nagesa- 
+bhatta, too, in his exposition of Kaiyata on 1. 1. 14 (page 319) 
+writes thus :--“ग्रहं संमाष्टींत्यादो तु ग्रहा्थत्वात्संमागस्य STET प्राधान्यमिति 
+न तद्गतसंख्या विवक्षितेति भावः? ॥ “See, too, Kaiyata on the closing 
+part of Patanjali 1. 1. 69 (vol. i. p. 169 bof Benares edition; 
+or page 450 ( column 1) of the Nirnayasagar edition of 1908). 
+
+
+—————— 5 
+
+
+ग्राव्णि रेखेव ॥ è, 
+
+Like ० delineation on stone. Used of something unalter- 
+ably fixed. “तन्मां वञ्रकुमाराय सम्प्रदत्तान्यथा उ से । मरणं शरणं तात 
+sift रेखेव गीरियम्‌.” Paris'istaparean > 275. Compare 
+Job's words (xix. 23):—“0h that my words were DOW written 
+eee that with an iron pen and lead they were graven 1n 
+the rock for ever.” 
+
+
+EE 
+
+
+MT I न nl 
+
+
+* E his ; 
+or this, seechalo Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta अशेशा Na Kosha 
+
+
+चन्दनन्यायः ॥ E: 
+
+
+i | The simile of Sandal-oil. Badariyana uses this as an ill. 
+ral tration in sütras 2. 3. 23, 24, As the applieation of 8 drop o 
+नी the oil to one part of the body produces a pleasant Sensation in 
+
+| the whole of it, so soul, abiding in one part, namely in th 
+i heart, is yet perceived as present in 
+
+
+the entire: frame, 
+b S'ankara's exposition of the former sutra is as follows:— 
+
+
+iu “यथा हरेचन्दनविन्दुः शरीरेकदेशसंवद्धो$पि सन्सकलदेहव्यापिनमार दं 
+T. करोल्यवमात्मापि देहेकदेशस्थ: सकलदेहव्यापिनीमुपलादिध्र करिष्यति | 
+| त्वक्संबन्धाच्चाय सकलशरीरगता वेदना न विरुध्यते | त्वगात्मनोहि संबन्धः 
+M कृत्लायां त्वचि वतेते । त्वक्च Heater’. 4 
+
+
+चित्राजुनान्यायः ॥ 
+
+
+The simile of & woman in a picture. An illustration 0 
+that which has only an appearance of reality. Raghunatha 
+connects with this the चित्रानलन्याय and चित्रास्रतन्याय, and, in his 
+larger work, भगवान्वसिष्ठः is quoted as follows —— "raras mana 
+विद्वि चित्रानलं नानलमेव विद्धि । चित्राङ्गना नूनमनङ्गनेति वाचाविवेकस्वः 
+विवेक एवेति”. Like his other quotations from Vasistha, this 
+100, is from the Yogavasistha, where it stands as verse 4, 18. 69. 
+Others of a like nature are 4, 1. 11 and 12:_“चित्रोद्यानमिवोत्फुलमः 
+रसं सरसाङृति । प्रकाशमपि निस्तेजश्चित्राकौनरूवतिस्थितम्‌ ॥ अनुभूतं मनोरा" 
+ज्यमिवासत्यमवास्तवम्‌ | चित्रपद्माकर इव सारसोगन्ध्यवर्जितम्‌? ॥ | 
+6. 57. 28:--“चित्राभिदाहो विज्ञातो यथा दाह्येषु Rene: | तथाहं 
+ज्ञातं निष्फलतामियात्‌” ॥ aA 
+
+
+Digitized By Siddha eGangotri Gyaan Kosha 
+
+
+वस्तुनो विद्यमानानर्थनिवृत्तेश्न पुरुपार्थत्वं इष्टमत्र तदभावात्कथं पुरुपा्थत्वमिति 
+aa तयोरेव पुरुपार्थत्वमिति नियमाभावात्खच्छायायामारोपितरक्षसों विस्टृत- 
+कण्ठगतचामीकरस्य आन्तपुरुषस्याप्तवाक्येन तयो निवृत्त्याध्योरपि AE | 
+अन्न संग्रहः | 'आत्माज्ञानमल॑ निरस्तममलं ग्रां च तत्त्वं परं कण्ठस्थाभरणादिव- 
+ळमवशाच्छायापिद्याची यथा | आप्तोक्त्याप्तिनिवृत्तिवच्छृतिश्निरोवाक्यादरुरोरत्यि- 
+तादुस्तध्वान्तनिरासत: परसुखं प्रास तयोरुच्यत' इति ॥ 
+
+
+जळतुंबिकान्यायः ॥ 
+
+
+The simile of ७ gourd 4m water, The idea is that of & 
+gourd, thickly covered with mud, and therefore sinking in the 
+
+
+water, but gradually resuming its buoyancy as the mud i8. 
+
+
+washed off. The Digambara Jains use the figure to illustrate 
+the release of the soul from the encumbrance of the body. 
+Raghunatha puts it thus:— wt पंकलिप्ता तुंबिका नदीसमुद्रादौ 
+मजन्ती पंके क्षीणेड्वकाश आगत्य तिष्ठति तथा जीवो देहादिपंके क्षीणेऽलोका- 
+कारो mar तिष्टति । अयमेव तस्य मोक्ष इति दिगम्बराः । इति जलतुंबिका- 
+न्यायः”? a 
+
+
+This description, without mention of the nyaya, is found in 
+very similar language in the Jaina chapter of Sarvadarsana- 
+sangraha (page 48 of Jivananda's edition), and also in Vedan- 
+takalpatarwparimala, for which see the पन्भरसुक्तपक्षिन्याय 
+below. The former passage is 88 follows:— «Tr वा के T 
+कृतमलाबुद्धव्यं जरेऽधःपतति पुनरपेतसत्तिकाबन्थमृध्वे गच्छति तथा कसैरहिंत 
+आत्मा असङ्गत्वादूध्वे गच्छति बन्धच्छेदादेरण्डबीजवचो््वगतिसवभावाचासिः 
+शिखावत्‌.” ‘The figure of the castor-oil seed is found in the 
+Parimala passage also. The term अलोकाकारा which appears m 
+Raghunatha’s definition, is the name of & subdivision of one of 
+the five categories (astikaya) of the Jaina system. Tt is explain- 
+ed as follows by Anandagiri on Brakmasitr 
+(page 563 ) E द्वेधा लोकिकाकाशोऽछो काराय ब A 
+लोकानामस्तर्व॑र्ती लोकाकाशः । तदुपरि मोक्षस्थानमळोकाकाश: + 18 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+abhāşya 2. 2. 33 
+
+
+Digitized By Siddhanta eGangotrlGyaan Kosha 
+
+
+is:—" However often they go away, the planets return, : sun, 
+moon, and the rest; but never to this day have returned 
+any who have gone to Alokakis‘a.” This should of course be 
+Alokaküsa, as the long vowel includes the preposition आ. 
+‘up to,’ ‘as far as, “those who have reached Alokükasa" (आ. 
+अलोकाकाशम ). 
+
+
+—_—__ 
+
+
+जातेष्टिन्यायः ॥ 
+
+
+The law regarding the oblation on the birth of a son. This 
+is the subject of Jaimini 4, 8, 38, 39. The question arises 
+whether the offering is for the benefit of the father or the son 
+(तत्र सन्देहः किमात्मनिःश्रेयसाय उत gafr: derme), and the answer is 
+that it benefits the latter. In the commentary on Laksanavali 
+this is applied as follows: नहि चेत्रानुष्ठिताभिहोत्रजनितमपूव 
+चेत्रसमवेतं मैत्र स्वरफलभागिनं कठुसुत्सहते | पुत्रेष्टिपितृयज्ञवदेतत्य्यात्‌ । त। 
+तन्नाप्यतिशयस्य पुत्रादिसमवेतत्वेनेवाभ्युपगमात्‌. 22 E 
+
+
+जामातृञुद्धिन्यायः ॥ 
+
+
+The story of the son-in-law's revision [of a book}, Th 
+is the original of the Marathi Hazara which Molesw 
+defines as * A phrase, founded on a popular story, to express 
+the examination of a piece of a composition by a shallow- 
+
+
+fellow incapable of discerning its merit.” The popular sto) 
+given on pages 6-9 of Merutunga’s Prabandhacing, ama 
+
+
+Vi i, having been instr 
+TomB) 
+
+
+Digitized By Siddhagtg eGangotri Gyaan Kosha 
+
+
+him by ber when his pupil, palmed off upon her an ignorant 
+cowherd as 8 man of learning! ‘The king accepted him, and he 
+became his son-in-law. “In accordance with the advice of the 
+pandit, the herdsman preserved unbroken silence; but the 
+princess, wishing to test his cleverness, entreated him to 
+revise & newly-written book. He placed the book in the palm 
+of his hand, and with a nail-parer proceeded to remoye from 
+the letters in it the dots and the oblique lines at the top 
+indicating vowels, and thus to isolate them, and then the 
+princess discovered that he was a cowherd. After that the 
+‘son-in-law’s revision’ became a proverb everywhere.’ This 
+quotation is from Mr. C. H. Tawney's admirable translation of 
+Merutunga's work; the original being as follows:—“qfteqt- 
+पदिष्टं सवैथा मौनमेवालम्बमानो [ महिषीपालः ] राजकन्यकया dager 
+जिज्ञासया नवलिखितपुस्तकस्य शोधनायोपरुद्धः | करतले पुस्तकं विन्यस्थ 
+तदक्षराणि बिन्दुमात्रारहितानि नखच्छेदिन्या केवलान्येव TA राजपुता 
+महिषीपाल एव Rolla: | ततःप्रश्गति जामातृशुद्धिरिति सवेत: प्रसिद्धिरभूत्‌. 
+In the subsequent part of the story we are informed that 
+the cowherd eventually became the famous poet Kalidasa ! 
+For a similar account from a Buddhist source, see Indian 
+Antiquary, vol iv. page 108; also vol vii. page 116. 
+
+
+A e 
+ज्ञानमज्ञानस्येव निवतकम्‌ ॥ 
+
+Knowledge {of Brahma] abolishes nothing but the ignorance 
+[which obscures that Impersonality]. This is a bit of VGH 
+ism pure and simple, and has scant claims to ७ place amongst 
+Popular maxims, It’ is admitted solely because Raghunétha 
+includes it in his list. His explanation is as follows:—‘‘snatal- 
+ध्यासेडज्ञानं कारणम्‌ । तत्त्वज्ञानेन वातदीपन्यायेन saga 
+तदध्यासो5पि Hada । न च ज्ञानेनैवोभयनिदृत्तिः कुतो स्यात्‌ । STU 
+
+
+जानस्यैव निवतेकमिति न्यायबिरोधात्‌ । द्विविधा हि निवृत्तिः । विरोधिना. 
+
+
+Wa च । यथा वातादिना दीपनाशों यथा च pe 
+iu । तत्रा्या-निबत्तिगनञ्दछ RAAT ॥ 
+
+
+DE cR ४५:४२ 
+
+
+Digitized By Siddhanta SC no sgan Kosha 
+
+
+The so-called nyaya is found in Vivaranaprame 
+
+
+yasangrala, 
+page 8, line 9, and in Pancapadiha, page 1, 
+
+
+डमरुकमणिन्यायः ॥ 
+
+
+The डमरुक or डमरू, is a sort of small drum, shaped like an 
+hour-glass, and held in one hand: The साणि is, I suppose, the 
+small piece of wood attached to the string tied round the 
+middle of the drum, which strikes each end alternately as it is 
+‘shaken in the hand, and thus fulfils a double purpose. The 
+garudis, or conjurors, use a drum of this kind ; and Apte's 
+dietionary tells us that the Kapalikas carry one, (For a 
+description of the latter, see Wilson's Religion of the Hindus 
+Voli pages 21 and 264.) The nyaya is found in Syadvada. 
+mamjari page 84, where in explaining the words “नोल्सृष्टमन्या- 
+थैमपोद्यते च? in Hemacandra's eleventh karika, Mallisena says, 
+“अन्यार्थमिति मध्यवर्ति पढं डमरुकमणिन्यायेनोभयत्रापि सम्बन्धनीयम्‌.” 
+See the nyaya “अपवादेस्त्सर्गा बाध्यन्ते’? and compare also, the 
+घण्टालोलान्याय 01 page 35 of Syüdvadamanjari. | 
+
+
+तटादशिशकुन्तपोतन्यायः ॥ ; 
+
+
+The simile of 6 young bird which [has got out to sea 018 
+floating log and ] is unable to discover the shore. Its applica 
+tion is obvious. It occurs in the second line of verse 19 of | 
+Hemacandra’s in Syadvadamanjari, as follows: —* 
+शङुन्तपोतन्यायाच्वदुक्तानि परे श्रयन्तु. Mallisena explains ib thus: 
+“ae न पञ्यतीति तटादर्शी यः शकुन्तपोतः पक्षिशावकस्तस्य न्याय उदाहरणम्‌ 
+तस्माद्यया किल कथमप्यपारपारावारान्तःपतितः काकादिशकुनिश्यावको बहिँ 
+निर्जिरामिषया म्रवहणकूपस्तंभादेस्तरम्रापये सुग्धतयोड्डीनः समन्ताजलेकाणेवमे 
+वावलोकयंस्तटमरट्रैव Riga तदेव कूपस्तंभादिस्थानमाश्रय्ते गरः 
+न्तराभावादेवं तेऽपि कुतीथ्यीः प्रायुक्तपक्षत्रयेडपि वस्तुसिद्धिमनासादयन्तरू 
+
+
+क्तमेव Taa a calles area ग्रतिपद्च 
+
+
+Digitized By Siddharth eGangotri Gyaan Kosha 
+
+
+तत्कतुन्यायः ॥ 
+
+
+The principle of meditation on that [viz. Brahman], Or, ote 
+who meditates on that. This is taken from Bralimasutra 
+43. 15, “ अप्रतीकालंबनाज्ञयतीति वार्दरायण उभयथाषदोपात्त्कतुश्र ?. 
+The bhàsya on the last term is as follows:—“ तत्क्रतुश्रोभयथाभावः 
+e समर्थकों देतद्रेश्‍्व्यः । यो हि ब्रहमकरतुः स ब्राह्ममेश्रयेमासीदेदिति शिष्यते 
+«qoam यथोपासते तदेव भवति’ इति श्रुतेः | न तु प्रतीकेषु बह्मक्रतुत्वमस्ति 
+प्रतीकप्रधानत्वादुपासनस्य | नन्वत्रह्मकतुरपि ब्रह्म गच्छतीति श्रूयते यथा 
+पञ्चा्चिविद्यायां “स aa गमयति [ छा ५. १ ०. २] इति । भवतु ae 
+वमाहत्यवाद उपलभ्यते तदभावे व्वौत्सर्मिकेण तत्कतुन्यायेन बह्मक्रतूनासेव 
+तस्प्रा्तिर्नेतरेपामिति गम्यते”. I subjoin Dr. Thibaut's rendering, 
+with a few additions of my own in parentheses. “ The words, 
+‘and the meditation on that, state the reason for this twofold 
+relation [viz. of those who meditate on Brahman with qualities, 
+and those who worship by means of symbols or images} For 
+he whose meditation is fixed on Brahman reaches lordship like 
+that of Brahman, according to the seriptural relation, ‘In what- 
+ever form they meditate on him, that they become themselves.’ 
+In the case of symbols, on the other hand, the meditation is nob 
+fixed on Brahman, the symbol being the chief element in the 
+meditation.—But scripture says also that persons whose mind 
+
+
+is not fixed on Brahman go to i5; 80 in the knowledge [ mle d 
+
+
+the doctrine (vidya )] of the five fires, ‘He leads them & 
+Brahman. —This may beso where we observe a direct scrip- . 
+tural declaration. We only mean to say that, where there 18 
+no such declaration, the general rule is that those only whose 
+purpose is Brahman [i e. whose mind is fixed on B.] go to it; 
+not any others" ‘This is a noteworthy passage. a practically 
+condemns the use of symbols, or images, in worship, by declar- 
+ing that the mind of the upasaka s directed to the TREES 
+and not to Brahman (or Ts'vara). The sruti, “ तं यथा यथोपासते 
+We.” which is quoted also in 3. 4. 52, may mean much more 
+
+
+than Sank: an aie for it is an undoubted fact that, in 
+ara WOR Bor Satya Vrat Shastri Collection. ड 
+
+
+* 
+
+
+a 
+
+
+Digitized By Siddhanta eGangotrk@yaan Kosha 
+the present life, the worshipper becomes assimilated to 
+j object of his worship; that the characteristics of that object, a 
+conceived by him, become his own characteristics ; and that 
+man never rises above the moral or spiritual level of tha 
+which he worships, This was clearly set before the Jewish 
+nation in the teaching of Psalms cxv and CXXXY, where, र 
+with reference to the making and worshipping of images, wa 
+read " They that make them shall be like them, every one tha 
+trusteth in them” ( Revised version ). d 
+
+
+E The तत्क्रतुन्याय, Which, in its full form seems to be तत्क्रतुस्तद्भवतिं 
+“| (as in Anandagiri on the closing part of 4. 8. 15), is constantly - 
+
+quoted in the Vedantakalpataruparimala, It will be found 
+: on pages 229 ( three times), 230 (line 9), 235 (line 11), 246 
+d (line 6), 478 ( line 1), 591 (line 4 from bottom ), 669 (line 10), 
+and 730 (lines 9 and 15). Also Pancadas't ix. 145. 3 
+
+
+तत्मख्यन्यायः ॥ 
+
+
+The principle that there is another scriptural passagi 
+declaratory of it ( namely, of the secondary matter connect 
+with a sacrifice, such as the deity to whom it is offered, th 
+materials to be used, &). The nyaya represents Jaimini! 
+sutra 1. 4. 4 ( तत्प्रख्यं चान्यशास्त्रम्‌ ), and is one of the four mean 
+
+. by which Mimamsakas prove that an injunction comes und 
+the head of नामघेय (‘name’), and is not a गुणविधि (1 à 
+injunetion relating to the accessories of the sacrifice,” proyisio 
+being made for them in other scriptural passages). Th 
+other tests are styled मत्वर्थलक्षणा (* possessive i 
+
+चाक्यमेद (‘split of the sentence’ caused by the inclusi d 
+. Or more distinct topics), and तब्यपदेशन्याय ( which see be OW 
+
+
+Digitized By SiddhamteGangotri Gyaan Kosha 
+
+
+यागस्य द्वे रूपे व्यं देवता च। तथा च रूपाश्रवणेऽसनिहोत्रं जुहोतीति कथमुत्पत्ति- 
+विधिः। अभिहोत्रराब्दस्य तु तत्मख्यन्यायेन नामघेयत्वादिति चेन्न । रूपाश्रवण5- 
+प्यस्योत्पत्तिविधित्वात्‌ । अन्यथा रूपश्रवणाइन्ना जुहोतीत्ययमेवोत्पत्तिविधिः 
+द्यात्‌ | तथा चाझिहोत्रं जुहोतीति वाक्यमनर्थक स्यात्‌ (Page 4) 
+
+
+“That injunction which merely indicates the general nature 
+of some action is called * originative injunction, as, for instance, 
+the passage ‘He is to offer the Agnihotra oblation’ But it 
+may be objected, the two forms (aspects) of a sacrifice are 
+the material (offered) and the divinity (to whom the material 
+is offered). How then can the passage ‘He is to offer the 
+Agnihotra-oblation, in which neither of these two forms is 
+mentioned, be considered an originative injunction, the word 
+Agnihotra (which seemingly indicates the divinity of the 
+sacrifice, viz. Agni) being merely a name (and not indicating 
+the divinity) according to “the principle of (the existence of 
+another scriptural passage ) declaratory of it. To this objection 
+we reply:—The passage is an originative injunction although 
+neither of the two forms of the sacrifice is mentioned in it, 
+Otherwise the passage ‘ He is to perform the oblation by means 
+of sour milk’ would have to be considered as the originative 
+injunction ( of the Agnihotra ) as it contains a statement of one 
+of the two forms (viz. the material ), and then the passage “He 
+is to offer the Agnihotra’ would be purposeless" ( Page T). 
+
+Again on page 20 of the same:— : 
+“एवं च प्रयाजेषु समिदादिदेवतानां समिधः “समिधो अझ आज्यस्थ व्यन्तु? 
+इत्यादिमन्रवर्णेभ्यः mana | समिधो यजतीत्यादिष समिदादिशव्दासअख्य- 
+शास्त्रात्कमेनामधेय़ा:? ॥ 
+of firewood called samidh 
+
+
+the divinities of the Prayaja | 
+
+
+* 
+
+
+A 
+
+
+Digitized By Siddhanta eGangotr-Gyaan Kosha r 
+
+
+be taken as names of certain sacrifices (not as denoting 
+secondary matters) on account of another scriptural Passage 
+declaratory of it.” 
+
+The nyaya is explained in almost identical language in 
+Apadeva’s work Mmimsanyayaprakasa, and is applied in 
+Vedantakalpataruparimala, page 150, line 7. We find it, 
+also, in Nages'a's Uddyota (vol. 3. page 623), under sūtra 2, 3.3. 
+
+
+तत्स्थानापन्ने quen: ॥ 
+
+
+One who takes the place of somebody else takes upon 
+himself also the functions of the latter. This is Professor 
+Kielhorn's rendering of the maxim as found in Nagojibhatta’s 
+comment on paribhasi cxvr It may have originated with 
+Kaiyata. On Pānini’s sūtra 1. 1. 56 (स्थानिवदादेदाः &e.) Katyayana 
+says “ स्थान्यादेशपथक्त्वादादेशे स्थानिवदनुदेशो गुरुवहुरुपुन्न इति यथा. ” 
+Patanjali follows with the remark “ लोकत एतात्सिद्धम्‌। quii 
+लोके यो यस्य प्रसंगे भवति रभतेऽसो तत्कायांणि। तद्यथा। उपाध्यायस्य शिष्यो 
+याज्यकुळानि गत्वा अग्रासनादीनि लभते.” Then Kaiyata says 
+“लोकत इति। लोके हि वचनमन्तरेणापि तत्स्थानापत्त्या queni eu" ll 
+Under sūtra 1. 1. 4, Nages'a Bhatta prepares us for this with 
+the remark (on page 209 of his Pradipoddyota) “saaneen 
+E तत्स्थानापन्ने तद्धर्मलाभ ” इति लोकन्यायेनातिदेश इति स्थानिवत्वे 
+ae १7 है 
+
+
+तदन्तापकर्षन्यायः ॥ 
+
+
+This nyaya, which is found in Vedantakalpataruparimala, 
+page 581, line 9, and again in line 8 of the next page, is taken 
+from the तदादितदन्तन्याय of Jaimini 5. 1. 23, 24, the अनुयाजायुत्कपे 
+'प्रयाजान्तापकर्षाधिकरण, which Kunte renders "The subject of 
+
+
+ण ERRAT Tena 040 /800क्ष the Anuyaja ofari 
+and the backward transference of acts which precede 97१४ 
+
+
+w Ese C 
+
+
+| 
+
+
+Digitized By Siddhast3 eGangotri Gyaan Kosha 
+
+
+offerings together with the offerings themselves.” Regarding the 
+तदादितदन्तन्याय he says:—“Tadadi signifies the first part of 
+that; the Tadanta signifies the last part of that. These are 
+Bahuvrihi compounds, and therefore signify that of which the 
+frst part is taken, and that of which the last part is taken, 
+When forward transference is to be made, the Tadadi is taken 
+and when backward transference is to be made, the Tadanta is 
+taken. ‘The following illustration will explain this. When the 
+Anuyája-offerings are to be transferred in point of time, the 
+Süktavàka and the Shanyuvaka which follow it, are to be 
+“transferred along with it, because the Anuyaja is the first part, 
+Again, when Prayaja-offerings are to be transferred in point of 
+time, the Aghara and the Samidheni which precede it, are to 
+be transferred along with it, because the Prayaja is the last 
+part.” 
+
+
+तदागमे हि तदुश्यत इति न्यायः ॥ 
+
+The law that a certain thing is seen to appear when ७ 
+certain other thing appeurs [ thus establishing a connection 
+between them]. Raghunathavarman expounds it thus:— 
+“ज्ञाग्रदादौ बुद्धौ सत्यां दुःखादयो TAA zai तन्निवृत्तौ नोपलभ्यन्त 
+इति तद्धमी एव नात्मधमौः सुपुप्तावष्युपलब्धिप्रसंगादिलयत्र तदागमे हि qeu 
+इति न्यायोऽवतरति | दृश्यते हि तेळादचुदरूतस्पशतेजोऽवयवागमे सन्तापोपल- 
+ब्थिरिते qud एव न तैलादिधर्म इति.” I have met with it in the 
+following passage of the Tantravartika (page 348), and 
+quote Prof. Ganganath Jha’s translation of it:— 
+
+“तथा क्रमवतोनित्य प्रकृतिम्रत्ययांशयोः | 
+प्रत्ययश्रुतिवेलायों भावनात्सावगम्यते ॥ A 
+न केवलमेतावेवान्वयव्य॒त्रिकों यौ परस्परपरित्यागेन लक्षयते तसिन्नेव हिं पदे 
+तदारमे हि Tegra इत्यनेन न्यायेन विवेको 5वधायेते 
+
+
+“The Root and the Affix are always found to appear ina — 
+
+
+definite or nid ES of fact, we find 
+nite order ७6-54५४१ ४१५०१) Shasi mater 
+
+
+Digitized By Siddhanta ९०७५०39 Kosha 
+
+
+that it is only when the Affix is heard to be 
+we have an idea of the Bhavana; and this, too, : us 
+the conclusion that the Bhāvanā is denoted by the a’ 
+Because the invariable concomitance of any two objects in 
+only such that one cannot exist in the absence of the of, . 
+but also of a kind which we find in the present case, wh 
+
+
+we find that it is only where a particular word—the Affix for 
+instance—is pronounced that there is 
+Bhavana 
+
+
+e 
+pronounced, that 
+
+
+a denotation of the | 
+;and as such, in accordance with the rule that When 1 
+one object is always seen to appear when another appears, : 
+there is always an invariable concomitance between the two, | 
+we must admit that the Bhavand is denoted by the Affix.” 
+
+
+न 
+(p. 483). 
+
+
+I may add that the passage here cited from the Tantra- 1 
+vartika is closely connected with that quoted under the nyüya - 
+“ ग्रकृतिप्रत्ययो प्रत्ययार्थं सह ब्रूतः? which see below. | 
+
+—————— 
+
+
+तठ्ल्यपदेशन्यायः ॥ 
+
+The principle of & name indicating resemblance to some | 
+thing. This is the title. of Jaimini’s sütra 1. 4. 5, where the 
+Sentences “ अथैष इयेनेनाभिचरन्यजेत ”, “ अभैप सन्दंशेनांभिचरन्यजेत ” 
+and “ sif गवाभिचरन्यजेत ?? are discussed, and it is decided that 
+ma, area, and गो are not the materials of the various sacrifices, | 
+
+
+but their names. This 15 well put in Colebrooke’s Essay on the - 
+Mimamsa :-- 
+
+
+y "3 
+
+
+ह १७ ial OT 
+
+
+हु 
+
+
+“Tt is a question whethe 
+which is attended with i 
+performed by the actual 
+
+
+r the hawk-sacrifice ( s'yenayaga ) 
+mprecations on a hated foe, 
+immolation of a bird of that kind. 
+
+
+mem " 36 
+Digitized By Siddhantd €Gangotri Gyaan Kosha 
+
+
+This nyays, as pointed out under wazaa, is one of the 
+proofs applied in the Mimamsa in support of the नामधेय divi- 
+sion of the Veda, and Laugaksibhaskara (on page 20) explains 
+it thus:— 
+
+pos MS > c (UR PTS ^ 
+
+“इयेनेनाभिचरन्यजेतेत्यत्र VAT कर्मनामधेयत्व TATE | तेन 
+व्यपदेशादुपमानात्तदन्यथाजुपपत्तेरिति यावत्‌ ।...यदा तु इयेनसंज्ञकों यागो 
+विधीयते तदार्थवादेन इयेनोपमानेन तस्य स्तुतिः wd शक्यत इति इयेनशब्दः 
+कर्मनामधेयं तद्मपदेशादिति” ॥ 
+
+In this passage, and in a similarly worded one in Apadeut, 
+उपमान is given as the equivalent of व्यपदेश्य, whilst Kumarila 
+employs सादृश्य. The dictionaries, however, are silent as to any 
+such sense of the word. In his translation Dr. Thibaut renders 
+it * comparison.” 
+
+a *- è SS 
+qu ada सवध्यतं ॥ 
+
+Hot goes with hot. Like loves like. This is found in the 
+following passage of Bhāmatī 3. 3. 25 (page 620 )--“ न च 
+सन्निधानमपि संबन्धकारणम्‌ | अयमेति YA राशः पुरुषो$पसायेतामित्यत्र राज्ञ 
+इत्यस्य पुन्रपुरूषपदसन्निधानाविशेषान्मा भूदविनिगमना । तस्मादाकांक्षा निश्चय 
+हेतुर्यक्तव्या ।... ... सत्यपि सन्निधाने आकांक्षाभावादसंबन्धः। तथा चाभाणकः I 
+तपतं तप्तेन संबध्यत इति । तथा चाकांक्षितमपि न यावत्सन्निधाप्यते तावन्न 
+संबध्यते. w”? Mr. M. R. Telang has given me another excellent 
+example in Vikramorvast ii. 16 :--“ साधारणोऽयसुभयोः प्रणयः 
+स्मरस्य aa त्तमयसा घटनाय योग्यम्‌; » Compare, ४00, “TA waa 
+सङ्गच्छते? of Mricchakagika; (page 40). 1 might be used as 
+the equivalent of “ Birds of a feather flock together”? 
+
+
+RRS 
+
+
+तप्तायःपीताम्बुवत्‌ l 
+
+The simile of [a drop of] 
+[when thrown upon it}, Ramtir 
+a Words “ न॒ तस्य प्राणा SARRI 
+य UGANI Satya Vrat Shastri Collection. 
+
+
+water consumed by hot won 
+tha employs it when expounding 
+» jn the last section of the 
+
+
+" 
+
+
+Digitized By Siddhanta eGangotrf)Gyaan Kosha | 
+
+
+“"निरगुणब्रह्मसाक्षात्कारवतः प्राणा नोत्क्रामन्ति किन्तु प्रत्यखह्मण्येव तप्तायः 
+पीताम्बुवहीयन्त इत्यत्र प्रमाणमाह न तस्येति.” In Nrisimha. 
+sarasvati's comment on the same portion the nyaya is expanded 
+and made clearer :— 
+
+
+“अस्य जीवन्सुक्तस्योपाधिबिगमसमये' प्राणाख्यं लिङ्गशरीरमतितप्षलोह क्षि 
+नीरविन्दुवस्मत्यगभिन्नपरमानन्दे लीनत्वात्स्थूलशरीर॑ नोत्तिष्ठतीति। अन्न श्रुतिमाह _ 
+न तस्येति.” 
+
+Neither of them, however, was the originator of the simile; 
+for it is clearly an adaptation of the line ४ सन्तप्तायसि संस्थितस्य 
+पयसो नामापि न ज्ञायते ?? which forms the commencement of 
+Pancatantra i. 250, and also of Bhartrihari's Witis‘ataka 67, 
+
+
+तमःप्रकाशनिदर्शनम्‌ ॥ 
+The illustration | of the co-existence J of light and darkness. 
+It is found in Pancapadika, page 3, as follows:—* कोऽयं विरोधः 
+कीरशो वा इतरेतरभावोऽभिप्रेतो यस्यानुपपत्तेस्तमःप्रकाशवदिति निदशैनम्‌ | 
+यदि तावत्सहानवस्थानलक्षणो विरोधस्ततः प्रकाशभावे तमसो भावानुपपत्तिः | 
+तदसत्‌ | द्यते हि मन्दग्रदीपे वेइमन्यस्पष्ट रूपदशेनमितरत्र च स्पष्टम्‌ | तेन 
+ज्ञायते मन्दप्रदीपे वेइमनि तमसो<पीषदजुबृत्तिरिति”?, 
+
+
+The substance of this is reproduced in Vivaranaprameyt- 
+sangraha, page 10. 
+
+
+तृणभक्षणन्यायः ॥ 
+
+The custom of taking grass in the mouth [ lit, of eating i 
+grass |, as a token of submission. This interesting illustration 
+is found in Prabandhacintämani, page 98 :--बैरिणोपि हि gaat á 
+माणान्ते तृणभक्षणात्‌ | तृणाहाराः सदेवेते हन्यन्ते पशवः कथम्‌.” 1 
+Tawney renders it thus:—“Since even enemies are let off, when E 
+near death, if they take grass in their mouths, how can you - 
+these harmless beasts [deer &c.] which always feed on grass! | | 
+
+
+Ci s s. n 
+In a note on eee AO G ९४119 ebd have here an allusi 
+to a most ancient custom. There is a referenco to.it in Hi 
+
+
+Digitized By SiddhantDeGangotri Gyaan Kosha 
+
+
+carita ( Bombay edn, 1892) page 132, line 11, On which, the 
+translators, Cowell and Thomas, remark, “To carry a straw in 
+the mouth was à sign of surrender; compare Aeworth's Mara- 
+thi Ballads, page 43 :— 
+
+‘ And’ twixt the teeth a straw is fit 
+
+For curs who arm but to submit.’ " 
+These two lines are deduced from the three words “ घ्याव तोंडांत 
+तृण २? of the original. 
+
+Merutunga refers to this custom again on page 300 :—“नाथो 
+नः mana वदनन्यस्तेन संरक्षितः । एथ्वीराजनराधिपादिति तृणं तत्पत्तने 
+पूज्यते. ^ Grass is now worshipped in Paramardin’s city, be- 
+cause, when taken in the mouth, it preserved our lord Paramar- 
+din from Prithviraja, the king of men.” (Tawney’s translation, 
+page 189). 
+
+The late Colonel Meadows Taylor, who was so thoroughly 
+acquainted with Indian life, put the following into the mouth 
+of one of his characters in 8086 ( chapter xLvu ):— We have 
+2 good many prisoners, for I could not kill the wretches who 
+had put grass in their mouths and were crying for quarter.” 
+
+
+तैलकलुषितशालिबीजादडूरानुदयनियमः ॥ 
+
+
+The certainty of the non-appearance of shoots from grains 
+of rice spoilt by | contact with ] où. Tt occurs in Vedanta- 
+kalpataru, page 545, line, 17—“ क्रियाभोगदात्त्योः eei त्तिः 
+वस्धास्कायजुदयः संभवति तेडकल॒पितशालिवीजादहुराल॒द्यनियमव् E 
+S'ankavabhüsya 9. 3. 31, we read “gay लोके पंस्त्वादीनि बीजा- 
+WA विद्यमानान्येव बाल्यादिष्वनुपलभ्यमानान्यविद्यमानवदमिम्रयमाण à - 
+वनादिष्वाविभवन्ति नाविद्यमानान्युत्पद्यन्ते पण्डादीनामपि तदुत्पत्तिप्रसज्ञात्‌, 
+Of the आदि in षण्ढादीनास्‌ .Anandagiri says :--तैलकलुषितबीजादि- 
+अहाथमादिपदम्‌.” See also Nyayamakaranda, page 60. Compare 
+aus मूपिकसक्षितबीजादावहुरादिजननप्रार्थना: in Second Handful. 
+
+
+C C TTE 
+-0. Prof. Satya Vrat Shastri Collection. 
+
+
+| 
+j 
+
+
+"he 
+
+
+Digitized By Siddhanta eGangotri (yaan Kosha 
+
+
+दग्धवीजन्यायः ॥ 
+
+The simile of the burnt seed. An illustration of that which 
+
+has for ever ceased to be an operative cause, It appears ina. 
+
+verse of Sydduddamanjari, page 208 :-- TX 
+
+दुग्धे वीजे यथालन्तं प्रादुर्भवति aim | 3 
+
+कर्मबीजे तथा दग्धे न रोहति भवांकुरः ॥ E 
+
+The following is from the Prabandhacintamani, page 206 = 
+
+राजप्रतिग्रहदग्धानां ब्राह्मणानां युत्रिष्टिर i 9 
+
+दग्धानामिव वीजानां पुनर्जन्म न विद्यते ॥ ग 
+
+Merutunga ascribes it to a Purana. Vijnana Bhiksu quotes 
+
+from some Smriti another of a like kind, under Vogavartika 
+
+ii, 3:— $ 
+बीजान्यस्युपदग्धानि न रोहन्ति यथा पुनः । 
+
+ज्ञानदग्धैस्तथा ङ्केशर्नात्मा सम्पद्यते पुनः ॥ be 
+
+See also a verse ascribed to a Charvaka in Prabodhacundro- 
+
+daya, page 35. E 
+
+
+N 
+दत्तमेकधा सहस्रगुणमुपलभ्यते ॥ 
+That which is given once is received buck a thousand times. 
+This is found in Merutunga's work, page 266, and I appen 
+Mr. Tawney's renderin 
+
+
+तेन दत्तमेकध 
+
+
+“Who git 
+
+
+T. Lon 
+
+
+Digitized By Siddhaifid eGangotri Gyaan Kosha 
+
+
+दत्तर्णाधमण इव स्वप्‌ ॥ 
+
+To sleep like a debtor whose debt has been paid. To sleep 
+like a top! It occurs in Hemacandra's Paris istaparvan, ii. 563:— 
+« इति gata दोःशील्यामर्षचिन्तां विहाय सः । सुष्वाप दत्तणे इवाधमण॑स्तत्र 
+faa.” 
+
+A » = 
+दांधिचपुस प्रत्यक्षां ज्वरः ॥ 
+
+Curds and cucumber are fever personified! That is, they 
+cause fever. This is found in Mahabhdsya 1, 1. 59 (vartika 
+6), and 6, 1. 82 (vàrt 6), as follows — अन्तरेणापि निमित्तशब्दं 
+निमित्तार्थों गम्यते । तद्यथा । दघित्रपुसं प्रत्यक्षो ज्वरः । ज्वरनिमित्तमिति 
+गम्यते । नडुलोदकं पादरोगः । पादरोगनिसित्तमिति गम्यते A | 
+आयुषो निसित्तमिति गम्यते? This closely resembles Raghunatha's 
+दधिपयसी प्रत्यक्षो ज्वर: which 1 have not yet met with anywhere, 
+See agai and लाङ्गलं जीवनम्‌ 17 Second Handful. 
+
+
+दवदाहस्य वेत्रवीजविनाशकत्वं रूपान्तरजनकत्बं च ॥ 
+
+The forest-fire which destroys the seeds of the Ratan is also 
+
+[ by that means] the promoter of the growth of another form 
+[namely, the plantain]. This is found in Cüfsukh i 15, as 
+follows:—“gat च दवदाहस्य वेत्रवीजाविनाशकत्वं रूपान्तरजनकत्व॑ च 
+तथा दोषाणामपि यथार्थज्ञानप्रतिबन्धकत्वमयथार्थज्ञानजनकत्वं च कि न 
+स्यात्‌.” The same idea, with the express mention of the plan- 
+tain tree, is found under i. 14, and also in the following passage 
+of the Nyayavartikatatparyatika page ४7:--दिष्ट च दुष्टानामपि 
+कारणानामोत्समिकका्यग्रतिबन्धेन कार्यान्तरोत्पादकत्वस्‌ । TAA वेत्रबीजानां 
+दावास्निद्ग्धानां कदलीप्रकाण्डजनकरत्व॑भस्मकठुण्स चोदयैस्य तेजसो बहुत- 
+रान्नपानपात्रकस्वस्‌.?? The same passage is found in Bh page 
+18, line 7; and, one of the same nature, in Sikhamans, page 
+184, line 8; whilst, in Sarvarthasiddhs ii. 46 (page 207), Venkata 
+says “दग्धवेत्रबीजस्य रस्भांझुरारम्भकत्वं zaa.” See also Maniprabha 
+ML 14 (page 55), and Nyáyomakaranda, page 75, line 6. 
+
+CC-0. Prof. Satya.Vrat-Bhastri Collection. 
+
+
+ISSN ear o e 
+a: 
+
+
+| 
+। 
+| 
+| 
+| 
+} 
+
+
+Digitized By Siddhanta Sangoi Gyaan Kosha A 
+
+
+दीर्घशष्कुलीभक्षणन्यायः ॥ 
+
+
+The illustration of the eating of an elongate [ confection 
+called) S’askult | said, by the commentator on Vajnavalhya. 
+smriti i 173, to be स्नेहपक्कगो धूमाविकारः ] The nyaya is weli 
+defined in the following extract from the Vas istadvaitin (vol. 
+i. p. 102), for which I am indebted to my friend Dr. Grierson— 
+“S‘ashkuli is a stick-like edible, which a person begins to eat 
+from one end. While he so eats there are several sensations 
+present, such as the hardness or the softness of the thing; its 
+surface, round, square &c., uniform or indented ; its taste, smell, 
+color & All the sensations do not affect the person simul- 
+taneously, but one after another. When he isintent on the taste, 
+he is non-intent on the color; when he is intent on the smell 
+he is non-intent on the surface; though all the sensations seem 
+to come to him simultaneously, by reason of the infinitesimal 
+interval of. time dividing one sensation from another." 
+
+
+N'yayasüLra i. 16 defines Mind as that in which knowledge 
+[ of more things than one ] does not arise simultaneously ; and 
+we find the following in Mallin&tha's comment on TZarkikara | 
+hsa 29, where that sūtra is referred to IW च दीर्घशप्कुलीभक्षणादौ 
+ज्ञानयोगपद्यसंभवाद्संभवि लक्षणमिति वाच्यम | शतपत्रशातनवदाशुभावति" 
+बन्धनो योगपद्माभिमानों यत इति सर्वमवदातम्‌? Again, in the Nyayo 
+Pradipu on the definition of मनस्‌ in Larkabhasa(p.126)we readi— - 
+“अण्विति । विभुत्वे दीर्घशप्कुलीं भक्षयतः gat रूपरसाद्यनेकविषयाणि ज्ञानाने | 
+युगपजायेरन्‌ | आत्मेन्द्रियविषयसंबन्धात्मिकाया: umet सत्त्वादणुत्वे त्विदि _ 
+याग्राप्तेन युगपज्ज्ञानानि भविष्यन्तीति ra ॥ , 
+
+In a diseussion on the same subject in Nyayamanjari page 
+497, Jayanta Bhatta brings forward three examples of ७४४५ 
+ent simultaneity, the first of which is quaintly versified 
+follows :-- | 
+
+
+£ सुगन्धि शीतलां दीघांमश्नन्तः पूपशप्कुली । 
+
+
+EE ॥ 
+
+
+Digitized By Siddhai8 eGangotri Gyaan Kosha 
+
+
+दूरस्थवनस्पतिन्यायः ॥ 
+
+
+The illustration of distant trees 4. e. of two trees standing 
+apart, but which, owing to their distance from the spectator, 
+seem to be one]. It is contained in the Laukikanyayoratna- 
+kara (IO MS. 582, page 219 a ), but not in the smaller work. 
+Its author most probably derived it from Citsukhi, where the 
+following passage is found at the beginning of the second 
+chapter:— ag क्षीरनोरयोविद्यमानभेदयोरपि स्वरूपग्रहणे भेदग्रहों न दश्यत 
+इति aaa तत्र समानाभिहारलक्षणदोपप्रतिबन्धादेव तदग्रहोपपत्तेः । एतेन 
+दूरस्थवनस्पत्योरपि भेदग्रहप्रसंगः ग्रत्युक्तः N The Muni then quotes 
+Sankhyakarika vii. “अतिदूरात्‌ &c.”, and the same karika, with 
+a somewhat similar context, is cited in the Pürnaprajna section 
+of sarvadars'anasangraha. The simile of the two trees is met 
+with in the much older work Sanksepas'ariraka (i. 44), name- 
+ly :--“ दूरस्थयोनेनु वनस्पतिवस्तुनोस्तक्वेदो न दृष्टिविषयो$वगते च dom 
+We have it again in the Pancapadika (page 7, line 13). 
+
+
+It is interesting to compare with Is'varakrisna’s causes of 
+anwpalabdhi those assigned by Patanjali in Mahabhasya 4. 1.3 
+(vol. ii. page 197). He says आळ त qai: सतां सावानामजुप्लब्धि- 
+सैवत्यतिसंनिकपाडेतिविप्रकपीन्मूल्यन्तरयवधानात्तमसावृतत्वादन्दियदान Tn 
+तिग्रमादादिति.?? 
+
+
+——— 
+
+
+देवदत्तशौयन्यायः ॥ 
+
+The figure of Devadatta’s bravery. Equivalent to Horace : 
+“Celum non animum mutant, qui trans mare currunt. The 
+illustration is used by S'ankara in his bbasya E 
+sūtra 3. 3. 10:--“एकस्यामपि शाखायां spat गुणाः श्रुता ए शान्त 
+गुणवतो भेदाभावात्‌ | न हि देवदत्तः जोया दिगुणत्वेन खदेरों प्रसिद्धो देशान्तरं 
+गतस्ते्येरनरिभात्रितशयौदिगुणोऽप्यतडुगो भवति | यथां च उ र 
+पादेशान्तरेऽपि देवदत्तगुणा विभाव्यन्ते? ॥ The दनव a 
+mentioned again in the phasya on the next sutra. : omp: : 
+With this the following pe Tantravartika, 3. 6. 41 (Ps 
+
+
+1108) ada 3 वेशनगमनश भेदेऽपि देवदत्तत्व 
+) यः SEDE atya Vrat Shastri Collection. 
+
+
+कना e c ciu fat di ANE IRAQ IUS ME CUP Mp t 
+
+
+E. 
+-ERSU 
+
+
+Digitized By Siddhanta eGangotr;Gyaan Kosha p. 
+
+
+नापेति &c.” See, also, Slokavartika, page 780 ; and compe 
+the following from Mahdbhasyc 1. 1. 1 ( vart. 18 nw ननु चभो 
+अभेदका अपि गुणा द्यन्ते | तद्यथा | देवदत्तो सुण्ड्यपि जट्यपि rer 
+स्वामाख्यां न जहाति.” Commenting on this, Kaiyata says :-- भुण्ठेन 
+हि कृते चोर्ये कुंतलित्वावस्थायामपि चौरोऽयमिति व्यपदिश्यते.”” E 
+
+
+देवदत्तहन्तृहतन्यायः ॥ | 
+
+The illustration of the slaying of the murderer of Devadaita, 
+The point is that the death of the murderer does not bring his 
+victim to life again. Tt is applied by Raghunatha as follows: | 
+“नन्वज्ञानबाधके ज्ञाने विनष्टे पुनरज्ञानोदयेन बन्धम्रसङ्ग इति शकायां देवदत्त. 
+हन्तृहतन्यायावतारः | यथा देवदत्तहन्तरि हतेऽपि न देवदत्तस्य जीवनं तथा 
+प्रकृतेऽपि.” He probably took it from Nagojibhatta’s comment 
+on paribhasa uxtv [ उपसंजनिष्यमाणनिमित्तः &c, which see above 
+where it reads thus :—“ aq देवदत्तस्य हन्तरि हते देवदत्तस्योन्मजन॑ 
+नेति न्यायस्य विषय एव नास्ति । हते देवदत्त उन्मजनं न । CECECECECA 
+तस्य तु हनने भवत्येवोन्मजनम्‌?॥ Nagoji, on the other hand, 
+derived it from the Mahabhdsya, where (in 1. 1. 57, vartika 4 he 
+it appears as “न ह्यन्यस्यासिद्धस्वादन्यस्य प्रादुभीवो भवति। न हि देवदत्तस्य 
+हन्तरि हते देवदत्तस्य प्रादुर्भावो भवति.” So, too, in 6. 1. 86 (var 
+Jt is quoted in the consolidated form in Pradipoddyota 1, Y. © 
+( page 218), र 
+
+
+धारावाहिकबुद्धिः ॥ 
+
+A persistent state of cognition. Thisis Mr. Arthur V be 
+rendering of the expression as it occurs in Vedantapariht 
+( The Pandit, vol. iv, page 105), and he elucidates it in foot- 
+note as follows :—“Tt may be described as a series of st 
+
+
+throughout which the same object is presented in conscii 
+Each state of consciousness las 
+
+
+oru r ime, 
+
+
+Digitized By SiddhafyB eGangotri Gyaan Kosha 
+
+
+refers to it as the घारावाहिकन्याय. 1 have met with it elsewhere 
+also. Yet, strange to say, the Vacaspatyam is the only Sanskrit 
+dictionary that contains it. The term भरावा हिन्‌ (with 'चाहिक also) 
+is there defined as “सन्तत्या पातुके क्रमेणाविच्छेदन जायमाने च+? and 
+then follows a quotation from Vedantaparibhasa which imme- 
+diately succeeds that referred to above:—“fea सिद्धान्ते धाराः 
+वाहिकडुद्धिस्थले न ज्ञानभेदः [ किन्तु यावद्धरस्फुरणं तावद्धटाकारान्त:करणवृ- 
+त्तिरकेव न तु नाना] “Moreover, according to (Vedantic) tenet, 
+there is no variation of knowledge in the case of a persistent 
+cognition; but as long as there is a presentation of the jar so 
+long the modification of the internal organ in the form of the 
+jar is one and the same and not various” (Venis). As found 
+in Marathi, it has the meaning “ Closeness or intentness of 
+thought; undiverted and unintermitting prosecution (of any 
+subject of meditation or study)” ( Molesworth). Strictly speak- 
+ing, I ought not to include this expression in my pages; but as 
+Béhtlingk, Monier- Williams, and Apte have ignored it, I admit 
+it in the hope that it may assist some perplexed student of 
+Indian philosophy. And let me add that readers of Mr, Venis’ 
+excellent translations will find there many valuable explanations 
+of technicalities, which they will search for in vain elsewhere. 
+
+
+> 0 
+न च सर्वत्र gene स्यात्मयोजककमणाम्‌ ॥ 
+
+
+Acts which impel others to action are not always of the same 
+
+
+kind. This is the first line of a verse in Kumirila’s Slokas 
+
+
+variika ( page 710 ), the context of which is as follows :-- 
+
+
+“धन्‌ च सर्वत्र तुल्यत्वं AMARA | 
+चलनेन ह्यसि योद्धा प्रयुक्ते छेदनं प्रति ॥ 
+सेनापतिस्तु वाचैव ZARI व्रिनियोजकः | 
+राजा सन्निधिमात्रेण वितियुङ्े कदाचन ॥ 
+
+
+9 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangojfByaan Kosha 
+
+
+A remark of S’ankaracharya’s in his comment on Mandate, 
+Upanishad 3.1.1, illustrates this, He says :— q त्वनक्षत्नन्योप. 
+भिचाकशीति पर्‍्यत्येव केवलम्‌ | दर्शनमात्रेण हि तस्य प्रेरयितृत्व राजवत्‌,” 
+
+
+नड्लोदकं पादरोगः ॥ 
+
+
+Water in a bed of reeds is disease of the feet. That is, it | 
+causes disease in the feet. See under दघित्रपुसं प्रत्यक्षो ज्वरः ।. 
+
+
+नतेकन्यायः ॥ 
+
+
+The simile of a dancer. One dancer gives pleasure to many 
+spectators, just as one lamp gives light to many persons. It 
+occurs in Jaiminiyanyayamalavistera 11. 1. 10 as follows:— 
+
+
+“अ्द्यद्ञिकायाण्यज्ञानि तन्त्रेणोताङ्गिनो यतः | 
+एकेकस्योपकारर G 
+स्वं तस्मात्म्रत्यङ्गःथनुष्टितिः ॥ 
+विधानवदनुष्ठानं सक्ृदेवोपकारकम्‌ । 
+तद्देशकालकर्द्णामेकक्वान्नतेकादिवत्‌?? ॥ 
+
+
+The last pads is thus explained: —“ यथा बहूनां पुरतो za 
+सर्वेपां सुखं युगपत्निर्वतयति तद्वत्‌ ” । 
+
+
+Of the same kind, apparently, is the following expression । | 
+of the Nyayavartika i. 10 (page 70) :--“कृतसंकेतानां वृद्धानामेक $): 
+स्मित्ञतैकीभ्रक्षेपे युगपदनेकप्रत्ययवत्‌ ??, which is reproduced in the 
+Nyadyavirtikatatparyatika, page 354 (line 9 from bottom) i! 3 E 
+these words:—“ उक्तमेतदू यथा नतेकीञ्रूरताभङ्गे एकस्मिन्बहूनां गतिः 
+
+सन्धानमिति.? . OM 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+ee 
+
+
+Digitized By SOOT aa Gyaan Kosha 
+
+
+नसि प्रोतोष्टन्यायः ॥ 
+
+
+The simile of a came, with a rope fastened in its nostrils, Tt 
+is found in verse 78 of Tattvamulktavali — 
+
+
+“माया यस्य वशं गता बलवती त्रैलोक्यसंमोहिनी 
+विज्ञेयः प्रभुरीश्वरः स भगवानानन्दसचिद्धनः | 
+यस्तस्या वशमागतः खलु A प्रोतोष्टकल्पः सदा 
+ज्ञातव्यः स हि जीव इत्थमनयोरस्त्येव भेदो महान्‌ ” ॥ 
+
+“He under whose control is that mighty illusion which de- 
+ceives the three worlds, He is to be recognized as the Supreme 
+Lord, the adorable, essentially thought, existence, and joy; but 
+he who is himself always under her control, like a camel drawn 
+by a string through his nostrils, is to be recognized as the indi- 
+vidual soul,—vast indeed is the difference between the two.” 
+The translation is Prof. Cowell's. The dictionaries give refer- 
+ences to three works where the figure is used, but always as 
+नस्योत, and, either in text or comment, applied to a bullock, not 
+to a camel The passages will be found in Tait. Samhita 2, 1, 
+1.2, Vanaparva xxx. 26, and Bhágavata Purana 6. 3. 12. 
+The second one reads thus:—* इश्वरस्य up तिष्ठेन्नान्येपां नात्मनः प्रभु: । 
+सणिः सूत्र इव प्रोतो नस्योत इव गोडूपः” ॥ 
+
+Compare, too, Magha xii. 10, with its description of a vain 
+attempt to load a pack-bullock though held by its nose-cord 
+( नस्या ). 
+
+
+न हि करकंकणदशनायादशापेक्षा ॥ 
+
+
+One does not need ७ looking-glass in order A look at d 
+bracelet on the wrist, The nearest approach to this that I haye 
+Met with is in the Karpuramanjar, page 17, line 2:—“argart 
+इत्थकंकणं किं दप्पणण पेक्खीआदि,” which is, in Sanskrit, “ अथवा 
+हस्तकंकणं कि दर्पणेन इऱ्यते.'? 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+. in 1, 8, 12 (5), and in 6. 1. 50. 
+
+
+Digitized By Siddhanta eGangqfgiGyaan Kosha 
+
+
+न हि काकिन्यां नष्टायां तदन्वेषणं कार्षापणेन क्रियते ॥ 
+
+If a mam has lost a cowrie he does not spend a kàrshápagg, 
+
+dm the search for it. That would be like expending a Sovereign 
+
+in order to recover a farthing! It occurs in the following por- 
+
+tion of S'abara's bhashya 4. 8. 39 :—“ न हि कपाले नष्टे तदन्वेपणारथा 
+इष्टियुक्ता । न हि काकिन्यां नष्टायां तदन्वेपणं कार्पापणेन क्रियते” T 
+
+
+न हि क्चिदश्रवणमन्यत्र शरुतं निवारयितुमुत्सहते ॥ 
+A things not being heard in one place does not get rid of 
+the fact of its being heard elsewhere, This is applied by 
+S'ankara in Brahmasttrabhdsya 2, 4, 1 (page 681) as 
+follows :— ननु केपुचित्परदेशेपु न प्राणानामुत्पत्तिः श्रूयत इत्युक्तं qum 
+प्रदेशान्तरेपु श्रवणात्‌ । न हि क्चिदुश्रवणमन्यत्र श्रुतं निवारयितुञुत्सहते,” 
+It is quoted as a nyaya in Vaiydsikanydyamala 2 3.2 
+(sūtra 8). Compare with it Slokavartika iv. 161:— “sa FA- 
+त्संकराभावात्सर्वंत्रेव निवर्तते । afr संकरं दृष्टा संकरोडन्यत्र कहप्यते,” 
+and see Dr. Ganginith Jhi's rendering of that and the 
+previous verse, 
+Compare too a saying of Vacaspatimis'ra's on Yogabhüsyd 
+मं, 22:4 हि रूपमन्धेन न दृश्यत इति चक्षुष्मतापि दृश्यमानमभावग्रार्त 
+HA.” £ 
+
+
+न हि गोथा सर्पन्ती सर्पणादहिर्भवति॥ | 3 
+An Iguana creeping along does not on that account become 
+@ snake, This is found in Mahabhasya 1. 1. 28 (4) as follows: 
+“न खल्वप्यन्यत्परकृतमनुवर्तनादन्यद्धवति न हि योधा सप॑न्ती सर्पणादहिभेवति। 
+ager न खल्वन्यत्मकृतमनुवर्तनादन्यद्ववति न हि गोधा. सप्ती 
+सर्पणादहिभंति wets स्यात्‌ | शब्दस्तु Uy येन येन ATT 
+'भिसंबध्यते तस्य तस्य विदोषको भवति.” Tho samo passage reappeat 
+
+
+. . CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By uas (ति य Gyaan Kosha - 
+
+
+न हि आमस्थः कदा आम गरा्ुयामित्यरण्यस्थ इवाशास्ते ॥ 
+
+
+A man who is already ina village does not express a, longing 
+to get there, such as a, man might who was out in the jungle! 
+This is found in, Brihadaranyakabhagya 1. 8, 28, page 87:— 
+“न हि प्राणात्मन्युत्पत्नात्माभिमानस्य तञ्माध्याशंसनं सम्भवति। न हि mer: 
+कदा AT प्रामुयामित्यरणस्थ इवाशास्ते | असंनिकृष्टविषये हानात्मन्याशंसन न 
+तत्स्वात्मनि सम्भवति. 
+
+
+न हि AJA द्विपुच इति कथ्यते ॥ 
+A man who has three sons could not be designated as u 
+man with two sons. Therefore, if an order were given to 
+bring the father of two sons, it would not do to bring one | 
+who had three! This nyaya of Raghunüthavarman's, taken za 
+from the Kas'ikauritti (with the substitution of कथ्यतते for व्यप- ; 
+दिड्यते ), is based on the words “a हि figa आनीयतामित्युक्ते त्रिपुत्र 
+आनीयते,?? which form part of Patanjali’s comment on Panini's 
+sutra 6. 4. 96 (छादेर्धेऽद्यपसगैस्य). ‘The meaning of that sūtra is 
+that when the affix q ( 2. e. the krit- affix a ) follows, the roo : 
+(technically described as छादि ) is shortened to छद when there — — 
+are not two upasargas. So we say प्रच्छद, and दन्तच्छद; bub 
+ससुपच्छाद because there are two upasargas. Bub would the root - 
+vowel be shortened if there were more tham two upasargas? 
+No; for we say geom, Yet the sütra seems to make no 
+Provision for this. Patanjali comments on it as follows E 
+“अद्विप्रभ्वत्युपसर्गस्येति वक्तव्यम्‌ | इहापि यथा स्यात्‌ | समुपाभिच्छाद इति e 
+तत्तर्हि वक्तव्यम्‌ । न वक्तव्यम्‌ । यत्र Bonis सन्ति द्वावपि तन्न स्तस्त- » 
+धाथ्युपसगैस्येत्येव Raq | न वा एष लोके सम्प्रत्ययः । न हि द्विपुत्र आनीयता- | 
+मित्युक्ते त्रिपुत्र आनीयते । तस्मादद्विप्रश्रत्युपसर्गस्येति वक्तब्यम्‌'' ॥ रर 
+Patanjali was 1070 of this kind of illustration. The follow- 
+ing one is employed again and again in various KW of t me 
+bhasya, and always in connection with the paribhasa नजिवयुक्तः | 
+
+
+“अन्न गाता J 
+सल्यसद्शाधिकरणे तथा anna: | 1 reads (॥॥५:-- अन्नाह्मणर 
+CC-0. Prof. Satya Vrat Shastri Collection. . ^ 
+
+
+' reference to the unfamiliar Cocoanut Island, and its cow-less con- 
+
+
+of Hiuen Thsang’s work ( Vol. ii. page 252) is suppossed M 2 
+
+
+i 
+Digitized By Siddhanta eGangotf(byaan Kosha 
+
+
+n^ 
+
+
+AMIE आनीयते नासो छोष्टमानीय कृती wala.” It occurs in 3; 
+1. 12 ( vārt. 4); 3. 3. 19; 6. 1. 45; 6. 1. 71 (vart. 7 ) 6. 1, 195 
+(värt. 12); 6. 3. 84 (vart. 7); 7. 1, 87 (vari. 7), The words 
+अब्राह्मणमानय appear also in 2. 2, 6, The paribhasa just quoted 
+is rendered by Prof. Kielhorn thus: ( An expression ) formed 
+by the addition of the negative a Or (of the particle of com- 
+parison ) इव ( to some word or other ) denotes something which 
+is different from and yet similar to ( what is denoted by the 
+latter), because it is so that (such expressions) are (generally) 
+understood (in ordinary life)" With the paribhasa, Nagoji 
+has also taken the illustration. In Kaiyata’s comment ona 
+portion of the bhásya under sütra 1, 1, 57 we find the expres- 
+sion “न हि frg द्विपुत्रव्यपदेशं लभते. !? 
+
+
+नहि नारिकेल ट्वीपवासिनोऽप्रसिद्धगोश्चवणात्कङुदा- 
+
+दिमदर्थग्रतिपत्तिर्भवति ॥ 
+
+From hearing the unfamiliar word ‘cow’, an inhabitant 
+of Cocounut Island would gam no perception of am object pos- 
+sessed of ८ hump &०. This Sentence is found in the Nydya- 
+vartilke on sūtra 8, 1. 67. Again, in Pras'astapüda's Vais'esika- 
+bhasya, page 182, we read — अजुमानविषयेज्पि नारिकेलद्वीपवासिनः 
+TAMAR नु खल्वयं प्राणी स्थादित्यनध्यवसायो भवति.” The 
+Commentator, S'ridhara, remarks on 618 :--“नारिकेलद्वीपे गवाम- 
+भावात्तत्रत्यो लोकोऽप्रसिद्वयोजातायः.?? 
+
+
+With some hesitation I have admitted the above into my col- . 
+lection of ‘inferences from familiar instances, on account of the EE, 
+
+
+dition! The following passage from Professor Beal's translation 
+refer to this island :—"Tho people of this island are smallo. 
+
+
+they have KA AA Aa but live 
+
+
+Digitized By Siddhanta ggangotri Gyaan Kosha 
+
+
+on cocoanuts.” The editor and translator of Tising’s Record 
+thinks that the island in question is one described by that pil- 
+grim as lying to the north of Sumatra, and therefore probably 
+one of the Nicobar group. See page xxxviii of that work. 
+
+
+Jayanta Bhatta refers more than once to the ignorance of these 
+islanders. See Nyayamanjari page 118, line 5; page 121, line 
+23; and page 391. Also Tatparyatika, p. 66. In Sarvartha- 
+siddhi, page 561, amongst strange things found in ordinary life, 
+Venkatanüth includes “ ज्ञारिकिलद्वीपवासिनामपक्कान्नेनिव देहधारणम्‌,” 
+It is interesting to note that, according to Prasastapids (page 
+267, line 6), the people of south India were at that time as 
+unacquainted with the camel as those islanders were with 
+the cow! Sridhara says:—"sgr दाक्षिणायस्यात्यन्तानजुभूताकारत्वादा- 
+श्रये भूतोऽर्थः”॥ 
+
+
+न हि cart पलायितुं पारयमाणो जानुभ्यां रंहितुमहति॥ 
+
+Ti is not likely that a man who could flee on his feet would 
+crawl on his knees. This is a part of S'ankara's argument on 
+Brahmasutra 3. 1. 10:--“तस्मात्कमेंव शीलोपलक्षितमनुशयभूत॑ योः 
+न्यापत्तो कारणमिति काष्णोजिनेमैतम्‌ । न हि कर्मणि संभवति शीलाद्योन्या- 
+पत्तियुक्ता । न हि yai पलायितुं पारयमाणो जानुभ्यां रंहितुमहेतीति.” “Tt is, 
+therefore, the opinion of Karsnajini that the remainder of 
+works only— which is connoted by the term © conduct —is the 
+cause of the soul’s entering on new births. For as work may be 
+the cause of new births, it is not proper to assume that conduct 
+is the cause. If a man is able to run away by means of his feet 
+he will surely not creep on his knees.” This is Dr, Thibaut's 
+
+
+rendering. 
+
+
+fz A^ 
+न हि पूतं स्याहोक्षीरं श्वद्दतो धृतम्‌ ॥ 
+
+Even cow's milk: would cease to be pure if placed im a vessel 
+made of dogskin. This nyaya of Raghunatha's is found in the 
+following passage of Juiminiyanyayamalalkuistara, 1. 8, 4:— 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+I 
+
+
+Digitized By Siddhanta eGangotA Syaan Kosha 
+
+
+“शाक्योक्ताहिंसनं धर्मा न वा at: श्रुतत्वतः । 
+
+न धमो न हि पूतं स्याद्गोक्षीरं श्वरतो ST ॥ 
+ब्रह्मचर्यमहिंसा चापरिग्रहं च सत्यं च यत्रेन रक्षेदिति श्रुतावहिंसादिधमत्वेनोक्त: | 
+स एव धर्मः शाक्येनाप्युक्तः | तस्माच्छाक्यस्मृतिर्धमें प्रमाणमिति चेत्‌ । न। 
+सरूपेण धर्मस्यापि गोक्षीरन्यायेन शाक्यसंबन्धे सत्यधर्मस्वप्रसज्ञात्‌ | तदीय- 
+अन्थेनाहिंसादिनावगन्तव्यः | तस्मान्न सा eaters प्रमाणम्‌? ॥ 
+
+Madhava, no doubt, took it from Kumirila’s vartike, on आ - 
+7 of the same adhikarana, where he speaks of the moral 
+teaching of S‘akyas and others as “हातिनिक्षिप्तक्षीरवदनुपयोग्याविसं- 
+भणीयं च.” The simile in this form is found, too, in Yamuni- 
+Cürya'g Agamaprümanya, page 11 line 8, in a context of the 
+same import. Colebrooke’s excellent summary of the teaching 
+of this part of the Mimürnsüdars'ana, given in his Zssays (i 
+337), may be usefully guoted here :—“Besides the evidence of 
+precept from an extant revelation or recorded hearing (s'ruti) 
+of it, another source of evidence is founded on the recollections 
+(smriti) of ancient; sages. They possess authori ty as grounded 
+on the Veda, being composed by holy personages conversant 
+with its contents.. The S'akyas (or Bauddhas ) and Jainas 
+
+
+(or Arhatas ), as Kumarila acknowledges, are considered to be 
+Kshatriyas, It is not to be coneluded, he says, that their re — 
+collections were founded upon a Veda which is now lost, There 
+can be no inference of a foundation in revelation for unauthen- 
+tic recollections of persons who deny its authenticity. Even 
+when they do concur with it, as recommending charitable gifts 
+and enjoining veracity, chastity, and innocence, the books of the 
+S'akyas are of no authority for the virtues which they incul- 
+cate. Duties are not taken from them: the association would su 
+
+
+Digitized By Siddhanta efigngotri Gyaan Kosha 
+b) 
+
+
+AA WA पर e 0 
+न है भिशुका gaara याचितुमहति सत्यन्यस्सि- 
+न्नमिक्षके ॥ 
+
+A beggar ought not to ask alms of another beggar, so long as 
+there 4s any one [to beg from ] who is not a beggar! The say- 
+ing appears in this form in S'astradipika 8. 3. 5 ; but S'abara, 
+in the same adhikarana (sütra 11), puts it thus यन च Ager 
+भिक्षका दाकांक्षन्ति सत्यन्यस्मन्प्रसवसमर्थेऽभिश्नुके.?” See, also, the Nya- 
+yumalavistara on the same portion. ‘The following, from 
+Ivanhoe (Chap. xi), runs parallel with the nyàya:—* He is 
+too like ourselves for us to make booty of him, since dogsshould 
+not worry dogs where wolves and foxes ure to be found.” 
+
+
+न हि भूमावम्भोरुहं सदिति दुष्टाक्षस्यापि नभसि 
+तदवभासते ॥ 
+
+Not even to a man whose sight is defective does a lotus on 
+the ground appear to be in the sky! It appears in Citsukhi 
+i. 17 (Pandit, vol. iv, page 594) :--“ न च देशान्तरे सत्त्वादत्रासत्त्वाच 
+ख्यातिवाधयोरन्यथाप्युपपत्तिः । अन्यत्र सत्ताया इह प्रतीलहेतुत्वात्‌ | न हि 
+भूमावस्भोरुहं सदिति RED नभसि तदवभासते.?? 
+
+
+नहि यद्देवदत्तस्य युध्यमानस्य स्थानमवगतं तदेव 
+अुञ्जानस्यापि भवति॥ 
+
+The position occupied by Devadatta when cating is not that 
+which he occupies when fighting! The force of this dristanta 
+is best seen from the darstdntika in Tantravartika, p. 575 :-- 
+
+““एकत्वे$पि हि शब्दस्थ शक्तिभेदः प्रयोजने | 
+तत्र कार्यान्तरस्थानं न स्यात्कायास्तरेष्वपि ॥ ` 
+न शब्दैकत्वेन यत्किज्ञित्कार्ये स्थानं ceed तदेवान्यत्रापीति शक्यते वक्तुस्‌। 
+न हि यद्देवदत्तस्य युध्यमानस्य स्थानमवगतं तदेव सुञ्जानस्यापिं अवतीति 
+रम्यते । कारयुक्ता हि स्थानविरोषादयो न स्वरूपमरयुक्ताः” ॥ 
+
+
+10 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Laukikanyayasangraha Raghunatha describes his effort i 
+
+
+Ec 
+
+
+fit 
+Digitized By Siddhanta eGangotfi yaan Kosha 
+
+
+EN a i q Ox भेन 2 
+
+न ig विधिशतेनापि तथा पुरुषः प्रवतेते यथा ठोभेन 
+Not even a hundred injunctions could Move a man to geti 
+
+as readily as the desire for gaim does, This is found in Tantra 
+vartika 3. 4. 34 ( page 999 ):— i 
+RR दक्षिणां दयादिति दानं विधीयतते । 
+रोसादेवाजेनाङ्गव्वात्माहस्तेपां अतिग्रहः ॥ F 
+न हि दद्यादित्यस्य प्रतियुह्णीयादित्ययमथो भवति | भवेदपि सामर्थ्यायदि, तदा- 
+
+क्षेपमन्तरेण दानविधिनोपपद्ते । स तु Sanga T 
+शक्नोयाक्षेप्तुम्‌ | न हि विधिशतेनापि तथा पुरुपः प्रवर्तते यथा लोभेन”॥ 
+Jayanta Bhatta (on page 361) puts the matter quaintly thus:— 
+
+“ चपेटापरिहाराय मोदकम्राप्तयेऽपि ar | 
+प्रवतेते ageret जुहुधीति नियोगतः” ॥ 
+
+Compare Nydyakanika, page 407:—“a च विधिमात्रमपि प्रव्रत्तिहेतु: | 
+अनिच्छतो विधीनां शतेनाप्यप्रक्तेः 7 ॥ See, too, verses 1040 and 104 
+of Sambandhavartika, and Anubhiatiprahis'a xiii, 277. ; 
+But many centuries before any of these worthies the sam 
+view had been expressed by Patanjali in Mahabhasya 1. ह: 
+72 ~ क्रियाफलं कतोरमभिमेति | याजका यजन्ति .गा लप्स्यामह ति। 
+कर्मकराः कुर्वन्ति पादिकमहप्स्यासह इति.” See another quotatio 
+g Di 3 
+from the same source under the nyaya “ प्रयोजनमनुद्दिव्य Re E 
+
+
+न हि aa: सर्व जानाति॥ 
+
+
+Exerybody does not know everything, Near the end 0 
+
+
+following verse :— 
+
+
+"व्याख्यातं न्‍्यायबृन्द निजमतिभनतिक्रम्य ग्रावन्मयाप॑ 
+पारं रुं तु शक्तो न हि भवति qe: कः gerent ना 
+वेत्ति दसतो नास्ति मेशत्रापराधः 
+
+
+तावि n 
+
+
+of the 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+above; namely, यावत्तेलं तावह्याख्यानमू्‌ and यावत्खाता MAYA with 
+the first pada, and, the maxim which we are now considering, 
+with the third, I think the second of these should read 
+qami. In the larger work the reading is यावस्स्रातं. Our 
+present nyaya is found in Upamitibhavaprapanca Katha, 
+page 501, as follows:—* fest: माह नैवात्र कोपः कायस्य चः | 
+aa: सर्वे न जानीते सिद्धभेतजगत्रये ?? ॥ On the other hand, we have 
+the following guery in Atmatattvavivela, page 94:— तथापि 
+चानुभवकल्पनायां सर्वः सर्वदा सवे जानाति न तुं निश्रिनोतीति के न स्यात्‌,” 
+
+
+न हि स्वतोऽसती शक्तिः कतुमन्येन शक्यते ॥ 
+
+Lf a power is not of itself present | in a person or thing], i 
+cannot be supplied by another. In Bralmasütrabhasya 2. 1. 
+24 we have part of a discussion as to Brahman’s ability to pro- 
+duce the world without extraneous aid. Ib is urged that he 
+has this power in himself, just as the power to produce curds 
+resides in milk. The objection is then raised that since curds 
+nre not produced without the action of heat, milk is nob in- 
+
+
+dependent of other agencies, and so the argument breaks , 
+
+
+down. The reply is as follows:—* यदि स्वयं दधिभावशीलता न 
+सयाननेवोष्ण्यादिनापि बलाइधिभावमापद्येत | न हि वायुराकाशो वोष्ण्यादिना 
+वलाइधिभावसापद्यते | साधनसामग्र्या च तस्य पूर्णता संपाद्यते.” On this 
+last clause Anandagiri says :-—“oradta | न हि स्वतोऽसती शक्तिः कतु- 
+मन्येन शक्यत इति न्यायाद्विद्यसानेव क्षीरादिशक्तिः साधनसामग्र्योपचीयत 
+इत्यर्थः.” The nyaya is taken from Slokuvartika ài. 47 ( page 
+59), of which verse it forms the second line. The first line is 
+“स्वत; सर्वेप्रमाणानां ग्रामाण्यमिंति गस्यतास्‌.? Dr. Ganganath Jha's 
+rendering of the verse is as follows:—“ You must understand 
+that authoritativeness is inherent in all means of right notion. 
+For a faculty, by itself non-existing, cannot possibly be brought 
+into existence by any other agency," The whole verse is quoted 
+in Nyayakanika, page 168; and in Vydyamanjari, page 165. 
+Compare with the above maxim the following from Brakma. 
+sutrabhdsya 2. 2, 29:—“a हि यो यस्य स्वतो धमो न संभवति सोऽन्यस्य 
+
+
+साध संभविष्यति ; 23 ij 
+. स्थतस्य CC-0. Prof-Satya-vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangofr;Gyaan Kosha 
+
+
+न ह्यन्थस्याज्यावेक्षणोपेते कमण्यधिकारो5स्ति | 
+A blind man is not qualified for work: involving the exam 
+nation of butter. This is found in Vaiydsikanyayamala 3.4, 
+2 (sütras 18-20), where it is followed by * नापि पज्ञोविष्णुक्रमादयु. 
+पेते कर्मण्याधिकारः.”” It was doubtless taken from Tamtravartita 
+‘1 4. 24 (page 332), where we read :--नन्वनेनेव न्यायेन यथा AFA- 
+दिति वाक्यशेपादन्धादीनामाज्यावेक्षणादिराहितः कर्माधिकारः स्यात्‌.” This 
+sutra 24 is Jaimini’s sütra 30, under which we have S'abara's 
+
+“ आख्यातशब्दानामर्थ gaai शक्तिः सहकारिणी ?? which seo above, 
+
+
+न ह्यन्यस्य वितथभावेडन्यस्य वैतथ्यं भवितुमर्हति॥ 
+
+Lhe falseness of one person does not prove somebody else to 
+be false. This is from Sabara 1, 1. 2 ( page 5, line 6 ):—“aq. 
+सामान्यतोदृष्टं पौरुषेयं वचनं दितथसुपलभ्य वचनसास्यादिदमपि वितथमव- 
+TAX । न अन्यत्वात्‌ । न ह्यन्यस्य वितथभावेऽन्यस्य aep भवितुमईति | 
+EHI | न हि देवदत्तस्य WAA यज्ञदत्तस्यापि इयामत्वं भवितुमर्हति!॥ 
+See the same in verse in S‘lokavartika, page 100; on which 
+Parthasirathi SQyS:—Á न ह्नाप्तवाक्यस्थ वेतथ्ये सत्याप्तवाक्यस्थापि वे- 
+
+
+ET" That Kumarila, however, had a poor opinion of human 
+
+
+veracity in general, is shown from the following verse on 
+page 88: सर्वदा चापि पुरुषाः ग्रायेणानृतवादिनः | यथाद्यत्वे न विर 
+भस्तथातीताथकीतंने.? Again, on page 178: 3 gaai at स- 
+यत्वेनावगम्यते | वागिह श्रूयते यस्मास्प्रायादनृतवादिनी.” Compare with 
+this nyaya “न हि खदिरगोचरे परशौ पारो zaa भवति,” and 
+“ अन्यवेश्‍मस्थिताळूमान्ञ वेइ्सान्तरमप्िमत्‌.?? | 
+
+
+न ह्येष स्थाणोरपराधो यदेनमन्धो न पश्यति॥ 
+It is not the fault of the post that a blind man cannot stt 
+i. Vücaspatimis'ra quotes this on page 87 of his Tatparya- 
+kika, prefaeing it with the words “ यथाहुनिर्क्तकाराः.? 1 will 
+be found on page 112 of the second volume of the Nirukta. 
+We meet with it again in the opening sentence of Kuswman : 
+jali ए.:-“नन्वीश्वरे प्रमाणोपपत्तो सत्यां सर्वमेतदेवं स्यात्तदेव तु न पश्याम 
+इति चेत्‌ । न GENESE न्म्ल, ` 7 ` F 
+url c ee 
+
+
+Wa क mem 
+
+
+Digitized By NEU Gyaan Kosha 
+
+
+नागृहीते विशेषणे विशिष्टबुद्धिरुदेति ॥ 
+
+
+Particular [or distinguishing ] knowledge does not arise 
+until that which particularizes [or defines, the object in 
+question] has been grasped. Tt isin this form that the nyaya 
+is found in Kuswmanjalt iii 21 (page 527), but in Tanira- 
+vartika, page 258 it appears in the contracted form “ नागृही- 
+तविश्येपणातिन्यायेन+? and, on page 287, as “ अगृहीतविशेषणा विशिष्टबु- 
+fet m.” In Madhava’s Nyāyamālāvistare 3. 1. 6, 
+it is quoted as “ नागरृहीतविशेषणा विशिष्चुद्धि:,? and in Sapta- 
+padarthi, page 2, line 6, as “ नागृहीताविशेषणा विशेष्यबुद्धिः.”” 
+In his. commentary on Tarkikaraksd, Mallinatha twice 
+(namely, on pages 47 and 107) cites the maxim in the con- 
+tracted form adopted by Kumarila, whilst Raghunathavarman’s 
+version of it 15 “ नाज्ञातविशेषणा विशिष्टबुद्धिविशेष्य॑ संक्रामति.” 
+
+In Nyāyasūtravritti ii. 126 2. 2 58) it appears as 
+नाग्रृहीतविज्ञेषणान्याय, and Dr. Ballantyne renders it, “Cognition 
+which does not apprehend the distinction, cannot infer [the 
+nature of] what is to be distinguished.” The nyaya occurs five 
+times in Nyāyamanjarī, and each time in a different form! 
+The references are as follows:—page 320, line 19; 483, line 4 
+from bottom; 449, line 8 from bottom; 538, line 6; and 543, 
+line 7, 
+
+In Sir Monier Williams’ Sanskrit Dictionary विशिष्बुद्धि 5 
+defined as “differenced or distinguishing knowledge (e. g. the 
+knowledge of ‘a man carrying a staff’ which distinguishes him 
+from an ordinary man)’; whilst Molesworth explains विशिष्टज्ञान 
+as “knowledge of an object distinguished or characterized by 
+something ( whether a property or an accident) standing out in 
+some speciality (inherent or attached ).” 
+
+
+Identical in meaning with the above, though differing some- 
+what in form, is S’abara’s “न ह्यप्रतीते विशेषणे विशिष्ट के चन प्रत्येतु- 
+wera” (1, 3. 88, page 82). 
+
+
+। Digitized By Siddhanta eGangotry 8yaan Kosha 
+
+
+F~ ____ नासाघितं करणम्‌ d 
+| 
+
+
+That which itself is not an accomplished fact 3 be 
+| instrument | with’ which to bring about some other resul 
+| In the Minanstiparibhasa, page 31, this Nyaya is quoted in 
+"| the discussion on the expression “अम्निहोत्र जुहोति”. The passage 
+l is as follows:—“q च होसस्य मत्यथवाच्यायामर्थेभावनायां N 
+| | मत्वे$झिहोत्रेणेति तृतीया. स्वाज्योतिष्टो मनेतिवदिति वाच्यं द्वितीयाया एव 
+| लक्षणया करणार्थकत्वात्‌ | नासाधितं करणमिति 
+
+I 
+
+| 
+
+
+न्यायेनासाधितस्य करणत्वा: 
+योगात्‌? ॥ Fora rendering of this, see page xxxi of Prof, 
+Ganganatha Jhü's Introduction to his translation of Sloka- 
+vartüka. j 
+
+
+E 
+
+
+4 Krishna Yajvan perhaps took the nyaya from the Jaimini- 
+i yanydyamalavistara, where, in connection with the same 
+
+
+subject, under the तत्प्रख्यन्याय, we find the following kārikā:— d 
+
+
+“ नासाधिते हि धात्वर्थे करणत्वं ततोऽस्य सा | 
+साध्यतां चक्ति संस्कारो aa क्रियात्वतः” ॥ 
+
+
+नासिकाग्रे कर्णमूलकर्षणन्यायः 
+
+
+à, 
+
+
+The figure of pulling the root of the 
+one's nose! It occurs in S ures’ 
+4. 3, 1184, as follows :— 
+
+
+ear with the tip 
+vara’s Brihadāranyakavār 
+
+
+“ स॒मस्तव्यस्ततामेव सति व्याचक्षते5त्र ये | 
+कर्षन्ति नासिकाग्रेण BAS सुखेन ते” ॥ 
+
+
+On which Anand 
+` दष्टान्तेनाह कपन्ती ति.?? 
+
+
+Digitized By Siddnan e Gyaan Kosha 
+
+
+निरामयस्य किमायुर्वेदविदा ॥ 
+
+
+What need has a, healthy man of one skilled in the 02002 
+of medicine? “ They that are whole need not a physician, but 
+they that are sick.” In the Prabondhacintamani (pages 
+106-7 ) there is a story about the poet Bana and his brother-in- 
+law the poet Mayüra, who were favourites of the King Bhoja. 
+The former, owing to the curse pronounced by his sister (the 
+wife of the latter), was attacked by leprosy ; but being healed 
+by the intervention of the Sun, he appeared at court—to quote 
+from Mr. Tawney’s translation—* with his body anointed 
+with golden sandal-wood, and clothed in a magnificent 
+white garment. When the king saw the healthy condition 
+of his body, Mayüra represented that it was all due to the 
+favour of the Sun-god. Then Bana pierced him in a vital spot 
+with an arrow-like speech, ‘If the propitiating of a god 
+is an easy matter then do you also display some wonderful 
+performance in this line”  Mayüra replied as follows:— 
+“ निरामयस्य किमायुर्वेदविदा तथापि तव वचः aera निजपादो पाणी 
+च gat विदार्य त्वया षष्टे काव्ये gå: परितोषितोऽहं तु पूर्वस्य काम्यस्य 
+पष्टेऽक्षरे भवानीं परितोपयामीति प्रतिश्रुत्य सुखासनमासीनश्रण्डिकाग्रासाद- 
+Taran निविष्टो 'मा भांक्षीविश्रमम्‌? इति पष्ठे$क्षरे प्रयक्षीकृतचण्डिकाप्रसा- 
+TAMIA: स्वसंमुखं च तत्रसादमालोक्यासिमुखागतेनपति- 
+मसुखराजलोकैः कृतजयजयारवो महता महेन पुरं TA,” 
+
+
+As pointed out by Mr. Tawney in a footnote, the poem hore 
+ascribed to Mayūra is the Candis'ataka of which Bana was the 
+author. Tt was published in the Kavyamala for 1887, and the 
+
+
+first verse commences thus :— 
+
+
+& मा आांक्षीविश्रमं seu विधुरता केयमास्यास्यरारा 
+पाणे ग्राण्येव नायं कलयसि करहश्रद्धया किं rey? | 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri 8१8831 Kosha 
+
+
+निषादस्थपतिन्यायः ॥ 
+
+
+The topic of a king whois a Nisada by caste. This forms 
+the subject of Jaimini 6. 1. 51, 52 and is thus expounded by 
+Kunte (in Saddars‘anacintanika, page 1788 ):—“The tem 
+Nishidasthapati occurs in the Veda. The question is—how is 
+ib to be interpreted? Is the term Nishādasthapati a Karma- 
+dharaya compound or Tatpurusa compound? The Karma. 
+dharaya overrules the Tatpurusa; because, in the latter, a case 
+not directly seen has to be understood, and because metonymy 
+is thus involved. A direct statement is always to be preferred to 
+metonymy. The Karmadharaya makes a direct statement and 
+therefore does not involve metonymy. He who is a Nisada is 
+a Sthapati; and therefore a superior Nisada is entitled to per- 
+form the Raudra sacrifice.” In other words, the compound 
+when dissolved is not निषादानां स्थपातिः but निषाद एव स्थपतिः. 
+
+
+In esplaining the term ब्रह्मलोक in S/ankara’s bhüsya on 
+Vedāntasūtra 1, 3. 15, Vacaspatimis'ra says (on page 219. 
+line 3 from bottom ):—* अन्न तावन्निपादस्थपातिन्यायेन पष्ठीसमासात्कर्मः 
+धारयो बलीयानिति स्थितमेव तथापीह पष्टीसमासनिराकरणेन कमेधारयस्थाप- 
+नाय छिङ्गमप्यधिकमस्तीति तदप्युक्तं सूत्रकारेण ? | The nyaya is quotel - 
+by Ramanuja in his exposition of the same sūtra, and Dr 
+Thibaut translates as follows:—* That this explanation of the” 
+‘Brahma-world’ is preferable to the one which understands by 
+Brahma world ‘the world of Brahman’ is proved by considerations - 
+similar to those by which the Pürva Mimamsa siitras prove J 
+that *Nishada-sthapati' means a headman who at the sama 
+time is Nishida.” The nyaya is also explained in full i 
+Vedantakalpatarw on this passage, and again in Vedanta 
+kalpataruparimala, Tt is quoted by Anandagiri on Brahma 
+sutrabhasya 3. 3. 24, and by Nages'a on Kaiyata 1, 1, 3. Fo 
+the origin of the Nisada, see Manu x. 8. à 
+
+
+CC-0. Prof. Satya-Vrat Shastri Collection. 
+
+
+Digitized By SOD Gyaan Kosha 
+
+
+वञ्जरंमुक्तपक्षिन्यायः ॥ 
+
+
+The simile of a bird let loose from its cage. Used to illus- 
+trate the upward flight of the soul when released from the 
+body. It occurs in Vedéntakalpataruparimala, page 443, as 
+follows :—“ ऊध्वैगमनं जीवस्य स्वभाव: | देहे स्थितिस्तत्मतिबन्धककर्माधी- 
+नेति मतमाश्रित्योक्तम्‌ | केचित्तु चिरकालझशरीरावस्थितप्रयुक्तबन्धमुक्तावूर्ध्वगमन 
+मन्यन्ते । ते खल्वेवमाहुः | बन्धसुक्तर्योध्वगमनं इष्टं यथा पज्ञरमुक्तशुकस्य 
+यथा वा वारिनिर्भिन्नपरिणंतेरण्डबीजस्य यथा वा इढपंकलिसजलनिमजनत्रक्षीण- 
+पंकलेपझुष्कालाबूफलस्य.”” It will be noticed that there are three 
+
+
+, illustrations in the last clause,—the third being really the 
+
+
+जलतुंबिकान्याय, which see above. 
+
+
+पदार्थानुसमयन्यायः ॥ 
+
+Sir M. Monier-Williams defines it thus:—“ The performance 
+of one ritual act for all objects in orderly succession before 
+performing another act for all objects in the same order.” 
+When 16 is not 8 matter of sacrificial ritual, but merely of the 
+bestowal of gifts, the definition given by Captain Molesworth 
+is more suitable; namely—" The order or method ( when a set 
+or number of things is to be given to each individual of a 
+multitude ) of giving first one article of the set to each person 
+all round ; going round again with another article; and again 
+
+
+» with a third; and thus, until all the articles composing the set 
+
+
+= 
+
+
+shall have been received by each person." The nyaya sum: 
+marizes the teaching of Jaimini 5. 2, 1, 2. See काण्डानुसमयल्याय, 
+and Karkacarya on Katyayana’s S'rautasuira i. 114. 
+
+
+परतन्त्रं बहिमनः ॥ 
+As to externals mind ९७ dependent on others. This oft-quoted 
+nyaya would seem to have originated with Mandanamisra. 
+lt is found in the following verse of his Vidhiviveka, page 
+
+
+1 14 — 
+1l CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta 8931900 @yaan Kosha 
+
+
+“हेत्वभावे फलाभावात्ममाणे सति न प्रसा । 
+चक्चुरा्ुक्तविपयं परतन्त्रं बहिमैनः ” ॥ 
+
+Students of the Survadars'anasangraha Will remember 
+that the second line is quoted ( without mention of lis source ) 
+in the first chapter of that work, and Prof. Cowell translated 
+it thus—" The eye &e. haye their objects as described, but 
+mind externally is dependent on the others.” The depend- 
+ence of manas is pointed out in three Other passages of 
+Vidhiviveka, on pages 120, 161, and 178. "The nyàya is found 
+in Citsukhz i. 12 (The Pandit, vol. iv, page 513 ) in the words 
+“न च मनसो RÀ: सम्बन्धः परतञ्ज बहिमंन इति न्यायात्‌.” 
+It is employed also by the author of Vidyasagar on Khand- 
+anakhandakhadya, page 307 :—“ रजतज्ञानस्यै न्द्रियकत्ववादी वक्तव्य: 
+किंतन्मानससुत बहिरक्षजम्‌ | नाद्यो मनसो बहिरर्थ$स्वातत्र्यादेतच quid 
+सर्वज्ञदूपणप्रस्तावे सण्डनमिश्रेरभिहितम्‌,?? He then cites the verse 
+“हेत्वभावे &e.” Is this Tativaviveka identical with Mandanas 
+Vidhiviveka, or is it the name given to a section of it? 
+
+
+परस्परविरोधे हि न प्रकारान्तरस्थितिः ॥ 
+
+This is the first line of Kusuméanjali iii. 8, the second being 
+
+“ नैकतापि विरुद्धानामुक्तिमात्रविरोधतः ? ॥ The following is Pro- 
+fessor Cowell’s translation of the verse and of a portion of 
+Haridasa’s explanatory comment;—"In the case of contradic- 
+tories, there can be no middle course ; nor can you assume | 
+two contradictories to be identical, because the fact of their 
+contradiction is directly asserted.” “There can be no middle 
+Course,’ 4. ८. you cannot make some third supposition different 
+from either, from the very fact that they are contradictories 
+[and therefore the one or the other must be true]; nor can you 
+assume them to be identical,” Raghunatha’s explanation of the — 
+first line, in his larger work, coincides with this 98 = 
+
+
+YA FERRE AAE TE RR तदन्यतरस्थेलर्ध 
+
+
+Digitized By Siha gg agaa Gyaan Kosha 
+
+
+The nyaya is quoted in the vritti on Pattwamniltakalapa iii. 48, 
+and in the last sentence of Khandanakhandakhidya ili (page 
+561); and the whole verse in the commentary on Udayana’s 
+Laksandvalt, page 47, and in the second chapter of Sarva- 
+dars'amasamgraha. In Lattvadipana, page 234, line 13, ib 
+appears in a somewhat modified form, namely, “परस्परप्रति- 
+स्पार्धेनोरन्यतरनिषेधे$न्यतरव्यवस्थेति न्यायात्‌.!? ; 
+
+
+पजेन्यवत्‌ ॥ 
+
+Like the rain | which falls on all places alike]. It is found 
+in the following passage of Mahabhdsya 1. 2. 9 and 6. 1, 127:— 
+“कृतकारि खल्वपि we पजेन्यवत्‌ | तद्यथा । पर्जन्यो यावदूनं पूर्ण च सर्व- 
+माभिवषाते l This is quoted by Nagojibhatta under paribhasa 
+९७४--पजेन्यवलक्षणप्रवृत्तिः,?? which Professor Kielhorn translates 
+thus :-- The rules of grammar are like the rain [in this that 
+they are] applied [both where they produce a change and 
+where they do not; just as the rain falls upon that which 
+already is full of water as well as upon that which is empty |.” 
+
+There is another example of this in the Panini chapter of 
+Sarvadars‘anasangraha:—* प्रकृत्यादिविभागकल्पनावत्सु लक्ष्य साः 
+सान्यविरोषरूपाणां लक्षणानां प्जन्यवत्सकृदेव प्रबृत्तो बहूनां शब्दानामनुः 
+झासनोपलंभान्न.? “And again, since general and special rules 
+apply at once to many examples, when these are divided into 
+the artificial parts called roots &c, (just as one cloud rains 
+over many spots of ground ), in this way we can easily compre- 
+hend an exposition of many words.” The translation is Prof. 
+Cowell's, We meet with it again in a most interesting passage 
+of Brahmasitrabhasya 2. 3. 42, where Sankara tells us that 
+just as the rain causes the production: of barley, rice; shrubs, 
+&c., by its action on the seeds, so God, making use of mene 
+vious works, impels them to either good or evil! त an 
+be little doubt that the mischievous saying, “कतो आणि र 
+
+
+ईश्वर ng,” current among the Marathas, was derived from this — 
+
+
+4 
+
+
+source, UP ELM 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta 89319०8६/331 Kosha 
+
+
+On page 926 of Merutunga's work the following verge ig 
+quoted as from Kamandakiyanitisara. Tt ig not to be found, 
+however, in the printed edition of that work, but stands ag 
+verse 161 of Hitopades'a i — "quier इव भूतानामाधारः परितपति; 
+विकलेऽपि हि पन्ये जीव्यते न तु भूपतो “The king is the main. | 
+stay of creatures, like the rain-cloud. For even if the rain. 
+cloud be somewhat wanting, it is possible to live, but notif the 
+king is wanting in any respect ” ( Tawney, page 138). 
+
+RT 
+
+
+पर्णमयीन्यायः ॥ 
+
+
+The simile of | the spoon ] made of the Parna wood, Vari- 
+008 Spoons are used in the sacrifices, as described in the foot- 
+note to Professor Eggeling's translation of S‘atapatha Brah- 
+mana 1, 8, 1, 1; and, of these, the juha is always made of the 
+wood of the Parna (4. e. the Palas’ ) tree. This is in accord- 
+ance with Taittirtya Samhita 3. 5, 7, where the praises of that 
+tree are sung, and blessings promised in connection with the 
+use of the ju/vi; made of its wood, as pointed out in S'abara on 
+Jaimini 3, 6, 1-8, The पर्णमयीत्व of the wg employed in the | 
+sacrifices is therefore used to illustrate something invariably 
+present, in contradistinction to that which is so occasionally, 
+as in the case of the godohana. Fora passage containing both 
+of these, see under गोदोहनन्याय. Other examples will be found 
+in Bhamati 8, 3. 61; Parimala, pages 624 to 626; and S'alikd 
+
+"page 157. 
+
+
+पलाळकूटस्य Mew कुज्ञरादिना ॥ 
+
+
+Digitized By Shan aa Gyaan Kosha 
+
+
+“यत्र स्वसदृशादेव कल्पयित्वोपजायते | 
+साइड्यप्रत्ययस्तत्र तदाभासत्वकल्पना ॥ ४० ॥ 
+बाधकम्रत्ययाच्चेषा साइइयाभासता मता | 
+यथा पलाळकूरस्य साइऱ्यं कुञ्जरादिना ॥ ४१॥ 
+
+
+समीपस्थोऽपि जानाति साइड्यं नेति तत्र हि 
+न बाध्यते समीपादौ ay साइऱ्यमेव तत्‌” ॥ ॥४२॥ 
+
+
+Prof. Ganganath Jha renders the passage thus:— 
+
+
+“40. Ina case where a notion of similarity is brought about 
+by means of objects that are not really similar, we have only a 
+(false ) semblance of similarity. 
+
+
+41—42. This is said to be a false semblance of similarity, 
+because it is subsequently set aside by an idea to the contrary, 
+e, g. the similarity of an elephant in a stack of hay; in which 
+case when one is sufficiently near the stack, he realizes that 
+there is no real similarity between the stack and the elephant. 
+That notion of similarity which is not set aside even on close 
+proximity to the object, is a case of real similarity,” Compare 
+
+
+the दूरस्थवनस्पतिल्याय. 
+
+
+HAKA ज्वलदग्निं न पुनः पादयोरधः ॥ 
+Thow seest the fire burning on the mowntain, but not that 
+which is under thy very feet! “Why beholdest thou the mote 
+
+
+that is in thy brother’s eye, but perceivest not the beam that 
+isin thine own eye?” The above is the first line of. Hema- 
+
+
+candra's Parisistaparvan i 382, the second line being “यत्परं 
+
+
+शिक्षयस्येव न स्वं शिक्षयसि स्वयम्‌, The next verse continues the 
+rebuke:— का हि पुंगणना तेषां ये$न्यशिक्षाविचक्षणाः | ये स्वं शिक्षयितुं 
+दक्षास्ेषां पुंगणना नृणाम्‌.” The teaching here 15 akin to that of the 
+
+
+भूिङ्गन्याय) namely “ Practise what you preach.” 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangot$ Ggyaan Kosha 
+
+
+पाटनमन्तरेण विषत्रणानां नोपशान्तिः T 
+
+
+Poisoned wounds will not heal without the use of the lancet 
+This is found in Jaiminiyanyayamalavistara 3. 8. 4, ag fol. 
+lows:—" हि दुःखरूपं तपो विना gars पापं नश्यति । यथा gu 
+पाटनमन्तरेण विषब्रणानां नोपञांतिः? This is, perhaps, the source 
+of Raghunátha's aot ज्िरामयिषोः शस्ग्रहणन्यायः which he makes 
+use of thus :—“निरन्तरं दुःखमयसंसारपरिवरत्तिशरान्तानां जीवानां कंचित्कालं 
+बिक्षेपविगमससुसदात्मानन्दानुभवेन विश्रान्ति संपादयितुकामस्य तस्य संहा- 
+
+
+राय तमोग्रहणस्य दुश्चिकित्स्यत्रणपी डितानां avi शिशमयिषो: श्रग्रहणन्यायेन 
+
+“ निदानज्ञस्य भिषजो wakai युञ्जतः | | 
+
+न किंचिदपि नेघण्यं घृणेवात्र प्रयोजिका! ॥ 
+इति शिवपुराणे ब्याख्यातेन निरतिशयकरुणास्बुधित्वलिङ्गात्‌”” ॥ ‘To under. 
+stand this somewhat involved sentence, it is necessary to bear 
+in mind that संपादयितुकामस्य refers to S'iva, whose benevolent 
+intentions towards humanity are the subject of the immediate 
+context. Contrast with the above the fol lowing saying of 
+Sures'vara's ( in Brihadéranyakavartika 4. 8. 176 ), “न दाहज्वर- 
+उत्त्यथमभिना स्वाद्षिपकूक्रिया.?? 
+= y 
+
+
+पाठक्रमन्यायः ॥ 
+
+
+The law of textual sequence. Tt forms the subject of 
+Jaimini 5. 1, 4— 7. According to the Mimarhsa, there aro six 
+kinds of sequence ; namely, (1 JS rutirama, or ‘direct sequence 
+Which is treated of in the first sūtra of this chapter. It is 
+known as the श्रुतिबलीयस्त्व न्याय, and is regarded as the strongest 
+of thesis. Then (2) Arthakrama, or ‘logical sequence, which 
+is discussed in sütra 2, and in which the sequence is deter- 
+mined by the sense rather than by the order of the text. For 
+example, take the sentence “अझ्निहोत्र जुहोत्योदनं पचति,” where 
+the boiling of the rice must necessarily precede the offering of 
+the agnihotra, although the former 18 mentioned first. Aga 
+
+
+when we reed. a ee e e गृह्णाति) ma 
+
+
+Digitized By Siddhantagepangotri Gyaan Kosha 
+
+
+प्राणिति,?? the logical sequence, as S'abara shows, isin the reverse 
+order of the textual. Then comes (3) Pathakrama, as above, 
+which S‘abara illustrates by the following Vedic passage:— 
+“समिधो यजति तनूनपातं यजति इडो यजति बर्हयति स्वाहाकारं यजति 
+इति.” To quote Kunte:—“ These are what are called the five 
+Prayaja oblations; and the sequence in which these texts occur 
+shows the order in which they are to be offered. This is the 
+application of what is called Pathakrama, or textual sequence,” 
+Under the राजपुरम्रवेशन्याय iu the Second Handful, will be 
+found a passage from Mahabhdsya 1. 1.58 (vart, 1) which 
+furnishes a good example of the supersession of this kind of 
+sequence by अर्थक्रम. The next is (4) Pravritiikrama, which 
+forms the subject of sütras 8-12, Kunte calls it “practical 
+Sequence.’ “In a series of acts, to be performed upon a series 
+of objects, a beginning is made from some one object; then, in 
+performing all the acts, the same object is acted upon first, 
+This sequence is called Pravrittikrama, which signifies sequence 
+determined by the conduct of the individual" Ib is known 
+as the प्रावर्तिकक्रमन्याय. The remaining two varieties are the 
+स्थानक्रम and मुख्यक्रम. 
+
+Kunte’s notes on this portion are well worth a reference; and 
+much help, too, is to be had from Dr. Thibaut's translation of 
+the Arthasangraha, where (on pages 11-15) the six forms of 
+krama are explained under प्रयोगाविधि. 
+
+The use of these technical terms is not confined to the 
+Mimanisakas, but is very common amongst writers on Vedanta 
+also. Four of the above varieties of krama are mentioned in 
+Bhamati 1. 1. 1, pages 47-49, beginning with the words 
+“मा भूदभिहोत्रयवागूपाकवदार्थः क्रमः Ue." and enlarged de oe 
+
+edàntakalpataru, pages 32-34; then, in Bhámatt m ^ NS 
+read “पाठक्रमादर्थकमो बळवानिति यथार्थक्रमं vert सूत्राणि>' an ie : 
+Sutra 12 is next explained, and afterwards sutra T. pe 
+Pathalrama only, see Anandagiri on Bralvasütrobhasya 
+
+
+2. 8. 15 (page 620). 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+| 
+
+
+Digitized By Siddhanta eGangotfi Byaan Kosha 
+
+
+पुरस्तादपवादा अनन्तरान्विधीन्वाधन्ते नोत्तरान्‌ ॥ 
+
+This grammatical nyaya is paribhasa LIX in Nagojibhatta’s 
+treatise, and is taken from Mahabhasya 6. 1. 89 (under vartike 
+2). Professor Kielhorn translates as follows :—“ Apavüdas 
+that precede | the rules which teach Operations that haye to be 
+superseded by the Apavada-operations ] Supersede only those 
+rules that stand nearest to them, not the subsequent rules.” Tt 
+is found also in Patanjali 1. 1. 28 ; 3. 2. 1 (6);3.3, 95 ; 9. 4, 85; 
+4, 1. 55 (4); 4. 3. 132 (6); 4. 8. 156 (7 ); 6. 1. 102 (6); 6. 4. 
+163 (2); and 8. 3, 112. In not one of these examples, 
+however, do the words “ नोत्तरान्‌ २? appear. 
+
+
+वि ह्यपवादा अभिनिबिन्ते पश्चादुत्सर्गाः ॥ 
+
+Special rules are taken into consideration first, and after- 
+wards general rules, “The meaning is this that he who is 
+guided solely by the rules ( of grammar) first looks about. to 
+find out Where the Apavida applies, and having thus ascertain- f 
+ed that a particular form does not fall under that ( Apavada), 
+he employs for its formation the general rule.” See Dr. Kielhorn’s 
+translation of Nagoji’s paribhdsa 62. It is found in Mahé. 
+bhagya 2. 4, 85 ( vàrt. 11); 3, 1, 3 (vr, 10 ); 3. 2. 124 ( vari, 
+10); 4. 1. 89 ( vart. ,2)5 6. 1. 5 (vàrt. 2); 6. 1. 161 and 186. 
+
+
+THT वापवादविषयं तत उत्सर्गो$भिनिविशते ॥ 
+
+
+This is another of Raghunatha's samples of grammatical rules — 
+and is closely connected with Td ह्यपवादाः &०, to which it- E 
+forms an alternative, Dr, Kielhorn's translation of it, in the ; 
+Paribhasendus'ekhara, is as follows:—*"Or (we may say that) — — 
+first all forms which fall under the Apavada axe set aside, and 
+that subsequently the general rule is employed (in the forma- 
+tion of the remaining forms >? It is found in Mahabhasya 
+2. 4. 85 (vart 11); 8. 1. 8. (vat, 10); 8, 2. 194 (vari, 10) 
+1. 5. ( värt. 2); 6. 1. 161; and 6. 1. 186, In each case ib i i 
+mediately preceded by the Paribhasa पूर्व mata: &c., the lat 
+
+
+standing 2०३६ 87 Betel ska ७9०० 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+89 
+
+
+प्रकृतिप्रत्ययो प्रत्ययार्थं सह बूतः ॥ 
+
+
+The base amd the suffi jointly convey the meaning which 
+is understood, | from the word] This is found in Patanjali 
+8. 1. 67, vartika 2, and the rendering is that which was given me 
+(in 1903) by my learned friend Dr. Kielhorn, who also explain- 
+ed that प्रत्ययाथे is equivalent to प्रतीयमाना्थ. This seems to be 
+the only reasonable explanation of the term. The nyaya is 
+used in the above form by S'abara on Jaimini 3, 4, 13 (page 
+320 ), and 10. 8. 24 ( page 677), and appears also in Tantra- 
+vartika 3. 1. 12 (page 686). It is quoted, however, with a slight 
+addition in Vévaranaprameyasangraha, page 4, line 14, where it 
+becomes “प्रकृतिप्रत्ययौ प्रत्ययाथ सह qa: प्राधान्येनेति न्यायेन”, and (in 
+Indian Thought for January 1907, page 51 ) it is rendered by 
+Dr. Thibaut, “According to the principle ‘that the root and the 
+affix of a yerb conjointly signify principally what the affix 
+denotes'"—a rendering which differs materially from that given 
+above. In this altered form 16 is found again in the Ramanuja 
+section of Sarvadars'anasamgraha, where Mr. Gough gives as its 
+English equivalent “The base and the suffix convey the mean- 
+ing conjointly, and of these the meaning of the suffix takes the 
+lead" This would seem to be based onan expression of Madhaya's 
+in Nydyamdlavistara 3. 4. 8, namely, “प्रक्नततिप्रत्ययो प्रत्यया सह बूत- 
+स्तयोस्तु प्रत्ययः ग्राधान्येनेति शाव्दिकेरुद्धोषणात.” To say that whilst the 
+root and the suffix unitedly convey the meaning, the latter is ihe 
+more important factor, is a very different thing from asserting 
+that the two parts together convey the meaning of one of them! 
+Jayanta Bhatta, on page 403 of the Nyayamanjari, says truly, 
+“अकृतिप्रत्ययो परस्परापेक्षमर्थमभिदधाते न च WES प्र्यार्थो5मिधीयते 
+नियोगस्य धातुवाच्यत्वान्न च अत्ययेन प्रकृत्यथो5मिधीयते यागादेः fx 
+
+
+वाच्यत्वाजुपपत्ते: । न च तौ STE स्वकार्यं कुरुतः” ॥ 
+
+
+One more example of the nyaya may be adduced from 
+
+
+Ta 506); 348), with Prof. Ganganath Jhas 
+idee Et LOBE $ Shastri Collection. 
+
+
+३०४/०1 AI E 
+
+
+Digitized By Siddhanta eGangotri fhan Kosha 
+
+
+translation :--“शाखे तु सर्वत्र अत्ययार्थों भावनेति व्यवहा 
+
+
+र्‌ः । तन्नायमः 
+भिप्रायः । 
+
+
+“ 
+TEU सह भूतः प्रकृतिप्रत्ययौ सदा । 
+याधान्याद्वावना तेन ग्रत्ययार्थोऽवधार्यते” ॥ 
+
+
+“In the Mimamsa 85019, however, the Bhavana ig always 
+held to be signified by the affix, The Sense of this theory may 
+be thus briefly explained. The sense of the affix ig always 
+expressed by the root and affix taken together; and as the 
+Bhàvanà is the most important factor in this joint signification, 
+it is held to be signified by the affix,” 
+
+
+The word भावना means ‘a creative energy,’ or ‘productive 
+energy’, or ‘tendency to realize something’. So Dr. Thibaut, 
+In the Arthasangraha ( page 2 ) it is defined as “भअवितुर्भवनाजु- 
+कूलो भावयितुव्योपारविशेप:??, “the particular activity of some pro- 
+ductive agent ( bhüvajitri) which tends to bring about the 
+existence of something which is going to be ( bhawitri); 
+which is capable of future existence" ( Trans p. 3). It is further 
+declared to be twofold, as aed and आर्थी. Tor the meaning 
+of these, see, specially, Professor Cowell's translation of the Jai- 
+mini section of Savvadars'anasangraha, page 182. 
+
+
+प्रतिनिधिन्यायः ॥ 
+
+
+The rule as to the substitution [ of one material for another, 
+in a sacrifice ]. This subject is dealt with in Jaimini 6, 3: 19- 
+17, the five sütras being styled “नित्यकर्मणोऽनित्यग्रारवधकर्मणश्च प्रति 
+निधिना समापनाधिकरणम्‌.?? Other aspects of प्रतिनिधान are dis — 
+cussed in all the Subsequent sütras of the pada. Kunte's sum 
+mary of the teaching of this pada is well worth reading. 
+
+
+The nyaya occurs in the following passage of S/ank 
+
+
+bhasya on Brahmasutra 3, 3. 40, and I append Dr. Thib: 
+
+
+Digitized By रप Gyaan Kosha 
+
+
+न्यायेन प्राणासिहोत्रस्यानुष्टानसिति. ” “Even in the case of the omis. 
+sion of eating, the agnihotra offered to the Prünas has to be 
+performed by means of water or some other not altogether un- 
+suitable material, according to the Mimamsa principle that in 
+the absence of the prescribed material some other suitable 
+material may be substituted.” It must not, however, be sup- 
+posed that the choice of the “suitable material” was left to the 
+sacrificer; the substitute was as rigidly prescribed as that for 
+which it might be substituted. For instance, the juice of the 
+Pütika plant was the only allowable substitute for that of the 
+Soma plant, and Nivüra for rice, Ramanuja mentions both in 
+S'ribhdsya, page 508, and Patanjali speaks of one, in his 
+discussion of आदेश, in Mahabhasya 1. 1. 56 (vārt. 13). The 
+passages from the two authors stand thus: सोमाभावे च 
+पूतीकग्रहणं श्रुतिचोदित सोमावयवसद्भावादिति न्यायविदो fuz: । त्रीद्यभावे 
+च नीवारग्रहणं ब्रीहिभावतः? ॥ (R) 
+
+
+K वेदेऽपि सोमस्य स्थाने पूतीकतृणान्यभिपुणुयादित्युच्यते” ॥ (P) 
+
+
+प्रति प्रधानं गुण आवतनीयः ॥ 
+
+
+A subordinate act is to be repeated 4m the ease of each 
+principle thing. The nyaya in this form is found in Jat- 
+miniyanydyamalavistara 3. 1, 7, and in the Mimamsapari- 
+bhásü, page 36, in connection with what is termed the अहेकत्व- 
+न्याय which is based on the Vedic injunction “दपवित्रेण अहे 
+साष्ट.” Madhava says:—"smffr द्वितीयया ग्रहस्योदेरयतया प्रयो- 
+जनवत्तया च प्राधान्यं गम्यते 1 अहं प्रति गुणः aan: । प्रतिग्रधानं च गुण 
+आवर्तनीय इति न्यायेन यावन्तो ग्रहाः सन्ति ते संमाजनीयाः?१॥ aim 
+niyasütravritii the nyaya is quoted as “श्रतिग्रधानसङ्गादत्तिः Prof. 
+Ganganatha's rendering (on page xxx iiiof the Introduction 
+to his translation of S'lokavartika ) is, “with regard to each 
+Primary, the Secondary is to 08 repeated”. See the ग्रहैकत्वन्याय 
+
+
+in connection with this. 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotf)@yaan Kosha 
+
+
+प्रत्यक्षे किमनुमानम्‌ ॥ 
+
+
+When there is sense-perception, what need is there of 4 
+ence? So Raghunatha; but I have nowhere met ली 
+saying in this form. It is a well-known principle howey, 
+Kumarila says in Tamtravartika, page 87 :- विदवाक्याजु » 
+हि तावदेव THU । तदर्थविपयं maai नोपलभ्यते ॥ ES 
+श्रूयमाणे तु न विद्येतानुमानिकम्‌ । न हि हस्तिनि इ्टेऽपि तत्पदेनानु मिष्यते ॥ 
+Amalananda, too, in Vedantukalpataru, page 368 :-— gà 
+यागविधावानुमानिकविधिकल्पना5चुपपन्ना??, E 
+
+
+In S'abara 3. 1. 12 (page 216) we read : 
+but Patanjali points out (in nae 3. 2. 1200 OR OR 
+is not always the case, He says:— भवति वे प्रत्यक्षादप्यनुमानबली- 
+यस्त्वम्‌ | TAM | अलातचक्रं प्रत्यक्षं हृश्यते5नुमानाचच गम्यते नतदस्तीति”, 
+There are two references to this in Nyayamanjari. On page 
+461 (line 7 from bottom ) we 7680 :--“यद्यपि च नेप नियमः प्रत्यक्षाः 
+चुमानयोविरोधे प्रत्यक्ष बलीय इति त्वरिततरपरिभ्रमितचक्तीभवदलातग्राहिणः 
+म्रक्षस्यानुमानवाधितत्वद॒शना दिति &e.”. Andon page 609 (line 6 
+gon bottom ) :--“अथ aga नियम u3q अत्यक्षानुमानयोविरोधे Tae 
+मेव बलीय इति तदेवानुमानस्य बाधकसुचितं नानुमानान्तरमिति | तदसत्‌ 
+अलातचक्रादी ्रत्यक्षमप्यनुमानेनानन्यथासिद्धेन बाध्यत एव | ननु भ्रमणविरतो 
+परिमितपरिमाणोल्सुकआहि प्रत्यक्षमेव तत्र म्रत्यक्षस्य बाधक नानुमानमिति । 
+भवम्‌ | अनवरतपरि्रमणससुद्भतचक्रावभाससमय एवानुमानेन तद्भान्ततानि- 
+श्वयात्‌ a For अलातचक्र see also Nyayasiitra 3. 2. 59; Bhamati, 
+page 373, line 15; S'alika, page 36; and Vakyapadiya, i. 191 
+
+
+WA the guotation from Kumarila compare the following 
+mx. Myayakanika page 268, and Tatparyatika, page शि - 
+न हि प्रत्यक्षेण करिणि दृष्टेडपि चीत्कारेण तमजुमिमते Aaaa: y Sankar 
+Mis'ra cites this in his comment on Vais'esikastitra 3.2.10. 
+
+
+Sd ES IN S 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta ggangotr Gyaan Kosha 
+
+
+प्रपानकरसन्यायः ॥ P 
+
+
+The simile of sherbet. Used to illustrate the produetion of 
+some new thing by the union of others, just as sherbet is the 
+result of the commingling of various ingredients. It appears : 
+in Batitgadarpangs Ho as follows —“ प्रतीयमानः प्रथम प्रत्येक हेतु 
+रुच्यते | ततः संवलितः सर्वो विभावादिः सचेतसाम्‌ | प्रपानकरसन्यायाच्चर्व्यमाणे 
+रसो भवेत्‌॥ यथा खण्डमरिचादीनां सम्मेळनादपूर्वं इव कश्चिदास्वादः प्रपानकरसे 
+सञ्जायते विभावादिसम्मेलनादिहापि तथेत्यर्थः ?. This is meant to show 
+how Flavour is single, though spoken of as resulting from a 
+composition of causes. Dr, Ballantyne translates thus:—“First 
+each reason is mentioned separately as being percei ved; and 
+[ then we say ] let all this commingled—the Excitants and the 
+rest—constitute, like the [composite] Flavour of sherbet, the 
+flavour tasted by the intelligent. As from the commingling > 
+of sugar, pepper &0,, a certain unprecedented relish is produced E 
+in the shape of the flavour of the sherbet, so is it here also, from 
+the commingling of the Excitants &c., such is the meaning.” 
+
+
+The same illustration is found in Nyayamanjart (page 
+372) with पानक instead of प्रपानक. ^ पदार्थभ्योऽन्य एव वाक्यार्थः 
+पानकादिवत्‌ । यथा पानकं शकेरानागकेशरमरिचादिभ्योऽयौन्तरमेव यथा च 
+सिन्दूरहरिताललाक्षादिभ्योऽथोन्तरमेव चित्रं.-.तथा पदेभ्यो वाक्यं पदार्थिम्यो 
+que" Also Taiparyatika, page 219, line 26. 
+
+
+: केन वार्यते ॥ 
+प्रमाणवत्त्वादायातः प्रवाहः केच वा 
+
+
+Who can resist a stream [of argument] flowing [steadily 
+
+
+on ] because established by proof? This seems to be the oe 
+of the nyaya as quoted at the beginning of the Ama e on 
+of Sarvadars‘anasangraha. The passage 18 as follows:—" अथ | 
+मन्येथाः प्रमाणवत्तादायातः प्रवाहः केन वार्यत इति es ONE : 
+मित्यादिना प्रमाणेन क्षणिकतायाः प्रमिततया &e. ie owe tm 
+renders it thus;—* But the opponent may maintain ‘The un- 
+CC-0. Prof. Satya Vrat.Shastri Collection. 
+
+
+Digitized By Siddhanta eGang$)e,Gyaan Kosha 
+
+
+broken stream (of momentary sensations) has been fairly 
+proved by argument, so who can prevent it? In this Way, 
+since our tenet has been demonstrated by the argument, what. 
+ever 15, is momentary &c'" Ina footnote to page 62 of his 
+translation of this portion of Sarvadars‘anasangraha in Le 
+Bouddhisme d'après les sources brakmaniques, Professor L, de 
+la Vallée Poussin has recorded Professor Leumann’s comment 
+on the above rendering which he considers inaccurate in respect 
+of the nyaya. The criticism is just,—but, unfortunately, the 
+printer has made a mess of the rendering which the critic pro- 
+poses to substitute for Mr. Cowell's, 
+
+
+प्रमाणवन्त्यद्ृष्टानि कल्प्यानि सुबहून्यपि ॥ 
+
+
+Unseen influences | springing from actions, and eventually 
+producing certain effects ], however numerous, may be assumed 
+[as the causes of those effects ] f of established, credibility. 
+This nyaya is the first line of a verse in Tantravartika 2. 1, 
+5, where the important dogma of the existence of apa 
+is discussed. The second line is “अदृष्शतभागो5्पि न कल्प्यो ह्यप्रमा- 
+णकः? ॥ The whole verse is quoted in Sures'vara's Brihad- 
+aranyakavartika, page 1124, and again on page 1797; whilst 
+the first line is found in Latparyatika, page 437, as follows :— 
+YA चानेकादृष्टकल्पनाभयान्सुख्यार्थपरित्यागो न्याय्य: प्रमाणसिद्धे नियोगपर्थः 
+चुयोगानुपपत्ते; | यथाहुः | श्रतासेड्यर्थमश्रतोपलव्धो यल्लवता भवितव्यं न तु 
+श्रुतसञथिल्यमादरणीयमिति । तथा प्रमाणवन्लयदष्टाने कहप्यानि सुबहून्यपि” 
+Thore is another example in Citsukhā i. 23 ( Pandit, vol. v, 
+page 27 ):—“ एतेनोभयपदलक्षणास्वीकारे गोरवदोषो निरस्तो वेदितव्यः 
+डुशुस्सितार्थम्रतिपादनप्रयोजनतया गोरवस्यैवो चितल्वातरमाणवन्त्यदृष्टानि कल्प्या 
+नि सुबहून्यपीति न्यायात्‌.” A third will be found in Khandana, 
+page 74, on which the commentator says, “यन्नादष्टे प्रमाण TUR 
+तददृष्टमपि...प्रामाणिकेरभ्युपगम्यते.'? See, too Tativadipana, pi 
+
+
+416, and Bhed ph Setup grat Shastr Collection. | 
+
+
+Digitized By Siddhantarpfpangotr Gyaan Kosha 
+
+
+Raghunathavarman gives the verse in a different form. 
+According to him, the first line 18 “ बालाग्रशतभागों5पि न कल्प्यो 
+निष्प्रमाणकः, ?? whilst “ प्रमाणवान्ति ७७” is the second, In the num- 
+bered part of his larger work it is called the बालाग्रशतभागो5पि 
+nyaya; but, towards the end of the volume, he guotes ( without 
+acknowledgment ) the above-cited passage of Citsukhi ( together 
+with a good deal of the context) which contains the nyaya in 
+its proper form. On page 514 of his translation of the Tantra- 
+vartika, Prof. Ganganatha Jha renders the whole verse 
+thus :—" It is a rule, in all cases, that a large number of unseen 
+agencies may always be assumed, when all of them are justified 
+by some authority; while even the hundredth part of an unseen 
+agency should not be assumed, if there is no authority for it.” 
+
+
+It may be well to call attention here to this transcendental 
+power adrista, or apirva, invented by the philosophers in 
+order to account for present things without divine intervention. 
+In his article on Mimauisa ( Essays, vol. i, page 343), Cole- 
+brooke says:—“ The subject which most engages attention 
+throughout the Mimamsd, recurring at every turn, is the in- 
+‘visible or spiritual operation of an act of merit. The action 
+ceases, yet the consequence does not immediately ensue, A 
+virtue meantime subsists, unseen, but efficacious to connect the 
+consequence with its past and remote cause, and to bring about 
+at a distant period, or in another world, the relative effect. That 
+Unseen virtue is termed apurva, being 8 relation superinduced, 
+not before possessed." Goldstucker (s. v. अपूव ) quotes Kuma- 
+rila to the effect that Mimamsakas apply that term exclusively 
+to the unseen influence which follows a sacrificial aa that 
+attending action of other kinds being styled संस्कार. he pass- 
+age will be found in Tantravartika page 367. A helpful des. 
+cription of apürva is given also in Rational J of 
+Hindu Philosophical Systems ( pages 149 and 150), where itis 
+rendered by Fitzedward Hall “ requitative afar p rE 
+Banerjea’s excellent work Dialogues on Hindu. Philosophy. 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangof)syaan Kosha 
+
+
+page 140, अदृष्ट is defined as follows:—< Technically, in the 
+usage of philosophers, it means a power or influence inhering 
+in things both animate and inanimate, Ag inherent in the 
+former it implies an unseen power, both intellectual and active; 
+as inherent in the latter it signifies a material power, perhaps 
+partly the effect of previous combinations and motions. .... This 
+unseen moving power in men is again the consequence of 
+works done in a previous life, and hence it stands sometimes 
+for dharma and adharma (virtue and vice) and karma 
+(works ).” I imagine that it would tax the ingenuity of even 
+a Mimàmsaka to produce Proof of अदृष्ट and its working; yet 
+they tell us that it is not to be accepted without proof! 
+
+
+प्रयोजनमनुद्दिश्य न मन्दोऽपि प्रवते ॥ 
+
+
+Even a stupid person, does not adopt a course of action 
+without a motive. This oft-quoted line is found in the S'lokavar- 
+tika (page 653 ) in connection with an argument regarding 
+a Creator of the universe. The need of a motive for action is 
+pointed out on page 4 also of the same work. The following 
+passage from Nyayamanjari, page 191, is a reminiscence of 
+Kumarila's argument that if the Creator acted without a 
+motive his intelligence would be at fault:—“t किमपि प्रयोजनः 
+मजुसन्धाय जगत्सर्गे प्रवतैते प्रजापतिरेव वा | निष्प्रयोजनायां SERIE EUER 4 
+कारित्वादुन्मत्ततुल्यो5सौ भवेत्‌ ^ ॥ On page 339 of the Nyayakanika 1 
+"Vacaspati Misra says —— amat हि प्रवृत्तिः प्रयोजनवत्ताब्याप्ता | l 
+अयोजनवत्ताभावे न भवति शिंशपावत्त्वमिव तरुत्वाभाव इत्यर्थः ^ ॥ 3 
+
+We find the nyaya quoted in full by Anandagiri in his | 
+comment on Brahmasūtrabhäsya 2.2.1. The two passage 
+aro the following :—“तन्निगुणं प्रधानं azgi चेतनस्य पुरुपस्यार्थ | 
+साधयितुं स्वभावेनेव विचित्रेण विकारात्मना विवतेत इति ॥? “ चेतनस्थेतिं 
+अर्थशब्दो भोगापवर्गार्थ: । अचेतनस्य मयोजनपरिज्ञानाभावादमरबुत्त P 
+सयोजनमजदिस हदो; fg. lena ल्यायाविष्याशंक्याह स्वभावेनेति 
+
+
+i Mi 
+
+
+Digitized By 5 बट तरच -Gyaan Kosha 
+
+
+Patanjali (in Mahabhasya 3. 1. 26, värt 14 OS idet 
+with whole classes of people the motive which actuates th 
+a purely selfish one. He says :— 
+
+
+“नेह कश्चित्परो5चुम्रहीतव्य इति vada सर्वं इमे स्वभू प्रवर्तन्ते। चे 
+तावदेते गुरुशुश्रूपवो नाम तेऽपि स््भूत्यर्थमेव प्रवतन्ते पारलौकिकं नो भवि- 
+प्यतीह च नः म्रीतो गुस्रध्यापयिष्यतीति। तथा यदेतद्दासकर्सकरं नामेते$पि 
+स्वभूत्य्थमेव प्रवर्तन्ते भक्तं चेलं च लप्स्यामहे परिभाषाश्र न नो भविष्यन्तीति । 
+तथा थ एते शिह्पिनो नाम तेऽपि स्वभूल्यर्थमेव ्रवर्तन्ते वेतनं च लप्स्यामहे 
+मित्राणि च नो भविष्यन्तीति ”॥ 
+
+
+em ig 
+
+
+Compare a passage from the same source under the nyaya 
+“न हि विधिशतेनापि ८८.” 
+Bhartrihari reproduces Patanjali’s view in the following 
+verse ( Vakyapadiya iii. page 255 ):— 
+“ निमित्तेभ्यः waded सर्व एव खभूतये | 
+अभिप्रायानुरोधे$पि स्वार्थस्येव प्रसिद्यये” ॥ 
+
+
+प्रस्तरप्रहरणन्यायः ॥ 
+
+
+The rule as to the throwing into the sacrificial fire ofa 
+handful of Darbha grass. Kunte says:—“The Prastarapra- 
+harananyaya is well known among the Mimauisakas. Prastara 
+is a handful of Darbha-grass ready for use before a sacrifice 
+is begun. It is spread on the sacrificial ground and 
+Serves as a seat for the sacrificial vessels When a sacrifice is 
+finished it is thrown into. the sacrificial fire as an offering: 
+A Vaidika text states— The handful of grass is to be thrown 
+into the fire with the Suktavaka.’” The nyaya forms the 
+subject of Jaimini 3.2. 11-14 which is otherwise m 
+सूक्तवाकस्य प्रस्तरप्रहरणाक्ष्ताधिकरणम्‌- » The question which has 
+
+
+be decided 18 thus put by the author of the bs x 
+सराय: । 5 
+
+
+" दुशेपूणेमासयोः शरूयते सूक्तवाकेन FRE प्रहरतीति a तत्र संर 
+अस्तरमहरणस्य SUIS कालार्थः संयोगो : 
+13 T -0. P. 
+
+
+UJ \ 
+
+
+rof. Satya Vrat Shastri Collection. 
+
+
+Ls 
+
+
+VS 
+
+
+Digitized By Siddhanta eGangot)§yaan Kosha 
+
+
+The decision is that the Süktavüka mantra is subordinate to 
+the act of offering up the grass, whilst the latter seryes the 
+
+
+double purpose of a resting-place for the vessels and an offering 
+“to the gods. 
+
+
+The term अतिपत्ति which is found in sütra 14 is thus explain- 
+ed by Kunte:—“The rule is that all things connected with a 
+sacrifice are somehow or other to be used in performing tho 
+same; nothing is to be thrown away, nothing is to be preserved. 
+The final disposal of sacrificial things for the sake of getting rid 
+of them is called Pratipatti.” 
+
+
+——— 
+
+
+On = 
+भ्रावातकक्रमन्याय: ॥ 
+See this explained under पाठक्रमन्याय. 
+
+
+फलवत्सहकारन्यायः ॥ 
+
+
+The simile of & fruitful mango-tree. Such a tree not only 
+produces luscious fruit, but also affords shade and fragrance for 
+the weary traveller in the hot Season. Some of us know from 
+experience how charming a camping-ground a mango-grove is! 
+Raghunatha’s explanation of the nyaya in connection with the 
+worship of Ganes’a is as follows :—* एकफलाकांक्षया तदाराधनमन्य- 
+दपि फलं प्रयच्छतीति विवक्षायां उ फळवत्सहकारन्यायः | यथा सहकारं | 
+MAH रसालोऽसो सहकारोऽतिसौरभः इत्यभिधानादतिसौरभ आम्रवृक्षो$ति- 
+मरपक्ककरनमितशाखः स्वसुपसन्नाय छायार्थिने जनाय फलं परिमलं चापरा 
+थितमपि ददाति तथा प्रक्ृतेऽपीत्यर्थः ॥? The quotation here is from 
+Amarakosa, 1v. 33 ( page 87). The thought expressed in the 
+above seems to be that of Apustambadharmasitra 1116 यी), 
+3. viz. “आम्रे फलार्थे नामिते छाया गान्ध इत्यनूरपद्येतरे,?? which see abo 
+
+CC-0. Prof. Satya Vrat Shastri-Gellection. 
+
+
+Digitized By Sicha nd Gyaan Kosha ' 
+
+
+3 Sue C s 
+बाहन्यायः ॥ 
+
+The question of Kus grass. This is based on the sentence 
+kazia ater,’ ? “I cut grass as a seat for the gods,” which 
+forms the subject of Jaimini 3. 2. 1. 2. The question is whether 
+the word afzq is to be taken in its primary sense or in a 
+secondary one; and the conclusion is “मुख्यगोणयोमुख्ये कायेसंप्रत्यय:,? 
+
+: a dan S ~. 8 i: 
+which see above in the form गांणसझुख्ययोः ४९. 
+
+
+बलवदपि शिक्षितानामात्मन्यप्रत्ययं चेतः ॥ 
+
+The mind of even those who are highly educated is distrust- 
+ful of itself. This is the second line of the second verse in 
+S'akuntalandtak. In Tarkikavaksa (page 208), in an ex- 
+position of वाद, we find the following:—“ae तु दैवादागताः 
+सदस्या वादिप्रतिवादिभ्यां संप्रतिपत्त्या प्रामादिककथाभासरशंकाव्यावतनायाड्री- 
+क्रियन्ते न जब्पवितण्डयोरिव प्रमेयादिव्यवस्थापनार्थमङ्गत्वेनोपादीयन्ते ” ॥ 
+On which, Mallinatha comments as follows:—“ वादे विशेषमाह 
+वादे स्विति । देवादागतानां वा किं प्रयोजनमत आह प्रामादिकेति | बलवदपि 
+शिक्षितानामात्मन्यप्रत्ययं चेत इति न्यायादिति भावः? ॥ 
+
+For the benefit of any who may consult the original, I may 
+add that the quotation from the Vyayavartika which imme- 
+diately follows in Varadarüja's text, is found on page 161 of 
+that work; and that from Vacaspatimisra's tika, on page 224 
+
+
+बहुराजकदेशन्यायः ॥ - 
+The simile of « country with several kings | working in 
+Opposition to one another]. It occurs in chap. Xix of Es 
+Amublvatiprakasa, which deals with the Kena Upanisad. The 
+passage is contained in verses 12 and 13 :-- 
+८ वाक्क्षुःशरत्रसुख्याति प्रेरयेत्करणानि कः । 
+इश्वरश्रेत्किमेको$सो बहवोऽीत्ुतेयैतास्‌ 1 
+प्रवर्त्यांनामनत्तत्वाद्वेळ क्षण्याच नकता | 
+नेकमत्य बहुत्वे स्याहहुराजकदेशवत ॥ 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+E 
+Digitized By Siddhanta eGangoli(iSyaan Kosha Si. 
+
+
+The nyaya is sufficiently esplained by the example, Raghu. | 
+nàtha links it with the Azia 
+
+
+हुत्चकाक़ृष्टम्ग न्याय which is Otherwise 
+unknown to me 
+
+
+बहूनामनुग्रहो न्याय्यः ॥ 
+
+The ussociation of many 18 good policy. Raghunathayarman 
+explains thus :—“ अनुग्रहः साहाय्यम्‌ | न्याय्यो न्यायादनपेतोऽरथात्तदुपेत पेतः 
+कार्यसाधक इति यावत, ? and then quotes Pancatantra i. 331 by 
+| way of illustration :—“ बहूनामप्यसाराणां Fay कार्यसाधकस्‌ | तृणैः 
+संपाद्यते रजञस्तया नागोपि aga?’ For the many variants of this 
+
+| verse see Indische Sprüche 4425, and Peterson’s Subhdshitaval, 
+| 2742, The maxim is found in Jaiminiyanydyamalavistura | 
+7. 1. 5, and in Nages'a on Kaiyata, page 16, | 
+
+
+Wes प्रदीपकलिकाक्रीडयैव नगरदाहः ॥ | 
+
+The burning of a city just by a child's playing with the — 
+
+wick of a lamp. “Behold how great a matter a little fire 
+kindleth.” I assume that कालिका means the bud-like charred 
+exeresence which often forms on the top of a wick in an open = 
+oil-light. The saying is found in Kusumanjali v. 3, page 89:-- — 
+
+“ ननु तस्य सर्वदा सर्वन्नाविशेषे कार्यस्य सवदोत्पत्तिप्रसंग. इति निरपेक्षेश्वरपक्षे 
+
+दोपः, सापेक्ष उपेक्षणीय एवास्त्विति बालस्य मदीपकिकाक्रीडयैव नगरदाहः 
+
+परन्तु तन्न स्थेमभाजो जगत एवाकारणर्वप्रसङ्कात्‌.?? A 
+
+
+Udayana seems to use the phrase ironically, but I do 
+
+
+quite grasp the drift of this. We meet With प्रदीपकालिका ag; 
+in Syadvadamanjart, page 157 :— qr च क्षणसन्त' 
+
+
+रोत्पद्यमाना.?” 
+
+
+बुभुक्षितस्य किं निमन्त्रणाग्रह उत्कण्टितस्य किं 
+श्रावणम्‌ ॥ M 
+
+
+D 
+
+
+Digitized By Sidanan FiO Gyaan Kosha 
+
+
+the peacock? In the Kumarapala chapter of Prabandhacinta- 
+mani, page 212, we are told that that king having given 
+Hemacandra (a Jain) a pressing invitation to join him in a 
+pilgrimage to the temple of Somanatha (dedicated to Siva), 
+the hermit replied as follows :—“ बुभुक्षितस्य किं निमत्रणाग्रह उत्क- 
+fore किं केकारवश्रावणमिति लोकरूढेसपस्विनामधिकृततीथीधिकाराणां को 
+नाम ayaa निर्बन्धः ॥ “What need is there toshow much 
+zeal about inviting one who is hungry? Why make one who 
+is longing, listen to the ery of the peacock? So runs the 
+popular proverb, and, in accordance with it, I ask, why does 
+your Majesty exert yourself to press hermits, whose very pro- 
+fession is the visiting of sacred places?” This is Mr. Tawney's 
+rendering, on page 130 of his translation. Indian writers often 
+tell us that the cries of the peacock intensify the longings of 
+separated lovers! For example, Raghwamsa xii 27:— 
+“Raa केकाः शिखिनां बभूवुर्यस्मिन्नसह्यानि विना त्वया मे.” 
+
+
+ाह्मणय़ामन्यायः ॥ 
+
+
+The figure of a village in which Brahmans abound. This ` 
+is in Raghunatha’s list, but hardly deserves a place amongst 
+nyüyas. In Vedantakalpataruparimala, page 188, a distinc- 
+tion is drawn between the expression sgema ILE and 
+घाह्मणप्रचुरो ग्रामः, the meaning, in the former case, being a 
+village in which Brahmans are more numerous than im some 
+other village, and, in the latter, ७ village in which the Brab- 
+mans outn aibe the other castes. The passage is as follows = 
+aa धर्मिविशेषणत्वेत्त निर्देश एव ब्यघिकरणसजातीयाल्पत्वस्य निरू- 
+पकत्वं THI । यथा प्रचुरबाह्यणो ग्राम इत्र VIA ग्रामान्तरगतब्राहमणास्परवं 
+निरूपकं इष्टमिति । तस्य खधर्मिविशोष्यत्वे तु प 
+स्वमेव निरूपकमत एव ब्राह्मणप्रचुरो आम इति अयोगे THAT ATCT ATT 
+mgt प्रतीयते.?” See also Zantravartika, p. 1066 line 2. Akin 
+
+
+to this is ० मह्गरामन्य़ायः 
+a CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGahghitti Gyaan Kosha 
+
+
+भछुन्यायः ॥ 
+
+
+The illustration afforded by Bharchu. We learn from the 
+commentary on Sanksepas'Griraka 1. 14 that Bharchy was a 
+Brühman and highly esteemed by the king of his country, 
+This, however, brought him into disfavour with the jealous 
+hangers-on at the royal court ; and, to get rid of him, they one 
+day blind-folded him and carried him off to a forest; at the 
+same time telling the king that he was dead and had become a 
+goblin! After a long time he returned to the townin company 
+with some foresters, but was prevented by his enemies from 
+entering it. On one occasion, when in a pleasure-ground ont- 
+side the city, the king actually saw him; but, in consequence of 
+the false statement that had been made, he supposed it to be 
+his ghost! Eventual ly the whole thing came to light, and the 
+king discovered that he had been deceived and that the sup- 
+posed ghost was really his old protégò:Bharchu himself, 
+
+
+The verse containing the nyaya is as follows: 
+
+
+“ पुरुषापराधमलिना धिषणा 
+निरवद्यचक्षुरुदयापि यथा । 
+न फलाय भछुविषया भवति 
+श्रुतिसंभवापि तु तथात्मनि धीः” ॥ 
+
+
+As under tho next verse we have a further short comment 
+on the illustration, and as the verse itself furnishes another 
+
+
+good example of the manimantranyaya in the First Handful, 
+I subjoin both:— 
+
+
+“ पुरुषापराधविगमे तु पुनः 
+प्रतिबन्धकव्युद्सनात्सफला | 
+माणेमत्रयोरपगमे तु तथा 
+सति पावकाद्भवति धूमलता? n 
+
+
+| ६ मलम ययोर लो दोरी फलप्रतिबन्धक इति 
+E : LAU 
+
+
+t 
+| 
+* (क 
+
+
+Digitized By Siddhagtg.-eGangotri Gyaan Kosha 
+
+
+शास्त्रीयेण विचारेण तस्यापगमें सत्यमासाण्यशंकारुपप्रतिबन्धाभावातुनस्स्मादेव 
+LEES क्यात्सफला fi wata 6 6 ea 
+निदो पवेदवाक्यात्सफला धीरुदेति यथा भछुटुजनररण्ये प्रक्षिस्तो जीवन्नेव पुन- 
+रागत इत्युपपत्त्या भर्छुज्ञानाप्रामाण्यशंकाकारणपुरुषापराधविगमे सति तद्विषया 
+भछुरेवायमिति सफला धीरुदेति.” 
+Raghunithavarman gives a different version of the story, 
+but names no authority in support of it, He calls iba aua 
+ar." 
+
+
+ya EN A 
+भस्मन्याज्याहातः ॥ 
+
+Ogerimg clarified butter on ashes [ instead of on the sacri- 
+ficial fire]. An illustration of wasted, or misdirected, effort. 
+Upanitibhavaprapanca Katha, page 240 र्र अकार्यवारणोद्युक्तो 
+मूढे यः परिखिद्यते । वाग्विस्तरो वृथा तस्य भस्मन्याज्याहुतियेथा ॥ नोपदेशः 
+शतेनापि मूढोऽकार्यान्निवर्यते । शीतांशुग्रसनात्केन राहुवोक्यैनिवारितः? ॥ 
+There is another instance in Hemacandra's Paris'‘istaparvan i. 
+58 :-- दध्यौ चेवं स राजपिरहो तेपां कुमञ्रिणाम्‌। सन्मानो यो मयाकारि 
+स भस्मनि हुतं gau." 
+
+The nyaya was doubtless derived from Chhandogya Upani- 
+shad 5. 24. 1:--“ q य इदमविद्वानस्निहोत्रं जुहोति यथाङ्गारानपोह्य SE 
+स्मनि जुहुयात्तादक्तत्स्यात्‌.” It is found also in Naiskarmyasiddla 
+11 6 — 
+
+८ अन्तरेण विधि मोहाद्यः कुयोत्साम्परायिकम्‌ | 
+न तत्स्यादुपकाराय भस्मनीव हुतं हविः” ॥ 
+
+
+भाण्डानुसारिस्नेहवत्‌ ॥ 
+
+The simile of [ a remnant of ] oil adhering to | the sides o£] 
+€ vessel | out of which oil has been poured}. In the bhasya oe 
+Brahmasitra 3. 1. 8, there is a lengthy a nd important D 
+cussion as to whether, on returning to earth, in some new birth, 
+after a residence iu the moon, a man brings with him a Eon 
+of the works which took him there,—this remnant being techni 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGanbétd.Gyaan Kosha 
+
+
+cally styled anus‘aya. Sankara affirms that he 
+“कः छुनरनुशयों नामेति । केचित्तावदाहुः । anite कर्मणो भुक्तफलस्यावशेप 
+कश्चिदनुशयो नाम भाण्डानुसारिस्रेहवत्‌ । यथा हि स्रेहभाण्डं रिच्यमानं न 
+सर्वात्मना रिच्यते भाण्डानुसारयेव कश्चित्स्रेहरोपोऽवतिष्टते तथानुञ्ञयोऽपीति” ॥ 
+
+' The question is then asked, why does he not remain in that | 
+blissful region until the whole of his merit is exhausted? The 
+answer is, that, just as a servant who has long served ing 
+king's household, finds his wardrobe ab last reduced to the — 
+slender proportions of a pair of shoes and an umbrella, and is 
+therefore unfit to continue in that-.exalted position, so, too, a 
+man is unworthy of a residence in the moon who has only a 
+small balance of merit remaining to his credit! Here is this | 
+unique reply in S'ankara's own words :—* ननु निरवरोपकर्मफलो- ; 
+पभोगाय चन्द्रमण्डलमारूढाः | बाढम्‌ । तथापि स्वल्पकमावशेपमात्रेण तत्राव- 
+स्थातु न लभ्यते | यथा किल कश्चित्सेवकः सकले: सेवोपकरणे राजकुलमुपसपत- 
+श्रिरप्रवासात्परिक्षीणबहूपकरणइछत्रपादुकादिमात्रावशेपो न राजकुलेऽवस्थातुं 
+शक्कोति । एवमचुरयमात्रपरिग्रहो न चन्द्रमण्डलेऽवस्थालुं शक्नोतीति.” Y 
+This is a portion of the system which is regarded as the 
+highest flight of the Indian mind, and to which some restless - 
+folk in Europe and America are betaking themselves, in ordex 
+to find rest for their Souls! There are nota few in India 
+to-day, however, who have found that rest by turning from 
+these gropings in the dark, to the midday light afforded by | 
+accredited revelation, To quote a modern writeri—" TI P 
+painful, toilsome, searching of the creature into things to 
+high for it, only ends in perplexity and bitter disappointment.” - 
+
+
+does, and says: 
+
+
+भाण्डालेख्यन्यायः |) 
+
+
+Digitized By SU eGangotri Gyaan Kosha 
+
+
+ada: खल्विमाः प्रत्मक्षादिप्रमितयो भिन्नवुद्धिव्यपदेशभाज: | न च माता 
+
+रमेयं वा तजेंदहेतु: | माणानि तु यथायर्थ चतसृष्वसाधारणानीति मिन्नवुद्धि 
+=~ ES e. D 
+
+व्यपदेशनिवन्धनानीति | मेवम्‌ । विवक्षितपदं Taga भाण्डालेल्यमिव 
+
+
+` 
+
+
+पुरुपेच्छानामनियतविषयस्वात्‌?? ॥ 
+
+The commentator S'ankara Mis'ra explains the nyaya thug— 
+“भाण्डालेख्यमिवेति | यथालेख्यं रेखोपरेखादि सर्वभाण्डसाधारण न भाण्डवि- 
+शेषलक्षणं तथा पुरुषाधीनविवक्षापि न ब्िरोषिकेलर्थः” ॥ 
+
+
+In the edition of S’ri-Harsa’s work, however, now in Course 
+of publication ( together with the commentary Vidyasagari ) 
+in the Chaukhamba Sanskrit Series (page 528), the form 
+of the simile differs, and a different explanation of it is given:— 
+“मैवमिति । भण्डो विप्रलम्भकस्तस्यालेख्यं भण्डालेख्यम्‌ | देवदत्तस्य जाया 
+rare जनयिष्यतीति पृष्टे पुत्रो न पुत्रीति विप्रझम्भकस्य कुड्योपयलेख्यं न 
+बिषयविरोपनियतं निषेधस्योभयथा योजयितुं शक्यत्वात्तथा विवक्षितपदमपि 
+पुरुपेच्छानामनियतत्वेन चतुष्टयजातीयस्य नियमेन म्रत्येतुमशक्यत्वात्कस्यचिच्चतस्रः 
+प्रमितयो विवक्षिताः कस्यचित्पञ्चेति” ॥ 
+
+The simile is found in Zaüfparyatika (page 496, last line) 
+aS आाण्डालेख्य. 
+
+
+भूतं भव्यायोपदिश्यत इति न्यायः ॥ 
+
+
+Tt is declared [by Mimamsakas] that an accomplished 
+[ sacrificial ] act is | not an end in itself, bub] for the bringing 
+about of a result in the future [such as the attainment of 
+Heaven &c.]. And this, they say, necessitates belief in an 
+Apiirva as a connecting link between the two. See the 
+arguments for and against this theory, in Professor Ganganatha 
+Jhà's translation of Tunéravartika 2. 1. 5. Most of us will Ru 
+thankful for the aid of so able an interpreter of the teaching 
+
+
+of that terribly difficult book ! gd 
+
+m SRS ; sii ifferent form, in the J 
+he nyaya is kaa, ०5419 00 नम don : ४ 
+
+14 
+
+
+Digitized By Siddhanta eGangeri Gyaan Kosha 
+
+
+Sanksepas'ariraka i. 148; and, in its usual form, in the com. 
+mentary, I quote only the second half of the verse -— i 
+“ भूतं भव्यप्रधानं भवति हि न पुनः स्त्रानं कदाचि- 
+च्छा्रस्थाः शब्दशक्तिस्थरितिनिपुणधियो विस्तरादेवमाहु:? ॥ 
+“ भूतं भव्यायोपदिश्यत इति जैमिनिशबरस्वामिनोमैत॑ तो च Terra shy. 
+कृताबिति तदुक्तमेव अहीतुसुचितमित्यभिम्नेत्याह । भूतमिति । awa: | 
+भव्य साध्यं प्रधानं यस्य भव्यशेषसित्यश्चः” ॥ 
+In verse 312 of the same chapter we meet with if again, 
+and also in the altered form in which a Vedantist would apply 
+it to his system :— 
+“ भव्याय भूतमिति किंच विधिप्रधाने 
+काण्डे नयोऽयमिह तद्विपरीतमाहुः । 
+भूताय भव्यमिति भूतपरं हि सर्वे 
+वेदावसानमिति सूत्रकृदाचचक्षे”” ॥ 
+^ भव्याय भूतमिति | विधिः प्रधानं प्रतिपिपादयिपितो यस्मिन्‌ काण्डे तस्मिन्‌ | 
+इह ब्रह्मकाण्डे । तद्विपरीतं भूतभव्यन्यायविपरीतम्‌ | तद्वैपरीत्यमेवाह | भूताय 
+भव्यमिति | हिहेतो | यतः भूतपरं सत्यसिद्धबरह्मपरं वेदावसानं वेदान्तं सूत्रकृदा- 
+चचक्षे समन्वयसून्रप्रसुखैः सूत्रेरक्तवानतो भाष्यकारादय एवमाहुरित्यर्थः” ॥ 
+The above extracts will be found in The Pandit, vol. iv, page 
+983; and vol. v. page 473. 
+
+
+| 
+4 
+1 
+q 
+
+
+The nyaya occurs again in i. 395 ( Pandit, vol. vi. p. 167) in 
+2 context dealing with bhavana, that topic so dear to the 
+Mimamsaka, for a right understanding of which nothing. | 
+could be better than the perusal of Dr. Thibaut's translation of a 
+the Arthasungraha, pp. 3-5. Verse 482 of the same chapter - 
+contains a fourth example. It appears also in Tattvadipamus 
+page 977, line 7 from bottom, and page 427, line 9 from bottom; 
+also in the Mimamsinyayaprakas'a, page 16, section 36. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanká)gGangotri Gyaan Kosha 
+
+
+भूमिरथिकन्यायः ॥ 
+
+
+The simile of the man who | in order to become proficient | 
+makes drawings of a war-chariot on the ground. This nyaya 
+is found in S'abara's bhashya on Jaimini 7. 2. 15, and again (in 
+conjunction with झुष्केष्टिन्याय ) in 9. 2. 13. The latter passage is 
+as follows :—" यत्तावदुपाध्यायः शिष्यसन्निधावधीते तड़हणार्थम्‌ । यच्छिष्य- 
+स्तद्धारणार्थस्‌ | ग्रहणधारणे प्रयोगार्थ भूमिरथिकवत्‌ आुष्केष्टिवद्वा | तद्यथा भूँ- 
+मिरथिको भूमो रथमालिख्य शिक्षां करोति संग्रामे प्राझुभावो भवितेति यथा 
+च छात्रः शुष्केष्टीः प्रयुक्ते प्रयोगे प्राशुकमी भवितास्सीति एवमेतद्रष्टव्यम्‌” ॥ 
+
+In his Lawakanyayaraimakara (page 186 b of India office 
+MS. 582) Raghunathavarman applies these two nyayas and 
+the शकुनिग्राहकगतिन्याय as 1011005:--परसतनिराकरणं च शिष्याणाम- 
+भ्यासदार्द्येनासं भावनादिसमुच्छेदाय न तु परद्वेपेणेति विवक्षायां भूमिरथिक- 
+न्यायः झुप्केष्टिन्यायः शकुनिग्राहकगतिन्यायश्र Tada ?॥ His explanations 
+of the three are taken from Jaiminiyanydyamalavistura 
+9. 1. 6 and 9. 2. 2 - 
+
+
+^ 
+
+
+स्त्रष्टाचसरन्यायः ॥ 
+
+The law that (something does not take place) when the 
+occasion [for its taking place] has once gone. This is Prof. 
+Kielhorn's rendering of the nyaya as ib oceurs under Nagoji- 
+bhatta’s Paribhdsa lxiv. The sentence is as follows—“ अत एव 
+निर्देशाकृष्टावसरन्यायस्यात्र शाखे नाश्रयणम्‌ । ध्वनितं चेदमिको गुण इति 
+
+
+सूत्रे भाष्य इति भाष्यप्रदीपोद्योते निरूपितम्‌ ?u s The reference is, to 
+the Uddyotw on 1. 1. 3, and the nyaya will be found in. vol. 1 
+
+
+pages 188, 1806, 190. 
+
+There is an instance of ib in Tantravartika 3. 5. 46 (page 
+1060)— Rp यजमानस्य अष्टावसरं कियमाणे विगुणं weit x 
+गुणलोपे मुख्यस्येत्यनेन विरुद्धमू, ” ‘The nyaya 5 expressive of ९ 
+lost opportunity. ; 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+S 
+Digitized By Siddhanta eGanb Al Gyaan Kosha 
+
+
+मदशक्तिवत्‌ ॥ 
+
+
+The simile of the power of an intoxicunt, It is employed 
+by S‘ankara in his bhasya on Brahmasūtra 3, 3. 53 त्रके 
+देहमान्रात्मदर्सिनो लोकायतिका देहच्यतिरिक्तस्यात्मनोऽभावं मन्यमानाः समः 
+स्तव्यस्तेपु बाह्येषु एथिव्यादिष्वदृष्टमपि चैतन्यं शरीराकारपरिणतेषु भूतेषु सादिति 
+संभावयन्तस्तेभ्यश्चेतन्यं मदशक्तिवद्विज्ञान चेतन्यविशिष्टः कायः पुरुप इति 
+चाहुः? Anandagiri comments on the latter part thus :—« मदेति। 
+यथैकैकस्मात्तास्वूलादेरदृ्टापि मदशक्तिः संधाते ae तथेदं ज्ञानमेकैक सन्नः 
+दृष्टमपि देहाकारपरिणत भूतेषु संहतेषु भवतीति चाहुरिति योजना,” 
+In the Lokayatika section of Saddarsanasamuccaya, karika 
+94 reads thus: एथ्व्यादिभूतसंहत्यां तथा देहादिसंभवः। मदशक्तिः 
+सुराङ्गेभ्यो यद्वततद्वत्स्थितात्मता.?” See, too, S'alikā, page 146, line 7 
+from bottom. 
+
+The illustration is found also in Nyayamanjari ( page 439, 
+line 4 from bottom pi यत्तु मदशक्तिवदित्युक्त॑ तत्र स दशक्तेदष्टत्वादभ्यु- 
+पमो न तु ज्ञानस्य तत्र array.” 
+
+
+मधु पश्यसि दुबुद्धे प्रपातं नानुपश्यसि ॥ 
+
+
+O foolish one! thou seest the honey but dost not see the prec : 
+pice. This is the second line of S’antiparva ०००४1. T. ( 0९९४ 
+Bombay «dn.), the first being “ स्वादुकासुक कामानां वैतृष्ण्यं कि न 
+TIN.” Anandabodhacarya quotes it in his Nyayamaka- 
+randa (page TT) as « WH पश्यसि ee प्रपातं कि न पञ्यसिः” 
+The editor of that work was apparently unaware of the exist- 
+ence of the passage in the Moksadharma, for he considered the 
+` आभाणक to be based on the following verse of the DOU 
+१८४८ :-- मठ पश्यति सूढात्मा प्रपातं नेव प्यति । करोति निन्दितं कर्म | 
+नरकान्न बिभेति a.” 
+
+Thanks to the St. Petersburg Lexicon, we can refer to five 
+
+
+other passages Sasha aki Wa GUSH same illustrati 
+
+
+Digitized By Siddhantg ¢Gangotri Gyaan Kosha 
+
+
+is found. In Vanaparva cexxxy, 21 (Cale.), we read.— 
+“ag प्रपश्यन्ति न तु प्रपातं यहयूतमालंव्य हरन्ति राज्यम्‌.” In Udyoga- 
+parva L. 27 1—" विषमं नावमन्यन्ते प्रपातं सघुदर्शिनः | संयुगं ये गमिष्य- 
+न्ति नररूपेण स्त्युना.?. In Dronaparva zi. 11: न Beat बुध्यते 
+दोषान्मोहाछो भात्यवर्तते | मधुलिप्साहे नापञ्यं ग्रपातमहमीदृराम्‌.” Again 
+in cxxxiti, 10 :—" धनं धनेश्वरस्येव हतवा पार्थस्य मे ga: | मधुप्रेप्सुरिवा- 
+बुद्धिः प्रपातं नावडुध्यते.” Lastly, in Striparva i 37: ४ मधु यः 
+केवलं दृष्टा प्रपातं नानुपश्यति | स wel मधुलोभेन शोचत्येव यथा war.” 
+
+
+Compare the following from Sastradipika 3. 6. 3, page 340:— 
+
+
+“यो हि agra दत्तदष्टिदुर्बलां शाखामंधिरोहति तस्य विनिपात एव भवति d 4 
+तद्वदिहापि । ` मधुदृट्टिवदेवास्य गुणकामं प्रपरयतः । क्रियाफलविनाशात्मा i 
+विनिपातः प्रसज्यते.” i 
+
+
+मध्येऽपवादाः पूर्वान्विधीन्बाधन्ते नोत्तरान्‌ ॥ 
+
+
+In the Paribhasendus'ekhard, this paribhasa stands between 
+घुरस्तादपचादाः &९., and अनन्तरस्य विधिवो wc. which see above. 
+Professor Kielhorn’s translation of the present one is as fol- 
+lows :—* Apavadas that are surrounded ( by rules which teach 
+operations that have to be superseded by the Apavada-opera- 
+tions), supersede only those rules that precede, not those that 
+follow, them.” “The reason for (the validity of) this Pari- 
+bhasa is this that (an Apavdda, when it has become effective ) 
+by Superseding the rule which presents itself first, no longer 
+Wants (to supersede something else). Tt appears m Mois 
+bhasya 8. 2. 1 (värt: 6); 4. 1. 55 (vārt. 4); 4. 1. 114 (vari. 4 
+and 6); 4, 3. 132 ( virt, 6); 4. 3. 156 (vari. 7); 0. २. 102 (ars 
+6); 6. 1. 166; 6. 3. 68 (vārt. 5); 6. 4. 148 (vir, 5); and T. 2. 
+44 (vat. 4). In no case, however, are the words नोत्तरान्‌ found 
+
+
+| 
+: 
+
+
+In the paribhasa. 
+
+
+——M— 
+CC-0. Prof. Satya Vrat Shastri Collection. — 
+
+
+Digitized By Siddhanta eGangekfbyaan Kosha 
+
+
+मन्देविषल्यायः ॥ 
+
+
+The simile of « slow-poison. It forms nyaya 150 of the 
+Pirvabhiga of Lauki vunyayaraimakara, and is used in oppo- 
+sition to तीब्रविषन्याय as follows :—“ एवं हि संशयादिनिवृत्तिमेन्द- 
+विपन्यायेन सुकरा | atest प्रतिवाद्यापादितं तु संशयादि तीब्रविपन्याञेन 
+दुष्परिहरं स्यात्‌ सद्योशुक्तं विषं मन्दमन्यथा ara.” 1b ous in 
+S'asiradipika 1. 3.4 ( page 148, line 2 from bottom ) र "gui 
+च संभवति प्रामाण्ये नाप्रामाण्यं युक्तमिति भवति केषांचिदाकांक्षा सापि मन्द- | 
+बिपन्यायेन निराकतेब्येत्येवसर्थमिदम frs," 
+
+
+महतापि प्रयलेन तमिस्रायां परामृशन्‌ । FTE 
+विवेकं हि न कश्चिदधिगच्छति ॥ 
+
+
+Not even by the most thorough examination, could one 
+distingwish between black and wh ite, in intense darkness. The 
+verse is Kumirila’s, and is used by him (in Zantravartika 1. 
+3. 1.) to illustrate the impossibility of tracing the sources from 
+which Manu and other Smriti-authors derived their laws. Just 
+betore aie nieto says ioe न च तद्विज्ञायते कीच्झाद्वाक्यादिदं मन्वा: 
+दिभिः ग्रतिपन्नं कि विधिपरादुतार्थवादरूपादिति. ? Then, immediately | 
+after the verse;—* न q मन्वादिवचनाद्वेदमूलव्वं Aaga: This | 
+latter clause, as the Nyayasudha points out, is with reference 
+to Manu's own statement, in chapter ii. 7, to the effect that 
+every precept of his was deduced from the Veda. 
+
+
+c. Ox = t a 
+Feld दपेणे महन्मुखं तदेव कनीनिकायामणु॥ —— 
+Lhe very sume face which looks large [ when seen] wn ४ | 
+large mirror, appears small [ when reflected ] in the pupil of " 
+the eye. The illustration is found in Latparyattha, page 137 
+line 16:—“ एकमपि व्यकभेदाुत्कर्षवन्निक्पवदृष्टं यथा महति em | 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By SiddhaptajeGangotri Gyaan Kosha 
+
+
+महाणवयुगच्छिद्रकूमग्रीवापेणल्यायः ॥ 
+
+
+This very curious simile is found in the Commentary on 
+S/autideva's Bodhicuryaratara i. 4,the fixst half of which 
+reads thus:—“ क्षणसंपदियं सुटुलंभा प्रातिळव्धा s» T 
+tika commences as pie i र ME ae 
+समग्रता | इयं सुदुर्लभा | सुष्ट दुःखेन लभ्यत इति कथङ्चित्माप्या । महार्णवः 
+युगच्छिद्रकूमंग्रीवापैणोपसा.? In a footnote, the editor tells us 
+that Professor Kern was unable to get any satisfactory 
+meaning out of the nyaya, but proposed the following:—* As 
+the entering of the tortoise’s neck into the hole of the yoke: 
+formed by the great ocean.” Before him, Burnouf, who was 
+
+
+equally puzzled, suggested, “It is as unlikly to happen as if &: 
+
+
+tortoise should put its neck into a hole opening every yuga in 
+the world’s ocean.” This was all that I knew when writing 
+on it early in 1904. A note, however, contributed to the Journal 
+of the Pali Text Society for 1906-1907, by Mr, Harinath De, 
+M. A, threw considerable light on the subject. He gave 
+extracts from three Pali works in which the simile is more or 
+less directly referred to, and one of them, namely that from the 
+Majjhima Nikaya, is said by him to be “the original passage 
+in which the comparison first occurred.” Mr. De did not trans- 
+
+
+late it, but I take the following to be the sense of it. “ Ifa 
+man were to throw into the sea 4 one-holed yoke, and it 
+d east and 
+
+
+were tossed to and fro between north and south, an 
+west, and if, ‘once in a hundred years, à tortoise, blind of one 
+eye, were to rise to the surface, would it be likely that its neck 
+would enter that yoke ?” | 
+
+It was not until after I had made use of this ina note 00 
+the simile which I contributed to the Journal of the Royal 
+Asiatic Society in October 1909, that 1 became aware that 
+my friend Mr. F. W. Thomas had really explained it six years 
+previously ! It came about on this wise. In the September num- 
+
+
+ber of the Indian Antiquary for 1 
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+903, in. an article entitled — 
+
+
+| 
+1 
+| 
+1 
+
+
+dosi WA 
+Digitized By Siddhanta eGardotri Gyaan Kosha 
+
+
+Matriceta and the Maharajakantkalekha, he quoted a verso 
+from a Tibetan work, and gave the following translation — 
+“When like the neck of a tortoise, entering the hole of a yoke 
+in the ocean, I had obtained the state of man, attended with 
+the great festival of the good religion.” He then added thig 
+explanatory remark :—“ The reference to the blind tortoise, 
+which rises from the bottom of the ocean once in a hundred 
+years, and by a rare chance happens to insert his neck into a | 
+yoke floating on the surface of the ocean, is used to illustrate 
+the extremely rare chance by which a living creature is born 
+as a human being.” After pointing out the recurrence of the 
+simile in two other Buddhist works, he added:—*I have noted 
+also a fourth recurrence of it in the Tibetan version of a work 
+entitled Subhdsituratnakarandakahatha, and ascribed to Sūra. 
+This reference will now be familiar to M, Lévi, who has 
+himself discovered in Nepal the Sanskrit text of the work... 
+The Sanskrit original here reads...as follows: 
+
+
+ata evaha bhagavān manusyam atidurlabham | 
+maharnavayugachhidre kürmagrivàrpanopamam ॥ 
+
+
+Ts it not probable that wer have here a saying ascribed io , | 
+Buddha, which we may hope also to find in the Pali literature? — 
+[I now learn from Prof. Rhys Davids that it does occur in the 
+Majjhima Nikdya: see the edition of Mr, Chalmers iii. page 
+1697.” 
+
+
+'This is the passage of the Nikdya quoted by Mr. Harinatha — | | 
+De, but as he makes no reference to Mr. Thomas’ article I | 
+
+
+infer that he, 600, in 1907, was as unacquainted with it as 
+myself. 
+
+
+Orthodox writers, such as Kumürila, Vacaspati Misra and 
+others, have not hesitated to make use of illustrations empl 
+ed by Buddhist writers, and that now under considerati ^ 
+forms no exception. I have recently met with a slightly mo 
+
+
+fied form of it in the Bodhas TA ioKedantio wor 
+ब G0 SR JC Kai i i E 
+S'ri-Narahari, püblis gi Sena vets wah a commentary, in the 
+
+
+Digitized By Siddha irc Gyaan Kosha 
+Y ilo 
+
+
+"Benares Sanskrit Series in 1906. On page 223 the author quotes 
+a verse from “ Vasistha” ( probably the Yogavasistha) which 
+I subjoin together with the comment: B 
+
+
+“ चलाणेवयुगच्छिद्रकूर्म्रीवाग्रवेशवत्‌ | 
+
+अनेकजन्मनामन्ते विवेकी जायते पुमान्‌ ॥ 
+चलेति | चलार्णवयुगच्छिदरकूमगरीवाम्रवेशवत्‌ | चलो wen यावणवो...ताव- 
+णवो तरङ्गो,..तयोर्युगं युग्मं तस्य च्छिद्रं सध्यवत्यौकाशं तत्र स्थितो यः a 
+कमठस्तस्थ॒कच्छपस्योभयपार्श बहुकालं निरन्तरं awed feed 
+ग्रीवाप्रवेशो ग्रीवा कण्ठस्तदुपलक्षिततदाङ्गप्रवेशो यथा जायते तद्वत्पुसान्पुरु- 
+पार्थ्यैनेकजन्मनामनन्तजन्ममरणोपलक्षितसुखदुःखानां स्पेन सिननस्तदन्तः- 
+करणवाह्यकरणानि स्वस्त्रविषयेभ्यो sae विचेक्यात्मानात्स विवेकव्राञ्षायते 
+अवति n” 
+
+
+According to this interpreter, then, we have the tortoise 
+swimming between two boisterous seas (or waves, according to 
+him), and becoming so distressed by the buffeting which 
+it receives that it thrusts its neck (which is said to stand for 
+the whole body ) into something or other not specified! And 
+this is intended to illustrate the distress caused to a man by 
+the ills of endless existences in this bhowasagara, and also his 
+final enlightenment and restraining of his organs of sense from 
+the external objects which formerly attracted them ! 
+
+
+A propos of the above remark as to the adoption by ortho- 
+dox writers of illustrations taken from so-called heretical 
+authors, में may add that possibly even the great grammarian 
+Patanjali borrowed his “आम्रान्पृष्टः कोविदारानाचष्टे” irom a 
+Buddhist source; for, in Childers Pali Dictionary under the 
+word Seyyatha, we find the following quotation from the 
+Samatiaphala Sutta :— 
+
+* Seyyathapi, bhante, ambane và puttho labujam vyakareyya, 
+labujam va—puttho ambam vyakareyya, evum evan &० “As 
+a man, Sir, who was asked about a mango, might answer about 
+a bread fruit, and vice versa, even So Ke, 
+
+irc ES 
+18 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangdftri{Gyaan Kosha 
+
+
+महिषीस्नेहप्रतिबद्धभिक्ष॒दृशन्तः ॥ | 
+
+The illustration of 6 devotee who was hindered [in the religious 
+life ] by the affection which he had for a, cowrtezan | when he 
+was a householder]. It is said to be the subject of a Gatha, 
+and is cited to show that the past, equally with the present or 
+future, may injuriously influence the seeker after the know. 
+ledge which leads to emancipation. It is found in Pancadas' 
+ix, 41;— 
+
+“ अतीतेनापि महिपीस््रेहेन प्रतिबन्धतः | 
+भिक्षसत्त्वं न वेदेति गाथा लोके प्रगीयते ? ॥ 
+
+We are told in the next verse that the Guru, making use of 
+that self-same incident as an instrument for the conveyance of 
+Brahmajndana, brought about its removal and secured the 
+man’s emancipation ! The commentator puts it thus :—“ गुसूस्तस्य 
+तत्त्वोपदेष्ठा तदीयं महिपीख्नहमलुरूत्य तस्यामेव महिष्यां तत्त्व तन्महिष्युपा- 
+Wa ब्रहमोक्तवान्‌ ततः सोऽपि महिपीस्रेहलक्षणप्रतिवन्धकापगमेन गुरूपदिष्ट 
+तत्त्वं यथावत्‌ शास्रोक्तप्रकारेणेव ज्ञातवानित्यर्थ: ?? u 
+
+
+The three verses immediately preceding the above will be 
+found under the हिरण्यनिधिदृष्टान्त. 
+
+
+मुनि्मचुते qui मुच्यते ॥ 
+
+A sage meditates [०1 Brahman ] and a fool is emancipated! 
+An impossible sequence. Compare Ezekiel xviii. 2:—“ The | 
+fathers have eaten sour grapes, and the children's teeth are seb 
+on edge." The nyàya forms part of an interesting passage 
+on page 37 of Vedantatattvavivela se एतेनेदमपास्तं सुनिर्मजुते 
+मूर्खो झुच्यत इत्येतच्छात्रफलं प्रयोक्तरीति FAITE ॥ तथा चाभाणक 
+काचिन्निपादी तनयं AHA कश्चिन्षिपाद्स्तु कषायपायीति | सनिकतुकश्रवणादि 
+Rinse साक्षात्कारस्य मूखेंऽनभ्युपयमात्‌ | STAES EUG EEE 
+अलड्यात्रयगततया तावन्मात्रतया मूखनिष्ठत्वाभावात्‌ | दृष्टफलानां यथादृशसुः 
+
+
+FAR.” For the n aya BIS E प्रयोक्तारि see below. 
+९ CC-0. Prof hi; 
+
+
+Digitized By Siddhafifh$Gangotri Gyaan Kosha 
+
+
+He who performs an action will himself reap the fruit 
+thereof [ whether in the form of reward or retribution ]. This 
+doctrine, common to all the orthodox schools, is found in Nyaya- 
+vartika 3. 1. 4 and is directed against the belief that the body 
+is the soul, and that when the body is cremated, the man, with 
+all his deeds, ceases to exist. This is reasserted in Tatparyatika, 
+page 403, thus :—“ थ एव कर्मणः कर्ता स एव तत्फलस्य भोक्तेति सर्वेरा- ` 
+स्तिकपथानुसारि भिरभ्युपेयम्‌.” The emphasis, therefore, here is 
+not so much on the fact that whatsoever a man soweth that" 
+shall he also reap, as that whosoever soweth the same shall also . 
+reap. ‘This, of course, implies that the reaper will be conscious 
+of the fact that he was the sower, for otherwise the precept 
+would be of no moral value. It is difficult to see how any one 
+can hold with the above, and at the same time be a believer in 
+the doctrine of transmigration, the advocates of which are 
+compelled to admit that the subjects of those repeated births | 
+have absolutely no consciousness of previous existences. I am 
+not unmindful of the fact that the followers of the Yoga system 
+[ sūtra iii. 16 ] profess to attain to a knowledge of the past and 
+the future by means of संयम ( that 18, by धारणा, ध्यान) and समाधि 
+collectively ); but, even if that were so, the number affected 
+
+
+would be infinitesimal. 
+
+
+य एव करोति स एव x ॥ | 
+i 
+[i 
+j 
+
+
+"t 
+
+
+| 
+i 
+| 
+| 
+i 
+| 
+: 
+1 
+| 
+
+
+Hawa पृष्ठे न माति तत्कण्ठे निबध्यते ॥ 
+
+o is no room on 6 camel's back ds tied to 
+his neck! llustrates the piling up of misfortunes almost be- 
+yond endurance, Perhaps akin to our “It is the me straw 
+which breaks the camels back.” Tt occurs in Upamatibhava 
+prapanca Katha, page 994 नर्म सया चिन्तितम्‌ \ अहो हता दैवेन qa 
+मन्दभाग्या: | तदिदमाभाणकमायातम्‌ | AGT AAT VS न माति 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+That for which ther 
+
+
+Digitized By Siddhanta eGandolricyaan Kosha 
+
+
+निबध्यत इति । तथाहि वेश्वानरपापसित्रयोगेणेव SUR गाढसुद्रेजिता वय 
+यावतेयमपरा कृत्येवास्य भाया सम्पन्नेति.?? Kritya is a female deity 
+who is invoked for evil purposes. There is another example 
+on page 895 of the same :— | 
+“ सहाभारसमाक्रान्तमूर्तराराटिकारिण: | | 
+
+
+"EE माति Aga गलके तन्निबध्यते ” |] 
+
+
+यत्राकृतिस्तत्र गुणाः ॥ 
+
+Where there is 4 good outward appearance, there also are 
+` good qualities. This is found in Hemacandra's Paris'ista- 
+parvam ii 2383 :—“ अस्थाकृत्यनुसारेण गुणानपि हि निश्चिनु। यत्राक्ृति- 
+स्तत्र गुणा इति लोकेऽपि गीयते.” It is contained also in verse 5076 
+of Indische Sprüche, bub whether as a quotation or not, I can 
+not say :--“यन्नाक्ृतिस्तन्न गुणा वसंति नेताद्वि सम्यक्कविभिः ufu 
+केनातिचार्वग्यपि मे हृदिस्था दुनाति गात्रं विरहे प्रियास.” Professor 
+Bóhtlingk took it from Kosegarten’s edition of the Pancatantra 
+(1. 208), but I cannot find it in the Bombay edition. Some 
+
+work on grep is a much more probabie source, 
+
+
+यदभिधित्सितं तदभिधीयतां फळे व्यक्तिर्भविष्यति ॥ 
+
+Say what you wish to say about a thing, but its real value 
+will be shown by the advantage derived from it. In the open- 
+ing part of the Tarkikaraksa the author says :---/ प्रारिष्सितस्य 
+ग्रन्थस्य ेकषाबडुपा दित्सामरयो जिकामभिमतफलसाधनतामञिधाय श्रोतूबुद्धिमनु* 
+कूलयन्वार्िप्यमाणमेवामे द्यति । 
+
+निःश्रेयसफलं agit तत्त्वावधारणम्‌ | 
+प्रमाणादिपदाथोस्ते लक्ष्यन्ते नातिविस्तरम्‌ ॥? 
+
+On which Mallinatha comments thus :— E. 
+“ag यदभिधिस्सितं तदसिधीयतां फले व्यक्तिर्भविष्यतीतिं न्यायात्किं पामरे di 
+वईर्‍यमाणार्थप्रतिज्ञाडंबरविलस्वेरित्यायइलोकाक्षपमाइक्‍्य समाधत्ते प्रारिप्सित- E! 
+स्येति । प्रेक्षावतां घीमतासुपादित्सा स्वचिकीर्पा तत्र गरयो जिकां हेतुभूतामि यथः 
+AMANI: MA रिता कार्येति भावः ॥ 
+
+M 
+
+
+CC-0. Prof. S; 
+
+
+Digitized By Siddhantg eGangotri Gyaan Kosha 
+
+
+agè यदपेक्षं चश्ष॒स्तदभावग्रहेडपि तदपेक्षते ॥ 
+
+
+That on which ihe eye depends to perceive am object, if must 
+also depend on to perceive that objects absence. This is Pro- 
+fessor Cowells rendering of the nyaya in the Aulukya 
+chapter of Sarvadars‘anasangraha (page 126, Jivananda's 
+edn. ):-- न चालोकाभावस्थ घटाद्यभाववद्रूपवद भावत्वेनालोकसापेक्षचश्ुज- 
+न्यज्ञानविषयत्वं स्थादित्येपितव्यं | age यदपेक्षं चक्षुस्तदभावग्रहे$पि तदपेक्षत 
+इति न्यायेनालोकग्रहे आलोकापेक्षाया अभावेन तदभावग्रहे$पि तदपेक्षाया अ- 
+mtata.” “And you need not assert that this absence of light 
+must be the object of a cognition produced by the eye in 
+dependence on light, since it is the absence of an object possess- 
+ing colour [ 4. e. light possesses colour, and we cannot see a jars 
+absence in the dark ], as we see in the case ofa jars absence; 
+because, by the very rule on which you rely, namely, that on 
+which the eye depends to perceive an object, it must also depend 
+on to perceive that object's absence, it follows that as there is 
+no dependence of the eye on light to perceive light, it need not 
+depend thereon to perceive this light’s absence.” 
+
+Most probably Madhava took this from Udayana's Kiranduali 
+where it stands (on page 18) in a similar context. It occurs 
+also in Laksandualitikd, page 12. 
+
+
+यववराहाधिकरणन्यायः ॥ 
+
+In Anandagiri on Brahmasitrabhasya 2. 9. 45 we read :— 
+* यववराहाधिकरणन्यायेन लोकप्रसिद्धिः शाखरीयप्रसिख्या eee.” There 
+is no adhikarana of this name in Mimamsa or Vedanta, but 
+the reference is doubtless to the ser Rr sees h 
+otherwise styled the आर्यम्लेच्छाधिकरण; which comprises Jaiminis 
+Sütras 1. 3. 8 and 9, under which the words यव, वराह) and ashen 
+having a double meaning, are discussed by the bhasyakira. 
+These two sutras are quoted by Sankara on Brahmasütra 3. 
+4. 49, and explained by Anandagiri. The matter is well put 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+i 
+t 
+1 
+| 
+
+
+Digitized By Siddhanta eGanggig Gyaan Kosha 
+
+
+in Colebrooke's Essay on Mimārsa (page 339 ) :--“॥ very 
+curious disquisition occurs in this part of the Mimanisa, on the 
+acceptation of words in correct language and barbaric dialects, 
+and on the use of terms taken from either. Instances alleged | 
+are yavo, signifying in Sanskrit, barley, but in the barbaric 
+
+tongue, the plant named priyangu; varaha in the one a hog, 
+and in the other a cow [or, rather, a crow ]; pilu, a certain | 
+tree, but among barbarians an elephant; vetasa, a ratten cane 
+
+and a citron [ or, rose-apple, jambu]. The Mimamsa concludes, 
+that in such instances of words having two acceptations, that 
+in which it is received by the civilized (Aryas), or which is 
+countenanced by use in sacred books, is to be preferred to the 
+practice of barbarians ( Mlechha ), who are apt to confound 
+words or their meanings” The above is of importance to 
+students of Vedanta; for, in addition to the passages named 
+above, it is discussed in Bhamati 3. 3. 52, and enlarged upon 
+in Veddntakalpataru, pages 461, 462. The brief allusion, too, 
+to the same thing, in Bhàmat 1. 3. 22, in the words:—*q हि 
+यावो वराहमनुधावन्तीति कृष्णाबेहङ्गानुधावनसुपपद्यते गवामपि तु ar 
+सूकरानुधावनम्‌,” is quite unintelligible alone. See too, 8८ 
+page 192; Tatparyatika, page 292 ; Kusumanjali, vol. 2, pages — 
+180, 154; and Nydyomanjari, page 288, line. 26, E 
+
+
+यश्चो भयोः समो दोषो न तेनैकश्रोद्यो भवति ॥ 
+
+
+When the sume Sault attaches to both sides of an argument 
+it cannot be urged against one alone. This is Professor 
+Cowell’s rendering of the nyaya in the Panini chapter of 
+Sarvadursonasangraha (page 142, Bib. Ind, and 161 Jiv 
+nanda’s edn.) It originated, however, with Patanjali, and 18 
+found in Mahabhasya 6.1.9 ( vàrt. 2) as “य॒श्चोभयोदोषो न Tata 
+
+द्यो भवाति.?? Sedorerotosewva hit Galectiono. it ag « qan 
+
+
+Digitized By SOON dO Gyaan Kosha 
+
+
+दॉपो नासावेकस्य वाच्यः+? In a form differing slightly from these 
+it is quoted in Nydyakanika (page 995, line 4 from bottom ) 
+and is still further changed in the following verse of Log 
+dha’s on Sankhyasitra i, 6 .— 
+“ यत्रोभयोः समो दोपः परिहारोऽपि arem: | 
+नेकः पर्यनुयोक्तव्यस्तादृगर्थविचारणे” ॥ 
+
+For other references to the nyaya, see Taniravartika, page 
+947; Nyāyamanjarī, page 95, line 10 from bottom; and (in 
+the poetical form) Turkabhasa, page 88. The Khandanakara 
+cites the first two words of the nyaya, on page 531, and ascribes 
+it to Bhatta ( Kumarila ). 
+
+
+d A क्रियन्ते 
+यस्य नास्ति पुत्रो न तस्य पुत्रस्य क्रीडनकानि क्रियन्ते ॥ 
+
+Toys are not made for the son ofa man who has na son! 
+This is used by S'abara to illustrate Jaimini's subra 10, 3. 5— 
+YA चाङ्गविधिरनङ्गे स्यात्‌. He says: नह्यनङ्गे कमेण्यङ्गस्य विशेषः 
+विधिः स्यात्‌। भवति च विशेषविधिः “आश्ववालः प्रस्तर’ इति। न ह्यसति प्रस्तर 
+प्रस्तरविशेषः शिष्येत यथा यस्य नास्ति पुत्रो न तस्य पुत्रस्य क्रीडनकानि Bored." 
+
+Then, in Parthasarathi’s Nyayaratnamdla, page 111, we 
+find the expression सवैमिदमजातपुत्रकीडनकमापद्यते.” 
+
+
+यस्याज्ञानं श्रमस्तस्य भ्रान्तः सम्यक्‌ च वेत्ति सः Ul 
+
+He who has Nescience [as an upadhi |) is the subject of 
+delusion ; [ but though] deluded he is also possessed of sound, 
+knowledge. "This is affirmed of the individuated Self, d 
+though a portion, ‘as it were” of the “undivided and indivisi- 
+ble Self, is also the आश्रय of Nescience. ‘This is one of the 
+mysteries of the advaitavada. For a full description of जीव 
+as found in S’ankaracarya’s famous bhasya, see Notes to my 
+edition of the Vedantasara. à 
+
+The above nyaya is found i 
+
+
+his exposition of it is extremel 
+; CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+n Raghunatha's two treatises, but 
+y meagre since he ignores the 
+
+
+/ 
+XE 
+oe 
+a 
+NY 
+=a. 
+
+
+Digitized By Siddhanta Gaza Gyaan Kosha 
+
+
+second pada of the line. He says :--“ यस्यानात्मनि देहादावात्मभरमो- 
+ऽस्ति तस्याज्ञानमिति कहप्यते.” 
+
+
+The verse of which if forms the first line is duoted in full by 
+Ramatirtha in his discussion of the term adhyaropa in Section 
+6 of Vedantasira. In the Calcutta editions of 1829 and 1886, 
+the reading of the second pada is “ srra: सम्यक्करोति सः,” whilst 
+Prof, A. E. Gough, in his translation published in The Pandit 
+of August 1872, followed the reading “ भ्राल्तो$सस्यक्करोति सः.” 
+In my edition of 1894 (page 104) 1 adopted the reading 
+© sea: amg वेत्ति सः,” but I now see that in so doing I wag 
+oxemplifying the truth of the first pada ! There was manuscript 
+authority for it, however, and go Vidydsdgari, p. 443. 
+
+
+In its true form the nyaya is found in the commentary on 
+Sanksepas Griraka iii. 8 (The Pandit, vol viii. page 660), and 
+again in Tativadipana, page 179 (with the mislection mfa: 
+for आन्तः ). The former passage is as follows :— 
+
+“ननु सिथ्यातच्वज्ञानयोविपयवेषम्येऽपि यस्याज्ञानं अरमस्तस्य आन्तः सम्यक्‌ च 
+वेत्ति स इति न्यायादज्ञानश्रान्तितत्ववो धानामेका श्रयव्वनियमादज्ञाना श्रयचिन्मा- 
+त्राश्रयत्वमेव श्रान्त्यादेः स्यात्‌ ७०.” 
+
+If any one can trace Ramatirtha’s verse to its source I | 
+shall be glad. The Yogavdsistha is a very likely kara; but | 
+
+
+2 E i 
+with the weight of Seventy summers upon me I am not myselt | 
+prepared to join in the search. ? 
+
+
+यस्योन्मूलनाय यस्य प्रसक्तिभवति ततस्तस्य बलवच्त्वम्‌॥ | 
+He who is bent on destroying another must be stronger than. — 
+he. This is contained in an extract (given by Prof, Kielhom 
+from Bhairavamis'ra's comment on Nagoji Bhattws paribh 
+ठ्य, namely fret बलीयांसः (=प्रतिपिधाश्च बलीयांसो wafa 0 
+Patanjali 1. 1. 68, vartika 6 ) which runs thus:—“ gg च परि 
+भाषा लोकसिडन्यायसूलिकेत्याह | विध्युन्मूलनायेति । uer विधेरनिवतेतायेः 
+ST: । एतेन येन नाप्राप्तन्यायेन freee निपेधशाखेण बाध इति दार 
+PRI लोकेऽपि0थश्थोन्मूलनितअः Ver HRS cae aca ` 
+
+
+Digitized By udo Gyaan Kosha 
+
+
+wwa.” The example given here, of one of superior might 
+
+overcoming a less mighty one, is that of Krishna and the 
+
+demon Kamsa. The death of the latter is described in Vishnu- 
+
+Purina, Book V, chapter xx. Those who are familiar with the 
+English Bible will call to mind the words « When a strong 
+man armed keepeth his palace, his goods are in peace; but 
+when a stronger than he shall come upon him, and overcome 
+him, he taketh from him all his armour wherein he ‘trusted, 
+and divideth his spoils.” The" strong man,’ here is the Prince 
+of this world—“ that old Serpent, called the Devil, and Satan, 
+which deceiveth the whole world”—his : goods’ are human 
+souls and bodies; the ‘stronger than he’ is Christ, the Prince 
+of Peace,—to whom has been given the commission “to bring 
+out the prisoners from the prison,” 
+
+
+येन नाप्राप्ते यो विधिरारभ्यते स तस्य बाधको भवति ॥ 
+
+
+Here is another of Raghunatha’s grammatical nyàyas It 
+forms paribhasà 57 in Nagojibhatta’s work, and is rendered by 
+Professor Kielhorn as follows:—“ A rule which is given (in refer- 
+ence to & particular case or particular cases) to which another 
+(rule) cannot but apply (or, in other words, which all fall 
+already under some other rule ), supersedes the latter.” “The 
+meaning of the words येन amma is ‘while another rule is méces- 
+sarily applying, for the two negatives (q and अ) import more 
+force to the word (ara, than this word would possess without - 
+them).” The Professor adds the following in a footnote:— 
+“This paribhasa teaches us the meaning of the term apavada, 
+and in doing so tells us the reason why an apavada possesses 
+greater force than antaranga and other rules. An apavada 
+18 a special rule ; it is given in reference to particular cases which 
+all fall under some general rule (uisarga); as it is not applic- 
+able in any case which does not fall under the general rule, it : 
+must necessarily supersede the latter, because it would गमावता 
+not serve any purpose whatever.” Kaiyata and Nagesa 
+
+
+generally quote it in the shortened form of येन नाप्नापिन्याय, 
+16 CC-0. Prof. Satya Vrat Shastri Collection. j 
+
+
+Digitized By Siddhanta eGari6t Gyaan Kosha 
+
+
+Under this paribhasa, Nagoji introduces and discusses the 
+तकरकोण्डिन्यन्याय, namely “ब्राह्मणेभ्यो दघि दीयतां qx atsam” 
+The paribhasa is found in the following passages of th 
+Mahabhasya:—1. 1. 6. (vārt. 1.); 1. 1. 28; 3. 4, 85 (vürt 2); 
+6. 1. 2 (vārt. 4), where the तक्रकोण्डिन्यन्याय is brought in; 61. 
+166; 6. 8. 68 (vart. 5 ); 6. 4 163 ( vàrb 2), with तक्रकोण्डिन्य 
+again; T. 2.44 (vart. 4) ; 7. 2. 117 (vart. 9 ), with तक्रकोण्डिन्य; | 
+8. 2. 23 (vart. 5); 8. 2, 72; and 8. 3. 119. र 
+
+
+—— 
+
+
+रथकारन्यायः II : 
+The simile of the Rathahkara, There isa Vedic text which | 
+says, “In the rainy season a Rathakara ought to establish a | 
+sacred fire.” The question then arises, what is meant by the | 
+word Rathakira? Does if mean a chariot-maker, or is it a. 
+member of the caste produced by the marriage of a Mahisya (the < 
+offspring of a Kshatriya and a Vais'ya-woman ) with a Karani 
+(the offspring of a Vaisya anda S'üdra-woman ) whieh is 
+called Rathakara? The question is discussed in Jaimini 6, 
+44-50, and is decided in favour of the latter. The discussio 
+thus summarized in Juiminiyanyayamadlavistara :— आधाने 
+श्रूयते । वर्षास रथकार आदधीतेति । तत्र रथं करोतीति व्युत्पत्त्या त्ैवाणिको 
+रथकार इति चेत्‌ । नेवम्‌ । संकीणजातिविशेषे रूढत्वात्‌ । वेश्यायां क्षत्रियाः 
+gerat माहिष्यः । शूद्रायां वेइयाहुत्पन्ना करणी । तस्यां करण्यां माहिष्या 
+पन्नो रथकारः । तथा च याज्ञवल्क्यः । ‹ माहिष्येण करण्यां तु रथकारः प्रजाः 
+` यत’ इति | तस्य च रथकारस्याधानकालो वर्षलः? ॥ 
+
+
+The nyaya is quoted by Nagojibhatta in his writti on th 
+ninety-eighth  paribhüsk ( अवयवप्रसिद्धे समुदायग्रसिद्धिबलीयसी 
+us Which Prof. Kielhorn renders thus |) 
+eaning which a word conveys wh 
+Stronger than the (etymolo 
+
+division of the word into ) its 
+
+hi h 
+iE I 
+
+
+Digitized By Me o Gyaan Kosha 
+
+
+रात्रिसत्रन्यायः ॥ 
+
+
+The rule as to a nighi-sacrifice. This is the topic of Jaimini 
+4. 3. 17-19, and is largely used by writers on Vedanta asa type 
+of scripture-passage conveying no direct promise of reward, and 
+therefore dependent on an arthavada-passage for such promise. 
+Though S'ankara does not mention the nyaya in his bhasya on 
+Brahmasiitra 3. 3. 88, it is evident that he has it in view, and 
+Anandagiri, and Amalünanda (in the Kalpataru), expressly con- 
+1666 his remarks with it. So also the Kalpataruparimala, 
+The last-mentioned work quotes it again on page 255 (in 
+connection with Brahmasūira 1. 2, 24):—“aay सर्वपापप्रदाहोऽपि 
+बरह्मलिङ्गप्रशचोत्तराभ्यां प्राधान्येन प्रतिपिपादयिषिततयोपत्रान्तस्योपासनस्य फलाः 
+कांक्षया रात्रिसत्रन्यायेनार्थवादिकफलविपरिणामे कर्तव्ये प्रधानार्थवाद इवाज्ञाथ- 
+वादे श्रुतस्थापि फलस्य ग्रहणोचित्यात्‌.?? 
+
+The nyaya is found also in Pancapadikavivarana, page 
+122, line 8 from bottom, and again on page 134, line 9 from the 
+bottom. . The latter passage is as follows:—“ ननु रात्रिसत्रन्यायेनार्थ- 
+वादगतसेव मोक्षं ब्रह्मज्ञानं वा ग्रयोजनं साध्यत्वेन परिणमय्य मोक्षकामो HI 
+ज्ञानकामो वा विचारयेत्‌ ४०.” See, too, S'alikd, p. 7 and 157; and 
+Tattvamuktakalapa v. 81. 
+
+
+A 
+राधावेधोपमा ॥ 
+
+'The simile of piercing the central figure ० ७ target That 
+is, hitting the bull’s eye. Itis used of something difficult of 
+accomplishment, and requiring great skill. “ In Prakrit WA 
+radha is generally called puttaliya, literally “ a little figure, as 
+apparently a little human figure was painted in the middle of 
+
+
+the butt.” This note, contributed by Professor Leumann to i 
+Mr. Tawney's translation of Merutungas work, is probably a 
+Correct explanation of the word राधा; rather than the dictionary N 
+meaning, ५ an attitude in. shooting.” The illustration apne on 
+
+pages 412, 420, and 434 of Upamitibhavaprapamea Katha, as 
+
+
+follows: —* सा चेयती भवेत्कस्य साम्रीयं सुदुर्लभा। राधावेधोपमानेन धर्मे” 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. र 
+
+
+"Ed 
+
+
+Digitized By Siddhanta eGangotridafaan Kosha 
+
+
+प्राप्ति: प्रकीतिता?? ॥ “एनं संसारविस्तारं fuor PARTE: | मानुष्यं प्राप्य 
+g राधावेधोपमं जनः qp “भो अव्याः मविहाय मोहललितं geniin 
+कर्ण्यतामेकान्तेन हितं मदीयवचनं कृत्वा विशुद्धं मनः । waged uf. 
+US लब्ध्वापि मानुष्यकं हिंसाक्रोधवशाचुगेरिदमहो जीवे: पुरा हारितम्‌,” 
+Two more examples will be found on Pages 575 and 981 of 
+the same, 
+
+
+The above meaning of radha fully explains the epithet 
+radhabhedin as applied to the renowned archer Arjuna, 
+
+
+रोहणाचळलाभे रलसम्पदः सम्पन्नाः ॥ 
+
+
+On acquiring the mountain Rohana one acquires the 
+wealth of. gems contained in it This occurs in the 
+Pratyabhijna-section of Sarvadars'anasangraha (page 106 
+of Jivananda’s edn. ) — परमेश्वरतालाभे हि सवाः सम्पदस्तन्निष्यन्द्‌ः 
+
+
+न्यत्यार्थेनीयम्‌ | तदुक्तमुत्पलाचार्ये: | भिक्तिलक्ष्मीससरद्धानां किमन्यदुपयाचि- 
+SH) एनया वा दरिद्राणां किमन्यदुपयाचितमिति.?” Professor GO 
+renders it thus:—« For when the nature of the Supreme Being 
+
+is attained, all felicities, which are but the efflux thereof, are 
+overtaken ; as if a man acquired the mountain Rohana (Adams | 
+Peak), he would acquire all the treasures it contains If a man 
+acquire the divine nature, what else is there that he can ask k 
+for? Accordingly Utpalacirya 8898-- What more can they — 
+ask who are rich in the wealth of devotion? What else — 
+can they ask who are poor in this 2^" र 
+
+
+wm. 
+For a Sbory in Connection with the mountain Rohana 88 — 
+a mine of wealth, see Prabandlhacintamgni, page 8, 
+
+
+CC-0. Prof. Satya Vrat Shastri Co /rat Shastri Collection. 
+
+
+Digitized By Siddhanta स Gyaan Kosha 
+125 
+
+
+वटे यक्षन्यायः ॥ 
+
+
+The belief as toa Yaksa in a Banyan treo, A popular be- 
+lief, based solely on the tradition of the elders, that a Yaksa, 
+or goblin, lives in every Banyan tree. Tt is used as an illustra- 
+tion of aaa (‘tradition’), which some regard as a pramana, but 
+which Gautama rejects as such. See Nyayasuütra2,9,1. The 
+Nydyastitravivarana expounds the term thus tate वृक्षे 
+यक्षः प्रतिवसतीति लोकप्रासिद्धिः | तत्र मूलवक्रनिर्देरोनाप्तोक्तत्वानिश्रयेन IERI 
+निश्चयस्य शाब्दबोधहेतुतया नास्य शब्दप्रमाणेन्तर्भावः This is the 
+position of the objector who maintains that tradition is a dis- 
+tinct pramana; the refutation is contained in sūtra 2. In 
+Ballantyne's Aphorisms of Nyaya Philosophy, Book ii, page 
+66, we have the following rendering of a portion of the Nyaya- 
+Sulravritli :—“A rumour (aitihya) is what is expressed in this 
+way—‘thus indeed people say’ &c. for it is an assertion which 
+has come from one to another, without any first assertor being 
+indicated :—for example, ‘In every Bengal fig-tree there is a 
+goblin, and the like.” In a foot-note to page 329 of Colebrooke's 
+Essays, vol. i, Professor Cowell gives to aitihya the meaning of 
+“fallible testimony (as opposed to infallible sruti), whilst 
+Colebrooke himself, on page 427, renders it by ‘tradition.’ In 
+Nyayamanjari, page 194, the nyaya is applied in the follow- 
+ing way by the disbeliever in the existence of God :-न च प्रसिद्धिः 
+सात्नेण युक्तमेतस्य कल्पनम्‌ | निमूलत्वात्तथा चोक्तं प्रसिद्धिवेटयक्षवत्‌. * And 
+at the top of page 64, there is the following, forming the second 
+half of a verse :— i 
+
+
+“Ofte तु न सत्यमत्र हि वटे यक्षो$स्ति वा नेति वा 
+को जानाति कदा च केन कलितं यक्षस्य कौडग्वपुः Il 
+
+
+In S'lokavürtiba (page 492) we read “ जगति बहु न तथ्यं नित्यः — 
+
+
+Magt भवति ठु यदि सख्यं arated तत्‌ whieh Prof. Ganga, 
+
+
+ü i i world as 
+nat hà y « Much of what is known in the wor 
+hary Tend Satya Vrat Shastri Collection. 
+
+
+ul E 
+i 
+di HA 
+Digitized By Siddhanta 60819७७9०8 Kosha 
+
+
+“Tradition ° is not always true; and whatever happens to be | 
+true that does not differ from < Valid Testimony,’ ” Pirtha- 
+sarathis comment on this is—* पुरुषवचनपरंपरा ऐतिहां वटे वरे चैश्रवण 
+इत्यादि | तञ्चानिर्णायकत्वाख्रमाणमेव न भवति l तद्भावेडप्यागमान्तर्भावात. 
+See, too, Tarkikaraksa, page 117. 
+
+
+वध्यतां वध्यतां बालः ॥ 
+
+As Raghunathavarman had the temerity to include this in 
+his list of nyayas, I introduce it in order to show its origin and 
+its worthlessness. At the bottom of page 53 of the Benares 
+edition of Laukibanyayasongraha, it stands thus: तथा च 
+` वध्यतां वध्यतां बालो नानेनाथो$स्ति जीवता । स्वपक्षहानिकतृत्वाद्यः 
+कुलाङ्गारतां गत ? इति न्यायविपयतां नातिवर्तते.” This verse, and the 
+words which follow it, are taken bodily, from Citsukhz i. 16 
+(The Pandit, vol. iv, page 534 ); but the real source of the ; 
+sloka is Vashnu, Purana 1. 17. 31, where it reads ४ दुरात्मा | 
+वध्यतामेपः,?? the remainder being the same as the above, `T got 
+the clue from the Luukikanydyaratnakara, where Raghu- 
+
+
+natha apologetically says :--* इदं विष्णुपुराणे Kaika हिरण्याक्षः 
+वचनं पूवैन्यायत्वेनोदाहतत्वात्तत्वेनोदाहतम्‌. 2 
+
+
+TAIT: ॥ 
+
+The topic of glory [or splendour}. This forms the topic of 
+Jaimini 3. 8. 25-27, The point discussed is whether in usi 
+the mantra “ KATA वर्चो विहवेष्वस्तु;?? “ Fire ! let there be glory 
+me in the offerings,” the officiating priest (at the new and fı 
+moon sacrifices).is to enjoy the fruit, or whether it falls to 
+Sacrificer. The Pürvapaksin holds the former view, but t Si 
+decision is that it goes to the latter. In this adhikarana ther 
+is mention of karana-mantras, but the term is not explained. 
+Kunte Says that a karana-mantra is t 
+= ficial operations ; 
+urse of a sacrific 
+
+
+Digitized By Siddhanta f8gnootri Gyaan Kosha 
+
+
+विळूननासिकस्यादर्शदर्शनम्‌ ॥ 
+
+
+Showing a looking-glass to ७ man whose nose has been cut 
+off! An incitement to wrath! It occurs in Prabondhacinta- 
+mani, page 291, as follows:— प्रायः सम्प्रतिकोपाय स्या पेड 
+नसू। विलूननासिकस्येव यद्ददादर्शदर्शनस्‌.'? “Asa general rule, point- 
+ing out the right way leads to immediate wrath, asthe showing 
+of a mirror to one whose nose has been cut off.” This is Mr. 
+Tawney's rendering, and I have adopted the reading of his 
+manuseripts in the first line. In the second line, the Mss, read 
+
+
+विशुद्धादशेदर्शनम्‌. 
+
+
+विश्वजिन््यायः ॥ 
+
+
+The law regarding the Vis'vajit-sacrifice. It forms part of the 
+great sacrifice called Gavam ayana which lasts for a year; for 
+a description of which see Dr. Eggeling’s translation of S’ata- 
+patha-Brahmana, vol. 2, page 427. A quite new explanation 
+of this sacrificial session is propounded in a book by the 
+learned Librarian of the Mysore Govt. Oriental Library, entitl- 
+ed Gavam Ayana, the Vedie era. It was favourably 
+reviewed by Prof. L. D. Barnett in the Journal of the 
+Royal Asiatic Society for April 1909. "The Vis'vajit is discussed 
+in Jaimini 4. 8. 10-16, and 6. 7. 1-20. In the former, the ques- 
+tion is raised of the reward which is to follow the offering of 
+the sacrifice, since none is mentioned in the scripture prescrib- 
+ing it: and the decision is that in this, and in all similar cases, 
+heaven is to be understood to be the reward. This is somewhat 
+quaintly put by S'abara under sūtra 16:— अनादिष्टफले कमणि 
+सर्गः फम्‌ । इति प्रत्ययो लोके । एवसुच्यते । आरामझद्देवदत्तो सियतोऽस्य 
+स्वर्ग: । तडागकद्वेवदत्तो नियतो5ऱ्य स्वर्ग इति । इत्थमनेन न्यायेन स्वरे सगत्य- 
+यो भवति यस्मारस्वमफलेषु कर्मसु sry फलवचनं नैवो्चारयन्ति गम्यत 
+
+
+एवेति || तस्मादप्यवगच्छाम एवंजातीयकेषु eni फलमिति.” The offerer 
+of the Vis'vajit is required to surrender all his property to the 
+
+
+int which gives rise to a very curious 
+
+
+Sacrificin 1 & po 
+g pr ests, 8 ee Satya Vrat S| e Collection. 
+
+
+128 
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+discussion in the Sixth Book. Is he then to give away his 
+father and mother; or, if a reigning monarch, is he to part with 
+all the lands of his kingdom? These and many other interest, 
+ing points are fully argued out by S'abara; and, for some ot 
+them, the English reader may with advantage refer to Cole. 
+brooke's Essay on the Mimamsa, vol. 1., page 345, 
+
+
+This nyaya is very frequently quoted by writers on Vedanta 
+and Nyaya. The fol lowing are examples. Bhamati, page 86 :— 
+“नच भह्मभूयादन्यदस्रृतत्वमार्थवादिकं किञ्चिदस्ति येन तत्काम उपासना. 
+यामधिक्रियेत, विश्वजिन््यायेन तु स्वर्गकल्पनायां qur सातिशयत्व क्षयित्वं चेति 
+न नित्यफळल्वसुपासनायाः??। Vedantakalpataru, page 430:— 8. 
+हितकरणोपकारे संभवति न विधजिन्यायेन स्वर्गकल्पना नापि दशेपूर्णमासफल- 
+स्वर्गस्यानुपङ्ः "| See, too, Pancapadákávivarana, pages 184 
+(line 9), 137 (line 13), and 164 (line 6 from bottom ) WNyaya- 
+manjari, page 524, line 13 from bottom :—* परग्रकरणपारिपठण- 
+विरहाच्च नास्य संपदादिविधिवसधानाधिकारनिवेञ्ित्वसतो विश्वजिद्धिकरण- 
+न्यायेन सर्गकासमधिकारिणमिह यावडुपात्तमध्यवसामस्तावदेव च न पुनरावर्तते 
+&c" There is another good example of it in the early part of 
+the Jaimini chapter of Sarvadarsanasangraha, 
+
+
+RRR 
+विषकुम्भं पयोमुखम्‌ ॥ 
+
+
+A bowl of poison with milk on the surface. A wolf in 
+sheep’s clothing, The illustration is found in Merutunga's work 
+the Prabandhacintamani, page 153:—« परोक्षे कार्यहन्तारं NU 
+प्रियवादिनम्‌ । वर्जयेत्ताहशं fürs विषकुंभं पयोमुखम्‌.?? “The friend who 
+behind one’s back tries to impede one’s business, but in one 
+presence speaks kindly, such a friend one should avoid, a bowl | 
+of poison with milk on the surface.” This is Mr. T 
+rendering ( on page 92), and he points out in a footnote t 
+the verse is quoted in Bohtlingk’s Indésche Sprüche, ® 
+ascribed by him to Canakya, idi 
+
+
+CC-0. Prof. Satya-Vrat-Shastri Collection. " 
+
+
+ya 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+129 
+
+
+व्यापकव्यावृत्त्या व्याप्यव्यावृत्तिः ॥ 
+
+This highly technical nyaya is found in hoth of Raghunatha- 
+varman's works. I have taken it from a passage in the Bauddha 
+section of Sarvadars'anasangraha (page 11 in Jivananda’s 
+edition), and subjoin Professor Gough's rendering ( italicizing 
+the words which represent the maxim ):—“aa क्षणिकत्व नीलादि- 
+क्षणानां सच््वेनानुमातव्यम्‌ | यत्सत्तत्क्षणिके यथा जलूधरपटलम्‌। सन्तश्चामी 
+भावा इति । न चायमसिद्धो हेतुः | अर्थक्रियाकारित्वलक्षणस्य स्त्वस्य नीलादि- 
+क्षणानां प्रत्यक्षसिद्धत्वात्‌ | व्यापकव्यावृत्त्या व्याप्यव्याव्ृत्तिन्यायेन व्यापकक्रमा- 
+क्रमव्यावृत्तावक्षणिकात्सत्त्वव्यावृत्ते: सिद्धत्वाच्च.” 
+
+“Of these points of view, the momentariness of fleeting things, 
+blue and so forth, is to be inferred from their existence ; thus, 
+whatever 4s is momentary ( or fluxional ) like a bank of clouds, 
+and all these things are, Nor may any one object that the 
+middle term (existence) is unestablished ; for an existence con- 
+sisting of practical efficiency is established by perception to 00- 
+long to the blue and other momentary things ; and the exclusion 
+of existence from that which is not momentary 18 established, 
+provided that we exclude from 16 the non-momentary succes- 
+sion and simultaneity, according to the rule that exclusion of 
+the continent is exclusion of the contained.” In Salika page 
+119, line 14, we find the nyaya as “ व्यापकनिवृत्तिहि व्याप्यनिवृत्त्या 
+sata,” and, on page 67, line 2 “sananta व्याप्यं नास्ति. 
+
+
+शकुनिग्राहकगतिन्यायः ॥ 
+
+The simile of the movements of a bird-catcher. It is found 
+in S'abara on Jaimini 9. 1. 22, as follows:— rer शकुनिग्राहकस्य 
+शकुनि जिध्चक्षतरछद़्ना गतिर्भवति शनैः पदन्यासो द्टिप्रणिधानमञन्दकरणञ्च 
+केथमनवडुद्धः शङुनिगृह्यतेति एवमिहाप्यनवबुद्धमिव अहीतु यज्ञ प्रच्छन्नगक्ति 
+RU नाम । यथा शकुनिग्राहकस्य यखिन्देरो शनेः पदन्यासो न स तदेश 
+योऽपि तु तद्देशाभिगतस्य शकुनेरथेन क्रियत एवमिहाप्युपांशुत्वं न तदेशानां 
+पदार्थानामर्थेन क्रियते तद्ेशाभिगतस्य यज्ञस्याथेन गम्यते See also 
+भूमिरथिकन्याय, 
+
+
+1 7 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta 8931060 Gyaan Kosha 
+
+
+शंखन्यायः ॥ 
+
+
+The simile of [the time for sounding ] the conch-shell, An 
+offering called उपांझुय़ाज, or ‘low-voiced offering,’ is performed 
+between the cake-oblation to Agni and that to Agni-Soma at 
+the full-moon, and between the cake-oblation to Agni and that 
+to Indra-Agni at the new-moon (Dr. Egsling's trans: of Sata- 
+. patha-Brahmana, vol. i. page 192). Sometimes, however, the 
+second oblation is omitted; and then the question arises how jg 
+the Upanis'uyaja to be offered, since that comes between the two? 
+The subject is discussed in Jaimini 10. 8, 62-70, and the above 
+question is answered by S'abara as follows +- यो हि द्वयोः पुरोडा- 
+शयोर्मध्य इति कालो$वगम्यते स एव पूर्वस्मादुत्तर इति । एवं चेदयद्यप्येकपुरो- 
+डाशायां ZI पुरोडाशो न स्तस्तथापि स पूर्व आझ्लेयोऽस्ति TMU: स एव 
+कालो योऽसावन्तरालेन लक्षितः । यथा “नागवेलायामागन्तव्यं,? "ur. 
+यामागन्तब्यं,? “परहवेलायामागन्तव्यं? इति यस्मिन्‌ ग्रामे न नागा न शंखा न 
+पटहस्तस्मिन्नपि स एव कालस्तत्र ह्यागमनं क्रियते । एवमिहापि ALMA 
+तस्मादेकपुरोडाशायासुपांशुयाजः कर्तब्य gta.” 
+
+
+The simile might well be called शंखध्वनिवेलान्याय, but I have 
+adopted the name given in the Nyayamalavistara on this adhi- 
+karana, which also explains it more fully :--“ शंखन्यायेनोपलक्षक- 
+स्थाझीपोमीयपुरोडाझास्येवाभावे5प्युपलक्ष्ये काले यागोऽस्ति । यथा संखध्वतिः 
+वेलायां राजसेवार्थ प्रतिंदिनमागन्तव्यमित्युक्ते कस्मिश्चिदिने d शंखं धमतः 
+पुरुपस्याभावेनोपलक्षकस्य ध्वनेरभावेऽप्युपलक्षिते तस्मिन्काले सेवकाः ससा । 
+च्छन्ति तथात्रापि द्रष्टव्यम्‌,” 
+
+
+This is very clear, but what is the meaning of नागवेला! 
+be in harmony with the rest of the sentence it ought to indic 
+something which, like the sounding of the s‘ankha or the 
+
+ing of the pataha, takes place regularly every day; bu hoy 
+
+
+र di it refers 0 
+can any Such sense be got out of maga, unless it ref 
+
+
+; trumpeting 6f thg fya हिच at some partic 
+
+
+Aa - 
+
+
+Digitized By Siddhanta 7811५0 Gyaan Kosha 
+
+
+oftheday? The S'astradipika, Nyayamalavistara, and Jaimi- 
+niyasutravritti ignore the expression altogether. 
+
+
+In Appai Diksita’s Vidhirasayana, page 22, we have an in- 
+stance of the शंखन्याय as follows:—* उपलः ये : 
+स्थ प्रतिदिनं शंखवेलायामागन्तव्यमित्यादो प्रसिद्धत्वात्‌ । न हि कालविरोषो- 
+परक्षणतयोपात्ते झंखध्वनौ Haat देवादकृते सति तदुपलक्षितः कालो 
+नास्तीति mamaa.” See also Vidhiviveka, page 7. 
+
+
+Compare the expression “Cockshut-time,” in Shakespeare’s 
+Richard iii (Act V. Scene 3):—“ Thomas the Earl of Surrey, 
+and himself, Much about cock-shut time, from troop to troop. 
+Went through the army, cheering up the soldiers.” In 
+Chambers’ Twentieth Century Dictionary the expression is 
+said to mean “ Twilight ; probably referring to the time when 
+poultry are shut up.” Websters International Dictionary 
+gives a different explanation. 
+
+
+शलभन्यायः ॥ 
+
+
+The illustration of the moth. The destruction of the silly 
+moth by flying into a lighted lamp is a figure often met with 
+in Sanskrit works; as for example in S’as‘upalavadha ii. 117, 
+Kuméarasambhava iv. 40, Rdjotarangint vii. 375, and 
+Kamandaki i, 48. According to Merutunga, however, the poor 
+moth is moved with envy at the brilliance of the light, and so 
+Seeks to diminish it! He says (on page 211, at the bottom ):— 
+“ उ्श्वल्गुणसभ्युदितं gat ge न कथमपि क्षमते । दरध्वा तनुमपि शळ्भो 
+दीप दीपाचिप॑ हरति.” “The mean man cannot anyhow endure 
+to behold the exaltation of the man of radiant merit; the 
+moth even burns its own body to extinguish the bright fame of 
+the candle,” ( Tawney's translation, page 130). 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangolrBéyaan Kosha 
+शान्ते कर्मणि वेताळोदयः ॥ 
+
+
+When the | prescribed ] ritual [for the removal or prevention 
+of evil] is at an end, wp comes ७ goblin! This implies ulii. 
+mate failure in spite of effort. It occurs in Citsukha Munis 
+comment on Nyayamakaranda, page 16, as follows ;—« ननु 
+सोऽयं झान्ते कर्मणि वेतालोदयोऽभेदं साधयिलुं प्रवृत्तेन भेदध्च॒तेरुदाहृतत्वात्‌.” 
+In Bhamati, page 93, line 1 7, the nyaya is quoted as “ शान्तिः 
+कर्मणि वेतालोदयः,?? which makes the goblin appear during the 
+Performance of the शान्ति, the rite to avert evil, So, too, in 
+Mandana-Mis'ra's Vidhiviveka, page 210. The purport, how- 
+ever, is the same as in the other case. In As'valàyana's 
+Grihyasitra 4. 6, 1, शान्तिकर्म is prescribed when a guru dies, 
+or on the loss of a son or of cattle. 
+
+
+शाब्दयाकांक्षा शब्देनैव पूर्यते ॥ 
+
+
+Verbal expectancy is satisfied, [or fulfilled ] by words only. 
+This nyaya of Raghunatha’s is very frequently met with, It 
+occurs in the last chapter of Sarvadars'anasangraha (page 157 
+of Bib. Ind. and 177 of Jivananda’s edn. ) with yaq as the last 
+word; in Vedantakalpataruparimala, page 680, line 7; in 
+Vaidyanatha’s comment on Kavyapradipa page 232 (in the 
+erroneous form शाब्दा साकांक्षा); in Haridasa’s vritti on Aust 
+méangals iii. 15 ( page 35), also in Rucidatta’s commentary 0n 
+the same portion (page 478 ); and, finally, in Sakityadarpana 
+u. 18 ( with प्रपूयते ) 
+
+
+In paragraph 70 of the Tarkasangraha we are told that 
+there are three requisites to the intelligibility of a sentence, 4 y 
+namely, expectancy ( akanisa ) compatibility ( yogyata), F 
+juxtaposition (sannidhi ). In para 71, the first of these 15 
+thus explained :—« Expectancy means a word's incapacity p. 
+
+
+t Shastri C piecon, 3 y the 
+Convey a coffe bet ROBIE NEY eing occasioned by We” 
+
+
+Digitized By Siddhanta #Sangoiri Gyaan Kosha 
+
+
+absence of another word (which, when it comes as expected, will 
+complete the construction and the sense].” Then in para 72 
+we read:—“ a collection of words deyoid of expectancy &c., is 
+no instrument of right knowledge; for example, ‘cow, horse 
+man, elephant, gives no information, from the absence of ex- 
+pectancy:; [the words haying no reference one to another, and 
+not looking out for one another |.” This is Dr. Ballantyne's 
+translation, accompanying the text; and the same subject is ex- 
+plained by him in his lucid rendering of Sahityadarpana 1. 6, 
+
+
+शाल्यादिविषयस्य सुशलादेः करणस्य इयामाकेऽभिह- 
+तिभेवति ॥ 
+
+
+A blow with an instrument such as a pestle, directed 
+towards the rice, falls instead on the syamaka grain. Aiming, 
+at a pigeon and killing a crow. It occurs in Nyayarartika, 
+page 46:—" घुनरन्याविपयं करणम यविषयां क्रियां करोति | शाल्यादि- 
+विषयस्य झुराळादेः करणस्य इयामाकेऽभिहतिरभवति | नानियमादिति यद्विषयं 
+करणं तद्विपया क्रियेति न नियमोऽस्ति । इष्टा हि वृक्षादिविषयस्थ छेदनस्यावयवः 
+क्रियेति । बक्षभ्छिद्यतेऽवयवे क्रियेति ” ॥ 
+
+
+WARS प्रयोक्तरि ॥ 
+The fruit promised in Scripture [in connection with a sacri- 
+ficial or other act ] 4s for the performer ( of that act J. These 
+are the first words of Jaimini’s sütra 3. 7. 18. They are quoted 
+
+
+as a nyaya in a passage of Vedantatativaviveka, for which 
+see “ मुनिर्मजुते, qu सुच्यते.?. It is cited by Vaeaspatt Mistra, 
+also, in 7atparyatika, page 296, line 6 from bottom, and page 
+408, line 4, and in his Bh@matt, pages 28 and 492. Also in Sri- 
+bhdsya 9. 8. 33 ( p. 1688), and 3. 4 45 (p. 2028), where Dr : 
+"Thibaut renders it, “the fruit of the injunction belongs to the 
+agent.” The first part of Tattvemuktakalapa प 59 reads thus;— 
+CC-0. Prof. Satya Vrat Shastri Collection. : 
+
+
+18 
+
+Digitized By Siddhanta eGangotri (on Kosha 
+
+५ न्यश्वेदन्यकर्मम्रजानितफलसुळ्‌ शाखवैयाकुली स्यात्‌ &e.,” on which the 
+author comments ag follows — अन्यस्यान्यक्ृतकर्मफलभोगे z E 
+
+
+SITES 
+प्रयोक्तरीति व्यवस्थाभङ्गाच्छात्रस्य व्याकुलता स्यात्‌ ४९.» Compare 
+Patanjali on Panini 1, 3, 72, 
+
+
+शिबिकोबच्छन्नरवत्‌ ॥ 
+
+The simile of men carrying a palanquin, Used by Jayanta 
+Bhatta to show how all the words in a sentence unitedly convey 
+the sense of the latter, If occurs in Nyadyamanjari, page 397, 
+line 12 :--“यथा हि वाह्यानि करणानि काष्टादीनि पाके व्याप्रियन्ते यथा च 
+शिविकाया geram: सर्वे शिबिकासुद्यच्छन्ति यथा त्रयोऽपि ग्रावाण sai RaR 
+तथा सर्वाण्येव पदानि वाक्‍्यार्थभवबोधयन्ति.”” Again, on page 400, line 
+11 from bottom :—“ शिबिकोद्यच्छन्नरवस्सवाणि पदानि कार्य संहत्य em 
+यन्ते इत्येतदपि aara.” CE Brihadārnyavārtika, 1. 4. 1600. 
+
+
+शिरोवेष्टनेन नासिकास्पर्शन्याय; ॥ 
+
+
+The simile of touching the nose by encircling the head [ with 
+one’s arm]. That is, putting the arm round the head instead 
+of bringing it directly to the face, Raghunathavarma classes 
+it with nyayas expressive of a round-about way of doing 
+things. It is quoted by Vijnànabhiksu on Brahmasitra 
+3. 3. 87, in the form शिरोवेष्ट नेनांगुल्या नासिकाग्रवेशवत्‌, 
+
+Raghunātha tells us that, by some, it is styled द्वविडप्राणा- 
+यामन्याय, and in Molesworth’s Marathi Dictionary we find 
+द्वाविडप्राणायाम defined as “a circuitous or devious mode of 
+Speaking or acting, ambages, tortuous procedure,” This is not 
+the first time that this fine dictionary has come to our aid. 
+when the more-pretentious Sanskrit lexicons have failed us! 
+
+
+But we should like to know how the expression came to 
+
+
+have the meaning here assigned to it, Doubtless hereby i 
+
+
+hangs a tale 3 Can our Indian pandits throw light on it? 
+CC-0. Prof. Satya-Vrat-Shasiri Collection. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+i 
+
+
+शिलाघनमध्यस्थप्रदीपसहस्रप्रथनवत्‌ ॥ 
+
+
+The simile of the shining-forth of a thousand lamps stand- 
+ing im the midst of solid rock! It occurs in Brahmasitra- 
+bhasya 2. 2. 28, near the end:—* किंचान्यत्मदीपव द्विज्ञानमवभास- 
+कान्तरनिरपेक्षं स्वयमेव प्रथत इति ब्रुवताप्रमाणगम्यं विज्ञानमनवगन्तृकमित्यक्त 
+स्यात्‌ | गिलाघनमध्यस्थप्रदीपसहस्रप्रथनवत्‌.? Dr. Thibaut renders it 
+thus :—“ Moreover, if you maintain that the idea, lamplike, 
+manifests itself without standing in need of a further principle 
+to illuminate it, you maintain thereby that ideas exist which 
+are not apprehended by any of the means of knowledge, and 
+which are without a knowing being; which is no better than to 
+assert that a thousand lamps burning inside some impenetrable 
+mass of rocks manifest themselves.” 
+
+
+शुष्केष्टिन्यायः t 
+
+
+The figure of ७ sham-sacrifice, That is, the performance 
+of sacrificial ceremonies, by a pupil, with a view to his becoming 
+proficient in them, without the offering of a real sacrifice. "This 
+is classed with भूमिरथिक in S/abara’s bbüshya on Jaimini 9. 2. 
+18, and an extract from the passage will be found under that 
+nyaya. The term जुष्केष्टि, as adopted in Marathi, is thus ex- 
+plained by Molesworth :—“ Dry exercise or blank practising; 
+performance or doing, antecedently to the occasion, of a work 
+or matter in which the performer is ignorant or inexperé (in 
+order that the necessary knowledge or ability may be acquired 
+in provision for occasions anticipated ).” 
+
+
+श्रुतिबलीयस्त्वन्यायः ॥ 
+See this explained under पाठक्रमन्याय. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangofrgRyaan Kosha 
+
+
+श्वः कार्यमद्य कुवीत ॥ 
+
+
+One should do to-day that which one intends to do tomorrow, 
+“Boast not thyself of tomorrow; for thou knowest not what a 
+day may bring forth.” The verse containing this nyaya of 
+Raghunātha’s occurs three times in S'antiparva, namely in 
+chapters CLXXV, CCLXXVIII, and cccxxtr of Calcutta edition, It 
+reads as follows :— 
+
+
+श्रःकार्यमद्य कुवीत पूर्वाह्न चापराह्लिकम्‌ । 
+न हि प्रतीक्षते aq: कृतं वास्य न वा कृतम्‌ ॥ 
+
+
+It is quoted in the Prabandhacintamani, page 111, and 
+Mr. Tawney (on page 68 of his translation ) renders it thus:— 
+“One should do to-day the duty of tomorrow, and in the fore- 
+noon the duty of the afternoon, for death will not consider 
+whether one has done one’s work or not.” 
+
+
+Compare the following well-known story. “An old Rabbi 
+was once asked by his pupil when he should fulfil a certain pre- 
+cept of the law, and the answer was * The day before you die’ 
+‘But,’ said the disciple, «I may die tomorrow. ‘Then, said the - 
+master, ‘do it to-day.” 
+
+
+श्वपुच्छोन्नामनन्यायः ॥ 
+
+
+The simile of zhe attempt to straighten a dog's tail. An : 
+illustration of wasted effort, Tt occurs in the following verse of - 
+the Upamitibhavaprapanca Katha, page 448:— 
+
+
+न चैष शक्यते ag नम्रो यल्लशतेरपि । 
+को हि स्वेदशतेनापि AIS नामयिष्यति ॥ 
+
+
+See also under अरण्यरोद्नन्याय in the second Handful | 
+CC-0. Prof. Satya Vrat Shastri Collection. : x 
+* Se = = 
+
+
+Digitized By Siddhanta 1899० Gyaan Kosha 
+9 
+
+
+श्वलीढमिव पायसम्‌ ॥ 
+
+
+Like a milky preparation that has been licked by a dog. 
+Used of something which has become impure and therefore 
+unacceptable, It is found in the following verse of the last 
+chapter of the Sarvadars‘anasangraha :--“फलाभिसन्यधेरूपघातकत्व- 
+मभिहितं भगवद्विर्नीलकण्ठभारतीश्रीचरणेः। 
+
+अपि प्रयल्लसम्पन्नं कामेनोपहतं तपः | 
+न तुष्टये महेशस्य श्वलीठमिव पायसम्‌ ॥ 
+
+
+Compare with this the nyaya “न हि पूतं स्याद्गोक्षीरं weal तम्‌,” 
+
+
+श्वा कर्णे वा पुच्छे वा छिन्ने AT भवति नाश्वो न गदेभः॥ 
+A dog, when am ear or its tail has been cut off is still a dog, 
+not a horse or ७ donkey / This is Patanjali’s illustration of the 
+vartika एकदेशविकृतमनन्यवत्‌ (which see above) and is referred 
+to by Nàges'a in his comment on Kaiyata ( under S'iva sūtra 2, 
+vartika 4), as the छिन्नपुच्छश्वदृष्टान्त. Compare also Nagojibhatta’s 
+paribhasa xxxvii. Akin to this illustration is Kumarila’s “न हि 
+गोर्गड़ुनि जाते विषाणे वा भशे गोत्वं तिरोधीयते,” which is found in 
+Tantravartika 2, 1, 34 page 418; and “न हि केवलभोजी देवदत्तोडन्ये 
+सह पंक्त्यां अुभ्ञानोउन्यत्वं suum" on page 617. 
+
+
+षोडशिग्रहणाग्रहणन्यायः ॥ 
+
+
+The rule as to the use or omission of the Sodasistotra [at 
+the Atiratra-sacrifice ] In very common use as an indication of 
+option being allowable in regard to something, From the in- | 
+troduction to the third volume of Dr Eggeling's translation of 
+the S atapatha Brahmana, we learn that “the distinctive feature 
+of the Atiratra-sacrifice, as the name itself indicates, is an “over- - 
+night’ performance of chants and recitation...At the end of each 
+Yound, libations are offered, followed by the inevitable potation: 
+of Soma-liquor...and the performance partook largely o 
+
+
+character of a regular nocturnal carousal.” Then, as to 
+E 18 CC®. Prof. Satya Vrat Shastri Collection 
+
+
+>. 
+
+
+Digitized By Siddhanta eGangqtf) Gyaan Kosha 
+
+
+S'odas'in, he says ( page xviii )—“As regards the ceremonies 
+preceding the night-performance, there 18 a difference of opinion 
+among ritualists as to whether the S'odas'i-stotra is or is nof a 
+necessary element of the Atiratra... As'valüyana (5.11.1 ) refers 
+incidentally to the S'odas'in, as part of the Atirütra, though itis 
+not quite clear from the text of the sūtra whether it is meant 
+to be a necessary or only an optional feature of that sacrifice.” 
+There can be little doubt, however, that the learned writers 
+who use the nyaya, regard the use of the stotra ag optional, 
+For example, as illustrations of option in aetion, S'ankara, 
+in his bhasya on sütra 1. 1. 2 (page 37), and again on sūtra 
+2. l. 27 (page 471), quotes the Vedie sentences “अतिरात्रे 
+पोडाशिनं गृह्णाति’? “नातिरात्रे पोडाशिनं गृह्णाति.” Then at the close 
+of 1. 4. 13, he ५३5: अपेक्षाभेदाञ्च समानेऽपि मत्रे ज्योतिषो ग्रहणाग्रहणे | 
+यथा समानेऽप्यतिरात्रे वचन भेदात्पोडञ्ञिनो ग्रहणाग्रहणे तद्वत्‌”; and in 8.3. 
+2, “न हि पोडशिग्रहणाग्रहणयोरातिरात्रो भिद्यते.” In his comment 
+on 3. 8. 26 ( page 893, line 5 from bottom ), Anandagiri makes 
+use of the expression “पोडशिग्रहणाय्रहणवद्विकल्पे mÀ,” and repeats 
+it three lines lower down. In Vedantakalpatarwparimala, 
+page 689 (line 7 from bottom), we read “पोडशिम्रहणन्यायेन विकल्पो 
+भविष्याति,?? and on page 656 (line 4), पोडशिग्रहणाम्रहणन्यायसङञ्जारणे 
+तथेव विरोधपरिहाराय विकल्पोऽभ्युपगन्तब्यः,” The optional character 
+of the stotra is made use of by Laugaksibhüskar also, in Artha 
+sangraha, page 24, from line 14 ; and by Nages‘abhatta in the — 
+Pradipoddyota on Mahabhasya 1. 1, 44 ( vàrt, 7 ). m 
+
+
+ss 
+
+
+T 
+
+
+सकृद्गतिन्यायः ॥ | 
+
+"This is Nagojibhatta’s shortened form of the paribhaga qaad 
+
+विग्रतिपेधे यद्वाधितं तद्वाधितमेव, which Professor Kielhorn rende 
+
+thus:—*When (two rules), while they apply (simultaneously = 
+mutually prohibit each other, that which is once superseded is _ 
+
+superseded altogether.” is is Ulnstzated,by the following 
+
+ordinary pe coed is भवति स तयोः पर्यायेण 
+
+
+t 
+
+
+Digitized By Siddhanta q@pogotri Gyaan Kosha 
+
+
+करोति यदा तसुभौ युगपत्मेषयतो नानादिश्लु च कार्ये तदोभयो करोति योग- 
+पद्यासंभवात्‌”!॥ The paribhasa is found in Mahabhasya 1. 1. 56 
+(vr, 25, 26, 27); 1. 4. 2 (vàrt. 7); 6. 3. 42 (vart, 5); 6. 3 139; 
+6. 4. 62 ( vàrt. 2); 7. 1. 26; 7. 1. 54; and 7.1. 73. The illustra- 
+tion is met with in 1. 4. 2 (vart. 5), and 6, 1, 85 (vārt. 3 » 
+
+
+सत्रन्यायः ॥ 
+
+The rule regarding æ sacrificial session. For this kind of 
+sacrifice, lasting several days, not less than seventeen sacrificers 
+are absolutely necessary. But what if one of them should leave 
+or die before the completion of the ceremony? In such a case 
+he must be replaced bya substitute, or the whole thing becomes 
+null and void. This, however, cannot be done when there is 
+only one sacrificer engaged in a sacrifice. The nyaya is the 
+subject of Jaimini 6, 3. 22. In sütras 23 to 26 itis laid down 
+that the substitute does not reap the benefit of the saerifice,— 
+but that it goes to thé man whose place he has taken, Tt is 
+very clear, from the above, that the mention of the सत्रन्याय on 
+page 430, line 5 of Vedantakalpataru, is wrong, and that the 
+reference is really to the रात्रिसत्रन्याय which see above. 
+
+
+संदिग्धस्य वाक्यरोषान्निर्णयः ॥ 
+The meaning of an ambiguous expression is to be determined : 
+from the context. In Brahmasutrabhdsya 1. 3. 14 there is a — 
+discussion as to the meaning of the ‘small ether’ of Chhandogya 
+Upanisad 8, 1. 1, and Anandagiri makes the following comment j 
+on the closing part of it -र्-'समुचयेति | सांदिग्धस्य वाक्यशेषान्निणय ^ 
+इति न्यायादादो तस्मिन्यदुन्तरिति तच्छब्दो5$नन्तरमप्याकाशमभिलंघ्य हत्पुण्डः 
+रीकं पराख्रशति तत्र geet तदन्वेष्टव्यं विजिज्ञासितब्यं चेत्युपसंहरति.” 
+-The nyaya is quoted again in his tika on 3. 8. 52. Itis tak 
+from Jaimini’s sūtra 1. 4. 29, “संदिरधेषु वाक्यसेषात्‌+' "YN h 
+quoted and applied by the author of the S'astradipika, 
+
+
+2-0. Prof. Satya Vrat Shastri Collection. ° 
+
+
+Digitized By Siddhanta eGangotli4Jaan Kosha 
+
+
+-discussion, under 1. 3. 8, of such words as यव, वराह, पीलु and 
+others, to which the Aryas attach one meaning and the Mleccha 
+another. We find it, too, in Kumirila’s lengthy exposition 2 
+the same portion, in the words :~ संदिग्धेषु च सर्वेषु वाक्यशेपेण 
+
+निर्णयम्‌ 7 (page 148); and again under 3. 4. 36 ( page. 1003):— 
+“संदिग्ध वाक्यशेपेण निर्णेयसवधारितम्‌ । विध्युद्देशेन निर्णीते (bog zn 
+करिष्याति.'? See also Bhümat 3. 3. 34 (page 641), E 
+
+
+समुदाये वाक्यपरिसमाप्तिः ॥ 
+
+
+For this paribhasa, see under गर्गशतदण्डनन्याय. 
+
+
+संभवत्येकवाक्यत्वे वाक्यभेदश्च नेष्यते ॥ 
+
+; When a sentence can suitably be regarded as one, it is nok 
+right to divide it. This oft-quoted line of Kumavila’s was 
+directed against an older writer, named 1315090858 (so Partha- 
+86186] ii tells us), who proposed to divide Jaimini’s sūtra 1. 1. 4 
+into two parts. The line is found in S‘lokavartika, page 135. It 
+18 quoted in Bhamatt 1. 1. 28 (page 159), 1. 8. 13 (page 206), 
+1, 4. 3 (page 286 ) ih A G (page 808), 8. 3. 57 (page 008), 
+i 3. 4. 20 ( page 678 ) In Anandagiri on Brahmasutrabhasyd 
+
+* 2. 15, we read —* वक्तुभेदेऽप्येकवाक्यता साकांक्षतवात्पू्वोत्तरवाक्ययोः 
+verde: वाक्यैक्यसंभवे qnum: and, in the latter part | 
+of the bhasya cn 1. 4. 3, Sankara himself has a good deal to say j 
+on एकवाक्यता. Then Anandagiri quotes the nyaya in his com- 
+ment on 2. 3. 2 and 3.3.14. «A vakyabheda—split of the : 
+
+
+Sentence-takes place according to the Mimamsa when one and E 
+
+
+xS Same sentence contains two new statements which are 
+
+re (Dr. Thibaut’s Translation of Sankara's F yos 
+
+Nor हे 177 note). See, too, Prof. Cowell's long note on 
+
+page 68 of his Translation of Sa qi atin ; +S 
+
+5 CC-0. Prof. Satya Vrat ena dilya sütras. E 
+—_ 
+
+
+Digitized By Siddhanta e$gnpotri Gyaan Kosha 
+
+
+सम्भवे व्यभिचारे च स्याद्विशेषणमर्थवत्‌ ॥ 
+
+
+A qualifying word is of use when it is appropriate [ that 
+is, when it suits the विशेष्य ], and when [ withoutit] a wrong 
+meaning would be conveyed. 
+
+The nyaya is quoted as above in the commentary on San- 
+ksepas'artraka i. 347 (The Pandit, vol. v. page 676), and on 
+page 401 of Vidydsagart (a comment on Khandanakhanda- 
+khadya); whilst, on page 215 of the latter, it appears without 
+स्यात. There is another good example on p. 592. 
+
+I have traced it, however, as far back as Kumarila, but can- 
+not say whether he was its author or not. In Vantravartika 
+1. 8. 18 (=Jaimini 1. 3. 24.) there is a discussion (as & 
+purvapaksa) of the reasons assigned by Patanjali for the 
+study of grammar. One of these is that, without a knowledge 
+of grammar, the performance of the injunction “ sranta निष्का- 
+रणो' धर्मः षडङ्गो वेदोड्थ्येयः” would be impossible; on which the 
+pürvapaksin says :— 
+
+
+“ पडङ्गो वेद इत्युक्तं शरतिलिङ्गाद्पेक्षया | 
+तैः fp: प्रविभक्तः सन्स हि कमेविवोधनः ॥ 
+ननु बाह्याङ्गानपेक्षत्वे वेदस्वरूपान्तगेतश्रत्याद्यपेक्षया विशेषणमनथकं प्रसज्यते | 
+तथाहि । 
+संभवव्यभिचाराभ्यां स्याद्विरोषणसंभवः | 
+्ुत्याद्यभिचारात्तु Wr किं विशेष्यते” ॥ 
+Dr. Ganganath Jha renders this (and the preceding clause ) 
+as follows :— 
+“We must explain the expression “the Veda with its six sub- D. 
+Sidiary sciences’ as referring to its constituent parts, in the i 
+following manner. The ‘six subsidiaries’ referred to must be | : 
+taken to be the six means of interpretation — Direct Assi 
+Re. ; as it is only when interpreted through these that the 
+
+
+becomes capable of rightly pointing out Dharma, An 
+, CC-0. Prof. Satya Vrat ee ri Collection. 
+
+
+Digitized By Siddhanta eGangokrfGyaan Kosha 
+
+
+tion is here raised :—If the subsidiaries referred to be taken gg 
+those contained in the Veda itself (४. ८. Direct Assertion, go, 
+and not anything outside it (as grammar, Nirukta, ७८. ), then 
+in that case the qualifieation with the sia subsidiaries would be 
+absolutely meaningless. Specially as we can have a qualifica- 
+tion, only when such a one 18 possible, and when a qualification 
+is actually needed. for the purpose of setting aside certain 
+incongruities (or contradictions ) and as there is certainly 
+‘no incongruity in the Veda with regard to Direct Asser 
+tion Wc. what could be specified by a qualification of these sub- 
+Sidiaries? ‘[ That is to say, Grammar not being invariably con- 
+comitant with the Veda, a qualification is needed in order to 
+make it an object of study together with the Veda ; while Direct 
+‘Assertion &c,, are always contained in the Veda, and hence 
+‘any qualification of these would be absolutely meaningless |” 
+Page 981. J 
+= "Another good example is furnished by Sures'vara in his 
+vārtika on Brihadāranyakopanişadbhāşya. At the beginning 
+of the second Brahmana of the sixth Chapter, referring to the - 
+prayer “HA नय सुपथा राये ४९.” at the end of the seventh chapter | 
+of the Granyake (the fifth of the Upanisad), he says;— 
+
+“सप्तमावसिताबुक्त॑ मार्गप्राथनमभित: | i 
+
+सुपथेति श्रुत तत्र श्रुत्या मार्गविशोषणम्‌ ॥ २॥ 
+. संभवे व्यभिचारे च विरेपणविरोष्ययोः 
+दष्टं विशेषणं लोके यथेहावि त थेक्ष्यतास” ॥ ३॥ 
+
+Anandagiri explains verse 3 as follows:— : 
+“संभव इति । नील्मुत्पलमित्यत्र विशेषणविदेष्ययो: संभवे विशेषण 
+विशेंष्यस्य व्यभिचारे प्रसक्ते . नीलमिति बिरोपणमर्थवृष्टस्‌ । तथा 
+नयेत्यत्रापि व्यभिचारसंभवे विशेषणमर्थवज्शेयमित्यर्थ:” ॥३॥ 
+र ` The fourth verse of tho vartika still further elucidates ib:— 
+. ' ` “ुपथेति ततो युक्त संभवे भूयसां पथाम्‌। 
+
+
+| ; . विशेषणमतो वाच्याः पन्थानः. कर्महेलव Ta? ॥ ४ ॥ 
+= +- CC-0..Prof. Satya Vrat Shastri Collection. 
+
+
+" 
+
+
+ae 
+
+
+£ 
+
+
+Digitized By Siddhanta ae Gyaan Kosha 
+
+
+सर्वे व्वतः पथ्यम्‌ N I A 
+
+
+Everything is suitable [or proper] for the strong. “Might 
+is right.” In other words, a strong man may be lawless with 
+impunity; or, to quote Prof. Ganganatha Jha's explanation of 
+it, *for & pious man all actions are equally lawful" This is 
+quite in accord with the teaching of the Bhagavata Purana 
+x. 83, 80, 81 :-- 
+
+“ घमव्यातिक्रमा इष्ट इश्वराणां च साहसम्‌। | 
+तेजीयसां न दोषाय ag: सर्वभुजो यथा ॥ 
+नतत्समाचरेजञातु मनसापि ह्यनीश्वरः | 
+विनइयत्याचरन्मोव्याद्यथारुद्रोऽविधजं विषम”? ॥ 
+
+
+Kumarila quotes the nyaya (in Tantravartika, page 
+
+
+134, line 14) in the course of a long explanation of the evil ' 
+
+
+doings attributed to certain holy personages; but, in order 
+. to discourage persons of less piety from imitating them, 
+adds: मन्दतपसां गजैरिव महावटकाष्ठादिभक्षणमात्सविनाद्यायेव स्यात्‌.” 
+In the opening part of the Tatparyatika, Vacaspati Misra 78: 
+produces Kumarila's warning in the following words :--तप:प्रभाव 
+एव हि ताहशस्तेषां यत एवंविधाः पाप्मानो विळीयन्त इति । न चास्मदादीनां 
+मन्दुतपसामय प्रसंगः | न हि गजानासुदय्यं तेजो वरकाष्ठम शितं पचतीत्यस्मदाः 
+दानामप्युदृय्येण तेजसा तथा भवितब्यम्‌.” 
+
+
+सवशांखाप्रत्ययमेकं कम ॥ 
+All the d uferent schools of a Veda acknowledge one and the 
+
+
+same sacrificial action. 
+ly regard this as an important point for Jaimini devotes 25 
+Sütras, viz. 2. 4. 8-32, to the discussion of it. Kuntes remarks 
+on the bearings of the question, in his Saddars‘anacintanika, 
+are worthy of perusal. The nyaya 15 frequently quoted in the 
+
+
+hilosophi rks. Instances of it will be found in Tantra- 
+p p CN -0. Prof. Satya Vrat Shastri Collection 
+
+
+The followers of the Mimims evident- - 
+
+
+* 
+1 
+
+
+Digitized By Siddhanta eGangptj (pyaan Kosha 
+
+
+vàrlika, page 84, line 7; in Pancapadikavivarana, page 167 
+
+ey = 6 4 2 
+line 3 from bottom; in Nydyamanjari, page 256, line 18; in 
+Vivaranaprameyasangraha, page 169, line 17 ; and in Sribha- 
+sya 3. 3. 53.. Raghunathavarman makes use of the nyàya but 
+does not include it in his numbered list. 
+
+
+साकमेधीयन्यायः ॥ 
+
+
+The law relating to the Sākamedha offerings. This is 
+the topic of Jaimini 5. 1. 19-22. The group of offerings called 
+Sakam-edhàh form the third of the three seasonal, or four- 
+monthly (citurmasya), sacrifices which are performed at the 
+parvans (or commencement of the spring, rainy, and autumn 
+Seasons ), and which, in this case, last for two days; three of the 
+group (consisting of seven) being offered on the first day, and 
+the remainder on the second day. An objector urges that two 
+days are required for each of the group, but this is set aside, 
+and the ruling is as above. For a full description of these four- - 
+monthly sacrifices, see Dr. Eggeling's translation of the Sato | 
+
+
+patha-Brahmana, vol. i. pages 383 and 408, ; 
+
+
+साक्षः पुरुषः परेण चेन्नीयते नूनमक्षिभ्यां न परयति॥ | 
+
+
+Tf a man with eyes is led by somebody else, it is clear that 3 
+does not see with his eyes! This is found in S’abara on Jaiminl | 
+1.2.81 and is used by an objector to illustrate his argument 
+that it is not necessary to understand the meaning of Vedie 
+sentences employed in sacrificial rites, since the way in whi 
+they are to be used is clearly laid down in works prepared foi d 
+the purpose. The illustration is quoted by Jayanta Bhatta 77 
+Nyayamanjari, page 286, line 12. 
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+forbidding the taking of life [* न॒ हिस्यात्सवी भूतानि]. In 
+
+
+Digitized By Siddhanta ११४०० Gyaan Kosha 
+
+
+सामान्यविघिरस्पष्टः ॥ 
+
+
+An injunction in general terms is indefinite. It appears 
+as a nyaya in the second part of the Laukikanyayaratnikura 
+(I. O. MS, page 319 ७), where Raghunath applies it thus:— 
+“ लोके कंचिद्ेशं जिगमिषुं प्रति तत्रत्यानि वस्तून्यानेयानीति सामान्यतो विधा- 
+
+
+येदमानेयमिदमानेयमिति स्पष्टीक्रियते.” It is doubtless derived from 
+the following verse in Tantravartika 3. 4, 47 (page 1020) :-- 
+
+
+“सामान्यविधिरस्पष्टः संहियेत विशेषतः । 
+स्पष्टस्य तु विधेर्नोन्यैरुपसंहारसंभवः?” ॥ 
+
+The verse is cited in Vedantakalpataruparimala (page 
+253), where the second line reads “ स्पष्टस्य लु विधेनेंवसुपसंहार इष्यते,” 
+and the first line is quoted by the author of the Vydyasudha 
+in his comment on Tantravartika 1. 2, 42 which defines the 
+term परिसंख्या (‘limitation, or ‘exclusive Specification, as Dr, 
+Thibaut and M. M. Kunte respectively render it). 
+
+
+The lack of definiteness in general statements is alluded to 
+by S'abara, also, on Jaimini 10. 8. 16, where he says “न हि सासा- 
+न्यवाची शब्दों विशषषानभिवदाति,?? but Kumarila points out (on page 
+1027) that the fq requires the सामान्य. He says 3 
+निःसामान्यः कश्चिद्विशेष उपपद्यते । ततश्च बक्षमानयेत्युक्ते शिंशपामित्यविरोधा- 
+सपश्चादुच्यमानं न विरुध्यते.?? 
+
+
+सावकाशनिरवकाशयोर्निरवकाशो बलीयान्‌ ॥ 
+
+
+That [injunction ] which leaves no room [for others] is | 
+stronger than one which does. For example, an iojun on 
+directing animal sacrifice [ “अझीषोसीयं पश्चुमालभेत | and which 
+leaves no room for option, overpowers the more general one 
+this 
+Way one Smriti may prevail over another. The m = 
+का as follows 
+
+
+Digitized By Siddhanta 8७819० gaan Kosha 
+
+
+“न चानुभवेन श्र॒तेर्वाधः aaa: श्रुतेनिरवकाशत्वात्‌ | निरवकाइस्य च सावका- 
+शनिरवकाशयोर्नेरवकाशो बलीयानिति न्यायाद्वाधकत्वोपपत्तेःश| 4 reference 
+to Brahmasitrabhdsya 2. 1. 1 will fully explain. the two terms 
+
+
+of this expression. In his comment on it Anandagiri quoteg 
+the nyàya twice, and again under 2. 1. 4, 6, and 13. In im. 
+mediate connection with the first of the five, Anandagiri quotes 
+also the nyaya “ सापक्षनिरपेक्षयोर्निरपेक्षस्य "qn," and the two 
+occur together in the following verses of Yamunicarya’s Aga- 
+mapramanya, page 68 :--“सापेक्षनिरपेक्षत्वे न हि बाधस्य कारणम्‌। 
+JA रजतवोधस्य निरपेक्षस्य वाधकस्‌ ॥ नेदं रजतविज्ञानं तत्सापेक्षमपीष्यते | 
+सेयं ज्वालेति संवित्तेस्तेलवर्तिविनाशजा ॥ अनुमा वाधिका इष्टा सापेक्षाप्यक्षजः 
+न्मनः। अतो निरवकाशेन सावकाशं निषिध्यते” See also Citsukha 
+Muni on Nydyamakaranda, pages 7 and 148; and “सापेक्षम- 
+समर्थ भवति” in Mahübhàsya 2. 1. 69 ( vürt..6) and Syadvada- 
+Manjari, page 19. 
+
+
+सिंहस्यैकपदं यथा ॥ 
+
+Like a lion’s first step. This obscure nyaya occurs in Men 
+tunga’s work, page 278 :—“ विचार्याविचार्य वा FATSA महानरे 
+्दरश्चालितः | सिंहस्येकपदं यथेति न्यायाच्चरित एव राजते.” Mr. Tawney 
+renders it thus (on page 174 ) :--/ Whether with due considers 
+
+
+tion or not, this great king has been set in motion, and has 
+started on his expedition; on the principle of the lion's first 
+
+
+step, he cuts a good figure on the march.” Does the illustration 
+
+
+mean that a lion in motion presents a finer appearance than one 
+at rest? 
+
+
+i 
+
+सिकताकूपवत्‌ ॥ ; 
+The simile of a well [dug] in sandy soil [the sides of which - 
+are incessantly falling in]. Used of an argument that will not 
+hold water. It is found in DBralumasütrabhasya 21:2; 7 
+“किं बहुना सर्वप्रकारेण यथा यथायं वैनाशिकसमय उपपत्तिमत्त्वाय Te 
+
+
+तया UA AA SAMA पश्यामः” ॥ 3 | x ; 
+
+
+x 
+
+
+Digitized By Siddhanta 12247 02 ५५] Gyaan Kosha 
+
+
+सिकतातैलन्यायः ॥ 
+
+
+The figure of oil from sand. A non-enti 
+horn. 
+5):— 
+
+
+“ota सिकतासु तेळमपि यत्रतः पीडवन्‌ 
+पिबेच्च gaglag सलिलं पिपासार्दितः १ 
+कदाचिदपि पयेटब्छराविषाणमासादचें- 
+
+a तु प्रति निविष्टमूखेजनचित्तमाराधवेत” ४ 
+
+
+In Brahmasütrabhasya 2. 1. 16, we read: घड a 
+
+
+चच Fare म 
+न add न तत्तत उत्पद्यते यथा ससिकताभ्यस्तैलम्‌.” Compare wai 
+Yogavasistha 2. 5. 23, “ न यल्लेनापि महता पराप्यते wama ऋ 
+तैलमझ्मतः is given as a variant. American roc 
+known in those days! There are two good ex 
+illustration in Nydyamanjart. On page 493, E 
+हि तिल्सर्पपानुपादत्ते न सिकताः | असत्त्वे च तेळख को EDS soe 
+सिकताभ्यः ?॥ On page 494 :--“ तैलार्थी सिकताः कश्िदाददालों र इर्के 
+WERT चाद्य नाल्यो$पि तदर्थी तासु raf" 
+
+Compare also Paris'istaparvan viii. 152 :— 
+
+
+“ब्याहार्षीन्सुनिरप्येव प्रसीद UI । 
+अस्मासु भवति द्रव्यं किं तेल वालुकास्दिव d 
+
+
+सूक्तवाकन्यायः ॥ 
+
+The law as to the Süktavake [or song of praise]. This is 
+the topic of Jaimini 3. 2. 15-18, and immediately follows the 
+Prastara-praharananydya with which it is closely connected. 
+Both form a part of the New and Full Moon sacrifices in com- 
+nection with which there is the direction * सूक्तवाकेत NUN शहरे. 
+The question then arises as to whether the whole of the mantras 
+which comprise the Siiktavaka are to be repeated on each of 
+the two occasions, or only a park S’abara’s argument is thus 
+
+
+paraphrased by Kunte :—“ Though the Veda mentions positively 
+: E by ce. Prof Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangpki 89981 Kosha 
+
+
+that certain mantras are to be used in certain sacrifices, yet they 
+are 706 to be so used blindly. The mantra which serves some 
+purpose of a sacrifice is to be used. Though the Veda prescribes 
+the use of the whole mantra, yet it is not to be obstinately 
+maintained that the whole is to be recited. A whole mantra 
+like the Stiktavaka, or a part only, is to be recited according 
+as it is necessary. This is to be ascertained by the sacrificer 
+himself. Hence it cannot be said that the whole Stiktavaka is 
+to be recited on the occasion either of the new or of the full 
+moon day.” Again :—“ That portion of the Süktavaka which is 
+recited at the new or full moon sacrifice is the whole of it in 
+reference to the sacrifice itself 3 because the Veda never pre- 
+Scribes a certain text as constituting the Süktavaka, and because 
+the Veda simply states that the Stktavaka, is to be recited... 
+The Siktavaka is not one text only, but is composed of different 
+texts. The principal god connected with a sacrifice is mention- 
+ed in the middle of the Stktavaka, while something connected 
+with the sacrifice to be performed is described at its beginning 
+and end...... All that is sought is the accomplishment of the 
+new or full moon sacrifice. Hence there is no necessity for dis- 
+cussing whether the whole Süktavaka or a portion of it is to be 
+recited; because whatever mantras are sufficient to accomplish 
+a sacrifice constitute the whole Siktavaka so far as the sacrifice 
+is concerned.” 
+
+
+ans Ce 
+सूचबद्धशकुनिन्यांय; ॥ ks 
+The simile of œ bird tied by a cord, It is found in ia 
+Chhamdogya Upanisad 6, 8. 2, namely :—“q यथा शङ्कनि 
+सूत्रेण प्रबद्धो दिशं दिशं पतित्वान्यत्रायतनमलब्ध्वा बन्ध॑नमेवोपश्रयत = 
+
+
+eas aa ett 
+प्रोणबन्धन हि सोस्य मन इति.” E 
+
+
+Digitized By Siddhanta #gapgotri Gyaan Kosha 
+
+
+Vidyaranya versified the above in his Armbhutiprakas'a 
+(iii. 81) and Paneadas't. (xi. 47) respectively as follows:— 
+« शकुनिः सूत्रबद्धो यः स गच्छन्विविधा दिशः d 
+अलब्ध्वाधारमाकादोे बन्धनस्थानमाब्रजेत्‌?? ॥ 
+“शकुनिः सूत्रबद्धः सन्दिक्ष॒ व्यापृत्य विश्रमम्‌ | 
+ABSA बन्धनस्थानं हस्तस्तम्भाद्युपा श्रयेत्‌?? ॥ 
+I have omitted, in each case, a second verse relating to the 
+
+
+darstantika. 
+
+
+सूत्रशाटिकान्यायः ॥ 
+
+
+The simile of the thread [about to be woven into a] gar- 
+ment [and already regarded as a garment]. Raghunatha ex- 
+plains it thus:—^f य॒त्र तु भाविसंज्ञया निर्देशों यथा नारुठ्रों वसेत्काइया- 
+fea तत्र सूत्रशाटिकान्यायावतारः । pr शाटिकां वापयतीत्यन्न यथा ` 
+सूत्रावस्थायां भाविन्या शाटिकेतिसंज्ञया निर्देशस्तथा दार्शन्तिके$पीति ater." 
+
+
+It is no doubt derived from the following passage in the 
+Mahabhasya 1. 3. 12 (vàrtika 2):—“ आत्मनेपदेषु चापि नेतरेतराश्रयं 
+भवति | कथम्‌। भाविनी संज्ञा विज्ञास्यते सूत्रशाटकवत्‌ । तद्यथा । कश्चित्क- 
+चित्तन्तुवायमाह अस्य सूत्रस्य शाटकं वयेति | स पश्यति यदि शाटको न वात- 
+व्योऽथ वातव्यो न शाटकः शाटको वातव्यश्चेति विप्रतिषिद्धम्‌ | भाविनी खल्व- 
+स्य संज्ञाभिप्रेता स मन्ये वातव्यो यस्मिन्नुते शाटक इस्येतद्भवतीलि” This 
+is repeated in 2. 1. 51 (vartika 4). Kumirila employs the 
+illustration in Tuntravartika 3. 7. 33 ( page 1145): यथैवास्य ` 
+YA शाटकं वयेत्युक्ते वानेन शाटकः क्रियत इति हि भाविसंज्ञाविज्ञानादांबे- 
+रोधो बिज्ञायते तथैवात्र प्रत्येतव्यम्‌.” 
+
+
+Light is thrown upon this by the following extract from 
+Ballantyne's Aphorisms of the Nyaya, i. 127. The sūtra so. 
+numbered is “ सहचरणस्थानतांदर्थ्य &e.” “Though its meaning be, 
+not so and so, it is figuratively so employed in the case of a 
+Bra XC घव à TOM 
+
+àhman, a scafiald, à pai, aa of association, | 
+
+
+ir 9 
+E 
+
+
+En 
+
+
+Digitized By Siddhanta eGangbtbi((byaan Kosha 
+
+
+place, design...... ‘Though it be not so and 80, ù e, though 
+such be not the direct meaning of the word, it is figuratively 
+employed; for example, the word ‘staff’ &c., is employed for a 
+Brahman &c., because of association...... In like manner... 
+from the ‘design’ (tadarthya), “He makes a mat’ ( kata) 
+implies his aiming after a mat; for the mat, inasmuch as it isa 
+thing non-existent [ until made] can have [at the time when 
+-one is spoken of as making it] no maker." 
+
+Again, under sūtra 4. 1. 50 | बुद्धिसिद्ध g तदसत्‌], the author 
+of the vritti says (as interpretted by Dr. Ballantyne ):—* The 
+weaver sets himself to work, having considered, that, ‘ In these 
+threads [%. e, constituted by these threads] there will bea 
+web, but not with the understanding that ‘there is a web; 
+for, if that were the case, then, the product being supposed ex- 
+tant, there would be no setting one’s self to work, because 
+desire | precluded by possession] would be absent.” See also 
+passage in Tatparyatikd, page 254, beginning at line 14; and 
+Sankhyatattvakawumudt on karika 9, pages 52, 53. 
+
+
+सोपानत्के पादे द्वितीयामुपानहमशक्यत्वान्नोपादत्ते ॥ 
+
+A man does not [attempt to] put a second shoe on ७ foo 
+already shod, for it would be an impossibility. This is found | 
+in the bhasya on Jaimini 1. 2, 33, where the pūrvapakehin 
+objects to certain Vedic texts as unnecessarily setting forth 
+things already known. i 
+
+
+a 
+
+
+. स्थावरजद्भमविषन्यायः ॥ 
+
+
+‘The simile of vegetable | or mineral ] poison and animal 
+son [जङ्गमविष]. An illustration of one thing being count 
+by anothersc olmbissmaliet Sant Rigs mat havarmon places 
+. amongst the purely grammatical nyayas, immediately 4 
+
+
+Digitized By Siddhanta etkdngotri Gyaan Kosha 
+
+
+पूर्वात्परबलीयस्त्वन्याय; and describes it as follows:—* स्थावरजङ्गम- 
+विपन्यायश्रेह बोध्यः | रजतादिज्ञानतक्घाधज्ञानयोः सर्पवत्सनाभादिरूपजङ्गसः 
+स्थावरविपयोश्चोत्तरेण पूर्ववाधः प्रसिद्धो यथा तथा प्रकृतेऽपि? ॥ In the 
+larger work, ib stands amongst miscellaneous ny&yas near the 
+end of the uttarabhdga, and is numbered 242. I extract from 
+it the following :—' स्थावरेण वत्सनाभादिविषेण जङ्गमस्य सर्पविषादेवांधो 
+जङ्गमेन च स्थावरस्येति प्रसिद्धम्‌ | सामान्येन परस्परवाध्यवाधकभावविवक्षायां 
+सुन्दोपसुन्दन्यायविपयेऽस्य प्रदृत्तिः । पूर्वै निवत्योन्यस्य स्वयमेव निव्रत्तो विव- 
+क्षितायां दरधेन्धनवह्निन्यायविषयेऽस्यावतरणस्‌ । परेण पूर्वबाधमात्रविवक्षायां 
+पूर्वात्परबळीयस्स्वन्यायस्येति बोध्यम्‌ | अपच्छेदन्यायस्त्वस्पष्टसुदाहरणस्ुभयन्रा- 
+नियतपूवीपरी भावेनानियतबाध्यबाधकभावात्‌?? ॥ 
+
+
+An example of animal poison proving an antidote to the 
+other kind is found in Adiparva, chap. exxviii (Cale). The 
+wicked Duryodhana mixed some kalakitaka in Bhima's food 
+and, when he had eaten it and become unconscious, threw bim 
+into the water. The story then continues thus:—“g निःसंज्ञो 
+जलस्यान्तमथ वे पाण्डवो5विशत्‌। आक्रामन्नागभवने तदा नागऊुमारकान्‌ ॥ ततः 
+समेत्य बहुभिस्तदा नागेमेहाविपेः | अदञ्यत wat भीमो महादंट्रोविषोल्बणे: ॥ 
+ततोऽस्य दइ्यमानस्य तद्विषं कालकूटकम्‌ | हृतं सपेविषेणेव स्थावरं जङ्गमेन TN 
+
+
+Compare the विषनाशकविषन्याय in Saredrthasiddhi on Tativa- 
+muktäkalāpa ii. 53. 
+
+
+स्वाज्जुलिज्वालया परं दिधक्षुः स परं दहेद्वा न वा स्वा- 
+ड्गुलिदाहमनुभवति ॥ 
+
+
+A man who tries to burn his enemy by setting fire to his 
+own fingers, may or may not burn. the enemy bui certainly 
+burns his own fingers! It occurs in Nydyavdrtika हे. १. 
+1 in reference to a person who denies the validity af Proof, 
+Sütras 8 and 12, as translated by Dr. Ballantyne, are as fol. 
+lows :—«[ Perhaps momsspnnansidsseyigctine nature of a Proof 
+
+
+Digitized By Siddhanta epgngotr Gyaan Kosha 
+
+
+does not belong to sense &c., for it cannot be so at any of the 
+three times [into which Time is divided ]" *[If there be no 
+such thing as Proof ] because [ forsooth ] nothing can be such at 
+any of the three times, then the objection itself cannot bo esta- 
+blished.” On this the author of the vārtika says :--* य॒त्खलु 
+त्रिष्वपि कालेषु न साधकं तदसाधनमिति gaa प्रतिपेधस्यासाधकत्वं ear. 
+चेवाभ्युपगतं भवति | यथा कश्चितस्वा ङ्कुलिजवालया परं दिधक्षुः स च परं दहेद्वा 
+न वा स्वाङ्कुलिदाहमचुभवति,?? 
+
+
+स्वेदजनिमित्तेन झाटकत्यागन्यायः ॥ 
+
+
+The illustration of throwing away a garment because of a louse 
+in i! Tt occurs in Upamitibhavaprapanca Katha (page 160 
+line 10) :--“यतो$हमनन्तापत्यापि दुर्जनचक्षदापभयादाविवेकादिभिमीत्रिभि- 
+
+> a A ^N M LU 
+वन्ध्येति प्रख्यापिता लोके ममैवापत्यान्यन्यजनापत्यतया गीयन्ते | सोऽयं स्वेद- 
+
+
+जनिमित्तेन शाटकत्यागन्यायः !? ॥ Compare Raghunatha's यूकाभिया 
+कन्थात्यागन्यायः ॥ 
+
+
+हिरण्यनिधिरष्टान्तः ॥ 
+
+
+The illustration afforded by buried treasure [ over which 
+
+
+men may walk again and again, unconscious of its existence }. 
+
+
+It is found in the Chhandogya Upanisad 8. 3. 9 as follows न्न 
+“यथापि हिरण्यनिधिं निहितमक्षेत्रज्ञा उपर्युपरि सञ्चरन्तो न विन्देयुरेवमेवेमाः 
+सवाः प्रजा अहरहर्गच्छत्य ud ब्रह्मलोकं न विन्दन्त्यनृतेन हि प्रत्यूढाः” ॥ 
+
+
+Suresvarücürya makes use of it in Sambandhavartika, 
+verses 294 and 295 :— 
+
+
+“ कुतस्तज्जञानमिति चेत्तद्धि बन्धपरिक्षयात्‌ । 
+असावपि च भूतो वा भावी वा वर्वतेञ्थवा ॥ 
+अधीतवेदवेदार्थोऽप्यत एव न gem l 
+ERNES T ATT? ॥ 
+
+
+7 
+1 
+
+
+Digitized By SiddhaptgseGangotri Gya 
+
+
+The translator of the vartika, Mr, S. Venkataram: 
+gives “ the illustration of the golden mine” as the ri 
+of the nyaya in verse 295; and adds in a footnote, 
+other than professional detectives of mines, will not dis 
+a rich mine of gold hidden deep beneath the surface 
+earth"; but I think that my rendering is more i 
+with S'ankarücarya's interpretation of it in the Vedic p 
+He says :— 
+
+“हिरण्यनिधिं हिरण्यमेव पुनम्रैहणाय निधातृभिर्नि्ीयत इति 
+हिरण्यनिधिं निहितं भूमेरधस्तान्निक्षितस्‌” ॥ 
+
+There is no thought here of a mine, but of treasure 
+in the ground with a view to its being taken up again 
+future occasion. ; 
+
+The two verses from the Vatika reappear as Pancad 
+39, 40, preceded by the following: — 
+
+
+* पुनःपुनविचारेऽपि त्रिविधप्रतिवन्धतः । 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+Digitized By Siddhanta eGangotri Gy: 
+
+
+क्र 
+ALPHABETICAL LIST - 
+
+
+t OF 
+
+
+NYAYAS EKPLAINED IN PART 
+
+
+in each handful, it i 
+to quote t 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+LIST OF NYAYAS. 
+
+
+अकाले paaga स्यात्‌ ii. 
+अक्षिपात्रन्याय iii. 
+अझ्िहोत्रन्याय iii. 
+अंगुलिदीपिकया ध्वान्तध्वंसविधि iii. 
+अंगुल्यग्रं न qu iii. 
+अंगुल्यग्रे हस्तियूथशतमास्ते iii. 
+अजाकृपाणीयन्याय 7. 
+अजातपुत्रनासोत्कीतेनन्याय 7. 
+अणुरपि विशेषः ii. 
+अत्यन्तपराजयात्‌ ii. 
+अत्यन्तवलवन्तो5पि iii. 
+अदित्सोवेणिज: iii. 
+अधिकरणसिद्धान्तन्याय dii. 
+अधिकारन्याय iii. 
+अध्यारोपापवा द च्याय ii. 
+HANA महाभाष्ये iii. 
+अनन्तरस्य विधिवां iii. 
+अनन्यलभ्यः Wega: iii. 
+अनिपिद्धसनुमतस्‌ iii. 
+अन्तरंगबहिरंगयोः ili. 
+अन्तर्दीपिकान्याय 1. 
+अन्धकवतेकीयन्याय 7. 
+अन्धगजन्याय . 
+अन्धगोलांगूलन्याय !- 
+अन्धदर्पणन्याय ii. 
+अन्धपरस्परान्याय | 
+अन्धस्पेवान्धलमस्य 1 
+अन्यवेइमस्थिताद्धमातू di 
+
+
+C-0. Prof. Satya Vrat Shastri Collection. 
+
+
+अन्यार्थमपि प्रकृतं ग. 
+अपथ्छेद्न्याय iii. 
+अपराद्धेपोरिव धानुष्कस्य ii. 
+अपवादेरुत्सगी बाध्यन्ते iii, 
+AMG शास्रमर्थवत्‌ ॐ. 
+arated पूर्वम्‌ ii. 
+अभ्युपगमसिद्धान्तन्याय ॐ. 
+अम्बुनि सजन्सलाबूनि गो. 
+अयमपरो गण्डस्य lii. 
+अरण्यरोदनन्याय ग. 
+अस्णेकहायनीच्याय li. 
+
+| अरुन्धतीप्रदर्शनच्याय उ. 
+
+| अके चेन्मधु विन्देत 7 
+
+| अर्थी समर्था विद्वानधिक्रियते म 
+
+| अर्धजरतीयन्याय i 
+अधैवेशसन्याय ii 
+wera मत्तकाशिन्याः प. 
+
+| अवतप्तेनकुलस्थितम्‌ ॐ 
+अवयवप्रसिद्धेः ग 
+अविराविकन्याय म 
+अशक्तोऽहं qum i 
+अशोकवनिकान्याय i 
+अश्मलोष्टन्याय © 
+अश्वतरीगर्भेत्याय i. 
+अश्वारूढाः कथं चाश्वान्‌ ग. ` 
+असाधारण्येन व्यपदेशा भवन्ति ii 
+
+
+n 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+अखमख्रेण शाम्यति i. 
+अहिकुण्डळन्याय i. 
+अहि भुक्केवतन्याय ii 
+अहृदुयवचसामहृदयुत्तरम्‌ iii. 
+आकाशास्ुष्टिहननन्याय d. 
+आख्यातानामर्थं gaat ili, 
+आदावन्ते च यन्नास्ति ii. 
+आम्रसेकपितृतर्पणन्याय ii. 
+STATE: ii. 
+आग्रे Bors निसिते ili. 
+sgg ii. 
+em? qui iii. 
+आशासो दुकतृन्याय iii. 
+आपाढवाते चलति iii. 
+इतो व्याघ्र इतस्तटी iii. 
+इपुकारन्याय ii. 
+इपुवेगक्षयन्याय ii. 
+इष्यमाणस्यैव प्राधान्य ili. 
+उत्कृष्टरष्टिः ii. 
+उत्खातदंष्टोरगन्याय ii. 
+TAWA कोशो शृतः iii. 
+उपजीब्यविरो घस्यायुक्तत्वम्‌ ii. 
+उपयन्नपयन्धमः i. 
+उपवासादरं भिक्षा iii. 
+उपसंजनिष्यमाणनिमित्तः iii. 
+उभयतःपाशा रञ्जुः ili. 
+उष्ट्कण्टकभक्षणन्याय 1. 
+उष्टूलगुडन्याय ii. 
+ऊषरवृष्टिन्याय 1. 
+ऋजुमार्गेण सिध्यतः ii. 
+A PT 
+
+
+| एकामसिद्धि परिहरतः ii. 
+| कटकगवोदाहरणसू i. 
+
+
+एकसस्बान्धि दर्शने iii. 
+एकाकिनी प्रतिज्ञा ii. 
+
+
+कण्ठचामीकरन्याय li. 
+कद॒म्बकोरकन्याय 1. 
+कपि्गळन्याच lii. 
+कफोणिगुडन्याय 1. 
+कम्बलनिर्णेजनन्याय dii. 
+करविन्यस्तबिल्वच्याय ii. 
+करिवृंहितन्याय iii. 
+कर्मभूयस्त्वात्फलभूयस्त्वम्‌ i. 
+करूञ्जन्याय iii. à 
+कलशपुरःसरग्रासाद dil. 
+काँस्यभोजिल्याच i. 
+काकतालीयन्याय 7. 
+काकद्‌धिघातकन्याय iii. 
+काकदन्तपरीक्षान्याय 1. 
+काकाक्षिगोलकब्याय i. 1 
+काकाधिकरणत्वन्याय ili. : 
+काकोलूकनिशा उं. 
+काचिन्निपादी ya ग्रसूते dii. 
+काण्डानुसमयन्याय iii. 
+कारणगुणग्रक्रमन्याय li. 
+कार्पासरक्तता i. 
+काशकुशावलूम्बनन्याय 1. 
+किमाट्रेकबणिजः ग. 
+कुठारच्छेद्यताम्‌ i. 
+
+कुड्यं विना चित्रकमेव ए. | 
+कुल्याप्रणयनन्याय i 
+कूटकार्षपणन्याय ए, | 
+
+
+Digitized By SC Gyaan Kosha 
+
+
+कूपयत्रवटिकान्याय i. 
+कूसोङ्गन्याय d. 
+FIARA नक्षत्रपरीक्षा lii. 
+छृत्रिमाछृत्रिमयोः dii. 
+कृत्वाचिन्तान्याय i. 
+
+केवलेवंचनेः iii. 
+
+क्रिया हि Rada न वस्तु iii. 
+SZ: क च नीराजना iii. 
+
+क्षते क्षारमिव ii. 
+
+क्षीरनीरन्याय ii. 
+
+क्षीरं विहाय i. 
+
+खलेकपोतन्याय ii. 
+खल्वाटबिह्वीयन्याय i. 
+गरानरोमन्थन्याय i. 
+राइरिकाप्रवाहन्याय i. 
+गन्धाश्मरजसा घ. 
+गगेशतदण्डनन्याय lii. 
+गतेवर्तिगोधामांसविभजनन्याय ii. 
+गतैस्थम्रतसर्पन्याय iii. 
+गलेपाहुकान्याय रं. 
+गाहंपत्यन्याय ili. 
+गुडजिह्विकान्याय i. 
+
+ग्रहीत्वार्थ गताश्चौराः ii. 
+गोदोहनन्याय iii. 
+गोबलीवर्दन्याय i. 
+गोसयपायसीयन्याय i. 
+गोणसुख्ययोः iii. 
+अहेकत्वन्याय iii. 
+aa yaa ii. 
+घटप्रदीपन्याय li. 
+घटीयन्नन्याय ॐ 
+घट्टकुरीप्रभातन्याय i. 
+सुणाक्षरन्याय i. 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+| चकश्नमणन्याय ii. 
+| यन्दनन्याय iii. 
+
+
+चन्द्रचन्द्रिकान्याय 1. 
+चित्राङ्गनान्याय iii. 
+चिन्तामणिं परित्यज्य ii, 
+चेतनस्य यत्नहीनस्य ii 
+चौरापराधान्माण्डव्यनिग्रहन्याय i 
+छात्तन्याय i. 
+छायापिद्याचीन्याय 10. 
+जलकतकरेणुन्याय ग. 
+जलतुस्बिकान्याय ग. 
+जातेष्टिन्याय iii. 
+जामावृशुद्धिन्याय ग. 
+MAMA श्रपितस्य सूपादेः d 
+ज्ञानमज्ञानस्यैव निवर्तकम्‌ ii. 
+उवरहरतक्षकचूडारल्ला' गं. 
+izara ii. 
+डमरूकमाणिन्याय iii. 
+तक्रकोण्डिन्यन्याय i 
+तटादर्शिशकुन्तपोतन्याय ii. 
+तत्कतुन्याय ग. 
+
+KATAA ii. 
+
+TAMNA TEAST: i 
+तदन्तापकपेन्याय lii. 
+तदागमे हि ii 
+तब्यपदेशल्याय iii. 
+तपनीयमपनीय i. 
+
+ae daa सम्बध्यते di. 
+तप्तायःपीतास्बुवत्‌ ii. 
+तमःप्रकाशन्याय dis 
+तमोदीपन्याय :. 
+तस्करकन्दुन्याय de 
+
+तस्करस्य पुरस्तात्कक्षे सुवण i 
+
+
+Digitized By Siddhanta eiepgotri Gyaan Kosha | 
+
+
+तिलतण्डुलन्याय ii. 
+तुलोन्नमनन्याय ii 
+तुषकण्डनन्याय ii. 
+gag दुजेनन्याय D 
+तृणजलायुकान्याय ii. 
+तृणभक्षणन्याय iii. 
+तृणारणिमणिन्याय li. 
+तेळकलुपितशातिबीजात्‌ ii. 
+तेळपात्रधरन्याय ii. 
+“BATH कुलस्यार्थे di. 
+दुग्धपटन्याय i. 
+दग्धबीजन्याय iii. 
+दग्धेन्धनवलह्लित्याय 7. 
+दण्डापूपिकान्याय 7. 
+दण्डन्याय ii. 
+
+
+दत्तमेकधा सहस्रगुणसुपळभ्यते iii. 
+
+
+द॒त्तणाधमर्ण इव iii. 
+qaga प्रत्यक्षो saz: iii. 
+दवदाहस्य वेत्रबोज di. 
+दासच्यारकटन्याय ii 
+दीघेशप्कुली भक्षणन्याय iii. 
+दूरस्थवनस्पतिन्याय iii. 
+देवदत्तशोर्यन्याय iii. 
+देवदत्तहन्तृहतन्याय iii. 
+देहलीदीपन्याय i. 
+श्रनंजयन्याय di. 
+धान्यपलालन्याय 7. 
+धाराबाहिकन्याय Hi. 
+
+न खलु शालग्रामे 7. 
+
+न च सवत्र तुल्यत्वं स्यात i. 
+agaaa पाद्रोराः ili. 
+
+
+C lt tx ब MI 
+न यद्विरिशज्ञमासत्छ-ही Prof. Satya Vrat S Ae REBAR TTA: s 
+
+
+'नरसिंहन्याय ii. 
+
+
+नर्तकन्याय iii. 
+
+नष्टाश्वदग्धरथन्याय 7. 
+
+नसि प्रोतोष्टन्याय iii. 
+
+न हि कडोरकण्डारवस्य 1. | 
+
+न हि करकंकणदरशनाय iii. 
+
+न हि काकिन्यां नष्टायां lii. 
+
+न हि magaan iii. 
+
+खदिरगोचरे परशौ 1. 
+
+गोधा सर्पन्ती iii. 
+
+सस्थः lii. 
+
+त्रिपुत्रो द्विपुत्र इति कथ्यते iii. 
+
+नारिकेल ङ्वीपवासिनः ii. 
+
+निन्दा ii. 
+
+पद्भयां पळायितु पारयमाणः ii. 
+
+पूतं स्या द्वोक्षीरं iii. 
+
+भवति तरक्षुः ii. 
+
+भिक्षुकाः सन्तीति ii. 
+
+भिक्षुको भिक्षुकान्तरं iii. 
+
+भूमावम्भोरुहं सत्‌ iii. 
+यददेवदृत्तस्य युध्यमानस्य ii. 
+
+न हि वरविघाताय 7. 
+
+न हि विधिशतेनापि तथा dii 
+
+न हि श्यामाकबीज ii. 
+
+न हि aa: सर्वं जानाति dii. 
+
+न हि सहस्रेणाप्यन्ध्रैः ii. 
+
+नहि सुश्चिक्षितोऽपि ag: ii. 
+
+न हि सुतीक्ष्णाप्यसिधारा ii. 
+
+न हि स्वतोऽसती शक्तिः iii. 
+
+न ह्यन्धस्याञ्यावेक्षणोपेते कर्मणि die 
+
+न ह्यन्यस्य वितथभावे iii. 
+
+a gara प्रदीपः ii. 
+
+
+पर 
+
+
+" 
+
+
+M4 
+
+
+न? AP AD AD AD AD GP AP D aD ap ap ai 
+
+
+4p dp ap Ap ap 4 4 4 A 4 oap a 4 
+
+
+नाग्रहीते विशेषणे iii. 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+नान्यदष्ट स्मरत्यन्यः li. 
+नासाधितं करणम्‌ iii. 
+
+
+नासिकाग्रेण कणेमूल्कर्षणन्याय iii, 
+
+
+निरामयस्थ किमायुर्वेदविदा iii. 
+निपादस्थपतिन्याय iii. 
+
+नो खल्वन्धाः सहस्रमपि ii. 
+पंकप्रक्षालनन्याय i. 
+पंग्वन्धन्याय i. 
+पञ्जरचाळनन्याय 7. 
+पश्षरसुक्तपक्षिन्याय ili. 
+पण्डकसुद्वाह्य i. 
+पदार्थानुसमयन्याय iii. 
+परतत्रं बहिमनः iii. 
+परस्परविरोधे हि iii. 
+पजन्यवत्‌ iii, 
+
+पणेमयीन्याय ili. 
+पलालकूटस्थ WIEN iii. 
+पश्यस्यद्रों ज्वलद्झि iii. 
+पाटचरलुण्ठिते वेश्मनि 1. 
+पाटनसन्तरेण iii. 
+पाठक्रमन्याय ग. 
+पादप्रसारिका i. 
+पिण्डमुत्सूज्य करं लेढि ii. 
+पिण्याकयाचनार्थ गतस्य i. 
+पिन्ननुस्गतस्तनंघयन्याय ग. 
+पिशाचानां पिशाचभाषयेव ii. 
+पिष्टपेषणन्याय i. 
+पुरस्तादपवादाः iii. 
+पुष्टलगुडन्याय i. 
+
+पूवे ह्यपवादाः Hi 
+
+THY चापवादविषयं li. 
+प्रकृतिप्रत्ययो ili. 
+प्रतिनिधिन्याय ii. 
+
+
+| ति प्रधानं गुण आवर्तनीयः 3, ` 
+
+| Fad किम ुमानेन म 
+
+प्रदीपवत्‌ ii. 
+
+प्रदीपे प्रदीपं प्रज्वाल्य i. 
+
+| रवानमहनिबहणन्याय i. 
+अपानकरसन्याय iii, 
+प्रमाणवत्त्वादायातः ili. 
+प्रमाणवन्त्यदृष्टानि iii. 
+प्रयोजनमचुदिर्य iii. 
+
+असक्त हि प्रतिपिध्यते म. 
+प्रस्तरम्रहरणन्याय dii. 
+प्रावर्तिकक्रमन्याय ili. 
+फळवत्सन्निधावफलं तदङ्गम्‌ ग. 
+फळलवत्सहकारन्याय iii. 
+बकबन्धनन्याय ii. 
+बधिरकर्णजपन्याय ii. 
+aata ii. 
+
+बलवदपि शिक्षितानां म. 
+
+बहु छिद्र घटप्रदीपन्याय ii. 
+बहुराजकदेशन्याय शो. 
+
+बहूनासनुग्रहो न्याय्यः iii. 
+
+बालस्य प्रदीपकलिकाक्रीडयैव 77. 
+
+बीजांङुरन्याय i. 
+
+बुभुक्षितस्य किं निमन्रणाग्रहः iii. 
+
+ब्राह्मणम्रामच्याय lii. 
+
+ब्राह्मणपरित्राजकन्याय उ. 
+
+ब्राह्मणवसिष्ठन्याय 7. 
+ब्राह्मणश्रमणन्याय उं. 
+
+भक्षितेऽपि लशुने ¦ 
+
+भछुत्याय ग. 
+भस्मच्याज्याहातिः dii 
+भाण्डानुसारिस्रेहैवत्‌ ii 
+
+
+| भाण्डालेख्यत्याय मे 
+
+
+91 CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta ९७०११४ Gyaan Kosha 
+pi 
+
+
+भारैकदेशावतरणन्याय ii. 
+भिक्षुपादग्रसारणन्याय i. 
+भीमभासहृढन्याय ii. 
+
+भूतं भन्यायोपदिइयते iii. 
+भूमिरथिकन्याय iii. 
+भूलिङ्गन्याय ii. 
+भौतविचारन्याय ii. 
+अष्टावसरन्याय iil, 
+मणिप्रभामणिमतिन्याय ii. 
+सणिमत्रादि i. 
+मणिविक्रयदृ्टान्त ii. 
+मण्डूक्जतिन्याय i. 
+मण्डूकवसाक्ताक्षाणां ii. 
+मदशक्तिवत्‌ lii. 
+
+मधु पश्यसि gà lii. 
+मध्यदीपिकान्याय i. 
+मध्येऽपचादाः ili. 
+मन्दविषन्याय iii. 
+
+
+महतापि प्रयलेन afirmar iii. 
+
+
+महति दर्पणे महन्सुखं lii. 
+महार्णवयुगच्छिद्र” i. 
+deese iii. 
+मात्स्यन्याय गं. 
+मानाधीना मेयसिद्धिः i. 
+मारणाय गृहीतः ii. 
+माळतीगन्धगुणबित्‌ i. 
+साषराशिप्रविष्टमषी ii. 
+मिथिलायां प्रदीप्तायां ii. 
+सुज्ञादिषीकोडरणन्याय i. 
+
+
+— मुण्डितरिरोनक्षत्रान्वेषणम्‌ ग. 
+
+
+मंते qe झुच्यते ii. 
+
+
+मृतं हुण्डुभं ग. 
+
+य एव करोति स एव sp i 
+
+यः कारयति स करोत्येव ii. 
+यत्करभस्य TÈ a साति गा. 
+यत्कृतकं तदनित्यसू ii. 
+यत्राकृतिस्तत्र गुणाः iii. 
+यदमिधिस्सितं तदभिधीयताम्‌ ग. 
+aqaa हृतं पुरा ii. 
+
+"EE यदपेक्षं qg; iii. 
+यद्विशेषयोः कार्यकारणभावः ii. 
+यववराहाधिकरणन्याय iii. 
+यश्चोभयोः समो दोषः iii, 
+यस्य नास्ति ga: ili. 
+यस्याज्ञानं iii. 
+यस्योन्मूलनाय iii. 
+याचितमण्डनन्याय i. 
+याइशो यक्षः d 
+
+यावद्वचनं घाचनिकम्‌ i, 
+येन नाप्राप्ते iii. 
+रथकारन्याय lii. 
+राजपुत्रव्याधन्याय li 
+राजपुरम्रवेशन्याय ii. 
+राजाथोंपयिकं ii. 
+रात्रिसत्रन्याय iii. 
+राधावेधोपमा iii. 
+रुधिरसंपर्कवतः ii. 
+रुमाक्षिप्त काष्ठवत्‌ म 
+रूढियागमपहराति ii. 
+रखागवयन्याय ii. 
+रोहणाचलळाभे ili. 
+SANTAN 
+
+
+Digitized By Siddhaata eGangotri Gyaan Kosha 
+
+
+वटे यक्षन्याय iii. 
+वधूमापमापनन्याय ग. 
+वध्यघातकन्याय ii. 
+वध्यतां वध्यतां बालः iii. 
+वनसिंहन्याय ii. 
+
+qi सांदायिकान्निष्कात्‌ i. 
+andiena ii. 
+
+वरमद्य कपोतः d. 
+वर्चोन्याय iii. 
+
+विक्रीतयवी रक्षणम्‌ ii. 
+
+
+विपुलकद॒ली फललिप्सया i. 
+
+
+विलूननासिकस्य iii. 
+kazaa iii. 
+विपकुस्भं पयोमुखम्‌ iii 
+विषकृमिल्याय i, 
+विधवृक्षन्याय 1. 
+वीचीतरङ्कन्याय i. 
+वृक्षम्रकस्पनन्याय 7. 
+कदकुमारीवाक्यन्याय i. 
+बद्धिमिष्टवतः i. 
+वृश्चिकभिया पलायमानः ii. 
+वृश्चिकीयर्भन्याय ii. 
+व्यापकव्यावृत्त्या iii. 
+व्यालनकुलन्याय di. 
+शाकुनिग्राहकगतिल्याय iii. 
+शंखन्याय iii. 
+शतपत्रपत्रशतभेद्न्याय li 
+शते पञ्चाशत्‌ मं 
+शरुरुषीयन्याय i. 
+श्केरोन्मजनीयन्याय i 
+
+श रूभन्याय iil 
+शवोद्वतैनन्याय ii. 
+राखाचन्द्रन्याय ii. 
+
+
+शान्ते कर्मणि वेतालोद्यः iii, 
+शाब्याकांक्षा iii. 
+शास्यादिविषयस्य iii. 
+BARS प्रयोक्तरि lii. 
+शिबिकोद्यच्छन्नरवत्‌ iii. 
+रिरश्छेदेऽपि i. 
+
+
+शिरोवेष्टनेन नासिकास्पशन्याय ii 
+
+
+शिलाघनसध्यस्थप्रदीप iii. 
+शीर्ष सः i. 
+शुकनलिकान्याय i. 
+शुष्केशिन्याय iii 
+झङ्गमाहिकान्याय उ. 
+इयेनकपोतीयन्याय i. 
+श्रुतिबलीयस्त्वन्याय iii 
+श्वः कार्य मद्य कुर्वीत ii. 
+श्वपुच्छोज्ञामनन्याय म. 
+श्वलीढमिव पायसम गे. 
+श्वश्रूनिर्गेच्छोक्तिन्याय i 
+
+श्वा कणे वा iii. 
+पोडशिग्रहणाग्रहणन्याय ii 
+सकृत्कृते na: AWN घ 
+सकृत्मवृत्तायाः li. 
+qug iii. 
+
+सत्रन्याय iit. 
+सद्यात्सच्शोद्धव: ii 
+
+
+सन्दिग्धस्य वाक्यशेषान्निणयः ii 
+
+
+सान्दिरधे न्यायः प्रवतेते ili. 
+aga वाक्यपरिसमातिः ii 
+सम्भवत्येकवाक्यत्वे ii 
+
+संभवे व्यभिचारे च i. 
+
+सवे ज्ञानं धर्मिण्यश्रान्तम्‌ 7: 
+सर्वनाशे ससुत्पन्न 7. 
+
+सवे बलवतः qun गं 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+AA AA ENESCO REESE WELT 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+सर्वशाखाप्रत्ययन्याय iii, 
+सावशपण ह 1. 
+
+सहैव quf पुत्रैः ii. 
+साकमेधीयन्याय iii. 
+साक्षः पुरुषः iii. 
+सामान्यविधिरस्पष्टः iii, 
+सावकाशनिर वकाइायोः ili. 
+सिंहस्येकपदे iii. 
+सिंहावलोकनन्याय i. 
+सिकताकूपवत्‌ iii. 
+सिकतातेलन्याय iii. 
+सुन्दोपसुन्दन्याय ii. 
+सुभगाभिक्षुकन्याय ii. 
+सूक्तवाकन्याय iii. 
+सूचीकटाहन्याय i. 
+सूत्रबद्धराकुनिल्याय iii. 
+
+
+सूत्रशाटिकान्याय iii, 
+
+सोपानत्के पादे iii. 
+सोपानारोहणन्याय ii, 
+सौभरिन्याय ii. 
+स्थालीपुराकन्याय 7. 
+स्थावरजङ्गमाविपन्याय iii. 
+स्थूणानिखननन्याय i. 
+स्फटिकलो हित्यन्याय ii 
+स्वभावो दुरतिक्रमः ii. 
+स्वविपमूच्छितो gag: ii. 
+स्वाङ्गं स्वव्यवेधायक न भवति i 
+स्वाहुलिज्वालया iii. 
+स्वामिस्तूत्यन्याय ii. 
+स्वेदजनिमित्तेन शाटकत्यागः iii. 
+हिरण्यनिधिदृष्टान्त iii. 
+हृदनक्रन्याय 11, 
+
+
+CC-0. Prof. Satya Vrat Shastri Collection. 
+
+
+Digitized By Siddhanta eGangotri 
+
+
+ERRATA. 
+
+
+Page 6, lines 7 and 9 from bottom :— 
+
+For युगपदूज्ज्ञा read युगपज्जञा | 
+Page 29, line 8 from bottom: — _ 
+Put the inverted comm: 
+
+
+ee 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+‘SANSKRIT BOOKS WITH ENGLISH NOTES, 
+
+
+Ss BE Price, Rs, A. Postage. 
+
+
+ABHIJNANA-S'AKUNTALA of Kalidasa, with 
+English Notes by N. B. Godabole B. A 
+
+
+.BHATTLKAVYA of Bhatti, with English ॑ 
+
+
+Notes by N.B. Godabole B.A. (14th Sarga)o- 
+m ( 15th Sarga ) .o- 
+HITOPADESH with English Notes by N. B 
+Godabole B. A. .. ... bo zI- 0 
+MALAVIKAGNIMITRA of Kalidasa, with 
+English Notes by K. P. Parab. ... ... 0-12 
+MRICHCHHAKATIKA of Sudraka, with 
+English Notes by Pandit H. M. S'arma 
+
+
+.M.A ०८० + 2- 0 
+MEGHADUTA of Kalidasa, with English 
+Notes by N. B. Godabole B. A coe 0-12 
+
+
+MUDRA-RAKSHASA of Vis'akha-datta, with 
+English Notes by K. T. Telang, M. A. 
+LE. B.C TLE =. ए <. -1-14 
+
+
+PANCHA-TANTRAKA of Vishnus'arman 
+
+
+_ with English Notes by N. B.Godabole B.A. 2- 8 . 
+
+
+RATNAVALI of S'riharsha-deva, with English 
+Notes by N. B. Godabole B. A. ... 0-8 
+RIK-SANGRAHA with Sayana-bhashya and 
+English Notes, by V. ७. Bijapurkar M. A. 2- o 
+RITU-SAMHARA of Kalidasa, with S'ringara- 
+tilaka and explanatory English Notes. by 
+N. B. Godabole B. A, — ... es . aan O° 6 
+TARKA-SANGRAHA of Annam-bhatta; with 
+
+
+his own gloss and an English Translation. 0- 6 
+ceo Prof. Satya Vrat Shastri Collection 
+
+
+0-2-6 
+
+
+0-0-6 
+0-0-6 
+
+
+0-1-6 
+
+
+0-1-0 
+
+
+| 
+| Digitized By Siddhanta eGangotf} Gyaan Kosha Ry 
+| 1 Price, Rs, 4 Postage, 4 
+VEDANTA-SARA of Sadananda, with English 
+Notes by Colonel G. A. Jacob `... -.. 1-8 0-2-6 
+LAUKIKANYAYANJALI (2 collection of popu- ; 
+lar sayings) by Colonel G. A. Jacob Part I o- 6 o-I-o 
+Part Il 0-12 0-1-0" 
+| E e Part III 1- 4 0-2-0 
+
+
+| A life of the late Hon. Mr. Justice RANADE o- 0-0-6 
+
+
+| ‘° 7 “USEFUL SCHOOL SERIES» 
+—080200——. 
+BEAUTIES of English literature... s O- 3 0-0-6 
+
+
+Bombay University. MATRICULATION 
+EXAMINATION PAPERS in Sanskrit 
+
+
+| ` with answers 1862-1901 vov “+, 0512 oz 
+
+| : 
+
+| GRAMMAR 01 Sanskrit language—by Dr. F 3 
+
+| ^. Kielhorn. Revised fourth edition e 2- 0 0-2-0 | 
+PRIMER of. MENSURATION for Schools— : 
+
+| ` by Dr. T. Cooke. Fourth Edition ee O- 3 0-0-6 - 
+
+| SAHITYA-SARA-SANGRAHA (Atreatiseon — | 
+
+| " Indian Poetics) ... . ... | .. . 0-8 0-1-0 
+
+| SAMASA-PRAKARANA ( Hints to the study | 
+
+| ' of Sanskrit Compoinds) NS COED | 
+
+
+SANSKRIT MANUAL.—(VERY USEFUL for 
+
+
+iddhanta 
+
+
+छः 
+> 
+m 
+coe 
+A 
+= 
+5o 
+
+
+न 
+
+
+Y - $ =, T. 
+- Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+शः p? 
+fis 
+
+
+Digitized By Siddhan 
+
+
+Digitized By Siddhanta eGangotri Gyaan Kosha 
+
+
+^ 
+
+

--- a/RussianTranslation/sol.md
+++ b/RussianTranslation/sol.md
@@ -1,0 +1,29 @@
+Read ORCHESTRATION_4ACCOUNT_MAX.md and PIPELINE_AUDIT_2026-07_H818.md completely.
+
+Execute the H818 Windows live acceptance on the currently checked-out PR #416 branch using the owner-authenticated Max profile already present in CLAUDE_CONFIG_DIR.
+
+Be aware that the needed FIX lives in another branch. Go to it, no use to replicate old errors
+
+Constraints:
+- exact generation model claude-sonnet-5;
+- RU-only no_pwg;
+- one account and strictly sequential execution;
+- do not inspect, print, copy, or modify credentials;
+- do not run any A/B experiments;
+- do not provision Linux;
+- stop immediately on authentication failure, malformed output, manifest drift, duplicate/lost key, promotion conflict, non-positive store delta, or failed probe;
+- retain run_events.jsonl, bug_census.json, manifests, statuses, hashes, audit reports, requeue artifacts, latency/call/retry/quota metrics, and per-attempt logs.
+
+Sequence:
+1. Verify PR #416 code and run all offline gates.
+2. Initialize the dedicated Max profile and require both auth status and the repository ≥5 KB exact-model live probe to pass.
+3. Build a known-heavy presplit manifest and run the non-promoting `presplit-canary`; prove fragment recovery and fidelity. Never import or promote this canary.
+4. Run and promote a fresh deterministic 1-headword no_pwg canary.
+5. Run and promote a fresh deterministic 10-headword stage.
+6. Run and promote one fresh 20-headword window.
+7. Prepare the deterministic next 100 unpromoted headwords as five disjoint 20-headword windows.
+8. Execute windows 1 and 2, deliberately stop/restart the scheduler, run recovery, then execute windows 3–5.
+9. Audit and serialize promotion after every production window; verify canonical store and TM after every promotion.
+10. Produce the final H818 GO/NO-GO report and update the audit/history/journals with measured evidence.
+
+Do not mark the PR ready and do not begin H841/H842/H843 unless every H818 GO criterion passes. If a criterion fails, classify it deterministically, preserve its requeue artifact, report NO-GO, and stop.

--- a/research-layers.txt
+++ b/research-layers.txt
@@ -1,3 +1,15 @@
+Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H792-Fable_claude-config_klammerdiagramm-skill-1to1_12.07.26.md and execute it.
+
+Next: запустить H792 (Fable) — довести Klammerdiagramm до 1:1 (встроенный Charis SIL) и оформить /klammerdiagramm 
+
+===
+Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H807-Fable_SanskritGrammar_kochergina-methodichka-v1_12.07.26.md and execute it.
+
+Дал Кодексу Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H818-Codex_RussianTranslation_pwg-ru-full-pipeline-audit-4account-max-orchestration_12.07.26.md and execute it.
+
+====
+
+
 Which family should I optimize the 30-capability roadmap around first?
 Reasearch-grade - done?
 Production pipeline


### PR DESCRIPTION
Left dirty by a prior/interrupted session (uncommitted on the local `master` checkout); committed by /tidy so the tree is clean and the work is recoverable.

- `LaukikaNyaya/raw_jacob_1907-1911_ocr.txt` -- public-domain (1907-1911) OCR source text, sibling files already tracked
- `RussianTranslation/sol.md` -- H818 orchestration instructions
- `research-layers.txt` -- appended session notes (pure append, verified)

Excluded from this PR (left dirty, need human review):
- `generation_api_probe_log.jsonl` -- its dirty-tree version would have deleted ~10 already-committed w07/w08/w09 log entries
- two untracked `papers/*.pdf` -- no rights clearance on file (same posture as the existing gitignored `papers/MDF_2000.pdf`)
- `IndologyScholars` (separate repo) has a similar stale `.gitignore` diff that reverts a nagari archive privacy protection -- not this PR, noted for the /tidy report