### PR TITLE
docs(russiantranslation): point bounded restart at H1110

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,4 +1,4 @@
-# Project Objective: Repository documentation & housekeeping
+# Project Objective: Repository documentation, PWG→Russian bounded CLI restart & housekeeping
 
 _Created: 09-07-2026 · Last updated: 17-07-2026_
 
@@ -21,6 +21,14 @@ Two live tracks:
   [RussianTranslation/.ai_state.md](RussianTranslation/.ai_state.md) + the queue below.
 
 ## ➡️ Next Steps (Queue)
+
+- **H1110 — 🟡 QUEUED 17-07-2026: post-H1080 audit, skill/goal repair, and bounded c4 restart.**
+  This is the active engineering/live successor to executed H963 after merged PRs #510/#511.
+  Opus audits current master, lands a separate fix PR, synchronizes the PWG skills and goals, and
+  only after every offline gate is green may run a maximum-three-call c4 ladder (health → synthetic
+  canary → one tiny real nominal batch). c5/c6 login is not a blocker for this single-profile route;
+  multi-account remains documented for later and H255 stays frozen. Resume:
+  `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H1110-Opus_SanskritLexicography_pwg-ru-post-h1080-audit-fix-skills-c4-restart_17.07.26.md and execute it.`
 
 - **RussianTranslation H1080 — store + launch controls repaired (17-07-2026).**
   PR #498 merged green. The hash-locked atomic repair completed: 11,605→11,603 rows, 668 placeholder

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1,10 +1,10 @@
-# Project Objective: PWG (Petersburg Dictionary) → Russian edition + the CDSL article-comparison study
+# Project Objective: Prove bounded PWG→Russian CLI correctness on one profile, then scale + the CDSL article-comparison study
 
-_Created: 09-07-2026 · Last updated: 15-07-2026_
+_Created: 09-07-2026 · Last updated: 17-07-2026_
 
 Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/archive/H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md)):
 
-- **Track A (PRIMARY):** scale PWG→Russian on the **Max** harness.
+- **Track A (PRIMARY):** prove a bounded manifest-v2 CLI run on c4, then scale PWG→Russian.
 - **Track B (SECONDARY):** lock the article-comparison flagship pair (**agni + akṣara**)
   and finish its Russian to 100 %.
 
@@ -13,6 +13,15 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 > the root copy. Audited + reconciled 2026-06-26.
 
 ## ➡️ Next Steps (Queue)
+
+- **H1110 — 🟡 QUEUED 17-07-2026: post-H1080 audit, skill/goal repair, and bounded c4 restart.**
+  This supersedes H963 as the active engineering/live resume pointer while retaining H963 as
+  historical evidence. Opus first audits current post-#511 master, lands a separate fix PR, updates
+  the PWG skills and G7–G10/G46, and requires every offline gate green. Only then: c4 health,
+  synthetic `dq_canary_puregloss`, and one tiny real nominal batch — at most three paid calls,
+  no retry/requeue/replacement. c5/c6 are optional later multi-account capacity, not a prerequisite;
+  H255/no-PWG stays frozen. Resume:
+  `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H1110-Opus_SanskritLexicography_pwg-ru-post-h1080-audit-fix-skills-c4-restart_17.07.26.md and execute it.`
 
 - **H1080 store + launch integrity — ✅ REPAIRED 17-07-2026 (Codex/GPT-5).** PR #498 and
   repair PR #510 merged green;
@@ -1992,6 +2001,10 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   after the preflight/runbook commit is pushed.
 
 ## 🚧 Current Work-In-Progress (WIP)
+
+- **H1110 handoff authored, not yet executed (17-07-2026, Codex/GPT-5).** Atomic handoff ID minted
+  and the active resume pointer moved from H963 to H1110. No code change, live probe, generation,
+  promotion, store mutation or TM rebuild occurred in the authoring session.
 
 - **PR #498 evidence reconciliation (17-07-2026, Codex/GPT-5).** Raw pilot artifacts preserved;
   derived JSONLs/report corrected; `window_selftest.py` now aggregates failures and reports


### PR DESCRIPTION
Updates the repository and RussianTranslation session journals to make H1110 the active post-H1080 engineering/live resume point. The handoff requires audit and fix PRs, synchronized skills/goals, all offline gates green, then at most three serial c4 calls. H963 remains historical evidence; H255 remains frozen. No production call, translation, promotion, store mutation, or TM rebuild occurred.