### PR TITLE
fix(EntryAnatomy): retract FINDINGS s80 misdiagnosis - MW servepdf serves 1899 correctly; re-enable MW auto-pull

### DIFF
--- a/EntryAnatomy/README.md
+++ b/EntryAnatomy/README.md
@@ -43,12 +43,13 @@ python build_entry_anatomy.py --image page.pdf --callouts spec.json --page 1
   continuation records into print paragraphs by `<e>` level; PWG typesets one
   paragraph per record). Without `--callouts` the build proposes a first-pass
   callout set from the entry structure, each label marked *"proposed — verify"* —
-  never presented as authoritative anatomy. The facsimile inset comes from
-  `--facsimile <img>`; for PWG it can also auto-pull from the Cologne scan
-  server (`servepdf.php`, soft fallback when the server throttles). For MW the
-  auto-pull is deliberately disabled: the `MWScan/2020` endpoint serves the
-  **1872 first edition**, whose page numbers silently collide with the 1899
-  `<pc>` loci of `mw.txt` — see
+  never presented as authoritative anatomy. The facsimile inset auto-pulls
+  from the Cologne scan server (`servepdf.php` with `dict=`, MW and PWG;
+  soft fallback when the server throttles) or comes from `--facsimile <img>`.
+  Caution when supplying MW pages by hand: the portal hosts BOTH editions
+  with colliding printed page numbers — 1899 per-page files are
+  `mw<page>-<headword>.pdf`, the 1872 first edition's are `pg_NNNN.pdf`;
+  check the running heads, see
   [FINDINGS §80](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).
 - `--image <path>` embeds a picture (a PDF page is rasterized first, `--page`,
   `--dpi`) as the annotation surface; callout targets are `x,y,w,h` regions in

--- a/EntryAnatomy/build_entry_anatomy.py
+++ b/EntryAnatomy/build_entry_anatomy.py
@@ -1156,16 +1156,18 @@ def load_callout_spec(path):
     return rows
 
 
-# mw is deliberately ABSENT: scans/MWScan/2020/.../servepdf.php?page=N serves
-# the 1872 FIRST-edition scan, whose pagination collides with the 1899 <pc>
-# loci of mw.txt (verified 15-07-2026: page=277 returned khel/gangambhas =
-# mw72 pc 0277, not 1899 kAla). Until the 1899 per-page endpoint is confirmed
-# (its files are named mw<page>-<headword>.pdf, unguessable without a
-# listing), supply --facsimile for MW; a wrong-edition inset fetched silently
-# would be worse than none.
+# dict= is carried explicitly (the endpoint's own nav links do the same).
+# MW re-enabled 15-07-2026 after an api=1 probe DISPROVED the earlier
+# "serves the 1872 edition" diagnosis: page=277 resolves to
+# MWScanpdf/mw0277-kArSNi.pdf, the correct 1899 page, with or without
+# dict=. The portal ALSO hosts the 1872 first-edition scan with colliding
+# printed page numbers under a different browser (pg_NNNN.pdf files) — a
+# hazard for manually-fetched pages, not for this endpoint. FINDINGS §80.
 SCAN_URL = {
+    "mw": ("https://www.sanskrit-lexicon.uni-koeln.de/scans/MWScan/2020/"
+           "web/webtc/servepdf.php?dict=mw&page={page}"),
     "pwg": ("https://www.sanskrit-lexicon.uni-koeln.de/scans/PWGScan/2020/"
-            "web/webtc/servepdf.php?page={page}"),
+            "web/webtc/servepdf.php?dict=pwg&page={page}"),
 }
 
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1339,31 +1339,37 @@ catalog rows.
 
 ---
 
-### §80. The MWScan/2020 `servepdf.php` serves the 1872 FIRST edition — its page numbers collide with the 1899 `<pc>` loci of mw.txt
+### §80. CORRECTED — the MWScan/2020 `servepdf.php` endpoint is RIGHT (serves 1899); the 1872 first-edition scan coexists on the portal with colliding page numbers
 
-🔴 **`/scans/MWScan/2020/web/webtc/servepdf.php?page=N` returns page N of the 1872
-first-edition scan, NOT the 1899 edition that `mw.txt` (CDSL dict `mw`) is keyed to —
-and because both editions print their own page numbers, the mismatch is silent.**
-Requesting `page=277` (the 1899 `<pc>` locus of *kāla*) returned a page whose corner
-really does say "277" but whose running heads are *khel./gaṅgāmbhas.* — which is
-`mw72.txt` pc `0277-a` exactly. The 1872-edition *kāla* sits at mw72 pc `0224–0225`.
-A facsimile auto-pull that maps `mw.txt` `<pc>` → this endpoint fetches a confidently
-wrong page every time.
+🟠 **Corrected 15-07-2026 (same session-day as first written): the endpoint was never
+wrong.** An `api=1` probe of
+`/scans/MWScan/2020/web/webtc/servepdf.php?api=1&page=277` (with AND without
+`dict=mw`) resolves to `MWScanpdf/mw0277-kArSNi.pdf` — the correct **1899** page for
+the `mw.txt` `<pc>` locus `277,1` (*kāla*). The `page` param maps 1:1 onto 1899 print
+pages; the per-page files are named `mw<page>-<first-headword>.pdf` but the endpoint
+does that lookup itself, so a `{page}` URL template is fine. The endpoint's own nav
+links carry `dict=mw` — include it for canonical form.
 
-Evidence: browser fetch 15-07-2026 of `?page=277`/`?page=278` (served as
-`pg_0277.pdf`/`pg_0278.pdf`) vs. `mw72.txt` loci for `Kel` (`0277-a`) and `kAla`
-(`0224-b`/`0225-b`). The genuine 1899 per-page files are named
-`mw<page>-<first-headword>.pdf` (e.g. `mw0277-kArSNi.pdf`, `mw1304-hetumAtratA.pdf` from
-H780) — the headword suffix makes the URL unguessable from a page number alone, so no
-`{page}` template can fetch 1899 pages without a directory listing. Sibling of [[§50]]
-(display paths are not uniform either).
+**The real, surviving trap is portal-navigation-level:** Cologne ALSO hosts the
+**1872 first-edition** scan set, browsable with per-page files named `pg_NNNN.pdf`,
+and both editions print their own page numbers — a manually saved "page 277" can be
+either edition's 277 (1872's is *khel/gaṅgāmbhas* = `mw72.txt` pc `0277-a`; 1872
+*kāla* sits at `0224–0225`). That is exactly how the wrong pages entered this session:
+a browser download of `pg_0277.pdf`/`pg_0278.pdf` from the 1872 browser, initially
+misattributed to the servepdf endpoint (the endpoint itself was 429-throttled for the
+probing IP, so the misdiagnosis went unchecked for one release). **Identify a
+manually fetched MW page by its running heads and filename pattern
+(`mw<page>-<headword>.pdf` = 1899 · `pg_NNNN.pdf` = 1872), never by the corner
+number.** Sibling of [[§50]] (display paths are not uniform either).
 
-Implication: `EntryAnatomy/build_entry_anatomy.py` ships with the `mw` scan-server
-auto-pull DISABLED (supply `--facsimile`); re-enable only after confirming an endpoint
-that demonstrably serves 1899 pagination (check the running heads, not the corner
-number). Applies to any future tool that wants "the MW print page for this record".
+Implication: `EntryAnatomy/build_entry_anatomy.py`'s MW auto-pull is re-enabled
+(v1.9.15; it was disabled in v1.9.14 on the misdiagnosis); kosha's
+[`app/scan_resolver.py`](https://github.com/gasyoun/kosha/blob/main/app/scan_resolver.py)
+was verified correct as-is and needs no change. The original v1.9.14 wording of this
+section claimed the endpoint served 1872 — that claim is retracted.
 
-> **Source:** H870 facsimile follow-up ([SanskritLexicography PR #473](https://github.com/gasyoun/SanskritLexicography/pull/473) + inset fix),
+> **Source:** H870 correction pass — `api=1` probes via independent egress
+> ([SanskritLexicography PR #479](https://github.com/gasyoun/SanskritLexicography/pull/479) context),
 > Fable 5 `claude-fable-5` · 15-07-2026
 
 ---

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,22 @@ not an error.
 
 ## [Unreleased]
 
+## [1.9.15] - 2026-07-15
+
+### Fixed
+- **H870 correction — FINDINGS §80 retracted-and-rewritten; MW facsimile auto-pull re-enabled (15-07-2026, Fable 5 `claude-fable-5`)**:
+  an `api=1` probe via an independent egress disproved v1.9.14's diagnosis — the
+  `MWScan/2020` `servepdf.php` endpoint correctly serves **1899** pages
+  (`page=277` → `MWScanpdf/mw0277-kArSNi.pdf`), with or without `dict=`. The wrong
+  1872 pages that prompted the diagnosis came from the portal's separate first-edition
+  browser (`pg_NNNN.pdf` files) — a manual-navigation hazard, not an endpoint bug.
+  [`EntryAnatomy/build_entry_anatomy.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/EntryAnatomy/build_entry_anatomy.py)
+  MW auto-pull re-enabled (URLs now carry `dict=` like the endpoint's own nav links);
+  [FINDINGS §80](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
+  rewritten as the navigation-level cross-edition trap with an explicit retraction.
+  Verified downstream: kosha's `app/scan_resolver.py` links are correct as-is — no
+  change needed there.
+
 ## [1.9.14] - 2026-07-15
 
 ### Added


### PR DESCRIPTION
H870 correction pass. api=1 probes via an independent egress disproved v1.9.14's diagnosis: scans/MWScan/2020/web/webtc/servepdf.php?page=277 resolves to MWScanpdf/mw0277-kArSNi.pdf - the correct 1899 page for mw.txt pc 277,1 - with or without dict=. The 1872 pages that prompted the diagnosis (pg_0277/pg_0278) came from the portal's separate first-edition browser, a manual-navigation hazard, not an endpoint bug. Changes: SCAN_URL mw restored + dict= added to both templates (matches the endpoint's own nav links); FINDINGS s80 rewritten with an explicit retraction (surviving trap = navigation-level: mw<page>-<headword>.pdf = 1899, pg_NNNN.pdf = 1872, check running heads); README corrected; CHANGELOG 1.9.15. Downstream verification: kosha app/scan_resolver.py links are correct as-is, no kosha change needed (closes the GTD quick-win row). Local IP still 429-throttled - soft fallback re-verified; endpoint correctness proven via the JSON api probes. Fable 5 (claude-fable-5), 15-07-2026. Generated with Claude Code.