### PR TITLE
H898/latency: pre-register the foreign-route decision rule (frozen before foreign data)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,13 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+- **Latency-policy investigation — foreign-route decision rule PRE-REGISTERED (frozen before any
+  foreign data).** Locked the exact thresholds in *Method step 2* Step C — ceiling 30 000 ms;
+  per foreign window median ≤ 30 000 ms AND ≤ 1/5 breaches, N ≥ 5; aggregate breaches/total ≤ 0.10
+  across ≥ 2 windows; **causality ratio 0.70**; identical warm-up policy excluded from stats — with
+  an explicit "do NOT tune post-hoc to obtain a preferred verdict" clause (git history is the
+  tamper-evidence). Noted the lock in `latency_sweep_analyze.py`'s `--causality-ratio` help. No
+  behaviour change; diagnostic still owner-gated and NOT yet run.
 - **Latency-policy investigation — foreign-route runbook refined + probe telemetry extended
   (diagnostic-only; NOT yet run).** Tightened *Method step 2* per review: **exact** decision rule
   (per foreign window median ≤ 30 000 ms AND ≤ 1/5 breaches with N ≥ 5; aggregate breaches/total

--- a/RussianTranslation/PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md
+++ b/RussianTranslation/PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md
@@ -316,6 +316,24 @@ Repeat for **≥ 2 windows** (W1, W2, … at different times of day — the home
 
 ### Step C — decision rule (EXACT; two SEPARATE conclusions — sol.md #1 + #3)
 
+> **⚖️ PRE-REGISTERED — frozen 14-07-2026, BEFORE any foreign-route data is collected. Do NOT
+> tune post-hoc.** These thresholds are locked in advance so the verdict cannot be steered by the
+> data. Changing any of them *after* seeing foreign readings — to obtain a preferred PASS/FAIL — is
+> forbidden and voids the diagnostic. The commit that adds this block is the pre-registration
+> timestamp (git history is the tamper-evidence); the analyzer defaults encode these exactly.
+>
+> - **ceiling** = 30 000 ms (unchanged)
+> - **per foreign window:** median ≤ 30 000 ms **AND** breaches ≤ 1/5 (rate ≤ 0.20), **N ≥ 5**
+> - **aggregate (foreign):** breaches / total ≤ 0.10 across **≥ 2** windows
+> - **causality ratio = 0.70** (foreign median ≤ 0.70 × the paired-home median in **every** paired
+>   window) — conservative, and acceptable *because operational readiness (A) is judged
+>   independently of causality (B)*
+> - **warm-up policy:** identical on both hosts, ≥ 1 warm-up per host per window, excluded from stats
+>
+> Locked against `origin/master` as of this commit; run the analyzer with its **defaults**
+> (`--causality-ratio 0.70`, `--ceiling 30000`) — overriding them to flip a verdict is the exact
+> post-hoc tuning this pre-registration prohibits.
+
 Summarise with the analyzer's decision-rule mode (warm-ups auto-excluded, grouped by `route`+`window`):
 
 ```bash

--- a/RussianTranslation/src/pilot/latency_sweep_analyze.py
+++ b/RussianTranslation/src/pilot/latency_sweep_analyze.py
@@ -190,7 +190,9 @@ def main():
     ap.add_argument('--foreign-route', default='foreign-linux')
     ap.add_argument('--home-route', default='home-windows')
     ap.add_argument('--causality-ratio', type=float, default=0.70,
-                    help='foreign median <= ratio x home median counts as "materially faster"')
+                    help='PRE-REGISTERED 0.70 (frozen 14-07-2026 before foreign data): foreign '
+                         'median <= ratio x home median = "materially faster". Do NOT override to '
+                         'flip a verdict post-hoc.')
     args = ap.parse_args()
     files = args.files or ['h898_sweep.jsonl', 'h898_interleaved.jsonl']
     rows = load(files)


### PR DESCRIPTION
## What

Locks the foreign-route diagnostic decision rule **before any foreign-route data is collected**, so the verdict can't be steered post-hoc. **Docs + help-text only** — no behaviour change; diagnostic still owner-gated and NOT yet run; 30 000 ms ceiling unchanged; Linux production + H841–H843 stay blocked.

## Pre-registered thresholds (frozen 14-07-2026)

- **ceiling** = 30 000 ms
- **per foreign window:** median ≤ 30 000 ms **AND** ≤ 1/5 breaches (rate ≤ 0.20), **N ≥ 5**
- **aggregate (foreign):** breaches / total ≤ 0.10 across **≥ 2** windows
- **causality ratio = 0.70** (foreign median ≤ 0.70 × paired-home median in every paired window) — conservative, acceptable because readiness is judged independently of causality
- **warm-up policy:** identical both hosts, excluded from stats

Explicit **"do NOT tune post-hoc to obtain a preferred verdict"** clause; git history is the tamper-evidence. The lock is also surfaced in [`latency_sweep_analyze.py`](https://github.com/gasyoun/SanskritLexicography/blob/h895-prereg/RussianTranslation/src/pilot/latency_sweep_analyze.py)'s `--causality-ratio` help.

## Verification

- `ruff --select=E9,F63,F7,F82` → All checks passed; `py_compile` OK; `--help` shows the lock; doc fences balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)