### PR TITLE
fix(pwg_ru): scope no-PWG promotion commands

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,5 +1,7 @@
 # Project Objective: Repository documentation & housekeeping
 
+_Created: 09-07-2026 · Last updated: 14-07-2026_
+
 Keep the SanskritLexicography data/research workspace documented and its git
 state tidy.
 
@@ -963,6 +965,14 @@ Two live tracks:
 
 ## ✅ Completed (Recent only)
 
+- **RussianTranslation resume audit + promotion-command safety fix (14-07-2026,
+  GPT-5 Codex).** Current state audited against `origin/master`: H911, not the older H255
+  scale note, owns readiness; the required continuation is H920's offline SAN-LOSS/
+  `missing_senses` repair. On branch `codex/russiantranslation-resume-audit`, the no-PWG
+  planner now emits an exact single-window promotion glob and model version, and RU promotion
+  refuses a broad implicit `--merge` glob. Full window selftests and 47-entry language parity
+  pass; no live generation or canonical-store mutation occurred.
+
 - **H780 EntryAnatomy specimen pages (Duden model) — DONE 12-07-2026 (Fable 5 `claude-fable-5`).**
   Three annotated "how to read an entry" pages + single-sheet PDFs in
   [EntryAnatomy/](https://github.com/gasyoun/SanskritLexicography/tree/master/EntryAnatomy):
@@ -1536,3 +1546,5 @@ Two live tracks:
 - Earlier session housekeeping (now superseded) — _status: history; date: 2026-06-14; source: existing-entry._ wrote repo-level
   `CLAUDE.md` (on `master` via PR #13), logged it in `changelog.md`, and deleted
   the fully-merged `feature/particles-explorer` branch (remote + local).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1,5 +1,7 @@
 # Project Objective: PWG (Petersburg Dictionary) → Russian edition + the CDSL article-comparison study
 
+_Created: 09-07-2026 · Last updated: 14-07-2026_
+
 Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/archive/H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md)):
 
 - **Track A (PRIMARY):** scale PWG→Russian on the **Max** harness.
@@ -2144,6 +2146,19 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **Codex resume audit + promotion-command safety fix — DONE 14-07-2026
+  (GPT-5 Codex).** Audited current `origin/master`, the live queue, H911, and the
+  no-PWG planner rather than following the stale H255 command literally. Confirmed H809 had already
+  fixed window-index reuse; fixed the remaining repeated promotion footgun:
+  [`no_pwg_scale_plan.py`](https://github.com/gasyoun/SanskritLexicography/blob/codex/russiantranslation-resume-audit/RussianTranslation/src/pilot/no_pwg_scale_plan.py)
+  now emits a single-window `--glob` plus exact `--gen-model-version`, while
+  [`promote_final_cards.py`](https://github.com/gasyoun/SanskritLexicography/blob/codex/russiantranslation-resume-audit/RussianTranslation/src/promote_final_cards.py)
+  refuses `--merge` with its implicit repo-root glob. Regression coverage added to
+  [`h809_selftest.py`](https://github.com/gasyoun/SanskritLexicography/blob/codex/russiantranslation-resume-audit/RussianTranslation/src/pilot/h809_selftest.py);
+  `window_selftest.py` and all 47 language-parity entries are green. **Resume remains H920**
+  (H911 FAIL branch: offline SAN-LOSS/`missing_senses` root-cause + guard); no generation or
+  store/TM mutation was performed.
+
 - **H809 — PWG→RU scale-unblock (W1 done · W2 partial · W3-code done · W0/W4 NO-GO), 12-07-2026 (Opus 4.8 `claude-opus-4-8`).**
   - **W1 ✅** — 687 missing verb rootmaps generated (`ROOT_SPLIT_MIN=0` on the positional verb-root
     splat; **reset the env var immediately** — never pass it with `--manifest freq` or it splits every
@@ -2953,3 +2968,5 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   cut" note — that was the 2026-06-25 tail only.)
 - **38-unit freq test** run + audited (38/38 fidelity-clean); giant-root split + glue solved;
   frequency-first queue built (41.4 % DCS-attested).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,12 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+- **No-PWG promotion command safety.** `no_pwg_scale_plan.py` now emits a directly
+  executable, single-window `promote_final_cards.py` command with an explicit output glob
+  and exact generation model id. `promote_final_cards.py --merge` now refuses its implicit
+  repo-root `wf_output*.json` glob, preventing the recurring ingestion of unrelated stale
+  workflow artifacts.
+
 - **H911 LOCAL-READINESS quality/economy gate — verdict `FAIL` (offline; Opus 4.8 executor-override
   of Fable 5).** Reconciled all recoverable H818 acceptance-canary + H255 no_pwg evidence into a
   denominator-honest [census](pwg_ru/h911/h911_quality_economy_census.json), ran a two-phase

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -336,7 +336,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "f098ed7dc3009ec44aaf415b57d639a191ec0012ba53df776b34bf27efefd563",
+      "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
     }
   },
@@ -393,7 +393,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED same day (2026-07-04): PR #140 (feat(provenance): pipeline versioning) added pipeline_version stamping only to promote_final_cards.py; found as a GAP while re-affirming H169's parity re-hash, closed immediately. promote_en.py now calls `pipeline_version.stamp(model_version=gen_model_version)` inside `en_index()`'s per-subcard provenance block, stored as `en_provenance.pipeline` (mirrors RU's `provenance.pipeline`; a distinct field since EN attaches onto an existing RU row rather than owning it). Pinned by an added assertion in `promote_en.selftest()`.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "f098ed7dc3009ec44aaf415b57d639a191ec0012ba53df776b34bf27efefd563",
+      "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
     }
   },
@@ -431,7 +431,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 1.1. The layer is derived purely from the sub-card KEY structure, which is identical for RU and EN. promote_en.py ATTACHES english onto the RU-owned row and leaves it otherwise untouched, so EN inherits `layer` for free — no EN-specific code needed. layer_of() pinned by dict_merge.py selftest + a promote_final_cards.selftest assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "f098ed7dc3009ec44aaf415b57d639a191ec0012ba53df776b34bf27efefd563",
+      "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
       "src/dict_merge.py": "0266e11980e3b8b12d0699665b2051b9f7b8b16ed89d5810adfe5a458e880eea"
     }
   },
@@ -451,7 +451,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/promote_final_cards.py": "f098ed7dc3009ec44aaf415b57d639a191ec0012ba53df776b34bf27efefd563"
+      "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2"
     }
   },
   {
@@ -597,7 +597,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
-      "src/promote_final_cards.py": "f098ed7dc3009ec44aaf415b57d639a191ec0012ba53df776b34bf27efefd563",
+      "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
       "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
     }
@@ -904,7 +904,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/store_path.py": "2b3be1415dc7a387717c60574abc36aec9600d7a5c138bf7ac85415aa1b1e152",
-      "src/promote_final_cards.py": "f098ed7dc3009ec44aaf415b57d639a191ec0012ba53df776b34bf27efefd563",
+      "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
     }
   },
@@ -959,7 +959,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/coordinator.py": "3fc844fe372b7511528aefeefbc90dcd83653b9cc09e85fed837fd599eac15f8",
       "src/pilot/headless_worker_selftest.py": "192bfedf95d2d86bccf010c0e4f7f4ececc9f3941ab284f51e84bfba12f638a9",
       "src/pilot/max_account_orchestrator_selftest.py": "f95ea774e5e4923b616ed69da20ef09812519b78ea695e324deffe1b4c917e82",
-      "src/pilot/no_pwg_scale_plan.py": "ec654b580278361a6fe27c1cb93a04acd1c1a219f8db223f2fdea9c0a657a105",
+      "src/pilot/no_pwg_scale_plan.py": "e181edad1960cb75a765fb1f2bda0614080142c63fbc33b3346501de33892548",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
       "src/pilot/run_observability.py": "371d0197b39e217ef1754eb60d8b09f79823678f728d65e276f864eaeb8e0d72",
       "src/pilot/run_observability_selftest.py": "75bc960a35080a0c84ca9b5ee62b63134a9e0bde334c5531d564b13019187b60",

--- a/RussianTranslation/src/pilot/h809_selftest.py
+++ b/RussianTranslation/src/pilot/h809_selftest.py
@@ -82,10 +82,30 @@ def test_no_pwg_window_index_autoselect():
         fail('next_free_index on empty dirs must floor at 2')
 
 
+def test_no_pwg_promotion_command_is_scoped_and_executable():
+    """A plan must never tell an operator to merge the repo-root default glob."""
+    import no_pwg_scale_plan as nps
+    cmd = nps.promotion_command(
+        'src/pilot/output/wf_output.no_pwg_w07.json', 'claude-sonnet-5')
+    expected = (
+        'python src/promote_final_cards.py --merge '
+        '--glob "src/pilot/output/wf_output.no_pwg_w07.json" '
+        '--gen-model-version claude-sonnet-5')
+    if cmd != expected:
+        fail('promotion command drifted: %r' % cmd)
+    try:
+        nps.promotion_command('wf_output.json', 'sonnet')
+    except ValueError:
+        pass
+    else:
+        fail('promotion command must refuse a non-exact model alias')
+
+
 def main():
     tests = [
         test_cost_rate_table_sonnet5_formula,
         test_no_pwg_window_index_autoselect,
+        test_no_pwg_promotion_command_is_scoped_and_executable,
     ]
     for t in tests:
         t()

--- a/RussianTranslation/src/pilot/no_pwg_scale_plan.py
+++ b/RussianTranslation/src/pilot/no_pwg_scale_plan.py
@@ -190,6 +190,16 @@ def preflight_json(root, keys):
     return json.loads(run_cmd(cmd, capture=True))
 
 
+def promotion_command(workflow_output, gen_model_version):
+    """Return the single-window, merge-safe promotion command for a plan row."""
+    if not gen_model_version or gen_model_version in ('sonnet', 'claude-sonnet'):
+        raise ValueError('an exact generation model id is required')
+    return (
+        'python src/promote_final_cards.py --merge --glob "%s" '
+        '--gen-model-version %s' % (workflow_output, gen_model_version)
+    )
+
+
 def prepare_window(args, index, heads, still_null_keys, tail_mode):
     root = '%s%02d' % (args.prefix, index)
     print('preparing %s: %d headword(s)%s' %
@@ -257,15 +267,16 @@ def prepare_window(args, index, heads, still_null_keys, tail_mode):
                 root, 'no_pwg_windows100', subcards, harness, execution_manifest,
                 preflight_path, artifact_path=os.path.dirname(execution_manifest))
     wf_out = os.path.join(OUT, 'wf_output.%s.json' % root)
+    wf_out_rel = os.path.relpath(wf_out, RT).replace('\\', '/')
     return {
         'root': root,
         'mode': 'still_null_tail' if tail_mode else 'queue',
         'headwords': heads,
         'subcards': subcards,
         'harness': os.path.relpath(harness, RT).replace('\\', '/'),
-        'workflow_output': os.path.relpath(wf_out, RT).replace('\\', '/'),
+        'workflow_output': wf_out_rel,
         'audit_command': 'python src/pilot/audit_window.py %s' % root,
-        'promote_command': 'python src/promote_final_cards.py --merge',
+        'promote_command': promotion_command(wf_out_rel, args.gen_model_version),
         'preflight': {
             'selected_keys': len(preflight.get('selected_keys') or []),
             'batches': preflight.get('batch_count'),
@@ -340,6 +351,9 @@ def main(argv=None):
                     help='generate headless artifacts/report without registering leases or calling Claude')
     ap.add_argument('--coordinator-dir', default=coordinator.DEFAULT_COORD_DIR,
                     help='coordinator state/artifact directory for --headless')
+    ap.add_argument('--gen-model-version', default='claude-sonnet-5',
+                    help='exact generation model id written into the promotion command '
+                         '(default %(default)s)')
     args = ap.parse_args(argv)
 
     if args.headless:
@@ -347,6 +361,8 @@ def main(argv=None):
 
     if args.window_size < 1 or args.window_size > 30:
         raise SystemExit('FAIL: --window-size must be between 1 and 30 for H255')
+    if args.gen_model_version in ('sonnet', 'claude-sonnet'):
+        raise SystemExit('FAIL: --gen-model-version must be an exact model id')
 
     # H809 W3: resolve the window index from disk unless the caller pins one.
     # `--plan-only` prepares nothing, so a stale/colliding label is harmless there and

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -56,6 +56,11 @@ MODEL = 'sonnet'                                    # the harness pins model:'so
 SELFTEST_MODEL_VERSION = 'claude-sonnet-5'
 
 
+def explicit_glob_supplied(argv):
+    """Whether argv explicitly scopes promotion inputs with --glob."""
+    return any(arg == '--glob' or arg.startswith('--glob=') for arg in argv)
+
+
 def load_wf(path):
     with open(path, encoding='utf-8') as f:
         wrapper = json.load(f)
@@ -264,6 +269,9 @@ def selftest():
     assert got['meta'].get('lang') != 'en', 'EN wf file must be excluded from the RU bridge'
     assert list(rows_for('p_a~~h5_00_pwg00', got, 'ai_translated',
                          SELFTEST_MODEL_VERSION)), 'RU rows survive the EN sibling'
+    assert explicit_glob_supplied(['--merge', '--glob', 'src/pilot/output/wf_output.w01.json'])
+    assert explicit_glob_supplied(['--glob=src/pilot/output/wf_output.w01.json', '--merge'])
+    assert not explicit_glob_supplied(['--merge'])
     print('promote_final_cards selftest OK')
 
 
@@ -295,6 +303,10 @@ def main():
                     help='override the promotion claim staleness TTL (default: promote_lock.'
                          'DEFAULT_TTL_SECONDS = 30 min)')
     args = ap.parse_args()
+    if args.merge and not explicit_glob_supplied(sys.argv[1:]):
+        sys.exit(
+            'refusing --merge with the implicit broad glob %r; pass --glob explicitly '
+            '(normally src/pilot/output/wf_output.<window>.json)' % DEFAULT_GLOB)
 
     # Provenance: make the resolved store path explicit — a worktree run promotes into the MAIN
     # checkout's store (store_path.canonical_store), never a discarded worktree copy (H255 w06 / H805).


### PR DESCRIPTION
## Summary
- emit exact single-window promotion commands from the no-PWG planner
- refuse implicit broad-glob merges in the RU promotion bridge
- reconcile project state: H920 is the current offline resume point

## Verification
- python src/pilot/h809_selftest.py
- python src/promote_final_cards.py --selftest
- python src/pilot/windows100_selftest.py
- python src/pilot/window_selftest.py
- python src/pilot/lang_parity_check.py (47 entries, clean)

No live generation or canonical store/TM mutation was performed.