### PR TITLE
fix(D-P follow-through): latency runbook + sweep actual_prompt_bytes require v1.9.17 probe

### DIFF
--- a/RussianTranslation/PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md
+++ b/RussianTranslation/PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md
@@ -1,6 +1,6 @@
 # pwg_ru live-acceptance latency-policy investigation (opened after the second consecutive NO-GO)
 
-_Created: 13-07-2026 · Last updated: 14-07-2026_
+_Created: 13-07-2026 · Last updated: 15-07-2026_
 
 Opened per the H818 acceptance STOP-branch directive and handoff
 [H895](https://github.com/gasyoun/Uprava/blob/main/handoffs/H895-Opus_SanskritLexicography_h818-acceptance-DE-DK-latency-blocked_13.07.26.md):
@@ -81,6 +81,10 @@ already honestly NO-GO'd; further probing is investigation, not gate re-rolling)
 
 ## Results — home-route payload-size sweep (executed 14-07-2026, Opus 4.8 `claude-opus-4-8[1m]`)
 
+> **⚠️ Old-probe caveat (see the 15-07 D-P note in Method step 2):** these numbers were measured with the
+> pre-v1.9.17 `'x'`-padding probe (artificially-fast-on-compliance / refusal-bimodal). Retained as history;
+> re-baseline with the v1.9.17+ probe before comparing to any fixed-probe data.
+
 Method step 1 executed on the same profile under test — Max account `max1`
 (`D:\ClaudeTools\profiles\claude1\.claude`), exact model `claude-sonnet-5`, plain-probe path
 (tiny `{"ok":boolean}` schema, output held ~constant at ~1.5 KB) via
@@ -148,6 +152,12 @@ R² = 0.02). Shrinking a card's prompt would trim ~1 s of the floor and do nothi
 tens-of-seconds jitter — **payload size is not the lever.**
 
 ## Results — intra-window latency variance (executed 14-07-2026, Opus 4.8 `claude-opus-4-8[1m]`)
+
+> **⚠️ Old-probe caveat (see the 15-07 D-P note in Method step 2):** measured with the pre-v1.9.17
+> `'x'`-padding probe. The huge spread here (**8.9 s → 59.2 s**) is now partly explained by the D-P
+> refuse/comply bimodality — fast compliance (`'x'` compresses to few tokens) vs a slow plan-mode refusal —
+> so this window's dispersion conflates route variance with a probe artifact. Re-measure with the v1.9.17+
+> probe before treating the variance as a route property.
 
 Method step 3, partial. Across all 31 calls in the ~19-min window: **min 8.9 s · p50 25.8 s ·
 p90 52.8 s · max 59.2 s · mean 27.5 s · stdev 14.5 s** — stdev is ≈ 0.53× the mean (coefficient
@@ -223,6 +233,19 @@ before the D-A rewrite can help.
 
 ## Method step 2 — foreign-route comparison runbook (PREPARED + REFINED 14-07-2026 per sol.md #1–#5, Opus 4.8 `claude-opus-4-8[1m]`; owner-gated, NOT yet run)
 
+> **⚠️ 15-07-2026 (H994) — the probe was FIXED (D-P); collect off v1.9.17+ and re-baseline.** The
+> home-route sweep + variance results **above**, and any foreign evidence gathered earlier, used the
+> **old** `_probe_call` prompt, which is unreliable in *both* directions: on compliance a long `'x'` run
+> BPE-compresses to a handful of tokens → **artificially fast**, and under `--permission-mode plan`
+> Sonnet-5 sometimes **refuses** it (prose citing the "end via AskUserQuestion" rule) → a spurious
+> slow/over-ceiling reading. Neither reflects real generation load, so the old probe conflates route
+> latency with a refuse/comply bimodality. [D-P / v1.9.17](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.9.17)
+> replaced it with a natural load-representative prompt; the first honest home reading is **c4 ~30–53 s**
+> (warm-up 29.7 s / measured 52.8 s, both `success`, high variance) — over the ceiling, consistent with
+> H818/H895. **Action:** collect the paired A-B-B-A evidence off a commit **≥ v1.9.17 on BOTH hosts**, and
+> **re-baseline the home route** with the fixed probe before drawing any route-causality conclusion. The
+> pre-v1.9.17 numbers below are kept as history but are **not comparable** to fixed-probe data.
+
 Prepared per the H895 STOP-branch close-out: this is the sanctioned **diagnostic-only** exception
 for foreign-route probing. It is **NOT** Linux production — **Linux production and H841/H842/H843
 stay blocked** until the route is confirmed *and* a new acceptance handoff is minted (Step D). The
@@ -233,8 +256,8 @@ output constraint are **byte-identical on both hosts by construction** (hard-cod
 off the **same merged commit**):
 
 - **model** `claude-sonnet-5` (hard-coded `EXACT_GEN_MODEL` — cannot drift)
-- **prompt** `Return JSON {"ok":true}. Preserve this padding as inert input.\n` (the `PREFIX`, **63 B**) + `x`×`padding_bytes`
-- **bytes — do NOT conflate (sol.md #4):** `padding_bytes` is the `--ladder`/`MEASURED_SIZE` argument (the `x` count); the **actual encoded prompt** = 63 + `padding_bytes`. The D-K measured size is **`padding_bytes = 6491` ⇒ `actual_prompt_bytes = 6554`** — *not* 6491. `--mode diurnal` uses exactly this size, and the telemetry records **both** `padding_bytes` and `actual_prompt_bytes`.
+- **prompt (v1.9.17+, D-P fix — REQUIRED, see the 15-07 note below)** the natural load-representative task `_probe_prompt(padding_bytes)` builds: one clear "reply with exactly `{"ok": true}` and nothing else" instruction + `padding_bytes` of inert, domain-shaped filler. **Do NOT use a pre-v1.9.17 probe** — its old `"Return JSON {ok:true}. Preserve this padding as inert input." + N×'x'` prompt tripped Sonnet-5's plan-mode refusal AND read artificially fast (a long `'x'` run BPE-compresses to few tokens), so it is neither refusal-free nor load-representative.
+- **bytes — do NOT conflate (sol.md #4):** `padding_bytes` is the `--ladder`/`MEASURED_SIZE` argument (the filler size); the **actual encoded prompt** is derived from the SAME `_probe_prompt` (single source of truth, can't drift). The D-K measured size is **`padding_bytes = 6491` ⇒ `actual_prompt_bytes = 6828`** (v1.9.17+; was 6554 under the old 63 B prefix). `--mode diurnal` uses exactly this size, and the telemetry records **both** `padding_bytes` and `actual_prompt_bytes`.
 - **schema** `{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"],"additionalProperties":false}`, call `-p --output-format json --json-schema … --model claude-sonnet-5 --permission-mode plan`
 - **output constraint** tiny `{"ok":true}`; only the output **byte count** is recorded, never its content.
 - **30 000 ms ceiling unchanged.**
@@ -251,10 +274,13 @@ off the **same merged commit**):
   host) — this isolates *route* from *account*, and is **not** a credential copy. The agent **never**
   runs `/login` and **never** copies credentials — do **not** transfer
   `D:\ClaudeTools\profiles\claude1\.claude` (or any token) from Windows to the foreign host.
-- **Same commit + CLI.** Pin both hosts to the identical merged commit under test (record
-  `git -C <repo> rev-parse origin/master` once, check that **same SHA** out on both) and use the
+- **Same commit + CLI, and ≥ v1.9.17 (the D-P probe fix).** Pin both hosts to the identical merged
+  commit under test — **which MUST be ≥ [v1.9.17](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.9.17)**
+  so the probe is the D-P-fixed, load-representative prompt (a pre-fix commit re-introduces the
+  artificially-fast / refusal-bimodal probe and confounds the comparison). Record
+  `git -C <repo> rev-parse origin/master` once, check that **same SHA** out on both, and use the
   **same `claude` CLI version** (the telemetry records `git_sha` and `cli_version` per call so drift
-  is auditable).
+  is auditable — reject any sample whose commit predates v1.9.17).
 - **Telemetry hygiene (sol.md #5).** Each JSONL row records host/`route` label, `window` ID,
   `sample_index` (crossover position), `account_label` **pseudonym**, exact `model`, `git_sha`,
   `cli_version`, `latency_ms`, `classification`, output **byte count**, and **both** `padding_bytes`

--- a/RussianTranslation/src/pilot/latency_payload_sweep.py
+++ b/RussianTranslation/src/pilot/latency_payload_sweep.py
@@ -8,13 +8,17 @@ acceptance gate, does NOT weaken the 30000 ms ceiling, and never imports/claims 
 job, promotes a result, or writes the canonical store / translation memory. It
 only measures wall-clock latency.
 
-Each ``_probe_call`` sends a fixed tiny-output request whose INPUT is
-``PREFIX + padding_bytes*'x'``. Two byte counts are reported and must not be
-conflated (sol.md #4):
-  * ``padding_bytes``       -- the ``--ladder`` / ``MEASURED_SIZE`` argument (the 'x' count).
-  * ``actual_prompt_bytes`` -- the real encoded prompt = len(PREFIX) + padding_bytes
-                               (== ``total_input_bytes``; kept under both names).
-For the D-K measured acceptance size, padding_bytes=6491 -> actual_prompt_bytes=6554.
+Each ``_probe_call`` sends a fixed tiny-output request whose INPUT is the exact prompt
+``_probe_prompt(padding_bytes)`` builds. Post-D-P (H994, v1.9.17) that is a natural
+load-representative task (one clear ``{"ok": true}`` instruction + ``padding_bytes`` of inert,
+domain-shaped filler) under ``--permission-mode plan`` -- NOT the old 63 B ``PREFIX`` + N*'x'
+(that padding tripped Sonnet-5's plan-mode refusal, a false NO-GO). Two byte counts are reported
+and must not be conflated (sol.md #4):
+  * ``padding_bytes``       -- the ``--ladder`` / ``MEASURED_SIZE`` argument (the filler size).
+  * ``actual_prompt_bytes`` -- the TRUE encoded prompt size, derived from the SAME
+                               ``_probe_prompt`` the probe sends (single source of truth, cannot
+                               drift; == ``total_input_bytes``, kept under both names).
+For the D-K measured acceptance size, padding_bytes=6491 -> actual_prompt_bytes=6828 (v1.9.17+).
 Output is validated by result-envelope structure ({"ok": true}); only its BYTE
 COUNT is recorded -- never the output content, never credentials.
 
@@ -44,13 +48,18 @@ sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from max_account_orchestrator import _probe_call, EXACT_GEN_MODEL  # noqa: E402
+from max_account_orchestrator import _probe_call, _probe_prompt, EXACT_GEN_MODEL  # noqa: E402
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-# Must match _probe_call's prompt prefix exactly to report true total input bytes.
-PREFIX = 'Return JSON {"ok":true}. Preserve this padding as inert input.\n'
-PREFIX_LEN = len(PREFIX.encode('utf-8'))  # 63 bytes
-MEASURED_SIZE = 6491  # padding_bytes of the D-K measured acceptance probe (-> 6554 actual)
+MEASURED_SIZE = 6491  # padding_bytes of the D-K measured acceptance probe (-> 6828 actual, v1.9.17+)
+
+
+def _actual_prompt_bytes(padding_bytes):
+    """True encoded size of the exact prompt ``_probe_call`` sends for this padding, derived from the
+    SAME ``_probe_prompt`` (single source of truth) so it can NEVER drift from the probe. Post-D-P
+    (H994) the prompt is a natural load-representative task, not a 63 B prefix + N*'x'; the old mirror
+    constant (PREFIX_LEN + padding_bytes) silently miscounted actual_prompt_bytes after the fix."""
+    return len(_probe_prompt(padding_bytes).encode('utf-8'))
 
 
 def _iso_utc():
@@ -80,6 +89,7 @@ def one_call(config_dir, claude, padding_bytes, *, route, window, account_label,
     t0 = time.monotonic()
     ts = _iso_utc()
     latency_ms, cls, output_bytes = _probe_call(config_dir, claude, padding_bytes, EXACT_GEN_MODEL)
+    actual_bytes = _actual_prompt_bytes(padding_bytes)   # from _probe_prompt -- cannot drift from the probe
     row = {
         'ts_utc': ts,
         'route': route,                          # host/route label (sol.md #5)
@@ -90,9 +100,9 @@ def one_call(config_dir, claude, padding_bytes, *, route, window, account_label,
         'model': EXACT_GEN_MODEL,                # exact generation model under test
         'git_sha': git_sha,
         'cli_version': cli_version,
-        'padding_bytes': padding_bytes,          # the 'x' padding argument
-        'actual_prompt_bytes': PREFIX_LEN + padding_bytes,  # real encoded prompt bytes
-        'total_input_bytes': PREFIX_LEN + padding_bytes,    # alias (analyzer key; == actual)
+        'padding_bytes': padding_bytes,          # the inert-filler size argument
+        'actual_prompt_bytes': actual_bytes,     # TRUE encoded prompt bytes (from _probe_prompt)
+        'total_input_bytes': actual_bytes,       # alias (analyzer key; == actual)
         'latency_ms': latency_ms,
         'classification': cls,
         'output_bytes': output_bytes,            # BYTE COUNT only -- never the output content
@@ -100,7 +110,7 @@ def one_call(config_dir, claude, padding_bytes, *, route, window, account_label,
     }
     tag = 'warmup' if warmup else 'seq=%s' % sample_index
     print('%s route=%s window=%s %s pad=%dB actual=%dB -> %d ms %s'
-          % (ts, route, window, tag, padding_bytes, PREFIX_LEN + padding_bytes,
+          % (ts, route, window, tag, padding_bytes, actual_bytes,
              latency_ms, cls), flush=True)
     return row
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,22 @@ not an error.
 
 ## [Unreleased]
 
+## [1.9.19] - 2026-07-15
+
+### Fixed
+- **D-P follow-through — `latency_payload_sweep.py` `actual_prompt_bytes` + latency runbook hardened for the v1.9.17 probe (15-07-2026, Opus 4.8 `claude-opus-4-8[1m]`, Ultracode)**:
+  the D-P fix (v1.9.17) changed `_probe_call`'s prompt but left `latency_payload_sweep.py` with a stale
+  mirror constant (`PREFIX_LEN + padding_bytes`) that **miscounted `actual_prompt_bytes`** (the field the
+  `latency_sweep_analyze.py` payload-size axis reads) — reporting 6554 when the real prompt is 6828 B.
+  Now derived from the SAME `_probe_prompt` (single source of truth, cannot drift):
+  `actual_prompt_bytes = len(_probe_prompt(padding_bytes))`. Also updated
+  `PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md` (the H909 owner runbook): Method step 2 now
+  **requires a probe ≥ v1.9.17** on both hosts (a pre-fix `'x'`-padding probe is artificially-fast on
+  compliance and refusal-bimodal under `--permission-mode plan`, confounding route latency), records the
+  first honest home reading (**c4 ~30–53 s**, over the 30 s ceiling), and caveats the prior home-route
+  sweep/variance results (the 8.9 s→59.2 s spread is partly that probe artifact) as needing a re-baseline.
+  No behaviour change to the probe itself; diagnostic-tooling + runbook correctness only.
+
 ## [1.9.18] - 2026-07-15
 
 ### Added


### PR DESCRIPTION
## What

Follow-through on the D-P fix (v1.9.17), propagated to the H909 owner-facing latency runbook + its tooling.

## Two problems fixed

1. **Stale telemetry constant** — the D-P fix changed `_probe_call`'s prompt but left [`latency_payload_sweep.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/latency_payload_sweep.py) with a mirror `PREFIX_LEN + padding_bytes` that **miscounted `actual_prompt_bytes`** (the payload-size axis `latency_sweep_analyze.py` reads) — reporting **6554** when the real prompt is **6828 B**. Now derived from the SAME `_probe_prompt` (single source of truth, cannot drift).
2. **Runbook collected evidence with the broken probe** — [`PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_RU_LATENCY_POLICY_INVESTIGATION_2026-07-13.md) Method step 2 pinned the old `'x'`-padding prompt. Now **requires ≥ v1.9.17 on both hosts** (a pre-fix probe is artificially-fast-on-compliance + refusal-bimodal under `--permission-mode plan`, which confounds route latency).

## Also

- Records the first honest home reading (**c4 ~30–53 s**, over the 30 s ceiling, consistent with H818/H895).
- Caveats the prior home-route sweep/variance results — the **8.9 s → 59.2 s** spread is now partly explained by the D-P refuse/comply bimodality, so those windows need a v1.9.17+ re-baseline before any route-causality conclusion.

Verified: `latency_payload_sweep._actual_prompt_bytes(6491) == len(_probe_prompt(6491)) == 6828`; no stray `PREFIX_LEN`/`6554` refs; import smoke green. CHANGELOG [1.9.19]. No probe behaviour change — diagnostic tooling + runbook correctness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)