### PR TITLE
H818 D-J: bounded best-effort Windows process-tree kill on timeout

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,21 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+- **H818 D-J — Windows process-tree kill on timeout (bounded best-effort).** A timed-out
+  generation call was killed with `subprocess.run(timeout=)`, whose Windows kill hits only
+  the immediate `node cli-wrapper.cjs` process — **orphaning the `spawnSync`'d native claude
+  binary** (confirmed at the wrapper source) that keeps holding the API call. That is the
+  bounded-scope diagnosis (defect A) of the arvant multi-minute non-termination (a
+  content-specific problem B is not ruled out until a post-merge bounded retry). Fix: a
+  `run_tree_kill` (Popen + `communicate(timeout=)`) that on timeout performs **bounded
+  best-effort** whole-tree termination — `taskkill /PID <pid> /T /F` while the parent is
+  alive on Windows, `killpg` on POSIX — always falling back to `proc.kill()`, draining pipes
+  and reaping within the remaining kill budget, and recording cleanup trouble diagnostically
+  without changing the primary `timeout` classification. Applied at every claude-spawning
+  kill point (worker calls, the outer worker subprocess, `live_probe`, `profile_status`,
+  presplit-canary worker). Not race-free (tree enumeration still races exit/spawn) —
+  correctness is asserted by a **parent→child→grandchild** regression test that fails if any
+  descendant survives. (13-07-2026, Opus 4.8 `claude-opus-4-8`, H818 lineage.)
 - **H818 acceptance hardening (follow-up) — D-G real-concurrency race + D-I telemetry
   cardinality.** Two further acceptance defects, following the D-E…D-H batch. The D-G
   selftest was strengthened to a **real** concurrency race — two independent SQLite

--- a/RussianTranslation/H818_WINDOWS_LIVE_ACCEPTANCE_RERUN_2026-07-13.md
+++ b/RussianTranslation/H818_WINDOWS_LIVE_ACCEPTANCE_RERUN_2026-07-13.md
@@ -34,9 +34,11 @@ What the run nonetheless established, and what it produced:
   `model_version=claude-sonnet-5`): canonical store **11,577 → 11,579 (+2)**, lease
   `promoted`/`clean`, and the TM rebuilds+validates (2455 cards). The full pipeline
   `generate → audit → promote → store → TM` works end-to-end on Windows.
-- **Five defects (D-E…D-I) were harvested and fixed** — D-E…D-H in
-  [PR #438](https://github.com/gasyoun/SanskritLexicography/pull/438) (merged), and the
-  real-concurrency D-G race hardening + D-I telemetry-cardinality fix in a follow-up PR.
+- **Six defects (D-E…D-J) were harvested and fixed** — D-E…D-H in
+  [PR #438](https://github.com/gasyoun/SanskritLexicography/pull/438) (merged), the
+  real-concurrency D-G race hardening + D-I telemetry-cardinality fix in
+  [PR #441](https://github.com/gasyoun/SanskritLexicography/pull/441) (merged), and the
+  **D-J** Windows process-tree kill (below) in a further follow-up PR.
 
 ## Why the sequence is invalid
 
@@ -63,16 +65,21 @@ What the run nonetheless established, and what it produced:
 
 - **Content-defect rate.** The RU `no_pwg` supplement lane's audit-clean rate is
   ~60–65% (observed here: `darvI` dropped a sense, `gaRanA` `SAN-LOSS`, `durgA`
-  clean; the deterministic queue front `arvant…bAhlika` is the documented
-  presplit-cohort residual that hangs/rejects). A single-headword canary is
-  therefore a coin-flip, and a multi-card window's window-level `go` cannot clear
-  the acceptance's `audit_clean ≥ 0.80` bar. **This bar sits above the lane's real
-  clean rate** — a strict window-level GO is unreachable for `no_pwg` as calibrated;
-  the achievable proof is a positive store delta on the audit-clean subset (as
-  `durgA` gave).
+  clean). A single-headword canary is therefore a coin-flip, and a multi-card
+  window's window-level `go` cannot clear the acceptance's `audit_clean ≥ 0.80` bar.
+  **This bar sits above the lane's real clean rate** — a strict window-level GO is
+  unreachable for `no_pwg` as calibrated; the achievable proof is a positive store
+  delta on the audit-clean subset (as `durgA` gave).
+- **`arvant` multi-minute non-termination — cause not yet conclusive.** The
+  deterministic queue front `arvant…bAhlika` did not complete within bounded time.
+  This is **consistent with D-J** (the Windows process-tree termination failure:
+  the timeout kills the node wrapper but orphans the `spawnSync`'d native binary,
+  which keeps holding the API call). Whether a **content-specific** non-termination
+  (B) *also* exists is **not confirmed** — it can only be told apart by a single
+  bounded live retry *after* D-J lands. Do not call `arvant` content-poisoned yet.
 - **Cold-start latency.** Probes cold-start > 30 s and warm to ~10 s. With D-F now
-  enforced, a valid restart needs a **pre-warmed profile** (repeat the probe until a
-  ≤ 30 s reading) before the gated staged-run.
+  enforced, a valid restart needs a **pre-warmed profile** before the gated
+  staged-run (a genuine warm-up, not re-rolling the gated reading until convenient).
 
 ## Retained evidence (local, gitignored `src/pilot/output/h818_accept/`)
 
@@ -82,11 +89,35 @@ What the run nonetheless established, and what it produced:
 hashes · `durgA` report + coordinator artifacts · `max.sqlite`. `durgA`'s +2 store
 rows are retained (a valid clean promotion).
 
-## Next — a clean restart (gated)
+## Restart run (run2, on merged D-E…D-I) + the D-J diagnosis
 
-After PR #438 merges, restart from a **fresh deterministic unpromoted one-headword
-canary** on a warmed profile. **Do not begin the 10-word stage unless that
-one-headword staged-run reaches full GO** — audit clean, positive store delta, TM
-build+validate, report, and bug census all passing.
+After D-E…D-I merged, a clean isolated restart ran on the fixed code: auth **PASS**;
+a single honest gated probe **PASS** (9368 ms standalone / 29565 ms in the
+staged-run — both ≤ 30 s, no re-rolling); the deterministic next-unpromoted canary
+`arvant` then did **not** terminate within bounded time and was cut off by the
+harness wall-clock limit → **NO-GO**, no promotion, canonical store unchanged
+(11,579), account not falsely parked, telemetry clean. Per the gate: **STOP — no
+10-word stage.**
+
+Root-cause diagnosis (bounded scope): the uncontrolled non-termination is defect
+**D-J** — the worker killed a generation call with `subprocess.run(timeout=)`, whose
+Windows kill hits only the immediate `node cli-wrapper.cjs` process, **orphaning the
+`spawnSync`'d native binary** (confirmed at the wrapper source) that keeps holding
+the API call. Fixed by a **bounded best-effort process-tree kill** (`taskkill
+/PID … /T /F` while the parent is alive; POSIX `killpg`), applied at every
+claude-spawning kill point, with a parent→child→grandchild regression test proving
+no descendant survives. **D-J explains the uncontrolled hang; it does not yet rule
+out a content-specific problem (B)** — that is settled only by the single bounded
+`arvant` retry after D-J merges.
+
+## Next — bounded retry, then a clean canary (gated)
+
+After D-J merges: exactly **one bounded live `arvant` retry**. If it times out
+again (now controlled), classify it a **deterministic content failure**, preserve
+its immutable requeue artifact, move it to the **poison/dead-letter lane**
+(accounted-but-unpromoted, not cherry-picking), and select the next eligible
+headword by deterministic queue policy. **Do not begin the 10-word stage unless a
+fresh one-headword staged-run reaches full GO** — audit clean, positive store delta,
+TM build+validate, report, and bug census all passing.
 
 _Dr. Mārcis Gasūns_

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,6 +1,6 @@
 # LANG_PARITY.md — cross-language fix/feature parity ledger
 
-_Created: 04-07-2026 · Last updated: 13-07-2026_
+_Created: 04-07-2026 · Last updated: 13-07-2026 (D-J re-verify)_
 
 This repo runs the same PWG→Russian and PWG→English translation pipeline through
 shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
@@ -953,11 +953,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/headless_worker.py": "95a43cf3c305db819b8006157cdbdead6bb282057dd1c5dd1481c6e6088f4b0b",
-      "src/pilot/max_account_orchestrator.py": "45ffcd4947e2d89088e18a31cb52b5f7b48c49b20ad3cddf1ccc388d0f023804",
+      "src/pilot/headless_worker.py": "769bbab47460bcc6c5fdd1c5307836a98143d74631d5c042987c0057a69cac6e",
+      "src/pilot/max_account_orchestrator.py": "cfcb91c489584d88cf164bf569bfbc1c91491eca9426fb9f0ae3706f6f075811",
       "src/pilot/coordinator.py": "3fc844fe372b7511528aefeefbc90dcd83653b9cc09e85fed837fd599eac15f8",
-      "src/pilot/headless_worker_selftest.py": "a5f6fb98e32b6e860848a5c2ed4f6871469ce1a576d2030b45485b9f460464ad",
-      "src/pilot/max_account_orchestrator_selftest.py": "7cc969ed24352cbb99f9845151f00ad817ab79c0d4858d3fbdf1ba45fe9d6a47",
+      "src/pilot/headless_worker_selftest.py": "a98c9e0380f9630f84ad3e8355b3d3db852765d0b7a0f36d6fa393e5fcdf9a02",
+      "src/pilot/max_account_orchestrator_selftest.py": "1e33e48c04fce36f4668d74b5d18031cb761544026cf5695f012a606b038fb7c",
       "src/pilot/no_pwg_scale_plan.py": "ec654b580278361a6fe27c1cb93a04acd1c1a219f8db223f2fdea9c0a657a105",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
       "src/pilot/run_observability.py": "c634d46b8267418b0fe6e8dbf248c98b5fa8435bac7715cd6c4c453b1dc1fbb5",

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -215,12 +215,87 @@ def card_token_multiset(card):
     return collections.Counter(tokens)
 
 
+def _terminate_tree(proc, deadline):
+    """**Bounded best-effort** tree termination — NOT race-free (tree enumeration still races
+    process exit/spawn; correctness is what the parent->child->grandchild regression test asserts).
+    Invoked WHILE ``proc`` is still alive so the tree is enumerable. The Windows claude launcher is
+    ``node cli-wrapper.cjs``, which ``spawnSync``'s the native binary as a CHILD; the stdlib timeout
+    kill (``TerminateProcess`` on the node process) leaves that binary orphaned (H818 defect D-J).
+    ``taskkill /PID <pid> /T /F`` reaps the live tree on Windows (acceptable for this known-stable
+    wrapper tree); ``killpg`` the session group on POSIX. Always falls back to ``proc.kill()`` if
+    the parent is still alive. Returns a short diagnostic string on cleanup trouble, else None —
+    the caller keeps the primary ``timeout`` classification regardless."""
+    if proc.poll() is not None:
+        return None
+    trouble = None
+    if os.name == 'nt':
+        budget = max(1.0, deadline - time.monotonic())
+        try:
+            subprocess.run(['taskkill', '/PID', str(proc.pid), '/T', '/F'],
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=budget)
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+            trouble = 'taskkill:%s' % type(exc).__name__
+    else:
+        import signal as _signal
+        try:
+            os.killpg(os.getpgid(proc.pid), _signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError) as exc:
+            trouble = 'killpg:%s' % type(exc).__name__
+    if proc.poll() is None:                            # always fall back if the parent still lives
+        try:
+            proc.kill()
+        except OSError as exc:
+            trouble = (trouble or '') + ';proc.kill:%s' % type(exc).__name__
+    return trouble
+
+
+def run_tree_kill(argv, input=None, timeout=None, text=True, encoding='utf-8',
+                  capture_output=False, cwd=None, env=None, **_ignored):
+    """Drop-in for ``subprocess.run`` (Popen + ``communicate(timeout=)``) that, on timeout,
+    performs bounded best-effort termination of the ENTIRE process tree instead of just the
+    immediate child — so a killed generation call is bounded and no orphaned native binary keeps
+    holding the API call (H818 defect D-J). Terminates the tree while the parent is still alive,
+    then drains the pipes and reaps the parent using the REMAINING kill budget to an absolute
+    deadline (a small grace beyond the call budget, not an independent fixed window). Cleanup
+    trouble is attached diagnostically to the raised ``subprocess.TimeoutExpired`` — the caller's
+    handling still records exactly one ``timeout`` event."""
+    pipe = subprocess.PIPE if capture_output else None
+    popen_kw = dict(stdin=subprocess.PIPE, stdout=pipe, stderr=pipe,
+                    text=text, encoding=encoding, cwd=cwd, env=env)
+    if os.name == 'nt':
+        popen_kw['creationflags'] = getattr(subprocess, 'CREATE_NEW_PROCESS_GROUP', 0)
+    else:
+        popen_kw['start_new_session'] = True          # own process group -> killpg reaches children
+    proc = subprocess.Popen(argv, **popen_kw)
+    start = time.monotonic()
+    try:
+        out, err = proc.communicate(input=input, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        grace = min(10.0, (timeout or 0) * 0.1 + 2.0)  # small, proportional, capped cleanup grace
+        deadline = start + (timeout or 0) + grace
+        trouble = _terminate_tree(proc, deadline)
+        try:
+            remaining = max(0.5, deadline - time.monotonic())
+            out, err = proc.communicate(timeout=remaining)     # drain pipes + reap within budget
+        except subprocess.TimeoutExpired:
+            trouble = (trouble or '') + ';reap-timeout'
+            try:
+                proc.kill()
+                proc.communicate(timeout=2)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+        if trouble:
+            exc.cleanup_trouble = trouble              # diagnostic only; classification stays 'timeout'
+        raise
+    return subprocess.CompletedProcess(argv, proc.returncode, out, err)
+
+
 class HeadlessEngine:
     def __init__(self, manifest, claude, timeout, runner):
         self.m = manifest
         self.claude = claude
         self.timeout = timeout
-        self.run = runner or subprocess.run
+        self.run = runner or run_tree_kill
         self.attempts = []
         self.failures = {}
         self.translate_calls = 0
@@ -244,11 +319,15 @@ class HeadlessEngine:
         try:
             proc = self.run(argv, input=prompt, text=True, encoding='utf-8',
                             capture_output=True, timeout=self.timeout)
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as exc:
             self.kill_timeouts += 1
-            self.attempts.append({'label': label, 'keys': keys, 'returncode': 124,
-                                  'elapsed_ms': int((time.monotonic() - started) * 1000),
-                                  'classification': 'timeout'})
+            attempt = {'label': label, 'keys': keys, 'returncode': 124,
+                       'elapsed_ms': int((time.monotonic() - started) * 1000),
+                       'classification': 'timeout'}
+            cleanup = getattr(exc, 'cleanup_trouble', None)
+            if cleanup:                                # D-J: diagnostic only; classification stays 'timeout'
+                attempt['cleanup_trouble'] = cleanup
+            self.attempts.append(attempt)
             return None, 'timeout'
         elapsed = int((time.monotonic() - started) * 1000)
         if proc.returncode:

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -157,6 +157,59 @@ def main():
     finally:
         h.os.name, h.shutil.which, h.glob.glob = _name, _which, _glob
     print('  D-A claude_argv_prefix: posix/.exe passthrough, .cmd->node-direct, no-node fallback OK')
+
+    # D-J: a timeout must terminate the ENTIRE process tree, not just the immediate child. The
+    # Windows claude launcher (node cli-wrapper.cjs) spawnSync's the native binary as a CHILD, so
+    # killing only the node process orphans it (the multi-minute 'hang'). Mirror the real
+    # python -> node(wrapper) -> native-binary depth with parent -> child -> GRANDCHILD: each level
+    # records its PID and writes a '.done<n>' marker ONLY if it survives its sleep. A correct
+    # tree-kill leaves NONE of the three PIDs alive and NONE of the three markers written.
+    import time as _time
+
+    def _alive(pid):
+        if os.name == 'nt':
+            out = subprocess.run(['tasklist', '/FI', 'PID eq %d' % pid, '/NH'],
+                                  capture_output=True, text=True).stdout or ''
+            return str(pid) in out.split()
+        try:
+            os.kill(pid, 0)
+            return True
+        except OSError:
+            return False
+
+    with tempfile.TemporaryDirectory() as td:
+        mk = os.path.join(td, 'm')
+        grand = ('import time,sys,os;'
+                 'open(sys.argv[1]+".pid3","w").write(str(os.getpid()));'
+                 'time.sleep(6);open(sys.argv[1]+".done3","w").write("1")')
+        child = ('import subprocess,sys,os,time;'
+                 'open(sys.argv[1]+".pid2","w").write(str(os.getpid()));'
+                 'subprocess.Popen([sys.executable,"-c",%r,sys.argv[1]]);'
+                 'time.sleep(30)') % grand
+        parent = ('import subprocess,sys,os,time;'
+                  'open(sys.argv[1]+".pid1","w").write(str(os.getpid()));'
+                  'subprocess.Popen([sys.executable,"-c",%r,sys.argv[1]]);'
+                  'time.sleep(30)') % child
+        t0 = _time.monotonic()
+        try:
+            h.run_tree_kill([sys.executable, '-c', parent, mk], timeout=3, capture_output=True)
+            assert False, 'expected TimeoutExpired'
+        except subprocess.TimeoutExpired:
+            pass
+        assert _time.monotonic() - t0 < 25, 'tree kill did not bound the timeout'
+        for _ in range(60):     # wait for the full 3-level tree to have recorded its PIDs
+            if all(os.path.exists('%s.pid%d' % (mk, i)) for i in (1, 2, 3)):
+                break
+            _time.sleep(0.1)
+        _time.sleep(5)          # > the grandchild's 6 s sleep offset: an orphan would have written .done3
+        for i in (1, 2, 3):
+            assert os.path.exists('%s.pid%d' % (mk, i)), 'level %d never started (test setup broken)' % i
+        pids = [int(open('%s.pid%d' % (mk, i)).read()) for i in (1, 2, 3)]
+        survived_marker = [i for i in (1, 2, 3) if os.path.exists('%s.done%d' % (mk, i))]
+        assert not survived_marker, 'level(s) %s SURVIVED the tree kill (orphaned)' % survived_marker
+        still_alive = [p for p in pids if _alive(p)]
+        assert not still_alive, 'tree PID(s) still alive after kill (orphaned): %s' % still_alive
+    print('  D-J tree-kill: parent->child->grandchild all gone (no orphan); timeout bounded + raised once')
     print('headless_worker_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -18,7 +18,7 @@ import sys
 import time
 
 from run_observability import append_event, write_census
-from headless_worker import claude_argv_prefix
+from headless_worker import claude_argv_prefix, run_tree_kill
 
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
@@ -242,8 +242,8 @@ def run_claimed(db_path, account, config_dir, job, timeout, events_path=None, ru
     env = os.environ.copy()
     env['CLAUDE_CONFIG_DIR'] = config_dir
     try:
-        proc = subprocess.run(argv, cwd=job['cwd'], env=env, text=True, encoding='utf-8',
-                              capture_output=True, timeout=timeout)
+        proc = run_tree_kill(argv, cwd=job['cwd'], env=env, text=True, encoding='utf-8',
+                             capture_output=True, timeout=timeout)   # D-J: tree-kill on timeout
         payload = json.dumps({'argv': argv, 'returncode': proc.returncode,
                               'stdout': proc.stdout, 'stderr': proc.stderr}, ensure_ascii=False, indent=1)
         atomic_write(attempt_log, payload)
@@ -301,9 +301,9 @@ def profile_status(config_dir, claude='claude'):
     env = os.environ.copy()
     env['CLAUDE_CONFIG_DIR'] = config_dir
     try:
-        proc = subprocess.run(claude_argv_prefix(claude) + ['auth', 'status', '--json'],
-                              env=env, text=True,
-                              encoding='utf-8', capture_output=True, timeout=30)
+        proc = run_tree_kill(claude_argv_prefix(claude) + ['auth', 'status', '--json'],
+                             env=env, text=True,
+                             encoding='utf-8', capture_output=True, timeout=30)   # D-J: tree-kill
     except (OSError, subprocess.TimeoutExpired) as exc:
         return False, str(exc)
     try:
@@ -312,7 +312,7 @@ def profile_status(config_dir, claude='claude'):
         return False, (proc.stderr or proc.stdout)[-500:]
     if proc.returncode or not data.get('loggedIn'):
         return False, data.get('subscriptionType') or 'not logged in'
-    probe = subprocess.run(
+    probe = run_tree_kill(               # D-J: tree-kill on timeout
         claude_argv_prefix(claude) + ['-p', 'Return exactly OK.', '--output-format', 'json',
          '--model', 'claude-sonnet-5', '--permission-mode', 'plan'],
         env=env, text=True, encoding='utf-8', capture_output=True, timeout=60)
@@ -473,7 +473,7 @@ def live_probe(config_dir, claude='claude', payload_bytes=6491, model=EXACT_GEN_
     prompt = ('Return JSON {"ok":true}. Preserve this padding as inert input.\n' +
               ('x' * payload_bytes))
     started = time.monotonic()
-    proc = subprocess.run(
+    proc = run_tree_kill(                # D-J: tree-kill on timeout
         claude_argv_prefix(claude) + ['-p', '--output-format', 'json', '--json-schema',
          '{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"],"additionalProperties":false}',
          '--model', model, '--permission-mode', 'plan'],
@@ -672,8 +672,8 @@ def cmd_presplit_canary(args):
            os.path.abspath(args.manifest), '--output', os.path.abspath(args.output),
            '--status-out', os.path.abspath(args.status), '--claude-bin', args.claude_bin,
            '--timeout', str(args.timeout)]
-    proc = subprocess.run(cmd, env=env, text=True, encoding='utf-8', capture_output=True,
-                          timeout=args.timeout)
+    proc = run_tree_kill(cmd, env=env, text=True, encoding='utf-8', capture_output=True,
+                         timeout=args.timeout)   # D-J: tree-kill on timeout (presplit canary worker)
     status = json.load(open(args.status, encoding='utf-8')) if os.path.exists(args.status) else {}
     canary_base = {'run_id': run_id, 'account': accounts[0]['name'],
                    'manifest_hash': status.get('manifest_sha256')}

--- a/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
@@ -123,9 +123,9 @@ def main():
         m.live_probe('cfg', model='claude-haiku-4-5'); assert False, 'exact-model gate missing'
     except SystemExit as e:
         assert 'exact generation model' in str(e)
-    _run, _mono = m.subprocess.run, m.time.monotonic
+    _run, _mono = m.run_tree_kill, m.time.monotonic   # live_probe spawns via run_tree_kill (D-J)
     try:
-        m.subprocess.run = lambda *a, **k: types.SimpleNamespace(returncode=0, stdout='{"ok":true}', stderr='')
+        m.run_tree_kill = lambda *a, **k: types.SimpleNamespace(returncode=0, stdout='{"ok":true}', stderr='')
         over = iter([1000.0, 1031.0])            # 31,000 ms elapsed -> over the 30 s ceiling
         m.time.monotonic = lambda: next(over)
         try:
@@ -136,7 +136,7 @@ def main():
         m.time.monotonic = lambda: next(good)
         assert m.live_probe('cfg') == 10000
     finally:
-        m.subprocess.run, m.time.monotonic = _run, _mono
+        m.run_tree_kill, m.time.monotonic = _run, _mono
     print('  D-F probe gate: <5KB/non-exact-model raise; >30s NO-GO; healthy <=30s passes')
 
     # D-G (H818 acceptance): one active job per account, atomic in the BEGIN IMMEDIATE claim.


### PR DESCRIPTION
Bounded-scope root-cause fix for the `arvant` multi-minute non-termination that stopped the gated acceptance restart. Follow-up to [#438](https://github.com/gasyoun/SanskritLexicography/pull/438) / [#441](https://github.com/gasyoun/SanskritLexicography/pull/441).

## Diagnosis (defect A — but B not ruled out)
The worker killed a timed-out generation call with `subprocess.run(timeout=)`, whose Windows kill hits only the immediate `node cli-wrapper.cjs` process. The wrapper does `spawnSync(binaryPath, …)` — it spawns the **native claude binary as a child** — so that binary is **orphaned** and keeps holding the API call (the "hang"). This is **consistent with D-J**; whether a **content-specific** non-termination (B) *also* exists is **not** settled until one bounded live `arvant` retry after this lands. `arvant` is **not** called content-poisoned yet.

## Fix — `run_tree_kill` (bounded best-effort, not race-free)
Popen + `communicate(timeout=)`; on timeout, terminate the **entire tree while the parent is alive**: `taskkill /PID <pid> /T /F` (Windows) / `killpg` (POSIX). Acceptable for this known-stable wrapper tree — but **not race-free** (tree enumeration still races exit/spawn), so correctness is asserted by a **parent→child→grandchild** regression test that fails if any descendant survives. Also:
- always falls back to `proc.kill()` if the parent remains alive;
- catches `TimeoutExpired`/`FileNotFoundError`/`OSError` from taskkill;
- drains pipes + reaps within the **remaining kill budget** (small grace beyond the call budget, not an independent fixed window);
- records cleanup trouble **diagnostically** (`attempt.cleanup_trouble`) **without** changing the primary `timeout` classification — one timeout event per invocation.

Applied at every claude-spawning kill point in [`headless_worker.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/headless_worker.py) and [`max_account_orchestrator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/max_account_orchestrator.py) (worker calls, the outer worker subprocess, `live_probe`, `profile_status`, presplit-canary worker).

## Tests
`headless_worker_selftest` parent→child→grandchild tree-kill: all three PIDs gone, no orphan, timeout bounded + raised once. Full offline gates **17/17**; LANG_PARITY SHARED re-verified.

**Next (post-merge):** exactly one bounded `arvant` retry → if it times out again, classify deterministic content failure, preserve immutable requeue artifact, move to the poison/dead-letter lane, select next eligible headword; do not begin the 10-word stage until a fresh one-headword canary is fully clean + promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)