### PR TITLE
fix(russiantranslation): repair requeue provenance and staged scope

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -994,6 +994,13 @@ Two live tracks:
 
 ## ✅ Completed (Recent only)
 
+- **RussianTranslation PR #478 follow-up — IMPLEMENTED 15-07-2026 (Codex/GPT-5;
+  draft PR pending).** Restored manifest-bound iterative requeues, scoped staged acceptance
+  denominators to prepared headless leases, and made residual-only planner chunks advance
+  without consuming the requested preparation count. Regression and parity checks pass; no
+  Max call, production translation, promotion, store write, or TM rebuild occurred. Detailed
+  operator and test record is in `RussianTranslation/.ai_state.md`.
+
 - **PWG→RU audit-findings hardening — DONE 15-07-2026 (Codex/GPT-5,
   [PR #478](https://github.com/gasyoun/SanskritLexicography/pull/478)).** Closed
   fail-open partial promotion and nominal provenance bypasses with execution-manifest-bound,

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -995,7 +995,7 @@ Two live tracks:
 ## ✅ Completed (Recent only)
 
 - **RussianTranslation PR #478 follow-up — IMPLEMENTED 15-07-2026 (Codex/GPT-5;
-  draft PR pending).** Restored manifest-bound iterative requeues, scoped staged acceptance
+  [draft PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482)).** Restored manifest-bound iterative requeues, scoped staged acceptance
   denominators to prepared headless leases, and made residual-only planner chunks advance
   without consuming the requested preparation count. Regression and parity checks pass; no
   Max call, production translation, promotion, store write, or TM rebuild occurred. Detailed

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2228,11 +2228,22 @@ the clean-output hash instead of trusting mutable coordinator state alone. The s
 made overwrite-style control artifacts atomic; a truncated JSON status/report must never be
 interpreted as an operational verdict.
 
+The review after PR #478 exposed the same rule at two later boundaries. First, narrowing a
+two-key run to a one-key requeue creates a **new provenance contract**: reusing the initial
+manifest makes the valid retry fail exact coverage, while dropping the manifest would reopen
+the bypass. Keep the retry on the same lease, but mint and retain an attempt-specific manifest
+and read subsequent retry files from the latest audit directory. Second, a staged plan is not
+an execution set: future unprepared rows must not enter acceptance denominators, and an omitted
+residual-only chunk must not consume the requested preparation quota. Scope acceptance to
+prepared lease IDs and count successful preparations independently of deterministic indices.
+
 > **Source:** RussianTranslation audit-findings implementation
 > ([PR #478](https://github.com/gasyoun/SanskritLexicography/pull/478))
 > ([`coordinator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/coordinator.py),
 > [`window_provenance.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_provenance.py),
-> [`window_common.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_common.py)) ·
+> [`window_common.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_common.py),
+> [`max_account_orchestrator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/max_account_orchestrator.py),
+> [`no_pwg_scale_plan.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/no_pwg_scale_plan.py)) ·
 > 15-07-2026, Codex/GPT-5.
 
 ---

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2238,7 +2238,8 @@ residual-only chunk must not consume the requested preparation quota. Scope acce
 prepared lease IDs and count successful preparations independently of deterministic indices.
 
 > **Source:** RussianTranslation audit-findings implementation
-> ([PR #478](https://github.com/gasyoun/SanskritLexicography/pull/478))
+> ([PR #478](https://github.com/gasyoun/SanskritLexicography/pull/478),
+> [follow-up PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482))
 > ([`coordinator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/coordinator.py),
 > [`window_provenance.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_provenance.py),
 > [`window_common.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_common.py),

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2179,6 +2179,16 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **PR #478 follow-up hardening — IMPLEMENTED 15-07-2026 (Codex/GPT-5; draft PR
+  pending).** Requeue attempts now retain immutable per-attempt harnesses/manifests and use
+  the latest audit directory; `ready_partial` must promote before retry preparation. Staged
+  acceptance derives its window/headword denominators only from prepared headless leases, and
+  residual-only chunks no longer consume the planner preparation limit. Regression coverage
+  includes two-key → one-key manifest binding, repeated attempts, future plan rows, and fully
+  blocked queues. `window_selftest.py`, `max_account_orchestrator_selftest.py`, 49-entry
+  language parity, Ruff fatal checks, and `git diff --check` pass at the implementation
+  milestone. No live generation, Max call, promotion, canonical-store write, or TM rebuild.
+
 - **Audit-findings hardening — DONE 15-07-2026 (Codex/GPT-5,
   [PR #478](https://github.com/gasyoun/SanskritLexicography/pull/478)).** Coordinator audit
   recording now fails closed; nominal/root-backed results are bound to their prepared manifest

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2179,8 +2179,8 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
-- **PR #478 follow-up hardening — IMPLEMENTED 15-07-2026 (Codex/GPT-5; draft PR
-  pending).** Requeue attempts now retain immutable per-attempt harnesses/manifests and use
+- **PR #478 follow-up hardening — IMPLEMENTED 15-07-2026 (Codex/GPT-5;
+  [draft PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482)).** Requeue attempts now retain immutable per-attempt harnesses/manifests and use
   the latest audit directory; `ready_partial` must promote before retry preparation. Staged
   acceptance derives its window/headword denominators only from prepared headless leases, and
   residual-only chunks no longer consume the planner preparation limit. Regression coverage

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,13 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+- **Requeue provenance and staged-scope follow-up.** Coordinator requeues now create an
+  immutable attempt directory and execution manifest for the exact retry keys, retain the
+  initial and prior manifest history, and read the next retry list from the latest audit.
+  An unpromoted `ready_partial` lease must promote its verified subset before retry preparation.
+  Staged acceptance counts only prepared headless windows, while residual-only planner chunks
+  are reported and skipped until the requested number of eligible windows is prepared.
+
 - **Audit-bound promotion and restart safety.** Coordinator recording now fails closed:
   only a provenance-valid `clean` audit becomes ready, and only explicit
   `needs_requeue`/`transient_only` audits can expose a verified clean subset. Every

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -301,7 +301,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/audit_window.py": "f296b605833a028b9be92aada63077432ea798a7d8df4f8e0cccb2e3ccd16a21",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878"
+      "src/pilot/requeue_from_audit.py": "598d8ad7dcede04198eef7f0c9c5152aecb576572fa8dfbc36008387f92adbb6"
     }
   },
   {
@@ -318,7 +318,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 (commit 8cb84f7): the helper is lang-agnostic (takes a root, not a --lang flag; gen_opt_harness2.py resolves lang from the rootmap), so the fix applies to any language's requeue in one place. Was a both-paths gap before the fix, not an RU/EN divergence.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878"
+      "src/pilot/requeue_from_audit.py": "598d8ad7dcede04198eef7f0c9c5152aecb576572fa8dfbc36008387f92adbb6"
     }
   },
   {
@@ -356,7 +356,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -375,7 +375,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -413,7 +413,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -472,7 +472,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -503,7 +503,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "f4fed9b930f31f725763899c49775cb190e61865db4dd16c6e1e9d5bb4494b85",
       "src/pilot/audit_window.py": "f296b605833a028b9be92aada63077432ea798a7d8df4f8e0cccb2e3ccd16a21",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -522,7 +522,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -540,7 +540,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "95797986db7c21210a55c8a13f324514d17110ba07d2f804d000a77a003d5bf3",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -559,7 +559,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -599,7 +599,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -621,10 +621,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window.py": "f296b605833a028b9be92aada63077432ea798a7d8df4f8e0cccb2e3ccd16a21",
-      "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
+      "src/pilot/requeue_from_audit.py": "598d8ad7dcede04198eef7f0c9c5152aecb576572fa8dfbc36008387f92adbb6",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -649,11 +649,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/window_common.py": "1535ba9e35a501d673f5c8e844f0b7916b055ba772d53159770e69b0b8f65e48",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/requeue_from_audit.py": "2796a6b00232cb7a55e177e999a964633ea90026ddda754eee8f6b3922be0878",
+      "src/pilot/requeue_from_audit.py": "598d8ad7dcede04198eef7f0c9c5152aecb576572fa8dfbc36008387f92adbb6",
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -673,7 +673,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -691,8 +691,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "99d094c0a188b42cf9b7ff7b9a4518abd8d7f5283d4a4e711fde2498ef30aeae",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/coordinator.py": "9226ebda04a6a6c26fae71adc043daa158179d2511cd82a5bec1611cd0369be8",
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -729,7 +729,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -787,7 +787,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -806,7 +806,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -825,7 +825,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -845,7 +845,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982",
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -867,7 +867,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -926,7 +926,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -955,11 +955,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
       "src/pilot/headless_worker.py": "4b090d502c514884a334cbf58cf2c1867db3f4fd3244bfda3132c253ef4caabe",
-      "src/pilot/max_account_orchestrator.py": "ff194e8b84ca3792e8ded72079691df3cb84cb000444677c153a3263175cbe56",
-      "src/pilot/coordinator.py": "99d094c0a188b42cf9b7ff7b9a4518abd8d7f5283d4a4e711fde2498ef30aeae",
+      "src/pilot/max_account_orchestrator.py": "1073515c49279abc4080a6352fb206b1d82ec621a881f8549c489714be072307",
+      "src/pilot/coordinator.py": "9226ebda04a6a6c26fae71adc043daa158179d2511cd82a5bec1611cd0369be8",
       "src/pilot/headless_worker_selftest.py": "64c0c6c2567ef2c02844c6495fa8f99a74b5200c1cd7e37d44365fcbcbf3a00a",
-      "src/pilot/max_account_orchestrator_selftest.py": "0fe8e794d9ce43a8e4200ebee0ba9feaf214affc34ffa8022a62a5470d98c906",
-      "src/pilot/no_pwg_scale_plan.py": "0a33da47afe9f291951654649cdf7c0083fde1138fbde8bce8fe835edf208341",
+      "src/pilot/max_account_orchestrator_selftest.py": "acf81e929dcf6ae3e86ad3ff3ba5c086c014a12539339c4debe56c76d52fba6d",
+      "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
       "src/pilot/run_observability.py": "371d0197b39e217ef1754eb60d8b09f79823678f728d65e276f864eaeb8e0d72",
       "src/pilot/run_observability_selftest.py": "75bc960a35080a0c84ca9b5ee62b63134a9e0bde334c5531d564b13019187b60",
@@ -986,7 +986,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -1005,7 +1005,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -1030,7 +1030,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "f296b605833a028b9be92aada63077432ea798a7d8df4f8e0cccb2e3ccd16a21",
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982"
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
     }
   },
   {
@@ -1052,7 +1052,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "b5a827b8d452bc1bd62051e53ac253ec0d8dde62209a809d9b6e907d70409982",
+      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b",
       "src/pilot/accept_sensecount_test.js": "dd5061a719bace4f4927b71dfe931f4ee447be1c50f9476ef22c1ad3614015fe"
     }
   }

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -381,10 +381,25 @@ not a substitute for it.
   Coordinator/headless runs additionally pass `--execution-manifest`: root, nominal mode,
   input hashes, and result keys must match that prepared contract, with every selected key
   present exactly once. A stale, duplicated, foreign, or unbound result is never promotable.
+- A coordinator retry is a new execution attempt on the same lease, not permission to reuse
+  the initial manifest. `prepare-requeue` accepts only `promoted_partial`, `needs_requeue`, or
+  `transient_only`; promote a `ready_partial` clean subset first. Each retry is preserved under
+  `artifacts/<lease>/requeue/rqNN-{transient|defect}/` with its own harness and execution
+  manifest. `record-output` writes and audits in that current attempt directory, and a later
+  retry reads the requeue list emitted by that latest audit. Do not copy a retry output back
+  over the lease's initial artifacts.
+- Standalone `requeue_from_audit.py` remains compatible with the commands below. For a manually
+  managed provenance-bound retry, add `--manifest-out <path>` and pass that exact manifest to
+  `audit_window.py --execution-manifest <path>` when recording the result.
 - `no_pwg_scale_plan.py` reads the tracked `no_pwg_residuals.jsonl` decision ledger and
   skips keys whose latest status is `blocked`. Append a later `retry` or `resolved` row to
   reopen one key, or use `--include-residuals` for a deliberate one-run override. Do not
   delete the history or repeatedly spend Max quota on a documented deterministic failure.
+  A fully blocked chunk is listed in `omitted_windows` and does not consume
+  `--limit-windows`; preparation advances to the next eligible deterministic index. Plan
+  manifests retain plan-wide `selected_headwords` and separately report
+  `prepared_headwords`. Staged acceptance uses only windows carrying prepared `headless`
+  metadata, so future plan rows cannot inflate its window or headword denominators.
 - DeepSeek corpus-lexicon API calls are append-only/resumable in `build_corpus_lexicon.py`.
   Use `DEEPSEEK_RETRIES`, `DEEPSEEK_CONNECT_TIMEOUT`, `DEEPSEEK_READ_TIMEOUT`, and
   `DEEPSEEK_BACKOFF_BASE` to tune retry behavior; failed API batches are logged locally and

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -556,6 +556,37 @@ def clean_result_payload(result, rejected):
     return payload
 
 
+def read_execution_manifest(path):
+    if not path:
+        raise SystemExit('execution manifest path is missing')
+    try:
+        with open(path, encoding='utf-8') as f:
+            manifest = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        raise SystemExit('execution manifest is unreadable: %s' % e)
+    if manifest.get('schema') != 'pwg.headless_execution_manifest.v1':
+        raise SystemExit('unsupported execution manifest schema: %r' % manifest.get('schema'))
+    if not isinstance(manifest.get('meta'), dict):
+        raise SystemExit('execution manifest meta is missing or invalid')
+    return manifest
+
+
+def manifest_history_entry(path, attempt, kind, artifact_path, prepared_at=None):
+    manifest = read_execution_manifest(path)
+    meta = manifest['meta']
+    return {
+        'attempt': int(attempt),
+        'kind': kind,
+        'path': os.path.abspath(path),
+        'sha256': sha256_file(path),
+        'artifact_dir': os.path.abspath(artifact_path),
+        'root': meta.get('root'),
+        'nominal': bool(meta.get('nominal')),
+        'selected_keys': list(meta.get('selected_keys') or []),
+        'prepared_at': prepared_at or utc_now(),
+    }
+
+
 def cost_from_transcript(path):
     if not path:
         return None
@@ -615,7 +646,8 @@ def record_output(args):
     with DirLock(paths()['lock']):
         state = load_state()
         lease = lease_by_id(state, args.lease_id)
-        adir = lease.get('artifact_dir') or artifact_dir(args.lease_id)
+        base_adir = lease.get('artifact_dir') or artifact_dir(args.lease_id)
+        adir = lease.get('current_artifact_dir') or base_adir
         os.makedirs(adir, exist_ok=True)
         wf = os.path.join(adir, 'wf_output.%s.json' % lease['id'])
         result = normalize_workflow_result(args.workflow_result, wf)
@@ -666,9 +698,12 @@ def record_output(args):
         lease['recorded_at'] = utc_now()
         lease['workflow_result_count'] = len(result.get('results') or [])
         lease['cost'] = cost_from_transcript(args.transcript_dir)
+        lease['current_artifact_dir'] = adir
         save_state(state)
         registry_event(lease, 'recorded', {
             'wf_output': wf,
+            'execution_manifest': manifest,
+            'artifact_dir': adir,
             'status': state_name,
             'audit_returncode': audit.returncode,
             'cost': lease.get('cost'),
@@ -684,27 +719,96 @@ def prepare_requeue(args):
     with DirLock(paths()['lock']):
         state = load_state()
         lease = lease_by_id(state, args.lease_id)
+        lease_state = lease.get('state')
+        if lease_state == 'ready_partial':
+            raise SystemExit(
+                '%s: promote the verified clean subset before preparing its requeue' % lease['id'])
+        allowed = ('promoted_partial', 'needs_requeue', 'transient_only')
+        if lease_state not in allowed:
+            raise SystemExit('%s: cannot prepare requeue from lease state %r' %
+                             (lease['id'], lease_state))
         adir = lease.get('artifact_dir') or artifact_dir(args.lease_id)
+        source_dir = os.path.dirname(lease.get('status_path') or '') or adir
         which = 'transient' if args.transient else 'defect'
-        rq = os.path.join(adir, 'requeue.%s.keys.txt' % which)
-        legacy = os.path.join(adir, {
+        rq = os.path.join(source_dir, 'requeue.%s.keys.txt' % which)
+        legacy = os.path.join(source_dir, {
             'transient': 'requeue.transient.keys.txt',
             'defect': 'requeue.defect.keys.txt',
         }[which])
         if not os.path.exists(rq) and os.path.exists(legacy):
             rq = legacy
-        harness = os.path.join(adir, 'run_pilot_wf.%s.requeue.%s.js' % (lease['id'], which))
-        root = 'nominal_%s' % lease['id'] if lease.get('kind') == 'nominal' else lease['target']
+        if not os.path.exists(rq):
+            raise SystemExit('%s: requeue file is missing: %s' % (lease['id'], rq))
+        with open(rq, encoding='utf-8') as f:
+            requeue_keys = [line.strip() for line in f if line.strip()]
+        if not requeue_keys:
+            raise SystemExit('%s: requeue file is empty: %s' % (lease['id'], rq))
+
+        current_manifest_path = lease.get('execution_manifest')
+        current_manifest = read_execution_manifest(current_manifest_path)
+        current_meta = current_manifest['meta']
+        root = current_meta.get('root')
+        if not root:
+            raise SystemExit('%s: execution manifest has no root' % lease['id'])
+        nominal = bool(current_meta.get('nominal'))
+        attempt = int(lease.get('requeue_attempt') or 0) + 1
+        attempt_tag = 'rq%02d-%s' % (attempt, which)
+        attempt_dir = os.path.join(adir, 'requeue', attempt_tag)
+        os.makedirs(attempt_dir, exist_ok=False)
+        harness = os.path.join(attempt_dir, 'run_pilot_wf.%s.%s.js' %
+                               (lease['id'], attempt_tag))
+        manifest = os.path.join(attempt_dir, 'execution_manifest.%s.%s.json' %
+                                (lease['id'], attempt_tag))
+        old_manifest_sha256 = sha256_file(current_manifest_path)
         cmd = [sys.executable, os.path.join(HERE, 'requeue_from_audit.py'),
-               root, '--%s' % which, '--requeue-file=%s' % rq, '--out=%s' % harness]
-        if lease.get('kind') == 'nominal':
+               root, '--%s' % which, '--requeue-file=%s' % rq, '--out=%s' % harness,
+               '--manifest-out=%s' % manifest]
+        if nominal:
             cmd += ['--nominal', '--no-grammar']
-        p = run_cmd(cmd)
+        try:
+            p = run_cmd(cmd)
+            if sha256_file(current_manifest_path) != old_manifest_sha256:
+                raise SystemExit(
+                    '%s: previous execution manifest changed during requeue preparation' %
+                    lease['id'])
+            prepared_manifest = read_execution_manifest(manifest)
+            if (prepared_manifest['meta'].get('selected_keys') or []) != requeue_keys:
+                raise SystemExit('%s: requeue execution manifest key drift' % lease['id'])
+        except BaseException:
+            shutil.rmtree(attempt_dir, ignore_errors=True)
+            raise
+        history = lease.setdefault('execution_manifest_history', [])
+        current_abs = os.path.abspath(current_manifest_path)
+        if not any(os.path.abspath(row.get('path') or '') == current_abs for row in history):
+            history.append(manifest_history_entry(
+                current_manifest_path, lease.get('requeue_attempt') or 0,
+                'initial' if not history else lease.get('requeue_kind') or 'requeue',
+                lease.get('current_artifact_dir') or adir,
+                lease.get('prepared_at') or lease.get('recorded_at')))
+        prepared_at = utc_now()
+        history.append(manifest_history_entry(
+            manifest, attempt, which, attempt_dir, prepared_at))
         lease['state'] = 'requeue_prepared'
         lease['requeue_harness'] = harness
         lease['requeue_kind'] = which
+        lease['requeue_attempt'] = attempt
+        lease['execution_manifest'] = manifest
+        lease['current_artifact_dir'] = attempt_dir
+        lease['current_attempt'] = {
+            'number': attempt,
+            'kind': which,
+            'artifact_dir': attempt_dir,
+            'harness': harness,
+            'execution_manifest': manifest,
+            'prepared_at': prepared_at,
+            'selected_keys': requeue_keys,
+        }
         save_state(state)
-        registry_event(lease, 'requeue_prepared', {'harness': harness, 'kind': which})
+        registry_event(lease, 'requeue_prepared', {
+            'attempt': attempt, 'artifact_dir': attempt_dir,
+            'harness': harness, 'manifest': manifest, 'kind': which,
+            'selected_keys': requeue_keys,
+        })
     if p.stdout.strip():
         print(p.stdout.rstrip())
     print('harness: %s' % harness)

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -640,15 +640,29 @@ def probe_fleet(accounts, claude='claude', payload_bytes=6491, model=EXACT_GEN_M
     return latencies
 
 
+def staged_plan_scope(plan, requested_lease_ids=None):
+    """Return the prepared headless windows that define one staged acceptance run."""
+    prepared = [window for window in plan.get('windows', []) if window.get('headless')]
+    prepared_ids = [window['root'] for window in prepared]
+    if requested_lease_ids and set(requested_lease_ids) != set(prepared_ids):
+        raise SystemExit('--lease-id set does not match the staged plan')
+    lease_ids = list(requested_lease_ids or prepared_ids)
+    lease_scope = set(lease_ids)
+    windows = [window for window in prepared if window['root'] in lease_scope]
+    return {
+        'lease_ids': lease_ids,
+        'windows': windows,
+        'expected_windows': len(windows),
+        'expected_headwords': sum(len(window.get('headwords') or []) for window in windows),
+    }
+
+
 def cmd_staged_run(args):
     plan = json.load(open(args.plan, encoding='utf-8'))
-    plan_lease_ids = [window['root'] for window in plan.get('windows', [])
-                      if window.get('headless')]
-    if args.lease_id and set(args.lease_id) != set(plan_lease_ids):
-        raise SystemExit('--lease-id set does not match the staged plan')
-    lease_ids = args.lease_id or plan_lease_ids
-    expected_windows = len(plan_lease_ids)
-    expected_headwords = int(plan.get('selected_headwords') or 0)
+    scope = staged_plan_scope(plan, args.lease_id)
+    lease_ids = scope['lease_ids']
+    expected_windows = scope['expected_windows']
+    expected_headwords = scope['expected_headwords']
     if not expected_windows or not expected_headwords:
         raise SystemExit('staged plan has no prepared headless windows')
     db = connect(args.db)

--- a/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
@@ -17,6 +17,27 @@ import max_account_orchestrator as m
 
 
 def main():
+    staged_plan = {
+        'selected_headwords': 2,
+        'prepared_headwords': 1,
+        'windows': [
+            {'root': 'prepared', 'headwords': ['a'], 'headless': {'manifest_sha256': 'x'}},
+            {'root': 'future', 'headwords': ['b'], 'headless': None},
+        ],
+    }
+    scope = m.staged_plan_scope(staged_plan)
+    assert scope['lease_ids'] == ['prepared']
+    assert scope['expected_windows'] == 1
+    assert scope['expected_headwords'] == 1
+    assert m.staged_plan_scope(staged_plan, ['prepared']) == scope
+    try:
+        m.staged_plan_scope(staged_plan, ['future'])
+        assert False, 'unprepared lease id must not enter staged acceptance'
+    except SystemExit as exc:
+        assert 'does not match' in str(exc)
+    assert scope['expected_windows'] == 1 and scope['expected_headwords'] == 1
+    print('  staged plan scope: prepared lease alone supplies the GO denominators')
+
     with tempfile.TemporaryDirectory() as td:
         scoped_db = os.path.join(td, 'scope.sqlite')
         m.main(['--db', scoped_db, 'init', '--account', 'acc=' + os.path.join(td, 'acc'),

--- a/RussianTranslation/src/pilot/no_pwg_scale_plan.py
+++ b/RussianTranslation/src/pilot/no_pwg_scale_plan.py
@@ -461,11 +461,12 @@ def main(argv=None):
     window_heads = list(chunked(tail_order, args.window_size)) + list(chunked(rest_order, args.window_size))
 
     to_prepare = 0 if args.plan_only else args.limit_windows
+    prepared_count = 0
     seen_subcards = set()
     for offset, heads in enumerate(window_heads):
         idx = args.start_index + offset
         tail_mode = all(h in tail_set for h in heads)
-        if to_prepare and offset < to_prepare:
+        if to_prepare and prepared_count < to_prepare:
             window = prepare_window(args, idx, heads, eligible_still_null, tail_mode)
             if window.get('omitted'):
                 omitted.append(window)
@@ -475,6 +476,7 @@ def main(argv=None):
                 raise SystemExit('FAIL: duplicate subcards across windows: %s' % ','.join(sorted(overlap)))
             seen_subcards.update(window['subcards'])
             windows.append(window)
+            prepared_count += 1
         else:
             windows.append({
                 'root': '%s%02d' % (args.prefix, idx),
@@ -507,6 +509,7 @@ def main(argv=None):
         'window_size': args.window_size,
         'prepared_windows': len([w for w in windows if w.get('harness')]),
         'selected_headwords': sum(len(w['headwords']) for w in windows),
+        'prepared_headwords': sum(len(w['headwords']) for w in windows if w.get('harness')),
         'selected_subcards': sum(len(w.get('subcards') or []) for w in windows),
         'presplit_subcards': sum(len((w.get('headless') or {}).get('presplit_keys') or []) for w in windows),
         'projected_calls': sum(((w.get('headless') or {}).get('projected_calls') or 0) for w in windows),
@@ -520,9 +523,14 @@ def main(argv=None):
               'gitignored local store is restored/present' % os.path.relpath(STORE, RT))
     print('remaining headwords: %d | windows: %d | prepared: %d'
           % (payload['remaining_headwords'], len(windows), payload['prepared_windows']))
-    if windows:
+    prepared = [window for window in windows if window.get('harness')]
+    if prepared:
+        first = prepared[0]
+        print('next prepared window: %s (%s) %d headword(s)' %
+              (first['root'], first['mode'], len(first['headwords'])))
+    elif windows:
         first = windows[0]
-        print('next window: %s (%s) %d headword(s)' %
+        print('next planned window: %s (%s) %d headword(s)' %
               (first['root'], first['mode'], len(first['headwords'])))
 
 

--- a/RussianTranslation/src/pilot/requeue_from_audit.py
+++ b/RussianTranslation/src/pilot/requeue_from_audit.py
@@ -125,6 +125,8 @@ def main():
                          'singleton, possibly not this one.')
     ap.add_argument('--out',
                     help='explicit generated harness path; default is src/pilot/run_pilot_wf.opt2.js')
+    ap.add_argument('--manifest-out',
+                    help='optional execution-manifest path bound to this exact requeue key set')
     ap.add_argument('--nominal', action='store_true',
                     help='resolve keys directly as nominal cards instead of requiring a rootmap')
     ap.add_argument('--no-grammar', action='store_true',
@@ -168,6 +170,8 @@ def main():
            root, '--keys=' + ','.join(resolved)]
     if args.out:
         cmd.append('--out=%s' % args.out)
+    if args.manifest_out:
+        cmd.append('--manifest-out=%s' % args.manifest_out)
     if args.nominal:
         cmd.append('--nominal')
     if args.no_grammar:
@@ -194,6 +198,8 @@ def main():
     if denied_frags:
         print('tm denylist       : +%d fragment fsha(s)' % denied_frags)
     print('generated harness : %s' % harness)
+    if args.manifest_out:
+        print('execution manifest: %s' % os.path.abspath(args.manifest_out))
     print('keys:')
     for k in resolved:
         print('  ' + k)

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -2627,6 +2627,79 @@ def test_no_pwg_residual_registry_and_audit_command():
             fail('a no-PWG head with only blocked residuals must be omitted')
 
 
+def test_no_pwg_preparation_advances_past_omitted_chunks():
+    import no_pwg_scale_plan as plan
+
+    def residual(key):
+        return {'schema': 'pwg.no_pwg_residual.v1', 'key': key,
+                'status': 'blocked', 'reason': 'repeat failure',
+                'source_window': 'old', 'updated_at': '2026-07-15T00:00:00Z'}
+
+    originals = {name: getattr(plan, name) for name in
+                 ('read_queue', 'read_store_heads', 'read_still_null',
+                  'read_residuals', 'prepare_window')}
+    with tempfile.TemporaryDirectory() as tmp:
+        registry = os.path.join(tmp, 'residuals.jsonl')
+        manifest = os.path.join(tmp, 'plan.json')
+        blocked = {'a~~x': residual('a~~x'), 'b~~x': residual('b~~x')}
+        plan.read_queue = lambda: [
+            {'key1': 'a'}, {'key1': 'b'}, {'key1': 'c'}]
+        plan.read_store_heads = lambda: set()
+        plan.read_still_null = lambda: []
+        plan.read_residuals = lambda _path: blocked
+
+        def prepare_some(args, index, heads, _still_null, _tail_mode):
+            head = heads[0]
+            if head == 'a':
+                return {'omitted': True, 'root': 'fixture_w%02d' % index,
+                        'headwords': heads,
+                        'residual_skipped': plan.residual_summary([blocked['a~~x']])}
+            return {'root': 'fixture_w%02d' % index, 'mode': 'queue',
+                    'headwords': heads, 'subcards': [head + '~~x'],
+                    'harness': 'run.js', 'workflow_output': 'wf.json',
+                    'preflight': {}, 'headless': {'projected_calls': 1},
+                    'residual_skipped': []}
+
+        try:
+            plan.prepare_window = prepare_some
+            plan.main(['--window-size', '1', '--limit-windows', '1',
+                       '--start-index', '900', '--force-index',
+                       '--prefix', 'fixture_w', '--manifest', manifest,
+                       '--residual-file', registry])
+            payload = json.load(open(manifest, encoding='utf-8'))
+            if payload['prepared_windows'] != 1 or payload['prepared_headwords'] != 1:
+                fail('an omitted chunk consumed the requested preparation quota')
+            if payload['windows'][0]['root'] != 'fixture_w901':
+                fail('planner did not advance to the first eligible deterministic index')
+            if [row['root'] for row in payload['omitted_windows']] != ['fixture_w900']:
+                fail('omitted chunk was not reported completely')
+            if payload['residual_skipped'][0]['reason'] != 'repeat failure':
+                fail('omitted residual reason was lost from the plan manifest')
+
+            def prepare_none(args, index, heads, _still_null, _tail_mode):
+                key = heads[0] + '~~x'
+                row = blocked.get(key) or residual(key)
+                blocked[key] = row
+                return {'omitted': True, 'root': 'blocked_w%02d' % index,
+                        'headwords': heads,
+                        'residual_skipped': plan.residual_summary([row])}
+
+            plan.prepare_window = prepare_none
+            blocked_manifest = os.path.join(tmp, 'blocked-plan.json')
+            plan.main(['--window-size', '1', '--limit-windows', '1',
+                       '--start-index', '910', '--force-index',
+                       '--prefix', 'blocked_w', '--manifest', blocked_manifest,
+                       '--residual-file', registry])
+            payload = json.load(open(blocked_manifest, encoding='utf-8'))
+            if payload['prepared_windows'] != 0 or payload['windows']:
+                fail('an entirely blocked queue must prepare zero windows')
+            if len(payload['omitted_windows']) != 3:
+                fail('an entirely blocked queue must report every omitted chunk')
+        finally:
+            for name, value in originals.items():
+                setattr(plan, name, value)
+
+
 def test_coordinator_expired_leases_release_cap():
     """A killed/offline pre-prepare claim must not hold one global translation lane
     forever, while an already-prepared harness remains a durable operator artifact."""
@@ -2707,6 +2780,7 @@ def test_coordinator_defect_requeue_uses_no_tm_and_out():
         with open(rqfile, 'w', encoding='utf-8') as f:
             f.write('a\n')
         out = os.path.join(tmp, 'run_pilot_wf.requeue.js')
+        manifest_out = os.path.join(tmp, 'execution_manifest.requeue.json')
 
         captured = {}
 
@@ -2727,7 +2801,7 @@ def test_coordinator_defect_requeue_uses_no_tm_and_out():
         rq.append_tm_denylist = lambda *_args, **_kwargs: (1, 0)
         sys.argv = ['requeue_from_audit.py', 'nominal_selftest', '--defect',
                     '--nominal', '--no-grammar', '--requeue-file=%s' % rqfile,
-                    '--out=%s' % out]
+                    '--out=%s' % out, '--manifest-out=%s' % manifest_out]
         try:
             rq.main()
         finally:
@@ -2742,6 +2816,137 @@ def test_coordinator_defect_requeue_uses_no_tm_and_out():
             fail('nominal requeue flags must pass through')
         if '--out=%s' % out not in cmd:
             fail('coordinator requeue must use an explicit harness output path')
+        if '--manifest-out=%s' % manifest_out not in cmd:
+            fail('coordinator requeue must bind the harness to its exact manifest')
+
+
+def test_coordinator_requeue_attempt_manifests():
+    import coordinator
+    import window_provenance
+    from types import SimpleNamespace
+    from window_common import input_paths
+
+    old_coord = os.environ.get('PWG_COORDINATOR_DIR')
+    original_run = coordinator.run_cmd
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ['PWG_COORDINATOR_DIR'] = tmp
+        artifacts = os.path.join(tmp, 'artifacts', 'lease')
+        os.makedirs(artifacts)
+        input_dir = os.path.join(tmp, 'input')
+        os.makedirs(input_dir)
+        input_hashes = {}
+        for key in ('a~~x', 'b~~x'):
+            raw_path, portrait_path = input_paths(key, input_dir=input_dir)
+            with open(raw_path, 'w', encoding='utf-8') as f:
+                f.write('raw ' + key)
+            with open(portrait_path, 'w', encoding='utf-8') as f:
+                json.dump({'key': key}, f)
+            input_hashes[key] = {
+                'raw_sha256': coordinator.sha256_file(raw_path),
+                'portrait_sha256': coordinator.sha256_file(portrait_path),
+            }
+        initial_manifest = os.path.join(artifacts, 'execution_manifest.lease.json')
+        original = {
+            'schema': 'pwg.headless_execution_manifest.v1',
+            'meta': {'root': 'no_pwg_fixture', 'nominal': True,
+                     'selected_keys': ['a~~x', 'b~~x'], 'input_hashes': input_hashes},
+        }
+        with open(initial_manifest, 'w', encoding='utf-8') as f:
+            json.dump(original, f)
+        original_bytes = open(initial_manifest, 'rb').read()
+        with open(os.path.join(artifacts, 'requeue.transient.keys.txt'),
+                  'w', encoding='utf-8') as f:
+            f.write('a~~x\n')
+        state = coordinator.default_state()
+        state['leases'] = [{
+            'id': 'lease', 'kind': 'nominal', 'target': 'a',
+            'state': 'promoted_partial', 'artifact_dir': artifacts,
+            'execution_manifest': initial_manifest,
+            'status_path': os.path.join(artifacts, 'window_status.json'),
+        }]
+        coordinator.save_state(state)
+
+        class FakeProc:
+            stdout = 'generated requeue harness\n'
+
+        def fake_run(cmd):
+            out = next(arg.split('=', 1)[1] for arg in cmd if arg.startswith('--out='))
+            manifest = next(arg.split('=', 1)[1] for arg in cmd
+                            if arg.startswith('--manifest-out='))
+            rqfile = next(arg.split('=', 1)[1] for arg in cmd
+                          if arg.startswith('--requeue-file='))
+            keys = [line.strip() for line in open(rqfile, encoding='utf-8') if line.strip()]
+            os.makedirs(os.path.dirname(out), exist_ok=True)
+            with open(out, 'w', encoding='utf-8') as f:
+                f.write('// generated\n')
+            with open(manifest, 'w', encoding='utf-8') as f:
+                json.dump({'schema': 'pwg.headless_execution_manifest.v1',
+                           'meta': {'root': 'no_pwg_fixture', 'nominal': True,
+                                    'selected_keys': keys,
+                                    'input_hashes': {key: input_hashes[key] for key in keys}}}, f)
+            return FakeProc()
+
+        coordinator.run_cmd = fake_run
+        try:
+            coordinator.prepare_requeue(SimpleNamespace(
+                lease_id='lease', transient=True, defect=False))
+            lease = coordinator.load_state()['leases'][0]
+            if lease['requeue_attempt'] != 1 or 'rq01-transient' not in lease['current_artifact_dir']:
+                fail('first requeue attempt did not receive its own artifact directory')
+            if json.load(open(lease['execution_manifest'], encoding='utf-8'))[
+                    'meta']['selected_keys'] != ['a~~x']:
+                fail('requeue attempt manifest was not narrowed to its exact keys')
+            if open(initial_manifest, 'rb').read() != original_bytes:
+                fail('requeue preparation modified the original execution manifest')
+            if len(lease['execution_manifest_history']) != 2:
+                fail('initial and first-attempt manifests were not retained in history')
+            attempt_manifest = json.load(open(lease['execution_manifest'], encoding='utf-8'))
+            old_inp = window_provenance.INP
+            window_provenance.INP = input_dir
+            try:
+                if not window_provenance.stale_check(
+                        None, attempt_manifest['meta'], ['a~~x'],
+                        execution_manifest=attempt_manifest)['ok']:
+                    fail('one-key requeue did not validate against its attempt manifest')
+                if window_provenance.stale_check(
+                        None, attempt_manifest['meta'], ['a~~x'],
+                        execution_manifest=original)['ok']:
+                    fail('one-key requeue unexpectedly validated against the two-key original')
+            finally:
+                window_provenance.INP = old_inp
+
+            latest_dir = lease['current_artifact_dir']
+            with open(os.path.join(latest_dir, 'requeue.transient.keys.txt'),
+                      'w', encoding='utf-8') as f:
+                f.write('a~~x\n')
+            state = coordinator.load_state()
+            state['leases'][0]['state'] = 'transient_only'
+            state['leases'][0]['status_path'] = os.path.join(latest_dir, 'window_status.json')
+            coordinator.save_state(state)
+            coordinator.prepare_requeue(SimpleNamespace(
+                lease_id='lease', transient=True, defect=False))
+            lease = coordinator.load_state()['leases'][0]
+            if lease['requeue_attempt'] != 2 or 'rq02-transient' not in lease['current_artifact_dir']:
+                fail('repeated requeue did not advance from the latest audit directory')
+            if len(lease['execution_manifest_history']) != 3:
+                fail('repeated requeue did not preserve every prior manifest')
+
+            state = coordinator.load_state()
+            state['leases'][0]['state'] = 'ready_partial'
+            coordinator.save_state(state)
+            try:
+                coordinator.prepare_requeue(SimpleNamespace(
+                    lease_id='lease', transient=True, defect=False))
+                fail('unpromoted ready_partial lease was allowed to prepare a requeue')
+            except SystemExit as exc:
+                if 'promote' not in str(exc):
+                    fail('ready_partial refusal did not explain the promotion prerequisite')
+        finally:
+            coordinator.run_cmd = original_run
+            if old_coord is None:
+                os.environ.pop('PWG_COORDINATOR_DIR', None)
+            else:
+                os.environ['PWG_COORDINATOR_DIR'] = old_coord
 
 
 def test_promote_nominal_key1():
@@ -4732,6 +4937,7 @@ def main():
         test_coordinator_lock_replaces_stale_dead_owner,
         test_coordinator_lock_creates_parent_dir,
         test_coordinator_defect_requeue_uses_no_tm_and_out,
+        test_coordinator_requeue_attempt_manifests,
         test_promote_nominal_key1,
         test_build_emits_nominal_keymap,
         test_generation_schema_carries_no_post_generation_field,
@@ -4772,6 +4978,7 @@ def main():
         test_nominal_provenance_without_rootmap,
         test_atomic_control_writes_preserve_previous_file,
         test_no_pwg_residual_registry_and_audit_command,
+        test_no_pwg_preparation_advances_past_omitted_chunks,
         test_no_pwg_card_source_profile_taxonomy,
         test_no_pwg_supplement_card_renders_without_pwg,
         test_h920_sense_count_top_level_ordinals,


### PR DESCRIPTION
## PR Type
- [ ] data
- [x] build
- [x] docs
- [ ] navigation

## Summary
- What changed: Requeue preparation now mints immutable attempt-specific harnesses and execution manifests, staged acceptance scopes its denominators to prepared headless leases, and the no-PWG planner advances past residual-only chunks until its eligible-window quota is filled.
- Why this change exists: Review of merged PR #478 found that subset requeues still pointed at the original full-window manifest, future unprepared plan rows inflated staged acceptance, and an omitted first planner chunk consumed `--limit-windows`.

## Root causes and behavior
- A requeue narrowed the selected keys without renewing the manifest-bound provenance contract. Each attempt now lives under `requeue/rqNN-{transient|defect}/`; initial and prior manifests remain immutable and are recorded in lease history.
- Staged acceptance treated plan rows as executed work. A pure scope helper now selects prepared headless windows and derives both expected window and headword counts from that scope.
- Planner queue offset was conflated with successful preparation count. Omitted residual-only chunks are now reported and skipped while deterministic indices continue forward.
- `ready_partial` must promote its verified clean subset before requeue preparation; accepted preparation states are `promoted_partial`, `needs_requeue`, and `transient_only`.

## Compatibility
- Coordinator state schema v1 is unchanged; attempt fields and manifest history are additive and lazily initialized.
- Standalone `requeue_from_audit.py` behavior is unchanged unless optional `--manifest-out` is supplied.
- Existing plan-wide `selected_headwords` remains; `prepared_headwords` is additive.
- Standalone unscoped orchestrator commands are unchanged. Explicit staged `--lease-id` values must still exactly match the prepared plan lease set.

## Residual registry policy
- Latest row per exact key remains authoritative.
- `blocked` keys remain excluded unless `--include-residuals` is used; `retry` and `resolved` remain eligible.
- A fully blocked chunk is retained in `omitted_windows`, including reasons, and does not consume the preparation limit.

## Test Surface
- Automated checks:
  - `python src/pilot/window_selftest.py` — PASS
  - `python src/pilot/headless_worker_selftest.py` — PASS
  - `python src/pilot/max_account_orchestrator_selftest.py` — PASS
  - `python src/pilot/lang_parity_check.py` — PASS, 49 entries/no drift
  - `python src/pilot/check_launch_ledger.py --since 2026-07-05` — PASS, 17 entries complete
  - `python -m ruff check --select E9,F63,F7,F82 ...` — PASS
  - `node --check src/pilot/run_pilot_wf.opt2.js` — PASS
  - `git diff --check` — PASS
- Manual checks: Two-key initial manifest stays byte-identical while a one-key retry validates only against its new manifest; a second retry reads the latest attempt audit directory.
- Pure helpers / decision points covered: prepared-plan scope, lease-set mismatch refusal, retry state gate, omitted-window top-up, entirely blocked queue.
- If build-related: import-safe verified? yes

## Invariants
- Must stay true: No audit-unbound output can be promoted; rejected/pending keys remain retry evidence, never clean output.
- Counts / alignment / join rules: Every retry key occurs exactly once in its attempt manifest; staged expected counts come only from prepared headless windows.
- Source-of-truth assumptions: The current execution manifest is authoritative for the current attempt; latest residual row per key wins.
- What would count as regression: Reusing the initial manifest for a subset retry, claiming a future plan row, or stopping preparation after an omitted residual-only chunk.

## Safety
- Fallback / failure mode: Failed retry generation removes only the incomplete new attempt directory and leaves all prior artifacts intact.
- Observable marker or sanity check: Lease `execution_manifest_history`, `current_attempt`, and `requeue_attempt`; plan `prepared_headwords` and `omitted_windows`.
- Rebuild / validate / verify command: Run the test commands listed above.

## Reader-Facing Done
- Navigation / entry point updated: Operator guidance updated in `RussianTranslation/src/pilot/RUN_FREQ_MAX.md`.
- Docs / changelog / handoff updated: RussianTranslation changelog, repository/subsystem `.ai_state.md`, and `FINDINGS.md` updated.
- Known limits or caveats exposed: No production Max calls, translations, promotions, canonical-store writes, or TM rebuilds were performed.