### PR TITLE
H960: verify H920 + earn four-profile PWG-RU production-readiness (offline)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -22,17 +22,17 @@ Two live tracks:
 
 ## ➡️ Next Steps (Queue)
 
-- **H960 PWG→Russian production-readiness verification — QUEUED 15-07-2026 (Opus 4.8
-  `claude-opus-4-8[1m]`, Ultracode).** Independent post-H920 audit reproduced every offline gate:
-  `window_selftest`, 48-entry language parity, H809/promotion safety, headless-worker, and
-  multi-account scheduler recovery/race tests all pass. Scale is **not yet earned**: H911 remains
-  the last measured quality verdict (FAIL); H920 is downstream-audit/offline proof, while harness
-  `accept()` still does not consume the expected sense count; grammar `{Tn}` restoration and
-  German-source anchoring remain open; `staged-run` accepts exactly one profile; no bounded continuous
-  supervisor exists. Credential-safe auth check: `c1`/`c4` logged-in Max, `c5`/`c6` logged out.
-  H255 remains frozen until H960's locked auth→latency→canary→10→20→multi-profile ladder passes.
-  Handoff: [H960](https://github.com/gasyoun/Uprava/blob/main/handoffs/H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md).
-  Resume: `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md and execute it.`
+- **H960 PWG→Russian four-profile production-readiness — 🔴 EXECUTED 15-07-2026 (Opus 4.8
+  `claude-opus-4-8[1m]`, Ultracode; OFFLINE).** Verified H920 (every offline gate green) and earned all
+  six load-bearing scale gaps as **SOFT / report-only** guards (each selftested, all wired into CI):
+  `accept()` sense-count consumption (`SANLOSS_*`, owner-gated arm) + cross-reference-hardened counter;
+  grammar `{Tn}` multiset check on the main path (`TNMASK_*`); `dropped_sanskrit_span` report-only risk;
+  `economy_ledger.py` (`agents_per_clean` + bounded `$/clean` from the frozen probe log); four-profile
+  `staged-run` (`probe_fleet`, guard ≥1); `bounded_supervisor.py` (injectable-seam nonstop loop). The
+  residual **NO-GO is the owner-gated live ladder only** (auth→latency→canary→arm→10→20→multi-profile);
+  H255 stays frozen until it passes. Gate report:
+  [H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md).
+  🔴 EXECUTED: H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md
 
 - **RussianTranslation H818 observability (13-07-2026, Codex/GPT-5):** PR #416 now includes a credential-safe joined event stream, derived bug census, strict accounting/store-delta GO gates, presplit live canary, and fault injection. Live 1→10→20→100 remains gated on owner Max login. Follow-on A/B handoffs: H841 recovery policy, H842 prompt quality, H843 window size.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
           python src/pilot/max_account_orchestrator_selftest.py
           python src/pilot/windows100_selftest.py
           python src/pilot/run_observability_selftest.py
+          python src/pilot/economy_ledger_selftest.py
+          python src/pilot/bounded_supervisor_selftest.py
+          python src/pilot/sense_count.py
           python src/pilot/window_selftest.py
           python src/store_path.py --selftest
           python src/pilot/translation_memory.py selftest

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -14,19 +14,21 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
-- **H960 four-profile production-readiness verification — 🟡 QUEUED 15-07-2026 (Opus 4.8
-  `claude-opus-4-8[1m]`, Claude Code Ultracode).** Post-H920 Codex audit found the offline codebase
-  green (`window_selftest`, 48 LANG_PARITY entries, H809/promotion safety, headless worker, and
-  multi-account race/recovery suites), but four-profile/nonstop scale is still **NO-GO** until an
-  evidence ladder passes. Remaining load-bearing gaps: harness `accept()` ignores its existing
-  expected-sense count; sense `grammar` mask tokens are not restored; embedded German `{#…#}` spans
-  can still drop; observed calls/cost per clean are not persistently measurable; `staged-run`
-  deliberately requires exactly one account; no bounded continuous supervisor exists. Auth status
-  on 15-07: `c1`/`c4` logged-in Max, `c5`/`c6` logged out. Home-route latency/H909 is independently
-  unresolved. H255 stays frozen unless H960 earns an explicit unfreeze through
-  auth→latency→targeted canary→10→20→multi-profile PASS.
-  [H960 handoff](https://github.com/gasyoun/Uprava/blob/main/handoffs/H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md).
-  Resume: `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md and execute it.`
+- **H960 four-profile production-readiness — 🔴 EXECUTED 15-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`,
+  Claude Code Ultracode; OFFLINE).** Verified H920 (every offline gate green) and closed all six
+  load-bearing gaps as **SOFT / report-only** guards, each pinned by a selftest, all wired into CI:
+  (1) `accept()` sense-count (H920's deferred deepest fix) — `source_senses` stamped + `SANLOSS_SHORTFALLS`
+  telemetry (`SANLOSS_HARD_REJECT` owner-gated); `sense_count.py` counter hardened to skip cross-reference
+  ordinals (~4.78% FP class). (2) Grammar `{Tn}` multiset check on the main `accept()` path
+  (`TNMASK_MISMATCHES`, owner-gated). (3) `dropped_sanskrit_span` in `prompt_rule_audit.py` — LOW/report-only,
+  head-label FP class excluded. (4) `economy_ledger.py` — `agents_per_clean` + bounded `$/clean` from the
+  frozen probe log (H911's "not_recoverable" economy metrics actually derivable). (5) `max_account_orchestrator.py`
+  four-profile: guard ≥1 account + `probe_fleet()` STOP-on-any-NO-GO + per-account `probe_latency_ms`.
+  (6) `bounded_supervisor.py` — injectable-seam bounded nonstop loop + crash-resume. **Residual NO-GO =
+  the owner-gated live ladder only** (auth→latency→canary→arm-hard-rejects→10→20→multi-profile); c5/c6 were
+  logged out on 15-07; H255 stays frozen until it passes. Gate report:
+  [H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md).
+  🔴 EXECUTED: H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md
 
 - **H920 no_pwg SAN-LOSS / `missing_senses` root-cause + deterministic guard — 🔴 EXECUTED 14-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; owner-authorized override of the minted Sonnet 5; OFFLINE).**
   Root-caused the H911 #1 defect to **(a) model omission**, silent because the no_pwg portrait declares

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,35 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+- **Four-profile production-readiness — verify H920 + earn every offline-earnable scale gap (H960, offline).**
+  Verified H920 (every offline gate green) and closed the six load-bearing gaps blocking four-profile
+  nonstop scale, each pinned by a selftest and each **SOFT / report-only by default** (telemetry, no
+  reject/requeue — arming a hard reject is a deliberate owner-gated step measured on live traffic).
+  (1) **`accept()` sense-count** — H920's deferred deepest fix: `gen_opt_harness2.py` stamps the hardened
+  `source_senses` and `accept()` records a `SANLOSS_SHORTFALLS` shortfall (`SANLOSS_HARD_REJECT` owner-gated);
+  [`sense_count.py`](src/pilot/sense_count.py)'s counter is hardened to skip cross-reference ordinals (the
+  ~4.78%-of-cards over-count the naive `\d+〉` findall carried: `gam~~h2_31_pari` 2→1, `s_ud~~h0_05_pra`
+  4→2, `_a_srayatva` 2→0). (2) **Grammar `{Tn}` multiset** — `accept()` now runs the heal path's `{Tn}`
+  multiset check on the main path (`TNMASK_MISMATCHES`, owner-gated), catching a dropped `<lex>` grammar
+  span the `<ls>/{#` count is blind to. (3) **German `{#..#}` span drop** (H911 backlog #3) —
+  [`prompt_rule_audit.py`](src/pilot/prompt_rule_audit.py) `dropped_sanskrit_span`, a content-multiset
+  source-vs-target diff, **LOW / report-only** (never requeues), excluding structural head-label spans (the
+  measured 95%-FP class). (4) **Economy telemetry** (H911 backlog #4) — new
+  [`economy_ledger.py`](src/pilot/economy_ledger.py) derives `agents_per_clean` + a bounded `$/clean` band
+  from the frozen probe log (metrics H911 called `not_recoverable` actually sit there), `gate()` on aggregate
+  breach. (5) **Four-profile `staged-run`** — [`max_account_orchestrator.py`](src/pilot/max_account_orchestrator.py)
+  guard relaxed from exactly-one to ≥1 account; `probe_fleet()` probes each profile, STOP-on-any-NO-GO
+  (`--drop-unhealthy` opt-in), `probe_latency_ms` rewired to a per-account map; the claim/dispatch/recover
+  substrate was already N-account-proven. (6) **Bounded supervisor** — new
+  [`bounded_supervisor.py`](src/pilot/bounded_supervisor.py): injectable `run_window` seam, bounds on
+  window-count / budget / clean-target / consecutive-empty, requeues partials, atomic checkpoint + crash
+  resume. New selftests: `test_h960_accept_sanloss_soft_gate` (node, extracts the real `accept()`),
+  `test_h960_dropped_sanskrit_span`, `economy_ledger_selftest.py`, `bounded_supervisor_selftest.py`,
+  +N=4 cases in `max_account_orchestrator_selftest.py`; all wired into CI. LANG_PARITY entry
+  `accept_sanloss_soft_gate_h960` (SHARED). No live generation — the residual NO-GO is exactly the
+  owner-gated live ladder (auth → latency → canary → arm → 10 → 20 → multi-profile). Gate report:
+  [pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md](pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md).
+
 - **SAN-LOSS (whole-dropped-sense) guard — the H911 FAIL-branch #1 defect (H920, offline).**
   Root-caused `missing_senses`/SAN-LOSS in the no_pwg / supplement lane to **model omission**, made
   silent by three compounding facts: the no_pwg portrait declares `senses:[]` (no expected count), the

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1026,7 +1026,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H920 (14-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes the no_pwg/supplement SAN-LOSS gap the H911 gate surfaced (darv_i~~h0_zz_pw dropped source sense 1 'Löffel', output 2/3, and the harness accept() <ls>/{# token match passed it clean because the dropped gloss-only sense carried neither a citation nor a masked Sanskrit span). Every part is language-neutral: sense_count.py counts SENSE OBJECTS and source 〉/N) markers (never gloss language); the portrait source_senses stamp + the sense-completeness prompt rule live in _pilot_gen_merged no_pwg generation, which is pre-lang (the source is German for RU and EN alike); the audit guard is the SAME sense_count.scan_sense_shortfall/sense_shortfall wired into BOTH audit_window.py (RU 'sense_loss' gate -> requeue defect) and audit_window_en.py (EN 'MISSING-SENSE' HARD flag) — one shared primitive, no RU/EN reimplementation. Conservative: a portrait without source_senses (pre-H920) or a null card is skipped, never a false positive. Pinned by test_h920_sense_count_top_level_ordinals, test_h920_sense_shortfall_gate_flags_dropped_sense, test_h920_no_pwg_portrait_stamps_source_senses, test_h920_en_missing_sense_hard_flag. H960 (15-07-2026) hardened count_source_senses to count only line-opening ordinals (skipping mid-prose cross-reference ordinals) — still SHARED / language-neutral, an FP reduction, not a behavior split; the harness accept()-side consumption of this count lands in accept_sanloss_soft_gate_h960.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/sense_count.py": "f884da16caf0ad172e37b4b97ca449ebbb7018b6761b3bf35a0d98fff11f9de7",
+      "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "a71003a7a266506f3a012257ab5717b572b3397d172309801509d9451e554d86",
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
@@ -1051,7 +1051,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
-      "src/pilot/sense_count.py": "f884da16caf0ad172e37b4b97ca449ebbb7018b6761b3bf35a0d98fff11f9de7",
+      "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
       "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9",
       "src/pilot/accept_sensecount_test.js": "dd5061a719bace4f4927b71dfe931f4ee447be1c50f9476ef22c1ad3614015fe"
     }

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759"
     }
   },
   {
@@ -117,8 +117,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -136,8 +136,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -155,8 +155,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -173,7 +173,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759"
     }
   },
   {
@@ -224,7 +224,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759"
     }
   },
   {
@@ -241,7 +241,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759"
     }
   },
   {
@@ -258,7 +258,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 closes the former divergence: exact model provenance is required across four accounts, so both RU and EN now request and stamp claude-sonnet-5. This prevents account/profile alias resolution from making cross-window provenance incomparable.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759"
     }
   },
   {
@@ -279,7 +279,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
-      "src/pilot/prompt_rule_audit.py": "d2c578eb62a1919c5c22c0726940df952dee7ead0791bf61d1a1bc7c83f26fdf",
+      "src/pilot/prompt_rule_audit.py": "bb07e6851707ee61f301e33172f8d26ba1e9180315c8c5a49baa4650afff7eee",
       "src/pilot/audit_window.py": "a71003a7a266506f3a012257ab5717b572b3397d172309801509d9451e554d86",
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48"
     }
@@ -355,8 +355,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -375,7 +375,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -412,8 +412,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
       "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2"
     }
   },
@@ -470,9 +470,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -503,7 +503,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "14409a15772df0c07e1337d795112d9f99f60388b003df241c5b1ccaf03e4e97",
       "src/pilot/audit_window.py": "a71003a7a266506f3a012257ab5717b572b3397d172309801509d9451e554d86",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -522,7 +522,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -540,7 +540,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "95797986db7c21210a55c8a13f324514d17110ba07d2f804d000a77a003d5bf3",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -559,7 +559,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -599,7 +599,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -624,7 +624,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "e1870c131b1a7138d75a14118ce4178b8075c968426a447ba62251ad28ca7708",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -653,7 +653,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -673,7 +673,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -692,7 +692,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "3fc844fe372b7511528aefeefbc90dcd83653b9cc09e85fed837fd599eac15f8",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -729,7 +729,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -787,7 +787,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -805,8 +805,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -824,8 +824,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -844,8 +844,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292",
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -866,8 +866,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -924,9 +924,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -953,12 +953,12 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 Windows readiness uses one language-parameterized manifest and worker contract. Whole-card retries, binary split, fragment TM/restore/fidelity, per-card budgets, timeout-no-bisect, partial stitching, audit-clean subset promotion, staged dispatch, and credential-safe event/census telemetry do not branch on RU/EN. Production policy selects RU no_pwg for the first 100-headword proof; the mechanism preserves EN field/schema behavior.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
       "src/pilot/headless_worker.py": "446af28c39e88337f6565964185b98a24ab9bc6876b186a6266b2a8d370f8866",
-      "src/pilot/max_account_orchestrator.py": "a679d219b821fef89e0251a67ff298ef3a80dc63f8d51515fb9aebfb947ffc60",
+      "src/pilot/max_account_orchestrator.py": "94de77d32bf97120771cb9bb88f5660a6a07b0568948c3fd6ced5f21401aac65",
       "src/pilot/coordinator.py": "3fc844fe372b7511528aefeefbc90dcd83653b9cc09e85fed837fd599eac15f8",
       "src/pilot/headless_worker_selftest.py": "192bfedf95d2d86bccf010c0e4f7f4ececc9f3941ab284f51e84bfba12f638a9",
-      "src/pilot/max_account_orchestrator_selftest.py": "f95ea774e5e4923b616ed69da20ef09812519b78ea695e324deffe1b4c917e82",
+      "src/pilot/max_account_orchestrator_selftest.py": "2efaea952892ddb67e17557c9a68657c3ff407e55c6ac1470169e08804b1a18a",
       "src/pilot/no_pwg_scale_plan.py": "e181edad1960cb75a765fb1f2bda0614080142c63fbc33b3346501de33892548",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
       "src/pilot/run_observability.py": "371d0197b39e217ef1754eb60d8b09f79823678f728d65e276f864eaeb8e0d72",
@@ -983,10 +983,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H390 Phase 1 (12-07-2026, Opus 4.8 claude-opus-4-8), extended by H818. gen_model is written into language-agnostic run meta and flows through the shared ledger writer and harvester identically for RU/EN; both paths now stamp exact claude-sonnet-5. Pinned by test_ledger_stamps_gen_model in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
       "src/pilot/window_reports.py": "e1870c131b1a7138d75a14118ce4178b8075c968426a447ba62251ad28ca7708",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -1004,8 +1004,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H823, fixes the H255 presplit-cohort loss). Both the citation presplit trigger (_presplit_hit) and the single-card kill budget (killBudgetForCur) are language-independent — they key on <ls>/fragment counts and FRAGS, never on --lang; the same floor + CEIL apply to RU and EN identically. Extends no_fallback_single_kill_budget_and_nominal_key_echo (H220) from no-fallback singles to all singles. Pinned by test_presplit_cite_floor_and_single_ceil.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "815fe75a1bdc7467d46a846deb96ff2cf5625c98d6f52d6a61db439b33b20f88",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
     }
   },
   {
@@ -1023,14 +1023,37 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "H920 (14-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes the no_pwg/supplement SAN-LOSS gap the H911 gate surfaced (darv_i~~h0_zz_pw dropped source sense 1 'Löffel', output 2/3, and the harness accept() <ls>/{# token match passed it clean because the dropped gloss-only sense carried neither a citation nor a masked Sanskrit span). Every part is language-neutral: sense_count.py counts SENSE OBJECTS and source 〉/N) markers (never gloss language); the portrait source_senses stamp + the sense-completeness prompt rule live in _pilot_gen_merged no_pwg generation, which is pre-lang (the source is German for RU and EN alike); the audit guard is the SAME sense_count.scan_sense_shortfall/sense_shortfall wired into BOTH audit_window.py (RU 'sense_loss' gate -> requeue defect) and audit_window_en.py (EN 'MISSING-SENSE' HARD flag) — one shared primitive, no RU/EN reimplementation. Conservative: a portrait without source_senses (pre-H920) or a null card is skipped, never a false positive. Pinned by test_h920_sense_count_top_level_ordinals, test_h920_sense_shortfall_gate_flags_dropped_sense, test_h920_no_pwg_portrait_stamps_source_senses, test_h920_en_missing_sense_hard_flag.",
+    "note": "H920 (14-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes the no_pwg/supplement SAN-LOSS gap the H911 gate surfaced (darv_i~~h0_zz_pw dropped source sense 1 'Löffel', output 2/3, and the harness accept() <ls>/{# token match passed it clean because the dropped gloss-only sense carried neither a citation nor a masked Sanskrit span). Every part is language-neutral: sense_count.py counts SENSE OBJECTS and source 〉/N) markers (never gloss language); the portrait source_senses stamp + the sense-completeness prompt rule live in _pilot_gen_merged no_pwg generation, which is pre-lang (the source is German for RU and EN alike); the audit guard is the SAME sense_count.scan_sense_shortfall/sense_shortfall wired into BOTH audit_window.py (RU 'sense_loss' gate -> requeue defect) and audit_window_en.py (EN 'MISSING-SENSE' HARD flag) — one shared primitive, no RU/EN reimplementation. Conservative: a portrait without source_senses (pre-H920) or a null card is skipped, never a false positive. Pinned by test_h920_sense_count_top_level_ordinals, test_h920_sense_shortfall_gate_flags_dropped_sense, test_h920_no_pwg_portrait_stamps_source_senses, test_h920_en_missing_sense_hard_flag. H960 (15-07-2026) hardened count_source_senses to count only line-opening ordinals (skipping mid-prose cross-reference ordinals) — still SHARED / language-neutral, an FP reduction, not a behavior split; the harness accept()-side consumption of this count lands in accept_sanloss_soft_gate_h960.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/sense_count.py": "c7221e41bc57845064a21bb3f0b298d6c3da5b4e78063d859f9d0bd86a49688d",
+      "src/pilot/sense_count.py": "f884da16caf0ad172e37b4b97ca449ebbb7018b6761b3bf35a0d98fff11f9de7",
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "a71003a7a266506f3a012257ab5717b572b3397d172309801509d9451e554d86",
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
-      "src/pilot/window_selftest.py": "8a7a89d42781487806b85b604494bd06d85120c85ce8bb85cb85522d5ea54292"
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9"
+    }
+  },
+  {
+    "id": "accept_sanloss_soft_gate_h960",
+    "mechanism": "Harness-side SAN-LOSS shortfall guard (H920's deferred deepest fix): gen_opt_harness2.py stamps the deterministic cross-reference-hardened source_senses (sense_count.count_source_senses) into each runtime input, and accept() compares the emitted top-level sense count to it — a shortfall is recorded as sanloss telemetry (SANLOSS_SHORTFALLS / sanloss_detail in the run summary) and, only when SANLOSS_HARD_REJECT is armed (owner-gated), rejected+requeued exactly like an <ls>/{# fidelity-reject.",
+    "files": [
+      "src/pilot/gen_opt_harness2.py",
+      "src/pilot/sense_count.py",
+      "src/pilot/window_selftest.py",
+      "src/pilot/accept_sensecount_test.js"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H960 (15-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes H920's explicitly-deferred accept()-side sense-count consumption. Language-neutral: accept() counts SENSE OBJECTS (records[].senses[]), never a gloss language, and source_senses is sense_count.count_source_senses over the German source markers (identical for the RU and EN lanes — the source is German for both). SOFT by default (SANLOSS_HARD_REJECT=false): a shortfall is telemetry only (no reject/requeue), so live traffic can measure the true drop-vs-false-flag rate before the reject is armed (owner-gated ladder). The shared counter is hardened against the ~4.78%-of-cards cross-reference over-count the naive count carried (gam~~h2_31_pari 2->1, s_ud~~h0_05_pra 4->2, _a_srayatva 2->0); under-counting is the safe direction, never a false shortfall. Pinned by test_h960_accept_sanloss_soft_gate (builds the real harness, extracts the emitted accept()+countOf, asserts soft-keep / surplus-ok / FP-regression / ls-sk-first / armed-hard-reject via accept_sensecount_test.js) plus the 3 cross-reference fixtures in sense_count._selftest.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "3fb21ae1456e48d655e5d40a9882d8da0abbd6a86cde75343eb6d2ff22783759",
+      "src/pilot/sense_count.py": "f884da16caf0ad172e37b4b97ca449ebbb7018b6761b3bf35a0d98fff11f9de7",
+      "src/pilot/window_selftest.py": "ea719e30f7a114f3e5f59d44a08e7c436bcd3b7ef6ae1555a903c7598c32d4b9",
+      "src/pilot/accept_sensecount_test.js": "dd5061a719bace4f4927b71dfe931f4ee447be1c50f9476ef22c1ad3614015fe"
     }
   }
 ]

--- a/RussianTranslation/ORCHESTRATION_4ACCOUNT_MAX.md
+++ b/RussianTranslation/ORCHESTRATION_4ACCOUNT_MAX.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable MD013 MD036 -->
 
-_Created: 12-07-2026 · Last updated: 12-07-2026_
+_Created: 12-07-2026 · Last updated: 15-07-2026_
 
 This dispatcher runs ordinary commands under four isolated profiles. It does not translate by itself or bypass coordinator/audit/promotion gates.
 
@@ -69,8 +69,14 @@ python src/pilot/no_pwg_scale_plan.py --headwords 100 --window-size 20 `
   --manifest src/pilot/output/h818_windows100_plan.json
 ```
 
-After the owner logs one Max account into a dedicated profile, repeat with
-`--headless --coordinator-dir <dir>`, initialize exactly that profile, and run:
+After the owner logs one or more Max accounts into dedicated profiles, repeat
+with `--headless --coordinator-dir <dir>`, initialize each of those profiles, and
+run. `staged-run` now fans across **N validated profiles** (one or more) instead
+of hard-capping at a single account: it probes every validated profile and
+dispatches disjoint jobs across the whole healthy fleet. `--max-accounts N` caps
+the fleet size; `--drop-unhealthy` is the explicit opt-in described below.
+Initializing exactly one profile (N=1) reproduces the original single-profile
+Windows-100 path byte-for-byte.
 
 ```powershell
 python src/pilot/max_account_orchestrator.py --db <db> staged-run `
@@ -82,7 +88,15 @@ python src/pilot/max_account_orchestrator.py --db <db> staged-run `
 # restart boundary: rerun the same command with --resume and without --stop-after
 ```
 
-The command refuses unauthenticated profiles, runs a ≥5 KB exact-model probe,
+The command refuses unauthenticated profiles and runs a ≥5 KB exact-model probe
+on **each** validated profile (the D-K two-phase warm-up + measured split per
+account, so the acceptance census carries exactly one measured latency sample per
+profile, never an inflated count). The default policy is **STOP-on-any-NO-GO**:
+the first profile whose probe fails or exceeds the health ceiling aborts the whole
+run (an honest fleet NO-GO), matching acceptance criterion #1. `--drop-unhealthy`
+is the explicit opt-in to instead drop the failing profile, park it, and proceed
+on the healthy subset (still requiring at least one healthy profile). `report`'s
+`probe_latency_ms` becomes a per-profile `name → measured_ms` map. The run then
 records/audits each window, promotes only its audit-clean subset under the global
 promotion lock, and emits a GO only when the exact headword/subcard census is
 accounted, every window has a positive canonical-store delta, no hard failure or

--- a/RussianTranslation/pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md
+++ b/RussianTranslation/pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md
@@ -1,0 +1,98 @@
+# H960 — PWG→Russian four-profile production-readiness gate (offline)
+
+_Created: 15-07-2026 · Last updated: 15-07-2026_
+
+**Verdict: `OFFLINE-READINESS = EARNED` · `FOUR-PROFILE NONSTOP SCALE = NO-GO (owner-gated live ladder is the only residue)`.**
+
+H960 had two charges: **verify H920**, and **earn four-profile nonstop PWG-RU scale**. The first is
+complete — every offline gate reproduces green. The second is earned *as far as offline work can take
+it*: the six load-bearing gaps the [H911 LOCAL-READINESS gate](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h911/H911_LOCAL_READINESS_QUALITY_ECONOMY_GATE_2026-07-14.md)
+(FAIL) and the post-H920 Codex audit surfaced are closed at the offline/deterministic layer, each pinned
+by a selftest. The residual NO-GO is **exactly** the owner-gated live ladder
+(auth → latency → targeted canary → 10 → 20 → multi-profile), which needs real Max logins (c5/c6 were
+logged out on 15-07) and live generation — categorically out of scope for an offline session.
+
+**Executor:** Opus 4.8 (`claude-opus-4-8[1m]`), Ultracode. Offline code/analysis only — **no** live
+translation generation, Claude Workflow/API call, account login, network probe, promotion, store/TM
+mutation, or orchestrator run against real accounts. Delivered from a worktree off `origin/master`.
+
+## A. H920 verified — the offline codebase is green
+
+Reproduced from the current tree (`RussianTranslation/`), independent of the Codex audit that recorded
+the gate:
+
+| Offline gate | Result |
+|---|---|
+| `window_selftest.py` (incl. all 4 `test_h920_*` sense-count guard tests) | **OK** |
+| `lang_parity_check.py` | **49 entries, all verdicts complete, no drift** |
+| `h809_selftest.py` | **OK** |
+| `headless_worker_selftest.py` | **PASS** |
+| `max_account_orchestrator_selftest.py` (D-G one-active-job, D-G REAL race ×8, D-I exactly-once) | **PASS** |
+| `run_observability_selftest.py` | **PASS** |
+| `economy_ledger_selftest.py` (new) · `bounded_supervisor_selftest.py` (new) | **PASS** |
+
+H920's merged deliverable (the deterministic SAN-LOSS sense-count guard, PR #467) is intact and its
+guard fires on the darvI 2/3 shape while skipping null/pre-stamp cards.
+
+## B. The six load-bearing gaps — closed offline
+
+Each was audited against the real code and its proposed fix adversarially verified for
+offline-testability before implementation. Every new guard is **SOFT / report-only by default**
+(telemetry, no reject/requeue) — arming any hard reject is a deliberate owner-gated step, because
+turning a silent pass into a reject changes throughput and must be measured on live traffic first.
+
+| # | Gap (H911 lineage) | Offline fix landed | Selftest | Live residue (owner-gated) |
+|---|---|---|---|---|
+| 1 | **`accept()` sense-count** — H920's explicitly-deferred deepest fix (SAN-LOSS backlog #1) | `gen_opt_harness2.py` stamps the hardened `source_senses`; `accept()` records a `SANLOSS_SHORTFALLS` shortfall (emitted<expected, exp>0) — **soft**, `SANLOSS_HARD_REJECT` owner-gated. Counter hardened to skip cross-reference ordinals (~4.78% FP class) | `test_h960_accept_sanloss_soft_gate` (node, extracts the real `accept()`); 3 cross-ref fixtures in `sense_count._selftest` | measure the live shortfall/false-flag rate, then arm the reject+requeue |
+| 2 | **Grammar `{Tn}` multiset** — dropped `<lex>` grammar span passes the `<ls>/{#` count | `accept()` compares the emitted `{Tn}` multiset to the source skeleton's (the heal path's existing check, brought to the main path) — `TNMASK_MISMATCHES`, **soft**, `TNMASK_HARD_REJECT` owner-gated | same node selftest (drop → soft telemetry while `<ls>/{#` passes; reorder-ok; armed → reject) | measure incidence (incl. self-expansion), then arm |
+| 3 | **German `{#..#}` span drop** — H911 backlog #3 (`untranslated_braced_german_gloss` family) | `prompt_rule_audit.dropped_sanskrit_span` — content-multiset diff of source-vs-target `{#..#}`, **LOW / report-only** (never in `HIGH_CONFIDENCE_RISKS`), excluding structural head-label spans (the measured 95%-FP class) | `test_h960_dropped_sanskrit_span` (mid-drop fires; head/root/retained silent; LOW) | measure the live false-flag rate, then consider arming a requeue |
+| 4 | **Economy telemetry** — H911 backlog #4; two INCONCLUSIVE economy gates unmeasurable | `economy_ledger.py` reduces the frozen `generation_api_probe_log.jsonl` to `agents_per_clean` + a bounded `$/clean` band, imports `parse_workflow_cost.PRICE`, `gate()` on aggregate breach | `economy_ledger_selftest.py` (8 tests, real-log integration) | exact `$/clean` needs the live per-agent cache-split transcript; blessing the ceilings is a human call |
+| 5 | **`staged-run` four-profile** — hard-capped to one account | `max_account_orchestrator.py`: guard relaxed to ≥1; `probe_fleet()` probes each account, STOP-on-any-NO-GO (`--drop-unhealthy` opt-in), `probe_latency_ms` rewired to a per-account map | `max_account_orchestrator_selftest.py` (+N=4 fan-out, one-active, recover exactly-once, probe_fleet unit, N=1 regression) | the real 4-account login + live staged-run loop |
+| 6 | **Bounded supervisor** — no nonstop drain loop | `bounded_supervisor.py` — injectable `run_window` seam; bounds on window-count / budget / clean-target / consecutive-empty; requeues partials; atomic checkpoint + crash resume | `bounded_supervisor_selftest.py` (8 cases incl. crash-resume, satisfied-not-failed) | wire `cmd_staged_run` to delegate with the live `run_window` |
+
+## C. Readiness gates — what H960 moves
+
+The [H911 gate table](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h911/H911_LOCAL_READINESS_QUALITY_ECONOMY_GATE_2026-07-14.md) is the reference. H960 **hardens the instrumentation** behind
+those gates; it does not, and cannot offline, flip the measured quality FAIL to a PASS.
+
+| Gate | H911 | After H960 (offline) |
+|---|---|---|
+| audit-clean subcards ≥ 80% | FAIL (~62%) | **still measured on live traffic** — the SAN-LOSS/`{Tn}`/`{#..#}` guards now make the loss *visible* (were silent passes); the clean-rate GO is a live-run measurement |
+| fidelity rejects < 5% | FAIL (SAN-LOSS 15–25%) | detection hardened + cross-ref FP removed; arming the rejects is owner-gated |
+| economy observed calls/clean ≤ 1.75 | INCONCLUSIVE (`not_recoverable`) | **now measurable**: `economy_ledger` derives `agents_per_clean` from the frozen log (a metric H911 called unrecoverable actually sits in the probe log) |
+| economy observed $/clean ≤ $0.75 | INCONCLUSIVE | **bounded band now derivable** offline; exact point value stays live-gated |
+| four-account scale | blocked | scheduler is N-account-capable + proven offline (fair-claim / one-active / exactly-once / recovery); real login+run is the residue |
+
+**Honest framing:** hardening a guard converts a *silent* SAN-LOSS pass into a *visible* requeue. That
+raises fidelity but does not by itself lift the clean-rate FAIL — the model must actually stop dropping
+senses, which is a live quality measurement. So H960 earns the **production-readiness scaffolding** and
+leaves one gate: the live ladder.
+
+## D. The owner-gated live ladder (the only residual NO-GO)
+
+H255 stays frozen until this passes, in order, each stage gating the next:
+
+1. **auth** — owner logs in the Max profiles (`claude /login` per `CLAUDE_CONFIG_DIR`); c5/c6 were logged out on 15-07.
+2. **latency** — `probe_fleet` per account within the 30 s ceiling (independent of H909's home-route latency, still WAITING ON OWNER).
+3. **targeted canary** — the darvI/gaRanA SAN-LOSS canaries, now with the accept() shortfall telemetry live, to measure the true drop rate and the guard's false-flag rate.
+4. **arm the hard rejects** — once the false-flag rate is acceptably low, flip `SANLOSS_HARD_REJECT` / `TNMASK_HARD_REJECT` and promote `dropped_sanskrit_span` to a requeue trigger.
+5. **10 → 20** — bounded-supervisor drains, `economy_ledger` measuring real `agents_per_clean` / `$/clean` against the ceilings.
+6. **multi-profile** — the four-profile staged-run loop across c1/c4/c5/c6.
+
+None of stages 1–6 is offline-earnable; all are delivered *ready* by H960.
+
+## Limitations
+
+- Every guard is soft/report-only; **no** live quality-rate improvement is claimed — only that the loss
+  is now instrumented. The clean-rate ≥80% GO is a live measurement H960 does not manufacture.
+- `economy_ledger`'s `$/clean` is a **bounded band** (blunt `subagent_tokens` totalTokens, cache-split
+  not recoverable offline; the in-band ceiling excludes the output-token premium — a true worst-case
+  `true_upper_output_rate` is exposed separately).
+- `bounded_supervisor` is a **parallel** module with an injectable seam; the live `cmd_staged_run` loop
+  is not yet delegated to it (deliberate — that wiring needs a live account).
+- The counter hardening is a strict FP reduction validated on the cited promoted-store shapes; a source
+  whose only sense markers are non-line-opening under-counts to 0 (skipped, never a false shortfall).
+
+_Auto-generated by Opus 4.8 (`claude-opus-4-8[1m]`) as the H960 executor, Ultracode; offline code/analysis, no live generation or store mutation._
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.meta.md
+++ b/RussianTranslation/pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.meta.md
@@ -1,0 +1,27 @@
+# Metadoc — H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md
+
+_Created: 15-07-2026 · Last updated: 15-07-2026_
+
+- **Purpose.** The GO/NO-GO record for H960: verify H920 and earn four-profile nonstop PWG-RU scale.
+  Documents what was earned offline (six load-bearing gaps closed as soft/report-only guards + the
+  economy ledger + four-profile scheduler + bounded supervisor) and the single residual NO-GO (the
+  owner-gated live auth→latency→canary→arm→10→20→multi-profile ladder).
+- **Audience.** The owner (M.G.) deciding whether to run the live ladder; any future session picking up
+  PWG-RU scale or arming the soft guards.
+- **Provenance.** Handoff [H960](https://github.com/gasyoun/Uprava/blob/main/handoffs/H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md)
+  (a stub; the real mission was reconstructed from the post-H920 Codex audit recorded in
+  `.ai_state.md` #474 and the [H911 gate](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h911/H911_LOCAL_READINESS_QUALITY_ECONOMY_GATE_2026-07-14.md)).
+  Executor Opus 4.8 (`claude-opus-4-8[1m]`), Ultracode. Built with a deep parallel gap-audit workflow
+  (adversarially verified) + parallel implementation of the file-disjoint gaps + a correctness-review pass.
+- **Improvement backlog (ranked).**
+  1. Run the live ladder (owner) → replace the NO-GO with a measured verdict.
+  2. After a live canary measures the false-flag rate, arm `SANLOSS_HARD_REJECT` / `TNMASK_HARD_REJECT`
+     and promote `dropped_sanskrit_span` to a requeue trigger.
+  3. Delegate `max_account_orchestrator.cmd_staged_run` to `bounded_supervisor` with the live
+     `run_window` seam (makes the tested loop the shipping loop).
+  4. Bless the `economy_ledger` ceilings (calls/clean ≤ 1.75, $/clean ≤ 0.75) from calibrated data.
+- **Limitations.** Soft-only (no live quality-rate improvement claimed); `$/clean` is a bounded band;
+  bounded_supervisor is a parallel module not yet wired to live generation.
+- **Revision history.** 15-07-2026 — created with the H960 offline deliverable (Opus 4.8, Ultracode).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/accept_sensecount_test.js
+++ b/RussianTranslation/src/pilot/accept_sensecount_test.js
@@ -1,0 +1,132 @@
+// H960 behavioral test for the accept() SAN-LOSS shortfall guard (H920's deferred deepest fix).
+// Extracts the REAL accept() + countOf emitted by gen_opt_harness2.py (so this can't drift from
+// the generator) and asserts, with restoreCard mocked to identity and fixtures that are already
+// "restored" cards:
+//   - SOFT (default SANLOSS_HARD_REJECT=false): a darvI 2/3 shortfall is COUNTED but the card is
+//     KEPT (not rejected), the ls/sk fidelity gate having passed;
+//   - a complete card and a surplus (emitted>expected) split are never flagged;
+//   - FP-regression: a cross-reference card whose hardened source_senses==0 is skipped entirely;
+//   - the ls/sk fidelity-reject still fires FIRST, before the sanloss guard;
+//   - HARD (owner-gated flip SANLOSS_HARD_REJECT=true): the same shortfall now REJECTS + requeues.
+//   node src/pilot/accept_sensecount_test.js <path-to-a-generated-harness.js>
+const fs = require('fs')
+
+const harnessPath = process.argv[2]
+if (!harnessPath) { console.error('FAIL: usage: node accept_sensecount_test.js <harness.js>'); process.exit(1) }
+const src = fs.readFileSync(harnessPath, 'utf8')
+
+// Pull countOf/tokensOf/cardTokens (one-liners) and accept (brace block to the first column-0
+// `\n}`) verbatim from the generated harness so this can't drift.
+const one = name => {
+  const m = src.match(new RegExp('const ' + name + ' = [^\\n]*'))
+  if (!m) { console.error('FAIL: ' + name + ' not found in ' + harnessPath); process.exit(1) }
+  return m[0].replace(new RegExp('^const ' + name + ' = '), '')
+}
+const am = src.match(/const accept = \(c, k\) => \{[\s\S]*?\n\}/)
+if (!am) { console.error('FAIL: accept not found in ' + harnessPath); process.exit(1) }
+
+// Runtime globals accept() closes over (all mocked). restoreCard = identity because the fixtures
+// are already-restored cards and the ls/sk counts are computed on them directly.
+let INPUTS = {}
+const FAIL = {}
+const noteFail = (k, why) => { FAIL[k] = String(why).slice(0, 300) }
+const restoreCard = (c, k) => c
+const log = () => {}
+let SANLOSS_HARD_REJECT = false
+let SANLOSS_SHORTFALLS = 0
+const SANLOSS_DETAIL = []
+let TNMASK_HARD_REJECT = false
+let TNMASK_MISMATCHES = 0
+const TNMASK_DETAIL = []
+// Direct eval so the extracted functions close over the locals above.
+const countOf = eval('(' + one('countOf') + ')')
+const tokensOf = eval('(' + one('tokensOf') + ')')
+const cardTokens = eval('(' + one('cardTokens') + ')')
+const accept = eval('(' + am[0].replace(/^const accept = /, '') + ')')
+
+let failed = 0
+const check = (name, cond, extra) => { if (cond) { console.log('PASS: ' + name) } else { console.error('FAIL: ' + name + (extra ? ' -- ' + extra : '')); failed++ } }
+const card = senses => ({ records: [{ senses }] })
+const reset = () => {
+  SANLOSS_SHORTFALLS = 0; SANLOSS_DETAIL.length = 0
+  TNMASK_MISMATCHES = 0; TNMASK_DETAIL.length = 0
+  for (const k in FAIL) delete FAIL[k]
+}
+
+// ---- SOFT (default): shortfall recorded, card KEPT ----
+// darvI 2/3: source declares 3 senses, model emits 2; ls 0==0 and sk 3==3 (the two {#..#}-carrying
+// senses survive), so the <ls>/{# fidelity gate passes and only the sense-count guard can see it.
+INPUTS = { darvI: { ls: 0, sk: 3, source_senses: 3 } }
+reset()
+let r = accept(card([{ german: '{#a#} {#b#}' }, { german: '{#c#}' }]), 'darvI')
+check('soft: darvI 2/3 shortfall is KEPT (not rejected)', r !== null)
+check('soft: darvI shortfall counted with dropped=1',
+  SANLOSS_SHORTFALLS === 1 && SANLOSS_DETAIL[0] && SANLOSS_DETAIL[0].dropped === 1, JSON.stringify(SANLOSS_DETAIL))
+check('soft: no FAIL recorded for a kept shortfall', FAIL.darvI === undefined)
+
+// complete 3/3: no shortfall.
+INPUTS = { ok: { ls: 0, sk: 0, source_senses: 3 } }
+reset()
+r = accept(card([{ german: 'a' }, { german: 'b' }, { german: 'c' }]), 'ok')
+check('complete card passes with no shortfall', r !== null && SANLOSS_SHORTFALLS === 0)
+
+// surplus 3 > 2: a faithful split that yields MORE senses is never flagged.
+INPUTS = { sur: { ls: 0, sk: 0, source_senses: 2 } }
+reset()
+r = accept(card([{ german: 'a' }, { german: 'b' }, { german: 'c' }]), 'sur')
+check('surplus (emitted>expected) is not flagged', r !== null && SANLOSS_SHORTFALLS === 0)
+
+// ---- FP-regression: a cross-reference card (hardened source_senses==0) never fires ----
+// gam~~h2_31_pari / _a_srayatva shape: the source's only ordinals are cross-references, so the
+// H960-hardened counter stamps source_senses=0 and the exp<1 skip keeps the guard silent.
+INPUTS = { xref: { ls: 0, sk: 0, source_senses: 0 } }
+reset()
+r = accept(card([{ german: 'single unnumbered sense' }]), 'xref')
+check('FP-regression: exp=0 cross-ref card is skipped (never flagged)', r !== null && SANLOSS_SHORTFALLS === 0)
+
+// ---- ls/sk fidelity-reject still fires FIRST, before the sanloss guard ----
+INPUTS = { mis: { ls: 1, sk: 0, source_senses: 1 } }
+reset()
+r = accept(card([{ german: 'no citation here' }]), 'mis')   // ls 0 != expected 1
+check('ls/sk fidelity-reject still fires first',
+  r === null && /fidelity-reject/.test(FAIL.mis || '') && SANLOSS_SHORTFALLS === 0)
+
+// ---- HARD (owner-gated flip): the same shortfall now REJECTS + requeues ----
+SANLOSS_HARD_REJECT = true
+INPUTS = { darvI: { ls: 0, sk: 3, source_senses: 3 } }
+reset()
+r = accept(card([{ german: '{#a#} {#b#}' }, { german: '{#c#}' }]), 'darvI')
+check('hard: darvI 2/3 shortfall REJECTED when armed',
+  r === null && /sanloss-reject/.test(FAIL.darvI || ''))
+SANLOSS_HARD_REJECT = false
+
+// ---- H960 grammar-{Tn} multiset guard (soft) ----
+// A dropped grammar <lex> {Tn}: the source skeleton masks 3 spans ({T1} grammar, {T2}, {T3}),
+// the model keeps {T1} {T3} but drops {T2}. It carries neither an <ls> nor a {#, so the ls/sk
+// count check passes (0==0) while the {Tn} multiset differs — the exact gap this guard closes.
+INPUTS = { gram: { ls: 0, sk: 0, source_senses: 0, skeleton: '{T1} {T2} {T3}' } }
+reset()
+r = accept(card([{ german: '{T1} {T3}' }]), 'gram')
+check('soft: dropped grammar {Tn} is KEPT but counted', r !== null && TNMASK_MISMATCHES === 1,
+  'mismatches=' + TNMASK_MISMATCHES)
+check('soft: the ls/sk count check is blind to the dropped {Tn} (no FAIL)', FAIL.gram === undefined)
+check('soft: {Tn} mismatch detail records got/want',
+  TNMASK_DETAIL[0] && TNMASK_DETAIL[0].got === '{T1} {T3}' && TNMASK_DETAIL[0].want === '{T1} {T2} {T3}',
+  JSON.stringify(TNMASK_DETAIL))
+
+// a card that keeps every {Tn} is clean (order-insensitive: tokensOf/cardTokens sort).
+INPUTS = { grOk: { ls: 0, sk: 0, source_senses: 0, skeleton: '{T1} {T2}' } }
+reset()
+r = accept(card([{ german: '{T2}' }, { german: '{T1}' }]), 'grOk')
+check('reordered-but-complete {Tn} multiset is not flagged', r !== null && TNMASK_MISMATCHES === 0)
+
+// armed (owner-gated): the same dropped {Tn} now REJECTS + requeues.
+TNMASK_HARD_REJECT = true
+INPUTS = { gram: { ls: 0, sk: 0, source_senses: 0, skeleton: '{T1} {T2} {T3}' } }
+reset()
+r = accept(card([{ german: '{T1} {T3}' }]), 'gram')
+check('hard: dropped {Tn} REJECTED when armed', r === null && /tnmask-reject/.test(FAIL.gram || ''))
+TNMASK_HARD_REJECT = false
+
+if (failed) { console.error(failed + ' check(s) failed'); process.exit(1) }
+console.log('accept_sensecount_test: PASS')

--- a/RussianTranslation/src/pilot/bounded_supervisor.py
+++ b/RussianTranslation/src/pilot/bounded_supervisor.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python
+r"""bounded_supervisor.py — a self-contained, bounded continuous-run supervisor for the
+no-PWG drain lane (the offline half of the 'nonstop' scaffolding, H960 gap #6).
+
+WHAT THIS IS (and is NOT)
+-------------------------
+This module is the *offline, hermetic* control loop that a continuous ("nonstop") drain
+would sit inside: pull a window from a plan, run it, audit the output, requeue the
+partials, and stop the moment a bound is crossed — persisting its whole state to a JSON
+checkpoint every iteration so a crash resumes exactly where it left off.
+
+It is deliberately SEPARABLE from live generation. The one thing it does NOT own is the
+actual model call: that is injected as a `run_window(window) -> wf_output_path` callable.
+Production would wrap the live staged-run/promotion path (max_account_orchestrator
+cmd_staged_run + coordinator promotion) in that callable; the self-test injects a
+fixture-returning fake and does ZERO live generation. Wiring this loop to the real
+cmd_staged_run against validated accounts is a LIVE-GATED follow-up (H960 gap #6 verify
+verdict: SPLIT) and is intentionally NOT implemented here.
+
+Design constraints honoured (all from the gap spec):
+  * The loop is driven by a SUPPLIED plan list — it never calls no_pwg_scale_plan against
+    the gitignored local store (that read is non-hermetic and would re-offer promoted
+    headwords).
+  * Auditing never shells out to audit_window.main() (its INPUT_DIR module constant is
+    bound to the untracked live input dir). Instead the loop accepts an injected
+    requeue-key report, or falls back to the H920 sense-count gate helper
+    (sense_count.scan_sense_shortfall) pointed at a caller-supplied tmp dir.
+
+THE AUDIT REPORT CONTRACT
+-------------------------
+The injected `audit(wf_output_path, window) -> report` returns a plain dict. Recognised
+fields (all optional, safe defaults shown):
+  requeue_keys   : list[str]  keys that still need rework -> appended as a requeue
+                              work-item and pulled BEFORE any new plan window next round.
+  clean_count    : int        clean cards this window (0). Drives the consecutive-empty
+                              streak and the clean-target signal.
+  cost           : number     per-window cost accumulated toward the running-budget cap
+                              (0). Overridable via an injected cost_fn.
+  satisfied_keys : list[str]  requeue keys resolved with a ZERO canonical-store delta —
+                              i.e. an already-promoted key. These are treated as
+                              satisfied-not-failed: they are NOT re-requeued and NOT a
+                              hard error (a zero store_delta on a fresh promotion is the
+                              coordinator's hard-fail signal, but on a REQUEUE key it just
+                              means the earlier window already landed it). ([]).
+
+THE CHECKPOINT
+--------------
+Every iteration the full loop state is written atomically (temp file + os.replace) to
+`checkpoint_path` as `pwg.bounded_supervisor.v1`. Re-instantiating with `resume=True`
+(or via `from_checkpoint`) restores windows_done / budget_spent / requeue_backlog /
+empty_streak / next_index / completed_window_ids, so no completed window is ever re-run
+and no spent budget is double-counted.
+
+Pure control flow: no model calls, no network, no store mutation, no promotion. The only
+side effect is writing the JSON checkpoint.
+"""
+import json
+import os
+import sys
+import tempfile
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+SCHEMA = 'pwg.bounded_supervisor.v1'
+
+# Stop reasons — the loop stops on the FIRST of these to fire.
+STOP_WINDOW_COUNT = 'window_count'          # ran the configured max number of windows
+STOP_BUDGET = 'budget'                       # accumulated per-window cost crossed the cap
+STOP_CLEAN_TARGET = 'clean_target'           # plan queue AND requeue backlog both drained
+STOP_CONSECUTIVE_EMPTY = 'consecutive_empty'  # N consecutive zero-progress iterations
+
+
+class BoundedSupervisor:
+    """A bounded, crash-resumable drain loop.
+
+    Parameters
+    ----------
+    plan : list[dict]
+        The supplied window backlog. Each entry is a window spec (any dict); an ``id`` is
+        derived from ``id`` / ``root`` / position and used for dedupe + resume. The list is
+        never mutated.
+    run_window : callable(window) -> wf_output_path
+        Injected. Runs one window and returns the path (or any handle) to its wf_output.
+        In production this wraps live generation; tests inject a fixture-returning fake.
+    audit : callable(wf_output_path, window) -> report dict, optional
+        Injected auditor. When omitted, ``default_audit`` (the H920 sense-count gate against
+        ``input_dir``) is used.
+    checkpoint_path : str
+        Where the atomic JSON checkpoint is written each iteration. Required for resume.
+    max_windows : int, optional
+        Window-count cap. ``None`` disables the bound.
+    budget_cap : number, optional
+        Running-budget cap; the loop stops once accumulated cost is >= this. ``None``
+        disables the bound.
+    empty_streak_cap : int, optional
+        Stop after this many consecutive zero-progress iterations. ``None`` disables it.
+    cost_fn : callable(window, wf_output_path, report) -> number, optional
+        Per-window cost. Defaults to ``report.get('cost', 0)``.
+    input_dir : str, optional
+        Portrait-sidecar dir for the default H920 auditor. When omitted a throwaway temp
+        dir is used (so the default auditor stays hermetic — an empty dir yields no
+        shortfall, only null-card requeues).
+    resume : bool
+        When True and ``checkpoint_path`` exists, restore state from it on construction.
+    """
+
+    def __init__(self, plan, run_window, checkpoint_path,
+                 audit=None, max_windows=None, budget_cap=None,
+                 empty_streak_cap=None, cost_fn=None, input_dir=None, resume=False):
+        if not callable(run_window):
+            raise TypeError('run_window must be callable(window) -> wf_output_path')
+        self.plan = [self._normalize_plan(w, i) for i, w in enumerate(plan or [])]
+        self.run_window = run_window
+        self.audit = audit
+        self.checkpoint_path = checkpoint_path
+        self.max_windows = max_windows
+        self.budget_cap = budget_cap
+        self.empty_streak_cap = empty_streak_cap
+        self.cost_fn = cost_fn or (lambda window, wf_output, report: report.get('cost', 0) or 0)
+        self.input_dir = input_dir
+        self._own_input_dir = None
+
+        # Loop state (all persisted).
+        self.windows_done = 0
+        self.budget_spent = 0.0
+        self.requeue_backlog = []
+        self.empty_streak = 0
+        self.next_index = 0
+        self.completed_window_ids = []
+        self.history = []
+        self.stop_reason = None
+        self._rq_counter = 0
+
+        if resume and checkpoint_path and os.path.exists(checkpoint_path):
+            self._load_checkpoint()
+
+    # ---- construction helpers -------------------------------------------------
+
+    @classmethod
+    def from_checkpoint(cls, checkpoint_path, plan, run_window, **kw):
+        """Build a supervisor already restored from ``checkpoint_path``."""
+        kw.pop('resume', None)
+        inst = cls(plan, run_window, checkpoint_path, resume=False, **kw)
+        inst._load_checkpoint()
+        return inst
+
+    @staticmethod
+    def _normalize_plan(window, index):
+        """Shallow-copy a plan window and stamp a stable ``id``."""
+        item = dict(window) if isinstance(window, dict) else {'value': window}
+        item.setdefault('id', item.get('root') or ('w%03d' % index))
+        item['requeue'] = False
+        return item
+
+    def _make_requeue_item(self, origin, keys):
+        self._rq_counter += 1
+        return {
+            'id': 'rq-%03d-%s' % (self._rq_counter, origin.get('id')),
+            'requeue': True,
+            'origin': origin.get('id'),
+            'keys': sorted(set(keys)),
+        }
+
+    def _ensure_input_dir(self):
+        if self.input_dir:
+            return self.input_dir
+        if not self._own_input_dir:
+            self._own_input_dir = tempfile.mkdtemp(prefix='bounded_supervisor_input_')
+        return self._own_input_dir
+
+    # ---- the loop -------------------------------------------------------------
+
+    def _pull(self):
+        """Next window to run, or None when both the requeue backlog and the plan queue
+        are drained. The requeue backlog is ALWAYS pulled before a fresh plan window, so a
+        partial's rework runs before new work (H304 requeue-first ordering)."""
+        while self.requeue_backlog:
+            item = self.requeue_backlog.pop(0)
+            if item.get('id') in self.completed_window_ids:
+                continue
+            return item
+        while self.next_index < len(self.plan):
+            item = self.plan[self.next_index]
+            self.next_index += 1
+            if item.get('id') in self.completed_window_ids:
+                continue
+            return item
+        return None
+
+    def _run_audit(self, wf_output, item):
+        if self.audit is not None:
+            return self.audit(wf_output, item) or {}
+        return self.default_audit(wf_output, item) or {}
+
+    def run(self):
+        """Drive the loop until the first bound fires. Idempotent once stopped:
+        re-calling on an already-stopped (resumed-past-completion) supervisor is a no-op
+        that returns the same summary."""
+        if self.stop_reason:
+            return self.summary()
+        try:
+            while True:
+                # (5a) window-count bound — checked before pulling/running new work, so a
+                # cap of N runs EXACTLY N windows.
+                if self.max_windows is not None and self.windows_done >= self.max_windows:
+                    self._finish(STOP_WINDOW_COUNT)
+                    break
+
+                # (1) PULL — requeue backlog first, then the plan queue.
+                item = self._pull()
+                if item is None:
+                    # (5c) clean-target — queue + backlog both drained.
+                    self._finish(STOP_CLEAN_TARGET)
+                    break
+                if item.get('id') in self.completed_window_ids:
+                    # Defensive: never re-run a completed window on resume.
+                    continue
+
+                # (2) RUN — injected; returns a wf_output handle/path.
+                wf_output = self.run_window(item)
+
+                # (3) AUDIT — injected report, or the H920 gate helper on a tmp dir.
+                report = self._run_audit(wf_output, item)
+
+                cost = self.cost_fn(item, wf_output, report) or 0
+                self.budget_spent += cost
+                self.windows_done += 1
+                self.completed_window_ids.append(item['id'])
+
+                # (4) REQUEUE PARTIALS — a work-item for the reported keys, pulled next
+                # round before any new window.
+                requeue_keys = [k for k in (report.get('requeue_keys') or []) if k]
+                satisfied = [k for k in (report.get('satisfied_keys') or []) if k]
+                if requeue_keys:
+                    self.requeue_backlog.append(self._make_requeue_item(item, requeue_keys))
+
+                clean = int(report.get('clean_count') or 0)
+                # (g) A satisfied (already-promoted, zero-store-delta) requeue key is
+                # progress, not a hard error: it drains the backlog and resets the streak.
+                made_progress = clean > 0 or bool(satisfied)
+                if made_progress:
+                    self.empty_streak = 0
+                else:
+                    self.empty_streak += 1
+
+                self.history.append({
+                    'window_id': item['id'],
+                    'requeue': bool(item.get('requeue')),
+                    'clean_count': clean,
+                    'requeued_keys': sorted(set(requeue_keys)),
+                    'satisfied_keys': sorted(set(satisfied)),
+                    'cost': cost,
+                    'budget_spent': self.budget_spent,
+                    'empty_streak': self.empty_streak,
+                })
+
+                # (6) PERSIST loop state atomically for crash resume.
+                self._write_checkpoint()
+
+                # (5b) running-budget bound — after accumulating this window's cost, so the
+                # window that crosses the cap runs, then the loop stops mid-queue.
+                if self.budget_cap is not None and self.budget_spent >= self.budget_cap:
+                    self._finish(STOP_BUDGET)
+                    break
+
+                # (5d) consecutive-empty bound.
+                if (self.empty_streak_cap is not None
+                        and self.empty_streak >= self.empty_streak_cap):
+                    self._finish(STOP_CONSECUTIVE_EMPTY)
+                    break
+        finally:
+            self._cleanup_own_input_dir()
+        return self.summary()
+
+    def _finish(self, reason):
+        self.stop_reason = reason
+        self._write_checkpoint()
+
+    def _cleanup_own_input_dir(self):
+        if self._own_input_dir and os.path.isdir(self._own_input_dir):
+            try:
+                import shutil
+                shutil.rmtree(self._own_input_dir)
+            except OSError:
+                pass
+            self._own_input_dir = None
+
+    # ---- the default (H920) auditor ------------------------------------------
+
+    def default_audit(self, wf_output, item):
+        """Offline fallback auditor: read the wf_output JSON, requeue null cards
+        (transient) and H920 SAN-LOSS sense-shortfall cards (defect), and count the rest
+        as clean. Uses sense_count.scan_sense_shortfall against a supplied/temp input dir
+        — never audit_window.main(), whose INPUT_DIR is bound to the live input tree.
+
+        NOTE: canonical-store deltas (the ``satisfied_keys`` reconciliation) are a
+        promotion-time signal this offline auditor cannot observe, so it never emits
+        satisfied_keys; that path is exercised via an injected report / the live wiring.
+        """
+        try:
+            with open(wf_output, encoding='utf-8') as f:
+                payload = json.load(f)
+        except (OSError, ValueError, TypeError):
+            return {'requeue_keys': [], 'clean_count': 0, 'cost': 0, 'satisfied_keys': []}
+        results = payload.get('results') or []
+        null_keys = [r.get('key') for r in results
+                     if isinstance(r, dict) and r.get('key') and r.get('card') is None]
+        defect_keys = []
+        try:
+            from sense_count import scan_sense_shortfall
+            short = scan_sense_shortfall(results, self._ensure_input_dir())
+            defect_keys = [s['key'] for s in short if s.get('key')]
+        except Exception:
+            defect_keys = []
+        requeue = sorted(set(null_keys) | set(defect_keys))
+        clean = sum(1 for r in results
+                    if isinstance(r, dict) and r.get('key')
+                    and r.get('card') is not None and r.get('key') not in set(defect_keys))
+        cost = (payload.get('summary') or {}).get('cost') or 0
+        return {'requeue_keys': requeue, 'clean_count': clean, 'cost': cost,
+                'satisfied_keys': []}
+
+    # ---- checkpoint persistence ----------------------------------------------
+
+    def _state_dict(self):
+        return {
+            'schema': SCHEMA,
+            'windows_done': self.windows_done,
+            'budget_spent': self.budget_spent,
+            'requeue_backlog': self.requeue_backlog,
+            'empty_streak': self.empty_streak,
+            'next_index': self.next_index,
+            'completed_window_ids': self.completed_window_ids,
+            'stop_reason': self.stop_reason,
+            'rq_counter': self._rq_counter,
+            'bounds': {
+                'max_windows': self.max_windows,
+                'budget_cap': self.budget_cap,
+                'empty_streak_cap': self.empty_streak_cap,
+            },
+            'history': self.history,
+        }
+
+    def _write_checkpoint(self):
+        if not self.checkpoint_path:
+            return
+        d = os.path.dirname(os.path.abspath(self.checkpoint_path))
+        if d and not os.path.isdir(d):
+            os.makedirs(d, exist_ok=True)
+        tmp = self.checkpoint_path + '.tmp'
+        with open(tmp, 'w', encoding='utf-8', newline='\n') as f:
+            json.dump(self._state_dict(), f, ensure_ascii=False, indent=2)
+            f.write('\n')
+        os.replace(tmp, self.checkpoint_path)
+
+    def _load_checkpoint(self):
+        with open(self.checkpoint_path, encoding='utf-8') as f:
+            state = json.load(f)
+        if state.get('schema') != SCHEMA:
+            raise ValueError('checkpoint schema mismatch: %r' % state.get('schema'))
+        self.windows_done = int(state.get('windows_done') or 0)
+        self.budget_spent = float(state.get('budget_spent') or 0)
+        self.requeue_backlog = list(state.get('requeue_backlog') or [])
+        self.empty_streak = int(state.get('empty_streak') or 0)
+        self.next_index = int(state.get('next_index') or 0)
+        self.completed_window_ids = list(state.get('completed_window_ids') or [])
+        self.stop_reason = state.get('stop_reason')
+        self._rq_counter = int(state.get('rq_counter') or 0)
+        self.history = list(state.get('history') or [])
+        return state
+
+    # ---- reporting ------------------------------------------------------------
+
+    def summary(self):
+        return {
+            'schema': SCHEMA,
+            'stop_reason': self.stop_reason,
+            'windows_done': self.windows_done,
+            'budget_spent': self.budget_spent,
+            'requeue_backlog_len': len(self.requeue_backlog),
+            'requeue_backlog_keys': sorted(
+                {k for item in self.requeue_backlog for k in (item.get('keys') or [])}),
+            'empty_streak': self.empty_streak,
+            'next_index': self.next_index,
+            'completed_window_ids': list(self.completed_window_ids),
+        }
+
+
+if __name__ == '__main__':
+    # Live delegation (wrapping cmd_staged_run against validated accounts) is a LIVE-GATED
+    # follow-up and is intentionally NOT wired here. Run the hermetic self-test instead.
+    print('bounded_supervisor: offline control-loop module (H960 gap #6).')
+    print('Live delegation is deferred (SPLIT verdict). Run the self-test:')
+    print('  python src/pilot/bounded_supervisor_selftest.py')

--- a/RussianTranslation/src/pilot/bounded_supervisor_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_supervisor_selftest.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+r"""Hermetic self-test for bounded_supervisor.py (H960 gap #6).
+
+Zero live generation: run_window is a scripted fake that writes a trivial fixture
+wf_output JSON in a tempdir and records call order; the auditor is an injected fake
+returning scripted requeue/clean/cost/satisfied reports. Every one of the gap's bound
+cases is exercised end to end:
+
+  (a) window-count bound stops after exactly N
+  (b) clean-target bound stops when queue + backlog are both drained
+  (c) requeue-partials: reported keys are appended as ONE work-item and pulled BEFORE any
+      new plan window next iteration
+  (d) running-budget bound stops mid-queue once accumulated cost crosses the cap
+  (e) consecutive-empty bound stops on the zero-progress streak
+  (f) crash recovery: re-instantiate from the persisted checkpoint and resume at the right
+      index/budget/backlog with NO completed window re-run
+  (g) an already-promoted requeue key with zero store-delta is satisfied-not-failed
+  (h) the offline default H920 auditor requeues a null card hermetically (no live gen)
+
+  python src/pilot/bounded_supervisor_selftest.py
+"""
+import json
+import os
+import re
+import sys
+import tempfile
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import bounded_supervisor as bs
+from bounded_supervisor import (
+    BoundedSupervisor,
+    STOP_WINDOW_COUNT,
+    STOP_BUDGET,
+    STOP_CLEAN_TARGET,
+    STOP_CONSECUTIVE_EMPTY,
+)
+
+
+def _safe(name):
+    return re.sub(r'[^A-Za-z0-9]+', '_', str(name))
+
+
+class ScriptedRunner:
+    """Fake run_window: records the order of windows run and returns a fixture wf_output
+    path (a trivial JSON file in the tempdir). Optionally raises on the Nth call to
+    simulate a mid-loop crash for the recovery test."""
+
+    def __init__(self, td, raise_on_call=None):
+        self.td = td
+        self.raise_on_call = raise_on_call
+        self.run_order = []       # window ids, in run order
+        self.run_windows = []     # full window items
+
+    def __call__(self, window):
+        self.run_windows.append(window)
+        self.run_order.append(window['id'])
+        if self.raise_on_call is not None and len(self.run_order) == self.raise_on_call:
+            raise RuntimeError('simulated crash while running %s' % window['id'])
+        path = os.path.join(self.td, 'wf_%s.json' % _safe(window['id']))
+        with open(path, 'w', encoding='utf-8', newline='\n') as f:
+            json.dump({'meta': {}, 'results': []}, f)
+        return path
+
+
+def make_plan(n):
+    return [{'id': 'w%d' % i, 'keys': ['k_%d' % i]} for i in range(n)]
+
+
+def clean_report(cost=1):
+    return {'requeue_keys': [], 'clean_count': 1, 'cost': cost, 'satisfied_keys': []}
+
+
+# ---------------------------------------------------------------------------
+
+def test_a_window_count(td):
+    plan = make_plan(5)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        return clean_report()
+
+    cp = os.path.join(td, 'a.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, max_windows=3)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_WINDOW_COUNT, summ
+    assert summ['windows_done'] == 3, summ
+    assert runner.run_order == ['w0', 'w1', 'w2'], runner.run_order
+    print('  (a) window-count bound stops after exactly N: PASS')
+
+
+def test_b_clean_target(td):
+    plan = make_plan(2)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        return clean_report()
+
+    cp = os.path.join(td, 'b.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, max_windows=10)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CLEAN_TARGET, summ
+    assert summ['windows_done'] == 2, summ
+    assert runner.run_order == ['w0', 'w1'], runner.run_order
+    print('  (b) clean-target bound stops when queue+backlog drained: PASS')
+
+
+def test_c_requeue_partials(td):
+    plan = make_plan(2)
+    runner = ScriptedRunner(td)
+    reports = {
+        'w0': {'requeue_keys': ['k1', 'k2'], 'clean_count': 1, 'cost': 1},
+        'w1': clean_report(),
+    }
+
+    def audit(wf_output, window):
+        if window.get('requeue'):
+            # rework of the requeued keys comes back clean
+            return {'requeue_keys': [], 'clean_count': 1, 'cost': 1}
+        return reports[window['id']]
+
+    cp = os.path.join(td, 'c.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, max_windows=10)
+    summ = sup.run()
+    # The requeue work-item (rq-001-w0) must run right after w0 and BEFORE the new plan
+    # window w1.
+    assert runner.run_order == ['w0', 'rq-001-w0', 'w1'], runner.run_order
+    # Exactly the reported keys were appended, as one work-item.
+    rq_items = [w for w in runner.run_windows if w.get('requeue')]
+    assert len(rq_items) == 1, rq_items
+    assert rq_items[0]['keys'] == ['k1', 'k2'], rq_items[0]
+    assert rq_items[0]['origin'] == 'w0', rq_items[0]
+    assert summ['stop_reason'] == STOP_CLEAN_TARGET, summ
+    assert summ['windows_done'] == 3, summ
+    print('  (c) requeue-partials appended and pulled before new windows: PASS')
+
+
+def test_d_budget(td):
+    plan = make_plan(10)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        return clean_report(cost=1)
+
+    cp = os.path.join(td, 'd.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, budget_cap=3)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_BUDGET, summ
+    assert summ['budget_spent'] == 3, summ
+    assert summ['windows_done'] == 3, summ
+    assert summ['next_index'] == 3 and summ['next_index'] < len(plan), summ  # stopped mid-queue
+    assert runner.run_order == ['w0', 'w1', 'w2'], runner.run_order
+    print('  (d) budget bound stops mid-queue at the cap: PASS')
+
+
+def test_e_consecutive_empty(td):
+    plan = make_plan(10)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        # zero-progress: no clean cards, no requeue, no satisfied keys
+        return {'requeue_keys': [], 'clean_count': 0, 'cost': 0, 'satisfied_keys': []}
+
+    cp = os.path.join(td, 'e.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, empty_streak_cap=3)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CONSECUTIVE_EMPTY, summ
+    assert summ['windows_done'] == 3, summ
+    assert summ['empty_streak'] == 3, summ
+    print('  (e) consecutive-empty bound stops on the zero-progress streak: PASS')
+
+
+def test_f_crash_recovery(td):
+    plan = make_plan(5)
+    cp = os.path.join(td, 'f.json')
+
+    # Supervisor A crashes while running the 3rd window (after 2 completed + checkpointed).
+    runner_a = ScriptedRunner(td, raise_on_call=3)
+    sup_a = BoundedSupervisor(plan, runner_a, cp, audit=lambda wf, w: clean_report(cost=2),
+                              max_windows=None)
+    crashed = False
+    try:
+        sup_a.run()
+    except RuntimeError:
+        crashed = True
+    assert crashed, 'expected a simulated crash on the 3rd window'
+    assert runner_a.run_order == ['w0', 'w1', 'w2'], runner_a.run_order  # w2 raised
+
+    # The persisted checkpoint reflects the 2 COMPLETED windows only.
+    state = json.load(open(cp, encoding='utf-8'))
+    assert state['windows_done'] == 2, state
+    assert state['next_index'] == 2, state          # w2 was not committed
+    assert state['budget_spent'] == 4, state         # 2 windows * cost 2
+    assert state['stop_reason'] is None, state       # crashed mid-loop, not a clean stop
+
+    # Supervisor B resumes from the checkpoint with a raised window cap.
+    runner_b = ScriptedRunner(td)
+    sup_b = BoundedSupervisor.from_checkpoint(cp, plan, runner_b,
+                                              audit=lambda wf, w: clean_report(cost=2),
+                                              max_windows=10)
+    assert sup_b.windows_done == 2, sup_b.windows_done
+    assert sup_b.budget_spent == 4, sup_b.budget_spent
+    assert sup_b.next_index == 2, sup_b.next_index
+    summ = sup_b.run()
+    # No completed window (w0/w1) is ever re-run; the resume picks up at w2.
+    assert runner_b.run_order == ['w2', 'w3', 'w4'], runner_b.run_order
+    assert summ['windows_done'] == 5, summ
+    assert summ['budget_spent'] == 10, summ          # 4 carried + 3 * 2
+    assert summ['stop_reason'] == STOP_CLEAN_TARGET, summ
+    print('  (f) crash recovery resumes at the right index/budget, no window re-run: PASS')
+
+
+def test_g_satisfied_zero_delta(td):
+    plan = make_plan(1)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        if window.get('requeue'):
+            # k9 was already promoted by w0 -> zero store-delta -> satisfied, NOT a failure.
+            return {'requeue_keys': [], 'clean_count': 0, 'cost': 0,
+                    'satisfied_keys': ['k9']}
+        return {'requeue_keys': ['k9'], 'clean_count': 1, 'cost': 1, 'satisfied_keys': []}
+
+    cp = os.path.join(td, 'g.json')
+    # empty_streak_cap=1: if a satisfied requeue key were (wrongly) counted as a zero-
+    # progress iteration, the requeue window would trip the consecutive-empty bound. It
+    # must instead be treated as progress, so the loop drains to clean-target.
+    raised = False
+    try:
+        sup = BoundedSupervisor(plan, runner, cp, audit=audit,
+                                max_windows=10, empty_streak_cap=1)
+        summ = sup.run()
+    except Exception as exc:  # noqa: BLE001 — a satisfied key must never be a hard error
+        raised = True
+        summ = None
+    assert not raised, 'a zero-store-delta requeue key must not be a hard error'
+    assert summ['stop_reason'] == STOP_CLEAN_TARGET, summ
+    assert summ['windows_done'] == 2, summ
+    assert summ['requeue_backlog_len'] == 0, summ    # k9 was NOT re-requeued
+    # The requeue window recorded k9 as satisfied, not requeued.
+    rq_hist = [h for h in sup.history if h['requeue']]
+    assert len(rq_hist) == 1, rq_hist
+    assert rq_hist[0]['satisfied_keys'] == ['k9'], rq_hist[0]
+    assert rq_hist[0]['requeued_keys'] == [], rq_hist[0]
+    print('  (g) already-promoted zero-delta requeue key is satisfied-not-failed: PASS')
+
+
+def test_h_default_h920_auditor(td):
+    # Exercise the offline default auditor (H920 sense-count gate on a temp input dir).
+    # A wf_output with one null card and one good card -> null card requeued, good clean.
+    wf = os.path.join(td, 'wf_default.json')
+    with open(wf, 'w', encoding='utf-8', newline='\n') as f:
+        json.dump({'meta': {}, 'results': [
+            {'key': 'good~~h0_zz_pw', 'card': {'records': [{'senses': [{'gloss': 'x'}]}]}},
+            {'key': 'null~~h0_zz_pw', 'card': None},
+        ]}, f)
+
+    plan = [{'id': 'w0', 'keys': ['good~~h0_zz_pw', 'null~~h0_zz_pw']}]
+    runner = ScriptedRunner(td)
+
+    def run_window(window):
+        runner(window)
+        return wf   # return the pre-built fixture wf_output
+
+    cp = os.path.join(td, 'h.json')
+    empty_input = tempfile.mkdtemp(prefix='bs_empty_input_')
+    # No injected auditor -> the default H920 auditor runs.
+    sup = BoundedSupervisor(plan, run_window, cp, max_windows=1, input_dir=empty_input)
+    sup.run()
+    assert sup.history, sup.history
+    h0 = sup.history[0]
+    assert h0['requeued_keys'] == ['null~~h0_zz_pw'], h0   # null card requeued (transient)
+    assert h0['clean_count'] == 1, h0                       # the good card counts clean
+    print('  (h) default H920 auditor requeues a null card hermetically: PASS')
+
+
+def main():
+    with tempfile.TemporaryDirectory() as td:
+        test_a_window_count(td)
+        test_b_clean_target(td)
+        test_c_requeue_partials(td)
+        test_d_budget(td)
+        test_e_consecutive_empty(td)
+        test_f_crash_recovery(td)
+        test_g_satisfied_zero_delta(td)
+        test_h_default_h920_auditor(td)
+    print('bounded_supervisor_selftest: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/economy_ledger.py
+++ b/RussianTranslation/src/pilot/economy_ledger.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python
+"""Persistent economy ledger for the PWG->Russian headless generation runs.
+
+A PURE, read-only reducer over the frozen `generation_api_probe_log.jsonl` outcome
+rows. It answers ONE aggregate question honestly: how many subagents, and how many
+dollars of token spend, did each *clean* promoted card actually cost — pooled across
+windows and their requeues.
+
+Deliberate honesty constraints baked in (from the H960 adversarial review):
+
+  * The numerator of `agents_per_clean` is `agents_used` — the number of SUBAGENTS
+    spawned for the run (`calls == agents_used` here). This is NOT the same as the
+    `run_summary.calls` counter in run_observability.build_census (which counts
+    model-call events). We name the metric `agents_per_clean` and never call it
+    "calls per clean" without qualification.
+
+  * A run with `audit_clean == 0` produced no clean card, so dividing by it is
+    undefined. Such a run is reported as `wasted_calls`, NEVER as an agents_per_clean
+    value. Its tokens still pool into the aggregate cost band (blunt total / total
+    clean), but it contributes 0 to the clean denominator.
+
+  * Three outcome rows (no_pwg_w08 / w08_rq1 / w09) had their structured outcome
+    payload nulled and dumped into the free-text `note`. `subagent_tokens` and `clean`
+    are recoverable from that note (so we still PRICE their tokens), but `agents_used`
+    is NOT present in the note, so those rows are flagged `calls_per_clean_incomplete`
+    and excluded from the agents_per_clean aggregate.
+
+  * DEDUP is keyed on `run_id` (+ per-run provenance), NOT the window-name string:
+    the label `no_pwg_w03` appears both as a fresh window and as a requeue of w02, so
+    grouping by window would wrongly collapse distinct runs. An exact re-append of the
+    same run_id is idempotent; a re-append carrying DIFFERENT figures is surfaced in
+    `conflicting_run_ids` (mirrors run_observability.build_census's call_id dedup).
+
+  * The cost band brackets [cache-read rate .. fresh-input rate] per token. The frozen
+    log carries only the blunt `subagent_tokens` totalTokens (the billing cache-split
+    is NOT recoverable), so the true billed cost lies somewhere inside the band. The
+    band EXCLUDES the output premium: subagent_tokens includes OUTPUT tokens billed
+    ~5x input (see parse_workflow_cost / h809_selftest cost formula), so the in-band
+    ceiling (fresh-input rate) is NOT a true upper bound; `true_upper_output_rate_usd`
+    prices every token at the output rate for an honest worst case.
+
+Rates are IMPORTED from parse_workflow_cost.PRICE — never re-hardcoded here.
+
+Offline / read-only. Run directly to print the ledger + coverage line:
+    python src/pilot/economy_ledger.py                # print only
+    python src/pilot/economy_ledger.py --write <path> # also write the durable JSON
+
+Model: authored by Opus 4.8 (claude-opus-4-8) for handoff H960 (gap: economy-telemetry).
+"""
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import parse_workflow_cost as pwc  # noqa: E402  (path insertion above must run first)
+
+# Single source of truth for $/million-token rates — do NOT duplicate rates here.
+PRICE = pwc.PRICE
+
+SCHEMA = 'pwg.economy_ledger.v1'
+FROZEN_LOG = os.path.join(HERE, 'generation_api_probe_log.jsonl')
+
+# note key=int pattern (e.g. "subagent_tokens=1836200 clean=6 store=11562")
+_NOTE_KV = re.compile(r'(\w+)=(-?\d+)\b')
+
+
+def utc_now():
+    return datetime.datetime.now(datetime.timezone.utc).isoformat(
+        timespec='milliseconds').replace('+00:00', 'Z')
+
+
+def read_rows(path):
+    """Read all jsonl rows (any kind) from the frozen log, read-only."""
+    rows = []
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def parse_note_kv(note):
+    """Recover the key=int pairs a nulled outcome row dumped into free text."""
+    return {m.group(1): int(m.group(2)) for m in _NOTE_KV.finditer(note or '')}
+
+
+def _normalize_outcome(row):
+    """Turn one kind=='outcome' row into a normalized economy record.
+
+    agents_used comes ONLY from the structured payload (the free-text note never
+    carries it); tokens and clean fall back to the note when the structured payload
+    was nulled. `provenance` records where the tokens came from.
+    """
+    outcome = row.get('outcome') or {}
+    kv = parse_note_kv(row.get('note', ''))
+
+    agents_used = outcome.get('agents_used')          # structured only; note has no such key
+    clean = outcome.get('audit_clean')
+    tokens = outcome.get('subagent_tokens')
+    provenance = 'structured'
+    if tokens is None:
+        tokens = kv.get('subagent_tokens')
+        provenance = 'nulled_note'
+    if clean is None:
+        clean = kv.get('clean')
+
+    rec = {
+        'run_id': row.get('run_id'),
+        'window': row.get('window'),
+        'handoff': row.get('handoff'),
+        'agents_used': agents_used,
+        'clean': clean,
+        'tokens': tokens,
+        'provenance': provenance,
+        'is_requeue': bool(re.search(r'_rq\d+$', row.get('window') or '')),
+        'flags': [],
+    }
+
+    # agents_per_clean: agents_used / clean, only when both known and clean>0
+    if agents_used is None:
+        rec['flags'].append('calls_per_clean_incomplete')
+    if clean == 0:
+        rec['flags'].append('wasted_calls')
+
+    if agents_used is not None and clean and clean > 0:
+        rec['agents_per_clean'] = round(agents_used / clean, 4)
+        rec['status'] = 'priced'
+    elif clean == 0:
+        rec['agents_per_clean'] = None
+        rec['status'] = 'wasted_calls'
+    else:
+        rec['agents_per_clean'] = None
+        rec['status'] = 'incomplete'
+
+    # cost band per clean — priced whenever tokens known and clean>0 (agents_used may
+    # still be missing; tokens are priced regardless, per spec). clean==0 -> no division.
+    if tokens is not None and clean and clean > 0:
+        rec['cost_per_clean'] = _cost_band(tokens, clean)
+    else:
+        rec['cost_per_clean'] = None
+    return rec
+
+
+def _cost_band(tokens, clean):
+    """Bounded per-clean $ band for `tokens` totalTokens over `clean` clean cards.
+
+    floor = cache-read rate (every token a cheap cache hit); ceil = fresh-input rate.
+    Both EXCLUDE the output premium; true_upper prices every token at the output rate.
+    """
+    floor = tokens * PRICE['cache_read'] / 1e6 / clean
+    ceil = tokens * PRICE['input'] / 1e6 / clean
+    true_upper = tokens * PRICE['output'] / 1e6 / clean
+    return {
+        'floor_usd': round(floor, 6),
+        'ceil_usd': round(ceil, 6),
+        'true_upper_output_rate_usd': round(true_upper, 6),
+        'basis': 'floor=cache_read rate, ceil=fresh-input rate; EXCLUDES output premium',
+    }
+
+
+def dedup_outcomes(rows):
+    """Group-then-dedup outcome rows keyed on run_id (first occurrence wins).
+
+    An exact re-append of an already-seen run_id is idempotent; a re-append whose
+    (tokens, clean, agents_used) differ is a conflicting duplicate, surfaced separately.
+    Mirrors run_observability.build_census's call_id dedup. Keyed on run_id, NOT window,
+    because one window label ('no_pwg_w03') is reused for a fresh window and a requeue.
+    """
+    seen = {}            # run_id -> signature of first occurrence
+    ordered = []         # deduped records, input order
+    conflicting = set()
+    for row in rows:
+        if row.get('kind') != 'outcome':
+            continue
+        rec = _normalize_outcome(row)
+        rid = rec['run_id']
+        sig = (rec['tokens'], rec['clean'], rec['agents_used'])
+        if rid is None:
+            ordered.append(rec)          # nothing to dedup on; keep as-is
+            continue
+        if rid not in seen:
+            seen[rid] = sig
+            ordered.append(rec)
+        elif seen[rid] != sig:
+            conflicting.add(rid)         # same run_id, different figures -> real conflict
+        # exact re-append -> silently dropped (idempotent)
+    return ordered, sorted(conflicting)
+
+
+def build_ledger(rows, source_log=None):
+    """Reduce raw log rows to the durable ledger payload (pure; no I/O)."""
+    recs, conflicting = dedup_outcomes(rows)
+
+    total = len(recs)
+    structured_au = sum(1 for r in recs
+                        if r['provenance'] == 'structured' and r['agents_used'] is not None)
+    enter_rows = [r for r in recs
+                  if r['agents_used'] is not None and r['clean'] and r['clean'] > 0]
+    wasted_rows = [r for r in recs if r['clean'] == 0]
+    nulled_rows = [r for r in recs if r['provenance'] == 'nulled_note']
+
+    coverage_line = (
+        '%d/%d outcome rows carry structured agents_used; '
+        '%d/%d enter agents-per-clean '
+        '(%d has clean=0 -> wasted_calls; %d nulled -> incomplete)'
+        % (structured_au, total, len(enter_rows), total,
+           len(wasted_rows), len(nulled_rows)))
+
+    # --- agents_per_clean aggregates (only rows with structured agents_used & clean>0) ---
+    def _apc(rows_subset):
+        a = sum(r['agents_used'] for r in rows_subset)
+        c = sum(r['clean'] for r in rows_subset)
+        return (a, c, round(a / c, 6) if c else None)
+
+    a_incl, c_incl, apc_incl = _apc(enter_rows)
+    first_pass_rows = [r for r in enter_rows if not r['is_requeue']]
+    a_fp, c_fp, apc_fp = _apc(first_pass_rows)
+
+    # --- pooled cost band: ALL priced-token outcome rows' tokens over total clean ---
+    # (blunt total / total clean; a clean==0 row adds tokens but 0 clean, honestly)
+    priced = [r for r in recs if r['tokens'] is not None and r['clean'] is not None]
+    total_tokens = sum(r['tokens'] for r in priced)
+    total_clean = sum(r['clean'] for r in priced)
+    pooled_band = _cost_band(total_tokens, total_clean) if total_clean else None
+
+    wasted_agents = sum(r['agents_used'] for r in wasted_rows if r['agents_used'] is not None)
+    wasted_tokens = sum(r['tokens'] for r in wasted_rows if r['tokens'] is not None)
+
+    return {
+        'schema': SCHEMA,
+        'generated_at': utc_now(),
+        'source_log': source_log or os.path.basename(FROZEN_LOG),
+        'price_basis_usd_per_million': dict(PRICE),
+        'price_basis_note':
+            'rates imported from parse_workflow_cost.PRICE (Sonnet 5 list); NOT re-hardcoded here',
+        'coverage': {
+            'outcome_rows': total,
+            'structured_agents_used': structured_au,
+            'enter_agents_per_clean': len(enter_rows),
+            'clean0_wasted': len(wasted_rows),
+            'nulled_incomplete': len(nulled_rows),
+            'line': coverage_line,
+        },
+        'aggregate': {
+            'agents_per_clean_incl_requeues': apc_incl,
+            'agents_per_clean_incl_requeues_label': 'total agents to fully drain incl. requeues',
+            'agents_per_clean_incl_requeues_basis':
+                '%d agents / %d clean over %d rows w/ structured agents_used & clean>0 '
+                '(fresh windows + their requeues pooled)' % (a_incl, c_incl, len(enter_rows)),
+            'agents_per_clean_first_pass': apc_fp,
+            'agents_per_clean_first_pass_basis':
+                '%d agents / %d clean over %d fresh (non-_rq) rows; LEXICAL _rq heuristic — '
+                'wf_a2b29683-835/no_pwg_w03 is semantically a w02 requeue but carries a '
+                'fresh-looking label, so first-pass is an approximation'
+                % (a_fp, c_fp, len(first_pass_rows)),
+            'cost_per_clean_band': pooled_band,
+            'cost_per_clean_band_basis':
+                'pooled %d subagent_tokens over %d clean cards (blunt total / total clean, '
+                'all priced outcome rows incl. mixed lanes and the clean=0 wasted run)'
+                % (total_tokens, total_clean),
+            'total_tokens': total_tokens,
+            'total_clean': total_clean,
+            'wasted_agents': wasted_agents,
+            'wasted_tokens': wasted_tokens,
+        },
+        'runs': recs,
+        'wasted_calls': [
+            {'run_id': r['run_id'], 'window': r['window'],
+             'agents_used': r['agents_used'], 'tokens': r['tokens']}
+            for r in wasted_rows],
+        'conflicting_run_ids': conflicting,
+        'provenance': {
+            'token_basis':
+                'subagent_tokens is the blunt workflow-notification totalTokens; the billing '
+                'cache-read/fresh-input split is NOT recoverable from the frozen log, so the '
+                'cost band brackets the two extremes rather than pricing the real split',
+            'output_premium':
+                'subagent_tokens INCLUDES output tokens billed ~5x input (parse_workflow_cost '
+                'PRICE output=$15 vs input=$3); the in-band ceil (fresh-input rate) is therefore '
+                'NOT a true upper bound — true_upper_output_rate_usd prices every token at output',
+            'metric_naming':
+                "agents_per_clean numerator == agents_used (subagents spawned); this is NOT "
+                "run_observability's run_summary.calls model-call counter",
+            'nulled_rows':
+                'no_pwg_w08 / w08_rq1 / w09 had structured outcome nulled into note; tokens+clean '
+                'recovered from the note and priced, but agents_used is unrecoverable -> incomplete',
+        },
+    }
+
+
+def write_ledger(output_path, rows=None, source_log=None):
+    """Atomically write the durable ledger JSON (mirrors run_observability.write_census)."""
+    if rows is None:
+        rows = read_rows(FROZEN_LOG)
+    payload = build_ledger(rows, source_log=source_log)
+    tmp = output_path + '.tmp.%d' % os.getpid()
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    with open(tmp, 'w', encoding='utf-8', newline='\n') as f:
+        json.dump(payload, f, ensure_ascii=False, indent=1)
+        f.write('\n')
+    os.replace(tmp, output_path)
+    return payload
+
+
+def gate(ledger, ceil_agents_per_clean=None, ceil_cost_per_clean=None):
+    """Return exit code 1 on an AGGREGATE breach (never per-card), else 0.
+
+    Compares the headline `agents_per_clean_incl_requeues` and the in-band fresh-input
+    `cost_per_clean_band.ceil_usd` against the supplied ceilings. Individual runs are
+    NEVER gated — a single expensive/wasted window cannot flip the gate; only the pooled
+    aggregate can.
+    """
+    agg = ledger['aggregate']
+    breaches = []
+    apc = agg.get('agents_per_clean_incl_requeues')
+    band = agg.get('cost_per_clean_band') or {}
+    cost = band.get('ceil_usd')
+    if ceil_agents_per_clean is not None and apc is not None and apc > ceil_agents_per_clean:
+        breaches.append('agents_per_clean_incl_requeues %.4f > ceiling %.4f'
+                        % (apc, ceil_agents_per_clean))
+    if ceil_cost_per_clean is not None and cost is not None and cost > ceil_cost_per_clean:
+        breaches.append('cost_per_clean ceil $%.4f > ceiling $%.4f'
+                        % (cost, ceil_cost_per_clean))
+    for b in breaches:
+        sys.stderr.write('ECONOMY GATE BREACH: %s\n' % b)
+    return 1 if breaches else 0
+
+
+def summary_lines(ledger):
+    """Human-readable economy summary. Every aggregate can be None when NO outcome row entered the
+    agents-per-clean set (an all-wasted / all-nulled log — exactly the honest 'nothing clean' case the
+    ledger exists to report), so each numeric line is guarded rather than %-formatted blindly."""
+    cov = ledger['coverage']
+    agg = ledger['aggregate']
+    band = agg['cost_per_clean_band']
+    lines = [cov['line']]
+    incl = agg['agents_per_clean_incl_requeues']
+    if incl is None:
+        lines.append('agents_per_clean: n/a — no clean cards in scope (all runs wasted/nulled)')
+    else:
+        lines.append('%s: %.3f (%s)' % (agg['agents_per_clean_incl_requeues_label'], incl,
+                                        agg['agents_per_clean_incl_requeues_basis']))
+    fp = agg['agents_per_clean_first_pass']
+    if fp is not None:
+        lines.append('first-pass agents_per_clean: %.3f' % fp)
+    if band is not None:
+        lines.append('cost per clean: $%.4f .. $%.4f (fresh-input ceil, excludes output premium; '
+                     'true upper $%.4f at output rate)'
+                     % (band['floor_usd'], band['ceil_usd'], band['true_upper_output_rate_usd']))
+    else:
+        lines.append('cost per clean: n/a — no clean cards in scope')
+    lines.append('wasted: %d agents / %d tokens on clean=0 runs'
+                 % (agg['wasted_agents'], agg['wasted_tokens']))
+    return lines
+
+
+def main():
+    ap = argparse.ArgumentParser(description='PWG->RU economy ledger (offline, read-only)')
+    ap.add_argument('--log', default=FROZEN_LOG, help='frozen outcome log (read-only)')
+    ap.add_argument('--write', metavar='PATH', help='also write the durable ledger JSON here')
+    ap.add_argument('--ceil-agents-per-clean', type=float, default=None)
+    ap.add_argument('--ceil-cost-per-clean', type=float, default=None)
+    args = ap.parse_args()
+
+    rows = read_rows(args.log)
+    ledger = build_ledger(rows, source_log=os.path.basename(args.log))
+    if args.write:
+        write_ledger(args.write, rows=rows, source_log=os.path.basename(args.log))
+        print('wrote', args.write)
+
+    for line in summary_lines(ledger):
+        print(line)
+
+    return gate(ledger, args.ceil_agents_per_clean, args.ceil_cost_per_clean)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/RussianTranslation/src/pilot/economy_ledger_selftest.py
+++ b/RussianTranslation/src/pilot/economy_ledger_selftest.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python
+"""Standalone selftests for economy_ledger.py (H960 gap: economy-telemetry).
+
+Kept OUT of window_selftest.py deliberately (that file is a LANG_PARITY-tracked shared
+file the parent session owns). Parity-free; run directly:
+
+    python src/pilot/economy_ledger_selftest.py
+
+Model: authored by Opus 4.8 (claude-opus-4-8) for handoff H960.
+"""
+import json
+import os
+import sys
+import tempfile
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import economy_ledger as el
+import parse_workflow_cost as pwc
+
+
+def fail(message):
+    raise AssertionError(message)
+
+
+def approx(a, b, tol=1e-9):
+    return a is not None and b is not None and abs(a - b) <= tol
+
+
+def outcome_row(run_id, window, agents_used=None, clean=None, tokens=None, note=''):
+    """Build a synthetic kind=='outcome' row. Passing agents_used/clean/tokens=None
+    with a `note` mimics the w08/w09 nulled-into-free-text rows."""
+    return {
+        'ts': '2026-07-14T00:00:00Z', 'kind': 'outcome', 'run_id': run_id,
+        'window': window, 'handoff': 'HTEST',
+        'outcome': {'cards': None, 'audit_clean': clean, 'agents_used': agents_used,
+                    'subagent_tokens': tokens, 'kill_timeouts': None, 'conn_errors': None,
+                    'budget_kill_switch_tripped': False},
+        'note': note,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. synthetic: agents_per_clean + [floor,ceil,true_upper] band == hand-computed
+# ---------------------------------------------------------------------------
+def test_synthetic_agents_per_clean_and_band():
+    rows = [outcome_row('r_full', 'no_pwg_wA', agents_used=10, clean=5, tokens=1_000_000)]
+    led = el.build_ledger(rows)
+    run = led['runs'][0]
+
+    if run['agents_per_clean'] != 2.0:
+        fail('agents_per_clean must be 10/5=2.0, got %s' % run['agents_per_clean'])
+    if run['status'] != 'priced':
+        fail('full row must be status=priced, got %s' % run['status'])
+
+    # hand-computed band for 1,000,000 tokens over 5 clean:
+    #   floor = 1e6 * 0.30 / 1e6 / 5 = 0.06 ; ceil = 1e6 * 3.00 /1e6 /5 = 0.60
+    #   true_upper = 1e6 * 15.00 /1e6 /5 = 3.00
+    band = run['cost_per_clean']
+    if not approx(band['floor_usd'], 0.06):
+        fail('band floor must be 0.06, got %s' % band['floor_usd'])
+    if not approx(band['ceil_usd'], 0.60):
+        fail('band ceil must be 0.60, got %s' % band['ceil_usd'])
+    if not approx(band['true_upper_output_rate_usd'], 3.00):
+        fail('band true_upper must be 3.00, got %s' % band['true_upper_output_rate_usd'])
+    if 'EXCLUDES output premium' not in band['basis']:
+        fail('band basis must flag the excluded output premium')
+
+
+# ---------------------------------------------------------------------------
+# 2. clean==0 -> excluded from division, reported wasted, tokens still pooled
+# ---------------------------------------------------------------------------
+def test_clean_zero_is_wasted_never_divided():
+    rows = [
+        outcome_row('r_full', 'no_pwg_wA', agents_used=10, clean=5, tokens=1_000_000),
+        outcome_row('r_wasted', 'medium_wB', agents_used=8, clean=0, tokens=500_000),
+    ]
+    led = el.build_ledger(rows)
+    wasted = [r for r in led['runs'] if r['run_id'] == 'r_wasted'][0]
+    if wasted['status'] != 'wasted_calls':
+        fail('clean=0 must be status=wasted_calls, got %s' % wasted['status'])
+    if wasted['agents_per_clean'] is not None:
+        fail('clean=0 must NEVER carry an agents_per_clean value')
+    if wasted['cost_per_clean'] is not None:
+        fail('clean=0 must NEVER carry a per-run cost (no division by zero)')
+    if 'wasted_calls' not in wasted['flags']:
+        fail('clean=0 must be flagged wasted_calls')
+
+    # reported in the wasted_calls list with its agents+tokens
+    wl = led['wasted_calls']
+    if not any(w['run_id'] == 'r_wasted' and w['agents_used'] == 8 and w['tokens'] == 500_000
+               for w in wl):
+        fail('wasted run must appear in wasted_calls with agents+tokens')
+    if led['aggregate']['wasted_agents'] != 8 or led['aggregate']['wasted_tokens'] != 500_000:
+        fail('aggregate wasted_agents/tokens must total the clean=0 rows')
+
+    # tokens still POOL into the aggregate band (1.5M over 5 clean), but agents_per_clean
+    # aggregate excludes the wasted run entirely (only the full run's 10/5 counts).
+    agg = led['aggregate']
+    if agg['total_tokens'] != 1_500_000 or agg['total_clean'] != 5:
+        fail('pooled band must include wasted tokens (1.5M) over 5 clean, got %s/%s'
+             % (agg['total_tokens'], agg['total_clean']))
+    if not approx(agg['agents_per_clean_incl_requeues'], 2.0):
+        fail('agents_per_clean aggregate must exclude the wasted run (10/5=2.0), got %s'
+             % agg['agents_per_clean_incl_requeues'])
+
+
+# ---------------------------------------------------------------------------
+# 3. nulled-into-note row -> incomplete on agents, but tokens ARE priced
+# ---------------------------------------------------------------------------
+def test_nulled_row_incomplete_but_priced():
+    rows = [outcome_row(
+        'r_nulled', 'no_pwg_w08',
+        note='cards=21 ok=2 clean=4 defect=1 subagent_tokens=800000 duration_ms=5')]
+    led = el.build_ledger(rows)
+    run = led['runs'][0]
+
+    if run['provenance'] != 'nulled_note':
+        fail('nulled row provenance must be nulled_note, got %s' % run['provenance'])
+    if run['agents_used'] is not None:
+        fail('agents_used must stay None (note carries no agents_used key)')
+    if 'calls_per_clean_incomplete' not in run['flags']:
+        fail('nulled row must be flagged calls_per_clean_incomplete')
+    if run['agents_per_clean'] is not None:
+        fail('nulled row must NOT produce an agents_per_clean value')
+    if run['status'] != 'incomplete':
+        fail('nulled row status must be incomplete, got %s' % run['status'])
+
+    # but clean+tokens recovered from the note -> band IS priced.
+    # floor = 800000*0.30/1e6/4 = 0.06 ; ceil = 800000*3.00/1e6/4 = 0.60
+    band = run['cost_per_clean']
+    if band is None:
+        fail('nulled row tokens MUST still be priced (clean+tokens recovered from note)')
+    if not approx(band['floor_usd'], 0.06) or not approx(band['ceil_usd'], 0.60):
+        fail('nulled row band must be [0.06,0.60], got %s' % band)
+
+
+# ---------------------------------------------------------------------------
+# 4. DEDUP keyed on run_id, NOT window; conflicting re-append surfaced
+# ---------------------------------------------------------------------------
+def test_dedup_on_run_id_not_window():
+    # same window label reused for two distinct runs (fresh + requeue) -> both kept
+    rows = [
+        outcome_row('r_fresh', 'no_pwg_w03', agents_used=10, clean=5, tokens=1_000_000),
+        outcome_row('r_requeue', 'no_pwg_w03', agents_used=6, clean=6, tokens=600_000),
+    ]
+    led = el.build_ledger(rows)
+    if len(led['runs']) != 2:
+        fail('window-label collision must NOT collapse distinct run_ids, got %d rows'
+             % len(led['runs']))
+
+    # exact re-append of the SAME run_id is idempotent -> deduped to one
+    rows2 = rows + [outcome_row('r_fresh', 'no_pwg_w03', agents_used=10, clean=5, tokens=1_000_000)]
+    led2 = el.build_ledger(rows2)
+    if len(led2['runs']) != 2:
+        fail('exact re-append of a run_id must be idempotent, got %d rows' % len(led2['runs']))
+    if led2['conflicting_run_ids']:
+        fail('an exact re-append is NOT a conflict, got %s' % led2['conflicting_run_ids'])
+
+    # re-append of same run_id with DIFFERENT figures -> conflict surfaced
+    rows3 = rows + [outcome_row('r_fresh', 'no_pwg_w03', agents_used=99, clean=5, tokens=1_000_000)]
+    led3 = el.build_ledger(rows3)
+    if led3['conflicting_run_ids'] != ['r_fresh']:
+        fail('conflicting re-append must surface run_id, got %s' % led3['conflicting_run_ids'])
+
+
+# ---------------------------------------------------------------------------
+# 5. ledger IMPORTS PRICE (single source of truth), never duplicates rates
+# ---------------------------------------------------------------------------
+def test_ledger_imports_price_not_duplicated():
+    if el.PRICE is not pwc.PRICE:
+        fail('economy_ledger.PRICE must BE parse_workflow_cost.PRICE (same object), not a copy')
+    src = open(os.path.join(HERE, 'economy_ledger.py'), encoding='utf-8').read()
+    # no re-hardcoded rate literals: the module must not contain its own PRICE dict
+    if "PRICE = {" in src or "'cache_read': 0.30" in src:
+        fail('economy_ledger must not re-hardcode a rate table; import pwc.PRICE only')
+
+
+# ---------------------------------------------------------------------------
+# 6. gate fires on AGGREGATE breach only, never per-card
+# ---------------------------------------------------------------------------
+def test_gate_is_aggregate_only():
+    # one cheap run + one absurdly expensive single run; aggregate stays modest.
+    rows = [
+        outcome_row('r_cheap', 'no_pwg_wA', agents_used=2, clean=100, tokens=1_000_000),
+        outcome_row('r_spike', 'no_pwg_wB', agents_used=50, clean=1, tokens=1_000_000),
+    ]
+    led = el.build_ledger(rows)
+    # aggregate agents_per_clean = (2+50)/(100+1) = 52/101 = 0.5148 -> under a ceiling of 5
+    if el.gate(led, ceil_agents_per_clean=5.0) != 0:
+        fail('a single per-card spike must NOT flip the aggregate gate')
+    # but a ceiling below the aggregate breaches
+    if el.gate(led, ceil_agents_per_clean=0.4) != 1:
+        fail('aggregate above ceiling must breach the gate')
+    # cost gate: aggregate ceil band per clean is small; a tiny ceiling breaches
+    if el.gate(led, ceil_cost_per_clean=0.0001) != 1:
+        fail('cost ceiling below aggregate must breach')
+    if el.gate(led, ceil_cost_per_clean=1e6) != 0:
+        fail('a huge cost ceiling must pass')
+
+
+# ---------------------------------------------------------------------------
+# 7. atomic write round-trips to a tempfile (mirrors write_census)
+# ---------------------------------------------------------------------------
+def test_write_ledger_roundtrip():
+    rows = [outcome_row('r_full', 'no_pwg_wA', agents_used=10, clean=5, tokens=1_000_000)]
+    d = tempfile.mkdtemp()
+    out = os.path.join(d, 'economy_ledger.v1.json')
+    el.write_ledger(out, rows=rows, source_log='synthetic.jsonl')
+    payload = json.load(open(out, encoding='utf-8'))
+    if payload['schema'] != 'pwg.economy_ledger.v1':
+        fail('written ledger must carry schema pwg.economy_ledger.v1, got %s' % payload['schema'])
+    if payload['runs'][0]['agents_per_clean'] != 2.0:
+        fail('written ledger figures must survive the round-trip')
+
+
+# ---------------------------------------------------------------------------
+# 8. INTEGRATION: real frozen log reproduces the pinned figures exactly
+# ---------------------------------------------------------------------------
+def test_integration_real_frozen_log():
+    rows = el.read_rows(el.FROZEN_LOG)   # read-only
+    led = el.build_ledger(rows)
+
+    # -- coverage line: the exact refinement-1 string --
+    expected_line = ('6/9 outcome rows carry structured agents_used; '
+                     '5/9 enter agents-per-clean '
+                     '(1 has clean=0 -> wasted_calls; 3 nulled -> incomplete)')
+    if led['coverage']['line'] != expected_line:
+        fail('coverage line drifted:\n  got: %s\n  exp: %s'
+             % (led['coverage']['line'], expected_line))
+    cov = led['coverage']
+    if (cov['outcome_rows'], cov['structured_agents_used'], cov['enter_agents_per_clean'],
+            cov['clean0_wasted'], cov['nulled_incomplete']) != (9, 6, 5, 1, 3):
+        fail('coverage counts drifted: %s' % cov)
+
+    # -- per-run w07 -> 38/5 = 7.6 --
+    w07 = [r for r in led['runs'] if r['run_id'] == 'wf_5ed6f8e0-b0b'][0]
+    if w07['agents_per_clean'] != 7.6:
+        fail('w07 (wf_5ed6f8e0-b0b) agents_per_clean must be 38/5=7.6, got %s'
+             % w07['agents_per_clean'])
+
+    agg = led['aggregate']
+
+    # -- headline aggregate: 139 agents / 49 clean = 2.836735 (incl requeues) --
+    if agg['agents_per_clean_incl_requeues'] != round(139 / 49, 6):
+        fail('agents_per_clean incl requeues must be 139/49=2.836735, got %s'
+             % agg['agents_per_clean_incl_requeues'])
+    if agg['agents_per_clean_incl_requeues_label'] != 'total agents to fully drain incl. requeues':
+        fail('headline aggregate MUST be labeled "total agents to fully drain incl. requeues"')
+
+    # -- first-pass: 95 agents / 27 clean = 3.518519 --
+    if agg['agents_per_clean_first_pass'] != round(95 / 27, 6):
+        fail('first-pass agents_per_clean must be 95/27=3.518519, got %s'
+             % agg['agents_per_clean_first_pass'])
+
+    # -- pooled cost band: 13,739,312 tokens / 59 clean --
+    if agg['total_tokens'] != 13_739_312 or agg['total_clean'] != 59:
+        fail('pooled totals must be 13,739,312 tokens / 59 clean, got %s/%s'
+             % (agg['total_tokens'], agg['total_clean']))
+    band = agg['cost_per_clean_band']
+    # hand-pinned REAL numbers (recomputed honestly from the frozen log; the audit's cited
+    # $0.073-$0.731 did NOT reconstruct — these are what the log actually yields):
+    if band['floor_usd'] != 0.069861:
+        fail('pooled floor must be $0.069861 (cache-read rate), got %s' % band['floor_usd'])
+    if band['ceil_usd'] != 0.698609:
+        fail('pooled ceil must be $0.698609 (fresh-input rate), got %s' % band['ceil_usd'])
+    if band['true_upper_output_rate_usd'] != 3.493045:
+        fail('true upper (output rate) must be $3.493045, got %s'
+             % band['true_upper_output_rate_usd'])
+    # the band figures must also equal the formula recomputed straight from PRICE
+    # (formula pin: a rate edit breaks this loudly, like h809_selftest's cache-multiplier pin)
+    if not approx(band['ceil_usd'], round(13_739_312 * pwc.PRICE['input'] / 1e6 / 59, 6)):
+        fail('band ceil must equal tokens*input_rate/1e6/clean from PRICE')
+    if not approx(band['floor_usd'], round(13_739_312 * pwc.PRICE['cache_read'] / 1e6 / 59, 6)):
+        fail('band floor must equal tokens*cache_read_rate/1e6/clean from PRICE')
+
+    # -- wasted (row 6, h317_w1b): 58 agents / 1,798,042 tokens, 0 clean --
+    if agg['wasted_agents'] != 58 or agg['wasted_tokens'] != 1_798_042:
+        fail('wasted totals must be 58 agents / 1,798,042 tokens, got %s/%s'
+             % (agg['wasted_agents'], agg['wasted_tokens']))
+
+    # -- no spurious conflicts on the real log (all 9 run_ids distinct) --
+    if led['conflicting_run_ids']:
+        fail('real log must yield no conflicting_run_ids, got %s' % led['conflicting_run_ids'])
+
+
+def test_all_wasted_summary_does_not_crash():
+    # Every row clean=0 -> no outcome row enters the agents-per-clean set, so the aggregate
+    # agents_per_clean / cost band are None. summary_lines() (the main() print path) must render the
+    # honest 'n/a' summary, not raise `TypeError: must be real number, not NoneType` — this is the
+    # exact 'everything wasted' case the ledger exists to report honestly.
+    rows = [
+        outcome_row('w1', 'no_pwg_wA', agents_used=8, clean=0, tokens=500_000),
+        outcome_row('w2', 'no_pwg_wB', agents_used=6, clean=0, tokens=300_000),
+    ]
+    led = el.build_ledger(rows)
+    agg = led['aggregate']
+    if agg['agents_per_clean_incl_requeues'] is not None or agg['cost_per_clean_band'] is not None:
+        fail('an all-wasted log must yield None aggregates, got %r' % agg)
+    lines = el.summary_lines(led)           # must NOT raise on the None aggregates
+    joined = '\n'.join(lines)
+    if 'n/a' not in joined or 'wasted: 14 agents' not in joined:
+        fail('all-wasted summary must report n/a + the wasted totals, got:\n%s' % joined)
+
+
+def main():
+    tests = [
+        test_synthetic_agents_per_clean_and_band,
+        test_clean_zero_is_wasted_never_divided,
+        test_nulled_row_incomplete_but_priced,
+        test_dedup_on_run_id_not_window,
+        test_ledger_imports_price_not_duplicated,
+        test_gate_is_aggregate_only,
+        test_write_ledger_roundtrip,
+        test_integration_real_frozen_log,
+        test_all_wasted_summary_does_not_crash,
+    ]
+    for t in tests:
+        t()
+        print('PASS:', t.__name__)
+    print('economy_ledger selftest OK')
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -44,6 +44,7 @@ from window_common import INP, REPO, SRC, input_paths, load_json, read_text, roo
 from agent_budget import derive_agent_budget
 import pwg_mask
 from autosplit_requeue import plan as split_plan     # deterministic per-card sense/citation split
+from sense_count import count_source_senses           # H920/H960 deterministic top-level source-sense count
 sys.path.insert(0, SRC)
 from safe_filename import safe_name
 from whitney_grammar import grammar_for
@@ -952,6 +953,10 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
                      'ls': raw.count('<ls'), 'sk': raw.count('{#'),
                      'senses': raw.count('〉'),  # '〉' sense-delimiter count — coarse
                                                      # output-complexity signal for the kill budget
+                     # H960: deterministic distinct top-level source-sense count (cross-reference
+                     # hardened; see sense_count._OPEN_PREFIX). Consumed by accept()'s SAN-LOSS
+                     # shortfall telemetry — distinct from the coarse 'senses' kill-budget signal.
+                     'source_senses': count_source_senses(raw),
                      'nws': 1 if 'NWS' in raw else 0}
         raws[k] = raw
         portraits[k] = portrait
@@ -1485,6 +1490,28 @@ let KILL_TIMEOUTS = 0
 let CONN_ERRORS = 0
 let HEAL_CALLS = 0
 let KILL_BISECT_BLOCKED = 0
+// H960 SAN-LOSS shortfall telemetry: TELEMETRY ONLY, no behavioural change (SOFT rollout).
+// accept() records — but does NOT reject on — a card whose emitted top-level sense count
+// falls short of the source's deterministic (cross-reference-hardened) source_senses. This
+// is the whole-dropped-sense signal the <ls>/{# fidelity guard is blind to (H920's deferred
+// deepest fix). It is soft-first so live traffic can measure the true drop-vs-false-flag
+// balance before the reject+requeue is armed; flipping SANLOSS_HARD_REJECT=true (owner-gated,
+// after the live measurement) turns each shortfall into the same deterministic requeue as an
+// ls/sk fidelity-reject. Counter + per-card details ride in `summary` for classify_run.py.
+const SANLOSS_HARD_REJECT = false
+let SANLOSS_SHORTFALLS = 0
+const SANLOSS_DETAIL = []
+// H960 grammar-{Tn} multiset telemetry: TELEMETRY ONLY, no behavioural change (SOFT rollout).
+// The main-path accept() <ls>/{# count check is blind to a dropped GRAMMAR <lex> {Tn} (or any
+// masked span carrying neither an <ls> nor a {#) — the exact gap the heal path's acceptFrag
+// already guards with a full {Tn}-multiset compare. accept() records — but does NOT reject on —
+// a card whose emitted {Tn} multiset differs from its source skeleton's. Soft-first so live
+// traffic can measure the drop-vs-self-expansion mix (a model that writes literal <ls>..</ls>
+// instead of {Tn} also trips this) before the reject is armed; flipping TNMASK_HARD_REJECT=true
+// (owner-gated) turns each mismatch into the same deterministic requeue as an ls/sk reject.
+const TNMASK_HARD_REJECT = false
+let TNMASK_MISMATCHES = 0
+const TNMASK_DETAIL = []
 const isConn = e => !!(e && !(e instanceof KillTimeout) && /connection closed|connection error|econnreset|econnrefused|socket hang up|fetch failed|network error/i.test(String(e && e.message)))
 async function agentKill(prompt, opts, skelBytes, budgetMsOverride) {
   const healLane = !!(opts && opts.label && /^heal:/.test(String(opts.label)))
@@ -1551,6 +1578,20 @@ const cardBlock = k => (GRAMMARS[k] || '') + '\\n\\n=== CARD ' + k + ' ===\\n---
 
 const accept = (c, k) => {
   if (!c) return null
+  // H960 grammar-{Tn} multiset guard (soft). BEFORE restore (the {Tn} placeholders are gone
+  // after restoreCard): a dropped grammar <lex> {Tn} carries neither an <ls> nor a {#, so the
+  // count check below is blind to it — but the {Tn} multiset is not. This is the heal path's
+  // acceptFrag check (which has run in production without incident) brought to the main path.
+  // SOFT by default: record telemetry, do NOT reject; arming is TNMASK_HARD_REJECT (owner-gated).
+  {
+    const tok = cardTokens(c), want = tokensOf(INPUTS[k].skeleton)
+    if (tok !== want) {
+      TNMASK_MISMATCHES++
+      TNMASK_DETAIL.push({ key: k, got: tok, want: want })
+      if (TNMASK_HARD_REJECT) { noteFail(k, 'tnmask-reject: {Tn} multiset [' + tok + '] != [' + want + ']'); return null }
+      log('{Tn} multiset mismatch (soft): ' + k + ' — kept, telemetry only')
+    }
+  }
   c = restoreCard(c, k)
   // Fidelity guard: restored <ls>/{#..#} counts MUST match the source — a mismatch
   // means misalignment / dropped {Tn}. Reject -> deterministic requeue, never emit garbled.
@@ -1558,6 +1599,26 @@ const accept = (c, k) => {
   if (ls !== INPUTS[k].ls || sk !== INPUTS[k].sk) {
     noteFail(k, 'fidelity-reject: <ls> ' + ls + '/' + INPUTS[k].ls + ', {# ' + sk + '/' + INPUTS[k].sk)
     return null
+  }
+  // H960 SAN-LOSS shortfall guard (H920's deferred deepest fix). The ls/sk fidelity check
+  // above is blind to a whole dropped sense that carries neither a citation nor a {#..#} span
+  // (darvI 2/3). Compare the emitted top-level sense count to the source's deterministic,
+  // cross-reference-hardened source_senses (stamped Python-side). exp<1 (unnumbered supplement)
+  // is skipped, and only a shortfall (emitted < exp) is flagged — a faithful split that yields
+  // MORE senses never trips it. SOFT by default: record telemetry, do NOT reject; arming the
+  // reject is SANLOSS_HARD_REJECT (owner-gated, after live measurement of the false-flag rate).
+  const exp = INPUTS[k].source_senses
+  if (exp > 0) {
+    const emitted = (c.records || []).reduce((n, rec) => n + ((rec.senses || []).length), 0)
+    if (emitted < exp) {
+      SANLOSS_SHORTFALLS++
+      SANLOSS_DETAIL.push({ key: k, expected: exp, emitted: emitted, dropped: exp - emitted })
+      if (SANLOSS_HARD_REJECT) {
+        noteFail(k, 'sanloss-reject: senses ' + emitted + '/' + exp)
+        return null
+      }
+      log('SAN-LOSS shortfall (soft): ' + k + ' senses ' + emitted + '/' + exp + ' — kept, telemetry only')
+    }
   }
   return c
 }
@@ -1983,6 +2044,14 @@ const summary = { root: META.root, lang: META.lang, cards: out.length, ok: _ok,
                   // was routed to requeue instead of bisection (KILL_TIMEOUT_NO_BISECT).
                   kill_timeouts: KILL_TIMEOUTS, conn_errors: CONN_ERRORS,
                   heal_calls: HEAL_CALLS, kill_bisect_blocked: KILL_BISECT_BLOCKED,
+                  // H960 SAN-LOSS shortfall telemetry (SOFT — no reject unless
+                  // SANLOSS_HARD_REJECT). sanloss_shortfalls counts kept-but-short cards;
+                  // sanloss_detail lists {key,expected,emitted,dropped} for the audit join.
+                  sanloss_shortfalls: SANLOSS_SHORTFALLS, sanloss_hard_reject: SANLOSS_HARD_REJECT,
+                  sanloss_detail: SANLOSS_DETAIL,
+                  // H960 grammar-{Tn} multiset telemetry (SOFT — no reject unless TNMASK_HARD_REJECT).
+                  tnmask_mismatches: TNMASK_MISMATCHES, tnmask_hard_reject: TNMASK_HARD_REJECT,
+                  tnmask_detail: TNMASK_DETAIL,
                   null_keys: out.filter(r => !r.card).map(r => r.key),
                   partial_keys: out.filter(r => r.card && r.card.partial).map(r => r.key),
                   failures: _failures }

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -424,6 +424,15 @@ def cmd_run_once(args):
     db = connect(args.db)
     accounts = list(db.execute('SELECT * FROM accounts ORDER BY name'))
     db.close()
+    # GAP #5 (four-profile): optional dispatch allow-list. cmd_staged_run passes the exact set of
+    # accounts that PASSED probe_fleet (set(probe_latencies)) so a --max-accounts-capped or
+    # --drop-unhealthy-dropped account — which was never health-probed — cannot receive a job. Without
+    # it, this re-select-all dispatch would claim jobs for every validated, unparked account,
+    # bypassing the mandatory pre-dispatch probe (the cap/drop would apply only to the probe set).
+    # Default (attribute absent / None) is unrestricted, so a standalone `run-once` is unchanged.
+    only = getattr(args, 'only_accounts', None)
+    if only is not None:
+        accounts = [a for a in accounts if a['name'] in only]
     work = []
     for acc in accounts:
         job = claim(args.db, acc['name'])
@@ -454,6 +463,10 @@ def cmd_status(args):
 EXACT_GEN_MODEL = 'claude-sonnet-5'      # D-F: exact generation model under test
 PROBE_MIN_PAYLOAD_BYTES = 5000           # D-F: repository >=5 KB load-representative floor
 PROBE_LATENCY_CEILING_MS = 30000         # D-F: health ceiling; a reading over this is NO-GO
+# GAP #5 (four-profile): an account dropped by --drop-unhealthy is parked far in the future so the
+# dispatch loop's runnable/claim gates exclude it while the fleet proceeds on the healthy subset.
+# Only the explicit opt-in ever parks this way; the default STOP-on-any-NO-GO path never drops.
+PARKED_FOREVER = 2147483647              # ~2038; a 10-digit epoch, safely "never" vs. any real reset
 # (>=5 KB applies to the INPUT payload; the probe validates the OUTPUT by result-envelope structure,
 # not by size -- a valid success wrapper with the small {"ok":true} schema result is fine.)
 
@@ -564,6 +577,43 @@ def live_probe(config_dir, claude='claude', payload_bytes=6491, model=EXACT_GEN_
     return meas_ms
 
 
+def probe_fleet(accounts, claude='claude', payload_bytes=6491, model=EXACT_GEN_MODEL,
+                latency_ceiling_ms=PROBE_LATENCY_CEILING_MS, events_path=None, run_id=None,
+                drop_unhealthy=False):
+    """GAP #5 (four-profile): probe EACH validated account through the D-K two-phase ``live_probe``
+    (exactly one warm-up + one measured >=5 KB call per account, with each account's warm-up latency
+    EXCLUDED from the census — a 4-profile fleet therefore yields exactly 4 measured latency samples,
+    not 8, so the acceptance census is not inflated). Every call is emitted with ``purpose`` warmup /
+    measured and its own ``account`` label. Returns an ordered ``name -> measured_ms`` map for the
+    accounts that passed — this map is what ``report['probe_latency_ms']`` is rewired from.
+
+    DEFAULT policy is STOP-on-any-NO-GO: the first account whose probe fails (a warm-up STOP, a
+    measured NO-GO, or an over-ceiling reading) aborts the WHOLE fleet by propagating the
+    ``live_probe`` ``SystemExit`` — matching acceptance #1 ("four profile probes succeed") and the
+    existing honest-NO-GO stance. ``drop_unhealthy=True`` is the explicit opt-in to instead DROP a
+    failing account and continue on the healthy subset (still requiring >=1 healthy account); the
+    caller parks the dropped accounts so dispatch proceeds only on the survivors.
+
+    N==1 is a pure pass-through: ``probe_fleet([acc])`` returns ``{acc: live_probe(acc.config_dir,
+    ...)}`` and the single measured latency is identical to the pre-N-profile
+    ``live_probe(accounts[0])`` reading — the Windows-100 single-profile path is unchanged."""
+    latencies = {}
+    for acc in accounts:
+        name = acc['name']
+        try:
+            latencies[name] = live_probe(acc['config_dir'], claude, payload_bytes=payload_bytes,
+                                         model=model, latency_ceiling_ms=latency_ceiling_ms,
+                                         events_path=events_path, run_id=run_id, account=name)
+        except SystemExit as exc:
+            if not drop_unhealthy:
+                # STOP-on-any-NO-GO: one unhealthy profile fails the whole fleet (honest NO-GO).
+                raise SystemExit('fleet probe STOP on account %s: %s' % (name, exc))
+            # explicit opt-in: drop this account and proceed on the healthy subset.
+    if not latencies:
+        raise SystemExit('fleet probe: no healthy validated account (probed %d)' % len(accounts))
+    return latencies
+
+
 def cmd_staged_run(args):
     plan = json.load(open(args.plan, encoding='utf-8'))
     plan_lease_ids = [window['root'] for window in plan.get('windows', [])
@@ -578,11 +628,24 @@ def cmd_staged_run(args):
     db = connect(args.db)
     accounts = list(db.execute('SELECT * FROM accounts WHERE validated=1 ORDER BY name'))
     db.close()
-    if len(accounts) != 1:
-        raise SystemExit('Windows staged-run requires exactly one validated account')
+    # GAP #5 (four-profile): the staged run now fans across N validated profiles instead of hard-
+    # capping at one. Require >=1 (a zero-account run has nothing to probe or dispatch); --max-
+    # accounts optionally caps the fleet. N==1 remains the exact single-profile Windows-100 path.
+    if not accounts:
+        raise SystemExit('Windows staged-run requires at least one validated account')
+    if getattr(args, 'max_accounts', 0):
+        accounts = accounts[:args.max_accounts]
     run_id = args.run_id or ('win100-' + now_iso().replace(':', '').replace('-', ''))
-    latency_ms = live_probe(accounts[0]['config_dir'], args.claude_bin,   # D-K: warmup+measured
-                            events_path=args.events, run_id=run_id, account=accounts[0]['name'])
+    # Probe EVERY validated account (D-K warmup+measured per account; census not inflated). DEFAULT
+    # STOP-on-any-NO-GO; --drop-unhealthy opts into proceeding on the healthy subset, parking the
+    # dropped accounts so the dispatch loop below claims only survivors.
+    probe_latencies = probe_fleet(accounts, args.claude_bin, events_path=args.events,
+                                  run_id=run_id, drop_unhealthy=getattr(args, 'drop_unhealthy', False))
+    if getattr(args, 'drop_unhealthy', False):
+        for acc in accounts:
+            if acc['name'] not in probe_latencies:
+                park(args.db, acc['name'], PARKED_FOREVER,
+                     'dropped after probe NO-GO (--drop-unhealthy); healthy subset proceeds')
     db = connect(args.db)
     existing_jobs = {row['external_id'] for row in db.execute('SELECT external_id FROM jobs')}
     db.close()
@@ -623,7 +686,10 @@ def cmd_staged_run(args):
                                  'until %s; rerun with --resume after the reset' % (pending, earliest))
             cmd_run_once(argparse.Namespace(db=args.db, timeout=args.timeout,
                                             events=args.events, run_id=run_id,
-                                            claude_bin=args.claude_bin))
+                                            claude_bin=args.claude_bin,
+                                            # dispatch ONLY to the probed, capped/healthy fleet —
+                                            # never to a capped-out or dropped (unprobed) account.
+                                            only_accounts=set(probe_latencies)))
         cmd_record_done(argparse.Namespace(db=args.db, coordinator=args.coordinator,
                                            cwd=args.cwd))
         promote = subprocess.run(
@@ -700,7 +766,7 @@ def cmd_staged_run(args):
                         for p in outputs)
     report = {
         'schema': 'pwg.windows100_readiness.v1', 'generated_at': now_iso(),
-        'probe_latency_ms': latency_ms, 'windows': len(outputs),
+        'probe_latency_ms': probe_latencies, 'windows': len(outputs),
         'headwords': expected_headwords, 'actual_unique_headwords': len(headwords),
         'subcards': cards, 'expected_subcards': len(selected_keys),
         'model_nonnull': clean, 'audit_clean': audited_clean,
@@ -784,6 +850,8 @@ def main(argv=None):
     p.add_argument('--plan', required=True)
     p.add_argument('--claude-bin', default='claude'); p.add_argument('--timeout', type=int, default=7200)
     p.add_argument('--stop-after', type=int, default=0); p.add_argument('--resume', action='store_true')
+    p.add_argument('--max-accounts', type=int, default=0)          # GAP #5: cap the validated fleet
+    p.add_argument('--drop-unhealthy', action='store_true')        # GAP #5: proceed on healthy subset
     p.add_argument('--report', required=True)
     p.add_argument('--events', required=True); p.add_argument('--census', required=True)
     p.add_argument('--run-id'); p.set_defaults(func=cmd_staged_run)

--- a/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
@@ -377,6 +377,192 @@ def main():
         assert cid0 in ro.build_census(ro.read_events(ev))['conflicting_call_ids']
     print('  D-I exactly-once: 5-key=1 sample; retry distinct; dupe dedup; conflict flagged; context preserved')
 
+    # GAP #5 (four-profile core): probe_fleet fans the D-K two-phase probe across EACH validated
+    # account. (e) 4 mocked accounts -> a 4-entry name->ms map, census NOT inflated (4 measured
+    # samples, the 4 warm-ups excluded), and one NO-GO account STOPs the whole fleet by default;
+    # --drop-unhealthy is the explicit opt-in to proceed on the healthy subset. (f) N=1 is a pure
+    # pass-through identical to the old single-account live_probe(accounts[0]).
+    _pc = m._probe_call
+    try:
+        # live_probe calls _probe_call twice per account (warm-up then measured); each account's
+        # FIRST call is its warm-up. A distinct, large warm-up latency (99999) proves the warm-up is
+        # excluded from the acceptance census while the per-account measured latency is retained.
+        def healthy(measured_by_cfg, warm_ms=99999):
+            seen = set()
+
+            def _mock(config_dir, claude, payload_bytes, model):
+                if config_dir not in seen:
+                    seen.add(config_dir)
+                    return warm_ms, 'success', 120          # warm-up (EXCLUDED from latency census)
+                return measured_by_cfg[config_dir], 'success', 120   # measured (the one gated reading)
+            return _mock
+
+        def with_bad(measured_by_cfg, bad_cfg, warm_ms=99999):
+            seen = set()
+
+            def _mock(config_dir, claude, payload_bytes, model):
+                first = config_dir not in seen
+                seen.add(config_dir)
+                if config_dir == bad_cfg:
+                    return 9000, 'auth', 0                   # warm-up auth -> STOP (NO-GO account)
+                if first:
+                    return warm_ms, 'success', 120
+                return measured_by_cfg[config_dir], 'success', 120
+            return _mock
+
+        accts = [{'name': 'acc%d' % i, 'config_dir': 'c%d' % i} for i in range(1, 5)]
+        measured = {'c1': 1000, 'c2': 2000, 'c3': 3000, 'c4': 4000}
+
+        # (e1) four healthy accounts -> ordered name->measured_ms map; warm-ups excluded from census
+        m._probe_call = healthy(measured)
+        with tempfile.TemporaryDirectory() as td:
+            ev = os.path.join(td, 'fleet.jsonl')
+            latencies = m.probe_fleet(accts, events_path=ev, run_id='rf')
+            assert latencies == {'acc1': 1000, 'acc2': 2000, 'acc3': 3000, 'acc4': 4000}, latencies
+            rows = ro.read_events(ev)
+            assert len([r for r in rows if r.get('purpose') == 'warmup']) == 4, 'one warm-up per account'
+            assert len([r for r in rows if r.get('purpose') == 'measured']) == 4, 'one measured per account'
+            cen = ro.build_census(rows)
+            # census NOT inflated: exactly 4 measured latency samples, the four 99999 warm-ups excluded
+            assert cen['latency_ms']['max'] == 4000, cen['latency_ms']
+            assert len(cen['probe']['warmup']) == 4 and len(cen['probe']['measured']) == 4, cen['probe']
+
+        # (e2) one NO-GO account STOPs the fleet by DEFAULT (STOP-on-any-NO-GO)
+        m._probe_call = with_bad(measured, bad_cfg='c3')
+        try:
+            m.probe_fleet(accts)
+            assert False, 'a NO-GO account must STOP the fleet by default'
+        except SystemExit as exc:
+            assert 'acc3' in str(exc) and 'fleet probe' in str(exc), exc
+
+        # (e3) --drop-unhealthy opt-in: drop the NO-GO account, proceed on the healthy subset
+        m._probe_call = with_bad(measured, bad_cfg='c3')
+        survivors = m.probe_fleet(accts, drop_unhealthy=True)
+        assert survivors == {'acc1': 1000, 'acc2': 2000, 'acc4': 4000}, survivors
+
+        # (f) N=1 REGRESSION: probe_fleet over a 1-element list == the old single-account live_probe.
+        m._probe_call = lambda config_dir, claude, payload_bytes, model: (5555, 'success', 120)
+        solo = [{'name': 'max1', 'config_dir': 'c1'}]
+        assert m.probe_fleet(solo) == {'max1': 5555}, 'N=1 must be a pure pass-through'
+        assert m.live_probe('c1') == 5555                 # the pre-N-profile single-account reading
+        assert m.probe_fleet(solo)['max1'] == m.live_probe('c1')   # value report['probe_latency_ms'] carries
+    finally:
+        m._probe_call = _pc
+    print('  GAP5 probe_fleet: N=4 map + warm-ups excluded; NO-GO STOPs by default; --drop-unhealthy subset; N=1 == old live_probe')
+
+    # GAP #5 fair fan-out + all-done at N=4: 4 accounts claim 4 DISTINCT jobs in ONE run-once pass
+    # and every job reaches 'done' exactly once (echo jobs; --skip-profile-check; never credentials).
+    with tempfile.TemporaryDirectory() as td:
+        db = os.path.join(td, 'fanout.sqlite')
+        m.main(['--db', db, 'init',
+                '--account', 'acc1=' + os.path.join(td, 'a1'),
+                '--account', 'acc2=' + os.path.join(td, 'a2'),
+                '--account', 'acc3=' + os.path.join(td, 'a3'),
+                '--account', 'acc4=' + os.path.join(td, 'a4'), '--skip-profile-check'])
+        argv = [sys.executable, '-c', 'import os; print(os.environ["CLAUDE_CONFIG_DIR"])']
+        for n in range(4):
+            m.main(['--db', db, 'enqueue', '--external-id', 'fan%d' % n,
+                    '--argv-json', json.dumps(argv), '--cwd', td,
+                    '--output', os.path.join(td, 'fan%d.json' % n)])
+        m.main(['--db', db, 'run-once', '--timeout', '30'])
+        con = sqlite3.connect(db)
+        rows = con.execute("select external_id, assigned_acc, state from jobs order by id").fetchall()
+        con.close()
+        assert len(rows) == 4 and all(r[2] == 'done' for r in rows), rows       # all 4 done exactly once
+        assert len({r[1] for r in rows}) == 4, 'each of 4 jobs ran under a DISTINCT account: %s' % rows
+        assert len({r[0] for r in rows}) == 4, rows
+    print('  GAP5 fair fan-out N=4: 4 accounts claim 4 distinct jobs in one pass; all 4 reach done exactly once')
+
+    # GAP #5 only_accounts dispatch filter: cmd_run_once must dispatch ONLY to the allow-listed
+    # (probed) fleet. Without it, --max-accounts / --drop-unhealthy would cap only the PROBE set while
+    # dispatch (which re-selects every validated account) still claimed jobs for capped-out, UNPROBED
+    # accounts — bypassing the mandatory pre-dispatch health gate.
+    with tempfile.TemporaryDirectory() as td:
+        db = os.path.join(td, 'onlyacc.sqlite')
+        m.main(['--db', db, 'init',
+                '--account', 'acc1=' + os.path.join(td, 'a1'),
+                '--account', 'acc2=' + os.path.join(td, 'a2'),
+                '--account', 'acc3=' + os.path.join(td, 'a3'),
+                '--account', 'acc4=' + os.path.join(td, 'a4'), '--skip-profile-check'])
+        argv = [sys.executable, '-c', 'import os; print(os.environ["CLAUDE_CONFIG_DIR"])']
+        for n in range(4):
+            m.main(['--db', db, 'enqueue', '--external-id', 'oa%d' % n,
+                    '--argv-json', json.dumps(argv), '--cwd', td,
+                    '--output', os.path.join(td, 'oa%d.json' % n)])
+        # dispatch restricted to the acc1/acc2 "probed" subset (acc3/acc4 == capped-out/unprobed).
+        m.cmd_run_once(m.argparse.Namespace(db=db, timeout=30, events=None, run_id=None,
+                                            claude_bin='claude', only_accounts={'acc1', 'acc2'}))
+        con = sqlite3.connect(db)
+        assigned = con.execute("select assigned_acc from jobs where assigned_acc is not null").fetchall()
+        pending = con.execute("select count(*) from jobs where state='pending'").fetchone()[0]
+        con.close()
+        owners = {a for (a,) in assigned}
+        assert owners <= {'acc1', 'acc2'}, 'only the allow-listed fleet may dispatch: %s' % owners
+        assert not (owners & {'acc3', 'acc4'}), 'a capped-out/unprobed account must get NO job: %s' % owners
+        assert len(assigned) == 2 and pending == 2, 'one job per allowed account; the rest stay pending'
+        # (the unfiltered / whole-fleet dispatch path is covered by the fair-fan-out test above, whose
+        # CLI run-once passes no only_accounts and reaches all 4 accounts.)
+    print('  GAP5 only_accounts dispatch filter: capped-out/unprobed accounts receive NO job')
+
+    # GAP #5 one-active-job-per-account at N=4: 8 jobs, 4 accounts. Round 1 claims 4 distinct jobs;
+    # each account's SECOND claim is refused while it still holds an active in_progress job.
+    with tempfile.TemporaryDirectory() as td:
+        db = os.path.join(td, 'oneactive.sqlite')
+        m.main(['--db', db, 'init',
+                '--account', 'acc1=' + os.path.join(td, 'a1'),
+                '--account', 'acc2=' + os.path.join(td, 'a2'),
+                '--account', 'acc3=' + os.path.join(td, 'a3'),
+                '--account', 'acc4=' + os.path.join(td, 'a4'), '--skip-profile-check'])
+        for n in range(8):
+            m.main(['--db', db, 'enqueue', '--external-id', 'oa%d' % n,
+                    '--argv-json', json.dumps(['x']), '--cwd', td,
+                    '--output', os.path.join(td, 'oa%d.json' % n)])
+        claimed = [m.claim(db, 'acc%d' % i) for i in (1, 2, 3, 4)]
+        assert all(j is not None for j in claimed), 'each of 4 accounts claims a job'
+        assert len({j['id'] for j in claimed}) == 4, 'four DISTINCT jobs claimed in round 1'
+        for i in (1, 2, 3, 4):
+            assert m.claim(db, 'acc%d' % i) is None, 'acc%d already busy -> second claim refused' % i
+        con = sqlite3.connect(db)
+        assert con.execute("select count(*) from jobs where state='in_progress'").fetchone()[0] == 4
+        assert con.execute("select count(distinct assigned_acc) from jobs where state='in_progress'").fetchone()[0] == 4
+        con.close()
+    print('  GAP5 one-active-job-per-account N=4: 4 distinct claims; each 2nd claim refused; 4 distinct owners')
+
+    # GAP #5 recover exactly-once (N=4): two crash-stranded in_progress rows (distinct accounts) are
+    # returned to pending; a coordinator-recorded DONE job is UNTOUCHED (coordinator_recorded stays 1,
+    # no duplicate promotion), and no other row flips.
+    with tempfile.TemporaryDirectory() as td:
+        db = os.path.join(td, 'recover.sqlite')
+        m.main(['--db', db, 'init',
+                '--account', 'acc1=' + os.path.join(td, 'a1'),
+                '--account', 'acc2=' + os.path.join(td, 'a2'),
+                '--account', 'acc3=' + os.path.join(td, 'a3'),
+                '--account', 'acc4=' + os.path.join(td, 'a4'), '--skip-profile-check'])
+        for n in range(4):
+            m.main(['--db', db, 'enqueue', '--external-id', 'rec%d' % n,
+                    '--argv-json', json.dumps(['x']), '--cwd', td,
+                    '--output', os.path.join(td, 'rec%d.json' % n)])
+        con = sqlite3.connect(db)
+        # rec0: a coordinator-recorded DONE job (recover must never touch it -> no dup promotion)
+        con.execute("update jobs set state='done', coordinator_recorded=1, assigned_acc='acc3' where external_id='rec0'")
+        # rec1/rec2: crash-stranded in_progress under two DISTINCT accounts
+        con.execute("update jobs set state='in_progress', assigned_acc='acc1' where external_id='rec1'")
+        con.execute("update jobs set state='in_progress', assigned_acc='acc2' where external_id='rec2'")
+        # rec3: stays pending
+        con.commit(); con.close()
+        m.main(['--db', db, 'recover'])
+        con = sqlite3.connect(db)
+        assert con.execute("select state,assigned_acc from jobs where external_id='rec1'").fetchone() == ('pending', None)
+        assert con.execute("select state,assigned_acc from jobs where external_id='rec2'").fetchone() == ('pending', None)
+        # the recorded DONE job is untouched: still done, coordinator_recorded still exactly 1
+        assert con.execute("select state,coordinator_recorded from jobs where external_id='rec0'").fetchone() == ('done', 1)
+        # exactly the two in_progress rows recovered; nothing else flipped
+        assert con.execute("select count(*) from jobs where state='in_progress'").fetchone()[0] == 0
+        assert con.execute("select count(*) from jobs where state='pending'").fetchone()[0] == 3      # rec1,rec2,rec3
+        assert con.execute("select count(*) from jobs where state='done'").fetchone()[0] == 1          # rec0 only
+        con.close()
+    print('  GAP5 recover exactly-once N=4: 2 in_progress -> pending; recorded-done untouched; coordinator_recorded stays 1')
+
     print('max_account_orchestrator_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/prompt_rule_audit.py
+++ b/RussianTranslation/src/pilot/prompt_rule_audit.py
@@ -15,6 +15,7 @@ import json
 import os
 import re
 import sys
+from collections import Counter
 
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
@@ -106,6 +107,28 @@ IAST_DIACRITIC = re.compile(r'[āīūṛṝḷḹṅñṭḍṇśṣ]')
 RETAINED_SPAN = re.compile(r'\{%.*?%\}|\{#.*?#\}|<(?:ab|ls|is)\b[^>]*>.*?</(?:ab|ls|is)>'
                            r'|<(?:ab|ls|is)\b[^>]*>', re.S | re.I)
 SANSKRIT_SPAN = re.compile(r'\{#.*?#\}', re.S)
+# A leading structural-head span: a {#..#} that is a sub-entry preverb/root/headword LABEL, not
+# an intra-sense Sanskrit span. A faithful Russian translation may legitimately omit such a head
+# label (it is card-level metadata), so it must NOT count as a dropped translation span. H960
+# verify measured 21/22 dropped_sanskrit_span firings corpus-wide to be exactly this class
+# (√{#mA#}, <hom>4.</hom> {#mA/#}¦, <div n="p">— {#aBi#}); excluding it isolates the 1/22 that
+# is a genuine intra-sense drop. Head positions: before the first ¦ (headword pipe), preceded by
+# √, or at the very head of the german after only structural tags / dashes.
+_HEAD_SPAN_AT_START = re.compile(r'^(?:\s|—|–|-|<[^>]*>)*(\{#.*?#\})', re.S)
+_HEAD_SPAN_ROOT = re.compile(r'√\s*(\{#.*?#\})', re.S)
+
+
+def head_label_spans(german):
+    """The set of {#..#} span TEXTS in `german` that sit in a sub-entry head/label position
+    (see _HEAD_SPAN_* above). Compared by content so a head label the translation drops is not
+    mistaken for a lost intra-sense span."""
+    g = german or ''
+    labels = set(SANSKRIT_SPAN.findall(g.split('¦', 1)[0])) if '¦' in g else set()
+    m = _HEAD_SPAN_AT_START.match(g)
+    if m:
+        labels.add(m.group(1))
+    labels.update(_HEAD_SPAN_ROOT.findall(g))
+    return labels
 
 SENSE_REQUIRED = (
     'tag', 'german', 'russian', 'equivalence_type', 'source_type', 'stratum',
@@ -555,6 +578,26 @@ def markup_sigla_risks(sense, russian, german, grammar, tag):
         add_risk(risks, 'markup_wrapper_dropped',
                  'braced gloss wrapper {%%..%%} dropped: %d source vs %d target' % (sgloss, dgloss),
                  tag=tag)
+    # H960 (H911 backlog #3): a {#..#} Sanskrit span present in the German source but dropped from
+    # the Russian translation. The harness accept()/tm gates count {#..#} only in the german echo,
+    # never the translation field, so an intra-sense span that survives the echo but vanishes from
+    # the actual Russian passes clean. Content-multiset diff (not a bare count) so a legitimately
+    # kept-once/repeated span isn't mis-flagged; structural HEAD labels are excluded (the measured
+    # 95%-FP class — see head_label_spans). LOW / report-only: NOT in HIGH_CONFIDENCE_RISKS, so it
+    # never drives a requeue (a systematic preverb-head omission would otherwise arm an unclearable
+    # loop) — a review signal until the live false-flag rate is measured and it can be armed.
+    g_spans = Counter(SANSKRIT_SPAN.findall(german or ''))
+    r_spans = Counter(SANSKRIT_SPAN.findall(russian or ''))
+    dropped = g_spans - r_spans
+    if dropped:
+        heads = head_label_spans(german)
+        real_dropped = Counter({s: n for s, n in dropped.items() if s not in heads})
+        if real_dropped:
+            add_risk(risks, 'dropped_sanskrit_span',
+                     '{#..#} Sanskrit span dropped from translation: %d source vs %d target; non-head dropped: %s'
+                     % (sum(g_spans.values()), sum(r_spans.values()),
+                        ', '.join(sorted(real_dropped.elements()))[:120]),
+                     tag=tag)
     return risks
 
 

--- a/RussianTranslation/src/pilot/sense_count.py
+++ b/RussianTranslation/src/pilot/sense_count.py
@@ -27,29 +27,41 @@ import json
 import os
 import re
 
-# A top-level source sense is marked by the PWG/PW sense-close glyph `N〉` (a digit
-# immediately followed by the U+3009 RIGHT ANGLE BRACKET). That glyph is used ONLY
-# for sense boundaries in the csl-orig markup, never inside a citation, so `\d+〉`
-# is a high-precision top-level-sense signal. `_LINE_SENSE` additionally catches the
-# line-anchored `N)` / `— N)` form used by the deterministic splitter
-# (autosplit_requeue._SENSE) for the presplit lane; the two are unioned so a source
-# in either notation is counted. Sub-senses (lettered a)/b), or `Nc`) are deliberately
-# NOT counted — only distinct top-level ARABIC ordinals, so a card that merges the
-# lettered sub-senses of one numbered sense is never mis-flagged as a shortfall.
-_SENSE_CLOSE = re.compile(r'(\d+)\s*〉')
-_LINE_SENSE = re.compile(r'^\s*(?:<div[^>]*>)?\s*(?:—\s*|-\s*)?(\d+)\s*[\)〉]')
+# A top-level source sense OPENS its line: the sense-ordinal `N〉` (PWG/PW sense-close
+# glyph, digit + U+3009 RIGHT ANGLE BRACKET) — or the line-anchored `N)` split notation
+# used by the deterministic splitter (autosplit_requeue._SENSE) — is the FIRST ordinal on
+# its line, preceded only by "opening" material: leading whitespace, a sense dash (— / – /
+# -), the headword pipe ¦, a structural tag (<div..>), a {Tn} mask token, or a masked/
+# unmasked headword ref {#..#}¦.
+#
+# H960 hardening (cross-reference false-positive fix). The pre-H960 counter did a naive
+# `\d+〉` findall over the whole blob, which counted every sense-ordinal glyph — including
+# CROSS-REFERENCES into ANOTHER entry's numbering ("pra 1〉 = {#sUd#} 3〉", "gehört zu 4〉",
+# "Nom. abstr. zu {#ASraya#} 1〉 und 6〉", "pari 5〉") — as if this card declared that many
+# senses. On a promoted-store corpus scan ~4.78% of cards carried such a mid-prose ordinal,
+# so the naive count over-stated `source_senses` and would spuriously flag a faithful card
+# as SAN-LOSS (H960 verify evidence: gam~~h2_31_pari 2->1, s_ud~~h0_05_pra 4->2,
+# _a_srayatva 2->0). A mid-line ordinal is never a sense of THIS card, so it is skipped;
+# only the FIRST ordinal per line can open a sense (any later N〉 on the same line is by
+# construction a cross-reference). Sub-senses (lettered a)/b), or `Nc`) remain uncounted —
+# only distinct top-level ARABIC ordinals, so merging one sense's lettered sub-senses never
+# mis-flags a shortfall. Under-counting (a genuinely-numbered sense whose marker is not
+# line-opening) is the safe direction: it lowers the expected count, never a false shortfall.
+_ORD = re.compile(r'(\d+)\s*[\)〉]')
+_OPEN_PREFIX = re.compile(r'^[\s—–\-|¦]*(?:(?:\{T\d+\}|<[^>]*>|\{#[^#]*#\}¦?)[\s—–\-|¦]*)*$')
 
 
 def source_sense_ordinals(text):
     """The set of distinct TOP-LEVEL arabic sense ordinals a raw/masked source blob
-    declares (via `N〉` close-glyphs or line-anchored `N)` markers). Empty when the
-    source carries no explicit top-level numbering (a single unnumbered supplement
-    sense) — the caller treats an empty/singleton set as "nothing to compare"."""
-    text = text or ''
-    ords = {int(m) for m in _SENSE_CLOSE.findall(text)}
-    for line in text.split('\n'):
-        m = _LINE_SENSE.match(line)
-        if m:
+    declares. An ordinal is counted only when it OPENS its line (preceded solely by the
+    opening material in _OPEN_PREFIX); a mid-line ordinal is a cross-reference into another
+    entry's numbering and is skipped. Empty when the source carries no line-opening
+    numbering (a single unnumbered supplement sense) — the caller treats an empty/singleton
+    set as "nothing to compare"."""
+    ords = set()
+    for line in (text or '').split('\n'):
+        m = _ORD.search(line)
+        if m and _OPEN_PREFIX.match(line[:m.start()]):
             ords.add(int(m.group(1)))
     return ords
 
@@ -57,10 +69,11 @@ def source_sense_ordinals(text):
 def count_source_senses(text):
     """Number of distinct top-level source senses (see source_sense_ordinals).
 
-    Deterministic and conservative: counts only explicitly-numbered top-level senses,
-    so it is a LOWER BOUND on the senses the model must emit — never an over-count
-    that could spuriously flag a faithfully-merged card. Matches the harness's own
-    `raw.count('〉')` coarse count on the darvI evidence (both == 3)."""
+    Deterministic and conservative: counts only line-opening top-level senses (never a
+    mid-prose cross-reference ordinal), so it is a LOWER BOUND on the senses the model
+    must emit — never an over-count that could spuriously flag a faithfully-merged card.
+    Equals 3 on the darvI evidence; unlike the harness's coarse `raw.count('〉')`, it does
+    NOT inflate on cross-reference ordinals (H960 hardening — see _OPEN_PREFIX)."""
     return len(source_sense_ordinals(text))
 
 
@@ -166,6 +179,17 @@ def _selftest():
     assert count_source_senses('<ls>MBH. 5,163,4</ls>. 2,33 1,5') == 0
     # line-anchored N) form (split_plan notation).
     assert count_source_senses('1) a\n2) b\n3) c') == 3
+    # H960 cross-reference FP regression (real promoted-store shapes, verify evidence):
+    # a mid-prose ordinal points into ANOTHER entry's numbering and must NOT be counted.
+    # gam~~h2_31_pari: one addendum sense whose prose cross-refs the base numbering -> 1.
+    assert count_source_senses('pari 5〉 {%...%}, gehört zu 4〉.') == 0, \
+        count_source_senses('pari 5〉 {%...%}, gehört zu 4〉.')
+    # s_ud~~h0_05_pra: two line-opening senses, each cross-referencing the base root -> 2.
+    assert count_source_senses('— 1〉 = {#sUd#} 3〉\n— 2〉 = {#sUd#} 4〉') == 2, \
+        count_source_senses('— 1〉 = {#sUd#} 3〉\n— 2〉 = {#sUd#} 4〉')
+    # _a_srayatva (main lane): one unnumbered abstract-noun sense that cross-refs 1〉/6〉 -> 0.
+    assert count_source_senses('Nom. abstr. zu {#ASraya#} 1〉 und 6〉.') == 0, \
+        count_source_senses('Nom. abstr. zu {#ASraya#} 1〉 und 6〉.')
     # shortfall math: darvI-shaped card (2 of 3 senses).
     card2 = {'records': [{'senses': [{'tag': '2'}, {'tag': '3'}]}]}
     assert sense_shortfall(card2, 3) == 1

--- a/RussianTranslation/src/pilot/sense_count.py
+++ b/RussianTranslation/src/pilot/sense_count.py
@@ -48,20 +48,38 @@ import re
 # mis-flags a shortfall. Under-counting (a genuinely-numbered sense whose marker is not
 # line-opening) is the safe direction: it lowers the expected count, never a false shortfall.
 _ORD = re.compile(r'(\d+)\s*[\)〉]')
-_OPEN_PREFIX = re.compile(r'^[\s—–\-|¦]*(?:(?:\{T\d+\}|<[^>]*>|\{#[^#]*#\}¦?)[\s—–\-|¦]*)*$')
+# One unit of "opening" material a line-opening sense ordinal may follow: a {Tn} mask token, an
+# <...> structural tag, a {#..#} headword ref (optionally followed by the ¦ pipe), or a run of
+# separator chars (whitespace, dashes —/–/-, pipe |, broken bar ¦). Anchored alternatives with NO
+# nested quantifier, matched left-to-right by _is_open_prefix — a linear scan, so a prefix like
+# `{#a#}¦{#b#}¦…` cannot trigger the catastrophic backtracking a `(...[sep]*)*$` regex would (py/redos).
+_OPEN_TOKEN = re.compile(r'\{T\d+\}|<[^>]*>|\{#[^#]*#\}¦?|[\s—–\-|¦]+')
+
+
+def _is_open_prefix(prefix):
+    """True iff `prefix` is composed ENTIRELY of opening material (see _OPEN_TOKEN) — i.e. an ordinal
+    at its end opens a line rather than sitting mid-prose as a cross-reference. Linear-time: greedily
+    consume one leading opening token at a time; clean iff the whole prefix is consumed."""
+    i, n = 0, len(prefix)
+    while i < n:
+        m = _OPEN_TOKEN.match(prefix, i)
+        if m is None or m.end() == i:
+            return False
+        i = m.end()
+    return True
 
 
 def source_sense_ordinals(text):
     """The set of distinct TOP-LEVEL arabic sense ordinals a raw/masked source blob
-    declares. An ordinal is counted only when it OPENS its line (preceded solely by the
-    opening material in _OPEN_PREFIX); a mid-line ordinal is a cross-reference into another
+    declares. An ordinal is counted only when it OPENS its line (preceded solely by opening
+    material — see _is_open_prefix); a mid-line ordinal is a cross-reference into another
     entry's numbering and is skipped. Empty when the source carries no line-opening
     numbering (a single unnumbered supplement sense) — the caller treats an empty/singleton
     set as "nothing to compare"."""
     ords = set()
     for line in (text or '').split('\n'):
         m = _ORD.search(line)
-        if m and _OPEN_PREFIX.match(line[:m.start()]):
+        if m and _is_open_prefix(line[:m.start()]):
             ords.add(int(m.group(1)))
     return ords
 

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -630,6 +630,94 @@ def test_h920_en_missing_sense_hard_flag():
             en.INPUT_DIR = old_dir
 
 
+def test_h960_accept_sanloss_soft_gate():
+    """H960: the harness stamps the deterministic (cross-reference-hardened) source_senses into
+    each input, and accept() carries the SAN-LOSS shortfall guard — H920's deferred deepest fix.
+    SOFT by default (SANLOSS_HARD_REJECT=false): a whole-dropped sense is COUNTED as telemetry but
+    the card is kept; the owner-gated flip rejects+requeues it. The behavioral half runs the REAL
+    emitted accept()+countOf (see accept_sensecount_test.js), so it can't drift from the generator."""
+    import gen_opt_harness2 as gh
+    saved_ip, saved_kill = gh.input_paths, gh.KILL
+    d = tempfile.mkdtemp()
+    try:
+        # darv_i: 3 line-opening senses -> source_senses 3. xref: only cross-reference ordinals
+        # ("zu {#ASraya#} 1〉 und 6〉") -> hardened source_senses 0 (the FP-regression shape).
+        raws = {
+            'darv_i~~h0_zz_pw': '=== LAYER: PW ===\n\n{#darvI#}¦\n— 1〉 {%a%}.\n— 2〉 {%b%}.\n— 3〉 {%c%}.',
+            'xref~~h0_zz_pw': '=== LAYER: PW ===\n\nNom. abstr. zu {#ASraya#} 1〉 und 6〉.',
+        }
+        keys = list(raws)
+        paths = {}
+        for k, raw in raws.items():
+            rp = os.path.join(d, k + '.raw.txt')
+            pp = os.path.join(d, k + '.portrait.json')
+            with open(rp, 'w', encoding='utf-8') as f:
+                f.write(raw)
+            with open(pp, 'w', encoding='utf-8') as f:
+                f.write('[]')
+            paths[k] = (rp, pp)
+        gh.input_paths = lambda k, input_dir=None: paths[k]
+        gh.KILL = False
+        js, _ = gh.build('zz_sanloss', keys, None, 12000,
+                         nominal=True, grammar_on=False, tm_path=None)
+        # (1) the soft gates (sanloss + grammar-{Tn}) + owner-gated hard paths + telemetry are emitted
+        for needle in ('const SANLOSS_HARD_REJECT = false', 'SANLOSS_SHORTFALLS',
+                       'sanloss-reject', 'sanloss_shortfalls',
+                       'const TNMASK_HARD_REJECT = false', 'TNMASK_MISMATCHES',
+                       'tnmask-reject', 'tnmask_mismatches'):
+            if needle not in js:
+                fail('accept() SAN-LOSS / {Tn} soft gate not emitted (missing %r)' % needle)
+        # (2) the deterministic source_senses count is stamped into the runtime INPUTS
+        if '"source_senses": 3' not in js:
+            fail('darv_i source_senses (3) must be stamped into the emitted INPUTS')
+        if '"source_senses": 0' not in js:
+            fail('cross-reference xref source_senses must harden to 0 in the emitted INPUTS')
+        # (3) behavioral: the REAL accept() rejects/keeps a shortfall exactly as specified
+        harness = os.path.join(d, 'sanloss_harness.js')
+        with open(harness, 'w', encoding='utf-8', newline='\n') as f:
+            f.write(js)
+        test_js = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               'accept_sensecount_test.js')
+        p = subprocess.run(['node', test_js, harness],
+                           capture_output=True, text=True, encoding='utf-8', timeout=30)
+        if p.returncode:
+            fail('accept() SAN-LOSS behavioral test failed:\n%s\n%s' % (p.stdout, p.stderr))
+    finally:
+        gh.input_paths, gh.KILL = saved_ip, saved_kill
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_h960_dropped_sanskrit_span():
+    """H960 (H911 backlog #3): a {#..#} Sanskrit span present in the German source but dropped from
+    the Russian translation is flagged (dropped_sanskrit_span). The harness/tm fidelity gates count
+    {#..#} only in the german echo, never the translation field, so an intra-sense span that
+    survives the echo but vanishes from the Russian passes clean. LOW / report-only (never in
+    HIGH_CONFIDENCE_RISKS -> never requeues). Structural HEAD labels (headword/preverb/root) are
+    excluded — the measured 95%-false-positive class — so only a genuine intra-sense drop fires."""
+    import prompt_rule_audit as pr
+    def ids(ru, de):
+        return [r['id'] for r in pr.markup_sigla_risks({}, ru, de, '', '3')]
+    # POSITIVE: a genuine mid-sense span drop fires.
+    if 'dropped_sanskrit_span' not in ids('делает что-то несмотря', 'делает что-то {#kar#} несмотря'):
+        fail('dropped_sanskrit_span must fire on a genuine mid-sense {#..#} drop')
+    # CONTROL: span retained -> silent.
+    if 'dropped_sanskrit_span' in ids('делает {#kar#} несмотря', 'делает {#kar#} несмотря'):
+        fail('dropped_sanskrit_span must NOT fire when the span is retained')
+    # CONTROL: a headword-label drop (the darvI FP class) is excluded.
+    if 'dropped_sanskrit_span' in ids('имя собственное страны', '{#darvI#} <ab>N. pr.</ab> eines Landes'):
+        fail('a headword-label {#..#} drop must be excluded (95% FP class)')
+    # CONTROL: a √-root label drop is excluded.
+    if 'dropped_sanskrit_span' in ids('мерить', '√{#mA#} messen'):
+        fail('a root-label {#..#} drop must be excluded')
+    # report-only: never high-confidence (never drives a requeue), and LOW severity.
+    if 'dropped_sanskrit_span' in pr.HIGH_CONFIDENCE_RISKS:
+        fail('dropped_sanskrit_span must stay out of HIGH_CONFIDENCE_RISKS (report-only)')
+    row = [r for r in pr.markup_sigla_risks({}, 'делает что-то несмотря', 'делает что-то {#kar#} несмотря', '', '3')
+           if r['id'] == 'dropped_sanskrit_span'][0]
+    if row['level'] != 'low' or row.get('high_confidence'):
+        fail('dropped_sanskrit_span must be LOW / non-high-confidence, got %r' % row)
+
+
 def test_no_pwg_worklist_runnable_lane():
     """H214: the worklist exposes a no_pwg_runnable lane for PW/SCH/PWKVN-only lemmas and does
     NOT reclassify a true miss (absent from every layer) as runnable, nor mix it into the
@@ -4504,6 +4592,8 @@ def main():
         test_h920_sense_shortfall_gate_flags_dropped_sense,
         test_h920_no_pwg_portrait_stamps_source_senses,
         test_h920_en_missing_sense_hard_flag,
+        test_h960_accept_sanloss_soft_gate,
+        test_h960_dropped_sanskrit_span,
         test_no_pwg_worklist_runnable_lane,
         test_no_pwg_layer_and_profile_survive_promotion,
         test_prompt_rule_audit_template,


### PR DESCRIPTION
Verify H920 (every offline gate green) and close the six load-bearing gaps blocking **four-profile nonstop PWG-RU scale**, each a **SOFT / report-only guard** pinned by a selftest and wired into CI. Arming any hard reject stays **owner-gated** (a silent pass → visible requeue changes throughput; measure on live traffic first). No live generation, login, or store mutation.

## Verify H920
Every offline gate reproduces green: `window_selftest` (incl. 4 `test_h920_*`), `lang_parity_check` (49 entries, no drift), `h809_selftest`, `headless_worker_selftest`, `max_account_orchestrator_selftest`, `run_observability_selftest`, + the two new gates.

## Six gaps closed offline
1. **`accept()` sense-count** (H920's deferred deepest fix) — stamps hardened `source_senses`; `accept()` records `SANLOSS_SHORTFALLS` (soft, `SANLOSS_HARD_REJECT` owner-gated). `sense_count.py` counter hardened to skip cross-reference ordinals (`gam~~h2_31_pari` 2→1, `s_ud~~h0_05_pra` 4→2, `_a_srayatva` 2→0).
2. **Grammar `{Tn}` multiset** — `accept()` runs the heal path's `{Tn}` check on the main path (`TNMASK_MISMATCHES`, soft), catching a dropped `<lex>` span the `<ls>/{#` count misses.
3. **German `{#..#}` span drop** (H911 backlog #3) — `dropped_sanskrit_span` content-multiset diff, **LOW / report-only**, head-label FP class (measured 95%) excluded.
4. **Economy telemetry** (H911 backlog #4) — `economy_ledger.py` derives `agents_per_clean` + bounded `$/clean` from the frozen probe log; `gate()` on aggregate breach only.
5. **Four-profile `staged-run`** — guard relaxed to ≥1 account; `probe_fleet()` (STOP-on-any-NO-GO, `--drop-unhealthy` opt-in); `probe_latency_ms`→per-account map; `cmd_run_once` gains an `only_accounts` dispatch filter so a capped-out/unprobed account can never receive a job.
6. **Bounded supervisor** — `bounded_supervisor.py`: injectable `run_window` seam, bounds on window-count / budget / clean-target / consecutive-empty, requeues partials, atomic checkpoint + crash resume.

## Process
Deep parallel gap-audit (adversarially verified for offline-testability) → parallel implementation of the file-disjoint gaps → an adversarial correctness-review pass that surfaced **2 confirmed bugs** (the `--max-accounts` dispatch-bypass and the `economy_ledger` all-wasted print crash), both fixed here with regression tests.

**Residual NO-GO** = the owner-gated live ladder only: auth → latency → canary → arm hard-rejects → 10 → 20 → multi-profile.

Gate report: [`RussianTranslation/pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md`](https://github.com/gasyoun/SanskritLexicography/blob/h960-four-profile-readiness/RussianTranslation/pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)