### PR TITLE
fix(D-P): natural load-representative acceptance-probe prompt (H994) — false-refusal gone + honest latency

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -20,11 +20,13 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   multi-profile-20; each rung gates the next, immutable PASS/NO-GO). **This session ran the owner-selected
   Option B (two-profile c1/c4 measurement, no promotion — store unchanged at 11,605):** rung 1 auth = c1/c4
   ✅ Max, **c5/c6 ❌ `loggedIn:false`** → **four-profile = NO-GO (unchanged)**; rung 2 = c1 `rate_limit`
-  (parked), **c4 genuinely healthy ~8–12 s (first sub-30 s pwg-ru reading; H818/H895 were ~40 s NO-GO ×2)**
-  — c4's probe NO-GO is a **FALSE NO-GO** from a probe-prompt defect; rung 3 canary **not reached** (only c4
-  usable + `darvI` is a deterministic fidelity-reject + inputs gitignored). **2 defects surfaced: D-P**
-  (probe padding prompt → Sonnet-5 plan-mode refusal → false NO-GO) + **D-Q** (curate a canary that passes
-  fidelity yet drops a sense). Gate report:
+  (parked); rung 3 canary **not reached** (only c4 usable + `darvI` is a deterministic fidelity-reject +
+  inputs gitignored). **D-P probe-prompt defect ✅ FIXED ([v1.9.17](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.9.17)):**
+  `_probe_call` now sends a natural load-representative prompt (plan mode kept, matches generation) + selftest.
+  **Latency CORRECTED by the fix:** the "~8–12 s sub-30 s c4" claim was an `'x'`-padding artifact — under a
+  representative ≥5 KB payload c4 is **~30–53 s → latency NO-GO** (consistent with H818/H895), so the latency
+  rung is a genuine blocker (H818/H909 foreign-route), independent of c5/c6. **D-Q** (curate a canary that
+  passes fidelity yet drops a sense) still open. Gate report:
   [H994](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h994/H994_TWO_PROFILE_LIVE_MEASUREMENT_GATE_2026-07-15.md).
   Handoff:
   [H994](https://github.com/gasyoun/Uprava/blob/main/handoffs/H994-Opus_SanskritLexicography_pwg-ru-four-profile-live-ladder-acceptance_15.07.26.md).

--- a/RussianTranslation/pwg_ru/h994/H994_TWO_PROFILE_LIVE_MEASUREMENT_GATE_2026-07-15.md
+++ b/RussianTranslation/pwg_ru/h994/H994_TWO_PROFILE_LIVE_MEASUREMENT_GATE_2026-07-15.md
@@ -65,9 +65,25 @@ But the two failures are different in kind, and one is a probe artifact:
     reports.
   - A **natural prompt** (`Reply with the JSON object {"ok": true} and nothing else.`) on the same profile
     returns `structured_output={'ok': True}` in **12 097 ms** — clean.
-  - **Conclusion:** c4's real latency is **~8–12 s, well under the 30 s ceiling** — the *first* sub-ceiling
-    pwg-ru probe reading in the whole saga (H818/H895 measured ~40 s honest NO-GO twice on the home route).
-    c4 is healthy and fast; its rung-2 NO-GO is entirely a probe-prompt artifact.
+  - **Conclusion (as recorded at first measurement — see the correction below):** c4's rung-2 NO-GO is a
+    probe-prompt artifact, not a refusal-vs-health question. The "~8–12 s sub-ceiling" gloss on that first
+    pass was itself wrong — corrected next.
+
+> **UPDATE 15-07-2026 — D-P FIXED, and the "sub-30 s c4" conclusion CORRECTED (Opus 4.8 `claude-opus-4-8[1m]`).**
+> The D-P probe-prompt defect is fixed in
+> [`max_account_orchestrator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/max_account_orchestrator.py)
+> ([v1.9.17](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.9.17)): `_probe_call` now sends
+> a natural, load-representative task (one unambiguous "reply with exactly `{"ok": true}` and nothing else"
+> instruction + ≥5 KB of inert, domain-shaped filler) under the **same `--permission-mode plan` the real
+> generation path (`headless_worker.call`) uses**, with a `D-P readiness prompt` selftest. Re-probing c4
+> with the FIXED probe: warm-up **29 743 ms** / measured **52 815 ms**, both `success`, output 1 483 B (no
+> refusal, no over-generation). **This corrects the "~8–12 s, first sub-ceiling reading" claim above:** the
+> old `'x'`-padding BPE-compresses to few tokens (artificially fast ~8 s) and the 12 s figure came from a
+> *payload-free* diagnostic — neither is load-representative. Under a representative ≥5 KB payload c4 is
+> **~30–53 s (high variance, at/over the 30 s ceiling)** — consistent with H818/H895's ~40 s NO-GOs, **NOT**
+> sub-ceiling. So the D-P fix's value is twofold: it removes the false-*refusal* NO-GO **and** restores an
+> honest latency reading. The latency rung remains a genuine NO-GO (H818/H909 foreign-route territory),
+> independent of the c5/c6 logins.
 
 ## Rung 3 — canary false-flag measurement — NOT REACHED / additionally blocked
 
@@ -97,17 +113,19 @@ them so the next session does not re-derive:
   fidelity while dropping a source sense (the H818 fc1 `darv_i` "output 2/3 passed clean" shape that
   H920/H960 instrumented), **not** a deterministic fidelity-reject — and rebuild its input portrait.
 
-## Defects surfaced this session (actionable, not patched here — Option B was measurement-only)
+## Defects surfaced this session
 
-1. **D-P · acceptance-probe prompt fragility (rung 2).** `_probe_call`'s degenerate padding prompt
-   (`max_account_orchestrator.py`) trips Sonnet-5's plan-mode refusal, yielding a false
-   `content`/`timeout`/`malformed` NO-GO on a genuinely healthy, fast profile — and corrupting the latency
-   reading (the refusal is long, so it also breaches the ceiling). **Fix direction:** give the probe a
-   natural, task-shaped prompt that reliably returns the schema object (a card-shaped micro-task rather
-   than "return `{ok:true}` + N bytes of `x` padding under plan mode"), and/or classify a plan-mode-refusal
-   prose result distinctly from a slow-but-valid call. This is a change to the *acceptance gate* itself, so
-   it needs deliberate design (it affects comparability with prior latency evidence) — documented, not
-   hastily patched in a measurement session.
+1. **D-P · acceptance-probe prompt fragility (rung 2) — ✅ FIXED 15-07-2026 ([v1.9.17](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.9.17)).**
+   `_probe_call`'s degenerate padding prompt (`"Return JSON {ok:true}. Preserve this padding as inert
+   input." + N×'x'`) tripped Sonnet-5's `--permission-mode plan` refusal, yielding a false
+   `content`/`timeout`/`malformed` NO-GO on a healthy profile. **Fix:** `_probe_call` now sends a natural,
+   load-representative task via a new `_probe_prompt()` helper — one unambiguous "reply with exactly
+   `{"ok": true}` and nothing else" instruction + ≥5 KB of inert, domain-shaped filler — under the **same
+   `--permission-mode plan` the real generation path (`headless_worker.call`) uses**, with a `D-P readiness
+   prompt` selftest that captures the argv + stdin. Live-verified on c4: both probe phases return `success`
+   (no refusal, 1 483 B output). **Bonus correction:** the fix also exposed that the old `'x'`-padding gave
+   *artificially fast* latency (few tokens after BPE) — under the fixed representative payload c4 is ~30–53 s
+   (latency NO-GO), not the sub-30 s the first pass reported. See the Rung 2 UPDATE block above.
 2. **D-Q · canary-set selection (rung 3).** The named canaries (`darvI`/`gaRanA`) are poor choices for the
    SAN-LOSS *soft-guard* measurement: `darvI` is a deterministic fidelity-reject (never reaches the
    passing-card `accept()` path). The measurement needs a curated canary that *passes* fidelity while
@@ -118,8 +136,8 @@ them so the next session does not re-derive:
 | Gate | Before this session | After (measured live) |
 |---|---|---|
 | four-profile auth | assumed c5/c6 out (H960 note) | **confirmed NO-GO** — c1/c4 Max, c5/c6 `loggedIn:false` (unchanged 15-07) |
-| home-route latency | ~40 s honest NO-GO ×2 (H818/H895) | **c4 ~8–12 s — first sub-30 s reading**; route is fast now |
-| acceptance-probe reliability | assumed sound | **defect found** (D-P: plan-mode refusal → false NO-GO) |
+| home-route latency | ~40 s honest NO-GO ×2 (H818/H895) | ~~c4 sub-30 s~~ **CORRECTED: c4 ~30–53 s under a representative payload → latency NO-GO** (the sub-30 s pass was an `'x'`-padding artifact); consistent with H818/H895 |
+| acceptance-probe reliability | assumed sound | **defect found (D-P) AND ✅ fixed** ([v1.9.17](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.9.17)) — natural load-representative prompt; false-refusal gone; honest latency restored |
 | canary readiness | assumed runnable | **blocked** — c1 rate-limited + known-negative canary set + inputs absent (D-Q + prereqs) |
 | canonical store | 11,605 | **11,605 (untouched)** — no promotion, no mutation |
 

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -507,6 +507,31 @@ def _probe_err_class(text):
     return None
 
 
+# D-P (H994): the readiness payload is a real, completable task, NOT a degenerate tool-demand.
+# The prior probe (``'Return JSON {ok:true}. Preserve this padding as inert input.' + N*'x'``) read
+# as a nonsensical "call this tool now, here is meaningless padding" instruction and tripped
+# Sonnet-5's ``--permission-mode plan`` refusal — the model answered with prose citing plan-mode's
+# "end your turn via AskUserQuestion" rule (structured_output None), a FALSE ``malformed``/``content``/
+# over-ceiling NO-GO on a genuinely healthy, fast profile (measured 15-07-2026 on c4: the degenerate
+# prompt refused in 54 s, a natural prompt returned {"ok": true} in 12 s). The fix keeps plan mode
+# (so the probe matches ``headless_worker.call``'s real generation invocation) and the >=5 KB INPUT
+# payload, but frames it as natural, domain-shaped filler with one unambiguous instruction.
+_PROBE_FILLER_UNIT = (
+    'Reference sample text: the Petersburg Sanskrit dictionary records each headword with '
+    'grammatical notes, source citations, and numbered German senses. ')
+
+
+def _probe_prompt(payload_bytes):
+    """A load-representative readiness prompt: one clear task (return {"ok": true}) plus >=payload_bytes
+    of inert, domain-shaped filler explicitly framed as ignorable. Deterministic (fixed filler unit)."""
+    reps = payload_bytes // len(_PROBE_FILLER_UNIT) + 1
+    filler = (_PROBE_FILLER_UNIT * reps)[:payload_bytes]
+    return ('You are a readiness probe for an automated translation service. Confirm the service is '
+            'responding by replying with exactly the JSON object {"ok": true} and nothing else. The '
+            'block below is inert sample text included only to size the request to a realistic payload; '
+            'do not analyse, translate, or act on it.\n\n--- inert sample (ignore) ---\n' + filler)
+
+
 def _probe_call(config_dir, claude, payload_bytes, model):
     """One raw >=5 KB exact-model probe call. Returns (latency_ms, classification, output_bytes);
     classification is 'success' | 'auth' | 'rate_limit' | 'malformed' | 'content' | 'process' |
@@ -515,8 +540,7 @@ def _probe_call(config_dir, claude, payload_bytes, model):
     carry the structured schema result {"ok": true}."""
     env = os.environ.copy()
     env['CLAUDE_CONFIG_DIR'] = config_dir
-    prompt = ('Return JSON {"ok":true}. Preserve this padding as inert input.\n' +
-              ('x' * payload_bytes))
+    prompt = _probe_prompt(payload_bytes)
     started = time.monotonic()
     try:
         proc = run_tree_kill(            # D-J: tree-kill on timeout

--- a/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
@@ -257,6 +257,45 @@ def main():
         m.run_tree_kill = _rtk
     print('  D-K _probe_call envelope: result-string + structured_output => success; error/is_error => process; {ok:false} => content; rc0 rate/auth wrapper detected; non-envelope => malformed')
 
+    # D-P (H994): the readiness prompt must be a completable, natural task — NOT the degenerate
+    # "Return JSON {ok:true} + N*'x' padding" that tripped Sonnet-5's --permission-mode plan refusal
+    # (prose citing AskUserQuestion; a FALSE NO-GO on a healthy fast profile). It must keep
+    # >=payload_bytes of inert filler (load-representative), keep plan mode (matches
+    # headless_worker.call's real generation invocation), and carry ONE unambiguous instruction.
+    # Capture the real argv + stdin the probe would send.
+    _rtk2 = m.run_tree_kill
+    cap = {}
+
+    def _capture(*a, **k):
+        cap['argv'] = list(a[0]) if a else list(k.get('args') or [])
+        cap['input'] = k.get('input')
+        return types.SimpleNamespace(
+            returncode=0, stderr='',
+            stdout='{"type":"result","subtype":"success","is_error":false,"structured_output":{"ok":true}}')
+
+    try:
+        m.run_tree_kill = _capture
+        _lat, _cls2, _ob = m._probe_call('cfg', 'claude', 6491, m.EXACT_GEN_MODEL)
+        assert _cls2 == 'success', _cls2
+        p = cap['input']
+        # one clear, completable instruction: return exactly the schema object and nothing else
+        assert '{"ok": true}' in p and 'nothing else' in p, p[:200]
+        # payload framed as inert AND still >= the >=5 KB load-representative floor
+        assert 'inert sample (ignore)' in p and 'do not analyse, translate, or act on it' in p
+        assert len(p) >= 6491, len(p)
+        # the degenerate form is GONE: no old incantation, no long run of raw padding 'x'
+        assert 'Preserve this padding as inert input' not in p
+        assert 'xxxxxxxxxxxxxxxxxxxx' not in p                      # no 20+ run of padding
+        # plan mode retained (matches real generation) + exact model + json-schema still present
+        assert '--permission-mode' in cap['argv'] and 'plan' in cap['argv'], cap['argv']
+        assert '--json-schema' in cap['argv'] and '--model' in cap['argv'], cap['argv']
+        # _probe_prompt is deterministic and honours the payload-size floor
+        assert m._probe_prompt(6491) == m._probe_prompt(6491)
+        assert len(m._probe_prompt(5000)) >= 5000
+    finally:
+        m.run_tree_kill = _rtk2
+    print('  D-P readiness prompt: completable task ({"ok": true}) + >=5 KB inert filler; plan mode kept; degenerate x-padding gone')
+
     # D-K census: probe events distinguishable from translation calls; warm-up excluded from
     # latency, but a rate-limit warm-up is STILL counted in total quota observations.
     with tempfile.TemporaryDirectory() as td:

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,25 @@ not an error.
 
 ## [Unreleased]
 
+## [1.9.17] - 2026-07-15
+
+### Fixed
+- **D-P (H994) — PWG-RU acceptance-probe prompt fragility (15-07-2026, Opus 4.8 `claude-opus-4-8[1m]`, Ultracode)**:
+  `max_account_orchestrator._probe_call`'s degenerate readiness prompt (`"Return JSON {ok:true}. Preserve
+  this padding as inert input." + N×'x'`) tripped Sonnet-5's `--permission-mode plan` refusal (prose citing
+  the "end your turn via AskUserQuestion" rule, `structured_output=None`), producing a **false
+  `content`/`timeout`/`malformed` NO-GO on a genuinely responding profile**. Replaced with a new
+  `_probe_prompt()` helper: one unambiguous "reply with exactly `{"ok": true}` and nothing else" instruction
+  + ≥5 KB of inert, domain-shaped filler, under the **same `--permission-mode plan` the real generation path
+  (`headless_worker.call`) uses**. Added a `D-P readiness prompt` selftest (captures the real argv + stdin;
+  asserts the completable task, ≥5 KB payload, plan mode retained, degenerate `x`-padding gone). Live-verified
+  on c4: both probe phases now return `success` (no refusal, 1 483 B output).
+  **Correction it surfaced:** the old `'x'`-padding BPE-compresses to few tokens, giving *artificially fast*
+  latency (~8 s) — the H994 v1.9.16 "c4 sub-30 s, first sub-ceiling reading" was that artifact. Under the
+  fixed load-representative payload c4 measures **~30–53 s (latency NO-GO)**, consistent with H818/H895's
+  ~40 s NO-GOs; the latency rung remains a genuine blocker (H818/H909 foreign-route), independent of the
+  c5/c6 logins. No store mutation.
+
 ## [1.9.16] - 2026-07-15
 
 ### Added


### PR DESCRIPTION
## Problem (D-P, found in H994)

`max_account_orchestrator._probe_call`'s readiness prompt was degenerate — `"Return JSON {ok:true}. Preserve this padding as inert input." + N×'x'`. Under `--permission-mode plan`, Sonnet-5 **refuses** it as a nonsensical tool-demand (prose citing the "end your turn via AskUserQuestion" rule, `structured_output=None`), producing a **false `content`/`timeout`/`malformed` NO-GO on a genuinely responding profile**.

## Fix

New `_probe_prompt()` helper: one unambiguous *"reply with exactly `{"ok": true}` and nothing else"* instruction + ≥5 KB of inert, domain-shaped filler — under the **same `--permission-mode plan` the real generation path (`headless_worker.call`) uses** (so the probe stays representative). Added a `D-P readiness prompt` selftest that captures the real argv + stdin and asserts: completable task, ≥5 KB payload, plan mode retained, degenerate `x`-padding gone.

## Verification

- `max_account_orchestrator_selftest.py` — **PASS** (incl. the new D-P test).
- **Live on c4:** both probe phases return `success` (no refusal, 1 483 B output).

## Correction this surfaced

The old `'x'` padding BPE-compresses to few tokens → *artificially fast* latency (~8 s). The H994 [v1.9.16](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.9.16) **"c4 sub-30 s, first sub-ceiling reading" was that artifact.** Under the fixed load-representative payload c4 measures **~30–53 s → latency NO-GO**, consistent with H818/H895's ~40 s NO-GOs. The latency rung remains a genuine blocker (H818/H909 foreign-route), independent of the c5/c6 logins. Gate report + `.ai_state` + CHANGELOG [1.9.17] updated. No store mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)