### PR TITLE
H931: h178_eval_bakeoff uses shared csl_pyutil emitter; document build_p2_sheet.py skip

### DIFF
--- a/HeadwordLists/works_catalogue/build_p2_sheet.py
+++ b/HeadwordLists/works_catalogue/build_p2_sheet.py
@@ -1,3 +1,13 @@
+# NOT ported to csl_pyutil.render_review_sheet() (H931, 14-07-2026, Sonnet 5
+# `claude-sonnet-5`) — deliberate skip, not an oversight. render_review_sheet()
+# pre-renders every card into one static server-side HTML blob; this sheet's
+# candidate set is 49,019 rows (Tier C 5,353 + Tier D 43,666, measured
+# 14-07-2026), so it instead virtualizes: only ~15-20 <div class="row"> nodes
+# ever exist in the DOM at once (absolute positioning + a scroll-driven
+# renderVisible() window), with the full dataset kept as an embedded JS array.
+# A full-DOM render at this scale would be a real regression (slow initial
+# paint, laggy scroll, high memory) for zero benefit — the emitter has no
+# virtualization support. Kept as its own hand-rolled shell.
 import sys
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')

--- a/RussianTranslation/src/h178_eval_bakeoff.py
+++ b/RussianTranslation/src/h178_eval_bakeoff.py
@@ -38,6 +38,8 @@ Usage (in order):
 """
 import sys, os, io, json, html, random, re, time, argparse, collections, math
 
+from csl_pyutil import render_review_sheet
+
 sys.stdout.reconfigure(encoding="utf-8")
 sys.stderr.reconfigure(encoding="utf-8")
 
@@ -246,21 +248,9 @@ def cmd_judge():
 
 
 # ----------------------------------------------------------------------- sheets
-# Template derived from build_h180_review_sheets.py (same decisions.json contract)
-# with rubric widgets + vote timestamps added.
-SHEET_TMPL = None  # loaded lazily from the sibling generator to avoid drift
-
-
-def _load_tmpl():
-    """Reuse the H180 template/render machinery instead of forking the CSS/JS."""
-    import importlib.util
-    spec = importlib.util.spec_from_file_location(
-        "h180sheets", os.path.join(HERE, "build_h180_review_sheets.py"))
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
+# Calls the shared csl_pyutil.render_review_sheet() emitter (H925/H931) instead
+# of hand-rolling the CSS/JS/TEMPLATE; the RUBRIC_JS widget script is spliced
+# onto the RETURNED html string (same decisions.json contract as before).
 RUBRIC_JS = """
 <script>
 (function () {
@@ -346,17 +336,16 @@ SHEETS = [
 
 def cmd_sheets():
     os.makedirs(REVIEW, exist_ok=True)
-    mod = _load_tmpl()
-    items = load_sample()
+    items_raw = load_sample()
     base = {json.loads(l)["id"]: json.loads(l) for l in io.open(BASELINE, encoding="utf-8")} \
         if os.path.exists(BASELINE) else {}
     rng = random.Random(SEED + 1)  # SAME stream as cmd_judge -> same blinding
     blinding = {}
-    for it in items:
+    for it in items_raw:
         blinding[it["id"]] = rng.random() < 0.5  # a_is_store
     for sheet_id, title, kind, question, alab, rlab in SHEETS:
-        cards = []
-        for it in items:
+        items = []
+        for it in items_raw:
             panels = [("German source (PWG 5-layer)", "<pre>%s</pre>" % esc(it["de"]))]
             if kind == "pairwise":
                 b = base.get(it["id"], {}).get("ru_baseline", "(baseline missing — run baseline)")
@@ -367,30 +356,25 @@ def cmd_sheets():
                 panels.append(("Candidate B", "<pre>%s</pre>" % esc(cb)))
             else:
                 panels.append(("Russian translation (promoted store)", "<pre>%s</pre>" % esc(it["ru"])))
-            card = {
+            items.append({
                 "id": it["id"], "filt": it["stratum"],
                 "title": "%s · %s" % (it["subcard"], it.get("sense_tag") or ""),
                 "badges": [it["stratum"], it.get("layer") or ""],
                 "question": esc(question) + _rubric_panel(kind, it, blinding),
                 "panels": panels,
                 "note_placeholder": "free-text note (H178 rubric line is auto-managed)",
-            }
-            cards.append(mod.render_card(card, alab, rlab))
-        filters = ('<button data-filter="all" class="active">all</button>'
-                   '<button data-filter="unvoted">unvoted</button>'
-                   '<button data-filter="flagged">flagged</button>'
-                   '<button data-filter="random">random</button>')
-        html_out = mod.TEMPLATE % {
-            "title": title, "n": len(items), "generated": GENERATED,
-            "sheet_id": sheet_id, "subtitle":
-                "H178 B-1 bake-off — one human channel (MG); DeepSeek is the model channel; "
-                "agreement is reported human×model, never human×human.",
-            "filters": filters, "cards": "\n".join(cards),
+            })
+        config = {
+            "sheet_id": sheet_id, "title": title, "generated": GENERATED,
+            "subtitle": "H178 B-1 bake-off — one human channel (MG); DeepSeek is the model channel; "
+                        "agreement is reported human×model, never human×human.",
             "footer": "Sheet %s of 4 — all four rubrics run on the SAME 30 glosses. " % sheet_id,
             "approve_label": alab, "reject_label": rlab,
-            "sheet_id_json": json.dumps(sheet_id), "ids_json": json.dumps([it["id"] for it in items]),
-            "generated_json": json.dumps(GENERATED),
+            # reproduces the original all/unvoted/flagged/random filter set; render_review_sheet
+            # always prepends "all" and appends "unvoted only" itself.
+            "filters": [("flagged", "flagged"), ("random", "random")],
         }
+        html_out = render_review_sheet(items, config, extras=True)
         html_out = html_out.replace("</body>", RUBRIC_JS % {"sheet_id_json": json.dumps(sheet_id)} + "</body>")
         out = os.path.join(REVIEW, sheet_id + "_sheet.html")
         io.open(out, "w", encoding="utf-8").write(html_out)


### PR DESCRIPTION
## Summary
- `h178_eval_bakeoff.py`'s `cmd_sheets()` now calls the shared `csl_pyutil.render_review_sheet()` emitter (H925/H931) instead of dynamically loading `build_h180_review_sheets.py`'s raw `TEMPLATE`/`render_card`. `extras=True` chosen deliberately — h178 sheets never had the H779 auto-save/legend additions, so this is a genuine upgrade.
- `build_p2_sheet.py` is documented, not refactored — 49,019 candidate rows (Tier C 5,353 + Tier D 43,666) rules out `render_review_sheet()`'s full-DOM server-side render; its windowed scroll renderer is the right shape at this scale.

## Verification
Browser-verified the h178 refactor end to end (http.server + Chrome pane, real sample data): all 4 sheets (mqm/likert/da/pairwise) render 30 cards each, zero console errors, vote+rubric+download flow produces the same `{sheet_id, generated, decided, items}` decisions.json contract as before.

**Found (not fixed, out of scope, flagged separately):** a pre-existing bug in `h178_eval_bakeoff.py`'s RUBRIC_JS (unchanged by this refactor, confirmed present in the byte-identical donor template too via csl-pyutil's own fixture test) — a second vote-button click after adjusting a rubric field can silently drop that item's rubric note from the exported decisions.json, because the core template's in-memory `state` and RUBRIC_JS's direct localStorage writes can race. No real H178 votes exist yet, so no data lost.

## Test plan
- [x] `python -m py_compile` both files
- [x] `h178_eval_bakeoff.py selftest` passes
- [x] `h178_eval_bakeoff.py sheets` generates all 4 sheets from real sample data
- [x] Browser-verified vote/rubric/download flow, zero console errors

Sonnet 5 (`claude-sonnet-5`). Part of [H931](https://github.com/gasyoun/Uprava/blob/main/handoffs/H931-Sonnet_SanskritLexicography_csl-pyutil-remaining-consumers-registration_14.07.26.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)