### PR TITLE
fix(russiantranslation): preserve requeue backlog provenance

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -769,14 +769,6 @@ Two live tracks:
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- **RussianTranslation PR #482 review hardening — IMPLEMENTED, DELIVERY PENDING
-  (15-07-2026, Codex/GPT-5).** Branch `codex/russiantranslation-pr482-review-fixes`, core
-  commit `9051b9ea`. Retry backlogs are now bound to the immutable origin manifest and source
-  audit-report hashes; mixed transient/defect lanes survive iterative attempts; allocation
-  preserves and skips orphan `rqNN-*` directories. Full window/headless/orchestrator and parity
-  checks pass. Documentation + draft PR remain; no live generation, promotion, store write, or
-  TM rebuild occurred. Detailed record is in `RussianTranslation/.ai_state.md`.
-
 - **No H960 implementation is active in this worktree (15-07-2026, Codex/GPT-5).** Audit and
   handoff only; no live generation, profile login, store/TM mutation, or scaling run occurred.
   The stale H317/H442 prepared-canary notes below are historical inputs, not permission to bypass
@@ -1001,6 +993,14 @@ Two live tracks:
   demote to plain text with "(не входит в этот репозиторий)", do not link.
 
 ## ✅ Completed (Recent only)
+
+- **RussianTranslation PR #482 review hardening — DELIVERED 15-07-2026 (Codex/GPT-5;
+  [draft PR #483](https://github.com/gasyoun/SanskritLexicography/pull/483)).** Retry backlogs
+  are bound to the immutable origin manifest and source audit-report hashes; mixed transient/
+  defect lanes survive iterative attempts; allocation preserves and skips orphan `rqNN-*`
+  directories. Full window/headless/orchestrator, 49-entry parity, 17-entry launch ledger,
+  Ruff fatal, Node syntax, and diff checks pass. No live generation, promotion, store write,
+  or TM rebuild occurred. Detailed record is in `RussianTranslation/.ai_state.md`.
 
 - **RussianTranslation PR #478 follow-up — MERGED 15-07-2026 (Codex/GPT-5;
   [PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482)).** Restored manifest-bound iterative requeues, scoped staged acceptance

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -769,6 +769,14 @@ Two live tracks:
 
 ## 🚧 Current Work-In-Progress (WIP)
 
+- **RussianTranslation PR #482 review hardening — IMPLEMENTED, DELIVERY PENDING
+  (15-07-2026, Codex/GPT-5).** Branch `codex/russiantranslation-pr482-review-fixes`, core
+  commit `9051b9ea`. Retry backlogs are now bound to the immutable origin manifest and source
+  audit-report hashes; mixed transient/defect lanes survive iterative attempts; allocation
+  preserves and skips orphan `rqNN-*` directories. Full window/headless/orchestrator and parity
+  checks pass. Documentation + draft PR remain; no live generation, promotion, store write, or
+  TM rebuild occurred. Detailed record is in `RussianTranslation/.ai_state.md`.
+
 - **No H960 implementation is active in this worktree (15-07-2026, Codex/GPT-5).** Audit and
   handoff only; no live generation, profile login, store/TM mutation, or scaling run occurred.
   The stale H317/H442 prepared-canary notes below are historical inputs, not permission to bypass
@@ -994,8 +1002,8 @@ Two live tracks:
 
 ## ✅ Completed (Recent only)
 
-- **RussianTranslation PR #478 follow-up — IMPLEMENTED 15-07-2026 (Codex/GPT-5;
-  [draft PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482)).** Restored manifest-bound iterative requeues, scoped staged acceptance
+- **RussianTranslation PR #478 follow-up — MERGED 15-07-2026 (Codex/GPT-5;
+  [PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482)).** Restored manifest-bound iterative requeues, scoped staged acceptance
   denominators to prepared headless leases, and made residual-only planner chunks advance
   without consuming the requested preparation count. Regression and parity checks pass; no
   Max call, production translation, promotion, store write, or TM rebuild occurred. Detailed

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2251,7 +2251,8 @@ This keeps retry cost policy split by lane without allowing one lane to erase th
 
 > **Source:** RussianTranslation audit-findings implementation
 > ([PR #478](https://github.com/gasyoun/SanskritLexicography/pull/478),
-> [follow-up PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482))
+> [follow-up PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482),
+> [review-fix PR #483](https://github.com/gasyoun/SanskritLexicography/pull/483))
 > ([`coordinator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/coordinator.py),
 > [`window_provenance.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_provenance.py),
 > [`window_common.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/window_common.py),

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2237,6 +2237,18 @@ an execution set: future unprepared rows must not enter acceptance denominators,
 residual-only chunk must not consume the requested preparation quota. Scope acceptance to
 prepared lease IDs and count successful preparations independently of deterministic indices.
 
+The review after PR #482 exposed three more instances of the boundary problem. A coordinator
+could still reconstruct work from mutable split-key files without proving that the keys came
+from the lease's original manifest; selecting the transient lane could silently lose a pending
+defect lane (or the reverse); and a hard interruption after directory creation could make the
+state counter reuse an existing `rqNN-*` path. The resolution is a durable, additive backlog:
+seal the attempt-zero manifest path/hash as the lease key universe, bind every pending key to
+its classifying audit-report path/hash, and carry the unselected lane through the next audit and
+promotion. Allocate from the maximum of state, manifest history, and disk; preserve and report
+unreferenced attempt directories as orphans, never auto-adopt or delete them. Materialize the
+selected keys and conservative defect fragment hashes inside the new attempt before generation.
+This keeps retry cost policy split by lane without allowing one lane to erase the other.
+
 > **Source:** RussianTranslation audit-findings implementation
 > ([PR #478](https://github.com/gasyoun/SanskritLexicography/pull/478),
 > [follow-up PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482))

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1919,15 +1919,6 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- **PR #482 review hardening — IMPLEMENTED, DELIVERY PENDING (15-07-2026, Codex/GPT-5).**
-  Branch `codex/russiantranslation-pr482-review-fixes`, core commit `9051b9ea`. The coordinator
-  now seals the initial manifest/key universe, persists source-report-bound transient/defect
-  backlog entries, carries the unselected lane across retry/promotion, and advances past
-  preserved orphan attempt directories. The public-operation mixed-lane regression proves
-  `needs_requeue → ready_partial → promoted_partial → ready → promoted`; full window, headless,
-  orchestrator, and 49-entry parity checks pass. Documentation + draft PR remain; no live Max
-  call, translation, promotion, canonical-store write, or TM rebuild occurred.
-
 - **H960 audit packaged; implementation not started (15-07-2026, Codex/GPT-5).** No live probe,
   generation, login, promotion, store mutation, or TM rebuild occurred. The H317/H442 material below
   is historical prepared evidence and does not override the current H911/H909/H960 gates.
@@ -2187,6 +2178,17 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   ([SamudraManthanam #16](https://github.com/gasyoun/SamudraManthanam/issues/16)).
 
 ## ✅ Completed (Recent only)
+
+- **PR #482 review hardening — DELIVERED 15-07-2026 (Codex/GPT-5;
+  [draft PR #483](https://github.com/gasyoun/SanskritLexicography/pull/483)).** The coordinator
+  seals the initial manifest/key universe, persists source-report-bound transient/defect
+  backlog entries, carries the unselected lane across retry/promotion, and advances past
+  preserved orphan attempt directories. The public-operation mixed-lane regression proves
+  `needs_requeue → ready_partial → promoted_partial → ready → promoted`; reverse order,
+  unresolved retries, tampering, duplicate/classification drift, orphan recovery, and caught
+  generator cleanup are pinned. Full window/headless/orchestrator suites, 49-entry parity,
+  17-entry launch ledger, Ruff fatal, Node syntax, and diff checks pass. No live Max call,
+  translation, promotion, canonical-store write, or TM rebuild occurred.
 
 - **PR #478 follow-up hardening — MERGED 15-07-2026 (Codex/GPT-5;
   [PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482)).** Requeue attempts now retain immutable per-attempt harnesses/manifests and use

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1919,6 +1919,15 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## 🚧 Current Work-In-Progress (WIP)
 
+- **PR #482 review hardening — IMPLEMENTED, DELIVERY PENDING (15-07-2026, Codex/GPT-5).**
+  Branch `codex/russiantranslation-pr482-review-fixes`, core commit `9051b9ea`. The coordinator
+  now seals the initial manifest/key universe, persists source-report-bound transient/defect
+  backlog entries, carries the unselected lane across retry/promotion, and advances past
+  preserved orphan attempt directories. The public-operation mixed-lane regression proves
+  `needs_requeue → ready_partial → promoted_partial → ready → promoted`; full window, headless,
+  orchestrator, and 49-entry parity checks pass. Documentation + draft PR remain; no live Max
+  call, translation, promotion, canonical-store write, or TM rebuild occurred.
+
 - **H960 audit packaged; implementation not started (15-07-2026, Codex/GPT-5).** No live probe,
   generation, login, promotion, store mutation, or TM rebuild occurred. The H317/H442 material below
   is historical prepared evidence and does not override the current H911/H909/H960 gates.
@@ -2179,8 +2188,8 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
-- **PR #478 follow-up hardening — IMPLEMENTED 15-07-2026 (Codex/GPT-5;
-  [draft PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482)).** Requeue attempts now retain immutable per-attempt harnesses/manifests and use
+- **PR #478 follow-up hardening — MERGED 15-07-2026 (Codex/GPT-5;
+  [PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482)).** Requeue attempts now retain immutable per-attempt harnesses/manifests and use
   the latest audit directory; `ready_partial` must promote before retry preparation. Staged
   acceptance derives its window/headword denominators only from prepared headless leases, and
   residual-only chunks no longer consume the planner preparation limit. Regression coverage

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,14 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+- **Provenance-bound mixed-lane requeues.** Each lease now seals its initial execution
+  manifest as the immutable key universe and stores every pending retry key with the path
+  and SHA-256 of the audit report that classified it. `record-output` rejects duplicate,
+  overlapping, foreign, or category-drifted retry sets; selecting one transient/defect lane
+  carries the other through promotion and later attempts. Attempt directories materialize
+  their exact key set and conservative defect-fragment hashes, while orphaned `rqNN-*`
+  directories are preserved, reported, and skipped by allocation.
+
 - **Requeue provenance and staged-scope follow-up.** Coordinator requeues now create an
   immutable attempt directory and execution manifest for the exact retry keys, retain the
   initial and prior manifest history, and read the next retry list from the latest audit.

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -356,7 +356,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -375,7 +375,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -413,7 +413,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -472,7 +472,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -503,7 +503,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "f4fed9b930f31f725763899c49775cb190e61865db4dd16c6e1e9d5bb4494b85",
       "src/pilot/audit_window.py": "f296b605833a028b9be92aada63077432ea798a7d8df4f8e0cccb2e3ccd16a21",
       "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -522,7 +522,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -540,7 +540,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "95797986db7c21210a55c8a13f324514d17110ba07d2f804d000a77a003d5bf3",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -559,7 +559,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -599,7 +599,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -624,7 +624,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "598d8ad7dcede04198eef7f0c9c5152aecb576572fa8dfbc36008387f92adbb6",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -653,7 +653,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -673,7 +673,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -691,8 +691,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "9226ebda04a6a6c26fae71adc043daa158179d2511cd82a5bec1611cd0369be8",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/coordinator.py": "e42c2635cbc1fead5ab6e0cfcd0866149cfd29eb786fb3ce1fa14e4227b4fbf4",
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -729,7 +729,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -787,7 +787,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -806,7 +806,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -825,7 +825,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -845,7 +845,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b",
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -867,7 +867,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -926,7 +926,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -956,7 +956,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
       "src/pilot/headless_worker.py": "4b090d502c514884a334cbf58cf2c1867db3f4fd3244bfda3132c253ef4caabe",
       "src/pilot/max_account_orchestrator.py": "1073515c49279abc4080a6352fb206b1d82ec621a881f8549c489714be072307",
-      "src/pilot/coordinator.py": "9226ebda04a6a6c26fae71adc043daa158179d2511cd82a5bec1611cd0369be8",
+      "src/pilot/coordinator.py": "e42c2635cbc1fead5ab6e0cfcd0866149cfd29eb786fb3ce1fa14e4227b4fbf4",
       "src/pilot/headless_worker_selftest.py": "64c0c6c2567ef2c02844c6495fa8f99a74b5200c1cd7e37d44365fcbcbf3a00a",
       "src/pilot/max_account_orchestrator_selftest.py": "acf81e929dcf6ae3e86ad3ff3ba5c086c014a12539339c4debe56c76d52fba6d",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
@@ -986,7 +986,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -1005,7 +1005,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -1030,7 +1030,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "f296b605833a028b9be92aada63077432ea798a7d8df4f8e0cccb2e3ccd16a21",
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b"
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153"
     }
   },
   {
@@ -1052,7 +1052,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "12c5e14a7bdf601b28d0336bfb748a0f7074077f4b76327b07eabbe30b0e4a4b",
+      "src/pilot/window_selftest.py": "373e32eac22e603f31ef73d93f0014d85085daec90ec58a2a816adef1744f153",
       "src/pilot/accept_sensecount_test.js": "dd5061a719bace4f4927b71dfe931f4ee447be1c50f9476ef22c1ad3614015fe"
     }
   }

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -381,13 +381,23 @@ not a substitute for it.
   Coordinator/headless runs additionally pass `--execution-manifest`: root, nominal mode,
   input hashes, and result keys must match that prepared contract, with every selected key
   present exactly once. A stale, duplicated, foreign, or unbound result is never promotable.
-- A coordinator retry is a new execution attempt on the same lease, not permission to reuse
-  the initial manifest. `prepare-requeue` accepts only `promoted_partial`, `needs_requeue`, or
-  `transient_only`; promote a `ready_partial` clean subset first. Each retry is preserved under
-  `artifacts/<lease>/requeue/rqNN-{transient|defect}/` with its own harness and execution
-  manifest. `record-output` writes and audits in that current attempt directory, and a later
-  retry reads the requeue list emitted by that latest audit. Do not copy a retry output back
-  over the lease's initial artifacts.
+- A coordinator retry is a new execution attempt on the same lease. The lease seals the
+  initial execution-manifest path and SHA-256 as its immutable key universe; every pending
+  transient/defect key is bound to the path and SHA-256 of the audit report that classified
+  it. `prepare-requeue` reads only this validated `pending_requeue` backlog, never a mutable
+  split-key file. Changed reports, foreign/duplicate keys, overlapping classifications, or
+  ambiguous legacy provenance fail closed.
+- `prepare-requeue` accepts only `promoted_partial`, `needs_requeue`, or `transient_only`;
+  promote a `ready_partial` clean subset first. Selecting one lane snapshots the other under
+  `current_attempt.remaining_pending`, so a transient retry cannot discard pending defects
+  (or vice versa). Clean rows with remaining work become `ready_partial`, promotion becomes
+  `promoted_partial`, and the lease reaches `promoted` only after the backlog is empty.
+- Each retry is preserved under `artifacts/<lease>/requeue/rqNN-{transient|defect}/` with its
+  exact key file, conservatively collected defect-fragment hashes, harness, and execution
+  manifest. Allocation advances past the highest state/history attempt and any existing
+  `rqNN-*` directory. Unreferenced directories from hard interruptions are recorded as
+  orphans and left untouched; only a newly created directory from a caught preparation
+  failure is removed. Never copy retry output over prior artifacts or adopt/delete an orphan.
 - Standalone `requeue_from_audit.py` remains compatible with the commands below. For a manually
   managed provenance-bound retry, add `--manifest-out <path>` and pass that exact manifest to
   `audit_window.py --execution-manifest <path>` when recording the result.

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -6,10 +6,12 @@ Max/Workflow surface; operators still run the generated harness from the coding
 session and feed the full result back through record-output.
 """
 import argparse
+from collections import Counter
 import datetime
 import glob
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -442,6 +444,8 @@ def register_prepared_lease(lease_id, lane, keys, harness, manifest, preflight_p
                         'keymap': dict(zip(run_keys, keys))},
             'harness': os.path.abspath(harness),
             'execution_manifest': os.path.abspath(manifest),
+            'origin_execution_manifest': os.path.abspath(manifest),
+            'origin_execution_manifest_sha256': sha256_file(manifest),
             'preflight_path': os.path.abspath(preflight_path),
         }
         state['leases'].append(lease)
@@ -524,6 +528,8 @@ def prepare(args):
         lease['state'] = 'prepared'
         lease['harness'] = harness
         lease['execution_manifest'] = manifest
+        lease['origin_execution_manifest'] = os.path.abspath(manifest)
+        lease['origin_execution_manifest_sha256'] = sha256_file(manifest)
         lease['preflight_path'] = preflight_path
         save_state(state)
         registry_event(lease, 'prepared', {'harness': harness, 'manifest': manifest,
@@ -587,6 +593,188 @@ def manifest_history_entry(path, attempt, kind, artifact_path, prepared_at=None)
     }
 
 
+def ensure_origin_manifest(lease):
+    path = lease.get('origin_execution_manifest')
+    recorded_hash = lease.get('origin_execution_manifest_sha256')
+    if not path:
+        history = [row for row in (lease.get('execution_manifest_history') or [])
+                   if int(row.get('attempt') or 0) == 0 and row.get('path')]
+        if history:
+            path = history[0]['path']
+            recorded_hash = history[0].get('sha256')
+        elif int(lease.get('requeue_attempt') or 0) == 0:
+            path = lease.get('execution_manifest')
+        else:
+            raise SystemExit(
+                '%s: attempted legacy lease has no verifiable origin manifest' % lease['id'])
+    manifest = read_execution_manifest(path)
+    actual_hash = sha256_file(path)
+    if recorded_hash and actual_hash != recorded_hash:
+        raise SystemExit('%s: origin execution manifest hash changed' % lease['id'])
+    lease['origin_execution_manifest'] = os.path.abspath(path)
+    lease['origin_execution_manifest_sha256'] = actual_hash
+    return manifest
+
+
+def empty_pending_requeue():
+    return {'transient': [], 'defect': [], 'sources': {}, 'updated_at': utc_now()}
+
+
+def pending_key_set(pending):
+    pending = pending or {}
+    return set(pending.get('transient') or []) | set(pending.get('defect') or [])
+
+
+def report_requeue_parts(report, selected_keys):
+    if 'requeue_transient' not in report or 'requeue_defect' not in report:
+        raise SystemExit('audit report has no split requeue classification')
+    transient = report.get('requeue_transient')
+    defect = report.get('requeue_defect')
+    requeue = report.get('requeue')
+    if not all(isinstance(value, list) for value in (transient, defect, requeue)):
+        raise SystemExit('audit requeue fields must be lists')
+    for label, values in (('transient', transient), ('defect', defect), ('all', requeue)):
+        if any(not isinstance(key, str) or not key for key in values):
+            raise SystemExit('audit %s requeue contains an invalid key' % label)
+        if len(values) != len(set(values)):
+            raise SystemExit('audit %s requeue contains duplicate keys' % label)
+    if set(transient) & set(defect):
+        raise SystemExit('audit requeue classifications overlap')
+    if Counter(transient + defect) != Counter(requeue):
+        raise SystemExit('audit split requeue classifications do not equal the requeue set')
+    selected = Counter(selected_keys or [])
+    if any(count != 1 for count in selected.values()):
+        raise SystemExit('execution manifest selected keys are not unique')
+    foreign = list((Counter(requeue) - selected).elements())
+    if foreign:
+        raise SystemExit('audit requeue contains foreign keys: %s' % ','.join(sorted(foreign)))
+    return list(transient), list(defect)
+
+
+def pending_from_report(report, report_path, selected_keys):
+    transient, defect = report_requeue_parts(report, selected_keys)
+    report_path = os.path.abspath(report_path)
+    report_hash = sha256_file(report_path)
+    sources = {
+        key: {'kind': kind, 'audit_report': report_path,
+              'audit_report_sha256': report_hash}
+        for kind, keys in (('transient', transient), ('defect', defect))
+        for key in keys
+    }
+    return {'transient': transient, 'defect': defect, 'sources': sources,
+            'updated_at': utc_now()}
+
+
+def validate_pending_requeue(lease, pending, origin_manifest=None):
+    pending = pending or empty_pending_requeue()
+    transient = pending.get('transient')
+    defect = pending.get('defect')
+    sources = pending.get('sources')
+    if not isinstance(transient, list) or not isinstance(defect, list) or not isinstance(sources, dict):
+        raise SystemExit('%s: pending requeue structure is invalid' % lease['id'])
+    for label, values in (('transient', transient), ('defect', defect)):
+        if any(not isinstance(key, str) or not key for key in values):
+            raise SystemExit('%s: pending %s requeue contains an invalid key' %
+                             (lease['id'], label))
+        if len(values) != len(set(values)):
+            raise SystemExit('%s: pending %s requeue contains duplicate keys' %
+                             (lease['id'], label))
+    all_keys = transient + defect
+    if set(transient) & set(defect):
+        raise SystemExit('%s: pending requeue classifications overlap' % lease['id'])
+    if set(sources) != set(all_keys):
+        raise SystemExit('%s: pending requeue sources do not match keys' % lease['id'])
+    origin_manifest = origin_manifest or ensure_origin_manifest(lease)
+    origin_keys = origin_manifest['meta'].get('selected_keys') or []
+    if any(count != 1 for count in Counter(origin_keys).values()):
+        raise SystemExit('%s: origin execution manifest keys are not unique' % lease['id'])
+    foreign = list((Counter(all_keys) - Counter(origin_keys)).elements())
+    if foreign:
+        raise SystemExit('%s: pending requeue escapes origin manifest: %s' %
+                         (lease['id'], ','.join(sorted(foreign))))
+    reports = {}
+    for kind, keys in (('transient', transient), ('defect', defect)):
+        for key in keys:
+            source = sources.get(key) or {}
+            if source.get('kind') != kind:
+                raise SystemExit('%s: pending requeue source kind drift for %s' %
+                                 (lease['id'], key))
+            path = source.get('audit_report')
+            expected_hash = source.get('audit_report_sha256')
+            if not path or not expected_hash:
+                raise SystemExit('%s: pending requeue source is incomplete for %s' %
+                                 (lease['id'], key))
+            if path not in reports:
+                try:
+                    with open(path, encoding='utf-8') as f:
+                        report = json.load(f)
+                except (OSError, json.JSONDecodeError) as e:
+                    raise SystemExit('%s: pending audit report is unreadable: %s' %
+                                     (lease['id'], e))
+                if sha256_file(path) != expected_hash:
+                    raise SystemExit('%s: pending audit report hash changed' % lease['id'])
+                report_requeue_parts(report, report.get('keys') or [])
+                reports[path] = report
+            if key not in (reports[path].get('requeue_%s' % kind) or []):
+                raise SystemExit('%s: pending key %s is not bound to its source audit' %
+                                 (lease['id'], key))
+    return pending
+
+
+def pending_without_kind(pending, selected_kind):
+    remaining = empty_pending_requeue()
+    keep_kind = 'defect' if selected_kind == 'transient' else 'transient'
+    remaining[keep_kind] = list(pending.get(keep_kind) or [])
+    remaining['sources'] = {
+        key: dict((pending.get('sources') or {})[key]) for key in remaining[keep_kind]
+    }
+    return remaining
+
+
+def merge_pending_requeue(lease, carried, latest, origin_manifest):
+    carried = validate_pending_requeue(lease, carried, origin_manifest)
+    latest = validate_pending_requeue(lease, latest, origin_manifest)
+    if pending_key_set(carried) & pending_key_set(latest):
+        raise SystemExit('%s: carried and current requeue keys overlap' % lease['id'])
+    merged = empty_pending_requeue()
+    for kind in ('transient', 'defect'):
+        merged[kind] = sorted((carried.get(kind) or []) + (latest.get(kind) or []))
+    merged['sources'] = dict(carried.get('sources') or {})
+    merged['sources'].update(latest.get('sources') or {})
+    return validate_pending_requeue(lease, merged, origin_manifest)
+
+
+ATTEMPT_DIR_RE = re.compile(r'^rq([0-9]+)-(transient|defect)$')
+
+
+def next_requeue_attempt(lease, artifact_path):
+    root = os.path.join(artifact_path, 'requeue')
+    found = []
+    if os.path.isdir(root):
+        for name in os.listdir(root):
+            match = ATTEMPT_DIR_RE.match(name)
+            path = os.path.abspath(os.path.join(root, name))
+            if match and os.path.isdir(path):
+                found.append((int(match.group(1)), match.group(2), path))
+    referenced = {
+        os.path.abspath(row.get('artifact_dir'))
+        for row in (lease.get('execution_manifest_history') or []) if row.get('artifact_dir')
+    }
+    current = (lease.get('current_attempt') or {}).get('artifact_dir')
+    if current:
+        referenced.add(os.path.abspath(current))
+    orphans = [
+        {'number': number, 'kind': kind, 'artifact_dir': path,
+         'discovered_at': utc_now(), 'reason': 'unreferenced_attempt_directory'}
+        for number, kind, path in found if path not in referenced
+    ]
+    recorded = [int(row.get('attempt') or 0)
+                for row in (lease.get('execution_manifest_history') or [])]
+    highest = max([int(lease.get('requeue_attempt') or 0)] + recorded +
+                  [number for number, _kind, _path in found])
+    return highest + 1, orphans
+
+
 def cost_from_transcript(path):
     if not path:
         return None
@@ -630,15 +818,24 @@ def validate_promotable_audit(wf, status, report, state_name, returncode):
     return errors
 
 
-def recorded_lease_state(state_name, audit_errors, clean_rows):
+def recorded_lease_state(state_name, audit_errors, clean_rows, pending=None):
     if state_name not in PROMOTABLE_AUDIT_EXITS:
         return state_name, False
     if audit_errors:
         return 'blocked', False
+    if pending is None:
+        if clean_rows:
+            return ('ready' if state_name == 'clean' else 'ready_partial'), True
+        if state_name in ('needs_requeue', 'transient_only'):
+            return state_name, False
+        return 'blocked', False
+    has_pending = bool(pending_key_set(pending))
     if clean_rows:
-        return ('ready' if state_name == 'clean' else 'ready_partial'), True
-    if state_name in ('needs_requeue', 'transient_only'):
-        return state_name, False
+        return ('ready_partial' if has_pending else 'ready'), True
+    if pending.get('defect'):
+        return 'needs_requeue', False
+    if pending.get('transient'):
+        return 'transient_only', False
     return 'blocked', False
 
 
@@ -680,7 +877,25 @@ def record_output(args):
         clean_rows = clean_payload['results']
         audit_errors = validate_promotable_audit(
             wf, status, report, state_name, audit.returncode)
-        lease_state, promotable = recorded_lease_state(state_name, audit_errors, clean_rows)
+        pending = lease.get('pending_requeue') or empty_pending_requeue()
+        if not audit_errors:
+            try:
+                origin_manifest = ensure_origin_manifest(lease)
+                current_manifest = read_execution_manifest(manifest)
+                latest_pending = pending_from_report(
+                    report, report_path, current_manifest['meta'].get('selected_keys') or [])
+                carried = ((lease.get('current_attempt') or {}).get('remaining_pending') or
+                           empty_pending_requeue())
+                if pending_key_set(carried) & set(
+                        current_manifest['meta'].get('selected_keys') or []):
+                    raise SystemExit('%s: carried requeue overlaps the current attempt' % lease['id'])
+                pending = merge_pending_requeue(
+                    lease, carried, latest_pending, origin_manifest)
+                lease['pending_requeue'] = pending
+            except SystemExit as e:
+                audit_errors.append(str(e))
+        lease_state, promotable = recorded_lease_state(
+            state_name, audit_errors, clean_rows, pending)
         clean_output = None
         if promotable:
             clean_output = os.path.join(adir, 'wf_output.clean.%s.json' % lease['id'])
@@ -699,6 +914,11 @@ def record_output(args):
         lease['workflow_result_count'] = len(result.get('results') or [])
         lease['cost'] = cost_from_transcript(args.transcript_dir)
         lease['current_artifact_dir'] = adir
+        if lease.get('current_attempt'):
+            lease['current_attempt']['audit_report'] = report_path
+            lease['current_attempt']['audit_report_sha256'] = (
+                sha256_file(report_path) if os.path.exists(report_path) else None)
+            lease['current_attempt']['recorded_at'] = lease['recorded_at']
         save_state(state)
         registry_event(lease, 'recorded', {
             'wf_output': wf,
@@ -706,6 +926,10 @@ def record_output(args):
             'artifact_dir': adir,
             'status': state_name,
             'audit_returncode': audit.returncode,
+            'pending_requeue': {
+                'transient': list((pending or {}).get('transient') or []),
+                'defect': list((pending or {}).get('defect') or []),
+            },
             'cost': lease.get('cost'),
         })
     if audit.stdout.strip():
@@ -728,22 +952,8 @@ def prepare_requeue(args):
             raise SystemExit('%s: cannot prepare requeue from lease state %r' %
                              (lease['id'], lease_state))
         adir = lease.get('artifact_dir') or artifact_dir(args.lease_id)
-        source_dir = os.path.dirname(lease.get('status_path') or '') or adir
         which = 'transient' if args.transient else 'defect'
-        rq = os.path.join(source_dir, 'requeue.%s.keys.txt' % which)
-        legacy = os.path.join(source_dir, {
-            'transient': 'requeue.transient.keys.txt',
-            'defect': 'requeue.defect.keys.txt',
-        }[which])
-        if not os.path.exists(rq) and os.path.exists(legacy):
-            rq = legacy
-        if not os.path.exists(rq):
-            raise SystemExit('%s: requeue file is missing: %s' % (lease['id'], rq))
-        with open(rq, encoding='utf-8') as f:
-            requeue_keys = [line.strip() for line in f if line.strip()]
-        if not requeue_keys:
-            raise SystemExit('%s: requeue file is empty: %s' % (lease['id'], rq))
-
+        origin_manifest = ensure_origin_manifest(lease)
         current_manifest_path = lease.get('execution_manifest')
         current_manifest = read_execution_manifest(current_manifest_path)
         current_meta = current_manifest['meta']
@@ -751,21 +961,64 @@ def prepare_requeue(args):
         if not root:
             raise SystemExit('%s: execution manifest has no root' % lease['id'])
         nominal = bool(current_meta.get('nominal'))
-        attempt = int(lease.get('requeue_attempt') or 0) + 1
+
+        pending = lease.get('pending_requeue')
+        if not pending:
+            if int(lease.get('requeue_attempt') or 0):
+                raise SystemExit(
+                    '%s: attempted legacy lease has no provenance-bound pending backlog' %
+                    lease['id'])
+            try:
+                status = json.load(open(lease['status_path'], encoding='utf-8'))
+                report = json.load(open(lease['audit_report'], encoding='utf-8'))
+            except (KeyError, OSError, json.JSONDecodeError) as e:
+                raise SystemExit('%s: cannot hydrate pending requeue: %s' % (lease['id'], e))
+            errors = validate_promotable_audit(
+                lease['wf_output'], status, report, lease.get('audit_state'),
+                lease.get('audit_returncode'))
+            if errors:
+                raise SystemExit('%s: cannot hydrate pending requeue: %s' %
+                                 (lease['id'], '; '.join(errors)))
+            pending = pending_from_report(
+                report, lease['audit_report'], current_meta.get('selected_keys') or [])
+            lease['pending_requeue'] = pending
+        pending = validate_pending_requeue(lease, pending, origin_manifest)
+        requeue_keys = list(pending.get(which) or [])
+        if not requeue_keys:
+            raise SystemExit('%s: pending %s requeue is empty' % (lease['id'], which))
+        remaining_pending = pending_without_kind(pending, which)
+
+        attempt, orphans = next_requeue_attempt(lease, adir)
         attempt_tag = 'rq%02d-%s' % (attempt, which)
         attempt_dir = os.path.join(adir, 'requeue', attempt_tag)
-        os.makedirs(attempt_dir, exist_ok=False)
         harness = os.path.join(attempt_dir, 'run_pilot_wf.%s.%s.js' %
                                (lease['id'], attempt_tag))
         manifest = os.path.join(attempt_dir, 'execution_manifest.%s.%s.json' %
                                 (lease['id'], attempt_tag))
+        rq = os.path.join(attempt_dir, 'requeue.%s.keys.txt' % which)
         old_manifest_sha256 = sha256_file(current_manifest_path)
         cmd = [sys.executable, os.path.join(HERE, 'requeue_from_audit.py'),
                root, '--%s' % which, '--requeue-file=%s' % rq, '--out=%s' % harness,
                '--manifest-out=%s' % manifest]
         if nominal:
             cmd += ['--nominal', '--no-grammar']
+        created = False
         try:
+            os.makedirs(attempt_dir, exist_ok=False)
+            created = True
+            atomic_write_text(rq, '\n'.join(requeue_keys) + '\n')
+            if which == 'defect':
+                fshas = set()
+                source_paths = {
+                    pending['sources'][key]['audit_report'] for key in requeue_keys
+                }
+                for source_path in source_paths:
+                    with open(source_path, encoding='utf-8') as f:
+                        source_report = json.load(f)
+                    fshas.update(source_report.get('requeue_defect_fshas') or [])
+                atomic_write_text(
+                    os.path.join(attempt_dir, 'requeue.defect.fshas.txt'),
+                    '\n'.join(sorted(fshas)) + ('\n' if fshas else ''))
             p = run_cmd(cmd)
             if sha256_file(current_manifest_path) != old_manifest_sha256:
                 raise SystemExit(
@@ -775,9 +1028,16 @@ def prepare_requeue(args):
             if (prepared_manifest['meta'].get('selected_keys') or []) != requeue_keys:
                 raise SystemExit('%s: requeue execution manifest key drift' % lease['id'])
         except BaseException:
-            shutil.rmtree(attempt_dir, ignore_errors=True)
+            if created:
+                shutil.rmtree(attempt_dir, ignore_errors=True)
             raise
         history = lease.setdefault('execution_manifest_history', [])
+        origin_path = lease['origin_execution_manifest']
+        origin_abs = os.path.abspath(origin_path)
+        if not any(os.path.abspath(row.get('path') or '') == origin_abs for row in history):
+            history.append(manifest_history_entry(
+                origin_path, 0, 'initial', adir,
+                lease.get('prepared_at') or lease.get('recorded_at')))
         current_abs = os.path.abspath(current_manifest_path)
         if not any(os.path.abspath(row.get('path') or '') == current_abs for row in history):
             history.append(manifest_history_entry(
@@ -794,6 +1054,13 @@ def prepare_requeue(args):
         lease['requeue_attempt'] = attempt
         lease['execution_manifest'] = manifest
         lease['current_artifact_dir'] = attempt_dir
+        known_orphans = {
+            os.path.abspath(row.get('artifact_dir'))
+            for row in (lease.get('orphaned_requeue_attempts') or [])
+            if row.get('artifact_dir')
+        }
+        lease.setdefault('orphaned_requeue_attempts', []).extend(
+            row for row in orphans if os.path.abspath(row['artifact_dir']) not in known_orphans)
         lease['current_attempt'] = {
             'number': attempt,
             'kind': which,
@@ -802,6 +1069,7 @@ def prepare_requeue(args):
             'execution_manifest': manifest,
             'prepared_at': prepared_at,
             'selected_keys': requeue_keys,
+            'remaining_pending': remaining_pending,
         }
         save_state(state)
         registry_event(lease, 'requeue_prepared', {
@@ -838,8 +1106,14 @@ def promote_ready(args):
             errors = validate_promotable_audit(
                 lease['wf_output'], status, report, lease.get('audit_state'),
                 lease.get('audit_returncode'))
-            expected_lease_state = ('ready' if lease.get('audit_state') == 'clean'
-                                    else 'ready_partial')
+            pending = lease.get('pending_requeue') or empty_pending_requeue()
+            try:
+                origin_manifest = ensure_origin_manifest(lease)
+                pending = validate_pending_requeue(lease, pending, origin_manifest)
+            except SystemExit as e:
+                errors.append(str(e))
+            has_pending = bool(pending_key_set(pending))
+            expected_lease_state = 'ready_partial' if has_pending else 'ready'
             if lease.get('state') != expected_lease_state:
                 errors.append('lease state does not match audited promotion class')
             clean_rows = clean_payload.get('results') or []
@@ -863,8 +1137,7 @@ def promote_ready(args):
             with DirLock(paths()['lock']):
                 state = load_state()
                 fresh = lease_by_id(state, lease['id'])
-                fresh['state'] = ('promoted_partial' if fresh.get('audit_state') != 'clean'
-                                  else 'promoted')
+                fresh['state'] = 'promoted_partial' if has_pending else 'promoted'
                 fresh['promoted_at'] = utc_now()
                 fresh['model_version'] = args.gen_model_version
                 fresh['store_before'] = store_before

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -2854,20 +2854,33 @@ def test_coordinator_requeue_attempt_manifests():
         with open(initial_manifest, 'w', encoding='utf-8') as f:
             json.dump(original, f)
         original_bytes = open(initial_manifest, 'rb').read()
-        with open(os.path.join(artifacts, 'requeue.transient.keys.txt'),
-                  'w', encoding='utf-8') as f:
-            f.write('a~~x\n')
+        audit_report = os.path.join(artifacts, 'audit_window.report.json')
+        report = {
+            'keys': ['a~~x', 'b~~x'], 'requeue': ['a~~x', 'b~~x'],
+            'requeue_transient': ['a~~x'], 'requeue_defect': ['b~~x'],
+            'requeue_defect_fshas': ['frag-b'],
+        }
+        with open(audit_report, 'w', encoding='utf-8') as f:
+            json.dump(report, f)
+        pending = coordinator.pending_from_report(
+            report, audit_report, original['meta']['selected_keys'])
+        orphan = os.path.join(artifacts, 'requeue', 'rq01-defect')
+        os.makedirs(orphan)
         state = coordinator.default_state()
         state['leases'] = [{
             'id': 'lease', 'kind': 'nominal', 'target': 'a',
             'state': 'promoted_partial', 'artifact_dir': artifacts,
             'execution_manifest': initial_manifest,
-            'status_path': os.path.join(artifacts, 'window_status.json'),
+            'origin_execution_manifest': initial_manifest,
+            'origin_execution_manifest_sha256': coordinator.sha256_file(initial_manifest),
+            'pending_requeue': pending,
         }]
         coordinator.save_state(state)
 
         class FakeProc:
             stdout = 'generated requeue harness\n'
+
+        fail_once = [True]
 
         def fake_run(cmd):
             out = next(arg.split('=', 1)[1] for arg in cmd if arg.startswith('--out='))
@@ -2876,6 +2889,9 @@ def test_coordinator_requeue_attempt_manifests():
             rqfile = next(arg.split('=', 1)[1] for arg in cmd
                           if arg.startswith('--requeue-file='))
             keys = [line.strip() for line in open(rqfile, encoding='utf-8') if line.strip()]
+            if fail_once[0]:
+                fail_once[0] = False
+                raise SystemExit('synthetic generation failure')
             os.makedirs(os.path.dirname(out), exist_ok=True)
             with open(out, 'w', encoding='utf-8') as f:
                 f.write('// generated\n')
@@ -2888,11 +2904,27 @@ def test_coordinator_requeue_attempt_manifests():
 
         coordinator.run_cmd = fake_run
         try:
+            try:
+                coordinator.prepare_requeue(SimpleNamespace(
+                    lease_id='lease', transient=True, defect=False))
+                fail('synthetic requeue generation failure was not propagated')
+            except SystemExit as exc:
+                if 'synthetic' not in str(exc):
+                    raise
+            lease = coordinator.load_state()['leases'][0]
+            failed_dir = os.path.join(artifacts, 'requeue', 'rq02-transient')
+            if os.path.exists(failed_dir) or lease.get('requeue_attempt'):
+                fail('caught generation failure consumed an attempt or left its directory')
+            if set(coordinator.pending_key_set(lease['pending_requeue'])) != {'a~~x', 'b~~x'}:
+                fail('caught generation failure changed the pending backlog')
+
             coordinator.prepare_requeue(SimpleNamespace(
                 lease_id='lease', transient=True, defect=False))
             lease = coordinator.load_state()['leases'][0]
-            if lease['requeue_attempt'] != 1 or 'rq01-transient' not in lease['current_artifact_dir']:
-                fail('first requeue attempt did not receive its own artifact directory')
+            if lease['requeue_attempt'] != 2 or 'rq02-transient' not in lease['current_artifact_dir']:
+                fail('requeue did not advance past the preserved orphan directory')
+            if not os.path.isdir(orphan) or not lease.get('orphaned_requeue_attempts'):
+                fail('orphaned requeue attempt was deleted or not recorded')
             if json.load(open(lease['execution_manifest'], encoding='utf-8'))[
                     'meta']['selected_keys'] != ['a~~x']:
                 fail('requeue attempt manifest was not narrowed to its exact keys')
@@ -2900,6 +2932,9 @@ def test_coordinator_requeue_attempt_manifests():
                 fail('requeue preparation modified the original execution manifest')
             if len(lease['execution_manifest_history']) != 2:
                 fail('initial and first-attempt manifests were not retained in history')
+            remaining = lease['current_attempt']['remaining_pending']
+            if remaining['transient'] or remaining['defect'] != ['b~~x']:
+                fail('unselected defect lane was not carried into the attempt')
             attempt_manifest = json.load(open(lease['execution_manifest'], encoding='utf-8'))
             old_inp = window_provenance.INP
             window_provenance.INP = input_dir
@@ -2916,20 +2951,115 @@ def test_coordinator_requeue_attempt_manifests():
                 window_provenance.INP = old_inp
 
             latest_dir = lease['current_artifact_dir']
-            with open(os.path.join(latest_dir, 'requeue.transient.keys.txt'),
-                      'w', encoding='utf-8') as f:
-                f.write('a~~x\n')
+            latest_report_path = os.path.join(latest_dir, 'audit_window.report.json')
+            latest_report = {
+                'keys': ['a~~x'], 'requeue': [],
+                'requeue_transient': [], 'requeue_defect': [],
+                'requeue_defect_fshas': [],
+            }
+            with open(latest_report_path, 'w', encoding='utf-8') as f:
+                json.dump(latest_report, f)
+            latest_pending = coordinator.pending_from_report(
+                latest_report, latest_report_path, ['a~~x'])
+            carried = coordinator.merge_pending_requeue(
+                lease, remaining, latest_pending,
+                coordinator.ensure_origin_manifest(lease))
+            if coordinator.recorded_lease_state('clean', [], [{'card': {}}], carried) != (
+                    'ready_partial', True):
+                fail('a clean transient retry with carried defect work must stay ready_partial')
             state = coordinator.load_state()
-            state['leases'][0]['state'] = 'transient_only'
-            state['leases'][0]['status_path'] = os.path.join(latest_dir, 'window_status.json')
+            state['leases'][0]['state'] = 'promoted_partial'
+            state['leases'][0]['pending_requeue'] = carried
             coordinator.save_state(state)
             coordinator.prepare_requeue(SimpleNamespace(
-                lease_id='lease', transient=True, defect=False))
+                lease_id='lease', transient=False, defect=True))
             lease = coordinator.load_state()['leases'][0]
-            if lease['requeue_attempt'] != 2 or 'rq02-transient' not in lease['current_artifact_dir']:
-                fail('repeated requeue did not advance from the latest audit directory')
+            if lease['requeue_attempt'] != 3 or 'rq03-defect' not in lease['current_artifact_dir']:
+                fail('carried defect lane did not receive the next attempt')
+            if lease['current_attempt']['selected_keys'] != ['b~~x']:
+                fail('carried defect key was not selected after transient recovery')
+            if coordinator.pending_key_set(lease['current_attempt']['remaining_pending']):
+                fail('final defect attempt retained a phantom pending sibling')
+            fsha_path = os.path.join(lease['current_artifact_dir'],
+                                     'requeue.defect.fshas.txt')
+            if open(fsha_path, encoding='utf-8').read().strip() != 'frag-b':
+                fail('defect fragment denylist evidence was not materialized per attempt')
             if len(lease['execution_manifest_history']) != 3:
                 fail('repeated requeue did not preserve every prior manifest')
+
+            reverse = coordinator.pending_without_kind(pending, 'defect')
+            if reverse['transient'] != ['a~~x'] or reverse['defect']:
+                fail('defect-first recovery did not preserve the transient sibling')
+            unresolved_report_path = os.path.join(tmp, 'unresolved.json')
+            unresolved_report = {
+                'keys': ['a~~x'], 'requeue': ['a~~x'],
+                'requeue_transient': ['a~~x'], 'requeue_defect': [],
+            }
+            with open(unresolved_report_path, 'w', encoding='utf-8') as f:
+                json.dump(unresolved_report, f)
+            unresolved = coordinator.pending_from_report(
+                unresolved_report, unresolved_report_path, ['a~~x'])
+            mixed_unresolved = coordinator.merge_pending_requeue(
+                lease, remaining, unresolved, coordinator.ensure_origin_manifest(lease))
+            if coordinator.recorded_lease_state(
+                    'transient_only', [], [], mixed_unresolved) != ('needs_requeue', False):
+                fail('an unresolved transient retry hid its carried defect sibling')
+
+            foreign_report_path = os.path.join(tmp, 'foreign.json')
+            foreign_report = {
+                'keys': ['foreign'], 'requeue': ['foreign'],
+                'requeue_transient': ['foreign'], 'requeue_defect': [],
+            }
+            with open(foreign_report_path, 'w', encoding='utf-8') as f:
+                json.dump(foreign_report, f)
+            foreign = coordinator.pending_from_report(
+                foreign_report, foreign_report_path, ['foreign'])
+            try:
+                coordinator.validate_pending_requeue(
+                    lease, foreign, coordinator.ensure_origin_manifest(lease))
+                fail('foreign pending key escaped the origin manifest')
+            except SystemExit as exc:
+                if 'escapes origin' not in str(exc):
+                    raise
+
+            tampered_report_path = os.path.join(tmp, 'tampered.json')
+            with open(tampered_report_path, 'w', encoding='utf-8') as f:
+                json.dump(unresolved_report, f)
+            tampered = coordinator.pending_from_report(
+                unresolved_report, tampered_report_path, ['a~~x'])
+            with open(tampered_report_path, 'w', encoding='utf-8') as f:
+                json.dump(dict(unresolved_report, marker='changed'), f)
+            try:
+                coordinator.validate_pending_requeue(
+                    lease, tampered, coordinator.ensure_origin_manifest(lease))
+                fail('changed pending source report was accepted')
+            except SystemExit as exc:
+                if 'hash changed' not in str(exc):
+                    raise
+
+            invalid_reports = [
+                ({'keys': ['a~~x'], 'requeue': ['a~~x', 'a~~x'],
+                  'requeue_transient': ['a~~x', 'a~~x'], 'requeue_defect': []},
+                 'duplicate'),
+                ({'keys': ['a~~x'], 'requeue': ['a~~x'],
+                  'requeue_transient': ['a~~x'], 'requeue_defect': ['a~~x']},
+                 'overlap'),
+                ({'keys': ['a~~x', 'b~~x'], 'requeue': ['a~~x', 'b~~x'],
+                  'requeue_transient': ['a~~x'], 'requeue_defect': []},
+                 'do not equal'),
+            ]
+            for invalid, expected in invalid_reports:
+                try:
+                    coordinator.report_requeue_parts(invalid, invalid['keys'])
+                    fail('invalid split requeue report was accepted')
+                except SystemExit as exc:
+                    if expected not in str(exc):
+                        raise
+
+            history_only = {'execution_manifest_history': [
+                {'attempt': 7, 'artifact_dir': os.path.join(tmp, 'gone-rq07')}]}
+            if coordinator.next_requeue_attempt(history_only, os.path.join(tmp, 'empty'))[0] != 8:
+                fail('attempt allocation ignored the maximum recorded historical attempt')
 
             state = coordinator.load_state()
             state['leases'][0]['state'] = 'ready_partial'
@@ -2943,6 +3073,155 @@ def test_coordinator_requeue_attempt_manifests():
                     fail('ready_partial refusal did not explain the promotion prerequisite')
         finally:
             coordinator.run_cmd = original_run
+            if old_coord is None:
+                os.environ.pop('PWG_COORDINATOR_DIR', None)
+            else:
+                os.environ['PWG_COORDINATOR_DIR'] = old_coord
+
+
+def test_coordinator_mixed_lane_public_state_sequence():
+    import coordinator
+    from types import SimpleNamespace
+
+    old_coord = os.environ.get('PWG_COORDINATOR_DIR')
+    original_run = coordinator.run_cmd
+    original_store = coordinator.promote_final_cards.DEFAULT_STORE
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ['PWG_COORDINATOR_DIR'] = tmp
+        store = os.path.join(tmp, 'store.jsonl')
+        open(store, 'w', encoding='utf-8').close()
+        coordinator.promote_final_cards.DEFAULT_STORE = store
+        initial_dir = os.path.join(tmp, 'artifacts', 'lease')
+        os.makedirs(initial_dir)
+        origin_manifest = os.path.join(initial_dir, 'execution_manifest.lease.json')
+        origin = {
+            'schema': 'pwg.headless_execution_manifest.v1',
+            'meta': {'root': 'nominal_mixed', 'nominal': True,
+                     'selected_keys': ['a~~x', 'b~~x'], 'input_hashes': {}},
+        }
+        with open(origin_manifest, 'w', encoding='utf-8') as f:
+            json.dump(origin, f)
+        state = coordinator.default_state()
+        state['leases'] = [{
+            'id': 'lease', 'kind': 'nominal', 'target': 'mixed', 'state': 'prepared',
+            'artifact_dir': initial_dir, 'current_artifact_dir': initial_dir,
+            'execution_manifest': origin_manifest,
+            'origin_execution_manifest': origin_manifest,
+            'origin_execution_manifest_sha256': coordinator.sha256_file(origin_manifest),
+        }]
+        coordinator.save_state(state)
+
+        audit_specs = [{
+            'state': 'needs_requeue', 'returncode': 1,
+            'requeue': ['a~~x', 'b~~x'],
+            'transient': ['a~~x'], 'defect': ['b~~x'],
+        }, {
+            'state': 'clean', 'returncode': 0, 'requeue': [],
+            'transient': [], 'defect': [],
+        }, {
+            'state': 'clean', 'returncode': 0, 'requeue': [],
+            'transient': [], 'defect': [],
+        }]
+
+        def fake_run(cmd, check=True):
+            script = os.path.basename(cmd[1]) if len(cmd) > 1 else ''
+            if script == 'audit_window.py':
+                spec = audit_specs.pop(0)
+                wf = cmd[2]
+                adir = cmd[cmd.index('--out-dir') + 1]
+                status = {'state': spec['state'], 'requeue_keys': spec['requeue']}
+                report = {
+                    'workflow': wf, 'keys': json.load(open(
+                        cmd[cmd.index('--execution-manifest') + 1], encoding='utf-8'))[
+                            'meta']['selected_keys'],
+                    'requeue': spec['requeue'],
+                    'requeue_transient': spec['transient'],
+                    'requeue_defect': spec['defect'],
+                    'requeue_defect_fshas': ['frag-b'] if spec['defect'] else [],
+                    'crashed': [], 'stale_check': {'ok': True},
+                }
+                with open(os.path.join(adir, 'window_status.json'), 'w', encoding='utf-8') as f:
+                    json.dump(status, f)
+                with open(os.path.join(adir, 'audit_window.report.json'),
+                          'w', encoding='utf-8') as f:
+                    json.dump(report, f)
+                return SimpleNamespace(returncode=spec['returncode'], stdout='', stderr='')
+            if script == 'promote_final_cards.py':
+                with open(store, 'a', encoding='utf-8') as f:
+                    f.write(json.dumps({'promoted': True}) + '\n')
+            return SimpleNamespace(returncode=0, stdout='', stderr='')
+
+        def result_file(name, keys):
+            path = os.path.join(tmp, name)
+            payload = {'results': [
+                {'key': key, 'card': {'key1': key, 'records': []}} for key in keys]}
+            with open(path, 'w', encoding='utf-8') as f:
+                json.dump(payload, f)
+            return path
+
+        def record(path):
+            coordinator.record_output(SimpleNamespace(
+                lease_id='lease', workflow_result=path, allow_stale=False,
+                transcript_dir=None))
+
+        def set_attempt(number, kind, key, remaining):
+            adir = os.path.join(initial_dir, 'requeue', 'rq%02d-%s' % (number, kind))
+            os.makedirs(adir)
+            manifest = os.path.join(adir, 'execution_manifest.json')
+            attempt = dict(origin)
+            attempt['meta'] = dict(origin['meta'], selected_keys=[key])
+            with open(manifest, 'w', encoding='utf-8') as f:
+                json.dump(attempt, f)
+            state = coordinator.load_state()
+            lease = state['leases'][0]
+            lease.update({
+                'state': 'requeue_prepared', 'current_artifact_dir': adir,
+                'execution_manifest': manifest, 'requeue_attempt': number,
+                'current_attempt': {
+                    'number': number, 'kind': kind, 'artifact_dir': adir,
+                    'execution_manifest': manifest, 'selected_keys': [key],
+                    'remaining_pending': remaining,
+                },
+            })
+            coordinator.save_state(state)
+
+        coordinator.run_cmd = fake_run
+        try:
+            record(result_file('initial.json', ['a~~x', 'b~~x']))
+            lease = coordinator.load_state()['leases'][0]
+            if lease['state'] != 'needs_requeue':
+                fail('mixed initial audit did not enter needs_requeue')
+            pending = lease['pending_requeue']
+            if pending['transient'] != ['a~~x'] or pending['defect'] != ['b~~x']:
+                fail('record-output did not persist both provenance-bound retry lanes')
+
+            carried_b = coordinator.pending_without_kind(pending, 'transient')
+            set_attempt(1, 'transient', 'a~~x', carried_b)
+            record(result_file('retry-a.json', ['a~~x']))
+            lease = coordinator.load_state()['leases'][0]
+            if lease['state'] != 'ready_partial' or lease['pending_requeue']['defect'] != ['b~~x']:
+                fail('clean transient retry did not retain the defect backlog')
+            coordinator.promote_ready(SimpleNamespace(
+                gen_model_version='claude-sonnet-5', lease_id=['lease']))
+            lease = coordinator.load_state()['leases'][0]
+            if lease['state'] != 'promoted_partial':
+                fail('mixed backlog promotion did not remain promoted_partial')
+
+            set_attempt(2, 'defect', 'b~~x', coordinator.empty_pending_requeue())
+            record(result_file('retry-b.json', ['b~~x']))
+            lease = coordinator.load_state()['leases'][0]
+            if lease['state'] != 'ready' or coordinator.pending_key_set(
+                    lease['pending_requeue']):
+                fail('final clean defect retry did not drain the pending backlog')
+            coordinator.promote_ready(SimpleNamespace(
+                gen_model_version='claude-sonnet-5', lease_id=['lease']))
+            if coordinator.load_state()['leases'][0]['state'] != 'promoted':
+                fail('drained mixed retry sequence did not finish promoted')
+            if audit_specs:
+                fail('mixed-lane integration did not consume every planned audit')
+        finally:
+            coordinator.run_cmd = original_run
+            coordinator.promote_final_cards.DEFAULT_STORE = original_store
             if old_coord is None:
                 os.environ.pop('PWG_COORDINATOR_DIR', None)
             else:
@@ -4938,6 +5217,7 @@ def main():
         test_coordinator_lock_creates_parent_dir,
         test_coordinator_defect_requeue_uses_no_tm_and_out,
         test_coordinator_requeue_attempt_manifests,
+        test_coordinator_mixed_lane_public_state_sequence,
         test_promote_nominal_key1,
         test_build_emits_nominal_keymap,
         test_generation_schema_carries_no_post_generation_field,


### PR DESCRIPTION
## PR Type
- [ ] data
- [x] build
- [x] docs
- [ ] navigation

## Summary
- What changed: sealed each lease's attempt-zero manifest as its immutable key universe; added a source-report-hashed `pending_requeue` backlog; carried unselected transient/defect work across attempts and promotion; and made allocation advance past recorded and on-disk orphan attempts.
- Why this change exists: review of merged PR #482 found that coordinator retries could still be reconstructed from mutable split files, selecting one retry lane could lose the other, and a hard-interrupted directory could collide with the next state-derived attempt number.

Mixed-lane state sequence now covered end to end:

`transient A + defect B → retry A → ready_partial → promote A → promoted_partial (B retained) → retry B → ready → promoted`

The reverse lane order and a still-unresolved retry are also covered.

## Test Surface
- Automated checks:
  - `python src/pilot/window_selftest.py` — PASS (`window selftest OK`)
  - `python src/pilot/headless_worker_selftest.py` — PASS
  - `python src/pilot/max_account_orchestrator_selftest.py` — PASS
  - `python src/pilot/lang_parity_check.py` — PASS (`49 entries`, no drift); hashes updated only through `--update-hash`
  - `python src/pilot/check_launch_ledger.py --since 2026-07-05` — PASS (`17 entries complete`)
  - `python -m ruff check --select E9,F63,F7,F82 src/pilot/coordinator.py src/pilot/window_selftest.py` — PASS
  - `node --check src/pilot/run_pilot_wf.opt2.js` — PASS
  - `git diff --check` — PASS
- Manual checks: inspected attempt history, origin-hash, pending-source, carry, and orphan records produced by fixtures. No production execution was performed.
- Pure helpers / decision points covered: duplicate, overlap, split-union drift, foreign-origin key, changed report hash, reverse lane order, unresolved retry, history-only numbering, orphan preservation, caught-generation cleanup, and promotion backlog revalidation.
- If build-related: import-safe verified? yes (`py_compile` and selftests).

## Invariants
- Must stay true: retry keys come only from a hash-verified audit report and remain within the hash-verified attempt-zero manifest; transient and defect lanes remain disjoint and independently priced; old artifacts never change.
- Counts / alignment / join rules: transient + defect is duplicate-free and equals the audited requeue set; each pending key has exactly one source record containing class, absolute report path, and report SHA-256.
- Source-of-truth assumptions: attempt zero defines the immutable lease key universe; `pending_requeue`, not mutable split files, defines remaining coordinator work.
- What would count as regression: accepting a foreign/duplicate/reclassified key, dropping the sibling lane, promoting while pending state disagrees, overwriting an old attempt, or reusing an orphan number.

## Safety
- Fallback / failure mode: ambiguous legacy attempted leases fail closed. A caught preparation failure removes only its newly created directory and leaves state/backlog unchanged. Hard-interruption orphans are recorded and preserved; they are never adopted or deleted automatically.
- Observable marker or sanity check: `origin_execution_manifest*`, `pending_requeue`, `current_attempt.remaining_pending`, `execution_manifest_history`, and `orphaned_requeue_attempts` expose the full decision chain.
- Rebuild / validate / verify command: run the three selftests above plus parity, launch-ledger, Ruff fatal, Node syntax, and `git diff --check`.

## Reader-Facing Done
- Navigation / entry point updated: operator guidance remains in `RussianTranslation/src/pilot/RUN_FREQ_MAX.md`.
- Docs / changelog / handoff updated: project changelog, operator guide, repository and subsystem `.ai_state.md`, and `FINDINGS.md` §85.
- Known limits or caveats exposed: lease schema v1 is retained through additive fields. Existing attempt-zero leases can upgrade lazily when their manifest and split audit report verify; ambiguous attempted legacy state is refused. Standalone `requeue_from_audit.py` behavior is unchanged.

## Type-Specific Notes
- No production Max calls, translations, canonical-store writes, promotions, or TM rebuilds were performed. Promotion tests use an isolated temporary store and stubbed commands.
