### PR TITLE
ai_state: point Next Steps at H963 (owner-gated live-ladder successor)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -22,17 +22,18 @@ Two live tracks:
 
 ## ➡️ Next Steps (Queue)
 
-- **H960 PWG→Russian four-profile production-readiness — 🔴 EXECUTED 15-07-2026 (Opus 4.8
-  `claude-opus-4-8[1m]`, Ultracode; OFFLINE).** Verified H920 (every offline gate green) and earned all
-  six load-bearing scale gaps as **SOFT / report-only** guards (each selftested, all wired into CI):
-  `accept()` sense-count consumption (`SANLOSS_*`, owner-gated arm) + cross-reference-hardened counter;
-  grammar `{Tn}` multiset check on the main path (`TNMASK_*`); `dropped_sanskrit_span` report-only risk;
-  `economy_ledger.py` (`agents_per_clean` + bounded `$/clean` from the frozen probe log); four-profile
-  `staged-run` (`probe_fleet`, guard ≥1); `bounded_supervisor.py` (injectable-seam nonstop loop). The
-  residual **NO-GO is the owner-gated live ladder only** (auth→latency→canary→arm→10→20→multi-profile);
-  H255 stays frozen until it passes. Gate report:
-  [H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md).
-  🔴 EXECUTED: H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md
+- **H963 — four-profile live-ladder production acceptance — 🟡 WAITING ON OWNER (owner-gated).** The
+  successor to H960 (🔴 EXECUTED 15-07 — offline scaffolding earned: six scale gaps closed as
+  SOFT/report-only guards, [PR #475](https://github.com/gasyoun/SanskritLexicography/pull/475) merged,
+  released [v1.9.13](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.9.13)). This is the
+  LIVE ladder that turns it into a measured GO / NO-GO: auth → latency → canary (**measure the guard
+  false-flag rate before arming**) → arm hard-rejects → 10 → 20 → multi-profile-20. **Gated on the owner
+  logging in the Max profiles** (c1/c4 Max; **c5/c6 logged out** on 15-07 — a two-profile c1/c4 path can
+  run meanwhile but must be labelled two-profile). "Production-ready" claimed only on a full PASS;
+  else blocked/partial, H255 stays frozen. Executor: Opus 4.8 (`claude-opus-4-8[1m]`), Ultracode.
+  Handoff: [H963](https://github.com/gasyoun/Uprava/blob/main/handoffs/H963-Opus_SanskritLexicography_pwg-ru-four-profile-live-ladder-acceptance_15.07.26.md);
+  full H960 record + gate report in [`RussianTranslation/.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md) ✅ Completed.
+  Resume (after the profile logins): `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H963-Opus_SanskritLexicography_pwg-ru-four-profile-live-ladder-acceptance_15.07.26.md and execute it.`
 
 - **RussianTranslation H818 observability (13-07-2026, Codex/GPT-5):** PR #416 now includes a credential-safe joined event stream, derived bug census, strict accounting/store-delta GO gates, presplit live canary, and fault injection. Live 1→10→20→100 remains gated on owner Max login. Follow-on A/B handoffs: H841 recovery policy, H842 prompt quality, H843 window size.
 

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -14,21 +14,20 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
-- **H960 four-profile production-readiness — 🔴 EXECUTED 15-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`,
-  Claude Code Ultracode; OFFLINE).** Verified H920 (every offline gate green) and closed all six
-  load-bearing gaps as **SOFT / report-only** guards, each pinned by a selftest, all wired into CI:
-  (1) `accept()` sense-count (H920's deferred deepest fix) — `source_senses` stamped + `SANLOSS_SHORTFALLS`
-  telemetry (`SANLOSS_HARD_REJECT` owner-gated); `sense_count.py` counter hardened to skip cross-reference
-  ordinals (~4.78% FP class). (2) Grammar `{Tn}` multiset check on the main `accept()` path
-  (`TNMASK_MISMATCHES`, owner-gated). (3) `dropped_sanskrit_span` in `prompt_rule_audit.py` — LOW/report-only,
-  head-label FP class excluded. (4) `economy_ledger.py` — `agents_per_clean` + bounded `$/clean` from the
-  frozen probe log (H911's "not_recoverable" economy metrics actually derivable). (5) `max_account_orchestrator.py`
-  four-profile: guard ≥1 account + `probe_fleet()` STOP-on-any-NO-GO + per-account `probe_latency_ms`.
-  (6) `bounded_supervisor.py` — injectable-seam bounded nonstop loop + crash-resume. **Residual NO-GO =
-  the owner-gated live ladder only** (auth→latency→canary→arm-hard-rejects→10→20→multi-profile); c5/c6 were
-  logged out on 15-07; H255 stays frozen until it passes. Gate report:
-  [H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md).
-  🔴 EXECUTED: H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md
+- **H963 — four-profile live-ladder production acceptance — 🟡 WAITING ON OWNER (owner-gated).** The
+  successor to H960 (which earned the offline scaffolding — see ✅ Completed): the LIVE ladder that
+  turns it into a measured GO / NO-GO. **Gated on the owner logging in the Max profiles** — c1/c4 are
+  already Max; **c5/c6 were logged out on 15-07** (a two-profile c1/c4 path can run meanwhile but must
+  be labelled two-profile, never four-profile). Ladder (each rung gates the next, immutable PASS/NO-GO
+  evidence, no reroll): auth → latency → **canary (MEASURE the SANLOSS/TNMASK/dropped_sanskrit_span
+  false-flag rate BEFORE arming)** → arm hard-rejects (flip `SANLOSS_HARD_REJECT` / `TNMASK_HARD_REJECT`
+  in `gen_opt_harness2.py`, promote `dropped_sanskrit_span` into `HIGH_CONFIDENCE_RISKS`) → 10 → 20 →
+  multi-profile-20. "Production-ready" is claimed ONLY if latency + audit-clean ≥ 80% + fidelity < 5% +
+  observed economy (≤ 1.75 calls/clean, ≤ $0.75/clean) + exactly-once promotion + restart recovery +
+  multi-profile-20 ALL pass; else blocked/partial, H255 stays frozen, mint the smallest successor.
+  Executor: Opus 4.8 (`claude-opus-4-8[1m]`), Ultracode. Handoff:
+  [H963](https://github.com/gasyoun/Uprava/blob/main/handoffs/H963-Opus_SanskritLexicography_pwg-ru-four-profile-live-ladder-acceptance_15.07.26.md).
+  Resume (after the profile logins): `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H963-Opus_SanskritLexicography_pwg-ru-four-profile-live-ladder-acceptance_15.07.26.md and execute it.`
 
 - **H920 no_pwg SAN-LOSS / `missing_senses` root-cause + deterministic guard — 🔴 EXECUTED 14-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; owner-authorized override of the minted Sonnet 5; OFFLINE).**
   Root-caused the H911 #1 defect to **(a) model omission**, silent because the no_pwg portrait declares
@@ -2179,6 +2178,18 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   ([SamudraManthanam #16](https://github.com/gasyoun/SamudraManthanam/issues/16)).
 
 ## ✅ Completed (Recent only)
+
+- **H960 four-profile production-readiness — 🔴 EXECUTED 15-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`,
+  Ultracode; OFFLINE).** Verified H920 (every offline gate green) + closed the six load-bearing
+  four-profile scale gaps as **SOFT / report-only** guards, each selftested + wired into CI: `accept()`
+  sense-count (`SANLOSS_*`) + cross-reference-hardened counter, grammar `{Tn}` multiset (`TNMASK_*`),
+  `dropped_sanskrit_span` report-only risk, `economy_ledger.py` (`agents_per_clean` + bounded `$/clean`),
+  four-profile `staged-run` (`probe_fleet` + `only_accounts` dispatch filter), `bounded_supervisor.py`.
+  Adversarial review fixed 2 bugs + a CodeQL ReDoS. [PR #475](https://github.com/gasyoun/SanskritLexicography/pull/475)
+  merged, released [v1.9.13](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.9.13).
+  "Production-ready" NOT claimed — no live rung run; residual NO-GO = the owner-gated live ladder →
+  successor **H963** (see ➡️ Next Steps). Gate report:
+  [pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h960/H960_FOUR_PROFILE_PRODUCTION_READINESS_GATE_2026-07-15.md).
 
 - **Codex resume audit + promotion-command safety fix — DONE 14-07-2026
   (GPT-5 Codex).** Audited current `origin/master`, the live queue, H911, and the


### PR DESCRIPTION
Session-state upkeep after H960: both `.ai_state.md` files now carry **H963** (the owner-gated live-ladder acceptance) as the top Next Step with its resume line, and the executed H960 record moves to ✅ Completed. H963 is gated on the owner logging in the Max profiles (c1/c4 Max; c5/c6 logged out on 15-07). No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)