### PR TITLE
H898/latency: refine foreign-route runbook + extend probe telemetry (diagnostic-only)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,19 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+- **Latency-policy investigation — foreign-route runbook refined + probe telemetry extended
+  (diagnostic-only; NOT yet run).** Tightened *Method step 2* per review: **exact** decision rule
+  (per foreign window median ≤ 30 000 ms AND ≤ 1/5 breaches with N ≥ 5; aggregate breaches/total
+  ≤ 0.10 across ≥ 2 windows — not "≈ 10–20 %"), **A-B-B-A paired crossover** order (same account
+  authenticated per host, exact model/CLI/SHA/prompt/schema; sequence position + UTC recorded),
+  **two separate conclusions** (route causality vs foreign operational readiness; diagnostic PASS
+  ≠ production GO), and the **byte correction** (`padding_bytes` 6491 ⇒ `actual_prompt_bytes`
+  **6554**, PREFIX 63 B). Extended [`latency_payload_sweep.py`](src/pilot/latency_payload_sweep.py)
+  with route/window/sample-index/account-pseudonym/git-SHA/CLI-version/warm-up telemetry (warm-ups
+  excluded from stats; never credentials or full outputs) and
+  [`latency_sweep_analyze.py`](src/pilot/latency_sweep_analyze.py) with a `--decision-rule` mode
+  that computes readiness + causality per route×window. 30 000 ms ceiling unchanged; Linux
+  production + H841–H843 stay blocked.
 - **Latency-policy investigation — foreign-route comparison runbook prepared (diagnostic-only,
   owner-gated; NOT yet run).** Appended *Method step 2* to
   [PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md](PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md):

--- a/RussianTranslation/PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md
+++ b/RussianTranslation/PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md
@@ -221,20 +221,22 @@ resolves the `node_modules/@anthropic-ai/claude-code/cli-wrapper.cjs` entry rela
 shim's own directory, so a bare `claude` abspath's to the CWD and dies with `[WinError 2]`
 before the D-A rewrite can help.
 
-## Method step 2 — foreign-route comparison runbook (PREPARED 14-07-2026, Opus 4.8 `claude-opus-4-8[1m]`; owner-gated, NOT yet run)
+## Method step 2 — foreign-route comparison runbook (PREPARED + REFINED 14-07-2026 per sol.md #1–#5, Opus 4.8 `claude-opus-4-8[1m]`; owner-gated, NOT yet run)
 
 Prepared per the H895 STOP-branch close-out: this is the sanctioned **diagnostic-only** exception
 for foreign-route probing. It is **NOT** Linux production — **Linux production and H841/H842/H843
-stay blocked** until the route is confirmed *and* a new acceptance handoff is minted (last step
-below). The comparison must reuse the exact same probe the home sweep used, so prompt, payload,
-schema, and model are **byte-identical on both hosts by construction** (they are hard-coded in
-`max_account_orchestrator._probe_call` and driven by the same
+stay blocked** until the route is confirmed *and* a new acceptance handoff is minted (Step D). The
+comparison reuses the exact same probe the home sweep used, so model, prompt, payload, schema and
+output constraint are **byte-identical on both hosts by construction** (hard-coded in
+`max_account_orchestrator._probe_call`, driven by the same
 [`latency_payload_sweep.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/latency_payload_sweep.py)
 off the **same merged commit**):
 
 - **model** `claude-sonnet-5` (hard-coded `EXACT_GEN_MODEL` — cannot drift)
-- **prompt/payload** `Return JSON {"ok":true}. Preserve this padding as inert input.\n` + `x`×**6491** ⇒ **6551 B** total input (the D-K measured-probe size; `--mode diurnal` uses exactly this)
+- **prompt** `Return JSON {"ok":true}. Preserve this padding as inert input.\n` (the `PREFIX`, **63 B**) + `x`×`padding_bytes`
+- **bytes — do NOT conflate (sol.md #4):** `padding_bytes` is the `--ladder`/`MEASURED_SIZE` argument (the `x` count); the **actual encoded prompt** = 63 + `padding_bytes`. The D-K measured size is **`padding_bytes = 6491` ⇒ `actual_prompt_bytes = 6554`** — *not* 6491. `--mode diurnal` uses exactly this size, and the telemetry records **both** `padding_bytes` and `actual_prompt_bytes`.
 - **schema** `{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"],"additionalProperties":false}`, call `-p --output-format json --json-schema … --model claude-sonnet-5 --permission-mode plan`
+- **output constraint** tiny `{"ok":true}`; only the output **byte count** is recorded, never its content.
 - **30 000 ms ceiling unchanged.**
 
 ### Guardrails (probe-only — do NOT cross these)
@@ -244,12 +246,20 @@ off the **same merged commit**):
   `promote_final_cards.py`, `audit_window.py`, or `translation_memory.py build`. **No jobs, no
   translations, no promotions, no canonical-store or TM writes.** `--permission-mode plan` already
   bars the model from any tool use / file write.
-- **Owner-only auth.** The **owner** authenticates the foreign Max profile interactively. The agent
-  **never** runs `/login` and **never** copies credentials — do **not** transfer
-  `D:\ClaudeTools\profiles\claude1\.claude` (or any token) from Windows to the foreign host. Each
-  route uses its own independently-authenticated profile.
-- **Same commit.** Pin both hosts to the identical merged commit under test: record
-  `git -C <repo> rev-parse origin/master` once and check that **same SHA** out on both hosts.
+- **Owner-only auth; hold the account constant, vary only the route.** The **owner** authenticates
+  the **same Max subscription/account** independently on each host (a separate device `/login` per
+  host) — this isolates *route* from *account*, and is **not** a credential copy. The agent **never**
+  runs `/login` and **never** copies credentials — do **not** transfer
+  `D:\ClaudeTools\profiles\claude1\.claude` (or any token) from Windows to the foreign host.
+- **Same commit + CLI.** Pin both hosts to the identical merged commit under test (record
+  `git -C <repo> rev-parse origin/master` once, check that **same SHA** out on both) and use the
+  **same `claude` CLI version** (the telemetry records `git_sha` and `cli_version` per call so drift
+  is auditable).
+- **Telemetry hygiene (sol.md #5).** Each JSONL row records host/`route` label, `window` ID,
+  `sample_index` (crossover position), `account_label` **pseudonym**, exact `model`, `git_sha`,
+  `cli_version`, `latency_ms`, `classification`, output **byte count**, and **both** `padding_bytes`
+  + `actual_prompt_bytes` — and **never** credentials or full outputs. Use an **identical warm-up
+  policy** on both hosts (`--warmups`, tagged `warmup` and **excluded** from measured statistics).
 
 ### Step A — provision + owner authentication (foreign Linux / non-Russian egress) — OWNER runs
 
@@ -258,61 +268,86 @@ off the **same merged commit**):
 sudo apt-get update && sudo apt-get install -y nodejs npm git python3   # or distro equivalent
 npm install -g @anthropic-ai/claude-code
 
-# Dedicated config dir — NEVER reuse or copy the Windows profile:
+# Dedicated config dir — authenticate the SAME Max account as home, independently (no copy):
 export CLAUDE_CONFIG_DIR="$HOME/.claude-max-foreign"
-claude /login            # OWNER does this interactively; choose the Max plan. Agent never runs it.
-claude auth status       # verify (prints status only, never the token)
-command -v claude        # record the shim path for --claude-bin below (e.g. /usr/bin/claude)
+claude /login            # OWNER, interactive; the SAME Max subscription/account as the home host.
+claude auth status       # verify (status only, never the token)
+claude --version ; command -v claude   # record CLI version + shim path (for --claude-bin)
 
-# Pin the same merged commit as the home route:
+# Pin the same merged commit as the home route (record SHA, use it on BOTH hosts):
+SHA="$(git ls-remote https://github.com/gasyoun/SanskritLexicography.git refs/heads/master | cut -f1)"
 git clone https://github.com/gasyoun/SanskritLexicography.git && cd SanskritLexicography
-git checkout "$(git rev-parse origin/master)"     # same SHA both hosts
+git checkout "$SHA"      # the SAME SHA on both hosts
 ```
 
-### Step B — paired 6.5 KB probes (run BOTH in the same UTC window; jitter is time-clustered)
+### Step B — paired **crossover** probes (A-B-B-A order, NOT all-foreign-then-all-home) — sol.md #2
 
-From `RussianTranslation/` on each host, `N ≥ 5` samples at the exact 6491-byte measured payload:
+The same account cannot be used on both hosts concurrently, and route-jitter is time-clustered, so
+sample **sequentially in a paired crossover**: alternate routes in a predetermined order
+(A-B-B-A, or a predetermined randomized order), one measured call per turn, recording sequence
+position (`--seq-start`) and UTC. This balances each route across time-of-call so a jitter spike
+can't land on only one route. Warm up **each host once** at window start (identical policy,
+excluded from stats), then run the measured crossover until **N ≥ 5 measured per route per window**.
+All calls: same account, exact model, CLI version, git SHA, prompt/schema/output constraint.
 
 ```bash
-# FOREIGN (Linux):
-python src/pilot/latency_payload_sweep.py --mode diurnal --samples 5 \
-  --config-dir "$HOME/.claude-max-foreign" \
-  --claude-bin "$(command -v claude)" \
-  --out foreign_route_6491.jsonl
+# From RussianTranslation/ on each host. A = foreign-linux, B = home-windows.
+FCFG="$HOME/.claude-max-foreign";  FBIN="$(command -v claude)"
+# Home host runs with: --config-dir "D:/ClaudeTools/profiles/claude1/.claude"
+#                      --claude-bin "C:/Users/user/AppData/Roaming/npm/claude"
+
+# --- WINDOW W1: warm up each host once (excluded from stats), --samples 0 --warmups 1 ---
+python src/pilot/latency_payload_sweep.py --mode diurnal --samples 0 --warmups 1 \
+  --route foreign-linux --window W1 --account-label acctA \
+  --config-dir "$FCFG" --claude-bin "$FBIN" --out foreign_W1.jsonl
+#   (same on the home host: --route home-windows … --out home_W1.jsonl)
+
+# --- measured crossover A-B-B-A, one sample per turn, --warmups 0 --samples 1 ---
+# turn 1  A foreign  --seq-start 1 --route foreign-linux --window W1 … --out foreign_W1.jsonl
+# turn 2  B home     --seq-start 2 --route home-windows  --window W1 … --out home_W1.jsonl
+# turn 3  B home     --seq-start 3 --route home-windows  --window W1 … --out home_W1.jsonl
+# turn 4  A foreign  --seq-start 4 --route foreign-linux --window W1 … --out foreign_W1.jsonl
+# …continue the A-B-B-A pattern until N ≥ 5 measured per route in W1.
 ```
 
-```powershell
-# HOME (Windows), same UTC window:
-python src/pilot/latency_payload_sweep.py --mode diurnal --samples 5 `
-  --config-dir "D:/ClaudeTools/profiles/claude1/.claude" `
-  --claude-bin "C:/Users/user/AppData/Roaming/npm/claude" `
-  --out home_route_6491.jsonl
+Repeat for **≥ 2 windows** (W1, W2, … at different times of day — the home data is a single
+~19-min window, not enough to rule out a diurnal artifact). Each row carries `route`/`window`/
+`sample_index`/UTC so the analyzer can reconstruct the crossover.
+
+### Step C — decision rule (EXACT; two SEPARATE conclusions — sol.md #1 + #3)
+
+Summarise with the analyzer's decision-rule mode (warm-ups auto-excluded, grouped by `route`+`window`):
+
+```bash
+python src/pilot/latency_sweep_analyze.py foreign_*.jsonl home_*.jsonl --decision-rule
 ```
-
-Repeat the pair across **≥ 2–3 UTC windows / times of day** (the home data is a single ~19-min
-window — one paired window is not enough to rule out a diurnal artifact). Summarise each file with
-[`src/pilot/latency_sweep_analyze.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/latency_sweep_analyze.py)
-(median, breach-rate).
-
-### Step C — decision rule (robust, not a single draw)
 
 The home route is a **wide, jitter-dominated** distribution (min 8.9 s · p50 25.8 s · max 59.2 s ·
-CoV 0.53; ~35 % over ceiling in-window), so a single fast foreign reading proves nothing. **Confirm
-the degraded-route hypothesis IFF**, per paired window with `N ≥ 5` across ≥ 2 windows:
+CoV 0.53; ~⅓ over ceiling in-window), so a single fast foreign reading proves nothing. Report **two
+conclusions independently — do not merge them**:
 
-- **Foreign:** median measured latency **≤ 30 000 ms AND** breach-rate (fraction > 30 000 ms)
-  **below a small bound** (≈ ≤ 10–20 %) — *consistently*, not one lucky draw; **AND**
-- **Home (Windows), same windows:** stays high (~40 s tail, p50 ≈ 26 s, ~⅓ breach).
+- **(A) Foreign operational readiness** — foreign *independently* satisfies the latency rule. **This
+  is the diagnostic PASS** (and *not yet a production GO*). PASS requires, with 5 samples/window
+  (the only per-window breach rates are 0 / 20 / 40 %, so state the rule exactly, not "≈ 10–20 %"):
+  - **per foreign window:** **median ≤ 30 000 ms** AND **at most 1/5 breaches** (breach = a call
+    > 30 000 ms; ≤ 1/5 ⇒ breach-rate ≤ 0.20), with **N ≥ 5**;
+  - **aggregate across ≥ 2 foreign windows:** **breaches / total ≤ 0.10**.
+- **(B) Route causality** — the foreign route is *consistently materially faster than the paired
+  home window*: **foreign median ≤ 0.70 × the same-window home median in every paired window**
+  (`--causality-ratio` is adjustable).
 
-If confirmed, the fix is the H818 foreign-server orchestration, **not** a threshold change (the
-30 000 ms ceiling stays). If the foreign route also breaches, the cause is **not** Russia→Anthropic
-egress and the investigation reopens (payload lever already ruled out above).
+Read (A) and (B) separately: if **both** routes are fast, causality is **inconclusive** but foreign
+**readiness (A) may still proceed** to Step D; if **both** are slow, **neither passes** — the cause
+is **not** Russia→Anthropic egress, so reopen the investigation (the payload-size lever is already
+ruled out above). Either way the **30 000 ms ceiling stays** and the fix, if (A) passes, is the H818
+foreign-server orchestration, not a threshold change.
 
-### Step D — ONLY on confirmation (separate step, NOT part of this diagnostic)
+### Step D — ONLY after a foreign-readiness (A) diagnostic PASS (separate step)
 
 Provision **four** Max profiles on the foreign route and **mint a new acceptance handoff** for the
 bounded `arvant` retry + the `1 → 10 → 20 → 100` sequence, gated by the **same 30 000 ms ceiling**
 (preferably the stricter N-probe median+breach-rate gate from the Gate-design implication above).
-Until that confirmation + handoff exist, Linux production and H841/H842/H843 remain **blocked**.
+**A diagnostic PASS is NOT this production GO.** Until (A) passes *and* that handoff exists, Linux
+production and H841/H842/H843 remain **blocked**.
 
 _Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/latency_payload_sweep.py
+++ b/RussianTranslation/src/pilot/latency_payload_sweep.py
@@ -1,29 +1,42 @@
 #!/usr/bin/env python3
-"""H898 diagnostic: home-route latency-vs-payload-bytes sweep + diurnal re-probe.
+"""H898 diagnostic: exact-model latency probe sweep + foreign/home route comparison.
 
 Reuses ``max_account_orchestrator._probe_call`` (the SAME exact-model
 ``claude-sonnet-5`` probe the D-K acceptance gate uses) with a scripted
 payload-bytes ladder. This is DIAGNOSTIC only -- it does NOT re-roll the
-acceptance gate, does NOT weaken the 30000 ms ceiling, and never promotes a
-result. It just measures wall-clock latency at controlled input sizes so we can
-tell whether the ~40 s measured-probe breach (H818 run5 40925 ms / H895 run1
-40339 ms) is payload-size-driven, a flat per-request route penalty, or diurnal.
+acceptance gate, does NOT weaken the 30000 ms ceiling, and never imports/claims a
+job, promotes a result, or writes the canonical store / translation memory. It
+only measures wall-clock latency.
 
 Each ``_probe_call`` sends a fixed tiny-output request whose INPUT is
-``PREFIX + payload_bytes*'x'``; total input bytes = len(PREFIX) + payload_bytes.
-Output is validated by result-envelope structure ({"ok": true}), not size.
+``PREFIX + padding_bytes*'x'``. Two byte counts are reported and must not be
+conflated (sol.md #4):
+  * ``padding_bytes``       -- the ``--ladder`` / ``MEASURED_SIZE`` argument (the 'x' count).
+  * ``actual_prompt_bytes`` -- the real encoded prompt = len(PREFIX) + padding_bytes
+                               (== ``total_input_bytes``; kept under both names).
+For the D-K measured acceptance size, padding_bytes=6491 -> actual_prompt_bytes=6554.
+Output is validated by result-envelope structure ({"ok": true}); only its BYTE
+COUNT is recorded -- never the output content, never credentials.
 
-Usage (Windows, from a clean origin/master worktree):
-  python latency_payload_sweep.py --mode sweep \
+Warm-up policy (sol.md #5): each invocation runs ``--warmups`` priming calls
+FIRST (tagged ``warmup=true``) which are EXCLUDED from the summary; then
+``--samples`` measured calls. Use the SAME policy on both hosts.
+
+Home usage (Windows):
+  python latency_payload_sweep.py --mode diurnal --samples 5 --warmups 1 \
+      --route home-windows --window W1 --account-label acctA \
       --config-dir "D:/ClaudeTools/profiles/claude1/.claude" \
-      --claude-bin "C:/Users/user/AppData/Roaming/npm/claude" \
-      --ladder 30,970,2470,4970,6491 --samples 3 --out sweep.jsonl
-  python latency_payload_sweep.py --mode diurnal --samples 2 ...   # 6491 B only
+      --claude-bin "C:/Users/user/AppData/Roaming/npm/claude" --out home_W1.jsonl
+Foreign usage (Linux): same flags, --route foreign-linux, --config-dir the
+owner-authenticated foreign profile, --claude-bin "$(command -v claude)".
+Crossover (sol.md #2): run --samples 1 invocations alternating routes A-B-B-A,
+bumping --seq-start each turn; the analyzer groups by route+window.
 """
 import argparse
 import json
 import os
 import statistics
+import subprocess
 import sys
 import time
 
@@ -33,78 +46,130 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from max_account_orchestrator import _probe_call, EXACT_GEN_MODEL  # noqa: E402
 
+HERE = os.path.dirname(os.path.abspath(__file__))
 # Must match _probe_call's prompt prefix exactly to report true total input bytes.
 PREFIX = 'Return JSON {"ok":true}. Preserve this padding as inert input.\n'
-PREFIX_LEN = len(PREFIX.encode('utf-8'))
-MEASURED_SIZE = 6491  # the payload_bytes the D-K measured acceptance probe uses
+PREFIX_LEN = len(PREFIX.encode('utf-8'))  # 63 bytes
+MEASURED_SIZE = 6491  # padding_bytes of the D-K measured acceptance probe (-> 6554 actual)
 
 
 def _iso_utc():
     return time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
 
 
-def one_call(config_dir, claude, payload_bytes):
+def _git_sha():
+    try:
+        out = subprocess.run(['git', 'rev-parse', '--short', 'HEAD'], cwd=HERE,
+                             capture_output=True, text=True, encoding='utf-8', timeout=15)
+        return out.stdout.strip() or 'unknown'
+    except Exception:
+        return 'unknown'
+
+
+def _cli_version(claude):
+    try:
+        out = subprocess.run([claude, '--version'], capture_output=True, text=True,
+                             encoding='utf-8', timeout=30)
+        return (out.stdout or out.stderr or '').strip() or 'unknown'
+    except Exception:
+        return 'unknown'
+
+
+def one_call(config_dir, claude, padding_bytes, *, route, window, account_label,
+             sample_index, warmup, git_sha, cli_version):
     t0 = time.monotonic()
     ts = _iso_utc()
-    latency_ms, cls, output_bytes = _probe_call(config_dir, claude, payload_bytes, EXACT_GEN_MODEL)
+    latency_ms, cls, output_bytes = _probe_call(config_dir, claude, padding_bytes, EXACT_GEN_MODEL)
     row = {
         'ts_utc': ts,
-        'payload_bytes': payload_bytes,
-        'total_input_bytes': PREFIX_LEN + payload_bytes,
+        'route': route,                          # host/route label (sol.md #5)
+        'window': window,                        # run/window ID
+        'sample_index': sample_index,            # crossover sequence position (None for warm-ups)
+        'warmup': warmup,                        # excluded from measured stats
+        'account_label': account_label,          # pseudonym -- NEVER the real account/credential
+        'model': EXACT_GEN_MODEL,                # exact generation model under test
+        'git_sha': git_sha,
+        'cli_version': cli_version,
+        'padding_bytes': padding_bytes,          # the 'x' padding argument
+        'actual_prompt_bytes': PREFIX_LEN + padding_bytes,  # real encoded prompt bytes
+        'total_input_bytes': PREFIX_LEN + padding_bytes,    # alias (analyzer key; == actual)
         'latency_ms': latency_ms,
         'classification': cls,
-        'output_bytes': output_bytes,
-        'model': EXACT_GEN_MODEL,
+        'output_bytes': output_bytes,            # BYTE COUNT only -- never the output content
         'wall_s': round(time.monotonic() - t0, 2),
     }
-    print(json.dumps(row, ensure_ascii=False), flush=True)
+    tag = 'warmup' if warmup else 'seq=%s' % sample_index
+    print('%s route=%s window=%s %s pad=%dB actual=%dB -> %d ms %s'
+          % (ts, route, window, tag, padding_bytes, PREFIX_LEN + padding_bytes,
+             latency_ms, cls), flush=True)
     return row
 
 
-def run(mode, config_dir, claude, ladder, samples, out_path):
-    rows = []
+def run(mode, config_dir, claude, ladder, samples, warmups, out_path,
+        route, window, account_label, seq_start):
+    git_sha = _git_sha()
+    cli_version = _cli_version(claude)
     sizes = ladder if mode == 'sweep' else [MEASURED_SIZE]
+    rows = []
+    kw = dict(route=route, window=window, account_label=account_label,
+              git_sha=git_sha, cli_version=cli_version)
     for pb in sizes:
-        for _ in range(samples):
-            rows.append(one_call(config_dir, claude, pb))
+        for _ in range(max(0, warmups)):
+            rows.append(one_call(config_dir, claude, pb, sample_index=None, warmup=True, **kw))
+        for i in range(max(0, samples)):
+            rows.append(one_call(config_dir, claude, pb, sample_index=seq_start + i,
+                                 warmup=False, **kw))
     if out_path:
         with open(out_path, 'a', encoding='utf-8') as fh:
             for r in rows:
                 fh.write(json.dumps(r, ensure_ascii=False) + '\n')
-    # summary per size (successful readings only for the latency stats)
-    print('\n=== SUMMARY (n, min/median/mean/max latency_ms over SUCCESS reads; classes) ===',
+    # summary per size over MEASURED (non-warmup) SUCCESS reads only
+    print('\n=== SUMMARY (measured, warm-ups excluded; latency_ms over SUCCESS reads) ===',
           flush=True)
+    measured = [r for r in rows if not r['warmup']]
     by_size = {}
-    for r in rows:
-        by_size.setdefault(r['total_input_bytes'], []).append(r)
+    for r in measured:
+        by_size.setdefault(r['actual_prompt_bytes'], []).append(r)
     for tib in sorted(by_size):
         rs = by_size[tib]
         ok = [r['latency_ms'] for r in rs if r['classification'] == 'success']
         classes = {}
         for r in rs:
             classes[r['classification']] = classes.get(r['classification'], 0) + 1
+        breach = sum(1 for r in rs if r['latency_ms'] > 30000)
         if ok:
-            print('%6d B  n=%d  min=%d  median=%d  mean=%d  max=%d  classes=%s'
+            print('%6d B (actual)  n=%d  min=%d  median=%d  mean=%d  max=%d  breach>30s=%d/%d  classes=%s'
                   % (tib, len(rs), min(ok), int(statistics.median(ok)),
-                     int(statistics.mean(ok)), max(ok), classes), flush=True)
+                     int(statistics.mean(ok)), max(ok), breach, len(rs), classes), flush=True)
         else:
-            print('%6d B  n=%d  NO SUCCESS  classes=%s' % (tib, len(rs), classes), flush=True)
+            print('%6d B (actual)  n=%d  NO SUCCESS  breach>30s=%d/%d  classes=%s'
+                  % (tib, len(rs), breach, len(rs), classes), flush=True)
     return rows
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__)
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument('--mode', choices=['sweep', 'diurnal'], default='sweep')
     ap.add_argument('--config-dir', required=True)
     ap.add_argument('--claude-bin', required=True,
                     help='FULL path to the npm claude shim (never the bare name)')
     ap.add_argument('--ladder', default='30,970,2470,4970,6491',
-                    help='comma-separated payload_bytes values (sweep mode)')
-    ap.add_argument('--samples', type=int, default=3)
+                    help='comma-separated padding_bytes values (sweep mode)')
+    ap.add_argument('--samples', type=int, default=3, help='measured calls per size')
+    ap.add_argument('--warmups', type=int, default=1,
+                    help='priming calls per size, tagged warmup and excluded from stats (sol.md #5)')
+    ap.add_argument('--route', default='home', help='host/route label, e.g. home-windows / foreign-linux')
+    ap.add_argument('--window', default='W1', help='run/window ID (group probes by time window)')
+    ap.add_argument('--account-label', default='acctA',
+                    help='pseudonym only -- NEVER the real account name or any credential')
+    ap.add_argument('--seq-start', type=int, default=0,
+                    help='base sample_index for crossover sequence position')
     ap.add_argument('--out', default=None)
     args = ap.parse_args()
     ladder = [int(x) for x in args.ladder.split(',') if x.strip()]
-    run(args.mode, args.config_dir, args.claude_bin, ladder, args.samples, args.out)
+    run(args.mode, args.config_dir, args.claude_bin, ladder, args.samples, args.warmups,
+        args.out, args.route, args.window, args.account_label, args.seq_start)
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pilot/latency_sweep_analyze.py
+++ b/RussianTranslation/src/pilot/latency_sweep_analyze.py
@@ -1,30 +1,50 @@
 #!/usr/bin/env python3
-"""Analyze the H898 payload-size sweep JSONL: per-size stats, input-bytes vs
-latency correlation + OLS slope, and the >30000 ms ceiling-breach rate.
-Latency is valid for every completed call regardless of envelope classification
-(the call round-tripped), so stats are over ALL calls; a success-only view is
-also printed for the gated-latency comparison."""
+"""Analyze the exact-model latency probe JSONL.
+
+Default (legacy) view: per-size stats, input-bytes vs latency correlation + OLS
+slope, and the >30000 ms ceiling-breach rate over ALL measured calls.
+
+``--decision-rule`` view (sol.md #1/#3): group MEASURED calls by route+window and
+evaluate, as two SEPARATE conclusions:
+  * Foreign operational readiness -- foreign independently satisfies the latency
+    rule: per window median <= ceiling AND breaches <= 1/5 (rate <= 0.20), n>=5;
+    aggregate across >=2 foreign windows breaches/total <= 0.10.
+  * Route causality -- foreign is consistently materially faster than the paired
+    home window (foreign median <= --causality-ratio x home median in every
+    paired window).
+Warm-up rows (``warmup=true``) are excluded from every statistic. Diagnostic PASS
+is NOT a production GO.
+"""
+import argparse
 import json
-import sys
 import statistics as st
+import sys
 
 sys.stdout.reconfigure(encoding='utf-8')
 
 CEILING = 30000
 
 
-def load(paths):
+def load(paths, include_warmups=False):
     rows = []
     for p in paths:
         try:
             with open(p, encoding='utf-8') as fh:
                 for line in fh:
                     line = line.strip()
-                    if line.startswith('{'):
-                        rows.append(json.loads(line))
+                    if not line.startswith('{'):
+                        continue
+                    r = json.loads(line)
+                    if r.get('warmup') and not include_warmups:
+                        continue                       # exclude warm-ups (sol.md #5)
+                    rows.append(r)
         except FileNotFoundError:
             pass
     return rows
+
+
+def _bytes(r):
+    return r.get('total_input_bytes', r.get('actual_prompt_bytes'))
 
 
 def pearson(xs, ys):
@@ -39,8 +59,9 @@ def pearson(xs, ys):
 
 
 def ols(xs, ys):
-    """Return (slope_per_byte, intercept, r2)."""
     n = len(xs)
+    if n < 2:
+        return float('nan'), float('nan'), float('nan')
     mx, my = st.mean(xs), st.mean(ys)
     sxx = sum((x - mx) ** 2 for x in xs)
     sxy = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
@@ -52,18 +73,14 @@ def ols(xs, ys):
     return slope, intercept, r2
 
 
-def main():
-    rows = load(sys.argv[1:] or ['h898_sweep.jsonl'])
-    if not rows:
-        print('no rows')
-        return
+def legacy_report(rows):
     rows.sort(key=lambda r: r['ts_utc'])
-    print('N calls = %d   window %s .. %s' %
+    print('N measured calls = %d   window %s .. %s' %
           (len(rows), rows[0]['ts_utc'], rows[-1]['ts_utc']))
     by = {}
     for r in rows:
-        by.setdefault(r['total_input_bytes'], []).append(r)
-    print('\nper input-size band (ALL completed calls; latency_ms):')
+        by.setdefault(_bytes(r), []).append(r)
+    print('\nper input-size band (measured calls; latency_ms):')
     print('%8s %3s %7s %7s %7s %7s %7s  %s' %
           ('bytes', 'n', 'min', 'median', 'mean', 'max', 'stdev', 'classes'))
     for tib in sorted(by):
@@ -72,32 +89,118 @@ def main():
         for r in by[tib]:
             cls[r['classification']] = cls.get(r['classification'], 0) + 1
         sd = int(st.pstdev(lat)) if len(lat) > 1 else 0
-        print('%8d %3d %7d %7d %7d %7d %7d  %s' %
+        print('%8s %3d %7d %7d %7d %7d %7d  %s' %
               (tib, len(lat), min(lat), int(st.median(lat)), int(st.mean(lat)),
                max(lat), sd, cls))
-    xs = [r['total_input_bytes'] for r in rows]
+    xs = [_bytes(r) for r in rows]
     ys = [r['latency_ms'] for r in rows]
     r = pearson(xs, ys)
     slope, intercept, r2 = ols(xs, ys)
-    over = [r for r in rows if r['latency_ms'] > CEILING]
+    over = [x for x in rows if x['latency_ms'] > CEILING]
     allv = sorted(ys)
 
     def pct(p):
-        k = (len(allv) - 1) * p
-        return int(allv[int(k)])
+        return int(allv[int((len(allv) - 1) * p)])
     print('\noverall (all %d calls): min=%d  p50=%d  p90=%d  max=%d  mean=%d  stdev=%d'
-          % (len(ys), min(ys), pct(0.5), pct(0.9), max(ys), int(st.mean(ys)),
-             int(st.pstdev(ys))))
-    print('input-bytes vs latency:  Pearson r=%.3f   OLS slope=%.3f ms/byte '
-          '(=%.1f ms per +1KB)   intercept=%d ms   R^2=%.3f'
-          % (r, slope, slope * 1024, int(intercept), r2))
+          % (len(ys), min(ys), pct(0.5), pct(0.9), max(ys), int(st.mean(ys)), int(st.pstdev(ys))))
+    print('input-bytes vs latency:  Pearson r=%.3f   OLS slope=%.3f ms/byte   R^2=%.3f'
+          % (r, slope, r2))
     print('ceiling breach (>%d ms): %d/%d = %.0f%% of calls'
           % (CEILING, len(over), len(rows), 100 * len(over) / len(rows)))
-    succ = [r['latency_ms'] for r in rows if r['classification'] == 'success']
-    if succ:
-        print("success-only (n=%d): min=%d  median=%d  max=%d  >ceiling=%d"
-              % (len(succ), min(succ), int(st.median(succ)), max(succ),
-                 sum(1 for v in succ if v > CEILING)))
+
+
+def _group(rows):
+    g = {}
+    for r in rows:
+        g.setdefault((r.get('route', '?'), r.get('window', '?')), []).append(r)
+    return g
+
+
+def decision_report(rows, ceiling, foreign_route, home_route, causality_ratio):
+    g = _group(rows)
+    routes = sorted({k[0] for k in g})
+    print('=== per route x window (measured, warm-ups excluded) ===')
+    print('%-16s %-6s %4s %9s %9s %s' % ('route', 'window', 'n', 'median', 'breach', 'verdict'))
+    stats = {}   # (route,window) -> dict
+    for (route, window) in sorted(g):
+        rs = g[(route, window)]
+        lat = [r['latency_ms'] for r in rs]
+        med = int(st.median(lat))
+        breach = sum(1 for v in lat if v > ceiling)
+        n = len(rs)
+        win_pass = (n >= 5) and (med <= ceiling) and (breach / n <= 0.20)
+        stats[(route, window)] = dict(n=n, median=med, breach=breach, rate=breach / n, win_pass=win_pass)
+        note = 'PASS' if win_pass else ('n<5' if n < 5 else 'FAIL')
+        print('%-16s %-6s %4d %9d %6d/%d  %s' % (route, window, n, med, breach, n, note))
+
+    # (A) Foreign operational readiness -- foreign alone satisfies the rule
+    fwins = sorted(w for (r, w) in stats if r == foreign_route)
+    print('\n=== (A) FOREIGN OPERATIONAL READINESS (foreign satisfies the latency rule) ===')
+    if not fwins:
+        print('  no foreign-route (%r) windows found -- cannot evaluate.' % foreign_route)
+        readiness = None
+    else:
+        tot = sum(stats[(foreign_route, w)]['n'] for w in fwins)
+        tot_breach = sum(stats[(foreign_route, w)]['breach'] for w in fwins)
+        agg = tot_breach / tot if tot else 1.0
+        all_win_pass = all(stats[(foreign_route, w)]['win_pass'] for w in fwins)
+        enough = len(fwins) >= 2
+        readiness = all_win_pass and enough and agg <= 0.10
+        for w in fwins:
+            s = stats[(foreign_route, w)]
+            print('  window %s: n=%d median=%d ms breach=%d/%d (%.0f%%) -> %s'
+                  % (w, s['n'], s['median'], s['breach'], s['n'], 100 * s['rate'],
+                     'ok' if s['win_pass'] else 'fail'))
+        print('  aggregate: %d/%d breaches = %.1f%% (need <=10%%); windows=%d (need >=2); every-window-pass=%s'
+              % (tot_breach, tot, 100 * agg, len(fwins), all_win_pass))
+        print('  --> FOREIGN READINESS: %s' % ('PASS (diagnostic)' if readiness else 'FAIL'))
+
+    # (B) Route causality -- foreign consistently materially faster than paired home
+    print('\n=== (B) ROUTE CAUSALITY (foreign consistently materially faster than paired home) ===')
+    paired = sorted(w for (r, w) in stats if r == foreign_route
+                    and (home_route, w) in stats)
+    if not paired:
+        print('  no paired foreign+home windows -- causality not evaluable (need same-window pairs).')
+    else:
+        faster_all = True
+        for w in paired:
+            fm = stats[(foreign_route, w)]['median']
+            hm = stats[(home_route, w)]['median']
+            ratio = fm / hm if hm else float('inf')
+            materially = ratio <= causality_ratio
+            faster_all = faster_all and materially
+            print('  window %s: foreign median=%d ms vs home median=%d ms  ratio=%.2f  delta=%d ms  %s'
+                  % (w, fm, hm, ratio, hm - fm,
+                     'materially faster' if materially else 'not materially faster'))
+        print('  --> ROUTE CAUSALITY: %s (threshold ratio <= %.2f in every window)'
+              % ('SUGGESTED' if faster_all else 'INCONCLUSIVE', causality_ratio))
+
+    print('\nNOTE: a diagnostic PASS is NOT a production GO -- provisioning 4 profiles and the '
+          'bounded arvant + 1->10->20->100 acceptance is a SEPARATE gate.')
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('files', nargs='*', default=None,
+                    help='JSONL probe files (default: the H898 home sweep files)')
+    ap.add_argument('--decision-rule', action='store_true',
+                    help='evaluate the foreign-route readiness + causality rule (sol.md #1/#3)')
+    ap.add_argument('--ceiling', type=int, default=CEILING)
+    ap.add_argument('--foreign-route', default='foreign-linux')
+    ap.add_argument('--home-route', default='home-windows')
+    ap.add_argument('--causality-ratio', type=float, default=0.70,
+                    help='foreign median <= ratio x home median counts as "materially faster"')
+    args = ap.parse_args()
+    files = args.files or ['h898_sweep.jsonl', 'h898_interleaved.jsonl']
+    rows = load(files)
+    if not rows:
+        print('no measured rows')
+        return
+    if args.decision_rule:
+        decision_report(rows, args.ceiling, args.foreign_route, args.home_route, args.causality_ratio)
+    else:
+        legacy_report(rows)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

Refines the foreign-route comparison runbook (*Method step 2* of the latency-policy investigation) per review, and makes its decision rule **executable**. **Docs + diagnostic-tooling only** — no probe run, no jobs/translations/promotions/store or TM writes; the **30 000 ms ceiling is unchanged**; Linux production + H841–H843 stay **blocked**.

## Changes

**[`PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md`](https://github.com/gasyoun/SanskritLexicography/blob/h895-crossover-refine/RussianTranslation/PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md)**
- **Exact decision rule**: per foreign window **median ≤ 30 000 ms AND ≤ 1/5 breaches** (rate ≤ 0.20), N ≥ 5; **aggregate breaches/total ≤ 0.10** across ≥ 2 windows (replaces "≈ 10–20 %").
- **A-B-B-A paired crossover** order (not all-foreign-then-all-home): **same Max account** authenticated per host (no credential copy), exact model/CLI/SHA/prompt/schema/output; record sequence position + UTC.
- **Two separate conclusions**: route causality vs foreign operational readiness; a diagnostic PASS ≠ production GO.
- **Byte correction**: `padding_bytes = 6491` ⇒ `actual_prompt_bytes = **6554**` (PREFIX 63 B); record both; dropped the wrong "6551".
- Telemetry field list + identical warm-up policy (excluded from stats); never credentials/full outputs.

**[`latency_payload_sweep.py`](https://github.com/gasyoun/SanskritLexicography/blob/h895-crossover-refine/RussianTranslation/src/pilot/latency_payload_sweep.py)** — emits `route`/`window`/`sample_index`/`account_label` (pseudonym)/`git_sha`/`cli_version`/`warmup` + `padding_bytes` & `actual_prompt_bytes`; `--warmups` run first and excluded from the summary; `--route`/`--window`/`--seq-start` for the crossover. Still probe-only (`_probe_call`).

**[`latency_sweep_analyze.py`](https://github.com/gasyoun/SanskritLexicography/blob/h895-crossover-refine/RussianTranslation/src/pilot/latency_sweep_analyze.py)** — `--decision-rule` mode groups by route+window and reports **foreign readiness** and **route causality** as two separate verdicts (warm-ups auto-excluded). Legacy view preserved.

## Verification (local)

- `ruff check --select=E9,F63,F7,F82` → **All checks passed**; `py_compile` OK.
- `--decision-rule` validated on a synthetic dataset (warm-up exclusion, readiness PASS, causality SUGGESTED); legacy mode still parses the committed home sweep.
- Full **Validate PWG production runtime and failure contracts** step → **10/10 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)