### PR TITLE
chore(release): 1.9.9

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.9.9] - 2026-07-14
+
 - **No-PWG promotion command safety.** `no_pwg_scale_plan.py` now emits a directly
   executable, single-window `promote_final_cards.py` command with an explicit output glob
   and exact generation model id. `promote_final_cards.py --merge` now refuses its implicit

--- a/RussianTranslation/CITATION.cff
+++ b/RussianTranslation/CITATION.cff
@@ -16,8 +16,8 @@ authors:
     affiliation: "Институт лингвистических исследований РАН (ИЛИ РАН)"
 repository-code: "https://github.com/gasyoun/SanskritLexicography"
 license: "CC-BY-SA-4.0"
-version: "1.4.0"
-date-released: "2026-07-06"
+version: "1.9.9"
+date-released: "2026-07-14"
 keywords:
   - sanskrit
   - russian

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,13 @@ not an error.
 
 ## [Unreleased]
 
+## [1.9.9] - 2026-07-14
+
+### Fixed
+- **PWG→Russian no-PWG promotion safety** — planner manifests now emit an explicit
+  single-window workflow glob and exact generation model id; merge promotions refuse the
+  implicit repo-root glob that repeatedly ingested unrelated stale workflow artifacts.
+
 ## [1.9.8] - 2026-07-14
 
 ### Added


### PR DESCRIPTION
Patch release for the PWG→Russian no-PWG promotion safety fix. Syncs both changelogs and RussianTranslation/CITATION.cff.