### PR TITLE
docs(H971): pwg_ru QA re-audit — NO REGRESSION on the grown store (11,605 rows / 67 roots)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -14,6 +14,17 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **H971 QA / methodology re-audit — 🔴 EXECUTED 15-07-2026 (Fable 5 `claude-fable-5`).**
+  Deterministic half of the H178 protocol re-run on the grown store (11,261/50 → **11,605 rows / 67
+  roots**): **NO REGRESSION** — window_selftest **131 PASS** (incl. `test_h920_*`/`test_h960_*` gate
+  pins), TM validate ru 2,411/217/2,392 all ok, provenance 11,605/11,605 stamped (the 9 SHA-less rows
+  = documented H188 `vid` backfill class, not a regression), lang-parity 49 no-drift, A-1(b) date
+  partition still 0 pre-merge roots, `h178_eval_bakeoff.py selftest` OK. Full results table:
+  [`pwg_ru/H971_QA_REAUDIT_2026-07-15.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H971_QA_REAUDIT_2026-07-15.md).
+  The bake-off COMPUTE half stays human-gated exactly as at H178 close (MG sheet votes → `pwg_ru/eval/`,
+  HF token for COMETKiwi) → [H274](https://github.com/gasyoun/Uprava/blob/main/handoffs/H274-Fable_DO_RussianTranslation_pwg_ru_bakeoff_compute_07.07.26.md)
+  remains the `@DO` successor. Overlap checked: read-only vs H963/H994 — no shared files touched.
+
 - **H994 (was pre-named H963) — four-profile live-ladder production acceptance — 🟡 STILL OWNER-GATED; two-profile Option-B measurement EXECUTED 15-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode).**
   Successor to H960 (offline scaffolding — see ✅ Completed): the LIVE ladder (auth → latency → **canary
   (MEASURE SANLOSS/TNMASK/dropped_sanskrit_span false-flag rate)** → arm hard-rejects → 10 → 20 →

--- a/RussianTranslation/pwg_ru/H971_QA_REAUDIT_2026-07-15.md
+++ b/RussianTranslation/pwg_ru/H971_QA_REAUDIT_2026-07-15.md
@@ -1,0 +1,72 @@
+# H971 — pwg_ru QA re-audit against the ACL-grade eval protocol (H178 lineage)
+
+_Created: 15-07-2026 · Last updated: 15-07-2026_
+
+Re-run of the deterministic half of the [H178](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H178-Fable_RussianTranslation_pwg_ru_acl_verify_improve_05.07.26.md)
+verify-and-improve protocol over the CURRENT promoted store, per
+[H971](https://github.com/gasyoun/Uprava/blob/main/handoffs/H971-Fable_RussianTranslation_pwg-ru-qa-methodology-reaudit_15.07.26.md).
+Audits executed by **Fable 5 (`claude-fable-5`)**, 15-07-2026 — all checks 0-token
+deterministic scripts, read-only against the local-only store
+(`src/pwg_ru_translated.jsonl`, gitignored); no generation, no store writes.
+
+## Verdict: NO REGRESSION — every H178 gate-fix holds on the grown store
+
+The store grew **11,261 → 11,605 rows (50 → 67 roots/keys)** since H178 closed
+(07-07-2026; growth = the H255 no_pwg lane + H901/H994-era additions), and every
+deterministic guarantee the H178 pass established still holds at the new size.
+
+| Check (protocol section) | H178 baseline (06/07-07) | H971 re-run (15-07) | Verdict |
+|---|---|---|---|
+| Promoted store size | 11,261 rows / 50 roots | 11,605 rows / 67 roots | growth only, no loss |
+| `window_selftest.py` (gate-fix pins) | 83 PASS (H220-era) | **131 PASS**, incl. `test_h920_*` ×4 (sense-loss gate) + `test_h960_*` ×2 (SANLOSS soft-gate, dropped-span) | ✅ all gate-fixes pinned + green |
+| `translation_memory.py selftest` | OK | OK (incl. D-E canonical-store path) | ✅ |
+| TM validate `--lang ru` — card | 2,302 ok | **2,411 ok** | ✅ grew, 0 invalid |
+| TM validate — fragment | 217 ok | 217 ok | ✅ unchanged |
+| TM validate — publication | 2,392 ok | 2,392 ok | ✅ (release artifact; rebuilt at release cadence, unchanged since) |
+| Provenance: `model_version` = `claude-sonnet-5` | 11,261/11,261 | **11,605/11,605** | ✅ |
+| Provenance: H170 `pipeline` stamp | 11,261/11,261 | **11,605/11,605** | ✅ |
+| Provenance: unresolved legacy rows | 0 | 0 | ✅ |
+| Provenance: rows missing input SHAs | 9 (`vid`) | 9 (`vid`, `backfilled: true`) | ✅ **known H188 class, NOT a regression** — the pre-fix autosplit rows; `_autosplit_meta()` fixed forward, input SHAs unrecoverable by design ([CODEX_AUDIT_2026-07-05.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/CODEX_AUDIT_2026-07-05.md)) |
+| `lang_parity_check.py` | 20 entries, no drift | **49 entries**, all verdicts complete, no drift | ✅ |
+| A-1(b) date partition (pre-merge / pure-PWG roots) | 0 pre-merge (CONFIRM-CLEAN) | **0 pre-merge of 67** (earliest `generated_at` 2026-06-29) | ✅ CONFIRM-CLEAN holds |
+| `h178_eval_bakeoff.py selftest` (protocol machinery) | OK at Part B close | OK | ✅ machinery intact |
+
+Partial-card rows: 70 (documented 🟡 residual class, promoted-as-partial by design).
+
+## The saved-window sweep was NOT re-derived — and why
+
+The 14 local `wf_output.*.json` artifacts are pre-H178 mid-run snapshots; their
+per-card flag decomposition is exactly H178 Part A-1(a)'s already-committed analysis
+([H178_REAUDIT_2026-07-06.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H178_REAUDIT_2026-07-06.md)),
+and no artifact changed since. The live guarantee that the gate FIXES still hold is
+carried by their selftest pins (131 PASS above), which run the fixed code paths on
+synthetic and frozen fixtures — re-analyzing stale snapshots would re-derive H178's
+conclusions, not test anything new (spot-check of `wf_output.no_pwg_w05.json`
+reproduced its known requeue decomposition unchanged).
+
+## The human-gated half of the protocol is UNCHANGED (still blocked, not regressed)
+
+The four-rubric bake-off **compute** stage
+([EVALUATION_PROTOCOL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/EVALUATION_PROTOCOL.md))
+still waits on its two human gates, exactly as recorded at H178 close:
+
+1. **MG votes** on the 4 `review/h178_*_sheet.html` sheets → `pwg_ru/eval/h178_<rubric>.decisions.json`
+   (no `eval/` decisions exist on `origin/master` as of this audit);
+2. **HF license/token** for the gated `Unbabel/wmt22-cometkiwi-da` (COMETKiwi secondary signal).
+
+Successor handoff [H274](https://github.com/gasyoun/Uprava/blob/main/handoffs/H274-Fable_DO_RussianTranslation_pwg_ru_bakeoff_compute_07.07.26.md)
+(bake-off compute: κ / discrimination / winner) remains `@DO`-gated on those votes —
+that is a standing human action, not a regression this re-audit could clear.
+
+## H960 / H963 / H994 overlap — checked, no collision
+
+Per the handoff's coordination clause: [H960](https://github.com/gasyoun/Uprava/blob/main/handoffs/H960-Opus_SanskritLexicography_pwg-ru-four-profile-production-readiness_15.07.26.md)
+closed 15-07 (offline scaffolding, [PR #475](https://github.com/gasyoun/SanskritLexicography/pull/475));
+its live-ladder successor **H963 is 🟡 WAITING ON OWNER** (c5/c6 Max logins), and the
+two-profile interim measurement **H994** landed earlier today
+([PR #484](https://github.com/gasyoun/SanskritLexicography/pull/484)–[#486](https://github.com/gasyoun/SanskritLexicography/pull/486)).
+This re-audit ran **read-only** against the local store from the main clone and touched
+none of the harness/ladder files those handoffs own; results here are a fresh
+deterministic baseline the H963 ladder can cite when it arms.
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Executes [H971](https://github.com/gasyoun/Uprava/blob/main/handoffs/H971-Fable_RussianTranslation_pwg-ru-qa-methodology-reaudit_15.07.26.md): re-run of the deterministic half of the [H178 ACL-grade protocol](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/EVALUATION_PROTOCOL.md) over the CURRENT promoted store. All audits 0-token, read-only (local gitignored store; no generation, no store writes). Full results table: [`pwg_ru/H971_QA_REAUDIT_2026-07-15.md`](https://github.com/gasyoun/SanskritLexicography/blob/h971-qa-reaudit/RussianTranslation/pwg_ru/H971_QA_REAUDIT_2026-07-15.md).

**Verdict: NO REGRESSION.** Store 11,261/50 → **11,605 rows / 67 roots** since H178; window_selftest **131 PASS** incl. the `test_h920_*` (sense-loss) and `test_h960_*` (SANLOSS/dropped-span) gate pins; TM validate ru **2,411 card / 217 frag / 2,392 publication** all ok; provenance **11,605/11,605** model_version + pipeline stamped, 0 unresolved — the 9 SHA-less rows are the documented H188 `vid` backfill class (fixed-forward, not a regression); lang-parity **49 entries no-drift**; A-1(b) date partition **0 pre-merge roots of 67**; `h178_eval_bakeoff.py selftest` OK.

**Human-gated half unchanged:** the four-rubric bake-off compute still waits on MG's 4 sheet votes (`pwg_ru/eval/` decisions absent on master) + the HF token for gated COMETKiwi → [H274](https://github.com/gasyoun/Uprava/blob/main/handoffs/H274-Fable_DO_RussianTranslation_pwg_ru_bakeoff_compute_07.07.26.md) stays the `@DO` successor.

**Overlap per the handoff's coordination clause:** H960 closed (PR #475), H963 🟡 owner-gated (c5/c6 logins), H994 landed today (PRs #484–486) — this audit is read-only against the local store and touches none of the harness/ladder files those own; it gives the H963 ladder a fresh deterministic baseline to cite. (Fable 5 `claude-fable-5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)