### PR TITLE
docs(pwg_ru): record H960 production-readiness gate

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Repository documentation & housekeeping
 
-_Created: 09-07-2026 · Last updated: 14-07-2026_
+_Created: 09-07-2026 · Last updated: 15-07-2026_
 
 Keep the SanskritLexicography data/research workspace documented and its git
 state tidy.
@@ -21,6 +21,18 @@ Two live tracks:
   [RussianTranslation/.ai_state.md](RussianTranslation/.ai_state.md) + the queue below.
 
 ## ➡️ Next Steps (Queue)
+
+- **H960 PWG→Russian production-readiness verification — QUEUED 15-07-2026 (Opus 4.8
+  `claude-opus-4-8[1m]`, Ultracode).** Independent post-H920 audit reproduced every offline gate:
+  `window_selftest`, 48-entry language parity, H809/promotion safety, headless-worker, and
+  multi-account scheduler recovery/race tests all pass. Scale is **not yet earned**: H911 remains
+  the last measured quality verdict (FAIL); H920 is downstream-audit/offline proof, while harness
+  `accept()` still does not consume the expected sense count; grammar `{Tn}` restoration and
+  German-source anchoring remain open; `staged-run` accepts exactly one profile; no bounded continuous
+  supervisor exists. Credential-safe auth check: `c1`/`c4` logged-in Max, `c5`/`c6` logged out.
+  H255 remains frozen until H960's locked auth→latency→canary→10→20→multi-profile ladder passes.
+  Handoff: [H960](https://github.com/gasyoun/Uprava/blob/main/handoffs/H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md).
+  Resume: `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md and execute it.`
 
 - **RussianTranslation H818 observability (13-07-2026, Codex/GPT-5):** PR #416 now includes a credential-safe joined event stream, derived bug census, strict accounting/store-delta GO gates, presplit live canary, and fault injection. Live 1→10→20→100 remains gated on owner Max login. Follow-on A/B handoffs: H841 recovery policy, H842 prompt quality, H843 window size.
 
@@ -755,6 +767,11 @@ Two live tracks:
       mw_ru working repo, documented in mw_ru.md §7). No doc gaps currently open.
 
 ## 🚧 Current Work-In-Progress (WIP)
+
+- **No H960 implementation is active in this worktree (15-07-2026, Codex/GPT-5).** Audit and
+  handoff only; no live generation, profile login, store/TM mutation, or scaling run occurred.
+  The stale H317/H442 prepared-canary notes below are historical inputs, not permission to bypass
+  H960/H911/H909 gates.
 
 - [ ] **H317/H442 split-pool live canary — PREPARED, BLOCKED ON WORKFLOW SURFACE
       (10-07-2026, Codex/GPT-5).** Fresh worktree

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: PWG (Petersburg Dictionary) → Russian edition + the CDSL article-comparison study
 
-_Created: 09-07-2026 · Last updated: 14-07-2026_
+_Created: 09-07-2026 · Last updated: 15-07-2026_
 
 Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/archive/H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md)):
 
@@ -13,6 +13,20 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 > the root copy. Audited + reconciled 2026-06-26.
 
 ## ➡️ Next Steps (Queue)
+
+- **H960 four-profile production-readiness verification — 🟡 QUEUED 15-07-2026 (Opus 4.8
+  `claude-opus-4-8[1m]`, Claude Code Ultracode).** Post-H920 Codex audit found the offline codebase
+  green (`window_selftest`, 48 LANG_PARITY entries, H809/promotion safety, headless worker, and
+  multi-account race/recovery suites), but four-profile/nonstop scale is still **NO-GO** until an
+  evidence ladder passes. Remaining load-bearing gaps: harness `accept()` ignores its existing
+  expected-sense count; sense `grammar` mask tokens are not restored; embedded German `{#…#}` spans
+  can still drop; observed calls/cost per clean are not persistently measurable; `staged-run`
+  deliberately requires exactly one account; no bounded continuous supervisor exists. Auth status
+  on 15-07: `c1`/`c4` logged-in Max, `c5`/`c6` logged out. Home-route latency/H909 is independently
+  unresolved. H255 stays frozen unless H960 earns an explicit unfreeze through
+  auth→latency→targeted canary→10→20→multi-profile PASS.
+  [H960 handoff](https://github.com/gasyoun/Uprava/blob/main/handoffs/H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md).
+  Resume: `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md and execute it.`
 
 - **H920 no_pwg SAN-LOSS / `missing_senses` root-cause + deterministic guard — 🔴 EXECUTED 14-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; owner-authorized override of the minted Sonnet 5; OFFLINE).**
   Root-caused the H911 #1 defect to **(a) model omission**, silent because the no_pwg portrait declares
@@ -1903,6 +1917,10 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   after the preflight/runbook commit is pushed.
 
 ## 🚧 Current Work-In-Progress (WIP)
+
+- **H960 audit packaged; implementation not started (15-07-2026, Codex/GPT-5).** No live probe,
+  generation, login, promotion, store mutation, or TM rebuild occurred. The H317/H442 material below
+  is historical prepared evidence and does not override the current H911/H909/H960 gates.
 
 - **H317/H442 split-pool live canary — PREPARED, BLOCKED ON WORKFLOW SURFACE
   10-07-2026 (Codex/GPT-5).** Fresh branch/worktree `codex/h317-w1b-split-canary` /


### PR DESCRIPTION
Post-H920 independent audit state only: offline suites are green, but four-profile/nonstop scale remains gated on H960's generation-time fidelity, route, profile, quality/economy, and restart-safe orchestration checks. No live generation or store/TM mutation. Handoff is tracked separately in Uprava.