### PR TITLE
chore(release): v1.12.0 changelog promotion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.12.0] — 17-07-2026
+
 ### Added
 - **A30 full paper draft — "When Zero Means Nothing: Recovering the Indigenous Microstructure
   of the *Śabdakalpadruma* and the *Vācaspatya*" (17-07-2026, Fable 5 `claude-fable-5`, H1073)**:


### PR DESCRIPTION
Promotes [Unreleased] to [1.12.0] — 17-07-2026 per the changelog contract (cut a version every time the changelog is updated). Covers the A30 full draft ([PR #503](https://github.com/gasyoun/SanskritLexicography/pull/503)), FINDINGS §86 and the RU onboarding entries. Tag + GitHub release follow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)