### PR TITLE
feat(D-Q): reliable silent-SAN-LOSS canary for the H994 rung-3 measurement

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -25,15 +25,18 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   `_probe_call` now sends a natural load-representative prompt (plan mode kept, matches generation) + selftest.
   **Latency CORRECTED by the fix:** the "~8–12 s sub-30 s c4" claim was an `'x'`-padding artifact — under a
   representative ≥5 KB payload c4 is **~30–53 s → latency NO-GO** (consistent with H818/H895), so the latency
-  rung is a genuine blocker (H818/H909 foreign-route), independent of c5/c6. **D-Q** (curate a canary that
-  passes fidelity yet drops a sense) still open. Gate report:
+  rung is a genuine blocker (H818/H909 foreign-route), independent of c5/c6. **D-Q ✅ RESOLVED:** curated a
+  deterministic silent-SAN-LOSS canary `dq_canary_puregloss` (3 pure-gloss senses, zero `<ls>`/`{#` → any
+  dropped sense passes fidelity while `source_senses` stays 3), proven against the real `accept()` + selftest
+  ([curation doc](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h994/H994_DQ_SANLOSS_CANARY_CURATION_2026-07-15.md)).
+  **Both D-P and D-Q now closed; the live rung-3 gates only on the latency rung + a usable profile.** Gate report:
   [H994](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h994/H994_TWO_PROFILE_LIVE_MEASUREMENT_GATE_2026-07-15.md).
   Handoff:
   [H994](https://github.com/gasyoun/Uprava/blob/main/handoffs/H994-Opus_SanskritLexicography_pwg-ru-four-profile-live-ladder-acceptance_15.07.26.md).
   **Production-ready** claimed ONLY if latency + audit-clean ≥ 80% + fidelity < 5% + observed economy
   (≤ 1.75 calls/clean, ≤ $0.75/clean) + exactly-once + restart recovery + multi-profile-20 ALL pass; else
-  H255 stays frozen. **Next (owner-gated):** log in c5/c6, land D-P fix + curate D-Q canary, then run rungs
-  3–6. Resume (after the profile logins): `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H994-Opus_SanskritLexicography_pwg-ru-four-profile-live-ladder-acceptance_15.07.26.md and execute it.`
+  H255 stays frozen. **Next (owner-gated):** log in c5/c6 + resolve the latency rung (H818/H909 foreign-route),
+  then run rungs 3–6 (D-P fixed, D-Q canary `dq_canary_puregloss` ready). Resume (after the profile logins): `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H994-Opus_SanskritLexicography_pwg-ru-four-profile-live-ladder-acceptance_15.07.26.md and execute it.`
 
 - **H920 no_pwg SAN-LOSS / `missing_senses` root-cause + deterministic guard — 🔴 EXECUTED 14-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; owner-authorized override of the minted Sonnet 5; OFFLINE).**
   Root-caused the H911 #1 defect to **(a) model omission**, silent because the no_pwg portrait declares

--- a/RussianTranslation/pwg_ru/h994/H994_DQ_SANLOSS_CANARY_CURATION_2026-07-15.md
+++ b/RussianTranslation/pwg_ru/h994/H994_DQ_SANLOSS_CANARY_CURATION_2026-07-15.md
@@ -1,0 +1,101 @@
+# H994 D-Q — a reliable silent-SAN-LOSS canary (passes fidelity, drops a sense)
+
+_Created: 15-07-2026 · Last updated: 15-07-2026_
+
+Resolves the **D-Q** residual from the [H994 two-profile measurement](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h994/H994_TWO_PROFILE_LIVE_MEASUREMENT_GATE_2026-07-15.md):
+the rung-3 canary false-flag measurement needs a card that **passes the `accept()` `<ls>`/`{#` fidelity
+gate while dropping a numbered source sense** — the "silent SAN-LOSS" shape the H920/H960 sense-count
+soft-guard exists to catch. `darvI`/`gaRanA` are poor canaries; this curates a deterministic one.
+
+## The mechanics the canary must satisfy
+
+The live gate is the JS `accept()` in
+[`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py)
+(mirrored by the Python `accept()`), which applies, in order:
+
+1. **Fidelity gate (HARD reject):** `ls = countOf(c, /<ls\b/g)`, `sk = countOf(c, /\{#/g)` counted **only
+   over the emitted senses' `german`** — must equal `INPUTS[k].ls = raw.count('<ls')` and
+   `INPUTS[k].sk = raw.count('{#')`. Any drift → `fidelity-reject`.
+2. **SAN-LOSS gate (SOFT / telemetry):** `exp = INPUTS[k].source_senses` (deterministic,
+   cross-reference-hardened [`count_source_senses`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/sense_count.py)).
+   If `emitted < exp` → `SANLOSS_SHORTFALLS++` (kept unless the owner-gated `SANLOSS_HARD_REJECT` is armed).
+
+So a **silent SAN-LOSS** card is one where a dropped sense is invisible to gate 1 but visible to gate 2 —
+i.e. **the dropped sense carries neither an `<ls>` citation nor a `{#…#}` masked span.**
+
+## Why `darvI`/`gaRanA` are poor canaries
+
+`darvI`'s three senses are `1〉 {%Löffel%}`, `2〉 {%die Haube einer Schlange%}`, `3〉 {#darvI#} N. pr.` — only
+**two of three** are pure gloss. `raw.count('{#') = 1` (sense 3). So:
+
+- If the model drops sense 1 or 2 (pure gloss) → `{#` count stays 1 → fidelity passes → **silent SAN-LOSS** ✓.
+- If the model drops sense 3 (the `{#`-bearer) → `{#` count 0 ≠ 1 → **`fidelity-reject`**, not a silent loss.
+
+Which sense the model drops is not controllable, so `darvI` reproduces the silent shape only *sometimes* —
+and in the no_pwg drain it is in fact a **deterministic `fidelity-reject`** (the `{#…#}`-span-drop class,
+[RUN_LOG](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_LOG.md)).
+A canary must remove that coupling.
+
+## The delivered canary (deterministic)
+
+**`dq_canary_puregloss~~h0_zz_pw`** ([raw](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h994/canary/dq_canary_puregloss~~h0_zz_pw.raw.txt) ·
+[portrait](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h994/canary/dq_canary_puregloss~~h0_zz_pw.portrait.json)) —
+three line-opening pure-gloss senses, **zero `<ls>`, zero `{#`**:
+
+```
+=== LAYER: PW ===
+
+— 1〉 {%eine Schildkröte%}.
+— 2〉 {%ein kleiner Fisch%}.
+— 3〉 {%eine Wasserpflanze%}.
+```
+
+Offline build-check (real `gen_opt_harness2.build()`, no generation): `count_source_senses = 3`,
+`raw.count('<ls') = 0`, `raw.count('{#') = 0`; `INPUTS` stamped `source_senses: 3, ls: 0, sk: 0`. Because
+both fidelity counts are 0, the gate is `0 == 0` **whichever** sense is dropped, so:
+
+| model emits | fidelity | SAN-LOSS | outcome |
+|---|---|---|---|
+| all 3 senses | pass | `emitted 3 == exp 3` | clean (no false flag) |
+| drop 1st / middle / last (any 2 of 3) | **pass** | `emitted 2 < exp 3` | **silent SAN-LOSS, dropped=1** |
+| drop two (1 of 3) | **pass** | `emitted 1 < exp 3` | silent SAN-LOSS, dropped=2 |
+
+This is the reliable positive control `darvI` cannot be: **every** drop is silent + counted. It is a
+synthetic control card (not a real headword) — appropriate for a canary, whose job is to force the exact
+shape, not to sample the corpus.
+
+## Using it in the live rung-3 measurement
+
+1. Place the two files where `input_paths(key)` resolves them (the deterministic no_pwg input dir), or
+   pass the key explicitly. Key: `dq_canary_puregloss~~h0_zz_pw`.
+2. Generate it through the headless worker (single card, single profile is fine — the guard behaviour is
+   profile-count-independent). **No promotion needed** — this is a measurement.
+3. Read the guard telemetry from the run summary: `sanloss_shortfalls` and `SANLOSS_DETAIL`
+   (`{key, expected, emitted, dropped}`). A faithful generation → `sanloss_shortfalls: 0` (the guard is
+   correctly silent); a dropped sense → `sanloss_shortfalls: 1` with `dropped ≥ 1` (true positive).
+4. The **false-flag** question the measurement answers: across a batch of *clean* cards, how often does the
+   guard fire when no sense was actually dropped? Pair this canary (guaranteed true-positive on a drop)
+   with a set of faithful real cards (true-negatives) to get both halves of the rate.
+
+## Mining real multi-sense candidates (for representativeness)
+
+The synthetic canary proves the guard; a *representative* false-flag rate also wants real headwords with
+the silent-drop shape. Select from the PWG/no_pwg source any entry with **≥2 line-opening top-level senses
+(`count_source_senses ≥ 2`) where at least one sense carries no `<ls>` and no `{#…#}`** — that gloss-only
+sense is the silently-droppable one. Citation-free PW/SCH/NWS supplement glosses are the richest seam (the
+[`sense_count.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/sense_count.py)
+docstring's `aklizwa`/`asakta` are single-sense cousins of this family). Filter, don't hand-pick.
+
+## Verification
+
+- Behavioral selftest extended: [`accept_sensecount_test.js`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/accept_sensecount_test.js)
+  now drives the **real** `accept()` with this canary — faithful is clean; dropping the 1st / middle / last
+  sense each keeps the card, passes fidelity, and fires SAN-LOSS (`dropped=1`); dropping two → `dropped=2`;
+  and a **contrast** case proves the `darvI` `{#`-sense drop `fidelity-reject`s instead. Runs green via
+  `window_selftest.test_h960_accept_sanloss_soft_gate`.
+- Offline harness build-check: the canary masks losslessly and stamps `source_senses: 3 / ls: 0 / sk: 0`.
+
+_Auto-generated by Opus 4.8 (`claude-opus-4-8[1m]`) as the H994 D-Q executor, Ultracode; offline
+curation + selftest, no live generation, no promotion, no store/TM mutation._
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/pwg_ru/h994/H994_TWO_PROFILE_LIVE_MEASUREMENT_GATE_2026-07-15.md
+++ b/RussianTranslation/pwg_ru/h994/H994_TWO_PROFILE_LIVE_MEASUREMENT_GATE_2026-07-15.md
@@ -126,10 +126,13 @@ them so the next session does not re-derive:
    (no refusal, 1 483 B output). **Bonus correction:** the fix also exposed that the old `'x'`-padding gave
    *artificially fast* latency (few tokens after BPE) — under the fixed representative payload c4 is ~30–53 s
    (latency NO-GO), not the sub-30 s the first pass reported. See the Rung 2 UPDATE block above.
-2. **D-Q · canary-set selection (rung 3).** The named canaries (`darvI`/`gaRanA`) are poor choices for the
-   SAN-LOSS *soft-guard* measurement: `darvI` is a deterministic fidelity-reject (never reaches the
-   passing-card `accept()` path). The measurement needs a curated canary that *passes* fidelity while
-   dropping a sense. Curate it before the live rung.
+2. **D-Q · canary-set selection (rung 3) — ✅ RESOLVED 15-07-2026.** `darvI`/`gaRanA` are poor SAN-LOSS
+   soft-guard canaries (`darvI` carries `{#darvI#}` in sense 3, so dropping it `fidelity-reject`s instead
+   of silently losing a sense — non-deterministic). Curated a **deterministic** silent-SAN-LOSS canary
+   `dq_canary_puregloss~~h0_zz_pw` (three pure-gloss senses, zero `<ls>`/`{#` → any dropped sense passes
+   the `ls/sk` gate at `0==0` while `source_senses` stays 3, so SAN-LOSS is the only catch). Proven against
+   the real `accept()` (extended `accept_sensecount_test.js`, green via `test_h960_accept_sanloss_soft_gate`)
+   and build-checked offline. See the [D-Q canary curation](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h994/H994_DQ_SANLOSS_CANARY_CURATION_2026-07-15.md).
 
 ## What this moves
 
@@ -138,7 +141,7 @@ them so the next session does not re-derive:
 | four-profile auth | assumed c5/c6 out (H960 note) | **confirmed NO-GO** — c1/c4 Max, c5/c6 `loggedIn:false` (unchanged 15-07) |
 | home-route latency | ~40 s honest NO-GO ×2 (H818/H895) | ~~c4 sub-30 s~~ **CORRECTED: c4 ~30–53 s under a representative payload → latency NO-GO** (the sub-30 s pass was an `'x'`-padding artifact); consistent with H818/H895 |
 | acceptance-probe reliability | assumed sound | **defect found (D-P) AND ✅ fixed** ([v1.9.17](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.9.17)) — natural load-representative prompt; false-refusal gone; honest latency restored |
-| canary readiness | assumed runnable | **blocked** — c1 rate-limited + known-negative canary set + inputs absent (D-Q + prereqs) |
+| canary readiness | assumed runnable | **canary curated (D-Q ✅)** — deterministic `dq_canary_puregloss` ready + selftested; the live *run* still gates on the latency rung + a usable profile |
 | canonical store | 11,605 | **11,605 (untouched)** — no promotion, no mutation |
 
 ## Limitations

--- a/RussianTranslation/pwg_ru/h994/canary/dq_canary_puregloss~~h0_zz_pw.portrait.json
+++ b/RussianTranslation/pwg_ru/h994/canary/dq_canary_puregloss~~h0_zz_pw.portrait.json
@@ -1,0 +1,7 @@
+[
+  {
+    "key1": "dq_canary_puregloss",
+    "source_senses": 3,
+    "note": "D-Q silent-SAN-LOSS canary (H994). Three line-opening pure-gloss senses, ZERO <ls>/{#. Dropping ANY sense keeps the accept() ls/sk fidelity gate at 0==0 (passes) while source_senses stays 3, so the SAN-LOSS soft-guard is the only thing that can catch the loss. Synthetic control card, not a real headword."
+  }
+]

--- a/RussianTranslation/pwg_ru/h994/canary/dq_canary_puregloss~~h0_zz_pw.raw.txt
+++ b/RussianTranslation/pwg_ru/h994/canary/dq_canary_puregloss~~h0_zz_pw.raw.txt
@@ -1,0 +1,5 @@
+=== LAYER: PW ===
+
+— 1〉 {%eine Schildkröte%}.
+— 2〉 {%ein kleiner Fisch%}.
+— 3〉 {%eine Wasserpflanze%}.

--- a/RussianTranslation/src/pilot/accept_sensecount_test.js
+++ b/RussianTranslation/src/pilot/accept_sensecount_test.js
@@ -128,5 +128,42 @@ r = accept(card([{ german: '{T1} {T3}' }]), 'gram')
 check('hard: dropped {Tn} REJECTED when armed', r === null && /tnmask-reject/.test(FAIL.gram || ''))
 TNMASK_HARD_REJECT = false
 
+// ---- D-Q (H994): a RELIABLE silent-SAN-LOSS canary — dropping ANY sense stays fidelity-clean ----
+// darvI is an UNRELIABLE canary (see the contrast below): only its pure-gloss senses are silently
+// droppable, and the model may instead drop its {#-carrying sense -> fidelity-REJECT, not a silent
+// loss. The reliable canary rung-3 needs has N pure-gloss senses and ZERO <ls>/{# (INPUTS ls:0 sk:0):
+// the ls/sk gate is 0==0 whichever sense is dropped, so the sense-count guard is the ONLY thing that
+// can catch the loss. Proven here against the REAL accept(): every drop is silent+counted, faithful
+// is clean, and (contrast) the darvI {#-drop rejects.
+INPUTS = { canary: { ls: 0, sk: 0, source_senses: 3 } }
+reset()
+r = accept(card([{ german: 'a' }, { german: 'b' }, { german: 'c' }]), 'canary')
+check('D-Q canary: faithful 3/3 is clean (no false SANLOSS)', r !== null && SANLOSS_SHORTFALLS === 0)
+for (const [label, senses] of [
+  ['drop 1st', [{ german: 'b' }, { german: 'c' }]],
+  ['drop middle', [{ german: 'a' }, { german: 'c' }]],
+  ['drop last', [{ german: 'a' }, { german: 'b' }]],
+]) {
+  reset()
+  r = accept(card(senses), 'canary')
+  check('D-Q canary: ' + label + ' sense -> KEPT, fidelity-clean, SANLOSS fires (dropped=1)',
+    r !== null && FAIL.canary === undefined && SANLOSS_SHORTFALLS === 1 &&
+    SANLOSS_DETAIL[0] && SANLOSS_DETAIL[0].dropped === 1, JSON.stringify(SANLOSS_DETAIL))
+}
+reset()
+r = accept(card([{ german: 'a' }]), 'canary')   // drop TWO of three
+check('D-Q canary: drop 2 senses -> KEPT, dropped=2',
+  r !== null && SANLOSS_SHORTFALLS === 1 && SANLOSS_DETAIL[0] && SANLOSS_DETAIL[0].dropped === 2)
+
+// contrast: darvI is UNRELIABLE. Its raw is ls:0 sk:1 (only sense 3 carries {#darvI#}),
+// source_senses:3. If the model drops the {#-bearing sense (not a gloss sense) the emitted {# count
+// is 0 != 1 -> fidelity-REJECT fires FIRST, so it is NOT a silent SAN-LOSS. darvI reproduces the
+// silent shape only on the specific gloss-sense drops -> exactly why it is a poor rung-3 canary.
+INPUTS = { darvIreal: { ls: 0, sk: 1, source_senses: 3 } }
+reset()
+r = accept(card([{ german: 'a' }, { german: 'b' }]), 'darvIreal')   // dropped the {#-bearing sense
+check('contrast: darvI dropping its {#-sense fidelity-REJECTS (not a silent loss)',
+  r === null && /fidelity-reject/.test(FAIL.darvIreal || '') && SANLOSS_SHORTFALLS === 0)
+
 if (failed) { console.error(failed + ' check(s) failed'); process.exit(1) }
 console.log('accept_sensecount_test: PASS')

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,24 @@ not an error.
 
 ## [Unreleased]
 
+## [1.9.18] - 2026-07-15
+
+### Added
+- **D-Q (H994) — reliable silent-SAN-LOSS canary for the rung-3 measurement (15-07-2026, Opus 4.8 `claude-opus-4-8[1m]`, Ultracode)**:
+  the rung-3 false-flag measurement needs a card that *passes* `accept()`'s `<ls>`/`{#` fidelity gate while
+  *dropping* a numbered source sense (the silent SAN-LOSS the H920/H960 sense-count soft-guard catches).
+  `darvI`/`gaRanA` are unreliable — `darvI` carries `{#darvI#}` in sense 3, so dropping it `fidelity-reject`s
+  instead of silently losing a sense. Curated a **deterministic** canary
+  `RussianTranslation/pwg_ru/h994/canary/dq_canary_puregloss~~h0_zz_pw` (three pure-gloss senses, **zero
+  `<ls>`, zero `{#`**): dropping *any* sense keeps the fidelity gate at `0==0` while `source_senses` stays 3,
+  so SAN-LOSS is the only catch. Extended `accept_sensecount_test.js` to prove it against the **real**
+  `accept()` (faithful clean; drop 1st/middle/last each → kept + fidelity-clean + `SANLOSS dropped=1`; drop
+  two → `dropped=2`; contrast: the `darvI` `{#`-sense drop `fidelity-reject`s) — green via
+  `test_h960_accept_sanloss_soft_gate`; offline harness build-check stamps `source_senses:3 / ls:0 / sk:0`.
+  Curation doc: `RussianTranslation/pwg_ru/h994/H994_DQ_SANLOSS_CANARY_CURATION_2026-07-15.md`. Both H994
+  probe/canary defects (D-P, D-Q) now closed; the live rung-3 gates only on the latency rung + a usable
+  profile. No live generation, no store mutation.
+
 ## [1.9.17] - 2026-07-15
 
 ### Fixed


### PR DESCRIPTION
## What

Resolves the **D-Q** residual from H994: the rung-3 false-flag measurement needs a card that **passes** `accept()`'s `<ls>`/`{#}` fidelity gate while **dropping** a numbered source sense — the silent SAN-LOSS the H920/H960 sense-count soft-guard exists to catch.

## Why darvI/gaRanA don't work

`darvI` carries `{#darvI#}` in sense 3, so `raw.count('{#') = 1`. If the model drops sense 3 (the `{#}`-bearer) → `{#}` count `0 ≠ 1` → **`fidelity-reject`**, not a silent loss. Which sense the model drops isn't controllable → non-deterministic (and in the no_pwg drain `darvI` is in fact a deterministic `fidelity-reject`).

## The curated canary

`dq_canary_puregloss~~h0_zz_pw` — three line-opening **pure-gloss** senses, **zero `<ls>`, zero `{#}`**:

```
=== LAYER: PW ===

— 1〉 {%eine Schildkröte%}.
— 2〉 {%ein kleiner Fisch%}.
— 3〉 {%eine Wasserpflanze%}.
```

Both fidelity counts are 0, so the gate is `0==0` **whichever** sense is dropped → dropping *any* sense is a silent SAN-LOSS while `source_senses` stays 3. Deterministic, unlike `darvI`.

## Verification (offline, no generation)

- Extended [`accept_sensecount_test.js`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/accept_sensecount_test.js) drives the **real** `accept()`: faithful 3/3 clean; drop 1st/middle/last each → kept + fidelity-clean + `SANLOSS dropped=1`; drop two → `dropped=2`; **contrast** — the `darvI` `{#}`-sense drop `fidelity-reject`s. Green via `test_h960_accept_sanloss_soft_gate`.
- Offline harness build-check: masks losslessly, stamps `source_senses:3 / ls:0 / sk:0`.

Curation doc + gate report (D-Q ✅) + `.ai_state` + CHANGELOG [1.9.18]. **Both H994 defects (D-P, D-Q) now closed;** the live rung-3 gates only on the latency rung + a usable profile. No live generation, no store mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)