### PR TITLE
H963: bounded staged-run integration (opt-in, cost fail-closed, dry-run) — offline continuation

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -22,6 +22,18 @@ Two live tracks:
 
 ## ➡️ Next Steps (Queue)
 
+- **H963 offline engineering continuation — 🔴 EXECUTED 16-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; OFFLINE).**
+  Bounded/restartable/plan-scoped/cost-aware staged operation, no prompt or semantic-policy change. New
+  [`bounded_staged_run.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_staged_run.py)
+  drives `bounded_supervisor` over a plan's prepared leases behind an **opt-in, dry-run-default** interface
+  (zero edits to the orchestrator/coordinator); opt-in ceilings + **cost fail-closed** (`STOP_COST_UNEVALUABLE`;
+  `economy_ledger.gate(strict=True)` opt-in, legacy unchanged); checkpoint restart is exactly-once. 15 new
+  tests, wired into CI. **14 gates PASS; 2 (`window_selftest`/`lang_parity_check`) FAIL on PRE-EXISTING
+  upstream `LANG_PARITY.md` drift proven at base `3f45d0b3` (3 entries, files not touched here) — human
+  `--update-hash` re-affirm owed.** No live gen/promotion/store-write (11,605 unchanged)/TM rebuild/reroll.
+  Draft PR [#495](https://github.com/gasyoun/SanskritLexicography/pull/495) (not merged). Ladder stays
+  owner-gated — see the WAITING-ON-OWNER entry below. Detail: [`RussianTranslation/.ai_state.md`](RussianTranslation/.ai_state.md).
+
 - **H963 — four-profile live-ladder production acceptance — 🟡 WAITING ON OWNER (owner-gated).** The
   successor to H960 (🔴 EXECUTED 15-07 — offline scaffolding earned: six scale gaps closed as
   SOFT/report-only guards, [PR #475](https://github.com/gasyoun/SanskritLexicography/pull/475) merged,

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -22,7 +22,7 @@ Two live tracks:
 
 ## ➡️ Next Steps (Queue)
 
-- **H963 offline engineering continuation — 🔴 EXECUTED 16-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; OFFLINE).**
+- **H963 offline bounded-operation continuation DELIVERED 16-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; OFFLINE) — live four-profile ladder INCOMPLETE (rungs 1–2 run, rungs 3–6 NOT executed); H963 stays 🟡 WAITING ON OWNER. Offline hardening, NOT live acceptance.**
   Bounded/restartable/plan-scoped/cost-aware staged operation, no prompt or semantic-policy change. New
   [`bounded_staged_run.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_staged_run.py)
   drives `bounded_supervisor` over a plan's prepared leases behind an **opt-in, dry-run-default** interface
@@ -31,8 +31,10 @@ Two live tracks:
   tests, wired into CI. **14 gates PASS; 2 (`window_selftest`/`lang_parity_check`) FAIL on PRE-EXISTING
   upstream `LANG_PARITY.md` drift proven at base `3f45d0b3` (3 entries, files not touched here) — human
   `--update-hash` re-affirm owed.** No live gen/promotion/store-write (11,605 unchanged)/TM rebuild/reroll.
-  Draft PR [#495](https://github.com/gasyoun/SanskritLexicography/pull/495) (not merged). Ladder stays
-  owner-gated — see the WAITING-ON-OWNER entry below. Detail: [`RussianTranslation/.ai_state.md`](RussianTranslation/.ai_state.md).
+  Draft PR [#495](https://github.com/gasyoun/SanskritLexicography/pull/495) (not merged) — **offline hardening,
+  NOT live-acceptance evidence**. Live ladder rungs 3–6 unrun (rung 2 latency failed closed, c4 ≈ 52.8 s vs
+  30 s; c5/c6 logged out); resume after auth + latency, then **rung 3 with `dq_canary_puregloss`** (not the
+  whole ladder, not H994) — see the WAITING-ON-OWNER entry below. Detail: [`RussianTranslation/.ai_state.md`](RussianTranslation/.ai_state.md).
 
 - **H963 — four-profile live-ladder production acceptance — 🟡 WAITING ON OWNER (owner-gated).** The
   successor to H960 (🔴 EXECUTED 15-07 — offline scaffolding earned: six scale gaps closed as

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
           python src/pilot/run_observability_selftest.py
           python src/pilot/economy_ledger_selftest.py
           python src/pilot/bounded_supervisor_selftest.py
+          python src/pilot/bounded_staged_run_selftest.py
           python src/pilot/sense_count.py
           python src/pilot/window_selftest.py
           python src/store_path.py --selftest

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2197,6 +2197,13 @@ When auditing pwg_ru no_pwg output quality (H911 LOCAL-READINESS gate), three re
    `elapsed_ms` but **no token field**; H818 dashboards carry `cost:null`. So observed calls/clean and
    $/clean cannot be measured from existing evidence — the deterministic **projection** ($58.09/100hw)
    is a separate, optimistic floor and must not be substituted for observed performance.
+   **Operationalized 16-07-2026 (H963):** because observed per-window cost is usually unrecoverable
+   (LAUNCH_STATS records output-tokens on 1/458 windows), the bounded staged runner treats a
+   requested cost/quota ceiling as **fail-closed** — a window whose cost is UNEVALUABLE stops the run
+   with `STOP_COST_UNEVALUABLE` rather than assuming $0 and continuing
+   ([`bounded_staged_run.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_staged_run.py)
+   + `bounded_supervisor.strict_cost_fn`; `economy_ledger.gate(strict=True)` is the opt-in ledger gate,
+   legacy None-skip unchanged).
 3. **Current-store membership is not the audit verdict and not exact provenance.** Absence ≠ audit
    rejection; presence ≠ *this* output passed. Keep reviewer quality, sealed audit verdict, and
    promotion status as **three separate** measurements; an audit-to-promotion escape needs an exact

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -14,6 +14,31 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **H963 offline engineering continuation — 🔴 EXECUTED 16-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; OFFLINE, no live generation).**
+  Made unattended staged operation **bounded, restartable, plan-scoped and cost-aware** without touching
+  translation prompts or semantic policy. New standalone module
+  [`bounded_staged_run.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_staged_run.py)
+  drives `BoundedSupervisor` over a plan's **prepared** leases (one lease/window, join key
+  `root==lease id==external_id`), reusing `probe_fleet`/`cmd_run_once`/`cmd_record_done`/coordinator
+  `promote-ready` — **zero edits** to `max_account_orchestrator.py`/`coordinator.py` (existing commands
+  unchanged). **Default is a dry-run planning view (ZERO generation calls)**; live drain needs `--execute`
+  + a healthy probe. Added opt-in ceilings (`--max-windows/--max-calls/--max-clean/--empty-streak/`
+  `--max-accounts/--cost-ceiling`) with a **cost fail-closed** stop (`STOP_COST_UNEVALUABLE` +
+  `strict_cost_fn`; `economy_ledger.gate(strict=True)` opt-in, legacy None-skip unchanged). Per-lease
+  scope excludes transient/defect/pending/historical/unrelated-plan work; checkpoint restart re-runs no
+  completed lease (exactly-once). Tests: 9 new adapter cases + 5 bounded-supervisor + 1 economy both-modes;
+  wired into the CI gate block. **Validation:** 14 gates PASS (`git diff --check` clean, ruff fatal clean,
+  launch-ledger 17 entries, `node --check` template); **2 gates FAIL on PRE-EXISTING upstream
+  `LANG_PARITY.md` drift** (`window_selftest.py`/`lang_parity_check.py`, 3 entries:
+  `max_account_orchestrator.py`+selftest, `accept_sensecount_test.js`) — **proven** by re-running the
+  identical checks in a disposable detached worktree at base `3f45d0b3` (byte-identical drift, none of
+  those files touched here); needs a **human** `--update-hash` re-affirm (not self-affirmed).
+  Offline launch-readiness report written **uncommitted** at
+  `pwg_ru/h963/H963_OFFLINE_LAUNCH_READINESS_REPORT_2026-07-16.md`. **No** live generation, promotion,
+  store write (11,605 unchanged), TM rebuild, or latency reroll. Draft PR:
+  [SanskritLexicography#495](https://github.com/gasyoun/SanskritLexicography/pull/495) (not merged).
+  H963 stays **owner-gated** (c5/c6 login + latency rung) — see the H971/H963 entries below.
+
 - **H971 QA / methodology re-audit — 🔴 EXECUTED 15-07-2026 (Fable 5 `claude-fable-5`).**
   Deterministic half of the H178 protocol re-run on the grown store (11,261/50 → **11,605 rows / 67
   roots**): **NO REGRESSION** — window_selftest **131 PASS** (incl. `test_h920_*`/`test_h960_*` gate

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -14,7 +14,7 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
-- **H963 offline engineering continuation — 🔴 EXECUTED 16-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; OFFLINE, no live generation).**
+- **H963 offline bounded-operation continuation DELIVERED 16-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; OFFLINE) — live four-profile ladder INCOMPLETE (rungs 1–2 run, rungs 3–6 NOT executed); H963 stays 🟡 WAITING ON OWNER. This is offline hardening, NOT live acceptance.**
   Made unattended staged operation **bounded, restartable, plan-scoped and cost-aware** without touching
   translation prompts or semantic policy. New standalone module
   [`bounded_staged_run.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_staged_run.py)
@@ -36,8 +36,12 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   Offline launch-readiness report written **uncommitted** at
   `pwg_ru/h963/H963_OFFLINE_LAUNCH_READINESS_REPORT_2026-07-16.md`. **No** live generation, promotion,
   store write (11,605 unchanged), TM rebuild, or latency reroll. Draft PR:
-  [SanskritLexicography#495](https://github.com/gasyoun/SanskritLexicography/pull/495) (not merged).
-  H963 stays **owner-gated** (c5/c6 login + latency rung) — see the H971/H963 entries below.
+  [SanskritLexicography#495](https://github.com/gasyoun/SanskritLexicography/pull/495) (not merged) — **offline
+  bounded-operation hardening, NOT evidence of live four-profile acceptance**. The live ladder's rungs 3–6
+  remain **unrun and owner-gated** (rung 2 latency failed closed — c4 ≈ 52.8 s vs the 30 s ceiling; c5/c6
+  logged out; `dq_canary_puregloss` prepared but not run); resume ONLY after auth + a natural schema-carrying
+  latency gate, then **rung 3 with `dq_canary_puregloss`** (not the whole ladder, not H994). See the
+  H971/H963 entries below.
 
 - **H971 QA / methodology re-audit — 🔴 EXECUTED 15-07-2026 (Fable 5 `claude-fable-5`).**
   Deterministic half of the H178 protocol re-run on the grown store (11,261/50 → **11,605 rows / 67

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,39 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+- **Bounded staged-run integration (opt-in, default-off) — H963.** New standalone module
+  [`src/pilot/bounded_staged_run.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_staged_run.py)
+  drives the max-account staged-run path (`probe_fleet` → `cmd_run_once` → `cmd_record_done`
+  → coordinator `promote-ready`) under the `bounded_supervisor` control loop, one prepared
+  lease per window. Zero edits to `max_account_orchestrator.py` / `coordinator.py`; every
+  existing command and default is unchanged. The **default action is a dry-run planning view**
+  that makes ZERO generation calls (prints the scoped work, ceilings, account allocation,
+  checkpoint path and stop policy); a live drain requires the explicit `--execute` opt-in AND
+  a healthy fleet probe. Lease scoping (`only_external_ids={root}` + per-`--lease-id`
+  promotion) keeps transient/defect/pending/historical/unrelated-plan work out of the current
+  run; deterministic restart from the checkpoint re-runs no completed lease (exactly-once, on
+  both the loop's `completed_window_ids` and the coordinator's promoted-terminal idempotence).
+- **Bounded-supervisor ceilings + cost fail-closed — H963.**
+  [`bounded_supervisor.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_supervisor.py)
+  gains opt-in `max_calls` (`STOP_CALL_COUNT`), `max_clean` (`STOP_CLEAN_QUOTA`) and a
+  `strict_cost_fn`; a window whose cost is UNEVALUABLE under an active cost ceiling now stops
+  the run closed with the distinct `STOP_COST_UNEVALUABLE` reason instead of the legacy
+  silent-zero. `calls_spent`/`clean_total` persist across the checkpoint. All new params are
+  `None`-default, so the existing behaviour and all prior tests are unchanged.
+- **Economy-ledger opt-in strict gate — H963.**
+  [`economy_ledger.gate(..., strict=False)`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/economy_ledger.py)
+  and a `--strict` CLI flag: legacy (default) still SKIPS a ceiling whose value is `None`
+  (unchanged for every existing caller); `strict=True` treats a requested-but-unevaluable
+  ceiling as a fail-closed breach (distinct `unevaluable` marker). Missing accounting data is
+  never treated as within-ceiling. Both modes are covered by tests.
+- **Tests + CI.** New
+  [`bounded_staged_run_selftest.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_staged_run_selftest.py)
+  (9 cases: plan scope, dry-run-makes-no-call, historical-jobs-excluded, clean completion,
+  restart/no-dup, ceiling exhaustion, cost fail-closed, consecutive-empty, audit seam), +5
+  bounded-supervisor cases, +1 economy-ledger both-modes case; wired into the CI gate block.
+  No translation prompt or semantic-policy change; no live generation, promotion, store write
+  or TM rebuild.
+
 - **Provenance-bound mixed-lane requeues.** Each lease now seals its initial execution
   manifest as the immutable key universe and stores every pending retry key with the path
   and SHA-256 of the audit report that classified it. `record-output` rejects duplicate,

--- a/RussianTranslation/src/pilot/bounded_staged_run.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python
+r"""bounded_staged_run.py — the OPT-IN bridge that runs the max-account staged-run path
+under the bounded_supervisor control loop (H963; the live-wiring half of H960 gap #6).
+
+WHAT THIS IS (and what it is NOT)
+---------------------------------
+`bounded_supervisor.BoundedSupervisor` is a hermetic, crash-resumable, bounded drain loop
+whose one live dependency — the actual model call — is INJECTED as `run_window(window) ->
+wf_output`. `max_account_orchestrator.cmd_staged_run` is the live probe→dispatch→record→
+promote path, scoped to a plan's prepared coordinator leases. This module is the smallest
+coherent bridge between the two: it drives the bounded loop over a staged plan's prepared
+leases, one lease per window, reusing the EXISTING staged-run building blocks
+(`probe_fleet`, `cmd_run_once`, `cmd_record_done`, coordinator `promote-ready`) as the
+injected `run_window`, and adding the bounded loop's ceilings + checkpoint + cost
+fail-closed policy AROUND them.
+
+It is a NEW, standalone module with its own CLI. It edits NOTHING in
+max_account_orchestrator.py / coordinator.py / bounded_supervisor.py — every existing
+command and default is byte-for-byte unchanged, so this is a pure opt-in (H963 objective 1,
+backward compatibility). The staged-run monolith is not refactored; its already-separate
+callables are simply composed under a bounded loop.
+
+SAFETY / DEFAULT-OFF
+--------------------
+The DEFAULT action is a DRY-RUN planning view that makes ZERO generation calls: it prints
+the exact scoped work, the ceilings, the account allocation, the checkpoint path and the
+stop policy, and returns. A live drain requires the explicit `--execute` opt-in AND a
+healthy fleet probe (STOP-on-any-NO-GO by default). Without `--execute` no probe, no
+dispatch, no promotion, no store write is ever attempted. This double-gates against an
+accidental production run (H963 prohibits any production Max/Workflow translation call).
+
+THE LEASE JOIN KEY
+------------------
+window['root'] == coordinator lease id == orchestrator job external_id (a single identifier
+across the plan JSON, coordinator state.json, and the sqlite jobs table). Every bounded
+window we build uses id == root, so the loop's completed_window_ids, the per-lease dispatch
+scope (`only_external_ids={root}`) and the per-lease promotion scope (`--lease-id root`) all
+line up. This is the mechanism that keeps transient/defect/pending/historical/unrelated-plan
+work out of the current staged run (H963 objective 7): a job whose external_id is not in this
+plan's lease set is invisible to every scoped count, claim, record and promote.
+
+CEILINGS (H963 objective 4) — all optional, default-disabled, backward compatible:
+  --max-windows   windows/calls attempted   (BoundedSupervisor.max_windows)
+  --max-calls     cumulative model calls     (BoundedSupervisor.max_calls)
+  --max-clean     clean rows requested       (BoundedSupervisor.max_clean)
+  --empty-streak  consecutive non-productive (BoundedSupervisor.empty_streak_cap)
+  --max-accounts  account/profile usage      (fleet cap, passed to probe/dispatch)
+  --cost-ceiling  estimated/observed cost    (BoundedSupervisor.budget_cap)
+
+COST FAIL-CLOSED (H963 objective 5): when --cost-ceiling is set the loop reads per-window
+cost with bounded_supervisor.strict_cost_fn, which returns None (UNEVALUABLE) rather than a
+silent zero when a window carries no trustworthy cost figure — the loop then stops with the
+distinct STOP_COST_UNEVALUABLE reason. Additionally, BEFORE any live call, we fail closed if
+a cost ceiling is requested but the economy ledger cannot price it at all (no clean cards on
+record). Missing cost data is NEVER treated as zero. Accounting is the EXISTING economy
+ledger + launch/probe ledgers — no parallel accounting store is introduced (objective 6).
+
+Pure control-plane. The only side effects on the LIVE path are those cmd_staged_run already
+performs (dispatch/record/promote); the dry-run and every code path in the self-test perform
+none. Model authored by Opus 4.8 (claude-opus-4-8[1m]) for handoff H963.
+"""
+import argparse
+import json
+import os
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import bounded_supervisor as bs                      # noqa: E402
+import economy_ledger as el                          # noqa: E402
+import max_account_orchestrator as mao               # noqa: E402
+from bounded_supervisor import BoundedSupervisor, strict_cost_fn   # noqa: E402
+
+SCHEMA = 'pwg.bounded_staged_run.v1'
+
+# The exact-version contract coordinator.promote_ready enforces (rejects '', 'sonnet',
+# 'claude-sonnet'); the staged loop hardcodes this same value. Never a bare tier alias.
+DEFAULT_GEN_MODEL_VERSION = 'claude-sonnet-5'
+
+
+# ---------------------------------------------------------------------------
+# Scope — reuse staged_plan_scope verbatim so the bounded windows are exactly the
+# staged-run's prepared headless leases (H963 objective 2/7: plan-scoped isolation).
+# ---------------------------------------------------------------------------
+
+def scope_windows(plan, requested_lease_ids=None):
+    """Return (windows, scope) where `windows` is the bounded-loop plan list — one entry per
+    prepared headless lease, id == window['root'] — and `scope` is the staged_plan_scope
+    summary. A window that is not headless (plan-only / beyond --limit-windows) is NOT in
+    scope, exactly as cmd_staged_run sees it. Pure; reads the frozen plan dict only."""
+    scope = mao.staged_plan_scope(plan, requested_lease_ids)
+    windows = []
+    for window in scope['windows']:
+        root = window['root']
+        headless = window.get('headless') or {}
+        windows.append({
+            'id': root,                       # == lease id == job external_id (the join key)
+            'root': root,
+            'headwords': list(window.get('headwords') or []),
+            'subcards': list(window.get('subcards') or []),
+            'headless': True,
+            'projected_calls': headless.get('projected_calls'),
+            'manifest_sha256': headless.get('manifest_sha256'),
+        })
+    return windows, scope
+
+
+def prepared_lease_ids(coord_state):
+    """The set of lease ids the staged run can import — state=='prepared' only (a lease
+    advanced past prepared is silently skipped by cmd_staged_run's import filter)."""
+    return {lease.get('id') for lease in (coord_state or {}).get('leases', [])
+            if lease.get('state') == 'prepared'}
+
+
+# ---------------------------------------------------------------------------
+# Cost fail-closed pre-check — reuse the economy ledger (objective 5/6).
+# ---------------------------------------------------------------------------
+
+def cost_ceiling_evaluable(cost_ceiling, ledger):
+    """(ok, reason) for a requested monetary/quota ceiling, evaluated from the EXISTING
+    economy ledger — never a parallel accounting source.
+
+      * cost_ceiling is None -> (True, 'no cost ceiling requested').
+      * a ceiling IS requested but the economy ledger has no priced clean cards (the pooled
+        cost band is None — an all-wasted / empty log) -> (False, ...) FAIL CLOSED: we cannot
+        price a single window, so a live run must not start against an unenforceable budget.
+      * otherwise (True, <band basis>): the ledger yields a real per-clean cost band.
+
+    This mirrors economy_ledger.gate(strict=True) semantics (a requested ceiling on
+    unevaluable data is a breach) applied as a pre-run gate rather than a post-run one."""
+    if cost_ceiling is None:
+        return True, 'no cost ceiling requested'
+    band = (ledger.get('aggregate') or {}).get('cost_per_clean_band')
+    if band is None:
+        return False, ('cost ceiling $%.4f requested but the economy ledger has no priced '
+                       'clean cards (pooled cost band is None) — UNEVALUABLE, fail closed; '
+                       'never treat missing cost data as zero' % cost_ceiling)
+    return True, ('cost basis from economy ledger: $%.4f..$%.4f per clean (fresh-input ceil)'
+                  % (band['floor_usd'], band['ceil_usd']))
+
+
+# ---------------------------------------------------------------------------
+# The audit callable — read the coordinator lease post-drain (LIVE path).
+# ---------------------------------------------------------------------------
+
+def _lease_by_id(coord_state, lease_id):
+    for lease in (coord_state or {}).get('leases', []):
+        if lease.get('id') == lease_id:
+            return lease
+    return None
+
+
+def _window_cost_usd(lease, wf_summary):
+    """A TRUSTWORTHY per-window cost in USD, or None when it cannot be honestly priced.
+
+    Prefers observed subagent tokens (from the wf_output summary) priced at the economy
+    ledger's fresh-input rate (the in-band figure, single-sourced from economy_ledger.PRICE);
+    falls back to a recorded numeric cost on the lease. Returns None — NOT 0 — when neither is
+    available (the common case: H911 found run-event tokens 'not_recoverable'), so a cost
+    ceiling fails the run closed rather than silently under-counting."""
+    tokens = (wf_summary or {}).get('subagent_tokens')
+    if isinstance(tokens, (int, float)) and not isinstance(tokens, bool):
+        return tokens * el.PRICE['input'] / 1e6
+    cost = lease.get('cost') if isinstance(lease, dict) else None
+    if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+        return cost
+    if isinstance(cost, dict):
+        usd = cost.get('est_cost_usd') if not cost.get('error') else None
+        if isinstance(usd, (int, float)) and not isinstance(usd, bool):
+            return usd
+    return None
+
+
+def audit_from_coordinator(coord_state_path, wf_output, window):
+    """Build a bounded_supervisor audit report from the coordinator lease's post-drain state.
+
+    clean_count   = lease['clean_count'] (promotable clean rows on record; 0 if not promotable)
+    requeue_keys  = pending_requeue transient + defect keys (rework, NOT completion)
+    satisfied_keys= a requeue key whose promotion produced a zero store-delta (already
+                    promoted upstream) — progress, not a hard error
+    calls         = wf summary translate_agents_spent + heal_agents_spent (model calls)
+    cost          = trustworthy per-window USD, else None (drives the fail-closed policy)
+
+    A blocked/unknown lease contributes clean_count 0 and its keys as requeue (non-productive),
+    so it counts toward the consecutive-empty streak rather than as clean completion."""
+    try:
+        with open(coord_state_path, encoding='utf-8') as f:
+            coord_state = json.load(f)
+    except (OSError, ValueError, TypeError):
+        coord_state = {}
+    lease = _lease_by_id(coord_state, window['id']) or {}
+    pending = lease.get('pending_requeue') or {}
+    requeue_keys = [k for k in (list(pending.get('transient') or []) +
+                                list(pending.get('defect') or [])) if k]
+    clean_count = int(lease.get('clean_count') or 0)
+    store_delta = lease.get('store_delta')
+    satisfied = []
+    if window.get('requeue') and requeue_keys and store_delta == 0:
+        # an already-promoted (zero-delta) requeue key: satisfied-not-failed
+        satisfied, requeue_keys = requeue_keys, []
+    wf_summary = {}
+    try:
+        with open(wf_output, encoding='utf-8') as f:
+            wf_summary = (json.load(f).get('summary') or {})
+    except (OSError, ValueError, TypeError):
+        wf_summary = {}
+    calls = int((wf_summary.get('translate_agents_spent') or 0) +
+                (wf_summary.get('heal_agents_spent') or 0))
+    return {
+        'requeue_keys': requeue_keys,
+        'satisfied_keys': satisfied,
+        'clean_count': clean_count,
+        'calls': calls,
+        'cost': _window_cost_usd(lease, wf_summary),
+        'audit_state': lease.get('audit_state'),
+        'lease_state': lease.get('state'),
+        'store_delta': store_delta,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The run_window callable — drain ONE lease via the existing staged-run pieces (LIVE path).
+# ---------------------------------------------------------------------------
+
+class RunContext:
+    """Everything the per-lease live drain needs. Built once per bounded run; the fleet is
+    probed ONCE by the caller (not per window) and its healthy set passed in as
+    `probe_latencies` so dispatch never reaches an unprobed account."""
+
+    def __init__(self, db, coord_dir, coordinator, cwd, events, run_id, probe_latencies,
+                 claude_bin='claude', timeout=7200, gen_model_version=DEFAULT_GEN_MODEL_VERSION,
+                 max_drain_iterations=1000):
+        self.db = db
+        self.coord_dir = coord_dir
+        self.coordinator = coordinator
+        self.cwd = cwd
+        self.events = events
+        self.run_id = run_id
+        self.probe_latencies = probe_latencies
+        self.claude_bin = claude_bin
+        self.timeout = timeout
+        self.gen_model_version = gen_model_version
+        self.max_drain_iterations = max_drain_iterations
+
+    @property
+    def coord_state_path(self):
+        return os.path.join(os.path.abspath(self.coord_dir), 'state.json')
+
+
+def _ensure_imported(ctx, lease_id):
+    """Import this lease as a scoped job if it is prepared and not already present (mirrors
+    cmd_staged_run's to_import filter, scoped to the single lease)."""
+    db = mao.connect(ctx.db)
+    existing = {row['external_id'] for row in db.execute('SELECT external_id FROM jobs')}
+    db.close()
+    if lease_id in existing:
+        return
+    with open(ctx.coord_state_path, encoding='utf-8') as f:
+        coord_state = json.load(f)
+    if lease_id not in prepared_lease_ids(coord_state):
+        return  # not prepared (already advanced / unknown) -> nothing to import
+    mao.cmd_import_coordinator(argparse.Namespace(
+        db=ctx.db, coord_dir=ctx.coord_dir, cwd=ctx.cwd, lease_id=[lease_id], max_attempts=2))
+
+
+def make_run_window(ctx):
+    """Return run_window(window) -> wf_output_path: drain exactly ONE lease scoped to its own
+    external_id, reusing cmd_run_once / cmd_record_done / coordinator promote-ready. The scope
+    (only_external_ids={lease_id}, --lease-id lease_id) guarantees no other plan's job is
+    dispatched, recorded or promoted (H963 objective 2/7). This is invoked ONLY on the live
+    (--execute) path; the dry-run and the self-test never call it."""
+    import subprocess
+    import time
+
+    def run_window(window):
+        lease_id = window['id']
+        scope = {lease_id}
+        _ensure_imported(ctx, lease_id)
+        iterations = 0
+        while True:
+            iterations += 1
+            if iterations > ctx.max_drain_iterations:
+                raise SystemExit('bounded_staged_run: lease %s exceeded %d drain iterations'
+                                 % (lease_id, ctx.max_drain_iterations))
+            db = mao.connect(ctx.db)
+            pending = mao.scoped_job_count(db, scope, "state='pending'")
+            done_unrecorded = mao.scoped_job_count(
+                db, scope, "state='done' AND coordinator_recorded=0")
+            failed = mao.scoped_job_count(db, scope, "state='failed'")
+            db.close()
+            if failed:
+                raise SystemExit('bounded_staged_run: lease %s has %d failed job(s) — fail closed'
+                                 % (lease_id, failed))
+            if not pending and not done_unrecorded:
+                break
+            if pending:
+                now_ts = int(time.time())
+                db = mao.connect(ctx.db)
+                runnable = db.execute(
+                    "SELECT count(*) FROM accounts WHERE validated=1 AND parked_until<=?",
+                    (now_ts,)).fetchone()[0]
+                db.close()
+                if not runnable:
+                    raise SystemExit('bounded_staged_run: lease %s pending but all accounts '
+                                     'parked — rerun with --resume after the reset' % lease_id)
+                mao.cmd_run_once(argparse.Namespace(
+                    db=ctx.db, timeout=ctx.timeout, events=ctx.events, run_id=ctx.run_id,
+                    claude_bin=ctx.claude_bin, only_accounts=set(ctx.probe_latencies),
+                    only_external_ids=scope))
+            mao.cmd_record_done(argparse.Namespace(
+                db=ctx.db, coordinator=ctx.coordinator, cwd=ctx.cwd, only_external_ids=scope))
+            promote = subprocess.run(
+                [sys.executable, os.path.abspath(ctx.coordinator), 'promote-ready',
+                 '--gen-model-version', ctx.gen_model_version, '--lease-id', lease_id],
+                cwd=os.path.abspath(ctx.cwd), text=True, encoding='utf-8', capture_output=True)
+            if promote.returncode and 'no ready leases to promote' not in (
+                    promote.stderr + promote.stdout):
+                raise SystemExit('bounded_staged_run: lease %s promotion failed: %s'
+                                 % (lease_id, (promote.stderr or promote.stdout)[-1000:]))
+        # Return the lease's recorded output path (the wf_output the audit reads).
+        db = mao.connect(ctx.db)
+        rows = mao.scoped_jobs(db, scope)
+        db.close()
+        for job in rows:
+            if job['output_path'] and os.path.exists(job['output_path']):
+                return job['output_path']
+        return None
+
+    return run_window
+
+
+# ---------------------------------------------------------------------------
+# Dry-run planning view — the exact scoped work + ceilings + stop policy, NO calls.
+# ---------------------------------------------------------------------------
+
+def plan_view(plan, coord_state, ceilings, checkpoint_path, requested_lease_ids=None,
+              accounts=None, ledger=None):
+    """Pure planning view (H963 objective 8): what a live run WOULD do — scoped work,
+    ceilings, account allocation, checkpoint path, cost-basis evaluability and the ordered
+    stop policy — computed WITHOUT any generation call. `accounts` is the validated-account
+    name list (optional); `ledger` is a prebuilt economy ledger (optional; built from the
+    frozen probe log when omitted)."""
+    windows, scope = scope_windows(plan, requested_lease_ids)
+    prepared = prepared_lease_ids(coord_state)
+    importable = [w['id'] for w in windows if w['id'] in prepared]
+    not_prepared = [w['id'] for w in windows if w['id'] not in prepared]
+    if ledger is None:
+        try:
+            ledger = el.build_ledger(el.read_rows(el.FROZEN_LOG))
+        except (OSError, ValueError):
+            ledger = {'aggregate': {}}
+    cost_ok, cost_reason = cost_ceiling_evaluable(ceilings.get('cost_ceiling'), ledger)
+    max_accounts = ceilings.get('max_accounts') or 0
+    allocated = list(accounts or [])
+    if max_accounts:
+        allocated = allocated[:max_accounts]
+    stop_policy = [
+        'window-count ceiling (max_windows=%s)' % ceilings.get('max_windows'),
+        'call-count ceiling (max_calls=%s)' % ceilings.get('max_calls'),
+        'clean-rows quota (max_clean=%s)' % ceilings.get('max_clean'),
+        'cost/quota ceiling (cost_ceiling=%s; UNEVALUABLE cost -> STOP_COST_UNEVALUABLE, '
+        'fail closed)' % ceilings.get('cost_ceiling'),
+        'consecutive non-productive streak (empty_streak=%s)' % ceilings.get('empty_streak'),
+        'clean-target drain (plan queue + requeue backlog both empty)',
+        'any failed job or all-accounts-parked -> fail closed',
+    ]
+    return {
+        'schema': SCHEMA,
+        'mode': 'dry-run (no generation call made)',
+        'scope': {
+            'lease_ids': scope['lease_ids'],
+            'expected_windows': scope['expected_windows'],
+            'expected_headwords': scope['expected_headwords'],
+            'expected_subcards': sum(len(w['subcards']) for w in windows),
+            'projected_calls_from_plan': sum((w.get('projected_calls') or 0) for w in windows),
+            'importable_prepared_leases': sorted(importable),
+            'windows_not_prepared_skipped': sorted(not_prepared),
+        },
+        'ceilings': dict(ceilings),
+        'cost_basis': {'evaluable': cost_ok, 'reason': cost_reason},
+        'account_allocation': {
+            'validated_accounts': list(accounts or []),
+            'max_accounts_cap': max_accounts or None,
+            'allocated': allocated,
+        },
+        'checkpoint_path': checkpoint_path,
+        'stop_policy': stop_policy,
+        'live_requires': "explicit --execute AND a healthy fleet probe (STOP-on-any-NO-GO)",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Orchestration — build the bounded supervisor and (dry-run | execute).
+# ---------------------------------------------------------------------------
+
+def _validated_accounts(db_path):
+    if not db_path or not os.path.exists(db_path):
+        return []
+    try:
+        db = mao.connect(db_path)
+        names = [row['name'] for row in
+                 db.execute('SELECT name FROM accounts WHERE validated=1 ORDER BY name')]
+        db.close()
+        return names
+    except Exception:  # noqa: BLE001 — a missing/locked db must not crash the dry-run
+        return []
+
+
+def build_supervisor(windows, checkpoint_path, ceilings, run_window, audit, resume=False):
+    """Construct the BoundedSupervisor with the H963 ceilings wired through. strict_cost_fn is
+    used exactly when a cost ceiling is active, so an unevaluable window cost fails closed."""
+    cost_ceiling = ceilings.get('cost_ceiling')
+    return BoundedSupervisor(
+        windows, run_window, checkpoint_path,
+        audit=audit,
+        max_windows=ceilings.get('max_windows'),
+        max_calls=ceilings.get('max_calls'),
+        max_clean=ceilings.get('max_clean'),
+        budget_cap=cost_ceiling,
+        empty_streak_cap=ceilings.get('empty_streak'),
+        cost_fn=strict_cost_fn if cost_ceiling is not None else None,
+        resume=resume,
+    )
+
+
+def run(args):
+    plan = json.load(open(args.plan, encoding='utf-8'))
+    coord_state_path = os.path.join(os.path.abspath(args.coord_dir), 'state.json')
+    coord_state = {}
+    if os.path.exists(coord_state_path):
+        with open(coord_state_path, encoding='utf-8') as f:
+            coord_state = json.load(f)
+    ceilings = {
+        'max_windows': args.max_windows, 'max_calls': args.max_calls,
+        'max_clean': args.max_clean, 'cost_ceiling': args.cost_ceiling,
+        'empty_streak': args.empty_streak, 'max_accounts': args.max_accounts,
+    }
+    accounts = _validated_accounts(args.db)
+    ledger = el.build_ledger(el.read_rows(el.FROZEN_LOG)) if os.path.exists(el.FROZEN_LOG) else \
+        {'aggregate': {}}
+    view = plan_view(plan, coord_state, ceilings, args.checkpoint,
+                     requested_lease_ids=args.lease_id, accounts=accounts, ledger=ledger)
+
+    if not args.execute:
+        # DEFAULT: dry-run planning view. No probe, no dispatch, no promotion, no store write.
+        print(json.dumps(view, ensure_ascii=False, indent=1))
+        return 0
+
+    # --- LIVE path (owner-gated). Everything below is only reached with --execute. ---
+    windows, scope = scope_windows(plan, args.lease_id)
+    if not windows:
+        raise SystemExit('bounded_staged_run: staged plan has no prepared headless windows')
+    # Cost fail-closed PRE-CHECK: refuse to start a cost-capped run we cannot price at all.
+    cost_ok, cost_reason = cost_ceiling_evaluable(args.cost_ceiling, ledger)
+    if not cost_ok:
+        raise SystemExit('bounded_staged_run: %s' % cost_reason)
+    db = mao.connect(args.db)
+    validated = list(db.execute('SELECT * FROM accounts WHERE validated=1 ORDER BY name'))
+    db.close()
+    if not validated:
+        raise SystemExit('bounded_staged_run requires at least one validated account')
+    if args.max_accounts:
+        validated = validated[:args.max_accounts]
+    run_id = args.run_id or ('bsr-' + mao.now_iso().replace(':', '').replace('-', ''))
+    # Probe the fleet ONCE (STOP-on-any-NO-GO by default; the honest-NO-GO stance).
+    probe_latencies = mao.probe_fleet(
+        validated, args.claude_bin, events_path=args.events, run_id=run_id,
+        drop_unhealthy=args.drop_unhealthy)
+    if args.drop_unhealthy:
+        for acc in validated:
+            if acc['name'] not in probe_latencies:
+                mao.park(args.db, acc['name'], mao.PARKED_FOREVER,
+                         'dropped after probe NO-GO (--drop-unhealthy); healthy subset proceeds')
+    ctx = RunContext(
+        db=args.db, coord_dir=args.coord_dir, coordinator=args.coordinator, cwd=args.cwd,
+        events=args.events, run_id=run_id, probe_latencies=probe_latencies,
+        claude_bin=args.claude_bin, timeout=args.timeout,
+        gen_model_version=args.gen_model_version)
+    run_window = make_run_window(ctx)
+
+    def audit(wf_output, window):
+        return audit_from_coordinator(ctx.coord_state_path, wf_output, window)
+
+    sup = build_supervisor(windows, args.checkpoint, ceilings, run_window, audit,
+                           resume=args.resume)
+    summary = sup.run()
+    report = {'schema': SCHEMA, 'run_id': run_id, 'plan_view': view, 'summary': summary}
+    if args.report:
+        mao.atomic_write(args.report, json.dumps(report, ensure_ascii=False, indent=1) + '\n')
+    print(json.dumps(summary, ensure_ascii=False, indent=1))
+    # A cost-unevaluable / non-clean stop is a non-zero exit so callers can gate on it.
+    return 0 if summary.get('stop_reason') in (bs.STOP_CLEAN_TARGET, bs.STOP_WINDOW_COUNT,
+                                               bs.STOP_CLEAN_QUOTA, bs.STOP_CALL_COUNT) else 1
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--plan', required=True, help='the pwg.no_pwg_scale_plan.v1 plan JSON')
+    ap.add_argument('--coord-dir', required=True, help='coordinator dir holding state.json')
+    ap.add_argument('--coordinator', help='path to coordinator.py (required for --execute)')
+    ap.add_argument('--cwd', help='working dir for record/promote subprocesses (--execute)')
+    ap.add_argument('--db', default='max_orchestrator.sqlite')
+    ap.add_argument('--lease-id', action='append', help='restrict scope to these lease roots')
+    ap.add_argument('--checkpoint', default='bounded_staged_run.checkpoint.json')
+    ap.add_argument('--execute', action='store_true',
+                    help='OPT-IN: run the live drain. Default (absent) is a dry-run planning '
+                         'view that makes ZERO generation calls.')
+    ap.add_argument('--resume', action='store_true',
+                    help='resume from --checkpoint (no completed lease re-run/re-promoted)')
+    # Ceilings (all optional / default-disabled).
+    ap.add_argument('--max-windows', type=int, default=None)
+    ap.add_argument('--max-calls', type=int, default=None)
+    ap.add_argument('--max-clean', type=int, default=None)
+    ap.add_argument('--cost-ceiling', type=float, default=None,
+                    help='max cumulative cost (USD). An UNEVALUABLE window cost fails closed.')
+    ap.add_argument('--empty-streak', type=int, default=None)
+    ap.add_argument('--max-accounts', type=int, default=0)
+    ap.add_argument('--drop-unhealthy', action='store_true')
+    ap.add_argument('--gen-model-version', default=DEFAULT_GEN_MODEL_VERSION)
+    ap.add_argument('--timeout', type=int, default=7200)
+    ap.add_argument('--events')
+    ap.add_argument('--report')
+    ap.add_argument('--run-id')
+    args = ap.parse_args(argv)
+    if args.execute and not (args.coordinator and args.cwd and args.events):
+        ap.error('--execute requires --coordinator, --cwd and --events')
+    return run(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python
+r"""Hermetic self-test for bounded_staged_run.py (H963).
+
+ZERO live generation: the bounded loop is driven with a scripted fake run_window (writes a
+fixture wf_output) and injected audit reports; the scope-isolation test seeds a real sqlite
+jobs table via the orchestrator's own CLI but never dispatches a model call. Every H963
+characterization/regression case is exercised end to end:
+
+  (a) plan scope        — only prepared headless windows enter scope; a bad --lease-id raises
+  (b) dry-run           — the default path prints the planning view and makes ZERO calls
+                          (probe_fleet is monkeypatched to raise; the dry-run never reaches it)
+  (c) historical jobs   — an unrelated other-plan job (failed/done) is invisible to the
+                          current plan's scoped counts/claims
+  (d) clean completion  — a full drain over N leases stops at clean-target, all windows done
+  (e) restart / no-dup  — resume from a checkpoint re-runs NO completed lease (exactly-once)
+  (f) ceiling exhaustion— a call-count ceiling stops the run mid-queue
+  (g) cost fail-closed  — an unevaluable window cost under a cost ceiling stops closed, and the
+                          pre-run economy-ledger cost check refuses an unpriceable ceiling
+  (h) consecutive-empty — a non-productive streak stops the run
+  (i) audit seam        — audit_from_coordinator reads a lease's clean/requeue/satisfied/calls
+
+  python src/pilot/bounded_staged_run_selftest.py
+"""
+import argparse
+import json
+import os
+import sys
+import tempfile
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import bounded_staged_run as bsr
+import bounded_supervisor as bs
+import max_account_orchestrator as mao
+from bounded_supervisor import (
+    STOP_CLEAN_TARGET, STOP_CALL_COUNT, STOP_COST_UNEVALUABLE, STOP_CONSECUTIVE_EMPTY,
+)
+
+
+def _plan(roots, headless=True):
+    """A synthetic pwg.no_pwg_scale_plan.v1-shaped plan with `roots` prepared headless windows."""
+    windows = []
+    for i, root in enumerate(roots):
+        windows.append({
+            'root': root, 'headwords': ['hw_%s' % root], 'subcards': ['%s~~h0_zz_pw' % root],
+            'headless': {'projected_calls': 2, 'manifest_sha256': 'sha_%d' % i} if headless else None,
+        })
+    return {'schema': 'pwg.no_pwg_scale_plan.v1', 'windows': windows}
+
+
+class FakeRunWindow:
+    """run_window fake: records order, writes a trivial wf_output fixture, returns its path."""
+
+    def __init__(self, td, raise_on_call=None):
+        self.td = td
+        self.raise_on_call = raise_on_call
+        self.order = []
+
+    def __call__(self, window):
+        self.order.append(window['id'])
+        if self.raise_on_call is not None and len(self.order) == self.raise_on_call:
+            raise RuntimeError('simulated crash on %s' % window['id'])
+        path = os.path.join(self.td, 'wf_%s.json' % window['id'].replace('/', '_'))
+        with open(path, 'w', encoding='utf-8', newline='\n') as f:
+            json.dump({'summary': {}, 'results': []}, f)
+        return path
+
+
+def _ceilings(**over):
+    base = {'max_windows': None, 'max_calls': None, 'max_clean': None, 'cost_ceiling': None,
+            'empty_streak': None, 'max_accounts': 0}
+    base.update(over)
+    return base
+
+
+# ---------------------------------------------------------------------------
+
+def test_a_plan_scope(td):
+    plan = _plan(['no_pwg_w02', 'no_pwg_w03'])
+    plan['windows'].append({'root': 'no_pwg_w04', 'headwords': ['x'], 'subcards': None,
+                            'headless': None})   # plan-only, NOT in scope
+    windows, scope = bsr.scope_windows(plan)
+    assert [w['id'] for w in windows] == ['no_pwg_w02', 'no_pwg_w03'], windows
+    assert scope['expected_windows'] == 2 and scope['expected_headwords'] == 2, scope
+    # a --lease-id subset must equal the prepared roots or staged_plan_scope raises.
+    _, s2 = bsr.scope_windows(plan, ['no_pwg_w02', 'no_pwg_w03'])
+    assert s2['lease_ids'] == ['no_pwg_w02', 'no_pwg_w03'], s2
+    raised = False
+    try:
+        bsr.scope_windows(plan, ['no_pwg_w04'])   # w04 is not a prepared headless root
+    except SystemExit:
+        raised = True
+    assert raised, 'an unprepared/mismatched --lease-id must raise'
+    print('  (a) plan scope: only prepared headless windows enter; bad --lease-id raises: PASS')
+
+
+def test_b_dry_run_no_generation_call(td):
+    plan = _plan(['no_pwg_w02'])
+    coord = os.path.join(td, 'coord'); os.makedirs(coord)
+    with open(os.path.join(coord, 'state.json'), 'w', encoding='utf-8') as f:
+        json.dump({'leases': [{'id': 'no_pwg_w02', 'state': 'prepared'}]}, f)
+    plan_path = os.path.join(td, 'plan.json')
+    with open(plan_path, 'w', encoding='utf-8') as f:
+        json.dump(plan, f)
+
+    # Monkeypatch probe_fleet AND make_run_window to raise: if the dry-run path touched either,
+    # the test blows up. It must not — dry-run returns before any live wiring.
+    _pf, _mrw = mao.probe_fleet, bsr.make_run_window
+    calls = {'probe': 0, 'run_window': 0}
+
+    def _boom_probe(*a, **k):
+        calls['probe'] += 1
+        raise AssertionError('dry-run must NOT probe the fleet')
+
+    def _boom_mrw(*a, **k):
+        calls['run_window'] += 1
+        raise AssertionError('dry-run must NOT build a run_window')
+
+    mao.probe_fleet = _boom_probe
+    bsr.make_run_window = _boom_mrw
+    try:
+        args = argparse.Namespace(
+            plan=plan_path, coord_dir=coord, db=os.path.join(td, 'nope.sqlite'),
+            checkpoint=os.path.join(td, 'cp.json'), lease_id=None, execute=False, report=None,
+            max_windows=1, max_calls=None, max_clean=None, cost_ceiling=None, empty_streak=None,
+            max_accounts=0)
+        rc = bsr.run(args)
+    finally:
+        mao.probe_fleet, bsr.make_run_window = _pf, _mrw
+    assert rc == 0, rc
+    assert calls == {'probe': 0, 'run_window': 0}, calls
+    print('  (b) dry-run planning view makes ZERO generation calls (default off): PASS')
+
+
+def test_c_historical_jobs_excluded(td):
+    # Seed a real sqlite jobs table (via the orchestrator CLI) holding an UNRELATED other-plan
+    # job plus the current plan's lease. The current plan's scope must exclude the historical
+    # job from every scoped count — the isolation the live run_window relies on.
+    db = os.path.join(td, 'scope.sqlite')
+    mao.main(['--db', db, 'init', '--account', 'acc=' + os.path.join(td, 'acc'),
+              '--skip-profile-check'])
+    for ext in ('other_plan_w99', 'no_pwg_w02'):
+        mao.main(['--db', db, 'enqueue', '--external-id', ext, '--argv-json',
+                  json.dumps([sys.executable, '-c', 'print(1)']), '--cwd', td,
+                  '--output', os.path.join(td, ext + '.json')])
+    con = mao.connect(db)
+    with con:
+        con.execute("UPDATE jobs SET state='failed' WHERE external_id='other_plan_w99'")
+    con.close()
+    scope = {'no_pwg_w02'}
+    con = mao.connect(db)
+    # the unrelated failed job is invisible to the current plan's scoped counts
+    assert mao.scoped_job_count(con, scope, "state='failed'") == 0, 'historical failed job leaked into scope'
+    assert mao.scoped_job_count(con, scope, "state='pending'") == 1, 'current lease not pending in scope'
+    assert [r['external_id'] for r in mao.scoped_jobs(con, scope, "1=1")] == ['no_pwg_w02'], 'scope not isolated'
+    con.close()
+    # a scoped claim never touches the historical job
+    claimed = mao.claim(db, 'acc', only_external_ids=scope)
+    assert claimed and claimed['external_id'] == 'no_pwg_w02', claimed
+    con = mao.connect(db)
+    assert con.execute("SELECT state FROM jobs WHERE external_id='other_plan_w99'").fetchone()[0] == 'failed', \
+        'historical job must be untouched by the scoped claim'
+    con.close()
+    print('  (c) unrelated historical/other-plan jobs excluded from the current scope: PASS')
+
+
+def test_d_clean_completion(td):
+    plan = _plan(['no_pwg_w02', 'no_pwg_w03', 'no_pwg_w05'])
+    windows, _ = bsr.scope_windows(plan)
+    runner = FakeRunWindow(td)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 1, 'cost': 0.5, 'calls': 1, 'satisfied_keys': []}
+
+    sup = bsr.build_supervisor(windows, os.path.join(td, 'd.json'), _ceilings(), runner, audit)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CLEAN_TARGET, summ
+    assert summ['windows_done'] == 3, summ
+    assert runner.order == ['no_pwg_w02', 'no_pwg_w03', 'no_pwg_w05'], runner.order
+    assert summ['completed_window_ids'] == ['no_pwg_w02', 'no_pwg_w03', 'no_pwg_w05'], summ
+    print('  (d) full clean completion drains all leases to clean-target: PASS')
+
+
+def test_e_restart_no_duplicate_completion(td):
+    # Realistic interruption = a kill/crash mid-window (the checkpoint keeps stop_reason=None,
+    # so --resume continues; a CLEAN ceiling stop is terminal by design and resume is a no-op).
+    plan = _plan(['no_pwg_w02', 'no_pwg_w03', 'no_pwg_w05'])
+    windows, _ = bsr.scope_windows(plan)
+    cp = os.path.join(td, 'e.json')
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 1, 'cost': 1, 'calls': 1, 'satisfied_keys': []}
+
+    # First pass CRASHES while running the 3rd lease (2 completed + checkpointed).
+    runner_a = FakeRunWindow(td, raise_on_call=3)
+    sup_a = bsr.build_supervisor(windows, cp, _ceilings(), runner_a, audit)
+    crashed = False
+    try:
+        sup_a.run()
+    except RuntimeError:
+        crashed = True
+    assert crashed, 'expected a simulated crash on the 3rd lease'
+    state = json.load(open(cp, encoding='utf-8'))
+    assert state['windows_done'] == 2 and state['completed_window_ids'] == ['no_pwg_w02', 'no_pwg_w03'], state
+    assert state['stop_reason'] is None, state          # crashed mid-loop, not a clean stop
+
+    # Resume: ONLY the uncompleted 3rd lease runs — no completed lease re-run/re-recorded.
+    runner_b = FakeRunWindow(td)
+    sup_b = bsr.build_supervisor(windows, cp, _ceilings(), runner_b, audit, resume=True)
+    summ_b = sup_b.run()
+    assert runner_b.order == ['no_pwg_w05'], runner_b.order   # exactly-once: w02/w03 NOT re-run
+    assert summ_b['windows_done'] == 3, summ_b
+    assert summ_b['completed_window_ids'] == ['no_pwg_w02', 'no_pwg_w03', 'no_pwg_w05'], summ_b
+    assert summ_b['stop_reason'] == STOP_CLEAN_TARGET, summ_b
+    print('  (e) restart after interruption re-runs NO completed lease (exactly-once): PASS')
+
+
+def test_f_ceiling_exhaustion(td):
+    plan = _plan(['no_pwg_w0%d' % i for i in range(6)])
+    windows, _ = bsr.scope_windows(plan)
+    runner = FakeRunWindow(td)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 1, 'cost': 1, 'calls': 2, 'satisfied_keys': []}
+
+    sup = bsr.build_supervisor(windows, os.path.join(td, 'f.json'),
+                               _ceilings(max_calls=5), runner, audit)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CALL_COUNT, summ
+    assert summ['calls_spent'] == 6 and summ['windows_done'] == 3, summ   # 3 windows * 2 calls
+    print('  (f) a call-count ceiling stops the run mid-queue: PASS')
+
+
+def test_g_cost_fail_closed(td):
+    # runtime fail-closed: an unevaluable window cost under an active cost ceiling stops closed.
+    plan = _plan(['no_pwg_w02', 'no_pwg_w03', 'no_pwg_w05'])
+    windows, _ = bsr.scope_windows(plan)
+    runner = FakeRunWindow(td)
+
+    def audit(wf_output, window):
+        if window['id'] == 'no_pwg_w03':
+            return {'requeue_keys': [], 'clean_count': 1, 'calls': 1, 'satisfied_keys': []}  # NO cost
+        return {'requeue_keys': [], 'clean_count': 1, 'cost': 1, 'calls': 1, 'satisfied_keys': []}
+
+    sup = bsr.build_supervisor(windows, os.path.join(td, 'g.json'),
+                               _ceilings(cost_ceiling=100), runner, audit)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_COST_UNEVALUABLE, summ
+    assert runner.order == ['no_pwg_w02', 'no_pwg_w03'], runner.order   # stops on the unpriceable one
+    # pre-run fail-closed: a cost ceiling requested but the economy ledger cannot price it.
+    empty_ledger = {'aggregate': {'cost_per_clean_band': None}}
+    ok, reason = bsr.cost_ceiling_evaluable(0.75, empty_ledger)
+    assert ok is False and 'UNEVALUABLE' in reason, (ok, reason)
+    ok2, _ = bsr.cost_ceiling_evaluable(None, empty_ledger)   # no ceiling -> never a breach
+    assert ok2 is True
+    priced = {'aggregate': {'cost_per_clean_band': {'floor_usd': 0.07, 'ceil_usd': 0.70}}}
+    ok3, reason3 = bsr.cost_ceiling_evaluable(0.75, priced)
+    assert ok3 is True and 'cost basis' in reason3, (ok3, reason3)
+    print('  (g) cost fail-closed: unevaluable cost stops closed; unpriceable ceiling refused: PASS')
+
+
+def test_h_consecutive_empty(td):
+    plan = _plan(['no_pwg_w0%d' % i for i in range(6)])
+    windows, _ = bsr.scope_windows(plan)
+    runner = FakeRunWindow(td)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': ['%s~~h0_zz_pw' % window['id']], 'clean_count': 0, 'cost': 0,
+                'calls': 1, 'satisfied_keys': []}   # non-productive: 0 clean, only requeue
+
+    sup = bsr.build_supervisor(windows, os.path.join(td, 'h.json'),
+                               _ceilings(empty_streak=3), runner, audit)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CONSECUTIVE_EMPTY, summ
+    assert summ['empty_streak'] == 3, summ
+    print('  (h) a consecutive non-productive streak stops the run: PASS')
+
+
+def test_i_audit_from_coordinator(td):
+    coord_state_path = os.path.join(td, 'state.json')
+    wf = os.path.join(td, 'wf_w02.json')
+    with open(wf, 'w', encoding='utf-8') as f:
+        json.dump({'summary': {'translate_agents_spent': 4, 'heal_agents_spent': 1,
+                               'subagent_tokens': 1_000_000}}, f)
+    # a recorded lease: 3 clean, one defect key still pending, positive store delta.
+    with open(coord_state_path, 'w', encoding='utf-8') as f:
+        json.dump({'leases': [{
+            'id': 'no_pwg_w02', 'state': 'promoted_partial', 'audit_state': 'needs_requeue',
+            'clean_count': 3, 'store_delta': 5,
+            'pending_requeue': {'transient': [], 'defect': ['d~~h0_zz_pw']},
+        }]}, f)
+    rep = bsr.audit_from_coordinator(coord_state_path, wf, {'id': 'no_pwg_w02'})
+    assert rep['clean_count'] == 3, rep
+    assert rep['requeue_keys'] == ['d~~h0_zz_pw'], rep
+    assert rep['satisfied_keys'] == [], rep
+    assert rep['calls'] == 5, rep                                    # 4 + 1
+    assert rep['cost'] is not None and rep['cost'] > 0, rep          # priced from tokens
+    # a zero-delta requeue window: the pending key is satisfied-not-failed
+    with open(coord_state_path, 'w', encoding='utf-8') as f:
+        json.dump({'leases': [{'id': 'no_pwg_w02', 'state': 'promoted', 'clean_count': 0,
+                               'store_delta': 0,
+                               'pending_requeue': {'transient': ['t~~h0_zz_pw'], 'defect': []}}]}, f)
+    rep2 = bsr.audit_from_coordinator(coord_state_path, wf, {'id': 'no_pwg_w02', 'requeue': True})
+    assert rep2['satisfied_keys'] == ['t~~h0_zz_pw'] and rep2['requeue_keys'] == [], rep2
+    print('  (i) audit_from_coordinator reads clean/requeue/satisfied/calls/cost from the lease: PASS')
+
+
+def main():
+    with tempfile.TemporaryDirectory() as td:
+        test_a_plan_scope(td)
+        test_b_dry_run_no_generation_call(td)
+        test_c_historical_jobs_excluded(td)
+        test_d_clean_completion(td)
+        test_e_restart_no_duplicate_completion(td)
+        test_f_ceiling_exhaustion(td)
+        test_g_cost_fail_closed(td)
+        test_h_consecutive_empty(td)
+        test_i_audit_from_coordinator(td)
+    print('bounded_staged_run_selftest: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/bounded_supervisor.py
+++ b/RussianTranslation/src/pilot/bounded_supervisor.py
@@ -69,10 +69,31 @@ if HERE not in sys.path:
 SCHEMA = 'pwg.bounded_supervisor.v1'
 
 # Stop reasons — the loop stops on the FIRST of these to fire.
-STOP_WINDOW_COUNT = 'window_count'          # ran the configured max number of windows
+STOP_WINDOW_COUNT = 'window_count'          # ran the configured max number of windows/calls attempted
 STOP_BUDGET = 'budget'                       # accumulated per-window cost crossed the cap
 STOP_CLEAN_TARGET = 'clean_target'           # plan queue AND requeue backlog both drained
 STOP_CONSECUTIVE_EMPTY = 'consecutive_empty'  # N consecutive zero-progress iterations
+STOP_CALL_COUNT = 'call_count'               # cumulative model calls crossed the max-calls ceiling
+STOP_CLEAN_QUOTA = 'clean_quota'             # cumulative clean rows reached the requested quota
+STOP_COST_UNEVALUABLE = 'cost_unevaluable'   # a cost ceiling is active but a window's cost could
+#                                              NOT be evaluated -> FAIL CLOSED (never treat missing
+#                                              cost as zero and keep spending). Distinct from
+#                                              STOP_BUDGET: this is a data-integrity stop, not an
+#                                              over-ceiling stop (H963 cost fail-closed contract).
+
+
+def strict_cost_fn(window, wf_output, report):
+    """A fail-closed per-window cost reader for use when a cost/quota ceiling is enforced.
+
+    Returns the report's numeric ``cost`` when present, else ``None`` — signalling the
+    supervisor that this window's spend is UNEVALUABLE. Paired with an active ``budget_cap``
+    the supervisor then stops with ``STOP_COST_UNEVALUABLE`` instead of silently treating the
+    missing figure as zero (the anti-pattern the default reader keeps for backward compat).
+    ``bool``/``str`` costs are rejected as invalid (None), not coerced."""
+    cost = (report or {}).get('cost')
+    if isinstance(cost, bool) or not isinstance(cost, (int, float)):
+        return None
+    return cost
 
 
 class BoundedSupervisor:
@@ -95,12 +116,27 @@ class BoundedSupervisor:
     max_windows : int, optional
         Window-count cap. ``None`` disables the bound.
     budget_cap : number, optional
-        Running-budget cap; the loop stops once accumulated cost is >= this. ``None``
-        disables the bound.
+        Running-budget (cost/quota) cap; the loop stops once accumulated cost is >= this.
+        ``None`` disables the bound. When a ``budget_cap`` is set AND ``cost_fn`` reports an
+        UNEVALUABLE cost (``None``) for a window, the loop FAILS CLOSED with
+        ``STOP_COST_UNEVALUABLE`` rather than treating the missing figure as zero — pair it
+        with ``strict_cost_fn`` (module-level) to get that fail-closed reader.
     empty_streak_cap : int, optional
-        Stop after this many consecutive zero-progress iterations. ``None`` disables it.
-    cost_fn : callable(window, wf_output_path, report) -> number, optional
-        Per-window cost. Defaults to ``report.get('cost', 0)``.
+        Stop after this many consecutive zero-progress (non-productive) iterations. ``None``
+        disables it.
+    max_calls : int, optional
+        Ceiling on cumulative model calls attempted (summed from ``report['calls']``). The
+        loop stops with ``STOP_CALL_COUNT`` once the running total is >= this. ``None``
+        disables the bound.
+    max_clean : int, optional
+        Clean-rows quota: stop with ``STOP_CLEAN_QUOTA`` once cumulative clean cards
+        (summed from ``report['clean_count']``) reach this many. ``None`` disables it.
+        Distinct from the clean-TARGET drain (queue+backlog empty) — this is an explicit
+        ceiling on how many clean rows to REQUEST before stopping.
+    cost_fn : callable(window, wf_output_path, report) -> number|None, optional
+        Per-window cost. Defaults to ``report.get('cost', 0)`` (missing -> 0, the legacy
+        silent-zero kept for backward compatibility). Pass ``strict_cost_fn`` to make a
+        missing cost ``None`` and engage the fail-closed policy above.
     input_dir : str, optional
         Portrait-sidecar dir for the default H920 auditor. When omitted a throwaway temp
         dir is used (so the default auditor stays hermetic — an empty dir yields no
@@ -111,7 +147,8 @@ class BoundedSupervisor:
 
     def __init__(self, plan, run_window, checkpoint_path,
                  audit=None, max_windows=None, budget_cap=None,
-                 empty_streak_cap=None, cost_fn=None, input_dir=None, resume=False):
+                 empty_streak_cap=None, cost_fn=None, input_dir=None, resume=False,
+                 max_calls=None, max_clean=None):
         if not callable(run_window):
             raise TypeError('run_window must be callable(window) -> wf_output_path')
         self.plan = [self._normalize_plan(w, i) for i, w in enumerate(plan or [])]
@@ -121,6 +158,8 @@ class BoundedSupervisor:
         self.max_windows = max_windows
         self.budget_cap = budget_cap
         self.empty_streak_cap = empty_streak_cap
+        self.max_calls = max_calls
+        self.max_clean = max_clean
         self.cost_fn = cost_fn or (lambda window, wf_output, report: report.get('cost', 0) or 0)
         self.input_dir = input_dir
         self._own_input_dir = None
@@ -128,6 +167,8 @@ class BoundedSupervisor:
         # Loop state (all persisted).
         self.windows_done = 0
         self.budget_spent = 0.0
+        self.calls_spent = 0
+        self.clean_total = 0
         self.requeue_backlog = []
         self.empty_streak = 0
         self.next_index = 0
@@ -227,8 +268,15 @@ class BoundedSupervisor:
                 # (3) AUDIT — injected report, or the H920 gate helper on a tmp dir.
                 report = self._run_audit(wf_output, item)
 
-                cost = self.cost_fn(item, wf_output, report) or 0
+                raw_cost = self.cost_fn(item, wf_output, report)
+                # A None cost means UNEVALUABLE — never coerce it to 0 for accounting. It
+                # only fails the run closed when a cost ceiling (budget_cap) is active
+                # (checked below); with no cost ceiling it is a harmless 0 contribution.
+                cost_unevaluable = raw_cost is None
+                cost = 0 if cost_unevaluable else (raw_cost or 0)
                 self.budget_spent += cost
+                calls = int(report.get('calls') or 0)
+                self.calls_spent += calls
                 self.windows_done += 1
                 self.completed_window_ids.append(item['id'])
 
@@ -240,6 +288,7 @@ class BoundedSupervisor:
                     self.requeue_backlog.append(self._make_requeue_item(item, requeue_keys))
 
                 clean = int(report.get('clean_count') or 0)
+                self.clean_total += clean
                 # (g) A satisfied (already-promoted, zero-store-delta) requeue key is
                 # progress, not a hard error: it drains the backlog and resets the streak.
                 made_progress = clean > 0 or bool(satisfied)
@@ -252,9 +301,13 @@ class BoundedSupervisor:
                     'window_id': item['id'],
                     'requeue': bool(item.get('requeue')),
                     'clean_count': clean,
+                    'clean_total': self.clean_total,
+                    'calls': calls,
+                    'calls_spent': self.calls_spent,
                     'requeued_keys': sorted(set(requeue_keys)),
                     'satisfied_keys': sorted(set(satisfied)),
-                    'cost': cost,
+                    'cost': None if cost_unevaluable else cost,
+                    'cost_unevaluable': cost_unevaluable,
                     'budget_spent': self.budget_spent,
                     'empty_streak': self.empty_streak,
                 })
@@ -262,13 +315,31 @@ class BoundedSupervisor:
                 # (6) PERSIST loop state atomically for crash resume.
                 self._write_checkpoint()
 
-                # (5b) running-budget bound — after accumulating this window's cost, so the
-                # window that crosses the cap runs, then the loop stops mid-queue.
+                # (5b0) COST FAIL-CLOSED — a cost ceiling is enforced but this window's spend
+                # could not be evaluated. Stop closed BEFORE any further work: never keep
+                # spending against a budget we can no longer enforce. Checked first so it
+                # pre-empts a would-be clean-target success on an unenforceable budget.
+                if cost_unevaluable and self.budget_cap is not None:
+                    self._finish(STOP_COST_UNEVALUABLE)
+                    break
+
+                # (5b) running-budget (cost/quota) bound — after accumulating this window's
+                # cost, so the window that crosses the cap runs, then the loop stops mid-queue.
                 if self.budget_cap is not None and self.budget_spent >= self.budget_cap:
                     self._finish(STOP_BUDGET)
                     break
 
-                # (5d) consecutive-empty bound.
+                # (5e) call-count bound — cumulative model calls attempted.
+                if self.max_calls is not None and self.calls_spent >= self.max_calls:
+                    self._finish(STOP_CALL_COUNT)
+                    break
+
+                # (5f) clean-rows quota — stop once the requested number of clean rows is met.
+                if self.max_clean is not None and self.clean_total >= self.max_clean:
+                    self._finish(STOP_CLEAN_QUOTA)
+                    break
+
+                # (5d) consecutive-empty (non-productive) bound.
                 if (self.empty_streak_cap is not None
                         and self.empty_streak >= self.empty_streak_cap):
                     self._finish(STOP_CONSECUTIVE_EMPTY)
@@ -332,6 +403,8 @@ class BoundedSupervisor:
             'schema': SCHEMA,
             'windows_done': self.windows_done,
             'budget_spent': self.budget_spent,
+            'calls_spent': self.calls_spent,
+            'clean_total': self.clean_total,
             'requeue_backlog': self.requeue_backlog,
             'empty_streak': self.empty_streak,
             'next_index': self.next_index,
@@ -342,6 +415,8 @@ class BoundedSupervisor:
                 'max_windows': self.max_windows,
                 'budget_cap': self.budget_cap,
                 'empty_streak_cap': self.empty_streak_cap,
+                'max_calls': self.max_calls,
+                'max_clean': self.max_clean,
             },
             'history': self.history,
         }
@@ -365,6 +440,8 @@ class BoundedSupervisor:
             raise ValueError('checkpoint schema mismatch: %r' % state.get('schema'))
         self.windows_done = int(state.get('windows_done') or 0)
         self.budget_spent = float(state.get('budget_spent') or 0)
+        self.calls_spent = int(state.get('calls_spent') or 0)
+        self.clean_total = int(state.get('clean_total') or 0)
         self.requeue_backlog = list(state.get('requeue_backlog') or [])
         self.empty_streak = int(state.get('empty_streak') or 0)
         self.next_index = int(state.get('next_index') or 0)
@@ -382,6 +459,8 @@ class BoundedSupervisor:
             'stop_reason': self.stop_reason,
             'windows_done': self.windows_done,
             'budget_spent': self.budget_spent,
+            'calls_spent': self.calls_spent,
+            'clean_total': self.clean_total,
             'requeue_backlog_len': len(self.requeue_backlog),
             'requeue_backlog_keys': sorted(
                 {k for item in self.requeue_backlog for k in (item.get('keys') or [])}),

--- a/RussianTranslation/src/pilot/bounded_supervisor_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_supervisor_selftest.py
@@ -39,6 +39,10 @@ from bounded_supervisor import (
     STOP_BUDGET,
     STOP_CLEAN_TARGET,
     STOP_CONSECUTIVE_EMPTY,
+    STOP_CALL_COUNT,
+    STOP_CLEAN_QUOTA,
+    STOP_COST_UNEVALUABLE,
+    strict_cost_fn,
 )
 
 
@@ -279,6 +283,124 @@ def test_h_default_h920_auditor(td):
     print('  (h) default H920 auditor requeues a null card hermetically: PASS')
 
 
+def test_i_call_count(td):
+    # H963 ceiling: cumulative model calls attempted. Each window reports 2 calls; the
+    # loop stops once the running total is >= 5, i.e. after the 3rd window (2/4/6).
+    plan = make_plan(10)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 1, 'cost': 1, 'calls': 2,
+                'satisfied_keys': []}
+
+    cp = os.path.join(td, 'i.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, max_calls=5)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CALL_COUNT, summ
+    assert summ['calls_spent'] == 6, summ                 # 3 windows * 2 calls, crossed 5
+    assert summ['windows_done'] == 3, summ
+    assert runner.run_order == ['w0', 'w1', 'w2'], runner.run_order
+    print('  (i) call-count bound stops once cumulative calls cross the ceiling: PASS')
+
+
+def test_j_clean_quota(td):
+    # H963 ceiling: clean-rows quota. Each window yields 2 clean rows; stop once the
+    # cumulative clean total reaches 5 -> after the 3rd window (2/4/6). Distinct from the
+    # clean-TARGET drain (queue emptied): here the queue still has windows left.
+    plan = make_plan(10)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 2, 'cost': 1, 'satisfied_keys': []}
+
+    cp = os.path.join(td, 'j.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, max_clean=5)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CLEAN_QUOTA, summ
+    assert summ['clean_total'] == 6, summ
+    assert summ['windows_done'] == 3, summ
+    assert summ['next_index'] == 3 and summ['next_index'] < len(plan), summ  # stopped mid-queue
+    print('  (j) clean-rows quota stops once the requested clean count is met: PASS')
+
+
+def test_k_cost_fail_closed(td):
+    # H963 cost fail-closed: with a cost ceiling active, a window whose cost is UNEVALUABLE
+    # (strict_cost_fn returns None because the report carries no numeric cost) must stop the
+    # run CLOSED with the distinct STOP_COST_UNEVALUABLE reason — never treat missing cost as
+    # zero and keep spending. w0 prices fine (cost=1), w1 has no cost -> fail closed on w1.
+    plan = make_plan(5)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        if window['id'] == 'w1':
+            return {'requeue_keys': [], 'clean_count': 1, 'satisfied_keys': []}  # NO cost key
+        return {'requeue_keys': [], 'clean_count': 1, 'cost': 1, 'satisfied_keys': []}
+
+    cp = os.path.join(td, 'k.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, budget_cap=100,
+                            cost_fn=strict_cost_fn)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_COST_UNEVALUABLE, summ
+    assert summ['windows_done'] == 2, summ                # w0 (priced) + w1 (unevaluable) ran
+    assert runner.run_order == ['w0', 'w1'], runner.run_order
+    assert summ['budget_spent'] == 1, summ               # only w0's cost accrued; w1 NOT coerced to 0-and-continue
+    # The history records w1 as unevaluable, cost None (not 0).
+    assert sup.history[-1]['cost_unevaluable'] is True, sup.history[-1]
+    assert sup.history[-1]['cost'] is None, sup.history[-1]
+    print('  (k) cost fail-closed: unevaluable cost under an active ceiling stops closed: PASS')
+
+
+def test_l_cost_unevaluable_harmless_without_ceiling(td):
+    # The mirror of (k): with NO cost ceiling, an unevaluable (None) cost is harmless — it
+    # contributes 0 and the loop drains normally. Fail-closed engages ONLY when a cost
+    # ceiling (budget_cap) is actually being enforced, so the default path is unchanged.
+    plan = make_plan(2)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 1, 'satisfied_keys': []}   # never any cost
+
+    cp = os.path.join(td, 'l.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, cost_fn=strict_cost_fn)  # no budget_cap
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CLEAN_TARGET, summ
+    assert summ['windows_done'] == 2, summ
+    assert summ['budget_spent'] == 0, summ
+    print('  (l) unevaluable cost without a ceiling is harmless (drains normally): PASS')
+
+
+def test_m_calls_clean_survive_restart(td):
+    # The new call/clean counters must persist across a checkpoint resume exactly like
+    # windows_done/budget_spent do, so a resumed run enforces the SAME cumulative ceilings.
+    plan = make_plan(5)
+    cp = os.path.join(td, 'm.json')
+    runner_a = ScriptedRunner(td, raise_on_call=3)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 2, 'cost': 1, 'calls': 3,
+                'satisfied_keys': []}
+
+    sup_a = BoundedSupervisor(plan, runner_a, cp, audit=audit)
+    crashed = False
+    try:
+        sup_a.run()
+    except RuntimeError:
+        crashed = True
+    assert crashed, 'expected a simulated crash on the 3rd window'
+    state = json.load(open(cp, encoding='utf-8'))
+    assert state['calls_spent'] == 6, state              # 2 windows * 3 calls
+    assert state['clean_total'] == 4, state              # 2 windows * 2 clean
+
+    runner_b = ScriptedRunner(td)
+    sup_b = BoundedSupervisor.from_checkpoint(cp, plan, runner_b, audit=audit)
+    assert sup_b.calls_spent == 6 and sup_b.clean_total == 4, (sup_b.calls_spent, sup_b.clean_total)
+    summ = sup_b.run()
+    assert runner_b.run_order == ['w2', 'w3', 'w4'], runner_b.run_order  # no completed window re-run
+    assert summ['calls_spent'] == 15, summ               # 6 carried + 3 * 3
+    assert summ['clean_total'] == 10, summ               # 4 carried + 3 * 2
+    print('  (m) call/clean counters persist across a checkpoint resume: PASS')
+
+
 def main():
     with tempfile.TemporaryDirectory() as td:
         test_a_window_count(td)
@@ -289,6 +411,11 @@ def main():
         test_f_crash_recovery(td)
         test_g_satisfied_zero_delta(td)
         test_h_default_h920_auditor(td)
+        test_i_call_count(td)
+        test_j_clean_quota(td)
+        test_k_cost_fail_closed(td)
+        test_l_cost_unevaluable_harmless_without_ceiling(td)
+        test_m_calls_clean_survive_restart(td)
     print('bounded_supervisor_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/economy_ledger.py
+++ b/RussianTranslation/src/pilot/economy_ledger.py
@@ -313,25 +313,53 @@ def write_ledger(output_path, rows=None, source_log=None):
     return payload
 
 
-def gate(ledger, ceil_agents_per_clean=None, ceil_cost_per_clean=None):
+def gate(ledger, ceil_agents_per_clean=None, ceil_cost_per_clean=None, strict=False):
     """Return exit code 1 on an AGGREGATE breach (never per-card), else 0.
 
     Compares the headline `agents_per_clean_incl_requeues` and the in-band fresh-input
     `cost_per_clean_band.ceil_usd` against the supplied ceilings. Individual runs are
     NEVER gated — a single expensive/wasted window cannot flip the gate; only the pooled
     aggregate can.
+
+    ``strict`` (default False) selects the missing-data policy — the ONE behavioural
+    switch, added for the bounded-staged-run cost fail-closed contract (H963):
+
+      * strict=False (LEGACY, unchanged): a requested ceiling whose ledger value is
+        ``None`` — an all-wasted / all-nulled log yields ``None`` aggregates — is
+        SKIPPED, so the gate passes on unevaluable data. Every existing caller
+        (``main`` default, the standalone CLI, economy_ledger_selftest) keeps this
+        exact behaviour: DO NOT make ``None`` start failing for them.
+
+      * strict=True (OPT-IN, fail-closed): a requested ceiling that cannot be
+        evaluated (its ledger value is ``None``) is itself a breach — missing or
+        invalid accounting data is NEVER treated as within-ceiling. The breach text
+        carries the distinct ``unevaluable`` marker so callers/tests can tell a
+        fail-closed stop from an over-ceiling stop. A ceiling left at ``None`` (not
+        requested) is never a breach in either mode.
     """
     agg = ledger['aggregate']
     breaches = []
     apc = agg.get('agents_per_clean_incl_requeues')
     band = agg.get('cost_per_clean_band') or {}
     cost = band.get('ceil_usd')
-    if ceil_agents_per_clean is not None and apc is not None and apc > ceil_agents_per_clean:
-        breaches.append('agents_per_clean_incl_requeues %.4f > ceiling %.4f'
-                        % (apc, ceil_agents_per_clean))
-    if ceil_cost_per_clean is not None and cost is not None and cost > ceil_cost_per_clean:
-        breaches.append('cost_per_clean ceil $%.4f > ceiling $%.4f'
-                        % (cost, ceil_cost_per_clean))
+    if ceil_agents_per_clean is not None:
+        if apc is None:
+            if strict:
+                breaches.append('agents_per_clean unevaluable (no clean cards / incomplete '
+                                'accounting) but a ceiling of %.4f was requested — fail-closed'
+                                % ceil_agents_per_clean)
+        elif apc > ceil_agents_per_clean:
+            breaches.append('agents_per_clean_incl_requeues %.4f > ceiling %.4f'
+                            % (apc, ceil_agents_per_clean))
+    if ceil_cost_per_clean is not None:
+        if cost is None:
+            if strict:
+                breaches.append('cost_per_clean unevaluable (no priced clean cards / incomplete '
+                                'accounting) but a ceiling of $%.4f was requested — fail-closed'
+                                % ceil_cost_per_clean)
+        elif cost > ceil_cost_per_clean:
+            breaches.append('cost_per_clean ceil $%.4f > ceiling $%.4f'
+                            % (cost, ceil_cost_per_clean))
     for b in breaches:
         sys.stderr.write('ECONOMY GATE BREACH: %s\n' % b)
     return 1 if breaches else 0
@@ -371,6 +399,10 @@ def main():
     ap.add_argument('--write', metavar='PATH', help='also write the durable ledger JSON here')
     ap.add_argument('--ceil-agents-per-clean', type=float, default=None)
     ap.add_argument('--ceil-cost-per-clean', type=float, default=None)
+    ap.add_argument('--strict', action='store_true',
+                    help='fail closed: a requested ceiling that cannot be evaluated '
+                         '(unevaluable/None accounting) breaches the gate instead of '
+                         'being skipped. Default off = legacy standalone behaviour.')
     args = ap.parse_args()
 
     rows = read_rows(args.log)
@@ -382,7 +414,7 @@ def main():
     for line in summary_lines(ledger):
         print(line)
 
-    return gate(ledger, args.ceil_agents_per_clean, args.ceil_cost_per_clean)
+    return gate(ledger, args.ceil_agents_per_clean, args.ceil_cost_per_clean, strict=args.strict)
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pilot/economy_ledger_selftest.py
+++ b/RussianTranslation/src/pilot/economy_ledger_selftest.py
@@ -289,6 +289,48 @@ def test_integration_real_frozen_log():
         fail('real log must yield no conflicting_run_ids, got %s' % led['conflicting_run_ids'])
 
 
+def test_gate_strict_vs_legacy_missing_data():
+    """H963 cost fail-closed: the opt-in ``strict`` mode is the ONLY behaviour switch;
+    legacy (default) None-skip is unchanged. Cover BOTH modes so a future edit that lets
+    ``None`` silently pass in strict mode — or breaks legacy None-skip — fails loudly."""
+    # (a) UNEVALUABLE aggregates (all-wasted log -> None apc / None cost band).
+    wasted = el.build_ledger([
+        outcome_row('w1', 'no_pwg_wA', agents_used=8, clean=0, tokens=500_000),
+        outcome_row('w2', 'no_pwg_wB', agents_used=6, clean=0, tokens=300_000),
+    ])
+    if wasted['aggregate']['agents_per_clean_incl_requeues'] is not None:
+        fail('precondition: all-wasted apc must be None')
+    # LEGACY: a requested ceiling on unevaluable data is SKIPPED -> passes (0). Unchanged.
+    if el.gate(wasted, ceil_agents_per_clean=1.0) != 0:
+        fail('legacy gate must SKIP an unevaluable agents ceiling (None-skip), got breach')
+    if el.gate(wasted, ceil_cost_per_clean=0.5) != 0:
+        fail('legacy gate must SKIP an unevaluable cost ceiling (None-skip), got breach')
+    if el.gate(wasted, ceil_agents_per_clean=1.0, ceil_cost_per_clean=0.5, strict=False) != 0:
+        fail('explicit strict=False must be identical to the legacy default')
+    # STRICT: the same requested ceiling on unevaluable data FAILS CLOSED (1).
+    if el.gate(wasted, ceil_agents_per_clean=1.0, strict=True) != 1:
+        fail('strict gate must FAIL CLOSED on an unevaluable agents ceiling')
+    if el.gate(wasted, ceil_cost_per_clean=0.5, strict=True) != 1:
+        fail('strict gate must FAIL CLOSED on an unevaluable cost ceiling')
+    # a ceiling NOT requested (None) is never a breach, even in strict mode.
+    if el.gate(wasted, strict=True) != 0:
+        fail('strict gate with NO ceiling requested must pass (nothing to evaluate)')
+
+    # (b) EVALUABLE aggregates: strict must not change the verdict vs legacy.
+    priced = el.build_ledger(
+        [outcome_row('r_full', 'no_pwg_wA', agents_used=10, clean=5, tokens=1_000_000)])
+    #   apc = 10/5 = 2.0 ; cost ceil band = 1e6*3/1e6/5 = $0.60
+    for strict in (False, True):
+        if el.gate(priced, ceil_agents_per_clean=5.0, strict=strict) != 0:
+            fail('within-ceiling agents must pass in %s mode' % ('strict' if strict else 'legacy'))
+        if el.gate(priced, ceil_agents_per_clean=1.0, strict=strict) != 1:
+            fail('over-ceiling agents must breach in %s mode' % ('strict' if strict else 'legacy'))
+        if el.gate(priced, ceil_cost_per_clean=0.0001, strict=strict) != 1:
+            fail('over-ceiling cost must breach in %s mode' % ('strict' if strict else 'legacy'))
+        if el.gate(priced, ceil_cost_per_clean=1e6, strict=strict) != 0:
+            fail('within-ceiling cost must pass in %s mode' % ('strict' if strict else 'legacy'))
+
+
 def test_all_wasted_summary_does_not_crash():
     # Every row clean=0 -> no outcome row enters the agents-per-clean set, so the aggregate
     # agents_per_clean / cost band are None. summary_lines() (the main() print path) must render the
@@ -316,6 +358,7 @@ def main():
         test_dedup_on_run_id_not_window,
         test_ledger_imports_price_not_duplicated,
         test_gate_is_aggregate_only,
+        test_gate_strict_vs_legacy_missing_data,
         test_write_ledger_roundtrip,
         test_integration_real_frozen_log,
         test_all_wasted_summary_does_not_crash,


### PR DESCRIPTION
**Handoff:** [H963](https://github.com/gasyoun/Uprava/blob/main/handoffs/H963-Opus_SanskritLexicography_pwg-ru-four-profile-live-ladder-acceptance_15.07.26.md) — offline engineering continuation. Executor: Opus 4.8 (`claude-opus-4-8[1m]`), Ultracode. Base commit `3f45d0b3`.

This is an **offline engineering continuation**, not a production translation run: it makes unattended staged operation bounded, restartable, plan-scoped and cost-aware **without** changing translation prompts or semantic policy. **No live generation, promotion, canonical-store write, TM rebuild, or latency reroll occurred.**

## The H963 blocker (unchanged — this PR does NOT lift it)

The live four-profile ladder is **NO-GO** on two independent, owner-gated rungs:

- **Auth:** `c1`/`c4` logged-in Max, **`c5`/`c6` logged out** → four-profile = **NO-GO**. `c1` rate-limited/parked.
- **Latency:** `c4` measured **~30–53 s** under a load-representative payload vs the **≤ 30 s** ceiling → latency **NO-GO** (H818/H895/H909 foreign-route territory).

The canonical store remains at 11,605; H255 stays frozen; `dq_canary_puregloss` was not run.

## Architectural root cause (why this work exists)

`bounded_supervisor.py` was a hermetic, crash-resumable bounded drain loop whose one live dependency — the model call — is injected as `run_window(window) -> wf_output`. It was **never wired** to the live staged-run path (an explicit "LIVE-GATED follow-up, H960 gap #6, verify verdict SPLIT"). Meanwhile `max_account_orchestrator.cmd_staged_run` owned the live probe→dispatch→record→promote path but had only two bounds (`--max-accounts`, `--stop-after`) and no cost awareness, and its cost reader silently treated missing cost as zero. So an unattended staged run had no call/clean/cost ceilings, no cost fail-closed, and no bounded-loop checkpointing.

## Behaviour & compatibility changes

- **New standalone module [`bounded_staged_run.py`](../blob/h963-bounded-staged-run/RussianTranslation/src/pilot/bounded_staged_run.py)** bridges the two: it drives `BoundedSupervisor` over a staged plan's **prepared** leases (one lease per window; the join key `window['root'] == lease id == job external_id`), reusing the existing `probe_fleet` / `cmd_run_once` / `cmd_record_done` / coordinator `promote-ready` building blocks as the injected `run_window`. **Zero edits to `max_account_orchestrator.py` / `coordinator.py`** — every existing command and default is byte-for-byte unchanged (backward compatible; opt-in by simply not invoking the new module).
- **Default-off / dry-run first:** the default action is a **dry-run planning view** that makes **zero** generation calls (prints the exact scoped work, ceilings, account allocation, checkpoint path and stop policy). A live drain requires the explicit `--execute` opt-in **and** a healthy fleet probe (STOP-on-any-NO-GO).
- **Explicit ceilings (opt-in, `None`-default):** windows/calls attempted (`--max-windows`/`--max-calls`), clean rows requested (`--max-clean`), consecutive non-productive attempts (`--empty-streak`), account/profile usage (`--max-accounts`), and cost/quota (`--cost-ceiling`).
- **Plan-scope isolation:** each lease is drained scoped to `only_external_ids={root}` and promoted with an explicit per-`--lease-id` scope, so transient (null → requeue), defect (sense-loss → requeue), pending, historical (other external_ids), and unrelated-plan leases are all excluded from the current run's counts, claims, completion and promotion.
- **Ledger reuse (no parallel accounting):** cost is priced via the existing `economy_ledger` (`PRICE` from `parse_workflow_cost`); launch/agent data is the existing probe/launch ledgers. No new accounting store is introduced.

## Checkpoint / restart model

Restart is the `bounded_supervisor` atomic JSON checkpoint (`pwg.bounded_supervisor.v1`, temp-file + `os.replace` every iteration). A realistic interruption is a kill/crash: the checkpoint keeps `stop_reason=None`, and resuming re-runs **only** the uncompleted leases — a completed lease is skipped by `completed_window_ids`, and the coordinator's promoted-terminal state makes re-promotion a no-op, so restart never reclaims or double-records completed work (exactly-once on two independent layers). `calls_spent`/`clean_total` now persist across the checkpoint so a resumed run enforces the same cumulative ceilings. (A *clean* ceiling stop is terminal by design; resume is a deliberate no-op.)

## Cost fail-closed policy

When a cost ceiling is set, per-window cost is read with `strict_cost_fn`, which returns `None` (UNEVALUABLE) — never a silent zero — when a window carries no trustworthy cost figure. Under an active ceiling the loop then stops with the distinct **`STOP_COST_UNEVALUABLE`** reason. Additionally, before any live call, the run **fails closed** if a cost ceiling is requested but the economy ledger cannot price it at all (no clean cards on record). This matches the compatibility constraint kept for the ledger itself: `economy_ledger.gate(..., strict=False)` default is unchanged (a `None` ceiling value is skipped for every existing caller); the opt-in `strict=True` (and `--strict` CLI) treats a requested-but-unevaluable ceiling as a fail-closed breach carrying a distinct `unevaluable` marker. Missing accounting data is **never** treated as within-ceiling. Both modes are covered by tests.

## Exact validation results

Run at base `3f45d0b3` in the isolated worktree (working-directory `RussianTranslation` unless noted).

**PASS (14):** `agent_budget.py` · `headless_worker_selftest.py` · `max_account_orchestrator_selftest.py` · `windows100_selftest.py` · `run_observability_selftest.py` · `economy_ledger_selftest.py` (10 tests incl. the new both-modes strict gate) · `bounded_supervisor_selftest.py` (13 tests incl. 5 new) · **`bounded_staged_run_selftest.py` (9 new tests)** · `sense_count.py` · `store_path.py --selftest` · `translation_memory.py selftest` · `check_launch_ledger.py --since 2026-07-05` (17 entries, launch-ledger validation) · `node --check src/pilot/run_pilot_wf.js` · `ruff check --select=E9,F63,F7,F82 .` (fatal set, full repo) · `git diff --check` (clean).

**FAIL (2) — pre-existing UPSTREAM parity drift, proven, NOT introduced here:** `lang_parity_check.py` (language-parity gate) and `window_selftest.py` both exit **1**, solely on `LANG_PARITY.md`'s 3 unresolved parity violations. **Proof:** the identical checks were run in a disposable detached worktree at the exact base commit `3f45d0b3` with none of this PR's changes present — both exit **1** with byte-identical drift signatures:

| entry | file | recorded sha256 | actual sha256 |
|---|---|---|---|
| `headless_execution_manifest_h818` | `src/pilot/max_account_orchestrator.py` | `1073515c4927…` | `e33a4f32908f…` |
| `headless_execution_manifest_h818` | `src/pilot/max_account_orchestrator_selftest.py` | `acf81e929dcf…` | `08f6c58db179…` |
| `accept_sanloss_soft_gate_h960` | `src/pilot/accept_sensecount_test.js` | `dd5061a719ba…` | `ae04e6390738…` |

These three files are **not touched by this PR**; no PR file is a `depends_on` of any parity entry; this PR adds **zero** new parity entries and **zero** new drift. Commits `3f45d0b3..625d6e84` never touch those files or `LANG_PARITY.md`, so the drift persists at the current `origin/master` tip too. Root cause: the 15–16 July D-P/D-K (v1.9.17) and D-Q (v1.9.18) edits committed those files without the human `--update-hash` re-affirmation of the SHARED (ru/en parity) verdict. **Resolution is a human call** (`python src/pilot/lang_parity_check.py --update-hash headless_execution_manifest_h818` and `--update-hash accept_sanloss_soft_gate_h960`, after re-confirming the parity verdict) — deliberately **not** done here, since this session did not author those edits and must not self-affirm the semantic verdict.

`node --check` of a freshly *generated* harness needs the gitignored rootmap/store (absent in an isolated worktree); the CI-authoritative template check (`run_pilot_wf.js`) passes and is the available equivalent.

## No-production confirmation

No production Max/Workflow translation calls · no latency reroll · no `dq_canary_puregloss` execution · no canonical-store write (store stays 11,605) · no promotion · no TM rebuild · no `c5`/`c6` login attempt · no H255 launch · no four-profile PASS claim. Every live code path is gated behind `--execute` + a healthy probe and was exercised only via injected fakes / the dry-run in the self-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
