### PR TITLE
H937 follow-up: fix download-filename regression in RUBRIC_JS's new Download listener

### DIFF
--- a/RussianTranslation/src/h178_eval_bakeoff.py
+++ b/RussianTranslation/src/h178_eval_bakeoff.py
@@ -342,7 +342,7 @@ RUBRIC_JS = """
         }) };
       var blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
       var url = URL.createObjectURL(blob); var a = document.createElement('a');
-      a.href = url; a.download = 'decisions.json'; document.body.appendChild(a); a.click();
+      a.href = url; a.download = SHEET_ID + '_decisions.json'; document.body.appendChild(a); a.click();
       document.body.removeChild(a); URL.revokeObjectURL(url);
     });
   }

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,17 @@ not an error.
 
 ## [Unreleased]
 
+### Fixed
+- **H937 follow-up — download-filename regression (14-07-2026, Sonnet 5 `claude-sonnet-5`)**:
+  H937's rubric-note-clobber fix cloned+replaced h178's Download button to strip the shared
+  `csl_pyutil` core template's stale-state listener, but the new listener's `a.download`
+  reverted to the literal `'decisions.json'` — reintroducing the exact generic-filename
+  collision [csl-pyutil#1](https://github.com/sanskrit-lexicon/csl-pyutil/issues/1)/H933 had
+  just fixed in the shared emitter (the two fixes shipped independently within the same hour
+  and didn't compose). Now `SHEET_ID + '_decisions.json'`, matching convention. Browser-verified
+  (synthetic 2-card sheet): vote-after-rubric-edit no longer clobbers a different card's note,
+  and the exported filename is correctly `<sheet_id>_decisions.json`.
+
 ## [1.9.10] - 2026-07-14
 
 ### Added


### PR DESCRIPTION
## Summary
- H937 (rubric-note clobber fix) cloned+replaced h178's Download button to strip csl_pyutil core's stale-state listener, but the new listener's `a.download` reverted to the literal `'decisions.json'` — reintroducing the exact generic-filename collision [csl-pyutil#1](https://github.com/sanskrit-lexicon/csl-pyutil/issues/1)/H933 had just fixed in the shared emitter minutes earlier. The two independent same-hour fixes didn't compose.
- Now `SHEET_ID + '_decisions.json'`, matching the convention H933 established.

## Test plan
- [x] `python RussianTranslation/src/h178_eval_bakeoff.py selftest` — green
- [x] Browser-verified (synthetic 2-card sheet reusing the real `render_review_sheet()` + `RUBRIC_JS`): set card1's rubric widget → vote reject on card2 → confirmed card1's note is NOT clobbered
- [x] Confirmed exported download filename is `h937verify_decisions.json`, not the generic `decisions.json`
- [x] Confirmed exported JSON payload carries both card1's note and card2's decision correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)