### PR TITLE
H920: deterministic SAN-LOSS sense-count guard for the no_pwg lane (offline)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -28,6 +28,17 @@ Two live tracks:
 
 - **RussianTranslation H818 (12-07-2026, Codex/GPT-5):** canonical manifest + headless adapter + four-profile coordinator-integrated dispatch are built; real translation is now blocked only by missing authenticated foreign-host profiles. Headless v1 deliberately refuses presplit/heal cards. See `RussianTranslation/PIPELINE_AUDIT_2026-07_H818.md` and the subsystem journal.
 
+- [x] **H920 no_pwg SAN-LOSS / `missing_senses` root-cause + deterministic guard — EXECUTED (14-07-2026, Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; OFFLINE).**
+      The H911 FAIL-branch #1 defect. Root cause = **(a) model omission**, silent because the no_pwg
+      portrait declares `senses:[]` and the only whole-card guard is `accept()`'s `<ls>`/`{#` token
+      match (blind to a dropped gloss-only sense — `darv_i~~h0_zz_pw` dropped source sense 1 "Löffel",
+      2/3, passed clean; harness computed `senses:3` and discarded it). SHARED lang-neutral guard: new
+      `sense_count.py`, portrait `source_senses` stamp + sense-completeness prompt rule, a `sense_loss`
+      gate (RU) + `MISSING-SENSE` HARD flag (EN), 4 `test_h920_*` pins, LANG_PARITY entry. Fixtures +
+      frozen evidence only, no live generation. Detail + report in the subsystem journal
+      [RussianTranslation/.ai_state.md](RussianTranslation/.ai_state.md) /
+      [pwg_ru/h911/H920_NO_PWG_SANLOSS_ROOTCAUSE_AND_GUARD_2026-07-14.md](RussianTranslation/pwg_ru/h911/H920_NO_PWG_SANLOSS_ROOTCAUSE_AND_GUARD_2026-07-14.md).
+
 - [x] **H779 okas/okya/guda/sphic Kochergina attestation verify — review sheet built (12-07-2026, Sonnet 5 `claude-sonnet-5`).**
       Re-verified the 2013 Nagari-list thread's 4 correction candidates against RV attestation
       (local VedaWeb accented corpus, `VisualDCS/non-derived/vedaweb/accented_text_scarlata_widmer_lubotsky.json`)

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -14,6 +14,22 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **H920 no_pwg SAN-LOSS / `missing_senses` root-cause + deterministic guard — 🔴 EXECUTED 14-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; owner-authorized override of the minted Sonnet 5; OFFLINE).**
+  Root-caused the H911 #1 defect to **(a) model omission**, silent because the no_pwg portrait declares
+  `senses:[]` (no expected count) and the only whole-card guard is `accept()`'s `<ls>`/`{#` token match —
+  blind to a dropped gloss-only sense (H818 fc1: `darv_i~~h0_zz_pw` dropped source sense 1 "Löffel", output
+  2/3, passed **clean**; the harness even computed `senses:3` and discarded it). (b) self-heal collapse and
+  (c) split/merge drop always flag `partial`, so neither is the silent vector. Fix (SHARED, lang-neutral):
+  new [`sense_count.py`](src/pilot/sense_count.py) primitive; per-subcard `source_senses` stamped into the
+  no_pwg portrait + a ≥2-sense **sense-completeness prompt rule** ([`_pilot_gen_merged.py`](src/_pilot_gen_merged.py));
+  a `sense_loss` gate in [`audit_window.py`](src/pilot/audit_window.py) (→ requeue **defect**) + a
+  `MISSING-SENSE` **HARD** flag in [`audit_window_en.py`](src/pilot/audit_window_en.py); 4 `test_h920_*`
+  pins; LANG_PARITY entry `sense_count_sanloss_guard_h920` (SHARED). Validated on fixtures + frozen evidence
+  only — **no live generation**. Deliverable:
+  [root-cause report](pwg_ru/h911/H920_NO_PWG_SANLOSS_ROOTCAUSE_AND_GUARD_2026-07-14.md).
+  **Residual (gated live validation, future):** consume `INPUT[k].senses` in the harness `accept()` so a
+  SAN-LOSS card is rejected at generation (needs a live run; still gated by H911/H909).
+
 - **H911 LOCAL-READINESS quality/economy gate — verdict `FAIL`, 14-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, owner-authorized executor-override of minted Fable 5; offline gate).**
   Reconciled all recoverable H818 acceptance-canary + H255 no_pwg evidence into a denominator-honest
   [census](pwg_ru/h911/h911_quality_economy_census.json); ran a two-phase **blind** review of 40 frozen
@@ -28,10 +44,8 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   [FINDINGS §84](../FINDINGS.md)). **Foreign generation, four-account scale, H841–H843 stay blocked.**
   Deliverables: [report](pwg_ru/h911/H911_LOCAL_READINESS_QUALITY_ECONOMY_GATE_2026-07-14.md) + census +
   [blind-review results](pwg_ru/h911/h911_blind_review_results.json), [PR #460](https://github.com/gasyoun/SanskritLexicography/pull/460), [issue #459](https://github.com/gasyoun/SanskritLexicography/issues/459).
-  **Next (FAIL branch, agent-ready, Sonnet 5, OFFLINE):**
-  ```
-  Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H920-Sonnet_SanskritLexicography_pwg-ru-no-pwg-san-loss-missing-senses-offline-fix_14.07.26.md and execute it.
-  ```
+  **Next (FAIL branch): 🔴 EXECUTED 14-07-2026 (H920)** — SAN-LOSS/`missing_senses` root-caused +
+  guarded offline; see the H920 item at the top of this queue.
 
 - **H818 Windows acceptance — H895 run1 executed → SECOND consecutive measured-probe NO-GO; latency-policy investigation OPENED, 13-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`).**
   Seven defects **D-E…D-K** fixed + merged (PRs #438/#441/#444/#445/#446), offline gates 17/17;

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,24 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+- **SAN-LOSS (whole-dropped-sense) guard — the H911 FAIL-branch #1 defect (H920, offline).**
+  Root-caused `missing_senses`/SAN-LOSS in the no_pwg / supplement lane to **model omission**, made
+  silent by three compounding facts: the no_pwg portrait declares `senses:[]` (no expected count), the
+  only whole-card guard is `accept()`'s `<ls>`/`{#` token match (blind to a dropped citation-free
+  sense), and `partial`/`missing_senses` are only set in the fragment-heal / autosplit lanes. Live
+  evidence: `darv_i~~h0_zz_pw` dropped source sense 1 ("Löffel"), output 2/3, passed **clean** — the
+  harness even computed `senses:3` and discarded it. Fix (SHARED, language-neutral): a new
+  [`sense_count.py`](src/pilot/sense_count.py) primitive (`count_source_senses` counts top-level
+  `N〉`/`N)` ordinals, `scan_sense_shortfall` compares to the output); `gen_no_pwg_card` stamps each
+  sub-card's `source_senses` into its portrait and prepends a **sense-completeness rule** to
+  ≥2-sense sources; a `sense_loss` gate in `audit_window.py` (→ requeue defect) and a `MISSING-SENSE`
+  HARD flag in `audit_window_en.py`. Conservative — a null card or a pre-H920 portrait is skipped
+  (never a false positive). Pinned by 4 `test_h920_*` selftests; LANG_PARITY entry
+  `sense_count_sanloss_guard_h920` (SHARED). No live generation — validated on fixtures + frozen
+  evidence; consuming `INPUT[k].senses` in the harness `accept()` is the deferred, live-gated deepest
+  fix. Root cause + guard:
+  [pwg_ru/h911/H920_NO_PWG_SANLOSS_ROOTCAUSE_AND_GUARD_2026-07-14.md](pwg_ru/h911/H920_NO_PWG_SANLOSS_ROOTCAUSE_AND_GUARD_2026-07-14.md).
+
 ## [1.9.9] - 2026-07-14
 
 - **No-PWG promotion command safety.** `no_pwg_scale_plan.py` now emits a directly

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,6 +1,6 @@
 # LANG_PARITY.md — cross-language fix/feature parity ledger
 
-_Created: 04-07-2026 · Last updated: 13-07-2026 (D-K re-verify)_
+_Created: 04-07-2026 · Last updated: 14-07-2026 (H920 SAN-LOSS sense-count guard)_
 
 This repo runs the same PWG→Russian and PWG→English translation pipeline through
 shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -280,8 +280,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
       "src/pilot/prompt_rule_audit.py": "d2c578eb62a1919c5c22c0726940df952dee7ead0791bf61d1a1bc7c83f26fdf",
-      "src/pilot/audit_window.py": "1790c31d101d4247bcf3a6bcb29eb979be32bcf15649527f8ce3de8cfb9db597",
-      "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a"
+      "src/pilot/audit_window.py": "a71003a7a266506f3a012257ab5717b572b3397d172309801509d9451e554d86",
+      "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48"
     }
   },
   {
@@ -299,7 +299,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The denylist append and load_frag_tm filtering are lang-agnostic (fsha encodes lang; requeue_from_audit takes --lang), but the fshas EMITTER lives only in the RU auditor: audit_window_en.py reimplements its gates and does not compute requeue_defect_fshas or write the file, so an EN defect requeue does not auto-denylist its fragments.",
     "tracking": "Uprava/handoffs/archive/H304-Fable_RussianTranslation_coordinator-driver-remake_07.07.26.md (EN-emitter port is the recorded follow-up)",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "1790c31d101d4247bcf3a6bcb29eb979be32bcf15649527f8ce3de8cfb9db597",
+      "src/pilot/audit_window.py": "a71003a7a266506f3a012257ab5717b572b3397d172309801509d9451e554d86",
       "src/pilot/window_reports.py": "e1870c131b1a7138d75a14118ce4178b8075c968426a447ba62251ad28ca7708",
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878"
     }
@@ -356,7 +356,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -374,8 +374,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H169 (2026-07-04 review, 'broken validators'): the advertised HARD DUP gate was never emitted -- the only within-record duplicate signal was soft SAME-GLOSS, gated on >=3 content words, so a short duplicate ('to go'/'to go') produced zero flags and --strict passed. Classified GAP-being-closed rather than INTENTIONAL-DIVERGENCE: RU's within-record duplicate protection is the cross-part audit_sense_dupes.py gate (already SHARED, see gate_fixes_20260703_ru_only/PR #135) plus the soft, all-senses-only identical_russian_glosses risk in prompt_rule_audit.py (MEDIUM, not high-confidence) -- neither is a pairwise HARD gate. EN now closes that with a real HARD pairwise DUP check; RU getting an equivalent pairwise HARD gate (rather than its current all-or-nothing soft signal) is left as a natural follow-up, not blocking this fix. Pinned by test_en_gate_dup_has_teeth in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -413,7 +413,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -472,7 +472,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -501,9 +501,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/preflight_remaining_gates.py": "00386c837b97986c9702abfceed9c29534736c3df3063af202ddfaae6b078b8f",
       "src/release_readiness.py": "db38a870bbc8b5dbe694e706e4a7b9089ba41211a3881ad9a1bd4eb02950c8a9",
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
-      "src/pilot/audit_window.py": "1790c31d101d4247bcf3a6bcb29eb979be32bcf15649527f8ce3de8cfb9db597",
+      "src/pilot/audit_window.py": "a71003a7a266506f3a012257ab5717b572b3397d172309801509d9451e554d86",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -522,7 +522,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -540,7 +540,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "95797986db7c21210a55c8a13f324514d17110ba07d2f804d000a77a003d5bf3",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -559,7 +559,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -599,7 +599,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -620,11 +620,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H336 (08-07-2026). window_reports.write_reports/write_window_status already took an out_dir parameter (pre-existing --out-dir escape hatch); --window-tag is a thin, lang-agnostic sugar layer over that same parameter computed once in audit_window.py and threaded through unchanged to requeue_from_audit.py/root_window_status.py. Neither RU nor EN branch differently. Pinned by test_audit_window_tag_routing.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "1790c31d101d4247bcf3a6bcb29eb979be32bcf15649527f8ce3de8cfb9db597",
+      "src/pilot/audit_window.py": "a71003a7a266506f3a012257ab5717b572b3397d172309801509d9451e554d86",
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "e1870c131b1a7138d75a14118ce4178b8075c968426a447ba62251ad28ca7708",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -653,7 +653,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -673,7 +673,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -692,7 +692,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "3fc844fe372b7511528aefeefbc90dcd83653b9cc09e85fed837fd599eac15f8",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -729,7 +729,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -748,7 +748,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/stage2_pregate.py": "f801740067f981f66e480330a586e12d9e98f85f7f564e40520d7ff43af139e2",
-      "src/pilot/audit_window.py": "1790c31d101d4247bcf3a6bcb29eb979be32bcf15649527f8ce3de8cfb9db597"
+      "src/pilot/audit_window.py": "a71003a7a266506f3a012257ab5717b572b3397d172309801509d9451e554d86"
     }
   },
   {
@@ -766,7 +766,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H405 (09-07-2026, resolved same day). Both editions now run the same pregate() module for the mechanical invariants; the difference is only the adapter (RU: subprocess --wf over file pairs; EN: in-process per-sense), not the logic. The partial-adoption (net-new flag types only) is deliberate — the EN auditor already reimplemented LS/SAN/AB/MISSING per-sense with its own thresholds, so pregate contributes exactly the invariants it lacked (<is>, stranded/leaked anchors) rather than duplicating. Verified by a functional test (clean / is-dropped→IS-LOSS / stranded→STRANDED-ANCHOR / ls-dropped→single LS-LOSS not double-flagged) + window_selftest.py green.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "9b5dbe7c70da82330b21a5b58c2c84cee9bf4bc1130662a3a7a1ff8400a2730a",
+      "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
       "src/stage2_pregate.py": "f801740067f981f66e480330a586e12d9e98f85f7f564e40520d7ff43af139e2"
     }
   },
@@ -787,7 +787,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -806,7 +806,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -825,7 +825,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -845,7 +845,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37",
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -867,7 +867,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -926,7 +926,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -986,7 +986,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
       "src/pilot/window_reports.py": "e1870c131b1a7138d75a14118ce4178b8075c968426a447ba62251ad28ca7708",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   },
   {
@@ -1005,7 +1005,32 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "89bc36e49e90a1b20e8a19798fb40bfcb0b0a17f49f34987e872fef29528bd37"
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+    }
+  },
+  {
+    "id": "sense_count_sanloss_guard_h920",
+    "mechanism": "Deterministic SAN-LOSS (whole-dropped-sense) guard: sense_count.py counts a supplement source's top-level senses (N〉 close-glyph / line-anchored N) markers); gen_no_pwg_card stamps that count as portrait.source_senses and prepends a sense-completeness rule to >=2-sense no_pwg sub-cards; both auditors flag a card whose OUTPUT sense count is short of the portrait count (audit_window.py 'sense_loss' gate -> requeue defect; audit_window_en.py 'MISSING-SENSE' HARD flag)",
+    "files": [
+      "src/pilot/sense_count.py",
+      "src/_pilot_gen_merged.py",
+      "src/pilot/audit_window.py",
+      "src/pilot/audit_window_en.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H920 (14-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes the no_pwg/supplement SAN-LOSS gap the H911 gate surfaced (darv_i~~h0_zz_pw dropped source sense 1 'Löffel', output 2/3, and the harness accept() <ls>/{# token match passed it clean because the dropped gloss-only sense carried neither a citation nor a masked Sanskrit span). Every part is language-neutral: sense_count.py counts SENSE OBJECTS and source 〉/N) markers (never gloss language); the portrait source_senses stamp + the sense-completeness prompt rule live in _pilot_gen_merged no_pwg generation, which is pre-lang (the source is German for RU and EN alike); the audit guard is the SAME sense_count.scan_sense_shortfall/sense_shortfall wired into BOTH audit_window.py (RU 'sense_loss' gate -> requeue defect) and audit_window_en.py (EN 'MISSING-SENSE' HARD flag) — one shared primitive, no RU/EN reimplementation. Conservative: a portrait without source_senses (pre-H920) or a null card is skipped, never a false positive. Pinned by test_h920_sense_count_top_level_ordinals, test_h920_sense_shortfall_gate_flags_dropped_sense, test_h920_no_pwg_portrait_stamps_source_senses, test_h920_en_missing_sense_hard_flag.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/sense_count.py": "c7221e41bc57845064a21bb3f0b298d6c3da5b4e78063d859f9d0bd86a49688d",
+      "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
+      "src/pilot/audit_window.py": "a71003a7a266506f3a012257ab5717b572b3397d172309801509d9451e554d86",
+      "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
+      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
     }
   }
 ]

--- a/RussianTranslation/pwg_ru/h911/H920_NO_PWG_SANLOSS_ROOTCAUSE_AND_GUARD_2026-07-14.md
+++ b/RussianTranslation/pwg_ru/h911/H920_NO_PWG_SANLOSS_ROOTCAUSE_AND_GUARD_2026-07-14.md
@@ -1,0 +1,136 @@
+# H920 — no_pwg SAN-LOSS / missing_senses: root cause + deterministic guard
+
+_Created: 14-07-2026 · Last updated: 14-07-2026_
+
+**Executor:** Opus 4.8 (`claude-opus-4-8[1m]`) in Ultracode mode, under the owner-authorized
+higher-tier override recorded in the [H920 handoff](https://github.com/gasyoun/Uprava/blob/main/handoffs/H920-Sonnet_SanskritLexicography_pwg-ru-no-pwg-san-loss-missing-senses-offline-fix_14.07.26.md).
+**Offline only** — no translation generation, probe, account login, or store/TM mutation was
+performed. Root-cause is drawn from committed H911 evidence plus the immutable H818 fc1 and
+`no_pwg_w05_rq1` snapshots; the guard is validated on deterministic fixtures.
+
+Fixes the #1 systemic defect the [H911 LOCAL-READINESS gate](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h911/H911_LOCAL_READINESS_QUALITY_ECONOMY_GATE_2026-07-14.md)
+issued **FAIL** on: `missing_senses` (= SAN-LOSS, whole-dropped senses).
+
+## 1. What the label `missing_senses` actually covered — two different classes
+
+The H911 report grouped six keys under `missing_senses`. The frozen evidence shows they are
+**two mechanistically distinct classes**, and only one is a genuine model sense-omission:
+
+| Class | Keys | Mechanism | Already caught? |
+|---|---|---|---|
+| **infra-null** | `_u_das~~h0_zz_pw` (`kill-timeout 84s`), `_sibi`/`a_sud_da`/`aklizwa~~h0_zz_pw` (`selfheal-nothing-resolved`) | the card **never generated** — a null result with no `records`; `prompt_rule_audit.semantic_risks` fires `missing_senses` only because "no translated senses found" | **yes** — null cards, requeued transient; the semantic `missing_senses` risk fires on the zero-sense proxy |
+| **genuine SAN-LOSS (a)** | `darv_i~~h0_zz_pw` (H818 fc1: SAN-LOSS(2/3)), `gaRanA` | the card **did** generate but the model **omitted a whole numbered sense** from a multi-sense source | **no** — silent; caught only by an operator eyeballing the fc1 canary |
+
+The `no_pwg_w05_rq1` window's four `missing_senses` keys are ALL infra-null (kill-timeout /
+selfheal-nothing-resolved). The genuine, silent SAN-LOSS class is the darvI shape.
+
+## 2. Root cause — which of (a)/(b)/(c) dominates
+
+Per the handoff's decomposition:
+
+- **(a) the model omits a sense from a multi-sense portrait — DOMINATES the silent loss.**
+- **(b) self-heal collapses a card to fewer senses — NOT a silent vector.** `selfHeal` skips any
+  fragment that never resolves, but records every reduction as `missing_fragments`/`missing_groups`
+  and sets `partial:true` (gen_opt_harness2.py). Heal-path drops are always flagged.
+- **(c) presplit / merge / stitch drops a fragment — NOT a silent vector.** `autosplit_requeue`
+  merge/topup leaves any unresolved `sense_ord` out and records it in `missing_si`/`missing_frags`.
+  Split-path drops are always flagged.
+
+### Why (a) is silent — the structural gap (primary evidence, H818 fc1)
+
+darvI's masked source skeleton, verbatim from the run harness:
+
+```
+=== LAYER: PW — Böhtlingk kürzere Fassung ===
+{T1} und {T2}¦ {T3}
+{T6}— 1〉 {%Löffel%}.
+{T7}— 2〉 {%die Haube einer Schlange%}.
+{T8}— 3〉 {T4} {T5} eines Landes.
+```
+
+The per-key inputs recorded `"ls": 0, "sk": 3, "senses": 3`. The output card had **2** senses,
+tagged **2** and **3** — sense **1 ("Löffel/spoon") was dropped entirely** (the model kept the
+source ordinals, it did not renumber). The `fc1_result` operator event: `SAN-LOSS(2/3): model
+dropped sense 1 (Loeffel/spoon)`, invocation **"clean (job done)"**.
+
+Three compounding facts make this loss invisible to every deterministic guard:
+
+1. **The no_pwg portrait declares no expected sense count.** `gen_no_pwg_card` writes
+   `senses: []` deliberately (no fabricated PWG sense-tree), so nothing on the input side told
+   any consumer that darvI has 3 senses.
+2. **The only whole-card completeness guard is `accept()`'s `<ls>`/`{#` token-count match.**
+   The dropped "Löffel" sense carried a gloss (`{%Löffel%}`) but **no citation and no masked
+   Sanskrit span**, so dropping it left `ls 0==0` and `sk 3==3` unchanged — `accept()` passed the
+   card clean. This is exactly the shape of a citation-free PW/SCH/NWS supplement gloss.
+3. **`partial`/`missing_senses`/`total_senses` are only ever set in the fragment-heal and
+   autosplit lanes** — a no_pwg sub-card translated *whole* (not presplit, not healed) never
+   enters them, so those markers are never even computed for it.
+
+The harness had already computed the answer — `inputs[k]['senses'] == 3` (`raw.count('〉')`) — but
+**that value has no consumer anywhere in the JS**; it was discarded. The audit's semantic
+`missing_senses` risk only fires on a **zero**-sense card, so a 2-of-3 partial drop is invisible to
+it. Result: darvI was promotion-eligible with sense 1 silently gone.
+
+## 3. The fix (deterministic, offline, language-neutral)
+
+A single shared primitive, [`src/pilot/sense_count.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/sense_count.py):
+`count_source_senses()` (distinct top-level `N〉` / line-anchored `N)` ordinals — high-precision,
+the `〉` close-glyph never appears in a citation), `output_sense_count()`, `sense_shortfall()`,
+`portrait_source_senses()`, `scan_sense_shortfall()`. Calibrated on the real evidence: darvI → 3,
+aklizwa keyed supplement → 1, unnumbered adjective → 0, citation numbers → 0.
+
+Wired at three points, all pre-lang or language-agnostic (verdict **SHARED** in
+[LANG_PARITY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md),
+entry `sense_count_sanloss_guard_h920`):
+
+1. **Enrich the no_pwg portrait** ([`_pilot_gen_merged.gen_no_pwg_card`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/_pilot_gen_merged.py)):
+   stamp each sub-card's deterministic `source_senses` count into its portrait sidecar — closing
+   the "empty portrait, no expected count" gap.
+2. **Generation-prompt rule** (root-cause-(a) mitigation, since (a) dominates): a source with
+   ≥2 numbered senses now carries an explicit **sense-completeness rule** telling the model to
+   render every numbered sense and never drop one — including a short gloss-only sense.
+3. **The audit guard, before promotion**, in BOTH auditors via the shared primitive:
+   [`audit_window.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window.py)
+   gains a `sense_loss` gate (portrait `source_senses` vs output count → requeue as a content
+   **defect**); [`audit_window_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window_en.py)
+   gains a `MISSING-SENSE` **HARD** flag (distinct from its existing per-sense `SAN-LOSS`
+   gloss-token flag).
+
+**Conservative by construction:** a portrait without `source_senses` (pre-H920) or a null card is
+skipped — never a false positive. The counter counts only explicitly-numbered top-level senses, a
+lower bound, so a faithfully-merged card is never mis-flagged (e.g. `aklizwa~~h0_zz_pwkvn`, source
+1 keyed sense, output 2 → clean).
+
+## 4. Verification (fixtures only — no live generation)
+
+New selftests in [`window_selftest.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_selftest.py),
+all green in the aggregate suite (`window selftest OK`):
+
+- `test_h920_sense_count_top_level_ordinals` — the counter on the darvI/aklizwa/a_sakta/citation/
+  line-anchored shapes.
+- `test_h920_sense_shortfall_gate_flags_dropped_sense` — the RU gate flags darvI 2/3, passes a
+  complete card, skips nulls + pre-H920 portraits, respects protected keys.
+- `test_h920_no_pwg_portrait_stamps_source_senses` — the portrait carries `source_senses` matching
+  `count_source_senses(raw)`, still fabricates no sense tree, and the completeness rule fires only
+  for ≥2-sense sources without inflating the count.
+- `test_h920_en_missing_sense_hard_flag` — the EN auditor emits a HARD `MISSING-SENSE` on a 2/3
+  card, none on a complete card.
+
+`lang_parity_check.py` clean (48 entries, no drift): every entry whose tracked file this change
+touched was re-affirmed, and the new SHARED entry added.
+
+## 5. Out of scope (separate handoffs — not minted here)
+
+- **Deepest fix — consume `INPUT[k].senses` in the harness `accept()`** so a SAN-LOSS card is
+  rejected at generation and routed to selfheal/requeue rather than caught downstream. This is a
+  JS-harness change that can only be validated by a live run, so it is deferred to the
+  separately-approved, bounded acceptance run (still gated by H911/H909).
+- **NWS-entry-count guard.** `count_source_senses` targets the `〉`/`N)` numbered-sense format
+  (the darvI class); NWS owner-map entries use an `N.` format and are governed by their existing
+  "emit EXACTLY one card row per numbered entry" directive, not by this count.
+- The **infra class** (`kill-timeout` / `selfheal-nothing-resolved`) and
+  `untranslated_braced_german_gloss` remain H911 backlog items.
+
+_Auto-generated by Opus 4.8 (`claude-opus-4-8[1m]`) as the H920 executor._
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/pwg_ru/h911/H920_NO_PWG_SANLOSS_ROOTCAUSE_AND_GUARD_2026-07-14.meta.md
+++ b/RussianTranslation/pwg_ru/h911/H920_NO_PWG_SANLOSS_ROOTCAUSE_AND_GUARD_2026-07-14.meta.md
@@ -1,0 +1,30 @@
+# Metadoc — H920_NO_PWG_SANLOSS_ROOTCAUSE_AND_GUARD_2026-07-14.md
+
+_Created: 14-07-2026 · Last updated: 14-07-2026_
+
+- **Purpose.** Root-cause writeup + delivered-guard record for the no_pwg SAN-LOSS /
+  `missing_senses` defect that made the [H911 gate](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h911/H911_LOCAL_READINESS_QUALITY_ECONOMY_GATE_2026-07-14.md)
+  FAIL. Read before touching the sense-count guard or reasoning about whole-dropped senses.
+- **Audience.** A future session extending/validating the SAN-LOSS guard, or running the gated
+  live acceptance that would exercise it end-to-end.
+- **Provenance.** Handoff [H920](https://github.com/gasyoun/Uprava/blob/main/handoffs/H920-Sonnet_SanskritLexicography_pwg-ru-no-pwg-san-loss-missing-senses-offline-fix_14.07.26.md);
+  executor Opus 4.8 (`claude-opus-4-8[1m]`), Ultracode, owner-authorized higher-tier override of the
+  minted Sonnet 5 tier. Offline only.
+- **Evidence base.** H911 committed evidence; the immutable H818 fc1 snapshot
+  (`darv_i~~h0_zz_pw` skeleton + output + `run_pilot_wf.h818_fc_w01.js` inputs, showing
+  `senses:3` computed and discarded); the frozen `no_pwg_w05_rq1` audit report.
+- **Key claims a reader relies on.** (1) The genuine silent SAN-LOSS class is (a) model omission,
+  not (b) self-heal collapse or (c) split/merge drop — those flag `partial`. (2) `accept()` is only
+  an `<ls>`/`{#` token match, blind to a dropped citation-free sense. (3) The no_pwg portrait's
+  `senses:[]` left no expected count to compare against. All three are backed by quoted evidence.
+- **Delivered artifacts.** `src/pilot/sense_count.py` (new shared primitive); portrait
+  `source_senses` stamp + sense-completeness prompt rule in `_pilot_gen_merged.py`; `sense_loss`
+  gate in `audit_window.py`; `MISSING-SENSE` HARD flag in `audit_window_en.py`; 4 `test_h920_*`
+  pins in `window_selftest.py`; LANG_PARITY entry `sense_count_sanloss_guard_h920` (SHARED).
+- **Limitations / follow-ups.** The deepest fix — consuming `INPUT[k].senses` in the harness
+  `accept()` — needs a live run to validate and is deferred (gated by H911/H909). NWS-entry
+  (`N.` format) drops are not counted by this guard. The guard fires only for sources with an
+  explicit `〉`/`N)` numbered-sense count; a portrait predating the H920 stamp is skipped.
+- **Revision history.** 14-07-2026 — created with the report at handoff-close.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/_pilot_gen_merged.py
+++ b/RussianTranslation/src/_pilot_gen_merged.py
@@ -38,6 +38,9 @@ OUT = os.path.join(HERE, 'pilot', 'input')
 sys.path.insert(0, os.path.join(HERE, '..', 'research'))
 import root_segment_proto as RS                 # the lossless <div n="p"> root slicer
 
+sys.path.insert(0, os.path.join(HERE, 'pilot'))
+from sense_count import count_source_senses      # H920 deterministic source-sense counter
+
 # Only explode genuinely GIANT roots (the ones that kill a single-pass translation);
 # small records with 1-2 prefix divisions stay whole.
 MIN_SPLIT = int(os.environ.get('ROOT_SPLIT_MIN', '8'))
@@ -584,6 +587,31 @@ def gen_root_split(key, pwg_idx, verbose=True):
     return len(submap)
 
 
+# H920 SAN-LOSS mitigation (root-cause (a): the model omits a whole sense from a multi-
+# sense supplement source — measured on darv_i~~h0_zz_pw, which dropped sense 1 "Löffel").
+# A no-PWG supplement sub-card carries NO PWG sense-tree, so nothing told the translator how
+# many senses the source declares. When the source has >=2 numbered senses we prepend an
+# explicit enumeration rule so the model renders every one and never silently drops a gloss-
+# only sense (the exact loss the accept() <ls>/{# guard is blind to). Deterministic, offline,
+# language-neutral (the source is German either way). Keep it free of `〉`/leading-digit lines
+# so count_source_senses() over the finished blob still counts only the real source senses.
+_SENSE_RULE_MIN = 2
+
+
+def _with_sense_rule(body, n_senses):
+    """Prepend the H920 sense-completeness rule to a supplement sub-card blob when its
+    source declares >= _SENSE_RULE_MIN numbered senses; otherwise return it unchanged."""
+    if n_senses < _SENSE_RULE_MIN:
+        return body
+    rule = (
+        '=== SENSE-COMPLETENESS RULE (H920) ===\n\n'
+        'This source layer declares %d numbered senses. Render EXACTLY all %d: emit one '
+        'output sense per source sense, tag each with its source sense number, and never '
+        'drop, merge, or omit a numbered sense. Omitting a whole sense (even a short gloss-'
+        'only one with no citation) is a SAN-LOSS content defect.' % (n_senses, n_senses))
+    return '%s\n\n%s' % (rule, body)
+
+
 def no_pwg_parts(key):
     """H214 — the labeled sub-card parts for a PWG-MISSING headword, one per non-PWG layer.
 
@@ -606,9 +634,11 @@ def no_pwg_parts(key):
         groups = chunk_records(supp[code], HEAD_BUDGET)
         for i, grp in enumerate(groups):
             label = code if len(groups) == 1 else '%s%02d' % (code, i)
-            blob = '\n\n'.join('=== LAYER: %s ===\n\n%s' % (ROLE.get(code, code.upper()), r)
+            body = '\n\n'.join('=== LAYER: %s ===\n\n%s' % (ROLE.get(code, code.upper()), r)
                                for r in grp)
-            parts.append((label, blob))
+            # H920: enumerate the source senses for the translator (source counted on the raw
+            # records, before the rule/LAYER headers, so the count is the true source total).
+            parts.append((label, _with_sense_rule(body, count_source_senses('\n'.join(grp)))))
     if supp.get('nws'):
         blocks = ['=== LAYER: %s ===\n\n%s' % (ROLE['nws'], r) for r in supp['nws']]
         omap = nws_owner_map(key)                    # authoritative owner->gloss pairing (kills F12)
@@ -670,7 +700,12 @@ def gen_no_pwg_card(key, pwg_idx, verbose=True):
     for part, (label, blob) in enumerate(parts):
         sub = '%s~~h0_zz_%s' % (root, label)
         open(os.path.join(OUT, sub + '.raw.txt'), 'w', encoding='utf-8').write(blob)
-        json.dump(portrait, open(os.path.join(OUT, sub + '.portrait.json'), 'w', encoding='utf-8'),
+        # H920: stamp THIS sub-card's deterministic source-sense count into its portrait, so
+        # the audit SAN-LOSS guard has an expected count to compare the output against. The
+        # no-PWG portrait otherwise carries senses:[] and no count — the exact gap that let
+        # darv_i~~h0_zz_pw (3 source senses) promote with only 2 (sense 1 "Löffel" dropped).
+        sub_portrait = [dict(portrait[0], source_senses=count_source_senses(blob))]
+        json.dump(sub_portrait, open(os.path.join(OUT, sub + '.portrait.json'), 'w', encoding='utf-8'),
                   ensure_ascii=False, indent=1)
         submap.append({'subkey': sub, 'layer': dm.layer_of(sub), 'section': label})
     if verbose:

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -22,6 +22,7 @@ sys.stderr.reconfigure(encoding='utf-8')
 HERE = os.path.dirname(os.path.abspath(__file__))          # .../src/pilot
 SRC = os.path.dirname(HERE)                                # .../src
 OUT = os.path.join(HERE, 'output')
+INPUT_DIR = os.path.join(HERE, 'input')                    # .../src/pilot/input (portrait sidecars)
 
 sys.path.insert(0, SRC)
 import nws_split
@@ -33,6 +34,7 @@ from prompt_rule_audit import (
     audit_cards as audit_semantic_cards,
     build_report as build_prompt_rule_report,
 )
+from sense_count import scan_sense_shortfall             # H920 SAN-LOSS sense-count guard
 from workflow_payload import workflow_payload
 from window_provenance import stale_check
 from window_reports import (
@@ -236,6 +238,38 @@ def run_prompt_semantic_audit(wf, protected, review_limit=25):
     }
 
 
+def run_sense_shortfall_gate(results, input_dir, protected):
+    """H920 deterministic SAN-LOSS guard: flag any translated card whose OUTPUT sense count
+    falls short of its input portrait's declared source_senses.
+
+    Closes the no_pwg / supplement whole-card gap the H911 gate surfaced: the harness
+    accept() gate is only an <ls>/{# token-count match, so a dropped citation-free sense
+    (e.g. darv_i~~h0_zz_pw: 3 source senses -> output 2, sense 1 "Löffel" dropped, ls 0==0 &
+    sk 3==3) passes clean and is never flagged partial/missing_senses. This gate compares the
+    portrait's deterministic source-sense count (stamped by _pilot_gen_merged.gen_no_pwg_card)
+    to the output card's sense count and requeues the shortfall as a content defect BEFORE
+    promotion. In-process, no model/network. A card whose portrait predates the H920 stamp
+    (source_senses absent) is silently skipped — never a false positive."""
+    t0 = time.perf_counter()
+    short = [s for s in scan_sense_shortfall(results, input_dir) if s['key'] not in protected]
+    lines = ['=== 7. SAN-LOSS sense-count guard (portrait source_senses vs output) ===']
+    if short:
+        for s in short:
+            lines.append('  %-30s SAN-LOSS: output %d < source %d (dropped %d sense(s))'
+                         % (s['key'], s['actual'], s['expected'], s['dropped']))
+        lines.append('')
+        lines.append('  GATE: FAIL — %d card(s) dropped a whole source sense: %s'
+                     % (len(short), ' '.join(s['key'] for s in short)))
+    else:
+        lines.append('  GATE: PASS — no output card falls short of its source sense count')
+    return {'argv': ['in-process', 'sense_count.scan_sense_shortfall'],
+            'returncode': 1 if short else 0,
+            'stdout': '\n'.join(lines) + '\n', 'stderr': '',
+            'requeue': sorted(s['key'] for s in short),
+            'sense_shortfall': short,
+            'seconds': round(time.perf_counter() - t0, 3)}
+
+
 def emit_audit_event(event_type, level='info', root=None, state=None, summary='', data=None):
     append_event('audit_window', event_type, level=level, root=root,
                  state=state, summary=summary, data=data or {})
@@ -423,6 +457,7 @@ def main():
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
         futures[ex.submit(run_nws_gate, keys, protected)] = ('nws', None)
         futures[ex.submit(run_prompt_semantic_audit, wf, protected)] = ('prompt_semantic', None)
+        futures[ex.submit(run_sense_shortfall_gate, results, INPUT_DIR, protected)] = ('sense_loss', None)
         for name, cmd, parser in commands:
             futures[ex.submit(run_py, cmd)] = (name, parser)
         for fut in concurrent.futures.as_completed(futures):
@@ -441,7 +476,7 @@ def main():
                     res['requeue'] = parsed
             gates[name] = res
 
-    for name in ['nws', 'translation', 'stage2_mechanical', 'coverage', 'sense_dupes', 'prompt_semantic']:
+    for name in ['nws', 'translation', 'stage2_mechanical', 'coverage', 'sense_dupes', 'prompt_semantic', 'sense_loss']:
         res = gates[name]
         print('\n=== %s ===' % name)
         print(res['stdout'].rstrip())
@@ -553,6 +588,7 @@ def main():
          for fp in ((r.get('card') or {}).get('frag_prov') or []) if fp.get('fsha')})
     report['prompt_rules'] = gates.get('prompt_semantic', {}).get('prompt_rules')
     report['semantic_risks'] = gates.get('prompt_semantic', {}).get('card_risks')
+    report['sense_shortfall'] = gates.get('sense_loss', {}).get('sense_shortfall') or []
     report['judge_sample_rate'] = args.judge_sample_rate
     report['judge_sample_min'] = args.judge_sample_min
     report['judge_sample_seed'] = args.judge_sample_seed

--- a/RussianTranslation/src/pilot/audit_window_en.py
+++ b/RussianTranslation/src/pilot/audit_window_en.py
@@ -61,6 +61,7 @@ sys.stderr.reconfigure(encoding='utf-8')
 HERE = os.path.dirname(os.path.abspath(__file__))          # .../src/pilot
 SRC = os.path.dirname(HERE)                                # .../src
 OUT = os.path.join(HERE, 'output')
+INPUT_DIR = os.path.join(HERE, 'input')                    # portrait sidecars (H920 source_senses)
 DEFAULT_MW_TM = os.path.join(SRC, 'mw_en_tm.json')
 
 if HERE not in sys.path:
@@ -69,6 +70,7 @@ if SRC not in sys.path:
     sys.path.insert(0, SRC)
 from foreign_literal_guards import FRENCH_CONTEXT_WORDS, AMBIGUOUS_DE_FR_WORDS
 import stage2_pregate   # H405: the shared mechanical pre-gate (RU + EN)
+from sense_count import portrait_source_senses, output_sense_count, sense_shortfall  # H920
 
 # Flag TYPES the pre-gate contributes to the EN path that this auditor's own
 # per-sense checks above do NOT already produce. LS/SAN/AB/LEX/LANG loss stay owned
@@ -242,6 +244,15 @@ def audit_card(result, tm, do_mw):
                 mw_words = set(content_words(mw))
                 if mw_words and not (mw_words & card_en_words):
                     flags.append(('%s/r%d' % (key, ri), 'MW-DIVERGE'))
+    # H920 SAN-LOSS (whole-dropped-sense) guard — SHARED with the RU auditor's sense_loss
+    # gate via sense_count.py. The per-sense SAN-LOSS flag above measures gloss token-loss
+    # WITHIN a surviving sense; this catches a whole numbered sense dropped from a no_pwg /
+    # supplement source (portrait source_senses vs output card sense count). A card whose
+    # portrait predates the H920 stamp is silently skipped (never a false positive).
+    expected = portrait_source_senses(INPUT_DIR, key)
+    dropped = sense_shortfall(card, expected) if expected is not None else 0
+    if dropped > 0:
+        flags.append((key, 'MISSING-SENSE(out %d<src %d)' % (output_sense_count(card), expected)))
     return {'key': key, 'null': False, 'flags': flags}
 
 
@@ -280,8 +291,8 @@ def run_sense_dupes(mod, path):
     return {'returncode': rc, 'summary': line.strip()}
 
 
-HARD = ('MISSING-EN', 'LS-LOSS', 'SAN-LOSS', 'AB-LOSS', 'IS-LOSS', 'STRANDED-ANCHOR',
-        'ANCHOR-LEAK', 'ANCHOR-MISMATCH', 'SENSE-DUPE', 'DUP')
+HARD = ('MISSING-EN', 'MISSING-SENSE', 'LS-LOSS', 'SAN-LOSS', 'AB-LOSS', 'IS-LOSS',
+        'STRANDED-ANCHOR', 'ANCHOR-LEAK', 'ANCHOR-MISMATCH', 'SENSE-DUPE', 'DUP')
 
 
 def is_hard(flag):

--- a/RussianTranslation/src/pilot/sense_count.py
+++ b/RussianTranslation/src/pilot/sense_count.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+r"""Deterministic source-sense counting + the SAN-LOSS (whole-dropped-sense) guard (H920).
+
+The pipeline had NO deterministic guard comparing the number of senses the SOURCE
+declares to the number of senses the model actually emitted. The only whole-card
+completeness check is the harness `accept()` <ls>/{# token-count match
+(gen_opt_harness2.py), which is blind to a dropped sense that carries neither a
+citation nor a masked Sanskrit span — exactly the shape of a citation-free PW/SCH/
+NWS supplement gloss. Live evidence (H818 fc1): `darv_i~~h0_zz_pw` had a 3-sense
+PW source
+
+    — 1〉 {%Löffel%}.
+    — 2〉 {%die Haube einer Schlange%}.
+    — 3〉 {#darvI#} <ab>N. pr.</ab> eines Landes.
+
+the model dropped sense 1 ("Löffel/spoon"), emitted senses {2,3}, and accept()
+passed it clean (ls 0==0, sk 3==3 — the dropped gloss carried neither). The harness
+even computed `inputs[k]['senses'] = raw.count('〉') == 3` but never consumed it.
+
+This module is the deterministic, language-agnostic guard the no_pwg / supplement
+lane was missing. It is imported by BOTH audit paths (audit_window.py for RU,
+audit_window_en.py for EN) and by _pilot_gen_merged.py (to stamp `source_senses`
+into the no_pwg portrait at input-generation time). Pure — no model calls, no
+network, no side effects.
+"""
+import json
+import os
+import re
+
+# A top-level source sense is marked by the PWG/PW sense-close glyph `N〉` (a digit
+# immediately followed by the U+3009 RIGHT ANGLE BRACKET). That glyph is used ONLY
+# for sense boundaries in the csl-orig markup, never inside a citation, so `\d+〉`
+# is a high-precision top-level-sense signal. `_LINE_SENSE` additionally catches the
+# line-anchored `N)` / `— N)` form used by the deterministic splitter
+# (autosplit_requeue._SENSE) for the presplit lane; the two are unioned so a source
+# in either notation is counted. Sub-senses (lettered a)/b), or `Nc`) are deliberately
+# NOT counted — only distinct top-level ARABIC ordinals, so a card that merges the
+# lettered sub-senses of one numbered sense is never mis-flagged as a shortfall.
+_SENSE_CLOSE = re.compile(r'(\d+)\s*〉')
+_LINE_SENSE = re.compile(r'^\s*(?:<div[^>]*>)?\s*(?:—\s*|-\s*)?(\d+)\s*[\)〉]')
+
+
+def source_sense_ordinals(text):
+    """The set of distinct TOP-LEVEL arabic sense ordinals a raw/masked source blob
+    declares (via `N〉` close-glyphs or line-anchored `N)` markers). Empty when the
+    source carries no explicit top-level numbering (a single unnumbered supplement
+    sense) — the caller treats an empty/singleton set as "nothing to compare"."""
+    text = text or ''
+    ords = {int(m) for m in _SENSE_CLOSE.findall(text)}
+    for line in text.split('\n'):
+        m = _LINE_SENSE.match(line)
+        if m:
+            ords.add(int(m.group(1)))
+    return ords
+
+
+def count_source_senses(text):
+    """Number of distinct top-level source senses (see source_sense_ordinals).
+
+    Deterministic and conservative: counts only explicitly-numbered top-level senses,
+    so it is a LOWER BOUND on the senses the model must emit — never an over-count
+    that could spuriously flag a faithfully-merged card. Matches the harness's own
+    `raw.count('〉')` coarse count on the darvI evidence (both == 3)."""
+    return len(source_sense_ordinals(text))
+
+
+def output_sense_count(card):
+    """Number of senses actually present in a generated card (records[].senses[]).
+    Language-agnostic — counts sense objects, independent of ru/en gloss field."""
+    if not isinstance(card, dict):
+        return 0
+    return sum(len([s for s in (rec.get('senses') or []) if isinstance(s, dict)])
+               for rec in (card.get('records') or []))
+
+
+def sense_shortfall(card, expected):
+    """Positive count of senses dropped from `card` versus an `expected` source-sense
+    count, or 0 when there is no shortfall (or `expected` is unknown/<1). This is the
+    SAN-LOSS signal: expected > output means whole source senses were dropped."""
+    try:
+        expected = int(expected)
+    except (TypeError, ValueError):
+        return 0
+    if expected < 1:
+        return 0
+    actual = output_sense_count(card)
+    return expected - actual if actual < expected else 0
+
+
+def _portrait_paths(input_dir, key):
+    # gen writes the sidecar as `<subcard-key>.portrait.json` (the key is already
+    # safe-name encoded); try that first, then a defensive safe_name() re-encoding.
+    names = [key + '.portrait.json']
+    try:
+        from safe_filename import safe_name
+        alt = safe_name(key) + '.portrait.json'
+        if alt not in names:
+            names.append(alt)
+    except Exception:
+        pass
+    return [os.path.join(input_dir, n) for n in names]
+
+
+def portrait_source_senses(input_dir, key):
+    """Read the declared `source_senses` for a sub-card from its input portrait sidecar
+    (`<input_dir>/<key>.portrait.json`), or None when the sidecar is absent or predates
+    the H920 enrichment. None means "no expected count available" — the guard then makes
+    no claim (conservative: never a false shortfall)."""
+    if not input_dir:
+        return None
+    for path in _portrait_paths(input_dir, key):
+        if not os.path.exists(path):
+            continue
+        try:
+            with open(path, encoding='utf-8') as f:
+                port = json.load(f)
+        except (OSError, ValueError):
+            return None
+        for entry in (port if isinstance(port, list) else [port]):
+            if isinstance(entry, dict) and entry.get('source_senses') is not None:
+                return entry.get('source_senses')
+        return None
+    return None
+
+
+def scan_sense_shortfall(results, input_dir):
+    """Deterministic SAN-LOSS scan over a window's translated results.
+
+    For every result row that produced a card, compare the input portrait's declared
+    `source_senses` to the card's output sense count; a shortfall is a whole-dropped
+    sense the accept() <ls>/{# guard is blind to. Null cards (card is None) are left to
+    the existing null-requeue path. Returns a list of
+    {key, expected, actual, dropped} dicts, one per short card (empty when clean)."""
+    short = []
+    for row in results or []:
+        if not isinstance(row, dict):
+            continue
+        key = row.get('key')
+        card = row.get('card')
+        if not key or not isinstance(card, dict):
+            continue
+        expected = portrait_source_senses(input_dir, key)
+        if expected is None:
+            continue
+        dropped = sense_shortfall(card, expected)
+        if dropped > 0:
+            short.append({'key': key, 'expected': int(expected),
+                          'actual': output_sense_count(card), 'dropped': dropped})
+    return short
+
+
+def _selftest():
+    # darvI evidence: 3-sense PW source -> count 3.
+    darvi = ('=== LAYER: PW ===\n\n{T1} und {T2}¦ {T3}\n'
+             '{T6}— 1〉 {%Löffel%}.\n'
+             '{T7}— 2〉 {%die Haube einer Schlange%}.\n'
+             '{T8}— 3〉 {T4} {T5} eines Landes.')
+    assert count_source_senses(darvi) == 3, count_source_senses(darvi)
+    # aklizwa pwkvn: single `3〉` supplement sense -> 1 (keyed to PW sense 3, not senses 1-3).
+    akl = '{#aklizwa#}¦ 3〉 {%keine Pein verursachend%} <ls>KAP. 2,33</ls>.'
+    assert count_source_senses(akl) == 1, count_source_senses(akl)
+    # unnumbered adjective supplement -> 0 (nothing to compare).
+    asakta = '{#aSakta#}¦ <lex>Adj.</lex> {%nicht könnend%} <ls n="Chr.">94,27</ls>.'
+    assert count_source_senses(asakta) == 0, count_source_senses(asakta)
+    # citation numbers must NOT be counted as senses (no bare `〉`).
+    assert count_source_senses('<ls>MBH. 5,163,4</ls>. 2,33 1,5') == 0
+    # line-anchored N) form (split_plan notation).
+    assert count_source_senses('1) a\n2) b\n3) c') == 3
+    # shortfall math: darvI-shaped card (2 of 3 senses).
+    card2 = {'records': [{'senses': [{'tag': '2'}, {'tag': '3'}]}]}
+    assert sense_shortfall(card2, 3) == 1
+    assert sense_shortfall(card2, 2) == 0
+    assert sense_shortfall(card2, None) == 0
+    assert output_sense_count(card2) == 2
+    print('sense_count selftest OK')
+
+
+if __name__ == '__main__':
+    import sys
+    sys.stdout.reconfigure(encoding='utf-8')
+    _selftest()

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -44,6 +44,12 @@ from prompt_rule_audit import (
 )
 from fix_german_connectives import fix_text as fix_german_text
 import audit_coverage
+from sense_count import (                                    # H920 SAN-LOSS guard
+    count_source_senses,
+    output_sense_count,
+    scan_sense_shortfall,
+    sense_shortfall,
+)
 
 
 def fail(message):
@@ -479,6 +485,149 @@ def test_no_pwg_supplement_card_renders_without_pwg():
                     fail('%s sub-card id must encode layer %s' % (key, want_layer))
         finally:
             pg.OUT = old_out
+
+
+def test_h920_sense_count_top_level_ordinals():
+    """H920: count_source_senses counts DISTINCT top-level source senses (N〉 close-glyph and
+    line-anchored N) markers), never citation numbers or lettered sub-senses. Calibrated on
+    the real darvI (3-sense PW source), aklizwa (single keyed supplement sense), and a_sakta
+    (unnumbered adjective) evidence."""
+    darvi = ('=== LAYER: PW ===\n\n{T1} und {T2}¦ {T3}\n'
+             '{T6}— 1〉 {%Löffel%}.\n{T7}— 2〉 {%die Haube einer Schlange%}.\n'
+             '{T8}— 3〉 {T4} {T5} eines Landes.')
+    cases = [
+        (darvi, 3),                                             # darvI: 3 top-level senses
+        ('{#aklizwa#}¦ 3〉 {%keine Pein verursachend%} <ls>KAP. 2,33</ls>.', 1),  # single keyed sense
+        ('{#aSakta#}¦ <lex>Adj.</lex> {%nicht könnend%} <ls n="Chr.">94,27</ls>.', 0),  # unnumbered
+        ('<ls>MBH. 5,163,4</ls>. 2,33 1,5', 0),                # citation numbers are NOT senses
+        ('1) a\n2) b\n3) c', 3),                               # line-anchored N) form
+        ('— 2〉 x\n— 2〉 x (batch repeat)', 1),                  # a repeated ordinal counts once
+    ]
+    for text, want in cases:
+        got = count_source_senses(text)
+        if got != want:
+            fail('count_source_senses(%r) = %d, expected %d' % (text[:40], got, want))
+
+
+def test_h920_sense_shortfall_gate_flags_dropped_sense():
+    """H920: the audit_window SAN-LOSS gate flags a card whose OUTPUT sense count falls short
+    of its input portrait's declared source_senses (the darvI 2/3 shape), passes a complete
+    card, and is CONSERVATIVE — it skips null cards and portraits that predate the source_senses
+    stamp (never a false positive)."""
+    import audit_window
+    with tempfile.TemporaryDirectory() as tmp:
+        def portrait(name, **extra):
+            json.dump([dict({'portrait_kind': 'no_pwg_supplement_chain', 'senses': []}, **extra)],
+                      open(os.path.join(tmp, name + '.portrait.json'), 'w', encoding='utf-8'),
+                      ensure_ascii=False)
+        portrait('darv_i~~h0_zz_pw', key1='darvI', source_senses=3)   # 3 source senses
+        portrait('ok~~h0_zz_pw', key1='ok', source_senses=2)          # complete
+        portrait('legacy~~h0_zz_pw', key1='legacy')                   # pre-H920, no count
+        results = [
+            {'key': 'darv_i~~h0_zz_pw',                               # 2 of 3 -> SAN-LOSS
+             'card': {'key1': 'darvI', 'records': [{'senses': [{'tag': '2'}, {'tag': '3'}]}]}},
+            {'key': 'ok~~h0_zz_pw',                                   # 2 of 2 -> clean
+             'card': {'records': [{'senses': [{'tag': '1'}, {'tag': '2'}]}]}},
+            {'key': 'legacy~~h0_zz_pw',                               # no expected count -> skipped
+             'card': {'records': [{'senses': [{'tag': '1'}]}]}},
+            {'key': 'null~~h0_zz_pw', 'card': None, 'error': 'kill-timeout'},  # null -> skipped
+        ]
+        # pure scan
+        short = scan_sense_shortfall(results, tmp)
+        if [s['key'] for s in short] != ['darv_i~~h0_zz_pw']:
+            fail('scan_sense_shortfall should flag ONLY darvI, got %r' % short)
+        if short[0]['expected'] != 3 or short[0]['actual'] != 2 or short[0]['dropped'] != 1:
+            fail('darvI shortfall math wrong: %r' % short[0])
+        # the wired audit gate
+        gate = audit_window.run_sense_shortfall_gate(results, tmp, set())
+        if gate['returncode'] != 1 or gate['requeue'] != ['darv_i~~h0_zz_pw']:
+            fail('SAN-LOSS gate must FAIL and requeue only darvI, got %r' % gate)
+        if 'SAN-LOSS' not in gate['stdout'] or 'dropped 1' not in gate['stdout']:
+            fail('SAN-LOSS gate stdout must report the drop: %r' % gate['stdout'])
+        # protected keys are never requeued
+        if audit_window.run_sense_shortfall_gate(results, tmp, {'darv_i~~h0_zz_pw'})['requeue']:
+            fail('a protected key must not be requeued by the SAN-LOSS gate')
+        # a fully-clean window passes
+        clean = audit_window.run_sense_shortfall_gate(results[1:], tmp, set())
+        if clean['returncode'] != 0 or clean['requeue']:
+            fail('SAN-LOSS gate must PASS a window with no shortfall, got %r' % clean)
+
+
+def test_h920_no_pwg_portrait_stamps_source_senses():
+    """H920: gen_no_pwg_card stamps a deterministic source_senses count into each sub-card's
+    portrait (matching count_source_senses on that sub-card's raw), while still fabricating NO
+    sense tree (senses stays []). A source with >=2 numbered senses also carries the explicit
+    sense-completeness rule so the model is told to render every sense."""
+    import _pilot_gen_merged as pg
+    import dict_merge as dm
+    # unit: the sense-completeness rule fires only for multi-sense sources and never inflates
+    # the deterministic count (the rule text carries no 〉 / leading-digit lines).
+    multi = '=== LAYER: PW ===\n\n{#x#}¦\n— 1〉 {%a%}.\n— 2〉 {%b%}.\n— 3〉 {%c%}.'
+    ruled = pg._with_sense_rule(multi, count_source_senses(multi))
+    if 'SENSE-COMPLETENESS RULE' not in ruled or 'all 3' not in ruled:
+        fail('multi-sense supplement must carry the H920 sense-completeness rule')
+    if count_source_senses(ruled) != 3:
+        fail('the sense-completeness rule must not inflate the deterministic count')
+    if pg._with_sense_rule('=== LAYER: PW ===\n\nsingle sense, no marker', 0) \
+            != '=== LAYER: PW ===\n\nsingle sense, no marker':
+        fail('a source with <2 senses must NOT get the sense-completeness rule')
+    # end-to-end: render a real no-PWG card and assert the portrait is enriched + consistent.
+    old_out = pg.OUT
+    with no_pwg_dictionary_fixture(), tempfile.TemporaryDirectory() as tmp:
+        pg.OUT = tmp
+        try:
+            pwg_idx = dm.index('pwg')
+            for key, layer in (('Bagavat', 'pw'), ('Akulita', 'sch')):
+                if not pg.gen_no_pwg_card(key, pwg_idx, verbose=False):
+                    fail('gen_no_pwg_card(%s) produced no sub-cards' % key)
+                sub = '%s~~h0_zz_%s' % (pg.safe_name(key), layer)
+                raw = open(os.path.join(pg.OUT, sub + '.raw.txt'), encoding='utf-8').read()
+                p0 = json.loads(open(os.path.join(pg.OUT, sub + '.portrait.json'), encoding='utf-8').read())[0]
+                if 'source_senses' not in p0:
+                    fail('%s portrait must carry the H920 source_senses count' % sub)
+                if p0['source_senses'] != count_source_senses(raw):
+                    fail('%s portrait source_senses (%r) must equal count_source_senses(raw) (%d)'
+                         % (sub, p0['source_senses'], count_source_senses(raw)))
+                if p0.get('senses') != []:
+                    fail('%s no-PWG portrait must still fabricate no sense tree' % sub)
+        finally:
+            pg.OUT = old_out
+
+
+def test_h920_en_missing_sense_hard_flag():
+    """H920: the EN auditor emits a HARD MISSING-SENSE flag when an output card falls short of
+    its portrait's source_senses (SHARED with the RU gate via sense_count.py), distinct from the
+    per-sense SAN-LOSS gloss-token flag; a complete card carries no such flag."""
+    import audit_window_en as en
+    with tempfile.TemporaryDirectory() as tmp:
+        json.dump([{'source_senses': 3}],
+                  open(os.path.join(tmp, 'darv_i~~h0_zz_pw.portrait.json'), 'w', encoding='utf-8'))
+        json.dump([{'source_senses': 2}],
+                  open(os.path.join(tmp, 'ok~~h0_zz_pw.portrait.json'), 'w', encoding='utf-8'))
+        old_dir = en.INPUT_DIR
+        en.INPUT_DIR = tmp
+        try:
+            short = en.audit_card(
+                {'key': 'darv_i~~h0_zz_pw',
+                 'card': {'records': [{'h': 'darvī', 'senses': [
+                     {'tag': '2', 'german': '2〉 x', 'english': 'the hood of a snake'},
+                     {'tag': '3', 'german': '3〉 y', 'english': 'name of a country'}]}]}},
+                None, False)
+            flags = [f for _, f in short['flags']]
+            if not any(f.startswith('MISSING-SENSE') for f in flags):
+                fail('EN auditor must emit MISSING-SENSE on a 2/3 card, got %r' % flags)
+            if not any(en.is_hard(f) for f in flags if f.startswith('MISSING-SENSE')):
+                fail('MISSING-SENSE must be a HARD flag')
+            ok = en.audit_card(
+                {'key': 'ok~~h0_zz_pw',
+                 'card': {'records': [{'h': 'ok', 'senses': [
+                     {'tag': '1', 'german': '1〉 a', 'english': 'first'},
+                     {'tag': '2', 'german': '2〉 b', 'english': 'second'}]}]}},
+                None, False)
+            if any(f.startswith('MISSING-SENSE') for _, f in ok['flags']):
+                fail('a complete 2/2 card must NOT get MISSING-SENSE')
+        finally:
+            en.INPUT_DIR = old_dir
 
 
 def test_no_pwg_worklist_runnable_lane():
@@ -4351,6 +4500,10 @@ def main():
         test_nominal_provenance_without_rootmap,
         test_no_pwg_card_source_profile_taxonomy,
         test_no_pwg_supplement_card_renders_without_pwg,
+        test_h920_sense_count_top_level_ordinals,
+        test_h920_sense_shortfall_gate_flags_dropped_sense,
+        test_h920_no_pwg_portrait_stamps_source_senses,
+        test_h920_en_missing_sense_hard_flag,
         test_no_pwg_worklist_runnable_lane,
         test_no_pwg_layer_and_profile_survive_promotion,
         test_prompt_rule_audit_template,


### PR DESCRIPTION
Closes the H911 LOCAL-READINESS FAIL-branch #1 defect: `missing_senses` / SAN-LOSS (whole-dropped senses) in the no_pwg / supplement lane. Offline root-cause + deterministic guard + selftests; **no live generation**.

## Root cause — (a) model omission, made silent by a structural gap
- The genuine silent SAN-LOSS class is **(a) the model omitting a whole numbered sense**. (b) self-heal collapse and (c) split/merge drop always flag `partial`, so neither is the silent vector.
- Why (a) is silent (primary evidence, H818 fc1): [`darv_i~~h0_zz_pw`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h911/H920_NO_PWG_SANLOSS_ROOTCAUSE_AND_GUARD_2026-07-14.md) had a **3-sense** PW source (`1〉 Löffel`, `2〉`, `3〉`); the model dropped sense 1 and emitted 2/3, and `accept()` — the only whole-card guard, an `<ls>`/`{#` token-count match — passed it **clean** because the dropped gloss-only sense carried neither a citation nor a masked Sanskrit span. The no_pwg portrait declares `senses:[]`, so nothing held an expected count; the harness even computed `senses:3` and **discarded** it.
- The `no_pwg_w05_rq1` `missing_senses` keys are a **different** (infra-null: kill-timeout / selfheal-nothing-resolved) class, already caught as nulls.

## Fix (SHARED, language-neutral — LANG_PARITY entry `sense_count_sanloss_guard_h920`)
- **New [`src/pilot/sense_count.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/sense_count.py)** — `count_source_senses` (top-level `N〉` / `N)` ordinals, high-precision), `scan_sense_shortfall`, `portrait_source_senses`. Calibrated on the real darvI/aklizwa/a_sakta evidence.
- **[`_pilot_gen_merged.gen_no_pwg_card`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/_pilot_gen_merged.py)** — stamps each sub-card's deterministic `source_senses` into its portrait and prepends a **sense-completeness rule** to ≥2-sense sources (the (a) mitigation).
- **[`audit_window.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window.py)** — a `sense_loss` gate → requeue **defect** before promotion; **[`audit_window_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window_en.py)** — a `MISSING-SENSE` **HARD** flag. Both via the one shared primitive.

**Conservative:** a null card or a pre-H920 portrait (no `source_senses`) is skipped — never a false positive.

## Verification
- 4 new `test_h920_*` selftests green in the aggregate suite (`window selftest OK`).
- `lang_parity_check.py` clean (48 entries, no drift); every drifted entry re-affirmed + new SHARED entry added.
- Validated on **fixtures + frozen evidence only**. The deepest fix (consume `INPUT[k].senses` in the harness `accept()`) is deferred to the live-gated acceptance run (still gated by H911/H909).

Handoff: [H920](https://github.com/gasyoun/Uprava/blob/main/handoffs/H920-Sonnet_SanskritLexicography_pwg-ru-no-pwg-san-loss-missing-senses-offline-fix_14.07.26.md). Executor: Opus 4.8 (`claude-opus-4-8[1m]`), Ultracode, owner-authorized override of the minted Sonnet 5 tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)