### PR TITLE
test(pwg_ru): behavioral pin for grammar-{Tn} restore — H1151 premise-stale close

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,35 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added — H1151: behavioral pin for the grammar-`{Tn}` restore (premise found already fixed)
+
+- **The handoff's diagnosed defect no longer exists on master.** The 13-07-2026 H858 diagnosis
+  (RUN_LOG:909, live on `gokzuraka` — `"grammar": "{T2}"` promoted) predates the C-01
+  centralization ([H963](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/card_fields.py)/H1080):
+  both restore lanes (plain `restoreCard` and the heal/stitch path, which restores `rec.h`/`rec.grammar`
+  **before** `owners.push`) now read `RESTORE_SPEC = card_fields.js_restore_spec(field)`, whose record
+  level is `('h', 'grammar')`. Verified empirically, not by reading: a synthetic harness generated from
+  current master restores `record.grammar` `{T2}`→value in 8/8 behavioral checks. Stated per the
+  honest-close pattern — this release pins the fixed behaviour, it does not fix anything.
+- [`src/pilot/grammar_restore_test.js`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/grammar_restore_test.js)
+  — behavioral pin in the house pattern ([FINDINGS §82](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md):
+  extract the REAL emitted `restore()`/`restoreCard()`/`RESTORE_SPEC` from a generated harness, never a
+  hand-written copy). 8 checks: spec keeps `grammar`+`h` at record level; the gokzuraka shape (`{T2}` in
+  `record.grammar`) restores; card/sense fields unregressed; no `{Tn}` survives; out-of-range `{T9}`
+  stays literal (C-42: never synthesise). Wired into `window_selftest.py` as
+  `test_grammar_field_restore_behavioral` (synthetic-harness generation, zero paid calls) — suite now
+  **136/136 green**; a future edit that drops `grammar` (or `h`) from the record-level restore fails
+  the suite, not the store.
+- **Blast radius, report-only (store untouched):** the main-tree `pwg_ru_translated.jsonl`
+  (11,603 rows) carries **zero** `{Tn}` tokens in ANY field — the promoted store rows have no
+  `grammar` field at all (grammar is card-level, read by consumers from cards, not store rows), and
+  the historical `{Tn}` residue (670 rows incl. gokzuraka's class) was already repaired by
+  [PR #510](https://github.com/gasyoun/SanskritLexicography/pull/510)/[PR #517](https://github.com/gasyoun/SanskritLexicography/pull/517).
+  Nothing to repair; nothing was repaired. `node --check` on a fresh generated harness: OK.
+- LANG_PARITY ledger: 28 entries tracking `window_selftest.py` re-verified and re-hashed
+  (`--update-hash`); the added test is language-agnostic (RESTORE_SPEC is lang-parameterized;
+  the record level does not branch on `--lang`).
+
 ### Added — H1080 follow-up: the 468 reconstructed headwords are now marked (owner-authorised 17-07-2026)
 
 - **`provenance.h_reconstructed` on 468 rows** (+ `iast_reconstructed` 462, `grammar_defaulted_empty`

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -356,7 +356,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -375,7 +375,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -413,7 +413,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -472,7 +472,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -503,7 +503,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "bd9626ca58ca67773ab157140a2b62afff46047ac2294a864783144f629a7d63",
       "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/autosplit_requeue.py": "7ada6e0aa8dc8d0be15cf4be725e380929282974cc19fc950690c07b09511448",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -522,7 +522,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -540,7 +540,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "95797986db7c21210a55c8a13f324514d17110ba07d2f804d000a77a003d5bf3",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -559,7 +559,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -599,7 +599,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -624,7 +624,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "062733fd593b4cde4213fcfba2840e19c319da74d0fb5e2eff445bba60520cd6",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -653,7 +653,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -673,7 +673,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -692,7 +692,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "ca41cb0055a98171e90031ba3a076ebac66306df0e283b609f4889291f158506",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -729,7 +729,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -787,7 +787,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -806,7 +806,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -825,7 +825,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -845,7 +845,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135",
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -867,7 +867,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -926,7 +926,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -986,7 +986,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -1005,7 +1005,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -1030,7 +1030,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/audit_window_en.py": "81250501c83fae903783384f773641a9c9132d83e35f41bc915722002d3a2e48",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135"
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1"
     }
   },
   {
@@ -1052,7 +1052,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "cc7e8787f71cbb91de0afbf8cb002dbef86dbd6a1f2245ca2ab862177bf0cd3c",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "432c23dc984d20425e32d0daca553ce493fd2d09ed99bb241be60b49555ac135",
+      "src/pilot/window_selftest.py": "c7751eb0dcd4616761800313d7a5a280e62d9c92970c365d5b9f9f6ba0fe9fa1",
       "src/pilot/accept_sensecount_test.js": "ae04e6390738fcc31ac39b4a292c967b4e26d8abc669fa12f690c9d694e88f3d"
     }
   }

--- a/RussianTranslation/src/pilot/grammar_restore_test.js
+++ b/RussianTranslation/src/pilot/grammar_restore_test.js
@@ -1,0 +1,65 @@
+// H1151 behavioral pin for the H858 grammar-field {Tn} stranding class.
+//
+// HISTORY, stated honestly: the 13-07-2026 diagnosis (RUN_LOG:909, live on gokzuraka)
+// found restoreCard restoring german/russian only. The C-01 centralization (H963/H1080,
+// card_fields.py) then made BOTH restore lanes read RESTORE_SPEC = js_restore_spec(field),
+// whose record level lists ('h', 'grammar') — so by the time H1151 ran (17-07-2026), the
+// defect was already absent on origin/master. This test therefore PINS the fixed behaviour
+// rather than proving a new fix: it extracts the REAL restore()/restoreCard()/RESTORE_SPEC
+// from a generated harness (FINDINGS §82: never test a hand-written copy) and fails loudly
+// if any future edit drops `grammar` (or `h`) from the record-level restore again.
+//
+//   node src/pilot/grammar_restore_test.js <path-to-a-generated-harness.js>
+const fs = require('fs')
+
+const harnessPath = process.argv[2]
+if (!harnessPath) { console.error('FAIL: usage: node grammar_restore_test.js <harness.js>'); process.exit(1) }
+const src = fs.readFileSync(harnessPath, 'utf8')
+
+const specM = src.match(/const RESTORE_SPEC = (\{[^\n]*\})/)
+if (!specM) { console.error('FAIL: RESTORE_SPEC not found in ' + harnessPath); process.exit(1) }
+const restoreM = src.match(/const restore = [^\n]*/)
+if (!restoreM) { console.error('FAIL: restore not found in ' + harnessPath); process.exit(1) }
+const cardM = src.match(/function restoreCard\([\s\S]*?\n\}/)
+if (!cardM) { console.error('FAIL: restoreCard not found in ' + harnessPath); process.exit(1) }
+
+// Runtime globals restoreCard closes over.
+const RESTORE_SPEC = eval('(' + specM[1] + ')')
+const PH = { k1: ['ALPHA', 'BETA', 'GAMMA'] }   // {T1}->ALPHA {T2}->BETA {T3}->GAMMA
+const restore = eval('(' + restoreM[0].replace(/^const restore = /, '') + ')')
+const restoreCard = eval('(' + cardM[0].replace(/^function restoreCard/, 'function ') + ')')
+
+let failed = 0
+const check = (name, cond, extra) => {
+  if (cond) { console.log('PASS: ' + name) } else { console.error('FAIL: ' + name + (extra ? ' -- ' + extra : '')); failed++ }
+}
+
+// ---- spec-level pin: the record level must keep restoring h AND grammar ----
+check('RESTORE_SPEC.record includes grammar', (RESTORE_SPEC.record || []).includes('grammar'),
+  'record spec = ' + JSON.stringify(RESTORE_SPEC.record))
+check('RESTORE_SPEC.record includes h', (RESTORE_SPEC.record || []).includes('h'))
+
+// ---- behavioural pin: the gokzuraka shape — a {T2} echoed into record.grammar ----
+const card = {
+  iast: 'x {T1}',
+  records: [{
+    h: '{T3}',
+    grammar: '{T2}',
+    senses: [{ tag: 't {T1}', german: 'g {T2}', russian: 'r {T3}', differentia: 'd {T1}' }],
+  }],
+}
+const out = restoreCard(JSON.parse(JSON.stringify(card)), 'k1')
+check('record.grammar {T2} restored (the gokzuraka class)', out.records[0].grammar === 'BETA',
+  'got ' + JSON.stringify(out.records[0].grammar))
+check('record.h {T3} restored', out.records[0].h === 'GAMMA')
+check('card.iast restored', out.iast === 'x ALPHA')
+check('sense fields still restored (no regression)',
+  out.records[0].senses[0].german === 'g BETA' && out.records[0].senses[0].russian === 'r GAMMA')
+check('no {Tn} survives anywhere in the restored card', !JSON.stringify(out).match(/\{T\d+\}/),
+  JSON.stringify(out))
+
+// ---- C-42 boundary unchanged: an out-of-range token stays literal, never invented ----
+const oob = restoreCard({ iast: null, records: [{ h: null, grammar: '{T9}', senses: [] }] }, 'k1')
+check('out-of-range {T9} stays literal (C-42: never synthesise)', oob.records[0].grammar === '{T9}')
+
+process.exit(failed ? 1 : 0)

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -718,6 +718,40 @@ def test_h960_accept_sanloss_soft_gate():
         shutil.rmtree(d, ignore_errors=True)
 
 
+def test_grammar_field_restore_behavioral():
+    """H1151 pin for the H858 grammar-{Tn} stranding class (live on gokzuraka, 13-07-2026).
+    The C-01 centralization (card_fields.js_restore_spec) already restores record.grammar in
+    both lanes; this behavioral test extracts the REAL restore()/restoreCard()/RESTORE_SPEC
+    from a freshly generated harness (grammar_restore_test.js) so a future edit that drops
+    `grammar` (or `h`) from the record-level restore fails HERE, not as silent store rows."""
+    import gen_opt_harness2 as gh
+    saved_ip, saved_kill = gh.input_paths, gh.KILL
+    d = tempfile.mkdtemp()
+    try:
+        rp = os.path.join(d, 'gok~~h0_zz_pw.raw.txt')
+        pp = os.path.join(d, 'gok~~h0_zz_pw.portrait.json')
+        with open(rp, 'w', encoding='utf-8') as f:
+            f.write('=== LAYER: PW ===\n\n{#gok#}¦ {%m%}\n— 1〉 {%a%}.')
+        with open(pp, 'w', encoding='utf-8') as f:
+            f.write('[]')
+        gh.input_paths = lambda k, input_dir=None: (rp, pp)
+        gh.KILL = False
+        js, _ = gh.build('zz_grestore', ['gok~~h0_zz_pw'], None, 12000,
+                         nominal=True, grammar_on=False, tm_path=None)
+        harness = os.path.join(d, 'grestore_harness.js')
+        with open(harness, 'w', encoding='utf-8', newline='\n') as f:
+            f.write(js)
+        test_js = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               'grammar_restore_test.js')
+        p = subprocess.run(['node', test_js, harness],
+                           capture_output=True, text=True, encoding='utf-8', timeout=30)
+        if p.returncode:
+            fail('grammar-field restore behavioral test failed:\n%s\n%s' % (p.stdout, p.stderr))
+    finally:
+        gh.input_paths, gh.KILL = saved_ip, saved_kill
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def test_h960_dropped_sanskrit_span():
     """H960 (H911 backlog #3): a {#..#} Sanskrit span present in the German source but dropped from
     the Russian translation is flagged (dropped_sanskrit_span). The harness/tm fidelity gates count
@@ -5504,6 +5538,7 @@ def main():
         test_run_telemetry_counters_returned,
         test_partial_cards_requeue_and_stay_out_of_clean_sample,
         test_classify_run_verdicts,
+        test_grammar_field_restore_behavioral,
     ]
     # Per-test isolation. This used to be a bare `for test in tests: test()`, so the FIRST
     # failure aborted the process and every later test silently never ran. That is not


### PR DESCRIPTION
Closes [H1151](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1151-Sonnet_SanskritLexicography_grammar-tn-restore-fix-h858_17.07.26.md) as **premise-stale with residue delivered**.

## Finding — the diagnosed defect no longer exists on master

The 13-07-2026 H858 diagnosis (RUN_LOG:909, live on `gokzuraka`: `"grammar": "{T2}"` promoted) predates the C-01 centralization (H963/H1080): both restore lanes — plain `restoreCard` and the heal/stitch path (which restores `rec.h`/`rec.grammar` **before** `owners.push`) — now read `RESTORE_SPEC = card_fields.js_restore_spec(field)` with record level `('h', 'grammar')`. Verified empirically: a synthetic harness generated from current master passes 8/8 behavioral checks.

## Residue delivered

- [grammar_restore_test.js](https://github.com/gasyoun/SanskritLexicography/blob/grammar-tn-restore/RussianTranslation/src/pilot/grammar_restore_test.js) — behavioral pin, house §82 pattern (extracts the REAL emitted `restore()`/`restoreCard()`/`RESTORE_SPEC`); 8 checks incl. the gokzuraka shape and the C-42 out-of-range boundary (`{T9}` stays literal).
- Wired into `window_selftest.py` as `test_grammar_field_restore_behavioral` (synthetic harness, zero paid calls): **136/136 green**.
- **Blast radius, report-only:** main-tree `pwg_ru_translated.jsonl` (11,603 rows) carries **zero** `{Tn}` tokens in any field — store rows have no `grammar` field at all, and historical residue was already repaired by #510/#517. Nothing repaired; `git status --porcelain -- '*.jsonl'` empty.
- `node --check` on a fresh generated harness: OK.
- LANG_PARITY: 28 `window_selftest.py`-tracking entries re-verified + re-hashed (language-agnostic change).

Handoff constraints honoured: read-only store, zero paid calls, no flag flips, no `promote_en.py`.

Model: Fable 5 (`claude-fable-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)