### PR TITLE
H818 D-K: two-phase probe protocol (warm-up + measured) — fixes the cold-start flap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
             RussianTranslation/src/lod_acceptance.py \
             RussianTranslation/src/mfs_baseline.py \
             RussianTranslation/src/government_sidecar.py \
+            RussianTranslation/src/pilot/proc_tree.py \
             RussianTranslation/src/pilot/headless_worker.py \
             RussianTranslation/src/pilot/max_account_orchestrator.py \
             RussianTranslation/src/pilot/windows100_selftest.py \

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,26 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+- **H818 D-K — two-phase probe protocol (fixes the cold-start flap without lowering the
+  ceiling).** The single-sample D-F gate NO-GO'd on a transient cold reading (a 30151 ms
+  flap on an otherwise ~8–10 s warm profile). `live_probe` now runs a deterministic
+  sequence: **exactly one warm-up call** (same profile + exact model; its latency is
+  EXCLUDED from the acceptance gate — it only stabilizes the cold connection) then
+  **immediately exactly one measured ≥5 KB probe** that IS gated (rc 0, auth/model/
+  output-size checks, latency **≤30000 ms unchanged**). A warm-up failure
+  (auth/model/malformed/rate-limit/timeout) is an immediate STOP; a failed or over-ceiling
+  *measured* probe is an honest NO-GO with **no retry and no manual pre-warming**. Both calls
+  are recorded separately in telemetry (`purpose` warmup/measured, latency, model,
+  output_bytes, classification); `build_census` keeps probe calls distinguishable from
+  translation, excludes the warm-up from acceptance latency, but **still counts warm-up
+  rate-limits in total quota observations**. `output_bytes` is measured from encoded UTF-8
+  bytes, not character count. Both probe calls use the shared D-J tree-kill runner (now
+  extracted to `proc_tree.py`, used by both `headless_worker` and `max_account_orchestrator`),
+  so a hanging probe kills its whole parent→child→grandchild tree before generation begins.
+  Regression tests: exactly one warm-up + one measurement, 30000 passes / 30001 NO-GO,
+  warm-up failure STOPs before the measured call, encoded output_bytes, census
+  distinguishability + quota, and a real 3-level hanging-probe tree-kill. (13-07-2026, Opus
+  4.8 `claude-opus-4-8`, H818 lineage.)
 - **H818 D-J — Windows process-tree kill on timeout (bounded best-effort).** A timed-out
   generation call was killed with `subprocess.run(timeout=)`, whose Windows kill hits only
   the immediate `node cli-wrapper.cjs` process — **orphaning the `spawnSync`'d native claude

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,6 +1,6 @@
 # LANG_PARITY.md — cross-language fix/feature parity ledger
 
-_Created: 04-07-2026 · Last updated: 13-07-2026 (D-J re-verify)_
+_Created: 04-07-2026 · Last updated: 13-07-2026 (D-K re-verify)_
 
 This repo runs the same PWG→Russian and PWG→English translation pipeline through
 shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
@@ -942,7 +942,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/no_pwg_scale_plan.py",
       "src/pilot/windows100_selftest.py",
       "src/pilot/run_observability.py",
-      "src/pilot/run_observability_selftest.py"
+      "src/pilot/run_observability_selftest.py",
+      "src/pilot/proc_tree.py"
     ],
     "languages": [
       "ru",
@@ -953,15 +954,16 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/headless_worker.py": "769bbab47460bcc6c5fdd1c5307836a98143d74631d5c042987c0057a69cac6e",
-      "src/pilot/max_account_orchestrator.py": "cfcb91c489584d88cf164bf569bfbc1c91491eca9426fb9f0ae3706f6f075811",
+      "src/pilot/headless_worker.py": "344df79a75dcbc85a90d8ccea8e271a88bde0e433c90eb131eb04d9d4ccbaeb9",
+      "src/pilot/max_account_orchestrator.py": "0cdaa47b88ae1713b259245f0ef5382d396d4fb4604fef71d33faec3bf7248d0",
       "src/pilot/coordinator.py": "3fc844fe372b7511528aefeefbc90dcd83653b9cc09e85fed837fd599eac15f8",
       "src/pilot/headless_worker_selftest.py": "a98c9e0380f9630f84ad3e8355b3d3db852765d0b7a0f36d6fa393e5fcdf9a02",
-      "src/pilot/max_account_orchestrator_selftest.py": "1e33e48c04fce36f4668d74b5d18031cb761544026cf5695f012a606b038fb7c",
+      "src/pilot/max_account_orchestrator_selftest.py": "403a2225141abb7f1e87fada9a276c6459b52986a94eedefbcfc9f70f35ad0a3",
       "src/pilot/no_pwg_scale_plan.py": "ec654b580278361a6fe27c1cb93a04acd1c1a219f8db223f2fdea9c0a657a105",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
-      "src/pilot/run_observability.py": "c634d46b8267418b0fe6e8dbf248c98b5fa8435bac7715cd6c4c453b1dc1fbb5",
-      "src/pilot/run_observability_selftest.py": "75bc960a35080a0c84ca9b5ee62b63134a9e0bde334c5531d564b13019187b60"
+      "src/pilot/run_observability.py": "371d0197b39e217ef1754eb60d8b09f79823678f728d65e276f864eaeb8e0d72",
+      "src/pilot/run_observability_selftest.py": "75bc960a35080a0c84ca9b5ee62b63134a9e0bde334c5531d564b13019187b60",
+      "src/pilot/proc_tree.py": "52ef9b80fb3f29187f8501ffb83be3d4bf0098757058373a84cb10be92d51e1e"
     }
   },
   {

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -15,6 +15,10 @@ import time
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
+if os.path.dirname(os.path.abspath(__file__)) not in sys.path:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from proc_tree import run_tree_kill, terminate_tree  # noqa: E402  (shared D-J tree-kill runner)
+
 AUTH_RE = re.compile(r'401|authentication|not logged in|invalid.*credential', re.I)
 RATE_RE = re.compile(r'429|rate.?limit|usage limit|too many requests', re.I)
 CONN_RE = re.compile(r'connection closed|econnreset|socket hang up|network error', re.I)
@@ -215,79 +219,7 @@ def card_token_multiset(card):
     return collections.Counter(tokens)
 
 
-def _terminate_tree(proc, deadline):
-    """**Bounded best-effort** tree termination — NOT race-free (tree enumeration still races
-    process exit/spawn; correctness is what the parent->child->grandchild regression test asserts).
-    Invoked WHILE ``proc`` is still alive so the tree is enumerable. The Windows claude launcher is
-    ``node cli-wrapper.cjs``, which ``spawnSync``'s the native binary as a CHILD; the stdlib timeout
-    kill (``TerminateProcess`` on the node process) leaves that binary orphaned (H818 defect D-J).
-    ``taskkill /PID <pid> /T /F`` reaps the live tree on Windows (acceptable for this known-stable
-    wrapper tree); ``killpg`` the session group on POSIX. Always falls back to ``proc.kill()`` if
-    the parent is still alive. Returns a short diagnostic string on cleanup trouble, else None —
-    the caller keeps the primary ``timeout`` classification regardless."""
-    if proc.poll() is not None:
-        return None
-    trouble = None
-    if os.name == 'nt':
-        budget = max(1.0, deadline - time.monotonic())
-        try:
-            subprocess.run(['taskkill', '/PID', str(proc.pid), '/T', '/F'],
-                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=budget)
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
-            trouble = 'taskkill:%s' % type(exc).__name__
-    else:
-        import signal as _signal
-        try:
-            os.killpg(os.getpgid(proc.pid), _signal.SIGKILL)
-        except (ProcessLookupError, PermissionError, OSError) as exc:
-            trouble = 'killpg:%s' % type(exc).__name__
-    if proc.poll() is None:                            # always fall back if the parent still lives
-        try:
-            proc.kill()
-        except OSError as exc:
-            trouble = (trouble or '') + ';proc.kill:%s' % type(exc).__name__
-    return trouble
-
-
-def run_tree_kill(argv, input=None, timeout=None, text=True, encoding='utf-8',
-                  capture_output=False, cwd=None, env=None, **_ignored):
-    """Drop-in for ``subprocess.run`` (Popen + ``communicate(timeout=)``) that, on timeout,
-    performs bounded best-effort termination of the ENTIRE process tree instead of just the
-    immediate child — so a killed generation call is bounded and no orphaned native binary keeps
-    holding the API call (H818 defect D-J). Terminates the tree while the parent is still alive,
-    then drains the pipes and reaps the parent using the REMAINING kill budget to an absolute
-    deadline (a small grace beyond the call budget, not an independent fixed window). Cleanup
-    trouble is attached diagnostically to the raised ``subprocess.TimeoutExpired`` — the caller's
-    handling still records exactly one ``timeout`` event."""
-    pipe = subprocess.PIPE if capture_output else None
-    popen_kw = dict(stdin=subprocess.PIPE, stdout=pipe, stderr=pipe,
-                    text=text, encoding=encoding, cwd=cwd, env=env)
-    if os.name == 'nt':
-        popen_kw['creationflags'] = getattr(subprocess, 'CREATE_NEW_PROCESS_GROUP', 0)
-    else:
-        popen_kw['start_new_session'] = True          # own process group -> killpg reaches children
-    proc = subprocess.Popen(argv, **popen_kw)
-    start = time.monotonic()
-    try:
-        out, err = proc.communicate(input=input, timeout=timeout)
-    except subprocess.TimeoutExpired as exc:
-        grace = min(10.0, (timeout or 0) * 0.1 + 2.0)  # small, proportional, capped cleanup grace
-        deadline = start + (timeout or 0) + grace
-        trouble = _terminate_tree(proc, deadline)
-        try:
-            remaining = max(0.5, deadline - time.monotonic())
-            out, err = proc.communicate(timeout=remaining)     # drain pipes + reap within budget
-        except subprocess.TimeoutExpired:
-            trouble = (trouble or '') + ';reap-timeout'
-            try:
-                proc.kill()
-                proc.communicate(timeout=2)
-            except (OSError, subprocess.TimeoutExpired):
-                pass
-        if trouble:
-            exc.cleanup_trouble = trouble              # diagnostic only; classification stays 'timeout'
-        raise
-    return subprocess.CompletedProcess(argv, proc.returncode, out, err)
+# run_tree_kill / terminate_tree moved to proc_tree (shared D-J runner); imported above.
 
 
 class HeadlessEngine:

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -456,36 +456,78 @@ PROBE_MIN_PAYLOAD_BYTES = 5000           # D-F: repository >=5 KB load-represent
 PROBE_LATENCY_CEILING_MS = 30000         # D-F: health ceiling; a reading over this is NO-GO
 
 
-def live_probe(config_dir, claude='claude', payload_bytes=6491, model=EXACT_GEN_MODEL,
-               latency_ceiling_ms=PROBE_LATENCY_CEILING_MS):
-    """Repository probe gate (D-F). A GO reading requires ALL of: payload >= 5 KB, exact model
-    ``claude-sonnet-5``, return code 0, AND latency <= 30000 ms. Any violation raises SystemExit
-    so the caller (``staged-run``/``presplit-canary``) STOPS before claim/import/execution — a
-    30,001 ms reading is a NO-GO (the H818 acceptance's 50,991 ms / 36,684 ms probes should have
-    stopped the run, not proceeded)."""
-    if payload_bytes < PROBE_MIN_PAYLOAD_BYTES:
-        raise SystemExit('probe payload %d B < %d B repository floor' %
-                         (payload_bytes, PROBE_MIN_PAYLOAD_BYTES))
-    if model != EXACT_GEN_MODEL:
-        raise SystemExit('probe model %r is not the exact generation model %r' % (model, EXACT_GEN_MODEL))
+def _probe_call(config_dir, claude, payload_bytes, model):
+    """One raw >=5 KB exact-model probe call. Returns (latency_ms, classification, output_bytes);
+    classification is 'success' | 'auth' | 'rate_limit' | 'malformed' | 'process' | 'timeout'.
+    NEVER raises on a non-zero rc — the two-phase gate (``live_probe``) decides what to STOP on."""
     env = os.environ.copy()
     env['CLAUDE_CONFIG_DIR'] = config_dir
     prompt = ('Return JSON {"ok":true}. Preserve this padding as inert input.\n' +
               ('x' * payload_bytes))
     started = time.monotonic()
-    proc = run_tree_kill(                # D-J: tree-kill on timeout
-        claude_argv_prefix(claude) + ['-p', '--output-format', 'json', '--json-schema',
-         '{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"],"additionalProperties":false}',
-         '--model', model, '--permission-mode', 'plan'],
-        input=prompt, env=env, text=True, encoding='utf-8', capture_output=True, timeout=300)
+    try:
+        proc = run_tree_kill(            # D-J: tree-kill on timeout
+            claude_argv_prefix(claude) + ['-p', '--output-format', 'json', '--json-schema',
+             '{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"],"additionalProperties":false}',
+             '--model', model, '--permission-mode', 'plan'],
+            input=prompt, env=env, text=True, encoding='utf-8', capture_output=True, timeout=300)
+    except subprocess.TimeoutExpired:
+        return int((time.monotonic() - started) * 1000), 'timeout', 0
     latency_ms = int((time.monotonic() - started) * 1000)
+    out = proc.stdout or ''
+    combined = out + '\n' + (proc.stderr or '')
+    output_bytes = len(out.encode('utf-8'))
     if proc.returncode:
-        raise SystemExit('load-representative profile probe failed: %s' %
-                         (((proc.stderr or '') + '\n' + (proc.stdout or ''))[-1000:]))
-    if latency_ms > latency_ceiling_ms:
-        raise SystemExit('probe latency %d ms exceeds %d ms health ceiling — NO-GO; stop before '
-                         'claim/import/execution (unhealthy profile)' % (latency_ms, latency_ceiling_ms))
-    return latency_ms
+        if re.search(r'401|authenticat|not logged in|invalid.*credential', combined, re.I):
+            return latency_ms, 'auth', output_bytes
+        if RATE_LIMIT.search(proc.stderr or ''):
+            return latency_ms, 'rate_limit', output_bytes
+        return latency_ms, 'process', output_bytes
+    try:                                 # output-size / validity check: a real {"ok":...} object
+        data = json.loads(out)
+        if not isinstance(data, dict) or 'ok' not in data:
+            return latency_ms, 'malformed', output_bytes
+    except (ValueError, TypeError):
+        return latency_ms, 'malformed', output_bytes
+    return latency_ms, 'success', output_bytes
+
+
+def live_probe(config_dir, claude='claude', payload_bytes=6491, model=EXACT_GEN_MODEL,
+               latency_ceiling_ms=PROBE_LATENCY_CEILING_MS, events_path=None, run_id=None,
+               account=None):
+    """D-K deterministic two-phase probe protocol (ceiling unchanged at 30000 ms). Runs EXACTLY
+    one warm-up call (same profile + exact model; its latency is EXCLUDED from the acceptance
+    gate — it only stabilizes the cold connection), then IMMEDIATELY EXACTLY one measured >=5 KB
+    probe that IS gated. PASS only when the measured call has rc 0, passes auth/model/output-size
+    checks, and latency <= ceiling. A warm-up failure (auth/model/malformed/rate-limit/timeout) is
+    an immediate STOP; a failed or over-ceiling MEASURED probe is an honest NO-GO with NO retry and
+    no manual pre-warming. Both calls are recorded separately in telemetry (purpose warmup /
+    measured), and the warm-up latency never enters the census."""
+    if payload_bytes < PROBE_MIN_PAYLOAD_BYTES:
+        raise SystemExit('probe payload %d B < %d B repository floor' %
+                         (payload_bytes, PROBE_MIN_PAYLOAD_BYTES))
+    if model != EXACT_GEN_MODEL:
+        raise SystemExit('probe model %r is not the exact generation model %r' % (model, EXACT_GEN_MODEL))
+
+    def _emit(purpose, latency, cls, obytes):
+        if events_path:
+            append_event(events_path, run_id=run_id, account=account, stage='probe',
+                         event='probe_call', purpose=purpose, elapsed_ms=latency,
+                         model=model, output_bytes=obytes, classification=cls)
+
+    warm_ms, warm_cls, warm_bytes = _probe_call(config_dir, claude, payload_bytes, model)
+    _emit('warmup', warm_ms, warm_cls, warm_bytes)     # excluded from the acceptance latency census
+    if warm_cls != 'success':
+        raise SystemExit('warm-up probe %s -> STOP (auth/model/output/rate-limit/timeout)' % warm_cls)
+
+    meas_ms, meas_cls, meas_bytes = _probe_call(config_dir, claude, payload_bytes, model)
+    _emit('measured', meas_ms, meas_cls, meas_bytes)   # the one gated acceptance reading
+    if meas_cls != 'success':
+        raise SystemExit('measured probe %s -> honest NO-GO (no retry, no re-warm)' % meas_cls)
+    if meas_ms > latency_ceiling_ms:
+        raise SystemExit('measured probe latency %d ms exceeds %d ms health ceiling — honest NO-GO '
+                         '(warm-up already done; no re-roll)' % (meas_ms, latency_ceiling_ms))
+    return meas_ms
 
 
 def cmd_staged_run(args):
@@ -505,9 +547,8 @@ def cmd_staged_run(args):
     if len(accounts) != 1:
         raise SystemExit('Windows staged-run requires exactly one validated account')
     run_id = args.run_id or ('win100-' + now_iso().replace(':', '').replace('-', ''))
-    latency_ms = live_probe(accounts[0]['config_dir'], args.claude_bin)
-    append_event(args.events, run_id=run_id, account=accounts[0]['name'], stage='probe',
-                 event='probe_end', classification='success', elapsed_ms=latency_ms)
+    latency_ms = live_probe(accounts[0]['config_dir'], args.claude_bin,   # D-K: warmup+measured
+                            events_path=args.events, run_id=run_id, account=accounts[0]['name'])
     db = connect(args.db)
     existing_jobs = {row['external_id'] for row in db.execute('SELECT external_id FROM jobs')}
     db.close()
@@ -663,9 +704,8 @@ def cmd_presplit_canary(args):
     if len(accounts) != 1:
         raise SystemExit('presplit canary requires exactly one validated account')
     run_id = args.run_id or ('presplit-' + now_iso().replace(':', '').replace('-', ''))
-    latency = live_probe(accounts[0]['config_dir'], args.claude_bin)
-    append_event(args.events, run_id=run_id, account=accounts[0]['name'], stage='probe',
-                 event='probe_end', classification='success', elapsed_ms=latency)
+    latency = live_probe(accounts[0]['config_dir'], args.claude_bin,   # D-K: warmup+measured
+                         events_path=args.events, run_id=run_id, account=accounts[0]['name'])
     env = os.environ.copy()
     env['CLAUDE_CONFIG_DIR'] = accounts[0]['config_dir']
     cmd = [sys.executable, os.path.join(os.path.dirname(__file__), 'headless_worker.py'),

--- a/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
@@ -2,6 +2,7 @@
 import json
 import os
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import threading
@@ -112,9 +113,9 @@ def main():
     assert m.is_rate_limited({}, '') is False
     print('  D-C is_rate_limited: hash-429 ignored; worker-class / real-429 detected')
 
-    # D-F (H818 acceptance): the repository probe gate. payload<5KB and a non-exact model raise
-    # before any subprocess call; a latency over the 30 s ceiling is a NO-GO (the observed
-    # 50,991 ms / 36,684 ms probes must stop the run). A healthy <=30 s rc-0 reading returns.
+    # D-F/D-K: the two-phase probe protocol. payload<5KB / non-exact model raise before any call.
+    # Then EXACTLY one warm-up call (latency excluded) + one measured call (gated): 30000 passes,
+    # 30001 is an honest NO-GO, and a warm-up failure STOPs before the measured call ever starts.
     try:
         m.live_probe('cfg', payload_bytes=100); assert False, 'payload floor not enforced'
     except SystemExit as e:
@@ -123,21 +124,122 @@ def main():
         m.live_probe('cfg', model='claude-haiku-4-5'); assert False, 'exact-model gate missing'
     except SystemExit as e:
         assert 'exact generation model' in str(e)
-    _run, _mono = m.run_tree_kill, m.time.monotonic   # live_probe spawns via run_tree_kill (D-J)
+    _pc = m._probe_call
     try:
-        m.run_tree_kill = lambda *a, **k: types.SimpleNamespace(returncode=0, stdout='{"ok":true}', stderr='')
-        over = iter([1000.0, 1031.0])            # 31,000 ms elapsed -> over the 30 s ceiling
-        m.time.monotonic = lambda: next(over)
+        seen = []
+
+        def fake(seq):
+            it = iter(seq)
+
+            def _mock(config_dir, claude, payload_bytes, model):
+                v = next(it)
+                seen.append(v)
+                return v
+            return _mock
+
+        # warm-up 99999 ms (EXCLUDED) + measured exactly 30000 ms -> PASS (ceiling inclusive)
+        seen.clear(); m._probe_call = fake([(99999, 'success', 120), (30000, 'success', 120)])
+        with tempfile.TemporaryDirectory() as td:
+            ev = os.path.join(td, 'e.jsonl')
+            assert m.live_probe('cfg', events_path=ev, run_id='r', account='a') == 30000
+            rows = ro.read_events(ev)
+            assert len([r for r in rows if r.get('purpose') == 'warmup']) == 1
+            assert len([r for r in rows if r.get('purpose') == 'measured']) == 1
+            assert len(seen) == 2                       # exactly one warm-up + one measured
+            cen = ro.build_census(rows)
+            assert cen['latency_ms']['max'] == 30000    # the 99999 warm-up is NOT in the latency census
+            assert len(cen['probe']['warmup']) == 1 and len(cen['probe']['measured']) == 1
+        # measured 30001 -> honest NO-GO (no retry)
+        seen.clear(); m._probe_call = fake([(9000, 'success', 120), (30001, 'success', 120)])
         try:
-            m.live_probe('cfg'); assert False, 'latency ceiling not enforced'
+            m.live_probe('cfg'); assert False, '30001 ms measured must NO-GO'
         except SystemExit as e:
             assert 'health ceiling' in str(e)
-        good = iter([1000.0, 1010.0])            # 10,000 ms -> healthy
-        m.time.monotonic = lambda: next(good)
-        assert m.live_probe('cfg') == 10000
+        assert len(seen) == 2
+        # warm-up auth failure -> immediate STOP, measured NEVER starts
+        seen.clear(); m._probe_call = fake([(9000, 'auth', 0)])
+        try:
+            m.live_probe('cfg'); assert False, 'warm-up auth must STOP'
+        except SystemExit as e:
+            assert 'warm-up' in str(e)
+        assert len(seen) == 1                           # measured never started
+        # measured malformed (output-size/validity) -> honest NO-GO
+        seen.clear(); m._probe_call = fake([(9000, 'success', 120), (9000, 'malformed', 3)])
+        try:
+            m.live_probe('cfg'); assert False, 'malformed measured must NO-GO'
+        except SystemExit:
+            pass
+        assert len(seen) == 2
     finally:
-        m.run_tree_kill, m.time.monotonic = _run, _mono
-    print('  D-F probe gate: <5KB/non-exact-model raise; >30s NO-GO; healthy <=30s passes')
+        m._probe_call = _pc
+    print('  D-F/D-K probe protocol: 1 warm-up (excluded) + 1 measured; 30000 pass / 30001 NO-GO; warm-up fail STOPs before measured')
+
+    # D-K output_bytes is measured from ENCODED UTF-8 bytes, not character count.
+    assert len('да') == 2 and len('да'.encode('utf-8')) == 4
+    _rtk = m.run_tree_kill
+    try:
+        body = '{"ok":true,"n":"да"}'
+        m.run_tree_kill = lambda *a, **k: types.SimpleNamespace(returncode=0, stdout=body, stderr='')
+        lat, cls, obytes = m._probe_call('cfg', 'claude', 6491, m.EXACT_GEN_MODEL)
+        assert cls == 'success' and obytes == len(body.encode('utf-8')) and obytes > len(body)
+    finally:
+        m.run_tree_kill = _rtk
+    print('  D-K output_bytes: encoded UTF-8 bytes, not character count')
+
+    # D-K census: probe events distinguishable from translation calls; warm-up excluded from
+    # latency, but a rate-limit warm-up is STILL counted in total quota observations.
+    with tempfile.TemporaryDirectory() as td:
+        ev = os.path.join(td, 'e.jsonl')
+        ro.append_event(ev, stage='probe', event='probe_call', purpose='warmup', elapsed_ms=99999,
+                        classification='rate_limit', model=m.EXACT_GEN_MODEL, output_bytes=0, run_id='r')
+        ro.append_event(ev, stage='probe', event='probe_call', purpose='measured', elapsed_ms=8000,
+                        classification='success', model=m.EXACT_GEN_MODEL, output_bytes=120, run_id='r')
+        m.emit_call_events(ev, {'keys': ['k'], 'elapsed_ms': 5000, 'classification': 'success', 'label': 'c'},
+                           0, 'mh', {'run_id': 'r', 'account': 'a'})
+        cen = ro.build_census(ro.read_events(ev))
+        assert cen['latency_ms']['max'] == 8000, cen['latency_ms']      # warm-up 99999 excluded
+        assert len(cen['probe']['warmup']) == 1 and len(cen['probe']['measured']) == 1
+        assert cen['quota_observations'] == 1 and cen['quota_incidents'] == 1   # warm-up rate-limit counted
+    print('  D-K census: probe distinguishable; warm-up excluded from latency but counted in quota')
+
+    # D-K integration: a hanging probe call kills its parent->child->grandchild tree (via the shared
+    # run_tree_kill) and returns 'timeout' -- so live_probe stops and the measured/generation phase
+    # never starts. Proves the probe path inherits the D-J tree-kill (not just subprocess.run).
+    import time as _time
+    with tempfile.TemporaryDirectory() as td:
+        mk = os.path.join(td, 'm')
+        grand = ('import time,sys,os;open(sys.argv[1]+".pid3","w").write(str(os.getpid()));'
+                 'time.sleep(6);open(sys.argv[1]+".done3","w").write("1")')
+        child = ('import subprocess,sys,os,time;open(sys.argv[1]+".pid2","w").write(str(os.getpid()));'
+                 'subprocess.Popen([sys.executable,"-c",%r,sys.argv[1]]);time.sleep(30)') % grand
+        parent = ('import subprocess,sys,os,time;open(sys.argv[1]+".pid1","w").write(str(os.getpid()));'
+                  'subprocess.Popen([sys.executable,"-c",%r,sys.argv[1]]);time.sleep(30)') % child
+
+        def _alive(pid):
+            if os.name == 'nt':
+                out = subprocess.run(['tasklist', '/FI', 'PID eq %d' % pid, '/NH'],
+                                     capture_output=True, text=True).stdout or ''
+                return str(pid) in out.split()
+            try:
+                os.kill(pid, 0); return True
+            except OSError:
+                return False
+
+        try:
+            m.run_tree_kill([sys.executable, '-c', parent, mk], timeout=3, capture_output=True)
+            assert False, 'expected the hanging probe tree to TimeoutExpired'
+        except subprocess.TimeoutExpired:
+            pass
+        for _ in range(60):
+            if all(os.path.exists('%s.pid%d' % (mk, i)) for i in (1, 2, 3)):
+                break
+            _time.sleep(0.1)
+        _time.sleep(5)
+        assert all(os.path.exists('%s.pid%d' % (mk, i)) for i in (1, 2, 3)), 'probe tree never reached depth 3'
+        assert not any(os.path.exists('%s.done%d' % (mk, i)) for i in (1, 2, 3)), 'a probe-tree level survived'
+        pids = [int(open('%s.pid%d' % (mk, i)).read()) for i in (1, 2, 3)]
+        assert not any(_alive(p) for p in pids), 'a hanging-probe tree PID survived: %s' % [p for p in pids if _alive(p)]
+    print('  D-K hanging-probe: parent->child->grandchild all gone; the next phase never starts')
 
     # D-G (H818 acceptance): one active job per account, atomic in the BEGIN IMMEDIATE claim.
     # Two claimers racing the same validated account -> only one obtains a job.

--- a/RussianTranslation/src/pilot/proc_tree.py
+++ b/RussianTranslation/src/pilot/proc_tree.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+"""Shared bounded-best-effort process-tree runner (H818 D-J).
+
+Both the headless worker's generation calls and the orchestrator's probe/worker subprocess
+calls spawn the SAME Windows claude launcher — ``node cli-wrapper.cjs``, which ``spawnSync``'s
+the native claude binary as a CHILD. The stdlib timeout kill (``TerminateProcess`` on the
+immediate node process) leaves that binary ORPHANED, still holding the API call — the observed
+multi-minute 'hang' as kill-timeouts accumulate orphans. This module is the single home for the
+tree-kill runner so every claude-spawning kill point (worker calls, the outer worker subprocess,
+``live_probe``, ``profile_status``, the presplit-canary worker) shares one implementation.
+"""
+import os
+import subprocess
+import sys
+import time
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+
+def terminate_tree(proc, deadline):
+    """**Bounded best-effort** tree termination — NOT race-free (tree enumeration still races
+    process exit/spawn; correctness is what the parent->child->grandchild regression test asserts).
+    Invoked WHILE ``proc`` is still alive so the tree is enumerable. ``taskkill /PID <pid> /T /F``
+    reaps the live tree on Windows (acceptable for this known-stable wrapper tree); ``killpg`` the
+    session group on POSIX. Always falls back to ``proc.kill()`` if the parent is still alive.
+    Returns a short diagnostic string on cleanup trouble, else None — the caller keeps the primary
+    ``timeout`` classification regardless."""
+    if proc.poll() is not None:
+        return None
+    trouble = None
+    if os.name == 'nt':
+        budget = max(1.0, deadline - time.monotonic())
+        try:
+            subprocess.run(['taskkill', '/PID', str(proc.pid), '/T', '/F'],
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=budget)
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+            trouble = 'taskkill:%s' % type(exc).__name__
+    else:
+        import signal as _signal
+        try:
+            os.killpg(os.getpgid(proc.pid), _signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError) as exc:
+            trouble = 'killpg:%s' % type(exc).__name__
+    if proc.poll() is None:                            # always fall back if the parent still lives
+        try:
+            proc.kill()
+        except OSError as exc:
+            trouble = (trouble or '') + ';proc.kill:%s' % type(exc).__name__
+    return trouble
+
+
+def run_tree_kill(argv, input=None, timeout=None, text=True, encoding='utf-8',
+                  capture_output=False, cwd=None, env=None, **_ignored):
+    """Drop-in for ``subprocess.run`` (Popen + ``communicate(timeout=)``) that, on timeout,
+    performs bounded best-effort termination of the ENTIRE process tree instead of just the
+    immediate child — so a killed call is bounded and no orphaned native binary keeps holding the
+    API call (H818 defect D-J). Terminates the tree while the parent is still alive, then drains
+    the pipes and reaps the parent using the REMAINING kill budget to an absolute deadline (a small
+    grace beyond the call budget, not an independent fixed window). Cleanup trouble is attached
+    diagnostically to the raised ``subprocess.TimeoutExpired`` — the caller still records exactly
+    one ``timeout`` event."""
+    pipe = subprocess.PIPE if capture_output else None
+    popen_kw = dict(stdin=subprocess.PIPE, stdout=pipe, stderr=pipe,
+                    text=text, encoding=encoding, cwd=cwd, env=env)
+    if os.name == 'nt':
+        popen_kw['creationflags'] = getattr(subprocess, 'CREATE_NEW_PROCESS_GROUP', 0)
+    else:
+        popen_kw['start_new_session'] = True          # own process group -> killpg reaches children
+    proc = subprocess.Popen(argv, **popen_kw)
+    start = time.monotonic()
+    try:
+        out, err = proc.communicate(input=input, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        grace = min(10.0, (timeout or 0) * 0.1 + 2.0)  # small, proportional, capped cleanup grace
+        deadline = start + (timeout or 0) + grace
+        trouble = terminate_tree(proc, deadline)
+        try:
+            remaining = max(0.5, deadline - time.monotonic())
+            out, err = proc.communicate(timeout=remaining)     # drain pipes + reap within budget
+        except subprocess.TimeoutExpired:
+            trouble = (trouble or '') + ';reap-timeout'
+            try:
+                proc.kill()
+                proc.communicate(timeout=2)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+        if trouble:
+            exc.cleanup_trouble = trouble              # diagnostic only; classification stays 'timeout'
+        raise
+    return subprocess.CompletedProcess(argv, proc.returncode, out, err)

--- a/RussianTranslation/src/pilot/run_observability.py
+++ b/RussianTranslation/src/pilot/run_observability.py
@@ -19,11 +19,16 @@ ALLOWED = {
     # The per-key events carry no elapsed_ms and are excluded from the latency/classification
     # census, so a 5-key call yields exactly one latency sample and one classification count.
     'call_id', 'key_count',
+    # D-K: the two-phase probe records each call separately with its purpose (warmup / measured),
+    # model, and output_bytes. The warm-up latency is EXCLUDED from the acceptance census.
+    'purpose', 'output_bytes', 'model',
 }
 
 # per-key relation events: kept for key<->call provenance / repeated-failure tracking, but
 # NEVER counted as a latency sample or a classification tally (that is the call-level event's job).
 KEY_RELATION_EVENT = 'model_call_key'
+# D-K: a warm-up probe call is telemetry-only — its latency/classification never enter the census.
+WARMUP_PURPOSE = 'warmup'
 
 
 def utc_now():
@@ -74,10 +79,27 @@ def build_census(rows):
     # toward calls, latency, or classification — they feed only the per-key repeated-failure map.
     seen_calls = {}                 # call_id -> (elapsed_ms, classification) of the first event
     conflicting = set()
-    census_rows = []                # deduped call-level rows + every non-call, non-key-relation row
+    census_rows = []                # deduped call rows + measured probe + other (latency+classification)
+    probe = {'warmup': [], 'measured': []}   # D-K: probe calls broken out, distinguishable from translation
+    quota = []                      # rate-limit observations incl. the WARM-UP probe (total quota)
+    seen_quota_calls = set()
     for r in rows:
         ev = r.get('event')
         if ev == KEY_RELATION_EVENT:
+            continue                # key relations mirror the call -> never counted anywhere
+        purpose = r.get('purpose')
+        if purpose in ('warmup', 'measured'):          # D-K: record every probe call, distinguishably
+            probe[purpose].append({'latency_ms': r.get('elapsed_ms'), 'classification': r.get('classification'),
+                                   'output_bytes': r.get('output_bytes'), 'model': r.get('model')})
+        if r.get('classification') == 'rate_limit':    # total quota observations: warm-up INCLUDED
+            cid = r.get('call_id')
+            if ev == 'model_call' and cid is not None:
+                if cid not in seen_quota_calls:
+                    seen_quota_calls.add(cid)
+                    quota.append(r)
+            else:
+                quota.append(r)
+        if purpose == WARMUP_PURPOSE:                  # D-K: warm-up EXCLUDED from latency + classification
             continue
         if ev == 'model_call' and r.get('call_id') is not None:
             cid = r['call_id']
@@ -95,7 +117,7 @@ def build_census(rows):
     for row in rows:                # by_key scans ALL rows, incl. key-relation events (they carry key+class)
         if row.get('key') and row.get('classification') not in (None, 'success'):
             by_key[row['key']][row['classification']] += 1
-    # one latency sample per unique call (key-relation events have no elapsed_ms; dupes deduped)
+    # one latency sample per unique call (key-relation + warm-up excluded; dupes deduped)
     latencies = [int(r['elapsed_ms']) for r in census_rows if r.get('elapsed_ms') is not None]
     unaccounted = sorted({key for r in rows for key in (r.get('unaccounted_keys') or [])})
     calls = sum(int(r.get('calls') or 0) for r in rows)
@@ -104,11 +126,12 @@ def build_census(rows):
     cards = sum(int(r.get('cards') or 0) for r in rows if r.get('event') == 'run_summary')
     fidelity = sum(int(r.get('fidelity_rejects') or 0) for r in rows
                    if r.get('event') == 'run_summary')
-    quota = [r for r in census_rows if r.get('classification') == 'rate_limit']
     return {
         'schema': 'pwg.bug_census.v1', 'generated_at': utc_now(),
         'events': len(rows), 'classification_counts': dict(sorted(classes.items())),
         'model_calls': len(seen_calls), 'conflicting_call_ids': sorted(conflicting),
+        'probe': probe,                 # D-K: warm-up + measured probe calls, distinct from translation
+        'quota_observations': len(quota),   # total rate-limit observations incl. the warm-up probe
         'repeated_by_key': {k: dict(v) for k, v in sorted(by_key.items()) if sum(v.values()) > 1},
         'latency_ms': {'p50': percentile(latencies, .50), 'p95': percentile(latencies, .95),
                        'max': max(latencies) if latencies else None},


### PR DESCRIPTION
Fixes the cold-start probe flap **without lowering the 30000 ms ceiling**. The single-sample D-F gate honestly NO-GO'd on a transient cold reading (30151 ms on an otherwise ~8–10 s warm profile), which blocked the bounded arvant retry. Follow-up to [#438](https://github.com/gasyoun/SanskritLexicography/pull/438)/[#441](https://github.com/gasyoun/SanskritLexicography/pull/441)/[#444](https://github.com/gasyoun/SanskritLexicography/pull/444).

## Protocol (one deterministic sequence in `live_probe`)
1. Exactly **one warm-up** call — same profile + exact model; its latency is **excluded** from the gate (it only stabilizes the cold connection).
2. Immediately exactly **one measured** ≥5 KB probe that **is** gated: rc 0, auth/model/output-size checks, latency **≤ 30000 ms (unchanged)**.
3. Warm-up auth/model/malformed/rate-limit/timeout → **immediate STOP**.
4. A failed or over-ceiling **measured** probe → **honest NO-GO, no retry, no manual pre-warming**.

## Telemetry + census
Both calls recorded separately (`purpose` warmup/measured, latency, model, `output_bytes`, classification). [`build_census`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/run_observability.py) keeps probe calls **distinguishable** from translation, **excludes** the warm-up from acceptance latency, but **still counts** warm-up rate-limits in total quota observations. `output_bytes` = encoded UTF-8 bytes, not char count.

## Shared tree-kill runner
Both probe calls use the D-J tree-kill runner, now **extracted to [`proc_tree.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/proc_tree.py)** and used by both `headless_worker` and `max_account_orchestrator` — so a hanging probe kills its whole parent→child→grandchild tree before generation begins (not `subprocess.run(timeout=)`).

## Tests
Exactly one warm-up + one measurement; **30000 passes / 30001 NO-GO**; warm-up failure STOPs before the measured call; encoded `output_bytes`; census distinguishability + quota; and a **real 3-level hanging-probe** tree-kill. Full offline gates **17/17**; LANG_PARITY SHARED re-verified.

**Next (post-merge):** one fresh staged-run — arvant runs only if its (now two-phase) probe passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)