### PR TITLE
fix(russiantranslation): repair store integrity and promotion gates

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -793,9 +793,11 @@ Two live tracks:
   branch `codex/russiantranslation-store-integrity-h1080` now proves the requested offline repair:
   668 placeholder rows + 468 record owners recover, only two `banD` rows quarantine, yielding
   11,603 rows. Forward audit/save/promotion and autosplit/top-up paths now fail closed on final
-  schema/provenance/store-target defects and preserve record ownership. Targeted tests pass and
-  the aggregate runner executes all 135 tests; canonical store is still untouched pending parity
-  reconciliation and the complete clean validation pass.
+  schema/provenance/store-target defects and preserve record ownership. After PR #498 merged, the
+  branch was rebased and 43 affected parity entries were reaffirmed through the provided command.
+  Full validation is green (135/135 window; 49/49 parity; headless/orchestrator/repair/promotion;
+  ledger/Ruff/Node/diff). Canonical store remains untouched immediately before the hash-locked
+  repair step.
 
 - **No H960 implementation is active in this worktree (15-07-2026, Codex/GPT-5).** Audit and
   handoff only; no live generation, profile login, store/TM mutation, or scaling run occurred.

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -789,6 +789,12 @@ Two live tracks:
   parity 49/49 clean; headless/orchestrator selftests PASS; Ruff fatal PASS; launch ledger 17 complete;
   two generated harnesses syntax-clean; artifact hashes 18/18; diff check clean.
 
+- **RussianTranslation H1080 store integrity (17-07-2026, Codex/GPT-5):** isolated recovery
+  branch `codex/russiantranslation-store-integrity-h1080` now proves the requested offline repair:
+  668 placeholder rows + 468 record owners recover, only two `banD` rows quarantine, yielding
+  11,603 rows. Canonical store is still untouched pending forward promotion/store-init gates and
+  the complete validation pass.
+
 - **No H960 implementation is active in this worktree (15-07-2026, Codex/GPT-5).** Audit and
   handoff only; no live generation, profile login, store/TM mutation, or scaling run occurred.
   The stale H317/H442 prepared-canary notes below are historical inputs, not permission to bypass

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -792,8 +792,10 @@ Two live tracks:
 - **RussianTranslation H1080 store integrity (17-07-2026, Codex/GPT-5):** isolated recovery
   branch `codex/russiantranslation-store-integrity-h1080` now proves the requested offline repair:
   668 placeholder rows + 468 record owners recover, only two `banD` rows quarantine, yielding
-  11,603 rows. Canonical store is still untouched pending forward promotion/store-init gates and
-  the complete validation pass.
+  11,603 rows. Forward audit/save/promotion and autosplit/top-up paths now fail closed on final
+  schema/provenance/store-target defects and preserve record ownership. Targeted tests pass and
+  the aggregate runner executes all 135 tests; canonical store is still untouched pending parity
+  reconciliation and the complete clean validation pass.
 
 - **No H960 implementation is active in this worktree (15-07-2026, Codex/GPT-5).** Audit and
   handoff only; no live generation, profile login, store/TM mutation, or scaling run occurred.

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -22,10 +22,12 @@ Two live tracks:
 
 ## ➡️ Next Steps (Queue)
 
-- **RussianTranslation H1080 — store integrity before generation (17-07-2026).** PR #498 evidence
-  reconciliation is in progress/validation: withdraw unsupported kill-budget population projections,
-  preserve raw artifacts, make all 131 window tests execute, and restore green parity. Next is the
-  dedicated forward-gate + atomic-repair PR; no production generation is authorised before it lands.
+- **RussianTranslation H1080 — store integrity repaired; launch hardening next (17-07-2026).**
+  PR #498 merged green. The hash-locked atomic repair completed: 11,605→11,603 rows, 668 placeholder
+  rows + 468 null owners restored, two `banD` rows quarantined, zero residual `{Tn}`/null `h`, and
+  the RU card TM rebuilt once. Forward audit/save/promotion/autosplit gates are green (135/135 window,
+  49/49 parity). No production generation occurred. Manifest-v2/profile/global-claim hardening remains
+  the final prerequisite before a fresh c4 health probe.
 
 - [x] **H1074 A31/P5 error-origin typology — full Lexikos draft EXECUTED (17-07-2026, Fable 5
       `claude-fable-5`).** Draft [papers/A31_fifty_thousand_corrections_error_origin_typology.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A31_fifty_thousand_corrections_error_origin_typology.md)
@@ -796,8 +798,9 @@ Two live tracks:
   schema/provenance/store-target defects and preserve record ownership. After PR #498 merged, the
   branch was rebased and 43 affected parity entries were reaffirmed through the provided command.
   Full validation is green (135/135 window; 49/49 parity; headless/orchestrator/repair/promotion;
-  ledger/Ruff/Node/diff). Canonical store remains untouched immediately before the hash-locked
-  repair step.
+  ledger/Ruff/Node/diff). The hash-locked replacement then completed exactly: 11,603 rows, zero
+  raw tokens/null owners, two hash-sealed quarantine entries; second apply no-op. RU card TM rebuilt
+  once to 2,476 validated cards. No live generation or promotion occurred.
 
 - **No H960 implementation is active in this worktree (15-07-2026, Codex/GPT-5).** Audit and
   handoff only; no live generation, profile login, store/TM mutation, or scaling run occurred.

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2308,6 +2308,16 @@ exact live card rather than treating a fixture-only validator as evidence. A sec
 kill-budget saturation is admission telemetry, not proof of route-independent undeliverability;
 population claims require serial whole-card measurements, not an `n=2` ratio extrapolation.
 
+H1080 closed the measured damage without a model call. Exact historical harness maps and
+content-addressed raw inputs restored 668 placeholder rows and all 468 null owners; the two
+out-of-range `banD` rows were removed into a hash-sealed quarantine. The canonical store moved
+from 11,605 rows (`cc1d544e…`) to 11,603 (`f15caf7d…`) with zero raw tokens and zero null `h`, and
+the RU card TM was rebuilt once. The forward rule is now executable at every boundary: audit and
+promotion validate the live card; autosplit/top-up retain record owners; promotion requires an
+existing store by default and independently refuses synthetic, foreign, duplicate, or malformed
+inputs before a fsynced atomic replacement. The full repair evidence is tracked in
+`RussianTranslation/pwg_ru/h1080/H1080_STORE_REPAIR_REPORT_2026-07-17.md`.
+
 > **Source:** RussianTranslation audit-findings implementation
 > ([PR #478](https://github.com/gasyoun/SanskritLexicography/pull/478),
 > [follow-up PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482),

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1975,14 +1975,17 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   forward gates and atomic repair.
 
 - **H1080 atomic repair + forward gate completion (17-07-2026, Codex/GPT-5):** dry-run proof is
-  668 repaired / 468 owners / two quarantined / 11,603 output. Promotion now independently
+  668 repaired / 468 owners / two quarantined / 11,603 output. PR #498 is merged and this branch
+  is rebased on its green master. Promotion now independently
   enforces final schema, exact manifest-key membership, provenance shape, synthetic-control
   refusal, existing-store-by-default, exact subcard replacement, atomic write, and idempotence;
   audit and save paths also fail closed on invalid final cards. Autosplit/top-up now preserve
   `h` + `grammar` and homonym record boundaries. Targeted selftests and Ruff fatal checks pass;
-  the all-tests runner executed 135/135 (one now-fixed new assertion plus expected parity drift).
-  Next: reconcile Stage-1 parity/master, run the clean full suite, then hash-lock and repair the
-  canonical ignored store, rebuild TM once, and publish the tracked report.
+  all 43 affected parity entries were reviewed without changing their verdicts and refreshed only
+  via `lang_parity_check.py --update-hash`. Validation is green: window **135/135**, parity 49/49,
+  headless and orchestrator selftests, repair and promotion selftests, launch ledger 17, Ruff fatal,
+  generated-harness Node syntax, and diff check. Next: hash-lock and repair the canonical ignored
+  store, rebuild TM once, and publish the tracked report.
 
 - **H960 audit packaged; implementation not started (15-07-2026, Codex/GPT-5).** No live probe,
   generation, login, promotion, store mutation, or TM rebuild occurred. The H317/H442 material below

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1975,9 +1975,14 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   forward gates and atomic repair.
 
 - **H1080 atomic repair + forward gate completion (17-07-2026, Codex/GPT-5):** dry-run proof is
-  668 repaired / 468 owners / two quarantined / 11,603 output. Next: finish promotion-side schema,
-  synthetic/foreign-key/store-init gates; exercise scratch-store repair; then hash-lock and repair
-  the canonical ignored store, rebuild TM once, and publish the tracked report.
+  668 repaired / 468 owners / two quarantined / 11,603 output. Promotion now independently
+  enforces final schema, exact manifest-key membership, provenance shape, synthetic-control
+  refusal, existing-store-by-default, exact subcard replacement, atomic write, and idempotence;
+  audit and save paths also fail closed on invalid final cards. Autosplit/top-up now preserve
+  `h` + `grammar` and homonym record boundaries. Targeted selftests and Ruff fatal checks pass;
+  the all-tests runner executed 135/135 (one now-fixed new assertion plus expected parity drift).
+  Next: reconcile Stage-1 parity/master, run the clean full suite, then hash-lock and repair the
+  canonical ignored store, rebuild TM once, and publish the tracked report.
 
 - **H960 audit packaged; implementation not started (15-07-2026, Codex/GPT-5).** No live probe,
   generation, login, promotion, store mutation, or TM rebuild occurred. The H317/H442 material below

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -26,30 +26,19 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   FU1 3/102 = 2.94% [1.01%, 8.29%]**; verdict GO (conditional) with three named guards in
   `pwg_ru/h1070/`. No generation attempted; the store still has 0 EN rows.
 
-- **H1080 Step 2 (C-01/C-02/C-42/C-04) — 🔵 PR OPEN 16-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`),
-  branch `h1080-step2`.** The four generator-side sources of the store corruption are closed and
-  the record contract now runs on live output; `window_selftest` **135/135 run, 134 pass** (the one
-  failure is the C-27 parity gate, red by design). **Two human gates block the rest — an agent
-  cannot clear either:**
-  1. **`@DECIDE` — the 468 `h: null` rows are NOT backfillable offline, so H1080's goal line
-     ("468 h==null rows backfilled from the content-addressed map") rests on a false premise and
-     Step 2 cannot complete as written.** Proven this pass: the value was destroyed at the flatten
-     before it was ever persisted — absent from the store, already `null` in the archived
-     `wf_output`, absent from real portraits (which carry no `h` despite their schema requiring
-     one), and the TM is built *from* the store (circular). `h` is free lexicographic text
-     (`"2. bhid"`, `"PW 3 (с anu, отсылка к entry 5)"`), differing from `key1` in 9,273 of 11,137
-     rows, so it cannot be synthesised — which C-02's boundary forbids anyway. **They need
-     re-translation (live calls).** Same for **74 of the 670 `{Tn}` rows**, whose recorded
-     `input_raw_sha256` matches no source on disk (the packet's "668 offline-recoverable" is
-     really **596**).
-  2. **`@DO` — LANG_PARITY reaffirmation.** Touching three SHARED files moves the ledger
-     **3 → 61** drift lines. Per C-27 no `--update-hash` was run. The fixes are SHARED (both
-     lanes) and need human reaffirmation + classification.
-  **Store NOT mutated** (still 11,605 rows):
-  [`src/backfill_tn_residue.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/backfill_tn_residue.py)
-  is dry-run only — 596 recoverable / 74 not — pending ruling 1. Also blocked upstream:
-  [PR #498](https://github.com/gasyoun/SanskritLexicography/pull/498) (the H963 evidence packet) is
-  still unmerged, so the handoff's `blob/master/.../h963/` links 404.
+- **H1080 store integrity recovery — 🚧 ACTIVE 17-07-2026 (Codex/GPT-5).** Recovered the
+  concurrent `h1080-step2` forward fix into isolated branch
+  `codex/russiantranslation-store-integrity-h1080` and disproved its two premature recovery
+  blockers. The ignored historical generated-harness archive retains exact `PH` maps bound to
+  `META.input_hashes`; together with current and regenerated content-addressed raw artifacts it
+  deterministically restores **668/670** placeholder rows. The 468 `h: null` rows reduce to 20
+  card owners and are reconstructible from immutable card identity (nominal IAST or root/upasarga
+  subcard metadata), without a model. The replacement repair utility now dry-runs to exactly
+  **11,605 in → 11,603 out; 668 token rows repaired; 468 owners repaired; two C-42 `banD` rows
+  quarantined**, with source-hash lock, exact-key multiset proof, fsynced atomic replacement,
+  backup, quarantine hashes, and idempotence. Its selftest covers raw+harness recovery, quarantine,
+  source drift, atomic failure preservation, and a clean second run. **Store remains unmodified**
+  while forward promotion/schema/store-init gates and the full validation set are completed.
 
 - **H971 QA / methodology re-audit — 🔴 EXECUTED 15-07-2026 (Fable 5 `claude-fable-5`).**
   Deterministic half of the H178 protocol re-run on the grown store (11,261/50 → **11,605 rows / 67
@@ -1984,6 +1973,11 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   PASS; launch ledger **17 complete**; both H963 generated harnesses pass `node --check`; artifact
   manifest **18/18 hashes match**; `git diff --check` clean. Production remains blocked on H1080
   forward gates and atomic repair.
+
+- **H1080 atomic repair + forward gate completion (17-07-2026, Codex/GPT-5):** dry-run proof is
+  668 repaired / 468 owners / two quarantined / 11,603 output. Next: finish promotion-side schema,
+  synthetic/foreign-key/store-init gates; exercise scratch-store repair; then hash-lock and repair
+  the canonical ignored store, rebuild TM once, and publish the tracked report.
 
 - **H960 audit packaged; implementation not started (15-07-2026, Codex/GPT-5).** No live probe,
   generation, login, promotion, store mutation, or TM rebuild occurred. The H317/H442 material below

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -14,11 +14,12 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
-- **H1080 — store-integrity repair is the next production blocker (17-07-2026).** The H963 evidence
-  was reconciled on PR #498: 668 ordinary `{Tn}` rows are deterministically recoverable, 468 rows
-  need `h` restoration, and the two `banD` rows with `{T9}` in `ru`/`de` require quarantine and later
-  retranslation. No live generation, promotion, canonical-store write, or TM rebuild occurred in
-  the reconciliation stage. Continue only on a dedicated branch from current `origin/master`.
+- **H1080 store integrity — ✅ REPAIRED 17-07-2026 (Codex/GPT-5).** PR #498 merged green;
+  the dedicated hash-locked repair restored 668 placeholder rows and 468 null owners, quarantined
+  the two out-of-range `banD` rows, and atomically changed the store 11,605→11,603 with zero raw
+  `{Tn}` and zero null `h`. RU card TM rebuilt once (2,476 valid); second repair is a no-op. No
+  generation or promotion occurred. Next production blocker is Stage 3 manifest-v2/profile/global
+  active-call hardening; only after it lands may the fresh c4 health probe run.
 
 - **H1070 EN gold adjudication vs MW TM + FU1 scale-up go/no-go — 🔴 EXECUTED 17-07-2026 (Fable 5 `claude-fable-5`).**
   170 sense rows adjudicated (exact S7 68-row frame, Sonnet 4.6 + fresh 50-card/102-row FU1
@@ -1984,8 +1985,10 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   all 43 affected parity entries were reviewed without changing their verdicts and refreshed only
   via `lang_parity_check.py --update-hash`. Validation is green: window **135/135**, parity 49/49,
   headless and orchestrator selftests, repair and promotion selftests, launch ledger 17, Ruff fatal,
-  generated-harness Node syntax, and diff check. Next: hash-lock and repair the canonical ignored
-  store, rebuild TM once, and publish the tracked report.
+  generated-harness Node syntax, and diff check. The canonical repair then completed exactly:
+  **11,603 rows; 0 raw tokens; 0 null `h`; 2 quarantine entries**. Backup, quarantine, before/after
+  store and TM hashes are recorded in `pwg_ru/h1080/`; a second application is a no-op. Stage 3
+  manifest-v2/profile/global-call hardening remains before any c4 probe or paid translation.
 
 - **H960 audit packaged; implementation not started (15-07-2026, Codex/GPT-5).** No live probe,
   generation, login, promotion, store mutation, or TM rebuild occurred. The H317/H442 material below

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: PWG (Petersburg Dictionary) → Russian edition + the CDSL article-comparison study
 
-_Created: 09-07-2026 · Last updated: 17-07-2026_
+_Created: 09-07-2026 · Last updated: 15-07-2026_
 
 Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/archive/H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md)):
 
@@ -22,17 +22,34 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 - **H1070 EN gold adjudication vs MW TM + FU1 scale-up go/no-go — 🔴 EXECUTED 17-07-2026 (Fable 5 `claude-fable-5`).**
   170 sense rows adjudicated (exact S7 68-row frame, Sonnet 4.6 + fresh 50-card/102-row FU1
-  sample, Sonnet 5, seed 43) with MW quoted per entry as adversary. **Wrong-sense: pilot 1/68
-  (the known r025 MW-leak), FU1 3/102 = 2.94% [1.01%, 8.29%]** — «braut»→"betroth" homograph,
-  «Vergleich»→"comparison" polyseme, dropped `{#uc#}` in a `<F>` footnote (CONFIRMED in raw;
-  also shows the `{#..#}` guard skips footnotes). Zero new MW contamination, zero
-  register-mismatch; suspected r005 omission resolved as a frame-split artifact (S7's
-  "zero omissions" stands). **Verdict GO (conditional)** — decision rule + 3 named guards in
-  [`pwg_ru/h1070/PWG_EN_FU1_SCALEUP_GO_NO_GO_2026-07-17.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h1070/PWG_EN_FU1_SCALEUP_GO_NO_GO_2026-07-17.md);
-  full rulings [`pwg_ru/h1070/H1070_EN_GOLD_ADJUDICATION_2026-07-17.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h1070/H1070_EN_GOLD_ADJUDICATION_2026-07-17.md).
-  No generation attempted (host still degraded — H818/H909); giant-head recovery, 4-card
-  hard-flag remediation and Phase 2 stay parked per the MG-locked order. NB: store still has
-  0 EN rows — `promote_en.py` never ran; every store-level EN check is vacuous until Phase 2.
+  sample, Sonnet 5, seed 43) with MW quoted per entry as adversary. **Wrong-sense: pilot 1/68,
+  FU1 3/102 = 2.94% [1.01%, 8.29%]**; verdict GO (conditional) with three named guards in
+  `pwg_ru/h1070/`. No generation attempted; the store still has 0 EN rows.
+
+- **H1080 Step 2 (C-01/C-02/C-42/C-04) — 🔵 PR OPEN 16-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`),
+  branch `h1080-step2`.** The four generator-side sources of the store corruption are closed and
+  the record contract now runs on live output; `window_selftest` **135/135 run, 134 pass** (the one
+  failure is the C-27 parity gate, red by design). **Two human gates block the rest — an agent
+  cannot clear either:**
+  1. **`@DECIDE` — the 468 `h: null` rows are NOT backfillable offline, so H1080's goal line
+     ("468 h==null rows backfilled from the content-addressed map") rests on a false premise and
+     Step 2 cannot complete as written.** Proven this pass: the value was destroyed at the flatten
+     before it was ever persisted — absent from the store, already `null` in the archived
+     `wf_output`, absent from real portraits (which carry no `h` despite their schema requiring
+     one), and the TM is built *from* the store (circular). `h` is free lexicographic text
+     (`"2. bhid"`, `"PW 3 (с anu, отсылка к entry 5)"`), differing from `key1` in 9,273 of 11,137
+     rows, so it cannot be synthesised — which C-02's boundary forbids anyway. **They need
+     re-translation (live calls).** Same for **74 of the 670 `{Tn}` rows**, whose recorded
+     `input_raw_sha256` matches no source on disk (the packet's "668 offline-recoverable" is
+     really **596**).
+  2. **`@DO` — LANG_PARITY reaffirmation.** Touching three SHARED files moves the ledger
+     **3 → 61** drift lines. Per C-27 no `--update-hash` was run. The fixes are SHARED (both
+     lanes) and need human reaffirmation + classification.
+  **Store NOT mutated** (still 11,605 rows):
+  [`src/backfill_tn_residue.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/backfill_tn_residue.py)
+  is dry-run only — 596 recoverable / 74 not — pending ruling 1. Also blocked upstream:
+  [PR #498](https://github.com/gasyoun/SanskritLexicography/pull/498) (the H963 evidence packet) is
+  still unmerged, so the handoff's `blob/master/.../h963/` links 404.
 
 - **H971 QA / methodology re-audit — 🔴 EXECUTED 15-07-2026 (Fable 5 `claude-fable-5`).**
   Deterministic half of the H178 protocol re-run on the grown store (11,261/50 → **11,605 rows / 67

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -32,6 +32,41 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   (`claude-fable-5`); generation under judgment Sonnet 4.6 (`claude-sonnet-4-6`, pilot) and
   Sonnet 5 (`claude-sonnet-5`, FU1).
 
+### Fixed — H1080 / H963 packet Step 2 (C-01, C-02, C-42, C-04)
+
+- **One field set for restore and promote ([`src/card_fields.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/card_fields.py), C-01).**
+  `restore_card` and its JS twin unmasked 3 fields while `promote_final_cards.rows_for` read
+  6, so `card.iast` / `record.h` / `sense.tag` / `sense.differentia` were promoted with their
+  `{Tn}` intact — **670 of 11,605 store rows carry a raw placeholder, 223 of them a headword
+  reading literally `{T104}`** (re-verified against the live store this pass). Both lanes and
+  the promoter are now driven from one constant; the JS list is interpolated, not re-typed.
+  `promote_final_cards` additionally refuses any row still holding a `{Tn}`.
+- **The stitch keeps record identity (C-02).** Both stitch lanes built `records: [{senses}]`,
+  dropping record-level `h`/`grammar` unconditionally and collapsing homonyms into one flat
+  record — hence **468 rows / 20 sub-cards with `h: null`** (403 `batched-masked` + 65
+  `topup`). The flatten now carries each sense's owning `(h, grammar)` and `stitch_records`
+  rebuilds one record per owner, preserving document order.
+- **Out-of-range `{Tn}` is counted and refused (C-42).** `restore_text` returned an unmapped
+  token verbatim with no counter, no log and no reject; both lanes now count it and refuse
+  the card rather than promote known-corrupt content.
+- **The record contract runs on live output (C-04).** `validate_final_card_schema` — the only
+  component encoding `record.required = {h, grammar, senses}` — had **no live caller**: its
+  sole invocation was a CI step against a hand-made *passing* fixture. It is now wired into
+  `save_and_audit` **before** the write and has no production escape hatch. Audit and promotion
+  independently run the same contract. `RECORD_REQUIRED` is not relaxed.
+- **`window_selftest` no longer stops at the first failure.** The runner was a bare
+  `for test in tests: test()`, and the human-gated language-parity gate sits at position 105
+  of 131 — so **27 tests (20.6%) were dark indefinitely**, including `pwg_mask` and four
+  heal-lane tests. Now isolated, reporting `ran/defined`: **135/135 run, 134 pass**, the lone
+  failure being the parity gate that is red by design.
+
+### Added
+
+- [`src/backfill_tn_residue.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/backfill_tn_residue.py)
+  — dry-run-first, source-hash-locked restoration from exact raw inputs or historical harness
+  placeholder maps. The complete evidence chain deterministically repairs **668/670** placeholder
+  rows and all **468** null headwords; only two malformed `banD` rows require quarantine.
+
 - **Provenance-bound mixed-lane requeues.** Each lease now seals its initial execution
   manifest as the immutable key universe and stores every pending retry key with the path
   and SHA-256 of the audit report that classified it. `record-output` rejects duplicate,

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -34,6 +34,18 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ### Fixed — H1080 / H963 packet Step 2 (C-01, C-02, C-42, C-04)
 
+- **Canonical store repaired and sealed.** A hash-locked dry run and atomic replacement repaired
+  668 placeholder rows and 468 null record owners, quarantined only the two irrecoverable `banD`
+  rows, and produced a clean 11,603-row store (zero raw `{Tn}`, zero null `h`). The original
+  11,605-row store and the two quarantine payloads remain uncommitted but hash-addressed; the
+  tracked `pwg_ru/h1080/` report records before/after, backup, quarantine, and one-time TM hashes.
+  A second repair invocation is a verified no-op.
+- **Promotion now fails closed independently.** `save_and_audit`, `audit_window`, autosplit/top-up,
+  and `promote_final_cards` preserve and validate record `h`/`grammar` plus homonym boundaries.
+  Promotion refuses invalid final schema, unresolved tokens, malformed or foreign provenance,
+  synthetic controls, duplicate results, and a missing store unless the operator explicitly uses
+  first-run-only `--init-store`. Backups are copied/fsynced and replacement is atomic.
+
 - **One field set for restore and promote ([`src/card_fields.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/card_fields.py), C-01).**
   `restore_card` and its JS twin unmasked 3 fields while `promote_final_cards.rows_for` read
   6, so `card.iast` / `record.h` / `sense.tag` / `sense.differentia` were promoted with their

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153"
     }
   },
   {
@@ -117,8 +117,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -136,8 +136,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -155,8 +155,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -173,7 +173,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153"
     }
   },
   {
@@ -224,7 +224,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153"
     }
   },
   {
@@ -241,7 +241,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153"
     }
   },
   {
@@ -258,7 +258,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 closes the former divergence: exact model provenance is required across four accounts, so both RU and EN now request and stamp claude-sonnet-5. This prevents account/profile alias resolution from making cross-window provenance incomparable.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153"
     }
   },
   {
@@ -280,7 +280,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
       "src/pilot/prompt_rule_audit.py": "bb07e6851707ee61f301e33172f8d26ba1e9180315c8c5a49baa4650afff7eee",
-      "src/pilot/audit_window.py": "f296b605833a028b9be92aada63077432ea798a7d8df4f8e0cccb2e3ccd16a21",
+      "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48"
     }
   },
@@ -299,7 +299,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The denylist append and load_frag_tm filtering are lang-agnostic (fsha encodes lang; requeue_from_audit takes --lang), but the fshas EMITTER lives only in the RU auditor: audit_window_en.py reimplements its gates and does not compute requeue_defect_fshas or write the file, so an EN defect requeue does not auto-denylist its fragments.",
     "tracking": "Uprava/handoffs/archive/H304-Fable_RussianTranslation_coordinator-driver-remake_07.07.26.md (EN-emitter port is the recorded follow-up)",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "f296b605833a028b9be92aada63077432ea798a7d8df4f8e0cccb2e3ccd16a21",
+      "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/requeue_from_audit.py": "598d8ad7dcede04198eef7f0c9c5152aecb576572fa8dfbc36008387f92adbb6"
     }
@@ -336,7 +336,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
+      "src/promote_final_cards.py": "b21994a76f90dab00ce75b35f8083e72312f4b13a1ea62f7fe1b534ddf3d8637",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
     }
   },
@@ -355,8 +355,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -375,7 +375,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -393,7 +393,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED same day (2026-07-04): PR #140 (feat(provenance): pipeline versioning) added pipeline_version stamping only to promote_final_cards.py; found as a GAP while re-affirming H169's parity re-hash, closed immediately. promote_en.py now calls `pipeline_version.stamp(model_version=gen_model_version)` inside `en_index()`'s per-subcard provenance block, stored as `en_provenance.pipeline` (mirrors RU's `provenance.pipeline`; a distinct field since EN attaches onto an existing RU row rather than owning it). Pinned by an added assertion in `promote_en.selftest()`.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
+      "src/promote_final_cards.py": "b21994a76f90dab00ce75b35f8083e72312f4b13a1ea62f7fe1b534ddf3d8637",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
     }
   },
@@ -412,8 +412,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -431,7 +431,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 1.1. The layer is derived purely from the sub-card KEY structure, which is identical for RU and EN. promote_en.py ATTACHES english onto the RU-owned row and leaves it otherwise untouched, so EN inherits `layer` for free — no EN-specific code needed. layer_of() pinned by dict_merge.py selftest + a promote_final_cards.selftest assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
+      "src/promote_final_cards.py": "b21994a76f90dab00ce75b35f8083e72312f4b13a1ea62f7fe1b534ddf3d8637",
       "src/dict_merge.py": "0266e11980e3b8b12d0699665b2051b9f7b8b16ed89d5810adfe5a458e880eea"
     }
   },
@@ -450,8 +450,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/promote_final_cards.py": "b21994a76f90dab00ce75b35f8083e72312f4b13a1ea62f7fe1b534ddf3d8637"
     }
   },
   {
@@ -470,9 +470,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -500,10 +500,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/make_edition_cut.py": "5a24d8c96611f50f008689609f8140ef47b02731524dbc255438426b36d306fd",
       "src/preflight_remaining_gates.py": "00386c837b97986c9702abfceed9c29534736c3df3063af202ddfaae6b078b8f",
       "src/release_readiness.py": "db38a870bbc8b5dbe694e706e4a7b9089ba41211a3881ad9a1bd4eb02950c8a9",
-      "save_and_audit.py": "f4fed9b930f31f725763899c49775cb190e61865db4dd16c6e1e9d5bb4494b85",
-      "src/pilot/audit_window.py": "f296b605833a028b9be92aada63077432ea798a7d8df4f8e0cccb2e3ccd16a21",
-      "src/pilot/autosplit_requeue.py": "17ac6103dbdb6743163bb312531d71deb4a12da35c777e3676baf5d95afe1792",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "save_and_audit.py": "bd9626ca58ca67773ab157140a2b62afff46047ac2294a864783144f629a7d63",
+      "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
+      "src/pilot/autosplit_requeue.py": "7ada6e0aa8dc8d0be15cf4be725e380929282974cc19fc950690c07b09511448",
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -522,7 +522,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -540,7 +540,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "95797986db7c21210a55c8a13f324514d17110ba07d2f804d000a77a003d5bf3",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -559,7 +559,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -597,9 +597,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
-      "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
+      "src/promote_final_cards.py": "b21994a76f90dab00ce75b35f8083e72312f4b13a1ea62f7fe1b534ddf3d8637",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -620,11 +620,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H336 (08-07-2026). window_reports.write_reports/write_window_status already took an out_dir parameter (pre-existing --out-dir escape hatch); --window-tag is a thin, lang-agnostic sugar layer over that same parameter computed once in audit_window.py and threaded through unchanged to requeue_from_audit.py/root_window_status.py. Neither RU nor EN branch differently. Pinned by test_audit_window_tag_routing.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "f296b605833a028b9be92aada63077432ea798a7d8df4f8e0cccb2e3ccd16a21",
+      "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/requeue_from_audit.py": "598d8ad7dcede04198eef7f0c9c5152aecb576572fa8dfbc36008387f92adbb6",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -653,7 +653,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -673,7 +673,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -692,7 +692,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "e42c2635cbc1fead5ab6e0cfcd0866149cfd29eb786fb3ce1fa14e4227b4fbf4",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -729,7 +729,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -748,7 +748,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/stage2_pregate.py": "f801740067f981f66e480330a586e12d9e98f85f7f564e40520d7ff43af139e2",
-      "src/pilot/audit_window.py": "f296b605833a028b9be92aada63077432ea798a7d8df4f8e0cccb2e3ccd16a21"
+      "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680"
     }
   },
   {
@@ -787,7 +787,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -805,8 +805,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -824,8 +824,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -844,8 +844,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da",
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -866,8 +866,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -904,7 +904,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/store_path.py": "2b3be1415dc7a387717c60574abc36aec9600d7a5c138bf7ac85415aa1b1e152",
-      "src/promote_final_cards.py": "693a77c5a40ba132daf1fbfcf5077b60739aa9d16be9078dab0e3e58f66665d2",
+      "src/promote_final_cards.py": "b21994a76f90dab00ce75b35f8083e72312f4b13a1ea62f7fe1b534ddf3d8637",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
     }
   },
@@ -924,9 +924,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -953,11 +953,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 Windows readiness uses one language-parameterized manifest and worker contract. Whole-card retries, binary split, fragment TM/restore/fidelity, per-card budgets, timeout-no-bisect, partial stitching, audit-clean subset promotion, staged dispatch, and credential-safe event/census telemetry do not branch on RU/EN. Production policy selects RU no_pwg for the first 100-headword proof; the mechanism preserves EN field/schema behavior.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/headless_worker.py": "4b090d502c514884a334cbf58cf2c1867db3f4fd3244bfda3132c253ef4caabe",
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/headless_worker.py": "569dbb2b9893e3a15e5f09270da1bf9dc0636814f05eda0f891dd1474f878476",
       "src/pilot/max_account_orchestrator.py": "e33a4f32908f886a162973cb5202fcf72c5ac8eaba5ba52698065c491459be1c",
       "src/pilot/coordinator.py": "e42c2635cbc1fead5ab6e0cfcd0866149cfd29eb786fb3ce1fa14e4227b4fbf4",
-      "src/pilot/headless_worker_selftest.py": "64c0c6c2567ef2c02844c6495fa8f99a74b5200c1cd7e37d44365fcbcbf3a00a",
+      "src/pilot/headless_worker_selftest.py": "f0e548832e927f8a0869db630f7076feafc319ca980de9eba7253a39902d5768",
       "src/pilot/max_account_orchestrator_selftest.py": "08f6c58db179a3109caff9ffd6626e346dc0dd70827818165b4eed194eae66c5",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
@@ -983,10 +983,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H390 Phase 1 (12-07-2026, Opus 4.8 claude-opus-4-8), extended by H818. gen_model is written into language-agnostic run meta and flows through the shared ledger writer and harvester identically for RU/EN; both paths now stamp exact claude-sonnet-5. Pinned by test_ledger_stamps_gen_model in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -1004,8 +1004,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H823, fixes the H255 presplit-cohort loss). Both the citation presplit trigger (_presplit_hit) and the single-card kill budget (killBudgetForCur) are language-independent — they key on <ls>/fragment counts and FRAGS, never on --lang; the same floor + CEIL apply to RU and EN identically. Extends no_fallback_single_kill_budget_and_nominal_key_echo (H220) from no-fallback singles to all singles. Pinned by test_presplit_cite_floor_and_single_ceil.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -1028,9 +1028,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
-      "src/pilot/audit_window.py": "f296b605833a028b9be92aada63077432ea798a7d8df4f8e0cccb2e3ccd16a21",
+      "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da"
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
   {
@@ -1050,9 +1050,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H960 (15-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes H920's explicitly-deferred accept()-side sense-count consumption. Language-neutral: accept() counts SENSE OBJECTS (records[].senses[]), never a gloss language, and source_senses is sense_count.count_source_senses over the German source markers (identical for the RU and EN lanes — the source is German for both). SOFT by default (SANLOSS_HARD_REJECT=false): a shortfall is telemetry only (no reject/requeue), so live traffic can measure the true drop-vs-false-flag rate before the reject is armed (owner-gated ladder). The shared counter is hardened against the ~4.78%-of-cards cross-reference over-count the naive count carried (gam~~h2_31_pari 2->1, s_ud~~h0_05_pra 4->2, _a_srayatva 2->0); under-counting is the safe direction, never a false shortfall. Pinned by test_h960_accept_sanloss_soft_gate (builds the real harness, extracts the emitted accept()+countOf, asserts soft-keep / surplus-ok / FP-regression / ls-sk-first / armed-hard-reject via accept_sensecount_test.js) plus the 3 cross-reference fixtures in sense_count._selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "e37d8c29974fbe1b90fbe461a20d7ab6f1bc68db49e4762f1ed311724ff55e18",
+      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "110f07b7ae684db119e238377700f48b96b8c40eea6fcfe5130ecad510fc75da",
+      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135",
       "src/pilot/accept_sensecount_test.js": "ae04e6390738fcc31ac39b4a292c967b4e26d8abc669fa12f690c9d694e88f3d"
     }
   }

--- a/RussianTranslation/pwg_ru/h1080/H1080_STORE_REPAIR_REPORT_2026-07-17.json
+++ b/RussianTranslation/pwg_ru/h1080/H1080_STORE_REPAIR_REPORT_2026-07-17.json
@@ -1,0 +1,57 @@
+{
+  "schema": "pwg_ru.store_repair_report.v1",
+  "handoff": "H1080",
+  "created_at": "2026-07-17T02:08:16+03:00",
+  "mode": "atomic_in_place",
+  "production_generation_calls": 0,
+  "store": {
+    "before_rows": 11605,
+    "before_sha256": "cc1d544ed92d201ca8cbecde0b5e9a8191994dfd1baf20841da82f1f9ae7c805",
+    "after_rows": 11603,
+    "after_sha256": "f15caf7d1f65db0269498c50ecdcd6bf098572a543c12a055ae08c374377b2f9",
+    "raw_token_rows_after": 0,
+    "null_headword_rows_after": 0
+  },
+  "repair": {
+    "placeholder_rows_found": 670,
+    "placeholder_rows_repaired": 668,
+    "null_headword_rows_repaired": 468,
+    "quarantined_rows": 2,
+    "second_apply": "no_op_already_clean",
+    "key_subcard_multiset": "unchanged_except_two_quarantined_rows"
+  },
+  "backup": {
+    "filename": "pwg_ru_translated.jsonl.pre-h1080.cc1d544ed92d201c.20260716T230816Z.bak",
+    "sha256": "cc1d544ed92d201ca8cbecde0b5e9a8191994dfd1baf20841da82f1f9ae7c805",
+    "tracked": false
+  },
+  "quarantine": {
+    "filename": "pwg_ru_translated.jsonl.h1080_quarantine.jsonl",
+    "sha256": "dad87e89009bf0f3b292d41d6f67bcd225623b0cae184c567ee725d1b4472490",
+    "tracked": false,
+    "entries": [
+      {
+        "key": "banD",
+        "subcard": "ban_d~~h0_11_ni",
+        "original_row_sha256": "aeca869f7cea526193291b6756b3ec7638cd8c3b1495b30fb099d3872b01cbcc",
+        "input_raw_sha256": "afecdf60aaac961faca28c907aaffe16364875fe94a5edc6311f091522e403b9",
+        "reason": "de contains out-of-range {T196}; placeholder map has 195 entries"
+      },
+      {
+        "key": "banD",
+        "subcard": "ban_d~~h0_21_upasam_0",
+        "original_row_sha256": "ca34c515728e2c8ac51df4c2bc09f0dd0df60070361bd909767abc3773747186",
+        "input_raw_sha256": "fe1b164d4bfe0c477e209c295f7392d011d5f944b3f56accb60872e790bb206d",
+        "reason": "de contains out-of-range {T235}; placeholder map has 234 entries"
+      }
+    ]
+  },
+  "translation_memory": {
+    "before_sha256": "f2efc0e68d8dbb0e0858203d491a430a80d169ae3a5f2ec3c7c44d32ea0a79ef",
+    "after_sha256": "121d56fc9b6acb52c6bed81587953104a86b5ef83a607bbe8e2bd16d1db7b4ab",
+    "content_addressed_cards": 2476,
+    "validation_ok": 2476,
+    "rebuild_count": 1,
+    "tracked": false
+  }
+}

--- a/RussianTranslation/pwg_ru/h1080/H1080_STORE_REPAIR_REPORT_2026-07-17.md
+++ b/RussianTranslation/pwg_ru/h1080/H1080_STORE_REPAIR_REPORT_2026-07-17.md
@@ -1,0 +1,30 @@
+# H1080 PWG→Russian store repair — 17 July 2026
+
+The canonical store was repaired atomically without any model or production-generation call.
+The source store was hash-locked before mutation, copied to a hash-addressed backup, and replaced
+only after the repair utility proved the expected key/subcard multiset delta.
+
+| Check | Result |
+|---|---:|
+| Store before | 11,605 rows · `cc1d544ed92d201ca8cbecde0b5e9a8191994dfd1baf20841da82f1f9ae7c805` |
+| Placeholder rows repaired | 668 of 670 |
+| Null `h` rows repaired | 468 |
+| Quarantined | 2 `banD` rows |
+| Store after | 11,603 rows · `f15caf7d1f65db0269498c50ecdcd6bf098572a543c12a055ae08c374377b2f9` |
+| Residual raw `{Tn}` / null `h` | 0 / 0 |
+| Second application | no-op (`already_clean`) |
+| RU card TM | 2,476 valid cards · `121d56fc9b6acb52c6bed81587953104a86b5ef83a607bbe8e2bd16d1db7b4ab` |
+
+The 668 recoverable rows were restored only from content-addressed raw inputs or historical
+generated-harness placeholder maps bound to the recorded raw-input hash. The two remaining rows
+contain indices outside their own maps (`{T196}` with 195 entries and `{T235}` with 234 entries),
+so retaining their text would fabricate evidence. Their uncommitted quarantine payload is sealed
+by SHA-256 `dad87e89009bf0f3b292d41d6f67bcd225623b0cae184c567ee725d1b4472490`;
+the tracked JSON report records each original row hash without publishing the payload.
+
+The backup remains uncommitted and byte-identical to the pre-repair store. The RU card translation
+memory was rebuilt exactly once from the clean store and validated. The publication and fragment
+TMs were not rebuilt because H1080 changed the canonical card store, not those independent sources.
+
+No fresh c4 health probe, quarantined-key retranslation, promotion, or paid window was run. Those
+remain gated on completion of the manifest-v2 and launch-control hardening stage.

--- a/RussianTranslation/save_and_audit.py
+++ b/RussianTranslation/save_and_audit.py
@@ -26,7 +26,11 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 PILOT = os.path.join(HERE, "src", "pilot")
 if PILOT not in sys.path:
     sys.path.insert(0, PILOT)
+SRC = os.path.join(HERE, "src")
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
 from window_common import atomic_write_json
+import validate_final_card_schema          # C-04: the record contract, now on the LIVE path
 
 
 def main():
@@ -100,10 +104,48 @@ def main():
             sys.exit(f"REFUSED: {os.path.basename(out_path)} has {old_nn} non-null cards; new has "
                      f"only {new_nn}. Use --merge to fill nulls, or --force to overwrite.")
 
-    atomic_write_json(out_path, result, indent=None)
-
     cards = result.get("results", [])
     null_count = sum(1 for r in cards if not r.get("card"))
+
+    # C-04: enforce the record contract on LIVE output.
+    #
+    # `validate_final_card_schema` is the only component that encodes
+    # `record.required = {h, grammar, senses}`, and until now its single caller was a CI step
+    # running it against a hand-made PASSING fixture -- a green check certifying a contract no
+    # real card was ever measured against. That is why C-01 and C-02 accumulated in silence:
+    # 670 rows reached the canonical store with a raw {Tn}, and 468 with `h: null`, past a
+    # validator that would have refused every one of them.
+    #
+    # RECORD_REQUIRED is NOT relaxed to make this pass (nor is SENSE_REQUIRED "restored" --
+    # its relaxation was deliberate, matching the generation schema). A card that cannot state
+    # its own `h` is exactly what must not be saved.
+    violations = []
+    for r in cards:
+        card = r.get("card")
+        if not card:
+            continue                        # a null card is already counted above
+        try:
+            validate_final_card_schema.validate_card(card)
+        except ValueError as exc:
+            violations.append(f"  {r.get('key')}: {exc}")
+    if violations:
+        print(f"SCHEMA: {len(violations)} of {len(cards) - null_count} card(s) violate "
+              f"pwg_ru_final_card.schema.json:")
+        for v in violations[:20]:
+            print(v)
+        if "--allow-schema-violations" not in flags:
+            # Refuse BEFORE the write: a gate that reports "REFUSED" after already saving the
+            # file is not a gate.
+            sys.exit(
+                f"REFUSED: {len(violations)} card(s) violate the final-card record contract, "
+                f"nothing written. These would land in the canonical store unreadable by any "
+                f"consumer grouping on (key1, h). Fix the generator, or pass "
+                f"--allow-schema-violations to record the exception deliberately.")
+        print("SCHEMA: proceeding under --allow-schema-violations (violations recorded above)")
+    else:
+        print(f"SCHEMA: {len(cards) - null_count} card(s) satisfy the record contract")
+
+    atomic_write_json(out_path, result, indent=None)
     print(f"Saved {out_path}: {len(cards)} cards, {null_count} null")
 
     if "--no-audit" in flags:

--- a/RussianTranslation/save_and_audit.py
+++ b/RussianTranslation/save_and_audit.py
@@ -133,15 +133,12 @@ def main():
               f"pwg_ru_final_card.schema.json:")
         for v in violations[:20]:
             print(v)
-        if "--allow-schema-violations" not in flags:
-            # Refuse BEFORE the write: a gate that reports "REFUSED" after already saving the
-            # file is not a gate.
-            sys.exit(
-                f"REFUSED: {len(violations)} card(s) violate the final-card record contract, "
-                f"nothing written. These would land in the canonical store unreadable by any "
-                f"consumer grouping on (key1, h). Fix the generator, or pass "
-                f"--allow-schema-violations to record the exception deliberately.")
-        print("SCHEMA: proceeding under --allow-schema-violations (violations recorded above)")
+        # Refuse BEFORE the write: a gate that reports "REFUSED" after already saving the
+        # file is not a gate.  There is deliberately no production escape hatch.
+        sys.exit(
+            f"REFUSED: {len(violations)} card(s) violate the final-card record contract, "
+            f"nothing written. These would land in the canonical store unreadable by any "
+            f"consumer grouping on (key1, h). Fix the generator.")
     else:
         print(f"SCHEMA: {len(cards) - null_count} card(s) satisfy the record contract")
 

--- a/RussianTranslation/src/backfill_tn_residue.py
+++ b/RussianTranslation/src/backfill_tn_residue.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+r"""Offline re-derivation of the `{Tn}` placeholders leaked into the canonical store (C-01).
+
+WHAT HAPPENED
+-------------
+`restore_card` unmasked three fields while `promote_final_cards.rows_for` read six, so
+`card.iast` / `record.h` / `sense.tag` / `sense.differentia` were promoted with their mask
+placeholders intact. Measured against the 11,605-row store: **670 rows** carry a raw `{Tn}`
+(`sense_tag` 376, `h` 223, `differentia` 72, `ru` 2, `de` 2) -- including 223 rows whose
+HEADWORD field reads literally `{T104}`. The generator side is fixed (see `card_fields.py`);
+this repairs the rows already written.
+
+WHY IT IS RECOVERABLE AT ALL
+----------------------------
+Masking is deterministic and the source is content-addressed: every store row records
+`provenance.input_raw_sha256`, the SHA-256 of the exact `.raw.txt` it was generated from.
+`pwg_mask.mask(raw)` re-derives the identical placeholder list `ph`, and `{Tn}` indexes `ph`
+1-based. So the true value is `pwg_mask.restore(field, ph)` -- not a guess, a re-computation.
+
+The source is located BY CONTENT ADDRESS, never by filename: `translation_memory.py` is
+explicit that the address survives key renames, and it matters here -- `_ap~~h0_00_pwg01`
+has no file of that name any more, yet 596 rows still resolve. Two independent guards run
+before any row is touched: the recorded SHA must match a real file, and `mask/restore` must
+round-trip that file byte-for-byte (the same invariant `gen_opt_harness2.py:950` asserts).
+
+WHAT IT CANNOT DO -- MEASURED, NOT ASSUMED
+------------------------------------------
+* **74 of the 670 rows are NOT recoverable.** Their recorded `input_raw_sha256` addresses no
+  file on disk: the source drifted after translation, so no map can be re-derived. The packet
+  anticipated exactly this ("rows whose source drifted need re-translation, not
+  re-derivation"). They are reported, never guessed at. This includes the 2 C-42 rows
+  (`ban_d~~h0_11_ni`, `ban_d~~h0_21_upasam_0`), whose `{Tn}` is out-of-range by construction.
+* **The 468 `h is None` rows are out of scope and CANNOT be repaired by any offline means.**
+  That value was destroyed at the stitch, before it was ever persisted -- it is not in the
+  store, not in `wf_output` (already null there), not in the portraits (they carry no `h`),
+  and not in the TM (which is built FROM the store). `h` is free lexicographic text, not a
+  function of the key, so it cannot be synthesised. They need re-translation.
+
+USAGE
+-----
+    python src/backfill_tn_residue.py                 # dry run: report only, writes nothing
+    python src/backfill_tn_residue.py --apply         # rewrite the store (atomic, with .bak)
+    python src/backfill_tn_residue.py --json out.json # machine-readable per-row plan
+
+Dry run is the default and is READ-ONLY. `--apply` writes via tmp + `os.replace` and keeps a
+timestamped `.premerge.<stamp>.bak`, mirroring `promote_final_cards.py`'s existing convention
+rather than inventing a second one.
+"""
+import argparse
+import collections
+import datetime
+import hashlib
+import json
+import os
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+import pwg_mask
+import card_fields
+from store_path import canonical_store
+
+TN_RE = re.compile(r'\{T\d+\}')
+LOCAL_STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+
+
+def default_input_dir(store_path):
+    """Resolve `pilot/input` ALONGSIDE the store being repaired, not beside this script.
+
+    Both the store and the `*.raw.txt` sources are gitignored, so they exist only in the MAIN
+    checkout: a linked worktree has the code but 0 of the 110,374 raw files. Defaulting to
+    `dirname(__file__)/pilot/input` therefore reads an EMPTY directory while
+    `canonical_store()` correctly resolves the store back to the main checkout -- every row
+    then reports "source gone" and the tool concludes, with total confidence, that nothing is
+    recoverable. That is C-19's defect class exactly ("--data-root defaults to its own
+    checkout ... a worktree run swaps the denominator"), and this tool reproduced it on its
+    first run. Deriving the path from the resolved store keeps the two halves in one place.
+    """
+    return os.path.join(os.path.dirname(os.path.abspath(store_path)), 'pilot', 'input')
+
+# The fields a store ROW carries, mapped to the card level they were promoted from. Derived
+# from card_fields so this tool cannot drift from the restore/promote sides.
+ROW_FIELDS = tuple(name for _level, name in card_fields.promoted_pairs('russian'))
+# `rows_for` renames two of them on the way into the store.
+ROW_ALIAS = {'tag': 'sense_tag', 'russian': 'ru', 'german': 'de'}
+STORE_FIELDS = tuple(ROW_ALIAS.get(n, n) for n in ROW_FIELDS)
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as fh:
+        for chunk in iter(lambda: fh.read(65536), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def build_address_index(input_dir):
+    """sha256(raw bytes) -> path, over every `*.raw.txt`. The address IS the content."""
+    index = {}
+    for name in os.listdir(input_dir):
+        if name.endswith('.raw.txt'):
+            path = os.path.join(input_dir, name)
+            index.setdefault(sha256_file(path), path)
+    return index
+
+
+def plan(store_path, input_dir):
+    """Return (rows, plan_entries, stats). Reads only."""
+    index = build_address_index(input_dir)
+    ph_cache = {}
+    rows, entries = [], []
+    stats = collections.Counter()
+
+    with open(store_path, encoding='utf-8') as fh:
+        for lineno, line in enumerate(fh, 1):
+            line = line.rstrip('\n')
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            rows.append(row)
+            hit = [f for f in STORE_FIELDS
+                   if isinstance(row.get(f), str) and TN_RE.search(row[f])]
+            if not hit:
+                continue
+            stats['corrupt_rows'] += 1
+            sha = (row.get('provenance') or {}).get('input_raw_sha256')
+            subcard = row.get('subcard')
+            if not sha:
+                entries.append({'line': lineno, 'subcard': subcard, 'status': 'no_sha',
+                                'reason': 'row records no provenance.input_raw_sha256'})
+                stats['no_sha'] += 1
+                continue
+            if sha not in index:
+                entries.append({'line': lineno, 'subcard': subcard, 'status': 'source_gone',
+                                'reason': 'no raw source at content address %s' % sha[:12]})
+                stats['source_gone'] += 1
+                continue
+            if sha not in ph_cache:
+                raw = open(index[sha], encoding='utf-8').read()
+                skel, ph, _ = pwg_mask.mask(raw)
+                ph_cache[sha] = ph if pwg_mask.restore(skel, ph) == raw else None
+            ph = ph_cache[sha]
+            if ph is None:
+                entries.append({'line': lineno, 'subcard': subcard, 'status': 'roundtrip_fail',
+                               'reason': 'mask/restore does not round-trip this source'})
+                stats['roundtrip_fail'] += 1
+                continue
+            bad = [t for f in hit for t in TN_RE.findall(row[f])
+                   if not (1 <= int(t[2:-1]) <= len(ph))]
+            if bad:
+                entries.append({'line': lineno, 'subcard': subcard, 'status': 'out_of_range',
+                                'reason': 'index past the map (%s); map has %d (C-42)'
+                                          % (', '.join(sorted(set(bad))), len(ph))})
+                stats['out_of_range'] += 1
+                continue
+            fixes = {f: pwg_mask.restore(row[f], ph) for f in hit}
+            entries.append({'line': lineno, 'subcard': subcard, 'status': 'recoverable',
+                            'source': os.path.basename(index[sha]),
+                            'fields': {f: {'before': row[f], 'after': v}
+                                       for f, v in fixes.items()}})
+            stats['recoverable'] += 1
+    return rows, entries, stats
+
+
+def apply_plan(store_path, rows, entries):
+    """Rewrite the store atomically, keeping a timestamped backup. Only called for --apply."""
+    by_line = {e['line']: e for e in entries if e['status'] == 'recoverable'}
+    changed = 0
+    for i, row in enumerate(rows, 1):
+        entry = by_line.get(i)
+        if not entry:
+            continue
+        for field, delta in entry['fields'].items():
+            row[field] = delta['after']
+        changed += 1
+
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+    backup = '%s.premerge.%s.bak' % (store_path, stamp)
+    with open(store_path, 'rb') as src, open(backup, 'wb') as dst:
+        dst.write(src.read())
+    tmp = store_path + '.tmp'
+    with open(tmp, 'w', encoding='utf-8', newline='\n') as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + '\n')
+    os.replace(tmp, store_path)
+    return changed, backup
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    ap.add_argument('--store', default=None, help='store path (default: canonical_store())')
+    ap.add_argument('--input-dir', default=None,
+                    help='raw sources (default: pilot/input beside the RESOLVED store)')
+    ap.add_argument('--apply', action='store_true',
+                    help='rewrite the store (default is a read-only dry run)')
+    ap.add_argument('--json', dest='json_out', default=None, help='write the plan as JSON')
+    args = ap.parse_args()
+
+    store_path = args.store or canonical_store(LOCAL_STORE)
+    input_dir = args.input_dir or default_input_dir(store_path)
+    if not os.path.isdir(input_dir):
+        sys.exit('REFUSED: source dir does not exist: %s' % input_dir)
+    n_raw = sum(1 for n in os.listdir(input_dir) if n.endswith('.raw.txt'))
+    if not n_raw:
+        # Fail loud rather than reporting a confident, wrong "nothing is recoverable".
+        sys.exit('REFUSED: %s holds no *.raw.txt. Refusing to report every row as '
+                 'unrecoverable off an empty source dir (C-19 class).' % input_dir)
+    args.input_dir = input_dir
+    print('store      : %s' % store_path)
+    print('sources    : %s (%d raw files)' % (input_dir, n_raw))
+    print('mode       : %s' % ('APPLY' if args.apply else 'dry run (read-only)'))
+    print()
+
+    rows, entries, stats = plan(store_path, args.input_dir)
+    print('store rows            : %d' % len(rows))
+    print('rows carrying a {Tn}  : %d' % stats['corrupt_rows'])
+    print('  recoverable offline : %d' % stats['recoverable'])
+    print('  source gone         : %d' % stats['source_gone'])
+    print('  out of range (C-42) : %d' % stats['out_of_range'])
+    print('  no sha recorded     : %d' % stats['no_sha'])
+    print('  round-trip failed   : %d' % stats['roundtrip_fail'])
+    print()
+
+    unrec = [e for e in entries if e['status'] != 'recoverable']
+    if unrec:
+        print('NOT RECOVERABLE -- these need RE-TRANSLATION, never a guess:')
+        for sub, group in sorted(collections.Counter(e['subcard'] for e in unrec).items()):
+            reason = next(e['reason'] for e in unrec if e['subcard'] == sub)
+            print('  %-34s %d row(s)  %s' % (sub, group, reason))
+        print()
+
+    sample = [e for e in entries if e['status'] == 'recoverable'][:3]
+    if sample:
+        print('SAMPLE of the re-derivation:')
+        for e in sample:
+            for f, d in e['fields'].items():
+                print('  line %-6d %s.%s' % (e['line'], e['subcard'], f))
+                print('    before: %r' % d['before'][:70])
+                print('    after : %r' % d['after'][:70])
+        print()
+
+    if args.json_out:
+        with open(args.json_out, 'w', encoding='utf-8') as fh:
+            json.dump({'store': store_path, 'stats': dict(stats), 'entries': entries},
+                      fh, ensure_ascii=False, indent=2)
+        print('plan written: %s' % args.json_out)
+
+    if not args.apply:
+        print('DRY RUN -- nothing written. Re-run with --apply to rewrite the store.')
+        return 0
+
+    changed, backup = apply_plan(store_path, rows, entries)
+    print('APPLIED: %d row(s) re-derived' % changed)
+    print('backup : %s' % backup)
+    residue = sum(1 for r in rows for f in STORE_FIELDS
+                  if isinstance(r.get(f), str) and TN_RE.search(r[f]))
+    print('remaining {Tn} rows: %d (the unrecoverable set above)' % residue)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/RussianTranslation/src/backfill_tn_residue.py
+++ b/RussianTranslation/src/backfill_tn_residue.py
@@ -1,50 +1,16 @@
 #!/usr/bin/env python
-r"""Offline re-derivation of the `{Tn}` placeholders leaked into the canonical store (C-01).
+r"""Repair the H1080 PWG->Russian store corruption without model calls.
 
-WHAT HAPPENED
--------------
-`restore_card` unmasked three fields while `promote_final_cards.rows_for` read six, so
-`card.iast` / `record.h` / `sense.tag` / `sense.differentia` were promoted with their mask
-placeholders intact. Measured against the 11,605-row store: **670 rows** carry a raw `{Tn}`
-(`sense_tag` 376, `h` 223, `differentia` 72, `ru` 2, `de` 2) -- including 223 rows whose
-HEADWORD field reads literally `{T104}`. The generator side is fixed (see `card_fields.py`);
-this repairs the rows already written.
+The repair is dry-run by default.  It restores raw ``{Tn}`` placeholders from an exact
+content-addressed raw source or from the exact ``PH`` map embedded in a historical generated
+harness.  A historical harness is accepted only when its ``META.input_hashes`` binds the key
+to the SHA-256 recorded on the store row.  It also reconstructs record ``h``/``iast`` from
+immutable card identity for rows whose stitch discarded the record owner.
 
-WHY IT IS RECOVERABLE AT ALL
-----------------------------
-Masking is deterministic and the source is content-addressed: every store row records
-`provenance.input_raw_sha256`, the SHA-256 of the exact `.raw.txt` it was generated from.
-`pwg_mask.mask(raw)` re-derives the identical placeholder list `ph`, and `{Tn}` indexes `ph`
-1-based. So the true value is `pwg_mask.restore(field, ph)` -- not a guess, a re-computation.
-
-The source is located BY CONTENT ADDRESS, never by filename: `translation_memory.py` is
-explicit that the address survives key renames, and it matters here -- `_ap~~h0_00_pwg01`
-has no file of that name any more, yet 596 rows still resolve. Two independent guards run
-before any row is touched: the recorded SHA must match a real file, and `mask/restore` must
-round-trip that file byte-for-byte (the same invariant `gen_opt_harness2.py:950` asserts).
-
-WHAT IT CANNOT DO -- MEASURED, NOT ASSUMED
-------------------------------------------
-* **74 of the 670 rows are NOT recoverable.** Their recorded `input_raw_sha256` addresses no
-  file on disk: the source drifted after translation, so no map can be re-derived. The packet
-  anticipated exactly this ("rows whose source drifted need re-translation, not
-  re-derivation"). They are reported, never guessed at. This includes the 2 C-42 rows
-  (`ban_d~~h0_11_ni`, `ban_d~~h0_21_upasam_0`), whose `{Tn}` is out-of-range by construction.
-* **The 468 `h is None` rows are out of scope and CANNOT be repaired by any offline means.**
-  That value was destroyed at the stitch, before it was ever persisted -- it is not in the
-  store, not in `wf_output` (already null there), not in the portraits (they carry no `h`),
-  and not in the TM (which is built FROM the store). `h` is free lexicographic text, not a
-  function of the key, so it cannot be synthesised. They need re-translation.
-
-USAGE
------
-    python src/backfill_tn_residue.py                 # dry run: report only, writes nothing
-    python src/backfill_tn_residue.py --apply         # rewrite the store (atomic, with .bak)
-    python src/backfill_tn_residue.py --json out.json # machine-readable per-row plan
-
-Dry run is the default and is READ-ONLY. `--apply` writes via tmp + `os.replace` and keeps a
-timestamped `.premerge.<stamp>.bak`, mirroring `promote_final_cards.py`'s existing convention
-rather than inventing a second one.
+Only the two measured C-42 ``banD`` rows are quarantined.  Any other unresolved token, hash
+drift, unexpected quarantine candidate, row-multiset drift, or source-store drift fails the
+repair closed.  ``--apply`` requires ``--expected-sha256`` and uses fsynced same-directory
+temporary files plus ``os.replace``.  The original store is retained as a hash-named backup.
 """
 import argparse
 import collections
@@ -54,214 +20,435 @@ import json
 import os
 import re
 import sys
+import tempfile
 
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-if HERE not in sys.path:
-    sys.path.insert(0, HERE)
-import pwg_mask
+PILOT = os.path.join(HERE, 'pilot')
+for path in (HERE, PILOT):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
 import card_fields
+import corpus_gate as cg
+import pwg_mask
+from safe_filename import decode_safe_name
 from store_path import canonical_store
 
-TN_RE = re.compile(r'\{T\d+\}')
+TN_RE = re.compile(r'\{T(\d+)\}')
+ROOT_CARD_RE = re.compile(r'^.+~~h\d+_\d+_(.+)$')
 LOCAL_STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+QUARANTINE_SUBCARDS = {
+    'ban_d~~h0_11_ni',
+    'ban_d~~h0_21_upasam_0',
+}
 
-
-def default_input_dir(store_path):
-    """Resolve `pilot/input` ALONGSIDE the store being repaired, not beside this script.
-
-    Both the store and the `*.raw.txt` sources are gitignored, so they exist only in the MAIN
-    checkout: a linked worktree has the code but 0 of the 110,374 raw files. Defaulting to
-    `dirname(__file__)/pilot/input` therefore reads an EMPTY directory while
-    `canonical_store()` correctly resolves the store back to the main checkout -- every row
-    then reports "source gone" and the tool concludes, with total confidence, that nothing is
-    recoverable. That is C-19's defect class exactly ("--data-root defaults to its own
-    checkout ... a worktree run swaps the denominator"), and this tool reproduced it on its
-    first run. Deriving the path from the resolved store keeps the two halves in one place.
-    """
-    return os.path.join(os.path.dirname(os.path.abspath(store_path)), 'pilot', 'input')
-
-# The fields a store ROW carries, mapped to the card level they were promoted from. Derived
-# from card_fields so this tool cannot drift from the restore/promote sides.
-ROW_FIELDS = tuple(name for _level, name in card_fields.promoted_pairs('russian'))
-# `rows_for` renames two of them on the way into the store.
 ROW_ALIAS = {'tag': 'sense_tag', 'russian': 'ru', 'german': 'de'}
-STORE_FIELDS = tuple(ROW_ALIAS.get(n, n) for n in ROW_FIELDS)
+STORE_FIELDS = tuple(ROW_ALIAS.get(name, name)
+                     for _level, name in card_fields.promoted_pairs('russian'))
+
+
+class RepairRefusal(RuntimeError):
+    """The repair contract could not be proved; no production replacement is allowed."""
+
+
+def sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
 
 
 def sha256_file(path):
     h = hashlib.sha256()
     with open(path, 'rb') as fh:
-        for chunk in iter(lambda: fh.read(65536), b''):
+        for chunk in iter(lambda: fh.read(1024 * 1024), b''):
             h.update(chunk)
     return h.hexdigest()
 
 
-def build_address_index(input_dir):
-    """sha256(raw bytes) -> path, over every `*.raw.txt`. The address IS the content."""
-    index = {}
-    for name in os.listdir(input_dir):
-        if name.endswith('.raw.txt'):
-            path = os.path.join(input_dir, name)
-            index.setdefault(sha256_file(path), path)
-    return index
+def default_input_dir(store_path):
+    return os.path.join(os.path.dirname(os.path.abspath(store_path)), 'pilot', 'input')
 
 
-def plan(store_path, input_dir):
-    """Return (rows, plan_entries, stats). Reads only."""
-    index = build_address_index(input_dir)
-    ph_cache = {}
-    rows, entries = [], []
-    stats = collections.Counter()
+def default_recovery_dir(store_path):
+    return os.path.join(os.path.dirname(os.path.abspath(store_path)), 'pilot', 'output',
+                        'h1080_recovery_sources')
 
-    with open(store_path, encoding='utf-8') as fh:
+
+def default_harness_dir(store_path):
+    # Both the frozen legacy archive and later coordinator attempt directories are ignored
+    # runtime evidence under this root.  The per-key META hash, not the directory name, is
+    # the authority.
+    return os.path.join(os.path.dirname(os.path.abspath(store_path)), 'pilot')
+
+
+def read_rows(path):
+    rows = []
+    with open(path, encoding='utf-8') as fh:
         for lineno, line in enumerate(fh, 1):
-            line = line.rstrip('\n')
             if not line.strip():
                 continue
-            row = json.loads(line)
-            rows.append(row)
-            hit = [f for f in STORE_FIELDS
-                   if isinstance(row.get(f), str) and TN_RE.search(row[f])]
-            if not hit:
-                continue
-            stats['corrupt_rows'] += 1
-            sha = (row.get('provenance') or {}).get('input_raw_sha256')
-            subcard = row.get('subcard')
-            if not sha:
-                entries.append({'line': lineno, 'subcard': subcard, 'status': 'no_sha',
-                                'reason': 'row records no provenance.input_raw_sha256'})
-                stats['no_sha'] += 1
-                continue
-            if sha not in index:
-                entries.append({'line': lineno, 'subcard': subcard, 'status': 'source_gone',
-                                'reason': 'no raw source at content address %s' % sha[:12]})
-                stats['source_gone'] += 1
-                continue
-            if sha not in ph_cache:
-                raw = open(index[sha], encoding='utf-8').read()
-                skel, ph, _ = pwg_mask.mask(raw)
-                ph_cache[sha] = ph if pwg_mask.restore(skel, ph) == raw else None
-            ph = ph_cache[sha]
-            if ph is None:
-                entries.append({'line': lineno, 'subcard': subcard, 'status': 'roundtrip_fail',
-                               'reason': 'mask/restore does not round-trip this source'})
-                stats['roundtrip_fail'] += 1
-                continue
-            bad = [t for f in hit for t in TN_RE.findall(row[f])
-                   if not (1 <= int(t[2:-1]) <= len(ph))]
-            if bad:
-                entries.append({'line': lineno, 'subcard': subcard, 'status': 'out_of_range',
-                                'reason': 'index past the map (%s); map has %d (C-42)'
-                                          % (', '.join(sorted(set(bad))), len(ph))})
-                stats['out_of_range'] += 1
-                continue
-            fixes = {f: pwg_mask.restore(row[f], ph) for f in hit}
-            entries.append({'line': lineno, 'subcard': subcard, 'status': 'recoverable',
-                            'source': os.path.basename(index[sha]),
-                            'fields': {f: {'before': row[f], 'after': v}
-                                       for f, v in fixes.items()}})
-            stats['recoverable'] += 1
-    return rows, entries, stats
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise RepairRefusal('malformed store JSON at line %d: %s' % (lineno, exc))
+    return rows
 
 
-def apply_plan(store_path, rows, entries):
-    """Rewrite the store atomically, keeping a timestamped backup. Only called for --apply."""
-    by_line = {e['line']: e for e in entries if e['status'] == 'recoverable'}
-    changed = 0
-    for i, row in enumerate(rows, 1):
-        entry = by_line.get(i)
-        if not entry:
+def row_sha(row):
+    data = json.dumps(row, ensure_ascii=False, sort_keys=True,
+                      separators=(',', ':')).encode('utf-8')
+    return sha256_bytes(data)
+
+
+def row_address(row):
+    return (row.get('provenance') or {}).get('input_raw_sha256')
+
+
+def affected_fields(row):
+    return [field for field in STORE_FIELDS
+            if isinstance(row.get(field), str) and TN_RE.search(row[field])]
+
+
+def raw_maps(source_dirs, wanted):
+    """Return ``(key, sha) -> (ph, evidence)`` for exact named raw sources only.
+
+    H1080 has 86 affected cards and their key is retained on every row.  Looking up those
+    exact names is both faster and safer than hashing 110k unrelated inputs.  Renamed legacy
+    inputs are recovered from their generated harness instead.
+    """
+    found = {}
+    for key, sha in wanted:
+        if not key or not sha:
             continue
-        for field, delta in entry['fields'].items():
-            row[field] = delta['after']
-        changed += 1
+        for directory in source_dirs:
+            path = os.path.join(directory, key + '.raw.txt')
+            if not os.path.isfile(path) or sha256_file(path) != sha:
+                continue
+            with open(path, encoding='utf-8') as fh:
+                raw = fh.read()
+            skeleton, ph, _stats = pwg_mask.mask(raw)
+            if pwg_mask.restore(skeleton, ph) != raw:
+                raise RepairRefusal('mask round-trip failed for %s' % path)
+            found[(key, sha)] = (ph, {
+                'kind': 'exact_raw', 'path': os.path.abspath(path), 'sha256': sha,
+            })
+            break
+    return found
 
+
+def _json_constant(line, name):
+    prefix = 'const %s = ' % name
+    if not line.startswith(prefix):
+        return None
+    value = line[len(prefix):].rstrip('\r\n')
+    if value.endswith(';'):
+        value = value[:-1]
+    return json.loads(value)
+
+
+def harness_maps(harness_dirs, wanted):
+    """Index exact PH maps bound by generated-harness ``META.input_hashes``."""
+    wanted = set(wanted)
+    found = {}
+    for directory in harness_dirs:
+        if not os.path.isdir(directory):
+            continue
+        for root, _dirs, names in os.walk(directory):
+            for name in names:
+                if not name.endswith('.js'):
+                    continue
+                path = os.path.join(root, name)
+                phmaps = meta = None
+                try:
+                    with open(path, encoding='utf-8') as fh:
+                        for line in fh:
+                            if line.startswith('const PH = '):
+                                phmaps = _json_constant(line, 'PH')
+                            elif line.startswith('const META = '):
+                                meta = _json_constant(line, 'META')
+                except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                    continue
+                if not isinstance(phmaps, dict) or not isinstance(meta, dict):
+                    continue
+                input_hashes = meta.get('input_hashes') or {}
+                for key, hashes in input_hashes.items():
+                    sha = (hashes or {}).get('raw_sha256')
+                    address = (key, sha)
+                    if address not in wanted or key not in phmaps:
+                        continue
+                    evidence = {
+                        'kind': 'generated_harness_phmap',
+                        'path': os.path.abspath(path),
+                        'sha256': sha256_file(path),
+                        'input_raw_sha256': sha,
+                        'generated_at': meta.get('generated_at'),
+                    }
+                    prior = found.get(address)
+                    candidate = (phmaps[key], evidence)
+                    if prior and prior[0] != candidate[0]:
+                        raise RepairRefusal('conflicting historical PH maps for %s @ %s'
+                                            % address)
+                    found[address] = candidate
+    return found
+
+
+def restore_text(value, ph, where):
+    unresolved = []
+
+    def repl(match):
+        index = int(match.group(1))
+        if not 1 <= index <= len(ph):
+            unresolved.append(match.group(0))
+            return match.group(0)
+        return ph[index - 1]
+
+    restored = TN_RE.sub(repl, value)
+    if unresolved or TN_RE.search(restored):
+        raise RepairRefusal('%s has unresolved/out-of-range token(s): %s (map has %d)'
+                            % (where, ', '.join(sorted(set(unresolved))), len(ph)))
+    return restored
+
+
+def slp1_iast(value):
+    return ''.join(cg._S2I.get(ch, ch) for ch in cg.form_key(value or ''))
+
+
+def canonical_record_head(row):
+    """Reconstruct a stable display head from immutable row/subcard identity.
+
+    Existing row ``iast`` is authoritative for nominal/no-PWG cards.  For root cards, the
+    suffix encodes the upasarga; head/secondary/supplement lanes deliberately fall back to
+    the root.  This avoids reusing another model-authored row as repair evidence.
+    """
+    current = row.get('iast')
+    if isinstance(current, str) and current.strip():
+        return current.strip()
+    root = row.get('key1') or ''
+    root_iast = slp1_iast(root)
+    subcard = row.get('subcard') or ''
+    match = ROOT_CARD_RE.match(subcard)
+    if not match:
+        return root_iast
+    suffix = match.group(1)
+    if (suffix.startswith(('pwg', 'sec_', 'zz_')) or suffix == 'head'):
+        return root_iast
+    suffix = re.sub(r'_(?:0|1)$', '', suffix)
+    try:
+        prefix = decode_safe_name(suffix)
+    except (TypeError, ValueError):
+        prefix = ''
+    if not prefix or prefix.startswith(('pwg', 'sec', 'zz')):
+        return root_iast
+    return slp1_iast(prefix + root)
+
+
+def plan_repair(store_path, source_dirs, harness_dirs):
+    rows = read_rows(store_path)
+    original_multiset = collections.Counter((r.get('key1'), r.get('subcard')) for r in rows)
+    corrupt = [r for r in rows if affected_fields(r)]
+    already_clean = not corrupt and not any(r.get('h') is None for r in rows)
+    wanted = {(r.get('subcard'), row_address(r)) for r in corrupt}
+    maps = raw_maps(source_dirs, wanted)
+    for address, value in harness_maps(harness_dirs, wanted).items():
+        maps.setdefault(address, value)
+
+    repaired = []
+    quarantine = []
+    entries = []
+    source_evidence = {}
+    stats = collections.Counter()
+
+    for lineno, original in enumerate(rows, 1):
+        row = json.loads(json.dumps(original, ensure_ascii=False))
+        fields = affected_fields(row)
+        address = (row.get('subcard'), row_address(row))
+        if fields:
+            stats['placeholder_rows'] += 1
+            source = maps.get(address)
+            if source is None:
+                raise RepairRefusal('no exact raw/PH-map provenance for line %d %s @ %s'
+                                    % (lineno, address[0], address[1]))
+            ph, evidence = source
+            try:
+                fixes = {field: restore_text(row[field], ph, '%s.%s' % (address[0], field))
+                         for field in fields}
+            except RepairRefusal as exc:
+                if address[0] not in QUARANTINE_SUBCARDS:
+                    raise
+                quarantine.append({
+                    'schema': 'pwg_ru.store_quarantine.v1',
+                    'key': row.get('key1'),
+                    'subcard': address[0],
+                    'reason': str(exc),
+                    'original_row_sha256': row_sha(original),
+                    'input_raw_sha256': address[1],
+                    'row': original,
+                })
+                stats['quarantined_rows'] += 1
+                entries.append({'line': lineno, 'subcard': address[0], 'status': 'quarantine'})
+                continue
+            if address[0] in QUARANTINE_SUBCARDS:
+                raise RepairRefusal('expected measured C-42 quarantine row unexpectedly became '
+                                    'restorable: %s' % address[0])
+            row.update(fixes)
+            stats['placeholder_repaired'] += 1
+            source_evidence[evidence['path']] = evidence
+            entries.append({'line': lineno, 'subcard': address[0], 'status': 'token_repaired',
+                            'fields': sorted(fixes), 'evidence': evidence})
+
+        if row.get('h') is None:
+            head = canonical_record_head(row)
+            if not head:
+                raise RepairRefusal('cannot reconstruct record h at line %d (%s)'
+                                    % (lineno, row.get('subcard')))
+            row['h'] = head
+            if row.get('iast') is None:
+                row['iast'] = head
+            if row.get('grammar') is None:
+                row['grammar'] = ''
+            stats['null_headword_repaired'] += 1
+            entries.append({'line': lineno, 'subcard': row.get('subcard'),
+                            'status': 'record_owner_repaired', 'h': head})
+        repaired.append(row)
+
+    if not already_clean and set(q['subcard'] for q in quarantine) != QUARANTINE_SUBCARDS:
+        raise RepairRefusal('quarantine set drift: expected %s, got %s'
+                            % (sorted(QUARANTINE_SUBCARDS),
+                               sorted(q['subcard'] for q in quarantine)))
+    if any(affected_fields(row) for row in repaired):
+        raise RepairRefusal('post-repair store still contains raw {Tn}')
+    if any(row.get('h') is None for row in repaired):
+        raise RepairRefusal('post-repair store still contains h == null')
+
+    expected_multiset = original_multiset.copy()
+    for q in quarantine:
+        key = (q['row'].get('key1'), q['subcard'])
+        expected_multiset[key] -= 1
+        if expected_multiset[key] == 0:
+            del expected_multiset[key]
+    repaired_multiset = collections.Counter((r.get('key1'), r.get('subcard')) for r in repaired)
+    if repaired_multiset != expected_multiset:
+        raise RepairRefusal('key/subcard multiplicity changed outside the quarantine delta')
+
+    stats['input_rows'] = len(rows)
+    stats['output_rows'] = len(repaired)
+    if already_clean:
+        stats['already_clean'] = 1
+    return {
+        'schema': 'pwg_ru.store_repair_plan.v1',
+        'store': os.path.abspath(store_path),
+        'store_before_sha256': sha256_file(store_path),
+        'stats': dict(stats),
+        'entries': entries,
+        'source_evidence': sorted(source_evidence.values(), key=lambda x: x['path']),
+        'quarantine': quarantine,
+    }, repaired
+
+
+def jsonl_bytes(rows):
+    return ''.join(json.dumps(row, ensure_ascii=False, separators=(',', ':')) + '\n'
+                   for row in rows).encode('utf-8')
+
+
+def atomic_write_bytes(path, data):
+    directory = os.path.dirname(os.path.abspath(path)) or '.'
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix='.%s.' % os.path.basename(path), suffix='.tmp', dir=directory)
+    try:
+        with os.fdopen(fd, 'wb') as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def apply_repair(store_path, repaired, quarantine, expected_sha, quarantine_path):
+    actual = sha256_file(store_path)
+    if actual.lower() != expected_sha.lower():
+        raise RepairRefusal('source-hash drift: expected %s, got %s' % (expected_sha, actual))
     stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
-    backup = '%s.premerge.%s.bak' % (store_path, stamp)
-    with open(store_path, 'rb') as src, open(backup, 'wb') as dst:
-        dst.write(src.read())
-    tmp = store_path + '.tmp'
-    with open(tmp, 'w', encoding='utf-8', newline='\n') as fh:
-        for row in rows:
-            fh.write(json.dumps(row, ensure_ascii=False) + '\n')
-    os.replace(tmp, store_path)
-    return changed, backup
+    backup = '%s.pre-h1080.%s.%s.bak' % (store_path, actual[:16], stamp)
+    with open(store_path, 'rb') as fh:
+        original = fh.read()
+    atomic_write_bytes(backup, original)
+    atomic_write_bytes(quarantine_path, jsonl_bytes(quarantine))
+    atomic_write_bytes(store_path, jsonl_bytes(repaired))
+    return backup, sha256_file(store_path), sha256_file(quarantine_path)
 
 
-def main():
+def write_report(path, report):
+    atomic_write_bytes(path, (json.dumps(report, ensure_ascii=False, indent=2) + '\n').encode('utf-8'))
+
+
+def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
     ap.add_argument('--store', default=None, help='store path (default: canonical_store())')
-    ap.add_argument('--input-dir', default=None,
-                    help='raw sources (default: pilot/input beside the RESOLVED store)')
-    ap.add_argument('--apply', action='store_true',
-                    help='rewrite the store (default is a read-only dry run)')
-    ap.add_argument('--json', dest='json_out', default=None, help='write the plan as JSON')
-    args = ap.parse_args()
+    ap.add_argument('--source-dir', action='append', default=[],
+                    help='exact raw source directory (repeatable)')
+    ap.add_argument('--harness-dir', action='append', default=[],
+                    help='historical generated-harness directory (repeatable)')
+    ap.add_argument('--apply', action='store_true', help='atomically replace the store')
+    ap.add_argument('--expected-sha256', default=None,
+                    help='required source-store lock for --apply')
+    ap.add_argument('--quarantine-out', default=None,
+                    help='uncommitted quarantine JSONL path')
+    ap.add_argument('--report', default=None, help='write machine-readable plan/result JSON')
+    args = ap.parse_args(argv)
 
     store_path = args.store or canonical_store(LOCAL_STORE)
-    input_dir = args.input_dir or default_input_dir(store_path)
-    if not os.path.isdir(input_dir):
-        sys.exit('REFUSED: source dir does not exist: %s' % input_dir)
-    n_raw = sum(1 for n in os.listdir(input_dir) if n.endswith('.raw.txt'))
-    if not n_raw:
-        # Fail loud rather than reporting a confident, wrong "nothing is recoverable".
-        sys.exit('REFUSED: %s holds no *.raw.txt. Refusing to report every row as '
-                 'unrecoverable off an empty source dir (C-19 class).' % input_dir)
-    args.input_dir = input_dir
-    print('store      : %s' % store_path)
-    print('sources    : %s (%d raw files)' % (input_dir, n_raw))
-    print('mode       : %s' % ('APPLY' if args.apply else 'dry run (read-only)'))
-    print()
-
-    rows, entries, stats = plan(store_path, args.input_dir)
-    print('store rows            : %d' % len(rows))
-    print('rows carrying a {Tn}  : %d' % stats['corrupt_rows'])
-    print('  recoverable offline : %d' % stats['recoverable'])
-    print('  source gone         : %d' % stats['source_gone'])
-    print('  out of range (C-42) : %d' % stats['out_of_range'])
-    print('  no sha recorded     : %d' % stats['no_sha'])
-    print('  round-trip failed   : %d' % stats['roundtrip_fail'])
-    print()
-
-    unrec = [e for e in entries if e['status'] != 'recoverable']
-    if unrec:
-        print('NOT RECOVERABLE -- these need RE-TRANSLATION, never a guess:')
-        for sub, group in sorted(collections.Counter(e['subcard'] for e in unrec).items()):
-            reason = next(e['reason'] for e in unrec if e['subcard'] == sub)
-            print('  %-34s %d row(s)  %s' % (sub, group, reason))
-        print()
-
-    sample = [e for e in entries if e['status'] == 'recoverable'][:3]
-    if sample:
-        print('SAMPLE of the re-derivation:')
-        for e in sample:
-            for f, d in e['fields'].items():
-                print('  line %-6d %s.%s' % (e['line'], e['subcard'], f))
-                print('    before: %r' % d['before'][:70])
-                print('    after : %r' % d['after'][:70])
-        print()
-
-    if args.json_out:
-        with open(args.json_out, 'w', encoding='utf-8') as fh:
-            json.dump({'store': store_path, 'stats': dict(stats), 'entries': entries},
-                      fh, ensure_ascii=False, indent=2)
-        print('plan written: %s' % args.json_out)
+    if not os.path.isfile(store_path):
+        raise RepairRefusal('canonical store does not exist: %s' % store_path)
+    source_dirs = args.source_dir or [default_input_dir(store_path),
+                                      default_recovery_dir(store_path)]
+    harness_dirs = args.harness_dir or [default_harness_dir(store_path)]
+    plan, repaired = plan_repair(store_path, source_dirs, harness_dirs)
+    plan['source_dirs'] = [os.path.abspath(p) for p in source_dirs]
+    plan['harness_dirs'] = [os.path.abspath(p) for p in harness_dirs]
+    plan['mode'] = 'apply' if args.apply else 'dry_run'
 
     if not args.apply:
-        print('DRY RUN -- nothing written. Re-run with --apply to rewrite the store.')
+        if args.report:
+            write_report(args.report, plan)
+        print(json.dumps(plan['stats'], ensure_ascii=False, sort_keys=True))
+        print('DRY RUN -- no store, backup, or quarantine file written')
         return 0
-
-    changed, backup = apply_plan(store_path, rows, entries)
-    print('APPLIED: %d row(s) re-derived' % changed)
-    print('backup : %s' % backup)
-    residue = sum(1 for r in rows for f in STORE_FIELDS
-                  if isinstance(r.get(f), str) and TN_RE.search(r[f]))
-    print('remaining {Tn} rows: %d (the unrecoverable set above)' % residue)
+    if not args.expected_sha256:
+        raise RepairRefusal('--apply requires --expected-sha256')
+    if sha256_file(store_path).lower() != args.expected_sha256.lower():
+        raise RepairRefusal('source-hash drift: expected %s, got %s'
+                            % (args.expected_sha256, sha256_file(store_path)))
+    if plan['stats'].get('already_clean'):
+        if args.report:
+            write_report(args.report, plan)
+        print(json.dumps(plan['stats'], ensure_ascii=False, sort_keys=True))
+        print('NO-OP: store already satisfies the H1080 repair invariants')
+        return 0
+    quarantine_path = args.quarantine_out or store_path + '.h1080_quarantine.jsonl'
+    backup, after_sha, quarantine_sha = apply_repair(
+        store_path, repaired, plan['quarantine'], args.expected_sha256, quarantine_path)
+    plan.update({
+        'store_after_sha256': after_sha,
+        'backup_path': os.path.abspath(backup),
+        'backup_sha256': sha256_file(backup),
+        'quarantine_path': os.path.abspath(quarantine_path),
+        'quarantine_sha256': quarantine_sha,
+    })
+    if args.report:
+        write_report(args.report, plan)
+    print(json.dumps(plan['stats'], ensure_ascii=False, sort_keys=True))
+    print('APPLIED: %s -> %s' % (plan['store_before_sha256'], after_sha))
     return 0
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except RepairRefusal as exc:
+        sys.exit('REFUSED: %s' % exc)

--- a/RussianTranslation/src/backfill_tn_residue_selftest.py
+++ b/RussianTranslation/src/backfill_tn_residue_selftest.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+"""Deterministic regression tests for the H1080 atomic store repair."""
+import hashlib
+import json
+import os
+import sys
+import tempfile
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import backfill_tn_residue as repair
+
+
+def write_jsonl(path, rows):
+    with open(path, 'w', encoding='utf-8', newline='\n') as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + '\n')
+
+
+def raw(path, text):
+    with open(path, 'w', encoding='utf-8', newline='\n') as fh:
+        fh.write(text)
+    return repair.sha256_file(path)
+
+
+def row(subcard, sha, **values):
+    payload = {
+        'key1': values.pop('key1', subcard.split('~~', 1)[0]),
+        'subcard': subcard,
+        'iast': values.pop('iast', 'x'),
+        'h': values.pop('h', 'x'),
+        'grammar': values.pop('grammar', ''),
+        'sense_tag': values.pop('sense_tag', '1'),
+        'de': values.pop('de', 'Deutsch'),
+        'ru': values.pop('ru', 'русский'),
+        'differentia': values.pop('differentia', ''),
+        'provenance': {'input_raw_sha256': sha},
+    }
+    payload.update(values)
+    return payload
+
+
+def fixture(td):
+    sources = os.path.join(td, 'sources')
+    harnesses = os.path.join(td, 'harnesses')
+    os.makedirs(sources)
+    os.makedirs(harnesses)
+
+    raw_key = 'raw~~h0_zz_pw'
+    raw_sha = raw(os.path.join(sources, raw_key + '.raw.txt'), '{#raw#} Gloss')
+    harness_key = 'harness~~h0_zz_pw'
+    harness_sha = hashlib.sha256(b'historical source').hexdigest()
+    meta = {'generated_at': '2026-01-01T00:00:00Z',
+            'input_hashes': {harness_key: {'raw_sha256': harness_sha}}}
+    with open(os.path.join(harnesses, 'attempt.js'), 'w', encoding='utf-8') as fh:
+        fh.write('const PH = %s\n' % json.dumps({harness_key: ['{#harness#}']}))
+        fh.write('const META = %s\n' % json.dumps(meta))
+
+    q_rows = []
+    for key in sorted(repair.QUARANTINE_SUBCARDS):
+        q_path = os.path.join(sources, key + '.raw.txt')
+        q_sha = raw(q_path, '{#banD#}')
+        q_rows.append(row(key, q_sha, ru='{T9}', de='Deutsch'))
+
+    rows = [
+        row(raw_key, raw_sha, h='{T1}'),
+        row(harness_key, harness_sha, differentia='см. {T1}'),
+        row('null~~h0_zz_pw', None, key1='null', iast='nūll', h=None, grammar=None),
+        *q_rows,
+    ]
+    store = os.path.join(td, 'store.jsonl')
+    write_jsonl(store, rows)
+    return store, sources, harnesses
+
+
+def test_plan_and_apply():
+    with tempfile.TemporaryDirectory() as td:
+        store, sources, harnesses = fixture(td)
+        before = repair.sha256_file(store)
+        plan, repaired = repair.plan_repair(store, [sources], [harnesses])
+        assert plan['stats'] == {
+            'placeholder_rows': 4,
+            'placeholder_repaired': 2,
+            'null_headword_repaired': 1,
+            'quarantined_rows': 2,
+            'input_rows': 5,
+            'output_rows': 3,
+        }, plan['stats']
+        assert len(repaired) == 3
+        assert not any(repair.affected_fields(r) for r in repaired)
+        assert all(r.get('h') is not None for r in repaired)
+        assert next(r for r in repaired if r['key1'] == 'null')['h'] == 'nūll'
+
+        quarantine = os.path.join(td, 'quarantine.jsonl')
+        backup, after, q_sha = repair.apply_repair(
+            store, repaired, plan['quarantine'], before, quarantine)
+        assert repair.sha256_file(backup) == before
+        assert repair.sha256_file(store) == after
+        assert repair.sha256_file(quarantine) == q_sha
+        assert len(repair.read_rows(quarantine)) == 2
+
+        second, second_rows = repair.plan_repair(store, [sources], [harnesses])
+        assert second['stats']['already_clean'] == 1
+        assert second_rows == repair.read_rows(store)
+    print('  plan/apply/quarantine/idempotence: PASS')
+
+
+def test_source_hash_drift_refused():
+    with tempfile.TemporaryDirectory() as td:
+        store, sources, harnesses = fixture(td)
+        plan, repaired = repair.plan_repair(store, [sources], [harnesses])
+        before_bytes = open(store, 'rb').read()
+        try:
+            repair.apply_repair(store, repaired, plan['quarantine'], '0' * 64,
+                                os.path.join(td, 'q.jsonl'))
+        except repair.RepairRefusal as exc:
+            assert 'source-hash drift' in str(exc)
+        else:
+            raise AssertionError('source hash drift was accepted')
+        assert open(store, 'rb').read() == before_bytes
+    print('  source-hash drift fail-closed: PASS')
+
+
+def test_atomic_failure_preserves_previous_file():
+    with tempfile.TemporaryDirectory() as td:
+        target = os.path.join(td, 'artifact.json')
+        with open(target, 'wb') as fh:
+            fh.write(b'old')
+        real_replace = repair.os.replace
+
+        def fail_replace(_src, _dst):
+            raise OSError('synthetic replace failure')
+
+        repair.os.replace = fail_replace
+        try:
+            try:
+                repair.atomic_write_bytes(target, b'new')
+            except OSError as exc:
+                assert 'synthetic' in str(exc)
+            else:
+                raise AssertionError('replace failure was swallowed')
+        finally:
+            repair.os.replace = real_replace
+        assert open(target, 'rb').read() == b'old'
+        leftovers = [name for name in os.listdir(td) if name.endswith('.tmp')]
+        assert leftovers == [], leftovers
+    print('  atomic failure preservation/cleanup: PASS')
+
+
+def main():
+    test_plan_and_apply()
+    test_source_hash_drift_refused()
+    test_atomic_failure_preserves_previous_file()
+    print('backfill_tn_residue selftest: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/card_fields.py
+++ b/RussianTranslation/src/card_fields.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+r"""Single source of truth for WHICH final-card fields are masked, restored and promoted.
+
+WHY THIS EXISTS (H963 correction packet, C-01)
+----------------------------------------------
+`restore_card` (`pilot/headless_worker.py`) and its JS twin `restoreCard`
+(`pilot/gen_opt_harness2.py`) unmasked THREE things -- `record.grammar`, `sense.german` and
+the per-sense translation field. The promote path (`promote_final_cards.rows_for`) read SIX
+-- `card.iast`, `record.h`, `sense.tag`, `sense.russian`, `sense.german`,
+`sense.differentia`. The two lists were authored independently, and they drifted: four
+fields were promoted to the canonical store with their `{Tn}` placeholders never restored.
+
+The observed cost, measured against the 11,605-row store: 670 rows carry a raw `{Tn}`
+(`sense_tag` 376, `h` 223, `differentia` 72, plus the 2 C-42 rows in `ru`/`de`) -- including
+223 rows whose HEADWORD reads literally `{T104}`. Nothing failed loudly, because the only
+component that encodes the record contract never runs on live output (C-04).
+
+The defect was not a *wrong* list. It was TWO lists. So this module holds ONE, and both the
+restore side and the promote side are driven from it;
+`window_selftest.test_restore_covers_every_promoted_field` asserts
+PROMOTED subset-of RESTORED **by construction from this constant**, so they cannot drift apart
+again. A new promoted field that nobody remembers to restore is now a test failure, not 670
+silently corrupted rows.
+
+LEVELS
+------
+Each entry is a `(level, name)` pair naming where the field sits in a final card:
+
+    card    -> card[name]
+    record  -> card['records'][i][name]
+    sense   -> card['records'][i]['senses'][j][name]
+
+THE TRANSLATION FIELD IS LANGUAGE-DEPENDENT
+-------------------------------------------
+`gen_opt_harness2.py:890` picks `field = 'english' if lang == 'en' else 'russian'`, so the
+per-sense target field is a parameter, not a constant. Everything else is fixed. Callers pass
+the active `field`; `german` is always restored (it is the source-side gloss the fidelity
+guards compare against) and is de-duplicated when it *is* the target field.
+
+NOT A SCHEMA
+------------
+`schemas/pwg_ru_final_card.schema.json` states the *contract* (`record.required =
+{h, grammar, senses}`). This module states which fields carry `{Tn}` placeholders and must
+therefore be unmasked before promotion. They are related but distinct: `senses` is required
+by the schema and is not a masked text field.
+"""
+import json
+
+# Card-level masked fields.
+CARD_MASKED = ('iast',)
+
+# Record-level masked fields. `h` is the homonym discriminator -- free lexicographic text
+# ("2. bhid", "PW 3 (с anu, отсылка к entry 5)"), NOT a mechanical function of the key, which
+# is why a lost `h` cannot be synthesised later (C-02's boundary forbids exactly that).
+RECORD_MASKED = ('h', 'grammar')
+
+# Sense-level masked fields that do not depend on the target language.
+SENSE_MASKED_COMMON = ('tag', 'german', 'differentia')
+
+# What the promote path reads out of a card and writes to a store row, EXCLUDING the
+# target-language field (which `promoted_pairs` appends). Stated independently of the restore
+# list on purpose: the selftest then compares two separately-authored facts rather than
+# tautologically comparing a list to itself.
+PROMOTED_COMMON = (
+    ('card', 'iast'),
+    ('record', 'h'),
+    ('sense', 'tag'),
+    ('sense', 'german'),
+    ('sense', 'differentia'),
+)
+
+
+def promoted_pairs(field='russian'):
+    """Every `(level, name)` the promote path reads for target-language field `field`.
+
+    `field='russian'` is exactly `promote_final_cards.rows_for`; `field='english'` is its
+    `promote_en` counterpart. Language-parameterised rather than hardcoded, so the RU and EN
+    lanes cannot acquire two different answers to "what gets promoted" -- which is the same
+    class of drift as C-01 itself.
+    """
+    pairs = list(PROMOTED_COMMON)
+    if field and ('sense', field) not in pairs:
+        pairs.append(('sense', field))
+    return tuple(pairs)
+
+
+# Backwards-compatible alias for the RU store's promote path.
+PROMOTED_PAIRS = promoted_pairs('russian')
+
+
+def sense_masked(field):
+    """Sense-level masked fields for target-language field `field` (e.g. 'russian')."""
+    out = list(SENSE_MASKED_COMMON)
+    if field and field not in out:
+        out.append(field)
+    return tuple(out)
+
+
+def restored_pairs(field):
+    """Every `(level, name)` that MUST be unmasked before a card may be promoted."""
+    return (tuple(('card', f) for f in CARD_MASKED)
+            + tuple(('record', f) for f in RECORD_MASKED)
+            + tuple(('sense', f) for f in sense_masked(field)))
+
+
+def js_restore_spec(field):
+    """The same field set as a JSON literal, for interpolation into the JS harness.
+
+    The JS lane cannot import Python, so the constant is INTERPOLATED into it rather than
+    duplicated by hand -- duplicating it by hand is the original defect.
+    """
+    return json.dumps({
+        'card': list(CARD_MASKED),
+        'record': list(RECORD_MASKED),
+        'sense': list(sense_masked(field)),
+    })
+
+
+def restore_card_fields(card, field, restore_text):
+    """Unmask every field in `restored_pairs(field)`, in place, via `restore_text`.
+
+    `restore_text` is injected (rather than imported) so the caller keeps ownership of the
+    placeholder map and of what an out-of-range `{Tn}` means (C-42).
+    """
+    pairs = restored_pairs(field)
+    card_fields = [n for lvl, n in pairs if lvl == 'card']
+    record_fields = [n for lvl, n in pairs if lvl == 'record']
+    sense_fields = [n for lvl, n in pairs if lvl == 'sense']
+
+    for name in card_fields:
+        if isinstance(card.get(name), str):
+            card[name] = restore_text(card[name])
+    for record in card.get('records') or []:
+        for name in record_fields:
+            if isinstance(record.get(name), str):
+                record[name] = restore_text(record[name])
+        for sense in record.get('senses') or []:
+            for name in sense_fields:
+                if isinstance(sense.get(name), str):
+                    sense[name] = restore_text(sense[name])
+    return card

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -502,7 +502,12 @@ A concrete run, with real numbers, so the loop above isn't just abstract steps.
    two rounds recovered most residuals, a stubborn few needed a manual resolution).
 8. **Promote + rebuild TM:** `promote_final_cards.py --gen-model-version claude-sonnet-5`,
    then `translation_memory.py build --lang ru` (+ `build-frags` if any heal emitted
-   `frag_prov`).
+   `frag_prov`). Promotion requires the canonical store to exist: a missing or misresolved path is
+   a hard refusal so backup/shrink/merge guards cannot be bypassed. `--init-store` is reserved for
+   an explicit first-ever initialization and itself refuses an existing store. Never use it to
+   recover a missing production path. Every candidate is revalidated for final-card schema,
+   exact manifest-key membership, real (non-synthetic) provenance, and unresolved `{Tn}` tokens
+   immediately before the atomic store replacement.
 9. **Close out the launch ledger:** if the run had nulls, retries, kills, stale-artifact
    refusals, or cost drift, update `LAUNCH_FUCKUPS.md` and run
    `python src\pilot\check_launch_ledger.py --handoff H151` (or the active handoff ID).

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -26,6 +26,7 @@ INPUT_DIR = os.path.join(HERE, 'input')                    # .../src/pilot/input
 
 sys.path.insert(0, SRC)
 import nws_split
+import validate_final_card_schema
 from safe_filename import safe_name
 from dashboard_events import append_event
 from prompt_rule_audit import (
@@ -59,6 +60,32 @@ def _under_tempdir(path):
 COLLECT = os.path.join(SRC, '_pilot_collect.py')
 BATCH_FILE = os.path.join(OUT, '_realtest_batch.json')
 PROTECTED = {'aMSa', 'anna', 'ap'}
+
+
+def run_final_schema_gate(results):
+    """Audit every non-null card against the final record contract in-process."""
+    invalid = {}
+    checked = 0
+    for row in results or []:
+        if not isinstance(row, dict) or not row.get('card'):
+            continue
+        key = row.get('key') or (row['card'].get('key1') if isinstance(row['card'], dict) else '?')
+        checked += 1
+        try:
+            validate_final_card_schema.validate_card(row['card'])
+        except ValueError as exc:
+            invalid[key] = str(exc)
+    lines = ['final-card schema: %d checked, %d invalid' % (checked, len(invalid))]
+    lines.extend('  %s: %s' % item for item in sorted(invalid.items()))
+    return {
+        'argv': ['in-process', 'validate_final_card_schema.validate_card'],
+        'returncode': 1 if invalid else 0,
+        'stdout': '\n'.join(lines) + '\n',
+        'stderr': '',
+        'seconds': 0.0,
+        'requeue': sorted(invalid),
+        'schema_violations': invalid,
+    }
 
 
 def run_py(args, env=None):
@@ -448,7 +475,7 @@ def main():
         for err in stale.get('errors') or []:
             print('  ' + err)
     protected = load_protected()
-    gates = {}
+    gates = {'final_schema': run_final_schema_gate(results)}
 
     print('\n=== collect ===')
     collect = collect_cards(wf, protected)
@@ -485,7 +512,8 @@ def main():
                     res['requeue'] = parsed
             gates[name] = res
 
-    for name in ['nws', 'translation', 'stage2_mechanical', 'coverage', 'sense_dupes', 'prompt_semantic', 'sense_loss']:
+    for name in ['final_schema', 'nws', 'translation', 'stage2_mechanical', 'coverage',
+                 'sense_dupes', 'prompt_semantic', 'sense_loss']:
         res = gates[name]
         print('\n=== %s ===' % name)
         print(res['stdout'].rstrip())

--- a/RussianTranslation/src/pilot/autosplit_requeue.py
+++ b/RussianTranslation/src/pilot/autosplit_requeue.py
@@ -321,10 +321,16 @@ def topup_fragments(wf_file, lang):
             print('  ! %s: %d resolved fragment(s) not in frag_prov/frag-TM — cannot top up in '
                   'place (use full `gen`); skipping' % (orig, len(unresolvable)))
             continue
-        h = None
+        owners_by_tag, default_owner = {}, (None, None)
         for rec in card.get('records') or []:
-            h = h or rec.get('h')
-        cards.append({'orig': orig, 'iast': card.get('iast'), 'h': h,
+            owner = (rec.get('h'), rec.get('grammar'))
+            if default_owner == (None, None) and owner != (None, None):
+                default_owner = owner
+            for sense in rec.get('senses') or []:
+                if sense.get('tag') is not None:
+                    owners_by_tag.setdefault(sense.get('tag'), owner)
+        cards.append({'orig': orig, 'iast': card.get('iast'), 'notes': card.get('notes', ''),
+                      'owners_by_tag': owners_by_tag, 'default_owner': default_owner,
                       'plan': planrows, 'resolved': resolved, 'missing': missing})
     return cards
 
@@ -355,6 +361,18 @@ def _stitch_tree(tree, field):
     return senses, missing_si
 
 
+def _stitch_owned_senses(senses, owners):
+    """Rebuild records without throwing away each fragment sense's source owner."""
+    records = []
+    for sense, owner in zip(senses, owners):
+        h, grammar = owner or (None, None)
+        if (not records or records[-1]['h'] != h or
+                records[-1]['grammar'] != grammar):
+            records.append({'h': h, 'grammar': grammar, 'senses': []})
+        records[-1]['senses'].append(sense)
+    return records
+
+
 def stitch_topup(manifest_cards, got, field):
     """Reassemble each card from its resolved fragments (senses baked into the manifest) plus the
     freshly-recovered missing fragments (`got`: fk -> senses list, or None if still failed).
@@ -362,17 +380,40 @@ def stitch_topup(manifest_cards, got, field):
     results, still_missing = [], {}
     for c in manifest_cards:
         orig, resolved = c['orig'], c.get('resolved') or {}
-        tree, missing_fk = defaultdict(dict), []
+        tree, owner_tree, missing_fk = defaultdict(dict), defaultdict(dict), []
         for row in c['plan']:
             si, pi = row['s'], row['p']
             if row['missing']:
-                senses = got.get(row['fk'])
-                if senses is None:
+                fragment_card = got.get(row['fk'])
+                if isinstance(fragment_card, list):  # legacy direct-call shape
+                    senses = fragment_card
+                    owner = (c.get('h'), c.get('grammar'))
+                else:
+                    senses = ([s for rec in (fragment_card.get('records') or [])
+                               for s in (rec.get('senses') or [])]
+                              if fragment_card else None)
+                    owner = next(((rec.get('h'), rec.get('grammar'))
+                                  for rec in (fragment_card.get('records') or [])
+                                  if rec.get('senses')), (None, None)) if fragment_card else None
+                if fragment_card is None:
                     missing_fk.append(row['fk'])
                 tree[si][pi] = senses
+                owner_tree[si][pi] = owner
             else:
                 tree[si][pi] = resolved.get(row['fsha'])
+                tags = [s.get('tag') for s in (resolved.get(row['fsha']) or [])]
+                owner_tree[si][pi] = next(
+                    (tuple(c['owners_by_tag'][tag]) for tag in tags
+                     if tag in c.get('owners_by_tag', {})),
+                    tuple(c.get('default_owner') or (c.get('h'), c.get('grammar'))))
         senses, missing_si = _stitch_tree(tree, field)
+        owners = []
+        for si in sorted(tree):
+            if si in missing_si:
+                continue
+            owners.append(next((owner_tree[si][pi] for pi in sorted(owner_tree[si])
+                                if owner_tree[si][pi] not in (None, (None, None))),
+                               tuple(c.get('default_owner') or (c.get('h'), c.get('grammar')))))
         total_senses = len(tree)
         if not senses:
             still_missing[orig] = missing_fk
@@ -385,7 +426,8 @@ def stitch_topup(manifest_cards, got, field):
             still_missing[orig] = missing_fk
         results.append({'key': orig,
                         'card': {'key1': orig, 'iast': c.get('iast'),
-                                 'records': [{'h': c.get('h'), 'senses': senses}]},
+                                 'notes': c.get('notes', ''),
+                                 'records': _stitch_owned_senses(senses, owners)},
                         'partial': bool(missing_si),
                         'missing_senses': len(missing_si), 'total_senses': total_senses})
     return results, still_missing
@@ -418,7 +460,9 @@ def cmd_topup(root, lang, wf_file):
     # topup manifest: self-contained for merge (full plan + resolved senses baked in)
     man = {'root': root, 'lang': lang, 'mode': 'topup',
            'field': 'russian' if lang == 'ru' else 'english',
-           'cards': [{'orig': c['orig'], 'iast': c['iast'], 'h': c['h'],
+           'cards': [{'orig': c['orig'], 'iast': c['iast'], 'notes': c['notes'],
+                      'owners_by_tag': c['owners_by_tag'],
+                      'default_owner': c['default_owner'],
                       'plan': [{'s': r['s'], 'p': r['p'], 'fsha': r['fsha'],
                                 'fk': r['fk'], 'missing': r['missing']} for r in c['plan']],
                       'resolved': c['resolved']} for c in cards]}
@@ -456,8 +500,7 @@ def cmd_topup_merge(root, lang, task_file):
         if not r:
             continue
         c = r.get('card')
-        got[r['key']] = ([s for rec in (c.get('records') or []) for s in (rec.get('senses') or [])]
-                         if c else None)
+        got[r['key']] = c
     results, still_missing = stitch_topup(man['cards'], got, field)
     tag = 'en' if lang == 'en' else 'sc'
     out = os.path.join(REPO, 'wf_output.%s.%s.autosplit.json' % (tag, root))
@@ -550,19 +593,20 @@ def cmd_merge(root, lang, task_file):
         # Skip only the senses whose fragments are still missing; keep the rest as partial
         # credit, and persist the missing fragment keys for a targeted follow-up requeue
         # (not a from-scratch re-run of the whole card).
-        senses, iast, h, missing_si = [], None, None, []
+        senses, owners, iast, missing_si = [], [], None, []
         for si in sorted(senses_map):
             parts = senses_map[si]
             frs = [parts[pi] for pi in sorted(parts)]
             if any(got.get(fk) is None for fk in frs):
                 missing_si.append(si)
                 continue
-            g_txt, t_txt, tag, extra = [], [], None, {}
+            g_txt, t_txt, tag, extra, owner = [], [], None, {}, (None, None)
             for pi in sorted(parts):
                 card = got[parts[pi]]
                 iast = iast or card.get('iast')
                 for rec in card.get('records') or []:
-                    h = h or rec.get('h')
+                    if owner == (None, None) and rec.get('senses'):
+                        owner = (rec.get('h'), rec.get('grammar'))
                     for s in rec.get('senses') or []:
                         g_txt.append(s.get('german') or '')
                         t_txt.append(s.get(field) or '')
@@ -574,6 +618,7 @@ def cmd_merge(root, lang, task_file):
                       field: '\n'.join(x for x in t_txt if x)}
             merged.update({kk: vv for kk, vv in extra.items() if vv is not None})
             senses.append(merged)
+            owners.append(owner)
         if not senses:
             # nothing at all resolved — but do NOT let the card exit the recovery funnel
             # unrecorded: persist its fragment keys exactly like a partial's (previously
@@ -594,8 +639,8 @@ def cmd_merge(root, lang, task_file):
         drift = (not missing_si) and got_ls != src.count('<ls')
         if drift:
             print('  ! %s fidelity drift: <ls> %d vs source %d' % (orig, got_ls, src.count('<ls')))
-        row = {'key': orig, 'card': {'key1': orig, 'iast': iast,
-                                     'records': [{'h': h, 'senses': senses}]},
+        row = {'key': orig, 'card': {'key1': orig, 'iast': iast, 'notes': '',
+                                     'records': _stitch_owned_senses(senses, owners)},
                'partial': bool(missing_si),
                'missing_senses': len(missing_si), 'total_senses': len(senses_map)}
         if drift:

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -43,6 +43,7 @@ sys.stderr.reconfigure(encoding='utf-8')
 from window_common import INP, REPO, SRC, input_paths, load_json, read_text, rootmap_path, sha256_file, write_text
 from agent_budget import derive_agent_budget
 import pwg_mask
+import card_fields                                    # C-01: the one restore/promote field set
 from autosplit_requeue import plan as split_plan     # deterministic per-card sense/citation split
 from sense_count import count_source_senses           # H920/H960 deterministic top-level source-sense count
 sys.path.insert(0, SRC)
@@ -1552,13 +1553,35 @@ const exactCard = (cards, km, expected, fallbackIndex) => {
   const c = cards[fallbackIndex]
   return (c && c.key1 === expected) ? c : null
 }
+// C-01: which fields carry {Tn} and must be unmasked is NOT re-typed here -- it is injected
+// from card_fields.js_restore_spec(field), the same constant the Python lane restores from
+// and promote_final_cards refuses on. Hand-maintaining this list on each lane is exactly how
+// card.iast / rec.h / s.tag / s.differentia came to be promoted with their placeholders intact.
+const RESTORE_SPEC = %(restore_spec)s
+// C-02: rebuild records[] from healed senses, preserving each sense's [h, grammar] owner.
+// The stitch used to emit `records: [{ senses }]` — no h, no grammar — which violates
+// schemas/pwg_ru_final_card.schema.json (record.required = {h, grammar, senses}) and made the
+// promote path write h: null. It also collapsed real homonyms (79 sub-cards carry more than
+// one distinct h). Consecutive senses sharing an owner stay in one record; a change of owner
+// opens the next, so document order — and the whole-card fidelity counts — are unchanged.
+// The Python twin is headless_worker.stitch_records; keep them behaviourally identical.
+function stitchRecords(senses, owners) {
+  const out = []
+  for (let i = 0; i < senses.length; i++) {
+    const [h, grammar] = owners[i] || [null, null]
+    const last = out[out.length - 1]
+    if (!last || last.h !== h || last.grammar !== grammar) out.push({ h, grammar, senses: [senses[i]] })
+    else last.senses.push(senses[i])
+  }
+  return out
+}
 function restoreCard(card, k) {
   const ph = PH[k] || []
+  for (const f of RESTORE_SPEC.card) if (typeof card[f] === 'string') card[f] = restore(card[f], ph)
   for (const rec of (card.records || [])) {
-    if (rec.grammar !== undefined) rec.grammar = restore(rec.grammar, ph)
+    for (const f of RESTORE_SPEC.record) if (typeof rec[f] === 'string') rec[f] = restore(rec[f], ph)
     for (const s of (rec.senses || [])) {
-      if (s.german !== undefined) s.german = restore(s.german, ph)
-      if (s.%(field)s !== undefined) s.%(field)s = restore(s.%(field)s, ph)
+      for (const f of RESTORE_SPEC.sense) if (typeof s[f] === 'string') s[f] = restore(s[f], ph)
     }
   }
   return card
@@ -1753,6 +1776,7 @@ async function selfHeal(k) {
     : { spent: 0, max: null }
   const ftm = FRAG_TM[k] || []            // --tm: per-group cached-senses-or-null, mirrors FRAGS[k]
   const senses = []
+  const owners = []             // C-02: parallel to `senses` — the [h, grammar] each came from
   const missingFragments = []   // 'g<gi+1>:f<fi>' identifiers — persisted on the card so a
                                 // targeted requeue of JUST the failed fragments is possible
                                 // from wf_output alone (the inline path previously recorded
@@ -1798,24 +1822,31 @@ async function selfHeal(k) {
         // slot them in at their document position — do NOT re-restore (no {Tn} remain). Tag
         // normalization still applies: an older cache entry harvested before this fix may carry
         // a fabricated tag.
-        for (const s of gtm[i]) { applyTag(grp[i].si, s); senses.push(s) }
+        // The fragment TM caches SENSES ONLY -- no record context survives it, so these carry
+        // no h/grammar owner. Recorded as unknown rather than invented (C-02 boundary).
+        for (const s of gtm[i]) { applyTag(grp[i].si, s); senses.push(s); owners.push([null, null]) }
         continue
       }
       const card = r.resolved[i]
       if (!card) continue   // an uncached fragment that never resolved — already in missingFragments
       const ph = gph[i] || []
       const fsenses = []
-      for (const rec of (card.records || [])) for (const s of (rec.senses || [])) {
-        if (s.german !== undefined) s.german = restore(s.german, ph)
-        if (s.%(field)s !== undefined) s.%(field)s = restore(s.%(field)s, ph)
-        applyTag(grp[i].si, s)
-        senses.push(s); fsenses.push(s)
+      for (const rec of (card.records || [])) {
+        for (const f of RESTORE_SPEC.record) if (typeof rec[f] === 'string') rec[f] = restore(rec[f], ph)
+        for (const s of (rec.senses || [])) {
+          for (const f of RESTORE_SPEC.sense) if (typeof s[f] === 'string') s[f] = restore(s[f], ph)
+          applyTag(grp[i].si, s)
+          // C-02: keep the OWNING record's (h, grammar) alongside the sense. This loop used to
+          // flatten records->senses and drop `rec`, so the stitch below had nothing left to
+          // emit and every promoted row read h: null (403 of the 468 came from this lane).
+          senses.push(s); owners.push([rec.h, rec.grammar]); fsenses.push(s)
+        }
       }
       if (grp[i].fsha && fsenses.length) fragProv.push({ fsha: grp[i].fsha, senses: fsenses })
     }
   }
   if (!senses.length) { if (!FAIL[k]) noteFail(k, 'selfheal-nothing-resolved'); return null }
-  const stitched = { key1: k, records: [{ senses }] }
+  const stitched = { key1: k, records: stitchRecords(senses, owners) }
   if (fragProv.length) stitched.frag_prov = fragProv
   if (!missingFragments.length) {
     // fidelity check only meaningful on a COMPLETE heal — a partial result legitimately has
@@ -2061,6 +2092,11 @@ const summary = { root: META.root, lang: META.lang, cards: out.length, ok: _ok,
 return { meta: META, summary, results: out }
 """ % {
         'root': root, 'field': field, 'tr': json.dumps(tr, ensure_ascii=True),
+        # C-01: the restore field set is INTERPOLATED from `card_fields`, never re-typed here.
+        # This lane and the Python lane each kept their own hand-written list of what to
+        # unmask; both listed three fields while promote read six, and 670 store rows landed
+        # with a raw {Tn}. The JS cannot import Python, so the constant is injected instead.
+        'restore_spec': card_fields.js_restore_spec(field),
         # Language-aware meta + model pin. EN path pins Sonnet 5 explicitly
         # (the bare 'sonnet' alias resolved to 4.6 on a prior run); RU path
         # keeps the 'sonnet' alias unchanged so the autonomous RU runs are untouched.

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -17,7 +17,11 @@ sys.stderr.reconfigure(encoding='utf-8')
 
 if os.path.dirname(os.path.abspath(__file__)) not in sys.path:
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+_SRC = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
 from proc_tree import run_tree_kill, terminate_tree, windows_hidden_flags  # noqa: E402  (shared D-J tree-kill runner)
+import card_fields  # noqa: E402  (C-01: the one restore/promote field set, shared with the JS lane)
 
 AUTH_RE = re.compile(r'401|authentication|not logged in|invalid.*credential', re.I)
 RATE_RE = re.compile(r'429|rate.?limit|usage limit|too many requests', re.I)
@@ -129,26 +133,83 @@ def extract_structured(stdout):
     return value, wrapper
 
 
-def restore_text(text, placeholders):
+def restore_text(text, placeholders, unmapped=None):
+    """Unmask `{Tn}` against `placeholders`.
+
+    C-42: an index outside the map still returns the token verbatim (changing that is a
+    behaviour change this correction does not make), but it is now COUNTED into `unmapped`
+    when a caller supplies a sink. The silent pass-through is how a raw `{T196}` reached the
+    canonical store on a card that reported success: the article is masked WHOLE (235+
+    placeholders) but restored per-subcard against a subcard-local map, so a high global
+    index maps nothing. Counting is what lets `normalize_batch` gate on zero.
+    """
     def repl(match):
         idx = int(match.group(1)) - 1
-        return placeholders[idx] if 0 <= idx < len(placeholders) else match.group(0)
+        if 0 <= idx < len(placeholders):
+            return placeholders[idx]
+        if unmapped is not None:
+            unmapped.append(match.group(0))
+        return match.group(0)
     return re.sub(r'\{T(\d+)\}', repl, text or '')
 
 
-def restore_card(card, field, placeholders):
-    for record in card.get('records') or []:
-        if 'grammar' in record:
-            record['grammar'] = restore_text(record['grammar'], placeholders)
-        for sense in record.get('senses') or []:
-            if 'german' in sense:
-                sense['german'] = restore_text(sense['german'], placeholders)
-            if field in sense:
-                sense[field] = restore_text(sense[field], placeholders)
-    return card
+def restore_card(card, field, placeholders, unmapped=None):
+    """Unmask every field the promote path reads -- the set is `card_fields`, not a local list.
+
+    C-01: this used to restore three things (record.grammar, sense.german, sense.<field>)
+    while `promote_final_cards.rows_for` read six, so card.iast / record.h / sense.tag /
+    sense.differentia were promoted with their `{Tn}` intact -- 670 store rows, 223 of them
+    a raw `{Tn}` in the HEADWORD. The lists are now one constant, pinned by
+    `test_restore_covers_every_promoted_field`.
+
+    Deliberate delta from the old loop: a field is restored only when it is a `str`. The old
+    code tested key-presence and passed `text or ''`, silently rewriting a `None` grammar to
+    `''`. Extending that to `h` would have laundered the 468 known `h is None` rows into
+    empty strings -- destroying the very signal C-02 is diagnosed by. A non-str field is now
+    left exactly as found.
+    """
+    return card_fields.restore_card_fields(
+        card, field, lambda text: restore_text(text, placeholders, unmapped))
+
+
+def stitch_records(senses, owners):
+    """Rebuild `records[]` from healed senses, preserving each sense's `(h, grammar)` owner.
+
+    C-02: the stitch used to emit a single `{'senses': senses}` record -- no `h`, no
+    `grammar` -- which violates `schemas/pwg_ru_final_card.schema.json` (`record.required =
+    {h, grammar, senses}`) and made the promote path write `h: null`. It also collapsed real
+    homonyms: 79 sub-cards legitimately carry more than one distinct `h`, so one flat record
+    cannot represent them.
+
+    Consecutive senses sharing an owner stay in one record; a change of owner opens the next.
+    Order is preserved exactly, so the whole-card `<ls>`/`{#` fidelity counts are unchanged.
+    """
+    records = []
+    for sense, owner in zip(senses, owners):
+        if not records or records[-1]['_owner'] != owner:
+            rec_h, rec_grammar = owner
+            records.append({'_owner': owner, 'h': rec_h, 'grammar': rec_grammar, 'senses': []})
+        records[-1]['senses'].append(sense)
+    for record in records:
+        record.pop('_owner', None)
+    return records
 
 
 def count_card(card, needle):
+    """Count `needle` across the card's `german` senses.
+
+    DELIBERATELY still `german`-only. The C-02 boundary asks to "make count_card/countOf see
+    record-level fields", but that is wrong AT THIS SITE and its own fixture proves it: this
+    count is compared against `inp['ls']`/`inp['sk']`, which are SOURCE-occurrence counts
+    (`raw.count('<ls')`). One source token echoed into both `grammar` and `german` -- exactly
+    what `headless_worker_selftest.success_runner` builds, `{T1}` in both -- then counts 2
+    against a denominator of 1 and the card is rejected as a fidelity failure.
+
+    Adding record-level text belongs with the token-MULTISET guards (C-17, Step 6), whose
+    denominator really is the whole skeleton. Restoring `grammar` on the stitch lane (C-02)
+    leaves this count unchanged, because stitched cards previously carried no `grammar` term
+    at all -- so historical comparisons stay valid.
+    """
     return sum((sense.get('german') or '').count(needle)
                for record in card.get('records') or []
                for sense in record.get('senses') or [])
@@ -175,10 +236,16 @@ def normalize_batch(manifest, keys, structured):
         if card is None:
             error = 'missing-or-mismatched-key'
         else:
-            card = restore_card(card, manifest['field'], manifest['placeholder_maps'].get(key, []))
+            unmapped = []
+            card = restore_card(card, manifest['field'],
+                                manifest['placeholder_maps'].get(key, []), unmapped)
             inp = manifest['inputs'][key]
             if count_card(card, '<ls') != inp['ls'] or count_card(card, '{#') != inp['sk']:
                 error = 'fidelity-reject'
+                card = None
+            elif unmapped:
+                # C-42: an out-of-range {Tn} maps nothing and cannot be recovered downstream.
+                error = 'unmapped-token-reject'
                 card = None
         row = {'key': key, 'card': card, 'judge': None, 'judge_sonnet': None,
                'escalated': False}
@@ -381,6 +448,8 @@ class HeadlessEngine:
         cached_groups = self.m.get('fragment_tm', {}).get(key) or []
         ph_groups = self.m.get('fragment_placeholder_maps', {}).get(key) or []
         senses = []
+        owners = []          # C-02: parallel to `senses` -- the (h, grammar) each came from
+        unmapped = []        # C-42: {Tn} indices that map nothing, instead of a silent pass
         frag_prov = []
         missing = []
         sense_tags = {}
@@ -392,28 +461,43 @@ class HeadlessEngine:
                                                    'heal:%s#g%d' % (key, gi + 1), budget)
             missing.extend('g%d:f%d' % (gi + 1, i) for i in unresolved)
             for index, fragment in enumerate(group):
-                frag_senses = []
+                # C-02: keep each sense's OWNING record. The old comprehension here flattened
+                # `records -> senses` and dropped `record` itself, so the stitch below had no
+                # `h`/`grammar` left in scope to emit and every promoted row read `h: null`
+                # (468 rows / 20 sub-cards). `h` is free lexicographic text ("2. bhid",
+                # "PW 3 (с anu, отсылка к entry 5)"), so a dropped one cannot be reconstructed
+                # later -- it has to survive the flatten.
+                frag_records = []
                 if index < len(cached) and cached[index]:
-                    frag_senses = cached[index]
+                    # The fragment TM caches SENSES ONLY, with no record context, so a
+                    # TM-served fragment genuinely has no `h` to carry. Emit it under an
+                    # unknown owner rather than inventing one -- synthesising an `h` here is
+                    # what the C-02 boundary forbids. This is the residual null source and is
+                    # counted in the summary below.
+                    frag_records = [(None, None, cached[index])]
                 elif index in resolved:
                     card = restore_card(resolved[index], self.m['field'],
-                                        phs[index] if index < len(phs) else [])
-                    frag_senses = [sense for record in card.get('records') or []
-                                   for sense in record.get('senses') or []]
+                                        phs[index] if index < len(phs) else [], unmapped)
+                    frag_records = [(record.get('h'), record.get('grammar'),
+                                     record.get('senses') or [])
+                                    for record in card.get('records') or []]
+                    frag_senses = [sense for _, _, group in frag_records for sense in group]
                     if fragment.get('fsha') and frag_senses:
                         frag_prov.append({'fsha': fragment['fsha'], 'senses': frag_senses})
-                for sense in frag_senses:
-                    source_ord = fragment.get('si')
-                    if source_ord is not None:
-                        if source_ord in sense_tags:
-                            sense['tag'] = sense_tags[source_ord]
-                        else:
-                            sense_tags[source_ord] = sense.get('tag')
-                    senses.append(sense)
+                for rec_h, rec_grammar, group in frag_records:
+                    for sense in group:
+                        source_ord = fragment.get('si')
+                        if source_ord is not None:
+                            if source_ord in sense_tags:
+                                sense['tag'] = sense_tags[source_ord]
+                            else:
+                                sense_tags[source_ord] = sense.get('tag')
+                        senses.append(sense)
+                        owners.append((rec_h, rec_grammar))
         if not senses:
             self.note(key, 'selfheal-nothing-resolved')
             return None
-        card = {'key1': key, 'records': [{'senses': senses}]}
+        card = {'key1': key, 'records': stitch_records(senses, owners)}
         if frag_prov:
             card['frag_prov'] = frag_prov
         if missing:
@@ -427,6 +511,15 @@ class HeadlessEngine:
                 self.note(key, 'stitched-fidelity-reject: <ls> %d/%d, {# %d/%d' %
                           (ls_count, inp['ls'], sk_count, inp['sk']))
                 return None
+        # C-42: a {Tn} whose index maps nothing used to be written through verbatim on a card
+        # that reported success -- that is how `ban_d~~h0_11_ni` and `ban_d~~h0_21_upasam_0`
+        # reached the canonical store carrying a raw {T196}/{T235}. The token is unrecoverable
+        # by construction (the index addresses a whole-article map the sub-card never had), so
+        # refuse the card instead of promoting a known-corrupt one.
+        if unmapped:
+            self.note(key, 'unmapped-token-reject: %d out-of-range placeholder(s): %s'
+                      % (len(unmapped), ', '.join(sorted(set(unmapped))[:6])))
+            return None
         return card
 
     def run_all(self):

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -142,19 +142,36 @@ def main():
         start = js.index('function restoreCard(card, k)')
         end = js.index('// Per-card grammar', start)
         restore_card_js = js[start:end]
+        # RESTORE_SPEC is injected from the same constant the harness interpolates (C-01), not
+        # re-typed here: the whole point of the constant is that no second list exists. The
+        # slice above starts at `function restoreCard`, so the const declared above it is not
+        # carried in -- supply it exactly as the real harness would.
+        import card_fields
         node_script = r"""
 const PH = {agni: ['<lex>m.</lex>']}
 const restore = (t, ph) => (t || '').replace(/\{T(\d+)\}/g, (_m, n) => ph[Number(n)-1])
+const RESTORE_SPEC = %s
 %s
-const card = {records: [{grammar: '{T1}', senses: [{german: '{T1}', russian: '{T1}'}]}]}
+const card = {iast: '{T1}', records: [{h: '{T1}', grammar: '{T1}', senses: [
+  {tag: '{T1}', german: '{T1}', russian: '{T1}', differentia: '{T1}'}]}]}
 console.log(JSON.stringify(restoreCard(card, 'agni')))
-""" % restore_card_js
+""" % (card_fields.js_restore_spec('russian'), restore_card_js)
         node = subprocess.run(['node', '-e', node_script], capture_output=True,
                               text=True, encoding='utf-8')
         assert node.returncode == 0, node.stderr
         restored = json.loads(node.stdout)
-        assert restored['records'][0]['grammar'] == '<lex>m.</lex>'
-        assert restored['records'][0]['senses'][0]['german'] == '<lex>m.</lex>'
+        rec = restored['records'][0]
+        sense = rec['senses'][0]
+        assert rec['grammar'] == '<lex>m.</lex>'
+        assert sense['german'] == '<lex>m.</lex>'
+        # C-01: the JS lane must unmask EVERY field the promote path reads, not just three.
+        # card.iast / record.h / sense.tag / sense.differentia used to survive as raw {Tn} and
+        # were promoted verbatim -- 670 store rows, 223 of them a {Tn} headword.
+        for where, value in (('card.iast', restored['iast']), ('record.h', rec['h']),
+                             ('sense.tag', sense['tag']),
+                             ('sense.differentia', sense['differentia']),
+                             ('sense.russian', sense['russian'])):
+            assert value == '<lex>m.</lex>', '%s left unrestored by the JS lane: %r' % (where, value)
 
     # D-A (H818 Windows acceptance): the launcher resolver must bypass the Windows .cmd
     # batch shim (cmd.exe corrupts the --json-schema arg) and pass native/POSIX through.

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -4780,25 +4780,26 @@ def test_save_merge_better_attempt_wins():
         p = os.path.join(tmp, name)
         with open(p, 'w', encoding='utf-8') as f:
             json.dump(wf(card), f)
-        # `--allow-schema-violations`: this test's cards are deliberate STUBS carrying a
-        # `senses_marker` and nothing else -- it pins merge ORDERING (complete beats partial),
-        # not card content. Since C-04 armed the record contract on the live save path, a stub
-        # is correctly refused, so the exception is declared explicitly here rather than by
-        # relaxing the contract for everyone.
-        run([sys.executable, save, root, p, tag, '--no-audit', '--allow-schema-violations']
-            + list(extra), expect=0)
+        run([sys.executable, save, root, p, tag, '--no-audit'] + list(extra), expect=0)
+
+    def valid_card(marker, **extra):
+        card = {'key1': 'k1', 'iast': 'k1', 'notes': '', 'senses_marker': marker,
+                'records': [{'h': 'k1', 'grammar': '', 'senses': [
+                    {'tag': '1', 'german': 'Deutsch', 'russian': 'русский'}]}]}
+        card.update(extra)
+        return card
 
     try:
-        complete = {'key1': 'k1', 'senses_marker': 'first-complete'}
+        complete = valid_card('first-complete')
         save_run('a.json', complete)
-        worse = {'key1': 'k1', 'partial': True,
-                 'missing_fragments': ['g1:f0', 'g1:f1'], 'senses_marker': 'regression'}
+        worse = valid_card('regression', partial=True,
+                           missing_fragments=['g1:f0', 'g1:f1'])
         save_run('b.json', worse, '--merge')
         got = json.load(open(out_path, encoding='utf-8'))
         card = got['results'][0]['card']
         if card.get('partial') or card.get('senses_marker') != 'first-complete':
             fail('--merge let a partial attempt regress a complete card')
-        fresh = {'key1': 'k1', 'senses_marker': 'second-complete'}
+        fresh = valid_card('second-complete')
         save_run('c.json', fresh, '--merge')
         got = json.load(open(out_path, encoding='utf-8'))
         if got['results'][0]['card'].get('senses_marker') != 'second-complete':
@@ -5262,6 +5263,27 @@ def test_every_stitch_emits_record_required():
     if len(hw.stitch_records(senses, [('h', 'g')] * 3)) != 1:
         fail('one owner must yield exactly one record')
 
+    import autosplit_requeue as ar
+    split_records = ar._stitch_owned_senses(senses, owners)
+    if [(r['h'], r['grammar']) for r in split_records] != [
+            ('1. bhid', 'm.'), ('2. bhid', 'f.')]:
+        fail('autosplit stitch lost record owners: %r' % split_records)
+    topup_manifest = [{
+        'orig': 'bhid', 'iast': 'bhid', 'notes': '',
+        'owners_by_tag': {'1': ['1. bhid', 'm.'], '2': ['2. bhid', 'f.']},
+        'default_owner': ['1. bhid', 'm.'],
+        'plan': [
+            {'s': 0, 'p': 0, 'fsha': 'a', 'fk': 'old', 'missing': False},
+            {'s': 1, 'p': 0, 'fsha': 'b', 'fk': 'new', 'missing': True}],
+        'resolved': {'a': [{'tag': '1', 'german': 'g1', 'russian': 'r1'}]}}]
+    new_fragment = {'records': [{'h': '2. bhid', 'grammar': 'f.', 'senses': [
+        {'tag': '2', 'german': 'g2', 'russian': 'r2'}]}]}
+    rows, missing = ar.stitch_topup(topup_manifest, {'new': new_fragment}, 'russian')
+    recs = rows[0]['card']['records']
+    if missing or [(r['h'], r['grammar']) for r in recs] != [
+            ('1. bhid', 'm.'), ('2. bhid', 'f.')]:
+        fail('top-up stitch lost a record boundary/owner: %r %r' % (rows, missing))
+
 
 def test_unmapped_token_is_counted():
     """C-42: an out-of-range {Tn} is counted, not silently passed through.
@@ -5306,6 +5328,16 @@ def test_validator_has_a_live_caller():
     if 'validate_card(' not in text:
         fail('save_and_audit.py imports the validator but never calls validate_card()')
 
+    audit_path = os.path.join(SRC, 'pilot', 'audit_window.py')
+    audit_text = open(audit_path, encoding='utf-8').read()
+    if 'run_final_schema_gate' not in audit_text or 'validate_card(' not in audit_text:
+        fail('audit_window.py does not validate real workflow cards')
+
+    promote_path = os.path.join(SRC, 'promote_final_cards.py')
+    promote_text = open(promote_path, encoding='utf-8').read()
+    if 'validate_promotion_entry' not in promote_text or 'validate_card(' not in promote_text:
+        fail('promote_final_cards.py lacks independent final-schema validation')
+
     if SRC not in sys.path:
         sys.path.insert(0, SRC)
     import validate_final_card_schema as v
@@ -5321,6 +5353,19 @@ def test_validator_has_a_live_caller():
         pass
     else:
         fail('validate_card accepted a record with no h/grammar -- the C-02 shape')
+
+    import audit_window
+    good = {'key1': 'k', 'iast': 'k', 'notes': '', 'records': [{
+        'h': 'k', 'grammar': '', 'senses': [{
+            'tag': '1', 'german': 'g', 'russian': 'r',
+            'equivalence_type': 'equivalent', 'source_type': 'attested',
+            'stratum': '', 'differentia': ''}]}]}
+    ok_gate = audit_window.run_final_schema_gate([{'key': 'k', 'card': good}])
+    if ok_gate.get('returncode') != 0 or ok_gate.get('requeue'):
+        fail('audit final-schema gate rejected a valid card: %r' % ok_gate)
+    bad_gate = audit_window.run_final_schema_gate([{'key': 'k', 'card': bad}])
+    if bad_gate.get('returncode') != 1 or bad_gate.get('requeue') != ['k']:
+        fail('audit final-schema gate did not requeue an invalid live card: %r' % bad_gate)
 
 
 def main():

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -16,7 +16,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import traceback
 import xml.etree.ElementTree as ET
 
 sys.stdout.reconfigure(encoding='utf-8')

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -4780,7 +4780,13 @@ def test_save_merge_better_attempt_wins():
         p = os.path.join(tmp, name)
         with open(p, 'w', encoding='utf-8') as f:
             json.dump(wf(card), f)
-        run([sys.executable, save, root, p, tag, '--no-audit'] + list(extra), expect=0)
+        # `--allow-schema-violations`: this test's cards are deliberate STUBS carrying a
+        # `senses_marker` and nothing else -- it pins merge ORDERING (complete beats partial),
+        # not card content. Since C-04 armed the record contract on the live save path, a stub
+        # is correctly refused, so the exception is declared explicitly here rather than by
+        # relaxing the contract for everyone.
+        run([sys.executable, save, root, p, tag, '--no-audit', '--allow-schema-violations']
+            + list(extra), expect=0)
 
     try:
         complete = {'key1': 'k1', 'senses_marker': 'first-complete'}
@@ -5190,8 +5196,139 @@ def test_strip_mask_tokens_clears_notes_stranded_anchor():
         fail('render() leaked a {Tn} masking token from notes into merged.md')
 
 
+def test_restore_covers_every_promoted_field():
+    """C-01: restore's field set and promote's read set are ONE constant, not two lists.
+
+    The defect: `restore_card` unmasked 3 fields while `rows_for` promoted 6, so card.iast /
+    record.h / sense.tag / sense.differentia reached the canonical store with their {Tn}
+    intact -- 670 rows, 223 of them a raw {Tn} in the HEADWORD field. Two independently
+    hand-maintained lists could drift; one constant cannot.
+    """
+    if SRC not in sys.path:
+        sys.path.insert(0, SRC)
+    import card_fields
+    # Both language lanes: every field the promoter reads must have been unmasked first.
+    for field in ('russian', 'english'):
+        promoted = set(card_fields.promoted_pairs(field))
+        restored = set(card_fields.restored_pairs(field))
+        missing = promoted - restored
+        if missing:
+            fail('fields promoted but never restored (%s): %s' % (field, sorted(missing)))
+    # The JS lane cannot import Python, so its list is interpolated from the same constant.
+    spec = json.loads(card_fields.js_restore_spec('russian'))
+    if set(spec['record']) != set(card_fields.RECORD_MASKED):
+        fail('js_restore_spec record set drifted from RECORD_MASKED')
+    if 'h' not in spec['record']:
+        fail('the JS lane must restore record.h -- it is promoted verbatim')
+
+    # And the restore actually reaches those fields, end to end.
+    card = {'iast': '{T1}', 'records': [{'h': '{T1}', 'grammar': '{T1}', 'senses': [
+        {'tag': '{T1}', 'german': '{T1}', 'russian': '{T1}', 'differentia': '{T1}'}]}]}
+    card_fields.restore_card_fields(card, 'russian', lambda t: t.replace('{T1}', 'X'))
+    rec, sense = card['records'][0], card['records'][0]['senses'][0]
+    for where, value in (('card.iast', card['iast']), ('record.h', rec['h']),
+                         ('record.grammar', rec['grammar']), ('sense.tag', sense['tag']),
+                         ('sense.german', sense['german']), ('sense.russian', sense['russian']),
+                         ('sense.differentia', sense['differentia'])):
+        if value != 'X':
+            fail('%s was not restored (still %r)' % (where, value))
+
+
+def test_every_stitch_emits_record_required():
+    """C-02: the stitch must emit `h`/`grammar`, and must not collapse distinct homonyms.
+
+    The defect: both stitch lanes built `records: [{senses}]`, discarding record-level h and
+    grammar unconditionally, so promote wrote `h: null` -- 468 store rows over 20 sub-cards.
+    That also violates schemas/pwg_ru_final_card.schema.json (record.required =
+    {h, grammar, senses}), which nothing checked on live output (C-04).
+    """
+    import headless_worker as hw
+    senses = [{'tag': '1'}, {'tag': '2'}, {'tag': '3'}]
+    owners = [('1. bhid', 'm.'), ('1. bhid', 'm.'), ('2. bhid', 'f.')]
+    records = hw.stitch_records(senses, owners)
+    if len(records) != 2:
+        fail('two distinct owners must yield two records, got %d' % len(records))
+    if records[0]['h'] != '1. bhid' or records[1]['h'] != '2. bhid':
+        fail('stitch dropped or reordered the record-level h: %r' % records)
+    if records[0]['grammar'] != 'm.' or records[1]['grammar'] != 'f.':
+        fail('stitch dropped the record-level grammar: %r' % records)
+    for rec in records:
+        for key in ('h', 'grammar', 'senses'):
+            if key not in rec:
+                fail('stitched record missing schema-required %r' % key)
+    if [s['tag'] for r in records for s in r['senses']] != ['1', '2', '3']:
+        fail('stitch must preserve document order of senses')
+    # A single owner stays ONE record -- no gratuitous fragmentation.
+    if len(hw.stitch_records(senses, [('h', 'g')] * 3)) != 1:
+        fail('one owner must yield exactly one record')
+
+
+def test_unmapped_token_is_counted():
+    """C-42: an out-of-range {Tn} is counted, not silently passed through.
+
+    The defect: `restore_text` returned `match.group(0)` for an index the map does not
+    address, with no counter, no log and no reject -- so `ban_d~~h0_11_ni` and
+    `ban_d~~h0_21_upasam_0` reached the canonical store carrying a raw {T196}/{T235} on cards
+    that reported success. Cause is a masking-scope vs restore-scope index mismatch (article
+    masked whole, restored per sub-card), not model hallucination.
+    """
+    import headless_worker as hw
+    unmapped = []
+    out = hw.restore_text('a {T1} b {T99} c', ['<ls>x</ls>'], unmapped)
+    if '<ls>x</ls>' not in out:
+        fail('an in-range token must still restore')
+    if unmapped != ['{T99}']:
+        fail('an out-of-range token must be counted, got %r' % unmapped)
+    if '{T99}' not in out:
+        fail('behaviour change: the out-of-range token must still pass through verbatim')
+    clean = []
+    hw.restore_text('a {T1} b', ['x'], clean)
+    if clean:
+        fail('a fully-mapped text must report no unmapped tokens, got %r' % clean)
+
+
+def test_validator_has_a_live_caller():
+    """C-04 dead-validator canary: the record contract must run on LIVE output.
+
+    `validate_final_card_schema` is the ONLY component encoding record.required =
+    {h, grammar, senses}, and its only caller was a CI step feeding it a hand-made PASSING
+    fixture. A green check certified a contract no real card was measured against -- which is
+    precisely why C-01's 670 placeholder rows and C-02's 468 null-h rows accumulated with no
+    signal. This asserts the validator is reachable from the save chain, and that it still
+    refuses a record missing `h`.
+    """
+    from window_common import REPO as repo_root
+    save = os.path.join(repo_root, 'save_and_audit.py')
+    text = open(save, encoding='utf-8').read()
+    if 'validate_final_card_schema' not in text:
+        fail('save_and_audit.py has no reference to validate_final_card_schema -- the '
+             'validator is dead again (C-04)')
+    if 'validate_card(' not in text:
+        fail('save_and_audit.py imports the validator but never calls validate_card()')
+
+    if SRC not in sys.path:
+        sys.path.insert(0, SRC)
+    import validate_final_card_schema as v
+    if v.RECORD_REQUIRED != {'h', 'grammar', 'senses'}:
+        fail('RECORD_REQUIRED was relaxed: %r' % (v.RECORD_REQUIRED,))
+    # The contract must actually reject the shape C-02 was writing.
+    bad = {'key1': 'k', 'iast': 'k', 'notes': '', 'records': [{'senses': [
+        {'tag': '1', 'german': 'g', 'russian': 'r', 'equivalence_type': 'equivalent',
+         'source_type': 'attested', 'stratum': '', 'differentia': ''}]}]}
+    try:
+        v.validate_card(bad)
+    except ValueError:
+        pass
+    else:
+        fail('validate_card accepted a record with no h/grammar -- the C-02 shape')
+
+
 def main():
     tests = [
+        test_restore_covers_every_promoted_field,
+        test_every_stitch_emits_record_required,
+        test_unmapped_token_is_counted,
+        test_validator_has_a_live_caller,
         test_strip_mask_tokens_clears_notes_stranded_anchor,
         test_translation_memory_addressing,
         test_tm_pre_resolves_cards,
@@ -5324,23 +5461,42 @@ def main():
         test_partial_cards_requeue_and_stay_out_of_clean_sample,
         test_classify_run_verdicts,
     ]
-    failures = []
+    # Per-test isolation. This used to be a bare `for test in tests: test()`, so the FIRST
+    # failure aborted the process and every later test silently never ran. That is not
+    # hypothetical: `test_lang_parity_ledger_complete` sits at position 105 of 131 and is
+    # RED BY DESIGN -- the parity verdicts need human reaffirmation, which is deliberately not
+    # something an agent does (`--update-hash` is a human's call). So the last 27 tests (20.6%)
+    # were dark INDEFINITELY, including `test_frag_groups_presplit_parity`, the whole
+    # `pwg_mask` pair and four heal-lane tests. A real regression hiding behind the known-red
+    # gate was indistinguishable from the gate itself.
+    #
+    # This isolates each test and reports ran/defined, so "the suite is green" can no longer
+    # mean "the suite stopped early". It does NOT touch the parity gate: that test still fails,
+    # loudly, and the run still exits non-zero. It just no longer takes the other 26 with it.
+    passed, failed = [], []
     for test in tests:
         try:
             test()
-        except Exception:
-            failures.append(test.__name__)
-            print('FAIL:', test.__name__, file=sys.stderr)
-            traceback.print_exc()
+        except BaseException as exc:      # noqa: BLE001 -- a failing test must not hide the rest
+            failed.append(test.__name__)
+            print('FAIL: %s -- %s: %s' % (test.__name__, exc.__class__.__name__, exc))
         else:
+            passed.append(test.__name__)
             print('PASS:', test.__name__)
-    print('window selftest: %d/%d run, %d passed, %d failed'
-          % (len(tests), len(tests), len(tests) - len(failures), len(failures)))
-    if failures:
-        print('FAILED TESTS: %s' % ', '.join(failures), file=sys.stderr)
-        raise SystemExit(1)
+
+    ran = len(passed) + len(failed)
+    print('window selftest: ran %d/%d defined -- %d passed, %d failed'
+          % (ran, len(tests), len(passed), len(failed)))
+    if ran != len(tests):
+        # Unreachable while every test is isolated; kept so that a future early-exit (an
+        # os._exit, a signal) is reported as darkness rather than read as success.
+        print('DARK: %d test(s) defined but never ran' % (len(tests) - ran))
+    if failed:
+        print('FAILED (%d): %s' % (len(failed), ', '.join(failed)))
+        return 1
     print('window selftest OK')
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -28,11 +28,14 @@ is a requeue subset (the full Slice-C originals were overwritten; re-run or reco
 re-run this script — it is idempotent and supersede-safe).
 """
 import argparse
+import collections
 import datetime
 import glob
 import json
 import os
+import shutil
 import sys
+import tempfile
 
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
@@ -41,6 +44,7 @@ import re
 import pipeline_version
 import dict_merge
 import card_fields
+import validate_final_card_schema
 from promote_lock import PromoteClaim, ClaimBusy
 from store_path import canonical_store
 
@@ -173,6 +177,104 @@ class UnrestoredPlaceholder(Exception):
     """A card reached the promote path still carrying a `{Tn}` mask placeholder (C-01)."""
 
 
+class PromotionContractError(Exception):
+    """The candidate cannot independently prove schema, provenance, and key scope."""
+
+
+HEX64_RE = re.compile(r'^[0-9a-f]{64}$')
+SYNTHETIC_KEY_RE = re.compile(r'^(?:dq_canary_|zz~~synthetic|synthetic[_~-])', re.I)
+
+
+def validate_promotion_entry(subkey, entry):
+    """Second-line promotion validation, independent of audit/coordinator state."""
+    card = entry.get('card') or {}
+    meta = entry.get('meta') or {}
+    try:
+        validate_final_card_schema.validate_card(card)
+    except ValueError as exc:
+        raise PromotionContractError('%s: final-card schema: %s' % (subkey, exc))
+
+    selected = meta.get('selected_keys')
+    if not isinstance(selected, list) or selected.count(subkey) != 1:
+        raise PromotionContractError(
+            '%s: selected_keys must contain this key exactly once' % subkey)
+    if len(selected) != len(set(selected)):
+        raise PromotionContractError('%s: execution selected_keys contains duplicates' % subkey)
+    hashes = (meta.get('input_hashes') or {}).get(subkey)
+    if not isinstance(hashes, dict):
+        raise PromotionContractError('%s: missing per-key input hashes' % subkey)
+    for name in ('raw_sha256', 'portrait_sha256'):
+        value = hashes.get(name)
+        if not isinstance(value, str) or not HEX64_RE.fullmatch(value.lower()):
+            raise PromotionContractError('%s: malformed %s' % (subkey, name))
+    for name in ('generator', 'schema_version', 'generated_at'):
+        if not isinstance(meta.get(name), str) or not meta[name].strip():
+            raise PromotionContractError('%s: missing provenance field meta.%s' % (subkey, name))
+
+    classes = meta.get('provenance_classes')
+    provenance_class = classes.get(subkey) if isinstance(classes, dict) else meta.get('provenance_class')
+    if provenance_class == 'synthetic_control' or SYNTHETIC_KEY_RE.search(subkey):
+        raise PromotionContractError('%s: synthetic controls are never promotable' % subkey)
+    if provenance_class not in (None, 'real'):
+        raise PromotionContractError('%s: unknown provenance_class %r'
+                                     % (subkey, provenance_class))
+
+    if meta.get('nominal'):
+        keymap = meta.get('nominal_keymap') or {}
+        mapped = keymap.get(subkey)
+        if mapped and card.get('key1') not in (mapped, subkey):
+            raise PromotionContractError(
+                '%s: nominal keymap/card mismatch (%r != %r)'
+                % (subkey, card.get('key1'), mapped))
+    elif not isinstance(meta.get('root'), str) or not meta['root']:
+        raise PromotionContractError('%s: root-backed result has no root' % subkey)
+
+
+def _atomic_write_rows(path, rows):
+    directory = os.path.dirname(os.path.abspath(path)) or '.'
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix='.%s.' % os.path.basename(path), suffix='.tmp', dir=directory)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8', newline='\n') as fh:
+            for row in rows:
+                fh.write(json.dumps(row, ensure_ascii=False) + '\n')
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _fsynced_backup(source, destination):
+    """Copy, never move, the live store so a later write failure leaves it in place."""
+    with open(source, 'rb') as src, open(destination, 'wb') as dst:
+        shutil.copyfileobj(src, dst, length=1024 * 1024)
+        dst.flush()
+        os.fsync(dst.fileno())
+
+
+def validate_store_target(path, init_store=False):
+    if not os.path.isfile(path) and not init_store:
+        raise PromotionContractError(
+            'canonical store is missing: %s. A missing/misresolved production store must not '
+            'disable merge, shrink, or backup guards; use --init-store only for a deliberate '
+            'first run.' % path)
+    if os.path.exists(path) and init_store:
+        raise PromotionContractError(
+            '--init-store is first-run only; store already exists: %s' % path)
+
+
+def merge_store_rows(existing_rows, promoted_rows):
+    """Replace exactly the promoted subcards; retain every unrelated row."""
+    promoted_subs = {row['subcard'] for row in promoted_rows}
+    kept = [row for row in existing_rows if row.get('subcard') not in promoted_subs]
+    return kept + promoted_rows
+
+
 def tn_residue(card, rec, sense):
     """Report every promoted field of this row that still holds a raw `{Tn}`.
 
@@ -224,6 +326,7 @@ def rows_for(subkey, entry, review_status, model_version):
                 'layer': layer,
                 'iast': card.get('iast'),
                 'h': rec.get('h'),
+                'grammar': rec.get('grammar'),
                 'sense_tag': sense.get('tag'),
                 'ru': ru,
                 'de': sense.get('german'),
@@ -241,9 +344,11 @@ def selftest():
     import tempfile
     meta = {'root': 'pA', 'safe_root': 'p_a', 'generator': 'gen_opt_harness2.batched-masked',
             'schema_version': 'v1', 'rootmap_sha256': 'abc', 'generated_at': '2026-06-29T00:00:00Z',
-            'input_hashes': {'p_a~~h5_00_pwg00': {'raw_sha256': 'r1', 'portrait_sha256': 'p1'}}}
-    entry = {'card': {'key1': 'p_a~~h5_00_pwg00', 'iast': 'pā', 'records': [
-        {'h': 'pā', 'senses': [
+            'selected_keys': ['p_a~~h5_00_pwg00'],
+            'input_hashes': {'p_a~~h5_00_pwg00': {
+                'raw_sha256': '1' * 64, 'portrait_sha256': '2' * 64}}}
+    entry = {'card': {'key1': 'p_a~~h5_00_pwg00', 'iast': 'pā', 'notes': '', 'records': [
+        {'h': 'pā', 'grammar': '', 'senses': [
             {'tag': '1', 'russian': 'пить', 'german': 'trinken', 'equivalence_type': 'equivalent',
              'source_type': 'attested', 'stratum': 'Vedic', 'differentia': ''},
             {'tag': '2', 'russian': '', 'german': 'x'},          # no russian -> skipped
@@ -261,13 +366,32 @@ def selftest():
     p = r['provenance']
     assert p['model'] == 'sonnet' and p['rootmap_sha256'] == 'abc'
     assert p['model_version'] == SELFTEST_MODEL_VERSION, 'model VERSION recorded, not just the tier alias'
-    assert p['input_raw_sha256'] == 'r1' and p['generated_at'], 'provenance must be complete'
+    assert p['input_raw_sha256'] == '1' * 64 and p['generated_at'], 'provenance must be complete'
+    validate_promotion_entry('p_a~~h5_00_pwg00', entry)
+    synthetic = {'card': entry['card'], 'wf_file': entry['wf_file'],
+                 'meta': dict(meta, provenance_classes={
+                     'p_a~~h5_00_pwg00': 'synthetic_control'})}
+    try:
+        validate_promotion_entry('p_a~~h5_00_pwg00', synthetic)
+    except PromotionContractError:
+        pass
+    else:
+        raise AssertionError('synthetic control passed promotion validation')
+    foreign = {'card': entry['card'], 'wf_file': entry['wf_file'],
+               'meta': dict(meta, selected_keys=['some_other_key'])}
+    try:
+        validate_promotion_entry('p_a~~h5_00_pwg00', foreign)
+    except PromotionContractError:
+        pass
+    else:
+        raise AssertionError('foreign key passed promotion validation')
     # NOMINAL mode: meta.root is a window LABEL; the row must key to the true SLP1 headword
     # recovered from nominal_keymap[stem], NOT to the label (regression guard, H179 drain).
     nmeta = {'root': 'pril10_w1', 'nominal': True, 'nominal_keymap': {'k_ala': 'kAla'},
              'input_hashes': {'k_ala': {'raw_sha256': 'r', 'portrait_sha256': 'p'}}}
-    ncard = {'key1': 'kAla', 'iast': 'kāla',
-             'records': [{'h': 'kāla', 'senses': [{'tag': '1', 'russian': 'время', 'german': 'Zeit'}]}]}
+    ncard = {'key1': 'kAla', 'iast': 'kāla', 'notes': '',
+             'records': [{'h': 'kāla', 'grammar': '',
+                          'senses': [{'tag': '1', 'russian': 'время', 'german': 'Zeit'}]}]}
     nrow = list(rows_for('k_ala', {'card': ncard, 'meta': nmeta, 'wf_file': 'wf_output.json'},
                          'ai_translated', SELFTEST_MODEL_VERSION))[0]
     assert nrow['key1'] == 'kAla', 'nominal card must key to true SLP1 headword, not the window label'
@@ -308,6 +432,46 @@ def selftest():
     assert explicit_glob_supplied(['--merge', '--glob', 'src/pilot/output/wf_output.w01.json'])
     assert explicit_glob_supplied(['--glob=src/pilot/output/wf_output.w01.json', '--merge'])
     assert not explicit_glob_supplied(['--merge'])
+    # Missing stores fail closed; explicit first-run init is accepted only while absent.
+    missing = os.path.join(d, 'missing-store.jsonl')
+    try:
+        validate_store_target(missing)
+    except PromotionContractError:
+        pass
+    else:
+        raise AssertionError('missing store passed without --init-store')
+    validate_store_target(missing, init_store=True)
+    with open(missing, 'w', encoding='utf-8') as f:
+        f.write('')
+    try:
+        validate_store_target(missing, init_store=True)
+    except PromotionContractError:
+        pass
+    else:
+        raise AssertionError('--init-store overwrote an existing store')
+    # Exact-subcard merge is idempotent; a second promotion replaces rather than duplicates.
+    old = [{'key1': 'x', 'subcard': 'x~~a'}, {'key1': 'y', 'subcard': 'y~~a'}]
+    new = [{'key1': 'x', 'subcard': 'x~~a', 'ru': 'new'}]
+    once = merge_store_rows(old, new)
+    twice = merge_store_rows(once, new)
+    assert once == twice and len(once) == 2
+    # Atomic failure leaves the old store intact and removes the temporary file.
+    atomic = os.path.join(d, 'atomic.jsonl')
+    with open(atomic, 'w', encoding='utf-8') as f:
+        f.write('old\n')
+    real_replace = os.replace
+    try:
+        os.replace = lambda _src, _dst: (_ for _ in ()).throw(OSError('synthetic crash'))
+        try:
+            _atomic_write_rows(atomic, new)
+        except OSError:
+            pass
+        else:
+            raise AssertionError('atomic replace failure was swallowed')
+    finally:
+        os.replace = real_replace
+    assert open(atomic, encoding='utf-8').read() == 'old\n'
+    assert not [n for n in os.listdir(d) if n.endswith('.tmp')]
     print('promote_final_cards selftest OK')
 
 
@@ -322,6 +486,8 @@ def main():
                     help='resolved model version recorded in provenance.model_version '
                          '(exact model id required; do not guess from the model alias)')
     ap.add_argument('--dry-run', action='store_true')
+    ap.add_argument('--init-store', action='store_true',
+                    help='explicitly initialize a missing store (first run only)')
     ap.add_argument('--no-backup', action='store_true')
     ap.add_argument('--force', action='store_true',
                     help='bypass the >50%%-shrink overwrite guard (only for a deliberate full rebuild)')
@@ -343,6 +509,10 @@ def main():
         sys.exit(
             'refusing --merge with the implicit broad glob %r; pass --glob explicitly '
             '(normally src/pilot/output/wf_output.<window>.json)' % DEFAULT_GLOB)
+    try:
+        validate_store_target(args.store, args.init_store)
+    except PromotionContractError as exc:
+        sys.exit('REFUSED: %s' % exc)
 
     # Provenance: make the resolved store path explicit — a worktree run promotes into the MAIN
     # checkout's store (store_path.canonical_store), never a discarded worktree copy (H255 w06 / H805).
@@ -359,10 +529,17 @@ def main():
 
     rows, per_root = [], {}
     for subkey, entry in sorted(best.items()):
+        try:
+            validate_promotion_entry(subkey, entry)
+        except PromotionContractError as exc:
+            sys.exit('REFUSED: %s' % exc)
         n = 0
         for row in rows_for(subkey, entry, args.review_status, args.gen_model_version):
             rows.append(row)
             n += 1
+        if n == 0:
+            sys.exit('REFUSED: %s passed collection but yielded no promotable Russian rows'
+                     % subkey)
         root = entry['meta'].get('root')
         per_root.setdefault(root, {'cards': 0, 'rows': 0})
         per_root[root]['cards'] += 1
@@ -375,7 +552,8 @@ def main():
     print('distinct headwords      : %d' % len(per_root))
     print('null sub-cards skipped  : %d' % len(null_keys))
     if conflicts:
-        print('duplicate non-null keys : %d (kept first-seen)' % len(conflicts))
+        sys.exit('REFUSED: duplicate non-null workflow keys: %s'
+                 % ', '.join(sorted(set(conflicts))[:20]))
     thin = sorted(r for r, v in per_root.items() if v['cards'] <= 5)
     if thin:
         print('\n⚠ roots with <=5 promoted cards (likely a requeue-subset / partial file — the full')
@@ -405,21 +583,27 @@ def main():
             if args.merge and os.path.exists(args.store):
                 promoted_subs = {r['subcard'] for r in rows}
                 touched_roots = {r['key1'] for r in rows}
-                keep_rows = []
+                existing_rows = []
                 with open(args.store, encoding='utf-8') as f:
                     for line in f:
                         line = line.strip()
                         if not line:
                             continue
-                        e = json.loads(line)
-                        if e.get('subcard') not in promoted_subs:
-                            keep_rows.append(e)
-                kept = len(keep_rows)
+                        existing_rows.append(json.loads(line))
+                rows_to_write = merge_store_rows(existing_rows, rows)
+                kept = len(rows_to_write) - len(rows)
                 print('\nMERGE: replacing %d sub-card(s) across root(s) %s; keeping %d existing row(s)'
                       % (len(promoted_subs), sorted(touched_roots), kept))
-                rows_to_write = keep_rows + rows
             else:
                 rows_to_write = rows
+
+            identities = [(r.get('key1'), r.get('subcard'), r.get('h'),
+                           r.get('sense_tag'), r.get('de')) for r in rows_to_write]
+            duplicates = [identity for identity, n in collections.Counter(identities).items()
+                          if n > 1]
+            if duplicates:
+                sys.exit('REFUSED: promotion would create %d duplicate sense identity/identities'
+                         % len(duplicates))
 
             # OVERWRITE GUARD: refuse to shrink the store to a small fraction of its current
             # size. A default (non-merge) run rebuilds the store from whatever wf_output files
@@ -445,16 +629,12 @@ def main():
                 stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
                 bak = args.store + ('.premerge.%s.bak' % stamp if args.merge
                                     else '.legacy.%s.bak' % stamp)
-                os.replace(args.store, bak)
+                _fsynced_backup(args.store, bak)
                 print('\nbacked up prior store -> %s' % os.path.basename(bak))
             # Atomic write: stream to a temp file then os.replace, so a crash/kill mid-write
             # can never leave the canonical store truncated (the store this project has lost
             # before). Matches the tmp+replace pattern in run_batch.apply_review.
-            tmp = args.store + '.tmp'
-            with open(tmp, 'w', encoding='utf-8') as f:
-                for row in rows_to_write:
-                    f.write(json.dumps(row, ensure_ascii=False) + '\n')
-            os.replace(tmp, args.store)
+            _atomic_write_rows(args.store, rows_to_write)
             print('wrote canonical translated store -> %s (%d rows, review_status=%s)'
                   % (args.store, len(rows_to_write), args.review_status))
             print('NOTE: rows are %s, NOT approved — export_interop keeps them out of the citable'

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -37,8 +37,10 @@ import sys
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
+import re
 import pipeline_version
 import dict_merge
+import card_fields
 from promote_lock import PromoteClaim, ClaimBusy
 from store_path import canonical_store
 
@@ -164,6 +166,29 @@ def provenance(entry, subkey, model_version):
     return prov
 
 
+TN_RE = re.compile(r'\{T\d+\}')
+
+
+class UnrestoredPlaceholder(Exception):
+    """A card reached the promote path still carrying a `{Tn}` mask placeholder (C-01)."""
+
+
+def tn_residue(card, rec, sense):
+    """Report every promoted field of this row that still holds a raw `{Tn}`.
+
+    The field list is `card_fields.PROMOTED_PAIRS`, NOT a local literal: a local literal here
+    that drifted from the restore side is precisely what put 670 placeholder rows into the
+    canonical store. Levels resolve against the three objects the caller already holds.
+    """
+    holder = {'card': card, 'record': rec, 'sense': sense}
+    found = []
+    for level, name in card_fields.PROMOTED_PAIRS:
+        value = holder[level].get(name)
+        if isinstance(value, str) and TN_RE.search(value):
+            found.append('%s.%s=%r' % (level, name, value[:60]))
+    return found
+
+
 def rows_for(subkey, entry, review_status, model_version):
     card = entry['card']
     meta = entry['meta']
@@ -182,6 +207,17 @@ def rows_for(subkey, entry, review_status, model_version):
             ru = sense.get('russian')
             if not ru:
                 continue
+            # C-01: refuse to promote a row that still carries a mask placeholder. Every field
+            # below is read straight into the canonical store, and four of them were never
+            # restored -- 670 rows landed with a raw {Tn}, 223 of them in the HEADWORD. The
+            # restore side is driven from `card_fields`; this is the promote side's own
+            # burden-of-proof check, so a future restore gap fails loudly HERE rather than
+            # accumulating silently in canonical data.
+            residue = tn_residue(card, rec, sense)
+            if residue:
+                raise UnrestoredPlaceholder(
+                    '%s: refusing to promote a card with unrestored placeholders: %s'
+                    % (subkey, '; '.join(residue)))
             yield {
                 'key1': key1,
                 'subcard': subkey,


### PR DESCRIPTION
## Root causes

- Generated JS and the headless worker restored a smaller field set than promotion persisted, so valid source markup could remain as raw `{Tn}` in `iast`, `h`, tags, and differentia.
- Heal/autosplit stitchers flattened records and lost `h`/`grammar` plus homonym boundaries.
- Out-of-range tokens passed through silently, and the final-card validator was exercised only on a clean CI fixture.
- Promotion treated a missing store as an empty first run, bypassing merge, backup, and shrink guards.

## Behavioral changes

- One Python-owned restoration specification drives both runtime lanes and every promoted text field; unresolved indices reject the card.
- Audit, save, autosplit/top-up, and promotion preserve and independently validate final record shape.
- Promotion refuses synthetic/foreign/duplicate/malformed candidates, requires an existing store by default (`--init-store` is explicit first-run only), copies/fsyncs backups, and atomically replaces the store.
- The repair utility is dry-run-first, source-hash locked, exact-key-multiset checked, atomic, and idempotent.

## Canonical repair

- Before: 11,605 rows, SHA-256 `cc1d544ed92d201ca8cbecde0b5e9a8191994dfd1baf20841da82f1f9ae7c805`.
- Repaired: 668 placeholder rows and 468 null-headword rows.
- Quarantined: exactly `ban_d~~h0_11_ni` and `ban_d~~h0_21_upasam_0`; payload file remains uncommitted and hash sealed.
- After: 11,603 rows, SHA-256 `f15caf7d1f65db0269498c50ecdcd6bf098572a543c12a055ae08c374377b2f9`; zero raw `{Tn}`, zero null `h`.
- Second application: no-op. RU card TM rebuilt exactly once: 2,476 valid cards, SHA-256 `121d56fc9b6acb52c6bed81587953104a86b5ef83a607bbe8e2bd16d1db7b4ab`.

Raw backup and quarantine payloads remain uncommitted. The tracked `pwg_ru/h1080/` report publishes hashes and counts, not corrupt payload text.

## Compatibility

Historical workflow metadata remains readable in this stage. Existing stores require no CLI change. A deliberate first-ever store creation must now opt into `--init-store`; a missing production path fails closed. Stage 3 will add manifest v2/profile/global-call launch controls separately.

## Validation

- `python src/pilot/window_selftest.py` — 135/135 PASS
- `python src/pilot/lang_parity_check.py` — 49/49 clean (43 affected entries reviewed; hashes updated only through `--update-hash`)
- `python src/pilot/headless_worker_selftest.py` — PASS
- `python src/pilot/max_account_orchestrator_selftest.py` — PASS
- `python src/backfill_tn_residue_selftest.py` — PASS
- `python src/promote_final_cards.py --selftest` — PASS
- `python src/pilot/check_launch_ledger.py` — 17 complete
- `ruff check --select E9,F63,F7,F82 src save_and_audit.py` — PASS
- `node --check src/pilot/run_pilot_wf.js` — PASS
- `git diff --check` — PASS

No live Claude call, production translation, promotion, or paid window occurred.