### PR TITLE
H898: pwg_ru latency investigation — home-route payload-size sweep executed

### DIFF
--- a/RussianTranslation/PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md
+++ b/RussianTranslation/PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md
@@ -1,6 +1,6 @@
 # pwg_ru live-acceptance latency-policy investigation (opened after the second consecutive NO-GO)
 
-_Created: 13-07-2026 · Last updated: 13-07-2026_
+_Created: 13-07-2026 · Last updated: 14-07-2026_
 
 Opened per the H818 acceptance STOP-branch directive and handoff
 [H895](https://github.com/gasyoun/Uprava/blob/main/handoffs/H895-Opus_SanskritLexicography_h818-acceptance-DE-DK-latency-blocked_13.07.26.md):
@@ -78,6 +78,107 @@ already honestly NO-GO'd; further probing is investigation, not gate re-rolling)
    answer is the H818 foreign-server orchestration, not a threshold change.
 3. **Time-of-day / recovery curve.** Re-probe at intervals to see whether the ceiling
    breach is diurnal (throttling window) or persistent.
+
+## Results — home-route payload-size sweep (executed 14-07-2026, Opus 4.8 `claude-opus-4-8[1m]`)
+
+Method step 1 executed on the same profile under test — Max account `max1`
+(`D:\ClaudeTools\profiles\claude1\.claude`), exact model `claude-sonnet-5`, plain-probe path
+(tiny `{"ok":boolean}` schema, output held ~constant at ~1.5 KB) via
+[`src/pilot/latency_payload_sweep.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/latency_payload_sweep.py)
+reusing `max_account_orchestrator._probe_call`. **Diagnostic only — no acceptance gate was
+re-rolled, the 30 000 ms ceiling is unchanged, nothing was promoted.** 31 calls total, one
+~19-min window (03:16–03:35 UTC 14-07-2026), quota-metered. Raw data committed:
+[`h898_sweep.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h898_sweep.jsonl),
+[`h898_interleaved.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h898_interleaved.jsonl),
+[`h898_validate.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h898_validate.jsonl); recompute with
+[`src/pilot/latency_sweep_analyze.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/latency_sweep_analyze.py).
+
+**A — blocked ladder** (3 back-to-back samples per size, 03:17–03:24 UTC), latency_ms:
+
+| total input B | n | min | median | mean | max | classes |
+|---:|---:|---:|---:|---:|---:|---|
+| 93 | 3 | 28 041 | 37 369 | 39 403 | 52 800 | 2 success, 1 malformed |
+| 1 033 | 3 | 10 093 | 21 211 | 24 013 | 40 735 | 1 success, 2 content |
+| 2 533 | 3 | 20 162 | 36 569 | 38 645 | 59 206 | 3 success |
+| 5 033 | 3 | 19 258 | 27 636 | 25 745 | 30 342 | 3 success |
+| 6 554 | 3 | 15 443 | 25 769 | 31 323 | 52 759 | 3 success |
+
+Input-bytes vs latency here: **Pearson r = −0.14, R² = 0.02, OLS slope −0.82 ms/byte**.
+Ceiling breach (>30 000 ms): **7/15**. The *smallest* payload (93 B) had the *highest* mean
+(39.4 s, max 52.8 s) — size is not predictive when route jitter is high, because the blocked
+ladder confounds size with time-of-call.
+
+**B — interleaved cycles** (1 sample/size × 3 ascending cycles, 03:28–03:35 UTC), which
+breaks that size↔time coupling:
+
+| total input B | n | min | median | mean | max | classes |
+|---:|---:|---:|---:|---:|---:|---|
+| 156 | 3 | 8 860 | 9 304 | 12 246 | 18 576 | 3 success |
+| 1 096 | 3 | 12 950 | 13 023 | 17 752 | 27 285 | 3 success |
+| 2 596 | 3 | 15 382 | 33 876 | 34 029 | 52 830 | 1 success, 2 content |
+| 5 096 | 3 | 17 916 | 26 249 | 33 004 | 54 848 | 2 success, 1 content |
+| 6 617 | 3 | 16 040 | 20 956 | 23 435 | 33 310 | 3 success |
+
+Per cycle (each cycle is time-adjacent, so a size trend *within* a cycle is a real size
+signal): cycle 1 `8 860 → 13 023 → 15 382 → 17 916 → 33 310` (clean monotonic ↑); cycle 2
+`9 304 → 12 950 → 52 830 → 26 249 → 20 956` (a single jitter spike at 2.6 KB overturns the
+order); cycle 3 `18 576 → 27 285 → 33 876 → 54 848 → 16 040` (monotonic for four rungs, then
+a jitter *drop* at 6.6 KB). With the confound broken: **Pearson r = +0.35, R² = 0.12, OLS
+slope ≈ +1–2 ms/byte** (interleaved OLS +1.98 ms/byte; the more robust **min-envelope floor
+slope ≈ +1 ms/byte, R² = 0.42**). Breach 4/15.
+
+**Min-envelope (the least-jitter "throughput floor")**: 156 B → 8.9 s, 1.1 KB → 13.0 s,
+2.6 KB → 15.4 s, 5.1 KB → 17.9 s, 6.6 KB → 16.0 s — rises ~9 s → ~18 s over the first 5 KB
+(≈ +1 ms/byte) then flattens.
+
+**Output is not the hidden driver.** Output bytes were held ~constant (1 274–1 912 B; 29 of
+31 within 1 476–1 508 B); output-vs-latency **r ≈ −0.04, R² = 0.001**, and its two outliers
+run *opposite* a size effect (largest output 1 912 B → 37.4 s; smallest 1 274 B → 52.8 s). A
+constant ~1.5 KB output alongside an 8.9–59.2 s latency spread rules out generation time as
+the variance source.
+
+**Verdict on observation 2 (does latency scale with payload size?)** — *partly, and
+secondarily*. There is a genuine but **modest** input-size throughput component
+(≈ +1 ms/byte robust floor; size explains ~12 % of variance in the confound-controlled
+interleaved set, only ~2 % across all 31 calls). It is **not** what causes the ceiling
+breach: that is driven by a **dominant, size-independent route-jitter** (next section) that
+spikes even a **93 B** payload to 52.8 s and 37.4 s. Neither original framing is right — it is
+**not a flat ~40 s floor** (range 8.9–59.2 s) and **not dominantly size-driven** (all-data
+R² = 0.02). Shrinking a card's prompt would trim ~1 s of the floor and do nothing about the
+tens-of-seconds jitter — **payload size is not the lever.**
+
+## Results — intra-window latency variance (executed 14-07-2026, Opus 4.8 `claude-opus-4-8[1m]`)
+
+Method step 3, partial. Across all 31 calls in the ~19-min window: **min 8.9 s · p50 25.8 s ·
+p90 52.8 s · max 59.2 s · mean 27.5 s · stdev 14.5 s** — stdev is ≈ 0.53× the mean (coefficient
+of variation 0.53: heavy dispersion). **11/31 calls breached the 30 000 ms ceiling in this
+window** (a single-window point estimate ≈ 35 %; the binomial 95 % CI is wide, ≈ 19–54 %, and
+breaches are time-clustered so the effective sample is smaller — do **not** read it as a
+steady-state rate). The within-size stdev (4.7–16.0 s) is as large as any between-size
+difference, and size explains only ~2–4 % of total latency variance. The route flaps across
+the ceiling call-to-call: **high-frequency jitter, not a stable diurnal plateau.** This
+directly explains the H818/H895 history — the same ~6.5 KB probe has read 8.5 s (run3), 9.4 s
+(run2 standalone), 29.6 s (run2 staged), 40.3 s (H895 run1) and 40.9 s (H818 run5): identical
+size, identical profile, **different draws from one wide, unstable distribution.** run5 and
+run1 caught slow draws; run2/run3 caught fast ones.
+
+**Caveat — not yet a true diurnal (time-of-day) series.** All 31 readings sit in one ~19-min
+window (~03:16–03:35 UTC). What is established is that the route is unstable at the
+*sub-minute* scale; whether the *baseline* shifts by hour of day is a follow-up — re-run
+`python src/pilot/latency_payload_sweep.py --mode diurnal --samples 3 --config-dir
+"D:/ClaudeTools/profiles/claude1/.claude" --claude-bin "C:/Users/user/AppData/Roaming/npm/claude"`
+at several times of day and append to the envelope.
+
+### Gate-design implication (does NOT weaken the 30 000 ms ceiling)
+
+Because the latency distribution is wide and jitter-dominated (roughly a third of calls over
+ceiling in this window), the D-K **single measured-probe gate is a noisy estimator** — it
+PASSes or NO-GOes on one random draw, so run5/run1's two consecutive NO-GOs were partly an
+unlucky pair on a genuinely unfit route. A more robust readiness gate would sample **N probes
+(e.g. 5)** and require the **median ≤ 30 000 ms AND breach-rate below a small bound**, rather
+than a single reading — estimating the true distribution instead of one point. This is a
+*stricter, less flappy* estimator, **not** a loosening of the threshold, which stays at
+30 000 ms.
 
 ## Policy (standing, do NOT weaken)
 

--- a/RussianTranslation/src/pilot/h898_interleaved.jsonl
+++ b/RussianTranslation/src/pilot/h898_interleaved.jsonl
@@ -1,0 +1,15 @@
+{"ts_utc": "2026-07-14T03:28:16Z", "payload_bytes": 93, "total_input_bytes": 156, "latency_ms": 8860, "classification": "success", "output_bytes": 1476, "model": "claude-sonnet-5", "wall_s": 8.86}
+{"ts_utc": "2026-07-14T03:28:25Z", "payload_bytes": 1033, "total_input_bytes": 1096, "latency_ms": 13023, "classification": "success", "output_bytes": 1476, "model": "claude-sonnet-5", "wall_s": 13.02}
+{"ts_utc": "2026-07-14T03:28:38Z", "payload_bytes": 2533, "total_input_bytes": 2596, "latency_ms": 15382, "classification": "content", "output_bytes": 1488, "model": "claude-sonnet-5", "wall_s": 15.38}
+{"ts_utc": "2026-07-14T03:28:54Z", "payload_bytes": 5033, "total_input_bytes": 5096, "latency_ms": 17916, "classification": "content", "output_bytes": 1498, "model": "claude-sonnet-5", "wall_s": 17.92}
+{"ts_utc": "2026-07-14T03:29:11Z", "payload_bytes": 6554, "total_input_bytes": 6617, "latency_ms": 33310, "classification": "success", "output_bytes": 1482, "model": "claude-sonnet-5", "wall_s": 33.31}
+{"ts_utc": "2026-07-14T03:30:41Z", "payload_bytes": 93, "total_input_bytes": 156, "latency_ms": 9304, "classification": "success", "output_bytes": 1508, "model": "claude-sonnet-5", "wall_s": 9.3}
+{"ts_utc": "2026-07-14T03:30:51Z", "payload_bytes": 1033, "total_input_bytes": 1096, "latency_ms": 12950, "classification": "success", "output_bytes": 1485, "model": "claude-sonnet-5", "wall_s": 12.95}
+{"ts_utc": "2026-07-14T03:31:04Z", "payload_bytes": 2533, "total_input_bytes": 2596, "latency_ms": 52830, "classification": "content", "output_bytes": 1274, "model": "claude-sonnet-5", "wall_s": 52.83}
+{"ts_utc": "2026-07-14T03:31:56Z", "payload_bytes": 5033, "total_input_bytes": 5096, "latency_ms": 26249, "classification": "success", "output_bytes": 1502, "model": "claude-sonnet-5", "wall_s": 26.25}
+{"ts_utc": "2026-07-14T03:32:23Z", "payload_bytes": 6554, "total_input_bytes": 6617, "latency_ms": 20956, "classification": "success", "output_bytes": 1482, "model": "claude-sonnet-5", "wall_s": 20.96}
+{"ts_utc": "2026-07-14T03:32:44Z", "payload_bytes": 93, "total_input_bytes": 156, "latency_ms": 18576, "classification": "success", "output_bytes": 1495, "model": "claude-sonnet-5", "wall_s": 18.58}
+{"ts_utc": "2026-07-14T03:33:03Z", "payload_bytes": 1033, "total_input_bytes": 1096, "latency_ms": 27285, "classification": "success", "output_bytes": 1481, "model": "claude-sonnet-5", "wall_s": 27.29}
+{"ts_utc": "2026-07-14T03:33:30Z", "payload_bytes": 2533, "total_input_bytes": 2596, "latency_ms": 33876, "classification": "success", "output_bytes": 1482, "model": "claude-sonnet-5", "wall_s": 33.88}
+{"ts_utc": "2026-07-14T03:34:04Z", "payload_bytes": 5033, "total_input_bytes": 5096, "latency_ms": 54848, "classification": "success", "output_bytes": 1481, "model": "claude-sonnet-5", "wall_s": 54.85}
+{"ts_utc": "2026-07-14T03:34:59Z", "payload_bytes": 6554, "total_input_bytes": 6617, "latency_ms": 16040, "classification": "success", "output_bytes": 1479, "model": "claude-sonnet-5", "wall_s": 16.04}

--- a/RussianTranslation/src/pilot/h898_sweep.jsonl
+++ b/RussianTranslation/src/pilot/h898_sweep.jsonl
@@ -1,0 +1,15 @@
+{"ts_utc": "2026-07-14T03:17:19Z", "payload_bytes": 30, "total_input_bytes": 93, "latency_ms": 28041, "classification": "success", "output_bytes": 1495, "model": "claude-sonnet-5", "wall_s": 28.04}
+{"ts_utc": "2026-07-14T03:17:47Z", "payload_bytes": 30, "total_input_bytes": 93, "latency_ms": 37369, "classification": "malformed", "output_bytes": 1912, "model": "claude-sonnet-5", "wall_s": 37.37}
+{"ts_utc": "2026-07-14T03:18:25Z", "payload_bytes": 30, "total_input_bytes": 93, "latency_ms": 52800, "classification": "success", "output_bytes": 1480, "model": "claude-sonnet-5", "wall_s": 52.8}
+{"ts_utc": "2026-07-14T03:19:18Z", "payload_bytes": 970, "total_input_bytes": 1033, "latency_ms": 10093, "classification": "content", "output_bytes": 1491, "model": "claude-sonnet-5", "wall_s": 10.09}
+{"ts_utc": "2026-07-14T03:19:28Z", "payload_bytes": 970, "total_input_bytes": 1033, "latency_ms": 40735, "classification": "content", "output_bytes": 1504, "model": "claude-sonnet-5", "wall_s": 40.74}
+{"ts_utc": "2026-07-14T03:20:08Z", "payload_bytes": 970, "total_input_bytes": 1033, "latency_ms": 21211, "classification": "success", "output_bytes": 1482, "model": "claude-sonnet-5", "wall_s": 21.21}
+{"ts_utc": "2026-07-14T03:20:30Z", "payload_bytes": 2470, "total_input_bytes": 2533, "latency_ms": 20162, "classification": "success", "output_bytes": 1501, "model": "claude-sonnet-5", "wall_s": 20.16}
+{"ts_utc": "2026-07-14T03:20:50Z", "payload_bytes": 2470, "total_input_bytes": 2533, "latency_ms": 59206, "classification": "success", "output_bytes": 1488, "model": "claude-sonnet-5", "wall_s": 59.21}
+{"ts_utc": "2026-07-14T03:21:49Z", "payload_bytes": 2470, "total_input_bytes": 2533, "latency_ms": 36569, "classification": "success", "output_bytes": 1491, "model": "claude-sonnet-5", "wall_s": 36.57}
+{"ts_utc": "2026-07-14T03:22:26Z", "payload_bytes": 4970, "total_input_bytes": 5033, "latency_ms": 19258, "classification": "success", "output_bytes": 1480, "model": "claude-sonnet-5", "wall_s": 19.26}
+{"ts_utc": "2026-07-14T03:22:45Z", "payload_bytes": 4970, "total_input_bytes": 5033, "latency_ms": 30342, "classification": "success", "output_bytes": 1483, "model": "claude-sonnet-5", "wall_s": 30.34}
+{"ts_utc": "2026-07-14T03:23:15Z", "payload_bytes": 4970, "total_input_bytes": 5033, "latency_ms": 27636, "classification": "success", "output_bytes": 1483, "model": "claude-sonnet-5", "wall_s": 27.64}
+{"ts_utc": "2026-07-14T03:23:43Z", "payload_bytes": 6491, "total_input_bytes": 6554, "latency_ms": 25769, "classification": "success", "output_bytes": 1483, "model": "claude-sonnet-5", "wall_s": 25.77}
+{"ts_utc": "2026-07-14T03:24:09Z", "payload_bytes": 6491, "total_input_bytes": 6554, "latency_ms": 15443, "classification": "success", "output_bytes": 1487, "model": "claude-sonnet-5", "wall_s": 15.44}
+{"ts_utc": "2026-07-14T03:24:24Z", "payload_bytes": 6491, "total_input_bytes": 6554, "latency_ms": 52759, "classification": "success", "output_bytes": 1485, "model": "claude-sonnet-5", "wall_s": 52.76}

--- a/RussianTranslation/src/pilot/h898_validate.jsonl
+++ b/RussianTranslation/src/pilot/h898_validate.jsonl
@@ -1,0 +1,1 @@
+{"ts_utc": "2026-07-14T03:16:38Z", "payload_bytes": 30, "total_input_bytes": 93, "latency_ms": 12677, "classification": "success", "output_bytes": 1484, "model": "claude-sonnet-5", "wall_s": 12.68}

--- a/RussianTranslation/src/pilot/latency_payload_sweep.py
+++ b/RussianTranslation/src/pilot/latency_payload_sweep.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""H898 diagnostic: home-route latency-vs-payload-bytes sweep + diurnal re-probe.
+
+Reuses ``max_account_orchestrator._probe_call`` (the SAME exact-model
+``claude-sonnet-5`` probe the D-K acceptance gate uses) with a scripted
+payload-bytes ladder. This is DIAGNOSTIC only -- it does NOT re-roll the
+acceptance gate, does NOT weaken the 30000 ms ceiling, and never promotes a
+result. It just measures wall-clock latency at controlled input sizes so we can
+tell whether the ~40 s measured-probe breach (H818 run5 40925 ms / H895 run1
+40339 ms) is payload-size-driven, a flat per-request route penalty, or diurnal.
+
+Each ``_probe_call`` sends a fixed tiny-output request whose INPUT is
+``PREFIX + payload_bytes*'x'``; total input bytes = len(PREFIX) + payload_bytes.
+Output is validated by result-envelope structure ({"ok": true}), not size.
+
+Usage (Windows, from a clean origin/master worktree):
+  python latency_payload_sweep.py --mode sweep \
+      --config-dir "D:/ClaudeTools/profiles/claude1/.claude" \
+      --claude-bin "C:/Users/user/AppData/Roaming/npm/claude" \
+      --ladder 30,970,2470,4970,6491 --samples 3 --out sweep.jsonl
+  python latency_payload_sweep.py --mode diurnal --samples 2 ...   # 6491 B only
+"""
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from max_account_orchestrator import _probe_call, EXACT_GEN_MODEL  # noqa: E402
+
+# Must match _probe_call's prompt prefix exactly to report true total input bytes.
+PREFIX = 'Return JSON {"ok":true}. Preserve this padding as inert input.\n'
+PREFIX_LEN = len(PREFIX.encode('utf-8'))
+MEASURED_SIZE = 6491  # the payload_bytes the D-K measured acceptance probe uses
+
+
+def _iso_utc():
+    return time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+
+
+def one_call(config_dir, claude, payload_bytes):
+    t0 = time.monotonic()
+    ts = _iso_utc()
+    latency_ms, cls, output_bytes = _probe_call(config_dir, claude, payload_bytes, EXACT_GEN_MODEL)
+    row = {
+        'ts_utc': ts,
+        'payload_bytes': payload_bytes,
+        'total_input_bytes': PREFIX_LEN + payload_bytes,
+        'latency_ms': latency_ms,
+        'classification': cls,
+        'output_bytes': output_bytes,
+        'model': EXACT_GEN_MODEL,
+        'wall_s': round(time.monotonic() - t0, 2),
+    }
+    print(json.dumps(row, ensure_ascii=False), flush=True)
+    return row
+
+
+def run(mode, config_dir, claude, ladder, samples, out_path):
+    rows = []
+    sizes = ladder if mode == 'sweep' else [MEASURED_SIZE]
+    for pb in sizes:
+        for _ in range(samples):
+            rows.append(one_call(config_dir, claude, pb))
+    if out_path:
+        with open(out_path, 'a', encoding='utf-8') as fh:
+            for r in rows:
+                fh.write(json.dumps(r, ensure_ascii=False) + '\n')
+    # summary per size (successful readings only for the latency stats)
+    print('\n=== SUMMARY (n, min/median/mean/max latency_ms over SUCCESS reads; classes) ===',
+          flush=True)
+    by_size = {}
+    for r in rows:
+        by_size.setdefault(r['total_input_bytes'], []).append(r)
+    for tib in sorted(by_size):
+        rs = by_size[tib]
+        ok = [r['latency_ms'] for r in rs if r['classification'] == 'success']
+        classes = {}
+        for r in rs:
+            classes[r['classification']] = classes.get(r['classification'], 0) + 1
+        if ok:
+            print('%6d B  n=%d  min=%d  median=%d  mean=%d  max=%d  classes=%s'
+                  % (tib, len(rs), min(ok), int(statistics.median(ok)),
+                     int(statistics.mean(ok)), max(ok), classes), flush=True)
+        else:
+            print('%6d B  n=%d  NO SUCCESS  classes=%s' % (tib, len(rs), classes), flush=True)
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--mode', choices=['sweep', 'diurnal'], default='sweep')
+    ap.add_argument('--config-dir', required=True)
+    ap.add_argument('--claude-bin', required=True,
+                    help='FULL path to the npm claude shim (never the bare name)')
+    ap.add_argument('--ladder', default='30,970,2470,4970,6491',
+                    help='comma-separated payload_bytes values (sweep mode)')
+    ap.add_argument('--samples', type=int, default=3)
+    ap.add_argument('--out', default=None)
+    args = ap.parse_args()
+    ladder = [int(x) for x in args.ladder.split(',') if x.strip()]
+    run(args.mode, args.config_dir, args.claude_bin, ladder, args.samples, args.out)
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/latency_sweep_analyze.py
+++ b/RussianTranslation/src/pilot/latency_sweep_analyze.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Analyze the H898 payload-size sweep JSONL: per-size stats, input-bytes vs
+latency correlation + OLS slope, and the >30000 ms ceiling-breach rate.
+Latency is valid for every completed call regardless of envelope classification
+(the call round-tripped), so stats are over ALL calls; a success-only view is
+also printed for the gated-latency comparison."""
+import json
+import sys
+import statistics as st
+
+sys.stdout.reconfigure(encoding='utf-8')
+
+CEILING = 30000
+
+
+def load(paths):
+    rows = []
+    for p in paths:
+        try:
+            with open(p, encoding='utf-8') as fh:
+                for line in fh:
+                    line = line.strip()
+                    if line.startswith('{'):
+                        rows.append(json.loads(line))
+        except FileNotFoundError:
+            pass
+    return rows
+
+
+def pearson(xs, ys):
+    n = len(xs)
+    if n < 2:
+        return float('nan')
+    mx, my = st.mean(xs), st.mean(ys)
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    dx = sum((x - mx) ** 2 for x in xs) ** 0.5
+    dy = sum((y - my) ** 2 for y in ys) ** 0.5
+    return num / (dx * dy) if dx and dy else float('nan')
+
+
+def ols(xs, ys):
+    """Return (slope_per_byte, intercept, r2)."""
+    n = len(xs)
+    mx, my = st.mean(xs), st.mean(ys)
+    sxx = sum((x - mx) ** 2 for x in xs)
+    sxy = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    slope = sxy / sxx if sxx else float('nan')
+    intercept = my - slope * mx
+    ss_tot = sum((y - my) ** 2 for y in ys)
+    ss_res = sum((y - (slope * x + intercept)) ** 2 for x, y in zip(xs, ys))
+    r2 = 1 - ss_res / ss_tot if ss_tot else float('nan')
+    return slope, intercept, r2
+
+
+def main():
+    rows = load(sys.argv[1:] or ['h898_sweep.jsonl'])
+    if not rows:
+        print('no rows')
+        return
+    rows.sort(key=lambda r: r['ts_utc'])
+    print('N calls = %d   window %s .. %s' %
+          (len(rows), rows[0]['ts_utc'], rows[-1]['ts_utc']))
+    by = {}
+    for r in rows:
+        by.setdefault(r['total_input_bytes'], []).append(r)
+    print('\nper input-size band (ALL completed calls; latency_ms):')
+    print('%8s %3s %7s %7s %7s %7s %7s  %s' %
+          ('bytes', 'n', 'min', 'median', 'mean', 'max', 'stdev', 'classes'))
+    for tib in sorted(by):
+        lat = [r['latency_ms'] for r in by[tib]]
+        cls = {}
+        for r in by[tib]:
+            cls[r['classification']] = cls.get(r['classification'], 0) + 1
+        sd = int(st.pstdev(lat)) if len(lat) > 1 else 0
+        print('%8d %3d %7d %7d %7d %7d %7d  %s' %
+              (tib, len(lat), min(lat), int(st.median(lat)), int(st.mean(lat)),
+               max(lat), sd, cls))
+    xs = [r['total_input_bytes'] for r in rows]
+    ys = [r['latency_ms'] for r in rows]
+    r = pearson(xs, ys)
+    slope, intercept, r2 = ols(xs, ys)
+    over = [r for r in rows if r['latency_ms'] > CEILING]
+    allv = sorted(ys)
+
+    def pct(p):
+        k = (len(allv) - 1) * p
+        return int(allv[int(k)])
+    print('\noverall (all %d calls): min=%d  p50=%d  p90=%d  max=%d  mean=%d  stdev=%d'
+          % (len(ys), min(ys), pct(0.5), pct(0.9), max(ys), int(st.mean(ys)),
+             int(st.pstdev(ys))))
+    print('input-bytes vs latency:  Pearson r=%.3f   OLS slope=%.3f ms/byte '
+          '(=%.1f ms per +1KB)   intercept=%d ms   R^2=%.3f'
+          % (r, slope, slope * 1024, int(intercept), r2))
+    print('ceiling breach (>%d ms): %d/%d = %.0f%% of calls'
+          % (CEILING, len(over), len(rows), 100 * len(over) / len(rows)))
+    succ = [r['latency_ms'] for r in rows if r['classification'] == 'success']
+    if succ:
+        print("success-only (n=%d): min=%d  median=%d  max=%d  >ceiling=%d"
+              % (len(succ), min(succ), int(st.median(succ)), max(succ),
+                 sum(1 for v in succ if v > CEILING)))
+
+
+if __name__ == '__main__':
+    main()

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,19 @@ not an error.
 ## [Unreleased]
 
 ### Added
+- **pwg_ru latency-policy investigation — payload-size sweep executed (H898)** —
+  31 diagnostic `claude-sonnet-5` plain-probes (new
+  `RussianTranslation/src/pilot/latency_payload_sweep.py` + `latency_sweep_analyze.py`,
+  reusing `max_account_orchestrator._probe_call`; raw JSONL committed as durable
+  evidence) settle the ~40 s measured-probe breach that NO-GO'd H818 acceptance
+  twice: it is **not** payload-size-driven (a 93 B call hit 52.8 s; all-data R²=0.02)
+  and **not** a flat ~40 s floor (range 8.9–59.2 s) — a modest input-size throughput
+  floor (~+1 ms/byte) superimposed on a dominant, size-independent, time-clustered
+  route jitter (CV 0.53) that spikes even tiny payloads over the ceiling (11/31
+  breaches in-window). Results + verdict in
+  `RussianTranslation/PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md`. Policy
+  unchanged (30 000 ms ceiling kept; fix is the H818 foreign-route, not smaller
+  payloads); step 3 (foreign-route comparison) stays human-gated.
 - **FAIR Release #1 metadata (H817 WS1.4)** — `CITATION.cff`, `DATA_LICENSE.md`,
   and `data/FAIR_RELEASE_1.md` prepared for a curated Zenodo dataset deposit of
   the markup-tag census (E39) and headword-overlap matrix (E40), cross-linked


### PR DESCRIPTION
Executes Method steps 1–2 of the pwg_ru latency-policy investigation opened by [H895](https://github.com/gasyoun/Uprava/blob/main/handoffs/H895-Opus_SanskritLexicography_h818-acceptance-DE-DK-latency-blocked_13.07.26.md)'s second measured-probe NO-GO (handoff [H898](https://github.com/gasyoun/Uprava/blob/main/handoffs/H898-Opus_SanskritLexicography_pwg-ru-latency-characterization-payload-route-sweep_14.07.26.md)).

**31 diagnostic `claude-sonnet-5` plain-probes** on the `max1` profile (output held ~1.5 KB) via a new [`latency_payload_sweep.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/latency_payload_sweep.py) reusing `max_account_orchestrator._probe_call`, plus [`latency_sweep_analyze.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/latency_sweep_analyze.py). Raw JSONL committed as durable evidence (the h895 telemetry was lost to gitignore).

**Finding.** The ~40 s measured-probe breach is:
- **NOT payload-size-driven** — a 93 B call hit 52.8 s; all-data input-bytes↔latency R²=0.02.
- **NOT a flat ~40 s floor** — range 8.9–59.2 s.
- A **modest input-size throughput floor** (~+1 ms/byte, visible once the size↔time confound is broken via interleaved cycles: r=+0.35, R²=0.12) **superimposed on a dominant, size-independent, time-clustered route jitter** (CV 0.53) that spikes even tiny payloads over the ceiling — **11/31 breaches in a single ~19-min window**.

**Policy unchanged** (do NOT weaken): the 30 000 ms ceiling stays; the fix is the H818 foreign-route, not smaller payloads. Added a gate-design note: the single measured-probe gate is a noisy estimator and should sample N probes (median ≤ ceiling + breach-rate bound) — a *stricter* estimator, not a threshold change. Step 3 (foreign-route 6.5 KB comparison) stays **human-gated** on the H818 server.

Diagnostic only — no acceptance gate re-rolled, canonical store untouched. Adversarially verified (independent recompute CONFIRMED; refutation lens VERDICT_HOLDS with scalar-framing softenings applied).

Executor: Opus 4.8 (\`claude-opus-4-8[1m]\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)