### PR TITLE
fix(russiantranslation): bind bounded launches to manifest v2

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -804,8 +804,9 @@ Two live tracks:
   work on top of H1080. Manifest v2 binds profile slot + config fingerprint + route/lane/model/
   validation + per-key real/control provenance; CLI execution holds a global fingerprint claim,
   refuses unresolved Windows shims, and applies the named strict probe policy. Promotion refuses
-  v1 and controls. Generated Workflow output is bound to the exact same v2 execution/provenance
-  contract as its manifest. Validation green: window 135/135, parity 49/49, headless/contract/orchestrator,
+  v1 and controls. Profile-bound v2 production is CLI/headless-only: a generated Workflow template
+  aborts before any agent call because Workflow cannot prove the config directory or join the global
+  host claim. Validation green: window 135/135, parity 49/49, headless/contract/orchestrator,
   bounded supervisor/staged/economy, promoter, ledger, Ruff, generated-v2 Node, diff. The headless
   selftest now injects a portable executable path, so clean Linux CI does not depend on a Claude CLI
   installation while production resolution remains fail-closed. No live call.

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -39,6 +39,18 @@ Two live tracks:
       (FINDINGS §87). **Remaining human gates:** second annotator (κ for both A12 gold and the
       A31 origin sample); Lexikos house-style pass + Afrikaans opsomming at submission time.
 
+- **H963 offline engineering continuation — 🔴 EXECUTED 16-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; OFFLINE).**
+  Bounded/restartable/plan-scoped/cost-aware staged operation, no prompt or semantic-policy change. New
+  [`bounded_staged_run.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_staged_run.py)
+  drives `bounded_supervisor` over a plan's prepared leases behind an **opt-in, dry-run-default** interface
+  (zero edits to the orchestrator/coordinator); opt-in ceilings + **cost fail-closed** (`STOP_COST_UNEVALUABLE`;
+  `economy_ledger.gate(strict=True)` opt-in, legacy unchanged); checkpoint restart is exactly-once. 15 new
+  tests, wired into CI. **14 gates PASS; 2 (`window_selftest`/`lang_parity_check`) FAIL on PRE-EXISTING
+  upstream `LANG_PARITY.md` drift proven at base `3f45d0b3` (3 entries, files not touched here) — human
+  `--update-hash` re-affirm owed.** No live gen/promotion/store-write (11,605 unchanged)/TM rebuild/reroll.
+  Draft PR [#495](https://github.com/gasyoun/SanskritLexicography/pull/495) (not merged). Ladder stays
+  owner-gated — see the WAITING-ON-OWNER entry below. Detail: [`RussianTranslation/.ai_state.md`](RussianTranslation/.ai_state.md).
+
 - **H963 — four-profile live-ladder production acceptance — 🟡 WAITING ON OWNER (owner-gated).** The
   successor to H960 (🔴 EXECUTED 15-07 — offline scaffolding earned: six scale gaps closed as
   SOFT/report-only guards, [PR #475](https://github.com/gasyoun/SanskritLexicography/pull/475) merged,

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -798,6 +798,14 @@ Two live tracks:
 
 ## 🚧 Current Work-In-Progress (WIP)
 
+- **RussianTranslation manifest-v2 launch controls (17-07-2026, Codex/GPT-5):** successor branch
+  `codex/russiantranslation-launch-controls-v2` includes PR #495's bounded dry-run/checkpoint/cost
+  work on top of H1080. Manifest v2 binds profile slot + config fingerprint + route/lane/model/
+  validation + per-key real/control provenance; CLI execution holds a global fingerprint claim,
+  refuses unresolved Windows shims, and applies the named strict probe policy. Promotion refuses
+  v1 and controls. Validation green: window 135/135, parity 49/49, headless/contract/orchestrator,
+  bounded supervisor/staged/economy, promoter, ledger, Ruff, generated-v2 Node, diff. No live call.
+
 - **RussianTranslation PR #498 reconciliation (17-07-2026, Codex/GPT-5).** Isolated worktree;
   no live calls, promotions, store writes, or TM rebuilds. Validation: window tests 131/131 PASS;
   parity 49/49 clean; headless/orchestrator selftests PASS; Ruff fatal PASS; launch ledger 17 complete;

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -806,7 +806,9 @@ Two live tracks:
   refuses unresolved Windows shims, and applies the named strict probe policy. Promotion refuses
   v1 and controls. Generated Workflow output is bound to the exact same v2 execution/provenance
   contract as its manifest. Validation green: window 135/135, parity 49/49, headless/contract/orchestrator,
-  bounded supervisor/staged/economy, promoter, ledger, Ruff, generated-v2 Node, diff. No live call.
+  bounded supervisor/staged/economy, promoter, ledger, Ruff, generated-v2 Node, diff. The headless
+  selftest now injects a portable executable path, so clean Linux CI does not depend on a Claude CLI
+  installation while production resolution remains fail-closed. No live call.
 
 - **RussianTranslation PR #498 reconciliation (17-07-2026, Codex/GPT-5).** Isolated worktree;
   no live calls, promotions, store writes, or TM rebuilds. Validation: window tests 131/131 PASS;

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -22,12 +22,13 @@ Two live tracks:
 
 ## ➡️ Next Steps (Queue)
 
-- **RussianTranslation H1080 — store integrity repaired; launch hardening next (17-07-2026).**
+- **RussianTranslation H1080 — store + launch controls repaired (17-07-2026).**
   PR #498 merged green. The hash-locked atomic repair completed: 11,605→11,603 rows, 668 placeholder
   rows + 468 null owners restored, two `banD` rows quarantined, zero residual `{Tn}`/null `h`, and
   the RU card TM rebuilt once. Forward audit/save/promotion/autosplit gates are green (135/135 window,
-  49/49 parity). No production generation occurred. Manifest-v2/profile/global-claim hardening remains
-  the final prerequisite before a fresh c4 health probe.
+  49/49 parity). PR #510 is merged; replacement PR #511 carries manifest-v2/profile/global-claim
+  hardening and the bounded runner superseding closed PR #495. No production generation occurred;
+  a fresh c4 health probe remains the next separately authorized live action after #511 lands.
 
 - [x] **H1074 A31/P5 error-origin typology — full Lexikos draft EXECUTED (17-07-2026, Fable 5
       `claude-fable-5`).** Draft [papers/A31_fifty_thousand_corrections_error_origin_typology.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A31_fifty_thousand_corrections_error_origin_typology.md)
@@ -803,7 +804,8 @@ Two live tracks:
   work on top of H1080. Manifest v2 binds profile slot + config fingerprint + route/lane/model/
   validation + per-key real/control provenance; CLI execution holds a global fingerprint claim,
   refuses unresolved Windows shims, and applies the named strict probe policy. Promotion refuses
-  v1 and controls. Validation green: window 135/135, parity 49/49, headless/contract/orchestrator,
+  v1 and controls. Generated Workflow output is bound to the exact same v2 execution/provenance
+  contract as its manifest. Validation green: window 135/135, parity 49/49, headless/contract/orchestrator,
   bounded supervisor/staged/economy, promoter, ledger, Ruff, generated-v2 Node, diff. No live call.
 
 - **RussianTranslation PR #498 reconciliation (17-07-2026, Codex/GPT-5).** Isolated worktree;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
           python src/pilot/run_observability_selftest.py
           python src/pilot/economy_ledger_selftest.py
           python src/pilot/bounded_supervisor_selftest.py
+          python src/pilot/bounded_staged_run_selftest.py
           python src/pilot/sense_count.py
           python src/pilot/window_selftest.py
           python src/store_path.py --selftest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
         run: |
           python src/pilot/agent_budget.py
           python src/pilot/headless_worker_selftest.py
+          python src/pilot/execution_contract_selftest.py
           python src/pilot/max_account_orchestrator_selftest.py
           python src/pilot/windows100_selftest.py
           python src/pilot/run_observability_selftest.py

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2197,6 +2197,13 @@ When auditing pwg_ru no_pwg output quality (H911 LOCAL-READINESS gate), three re
    `elapsed_ms` but **no token field**; H818 dashboards carry `cost:null`. So observed calls/clean and
    $/clean cannot be measured from existing evidence — the deterministic **projection** ($58.09/100hw)
    is a separate, optimistic floor and must not be substituted for observed performance.
+   **Operationalized 16-07-2026 (H963):** because observed per-window cost is usually unrecoverable
+   (LAUNCH_STATS records output-tokens on 1/458 windows), the bounded staged runner treats a
+   requested cost/quota ceiling as **fail-closed** — a window whose cost is UNEVALUABLE stops the run
+   with `STOP_COST_UNEVALUABLE` rather than assuming $0 and continuing
+   ([`bounded_staged_run.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_staged_run.py)
+   + `bounded_supervisor.strict_cost_fn`; `economy_ledger.gate(strict=True)` is the opt-in ledger gate,
+   legacy None-skip unchanged).
 3. **Current-store membership is not the audit verdict and not exact provenance.** Absence ≠ audit
    rejection; presence ≠ *this* output passed. Keep reviewer quality, sealed audit verdict, and
    promotion status as **three separate** measurements; an audit-to-promotion escape needs an exact

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2334,7 +2334,9 @@ fingerprint and takes one global active-call claim keyed by that fingerprint. V1
 history but is non-promotable; controls are explicitly typed and rejected by promotion. On Windows,
 an unresolved npm `.cmd` shim is a configuration failure, not a fallback. Probe GO is likewise a
 derived typed verdict: named production policy, representative schema success, zero connection
-errors, and latency strictly below 30 seconds.
+errors, and latency strictly below 30 seconds. A Workflow session cannot prove its config directory
+or participate in the host claim, so profile-bound v2 production is CLI/headless-only; a bound
+Workflow template must abort before its first agent call rather than mislabel its billing route.
 
 > **Source:** RussianTranslation audit-findings implementation
 > ([PR #478](https://github.com/gasyoun/SanskritLexicography/pull/478),

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2325,6 +2325,17 @@ existing store by default and independently refuses synthetic, foreign, duplicat
 inputs before a fsynced atomic replacement. The full repair evidence is tracked in
 `RussianTranslation/pwg_ru/h1080/H1080_STORE_REPAIR_REPORT_2026-07-17.md`.
 
+The launch-control follow-up closes the identity boundary as well. A friendly name such as `c4`
+does not prove which credential directory or billing identity a process will use, and per-manifest
+width caps do not prevent two independent manifests from spending through the same profile. New
+production work therefore uses manifest v2: slot + canonical config-directory fingerprint + route/
+lane/model/validation + per-key real/control class. The executor verifies the roster and sealed
+fingerprint and takes one global active-call claim keyed by that fingerprint. V1 stays readable as
+history but is non-promotable; controls are explicitly typed and rejected by promotion. On Windows,
+an unresolved npm `.cmd` shim is a configuration failure, not a fallback. Probe GO is likewise a
+derived typed verdict: named production policy, representative schema success, zero connection
+errors, and latency strictly below 30 seconds.
+
 > **Source:** RussianTranslation audit-findings implementation
 > ([PR #478](https://github.com/gasyoun/SanskritLexicography/pull/478),
 > [follow-up PR #482](https://github.com/gasyoun/SanskritLexicography/pull/482),

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -14,12 +14,14 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
-- **H1080 store integrity — ✅ REPAIRED 17-07-2026 (Codex/GPT-5).** PR #498 merged green;
+- **H1080 store + launch integrity — ✅ REPAIRED 17-07-2026 (Codex/GPT-5).** PR #498 and
+  repair PR #510 merged green;
   the dedicated hash-locked repair restored 668 placeholder rows and 468 null owners, quarantined
   the two out-of-range `banD` rows, and atomically changed the store 11,605→11,603 with zero raw
   `{Tn}` and zero null `h`. RU card TM rebuilt once (2,476 valid); second repair is a no-op. No
-  generation or promotion occurred. Next production blocker is Stage 3 manifest-v2/profile/global
-  active-call hardening; only after it lands may the fresh c4 health probe run.
+  generation or promotion occurred. Replacement PR #511 carries Stage 3 manifest-v2/profile/global
+  active-call hardening and supersedes closed PR #495; only after it lands may a separately authorized
+  fresh c4 health probe run.
 
 - **H1070 EN gold adjudication vs MW TM + FU1 scale-up go/no-go — 🔴 EXECUTED 17-07-2026 (Fable 5 `claude-fable-5`).**
   170 sense rows adjudicated (exact S7 68-row frame, Sonnet 4.6 + fresh 50-card/102-row FU1
@@ -1997,7 +1999,9 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   exact model/validation method, and every key's `real|synthetic_control` class. Headless execution
   enforces `--only-profile` and one global active claim per config fingerprint; promotion refuses
   v1/control output; Windows bare-CLI resolution goes Node-direct or fails; probe policy is typed,
-  schema-valid, zero-connection-error and strictly `<30s`. Full offline validation green; no probe.
+  schema-valid, zero-connection-error and strictly `<30s`. Generated Workflow output now carries
+  the exact manifest-v2 execution and per-key provenance contract, so promotion can revalidate it
+  independently. Full offline validation green; replacement PR #511; no probe.
 
 - **PR #498 evidence reconciliation (17-07-2026, Codex/GPT-5).** Raw pilot artifacts preserved;
   derived JSONLs/report corrected; `window_selftest.py` now aggregates failures and reports

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -41,6 +41,31 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   source drift, atomic failure preservation, and a clean second run. **Store remains unmodified**
   while forward promotion/schema/store-init gates and the full validation set are completed.
 
+- **H963 offline engineering continuation — 🔴 EXECUTED 16-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`, Ultracode; OFFLINE, no live generation).**
+  Made unattended staged operation **bounded, restartable, plan-scoped and cost-aware** without touching
+  translation prompts or semantic policy. New standalone module
+  [`bounded_staged_run.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_staged_run.py)
+  drives `BoundedSupervisor` over a plan's **prepared** leases (one lease/window, join key
+  `root==lease id==external_id`), reusing `probe_fleet`/`cmd_run_once`/`cmd_record_done`/coordinator
+  `promote-ready` — **zero edits** to `max_account_orchestrator.py`/`coordinator.py` (existing commands
+  unchanged). **Default is a dry-run planning view (ZERO generation calls)**; live drain needs `--execute`
+  + a healthy probe. Added opt-in ceilings (`--max-windows/--max-calls/--max-clean/--empty-streak/`
+  `--max-accounts/--cost-ceiling`) with a **cost fail-closed** stop (`STOP_COST_UNEVALUABLE` +
+  `strict_cost_fn`; `economy_ledger.gate(strict=True)` opt-in, legacy None-skip unchanged). Per-lease
+  scope excludes transient/defect/pending/historical/unrelated-plan work; checkpoint restart re-runs no
+  completed lease (exactly-once). Tests: 9 new adapter cases + 5 bounded-supervisor + 1 economy both-modes;
+  wired into the CI gate block. **Validation:** 14 gates PASS (`git diff --check` clean, ruff fatal clean,
+  launch-ledger 17 entries, `node --check` template); **2 gates FAIL on PRE-EXISTING upstream
+  `LANG_PARITY.md` drift** (`window_selftest.py`/`lang_parity_check.py`, 3 entries:
+  `max_account_orchestrator.py`+selftest, `accept_sensecount_test.js`) — **proven** by re-running the
+  identical checks in a disposable detached worktree at base `3f45d0b3` (byte-identical drift, none of
+  those files touched here); needs a **human** `--update-hash` re-affirm (not self-affirmed).
+  Offline launch-readiness report written **uncommitted** at
+  `pwg_ru/h963/H963_OFFLINE_LAUNCH_READINESS_REPORT_2026-07-16.md`. **No** live generation, promotion,
+  store write (11,605 unchanged), TM rebuild, or latency reroll. Draft PR:
+  [SanskritLexicography#495](https://github.com/gasyoun/SanskritLexicography/pull/495) (not merged).
+  H963 stays **owner-gated** (c5/c6 login + latency rung) — see the H971/H963 entries below.
+
 - **H971 QA / methodology re-audit — 🔴 EXECUTED 15-07-2026 (Fable 5 `claude-fable-5`).**
   Deterministic half of the H178 protocol re-run on the grown store (11,261/50 → **11,605 rows / 67
   roots**): **NO REGRESSION** — window_selftest **131 PASS** (incl. `test_h920_*`/`test_h960_*` gate

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1999,9 +1999,10 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   exact model/validation method, and every key's `real|synthetic_control` class. Headless execution
   enforces `--only-profile` and one global active claim per config fingerprint; promotion refuses
   v1/control output; Windows bare-CLI resolution goes Node-direct or fails; probe policy is typed,
-  schema-valid, zero-connection-error and strictly `<30s`. Generated Workflow output now carries
-  the exact manifest-v2 execution and per-key provenance contract, so promotion can revalidate it
-  independently. The fake-runner selftest injects `sys.executable`, keeping clean Linux CI hermetic
+  schema-valid, zero-connection-error and strictly `<30s`. Profile-bound v2 production is
+  CLI/headless-only; the generated Workflow template aborts before any paid call because it cannot
+  prove `CLAUDE_CONFIG_DIR` or join the global host claim. The fake-runner selftest injects
+  `sys.executable`, keeping clean Linux CI hermetic
   without weakening production CLI resolution. Full offline validation green; replacement PR #511;
   no probe.
 

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2001,7 +2001,9 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   v1/control output; Windows bare-CLI resolution goes Node-direct or fails; probe policy is typed,
   schema-valid, zero-connection-error and strictly `<30s`. Generated Workflow output now carries
   the exact manifest-v2 execution and per-key provenance contract, so promotion can revalidate it
-  independently. Full offline validation green; replacement PR #511; no probe.
+  independently. The fake-runner selftest injects `sys.executable`, keeping clean Linux CI hermetic
+  without weakening production CLI resolution. Full offline validation green; replacement PR #511;
+  no probe.
 
 - **PR #498 evidence reconciliation (17-07-2026, Codex/GPT-5).** Raw pilot artifacts preserved;
   derived JSONLs/report corrected; `window_selftest.py` now aggregates failures and reports

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1991,6 +1991,14 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## 🚧 Current Work-In-Progress (WIP)
 
+- **H1080 Stage 3 manifest-v2 + bounded launch controls (17-07-2026, Codex/GPT-5):** PR #495's
+  dry-run-default bounded supervisor was carried forward. New production manifests bind logical
+  profile slot (not billing proof), canonical config-directory fingerprint, execution route/lane,
+  exact model/validation method, and every key's `real|synthetic_control` class. Headless execution
+  enforces `--only-profile` and one global active claim per config fingerprint; promotion refuses
+  v1/control output; Windows bare-CLI resolution goes Node-direct or fails; probe policy is typed,
+  schema-valid, zero-connection-error and strictly `<30s`. Full offline validation green; no probe.
+
 - **PR #498 evidence reconciliation (17-07-2026, Codex/GPT-5).** Raw pilot artifacts preserved;
   derived JSONLs/report corrected; `window_selftest.py` now aggregates failures and reports
   run/defined; SHARED parity diffs reviewed and hashes updated through the required command.

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -17,8 +17,10 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 - **Profile and concurrency enforcement.** Coordinator prepare/requeue accepts the profile binding;
   orchestrator and bounded staged-run expose `--only-profile`, verify both roster slot and config
   fingerprint, and every headless manifest holds one cross-process active-call claim keyed by that
-  fingerprint. Two c4 manifests therefore cannot call concurrently even across launch entry points;
-  `max-wide=1` remains an independent within-manifest limit.
+  fingerprint. Two c4 manifests therefore cannot call concurrently across admitted production entry
+  points; `max-wide=1` remains an independent within-manifest limit. Because Workflow cannot prove
+  its config directory or join that host lock, profile-bound v2 production is CLI/headless-only and
+  a bound generated Workflow template aborts before its first agent call.
 - **Windows CLI and probe policy fail closed.** Bare `claude` is resolved with `shutil.which`; a
   Windows npm shim is invoked through its Node CLI entry or refused, never handed back unresolved.
   Probe telemetry names its policy and lane, requires a representative schema-valid response, zero

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -79,6 +79,39 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   placeholder maps. The complete evidence chain deterministically repairs **668/670** placeholder
   rows and all **468** null headwords; only two malformed `banD` rows require quarantine.
 
+- **Bounded staged-run integration (opt-in, default-off) — H963.** New standalone module
+  [`src/pilot/bounded_staged_run.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_staged_run.py)
+  drives the max-account staged-run path (`probe_fleet` → `cmd_run_once` → `cmd_record_done`
+  → coordinator `promote-ready`) under the `bounded_supervisor` control loop, one prepared
+  lease per window. Zero edits to `max_account_orchestrator.py` / `coordinator.py`; every
+  existing command and default is unchanged. The **default action is a dry-run planning view**
+  that makes ZERO generation calls (prints the scoped work, ceilings, account allocation,
+  checkpoint path and stop policy); a live drain requires the explicit `--execute` opt-in AND
+  a healthy fleet probe. Lease scoping (`only_external_ids={root}` + per-`--lease-id`
+  promotion) keeps transient/defect/pending/historical/unrelated-plan work out of the current
+  run; deterministic restart from the checkpoint re-runs no completed lease (exactly-once, on
+  both the loop's `completed_window_ids` and the coordinator's promoted-terminal idempotence).
+- **Bounded-supervisor ceilings + cost fail-closed — H963.**
+  [`bounded_supervisor.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_supervisor.py)
+  gains opt-in `max_calls` (`STOP_CALL_COUNT`), `max_clean` (`STOP_CLEAN_QUOTA`) and a
+  `strict_cost_fn`; a window whose cost is UNEVALUABLE under an active cost ceiling now stops
+  the run closed with the distinct `STOP_COST_UNEVALUABLE` reason instead of the legacy
+  silent-zero. `calls_spent`/`clean_total` persist across the checkpoint. All new params are
+  `None`-default, so the existing behaviour and all prior tests are unchanged.
+- **Economy-ledger opt-in strict gate — H963.**
+  [`economy_ledger.gate(..., strict=False)`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/economy_ledger.py)
+  and a `--strict` CLI flag: legacy (default) still SKIPS a ceiling whose value is `None`
+  (unchanged for every existing caller); `strict=True` treats a requested-but-unevaluable
+  ceiling as a fail-closed breach (distinct `unevaluable` marker). Missing accounting data is
+  never treated as within-ceiling. Both modes are covered by tests.
+- **Tests + CI.** New
+  [`bounded_staged_run_selftest.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/bounded_staged_run_selftest.py)
+  (9 cases: plan scope, dry-run-makes-no-call, historical-jobs-excluded, clean completion,
+  restart/no-dup, ceiling exhaustion, cost fail-closed, consecutive-empty, audit seam), +5
+  bounded-supervisor cases, +1 economy-ledger both-modes case; wired into the CI gate block.
+  No translation prompt or semantic-policy change; no live generation, promotion, store write
+  or TM rebuild.
+
 - **Provenance-bound mixed-lane requeues.** Each lease now seals its initial execution
   manifest as the immutable key universe and stores every pending retry key with the path
   and SHA-256 of the audit report that classified it. `record-output` rejects duplicate,

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,25 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+- **Manifest-v2 production launch contract.** New live manifests bind a logical profile slot,
+  canonical `CLAUDE_CONFIG_DIR` fingerprint, execution route/lane, exact model and validation
+  method, plus an exact per-key `real | synthetic_control` map. V1 remains readable for historical
+  audit but cannot be newly promoted. Synthetic controls are never promotable.
+- **Profile and concurrency enforcement.** Coordinator prepare/requeue accepts the profile binding;
+  orchestrator and bounded staged-run expose `--only-profile`, verify both roster slot and config
+  fingerprint, and every headless manifest holds one cross-process active-call claim keyed by that
+  fingerprint. Two c4 manifests therefore cannot call concurrently even across launch entry points;
+  `max-wide=1` remains an independent within-manifest limit.
+- **Windows CLI and probe policy fail closed.** Bare `claude` is resolved with `shutil.which`; a
+  Windows npm shim is invoked through its Node CLI entry or refused, never handed back unresolved.
+  Probe telemetry names its policy and lane, requires a representative schema-valid response, zero
+  connection errors, and latency strictly below 30 seconds; a supplied verdict that contradicts the
+  measured gate is refused.
+- **Bounded staged-run retained from PR #495.** The dry-run-default, opt-in execution adapter keeps
+  cumulative window/call/clean/cost ceilings, checkpoint restart, prepared-plan scope, and strict
+  unevaluable-cost failure. It is carried by the replacement launch-control branch rather than
+  merged independently.
+
 - **H963 correction-evidence reconciliation.** Reclassified the 2 h 10 min offline campaign
   honestly (108-agent subworkflow: 98 minutes): 87 provisional candidates resolve to 49 confirmed,
   9 plausible, 1 mixed, 19 merged, and 9 refuted/dropped. Withdrawn the unsupported

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -958,7 +958,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/max_account_orchestrator.py": "39e7a60c0dbd89b6d2d2a8554832c19489f228409aef558062a260844d824635",
       "src/pilot/coordinator.py": "ca41cb0055a98171e90031ba3a076ebac66306df0e283b609f4889291f158506",
       "src/pilot/headless_worker_selftest.py": "33a55b92d6122d5f387a9a2fd10b037b1f00e3490246474678d84216b66808cb",
-      "src/pilot/max_account_orchestrator_selftest.py": "d8562c4e2b2b9e6c50f3a2de02df1080bcc7f0a944f9770db306e2d3407653f9",
+      "src/pilot/max_account_orchestrator_selftest.py": "7380473e18a6523e0cdc4ec831aa745e15e0f608673c06aad8b5a7c8515a564c",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
       "src/pilot/run_observability.py": "eb21e08ba4f0e7ab7ab5dacf9db4e4d0d38234f2d63385157735ca8d7b8ced61",

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -957,7 +957,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/headless_worker.py": "d8a14672fd37a22364775002d7b37255c2755ffd975f2f6ccaef76e66d911fb3",
       "src/pilot/max_account_orchestrator.py": "39e7a60c0dbd89b6d2d2a8554832c19489f228409aef558062a260844d824635",
       "src/pilot/coordinator.py": "ca41cb0055a98171e90031ba3a076ebac66306df0e283b609f4889291f158506",
-      "src/pilot/headless_worker_selftest.py": "05b9e6e51b4ac1c7d93e9a0bd34d51d628f9fa900982e429b3216c11a9c39856",
+      "src/pilot/headless_worker_selftest.py": "3b6eb1b7f3cbb4c82380e048a6d35ff2589814a60704af511dcb6b09bb1d466d",
       "src/pilot/max_account_orchestrator_selftest.py": "d8562c4e2b2b9e6c50f3a2de02df1080bcc7f0a944f9770db306e2d3407653f9",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -957,7 +957,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/headless_worker.py": "d8a14672fd37a22364775002d7b37255c2755ffd975f2f6ccaef76e66d911fb3",
       "src/pilot/max_account_orchestrator.py": "39e7a60c0dbd89b6d2d2a8554832c19489f228409aef558062a260844d824635",
       "src/pilot/coordinator.py": "ca41cb0055a98171e90031ba3a076ebac66306df0e283b609f4889291f158506",
-      "src/pilot/headless_worker_selftest.py": "3b6eb1b7f3cbb4c82380e048a6d35ff2589814a60704af511dcb6b09bb1d466d",
+      "src/pilot/headless_worker_selftest.py": "f3376889319a4b6a33f4485bf75b53835b2663c5f2590c6dee8c60f2f6f69bc1",
       "src/pilot/max_account_orchestrator_selftest.py": "d8562c4e2b2b9e6c50f3a2de02df1080bcc7f0a944f9770db306e2d3407653f9",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509"
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c"
     }
   },
   {
@@ -117,7 +117,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -136,7 +136,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -155,7 +155,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -173,7 +173,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509"
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509"
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c"
     }
   },
   {
@@ -224,7 +224,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509"
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c"
     }
   },
   {
@@ -241,7 +241,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509"
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c"
     }
   },
   {
@@ -258,7 +258,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 closes the former divergence: exact model provenance is required across four accounts, so both RU and EN now request and stamp claude-sonnet-5. This prevents account/profile alias resolution from making cross-window provenance incomparable.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509"
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c"
     }
   },
   {
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357"
     }
   },
@@ -470,7 +470,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
@@ -805,7 +805,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -824,7 +824,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -844,7 +844,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
@@ -866,7 +866,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -924,7 +924,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
@@ -953,11 +953,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 Windows readiness uses one language-parameterized manifest and worker contract. Whole-card retries, binary split, fragment TM/restore/fidelity, per-card budgets, timeout-no-bisect, partial stitching, audit-clean subset promotion, staged dispatch, and credential-safe event/census telemetry do not branch on RU/EN. Production policy selects RU no_pwg for the first 100-headword proof; the mechanism preserves EN field/schema behavior.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/headless_worker.py": "d8a14672fd37a22364775002d7b37255c2755ffd975f2f6ccaef76e66d911fb3",
       "src/pilot/max_account_orchestrator.py": "39e7a60c0dbd89b6d2d2a8554832c19489f228409aef558062a260844d824635",
       "src/pilot/coordinator.py": "ca41cb0055a98171e90031ba3a076ebac66306df0e283b609f4889291f158506",
-      "src/pilot/headless_worker_selftest.py": "f3376889319a4b6a33f4485bf75b53835b2663c5f2590c6dee8c60f2f6f69bc1",
+      "src/pilot/headless_worker_selftest.py": "33a55b92d6122d5f387a9a2fd10b037b1f00e3490246474678d84216b66808cb",
       "src/pilot/max_account_orchestrator_selftest.py": "d8562c4e2b2b9e6c50f3a2de02df1080bcc7f0a944f9770db306e2d3407653f9",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
@@ -983,7 +983,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H390 Phase 1 (12-07-2026, Opus 4.8 claude-opus-4-8), extended by H818. gen_model is written into language-agnostic run meta and flows through the shared ledger writer and harvester identically for RU/EN; both paths now stamp exact claude-sonnet-5. Pinned by test_ledger_stamps_gen_model in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
@@ -1004,7 +1004,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H823, fixes the H255 presplit-cohort loss). Both the citation presplit trigger (_presplit_hit) and the single-card kill budget (killBudgetForCur) are language-independent — they key on <ls>/fragment counts and FRAGS, never on --lang; the same floor + CEIL apply to RU and EN identically. Extends no_fallback_single_kill_budget_and_nominal_key_echo (H220) from no-fallback singles to all singles. Pinned by test_presplit_cite_floor_and_single_ceil.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -1050,7 +1050,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H960 (15-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes H920's explicitly-deferred accept()-side sense-count consumption. Language-neutral: accept() counts SENSE OBJECTS (records[].senses[]), never a gloss language, and source_senses is sense_count.count_source_senses over the German source markers (identical for the RU and EN lanes — the source is German for both). SOFT by default (SANLOSS_HARD_REJECT=false): a shortfall is telemetry only (no reject/requeue), so live traffic can measure the true drop-vs-false-flag rate before the reject is armed (owner-gated ladder). The shared counter is hardened against the ~4.78%-of-cards cross-reference over-count the naive count carried (gam~~h2_31_pari 2->1, s_ud~~h0_05_pra 4->2, _a_srayatva 2->0); under-counting is the safe direction, never a false shortfall. Pinned by test_h960_accept_sanloss_soft_gate (builds the real harness, extracts the emitted accept()+countOf, asserts soft-keep / surplus-ok / FP-regression / ls-sk-first / armed-hard-reject via accept_sensecount_test.js) plus the 3 cross-reference fixtures in sense_count._selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
+      "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135",
       "src/pilot/accept_sensecount_test.js": "ae04e6390738fcc31ac39b4a292c967b4e26d8abc669fa12f690c9d694e88f3d"

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153"
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4"
     }
   },
   {
@@ -117,7 +117,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -136,7 +136,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -155,7 +155,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -173,7 +173,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153"
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153"
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4"
     }
   },
   {
@@ -224,7 +224,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153"
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4"
     }
   },
   {
@@ -241,7 +241,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153"
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4"
     }
   },
   {
@@ -258,7 +258,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 closes the former divergence: exact model provenance is required across four accounts, so both RU and EN now request and stamp claude-sonnet-5. This prevents account/profile alias resolution from making cross-window provenance incomparable.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153"
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4"
     }
   },
   {
@@ -301,7 +301,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/requeue_from_audit.py": "598d8ad7dcede04198eef7f0c9c5152aecb576572fa8dfbc36008387f92adbb6"
+      "src/pilot/requeue_from_audit.py": "062733fd593b4cde4213fcfba2840e19c319da74d0fb5e2eff445bba60520cd6"
     }
   },
   {
@@ -318,7 +318,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 (commit 8cb84f7): the helper is lang-agnostic (takes a root, not a --lang flag; gen_opt_harness2.py resolves lang from the rootmap), so the fix applies to any language's requeue in one place. Was a both-paths gap before the fix, not an RU/EN divergence.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/requeue_from_audit.py": "598d8ad7dcede04198eef7f0c9c5152aecb576572fa8dfbc36008387f92adbb6"
+      "src/pilot/requeue_from_audit.py": "062733fd593b4cde4213fcfba2840e19c319da74d0fb5e2eff445bba60520cd6"
     }
   },
   {
@@ -336,7 +336,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "b21994a76f90dab00ce75b35f8083e72312f4b13a1ea62f7fe1b534ddf3d8637",
+      "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
     }
   },
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -393,7 +393,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED same day (2026-07-04): PR #140 (feat(provenance): pipeline versioning) added pipeline_version stamping only to promote_final_cards.py; found as a GAP while re-affirming H169's parity re-hash, closed immediately. promote_en.py now calls `pipeline_version.stamp(model_version=gen_model_version)` inside `en_index()`'s per-subcard provenance block, stored as `en_provenance.pipeline` (mirrors RU's `provenance.pipeline`; a distinct field since EN attaches onto an existing RU row rather than owning it). Pinned by an added assertion in `promote_en.selftest()`.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "b21994a76f90dab00ce75b35f8083e72312f4b13a1ea62f7fe1b534ddf3d8637",
+      "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
     }
   },
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -431,7 +431,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 1.1. The layer is derived purely from the sub-card KEY structure, which is identical for RU and EN. promote_en.py ATTACHES english onto the RU-owned row and leaves it otherwise untouched, so EN inherits `layer` for free — no EN-specific code needed. layer_of() pinned by dict_merge.py selftest + a promote_final_cards.selftest assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "b21994a76f90dab00ce75b35f8083e72312f4b13a1ea62f7fe1b534ddf3d8637",
+      "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357",
       "src/dict_merge.py": "0266e11980e3b8b12d0699665b2051b9f7b8b16ed89d5810adfe5a458e880eea"
     }
   },
@@ -450,8 +450,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
-      "src/promote_final_cards.py": "b21994a76f90dab00ce75b35f8083e72312f4b13a1ea62f7fe1b534ddf3d8637"
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357"
     }
   },
   {
@@ -470,7 +470,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
@@ -597,7 +597,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
-      "src/promote_final_cards.py": "b21994a76f90dab00ce75b35f8083e72312f4b13a1ea62f7fe1b534ddf3d8637",
+      "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
@@ -621,7 +621,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
-      "src/pilot/requeue_from_audit.py": "598d8ad7dcede04198eef7f0c9c5152aecb576572fa8dfbc36008387f92adbb6",
+      "src/pilot/requeue_from_audit.py": "062733fd593b4cde4213fcfba2840e19c319da74d0fb5e2eff445bba60520cd6",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
@@ -649,7 +649,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/window_common.py": "1535ba9e35a501d673f5c8e844f0b7916b055ba772d53159770e69b0b8f65e48",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/requeue_from_audit.py": "598d8ad7dcede04198eef7f0c9c5152aecb576572fa8dfbc36008387f92adbb6",
+      "src/pilot/requeue_from_audit.py": "062733fd593b4cde4213fcfba2840e19c319da74d0fb5e2eff445bba60520cd6",
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
@@ -691,7 +691,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "e42c2635cbc1fead5ab6e0cfcd0866149cfd29eb786fb3ce1fa14e4227b4fbf4",
+      "src/pilot/coordinator.py": "ca41cb0055a98171e90031ba3a076ebac66306df0e283b609f4889291f158506",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -805,7 +805,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -824,7 +824,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -844,7 +844,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
@@ -866,7 +866,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -904,7 +904,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/store_path.py": "2b3be1415dc7a387717c60574abc36aec9600d7a5c138bf7ac85415aa1b1e152",
-      "src/promote_final_cards.py": "b21994a76f90dab00ce75b35f8083e72312f4b13a1ea62f7fe1b534ddf3d8637",
+      "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
     }
   },
@@ -924,7 +924,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
@@ -953,15 +953,15 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 Windows readiness uses one language-parameterized manifest and worker contract. Whole-card retries, binary split, fragment TM/restore/fidelity, per-card budgets, timeout-no-bisect, partial stitching, audit-clean subset promotion, staged dispatch, and credential-safe event/census telemetry do not branch on RU/EN. Production policy selects RU no_pwg for the first 100-headword proof; the mechanism preserves EN field/schema behavior.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
-      "src/pilot/headless_worker.py": "569dbb2b9893e3a15e5f09270da1bf9dc0636814f05eda0f891dd1474f878476",
-      "src/pilot/max_account_orchestrator.py": "e33a4f32908f886a162973cb5202fcf72c5ac8eaba5ba52698065c491459be1c",
-      "src/pilot/coordinator.py": "e42c2635cbc1fead5ab6e0cfcd0866149cfd29eb786fb3ce1fa14e4227b4fbf4",
-      "src/pilot/headless_worker_selftest.py": "f0e548832e927f8a0869db630f7076feafc319ca980de9eba7253a39902d5768",
-      "src/pilot/max_account_orchestrator_selftest.py": "08f6c58db179a3109caff9ffd6626e346dc0dd70827818165b4eed194eae66c5",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/headless_worker.py": "d8a14672fd37a22364775002d7b37255c2755ffd975f2f6ccaef76e66d911fb3",
+      "src/pilot/max_account_orchestrator.py": "39e7a60c0dbd89b6d2d2a8554832c19489f228409aef558062a260844d824635",
+      "src/pilot/coordinator.py": "ca41cb0055a98171e90031ba3a076ebac66306df0e283b609f4889291f158506",
+      "src/pilot/headless_worker_selftest.py": "05b9e6e51b4ac1c7d93e9a0bd34d51d628f9fa900982e429b3216c11a9c39856",
+      "src/pilot/max_account_orchestrator_selftest.py": "d8562c4e2b2b9e6c50f3a2de02df1080bcc7f0a944f9770db306e2d3407653f9",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
-      "src/pilot/run_observability.py": "371d0197b39e217ef1754eb60d8b09f79823678f728d65e276f864eaeb8e0d72",
+      "src/pilot/run_observability.py": "eb21e08ba4f0e7ab7ab5dacf9db4e4d0d38234f2d63385157735ca8d7b8ced61",
       "src/pilot/run_observability_selftest.py": "75bc960a35080a0c84ca9b5ee62b63134a9e0bde334c5531d564b13019187b60",
       "src/pilot/proc_tree.py": "7b4eb10defbca8efe84b2db6eef1d63c1124e92d0851da78549c7440734f24c4"
     }
@@ -983,7 +983,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H390 Phase 1 (12-07-2026, Opus 4.8 claude-opus-4-8), extended by H818. gen_model is written into language-agnostic run meta and flows through the shared ledger writer and harvester identically for RU/EN; both paths now stamp exact claude-sonnet-5. Pinned by test_ledger_stamps_gen_model in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
@@ -1004,7 +1004,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H823, fixes the H255 presplit-cohort loss). Both the citation presplit trigger (_presplit_hit) and the single-card kill budget (killBudgetForCur) are language-independent — they key on <ls>/fragment counts and FRAGS, never on --lang; the same floor + CEIL apply to RU and EN identically. Extends no_fallback_single_kill_budget_and_nominal_key_echo (H220) from no-fallback singles to all singles. Pinned by test_presplit_cite_floor_and_single_ceil.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -1050,7 +1050,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H960 (15-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes H920's explicitly-deferred accept()-side sense-count consumption. Language-neutral: accept() counts SENSE OBJECTS (records[].senses[]), never a gloss language, and source_senses is sense_count.count_source_senses over the German source markers (identical for the RU and EN lanes — the source is German for both). SOFT by default (SANLOSS_HARD_REJECT=false): a shortfall is telemetry only (no reject/requeue), so live traffic can measure the true drop-vs-false-flag rate before the reject is armed (owner-gated ladder). The shared counter is hardened against the ~4.78%-of-cards cross-reference over-count the naive count carried (gam~~h2_31_pari 2->1, s_ud~~h0_05_pra 4->2, _a_srayatva 2->0); under-counting is the safe direction, never a false shortfall. Pinned by test_h960_accept_sanloss_soft_gate (builds the real harness, extracts the emitted accept()+countOf, asserts soft-keep / surplus-ok / FP-regression / ls-sk-first / armed-hard-reject via accept_sensecount_test.js) plus the 3 cross-reference fixtures in sense_count._selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "cee085a78a046ed6dd55e062d2fa413867eafaea29afa40d6355a513ec023153",
+      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135",
       "src/pilot/accept_sensecount_test.js": "ae04e6390738fcc31ac39b4a292c967b4e26d8abc669fa12f690c9d694e88f3d"

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4"
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509"
     }
   },
   {
@@ -117,7 +117,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -136,7 +136,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -155,7 +155,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -173,7 +173,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4"
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4"
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509"
     }
   },
   {
@@ -224,7 +224,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4"
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509"
     }
   },
   {
@@ -241,7 +241,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4"
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509"
     }
   },
   {
@@ -258,7 +258,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 closes the former divergence: exact model provenance is required across four accounts, so both RU and EN now request and stamp claude-sonnet-5. This prevents account/profile alias resolution from making cross-window provenance incomparable.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4"
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509"
     }
   },
   {
@@ -355,7 +355,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -412,7 +412,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357"
     }
   },
@@ -470,7 +470,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
@@ -805,7 +805,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -824,7 +824,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -844,7 +844,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
@@ -866,7 +866,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -924,7 +924,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
@@ -953,7 +953,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 Windows readiness uses one language-parameterized manifest and worker contract. Whole-card retries, binary split, fragment TM/restore/fidelity, per-card budgets, timeout-no-bisect, partial stitching, audit-clean subset promotion, staged dispatch, and credential-safe event/census telemetry do not branch on RU/EN. Production policy selects RU no_pwg for the first 100-headword proof; the mechanism preserves EN field/schema behavior.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/headless_worker.py": "d8a14672fd37a22364775002d7b37255c2755ffd975f2f6ccaef76e66d911fb3",
       "src/pilot/max_account_orchestrator.py": "39e7a60c0dbd89b6d2d2a8554832c19489f228409aef558062a260844d824635",
       "src/pilot/coordinator.py": "ca41cb0055a98171e90031ba3a076ebac66306df0e283b609f4889291f158506",
@@ -983,7 +983,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H390 Phase 1 (12-07-2026, Opus 4.8 claude-opus-4-8), extended by H818. gen_model is written into language-agnostic run meta and flows through the shared ledger writer and harvester identically for RU/EN; both paths now stamp exact claude-sonnet-5. Pinned by test_ledger_stamps_gen_model in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
@@ -1004,7 +1004,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H823, fixes the H255 presplit-cohort loss). Both the citation presplit trigger (_presplit_hit) and the single-card kill budget (killBudgetForCur) are language-independent — they key on <ls>/fragment counts and FRAGS, never on --lang; the same floor + CEIL apply to RU and EN identically. Extends no_fallback_single_kill_budget_and_nominal_key_echo (H220) from no-fallback singles to all singles. Pinned by test_presplit_cite_floor_and_single_ceil.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
     }
   },
@@ -1050,7 +1050,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H960 (15-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes H920's explicitly-deferred accept()-side sense-count consumption. Language-neutral: accept() counts SENSE OBJECTS (records[].senses[]), never a gloss language, and source_senses is sense_count.count_source_senses over the German source markers (identical for the RU and EN lanes — the source is German for both). SOFT by default (SANLOSS_HARD_REJECT=false): a shortfall is telemetry only (no reject/requeue), so live traffic can measure the true drop-vs-false-flag rate before the reject is armed (owner-gated ladder). The shared counter is hardened against the ~4.78%-of-cards cross-reference over-count the naive count carried (gam~~h2_31_pari 2->1, s_ud~~h0_05_pra 4->2, _a_srayatva 2->0); under-counting is the safe direction, never a false shortfall. Pinned by test_h960_accept_sanloss_soft_gate (builds the real harness, extracts the emitted accept()+countOf, asserts soft-keep / surplus-ok / FP-regression / ls-sk-first / armed-hard-reject via accept_sensecount_test.js) plus the 3 cross-reference fixtures in sense_count._selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01135c770599784430459a16bf50f37f7278bb99c52b55ccef8c3d52db49e6e4",
+      "src/pilot/gen_opt_harness2.py": "6950b3d3acc26b252afd185273a273001b62e92358ccd5d798a5fafab7835509",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
       "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135",
       "src/pilot/accept_sensecount_test.js": "ae04e6390738fcc31ac39b4a292c967b4e26d8abc669fa12f690c9d694e88f3d"

--- a/RussianTranslation/pwg_ru/h1080/H1080_STORE_REPAIR_REPORT_2026-07-17.md
+++ b/RussianTranslation/pwg_ru/h1080/H1080_STORE_REPAIR_REPORT_2026-07-17.md
@@ -26,5 +26,8 @@ The backup remains uncommitted and byte-identical to the pre-repair store. The R
 memory was rebuilt exactly once from the clean store and validated. The publication and fragment
 TMs were not rebuilt because H1080 changed the canonical card store, not those independent sources.
 
-No fresh c4 health probe, quarantined-key retranslation, promotion, or paid window was run. Those
-remain gated on completion of the manifest-v2 and launch-control hardening stage.
+No fresh c4 health probe, quarantined-key retranslation, promotion, or paid window was run.
+Follow-up [PR #511](https://github.com/gasyoun/SanskritLexicography/pull/511) completed the offline
+manifest-v2/profile/global-call/probe-policy hardening and superseded closed PR #495. The next step
+is a separately authorized fresh c4 health probe; a `GO` permits only serial retranslation of the
+two quarantined keys before a tiny nominal window, while `NO-GO` keeps the quarantine and stops.

--- a/RussianTranslation/pwg_ru/h963/H963_C4_FINAL_CORRECTION_INPUT_FOR_SOL_2026-07-16.md
+++ b/RussianTranslation/pwg_ru/h963/H963_C4_FINAL_CORRECTION_INPUT_FOR_SOL_2026-07-16.md
@@ -2,6 +2,15 @@
 
 _Created: 16-07-2026 · Last updated: 17-07-2026_
 
+> **Implementation status (17-07-2026).** Evidence reconciliation landed in
+> [PR #498](https://github.com/gasyoun/SanskritLexicography/pull/498); the atomic H1080 store repair
+> and forward schema/promotion gates landed in
+> [PR #510](https://github.com/gasyoun/SanskritLexicography/pull/510); manifest-v2 profile binding,
+> global active-call serialization, typed probe policy, and bounded execution are delivered by
+> [PR #511](https://github.com/gasyoun/SanskritLexicography/pull/511). The historical campaign facts
+> below remain unchanged. No production call was made by those implementation stages; H963 still
+> requires a fresh serial c4 health probe before any paid translation.
+
 **This campaign fired ZERO live generation calls.** Nothing below was measured by running the
 model. Every claim is anchored to a file:line in the worktree
 [`SanskritLexicography-h963-c4-live`](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation)

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -481,8 +481,24 @@ A concrete run, with real numbers, so the loop above isn't just abstract steps.
    order `vid, as, BU, yuj` (agent estimates as of the fixed estimator: 63/21/…).
 2. **Generate:** `python src\pilot\gen_opt_harness2.py vid` → 55 cards in 8 batches,
    5 cards routed to presplit (each too dense for one call).
+
+   A new CLI/headless production attempt must mint manifest v2 and bind the actual logical slot
+   and config directory at preparation time, for example:
+
+   ```powershell
+   python src\pilot\coordinator.py prepare LEASE_ID `
+     --profile-slot c4 --config-dir C:\path\to\claude-c4 `
+     --executor-lane serial-whole-card
+   ```
+
+   `c4` is a roster slot, not evidence of billing identity. Later execution must repeat
+   `--only-profile c4`; the orchestrator checks the slot and directory fingerprint against the
+   sealed manifest. Old v1 manifests are historical-audit inputs only and cannot be promoted.
 3. **Run:** drive `run_pilot_wf.opt2.js` via the Workflow tool from the Claude Code
    session (not a manual Max-surface save — see the H145 loss lesson above).
+   For the bounded CLI route, use its default dry-run first, then explicitly add `--execute
+   --only-profile c4`. All entry points share the global config-fingerprint call claim, so a
+   second c4 launch fails closed instead of spending concurrently.
    Real result: **102 agents, 6,626,992 tokens, ~19 min wall-clock.**
 4. **Capture:** read the workflow task's `.result` from its output file (holds the
    full `{meta, summary, results}` payload uncapped) and write it to `wf_output.json`

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -494,11 +494,13 @@ A concrete run, with real numbers, so the loop above isn't just abstract steps.
    `c4` is a roster slot, not evidence of billing identity. Later execution must repeat
    `--only-profile c4`; the orchestrator checks the slot and directory fingerprint against the
    sealed manifest. Old v1 manifests are historical-audit inputs only and cannot be promoted.
-3. **Run:** drive `run_pilot_wf.opt2.js` via the Workflow tool from the Claude Code
-   session (not a manual Max-surface save — see the H145 loss lesson above).
-   For the bounded CLI route, use its default dry-run first, then explicitly add `--execute
-   --only-profile c4`. All entry points share the global config-fingerprint call claim, so a
-   second c4 launch fails closed instead of spending concurrently.
+3. **Run:** the historical `vid` run drove `run_pilot_wf.opt2.js` via Workflow. Do not use that
+   route for a new profile-bound v2 attempt: Workflow cannot prove `CLAUDE_CONFIG_DIR` or join the
+   host-wide active-call claim, so a bound generated template now aborts before its first agent
+   call. Run the execution manifest through the CLI/headless route instead: use the bounded
+   command's default dry-run first, then explicitly add `--execute --only-profile c4`. Every
+   admitted production entry point holds the global config-fingerprint claim, so a second c4
+   launch fails closed instead of spending concurrently.
    Real result: **102 agents, 6,626,992 tokens, ~19 min wall-clock.**
 4. **Capture:** read the workflow task's `.result` from its output file (holds the
    full `{meta, summary, results}` payload uncapped) and write it to `wf_output.json`

--- a/RussianTranslation/src/pilot/bounded_staged_run.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python
+r"""bounded_staged_run.py — the OPT-IN bridge that runs the max-account staged-run path
+under the bounded_supervisor control loop (H963; the live-wiring half of H960 gap #6).
+
+WHAT THIS IS (and what it is NOT)
+---------------------------------
+`bounded_supervisor.BoundedSupervisor` is a hermetic, crash-resumable, bounded drain loop
+whose one live dependency — the actual model call — is INJECTED as `run_window(window) ->
+wf_output`. `max_account_orchestrator.cmd_staged_run` is the live probe→dispatch→record→
+promote path, scoped to a plan's prepared coordinator leases. This module is the smallest
+coherent bridge between the two: it drives the bounded loop over a staged plan's prepared
+leases, one lease per window, reusing the EXISTING staged-run building blocks
+(`probe_fleet`, `cmd_run_once`, `cmd_record_done`, coordinator `promote-ready`) as the
+injected `run_window`, and adding the bounded loop's ceilings + checkpoint + cost
+fail-closed policy AROUND them.
+
+It is a NEW, standalone module with its own CLI. It edits NOTHING in
+max_account_orchestrator.py / coordinator.py / bounded_supervisor.py — every existing
+command and default is byte-for-byte unchanged, so this is a pure opt-in (H963 objective 1,
+backward compatibility). The staged-run monolith is not refactored; its already-separate
+callables are simply composed under a bounded loop.
+
+SAFETY / DEFAULT-OFF
+--------------------
+The DEFAULT action is a DRY-RUN planning view that makes ZERO generation calls: it prints
+the exact scoped work, the ceilings, the account allocation, the checkpoint path and the
+stop policy, and returns. A live drain requires the explicit `--execute` opt-in AND a
+healthy fleet probe (STOP-on-any-NO-GO by default). Without `--execute` no probe, no
+dispatch, no promotion, no store write is ever attempted. This double-gates against an
+accidental production run (H963 prohibits any production Max/Workflow translation call).
+
+THE LEASE JOIN KEY
+------------------
+window['root'] == coordinator lease id == orchestrator job external_id (a single identifier
+across the plan JSON, coordinator state.json, and the sqlite jobs table). Every bounded
+window we build uses id == root, so the loop's completed_window_ids, the per-lease dispatch
+scope (`only_external_ids={root}`) and the per-lease promotion scope (`--lease-id root`) all
+line up. This is the mechanism that keeps transient/defect/pending/historical/unrelated-plan
+work out of the current staged run (H963 objective 7): a job whose external_id is not in this
+plan's lease set is invisible to every scoped count, claim, record and promote.
+
+CEILINGS (H963 objective 4) — all optional, default-disabled, backward compatible:
+  --max-windows   windows/calls attempted   (BoundedSupervisor.max_windows)
+  --max-calls     cumulative model calls     (BoundedSupervisor.max_calls)
+  --max-clean     clean rows requested       (BoundedSupervisor.max_clean)
+  --empty-streak  consecutive non-productive (BoundedSupervisor.empty_streak_cap)
+  --max-accounts  account/profile usage      (fleet cap, passed to probe/dispatch)
+  --cost-ceiling  estimated/observed cost    (BoundedSupervisor.budget_cap)
+
+COST FAIL-CLOSED (H963 objective 5): when --cost-ceiling is set the loop reads per-window
+cost with bounded_supervisor.strict_cost_fn, which returns None (UNEVALUABLE) rather than a
+silent zero when a window carries no trustworthy cost figure — the loop then stops with the
+distinct STOP_COST_UNEVALUABLE reason. Additionally, BEFORE any live call, we fail closed if
+a cost ceiling is requested but the economy ledger cannot price it at all (no clean cards on
+record). Missing cost data is NEVER treated as zero. Accounting is the EXISTING economy
+ledger + launch/probe ledgers — no parallel accounting store is introduced (objective 6).
+
+Pure control-plane. The only side effects on the LIVE path are those cmd_staged_run already
+performs (dispatch/record/promote); the dry-run and every code path in the self-test perform
+none. Model authored by Opus 4.8 (claude-opus-4-8[1m]) for handoff H963.
+"""
+import argparse
+import json
+import os
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import bounded_supervisor as bs                      # noqa: E402
+import economy_ledger as el                          # noqa: E402
+import max_account_orchestrator as mao               # noqa: E402
+from bounded_supervisor import BoundedSupervisor, strict_cost_fn   # noqa: E402
+
+SCHEMA = 'pwg.bounded_staged_run.v1'
+
+# The exact-version contract coordinator.promote_ready enforces (rejects '', 'sonnet',
+# 'claude-sonnet'); the staged loop hardcodes this same value. Never a bare tier alias.
+DEFAULT_GEN_MODEL_VERSION = 'claude-sonnet-5'
+
+
+# ---------------------------------------------------------------------------
+# Scope — reuse staged_plan_scope verbatim so the bounded windows are exactly the
+# staged-run's prepared headless leases (H963 objective 2/7: plan-scoped isolation).
+# ---------------------------------------------------------------------------
+
+def scope_windows(plan, requested_lease_ids=None):
+    """Return (windows, scope) where `windows` is the bounded-loop plan list — one entry per
+    prepared headless lease, id == window['root'] — and `scope` is the staged_plan_scope
+    summary. A window that is not headless (plan-only / beyond --limit-windows) is NOT in
+    scope, exactly as cmd_staged_run sees it. Pure; reads the frozen plan dict only."""
+    scope = mao.staged_plan_scope(plan, requested_lease_ids)
+    windows = []
+    for window in scope['windows']:
+        root = window['root']
+        headless = window.get('headless') or {}
+        windows.append({
+            'id': root,                       # == lease id == job external_id (the join key)
+            'root': root,
+            'headwords': list(window.get('headwords') or []),
+            'subcards': list(window.get('subcards') or []),
+            'headless': True,
+            'projected_calls': headless.get('projected_calls'),
+            'manifest_sha256': headless.get('manifest_sha256'),
+        })
+    return windows, scope
+
+
+def prepared_lease_ids(coord_state):
+    """The set of lease ids the staged run can import — state=='prepared' only (a lease
+    advanced past prepared is silently skipped by cmd_staged_run's import filter)."""
+    return {lease.get('id') for lease in (coord_state or {}).get('leases', [])
+            if lease.get('state') == 'prepared'}
+
+
+# ---------------------------------------------------------------------------
+# Cost fail-closed pre-check — reuse the economy ledger (objective 5/6).
+# ---------------------------------------------------------------------------
+
+def cost_ceiling_evaluable(cost_ceiling, ledger):
+    """(ok, reason) for a requested monetary/quota ceiling, evaluated from the EXISTING
+    economy ledger — never a parallel accounting source.
+
+      * cost_ceiling is None -> (True, 'no cost ceiling requested').
+      * a ceiling IS requested but the economy ledger has no priced clean cards (the pooled
+        cost band is None — an all-wasted / empty log) -> (False, ...) FAIL CLOSED: we cannot
+        price a single window, so a live run must not start against an unenforceable budget.
+      * otherwise (True, <band basis>): the ledger yields a real per-clean cost band.
+
+    This mirrors economy_ledger.gate(strict=True) semantics (a requested ceiling on
+    unevaluable data is a breach) applied as a pre-run gate rather than a post-run one."""
+    if cost_ceiling is None:
+        return True, 'no cost ceiling requested'
+    band = (ledger.get('aggregate') or {}).get('cost_per_clean_band')
+    if band is None:
+        return False, ('cost ceiling $%.4f requested but the economy ledger has no priced '
+                       'clean cards (pooled cost band is None) — UNEVALUABLE, fail closed; '
+                       'never treat missing cost data as zero' % cost_ceiling)
+    return True, ('cost basis from economy ledger: $%.4f..$%.4f per clean (fresh-input ceil)'
+                  % (band['floor_usd'], band['ceil_usd']))
+
+
+# ---------------------------------------------------------------------------
+# The audit callable — read the coordinator lease post-drain (LIVE path).
+# ---------------------------------------------------------------------------
+
+def _lease_by_id(coord_state, lease_id):
+    for lease in (coord_state or {}).get('leases', []):
+        if lease.get('id') == lease_id:
+            return lease
+    return None
+
+
+def _window_cost_usd(lease, wf_summary):
+    """A TRUSTWORTHY per-window cost in USD, or None when it cannot be honestly priced.
+
+    Prefers observed subagent tokens (from the wf_output summary) priced at the economy
+    ledger's fresh-input rate (the in-band figure, single-sourced from economy_ledger.PRICE);
+    falls back to a recorded numeric cost on the lease. Returns None — NOT 0 — when neither is
+    available (the common case: H911 found run-event tokens 'not_recoverable'), so a cost
+    ceiling fails the run closed rather than silently under-counting."""
+    tokens = (wf_summary or {}).get('subagent_tokens')
+    if isinstance(tokens, (int, float)) and not isinstance(tokens, bool):
+        return tokens * el.PRICE['input'] / 1e6
+    cost = lease.get('cost') if isinstance(lease, dict) else None
+    if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+        return cost
+    if isinstance(cost, dict):
+        usd = cost.get('est_cost_usd') if not cost.get('error') else None
+        if isinstance(usd, (int, float)) and not isinstance(usd, bool):
+            return usd
+    return None
+
+
+def audit_from_coordinator(coord_state_path, wf_output, window):
+    """Build a bounded_supervisor audit report from the coordinator lease's post-drain state.
+
+    clean_count   = lease['clean_count'] (promotable clean rows on record; 0 if not promotable)
+    requeue_keys  = pending_requeue transient + defect keys (rework, NOT completion)
+    satisfied_keys= a requeue key whose promotion produced a zero store-delta (already
+                    promoted upstream) — progress, not a hard error
+    calls         = wf summary translate_agents_spent + heal_agents_spent (model calls)
+    cost          = trustworthy per-window USD, else None (drives the fail-closed policy)
+
+    A blocked/unknown lease contributes clean_count 0 and its keys as requeue (non-productive),
+    so it counts toward the consecutive-empty streak rather than as clean completion."""
+    try:
+        with open(coord_state_path, encoding='utf-8') as f:
+            coord_state = json.load(f)
+    except (OSError, ValueError, TypeError):
+        coord_state = {}
+    lease = _lease_by_id(coord_state, window['id']) or {}
+    pending = lease.get('pending_requeue') or {}
+    requeue_keys = [k for k in (list(pending.get('transient') or []) +
+                                list(pending.get('defect') or [])) if k]
+    clean_count = int(lease.get('clean_count') or 0)
+    store_delta = lease.get('store_delta')
+    satisfied = []
+    if window.get('requeue') and requeue_keys and store_delta == 0:
+        # an already-promoted (zero-delta) requeue key: satisfied-not-failed
+        satisfied, requeue_keys = requeue_keys, []
+    wf_summary = {}
+    try:
+        with open(wf_output, encoding='utf-8') as f:
+            wf_summary = (json.load(f).get('summary') or {})
+    except (OSError, ValueError, TypeError):
+        wf_summary = {}
+    calls = int((wf_summary.get('translate_agents_spent') or 0) +
+                (wf_summary.get('heal_agents_spent') or 0))
+    return {
+        'requeue_keys': requeue_keys,
+        'satisfied_keys': satisfied,
+        'clean_count': clean_count,
+        'calls': calls,
+        'cost': _window_cost_usd(lease, wf_summary),
+        'audit_state': lease.get('audit_state'),
+        'lease_state': lease.get('state'),
+        'store_delta': store_delta,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The run_window callable — drain ONE lease via the existing staged-run pieces (LIVE path).
+# ---------------------------------------------------------------------------
+
+class RunContext:
+    """Everything the per-lease live drain needs. Built once per bounded run; the fleet is
+    probed ONCE by the caller (not per window) and its healthy set passed in as
+    `probe_latencies` so dispatch never reaches an unprobed account."""
+
+    def __init__(self, db, coord_dir, coordinator, cwd, events, run_id, probe_latencies,
+                 claude_bin='claude', timeout=7200, gen_model_version=DEFAULT_GEN_MODEL_VERSION,
+                 max_drain_iterations=1000):
+        self.db = db
+        self.coord_dir = coord_dir
+        self.coordinator = coordinator
+        self.cwd = cwd
+        self.events = events
+        self.run_id = run_id
+        self.probe_latencies = probe_latencies
+        self.claude_bin = claude_bin
+        self.timeout = timeout
+        self.gen_model_version = gen_model_version
+        self.max_drain_iterations = max_drain_iterations
+
+    @property
+    def coord_state_path(self):
+        return os.path.join(os.path.abspath(self.coord_dir), 'state.json')
+
+
+def _ensure_imported(ctx, lease_id):
+    """Import this lease as a scoped job if it is prepared and not already present (mirrors
+    cmd_staged_run's to_import filter, scoped to the single lease)."""
+    db = mao.connect(ctx.db)
+    existing = {row['external_id'] for row in db.execute('SELECT external_id FROM jobs')}
+    db.close()
+    if lease_id in existing:
+        return
+    with open(ctx.coord_state_path, encoding='utf-8') as f:
+        coord_state = json.load(f)
+    if lease_id not in prepared_lease_ids(coord_state):
+        return  # not prepared (already advanced / unknown) -> nothing to import
+    mao.cmd_import_coordinator(argparse.Namespace(
+        db=ctx.db, coord_dir=ctx.coord_dir, cwd=ctx.cwd, lease_id=[lease_id], max_attempts=2))
+
+
+def make_run_window(ctx):
+    """Return run_window(window) -> wf_output_path: drain exactly ONE lease scoped to its own
+    external_id, reusing cmd_run_once / cmd_record_done / coordinator promote-ready. The scope
+    (only_external_ids={lease_id}, --lease-id lease_id) guarantees no other plan's job is
+    dispatched, recorded or promoted (H963 objective 2/7). This is invoked ONLY on the live
+    (--execute) path; the dry-run and the self-test never call it."""
+    import subprocess
+    import time
+
+    def run_window(window):
+        lease_id = window['id']
+        scope = {lease_id}
+        _ensure_imported(ctx, lease_id)
+        iterations = 0
+        while True:
+            iterations += 1
+            if iterations > ctx.max_drain_iterations:
+                raise SystemExit('bounded_staged_run: lease %s exceeded %d drain iterations'
+                                 % (lease_id, ctx.max_drain_iterations))
+            db = mao.connect(ctx.db)
+            pending = mao.scoped_job_count(db, scope, "state='pending'")
+            done_unrecorded = mao.scoped_job_count(
+                db, scope, "state='done' AND coordinator_recorded=0")
+            failed = mao.scoped_job_count(db, scope, "state='failed'")
+            db.close()
+            if failed:
+                raise SystemExit('bounded_staged_run: lease %s has %d failed job(s) — fail closed'
+                                 % (lease_id, failed))
+            if not pending and not done_unrecorded:
+                break
+            if pending:
+                now_ts = int(time.time())
+                db = mao.connect(ctx.db)
+                runnable = db.execute(
+                    "SELECT count(*) FROM accounts WHERE validated=1 AND parked_until<=?",
+                    (now_ts,)).fetchone()[0]
+                db.close()
+                if not runnable:
+                    raise SystemExit('bounded_staged_run: lease %s pending but all accounts '
+                                     'parked — rerun with --resume after the reset' % lease_id)
+                mao.cmd_run_once(argparse.Namespace(
+                    db=ctx.db, timeout=ctx.timeout, events=ctx.events, run_id=ctx.run_id,
+                    claude_bin=ctx.claude_bin, only_accounts=set(ctx.probe_latencies),
+                    only_external_ids=scope))
+            mao.cmd_record_done(argparse.Namespace(
+                db=ctx.db, coordinator=ctx.coordinator, cwd=ctx.cwd, only_external_ids=scope))
+            promote = subprocess.run(
+                [sys.executable, os.path.abspath(ctx.coordinator), 'promote-ready',
+                 '--gen-model-version', ctx.gen_model_version, '--lease-id', lease_id],
+                cwd=os.path.abspath(ctx.cwd), text=True, encoding='utf-8', capture_output=True)
+            if promote.returncode and 'no ready leases to promote' not in (
+                    promote.stderr + promote.stdout):
+                raise SystemExit('bounded_staged_run: lease %s promotion failed: %s'
+                                 % (lease_id, (promote.stderr or promote.stdout)[-1000:]))
+        # Return the lease's recorded output path (the wf_output the audit reads).
+        db = mao.connect(ctx.db)
+        rows = mao.scoped_jobs(db, scope)
+        db.close()
+        for job in rows:
+            if job['output_path'] and os.path.exists(job['output_path']):
+                return job['output_path']
+        return None
+
+    return run_window
+
+
+# ---------------------------------------------------------------------------
+# Dry-run planning view — the exact scoped work + ceilings + stop policy, NO calls.
+# ---------------------------------------------------------------------------
+
+def plan_view(plan, coord_state, ceilings, checkpoint_path, requested_lease_ids=None,
+              accounts=None, ledger=None):
+    """Pure planning view (H963 objective 8): what a live run WOULD do — scoped work,
+    ceilings, account allocation, checkpoint path, cost-basis evaluability and the ordered
+    stop policy — computed WITHOUT any generation call. `accounts` is the validated-account
+    name list (optional); `ledger` is a prebuilt economy ledger (optional; built from the
+    frozen probe log when omitted)."""
+    windows, scope = scope_windows(plan, requested_lease_ids)
+    prepared = prepared_lease_ids(coord_state)
+    importable = [w['id'] for w in windows if w['id'] in prepared]
+    not_prepared = [w['id'] for w in windows if w['id'] not in prepared]
+    if ledger is None:
+        try:
+            ledger = el.build_ledger(el.read_rows(el.FROZEN_LOG))
+        except (OSError, ValueError):
+            ledger = {'aggregate': {}}
+    cost_ok, cost_reason = cost_ceiling_evaluable(ceilings.get('cost_ceiling'), ledger)
+    max_accounts = ceilings.get('max_accounts') or 0
+    allocated = list(accounts or [])
+    if max_accounts:
+        allocated = allocated[:max_accounts]
+    stop_policy = [
+        'window-count ceiling (max_windows=%s)' % ceilings.get('max_windows'),
+        'call-count ceiling (max_calls=%s)' % ceilings.get('max_calls'),
+        'clean-rows quota (max_clean=%s)' % ceilings.get('max_clean'),
+        'cost/quota ceiling (cost_ceiling=%s; UNEVALUABLE cost -> STOP_COST_UNEVALUABLE, '
+        'fail closed)' % ceilings.get('cost_ceiling'),
+        'consecutive non-productive streak (empty_streak=%s)' % ceilings.get('empty_streak'),
+        'clean-target drain (plan queue + requeue backlog both empty)',
+        'any failed job or all-accounts-parked -> fail closed',
+    ]
+    return {
+        'schema': SCHEMA,
+        'mode': 'dry-run (no generation call made)',
+        'scope': {
+            'lease_ids': scope['lease_ids'],
+            'expected_windows': scope['expected_windows'],
+            'expected_headwords': scope['expected_headwords'],
+            'expected_subcards': sum(len(w['subcards']) for w in windows),
+            'projected_calls_from_plan': sum((w.get('projected_calls') or 0) for w in windows),
+            'importable_prepared_leases': sorted(importable),
+            'windows_not_prepared_skipped': sorted(not_prepared),
+        },
+        'ceilings': dict(ceilings),
+        'cost_basis': {'evaluable': cost_ok, 'reason': cost_reason},
+        'account_allocation': {
+            'validated_accounts': list(accounts or []),
+            'max_accounts_cap': max_accounts or None,
+            'allocated': allocated,
+        },
+        'checkpoint_path': checkpoint_path,
+        'stop_policy': stop_policy,
+        'live_requires': "explicit --execute AND a healthy fleet probe (STOP-on-any-NO-GO)",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Orchestration — build the bounded supervisor and (dry-run | execute).
+# ---------------------------------------------------------------------------
+
+def _validated_accounts(db_path):
+    if not db_path or not os.path.exists(db_path):
+        return []
+    try:
+        db = mao.connect(db_path)
+        names = [row['name'] for row in
+                 db.execute('SELECT name FROM accounts WHERE validated=1 ORDER BY name')]
+        db.close()
+        return names
+    except Exception:  # noqa: BLE001 — a missing/locked db must not crash the dry-run
+        return []
+
+
+def build_supervisor(windows, checkpoint_path, ceilings, run_window, audit, resume=False):
+    """Construct the BoundedSupervisor with the H963 ceilings wired through. strict_cost_fn is
+    used exactly when a cost ceiling is active, so an unevaluable window cost fails closed."""
+    cost_ceiling = ceilings.get('cost_ceiling')
+    return BoundedSupervisor(
+        windows, run_window, checkpoint_path,
+        audit=audit,
+        max_windows=ceilings.get('max_windows'),
+        max_calls=ceilings.get('max_calls'),
+        max_clean=ceilings.get('max_clean'),
+        budget_cap=cost_ceiling,
+        empty_streak_cap=ceilings.get('empty_streak'),
+        cost_fn=strict_cost_fn if cost_ceiling is not None else None,
+        resume=resume,
+    )
+
+
+def run(args):
+    plan = json.load(open(args.plan, encoding='utf-8'))
+    coord_state_path = os.path.join(os.path.abspath(args.coord_dir), 'state.json')
+    coord_state = {}
+    if os.path.exists(coord_state_path):
+        with open(coord_state_path, encoding='utf-8') as f:
+            coord_state = json.load(f)
+    ceilings = {
+        'max_windows': args.max_windows, 'max_calls': args.max_calls,
+        'max_clean': args.max_clean, 'cost_ceiling': args.cost_ceiling,
+        'empty_streak': args.empty_streak, 'max_accounts': args.max_accounts,
+    }
+    accounts = _validated_accounts(args.db)
+    ledger = el.build_ledger(el.read_rows(el.FROZEN_LOG)) if os.path.exists(el.FROZEN_LOG) else \
+        {'aggregate': {}}
+    view = plan_view(plan, coord_state, ceilings, args.checkpoint,
+                     requested_lease_ids=args.lease_id, accounts=accounts, ledger=ledger)
+
+    if not args.execute:
+        # DEFAULT: dry-run planning view. No probe, no dispatch, no promotion, no store write.
+        print(json.dumps(view, ensure_ascii=False, indent=1))
+        return 0
+
+    # --- LIVE path (owner-gated). Everything below is only reached with --execute. ---
+    windows, scope = scope_windows(plan, args.lease_id)
+    if not windows:
+        raise SystemExit('bounded_staged_run: staged plan has no prepared headless windows')
+    # Cost fail-closed PRE-CHECK: refuse to start a cost-capped run we cannot price at all.
+    cost_ok, cost_reason = cost_ceiling_evaluable(args.cost_ceiling, ledger)
+    if not cost_ok:
+        raise SystemExit('bounded_staged_run: %s' % cost_reason)
+    db = mao.connect(args.db)
+    validated = list(db.execute('SELECT * FROM accounts WHERE validated=1 ORDER BY name'))
+    db.close()
+    if not validated:
+        raise SystemExit('bounded_staged_run requires at least one validated account')
+    if args.max_accounts:
+        validated = validated[:args.max_accounts]
+    run_id = args.run_id or ('bsr-' + mao.now_iso().replace(':', '').replace('-', ''))
+    # Probe the fleet ONCE (STOP-on-any-NO-GO by default; the honest-NO-GO stance).
+    probe_latencies = mao.probe_fleet(
+        validated, args.claude_bin, events_path=args.events, run_id=run_id,
+        drop_unhealthy=args.drop_unhealthy)
+    if args.drop_unhealthy:
+        for acc in validated:
+            if acc['name'] not in probe_latencies:
+                mao.park(args.db, acc['name'], mao.PARKED_FOREVER,
+                         'dropped after probe NO-GO (--drop-unhealthy); healthy subset proceeds')
+    ctx = RunContext(
+        db=args.db, coord_dir=args.coord_dir, coordinator=args.coordinator, cwd=args.cwd,
+        events=args.events, run_id=run_id, probe_latencies=probe_latencies,
+        claude_bin=args.claude_bin, timeout=args.timeout,
+        gen_model_version=args.gen_model_version)
+    run_window = make_run_window(ctx)
+
+    def audit(wf_output, window):
+        return audit_from_coordinator(ctx.coord_state_path, wf_output, window)
+
+    sup = build_supervisor(windows, args.checkpoint, ceilings, run_window, audit,
+                           resume=args.resume)
+    summary = sup.run()
+    report = {'schema': SCHEMA, 'run_id': run_id, 'plan_view': view, 'summary': summary}
+    if args.report:
+        mao.atomic_write(args.report, json.dumps(report, ensure_ascii=False, indent=1) + '\n')
+    print(json.dumps(summary, ensure_ascii=False, indent=1))
+    # A cost-unevaluable / non-clean stop is a non-zero exit so callers can gate on it.
+    return 0 if summary.get('stop_reason') in (bs.STOP_CLEAN_TARGET, bs.STOP_WINDOW_COUNT,
+                                               bs.STOP_CLEAN_QUOTA, bs.STOP_CALL_COUNT) else 1
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--plan', required=True, help='the pwg.no_pwg_scale_plan.v1 plan JSON')
+    ap.add_argument('--coord-dir', required=True, help='coordinator dir holding state.json')
+    ap.add_argument('--coordinator', help='path to coordinator.py (required for --execute)')
+    ap.add_argument('--cwd', help='working dir for record/promote subprocesses (--execute)')
+    ap.add_argument('--db', default='max_orchestrator.sqlite')
+    ap.add_argument('--lease-id', action='append', help='restrict scope to these lease roots')
+    ap.add_argument('--checkpoint', default='bounded_staged_run.checkpoint.json')
+    ap.add_argument('--execute', action='store_true',
+                    help='OPT-IN: run the live drain. Default (absent) is a dry-run planning '
+                         'view that makes ZERO generation calls.')
+    ap.add_argument('--resume', action='store_true',
+                    help='resume from --checkpoint (no completed lease re-run/re-promoted)')
+    # Ceilings (all optional / default-disabled).
+    ap.add_argument('--max-windows', type=int, default=None)
+    ap.add_argument('--max-calls', type=int, default=None)
+    ap.add_argument('--max-clean', type=int, default=None)
+    ap.add_argument('--cost-ceiling', type=float, default=None,
+                    help='max cumulative cost (USD). An UNEVALUABLE window cost fails closed.')
+    ap.add_argument('--empty-streak', type=int, default=None)
+    ap.add_argument('--max-accounts', type=int, default=0)
+    ap.add_argument('--drop-unhealthy', action='store_true')
+    ap.add_argument('--gen-model-version', default=DEFAULT_GEN_MODEL_VERSION)
+    ap.add_argument('--timeout', type=int, default=7200)
+    ap.add_argument('--events')
+    ap.add_argument('--report')
+    ap.add_argument('--run-id')
+    args = ap.parse_args(argv)
+    if args.execute and not (args.coordinator and args.cwd and args.events):
+        ap.error('--execute requires --coordinator, --cwd and --events')
+    return run(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/RussianTranslation/src/pilot/bounded_staged_run.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run.py
@@ -234,7 +234,7 @@ class RunContext:
 
     def __init__(self, db, coord_dir, coordinator, cwd, events, run_id, probe_latencies,
                  claude_bin='claude', timeout=7200, gen_model_version=DEFAULT_GEN_MODEL_VERSION,
-                 max_drain_iterations=1000):
+                 max_drain_iterations=1000, only_profile=None):
         self.db = db
         self.coord_dir = coord_dir
         self.coordinator = coordinator
@@ -246,6 +246,7 @@ class RunContext:
         self.timeout = timeout
         self.gen_model_version = gen_model_version
         self.max_drain_iterations = max_drain_iterations
+        self.only_profile = only_profile
 
     @property
     def coord_state_path(self):
@@ -311,6 +312,7 @@ def make_run_window(ctx):
                 mao.cmd_run_once(argparse.Namespace(
                     db=ctx.db, timeout=ctx.timeout, events=ctx.events, run_id=ctx.run_id,
                     claude_bin=ctx.claude_bin, only_accounts=set(ctx.probe_latencies),
+                    only_profile=ctx.only_profile,
                     only_external_ids=scope))
             mao.cmd_record_done(argparse.Namespace(
                 db=ctx.db, coordinator=ctx.coordinator, cwd=ctx.cwd, only_external_ids=scope))
@@ -462,6 +464,10 @@ def run(args):
     db = mao.connect(args.db)
     validated = list(db.execute('SELECT * FROM accounts WHERE validated=1 ORDER BY name'))
     db.close()
+    if args.only_profile:
+        validated = [account for account in validated if account['name'] == args.only_profile]
+        if not validated:
+            raise SystemExit('--only-profile is not a validated roster slot')
     if not validated:
         raise SystemExit('bounded_staged_run requires at least one validated account')
     if args.max_accounts:
@@ -480,7 +486,7 @@ def run(args):
         db=args.db, coord_dir=args.coord_dir, coordinator=args.coordinator, cwd=args.cwd,
         events=args.events, run_id=run_id, probe_latencies=probe_latencies,
         claude_bin=args.claude_bin, timeout=args.timeout,
-        gen_model_version=args.gen_model_version)
+        gen_model_version=args.gen_model_version, only_profile=args.only_profile)
     run_window = make_run_window(ctx)
 
     def audit(wf_output, window):
@@ -520,6 +526,7 @@ def main(argv=None):
                     help='max cumulative cost (USD). An UNEVALUABLE window cost fails closed.')
     ap.add_argument('--empty-streak', type=int, default=None)
     ap.add_argument('--max-accounts', type=int, default=0)
+    ap.add_argument('--only-profile', help='enforce one manifest-bound logical profile slot')
     ap.add_argument('--drop-unhealthy', action='store_true')
     ap.add_argument('--gen-model-version', default=DEFAULT_GEN_MODEL_VERSION)
     ap.add_argument('--timeout', type=int, default=7200)

--- a/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python
+r"""Hermetic self-test for bounded_staged_run.py (H963).
+
+ZERO live generation: the bounded loop is driven with a scripted fake run_window (writes a
+fixture wf_output) and injected audit reports; the scope-isolation test seeds a real sqlite
+jobs table via the orchestrator's own CLI but never dispatches a model call. Every H963
+characterization/regression case is exercised end to end:
+
+  (a) plan scope        — only prepared headless windows enter scope; a bad --lease-id raises
+  (b) dry-run           — the default path prints the planning view and makes ZERO calls
+                          (probe_fleet is monkeypatched to raise; the dry-run never reaches it)
+  (c) historical jobs   — an unrelated other-plan job (failed/done) is invisible to the
+                          current plan's scoped counts/claims
+  (d) clean completion  — a full drain over N leases stops at clean-target, all windows done
+  (e) restart / no-dup  — resume from a checkpoint re-runs NO completed lease (exactly-once)
+  (f) ceiling exhaustion— a call-count ceiling stops the run mid-queue
+  (g) cost fail-closed  — an unevaluable window cost under a cost ceiling stops closed, and the
+                          pre-run economy-ledger cost check refuses an unpriceable ceiling
+  (h) consecutive-empty — a non-productive streak stops the run
+  (i) audit seam        — audit_from_coordinator reads a lease's clean/requeue/satisfied/calls
+
+  python src/pilot/bounded_staged_run_selftest.py
+"""
+import argparse
+import json
+import os
+import sys
+import tempfile
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import bounded_staged_run as bsr
+import bounded_supervisor as bs
+import max_account_orchestrator as mao
+from bounded_supervisor import (
+    STOP_CLEAN_TARGET, STOP_CALL_COUNT, STOP_COST_UNEVALUABLE, STOP_CONSECUTIVE_EMPTY,
+)
+
+
+def _plan(roots, headless=True):
+    """A synthetic pwg.no_pwg_scale_plan.v1-shaped plan with `roots` prepared headless windows."""
+    windows = []
+    for i, root in enumerate(roots):
+        windows.append({
+            'root': root, 'headwords': ['hw_%s' % root], 'subcards': ['%s~~h0_zz_pw' % root],
+            'headless': {'projected_calls': 2, 'manifest_sha256': 'sha_%d' % i} if headless else None,
+        })
+    return {'schema': 'pwg.no_pwg_scale_plan.v1', 'windows': windows}
+
+
+class FakeRunWindow:
+    """run_window fake: records order, writes a trivial wf_output fixture, returns its path."""
+
+    def __init__(self, td, raise_on_call=None):
+        self.td = td
+        self.raise_on_call = raise_on_call
+        self.order = []
+
+    def __call__(self, window):
+        self.order.append(window['id'])
+        if self.raise_on_call is not None and len(self.order) == self.raise_on_call:
+            raise RuntimeError('simulated crash on %s' % window['id'])
+        path = os.path.join(self.td, 'wf_%s.json' % window['id'].replace('/', '_'))
+        with open(path, 'w', encoding='utf-8', newline='\n') as f:
+            json.dump({'summary': {}, 'results': []}, f)
+        return path
+
+
+def _ceilings(**over):
+    base = {'max_windows': None, 'max_calls': None, 'max_clean': None, 'cost_ceiling': None,
+            'empty_streak': None, 'max_accounts': 0}
+    base.update(over)
+    return base
+
+
+# ---------------------------------------------------------------------------
+
+def test_a_plan_scope(td):
+    plan = _plan(['no_pwg_w02', 'no_pwg_w03'])
+    plan['windows'].append({'root': 'no_pwg_w04', 'headwords': ['x'], 'subcards': None,
+                            'headless': None})   # plan-only, NOT in scope
+    windows, scope = bsr.scope_windows(plan)
+    assert [w['id'] for w in windows] == ['no_pwg_w02', 'no_pwg_w03'], windows
+    assert scope['expected_windows'] == 2 and scope['expected_headwords'] == 2, scope
+    # a --lease-id subset must equal the prepared roots or staged_plan_scope raises.
+    _, s2 = bsr.scope_windows(plan, ['no_pwg_w02', 'no_pwg_w03'])
+    assert s2['lease_ids'] == ['no_pwg_w02', 'no_pwg_w03'], s2
+    raised = False
+    try:
+        bsr.scope_windows(plan, ['no_pwg_w04'])   # w04 is not a prepared headless root
+    except SystemExit:
+        raised = True
+    assert raised, 'an unprepared/mismatched --lease-id must raise'
+    print('  (a) plan scope: only prepared headless windows enter; bad --lease-id raises: PASS')
+
+
+def test_b_dry_run_no_generation_call(td):
+    plan = _plan(['no_pwg_w02'])
+    coord = os.path.join(td, 'coord'); os.makedirs(coord)
+    with open(os.path.join(coord, 'state.json'), 'w', encoding='utf-8') as f:
+        json.dump({'leases': [{'id': 'no_pwg_w02', 'state': 'prepared'}]}, f)
+    plan_path = os.path.join(td, 'plan.json')
+    with open(plan_path, 'w', encoding='utf-8') as f:
+        json.dump(plan, f)
+
+    # Monkeypatch probe_fleet AND make_run_window to raise: if the dry-run path touched either,
+    # the test blows up. It must not — dry-run returns before any live wiring.
+    _pf, _mrw = mao.probe_fleet, bsr.make_run_window
+    calls = {'probe': 0, 'run_window': 0}
+
+    def _boom_probe(*a, **k):
+        calls['probe'] += 1
+        raise AssertionError('dry-run must NOT probe the fleet')
+
+    def _boom_mrw(*a, **k):
+        calls['run_window'] += 1
+        raise AssertionError('dry-run must NOT build a run_window')
+
+    mao.probe_fleet = _boom_probe
+    bsr.make_run_window = _boom_mrw
+    try:
+        args = argparse.Namespace(
+            plan=plan_path, coord_dir=coord, db=os.path.join(td, 'nope.sqlite'),
+            checkpoint=os.path.join(td, 'cp.json'), lease_id=None, execute=False, report=None,
+            max_windows=1, max_calls=None, max_clean=None, cost_ceiling=None, empty_streak=None,
+            max_accounts=0)
+        rc = bsr.run(args)
+    finally:
+        mao.probe_fleet, bsr.make_run_window = _pf, _mrw
+    assert rc == 0, rc
+    assert calls == {'probe': 0, 'run_window': 0}, calls
+    print('  (b) dry-run planning view makes ZERO generation calls (default off): PASS')
+
+
+def test_c_historical_jobs_excluded(td):
+    # Seed a real sqlite jobs table (via the orchestrator CLI) holding an UNRELATED other-plan
+    # job plus the current plan's lease. The current plan's scope must exclude the historical
+    # job from every scoped count — the isolation the live run_window relies on.
+    db = os.path.join(td, 'scope.sqlite')
+    mao.main(['--db', db, 'init', '--account', 'acc=' + os.path.join(td, 'acc'),
+              '--skip-profile-check'])
+    for ext in ('other_plan_w99', 'no_pwg_w02'):
+        mao.main(['--db', db, 'enqueue', '--external-id', ext, '--argv-json',
+                  json.dumps([sys.executable, '-c', 'print(1)']), '--cwd', td,
+                  '--output', os.path.join(td, ext + '.json')])
+    con = mao.connect(db)
+    with con:
+        con.execute("UPDATE jobs SET state='failed' WHERE external_id='other_plan_w99'")
+    con.close()
+    scope = {'no_pwg_w02'}
+    con = mao.connect(db)
+    # the unrelated failed job is invisible to the current plan's scoped counts
+    assert mao.scoped_job_count(con, scope, "state='failed'") == 0, 'historical failed job leaked into scope'
+    assert mao.scoped_job_count(con, scope, "state='pending'") == 1, 'current lease not pending in scope'
+    assert [r['external_id'] for r in mao.scoped_jobs(con, scope, "1=1")] == ['no_pwg_w02'], 'scope not isolated'
+    con.close()
+    # a scoped claim never touches the historical job
+    claimed = mao.claim(db, 'acc', only_external_ids=scope)
+    assert claimed and claimed['external_id'] == 'no_pwg_w02', claimed
+    con = mao.connect(db)
+    assert con.execute("SELECT state FROM jobs WHERE external_id='other_plan_w99'").fetchone()[0] == 'failed', \
+        'historical job must be untouched by the scoped claim'
+    con.close()
+    print('  (c) unrelated historical/other-plan jobs excluded from the current scope: PASS')
+
+
+def test_d_clean_completion(td):
+    plan = _plan(['no_pwg_w02', 'no_pwg_w03', 'no_pwg_w05'])
+    windows, _ = bsr.scope_windows(plan)
+    runner = FakeRunWindow(td)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 1, 'cost': 0.5, 'calls': 1, 'satisfied_keys': []}
+
+    sup = bsr.build_supervisor(windows, os.path.join(td, 'd.json'), _ceilings(), runner, audit)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CLEAN_TARGET, summ
+    assert summ['windows_done'] == 3, summ
+    assert runner.order == ['no_pwg_w02', 'no_pwg_w03', 'no_pwg_w05'], runner.order
+    assert summ['completed_window_ids'] == ['no_pwg_w02', 'no_pwg_w03', 'no_pwg_w05'], summ
+    print('  (d) full clean completion drains all leases to clean-target: PASS')
+
+
+def test_e_restart_no_duplicate_completion(td):
+    # Realistic interruption = a kill/crash mid-window (the checkpoint keeps stop_reason=None,
+    # so --resume continues; a CLEAN ceiling stop is terminal by design and resume is a no-op).
+    plan = _plan(['no_pwg_w02', 'no_pwg_w03', 'no_pwg_w05'])
+    windows, _ = bsr.scope_windows(plan)
+    cp = os.path.join(td, 'e.json')
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 1, 'cost': 1, 'calls': 1, 'satisfied_keys': []}
+
+    # First pass CRASHES while running the 3rd lease (2 completed + checkpointed).
+    runner_a = FakeRunWindow(td, raise_on_call=3)
+    sup_a = bsr.build_supervisor(windows, cp, _ceilings(), runner_a, audit)
+    crashed = False
+    try:
+        sup_a.run()
+    except RuntimeError:
+        crashed = True
+    assert crashed, 'expected a simulated crash on the 3rd lease'
+    state = json.load(open(cp, encoding='utf-8'))
+    assert state['windows_done'] == 2 and state['completed_window_ids'] == ['no_pwg_w02', 'no_pwg_w03'], state
+    assert state['stop_reason'] is None, state          # crashed mid-loop, not a clean stop
+
+    # Resume: ONLY the uncompleted 3rd lease runs — no completed lease re-run/re-recorded.
+    runner_b = FakeRunWindow(td)
+    sup_b = bsr.build_supervisor(windows, cp, _ceilings(), runner_b, audit, resume=True)
+    summ_b = sup_b.run()
+    assert runner_b.order == ['no_pwg_w05'], runner_b.order   # exactly-once: w02/w03 NOT re-run
+    assert summ_b['windows_done'] == 3, summ_b
+    assert summ_b['completed_window_ids'] == ['no_pwg_w02', 'no_pwg_w03', 'no_pwg_w05'], summ_b
+    assert summ_b['stop_reason'] == STOP_CLEAN_TARGET, summ_b
+    print('  (e) restart after interruption re-runs NO completed lease (exactly-once): PASS')
+
+
+def test_f_ceiling_exhaustion(td):
+    plan = _plan(['no_pwg_w0%d' % i for i in range(6)])
+    windows, _ = bsr.scope_windows(plan)
+    runner = FakeRunWindow(td)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 1, 'cost': 1, 'calls': 2, 'satisfied_keys': []}
+
+    sup = bsr.build_supervisor(windows, os.path.join(td, 'f.json'),
+                               _ceilings(max_calls=5), runner, audit)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CALL_COUNT, summ
+    assert summ['calls_spent'] == 6 and summ['windows_done'] == 3, summ   # 3 windows * 2 calls
+    print('  (f) a call-count ceiling stops the run mid-queue: PASS')
+
+
+def test_g_cost_fail_closed(td):
+    # runtime fail-closed: an unevaluable window cost under an active cost ceiling stops closed.
+    plan = _plan(['no_pwg_w02', 'no_pwg_w03', 'no_pwg_w05'])
+    windows, _ = bsr.scope_windows(plan)
+    runner = FakeRunWindow(td)
+
+    def audit(wf_output, window):
+        if window['id'] == 'no_pwg_w03':
+            return {'requeue_keys': [], 'clean_count': 1, 'calls': 1, 'satisfied_keys': []}  # NO cost
+        return {'requeue_keys': [], 'clean_count': 1, 'cost': 1, 'calls': 1, 'satisfied_keys': []}
+
+    sup = bsr.build_supervisor(windows, os.path.join(td, 'g.json'),
+                               _ceilings(cost_ceiling=100), runner, audit)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_COST_UNEVALUABLE, summ
+    assert runner.order == ['no_pwg_w02', 'no_pwg_w03'], runner.order   # stops on the unpriceable one
+    # pre-run fail-closed: a cost ceiling requested but the economy ledger cannot price it.
+    empty_ledger = {'aggregate': {'cost_per_clean_band': None}}
+    ok, reason = bsr.cost_ceiling_evaluable(0.75, empty_ledger)
+    assert ok is False and 'UNEVALUABLE' in reason, (ok, reason)
+    ok2, _ = bsr.cost_ceiling_evaluable(None, empty_ledger)   # no ceiling -> never a breach
+    assert ok2 is True
+    priced = {'aggregate': {'cost_per_clean_band': {'floor_usd': 0.07, 'ceil_usd': 0.70}}}
+    ok3, reason3 = bsr.cost_ceiling_evaluable(0.75, priced)
+    assert ok3 is True and 'cost basis' in reason3, (ok3, reason3)
+    print('  (g) cost fail-closed: unevaluable cost stops closed; unpriceable ceiling refused: PASS')
+
+
+def test_h_consecutive_empty(td):
+    plan = _plan(['no_pwg_w0%d' % i for i in range(6)])
+    windows, _ = bsr.scope_windows(plan)
+    runner = FakeRunWindow(td)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': ['%s~~h0_zz_pw' % window['id']], 'clean_count': 0, 'cost': 0,
+                'calls': 1, 'satisfied_keys': []}   # non-productive: 0 clean, only requeue
+
+    sup = bsr.build_supervisor(windows, os.path.join(td, 'h.json'),
+                               _ceilings(empty_streak=3), runner, audit)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CONSECUTIVE_EMPTY, summ
+    assert summ['empty_streak'] == 3, summ
+    print('  (h) a consecutive non-productive streak stops the run: PASS')
+
+
+def test_i_audit_from_coordinator(td):
+    coord_state_path = os.path.join(td, 'state.json')
+    wf = os.path.join(td, 'wf_w02.json')
+    with open(wf, 'w', encoding='utf-8') as f:
+        json.dump({'summary': {'translate_agents_spent': 4, 'heal_agents_spent': 1,
+                               'subagent_tokens': 1_000_000}}, f)
+    # a recorded lease: 3 clean, one defect key still pending, positive store delta.
+    with open(coord_state_path, 'w', encoding='utf-8') as f:
+        json.dump({'leases': [{
+            'id': 'no_pwg_w02', 'state': 'promoted_partial', 'audit_state': 'needs_requeue',
+            'clean_count': 3, 'store_delta': 5,
+            'pending_requeue': {'transient': [], 'defect': ['d~~h0_zz_pw']},
+        }]}, f)
+    rep = bsr.audit_from_coordinator(coord_state_path, wf, {'id': 'no_pwg_w02'})
+    assert rep['clean_count'] == 3, rep
+    assert rep['requeue_keys'] == ['d~~h0_zz_pw'], rep
+    assert rep['satisfied_keys'] == [], rep
+    assert rep['calls'] == 5, rep                                    # 4 + 1
+    assert rep['cost'] is not None and rep['cost'] > 0, rep          # priced from tokens
+    # a zero-delta requeue window: the pending key is satisfied-not-failed
+    with open(coord_state_path, 'w', encoding='utf-8') as f:
+        json.dump({'leases': [{'id': 'no_pwg_w02', 'state': 'promoted', 'clean_count': 0,
+                               'store_delta': 0,
+                               'pending_requeue': {'transient': ['t~~h0_zz_pw'], 'defect': []}}]}, f)
+    rep2 = bsr.audit_from_coordinator(coord_state_path, wf, {'id': 'no_pwg_w02', 'requeue': True})
+    assert rep2['satisfied_keys'] == ['t~~h0_zz_pw'] and rep2['requeue_keys'] == [], rep2
+    print('  (i) audit_from_coordinator reads clean/requeue/satisfied/calls/cost from the lease: PASS')
+
+
+def main():
+    with tempfile.TemporaryDirectory() as td:
+        test_a_plan_scope(td)
+        test_b_dry_run_no_generation_call(td)
+        test_c_historical_jobs_excluded(td)
+        test_d_clean_completion(td)
+        test_e_restart_no_duplicate_completion(td)
+        test_f_ceiling_exhaustion(td)
+        test_g_cost_fail_closed(td)
+        test_h_consecutive_empty(td)
+        test_i_audit_from_coordinator(td)
+    print('bounded_staged_run_selftest: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/bounded_supervisor.py
+++ b/RussianTranslation/src/pilot/bounded_supervisor.py
@@ -69,10 +69,31 @@ if HERE not in sys.path:
 SCHEMA = 'pwg.bounded_supervisor.v1'
 
 # Stop reasons — the loop stops on the FIRST of these to fire.
-STOP_WINDOW_COUNT = 'window_count'          # ran the configured max number of windows
+STOP_WINDOW_COUNT = 'window_count'          # ran the configured max number of windows/calls attempted
 STOP_BUDGET = 'budget'                       # accumulated per-window cost crossed the cap
 STOP_CLEAN_TARGET = 'clean_target'           # plan queue AND requeue backlog both drained
 STOP_CONSECUTIVE_EMPTY = 'consecutive_empty'  # N consecutive zero-progress iterations
+STOP_CALL_COUNT = 'call_count'               # cumulative model calls crossed the max-calls ceiling
+STOP_CLEAN_QUOTA = 'clean_quota'             # cumulative clean rows reached the requested quota
+STOP_COST_UNEVALUABLE = 'cost_unevaluable'   # a cost ceiling is active but a window's cost could
+#                                              NOT be evaluated -> FAIL CLOSED (never treat missing
+#                                              cost as zero and keep spending). Distinct from
+#                                              STOP_BUDGET: this is a data-integrity stop, not an
+#                                              over-ceiling stop (H963 cost fail-closed contract).
+
+
+def strict_cost_fn(window, wf_output, report):
+    """A fail-closed per-window cost reader for use when a cost/quota ceiling is enforced.
+
+    Returns the report's numeric ``cost`` when present, else ``None`` — signalling the
+    supervisor that this window's spend is UNEVALUABLE. Paired with an active ``budget_cap``
+    the supervisor then stops with ``STOP_COST_UNEVALUABLE`` instead of silently treating the
+    missing figure as zero (the anti-pattern the default reader keeps for backward compat).
+    ``bool``/``str`` costs are rejected as invalid (None), not coerced."""
+    cost = (report or {}).get('cost')
+    if isinstance(cost, bool) or not isinstance(cost, (int, float)):
+        return None
+    return cost
 
 
 class BoundedSupervisor:
@@ -95,12 +116,27 @@ class BoundedSupervisor:
     max_windows : int, optional
         Window-count cap. ``None`` disables the bound.
     budget_cap : number, optional
-        Running-budget cap; the loop stops once accumulated cost is >= this. ``None``
-        disables the bound.
+        Running-budget (cost/quota) cap; the loop stops once accumulated cost is >= this.
+        ``None`` disables the bound. When a ``budget_cap`` is set AND ``cost_fn`` reports an
+        UNEVALUABLE cost (``None``) for a window, the loop FAILS CLOSED with
+        ``STOP_COST_UNEVALUABLE`` rather than treating the missing figure as zero — pair it
+        with ``strict_cost_fn`` (module-level) to get that fail-closed reader.
     empty_streak_cap : int, optional
-        Stop after this many consecutive zero-progress iterations. ``None`` disables it.
-    cost_fn : callable(window, wf_output_path, report) -> number, optional
-        Per-window cost. Defaults to ``report.get('cost', 0)``.
+        Stop after this many consecutive zero-progress (non-productive) iterations. ``None``
+        disables it.
+    max_calls : int, optional
+        Ceiling on cumulative model calls attempted (summed from ``report['calls']``). The
+        loop stops with ``STOP_CALL_COUNT`` once the running total is >= this. ``None``
+        disables the bound.
+    max_clean : int, optional
+        Clean-rows quota: stop with ``STOP_CLEAN_QUOTA`` once cumulative clean cards
+        (summed from ``report['clean_count']``) reach this many. ``None`` disables it.
+        Distinct from the clean-TARGET drain (queue+backlog empty) — this is an explicit
+        ceiling on how many clean rows to REQUEST before stopping.
+    cost_fn : callable(window, wf_output_path, report) -> number|None, optional
+        Per-window cost. Defaults to ``report.get('cost', 0)`` (missing -> 0, the legacy
+        silent-zero kept for backward compatibility). Pass ``strict_cost_fn`` to make a
+        missing cost ``None`` and engage the fail-closed policy above.
     input_dir : str, optional
         Portrait-sidecar dir for the default H920 auditor. When omitted a throwaway temp
         dir is used (so the default auditor stays hermetic — an empty dir yields no
@@ -111,7 +147,8 @@ class BoundedSupervisor:
 
     def __init__(self, plan, run_window, checkpoint_path,
                  audit=None, max_windows=None, budget_cap=None,
-                 empty_streak_cap=None, cost_fn=None, input_dir=None, resume=False):
+                 empty_streak_cap=None, cost_fn=None, input_dir=None, resume=False,
+                 max_calls=None, max_clean=None):
         if not callable(run_window):
             raise TypeError('run_window must be callable(window) -> wf_output_path')
         self.plan = [self._normalize_plan(w, i) for i, w in enumerate(plan or [])]
@@ -121,6 +158,8 @@ class BoundedSupervisor:
         self.max_windows = max_windows
         self.budget_cap = budget_cap
         self.empty_streak_cap = empty_streak_cap
+        self.max_calls = max_calls
+        self.max_clean = max_clean
         self.cost_fn = cost_fn or (lambda window, wf_output, report: report.get('cost', 0) or 0)
         self.input_dir = input_dir
         self._own_input_dir = None
@@ -128,6 +167,8 @@ class BoundedSupervisor:
         # Loop state (all persisted).
         self.windows_done = 0
         self.budget_spent = 0.0
+        self.calls_spent = 0
+        self.clean_total = 0
         self.requeue_backlog = []
         self.empty_streak = 0
         self.next_index = 0
@@ -227,8 +268,15 @@ class BoundedSupervisor:
                 # (3) AUDIT — injected report, or the H920 gate helper on a tmp dir.
                 report = self._run_audit(wf_output, item)
 
-                cost = self.cost_fn(item, wf_output, report) or 0
+                raw_cost = self.cost_fn(item, wf_output, report)
+                # A None cost means UNEVALUABLE — never coerce it to 0 for accounting. It
+                # only fails the run closed when a cost ceiling (budget_cap) is active
+                # (checked below); with no cost ceiling it is a harmless 0 contribution.
+                cost_unevaluable = raw_cost is None
+                cost = 0 if cost_unevaluable else (raw_cost or 0)
                 self.budget_spent += cost
+                calls = int(report.get('calls') or 0)
+                self.calls_spent += calls
                 self.windows_done += 1
                 self.completed_window_ids.append(item['id'])
 
@@ -240,6 +288,7 @@ class BoundedSupervisor:
                     self.requeue_backlog.append(self._make_requeue_item(item, requeue_keys))
 
                 clean = int(report.get('clean_count') or 0)
+                self.clean_total += clean
                 # (g) A satisfied (already-promoted, zero-store-delta) requeue key is
                 # progress, not a hard error: it drains the backlog and resets the streak.
                 made_progress = clean > 0 or bool(satisfied)
@@ -252,9 +301,13 @@ class BoundedSupervisor:
                     'window_id': item['id'],
                     'requeue': bool(item.get('requeue')),
                     'clean_count': clean,
+                    'clean_total': self.clean_total,
+                    'calls': calls,
+                    'calls_spent': self.calls_spent,
                     'requeued_keys': sorted(set(requeue_keys)),
                     'satisfied_keys': sorted(set(satisfied)),
-                    'cost': cost,
+                    'cost': None if cost_unevaluable else cost,
+                    'cost_unevaluable': cost_unevaluable,
                     'budget_spent': self.budget_spent,
                     'empty_streak': self.empty_streak,
                 })
@@ -262,13 +315,31 @@ class BoundedSupervisor:
                 # (6) PERSIST loop state atomically for crash resume.
                 self._write_checkpoint()
 
-                # (5b) running-budget bound — after accumulating this window's cost, so the
-                # window that crosses the cap runs, then the loop stops mid-queue.
+                # (5b0) COST FAIL-CLOSED — a cost ceiling is enforced but this window's spend
+                # could not be evaluated. Stop closed BEFORE any further work: never keep
+                # spending against a budget we can no longer enforce. Checked first so it
+                # pre-empts a would-be clean-target success on an unenforceable budget.
+                if cost_unevaluable and self.budget_cap is not None:
+                    self._finish(STOP_COST_UNEVALUABLE)
+                    break
+
+                # (5b) running-budget (cost/quota) bound — after accumulating this window's
+                # cost, so the window that crosses the cap runs, then the loop stops mid-queue.
                 if self.budget_cap is not None and self.budget_spent >= self.budget_cap:
                     self._finish(STOP_BUDGET)
                     break
 
-                # (5d) consecutive-empty bound.
+                # (5e) call-count bound — cumulative model calls attempted.
+                if self.max_calls is not None and self.calls_spent >= self.max_calls:
+                    self._finish(STOP_CALL_COUNT)
+                    break
+
+                # (5f) clean-rows quota — stop once the requested number of clean rows is met.
+                if self.max_clean is not None and self.clean_total >= self.max_clean:
+                    self._finish(STOP_CLEAN_QUOTA)
+                    break
+
+                # (5d) consecutive-empty (non-productive) bound.
                 if (self.empty_streak_cap is not None
                         and self.empty_streak >= self.empty_streak_cap):
                     self._finish(STOP_CONSECUTIVE_EMPTY)
@@ -332,6 +403,8 @@ class BoundedSupervisor:
             'schema': SCHEMA,
             'windows_done': self.windows_done,
             'budget_spent': self.budget_spent,
+            'calls_spent': self.calls_spent,
+            'clean_total': self.clean_total,
             'requeue_backlog': self.requeue_backlog,
             'empty_streak': self.empty_streak,
             'next_index': self.next_index,
@@ -342,6 +415,8 @@ class BoundedSupervisor:
                 'max_windows': self.max_windows,
                 'budget_cap': self.budget_cap,
                 'empty_streak_cap': self.empty_streak_cap,
+                'max_calls': self.max_calls,
+                'max_clean': self.max_clean,
             },
             'history': self.history,
         }
@@ -365,6 +440,8 @@ class BoundedSupervisor:
             raise ValueError('checkpoint schema mismatch: %r' % state.get('schema'))
         self.windows_done = int(state.get('windows_done') or 0)
         self.budget_spent = float(state.get('budget_spent') or 0)
+        self.calls_spent = int(state.get('calls_spent') or 0)
+        self.clean_total = int(state.get('clean_total') or 0)
         self.requeue_backlog = list(state.get('requeue_backlog') or [])
         self.empty_streak = int(state.get('empty_streak') or 0)
         self.next_index = int(state.get('next_index') or 0)
@@ -382,6 +459,8 @@ class BoundedSupervisor:
             'stop_reason': self.stop_reason,
             'windows_done': self.windows_done,
             'budget_spent': self.budget_spent,
+            'calls_spent': self.calls_spent,
+            'clean_total': self.clean_total,
             'requeue_backlog_len': len(self.requeue_backlog),
             'requeue_backlog_keys': sorted(
                 {k for item in self.requeue_backlog for k in (item.get('keys') or [])}),

--- a/RussianTranslation/src/pilot/bounded_supervisor_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_supervisor_selftest.py
@@ -39,6 +39,10 @@ from bounded_supervisor import (
     STOP_BUDGET,
     STOP_CLEAN_TARGET,
     STOP_CONSECUTIVE_EMPTY,
+    STOP_CALL_COUNT,
+    STOP_CLEAN_QUOTA,
+    STOP_COST_UNEVALUABLE,
+    strict_cost_fn,
 )
 
 
@@ -279,6 +283,124 @@ def test_h_default_h920_auditor(td):
     print('  (h) default H920 auditor requeues a null card hermetically: PASS')
 
 
+def test_i_call_count(td):
+    # H963 ceiling: cumulative model calls attempted. Each window reports 2 calls; the
+    # loop stops once the running total is >= 5, i.e. after the 3rd window (2/4/6).
+    plan = make_plan(10)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 1, 'cost': 1, 'calls': 2,
+                'satisfied_keys': []}
+
+    cp = os.path.join(td, 'i.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, max_calls=5)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CALL_COUNT, summ
+    assert summ['calls_spent'] == 6, summ                 # 3 windows * 2 calls, crossed 5
+    assert summ['windows_done'] == 3, summ
+    assert runner.run_order == ['w0', 'w1', 'w2'], runner.run_order
+    print('  (i) call-count bound stops once cumulative calls cross the ceiling: PASS')
+
+
+def test_j_clean_quota(td):
+    # H963 ceiling: clean-rows quota. Each window yields 2 clean rows; stop once the
+    # cumulative clean total reaches 5 -> after the 3rd window (2/4/6). Distinct from the
+    # clean-TARGET drain (queue emptied): here the queue still has windows left.
+    plan = make_plan(10)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 2, 'cost': 1, 'satisfied_keys': []}
+
+    cp = os.path.join(td, 'j.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, max_clean=5)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CLEAN_QUOTA, summ
+    assert summ['clean_total'] == 6, summ
+    assert summ['windows_done'] == 3, summ
+    assert summ['next_index'] == 3 and summ['next_index'] < len(plan), summ  # stopped mid-queue
+    print('  (j) clean-rows quota stops once the requested clean count is met: PASS')
+
+
+def test_k_cost_fail_closed(td):
+    # H963 cost fail-closed: with a cost ceiling active, a window whose cost is UNEVALUABLE
+    # (strict_cost_fn returns None because the report carries no numeric cost) must stop the
+    # run CLOSED with the distinct STOP_COST_UNEVALUABLE reason — never treat missing cost as
+    # zero and keep spending. w0 prices fine (cost=1), w1 has no cost -> fail closed on w1.
+    plan = make_plan(5)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        if window['id'] == 'w1':
+            return {'requeue_keys': [], 'clean_count': 1, 'satisfied_keys': []}  # NO cost key
+        return {'requeue_keys': [], 'clean_count': 1, 'cost': 1, 'satisfied_keys': []}
+
+    cp = os.path.join(td, 'k.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, budget_cap=100,
+                            cost_fn=strict_cost_fn)
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_COST_UNEVALUABLE, summ
+    assert summ['windows_done'] == 2, summ                # w0 (priced) + w1 (unevaluable) ran
+    assert runner.run_order == ['w0', 'w1'], runner.run_order
+    assert summ['budget_spent'] == 1, summ               # only w0's cost accrued; w1 NOT coerced to 0-and-continue
+    # The history records w1 as unevaluable, cost None (not 0).
+    assert sup.history[-1]['cost_unevaluable'] is True, sup.history[-1]
+    assert sup.history[-1]['cost'] is None, sup.history[-1]
+    print('  (k) cost fail-closed: unevaluable cost under an active ceiling stops closed: PASS')
+
+
+def test_l_cost_unevaluable_harmless_without_ceiling(td):
+    # The mirror of (k): with NO cost ceiling, an unevaluable (None) cost is harmless — it
+    # contributes 0 and the loop drains normally. Fail-closed engages ONLY when a cost
+    # ceiling (budget_cap) is actually being enforced, so the default path is unchanged.
+    plan = make_plan(2)
+    runner = ScriptedRunner(td)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 1, 'satisfied_keys': []}   # never any cost
+
+    cp = os.path.join(td, 'l.json')
+    sup = BoundedSupervisor(plan, runner, cp, audit=audit, cost_fn=strict_cost_fn)  # no budget_cap
+    summ = sup.run()
+    assert summ['stop_reason'] == STOP_CLEAN_TARGET, summ
+    assert summ['windows_done'] == 2, summ
+    assert summ['budget_spent'] == 0, summ
+    print('  (l) unevaluable cost without a ceiling is harmless (drains normally): PASS')
+
+
+def test_m_calls_clean_survive_restart(td):
+    # The new call/clean counters must persist across a checkpoint resume exactly like
+    # windows_done/budget_spent do, so a resumed run enforces the SAME cumulative ceilings.
+    plan = make_plan(5)
+    cp = os.path.join(td, 'm.json')
+    runner_a = ScriptedRunner(td, raise_on_call=3)
+
+    def audit(wf_output, window):
+        return {'requeue_keys': [], 'clean_count': 2, 'cost': 1, 'calls': 3,
+                'satisfied_keys': []}
+
+    sup_a = BoundedSupervisor(plan, runner_a, cp, audit=audit)
+    crashed = False
+    try:
+        sup_a.run()
+    except RuntimeError:
+        crashed = True
+    assert crashed, 'expected a simulated crash on the 3rd window'
+    state = json.load(open(cp, encoding='utf-8'))
+    assert state['calls_spent'] == 6, state              # 2 windows * 3 calls
+    assert state['clean_total'] == 4, state              # 2 windows * 2 clean
+
+    runner_b = ScriptedRunner(td)
+    sup_b = BoundedSupervisor.from_checkpoint(cp, plan, runner_b, audit=audit)
+    assert sup_b.calls_spent == 6 and sup_b.clean_total == 4, (sup_b.calls_spent, sup_b.clean_total)
+    summ = sup_b.run()
+    assert runner_b.run_order == ['w2', 'w3', 'w4'], runner_b.run_order  # no completed window re-run
+    assert summ['calls_spent'] == 15, summ               # 6 carried + 3 * 3
+    assert summ['clean_total'] == 10, summ               # 4 carried + 3 * 2
+    print('  (m) call/clean counters persist across a checkpoint resume: PASS')
+
+
 def main():
     with tempfile.TemporaryDirectory() as td:
         test_a_window_count(td)
@@ -289,6 +411,11 @@ def main():
         test_f_crash_recovery(td)
         test_g_satisfied_zero_delta(td)
         test_h_default_h920_auditor(td)
+        test_i_call_count(td)
+        test_j_clean_quota(td)
+        test_k_cost_fail_closed(td)
+        test_l_cost_unevaluable_harmless_without_ceiling(td)
+        test_m_calls_clean_survive_restart(td)
     print('bounded_supervisor_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -494,6 +494,15 @@ def prepare(args):
         lease = lease_by_id(state, args.lease_id)
         adir = lease.get('artifact_dir') or artifact_dir(args.lease_id)
         os.makedirs(adir, exist_ok=True)
+        binding = []
+        if bool(args.profile_slot) != bool(args.config_dir):
+            raise SystemExit('--profile-slot and --config-dir must be supplied together')
+        if args.profile_slot:
+            binding = ['--profile-slot=%s' % args.profile_slot,
+                       '--config-dir=%s' % os.path.abspath(args.config_dir),
+                       '--execution-route=claude-cli-headless',
+                       '--executor-lane=%s' % args.executor_lane,
+                       '--validation-method=audit_window+final_schema']
         if lease['kind'] == 'verb':
             root = lease['target']
             preflight_path = os.path.join(adir, 'preflight.json')
@@ -505,7 +514,7 @@ def prepare(args):
             harness = os.path.join(adir, 'run_pilot_wf.%s.js' % lease['id'])
             manifest = os.path.join(adir, 'execution_manifest.%s.json' % lease['id'])
             run_cmd([sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'),
-                     root, '--out=%s' % harness, '--manifest-out=%s' % manifest])
+                     root, '--out=%s' % harness, '--manifest-out=%s' % manifest] + binding)
         elif lease['kind'] == 'nominal':
             keys = lease.get('details', {}).get('run_keys') or lease.get('details', {}).get('keys') or []
             if not keys:
@@ -522,7 +531,7 @@ def prepare(args):
             manifest = os.path.join(adir, 'execution_manifest.%s.json' % lease['id'])
             run_cmd([sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'),
                      root, '--nominal', '--no-grammar', '--keys=%s' % key_arg,
-                     '--out=%s' % harness, '--manifest-out=%s' % manifest])
+                     '--out=%s' % harness, '--manifest-out=%s' % manifest] + binding)
         else:
             raise SystemExit('prepare is only for verb/nominal translation leases')
         lease['state'] = 'prepared'
@@ -530,6 +539,9 @@ def prepare(args):
         lease['execution_manifest'] = manifest
         lease['origin_execution_manifest'] = os.path.abspath(manifest)
         lease['origin_execution_manifest_sha256'] = sha256_file(manifest)
+        lease['profile_slot'] = args.profile_slot
+        lease['config_dir'] = os.path.abspath(args.config_dir) if args.config_dir else None
+        lease['executor_lane'] = args.executor_lane
         lease['preflight_path'] = preflight_path
         save_state(state)
         registry_event(lease, 'prepared', {'harness': harness, 'manifest': manifest,
@@ -1000,6 +1012,10 @@ def prepare_requeue(args):
         cmd = [sys.executable, os.path.join(HERE, 'requeue_from_audit.py'),
                root, '--%s' % which, '--requeue-file=%s' % rq, '--out=%s' % harness,
                '--manifest-out=%s' % manifest]
+        if lease.get('profile_slot') and lease.get('config_dir'):
+            cmd += ['--profile-slot=%s' % lease['profile_slot'],
+                    '--config-dir=%s' % lease['config_dir'],
+                    '--executor-lane=%s' % (lease.get('executor_lane') or 'serial-whole-card')]
         if nominal:
             cmd += ['--nominal', '--no-grammar']
         created = False
@@ -1246,6 +1262,9 @@ def main(argv=None):
     p.add_argument('--allow-over-cost', action='store_true',
                    help='H304 cap-and-defer override: prepare a cost-gate-flagged window '
                         'anyway (dedicated human-budgeted monster session only)')
+    p.add_argument('--profile-slot', help='logical profile slot (for example c4; not billing proof)')
+    p.add_argument('--config-dir', help='canonical CLAUDE_CONFIG_DIR bound into manifest v2')
+    p.add_argument('--executor-lane', default='serial-whole-card')
     p.set_defaults(func=prepare)
     r = sub.add_parser('record-output')
     r.add_argument('lease_id')

--- a/RussianTranslation/src/pilot/economy_ledger.py
+++ b/RussianTranslation/src/pilot/economy_ledger.py
@@ -313,25 +313,53 @@ def write_ledger(output_path, rows=None, source_log=None):
     return payload
 
 
-def gate(ledger, ceil_agents_per_clean=None, ceil_cost_per_clean=None):
+def gate(ledger, ceil_agents_per_clean=None, ceil_cost_per_clean=None, strict=False):
     """Return exit code 1 on an AGGREGATE breach (never per-card), else 0.
 
     Compares the headline `agents_per_clean_incl_requeues` and the in-band fresh-input
     `cost_per_clean_band.ceil_usd` against the supplied ceilings. Individual runs are
     NEVER gated — a single expensive/wasted window cannot flip the gate; only the pooled
     aggregate can.
+
+    ``strict`` (default False) selects the missing-data policy — the ONE behavioural
+    switch, added for the bounded-staged-run cost fail-closed contract (H963):
+
+      * strict=False (LEGACY, unchanged): a requested ceiling whose ledger value is
+        ``None`` — an all-wasted / all-nulled log yields ``None`` aggregates — is
+        SKIPPED, so the gate passes on unevaluable data. Every existing caller
+        (``main`` default, the standalone CLI, economy_ledger_selftest) keeps this
+        exact behaviour: DO NOT make ``None`` start failing for them.
+
+      * strict=True (OPT-IN, fail-closed): a requested ceiling that cannot be
+        evaluated (its ledger value is ``None``) is itself a breach — missing or
+        invalid accounting data is NEVER treated as within-ceiling. The breach text
+        carries the distinct ``unevaluable`` marker so callers/tests can tell a
+        fail-closed stop from an over-ceiling stop. A ceiling left at ``None`` (not
+        requested) is never a breach in either mode.
     """
     agg = ledger['aggregate']
     breaches = []
     apc = agg.get('agents_per_clean_incl_requeues')
     band = agg.get('cost_per_clean_band') or {}
     cost = band.get('ceil_usd')
-    if ceil_agents_per_clean is not None and apc is not None and apc > ceil_agents_per_clean:
-        breaches.append('agents_per_clean_incl_requeues %.4f > ceiling %.4f'
-                        % (apc, ceil_agents_per_clean))
-    if ceil_cost_per_clean is not None and cost is not None and cost > ceil_cost_per_clean:
-        breaches.append('cost_per_clean ceil $%.4f > ceiling $%.4f'
-                        % (cost, ceil_cost_per_clean))
+    if ceil_agents_per_clean is not None:
+        if apc is None:
+            if strict:
+                breaches.append('agents_per_clean unevaluable (no clean cards / incomplete '
+                                'accounting) but a ceiling of %.4f was requested — fail-closed'
+                                % ceil_agents_per_clean)
+        elif apc > ceil_agents_per_clean:
+            breaches.append('agents_per_clean_incl_requeues %.4f > ceiling %.4f'
+                            % (apc, ceil_agents_per_clean))
+    if ceil_cost_per_clean is not None:
+        if cost is None:
+            if strict:
+                breaches.append('cost_per_clean unevaluable (no priced clean cards / incomplete '
+                                'accounting) but a ceiling of $%.4f was requested — fail-closed'
+                                % ceil_cost_per_clean)
+        elif cost > ceil_cost_per_clean:
+            breaches.append('cost_per_clean ceil $%.4f > ceiling $%.4f'
+                            % (cost, ceil_cost_per_clean))
     for b in breaches:
         sys.stderr.write('ECONOMY GATE BREACH: %s\n' % b)
     return 1 if breaches else 0
@@ -371,6 +399,10 @@ def main():
     ap.add_argument('--write', metavar='PATH', help='also write the durable ledger JSON here')
     ap.add_argument('--ceil-agents-per-clean', type=float, default=None)
     ap.add_argument('--ceil-cost-per-clean', type=float, default=None)
+    ap.add_argument('--strict', action='store_true',
+                    help='fail closed: a requested ceiling that cannot be evaluated '
+                         '(unevaluable/None accounting) breaches the gate instead of '
+                         'being skipped. Default off = legacy standalone behaviour.')
     args = ap.parse_args()
 
     rows = read_rows(args.log)
@@ -382,7 +414,7 @@ def main():
     for line in summary_lines(ledger):
         print(line)
 
-    return gate(ledger, args.ceil_agents_per_clean, args.ceil_cost_per_clean)
+    return gate(ledger, args.ceil_agents_per_clean, args.ceil_cost_per_clean, strict=args.strict)
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pilot/economy_ledger_selftest.py
+++ b/RussianTranslation/src/pilot/economy_ledger_selftest.py
@@ -289,6 +289,48 @@ def test_integration_real_frozen_log():
         fail('real log must yield no conflicting_run_ids, got %s' % led['conflicting_run_ids'])
 
 
+def test_gate_strict_vs_legacy_missing_data():
+    """H963 cost fail-closed: the opt-in ``strict`` mode is the ONLY behaviour switch;
+    legacy (default) None-skip is unchanged. Cover BOTH modes so a future edit that lets
+    ``None`` silently pass in strict mode — or breaks legacy None-skip — fails loudly."""
+    # (a) UNEVALUABLE aggregates (all-wasted log -> None apc / None cost band).
+    wasted = el.build_ledger([
+        outcome_row('w1', 'no_pwg_wA', agents_used=8, clean=0, tokens=500_000),
+        outcome_row('w2', 'no_pwg_wB', agents_used=6, clean=0, tokens=300_000),
+    ])
+    if wasted['aggregate']['agents_per_clean_incl_requeues'] is not None:
+        fail('precondition: all-wasted apc must be None')
+    # LEGACY: a requested ceiling on unevaluable data is SKIPPED -> passes (0). Unchanged.
+    if el.gate(wasted, ceil_agents_per_clean=1.0) != 0:
+        fail('legacy gate must SKIP an unevaluable agents ceiling (None-skip), got breach')
+    if el.gate(wasted, ceil_cost_per_clean=0.5) != 0:
+        fail('legacy gate must SKIP an unevaluable cost ceiling (None-skip), got breach')
+    if el.gate(wasted, ceil_agents_per_clean=1.0, ceil_cost_per_clean=0.5, strict=False) != 0:
+        fail('explicit strict=False must be identical to the legacy default')
+    # STRICT: the same requested ceiling on unevaluable data FAILS CLOSED (1).
+    if el.gate(wasted, ceil_agents_per_clean=1.0, strict=True) != 1:
+        fail('strict gate must FAIL CLOSED on an unevaluable agents ceiling')
+    if el.gate(wasted, ceil_cost_per_clean=0.5, strict=True) != 1:
+        fail('strict gate must FAIL CLOSED on an unevaluable cost ceiling')
+    # a ceiling NOT requested (None) is never a breach, even in strict mode.
+    if el.gate(wasted, strict=True) != 0:
+        fail('strict gate with NO ceiling requested must pass (nothing to evaluate)')
+
+    # (b) EVALUABLE aggregates: strict must not change the verdict vs legacy.
+    priced = el.build_ledger(
+        [outcome_row('r_full', 'no_pwg_wA', agents_used=10, clean=5, tokens=1_000_000)])
+    #   apc = 10/5 = 2.0 ; cost ceil band = 1e6*3/1e6/5 = $0.60
+    for strict in (False, True):
+        if el.gate(priced, ceil_agents_per_clean=5.0, strict=strict) != 0:
+            fail('within-ceiling agents must pass in %s mode' % ('strict' if strict else 'legacy'))
+        if el.gate(priced, ceil_agents_per_clean=1.0, strict=strict) != 1:
+            fail('over-ceiling agents must breach in %s mode' % ('strict' if strict else 'legacy'))
+        if el.gate(priced, ceil_cost_per_clean=0.0001, strict=strict) != 1:
+            fail('over-ceiling cost must breach in %s mode' % ('strict' if strict else 'legacy'))
+        if el.gate(priced, ceil_cost_per_clean=1e6, strict=strict) != 0:
+            fail('within-ceiling cost must pass in %s mode' % ('strict' if strict else 'legacy'))
+
+
 def test_all_wasted_summary_does_not_crash():
     # Every row clean=0 -> no outcome row enters the agents-per-clean set, so the aggregate
     # agents_per_clean / cost band are None. summary_lines() (the main() print path) must render the
@@ -316,6 +358,7 @@ def main():
         test_dedup_on_run_id_not_window,
         test_ledger_imports_price_not_duplicated,
         test_gate_is_aggregate_only,
+        test_gate_strict_vs_legacy_missing_data,
         test_write_ledger_roundtrip,
         test_integration_real_frozen_log,
         test_all_wasted_summary_does_not_crash,

--- a/RussianTranslation/src/pilot/execution_contract.py
+++ b/RussianTranslation/src/pilot/execution_contract.py
@@ -58,6 +58,18 @@ def validate_profile(manifest, config_dir, only_profile=None):
                          % execution['profile_slot'])
 
 
+def bind_output_meta(meta, manifest):
+    """Stamp a workflow result with the same v2 contract used to launch it."""
+    validate_manifest(manifest, require_v2=True)
+    if set(meta.get('selected_keys') or []) != set(
+            (manifest.get('meta') or {}).get('selected_keys') or []):
+        raise ValueError('workflow metadata keys disagree with execution manifest')
+    meta['execution_manifest_schema'] = SCHEMA_V2
+    meta['execution'] = dict(manifest['execution'])
+    meta['provenance_classes'] = dict(manifest['key_provenance'])
+    return meta
+
+
 class ActiveCallClaim:
     """Cross-process one-active-call claim keyed by credential-directory fingerprint."""
     def __init__(self, fingerprint, root=None):

--- a/RussianTranslation/src/pilot/execution_contract.py
+++ b/RussianTranslation/src/pilot/execution_contract.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""Profile-bound manifest-v2 validation and global active-call serialization."""
+import hashlib
+import json
+import os
+import tempfile
+
+SCHEMA_V1 = 'pwg.headless_execution_manifest.v1'
+SCHEMA_V2 = 'pwg.headless_execution_manifest.v2'
+PROVENANCE_CLASSES = {'real', 'synthetic_control'}
+
+
+def canonical_config_dir(path):
+    return os.path.normcase(os.path.realpath(os.path.abspath(path)))
+
+
+def config_dir_fingerprint(path):
+    canonical = canonical_config_dir(path)
+    return hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+
+
+def validate_manifest(manifest, require_v2=False):
+    schema = manifest.get('schema')
+    if schema == SCHEMA_V1 and not require_v2:
+        return
+    if schema != SCHEMA_V2:
+        raise ValueError('production requires %s (got %r)' % (SCHEMA_V2, schema))
+    execution = manifest.get('execution') or {}
+    required = ('profile_slot', 'config_dir_fingerprint', 'execution_route',
+                'executor_lane', 'validation_method', 'model_identifier')
+    missing = [name for name in required if not isinstance(execution.get(name), str)
+               or not execution[name].strip()]
+    if missing:
+        raise ValueError('manifest v2 missing execution field(s): %s' % ', '.join(missing))
+    if len(execution['config_dir_fingerprint']) != 64:
+        raise ValueError('manifest v2 has malformed config-directory fingerprint')
+    keys = (manifest.get('meta') or {}).get('selected_keys') or []
+    classes = manifest.get('key_provenance')
+    if not isinstance(classes, dict) or set(classes) != set(keys):
+        raise ValueError('manifest v2 key_provenance must exactly cover selected_keys')
+    unknown = {key: value for key, value in classes.items()
+               if value not in PROVENANCE_CLASSES}
+    if unknown:
+        raise ValueError('manifest v2 has unknown provenance class(es): %r' % unknown)
+    if execution['model_identifier'] != manifest.get('model'):
+        raise ValueError('manifest v2 model identifier disagrees with executable model')
+
+
+def validate_profile(manifest, config_dir, only_profile=None):
+    validate_manifest(manifest, require_v2=True)
+    execution = manifest['execution']
+    if only_profile and execution['profile_slot'] != only_profile:
+        raise ValueError('profile mismatch: manifest=%s --only-profile=%s'
+                         % (execution['profile_slot'], only_profile))
+    actual = config_dir_fingerprint(config_dir)
+    if actual != execution['config_dir_fingerprint']:
+        raise ValueError('config-directory fingerprint mismatch for profile %s'
+                         % execution['profile_slot'])
+
+
+class ActiveCallClaim:
+    """Cross-process one-active-call claim keyed by credential-directory fingerprint."""
+    def __init__(self, fingerprint, root=None):
+        self.root = root or os.path.join(tempfile.gettempdir(), 'pwg-active-calls')
+        self.path = os.path.join(self.root, fingerprint + '.lock')
+        self.owned = False
+
+    def __enter__(self):
+        os.makedirs(self.root, exist_ok=True)
+        try:
+            fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            raise RuntimeError('profile already has an active model call')
+        with os.fdopen(fd, 'w', encoding='utf-8') as fh:
+            json.dump({'pid': os.getpid()}, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
+        self.owned = True
+        return self
+
+    def __exit__(self, _typ, _value, _tb):
+        if self.owned:
+            try:
+                os.unlink(self.path)
+            except FileNotFoundError:
+                pass
+            self.owned = False

--- a/RussianTranslation/src/pilot/execution_contract_selftest.py
+++ b/RussianTranslation/src/pilot/execution_contract_selftest.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+import os
+import sys
+import tempfile
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+from execution_contract import (ActiveCallClaim, SCHEMA_V2, config_dir_fingerprint,
+                                validate_manifest, validate_profile)
+from probe_log import verdict_for
+
+
+def fixture(config_dir):
+    return {
+        'schema': SCHEMA_V2,
+        'model': 'claude-sonnet-5',
+        'meta': {'selected_keys': ['real', 'canary']},
+        'execution': {
+            'profile_slot': 'c4',
+            'config_dir_fingerprint': config_dir_fingerprint(config_dir),
+            'execution_route': 'claude-cli-headless',
+            'executor_lane': 'serial-whole-card',
+            'validation_method': 'audit_window+final_schema',
+            'model_identifier': 'claude-sonnet-5',
+        },
+        'key_provenance': {'real': 'real', 'canary': 'synthetic_control'},
+    }
+
+
+def main():
+    with tempfile.TemporaryDirectory() as d:
+        cfg = os.path.join(d, 'profile')
+        os.makedirs(cfg)
+        manifest = fixture(cfg)
+        validate_manifest(manifest, require_v2=True)
+        validate_profile(manifest, cfg, 'c4')
+        try:
+            validate_profile(manifest, cfg, 'c1')
+        except ValueError:
+            pass
+        else:
+            raise AssertionError('profile-slot mismatch passed')
+        other = os.path.join(d, 'other'); os.makedirs(other)
+        try:
+            validate_profile(manifest, other, 'c4')
+        except ValueError:
+            pass
+        else:
+            raise AssertionError('config-directory mismatch passed')
+        locks = os.path.join(d, 'locks')
+        with ActiveCallClaim(manifest['execution']['config_dir_fingerprint'], locks):
+            try:
+                with ActiveCallClaim(manifest['execution']['config_dir_fingerprint'], locks):
+                    pass
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError('two concurrent c4 claims were admitted')
+        with ActiveCallClaim(manifest['execution']['config_dir_fingerprint'], locks):
+            pass
+        assert verdict_for(29999, 0, 6000, 'warmup', schema_valid=True)[0] == 'GO'
+        assert verdict_for(30000, 0, 6000, 'warmup', schema_valid=True)[0] == 'NO-GO'
+        assert verdict_for(1000, 0, 6000, 'warmup', schema_valid=None)[0] == 'NO-GO'
+    print('execution_contract_selftest: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/pilot/execution_contract_selftest.py
+++ b/RussianTranslation/src/pilot/execution_contract_selftest.py
@@ -6,8 +6,9 @@ import tempfile
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
-from execution_contract import (ActiveCallClaim, SCHEMA_V2, config_dir_fingerprint,
-                                validate_manifest, validate_profile)
+from execution_contract import (ActiveCallClaim, SCHEMA_V2, bind_output_meta,
+                                config_dir_fingerprint, validate_manifest,
+                                validate_profile)
 from probe_log import verdict_for
 
 
@@ -34,6 +35,17 @@ def main():
         os.makedirs(cfg)
         manifest = fixture(cfg)
         validate_manifest(manifest, require_v2=True)
+        output_meta = {'selected_keys': ['real', 'canary']}
+        bind_output_meta(output_meta, manifest)
+        assert output_meta['execution'] == manifest['execution']
+        assert output_meta['provenance_classes'] == manifest['key_provenance']
+        assert output_meta['execution_manifest_schema'] == SCHEMA_V2
+        try:
+            bind_output_meta({'selected_keys': ['foreign']}, manifest)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError('foreign workflow output keys were contract-bound')
         validate_profile(manifest, cfg, 'c4')
         try:
             validate_profile(manifest, cfg, 'c1')

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -48,7 +48,7 @@ from autosplit_requeue import plan as split_plan     # deterministic per-card se
 from sense_count import count_source_senses           # H920/H960 deterministic top-level source-sense count
 sys.path.insert(0, SRC)
 from safe_filename import safe_name
-from execution_contract import SCHEMA_V2, config_dir_fingerprint
+from execution_contract import SCHEMA_V2, bind_output_meta, config_dir_fingerprint
 from whitney_grammar import grammar_for
 from nominal_grammar import nominal_grammar_for
 
@@ -1336,21 +1336,24 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     synthetic_keys = set(synthetic_keys or [])
     if synthetic_keys - set(keys):
         raise ValueError('synthetic keys are outside selected_keys')
+    execution = ({
+        'profile_slot': profile_slot,
+        'config_dir_fingerprint': config_dir_fingerprint(config_dir),
+        'execution_route': execution_route or 'claude-cli-headless',
+        'executor_lane': executor_lane or 'serial-whole-card',
+        'validation_method': validation_method or 'audit_window+final_schema',
+        'model_identifier': 'claude-sonnet-5',
+    } if bound else None)
+    key_provenance = ({
+        k: ('synthetic_control' if k in synthetic_keys else 'real') for k in keys
+    } if bound else None)
     execution_manifest = {
         'schema': SCHEMA_V2 if bound else 'pwg.headless_execution_manifest.v1',
         'meta': meta,
         'field': field,
         'model': 'claude-sonnet-5',
-        'execution': ({
-            'profile_slot': profile_slot,
-            'config_dir_fingerprint': config_dir_fingerprint(config_dir),
-            'execution_route': execution_route or 'claude-cli-headless',
-            'executor_lane': executor_lane or 'serial-whole-card',
-            'validation_method': validation_method or 'audit_window+final_schema',
-            'model_identifier': 'claude-sonnet-5',
-        } if bound else None),
-        'key_provenance': ({k: ('synthetic_control' if k in synthetic_keys else 'real')
-                           for k in keys} if bound else None),
+        'execution': execution,
+        'key_provenance': key_provenance,
         'prompt': {
             'preamble': MASK_PREAMBLE.replace('`russian`', '`%s`' % field),
             'grammar': single_grammar,
@@ -1387,6 +1390,11 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
             'stagger_ms': STAGGER_MS,
         },
     }
+    # The workflow output must carry the same promotion contract as its execution
+    # manifest. Otherwise audit can verify the launch while promotion cannot
+    # independently distinguish a real card from a synthetic control.
+    if bound:
+        bind_output_meta(meta, execution_manifest)
 
     js = """// AUTO-DERIVED v2 (batched + masked, canonical output) from run_pilot_wf.js - root=%(root)s.
 // Several masked cards per agent call; {Tn} restored to source markup in-JS so the

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -48,6 +48,7 @@ from autosplit_requeue import plan as split_plan     # deterministic per-card se
 from sense_count import count_source_senses           # H920/H960 deterministic top-level source-sense count
 sys.path.insert(0, SRC)
 from safe_filename import safe_name
+from execution_contract import SCHEMA_V2, config_dir_fingerprint
 from whitney_grammar import grammar_for
 from nominal_grammar import nominal_grammar_for
 
@@ -354,6 +355,8 @@ def parse_args(argv):
                                        #  no sidecar = no-op with a loud summary. --no-tm disables.
     suggest_tm = '__auto__'            # suggestion memory: advisory prompt context only
     suggest_profile = 'semantic'       # MG prior: semantic-tag/register channel first
+    profile_slot = config_dir = execution_route = executor_lane = validation_method = None
+    synthetic_keys = set()
     tm_auto = True
     budget_explicit = output_explicit = False
     for a in argv[1:]:                 # gen->copy race when several chats generate at once)
@@ -367,6 +370,18 @@ def parse_args(argv):
             out_path = a.split('=', 1)[1]
         elif a.startswith('--manifest-out='):
             manifest_path = a.split('=', 1)[1]
+        elif a.startswith('--profile-slot='):
+            profile_slot = a.split('=', 1)[1]
+        elif a.startswith('--config-dir='):
+            config_dir = a.split('=', 1)[1]
+        elif a.startswith('--execution-route='):
+            execution_route = a.split('=', 1)[1]
+        elif a.startswith('--executor-lane='):
+            executor_lane = a.split('=', 1)[1]
+        elif a.startswith('--validation-method='):
+            validation_method = a.split('=', 1)[1]
+        elif a.startswith('--synthetic-keys='):
+            synthetic_keys = {k for k in a.split('=', 1)[1].split(',') if k}
         elif a.startswith('--lang='):
             lang = a.split('=', 1)[1].strip().lower()
         elif a.startswith('--mw-tm='):
@@ -465,7 +480,9 @@ def parse_args(argv):
     if suggest_profile not in ('semantic', 'german', 'sanskrit', 'balanced'):
         die('unknown --suggest-profile %r (semantic|german|sanskrit|balanced)' % suggest_profile)
     return (root, keyfilter, keylist, budget, lean, nws_gate, nominal, grammar_on,
-            out_path, manifest_path, lang, mw_tm, tm, tm_auto, suggest_tm, suggest_profile)
+            out_path, manifest_path, lang, mw_tm, tm, tm_auto, suggest_tm, suggest_profile,
+            profile_slot, config_dir, execution_route, executor_lane, validation_method,
+            synthetic_keys)
 
 
 def extract_nws(tr):
@@ -887,7 +904,9 @@ def tm_senses_sane(senses, field):
 def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
           nominal=False, grammar_on=True, lang='ru', mw_tm_path=None, tm_path=None,
           tm_auto=False, suggest_tm_path=None, suggest_profile='semantic',
-          return_manifest=False):
+          return_manifest=False, profile_slot=None, config_dir=None,
+          execution_route=None, executor_lane=None, validation_method=None,
+          synthetic_keys=None):
     field = 'english' if lang == 'en' else 'russian'   # the per-sense translation field
     nws_block = ''
     if lang == 'en':
@@ -1311,11 +1330,27 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
           % (meta['tm_cards'], len(meta['frag_tm_cards']),
              len(meta['degenerate_passthrough_keys']), meta['agent_expected_after_tm']))
 
+    bound = bool(profile_slot or config_dir)
+    if bound and not (profile_slot and config_dir):
+        raise ValueError('manifest v2 requires both profile_slot and config_dir')
+    synthetic_keys = set(synthetic_keys or [])
+    if synthetic_keys - set(keys):
+        raise ValueError('synthetic keys are outside selected_keys')
     execution_manifest = {
-        'schema': 'pwg.headless_execution_manifest.v1',
+        'schema': SCHEMA_V2 if bound else 'pwg.headless_execution_manifest.v1',
         'meta': meta,
         'field': field,
         'model': 'claude-sonnet-5',
+        'execution': ({
+            'profile_slot': profile_slot,
+            'config_dir_fingerprint': config_dir_fingerprint(config_dir),
+            'execution_route': execution_route or 'claude-cli-headless',
+            'executor_lane': executor_lane or 'serial-whole-card',
+            'validation_method': validation_method or 'audit_window+final_schema',
+            'model_identifier': 'claude-sonnet-5',
+        } if bound else None),
+        'key_provenance': ({k: ('synthetic_control' if k in synthetic_keys else 'real')
+                           for k in keys} if bound else None),
         'prompt': {
             'preamble': MASK_PREAMBLE.replace('`russian`', '`%s`' % field),
             'grammar': single_grammar,
@@ -2202,7 +2237,8 @@ def main():
         return
     (root, keyfilter, keylist, budget, lean, nws_gate, nominal, grammar_on,
      out_path, manifest_path, lang, mw_tm, tm, tm_auto, suggest_tm,
-     suggest_profile) = parse_args(sys.argv[1:])
+     suggest_profile, profile_slot, config_dir, execution_route, executor_lane,
+     validation_method, synthetic_keys) = parse_args(sys.argv[1:])
     if nominal:
         # No rootmap: the headword keys ARE the cards, in the order given.
         if not keylist:
@@ -2214,7 +2250,11 @@ def main():
             keys = [k for k in keylist if k in set(keys)]
     js, batches, manifest = build(root, keys, rootmap, budget, lean, nws_gate,
                                   nominal, grammar_on, lang, mw_tm, tm, tm_auto,
-                                  suggest_tm, suggest_profile, return_manifest=True)
+                                  suggest_tm, suggest_profile, return_manifest=True,
+                                  profile_slot=profile_slot, config_dir=config_dir,
+                                  execution_route=execution_route, executor_lane=executor_lane,
+                                  validation_method=validation_method,
+                                  synthetic_keys=synthetic_keys)
     out = os.path.abspath(out_path) if out_path else os.path.join(REPO, 'src', 'pilot', 'run_pilot_wf.opt2.js')
     # Write LF (not CRLF): the Workflow-tool approval rejects scripts containing
     # raw \r control chars, so a CRLF harness cannot be launched on Windows.

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -1333,6 +1333,8 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
     bound = bool(profile_slot or config_dir)
     if bound and not (profile_slot and config_dir):
         raise ValueError('manifest v2 requires both profile_slot and config_dir')
+    if bound and (execution_route or 'claude-cli-headless') != 'claude-cli-headless':
+        raise ValueError('profile-bound manifest v2 production is CLI/headless-only')
     synthetic_keys = set(synthetic_keys or [])
     if synthetic_keys - set(keys):
         raise ValueError('synthetic keys are outside selected_keys')
@@ -2067,6 +2069,12 @@ async function boundedParallel(thunks, width, staggerMs) {
   }
   await Promise.all(workers)
   return results
+}
+// A Workflow session cannot prove which CLAUDE_CONFIG_DIR it billed or participate in
+// the host-wide active-call lock. A profile-bound v2 artifact is therefore executable
+// only through headless_worker.py; abort here before the first paid agent() call.
+if (META.execution_manifest_schema === 'pwg.headless_execution_manifest.v2') {
+  throw new Error('manifest-v2 production is CLI/headless-only; run the execution manifest')
 }
 // UNITS pairs each parallel slot with the exact keys it owes rows for, so the accounting
 // backfill below stays index-correct with the presplit lane appended after the batches.

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -22,6 +22,7 @@ if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 from proc_tree import run_tree_kill, terminate_tree, windows_hidden_flags  # noqa: E402  (shared D-J tree-kill runner)
 import card_fields  # noqa: E402  (C-01: the one restore/promote field set, shared with the JS lane)
+from execution_contract import ActiveCallClaim, SCHEMA_V1, SCHEMA_V2, validate_manifest, validate_profile  # noqa: E402
 
 AUTH_RE = re.compile(r'401|authentication|not logged in|invalid.*credential', re.I)
 RATE_RE = re.compile(r'429|rate.?limit|usage limit|too many requests', re.I)
@@ -44,18 +45,24 @@ def claude_argv_prefix(claude_bin):
     ``[node, <cli entry>.cjs]`` and invoke that directly, bypassing cmd.exe. A native
     executable, or any POSIX launcher, is returned unchanged.
     """
+    resolved = claude_bin
+    if not os.path.dirname(claude_bin):
+        resolved = shutil.which(claude_bin)
+        if not resolved:
+            raise FileNotFoundError('Claude CLI %r is not resolvable on PATH' % claude_bin)
     if os.name != 'nt':
-        return [claude_bin]
-    if os.path.splitext(claude_bin)[1].lower() in ('.exe', '.com'):
-        return [claude_bin]
+        return [resolved]
+    if os.path.splitext(resolved)[1].lower() in ('.exe', '.com'):
+        return [resolved]
     node = shutil.which('node')
-    shim_dir = os.path.dirname(os.path.abspath(claude_bin)) or '.'
+    shim_dir = os.path.dirname(os.path.abspath(resolved)) or '.'
     base = os.path.join(shim_dir, 'node_modules', '@anthropic-ai', 'claude-code')
     entries = sorted(glob.glob(os.path.join(base, 'cli*.cjs')) +
                      glob.glob(os.path.join(base, 'cli*.js')))
     if node and entries:
         return [node, entries[0]]
-    return [claude_bin]
+    raise FileNotFoundError('refusing unresolved Windows Claude shim %r; Node CLI entry missing'
+                            % resolved)
 
 
 class HardFailure(Exception):
@@ -552,8 +559,7 @@ class HeadlessEngine:
 
 
 def execute(manifest, claude='claude', timeout=7200, runner=None):
-    if manifest.get('schema') != 'pwg.headless_execution_manifest.v1':
-        raise ValueError('unsupported manifest schema')
+    validate_manifest(manifest, require_v2=False)
     engine = HeadlessEngine(manifest, claude, timeout, runner)
     try:
         results, healed, presplit = engine.run_all()
@@ -582,7 +588,11 @@ def execute(manifest, claude='claude', timeout=7200, runner=None):
                'heal_agents_spent': engine.heal_calls,
                'kill_timeouts': engine.kill_timeouts, 'conn_errors': engine.conn_errors,
                'headless_attempts': engine.attempts}
-    payload = {'meta': manifest['meta'], 'summary': summary, 'results': results}
+    output_meta = dict(manifest['meta'])
+    output_meta['execution_manifest_schema'] = manifest.get('schema')
+    output_meta['execution'] = manifest.get('execution')
+    output_meta['provenance_classes'] = manifest.get('key_provenance')
+    payload = {'meta': output_meta, 'summary': summary, 'results': results}
     status = {'classification': 'completed_with_residuals' if failures else 'success',
               'attempts': engine.attempts, 'null_keys': list(failures)}
     return payload, status, 0
@@ -594,14 +604,27 @@ def main(argv=None):
     ap.add_argument('--output', required=True)
     ap.add_argument('--status-out', required=True)
     ap.add_argument('--claude-bin', default='claude')
+    ap.add_argument('--only-profile', help='required profile-slot assertion for live v2 execution')
+    ap.add_argument('--allow-historical-v1', action='store_true',
+                    help='read-only/historical replay only; v1 is not a production contract')
     ap.add_argument('--timeout', type=int, default=7200)
     args = ap.parse_args(argv)
     manifest_hash = sha256_path(args.manifest)
     with open(args.manifest, encoding='utf-8') as f:
         manifest = json.load(f)
     try:
-        payload, status, code = execute(manifest, args.claude_bin, args.timeout)
-    except (OSError, ValueError) as exc:
+        if manifest.get('schema') == SCHEMA_V1:
+            if not args.allow_historical_v1:
+                raise ValueError('v1 manifest is historical-only; production requires %s' % SCHEMA_V2)
+            payload, status, code = execute(manifest, args.claude_bin, args.timeout)
+        else:
+            config_dir = os.environ.get('CLAUDE_CONFIG_DIR')
+            if not config_dir:
+                raise ValueError('CLAUDE_CONFIG_DIR is required for manifest v2')
+            validate_profile(manifest, config_dir, args.only_profile)
+            with ActiveCallClaim(manifest['execution']['config_dir_fingerprint']):
+                payload, status, code = execute(manifest, args.claude_bin, args.timeout)
+    except (OSError, RuntimeError, ValueError) as exc:
         payload, status, code = None, {'classification': 'configuration', 'error': str(exc)}, 2
     status['manifest_sha256'] = manifest_hash
     if payload is not None:

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -185,15 +185,17 @@ console.log(JSON.stringify(restoreCard(card, 'agni')))
         h.os.name = 'posix'
         assert h.claude_argv_prefix('/usr/bin/claude') == ['/usr/bin/claude']
         h.os.name = 'nt'
-        assert h.claude_argv_prefix(r'C:\p\claude.exe') == [r'C:\p\claude.exe']
-        h.shutil.which = lambda _n: r'C:\node.exe'
-        h.glob.glob = lambda pat: ([r'C:\p\node_modules\@anthropic-ai\claude-code\cli-wrapper.cjs']
+        # Forward slashes are accepted by Windows and keep this simulated-nt branch
+        # meaningful when the selftest itself runs with POSIX os.path semantics in CI.
+        assert h.claude_argv_prefix('/p/claude.exe') == ['/p/claude.exe']
+        h.shutil.which = lambda _n: '/node.exe'
+        h.glob.glob = lambda pat: (['/p/node_modules/@anthropic-ai/claude-code/cli-wrapper.cjs']
                                    if 'cli*.cjs' in pat else [])
-        assert h.claude_argv_prefix(r'C:\p\claude.cmd') == [
-            r'C:\node.exe', r'C:\p\node_modules\@anthropic-ai\claude-code\cli-wrapper.cjs']
+        assert h.claude_argv_prefix('/p/claude.cmd') == [
+            '/node.exe', '/p/node_modules/@anthropic-ai/claude-code/cli-wrapper.cjs']
         h.shutil.which = lambda _n: None
         try:
-            h.claude_argv_prefix(r'C:\p\claude.cmd')
+            h.claude_argv_prefix('/p/claude.cmd')
         except FileNotFoundError:
             pass
         else:

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -186,11 +186,16 @@ console.log(JSON.stringify(restoreCard(card, 'agni')))
                                    if 'cli*.cjs' in pat else [])
         assert h.claude_argv_prefix(r'C:\p\claude.cmd') == [
             r'C:\node.exe', r'C:\p\node_modules\@anthropic-ai\claude-code\cli-wrapper.cjs']
-        h.shutil.which = lambda _n: None                    # no node -> fall back to the shim
-        assert h.claude_argv_prefix(r'C:\p\claude.cmd') == [r'C:\p\claude.cmd']
+        h.shutil.which = lambda _n: None
+        try:
+            h.claude_argv_prefix(r'C:\p\claude.cmd')
+        except FileNotFoundError:
+            pass
+        else:
+            raise AssertionError('unresolved .cmd shim must fail closed')
     finally:
         h.os.name, h.shutil.which, h.glob.glob = _name, _which, _glob
-    print('  D-A claude_argv_prefix: posix/.exe passthrough, .cmd->node-direct, no-node fallback OK')
+    print('  D-A claude_argv_prefix: posix/.exe passthrough, .cmd->node-direct, unresolved shim refused')
 
     # D-J: a timeout must terminate the ENTIRE process tree, not just the immediate child. The
     # Windows claude launcher (node cli-wrapper.cjs) spawnSync's the native binary as a CHILD, so

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -39,6 +39,11 @@ def proc(returncode=0, stdout='', stderr=''):
     return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
 
 
+def execute(test_manifest, runner):
+    """Use a real, portable executable path while the runner fakes its output."""
+    return h.execute(test_manifest, claude=sys.executable, runner=runner)
+
+
 def success_runner(argv, **kwargs):
     assert '--json-schema' in argv and '--model' in argv
     card = {'key1': 'agni', 'records': [{'grammar': '{T1} m.', 'senses': [
@@ -48,7 +53,7 @@ def success_runner(argv, **kwargs):
 
 
 def main():
-    payload, status, code = h.execute(manifest(), runner=success_runner)
+    payload, status, code = execute(manifest(), success_runner)
     assert code == 0 and status['classification'] == 'success'
     assert payload['results'][0]['card']['records'][0]['senses'][0]['german'].startswith('<ls>')
     assert payload['results'][0]['card']['records'][0]['grammar'].startswith('<ls>')
@@ -56,25 +61,25 @@ def main():
 
     def auth_runner(argv, **kwargs):
         return proc(1, stderr='API Error: 401 Invalid authentication credentials')
-    assert h.execute(manifest(), runner=auth_runner)[2] == h.EXIT_AUTH
+    assert execute(manifest(), auth_runner)[2] == h.EXIT_AUTH
 
     def rate_runner(argv, **kwargs):
         return proc(1, stderr='429 rate limit reset_at=1999999999')
-    assert h.execute(manifest(), runner=rate_runner)[2] == h.EXIT_RATE_LIMIT
+    assert execute(manifest(), rate_runner)[2] == h.EXIT_RATE_LIMIT
 
     def malformed_runner(argv, **kwargs):
         return proc(stdout='not json')
-    payload, status, code = h.execute(manifest(), runner=malformed_runner)
+    payload, status, code = execute(manifest(), malformed_runner)
     assert code == 0 and status['classification'] == 'completed_with_residuals'
 
     def missing_runner(argv, **kwargs):
         return proc(stdout=json.dumps({'structured_output': {'cards': []}}))
-    payload, status, code = h.execute(manifest(), runner=missing_runner)
+    payload, status, code = execute(manifest(), missing_runner)
     assert code == 0 and payload['summary']['null_keys'] == ['agni']
 
     def timeout_runner(argv, **kwargs):
         raise subprocess.TimeoutExpired(argv, 1)
-    payload, status, code = h.execute(manifest(), runner=timeout_runner)
+    payload, status, code = execute(manifest(), timeout_runner)
     assert code == 0 and payload['summary']['kill_timeouts'] == 1
 
     presplit = manifest()
@@ -99,7 +104,7 @@ def main():
                     'russian': '{T1}'}]}]})
         return proc(stdout=json.dumps({'structured_output': {'cards': cards}}))
 
-    payload, status, code = h.execute(presplit, runner=fragment_runner)
+    payload, status, code = execute(presplit, fragment_runner)
     assert code == 0 and status['classification'] == 'success'
     card = payload['results'][0]['card']
     assert payload['summary']['presplit'] == 1 and payload['summary']['healed'] == 1
@@ -111,13 +116,13 @@ def main():
         card = {'key1': 'agni_f0', 'records': [{'senses': [
             {'tag': '1', 'german': '{T1}', 'russian': '{T1}'}]}]}
         return proc(stdout=json.dumps({'structured_output': {'cards': [card]}}))
-    payload, _status, code = h.execute(presplit, runner=partial_runner)
+    payload, _status, code = execute(presplit, partial_runner)
     assert code == 0 and payload['results'][0]['card']['partial']
     assert payload['results'][0]['card']['missing_fragments']
 
     def fragment_timeout(argv, **kwargs):
         raise subprocess.TimeoutExpired(argv, 1)
-    payload, _status, code = h.execute(presplit, runner=fragment_timeout)
+    payload, _status, code = execute(presplit, fragment_timeout)
     assert code == 0 and payload['summary']['null'] == 1
     assert payload['summary']['heal_agents_spent'] == 1  # timeout-no-bisect
 

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -139,11 +139,29 @@ def main():
             js, batches, built = generator.build(
                 'fixture', ['agni'], None, 12000, nominal=True, grammar_on=False,
                 tm_path=None, suggest_tm_path=None, return_manifest=True)
+            js_v2, _batches_v2, built_v2 = generator.build(
+                'fixture', ['agni'], None, 12000, nominal=True, grammar_on=False,
+                tm_path=None, suggest_tm_path=None, return_manifest=True,
+                profile_slot='c4', config_dir=td,
+                execution_route='claude-cli-headless')
+            try:
+                generator.build(
+                    'fixture', ['agni'], None, 12000, nominal=True, grammar_on=False,
+                    tm_path=None, suggest_tm_path=None, return_manifest=True,
+                    profile_slot='c4', config_dir=td,
+                    execution_route='claude-workflow')
+            except ValueError:
+                pass
+            else:
+                raise AssertionError('profile-bound Workflow route was admitted')
         finally:
             generator.input_paths = original
         assert built['schema'] == 'pwg.headless_execution_manifest.v1'
         assert built['batches'] == batches and built['model'] == 'claude-sonnet-5'
         assert json.dumps(built['inputs'], ensure_ascii=True) in js
+        assert built_v2['schema'] == 'pwg.headless_execution_manifest.v2'
+        assert built_v2['meta']['execution_manifest_schema'] == built_v2['schema']
+        assert "manifest-v2 production is CLI/headless-only" in js_v2
         start = js.index('function restoreCard(card, k)')
         end = js.index('// Per-card grammar', start)
         restore_card_js = js[start:end]

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -20,6 +20,7 @@ import time
 from run_observability import append_event, write_census
 from headless_worker import claude_argv_prefix, run_tree_kill, windows_hidden_flags
 from window_common import atomic_write_text
+from execution_contract import validate_manifest, validate_profile
 
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
@@ -256,10 +257,15 @@ def run_claimed(db_path, account, config_dir, job, timeout, events_path=None, ru
         if sha256_path(job['manifest_path']) != job['manifest_sha256']:
             return fail_or_retry(db_path, job['id'], 2, 'manifest hash changed',
                                  'manifest_drift', attempt_log)
+        manifest = json.load(open(job['manifest_path'], encoding='utf-8'))
+        try:
+            validate_profile(manifest, config_dir, account)
+        except ValueError as exc:
+            return fail_or_retry(db_path, job['id'], 2, str(exc), 'configuration', attempt_log)
         argv = [sys.executable, os.path.join(os.path.dirname(__file__), 'headless_worker.py'),
                 job['manifest_path'], '--output', job['output_path'],
                 '--status-out', status_path, '--timeout', str(timeout),
-                '--claude-bin', claude_bin]
+                '--claude-bin', claude_bin, '--only-profile', account]
     else:
         argv = json.loads(job['argv_json'])
     env = os.environ.copy()
@@ -393,6 +399,10 @@ def cmd_import_coordinator(args):
             if not manifest_path or not os.path.exists(manifest_path):
                 raise SystemExit('%s: execution manifest missing' % lease.get('id'))
             manifest = json.load(open(manifest_path, encoding='utf-8'))
+            try:
+                validate_manifest(manifest, require_v2=True)
+            except ValueError as exc:
+                raise SystemExit('%s: %s' % (lease['id'], exc))
             if manifest['meta'].get('lang') != 'ru':
                 raise SystemExit('%s: H818 production default is RU only' % lease['id'])
             keys = set(manifest['meta']['selected_keys'])
@@ -456,6 +466,9 @@ def cmd_run_once(args):
     # bypassing the mandatory pre-dispatch probe (the cap/drop would apply only to the probe set).
     # Default (attribute absent / None) is unrestricted, so a standalone `run-once` is unchanged.
     only = getattr(args, 'only_accounts', None)
+    if getattr(args, 'only_profile', None):
+        requested = {args.only_profile}
+        only = requested if only is None else set(only) & requested
     if only is not None:
         accounts = [a for a in accounts if a['name'] in only]
     work = []
@@ -489,6 +502,8 @@ def cmd_status(args):
 EXACT_GEN_MODEL = 'claude-sonnet-5'      # D-F: exact generation model under test
 PROBE_MIN_PAYLOAD_BYTES = 5000           # D-F: repository >=5 KB load-representative floor
 PROBE_LATENCY_CEILING_MS = 30000         # D-F: health ceiling; a reading over this is NO-GO
+PROBE_POLICY = 'production_v1'
+PROBE_LANE = 'claude-cli-headless/readiness-schema'
 # GAP #5 (four-profile): an account dropped by --drop-unhealthy is parked far in the future so the
 # dispatch loop's runnable/claim gates exclude it while the fleet proceeds on the healthy subset.
 # Only the explicit opt-in ever parks this way; the default STOP-on-any-NO-GO path never drops.
@@ -610,7 +625,9 @@ def live_probe(config_dir, claude='claude', payload_bytes=6491, model=EXACT_GEN_
         if events_path:
             append_event(events_path, run_id=run_id, account=account, stage='probe',
                          event='probe_call', purpose=purpose, elapsed_ms=latency,
-                         model=model, output_bytes=obytes, classification=cls)
+                         model=model, output_bytes=obytes, classification=cls,
+                         policy=PROBE_POLICY, executor_lane=PROBE_LANE,
+                         schema_valid=(cls == 'success'))
 
     warm_ms, warm_cls, warm_bytes = _probe_call(config_dir, claude, payload_bytes, model)
     _emit('warmup', warm_ms, warm_cls, warm_bytes)     # excluded from the acceptance latency census
@@ -621,8 +638,8 @@ def live_probe(config_dir, claude='claude', payload_bytes=6491, model=EXACT_GEN_
     _emit('measured', meas_ms, meas_cls, meas_bytes)   # the one gated acceptance reading
     if meas_cls != 'success':
         raise SystemExit('measured probe %s -> honest NO-GO (no retry, no re-warm)' % meas_cls)
-    if meas_ms > latency_ceiling_ms:
-        raise SystemExit('measured probe latency %d ms exceeds %d ms health ceiling — honest NO-GO '
+    if meas_ms >= latency_ceiling_ms:
+        raise SystemExit('measured probe latency %d ms is not below %d ms health ceiling — honest NO-GO '
                          '(warm-up already done; no re-roll)' % (meas_ms, latency_ceiling_ms))
     return meas_ms
 
@@ -692,6 +709,10 @@ def cmd_staged_run(args):
     db = connect(args.db)
     accounts = list(db.execute('SELECT * FROM accounts WHERE validated=1 ORDER BY name'))
     db.close()
+    if getattr(args, 'only_profile', None):
+        accounts = [account for account in accounts if account['name'] == args.only_profile]
+        if not accounts:
+            raise SystemExit('--only-profile is not a validated roster slot')
     # GAP #5 (four-profile): the staged run now fans across N validated profiles instead of hard-
     # capping at one. Require >=1 (a zero-account run has nothing to probe or dispatch); --max-
     # accounts optionally caps the fleet. N==1 remains the exact single-profile Windows-100 path.
@@ -758,6 +779,7 @@ def cmd_staged_run(args):
                                             # dispatch ONLY to the probed, capped/healthy fleet —
                                             # never to a capped-out or dropped (unprobed) account.
                                             only_accounts=set(probe_latencies),
+                                            only_profile=getattr(args, 'only_profile', None),
                                             only_external_ids=lease_scope))
         cmd_record_done(argparse.Namespace(db=args.db, coordinator=args.coordinator,
                                            cwd=args.cwd, only_external_ids=lease_scope))
@@ -914,7 +936,7 @@ def main(argv=None):
     p = sub.add_parser('import-coordinator'); p.add_argument('--coord-dir', required=True); p.add_argument('--cwd', required=True); p.add_argument('--lease-id', action='append'); p.add_argument('--max-attempts', type=int, default=3); p.set_defaults(func=cmd_import_coordinator)
     p = sub.add_parser('recover'); p.set_defaults(func=cmd_recover)
     p = sub.add_parser('record-done'); p.add_argument('--coordinator', required=True); p.add_argument('--cwd', required=True); p.set_defaults(func=cmd_record_done)
-    p = sub.add_parser('run-once'); p.add_argument('--timeout', type=int, default=7200); p.add_argument('--claude-bin', default='claude'); p.set_defaults(func=cmd_run_once)
+    p = sub.add_parser('run-once'); p.add_argument('--timeout', type=int, default=7200); p.add_argument('--claude-bin', default='claude'); p.add_argument('--only-profile'); p.set_defaults(func=cmd_run_once)
     p = sub.add_parser('status'); p.set_defaults(func=cmd_status)
     p = sub.add_parser('staged-run')
     p.add_argument('--coord-dir', required=True); p.add_argument('--cwd', required=True)
@@ -923,6 +945,7 @@ def main(argv=None):
     p.add_argument('--claude-bin', default='claude'); p.add_argument('--timeout', type=int, default=7200)
     p.add_argument('--stop-after', type=int, default=0); p.add_argument('--resume', action='store_true')
     p.add_argument('--max-accounts', type=int, default=0)          # GAP #5: cap the validated fleet
+    p.add_argument('--only-profile', help='enforce one logical profile slot and its bound directory')
     p.add_argument('--drop-unhealthy', action='store_true')        # GAP #5: proceed on healthy subset
     p.add_argument('--report', required=True)
     p.add_argument('--events', required=True); p.add_argument('--census', required=True)

--- a/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
@@ -14,6 +14,7 @@ sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
 import max_account_orchestrator as m
+from execution_contract import config_dir_fingerprint
 
 
 def main():
@@ -133,8 +134,17 @@ def main():
         os.makedirs(artifacts)
         manifest = os.path.join(artifacts, 'manifest.json')
         with open(manifest, 'w', encoding='utf-8') as f:
-            json.dump({'schema': 'pwg.headless_execution_manifest.v1',
-                       'meta': {'lang': 'ru', 'selected_keys': ['unique']}}, f)
+            json.dump({'schema': 'pwg.headless_execution_manifest.v2',
+                       'model': 'claude-sonnet-5',
+                       'meta': {'lang': 'ru', 'selected_keys': ['unique']},
+                       'execution': {'profile_slot': 'acc1',
+                                     'config_dir_fingerprint': config_dir_fingerprint(
+                                         os.path.join(td, 'a1')),
+                                     'execution_route': 'claude-cli-headless',
+                                     'executor_lane': 'serial-whole-card',
+                                     'validation_method': 'audit_window+final_schema',
+                                     'model_identifier': 'claude-sonnet-5'},
+                       'key_provenance': {'unique': 'real'}}, f)
         with open(os.path.join(coord, 'state.json'), 'w', encoding='utf-8') as f:
             json.dump({'leases': [{'id': 'lease1', 'state': 'prepared',
                                    'artifact_dir': artifacts,
@@ -157,8 +167,8 @@ def main():
     print('  D-C is_rate_limited: hash-429 ignored; worker-class / real-429 detected')
 
     # D-F/D-K: the two-phase probe protocol. payload<5KB / non-exact model raise before any call.
-    # Then EXACTLY one warm-up call (latency excluded) + one measured call (gated): 30000 passes,
-    # 30001 is an honest NO-GO, and a warm-up failure STOPs before the measured call ever starts.
+    # Then EXACTLY one warm-up call (latency excluded) + one measured call (gated): policy is
+    # strictly below 30000; 30000 is an honest NO-GO.
     try:
         m.live_probe('cfg', payload_bytes=100); assert False, 'payload floor not enforced'
     except SystemExit as e:
@@ -180,22 +190,22 @@ def main():
                 return v
             return _mock
 
-        # warm-up 99999 ms (EXCLUDED) + measured exactly 30000 ms -> PASS (ceiling inclusive)
-        seen.clear(); m._probe_call = fake([(99999, 'success', 120), (30000, 'success', 120)])
+        # warm-up 99999 ms (EXCLUDED) + measured 29999 ms -> PASS
+        seen.clear(); m._probe_call = fake([(99999, 'success', 120), (29999, 'success', 120)])
         with tempfile.TemporaryDirectory() as td:
             ev = os.path.join(td, 'e.jsonl')
-            assert m.live_probe('cfg', events_path=ev, run_id='r', account='a') == 30000
+            assert m.live_probe('cfg', events_path=ev, run_id='r', account='a') == 29999
             rows = ro.read_events(ev)
             assert len([r for r in rows if r.get('purpose') == 'warmup']) == 1
             assert len([r for r in rows if r.get('purpose') == 'measured']) == 1
             assert len(seen) == 2                       # exactly one warm-up + one measured
             cen = ro.build_census(rows)
-            assert cen['latency_ms']['max'] == 30000    # the 99999 warm-up is NOT in the latency census
+            assert cen['latency_ms']['max'] == 29999    # the 99999 warm-up is NOT in the latency census
             assert len(cen['probe']['warmup']) == 1 and len(cen['probe']['measured']) == 1
-        # measured 30001 -> honest NO-GO (no retry)
-        seen.clear(); m._probe_call = fake([(9000, 'success', 120), (30001, 'success', 120)])
+        # measured 30000 -> honest NO-GO (no retry)
+        seen.clear(); m._probe_call = fake([(9000, 'success', 120), (30000, 'success', 120)])
         try:
-            m.live_probe('cfg'); assert False, '30001 ms measured must NO-GO'
+            m.live_probe('cfg'); assert False, '30000 ms measured must NO-GO'
         except SystemExit as e:
             assert 'health ceiling' in str(e)
         assert len(seen) == 2
@@ -215,7 +225,7 @@ def main():
         assert len(seen) == 2
     finally:
         m._probe_call = _pc
-    print('  D-F/D-K probe protocol: 1 warm-up (excluded) + 1 measured; 30000 pass / 30001 NO-GO; warm-up fail STOPs before measured')
+    print('  D-F/D-K probe protocol: 1 warm-up (excluded) + 1 measured; 29999 pass / 30000 NO-GO; warm-up fail STOPs before measured')
 
     # D-K _probe_call: rc 0 is NOT enough. The Claude CLI result envelope must indicate success
     # (type=result, subtype=success, not is_error) AND carry the structured schema result

--- a/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
@@ -238,13 +238,13 @@ def main():
 
     def _cls(stdout='', rc=0, stderr=''):
         _out(stdout, rc, stderr)
-        return m._probe_call('cfg', 'claude', 6491, m.EXACT_GEN_MODEL)[1]
+        return m._probe_call('cfg', sys.executable, 6491, m.EXACT_GEN_MODEL)[1]
 
     try:
         # (1) observed successful result-STRING wrapper (result is a JSON string) + Cyrillic body
         w1 = '{"type":"result","subtype":"success","is_error":false,"result":"{\\"ok\\":true}","usage":{"n":"да"}}'
         _out(w1)
-        lat, cls, ob = m._probe_call('cfg', 'claude', 6491, m.EXACT_GEN_MODEL)
+        lat, cls, ob = m._probe_call('cfg', sys.executable, 6491, m.EXACT_GEN_MODEL)
         assert cls == 'success', cls
         assert ob == len(w1.encode('utf-8')) and ob > len(w1)     # encoded bytes, not char count
         # (2) successful structured_output wrapper
@@ -285,7 +285,7 @@ def main():
 
     try:
         m.run_tree_kill = _capture
-        _lat, _cls2, _ob = m._probe_call('cfg', 'claude', 6491, m.EXACT_GEN_MODEL)
+        _lat, _cls2, _ob = m._probe_call('cfg', sys.executable, 6491, m.EXACT_GEN_MODEL)
         assert _cls2 == 'success', _cls2
         p = cap['input']
         # one clear, completable instruction: return exactly the schema object and nothing else

--- a/RussianTranslation/src/pilot/probe_log.py
+++ b/RussianTranslation/src/pilot/probe_log.py
@@ -46,6 +46,11 @@ PAYLOAD_FLOOR_BYTES = 5 * 1024
 
 KINDS = ('warmup', 'launch', 'abort')
 VERDICTS = ('GO', 'NO-GO')
+POLICIES = {
+    'production_v1': {'latency_ceil_ms': 30_000, 'conn_error_ceil': 0,
+                      'payload_floor_bytes': PAYLOAD_FLOOR_BYTES,
+                      'require_schema_valid': True},
+}
 
 
 def _now():
@@ -69,32 +74,40 @@ def _append(row):
         fh.write(json.dumps(row, ensure_ascii=False) + '\n')
 
 
-def verdict_for(latency_ms, conn_errors, payload_bytes=None, kind=None):
+def verdict_for(latency_ms, conn_errors, payload_bytes=None, kind=None,
+                policy='production_v1', schema_valid=None):
     """The mechanical gate. Returns (verdict, reason)."""
-    if conn_errors is not None and conn_errors > CONN_ERR_CEIL:
-        return 'NO-GO', f'{conn_errors} connection error(s) > {CONN_ERR_CEIL}'
-    if latency_ms is not None and latency_ms > LATENCY_CEIL_MS:
-        return 'NO-GO', f'latency {latency_ms}ms > {LATENCY_CEIL_MS}ms'
+    if policy not in POLICIES:
+        raise ValueError('unknown probe policy %r' % policy)
+    spec = POLICIES[policy]
+    if conn_errors is not None and conn_errors > spec['conn_error_ceil']:
+        return 'NO-GO', f'{conn_errors} connection error(s) > {spec["conn_error_ceil"]}'
+    if latency_ms is None or latency_ms >= spec['latency_ceil_ms']:
+        return 'NO-GO', f'latency {latency_ms}ms is not < {spec["latency_ceil_ms"]}ms'
     # H462: only a load-representative warm-up may authorize a launch. A missing
     # payload size is treated as trivial — the burden of proof is on the probe.
-    if kind == 'warmup' and (payload_bytes is None or payload_bytes < PAYLOAD_FLOOR_BYTES):
+    if kind == 'warmup' and (payload_bytes is None or payload_bytes < spec['payload_floor_bytes']):
         return 'NO-GO', (f'probe not load-representative: payload '
-                         f'{payload_bytes or 0}B < {PAYLOAD_FLOOR_BYTES}B '
+                         f'{payload_bytes or 0}B < {spec["payload_floor_bytes"]}B '
                          f'(use `probe_log.py prompt`)')
-    return 'GO', 'within ceilings, load-representative' if kind == 'warmup' else 'within ceilings'
+    if kind == 'warmup' and spec['require_schema_valid'] and schema_valid is not True:
+        return 'NO-GO', 'representative schema payload did not validate'
+    return 'GO', '%s: within ceilings, load-representative schema payload' % policy
 
 
 def cmd_append(a):
-    auto, reason = verdict_for(a.latency_ms, a.conn_errors, a.payload_bytes, a.kind)
+    auto, reason = verdict_for(a.latency_ms, a.conn_errors, a.payload_bytes, a.kind,
+                               a.policy, a.schema_valid)
     verdict = a.verdict or auto
-    if a.verdict and a.verdict != auto and a.kind == 'warmup':
-        print(f'WARN: stated verdict {a.verdict} disagrees with mechanical {auto} ({reason})',
-              file=sys.stderr)
+    if a.verdict and a.verdict != auto:
+        raise SystemExit('REFUSED: stated verdict %s contradicts mechanical %s (%s)'
+                         % (a.verdict, auto, reason))
     row = {
         'ts': a.ts or _now(),
         'kind': a.kind,
         'verdict': verdict,
         'gate_reason': reason,
+        'policy': a.policy,
         'lane': a.lane,
         'window': a.window,
         'handoff': a.handoff,
@@ -104,6 +117,7 @@ def cmd_append(a):
             'conn_errors': a.conn_errors,
             'payload_bytes': a.payload_bytes,
             'agent_model': a.agent_model,
+            'schema_valid': a.schema_valid,
         },
         'orchestrator': a.orchestrator,
         # Comparability provenance: a TM sidecar that grew between runs silently
@@ -280,6 +294,9 @@ def main():
                         'this flag) is NO-GO — see `probe_log.py prompt` (H462)'
                         % PAYLOAD_FLOOR_BYTES)
     p.add_argument('--agent-model', default='claude-sonnet-5')
+    p.add_argument('--policy', choices=sorted(POLICIES), default='production_v1')
+    p.add_argument('--schema-valid', action='store_true', default=None,
+                   help='measured response passed the representative output schema')
     p.add_argument('--lane', default='nominal medium50 (band-4 singleton)')
     p.add_argument('--window')
     p.add_argument('--handoff')

--- a/RussianTranslation/src/pilot/requeue_from_audit.py
+++ b/RussianTranslation/src/pilot/requeue_from_audit.py
@@ -131,6 +131,9 @@ def main():
                     help='resolve keys directly as nominal cards instead of requiring a rootmap')
     ap.add_argument('--no-grammar', action='store_true',
                     help='pass --no-grammar through for nominal requeues')
+    ap.add_argument('--profile-slot')
+    ap.add_argument('--config-dir')
+    ap.add_argument('--executor-lane', default='serial-whole-card')
     args = ap.parse_args()
     which = 'transient' if args.transient else 'defect' if args.defect else 'all'
     lang = args.lang
@@ -172,6 +175,14 @@ def main():
         cmd.append('--out=%s' % args.out)
     if args.manifest_out:
         cmd.append('--manifest-out=%s' % args.manifest_out)
+    if bool(args.profile_slot) != bool(args.config_dir):
+        sys.exit('--profile-slot and --config-dir must be supplied together')
+    if args.profile_slot:
+        cmd += ['--profile-slot=%s' % args.profile_slot,
+                '--config-dir=%s' % args.config_dir,
+                '--execution-route=claude-cli-headless',
+                '--executor-lane=%s' % args.executor_lane,
+                '--validation-method=audit_window+final_schema']
     if args.nominal:
         cmd.append('--nominal')
     if args.no_grammar:

--- a/RussianTranslation/src/pilot/run_observability.py
+++ b/RussianTranslation/src/pilot/run_observability.py
@@ -22,6 +22,8 @@ ALLOWED = {
     # D-K: the two-phase probe records each call separately with its purpose (warmup / measured),
     # model, and output_bytes. The warm-up latency is EXCLUDED from the acceptance census.
     'purpose', 'output_bytes', 'model',
+    # H1080 launch-control follow-up: typed probe policy/lane and measured schema verdict.
+    'policy', 'executor_lane', 'schema_valid',
 }
 
 # per-key relation events: kept for key<->call provenance / repeated-failure tracking, but

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -189,6 +189,14 @@ def validate_promotion_entry(subkey, entry):
     """Second-line promotion validation, independent of audit/coordinator state."""
     card = entry.get('card') or {}
     meta = entry.get('meta') or {}
+    if meta.get('execution_manifest_schema') != 'pwg.headless_execution_manifest.v2':
+        raise PromotionContractError(
+            '%s: v1/unbound workflow output is historical-only and cannot be promoted' % subkey)
+    execution = meta.get('execution') or {}
+    for name in ('profile_slot', 'config_dir_fingerprint', 'execution_route',
+                 'executor_lane', 'validation_method', 'model_identifier'):
+        if not isinstance(execution.get(name), str) or not execution[name].strip():
+            raise PromotionContractError('%s: missing manifest-v2 execution.%s' % (subkey, name))
     try:
         validate_final_card_schema.validate_card(card)
     except ValueError as exc:
@@ -215,7 +223,7 @@ def validate_promotion_entry(subkey, entry):
     provenance_class = classes.get(subkey) if isinstance(classes, dict) else meta.get('provenance_class')
     if provenance_class == 'synthetic_control' or SYNTHETIC_KEY_RE.search(subkey):
         raise PromotionContractError('%s: synthetic controls are never promotable' % subkey)
-    if provenance_class not in (None, 'real'):
+    if provenance_class != 'real':
         raise PromotionContractError('%s: unknown provenance_class %r'
                                      % (subkey, provenance_class))
 
@@ -345,6 +353,13 @@ def selftest():
     meta = {'root': 'pA', 'safe_root': 'p_a', 'generator': 'gen_opt_harness2.batched-masked',
             'schema_version': 'v1', 'rootmap_sha256': 'abc', 'generated_at': '2026-06-29T00:00:00Z',
             'selected_keys': ['p_a~~h5_00_pwg00'],
+            'execution_manifest_schema': 'pwg.headless_execution_manifest.v2',
+            'execution': {'profile_slot': 'c4', 'config_dir_fingerprint': 'f' * 64,
+                          'execution_route': 'claude-cli-headless',
+                          'executor_lane': 'serial-whole-card',
+                          'validation_method': 'audit_window+final_schema',
+                          'model_identifier': 'claude-sonnet-5'},
+            'provenance_classes': {'p_a~~h5_00_pwg00': 'real'},
             'input_hashes': {'p_a~~h5_00_pwg00': {
                 'raw_sha256': '1' * 64, 'portrait_sha256': '2' * 64}}}
     entry = {'card': {'key1': 'p_a~~h5_00_pwg00', 'iast': 'pā', 'notes': '', 'records': [
@@ -368,6 +383,15 @@ def selftest():
     assert p['model_version'] == SELFTEST_MODEL_VERSION, 'model VERSION recorded, not just the tier alias'
     assert p['input_raw_sha256'] == '1' * 64 and p['generated_at'], 'provenance must be complete'
     validate_promotion_entry('p_a~~h5_00_pwg00', entry)
+    historical = {'card': entry['card'], 'wf_file': entry['wf_file'],
+                  'meta': dict(meta, execution_manifest_schema=
+                               'pwg.headless_execution_manifest.v1')}
+    try:
+        validate_promotion_entry('p_a~~h5_00_pwg00', historical)
+    except PromotionContractError:
+        pass
+    else:
+        raise AssertionError('historical v1 output passed new production promotion')
     synthetic = {'card': entry['card'], 'wf_file': entry['wf_file'],
                  'meta': dict(meta, provenance_classes={
                      'p_a~~h5_00_pwg00': 'synthetic_control'})}


### PR DESCRIPTION
## Delivery

Stage 3 follows merged store-repair PR #510 and supersedes closed PR #495. The branch is rebased directly onto current `master`.

No live probe, Claude call, production translation, promotion, or paid window was run.

## Behavioral changes

- Introduces `pwg.headless_execution_manifest.v2`: logical `profile_slot`, canonical config-directory fingerprint, execution route/lane, exact model identifier, validation method, and exact per-key `real | synthetic_control` provenance.
- V1 remains readable for historical replay/audit, but headless production defaults to v2 and promotion independently refuses v1.
- Profile-bound v2 production is CLI/headless-only. A generated Workflow template aborts before its first agent call because Workflow cannot prove `CLAUDE_CONFIG_DIR` or join the host-wide active-call claim.
- Headless output carries the exact v2 execution/provenance contract; promotion independently rejects drift and synthetic controls.
- Coordinator prepare/requeue carries profile binding; orchestrator and bounded staged-run add `--only-profile` and verify roster slot plus directory fingerprint.
- Every admitted v2 execution holds one cross-process active-call claim keyed by the config fingerprint. Two c4 manifests fail closed even across launch entry points; `max-wide=1` remains an additional within-manifest control.
- Bare `claude` resolves through `shutil.which`; Windows npm shims invoke the Node CLI entry directly or fail closed.
- Probe telemetry records a named policy and lane. Production GO requires a representative schema-valid response, zero connection errors, and latency strictly `<30s`; contradictory supplied verdicts are refused.

## PR #495 compatibility

Carries forward its dry-run-by-default bounded staged run, cumulative window/call/clean/cost ceilings, restart checkpoint, prepared-plan scope, and strict unevaluable-cost failure. Existing standalone commands remain unchanged unless production v2 enforcement is entered.

## Validation

- `window_selftest.py` — 135/135 PASS
- language parity — 49/49 clean (affected generator/test entries reviewed as language-neutral and updated only via `--update-hash`)
- `headless_worker_selftest.py` — PASS, including clean-Linux hermetic CLI injection and host-neutral Windows path simulation
- `execution_contract_selftest.py` — PASS (output binding, profile mismatch, directory mismatch, two concurrent c4 claims, typed probe policy)
- profile-bound Workflow route — rejected before paid calls; regression-pinned
- `max_account_orchestrator_selftest.py` — PASS
- `bounded_supervisor_selftest.py` — PASS (13 cases)
- `bounded_staged_run_selftest.py` — PASS (9 cases)
- `economy_ledger_selftest.py` — PASS
- `promote_final_cards.py --selftest` — PASS
- launch ledger — 17 entries complete
- Ruff fatal set — PASS
- generated manifest-v2 harness `node --check` — PASS
- `git diff --check` — PASS