### PR TITLE
feat(M01): Ch. 2 §6 'The corpus as a bounded witness' — corpus-methods section (H1078, v1.13.0)

### DIFF
--- a/Digital_Sanskrit_Lexicography-BOOK/.ai_state.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Build the Book A monograph plan into a submittable Brill manuscript
 
-_Created: 07-07-2026 · Last updated: 13-07-2026_
+_Created: 07-07-2026 · Last updated: 17-07-2026_
 
 ## ➡️ Next Steps (Queue)
 
@@ -26,9 +26,6 @@ _Created: 07-07-2026 · Last updated: 13-07-2026_
 - **Goal-loop (13-07-2026):** 12 of 14 chapters landed this session (Ch. 8, 12, 13, 14, 7, 6).
   Stop condition = all 14 `chapters/ch*.md` in book form; only the two prose-thin data chapters
   remain, each a first-draft-from-data task, not a conversion.
-- **Ch. 2 corpus-methods section** — write the ~6–8 pp. "The corpus as a bounded witness"
-  section into ch02 at its next revision (MG ruled (b) on 13-07-2026; see Completed).
-
 ## 🚧 Current Work-In-Progress (WIP)
 
 - Goal-loop: H866 (Ch. 6 A02+A33 interleave) landed; 12 of 14 now in book form. Only the two
@@ -50,6 +47,15 @@ _Created: 07-07-2026 · Last updated: 13-07-2026_
 
 ## ✅ Completed (Recent only)
 
+- 17-07-2026 ([H1078](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1078-Fable_SanskritLexicography_m01-ch2-corpus-methods-section_16.07.26.md),
+  Fable 5 `claude-fable-5`): **Ch. 2 §6 "The corpus as a bounded witness" written** (~7 pp.,
+  book-only) into
+  [chapters/ch02_measurement_framework.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch02_measurement_framework.md)
+  — DCS disclosure (5,688,416 content tokens · 270 texts · 95,457 lemmas · 41.9 % hapax, per
+  the committed VisualDCS census), the absence-inference rule, the five-clause
+  statistical-practice contract, and the Ch. 3/5/11/13 binding map; old §6–§9 → §7–§10.
+  Proposal ToC, BOOK_PLAN §11, crosswalk §4.2, and BOOK_PLAN.meta backlog ticked same pass.
+  The queue item "Ch. 2 corpus-methods section" is done and removed above.
 - 13-07-2026 ([H866](https://github.com/gasyoun/Uprava/blob/main/handoffs/H866-Opus_SanskritLexicography_ch06_a02_a33_senses_inheritance_and_order_merge_book_conversion_13.07.26.md),
   Opus 4.8 `claude-opus-4-8[1m]`): **Ch. 6 written as a genuine MERGE of A02 + A33** —
   [chapters/ch06_senses_inheritance_and_order.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch06_senses_inheritance_and_order.md).

--- a/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md
@@ -1,6 +1,6 @@
 # How to Make the Brill Book — *Digital Sanskrit Lexicography*
 
-_Created: 06-07-2026 · Last updated: 11-07-2026_
+_Created: 06-07-2026 · Last updated: 17-07-2026_
 
 A build plan for a single-authored English monograph at Brill, drawn from work already
 committed across the `sanskrit-lexicon` / `gasyoun` GitHub repos, and coordinated with
@@ -397,6 +397,12 @@ is resolved as **(b) — a marked section inside Ch. 2** ("The corpus as a bound
 ~6–8 pp.), *not* a standalone chapter. The 14-chapter/15-article architecture is unchanged;
 the DCS-disclosure + statistical-practice + absence-inference material is written into Ch. 2
 at its next revision. Both `@DECIDE` forks from H505 are now closed.
+**✍️ Written 17-07-2026** (H1078, Fable 5 `claude-fable-5`):
+[ch02 §6 *The corpus as a bounded witness*](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch02_measurement_framework.md)
+— §6.1 DCS disclosure (5,688,416 content tokens · 270 texts · 95,457 lemmas · 41.9 % hapax),
+§6.2 the absence-inference rule, §6.3 the five-clause statistical contract, §6.4 the binding
+map. Cited by Ch. 3/5/11/13 (the post-merge numbering of the "Ch. 3/5/12/14" named in the
+15-chapter-era fork text); ch02's old §6–§9 renumbered §7–§10.
 
 **Done 13-07-2026 (H846 execution, Opus 4.8 `claude-opus-4-8`):**
 - ✅ **Ch. 1 converted journal→book** →

--- a/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.meta.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.meta.md
@@ -1,6 +1,6 @@
 # BOOK_PLAN.meta.md — metadoc for `BOOK_PLAN.md`
 
-_Created: 13-07-2026 · Last updated: 13-07-2026_
+_Created: 13-07-2026 · Last updated: 17-07-2026_
 
 This is a **metadoc** — a document *about* a document. Its subject is
 [BOOK_PLAN.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md),
@@ -88,7 +88,7 @@ Who consults this document and for what — and what the book plus its committed
 |---|---|---|---|
 | 1 | **Ch. 3 ← A40** — write the CDSL-headword-inventory + corpus-grounding chapter from data | one of two chapters not yet in book form; A40 is data-only (no article prose to convert) — genuine first-drafting atop [HeadwordLists/NOW_VS_THEN.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/NOW_VS_THEN.md) + union_headwords.tsv + dcs_cdsl_xref.tsv; **mandatory** McEnery & Brezina corpus-absence/representativeness reframe | queued — own focused session |
 | 2 | **Ch. 11 ← A50** — write the `<ls>` citation-frequency-graph chapter from data | A50 is a readiness-2/5 **skeleton** (prose 1/5); its §4 tradition-profiles rest on an **inferred map, 0/119 human-reviewed** that must NOT be asserted as fact yet; needs the review gate cleared or the section written as explicitly inferred; **mandatory** significance-at-N=828K (effect-sizes-not-p-values) reframe | queued (gated on human review of `tradition_tags.tsv`) |
-| 3 | **Ch. 2 corpus-methods section** — write the ~6–8 pp. "The corpus as a bounded witness" section into ch02 | MG ruled (b) on 13-07-2026 (fold, not a standalone chapter); the DCS-disclosure + statistical-practice + absence-inference material is owed at ch02's next revision | queued (H867 next-steps) |
+| 3 | **Ch. 2 corpus-methods section** — write the ~6–8 pp. "The corpus as a bounded witness" section into ch02 | MG ruled (b) on 13-07-2026 (fold, not a standalone chapter); the DCS-disclosure + statistical-practice + absence-inference material is owed at ch02's next revision | ✅ **done 17-07-2026** (H1078, Fable 5 `claude-fable-5`) — [ch02 §6](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch02_measurement_framework.md) |
 | 4 | **FAIR/DOI sprint** — Zenodo-deposit every cited dataset, re-mint the false correction-dataset DOI, get the DCS denominator DOI (Hellwig sign-off), add CITATION.cff to kosha/SanskritLexicography/SanskritRussian | the real critical path — nothing citable ships without it; the DOI *minting* is a human/credentials @DO | ⏸ **deferred by MG to ~09-08-2026** |
 | 5 | **Front/back matter** — Introduction, 5 Part-bridges, Conclusion, unified method appendix, index | the genuine remaining new-writing load once the 14 chapters exist (BOOK_PLAN §4); the comparative part-bridge is upgraded by the crosswalk §4.1 (Baalbaki/Ferri/Dickey) | queued |
 | 6 | **κ / second-annotator** — one recruitment fixes the "reviewed"-claim reliability gap | the evidence-graded thesis's own selling point has unmeasurable reliability at n=1 reviewer (BOOK_PLAN §6/§9) | parked — human/recruitment @DO |
@@ -149,5 +149,6 @@ Who consults this document and for what — and what the book plus its committed
 | Date | Event | Who (tier + version) |
 |---|---|---|
 | 13-07-2026 | Metadoc created; captures the 13-07-2026 conversion wave (2→12 chapters in book form, H846–H866), the two locked MG rulings, the use-cases inventory, and the ranked backlog (Ch. 3 / Ch. 11 / ch02-section / DOI / matter) | H867, Opus 4.8 `claude-opus-4-8[1m]` |
+| 17-07-2026 | Backlog #3 closed: ch02 §6 *The corpus as a bounded witness* written (~7 pp., DCS disclosure + absence-inference rule + statistical contract + Ch. 3/5/11/13 binding map); BOOK_PLAN §11 and the crosswalk §4.2 carry the ✍️-written notes with the 15→14-chapter consumer-numbering mapping | H1078, Fable 5 `claude-fable-5` |
 
 _Dr. Mārcis Gasūns_

--- a/Digital_Sanskrit_Lexicography-BOOK/BRILL_PROPOSAL.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/BRILL_PROPOSAL.md
@@ -1,6 +1,6 @@
 # Book proposal — *Digital Sanskrit Lexicography: The Dictionary as a Layered Evidence Graph*
 
-_Created: 08-07-2026 · Last updated: 10-07-2026_
+_Created: 08-07-2026 · Last updated: 17-07-2026_
 
 Draft proposal for the single-authored monograph **M01**, built to the
 [Brill Book Proposal Guidelines](https://brill.com/fileasset/downloads_products/brill_bookproposal_guidelines.pdf)
@@ -97,6 +97,10 @@ thesis stated; a roadmap of the book.
   "two metalanguages" motif.
 - **Ch. 2 · The Measurement Framework** *(← A01, 4/5).* The methodological spine: evidence
   grading, reproducibility, the graph model. The apparatus the later chapters lean on.
+  Carries the marked section *The corpus as a bounded witness* (~7 pp., book-only new
+  writing; ruled 13-07-2026, written 17-07-2026): the DCS corpus disclosure, the
+  absence-inference rule, and the statistical-practice contract that Ch. 3/5/11/13 cite
+  instead of restating.
 
 ### Part II — Macrostructure: the shape of the dictionary
 

--- a/Digital_Sanskrit_Lexicography-BOOK/CHANGELOG.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/CHANGELOG.md
@@ -1,11 +1,36 @@
 # Digital Sanskrit Lexicography (Brill monograph) — changelog
 
-_Created: 07-07-2026 · Last updated: 13-07-2026_
+_Created: 07-07-2026 · Last updated: 17-07-2026_
 
 Tracks changes to the book build plan and any future manuscript/front-matter drafts in this
 folder. Registry ID **M01** in [Uprava/ARTICLES.md](https://github.com/gasyoun/Uprava/blob/main/ARTICLES.md).
 
 ## [Unreleased]
+
+### Added — 17-07-2026 (H1078, ch02 corpus-methods section)
+
+- **Ch. 2 §6 *The corpus as a bounded witness* written** (~7 pp., book-only new writing —
+  the execution of MG's 13-07-2026 ruling (b) on the
+  [crosswalk §4.2](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/LITERATURE_CROSSWALK.md)
+  fork) →
+  [chapters/ch02_measurement_framework.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch02_measurement_framework.md).
+  Status-boxed as the book's single canonical corpus-epistemics statement: **§6.1** the DCS
+  disclosure (release 2026: 5,688,416 content tokens · 270 texts · 95,457 disambiguated
+  lemmas · 41.9 % hapax share, 42.3 % of hapaxes transparent samāsa — per the committed
+  [VisualDCS census](https://github.com/gasyoun/VisualDCS/blob/main/derived-data/Leksicheskie-issledovaniya/Gapaksy-DCS-2026/README.md);
+  size floor, no sampling frame); **§6.2** the absence-inference rule (bounded DCS-coverage
+  statements, never "non-existent" — McEnery & Brezina induction caveat; Ch. 13's 484-of-709
+  épigraphique vs 0 % jaina as the worked coverage-boundary case); **§6.3** the five-clause
+  statistical-practice contract (effect size first / dispersion / denominators / minimally
+  sufficient statistics / negative results visible — Kilgarriff 2005, Egbert-Larsson-Biber);
+  **§6.4** the binding map (Ch. 3/5/11/13 cite, never restate). Old §6–§9 renumbered
+  §7–§10; provenance headnote marks §6 as the one book-only exception to
+  "carried over unchanged"; 9 references added (McEnery & Brezina, Kilgarriff, Biber,
+  Reppen, Walter, O'Keeffe & McCarthy, Desagulier, Egbert-Larsson-Biber, Hellwig DCS).
+  Proposal ToC (Ch. 2 bullet), BOOK_PLAN §11, crosswalk §4.2 (with the 15→14-chapter
+  consumer-numbering mapping made explicit), and the BOOK_PLAN.meta backlog all ticked in
+  the same pass. **All new-writing owed to the 12 committed chapters is now done; only the
+  two data chapters (Ch. 3, Ch. 11) remain unwritten.**
 
 ### Added — 13-07-2026 (H867, BOOK_PLAN metadoc)
 

--- a/Digital_Sanskrit_Lexicography-BOOK/LITERATURE_CROSSWALK.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/LITERATURE_CROSSWALK.md
@@ -1,6 +1,6 @@
 # M01 literature crosswalk — the 37-manual library against the book plan
 
-_Created: 10-07-2026 · Last updated: 10-07-2026_
+_Created: 10-07-2026 · Last updated: 17-07-2026_
 
 The book-scoped deliverable of handoff
 [H505](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H505-Fable_SanskritLexicography_m01_literature_crosswalk_gap_audit_10.07.26.md):
@@ -254,6 +254,14 @@ Ch. 3/5/12/14; the risk noted under (b) (a caveat buried where a referee is leas
 re-read) is mitigated by keeping the section clearly marked and cross-referenced from every
 chapter that leans on it. This section is written when Ch. 2 is next revised; it does not
 alter the locked spine.
+**✍️ Written 17-07-2026 (H1078, Fable 5 `claude-fable-5`):**
+[ch02 §6 *The corpus as a bounded witness*](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch02_measurement_framework.md)
+— a marked, status-boxed section carrying the DCS disclosure (§6.1), the absence-inference
+rule (§6.2), the five-clause statistical-practice contract (§6.3), and the binding map
+(§6.4). The consumers "Ch. 3/5/12/14" above are the 15-chapter-era numbers; in the
+post-merge 14-chapter spine they are **Ch. 3 (headword inventory), Ch. 5 (block economy),
+Ch. 11 (citation-frequency graph), Ch. 13 (Renou's registers)**, and the section names them
+by title so the mapping cannot drift again.
 
 ### 4.3 Rejected candidates (considered, not recommended)
 

--- a/Digital_Sanskrit_Lexicography-BOOK/chapters/ch02_measurement_framework.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/chapters/ch02_measurement_framework.md
@@ -1,6 +1,6 @@
 # Chapter 2 — The Measurement Framework: Measuring the Dictionary Family
 
-_Created: 09-07-2026 · Last updated: 12-07-2026_
+_Created: 09-07-2026 · Last updated: 17-07-2026_
 
 > **Provenance.** This chapter is the book-form version of the article *Measuring the
 > Dictionary Family: A Traceable Measurement Framework for Computational Lexicography*
@@ -9,8 +9,13 @@ _Created: 09-07-2026 · Last updated: 12-07-2026_
 > which is being published separately in a journal version; where the article must remain
 > independently citable, cite that version. Every figure and measured number below is
 > carried over from the article unchanged; only the framing has been converted from
-> journal to book form. Section numbering is chapter-internal (§1–§9); the book-wide
-> renumbering and bibliography merge are a later production pass.
+> journal to book form — with one exception: **§6, *The corpus as a bounded witness*, is
+> book-only new writing** with no counterpart in the journal article, added 17-07-2026
+> under the corpus-methods ruling of 13-07-2026
+> ([LITERATURE_CROSSWALK.md §4.2](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/LITERATURE_CROSSWALK.md));
+> its figures are carried unchanged from the committed corpus artifacts cited in place.
+> Section numbering is chapter-internal (§1–§10); the book-wide renumbering and
+> bibliography merge are a later production pass.
 
 The Introduction stated this book's thesis: a digital dictionary is not a text but a
 **layered evidence graph**, in which every lexicographic statement — headword, sense,
@@ -49,8 +54,12 @@ makes each metric publishable and re-checkable (§4), and a routing discipline t
 claims falsifiable and inside their bounds (§5) — and one governing commitment, stated
 once here and assumed everywhere in this book: **every claim is a traceable
 `Claim → Evidence → Source` path, and an automated measurement only proposes; a human
-ratifies before anything is written back to the canonical text.** §6 walks a single
-inheritance edge through all three layers on real data.
+ratifies before anything is written back to the canonical text.** To the three layers
+this book adds one standing disclosure, stated once and thereafter cited rather than
+restated: §6, *The corpus as a bounded witness*, fixes what the reference corpus behind
+every attestation claim can and cannot testify to, and the statistical practice every
+quantitative chapter follows. §7 then walks a single inheritance edge through the three
+layers on real data.
 
 **This is not a measurement framework for the *project*.** A well-known and worthwhile
 programme — quantifying the *production* of a digital edition through repository-health
@@ -252,7 +261,7 @@ on both the semantic partition and the size of its formal remainder — which is
 precisely the property a cross-epoch measurement scaffold needs.
 
 The point of stating these together is that they are **independent estimators of
-relatedness and structure**, not facets of one similarity score. §6 shows why that
+relatedness and structure**, not facets of one similarity score. §7 shows why that
 independence matters.
 
 ## 4. The traceability layer
@@ -304,7 +313,168 @@ granularity-inflation hypothesis became its own refutation); and thresholds, pan
 proxies are reported as bounds, not point measurements. These are not editorial niceties —
 they are the difference between a measurement and an over-reading.
 
-## 6. A worked example: one edition edge, end to end
+## 6. The corpus as a bounded witness
+
+> **Status.** This section is the book's single, canonical statement of what its
+> reference corpus can and cannot witness, and of the statistical practice every
+> quantitative chapter observes. The corpus-facing chapters — the headword inventory
+> (Ch. 3), the Monier-Williams entry benchmark (Ch. 5), the citation-frequency graph
+> (Ch. 11), and the register study (Ch. 13) — cite this section instead of restating it,
+> and every other chapter that touches corpus attestation inherits it the same way. If a
+> passage anywhere in this book appears to claim more from a corpus figure than this
+> section licenses, this section wins.
+
+The metrics of §3 measure the dictionaries against each other. Several chapters go a
+step further and measure the dictionaries against **text**: whether a headword is
+attested in a corpus at all, how often, and in which registers. The moment the framework
+takes that step it acquires a fourth witness — not a dictionary but a corpus — and that
+witness must be examined under the same floor-and-ceiling discipline §3 imposes on every
+estimator: what it is, what it can testify to, and what no honest reading can extract
+from it. Corpus linguistics has stated this discipline for decades (McEnery and Brezina
+2022 is the current synthesis); this section fixes its consequences for this book once,
+so that no later chapter has to re-derive them — and no later chapter can quietly
+outrun them.
+
+### 6.1 The witness disclosed
+
+Every attestation figure in this book is computed against one corpus: the **Digital
+Corpus of Sanskrit** (DCS; Hellwig 2010–), release 2026 — the only large lemmatized,
+morphologically disambiguated corpus of Sanskrit in existence, and the de-facto
+substrate of computational Sanskrit studies. The committed snapshot used throughout
+holds **5,688,416 content tokens (punctuation excluded) across 270 texts**, with an
+attested vocabulary of **95,457 distinct disambiguated lemmas**. Within the evidence
+graph, this corpus supplies the attestation layer — the "corpus attestation where
+available" of the book's thesis statement — and every figure drawn from it is `derived`
+in the sense of §4: a deterministic count over a pinned snapshot, enveloped and walkable
+like every other artifact. Three properties of this witness bound everything it can say.
+
+**It is small — by lexicographic standards, very small.** The corpus-lexicography
+literature puts the working size for *sense-level* dictionary evidence at tens to
+hundreds of millions of words (Biber 1993; Reppen 2010; Walter 2010): a sense is
+captured only when a lemma is attested often enough for its uses to cluster into
+patterns, which is why the corpus-driven dictionaries of the COBUILD line were built on
+corpora three orders of magnitude larger than anything available for Sanskrit. DCS's
+5.7 million tokens sit one to two orders of magnitude below that floor. The consequence
+is not that the corpus is useless; it is that DCS can witness **attestation and
+distribution** — this lemma occurs, in these texts, this often — but cannot adjudicate
+**sense inventories**, and no chapter of this book asks it to. Where the graph records
+corpus attestation for a headword, the datum is a presence signal with a frequency,
+never a semantic verdict.
+
+**It has no sampling frame.** DCS is an opportunistic corpus: it grew over two decades
+by what had been digitized, philologically edited, and morphologically tagged, not by a
+design that samples the language's registers in known proportions — representativeness
+in Biber's (1993) sense is not claimed by its maker and cannot be claimed on its behalf.
+Epic and śāstric prose dominate; inscriptions are absent by construction, since DCS is a
+corpus of *literary* transmission; documentary, lyric, and technical registers enter
+only as far as tagging projects have reached them. An absence can therefore reflect the
+language, the archive, or merely the tagging queue — and nothing in the corpus itself
+says which.
+
+**Its own frequency structure guarantees absence.** In the committed hapax census of the
+2026 release, **39,987 of the 95,457 attested lemmas — 41.9 % — occur exactly once**,
+and 78.3 % occur fewer than ten times, while 0.8 % of lemmas carry most of the tokens:
+textbook Zipf. A vocabulary whose attested half is this rare is the visible edge of a
+much larger unseen mass — the next million tokens of tagged Sanskrit would, with
+certainty, surface thousands of lemmas the current corpus has never seen. Productive
+morphology sharpens the point: 42.3 % of those hapaxes are transparent nominal
+compounds, hapax only because samāsa formation mints new types on demand. Against such a
+distribution, the absence of any *particular* lemma is the expected continuation of the
+frequency curve, not a fact demanding a special explanation.
+
+### 6.2 The absence-inference rule
+
+The tempting move — the one a dictionary-versus-corpus comparison invites on every
+page — runs: *this headword is unattested in the corpus, therefore it is a
+lexicographers' phantom; that dictionary stratum is two-thirds unattested, therefore it
+records vocabulary that never existed.* McEnery and Brezina (2022) dissect this as the
+problem of induction writ large: a corpus is a finite sample of performance, and
+non-occurrence in a sample is not non-existence in the language. §6.1 gives the local
+reasons the inference fails here with unusual force: the corpus sits below the size
+floor (absence is under-powered), it has no sampling frame (absence may measure the
+archive), and its frequency structure makes absence the statistical default (absence is
+expected). In a 5.7-million-token corpus, a lemma that is merely *rare* and a lemma that
+is truly *absent from the language* are observationally indistinguishable — the mirror
+of the neologism caveat in corpus-based dictionary-making (Walter 2010). The inference
+would begin to bear weight only where the corpus could be shown to cover the relevant
+register at known depth — a condition met nowhere in this family today.
+
+This book therefore operates under one rule, stated here once:
+
+> **The absence-inference rule.** Every corpus-absence figure in this book is a bounded
+> statement about **DCS coverage** — never about the Sanskrit language, and never about
+> a dictionary's veracity. It travels with its denominator and its register or source
+> composition where known, and it is phrased as *unattested in DCS*, never as
+> *non-existent*.
+
+The rule has a positive half. Precisely because absence measures coverage,
+*differential* absence is informative — about the corpus and about the dictionaries, the
+two things actually in view. Chapter 13 supplies the worked case: of 709 headwords the
+Petersburg lexicographers tagged *épigraphique*, 484 (68.3 %) have no DCS attestation,
+against 0 % for the *jaina*-tagged stratum — and the contrast reads straight off the
+witness's own boundary, since DCS includes Jaina literary texts and, by construction, no
+inscriptions. The register label predicts the corpus hole; the absence rate maps the
+edge of the witness's competence; and that map is itself a publishable finding — an
+agenda for digitization, not a verdict on the lexicographers. Chapter 3 does the same
+corpus-wide: its per-dictionary absence rates (from 69.8 % for the Vedic index VEI down
+to 14.1 % for the Śabdakalpadruma) are read throughout as coverage geometry — which
+strata of the dictionary record the corpus can currently see — under exactly this rule.
+
+### 6.3 The statistical-practice contract
+
+The second discipline concerns not what a figure means but how it is reported. At corpus
+scale, classical significance testing stops discriminating: with N in the hundreds of
+thousands, any non-trivial difference "rejects" at any conventional threshold, because
+language is never random (Kilgarriff 2005). Chapter 11 operates on 828,505 citations;
+several estimators of §3 run over a million and a half entries. At these sizes a bare
+p-value is not evidence but decoration. Every quantitative chapter of this book
+therefore observes five clauses:
+
+1. **Effect size first, test second.** The claim is always a magnitude — a difference, a
+   ratio, a containment, an association strength — with an uncertainty interval where
+   the estimator admits one; a p-value may appear only beside its effect size and its N,
+   never alone (the "new statistics" of McEnery and Brezina 2022; Desagulier 2017 for
+   the working practice).
+2. **Dispersion before generalization.** A corpus-wide or family-wide rate whose signal
+   rides on one text, one edge, or one dictionary is reported as exactly that: §3.3's
+   sense-survival gap is stated as citation-concentrated — 82 of 84 cited senses sit on
+   a single edge — rather than as a family fact.
+3. **Denominators travel with figures.** No naked percentages: 68.3 % arrives as
+   484-of-709, granularity proxies arrive with their ±13 % validation bound, and
+   normalized rates state their base (per 1,000 entries, §3.8).
+4. **Minimally sufficient statistics.** The simplest statistic that answers the question
+   (Egbert, Larsson, and Biber 2020); fitted models appear only where a confound
+   genuinely requires a control — §3.3's cluster-robust refit — never as ornament.
+5. **Negative results stay visible.** The routing layer's anti-over-claim rule (§5)
+   applies to statistics too: a hypothesis that dies — the granularity-inflation reading
+   refuted in §3.3 — is reported as its own finding, not silently dropped.
+
+The book already contains the contract's instances: Chapter 5's benchmark reports κ and
+per-type precision with its definitional boundaries disclosed; Chapter 14 reports
+Cramér's V beside its χ² rather than the χ² alone; §3.3 above reports a two-sided
+p ≈ 0.07 as suggestive but not significant, *with* its concentration caveat. Chapter 11,
+drafted after this contract was fixed, is written to it from the first figure.
+
+### 6.4 Where the discipline binds
+
+Four chapters lean on this section by name and cite it rather than restating it:
+
+- **Chapter 3 — the headword inventory.** The corpus-grounding bridge: per-dictionary
+  DCS-absence rates read as coverage geometry under §6.2, never as phantom rates.
+- **Chapter 5 — the Monier-Williams entry benchmark.** Benchmark statistics (κ, per-type
+  precision and recall, gold-sample construction) reported under §6.3's
+  interval-and-disclosure clauses.
+- **Chapter 11 — the citation-frequency graph.** N = 828,505: effect sizes,
+  normalization, and dispersion in place of bare significance, per §6.3.
+- **Chapter 13 — Renou's registers.** The worked case of the absence-inference rule:
+  68.3 % as a coverage boundary, with the register labels supplying the map.
+
+Every other chapter that touches corpus attestation — and any future one that will —
+inherits the same two disciplines by citing this section. That is the sense in which the
+corpus is this framework's bounded witness: fully admitted, heard on everything it can
+see, and never asked to testify beyond it.
+
+## 7. A worked example: one edition edge, end to end
 
 Take the single inheritance edge from Apte's 1890 *Practical Sanskrit–English Dictionary*
 (AP90) to its 1957 revised expansion (AP) — a *documented* edition continuity, used here
@@ -340,11 +510,11 @@ very similar" but could neither separate the carried word list from the inherite
 from the revised senses, nor expose that the headword containment alone is
 size-confounded. The framework's value is exactly this refusal to average.
 
-## 7. Discussion
+## 8. Discussion
 
 **Why a framework, not a pile of metrics.** Any one estimator above is unremarkable.
 Their value is that they are *independent* and *traceable*: when three of them agree on
-an edge (§6), the agreement is evidence; when one contradicts the others, the
+an edge (§7), the agreement is evidence; when one contradicts the others, the
 contradiction is locatable. A single fused score destroys both properties. The framework
 is the commitment to keep the estimators separate and every number walkable to its
 source.
@@ -355,7 +525,11 @@ headword-overlap, citation-resolvability, cross-reference, and structural questi
 faces the same temptation to publish a number a reader cannot check. The envelope, the
 three evidence levels, the trust block, and the review gate are a low-ceremony
 alternative to ad-hoc data releases, implementable in any static-site or notebook
-pipeline.
+pipeline. The corpus discipline of §6 transfers just as directly, because its premise —
+a reference corpus one to two orders of magnitude below the lexicographic size floor —
+is the *normal* condition of historical languages, not a Sanskrit misfortune: only the
+facts of the disclosure change; the bounded-witness rule and the statistical contract
+port verbatim.
 
 **Relation to existing practice.** The questions behind the descent metrics are
 classical. That Monier-Williams depends on the Petersburg lexica has been established
@@ -385,7 +559,7 @@ function of the committed source (Peng 2011; Sandve et al. 2013). The contributi
 *granularity and the enforcement* — every artifact, every build — rather than a new
 principle.
 
-## 8. Limitations
+## 9. Limitations
 
 - **The catalog is the atlas's catalog.** Ten estimators cover the questions this project
   has asked; a different family might need others. The framework is the *discipline*, not
@@ -403,14 +577,21 @@ principle.
 - **`model-pending` is a promissory note.** The evidence-level discipline keeps neural
   cross-checks out of the build, but a cross-check that never reaches human review adds no
   evidence; the gate must actually be worked.
+- **The corpus disclosure maps known holes; it does not estimate bias.** §6 bounds what
+  an absence may claim and fixes statistical practice, but it does not quantify DCS's
+  sampling bias — there is no held-out digitization test. The coverage boundary is
+  visible only where a register or source label exposes it (Chapter 13's épigraphique
+  stratum is the worked case); unlabelled holes remain invisible by construction.
 
-## 9. Conclusion
+## 10. Conclusion
 
 A digital dictionary family is only as credible as the toolkit that measures it and the
 trail that leads from each published number back to a dictionary line. I have described
 that toolkit as three reusable layers — ten independent, operationally-defined
 estimators; a traceability discipline that envelopes, grades, and gates every datum; and
-a routing discipline that keeps each claim falsifiable and in its lane — under one rule:
+a routing discipline that keeps each claim falsifiable and in its lane — plus one
+standing disclosure (§6) that keeps every attestation reading inside what a
+5.7-million-token witness can actually testify to — under one rule:
 every claim is a `Claim → Evidence → Source` path, and the machine only ever proposes.
 Walked end to end on a single edition edge, the framework turns "these two dictionaries
 are similar" into three independent, separately-bounded, source-linked statements that
@@ -433,16 +614,42 @@ Bender, Emily M., and Batya Friedman. 2018. "Data Statements for Natural Languag
 Processing: Toward Mitigating System Bias and Enabling Better Science." *Transactions of
 the Association for Computational Linguistics* 6: 587–604.
 
+Biber, Douglas. 1993. "Representativeness in Corpus Design." *Literary and Linguistic
+Computing* 8 (4): 243–257.
+
+Desagulier, Guillaume. 2017. *Corpus Linguistics and Statistics with R: Introduction to
+Quantitative Methods in Linguistics.* Cham: Springer.
+
+Egbert, Jesse, Tove Larsson, and Douglas Biber. 2020. *Doing Linguistics with a Corpus:
+Methodological Considerations for the Everyday User.* (Elements in Corpus Linguistics.)
+Cambridge: Cambridge University Press.
+
 Hanneder, Jürgen. 2020. "Woher hat er das? Zum Charakter des *Sanskrit-English
 Dictionary* von Monier-Williams." *Zeitschrift der Deutschen Morgenländischen
 Gesellschaft* 170 (1): 107–117.
+
+Hellwig, Oliver. 2010–. *DCS — The Digital Corpus of Sanskrit.*
+[www.sanskrit-linguistics.org/dcs/](https://www.sanskrit-linguistics.org/dcs/) (release
+2026, CC BY-SA).
+
+Kilgarriff, Adam. 2005. "Language Is Never, Ever, Ever, Random." *Corpus Linguistics and
+Linguistic Theory* 1 (2): 263–276.
 
 Lebo, Timothy, Satya Sahoo, and Deborah McGuinness (eds.). 2013. *PROV-O: The PROV
 Ontology.* W3C Recommendation, 30 April 2013.
 [www.w3.org/TR/prov-o/](https://www.w3.org/TR/prov-o/).
 
+McEnery, Tony, and Vaclav Brezina. 2022. *Fundamental Principles of Corpus Linguistics.*
+Cambridge: Cambridge University Press.
+
+O'Keeffe, Anne, and Michael McCarthy (eds.). 2010. *The Routledge Handbook of Corpus
+Linguistics.* London and New York: Routledge.
+
 Peng, Roger D. 2011. "Reproducible Research in Computational Science." *Science* 334
 (6060): 1226–1227.
+
+Reppen, Randi. 2010. "Building a Corpus: What Are the Key Considerations?" In O'Keeffe
+and McCarthy 2010.
 
 Sandve, Geir Kjetil, Anton Nekrutenko, James Taylor, and Eivind Hovig. 2013. "Ten Simple
 Rules for Reproducible Computational Research." *PLOS Computational Biology* 9 (10):
@@ -451,6 +658,9 @@ e1003285.
 Setiawan, David, Temuulen Khishigsuren, Milind Agarwal, Pagnarith Pit, Aso Mahmudi, and
 Ekaterina Vylomova. 2026. "MUDIDI: A Two-Stage Framework for Multilingual Dictionary
 Digitization with Language Models." arXiv:2606.09435.
+
+Walter, Elizabeth. 2010. "Using Corpora to Write Dictionaries." In O'Keeffe and McCarthy
+2010.
 
 Wiegand, Herbert Ernst. 1989. "Der Begriff der Mikrostruktur: Geschichte, Probleme,
 Perspektiven." In Hausmann, Reichmann, Wiegand and Zgusta (eds.), *Wörterbücher /
@@ -480,7 +690,10 @@ corpus figures §3.2 anchors); *Two Citation Registers* (Ch. 10, citation regist
 likewise). Each instantiates one or more of the metrics in §3
 under the discipline of §§4–5; where this chapter quotes a sibling's headline figure
 (§3.2, §3.4), the sibling chapter owns the full result and this chapter owns only the
-metric's definition.
+metric's definition. The corpus-facing chapters — *The Headword Inventory* (Ch. 3),
+*The Block Economy of Monier-Williams* (Ch. 5), *What the Tradition Cites* (Ch. 11), and
+*Renou's Registers* (Ch. 13) — additionally cite §6's bounded-witness rule and
+statistical contract rather than restating them (§6.4).
 
 *[Data note, 2026-07-03: every §3 anchor is walkable to a committed enveloped artifact.
 §3.4's corpus figures are regenerated from
@@ -492,6 +705,16 @@ metric's definition.
 (generator
 [`scripts/obs/headword_multiplicity.py`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/scripts/obs/headword_multiplicity.py),
 now format-aware for the `<s>`-less nmmb kośa added to csl-orig in 2026-06; the
-previously doc-sourced 409,649 reflected the pre-nmmb corpus).]*
+previously doc-sourced 409,649 reflected the pre-nmmb corpus). §6's corpus figures are
+per the committed DCS 2026 snapshot and hapax census in the sibling VisualDCS
+repository: the 270-text snapshot import per the
+[VisualDCS CHANGELOG](https://github.com/gasyoun/VisualDCS/blob/main/CHANGELOG.md); the
+5,688,416 content tokens, the 95,457-lemma vocabulary, its frequency bands, and the
+39,987-hapax census (41.9 %, compound split 42.3 %) per
+[Gapaksy-DCS-2026](https://github.com/gasyoun/VisualDCS/blob/main/derived-data/Leksicheskie-issledovaniya/Gapaksy-DCS-2026/README.md)
+(generator
+[`gen_dcs_hapax.py`](https://github.com/gasyoun/VisualDCS/blob/main/derived-data/Leksicheskie-issledovaniya/Gapaksy-DCS-2026/gen_dcs_hapax.py),
+deterministic, no network). Chapter 13's 484-of-709 épigraphique figure and Chapter 3's
+per-dictionary absence range are owned by those chapters and quoted here under §6.2.]*
 
 _Dr. Mārcis Gasūns_

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,24 @@ not an error.
 
 ## [Unreleased]
 
+## [1.14.0] — 17-07-2026
+
+### Added
+- **M01 Ch. 2 §6 *The corpus as a bounded witness* — the monograph's canonical corpus-epistemics section (17-07-2026, Fable 5 `claude-fable-5`, H1078)**:
+  executes MG's 13-07-2026 ruling (b) on the corpus-methods fork
+  ([LITERATURE_CROSSWALK.md §4.2](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/LITERATURE_CROSSWALK.md)).
+  ~7 pp. of book-only new writing in
+  [ch02_measurement_framework.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch02_measurement_framework.md):
+  the DCS 2026 disclosure (5,688,416 content tokens · 270 texts · 95,457 disambiguated
+  lemmas · 41.9 % hapax share, per the committed
+  [VisualDCS census](https://github.com/gasyoun/VisualDCS/blob/main/derived-data/Leksicheskie-issledovaniya/Gapaksy-DCS-2026/README.md)),
+  the absence-inference rule (bounded DCS-coverage statements, never "non-existent" —
+  McEnery & Brezina), the five-clause statistical-practice contract (effect sizes, not bare
+  p-values at corpus N — Kilgarriff 2005), and the Ch. 3/5/11/13 binding map; ch02's old
+  §6–§9 renumbered §7–§10, 9 references added. Proposal ToC (Ch. 2 bullet), BOOK_PLAN §11,
+  crosswalk §4.2 (15→14-chapter consumer numbering made explicit), BOOK_PLAN.meta backlog
+  #3 and the book CHANGELOG all ticked in the same pass.
+
 ## [1.13.0] — 17-07-2026
 
 ### Added


### PR DESCRIPTION
Executes [H1078](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1078-Fable_SanskritLexicography_m01-ch2-corpus-methods-section_16.07.26.md) — MG's 13-07-2026 ruling (b) on the corpus-methods fork in [LITERATURE_CROSSWALK.md §4.2](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/LITERATURE_CROSSWALK.md): the corpus-absence/representativeness/statistics material folds into Ch. 2 as a marked section, not a standalone chapter.

## What's in the section (~7 pp., book-only new writing)

[chapters/ch02_measurement_framework.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch02_measurement_framework.md) gains **§6 *The corpus as a bounded witness***, status-boxed as the book's single canonical corpus-epistemics statement:

- **§6.1 The witness disclosed** — DCS release 2026: 5,688,416 content tokens · 270 texts · 95,457 disambiguated lemmas · 41.9 % hapax share (42.3 % of hapaxes transparent samāsa), per the committed [VisualDCS census](https://github.com/gasyoun/VisualDCS/blob/main/derived-data/Leksicheskie-issledovaniya/Gapaksy-DCS-2026/README.md); one-to-two orders of magnitude below the lexicographic size floor (Biber/Reppen/Walter); no sampling frame.
- **§6.2 The absence-inference rule** — every corpus-absence figure is a bounded DCS-coverage statement, never a claim about the language or a dictionary's veracity (McEnery & Brezina); worked case: Ch. 13's 484-of-709 épigraphique vs 0 % jaina as a coverage boundary.
- **§6.3 The statistical-practice contract** — five clauses: effect size first, dispersion before generalization, denominators travel, minimally sufficient statistics, negative results visible (Kilgarriff 2005; Egbert-Larsson-Biber 2020; Desagulier 2017).
- **§6.4 The binding map** — Ch. 3 / Ch. 5 / Ch. 11 / Ch. 13 cite the section instead of restating it (the post-merge numbering of the fork text's "Ch. 3/5/12/14", made explicit in the crosswalk).

Mechanics: old §6–§9 renumbered §7–§10 (all internal refs updated; sibling chapters only reference ch02 §3/§4, unaffected); provenance headnote marks §6 as the one book-only exception to "carried over unchanged"; 9 references added.

## Companion updates in the same pass

- [BRILL_PROPOSAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BRILL_PROPOSAL.md) — Ch. 2 ToC bullet now names the marked section.
- [BOOK_PLAN.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md) §11 + [LITERATURE_CROSSWALK.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/LITERATURE_CROSSWALK.md) §4.2 — ✍️-written notes with the 15→14-chapter consumer-numbering mapping.
- [BOOK_PLAN.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.meta.md) backlog #3 → done + revision-history row; book [CHANGELOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/CHANGELOG.md) + [.ai_state.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/.ai_state.md) updated.
- Root [changelog.md](https://github.com/gasyoun/SanskritLexicography/blob/master/changelog.md) gains **1.14.0** ([release](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.14.0); v1.12.0/v1.13.0 were taken by the concurrent H1073/H1074 promotions — rebased onto both).

Fable 5 (`claude-fable-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
