### PR TITLE
H790: changelog backfill — v0.0.34 section

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -555,8 +555,20 @@ Section backfilled 11-07-2026 from the
   gloss-language ortho-drift ∝ reform type (RU 358/1k ≫ DE 10.3 ≫ FR/EN ≤ 0.5 ≫ LA 0);
   body-text headword mining dead end (38.6 % precision — negative result rescued from a
   deleted review artifact).
-- Note: tag `v0.0.34` exists (kosha triage, 2026-07-02) without a changelog entry — left as-is;
-  this release is numbered past it.
+## [0.0.34] - 2026-07-02
+
+### Changed — kosha planning-corpus triage (audit, 4 locked meta-decisions, scaffold removed)
+- `KOSHA_FOLDER_SETUP.md` rewritten as an honest status doc (was "Setup Complete" over empty
+  directories); `KOSHA_DECISIONS_NEEDED.md` blanks filled with real decisions (M1–M4;
+  cadence/etymology left OPEN).
+- Triage banners + inline fixes: real `<pc>` formats (MW page/column single-volume; PWG
+  volume-page hyphen; AP90 page-column-letter), real Heritage/Cologne endpoints, current
+  headword counts, VedaWeb/Lexonomy URLs, `union_headwords` marked already-built.
+- `KOSHA_DEPLOYMENT.md` added: salvage of `kosha/DEPLOYMENT.md` + README API contract with
+  4 config defects fixed (`Type=notify`, missing `proxy_pass`, `WorkingDirectory`,
+  force-push advice).
+- The `kosha/` scaffold in this repo deleted until code is real (M2: dedicated `kosha` repo;
+  M4: own Pages). (Fable 5 `claude-fable-5`.)
 
 ## [0.0.33] - 2026-06-29
 


### PR DESCRIPTION
Part of H790 (full-history CHANGELOG backfill, Tier 1). Root changelog.md was already at 68/68 tag coverage except v0.0.34 (kosha planning-corpus triage, 2026-07-02), previously left undocumented with a note. Reconstructed the section from commit c02f583 at its true commit-history position between 0.0.35 and 0.0.33, removed the stale note. Every git tag now has a matching section.