### PR TITLE
H1080 Step 2: stop the pwg_ru store corruption at its four sources (C-01/C-02/C-42/C-04)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -14,6 +14,31 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **H1080 Step 2 (C-01/C-02/C-42/C-04) — 🔵 PR OPEN 16-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`),
+  branch `h1080-step2`.** The four generator-side sources of the store corruption are closed and
+  the record contract now runs on live output; `window_selftest` **135/135 run, 134 pass** (the one
+  failure is the C-27 parity gate, red by design). **Two human gates block the rest — an agent
+  cannot clear either:**
+  1. **`@DECIDE` — the 468 `h: null` rows are NOT backfillable offline, so H1080's goal line
+     ("468 h==null rows backfilled from the content-addressed map") rests on a false premise and
+     Step 2 cannot complete as written.** Proven this pass: the value was destroyed at the flatten
+     before it was ever persisted — absent from the store, already `null` in the archived
+     `wf_output`, absent from real portraits (which carry no `h` despite their schema requiring
+     one), and the TM is built *from* the store (circular). `h` is free lexicographic text
+     (`"2. bhid"`, `"PW 3 (с anu, отсылка к entry 5)"`), differing from `key1` in 9,273 of 11,137
+     rows, so it cannot be synthesised — which C-02's boundary forbids anyway. **They need
+     re-translation (live calls).** Same for **74 of the 670 `{Tn}` rows**, whose recorded
+     `input_raw_sha256` matches no source on disk (the packet's "668 offline-recoverable" is
+     really **596**).
+  2. **`@DO` — LANG_PARITY reaffirmation.** Touching three SHARED files moves the ledger
+     **3 → 61** drift lines. Per C-27 no `--update-hash` was run. The fixes are SHARED (both
+     lanes) and need human reaffirmation + classification.
+  **Store NOT mutated** (still 11,605 rows):
+  [`src/backfill_tn_residue.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/backfill_tn_residue.py)
+  is dry-run only — 596 recoverable / 74 not — pending ruling 1. Also blocked upstream:
+  [PR #498](https://github.com/gasyoun/SanskritLexicography/pull/498) (the H963 evidence packet) is
+  still unmerged, so the handoff's `blob/master/.../h963/` links 404.
+
 - **H971 QA / methodology re-audit — 🔴 EXECUTED 15-07-2026 (Fable 5 `claude-fable-5`).**
   Deterministic half of the H178 protocol re-run on the grown store (11,261/50 → **11,605 rows / 67
   roots**): **NO REGRESSION** — window_selftest **131 PASS** (incl. `test_h920_*`/`test_h960_*` gate

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,43 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — H1080 / H963 packet Step 2 (C-01, C-02, C-42, C-04)
+
+- **One field set for restore and promote ([`src/card_fields.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/card_fields.py), C-01).**
+  `restore_card` and its JS twin unmasked 3 fields while `promote_final_cards.rows_for` read
+  6, so `card.iast` / `record.h` / `sense.tag` / `sense.differentia` were promoted with their
+  `{Tn}` intact — **670 of 11,605 store rows carry a raw placeholder, 223 of them a headword
+  reading literally `{T104}`** (re-verified against the live store this pass). Both lanes and
+  the promoter are now driven from one constant; the JS list is interpolated, not re-typed.
+  `promote_final_cards` additionally refuses any row still holding a `{Tn}`.
+- **The stitch keeps record identity (C-02).** Both stitch lanes built `records: [{senses}]`,
+  dropping record-level `h`/`grammar` unconditionally and collapsing homonyms into one flat
+  record — hence **468 rows / 20 sub-cards with `h: null`** (403 `batched-masked` + 65
+  `topup`). The flatten now carries each sense's owning `(h, grammar)` and `stitch_records`
+  rebuilds one record per owner, preserving document order.
+- **Out-of-range `{Tn}` is counted and refused (C-42).** `restore_text` returned an unmapped
+  token verbatim with no counter, no log and no reject; both lanes now count it and refuse
+  the card rather than promote known-corrupt content.
+- **The record contract runs on live output (C-04).** `validate_final_card_schema` — the only
+  component encoding `record.required = {h, grammar, senses}` — had **no live caller**: its
+  sole invocation was a CI step against a hand-made *passing* fixture. It is now wired into
+  `save_and_audit` **before** the write, with an explicit `--allow-schema-violations` escape
+  and a dead-validator canary. `RECORD_REQUIRED` is not relaxed.
+- **`window_selftest` no longer stops at the first failure.** The runner was a bare
+  `for test in tests: test()`, and the human-gated language-parity gate sits at position 105
+  of 131 — so **27 tests (20.6%) were dark indefinitely**, including `pwg_mask` and four
+  heal-lane tests. Now isolated, reporting `ran/defined`: **135/135 run, 134 pass**, the lone
+  failure being the parity gate that is red by design.
+
+### Added
+
+- [`src/backfill_tn_residue.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/backfill_tn_residue.py)
+  — offline re-derivation of the leaked `{Tn}` rows via `pwg_mask.mask(raw)` keyed by
+  `provenance.input_raw_sha256`, guarded by a SHA match plus a mask/restore round-trip.
+  Dry-run by default. Measured: **596 of 670 rows recoverable; 74 are not** (their recorded
+  content address matches no source on disk — the source drifted, so they need
+  re-translation). Not yet applied — see the handoff's `@DECIDE`.
+
 - **Provenance-bound mixed-lane requeues.** Each lease now seals its initial execution
   manifest as the immutable key universe and stores every pending retry key with the path
   and SHA-256 of the audit report that classified it. `record-output` rejects duplicate,

--- a/RussianTranslation/save_and_audit.py
+++ b/RussianTranslation/save_and_audit.py
@@ -26,7 +26,11 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 PILOT = os.path.join(HERE, "src", "pilot")
 if PILOT not in sys.path:
     sys.path.insert(0, PILOT)
+SRC = os.path.join(HERE, "src")
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
 from window_common import atomic_write_json
+import validate_final_card_schema          # C-04: the record contract, now on the LIVE path
 
 
 def main():
@@ -100,10 +104,48 @@ def main():
             sys.exit(f"REFUSED: {os.path.basename(out_path)} has {old_nn} non-null cards; new has "
                      f"only {new_nn}. Use --merge to fill nulls, or --force to overwrite.")
 
-    atomic_write_json(out_path, result, indent=None)
-
     cards = result.get("results", [])
     null_count = sum(1 for r in cards if not r.get("card"))
+
+    # C-04: enforce the record contract on LIVE output.
+    #
+    # `validate_final_card_schema` is the only component that encodes
+    # `record.required = {h, grammar, senses}`, and until now its single caller was a CI step
+    # running it against a hand-made PASSING fixture -- a green check certifying a contract no
+    # real card was ever measured against. That is why C-01 and C-02 accumulated in silence:
+    # 670 rows reached the canonical store with a raw {Tn}, and 468 with `h: null`, past a
+    # validator that would have refused every one of them.
+    #
+    # RECORD_REQUIRED is NOT relaxed to make this pass (nor is SENSE_REQUIRED "restored" --
+    # its relaxation was deliberate, matching the generation schema). A card that cannot state
+    # its own `h` is exactly what must not be saved.
+    violations = []
+    for r in cards:
+        card = r.get("card")
+        if not card:
+            continue                        # a null card is already counted above
+        try:
+            validate_final_card_schema.validate_card(card)
+        except ValueError as exc:
+            violations.append(f"  {r.get('key')}: {exc}")
+    if violations:
+        print(f"SCHEMA: {len(violations)} of {len(cards) - null_count} card(s) violate "
+              f"pwg_ru_final_card.schema.json:")
+        for v in violations[:20]:
+            print(v)
+        if "--allow-schema-violations" not in flags:
+            # Refuse BEFORE the write: a gate that reports "REFUSED" after already saving the
+            # file is not a gate.
+            sys.exit(
+                f"REFUSED: {len(violations)} card(s) violate the final-card record contract, "
+                f"nothing written. These would land in the canonical store unreadable by any "
+                f"consumer grouping on (key1, h). Fix the generator, or pass "
+                f"--allow-schema-violations to record the exception deliberately.")
+        print("SCHEMA: proceeding under --allow-schema-violations (violations recorded above)")
+    else:
+        print(f"SCHEMA: {len(cards) - null_count} card(s) satisfy the record contract")
+
+    atomic_write_json(out_path, result, indent=None)
     print(f"Saved {out_path}: {len(cards)} cards, {null_count} null")
 
     if "--no-audit" in flags:

--- a/RussianTranslation/src/backfill_tn_residue.py
+++ b/RussianTranslation/src/backfill_tn_residue.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+r"""Offline re-derivation of the `{Tn}` placeholders leaked into the canonical store (C-01).
+
+WHAT HAPPENED
+-------------
+`restore_card` unmasked three fields while `promote_final_cards.rows_for` read six, so
+`card.iast` / `record.h` / `sense.tag` / `sense.differentia` were promoted with their mask
+placeholders intact. Measured against the 11,605-row store: **670 rows** carry a raw `{Tn}`
+(`sense_tag` 376, `h` 223, `differentia` 72, `ru` 2, `de` 2) -- including 223 rows whose
+HEADWORD field reads literally `{T104}`. The generator side is fixed (see `card_fields.py`);
+this repairs the rows already written.
+
+WHY IT IS RECOVERABLE AT ALL
+----------------------------
+Masking is deterministic and the source is content-addressed: every store row records
+`provenance.input_raw_sha256`, the SHA-256 of the exact `.raw.txt` it was generated from.
+`pwg_mask.mask(raw)` re-derives the identical placeholder list `ph`, and `{Tn}` indexes `ph`
+1-based. So the true value is `pwg_mask.restore(field, ph)` -- not a guess, a re-computation.
+
+The source is located BY CONTENT ADDRESS, never by filename: `translation_memory.py` is
+explicit that the address survives key renames, and it matters here -- `_ap~~h0_00_pwg01`
+has no file of that name any more, yet 596 rows still resolve. Two independent guards run
+before any row is touched: the recorded SHA must match a real file, and `mask/restore` must
+round-trip that file byte-for-byte (the same invariant `gen_opt_harness2.py:950` asserts).
+
+WHAT IT CANNOT DO -- MEASURED, NOT ASSUMED
+------------------------------------------
+* **74 of the 670 rows are NOT recoverable.** Their recorded `input_raw_sha256` addresses no
+  file on disk: the source drifted after translation, so no map can be re-derived. The packet
+  anticipated exactly this ("rows whose source drifted need re-translation, not
+  re-derivation"). They are reported, never guessed at. This includes the 2 C-42 rows
+  (`ban_d~~h0_11_ni`, `ban_d~~h0_21_upasam_0`), whose `{Tn}` is out-of-range by construction.
+* **The 468 `h is None` rows are out of scope and CANNOT be repaired by any offline means.**
+  That value was destroyed at the stitch, before it was ever persisted -- it is not in the
+  store, not in `wf_output` (already null there), not in the portraits (they carry no `h`),
+  and not in the TM (which is built FROM the store). `h` is free lexicographic text, not a
+  function of the key, so it cannot be synthesised. They need re-translation.
+
+USAGE
+-----
+    python src/backfill_tn_residue.py                 # dry run: report only, writes nothing
+    python src/backfill_tn_residue.py --apply         # rewrite the store (atomic, with .bak)
+    python src/backfill_tn_residue.py --json out.json # machine-readable per-row plan
+
+Dry run is the default and is READ-ONLY. `--apply` writes via tmp + `os.replace` and keeps a
+timestamped `.premerge.<stamp>.bak`, mirroring `promote_final_cards.py`'s existing convention
+rather than inventing a second one.
+"""
+import argparse
+import collections
+import datetime
+import hashlib
+import json
+import os
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+import pwg_mask
+import card_fields
+from store_path import canonical_store
+
+TN_RE = re.compile(r'\{T\d+\}')
+LOCAL_STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+
+
+def default_input_dir(store_path):
+    """Resolve `pilot/input` ALONGSIDE the store being repaired, not beside this script.
+
+    Both the store and the `*.raw.txt` sources are gitignored, so they exist only in the MAIN
+    checkout: a linked worktree has the code but 0 of the 110,374 raw files. Defaulting to
+    `dirname(__file__)/pilot/input` therefore reads an EMPTY directory while
+    `canonical_store()` correctly resolves the store back to the main checkout -- every row
+    then reports "source gone" and the tool concludes, with total confidence, that nothing is
+    recoverable. That is C-19's defect class exactly ("--data-root defaults to its own
+    checkout ... a worktree run swaps the denominator"), and this tool reproduced it on its
+    first run. Deriving the path from the resolved store keeps the two halves in one place.
+    """
+    return os.path.join(os.path.dirname(os.path.abspath(store_path)), 'pilot', 'input')
+
+# The fields a store ROW carries, mapped to the card level they were promoted from. Derived
+# from card_fields so this tool cannot drift from the restore/promote sides.
+ROW_FIELDS = tuple(name for _level, name in card_fields.promoted_pairs('russian'))
+# `rows_for` renames two of them on the way into the store.
+ROW_ALIAS = {'tag': 'sense_tag', 'russian': 'ru', 'german': 'de'}
+STORE_FIELDS = tuple(ROW_ALIAS.get(n, n) for n in ROW_FIELDS)
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as fh:
+        for chunk in iter(lambda: fh.read(65536), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def build_address_index(input_dir):
+    """sha256(raw bytes) -> path, over every `*.raw.txt`. The address IS the content."""
+    index = {}
+    for name in os.listdir(input_dir):
+        if name.endswith('.raw.txt'):
+            path = os.path.join(input_dir, name)
+            index.setdefault(sha256_file(path), path)
+    return index
+
+
+def plan(store_path, input_dir):
+    """Return (rows, plan_entries, stats). Reads only."""
+    index = build_address_index(input_dir)
+    ph_cache = {}
+    rows, entries = [], []
+    stats = collections.Counter()
+
+    with open(store_path, encoding='utf-8') as fh:
+        for lineno, line in enumerate(fh, 1):
+            line = line.rstrip('\n')
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            rows.append(row)
+            hit = [f for f in STORE_FIELDS
+                   if isinstance(row.get(f), str) and TN_RE.search(row[f])]
+            if not hit:
+                continue
+            stats['corrupt_rows'] += 1
+            sha = (row.get('provenance') or {}).get('input_raw_sha256')
+            subcard = row.get('subcard')
+            if not sha:
+                entries.append({'line': lineno, 'subcard': subcard, 'status': 'no_sha',
+                                'reason': 'row records no provenance.input_raw_sha256'})
+                stats['no_sha'] += 1
+                continue
+            if sha not in index:
+                entries.append({'line': lineno, 'subcard': subcard, 'status': 'source_gone',
+                                'reason': 'no raw source at content address %s' % sha[:12]})
+                stats['source_gone'] += 1
+                continue
+            if sha not in ph_cache:
+                raw = open(index[sha], encoding='utf-8').read()
+                skel, ph, _ = pwg_mask.mask(raw)
+                ph_cache[sha] = ph if pwg_mask.restore(skel, ph) == raw else None
+            ph = ph_cache[sha]
+            if ph is None:
+                entries.append({'line': lineno, 'subcard': subcard, 'status': 'roundtrip_fail',
+                               'reason': 'mask/restore does not round-trip this source'})
+                stats['roundtrip_fail'] += 1
+                continue
+            bad = [t for f in hit for t in TN_RE.findall(row[f])
+                   if not (1 <= int(t[2:-1]) <= len(ph))]
+            if bad:
+                entries.append({'line': lineno, 'subcard': subcard, 'status': 'out_of_range',
+                                'reason': 'index past the map (%s); map has %d (C-42)'
+                                          % (', '.join(sorted(set(bad))), len(ph))})
+                stats['out_of_range'] += 1
+                continue
+            fixes = {f: pwg_mask.restore(row[f], ph) for f in hit}
+            entries.append({'line': lineno, 'subcard': subcard, 'status': 'recoverable',
+                            'source': os.path.basename(index[sha]),
+                            'fields': {f: {'before': row[f], 'after': v}
+                                       for f, v in fixes.items()}})
+            stats['recoverable'] += 1
+    return rows, entries, stats
+
+
+def apply_plan(store_path, rows, entries):
+    """Rewrite the store atomically, keeping a timestamped backup. Only called for --apply."""
+    by_line = {e['line']: e for e in entries if e['status'] == 'recoverable'}
+    changed = 0
+    for i, row in enumerate(rows, 1):
+        entry = by_line.get(i)
+        if not entry:
+            continue
+        for field, delta in entry['fields'].items():
+            row[field] = delta['after']
+        changed += 1
+
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+    backup = '%s.premerge.%s.bak' % (store_path, stamp)
+    with open(store_path, 'rb') as src, open(backup, 'wb') as dst:
+        dst.write(src.read())
+    tmp = store_path + '.tmp'
+    with open(tmp, 'w', encoding='utf-8', newline='\n') as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + '\n')
+    os.replace(tmp, store_path)
+    return changed, backup
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    ap.add_argument('--store', default=None, help='store path (default: canonical_store())')
+    ap.add_argument('--input-dir', default=None,
+                    help='raw sources (default: pilot/input beside the RESOLVED store)')
+    ap.add_argument('--apply', action='store_true',
+                    help='rewrite the store (default is a read-only dry run)')
+    ap.add_argument('--json', dest='json_out', default=None, help='write the plan as JSON')
+    args = ap.parse_args()
+
+    store_path = args.store or canonical_store(LOCAL_STORE)
+    input_dir = args.input_dir or default_input_dir(store_path)
+    if not os.path.isdir(input_dir):
+        sys.exit('REFUSED: source dir does not exist: %s' % input_dir)
+    n_raw = sum(1 for n in os.listdir(input_dir) if n.endswith('.raw.txt'))
+    if not n_raw:
+        # Fail loud rather than reporting a confident, wrong "nothing is recoverable".
+        sys.exit('REFUSED: %s holds no *.raw.txt. Refusing to report every row as '
+                 'unrecoverable off an empty source dir (C-19 class).' % input_dir)
+    args.input_dir = input_dir
+    print('store      : %s' % store_path)
+    print('sources    : %s (%d raw files)' % (input_dir, n_raw))
+    print('mode       : %s' % ('APPLY' if args.apply else 'dry run (read-only)'))
+    print()
+
+    rows, entries, stats = plan(store_path, args.input_dir)
+    print('store rows            : %d' % len(rows))
+    print('rows carrying a {Tn}  : %d' % stats['corrupt_rows'])
+    print('  recoverable offline : %d' % stats['recoverable'])
+    print('  source gone         : %d' % stats['source_gone'])
+    print('  out of range (C-42) : %d' % stats['out_of_range'])
+    print('  no sha recorded     : %d' % stats['no_sha'])
+    print('  round-trip failed   : %d' % stats['roundtrip_fail'])
+    print()
+
+    unrec = [e for e in entries if e['status'] != 'recoverable']
+    if unrec:
+        print('NOT RECOVERABLE -- these need RE-TRANSLATION, never a guess:')
+        for sub, group in sorted(collections.Counter(e['subcard'] for e in unrec).items()):
+            reason = next(e['reason'] for e in unrec if e['subcard'] == sub)
+            print('  %-34s %d row(s)  %s' % (sub, group, reason))
+        print()
+
+    sample = [e for e in entries if e['status'] == 'recoverable'][:3]
+    if sample:
+        print('SAMPLE of the re-derivation:')
+        for e in sample:
+            for f, d in e['fields'].items():
+                print('  line %-6d %s.%s' % (e['line'], e['subcard'], f))
+                print('    before: %r' % d['before'][:70])
+                print('    after : %r' % d['after'][:70])
+        print()
+
+    if args.json_out:
+        with open(args.json_out, 'w', encoding='utf-8') as fh:
+            json.dump({'store': store_path, 'stats': dict(stats), 'entries': entries},
+                      fh, ensure_ascii=False, indent=2)
+        print('plan written: %s' % args.json_out)
+
+    if not args.apply:
+        print('DRY RUN -- nothing written. Re-run with --apply to rewrite the store.')
+        return 0
+
+    changed, backup = apply_plan(store_path, rows, entries)
+    print('APPLIED: %d row(s) re-derived' % changed)
+    print('backup : %s' % backup)
+    residue = sum(1 for r in rows for f in STORE_FIELDS
+                  if isinstance(r.get(f), str) and TN_RE.search(r[f]))
+    print('remaining {Tn} rows: %d (the unrecoverable set above)' % residue)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/RussianTranslation/src/card_fields.py
+++ b/RussianTranslation/src/card_fields.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+r"""Single source of truth for WHICH final-card fields are masked, restored and promoted.
+
+WHY THIS EXISTS (H963 correction packet, C-01)
+----------------------------------------------
+`restore_card` (`pilot/headless_worker.py`) and its JS twin `restoreCard`
+(`pilot/gen_opt_harness2.py`) unmasked THREE things -- `record.grammar`, `sense.german` and
+the per-sense translation field. The promote path (`promote_final_cards.rows_for`) read SIX
+-- `card.iast`, `record.h`, `sense.tag`, `sense.russian`, `sense.german`,
+`sense.differentia`. The two lists were authored independently, and they drifted: four
+fields were promoted to the canonical store with their `{Tn}` placeholders never restored.
+
+The observed cost, measured against the 11,605-row store: 670 rows carry a raw `{Tn}`
+(`sense_tag` 376, `h` 223, `differentia` 72, plus the 2 C-42 rows in `ru`/`de`) -- including
+223 rows whose HEADWORD reads literally `{T104}`. Nothing failed loudly, because the only
+component that encodes the record contract never runs on live output (C-04).
+
+The defect was not a *wrong* list. It was TWO lists. So this module holds ONE, and both the
+restore side and the promote side are driven from it;
+`window_selftest.test_restore_covers_every_promoted_field` asserts
+PROMOTED subset-of RESTORED **by construction from this constant**, so they cannot drift apart
+again. A new promoted field that nobody remembers to restore is now a test failure, not 670
+silently corrupted rows.
+
+LEVELS
+------
+Each entry is a `(level, name)` pair naming where the field sits in a final card:
+
+    card    -> card[name]
+    record  -> card['records'][i][name]
+    sense   -> card['records'][i]['senses'][j][name]
+
+THE TRANSLATION FIELD IS LANGUAGE-DEPENDENT
+-------------------------------------------
+`gen_opt_harness2.py:890` picks `field = 'english' if lang == 'en' else 'russian'`, so the
+per-sense target field is a parameter, not a constant. Everything else is fixed. Callers pass
+the active `field`; `german` is always restored (it is the source-side gloss the fidelity
+guards compare against) and is de-duplicated when it *is* the target field.
+
+NOT A SCHEMA
+------------
+`schemas/pwg_ru_final_card.schema.json` states the *contract* (`record.required =
+{h, grammar, senses}`). This module states which fields carry `{Tn}` placeholders and must
+therefore be unmasked before promotion. They are related but distinct: `senses` is required
+by the schema and is not a masked text field.
+"""
+import json
+
+# Card-level masked fields.
+CARD_MASKED = ('iast',)
+
+# Record-level masked fields. `h` is the homonym discriminator -- free lexicographic text
+# ("2. bhid", "PW 3 (с anu, отсылка к entry 5)"), NOT a mechanical function of the key, which
+# is why a lost `h` cannot be synthesised later (C-02's boundary forbids exactly that).
+RECORD_MASKED = ('h', 'grammar')
+
+# Sense-level masked fields that do not depend on the target language.
+SENSE_MASKED_COMMON = ('tag', 'german', 'differentia')
+
+# What the promote path reads out of a card and writes to a store row, EXCLUDING the
+# target-language field (which `promoted_pairs` appends). Stated independently of the restore
+# list on purpose: the selftest then compares two separately-authored facts rather than
+# tautologically comparing a list to itself.
+PROMOTED_COMMON = (
+    ('card', 'iast'),
+    ('record', 'h'),
+    ('sense', 'tag'),
+    ('sense', 'german'),
+    ('sense', 'differentia'),
+)
+
+
+def promoted_pairs(field='russian'):
+    """Every `(level, name)` the promote path reads for target-language field `field`.
+
+    `field='russian'` is exactly `promote_final_cards.rows_for`; `field='english'` is its
+    `promote_en` counterpart. Language-parameterised rather than hardcoded, so the RU and EN
+    lanes cannot acquire two different answers to "what gets promoted" -- which is the same
+    class of drift as C-01 itself.
+    """
+    pairs = list(PROMOTED_COMMON)
+    if field and ('sense', field) not in pairs:
+        pairs.append(('sense', field))
+    return tuple(pairs)
+
+
+# Backwards-compatible alias for the RU store's promote path.
+PROMOTED_PAIRS = promoted_pairs('russian')
+
+
+def sense_masked(field):
+    """Sense-level masked fields for target-language field `field` (e.g. 'russian')."""
+    out = list(SENSE_MASKED_COMMON)
+    if field and field not in out:
+        out.append(field)
+    return tuple(out)
+
+
+def restored_pairs(field):
+    """Every `(level, name)` that MUST be unmasked before a card may be promoted."""
+    return (tuple(('card', f) for f in CARD_MASKED)
+            + tuple(('record', f) for f in RECORD_MASKED)
+            + tuple(('sense', f) for f in sense_masked(field)))
+
+
+def js_restore_spec(field):
+    """The same field set as a JSON literal, for interpolation into the JS harness.
+
+    The JS lane cannot import Python, so the constant is INTERPOLATED into it rather than
+    duplicated by hand -- duplicating it by hand is the original defect.
+    """
+    return json.dumps({
+        'card': list(CARD_MASKED),
+        'record': list(RECORD_MASKED),
+        'sense': list(sense_masked(field)),
+    })
+
+
+def restore_card_fields(card, field, restore_text):
+    """Unmask every field in `restored_pairs(field)`, in place, via `restore_text`.
+
+    `restore_text` is injected (rather than imported) so the caller keeps ownership of the
+    placeholder map and of what an out-of-range `{Tn}` means (C-42).
+    """
+    pairs = restored_pairs(field)
+    card_fields = [n for lvl, n in pairs if lvl == 'card']
+    record_fields = [n for lvl, n in pairs if lvl == 'record']
+    sense_fields = [n for lvl, n in pairs if lvl == 'sense']
+
+    for name in card_fields:
+        if isinstance(card.get(name), str):
+            card[name] = restore_text(card[name])
+    for record in card.get('records') or []:
+        for name in record_fields:
+            if isinstance(record.get(name), str):
+                record[name] = restore_text(record[name])
+        for sense in record.get('senses') or []:
+            for name in sense_fields:
+                if isinstance(sense.get(name), str):
+                    sense[name] = restore_text(sense[name])
+    return card

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -43,6 +43,7 @@ sys.stderr.reconfigure(encoding='utf-8')
 from window_common import INP, REPO, SRC, input_paths, load_json, read_text, rootmap_path, sha256_file, write_text
 from agent_budget import derive_agent_budget
 import pwg_mask
+import card_fields                                    # C-01: the one restore/promote field set
 from autosplit_requeue import plan as split_plan     # deterministic per-card sense/citation split
 from sense_count import count_source_senses           # H920/H960 deterministic top-level source-sense count
 sys.path.insert(0, SRC)
@@ -1552,13 +1553,35 @@ const exactCard = (cards, km, expected, fallbackIndex) => {
   const c = cards[fallbackIndex]
   return (c && c.key1 === expected) ? c : null
 }
+// C-01: which fields carry {Tn} and must be unmasked is NOT re-typed here -- it is injected
+// from card_fields.js_restore_spec(field), the same constant the Python lane restores from
+// and promote_final_cards refuses on. Hand-maintaining this list on each lane is exactly how
+// card.iast / rec.h / s.tag / s.differentia came to be promoted with their placeholders intact.
+const RESTORE_SPEC = %(restore_spec)s
+// C-02: rebuild records[] from healed senses, preserving each sense's [h, grammar] owner.
+// The stitch used to emit `records: [{ senses }]` — no h, no grammar — which violates
+// schemas/pwg_ru_final_card.schema.json (record.required = {h, grammar, senses}) and made the
+// promote path write h: null. It also collapsed real homonyms (79 sub-cards carry more than
+// one distinct h). Consecutive senses sharing an owner stay in one record; a change of owner
+// opens the next, so document order — and the whole-card fidelity counts — are unchanged.
+// The Python twin is headless_worker.stitch_records; keep them behaviourally identical.
+function stitchRecords(senses, owners) {
+  const out = []
+  for (let i = 0; i < senses.length; i++) {
+    const [h, grammar] = owners[i] || [null, null]
+    const last = out[out.length - 1]
+    if (!last || last.h !== h || last.grammar !== grammar) out.push({ h, grammar, senses: [senses[i]] })
+    else last.senses.push(senses[i])
+  }
+  return out
+}
 function restoreCard(card, k) {
   const ph = PH[k] || []
+  for (const f of RESTORE_SPEC.card) if (typeof card[f] === 'string') card[f] = restore(card[f], ph)
   for (const rec of (card.records || [])) {
-    if (rec.grammar !== undefined) rec.grammar = restore(rec.grammar, ph)
+    for (const f of RESTORE_SPEC.record) if (typeof rec[f] === 'string') rec[f] = restore(rec[f], ph)
     for (const s of (rec.senses || [])) {
-      if (s.german !== undefined) s.german = restore(s.german, ph)
-      if (s.%(field)s !== undefined) s.%(field)s = restore(s.%(field)s, ph)
+      for (const f of RESTORE_SPEC.sense) if (typeof s[f] === 'string') s[f] = restore(s[f], ph)
     }
   }
   return card
@@ -1753,6 +1776,7 @@ async function selfHeal(k) {
     : { spent: 0, max: null }
   const ftm = FRAG_TM[k] || []            // --tm: per-group cached-senses-or-null, mirrors FRAGS[k]
   const senses = []
+  const owners = []             // C-02: parallel to `senses` — the [h, grammar] each came from
   const missingFragments = []   // 'g<gi+1>:f<fi>' identifiers — persisted on the card so a
                                 // targeted requeue of JUST the failed fragments is possible
                                 // from wf_output alone (the inline path previously recorded
@@ -1798,24 +1822,31 @@ async function selfHeal(k) {
         // slot them in at their document position — do NOT re-restore (no {Tn} remain). Tag
         // normalization still applies: an older cache entry harvested before this fix may carry
         // a fabricated tag.
-        for (const s of gtm[i]) { applyTag(grp[i].si, s); senses.push(s) }
+        // The fragment TM caches SENSES ONLY -- no record context survives it, so these carry
+        // no h/grammar owner. Recorded as unknown rather than invented (C-02 boundary).
+        for (const s of gtm[i]) { applyTag(grp[i].si, s); senses.push(s); owners.push([null, null]) }
         continue
       }
       const card = r.resolved[i]
       if (!card) continue   // an uncached fragment that never resolved — already in missingFragments
       const ph = gph[i] || []
       const fsenses = []
-      for (const rec of (card.records || [])) for (const s of (rec.senses || [])) {
-        if (s.german !== undefined) s.german = restore(s.german, ph)
-        if (s.%(field)s !== undefined) s.%(field)s = restore(s.%(field)s, ph)
-        applyTag(grp[i].si, s)
-        senses.push(s); fsenses.push(s)
+      for (const rec of (card.records || [])) {
+        for (const f of RESTORE_SPEC.record) if (typeof rec[f] === 'string') rec[f] = restore(rec[f], ph)
+        for (const s of (rec.senses || [])) {
+          for (const f of RESTORE_SPEC.sense) if (typeof s[f] === 'string') s[f] = restore(s[f], ph)
+          applyTag(grp[i].si, s)
+          // C-02: keep the OWNING record's (h, grammar) alongside the sense. This loop used to
+          // flatten records->senses and drop `rec`, so the stitch below had nothing left to
+          // emit and every promoted row read h: null (403 of the 468 came from this lane).
+          senses.push(s); owners.push([rec.h, rec.grammar]); fsenses.push(s)
+        }
       }
       if (grp[i].fsha && fsenses.length) fragProv.push({ fsha: grp[i].fsha, senses: fsenses })
     }
   }
   if (!senses.length) { if (!FAIL[k]) noteFail(k, 'selfheal-nothing-resolved'); return null }
-  const stitched = { key1: k, records: [{ senses }] }
+  const stitched = { key1: k, records: stitchRecords(senses, owners) }
   if (fragProv.length) stitched.frag_prov = fragProv
   if (!missingFragments.length) {
     // fidelity check only meaningful on a COMPLETE heal — a partial result legitimately has
@@ -2061,6 +2092,11 @@ const summary = { root: META.root, lang: META.lang, cards: out.length, ok: _ok,
 return { meta: META, summary, results: out }
 """ % {
         'root': root, 'field': field, 'tr': json.dumps(tr, ensure_ascii=True),
+        # C-01: the restore field set is INTERPOLATED from `card_fields`, never re-typed here.
+        # This lane and the Python lane each kept their own hand-written list of what to
+        # unmask; both listed three fields while promote read six, and 670 store rows landed
+        # with a raw {Tn}. The JS cannot import Python, so the constant is injected instead.
+        'restore_spec': card_fields.js_restore_spec(field),
         # Language-aware meta + model pin. EN path pins Sonnet 5 explicitly
         # (the bare 'sonnet' alias resolved to 4.6 on a prior run); RU path
         # keeps the 'sonnet' alias unchanged so the autonomous RU runs are untouched.

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -17,7 +17,11 @@ sys.stderr.reconfigure(encoding='utf-8')
 
 if os.path.dirname(os.path.abspath(__file__)) not in sys.path:
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+_SRC = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
 from proc_tree import run_tree_kill, terminate_tree, windows_hidden_flags  # noqa: E402  (shared D-J tree-kill runner)
+import card_fields  # noqa: E402  (C-01: the one restore/promote field set, shared with the JS lane)
 
 AUTH_RE = re.compile(r'401|authentication|not logged in|invalid.*credential', re.I)
 RATE_RE = re.compile(r'429|rate.?limit|usage limit|too many requests', re.I)
@@ -129,26 +133,83 @@ def extract_structured(stdout):
     return value, wrapper
 
 
-def restore_text(text, placeholders):
+def restore_text(text, placeholders, unmapped=None):
+    """Unmask `{Tn}` against `placeholders`.
+
+    C-42: an index outside the map still returns the token verbatim (changing that is a
+    behaviour change this correction does not make), but it is now COUNTED into `unmapped`
+    when a caller supplies a sink. The silent pass-through is how a raw `{T196}` reached the
+    canonical store on a card that reported success: the article is masked WHOLE (235+
+    placeholders) but restored per-subcard against a subcard-local map, so a high global
+    index maps nothing. Counting is what lets `normalize_batch` gate on zero.
+    """
     def repl(match):
         idx = int(match.group(1)) - 1
-        return placeholders[idx] if 0 <= idx < len(placeholders) else match.group(0)
+        if 0 <= idx < len(placeholders):
+            return placeholders[idx]
+        if unmapped is not None:
+            unmapped.append(match.group(0))
+        return match.group(0)
     return re.sub(r'\{T(\d+)\}', repl, text or '')
 
 
-def restore_card(card, field, placeholders):
-    for record in card.get('records') or []:
-        if 'grammar' in record:
-            record['grammar'] = restore_text(record['grammar'], placeholders)
-        for sense in record.get('senses') or []:
-            if 'german' in sense:
-                sense['german'] = restore_text(sense['german'], placeholders)
-            if field in sense:
-                sense[field] = restore_text(sense[field], placeholders)
-    return card
+def restore_card(card, field, placeholders, unmapped=None):
+    """Unmask every field the promote path reads -- the set is `card_fields`, not a local list.
+
+    C-01: this used to restore three things (record.grammar, sense.german, sense.<field>)
+    while `promote_final_cards.rows_for` read six, so card.iast / record.h / sense.tag /
+    sense.differentia were promoted with their `{Tn}` intact -- 670 store rows, 223 of them
+    a raw `{Tn}` in the HEADWORD. The lists are now one constant, pinned by
+    `test_restore_covers_every_promoted_field`.
+
+    Deliberate delta from the old loop: a field is restored only when it is a `str`. The old
+    code tested key-presence and passed `text or ''`, silently rewriting a `None` grammar to
+    `''`. Extending that to `h` would have laundered the 468 known `h is None` rows into
+    empty strings -- destroying the very signal C-02 is diagnosed by. A non-str field is now
+    left exactly as found.
+    """
+    return card_fields.restore_card_fields(
+        card, field, lambda text: restore_text(text, placeholders, unmapped))
+
+
+def stitch_records(senses, owners):
+    """Rebuild `records[]` from healed senses, preserving each sense's `(h, grammar)` owner.
+
+    C-02: the stitch used to emit a single `{'senses': senses}` record -- no `h`, no
+    `grammar` -- which violates `schemas/pwg_ru_final_card.schema.json` (`record.required =
+    {h, grammar, senses}`) and made the promote path write `h: null`. It also collapsed real
+    homonyms: 79 sub-cards legitimately carry more than one distinct `h`, so one flat record
+    cannot represent them.
+
+    Consecutive senses sharing an owner stay in one record; a change of owner opens the next.
+    Order is preserved exactly, so the whole-card `<ls>`/`{#` fidelity counts are unchanged.
+    """
+    records = []
+    for sense, owner in zip(senses, owners):
+        if not records or records[-1]['_owner'] != owner:
+            rec_h, rec_grammar = owner
+            records.append({'_owner': owner, 'h': rec_h, 'grammar': rec_grammar, 'senses': []})
+        records[-1]['senses'].append(sense)
+    for record in records:
+        record.pop('_owner', None)
+    return records
 
 
 def count_card(card, needle):
+    """Count `needle` across the card's `german` senses.
+
+    DELIBERATELY still `german`-only. The C-02 boundary asks to "make count_card/countOf see
+    record-level fields", but that is wrong AT THIS SITE and its own fixture proves it: this
+    count is compared against `inp['ls']`/`inp['sk']`, which are SOURCE-occurrence counts
+    (`raw.count('<ls')`). One source token echoed into both `grammar` and `german` -- exactly
+    what `headless_worker_selftest.success_runner` builds, `{T1}` in both -- then counts 2
+    against a denominator of 1 and the card is rejected as a fidelity failure.
+
+    Adding record-level text belongs with the token-MULTISET guards (C-17, Step 6), whose
+    denominator really is the whole skeleton. Restoring `grammar` on the stitch lane (C-02)
+    leaves this count unchanged, because stitched cards previously carried no `grammar` term
+    at all -- so historical comparisons stay valid.
+    """
     return sum((sense.get('german') or '').count(needle)
                for record in card.get('records') or []
                for sense in record.get('senses') or [])
@@ -175,10 +236,16 @@ def normalize_batch(manifest, keys, structured):
         if card is None:
             error = 'missing-or-mismatched-key'
         else:
-            card = restore_card(card, manifest['field'], manifest['placeholder_maps'].get(key, []))
+            unmapped = []
+            card = restore_card(card, manifest['field'],
+                                manifest['placeholder_maps'].get(key, []), unmapped)
             inp = manifest['inputs'][key]
             if count_card(card, '<ls') != inp['ls'] or count_card(card, '{#') != inp['sk']:
                 error = 'fidelity-reject'
+                card = None
+            elif unmapped:
+                # C-42: an out-of-range {Tn} maps nothing and cannot be recovered downstream.
+                error = 'unmapped-token-reject'
                 card = None
         row = {'key': key, 'card': card, 'judge': None, 'judge_sonnet': None,
                'escalated': False}
@@ -381,6 +448,8 @@ class HeadlessEngine:
         cached_groups = self.m.get('fragment_tm', {}).get(key) or []
         ph_groups = self.m.get('fragment_placeholder_maps', {}).get(key) or []
         senses = []
+        owners = []          # C-02: parallel to `senses` -- the (h, grammar) each came from
+        unmapped = []        # C-42: {Tn} indices that map nothing, instead of a silent pass
         frag_prov = []
         missing = []
         sense_tags = {}
@@ -392,28 +461,43 @@ class HeadlessEngine:
                                                    'heal:%s#g%d' % (key, gi + 1), budget)
             missing.extend('g%d:f%d' % (gi + 1, i) for i in unresolved)
             for index, fragment in enumerate(group):
-                frag_senses = []
+                # C-02: keep each sense's OWNING record. The old comprehension here flattened
+                # `records -> senses` and dropped `record` itself, so the stitch below had no
+                # `h`/`grammar` left in scope to emit and every promoted row read `h: null`
+                # (468 rows / 20 sub-cards). `h` is free lexicographic text ("2. bhid",
+                # "PW 3 (с anu, отсылка к entry 5)"), so a dropped one cannot be reconstructed
+                # later -- it has to survive the flatten.
+                frag_records = []
                 if index < len(cached) and cached[index]:
-                    frag_senses = cached[index]
+                    # The fragment TM caches SENSES ONLY, with no record context, so a
+                    # TM-served fragment genuinely has no `h` to carry. Emit it under an
+                    # unknown owner rather than inventing one -- synthesising an `h` here is
+                    # what the C-02 boundary forbids. This is the residual null source and is
+                    # counted in the summary below.
+                    frag_records = [(None, None, cached[index])]
                 elif index in resolved:
                     card = restore_card(resolved[index], self.m['field'],
-                                        phs[index] if index < len(phs) else [])
-                    frag_senses = [sense for record in card.get('records') or []
-                                   for sense in record.get('senses') or []]
+                                        phs[index] if index < len(phs) else [], unmapped)
+                    frag_records = [(record.get('h'), record.get('grammar'),
+                                     record.get('senses') or [])
+                                    for record in card.get('records') or []]
+                    frag_senses = [sense for _, _, group in frag_records for sense in group]
                     if fragment.get('fsha') and frag_senses:
                         frag_prov.append({'fsha': fragment['fsha'], 'senses': frag_senses})
-                for sense in frag_senses:
-                    source_ord = fragment.get('si')
-                    if source_ord is not None:
-                        if source_ord in sense_tags:
-                            sense['tag'] = sense_tags[source_ord]
-                        else:
-                            sense_tags[source_ord] = sense.get('tag')
-                    senses.append(sense)
+                for rec_h, rec_grammar, group in frag_records:
+                    for sense in group:
+                        source_ord = fragment.get('si')
+                        if source_ord is not None:
+                            if source_ord in sense_tags:
+                                sense['tag'] = sense_tags[source_ord]
+                            else:
+                                sense_tags[source_ord] = sense.get('tag')
+                        senses.append(sense)
+                        owners.append((rec_h, rec_grammar))
         if not senses:
             self.note(key, 'selfheal-nothing-resolved')
             return None
-        card = {'key1': key, 'records': [{'senses': senses}]}
+        card = {'key1': key, 'records': stitch_records(senses, owners)}
         if frag_prov:
             card['frag_prov'] = frag_prov
         if missing:
@@ -427,6 +511,15 @@ class HeadlessEngine:
                 self.note(key, 'stitched-fidelity-reject: <ls> %d/%d, {# %d/%d' %
                           (ls_count, inp['ls'], sk_count, inp['sk']))
                 return None
+        # C-42: a {Tn} whose index maps nothing used to be written through verbatim on a card
+        # that reported success -- that is how `ban_d~~h0_11_ni` and `ban_d~~h0_21_upasam_0`
+        # reached the canonical store carrying a raw {T196}/{T235}. The token is unrecoverable
+        # by construction (the index addresses a whole-article map the sub-card never had), so
+        # refuse the card instead of promoting a known-corrupt one.
+        if unmapped:
+            self.note(key, 'unmapped-token-reject: %d out-of-range placeholder(s): %s'
+                      % (len(unmapped), ', '.join(sorted(set(unmapped))[:6])))
+            return None
         return card
 
     def run_all(self):

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -142,19 +142,36 @@ def main():
         start = js.index('function restoreCard(card, k)')
         end = js.index('// Per-card grammar', start)
         restore_card_js = js[start:end]
+        # RESTORE_SPEC is injected from the same constant the harness interpolates (C-01), not
+        # re-typed here: the whole point of the constant is that no second list exists. The
+        # slice above starts at `function restoreCard`, so the const declared above it is not
+        # carried in -- supply it exactly as the real harness would.
+        import card_fields
         node_script = r"""
 const PH = {agni: ['<lex>m.</lex>']}
 const restore = (t, ph) => (t || '').replace(/\{T(\d+)\}/g, (_m, n) => ph[Number(n)-1])
+const RESTORE_SPEC = %s
 %s
-const card = {records: [{grammar: '{T1}', senses: [{german: '{T1}', russian: '{T1}'}]}]}
+const card = {iast: '{T1}', records: [{h: '{T1}', grammar: '{T1}', senses: [
+  {tag: '{T1}', german: '{T1}', russian: '{T1}', differentia: '{T1}'}]}]}
 console.log(JSON.stringify(restoreCard(card, 'agni')))
-""" % restore_card_js
+""" % (card_fields.js_restore_spec('russian'), restore_card_js)
         node = subprocess.run(['node', '-e', node_script], capture_output=True,
                               text=True, encoding='utf-8')
         assert node.returncode == 0, node.stderr
         restored = json.loads(node.stdout)
-        assert restored['records'][0]['grammar'] == '<lex>m.</lex>'
-        assert restored['records'][0]['senses'][0]['german'] == '<lex>m.</lex>'
+        rec = restored['records'][0]
+        sense = rec['senses'][0]
+        assert rec['grammar'] == '<lex>m.</lex>'
+        assert sense['german'] == '<lex>m.</lex>'
+        # C-01: the JS lane must unmask EVERY field the promote path reads, not just three.
+        # card.iast / record.h / sense.tag / sense.differentia used to survive as raw {Tn} and
+        # were promoted verbatim -- 670 store rows, 223 of them a {Tn} headword.
+        for where, value in (('card.iast', restored['iast']), ('record.h', rec['h']),
+                             ('sense.tag', sense['tag']),
+                             ('sense.differentia', sense['differentia']),
+                             ('sense.russian', sense['russian'])):
+            assert value == '<lex>m.</lex>', '%s left unrestored by the JS lane: %r' % (where, value)
 
     # D-A (H818 Windows acceptance): the launcher resolver must bypass the Windows .cmd
     # batch shim (cmd.exe corrupts the --json-schema arg) and pass native/POSIX through.

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -4779,7 +4779,13 @@ def test_save_merge_better_attempt_wins():
         p = os.path.join(tmp, name)
         with open(p, 'w', encoding='utf-8') as f:
             json.dump(wf(card), f)
-        run([sys.executable, save, root, p, tag, '--no-audit'] + list(extra), expect=0)
+        # `--allow-schema-violations`: this test's cards are deliberate STUBS carrying a
+        # `senses_marker` and nothing else -- it pins merge ORDERING (complete beats partial),
+        # not card content. Since C-04 armed the record contract on the live save path, a stub
+        # is correctly refused, so the exception is declared explicitly here rather than by
+        # relaxing the contract for everyone.
+        run([sys.executable, save, root, p, tag, '--no-audit', '--allow-schema-violations']
+            + list(extra), expect=0)
 
     try:
         complete = {'key1': 'k1', 'senses_marker': 'first-complete'}
@@ -5189,8 +5195,139 @@ def test_strip_mask_tokens_clears_notes_stranded_anchor():
         fail('render() leaked a {Tn} masking token from notes into merged.md')
 
 
+def test_restore_covers_every_promoted_field():
+    """C-01: restore's field set and promote's read set are ONE constant, not two lists.
+
+    The defect: `restore_card` unmasked 3 fields while `rows_for` promoted 6, so card.iast /
+    record.h / sense.tag / sense.differentia reached the canonical store with their {Tn}
+    intact -- 670 rows, 223 of them a raw {Tn} in the HEADWORD field. Two independently
+    hand-maintained lists could drift; one constant cannot.
+    """
+    if SRC not in sys.path:
+        sys.path.insert(0, SRC)
+    import card_fields
+    # Both language lanes: every field the promoter reads must have been unmasked first.
+    for field in ('russian', 'english'):
+        promoted = set(card_fields.promoted_pairs(field))
+        restored = set(card_fields.restored_pairs(field))
+        missing = promoted - restored
+        if missing:
+            fail('fields promoted but never restored (%s): %s' % (field, sorted(missing)))
+    # The JS lane cannot import Python, so its list is interpolated from the same constant.
+    spec = json.loads(card_fields.js_restore_spec('russian'))
+    if set(spec['record']) != set(card_fields.RECORD_MASKED):
+        fail('js_restore_spec record set drifted from RECORD_MASKED')
+    if 'h' not in spec['record']:
+        fail('the JS lane must restore record.h -- it is promoted verbatim')
+
+    # And the restore actually reaches those fields, end to end.
+    card = {'iast': '{T1}', 'records': [{'h': '{T1}', 'grammar': '{T1}', 'senses': [
+        {'tag': '{T1}', 'german': '{T1}', 'russian': '{T1}', 'differentia': '{T1}'}]}]}
+    card_fields.restore_card_fields(card, 'russian', lambda t: t.replace('{T1}', 'X'))
+    rec, sense = card['records'][0], card['records'][0]['senses'][0]
+    for where, value in (('card.iast', card['iast']), ('record.h', rec['h']),
+                         ('record.grammar', rec['grammar']), ('sense.tag', sense['tag']),
+                         ('sense.german', sense['german']), ('sense.russian', sense['russian']),
+                         ('sense.differentia', sense['differentia'])):
+        if value != 'X':
+            fail('%s was not restored (still %r)' % (where, value))
+
+
+def test_every_stitch_emits_record_required():
+    """C-02: the stitch must emit `h`/`grammar`, and must not collapse distinct homonyms.
+
+    The defect: both stitch lanes built `records: [{senses}]`, discarding record-level h and
+    grammar unconditionally, so promote wrote `h: null` -- 468 store rows over 20 sub-cards.
+    That also violates schemas/pwg_ru_final_card.schema.json (record.required =
+    {h, grammar, senses}), which nothing checked on live output (C-04).
+    """
+    import headless_worker as hw
+    senses = [{'tag': '1'}, {'tag': '2'}, {'tag': '3'}]
+    owners = [('1. bhid', 'm.'), ('1. bhid', 'm.'), ('2. bhid', 'f.')]
+    records = hw.stitch_records(senses, owners)
+    if len(records) != 2:
+        fail('two distinct owners must yield two records, got %d' % len(records))
+    if records[0]['h'] != '1. bhid' or records[1]['h'] != '2. bhid':
+        fail('stitch dropped or reordered the record-level h: %r' % records)
+    if records[0]['grammar'] != 'm.' or records[1]['grammar'] != 'f.':
+        fail('stitch dropped the record-level grammar: %r' % records)
+    for rec in records:
+        for key in ('h', 'grammar', 'senses'):
+            if key not in rec:
+                fail('stitched record missing schema-required %r' % key)
+    if [s['tag'] for r in records for s in r['senses']] != ['1', '2', '3']:
+        fail('stitch must preserve document order of senses')
+    # A single owner stays ONE record -- no gratuitous fragmentation.
+    if len(hw.stitch_records(senses, [('h', 'g')] * 3)) != 1:
+        fail('one owner must yield exactly one record')
+
+
+def test_unmapped_token_is_counted():
+    """C-42: an out-of-range {Tn} is counted, not silently passed through.
+
+    The defect: `restore_text` returned `match.group(0)` for an index the map does not
+    address, with no counter, no log and no reject -- so `ban_d~~h0_11_ni` and
+    `ban_d~~h0_21_upasam_0` reached the canonical store carrying a raw {T196}/{T235} on cards
+    that reported success. Cause is a masking-scope vs restore-scope index mismatch (article
+    masked whole, restored per sub-card), not model hallucination.
+    """
+    import headless_worker as hw
+    unmapped = []
+    out = hw.restore_text('a {T1} b {T99} c', ['<ls>x</ls>'], unmapped)
+    if '<ls>x</ls>' not in out:
+        fail('an in-range token must still restore')
+    if unmapped != ['{T99}']:
+        fail('an out-of-range token must be counted, got %r' % unmapped)
+    if '{T99}' not in out:
+        fail('behaviour change: the out-of-range token must still pass through verbatim')
+    clean = []
+    hw.restore_text('a {T1} b', ['x'], clean)
+    if clean:
+        fail('a fully-mapped text must report no unmapped tokens, got %r' % clean)
+
+
+def test_validator_has_a_live_caller():
+    """C-04 dead-validator canary: the record contract must run on LIVE output.
+
+    `validate_final_card_schema` is the ONLY component encoding record.required =
+    {h, grammar, senses}, and its only caller was a CI step feeding it a hand-made PASSING
+    fixture. A green check certified a contract no real card was measured against -- which is
+    precisely why C-01's 670 placeholder rows and C-02's 468 null-h rows accumulated with no
+    signal. This asserts the validator is reachable from the save chain, and that it still
+    refuses a record missing `h`.
+    """
+    from window_common import REPO as repo_root
+    save = os.path.join(repo_root, 'save_and_audit.py')
+    text = open(save, encoding='utf-8').read()
+    if 'validate_final_card_schema' not in text:
+        fail('save_and_audit.py has no reference to validate_final_card_schema -- the '
+             'validator is dead again (C-04)')
+    if 'validate_card(' not in text:
+        fail('save_and_audit.py imports the validator but never calls validate_card()')
+
+    if SRC not in sys.path:
+        sys.path.insert(0, SRC)
+    import validate_final_card_schema as v
+    if v.RECORD_REQUIRED != {'h', 'grammar', 'senses'}:
+        fail('RECORD_REQUIRED was relaxed: %r' % (v.RECORD_REQUIRED,))
+    # The contract must actually reject the shape C-02 was writing.
+    bad = {'key1': 'k', 'iast': 'k', 'notes': '', 'records': [{'senses': [
+        {'tag': '1', 'german': 'g', 'russian': 'r', 'equivalence_type': 'equivalent',
+         'source_type': 'attested', 'stratum': '', 'differentia': ''}]}]}
+    try:
+        v.validate_card(bad)
+    except ValueError:
+        pass
+    else:
+        fail('validate_card accepted a record with no h/grammar -- the C-02 shape')
+
+
 def main():
     tests = [
+        test_restore_covers_every_promoted_field,
+        test_every_stitch_emits_record_required,
+        test_unmapped_token_is_counted,
+        test_validator_has_a_live_caller,
         test_strip_mask_tokens_clears_notes_stranded_anchor,
         test_translation_memory_addressing,
         test_tm_pre_resolves_cards,
@@ -5323,11 +5460,42 @@ def main():
         test_partial_cards_requeue_and_stay_out_of_clean_sample,
         test_classify_run_verdicts,
     ]
+    # Per-test isolation. This used to be a bare `for test in tests: test()`, so the FIRST
+    # failure aborted the process and every later test silently never ran. That is not
+    # hypothetical: `test_lang_parity_ledger_complete` sits at position 105 of 131 and is
+    # RED BY DESIGN -- the parity verdicts need human reaffirmation, which is deliberately not
+    # something an agent does (`--update-hash` is a human's call). So the last 27 tests (20.6%)
+    # were dark INDEFINITELY, including `test_frag_groups_presplit_parity`, the whole
+    # `pwg_mask` pair and four heal-lane tests. A real regression hiding behind the known-red
+    # gate was indistinguishable from the gate itself.
+    #
+    # This isolates each test and reports ran/defined, so "the suite is green" can no longer
+    # mean "the suite stopped early". It does NOT touch the parity gate: that test still fails,
+    # loudly, and the run still exits non-zero. It just no longer takes the other 26 with it.
+    passed, failed = [], []
     for test in tests:
-        test()
-        print('PASS:', test.__name__)
+        try:
+            test()
+        except BaseException as exc:      # noqa: BLE001 -- a failing test must not hide the rest
+            failed.append(test.__name__)
+            print('FAIL: %s -- %s: %s' % (test.__name__, exc.__class__.__name__, exc))
+        else:
+            passed.append(test.__name__)
+            print('PASS:', test.__name__)
+
+    ran = len(passed) + len(failed)
+    print('window selftest: ran %d/%d defined -- %d passed, %d failed'
+          % (ran, len(tests), len(passed), len(failed)))
+    if ran != len(tests):
+        # Unreachable while every test is isolated; kept so that a future early-exit (an
+        # os._exit, a signal) is reported as darkness rather than read as success.
+        print('DARK: %d test(s) defined but never ran' % (len(tests) - ran))
+    if failed:
+        print('FAILED (%d): %s' % (len(failed), ', '.join(failed)))
+        return 1
     print('window selftest OK')
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -37,8 +37,10 @@ import sys
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
+import re
 import pipeline_version
 import dict_merge
+import card_fields
 from promote_lock import PromoteClaim, ClaimBusy
 from store_path import canonical_store
 
@@ -164,6 +166,29 @@ def provenance(entry, subkey, model_version):
     return prov
 
 
+TN_RE = re.compile(r'\{T\d+\}')
+
+
+class UnrestoredPlaceholder(Exception):
+    """A card reached the promote path still carrying a `{Tn}` mask placeholder (C-01)."""
+
+
+def tn_residue(card, rec, sense):
+    """Report every promoted field of this row that still holds a raw `{Tn}`.
+
+    The field list is `card_fields.PROMOTED_PAIRS`, NOT a local literal: a local literal here
+    that drifted from the restore side is precisely what put 670 placeholder rows into the
+    canonical store. Levels resolve against the three objects the caller already holds.
+    """
+    holder = {'card': card, 'record': rec, 'sense': sense}
+    found = []
+    for level, name in card_fields.PROMOTED_PAIRS:
+        value = holder[level].get(name)
+        if isinstance(value, str) and TN_RE.search(value):
+            found.append('%s.%s=%r' % (level, name, value[:60]))
+    return found
+
+
 def rows_for(subkey, entry, review_status, model_version):
     card = entry['card']
     meta = entry['meta']
@@ -182,6 +207,17 @@ def rows_for(subkey, entry, review_status, model_version):
             ru = sense.get('russian')
             if not ru:
                 continue
+            # C-01: refuse to promote a row that still carries a mask placeholder. Every field
+            # below is read straight into the canonical store, and four of them were never
+            # restored -- 670 rows landed with a raw {Tn}, 223 of them in the HEADWORD. The
+            # restore side is driven from `card_fields`; this is the promote side's own
+            # burden-of-proof check, so a future restore gap fails loudly HERE rather than
+            # accumulating silently in canonical data.
+            residue = tn_residue(card, rec, sense)
+            if residue:
+                raise UnrestoredPlaceholder(
+                    '%s: refusing to promote a card with unrestored placeholders: %s'
+                    % (subkey, '; '.join(residue)))
             yield {
                 'key1': key1,
                 'subcard': subkey,


### PR DESCRIPTION
Executes **Step 2** of the H963 correction packet, per [H1080](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1080-Opus_SanskritLexicography_pwg-ru-killgate-envelope-correction-packet_16.07.26.md).

> **Depends on [#498](https://github.com/gasyoun/SanskritLexicography/pull/498)** (the evidence packet). That branch is still unmerged, so every `blob/master/.../h963/...` link in the handoff currently 404s.

## Verified against live canonical data first

I re-derived the packet's headline counts before changing anything. They are exact:

| Claim | Packet | Measured |
|---|---|---|
| Store rows | 11,605 | **11,605** |
| Rows with a raw `{Tn}` | 668 (C-01) + 2 (C-42) | **670** — `sense_tag` 376 · `h` 223 · `differentia` 72 · `ru` 2 · `de` 2 |
| Rows with `h == null` | 468 / 20 sub-cards | **468 / 20** (403 `batched-masked` + 65 `topup`) |

A headword field reading literally `{T104}` is real.

## The causal chain (all four confirmed by reading, not inference)

1. **C-01** — `restore_card` (and its JS twin) unmask **3** fields; `rows_for` promotes **6**. The 4 never-restored-yet-promoted fields (`card.iast`, `record.h`, `sense.tag`, `sense.differentia`) are exactly where the corruption is. The defect was not a *wrong* list — it was **two** lists. Now one constant, [`src/card_fields.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/card_fields.py), drives both lanes (the JS list is *interpolated*, since JS cannot import Python) and the promoter, which now refuses any row still holding a `{Tn}`.
2. **C-02** — both stitches built `records: [{senses}]`, violating `record.required = {h, grammar, senses}` and collapsing homonyms (**79 sub-cards legitimately carry >1 distinct `h`**). The true cause is *upstream* of the stitch: the flatten dropped `record` itself. Senses now carry their owning `(h, grammar)`; `stitch_records` rebuilds one record per owner, order preserved.
3. **C-42** — `restore_text` returned an out-of-range `{Tn}` verbatim with no counter and no reject. Now counted; the card is refused rather than promoted corrupt.
4. **C-04** — `validate_final_card_schema` had **no live caller**; its only invocation was CI against a hand-made *passing* fixture. **That is why 1 and 2 accumulated silently.** Wired into `save_and_audit` **before** the write (a gate that reports REFUSED after saving is not a gate), with an explicit `--allow-schema-violations` escape and a dead-validator canary. `RECORD_REQUIRED` not relaxed; `SENSE_REQUIRED`'s deliberate relaxation kept.

## The selftest runner was hiding a fifth of the suite

A bare `for test in tests: test()`, with the human-gated parity gate at position **105 of 131** — so the last **27 tests (20.6%)** were dark *indefinitely*, including both `pwg_mask` tests and four heal-lane tests. Now isolated and reporting `ran/defined`:

```
window selftest: ran 135/135 defined -- 134 passed, 1 failed
```

The lone failure is `test_lang_parity_ledger_complete` — **red by design** (C-27), which an agent must not green. Fixing the runner paid for itself immediately: it surfaced that arming C-04 breaks `test_save_merge_better_attempt_wins`, one of the formerly-dark tests, whose cards are deliberate stubs. That test now declares the exception explicitly rather than the contract being relaxed for everyone.

## Two packet claims corrected — by measurement

- **"make `count_card`/`countOf` see record-level fields" is wrong at that site.** Its denominator is a *source-occurrence* count (`raw.count('<ls')`); one source token echoed into both `grammar` and `german` counts 2 against 1. The repo's own fixture (`{T1}` in both) proves it — the change made the suite fail. Left `german`-only; this belongs with C-17 in Step 6.
- **"the 668 leaked rows are offline-recoverable" is 596, not 670.** 74 rows' recorded `input_raw_sha256` matches no source on disk.

## The goal line's premise is false: the 468 `h: null` rows are NOT backfillable

H1080's goal says *"the 670 {Tn}-corrupted + 468 h==null rows backfilled **from the content-addressed map**"*. There is no such map for `h`, and it cannot be built. The value was destroyed at the flatten **before it was ever persisted**:

- not in the store (it is `null`);
- **not in `wf_output`** — the archived files already read `h: None`;
- **not in the portraits** — real portraits carry no `h` (the portrait *schema* requires one; reality drifted, another unenforced schema);
- **not in the TM** — it is built *from the store*, so it is circular;
- **not derivable from the key** — 9,273 of 11,137 `h` values differ from `key1`; it is free lexicographic text (`"2. bhid"`, `"PW 3 (с anu, отсылка к entry 5)"`).

Synthesising one is what C-02's boundary explicitly forbids. **They need re-translation** — live calls, which this handoff forbids without a genuine c4 session. So Step 2 cannot complete as specified, and its prescribed order (C-02 → *backfill the 468* → C-01 → …) is broken at its second move. That is a human's call, not an agent's.

## Store NOT mutated

[`src/backfill_tn_residue.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/backfill_tn_residue.py) is **dry-run only**, pending that ruling. Measured: **596 recoverable / 74 not**. Two independent implementations agree on those numbers. Real output:

```
before: '1. {T1} [PWKVN supplement: sense 7 mit antar]'
after : '1. {#Bid#} [PWKVN supplement: sense 7 mit antar]'
```

Its first run reproduced **C-19's own defect class** — defaulting the source dir to its own checkout, where the gitignored `*.raw.txt` do not exist (0 files vs 110,374 in the main checkout), reporting a confident, wrong "nothing is recoverable". It now derives the path from the *resolved* store and refuses an empty source dir rather than reporting a false negative.

## Human gates (not agent-resolvable)

- **LANG_PARITY:** touching three SHARED files takes the ledger from **3 → 61** drift lines. Per C-27 I did **not** run `--update-hash`. These fixes are SHARED (both lanes) and need human reaffirmation + classification.
- **The 468 + 74 rows** need a re-translation ruling.
- H255 / no-PWG untouched · `KILL_CEIL_MS` and the 30 s gate untouched · no live generation calls · store unchanged at 11,605 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
