### PR TITLE
H1110 Phase 2 — headless fidelity + spend bounds (12 audit gaps + 4 adversarial hardenings)

### DIFF
--- a/RussianTranslation/AGENTS.md
+++ b/RussianTranslation/AGENTS.md
@@ -19,8 +19,14 @@ pipeline, with article-comparison Russian review work as the secondary track.
 
 ## PWG → Russian Production Loop
 
-Use the optimized Max Workflow route. Do not run the committed template
-`src/pilot/run_pilot_wf.js` directly for production windows.
+The production route is the **headless CLI on manifest v2** — `headless_worker.py` under a
+profile-bound manifest v2 (`execution_route: claude-cli-headless`), driven by
+`bounded_staged_run.py` / the coordinator. H1110 replaced the former Max-Workflow-session execution;
+the Workflow harness lane (`run_pilot_wf.opt2.js`) is retained only for historical forensics, not
+production. Do not run the committed template `src/pilot/run_pilot_wf.js` directly for production
+windows. Per-profile call concurrency is serialized by the kernel-backed `ActiveCallClaim`, agent and
+timeout budgets are enforced in `headless_worker.py`, and a `--stop-before-promote` review checkpoint
+gates promotion.
 
 Immediate next operator action: read the live queue in
 [`.ai_state.md`](.ai_state.md) — do NOT take a hardcoded root list from this
@@ -48,8 +54,10 @@ Canonical loop from the repo root:
 ```powershell
 python src\pilot\root_window_status.py <root>
 python src\pilot\gen_opt_harness2.py <root>          # batched+masked, canonical (-72..-90% cost)
-# run src\pilot\run_pilot_wf.opt2.js in Claude/Max Workflow and save wf_output.json
-# (use --out=run_pilot_wf.<tag>_<root>.js when several chats generate at once)
+# HEADLESS route (H1110): execute the emitted manifest v2 via headless_worker.py with
+# CLAUDE_CONFIG_DIR bound to the profile, driven by bounded_staged_run.py / the coordinator,
+# saving wf_output.json. The legacy Max-Workflow lane (run_pilot_wf.opt2.js in a Workflow) is
+# retained for forensics only, not production.
 python src\pilot\audit_window.py wf_output.json --root <root> --write-requeue
 ```
 

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -59,6 +59,43 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   updated `accept_sensecount_test.js`. Full suite: **139/139 green** (baseline measured this
   session: **137/137**, not the handoff-cited 135/135 — same staleness).
 
+### Added — H1110 Phase 2: enforce headless fidelity and spend bounds (12 live-route gaps)
+
+The post-H1080 audit ([PR #524](https://github.com/gasyoun/SanskritLexicography/pull/524)) ranked 12
+live-route gaps; this fix closes them, each behavior-pinned (assert the value at the executing
+boundary, not a constant):
+
+- **R3 agent-budget enforcement** — `headless_worker.py` enforces `manifest['budgets']`
+  (`max_translate_agents`/`max_heal_agents`/`max_agents`) + a `--max-agents` override at the `call()`
+  choke point; a refused call consumes no spawn. The budgets block was previously never read by the
+  executor.
+- **R4 timeout clamp** — every subprocess clamped to `min(operator, budgets.timeout_ceil_ms, 180000 ms)`.
+- **R5 cost telemetry** — the CLI wrapper's usage/cost survive into `summary['usage']` (summed across
+  calls, authoritative `observed_cost_usd`, `cost_evaluable`, `missing_usage_calls`) instead of being
+  discarded — no more silent `STOP_COST_UNEVALUABLE`.
+- **R2 grammar-token twin** — `card_token_multiset` counts `record.grammar` + `sense.german` via the
+  shared `card_fields.TOKEN_FIDELITY_FIELDS`, matching JS `cardTokens`.
+- **R6 fragment-TM v2** — per-sense `owners[]` flow harvest → sidecar → serve → stitch; a v1
+  (ownerless) row is a live cache miss (re-translated, still audit-readable), so a warm stitch no
+  longer regenerates null-`h` rows.
+- **R7 degenerate-card schema** — a degenerate stub emits `{h:'', grammar:''}` (honest source
+  identity), so `validate_final_card_schema` passes and one xref stub cannot refuse a whole paid window.
+- **R8 / P-1 manifest gates** — duplicate `selected_keys` rejected (multiset via `Counter`);
+  `batches`/`presplit` keys outside `selected_keys` refused before any spawn.
+- **R9 kernel-backed active-call lock** — `ActiveCallClaim` holds an OS lock (fcntl/msvcrt) the kernel
+  releases on process death (no PID/TTL/stale reclaim), so a tree-kill no longer strands a permanent
+  per-profile DoS. This is also the P-2 cross-process serialization ("two launches on one fingerprint
+  serialise"); `max_wide`/`stagger` are marked advisory intra-process hints.
+- **P-3 route enforcement** — a foreign `execution_route` is refused at execution, before any call.
+- **R10 `--stop-before-promote`** — skips promotion and writes a durable, self-hashing, hash-bound
+  `AWAITING_REVIEW` terminal checkpoint after a clean audit (store and TM untouched; audit-rejected
+  output never becomes AWAITING_REVIEW).
+
+### Changed
+
+- Operator docs (`AGENTS.md`, `README.md`) now name the **headless / manifest-v2** route as
+  production; the Max-Workflow lane (`run_pilot_wf.opt2.js`) is retained for forensics only.
+
 ## [1.16.0] - 2026-07-17
 
 ### Added — H1151: behavioral pin for the grammar-`{Tn}` restore (premise found already fixed)

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -99,7 +99,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1"
     }
   },
   {
@@ -117,8 +117,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -136,8 +136,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -155,8 +155,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -173,7 +173,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1"
     }
   },
   {
@@ -207,7 +207,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "lang is a first-class parameter of the TM address (sha256(lang + ...)); --lang=ru|en both get full reuse.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670"
+      "src/pilot/translation_memory.py": "958b069fc3a88e1032900f44498410fab88646409c9f0ca4e0952272a446cea1"
     }
   },
   {
@@ -224,7 +224,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1"
     }
   },
   {
@@ -241,7 +241,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1"
     }
   },
   {
@@ -258,7 +258,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 closes the former divergence: exact model provenance is required across four accounts, so both RU and EN now request and stamp claude-sonnet-5. This prevents account/profile alias resolution from making cross-window provenance incomparable.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1"
     }
   },
   {
@@ -355,8 +355,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -375,7 +375,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "c3840034737640dd701d772b6f2c25f5b4358c9ca003de561e35c462e4ea03ed",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -412,8 +412,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357"
     }
   },
@@ -470,9 +470,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -503,7 +503,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "bd9626ca58ca67773ab157140a2b62afff46047ac2294a864783144f629a7d63",
       "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/autosplit_requeue.py": "7ada6e0aa8dc8d0be15cf4be725e380929282974cc19fc950690c07b09511448",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -521,8 +521,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H321 (code review 2026-07-04 item #3b): the fragment sidecar is content-addressed on the fragment SOURCE and was harvested append-only first-seen-wins with NO fidelity check, so a hand-edited/corrupt wf_output*.json (blanked or malformed senses) permanently poisoned reuse and a later good harvest of the same fsha could never override it. frag_senses_sane(senses, lang) keys on the CARD-shaped translation field ('russian'/'english') and is applied at BOTH harvest (never cache garbage; a cached-corrupt fsha maps to False so a good row overrides it) and serve (load_frag_tm drops any corrupt historical row). Entirely lang-agnostic — lang is a first-class parameter of frag_address/frag_senses_sane/load_frag_tm/build_frags, no RU/EN branch. Pinned by test_frag_tm_fidelity_gate_and_override. Extends translation_memory_card_and_fragment.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/translation_memory.py": "958b069fc3a88e1032900f44498410fab88646409c9f0ca4e0952272a446cea1",
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -540,7 +540,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "95797986db7c21210a55c8a13f324514d17110ba07d2f804d000a77a003d5bf3",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -559,7 +559,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -599,7 +599,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dca26a006a32ba4a9eeb98453fa059585ccb8504ada8423f5e22d3fe1b25310f",
       "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -624,7 +624,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "062733fd593b4cde4213fcfba2840e19c319da74d0fb5e2eff445bba60520cd6",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -652,8 +652,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "062733fd593b4cde4213fcfba2840e19c319da74d0fb5e2eff445bba60520cd6",
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
-      "src/pilot/translation_memory.py": "016851d38fd1e62f301c8ef41f5afce833d50b99c9dd1bacb6d5406579cc4670",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/translation_memory.py": "958b069fc3a88e1032900f44498410fab88646409c9f0ca4e0952272a446cea1",
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -673,7 +673,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -692,7 +692,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "ca41cb0055a98171e90031ba3a076ebac66306df0e283b609f4889291f158506",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -729,7 +729,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -787,7 +787,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -805,8 +805,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -824,8 +824,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -844,8 +844,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81",
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -866,8 +866,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -924,9 +924,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -953,11 +953,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 Windows readiness uses one language-parameterized manifest and worker contract. Whole-card retries, binary split, fragment TM/restore/fidelity, per-card budgets, timeout-no-bisect, partial stitching, audit-clean subset promotion, staged dispatch, and credential-safe event/census telemetry do not branch on RU/EN. Production policy selects RU no_pwg for the first 100-headword proof; the mechanism preserves EN field/schema behavior.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
-      "src/pilot/headless_worker.py": "d8a14672fd37a22364775002d7b37255c2755ffd975f2f6ccaef76e66d911fb3",
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
+      "src/pilot/headless_worker.py": "5022695ffd42d6912bc8d1e2d24c130b744461990afaa89b0f5f13f6ebd57f91",
       "src/pilot/max_account_orchestrator.py": "39e7a60c0dbd89b6d2d2a8554832c19489f228409aef558062a260844d824635",
       "src/pilot/coordinator.py": "ca41cb0055a98171e90031ba3a076ebac66306df0e283b609f4889291f158506",
-      "src/pilot/headless_worker_selftest.py": "33a55b92d6122d5f387a9a2fd10b037b1f00e3490246474678d84216b66808cb",
+      "src/pilot/headless_worker_selftest.py": "8adf980678db843100938045f4057c10d5fb7dc6c2cfe17f936028533e15654c",
       "src/pilot/max_account_orchestrator_selftest.py": "7380473e18a6523e0cdc4ec831aa745e15e0f608673c06aad8b5a7c8515a564c",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
@@ -983,10 +983,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H390 Phase 1 (12-07-2026, Opus 4.8 claude-opus-4-8), extended by H818. gen_model is written into language-agnostic run meta and flows through the shared ledger writer and harvester identically for RU/EN; both paths now stamp exact claude-sonnet-5. Pinned by test_ledger_stamps_gen_model in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -1004,8 +1004,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H823, fixes the H255 presplit-cohort loss). Both the citation presplit trigger (_presplit_hit) and the single-card kill budget (killBudgetForCur) are language-independent — they key on <ls>/fragment counts and FRAGS, never on --lang; the same floor + CEIL apply to RU and EN identically. Extends no_fallback_single_kill_budget_and_nominal_key_echo (H220) from no-fallback singles to all singles. Pinned by test_presplit_cite_floor_and_single_ceil.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -1030,7 +1030,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/audit_window_en.py": "c3840034737640dd701d772b6f2c25f5b4358c9ca003de561e35c462e4ea03ed",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -1050,10 +1050,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H960 (15-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes H920's explicitly-deferred accept()-side sense-count consumption. Language-neutral: accept() counts SENSE OBJECTS (records[].senses[]), never a gloss language, and source_senses is sense_count.count_source_senses over the German source markers (identical for the RU and EN lanes — the source is German for both). SOFT by default (SANLOSS_HARD_REJECT=false): a shortfall is telemetry only (no reject/requeue), so live traffic can measure the true drop-vs-false-flag rate before the reject is armed (owner-gated ladder). The shared counter is hardened against the ~4.78%-of-cards cross-reference over-count the naive count carried (gam~~h2_31_pari 2->1, s_ud~~h0_05_pra 4->2, _a_srayatva 2->0); under-counting is the safe direction, never a false shortfall. Pinned by test_h960_accept_sanloss_soft_gate (builds the real harness, extracts the emitted accept()+countOf, asserts soft-keep / surplus-ok / FP-regression / ls-sk-first / armed-hard-reject via accept_sensecount_test.js) plus the 3 cross-reference fixtures in sense_count._selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81",
-      "src/pilot/accept_sensecount_test.js": "3a5683730c0495e9ddea76d6601920434a6890f603d1865033408950d92c9ef7"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba",
+      "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
   {
@@ -1072,7 +1072,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   },
   {
@@ -1090,8 +1090,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1152 guard 2 (17-07-2026, Sonnet 4.6 claude-sonnet-4-6), closing H1070's r102 finding (PWG->EN FU1 pilot, vac~~h0_00_pwg00: a {#uc#} span inside a <F> footnote survived the german echo 33/33 but was dropped from english 32/33 -- invisible to the pre-existing check because it never reads the translation field). accept() is lang-parameterized code shared by both lanes (field = 'russian' or 'english', same code path); the new check is symmetric and applies identically to RU and EN generation. Verified against the live RU regression suite: window_selftest.py full run stays green (137/137 baseline, +2 new content-check tests for guards 1/3), and the new/updated fixtures in accept_sensecount_test.js reproduce the exact r102 shape (RED before this change -- proven via git-stash against the pre-fix accept(), the fixture is silently ACCEPTED -- GREEN after). No RU store data touched; this only changes the generation-time accept-path gate for FUTURE generation, never re-validates the 11,605 already-promoted RU rows.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "01f0167c7228a0a2e8ccad405a6b684a22170b0635701f210626553eab9d67c9",
-      "src/pilot/accept_sensecount_test.js": "3a5683730c0495e9ddea76d6601920434a6890f603d1865033408950d92c9ef7"
+      "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
+      "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
   {
@@ -1127,7 +1127,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "c3840034737640dd701d772b6f2c25f5b4358c9ca003de561e35c462e4ea03ed",
-      "src/pilot/window_selftest.py": "e351d598ccaf7af55dc68e93525047560355abd860e38fc0f2c729362d548e81"
+      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
     }
   }
 ]

--- a/RussianTranslation/README.md
+++ b/RussianTranslation/README.md
@@ -127,8 +127,10 @@ forced the change):
 
 ## Operating the pipeline (quickstart)
 
-The production route is the frequency-window Max workflow documented step by
-step in
+The production route is the **headless CLI on manifest v2** (`headless_worker.py`,
+`execution_route: claude-cli-headless`), driven by `bounded_staged_run.py` / the coordinator (H1110
+replaced the former Max-Workflow-session execution; the Workflow lane is retained for forensics
+only). The frequency-window operating steps are in
 [`src/pilot/RUN_FREQ_MAX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_FREQ_MAX.md);
 task-oriented flows for every operator situation are in
 [`USE_CASES.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/USE_CASES.md).
@@ -136,8 +138,10 @@ task-oriented flows for every operator situation are in
 ```powershell
 python src\pilot\perf_preflight.py <root> --json     # cost gate first, always
 python src\pilot\root_window_status.py <root>        # pre-spend truth source
-python src\pilot\gen_opt_harness2.py <root>          # emit the optimized harness
-# run src\pilot\run_pilot_wf.opt2.js in the Claude/Max Workflow, save wf_output.json
+python src\pilot\gen_opt_harness2.py <root>          # emit the optimized manifest v2 + harness
+# HEADLESS route (H1110): execute the emitted manifest v2 via headless_worker.py (profile-bound),
+# driven by bounded_staged_run.py / the coordinator, saving wf_output.json. The Max-Workflow lane
+# (run_pilot_wf.opt2.js) is retained for forensics only.
 python src\pilot\audit_window.py wf_output.json --root <root> --write-requeue
 ```
 

--- a/RussianTranslation/pwg_ru/h1110/H1110_POST_H1080_AUDIT_MEMO_2026-07-17.md
+++ b/RussianTranslation/pwg_ru/h1110/H1110_POST_H1080_AUDIT_MEMO_2026-07-17.md
@@ -121,10 +121,12 @@ billed. Phases 1–5 are the prerequisites and are unaffected.
 
 ## 4. Execution-route parity — declared vs validated vs enforced
 
-**Headline: the manifest's entire `budgets{}` block is write-only.** A grep for any read of
-`budgets` across `RussianTranslation/src/` returns **zero matches**. It is emitted
-(`gen_opt_harness2.py:1386-1393`), carried through the coordinator, hashed, validated-adjacent and
-promoted against — and never read by the component that makes the model call.
+**Headline: the live headless executor never *enforces* the manifest `budgets{}` block.** The
+block is legitimately emitted and serialized by the generator (`gen_opt_harness2.py:1386-1393`) and
+carried through the coordinator, hashed and validated-adjacent — that is expected. The defect is
+downstream: `headless_worker.py`, the component that makes the model call, performs **zero
+enforcement reads** of those ceilings before it spawns. The block is declared and serialized;
+it is consumed as a limit nowhere on the live route.
 
 The mechanism is the same structural trap R3 identified. Those ceilings are enforced only in the
 generated JS harness. But manifest v2 hardcodes `execution_route: 'claude-cli-headless'`
@@ -177,18 +179,19 @@ harness, and inert on the bounded-run path every coordinator-imported lease actu
 
 ### 4.3 R3 exact production call sites (`headless_worker.py` @ `a6385eda`)
 
-The rank-1 gap is line-precise on current master. The manifest `budgets{}` block has **zero**
-references anywhere in `src/pilot/` (independently re-confirmed this session — a dict-read grep
-returns 0 hits, and `headless_worker.py` has 0 `budgets` references), so `max_translate_agents`,
-`max_heal_agents`, `timeout_ceil_ms`, `max_wide` and `stagger_ms` are all inert.
+The rank-1 gap is line-precise on current master. The live headless executor performs **zero
+enforcement reads** of the manifest `budgets{}` block: the generator emits and serializes it and the
+contract carries it (as they must), but `headless_worker.py` never consumes those ceilings before a
+call (independently re-confirmed this session), so `max_translate_agents`, `max_heal_agents`,
+`timeout_ceil_ms`, `max_wide` and `stagger_ms` are inert on the live route.
 
 | Element | Exact site (`a6385eda`) | Fact |
 |---|---|---|
 | Model-call driver | `call()` `:317`–`:356`; subprocess at `:328-329` | Increments `translate_calls` (`:326`) / `heal_calls` (`:324`) — compares nothing |
 | **Translate lane (unguarded)** | `resolve_group()` `:361`–`:392`; call at `:369`; `binary_split` recursion `:388-390` | Only bound is `whole_attempts` (`:364`); the recursion spawns child `resolve_group` with zero agent-budget accounting — and this is the sole production lane |
 | Heal lane (guarded, but not by the manifest) | `heal_group(..., budget)` `:404`–`:442`; check `:410`, incr `:412`, bisect gate `:436` | `budget` is a per-card dict built in `self_heal()` `:450-454` from `runtime.per_card_heal_*`, **not** `manifest['budgets']` |
-| Timeout (R4) | `call()` `:329` `timeout=self.timeout`; `execute()` default `timeout=7200` (`:561`) | Never clamped to `manifest.budgets.timeout_ceil_ms` — 40x the declared 180 s ceiling |
-| Counters | `:309-310`, surfaced `:587-588` (`translate_agents_spent` / `heal_agents_spent`) | Reported, never compared to any ceiling |
+| Timeout (R4) | `call()` `:329` `timeout=self.timeout`; `execute()` default `timeout=7200` s (`:561`) | The 7200 s runtime default vs the 180 s manifest ceiling is a **possible 40× breach** — `manifest.budgets.timeout_ceil_ms` is never consumed |
+| Counters | `:309-310`, surfaced `:587-588` (`translate_agents_spent` / `heal_agents_spent`) | **Call counters** — one process per call, so calls are read as "agents" under the current implementation; reported, never compared to any ceiling |
 
 ---
 
@@ -330,8 +333,8 @@ hats: **the suite pins declarations, not behaviour** — a constant's value, a J
 fixture that silently skips. Every test added in Phase 2 must assert the value that reached the
 *executing* boundary (the `timeout=` kwarg actually handed to `subprocess.run`, the spawn count
 actually reached), never the constant or the manifest field that was supposed to govern it. That
-is the discipline whose absence let a write-only `budgets{}` block sit green through H963 and
-H1080.
+is the discipline whose absence let a serialized-but-never-enforced `budgets{}` block sit green
+through H963 and H1080.
 
 **Phase 2 scope note.** Handoff item 10 (the 468 marker) is already delivered — see D-1. Item 4's
 "restoration-field specification" is narrower than the handoff implies: restoration already shares

--- a/RussianTranslation/src/card_fields.py
+++ b/RussianTranslation/src/card_fields.py
@@ -88,6 +88,24 @@ def promoted_pairs(field='russian'):
 PROMOTED_PAIRS = promoted_pairs('russian')
 
 
+# C-17: the masked fields whose {Tn} tokens must MATCH the source skeleton for a card to pass the
+# fragment-fidelity guard. This is the SOURCE-mirror subset -- the model echoes the German
+# skeleton's placeholders back into `record.grammar` and `sense.german`; the output-only fields
+# (h/iast/tag/differentia) are not in the skeleton and must NOT enter the multiset. Python
+# `card_token_multiset` and JS `cardTokens` both derive from this one tuple, so they cannot drift
+# (the C-17 defect: Python omitted `grammar` while JS included it -> a grammar-{Tn} card was
+# fidelity-rejected on the Python/headless lane and accepted on JS).
+TOKEN_FIDELITY_FIELDS = (('record', 'grammar'), ('sense', 'german'))
+
+
+def js_token_fidelity_spec():
+    """`TOKEN_FIDELITY_FIELDS` as a JSON literal, for interpolation into the JS harness."""
+    return json.dumps({
+        'record': [n for lvl, n in TOKEN_FIDELITY_FIELDS if lvl == 'record'],
+        'sense': [n for lvl, n in TOKEN_FIDELITY_FIELDS if lvl == 'sense'],
+    })
+
+
 def sense_masked(field):
     """Sense-level masked fields for target-language field `field` (e.g. 'russian')."""
     out = list(SENSE_MASKED_COMMON)

--- a/RussianTranslation/src/pilot/accept_sensecount_test.js
+++ b/RussianTranslation/src/pilot/accept_sensecount_test.js
@@ -50,6 +50,7 @@ const countOf = eval('(' + one('countOf') + ')')
 const countOfField = eval('(' + one('countOfField') + ')')
 const TARGET_FIELD = eval(one('TARGET_FIELD'))
 const tokensOf = eval('(' + one('tokensOf') + ')')
+const TOKEN_FIDELITY_SPEC = eval('(' + one('TOKEN_FIDELITY_SPEC') + ')')   // R2/C-17: cardTokens is spec-driven now
 const cardTokens = eval('(' + one('cardTokens') + ')')
 const accept = eval('(' + am[0].replace(/^const accept = /, '') + ')')
 

--- a/RussianTranslation/src/pilot/bounded_staged_run.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run.py
@@ -234,7 +234,8 @@ class RunContext:
 
     def __init__(self, db, coord_dir, coordinator, cwd, events, run_id, probe_latencies,
                  claude_bin='claude', timeout=7200, gen_model_version=DEFAULT_GEN_MODEL_VERSION,
-                 max_drain_iterations=1000, only_profile=None):
+                 max_drain_iterations=1000, only_profile=None, checkpoint=None,
+                 stop_before_promote=False):
         self.db = db
         self.coord_dir = coord_dir
         self.coordinator = coordinator
@@ -247,6 +248,8 @@ class RunContext:
         self.gen_model_version = gen_model_version
         self.max_drain_iterations = max_drain_iterations
         self.only_profile = only_profile
+        self.checkpoint = checkpoint
+        self.stop_before_promote = stop_before_promote     # R10
 
     @property
     def coord_state_path(self):
@@ -267,6 +270,100 @@ def _ensure_imported(ctx, lease_id):
         return  # not prepared (already advanced / unknown) -> nothing to import
     mao.cmd_import_coordinator(argparse.Namespace(
         db=ctx.db, coord_dir=ctx.coord_dir, cwd=ctx.cwd, lease_id=[lease_id], max_attempts=2))
+
+
+def _canonical_bytes(obj):
+    """Stable canonical JSON bytes for hashing (sorted keys, no whitespace, ASCII-escaped)."""
+    return json.dumps(obj, sort_keys=True, separators=(',', ':'), ensure_ascii=True).encode('utf-8')
+
+
+def _sha256_bytes(b):
+    import hashlib
+    return hashlib.sha256(b).hexdigest()
+
+
+def _audit_is_clean(report):
+    """R10: a window is eligible for AWAITING_REVIEW only if the audit did NOT reject it (no requeue
+    keys) AND it produced reviewable output (clean cards or satisfied keys)."""
+    report = report or {}
+    if report.get('requeue_keys'):
+        return False
+    return bool(report.get('clean_count') or report.get('satisfied_keys'))
+
+
+def awaiting_review_path(ctx, window_id):
+    return '%s.AWAITING_REVIEW.%s.json' % (
+        ctx.checkpoint or 'bounded_staged_run.checkpoint.json', window_id)
+
+
+def write_awaiting_review_checkpoint(ctx, window, wf_output_path, report):
+    """R10 (--stop-before-promote): write a durable, atomic, self-hashing AWAITING_REVIEW TERMINAL
+    checkpoint AFTER a clean audit. Binds, by sha256, the execution manifest + exact selected keys,
+    the lease/attempt, the audit report, the clean-candidate artifact, profile/route/exact model,
+    and the usage/cost summary + audit state; the canonical payload carries its own SHA-256. Touches
+    no store, no TM and never calls promote-ready. The caller writes this ONLY when the audit is
+    clean, so an audit-rejected window never becomes AWAITING_REVIEW."""
+    import time
+    wf = json.load(open(wf_output_path, encoding='utf-8'))
+    meta = wf.get('meta') or {}
+    execution = meta.get('execution') or {}
+    summary = wf.get('summary') or {}
+    selected = sorted(meta.get('selected_keys') or [])
+    with open(wf_output_path, 'rb') as f:
+        candidate_sha = _sha256_bytes(f.read())
+    bound = {
+        'lease_id': window.get('id'),
+        'attempt': window.get('attempt'),
+        'selected_keys': selected,
+        'execution': {k: execution.get(k) for k in
+                      ('profile_slot', 'execution_route', 'executor_lane',
+                       'validation_method', 'config_dir_fingerprint', 'model_identifier')},
+        'model': meta.get('gen_model') or execution.get('model_identifier'),
+        'usage': summary.get('usage'),
+        'audit_state': {'clean_count': report.get('clean_count'),
+                        'requeue_keys': sorted(report.get('requeue_keys') or []),
+                        'satisfied_keys': sorted(report.get('satisfied_keys') or []),
+                        'state': report.get('state') or report.get('classification')},
+    }
+    bound['hashes'] = {
+        'execution_manifest': _sha256_bytes(_canonical_bytes(
+            {'selected_keys': selected, 'execution': bound['execution']})),
+        'lease_attempt': _sha256_bytes(_canonical_bytes(
+            {'lease_id': bound['lease_id'], 'attempt': bound['attempt']})),
+        'audit_report': _sha256_bytes(_canonical_bytes(report)),
+        'clean_candidate': candidate_sha,
+        'profile_route_model': _sha256_bytes(_canonical_bytes(
+            {'execution': bound['execution'], 'model': bound['model']})),
+        'usage_audit_state': _sha256_bytes(_canonical_bytes(
+            {'usage': bound['usage'], 'audit_state': bound['audit_state']})),
+    }
+    payload = {'schema': 'pwg.awaiting_review.v1', 'status': 'AWAITING_REVIEW', 'run_id': ctx.run_id,
+               'wf_output': os.path.abspath(wf_output_path), 'ts': int(time.time()), 'bound': bound}
+    record = {'payload': payload, 'payload_sha256': _sha256_bytes(_canonical_bytes(payload))}
+    path = awaiting_review_path(ctx, window.get('id'))
+    mao.atomic_write(path, json.dumps(record, ensure_ascii=False, indent=1) + '\n')
+    return path, record
+
+
+def verify_awaiting_review_checkpoint(path):
+    """R10: True iff the checkpoint's canonical payload still hashes to its stored payload_sha256 AND
+    the bound clean-candidate artifact on disk still hashes to its recorded value. Tampering with any
+    bound field (self-hash) OR with the wf_output artifact invalidates the checkpoint."""
+    try:
+        rec = json.load(open(path, encoding='utf-8'))
+    except (OSError, ValueError):
+        return False
+    payload = rec.get('payload') or {}
+    if _sha256_bytes(_canonical_bytes(payload)) != rec.get('payload_sha256'):
+        return False
+    hashes = ((payload.get('bound') or {}).get('hashes') or {})
+    wf = payload.get('wf_output')
+    if not wf or not os.path.exists(wf):
+        return False
+    with open(wf, 'rb') as f:
+        if _sha256_bytes(f.read()) != hashes.get('clean_candidate'):
+            return False
+    return True
 
 
 def make_run_window(ctx):
@@ -316,6 +413,12 @@ def make_run_window(ctx):
                     only_external_ids=scope))
             mao.cmd_record_done(argparse.Namespace(
                 db=ctx.db, coordinator=ctx.coordinator, cwd=ctx.cwd, only_external_ids=scope))
+            if ctx.stop_before_promote:
+                # R10: skip promotion -- the window is recorded + auditable but NOT promoted, so the
+                # store and TM stay untouched. The durable AWAITING_REVIEW terminal checkpoint is
+                # written by the audit wrapper ONLY after a clean audit (an audit-rejected/requeued
+                # window never becomes AWAITING_REVIEW).
+                continue
             promote = subprocess.run(
                 [sys.executable, os.path.abspath(ctx.coordinator), 'promote-ready',
                  '--gen-model-version', ctx.gen_model_version, '--lease-id', lease_id],
@@ -486,11 +589,18 @@ def run(args):
         db=args.db, coord_dir=args.coord_dir, coordinator=args.coordinator, cwd=args.cwd,
         events=args.events, run_id=run_id, probe_latencies=probe_latencies,
         claude_bin=args.claude_bin, timeout=args.timeout,
-        gen_model_version=args.gen_model_version, only_profile=args.only_profile)
+        gen_model_version=args.gen_model_version, only_profile=args.only_profile,
+        checkpoint=args.checkpoint, stop_before_promote=args.stop_before_promote)
     run_window = make_run_window(ctx)
 
     def audit(wf_output, window):
-        return audit_from_coordinator(ctx.coord_state_path, wf_output, window)
+        report = audit_from_coordinator(ctx.coord_state_path, wf_output, window)
+        # R10: a durable, hash-bound AWAITING_REVIEW terminal checkpoint is written ONLY after a
+        # clean audit (never for a rejected/requeued window). Promotion was already skipped in
+        # run_window, so the store and TM are untouched.
+        if ctx.stop_before_promote and _audit_is_clean(report):
+            write_awaiting_review_checkpoint(ctx, window, wf_output, report)
+        return report
 
     sup = build_supervisor(windows, args.checkpoint, ceilings, run_window, audit,
                            resume=args.resume)
@@ -518,6 +628,11 @@ def main(argv=None):
                          'view that makes ZERO generation calls.')
     ap.add_argument('--resume', action='store_true',
                     help='resume from --checkpoint (no completed lease re-run/re-promoted)')
+    ap.add_argument('--stop-before-promote', action='store_true',
+                    help='R10: dispatch+record+audit each lease but do NOT promote, mutate the '
+                         'store or rebuild TM; write a durable hash-bound AWAITING_REVIEW terminal '
+                         'checkpoint after a clean audit for human/Opus review (the bounded c4 '
+                         'ladder requires this).')
     # Ceilings (all optional / default-disabled).
     ap.add_argument('--max-windows', type=int, default=None)
     ap.add_argument('--max-calls', type=int, default=None)

--- a/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
@@ -310,6 +310,104 @@ def test_i_audit_from_coordinator(td):
     print('  (i) audit_from_coordinator reads clean/requeue/satisfied/calls/cost from the lease: PASS')
 
 
+def test_j_stop_before_promote_awaiting_review(td):
+    from types import SimpleNamespace
+
+    def _wf(path, keys):
+        with open(path, 'w', encoding='utf-8', newline='\n') as f:
+            json.dump({'meta': {'selected_keys': keys, 'gen_model': 'claude-sonnet-5',
+                                 'execution': {'profile_slot': 'c4',
+                                               'execution_route': 'claude-cli-headless',
+                                               'executor_lane': 'serial', 'validation_method': 'audit',
+                                               'config_dir_fingerprint': 'f' * 64,
+                                               'model_identifier': 'claude-sonnet-5'}},
+                       'summary': {'usage': {'input_tokens': 10, 'observed_cost_usd': 0.01,
+                                             'cost_evaluable': True}}, 'results': []}, f)
+        return path
+
+    # (1) gating — only a clean, productive audit is eligible; a rejected/empty one is not.
+    assert bsr._audit_is_clean({'clean_count': 2, 'requeue_keys': []})
+    assert bsr._audit_is_clean({'satisfied_keys': ['k'], 'requeue_keys': []})
+    assert not bsr._audit_is_clean({'clean_count': 1, 'requeue_keys': ['k']})   # audit-rejected
+    assert not bsr._audit_is_clean({'requeue_keys': [], 'clean_count': 0})       # nothing produced
+    assert not bsr._audit_is_clean({})
+
+    jdir = os.path.join(td, 'r10'); os.makedirs(jdir)
+    wf = _wf(os.path.join(jdir, 'wf.json'), ['b', 'a'])
+    ctx = SimpleNamespace(checkpoint=os.path.join(jdir, 'cp.json'), run_id='r10', stop_before_promote=True)
+    report = {'clean_count': 2, 'requeue_keys': [], 'satisfied_keys': [], 'state': 'clean', 'calls': 1}
+
+    # (2) a clean audit writes a durable, hash-bound, self-hashing checkpoint; store/TM untouched.
+    path, record = bsr.write_awaiting_review_checkpoint(ctx, {'id': 'lease1', 'attempt': 1}, wf, report)
+    assert bsr.verify_awaiting_review_checkpoint(path)
+    hs = record['payload']['bound']['hashes']
+    for k in ('execution_manifest', 'lease_attempt', 'audit_report', 'clean_candidate',
+              'profile_route_model', 'usage_audit_state'):
+        assert hs.get(k), (k, hs)
+    assert record['payload_sha256'] and record['payload']['status'] == 'AWAITING_REVIEW'
+    files = set(os.listdir(jdir))
+    assert 'wf.json' in files and os.path.basename(path) in files, files
+    assert not any('translated' in f or 'translation_memory' in f or f.endswith('.jsonl')
+                   for f in files), files                          # no store, no TM
+
+    # (3) tampering with the checkpoint payload OR the bound wf artifact invalidates it.
+    rec = json.load(open(path, encoding='utf-8'))
+    rec['payload']['bound']['selected_keys'] = ['tampered']
+    with open(path, 'w', encoding='utf-8', newline='\n') as f:
+        json.dump(rec, f)
+    assert not bsr.verify_awaiting_review_checkpoint(path), 'tampered payload verified'
+    bsr.write_awaiting_review_checkpoint(ctx, {'id': 'lease1', 'attempt': 1}, wf, report)  # restore
+    assert bsr.verify_awaiting_review_checkpoint(path)
+    with open(wf, 'a', encoding='utf-8') as f:
+        f.write('\n#tampered')
+    assert not bsr.verify_awaiting_review_checkpoint(path), 'tampered artifact verified'
+
+    # (4) through the real supervisor: clean audit -> AWAITING_REVIEW per window; resume relaunches nothing.
+    class RichRunner:
+        def __init__(self, tdir):
+            self.tdir, self.order = tdir, []
+        def __call__(self, window):
+            self.order.append(window['id'])
+            return _wf(os.path.join(self.tdir, 'wf_%s.json' % window['id']), [window['id']])
+
+    plan = _plan(['no_pwg_w02', 'no_pwg_w03'])
+    windows, _ = bsr.scope_windows(plan)
+    cp2 = os.path.join(jdir, 'sup.json')
+    ctx2 = SimpleNamespace(checkpoint=cp2, run_id='sup', stop_before_promote=True)
+
+    def wrapped_audit(wf_output, window):
+        rep = {'requeue_keys': [], 'clean_count': 1, 'calls': 1, 'satisfied_keys': []}
+        if ctx2.stop_before_promote and bsr._audit_is_clean(rep):
+            bsr.write_awaiting_review_checkpoint(ctx2, window, wf_output, rep)
+        return rep
+
+    runner = RichRunner(jdir)
+    bsr.build_supervisor(windows, cp2, _ceilings(), runner, wrapped_audit).run()
+    assert runner.order == ['no_pwg_w02', 'no_pwg_w03'], runner.order
+    for w in ('no_pwg_w02', 'no_pwg_w03'):
+        cpath = bsr.awaiting_review_path(ctx2, w)
+        assert os.path.exists(cpath) and bsr.verify_awaiting_review_checkpoint(cpath), cpath
+    runner2 = RichRunner(jdir)
+    bsr.build_supervisor(windows, cp2, _ceilings(), runner2, wrapped_audit, resume=True).run()
+    assert runner2.order == [], runner2.order            # restart launches the model for NO window
+
+    # (5) backward compatible: default (flag absent) writes no AWAITING_REVIEW checkpoint.
+    off = os.path.join(jdir, 'off.json')
+    ctx_off = SimpleNamespace(checkpoint=off, run_id='off', stop_before_promote=False)
+    runner3 = RichRunner(jdir)
+
+    def audit_off(wf_output, window):
+        rep = {'requeue_keys': [], 'clean_count': 1, 'calls': 1, 'satisfied_keys': []}
+        if ctx_off.stop_before_promote and bsr._audit_is_clean(rep):
+            bsr.write_awaiting_review_checkpoint(ctx_off, window, wf_output, rep)
+        return rep
+
+    bsr.build_supervisor(windows, off, _ceilings(), runner3, audit_off).run()
+    assert not os.path.exists(bsr.awaiting_review_path(ctx_off, 'no_pwg_w02')), 'flag-off wrote a checkpoint'
+    print('  (j) --stop-before-promote: durable hash-bound AWAITING_REVIEW; clean-only; tamper-evident; '
+          'no relaunch; flag-off backward compatible: PASS')
+
+
 def main():
     with tempfile.TemporaryDirectory() as td:
         test_a_plan_scope(td)
@@ -321,6 +419,7 @@ def main():
         test_g_cost_fail_closed(td)
         test_h_consecutive_empty(td)
         test_i_audit_from_coordinator(td)
+        test_j_stop_before_promote_awaiting_review(td)
     print('bounded_staged_run_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/execution_contract.py
+++ b/RussianTranslation/src/pilot/execution_contract.py
@@ -4,10 +4,15 @@ import hashlib
 import json
 import os
 import tempfile
+import time
 
 SCHEMA_V1 = 'pwg.headless_execution_manifest.v1'
 SCHEMA_V2 = 'pwg.headless_execution_manifest.v2'
 PROVENANCE_CLASSES = {'real', 'synthetic_control'}
+# P-3: the only execution route this headless executor can actually run. A v2 manifest declaring
+# any other route (generation refuses it, but a hand-edited manifest could carry one) is refused at
+# execution time, not run unmodified.
+HEADLESS_ROUTE = 'claude-cli-headless'
 
 
 def canonical_config_dir(path):
@@ -20,6 +25,19 @@ def config_dir_fingerprint(path):
 
 
 def validate_manifest(manifest, require_v2=False):
+    # P-1: batches/presplit must not drive a model call for a key outside selected_keys -- else a
+    # manifest whose batches name a key outside the declared set is billed anyway (selected_keys
+    # gates enqueue; this gates dispatch). Applies to any executable manifest (v1 and v2).
+    selected = (manifest.get('meta') or {}).get('selected_keys') or []
+    if selected:
+        driven = set()
+        for batch in manifest.get('batches') or []:
+            driven.update(batch)
+        driven.update(manifest.get('presplit_keys') or [])
+        stray = sorted(driven - set(selected))
+        if stray:
+            raise ValueError('manifest drives a call for key(s) outside selected_keys: %s'
+                             % ', '.join(stray[:10]))
     schema = manifest.get('schema')
     if schema == SCHEMA_V1 and not require_v2:
         return
@@ -34,7 +52,12 @@ def validate_manifest(manifest, require_v2=False):
         raise ValueError('manifest v2 missing execution field(s): %s' % ', '.join(missing))
     if len(execution['config_dir_fingerprint']) != 64:
         raise ValueError('manifest v2 has malformed config-directory fingerprint')
-    keys = (manifest.get('meta') or {}).get('selected_keys') or []
+    keys = list(selected)
+    # R8: reject duplicate selected_keys -- set(classes)==set(keys) admits a duplicated key (billed
+    # once, double-counted downstream), so compare lengths (multiset semantics) before launch.
+    if len(keys) != len(set(keys)):
+        dupes = sorted({k for k in keys if keys.count(k) > 1})
+        raise ValueError('manifest v2 selected_keys has duplicate key(s): %s' % ', '.join(dupes))
     classes = manifest.get('key_provenance')
     if not isinstance(classes, dict) or set(classes) != set(keys):
         raise ValueError('manifest v2 key_provenance must exactly cover selected_keys')
@@ -49,6 +72,12 @@ def validate_manifest(manifest, require_v2=False):
 def validate_profile(manifest, config_dir, only_profile=None):
     validate_manifest(manifest, require_v2=True)
     execution = manifest['execution']
+    # P-3: enforce the declared route at EXECUTION, not just at generation. The headless executor
+    # runs only the claude-cli-headless route; a hand-edited manifest declaring a foreign route is
+    # refused here, not run unmodified ("generation-time refusal is birth control, not a gate").
+    if execution['execution_route'] != HEADLESS_ROUTE:
+        raise ValueError('headless executor refuses execution_route=%r (executable route is %r)'
+                         % (execution['execution_route'], HEADLESS_ROUTE))
     if only_profile and execution['profile_slot'] != only_profile:
         raise ValueError('profile mismatch: manifest=%s --only-profile=%s'
                          % (execution['profile_slot'], only_profile))
@@ -70,25 +99,92 @@ def bind_output_meta(meta, manifest):
     return meta
 
 
+def _pid_alive(pid):
+    """Best-effort cross-platform liveness. POSIX: os.kill(pid, 0). Windows: OpenProcess +
+    GetExitCodeProcess -- os.kill on Windows can TerminateProcess, so it is never used here."""
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if pid <= 0:
+        return False
+    if os.name == 'nt':
+        import ctypes
+        PROCESS_QUERY_LIMITED_INFORMATION, STILL_ACTIVE = 0x1000, 259
+        k32 = ctypes.windll.kernel32
+        handle = k32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return False
+        try:
+            code = ctypes.c_ulong()
+            if k32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                return code.value == STILL_ACTIVE
+            return True
+        finally:
+            k32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True                       # exists, but no permission to signal
+    except OSError:
+        return False
+    return True
+
+
 class ActiveCallClaim:
-    """Cross-process one-active-call claim keyed by credential-directory fingerprint."""
+    """Cross-process one-active-call claim keyed by credential-directory fingerprint.
+
+    R9 (C-09/H818): a bare O_EXCL lock is NOT crash-safe. The orchestrator tree-kills the lock
+    holder on a call timeout (a routine path, not a rare crash), so `__exit__` never runs and the
+    lock would survive forever -- a permanent self-inflicted DoS on a credential profile. A
+    contended claim therefore reclaims a lock whose owner PID is dead, or (unreadable/legacy lock)
+    one older than STALE_SECS -- well past the 180 s call ceiling. It NEVER reclaims a live holder.
+    """
+    STALE_SECS = 300
+
     def __init__(self, fingerprint, root=None):
         self.root = root or os.path.join(tempfile.gettempdir(), 'pwg-active-calls')
         self.path = os.path.join(self.root, fingerprint + '.lock')
         self.owned = False
 
+    def _stale(self):
+        try:
+            info = json.load(open(self.path, encoding='utf-8'))
+        except (OSError, ValueError):
+            info = None
+        if isinstance(info, dict) and info.get('pid') is not None:
+            if not _pid_alive(info.get('pid')):
+                return True                                   # dead holder -> immediate reclaim
+            ts = info.get('ts')
+            return ts is not None and (time.time() - float(ts)) > self.STALE_SECS
+        # unreadable / legacy lock (no pid): fall back to file age
+        try:
+            return (time.time() - os.path.getmtime(self.path)) > self.STALE_SECS
+        except OSError:
+            return False
+
     def __enter__(self):
         os.makedirs(self.root, exist_ok=True)
-        try:
-            fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-        except FileExistsError:
-            raise RuntimeError('profile already has an active model call')
-        with os.fdopen(fd, 'w', encoding='utf-8') as fh:
-            json.dump({'pid': os.getpid()}, fh)
-            fh.flush()
-            os.fsync(fh.fileno())
-        self.owned = True
-        return self
+        for _ in range(2):
+            try:
+                fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            except FileExistsError:
+                if self._stale():
+                    try:
+                        os.unlink(self.path)      # reclaim abandoned lock; retry the O_EXCL create
+                    except FileNotFoundError:
+                        pass
+                    continue
+                raise RuntimeError('profile already has an active model call')
+            with os.fdopen(fd, 'w', encoding='utf-8') as fh:
+                json.dump({'pid': os.getpid(), 'ts': time.time()}, fh)
+                fh.flush()
+                os.fsync(fh.fileno())
+            self.owned = True
+            return self
+        raise RuntimeError('profile already has an active model call')
 
     def __exit__(self, _typ, _value, _tb):
         if self.owned:

--- a/RussianTranslation/src/pilot/execution_contract.py
+++ b/RussianTranslation/src/pilot/execution_contract.py
@@ -1,10 +1,42 @@
 #!/usr/bin/env python
 """Profile-bound manifest-v2 validation and global active-call serialization."""
+import collections
 import hashlib
-import json
 import os
 import tempfile
-import time
+
+# R9: a KERNEL-backed exclusive lock, released automatically by the OS on process death. POSIX uses
+# fcntl.flock; Windows uses an msvcrt byte-range lock. Both are held for as long as the file handle
+# is open and are dropped by the kernel when the holder dies -- no PID probing, TTL or stale
+# adoption. Non-blocking acquisition raises OSError on contention.
+if os.name == 'nt':
+    import msvcrt
+
+    def _os_lock_nb(fh):
+        fh.seek(0, os.SEEK_END)
+        if fh.tell() == 0:
+            fh.write(b'\0')          # msvcrt locks a byte range; guarantee byte 0 exists
+            fh.flush()
+        fh.seek(0)
+        msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
+
+    def _os_unlock(fh):
+        try:
+            fh.seek(0)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+else:
+    import fcntl
+
+    def _os_lock_nb(fh):
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def _os_unlock(fh):
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
 
 SCHEMA_V1 = 'pwg.headless_execution_manifest.v1'
 SCHEMA_V2 = 'pwg.headless_execution_manifest.v2'
@@ -53,10 +85,10 @@ def validate_manifest(manifest, require_v2=False):
     if len(execution['config_dir_fingerprint']) != 64:
         raise ValueError('manifest v2 has malformed config-directory fingerprint')
     keys = list(selected)
-    # R8: reject duplicate selected_keys -- set(classes)==set(keys) admits a duplicated key (billed
-    # once, double-counted downstream), so compare lengths (multiset semantics) before launch.
-    if len(keys) != len(set(keys)):
-        dupes = sorted({k for k in keys if keys.count(k) > 1})
+    # R8: reject duplicate selected_keys with explicit multiset semantics -- set(classes)==set(keys)
+    # admitted a duplicated key (billed once, double-counted downstream). Counter, not keys.count().
+    dupes = sorted(k for k, n in collections.Counter(keys).items() if n > 1)
+    if dupes:
         raise ValueError('manifest v2 selected_keys has duplicate key(s): %s' % ', '.join(dupes))
     classes = manifest.get('key_provenance')
     if not isinstance(classes, dict) or set(classes) != set(keys):
@@ -99,97 +131,37 @@ def bind_output_meta(meta, manifest):
     return meta
 
 
-def _pid_alive(pid):
-    """Best-effort cross-platform liveness. POSIX: os.kill(pid, 0). Windows: OpenProcess +
-    GetExitCodeProcess -- os.kill on Windows can TerminateProcess, so it is never used here."""
-    try:
-        pid = int(pid)
-    except (TypeError, ValueError):
-        return False
-    if pid <= 0:
-        return False
-    if os.name == 'nt':
-        import ctypes
-        PROCESS_QUERY_LIMITED_INFORMATION, STILL_ACTIVE = 0x1000, 259
-        k32 = ctypes.windll.kernel32
-        handle = k32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
-        if not handle:
-            return False
-        try:
-            code = ctypes.c_ulong()
-            if k32.GetExitCodeProcess(handle, ctypes.byref(code)):
-                return code.value == STILL_ACTIVE
-            return True
-        finally:
-            k32.CloseHandle(handle)
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True                       # exists, but no permission to signal
-    except OSError:
-        return False
-    return True
-
-
 class ActiveCallClaim:
-    """Cross-process one-active-call claim keyed by credential-directory fingerprint.
+    """R9: a KERNEL-backed one-active-call lock keyed by the config-directory fingerprint.
 
-    R9 (C-09/H818): a bare O_EXCL lock is NOT crash-safe. The orchestrator tree-kills the lock
-    holder on a call timeout (a routine path, not a rare crash), so `__exit__` never runs and the
-    lock would survive forever -- a permanent self-inflicted DoS on a credential profile. A
-    contended claim therefore reclaims a lock whose owner PID is dead, or (unreadable/legacy lock)
-    one older than STALE_SECS -- well past the 180 s call ceiling. It NEVER reclaims a live holder.
+    An exclusive OS advisory lock (fcntl.flock on POSIX, an msvcrt byte-range lock on Windows) is
+    held on an open file handle for the claim's lifetime. The KERNEL releases it automatically when
+    the holder dies -- a tree-kill on a call timeout, a crash -- so there is NO PID probe, TTL,
+    deletion or stale adoption (the permanent-DoS class the old bare O_EXCL created: __exit__ never
+    ran after a tree-kill, so the lock file survived forever, blocking the profile indefinitely).
+
+    The lock FILE is a diagnostic artifact; its existence never represents ownership -- only the
+    live OS lock does -- so a leftover file after a crash is harmless: the next process locks it
+    immediately. Non-blocking acquisition raises a typed RuntimeError on contention.
     """
-    STALE_SECS = 300
-
     def __init__(self, fingerprint, root=None):
         self.root = root or os.path.join(tempfile.gettempdir(), 'pwg-active-calls')
         self.path = os.path.join(self.root, fingerprint + '.lock')
-        self.owned = False
-
-    def _stale(self):
-        try:
-            info = json.load(open(self.path, encoding='utf-8'))
-        except (OSError, ValueError):
-            info = None
-        if isinstance(info, dict) and info.get('pid') is not None:
-            if not _pid_alive(info.get('pid')):
-                return True                                   # dead holder -> immediate reclaim
-            ts = info.get('ts')
-            return ts is not None and (time.time() - float(ts)) > self.STALE_SECS
-        # unreadable / legacy lock (no pid): fall back to file age
-        try:
-            return (time.time() - os.path.getmtime(self.path)) > self.STALE_SECS
-        except OSError:
-            return False
+        self._fh = None
 
     def __enter__(self):
         os.makedirs(self.root, exist_ok=True)
-        for _ in range(2):
-            try:
-                fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            except FileExistsError:
-                if self._stale():
-                    try:
-                        os.unlink(self.path)      # reclaim abandoned lock; retry the O_EXCL create
-                    except FileNotFoundError:
-                        pass
-                    continue
-                raise RuntimeError('profile already has an active model call')
-            with os.fdopen(fd, 'w', encoding='utf-8') as fh:
-                json.dump({'pid': os.getpid(), 'ts': time.time()}, fh)
-                fh.flush()
-                os.fsync(fh.fileno())
-            self.owned = True
-            return self
-        raise RuntimeError('profile already has an active model call')
+        fh = open(self.path, 'a+b')
+        try:
+            _os_lock_nb(fh)
+        except OSError:
+            fh.close()
+            raise RuntimeError('profile already has an active model call')
+        self._fh = fh
+        return self
 
     def __exit__(self, _typ, _value, _tb):
-        if self.owned:
-            try:
-                os.unlink(self.path)
-            except FileNotFoundError:
-                pass
-            self.owned = False
+        fh, self._fh = self._fh, None
+        if fh is not None:
+            _os_unlock(fh)
+            fh.close()

--- a/RussianTranslation/src/pilot/execution_contract_selftest.py
+++ b/RussianTranslation/src/pilot/execution_contract_selftest.py
@@ -114,9 +114,12 @@ def main():
         else:
             raise AssertionError('P-3: foreign execution_route executed')
 
-        # R9: KERNEL-backed lock. A live SEPARATE process holding it refuses a second acquisition;
-        # forcibly terminating the holder releases the lock IMMEDIATELY (no TTL, no PID probe, no
-        # stale adoption). A leftover lock file may remain but must not represent ownership.
+        # R9 KERNEL-backed lock -- this is ALSO the P-2 pin ("two concurrent launches on one
+        # fingerprint serialise"): a live SEPARATE process holding it refuses a second acquisition,
+        # so cross-process concurrency on one profile is bounded to 1 regardless of the manifest's
+        # advisory max_wide/stagger. Forcibly terminating the holder releases the lock IMMEDIATELY
+        # (no TTL, no PID probe, no stale adoption). A leftover lock file may remain but must not
+        # represent ownership.
         srcdir = os.path.dirname(os.path.abspath(__file__))
         fp = manifest['execution']['config_dir_fingerprint']
         r9 = os.path.join(d, 'r9'); os.makedirs(r9)

--- a/RussianTranslation/src/pilot/execution_contract_selftest.py
+++ b/RussianTranslation/src/pilot/execution_contract_selftest.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import json
 import os
 import subprocess
 import sys
@@ -115,21 +114,36 @@ def main():
         else:
             raise AssertionError('P-3: foreign execution_route executed')
 
-        # R9: a crashed holder's lock (dead pid) is reclaimed; a live holder is NOT.
+        # R9: KERNEL-backed lock. A live SEPARATE process holding it refuses a second acquisition;
+        # forcibly terminating the holder releases the lock IMMEDIATELY (no TTL, no PID probe, no
+        # stale adoption). A leftover lock file may remain but must not represent ownership.
+        srcdir = os.path.dirname(os.path.abspath(__file__))
         fp = manifest['execution']['config_dir_fingerprint']
         r9 = os.path.join(d, 'r9'); os.makedirs(r9)
-        dead = subprocess.Popen([sys.executable, '-c', 'import sys; sys.exit(0)'])
-        dead.wait()                                     # dead.pid is now a dead PID
-        with open(os.path.join(r9, fp + '.lock'), 'w', encoding='utf-8') as fh:
-            json.dump({'pid': dead.pid, 'ts': time.time()}, fh)
-        with ActiveCallClaim(fp, r9):                   # reclaims the dead-holder lock, then holds it
+        ready = os.path.join(d, 'holder.ready')
+        holder_code = (
+            'import sys, os, time; sys.path.insert(0, %r);'
+            'from execution_contract import ActiveCallClaim;'
+            'c = ActiveCallClaim(%r, %r); c.__enter__();'
+            'open(%r, "w").close(); time.sleep(120)'
+        ) % (srcdir, fp, r9, ready)
+        holder = subprocess.Popen([sys.executable, '-c', holder_code])
+        try:
+            for _ in range(200):
+                if os.path.exists(ready):
+                    break
+                time.sleep(0.05)
+            assert os.path.exists(ready), 'R9: holder process never acquired the lock'
             try:
                 with ActiveCallClaim(fp, r9):
-                    pass
+                    raise AssertionError('R9: acquired a lock held by a live separate process')
             except RuntimeError:
                 pass
-            else:
-                raise AssertionError('R9: reclaimed a LIVE holder lock')
+        finally:
+            holder.kill()
+            holder.wait()
+        with ActiveCallClaim(fp, r9):        # kernel released it on death -> immediate reacquire
+            pass
     print('execution_contract_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/execution_contract_selftest.py
+++ b/RussianTranslation/src/pilot/execution_contract_selftest.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
+import json
 import os
+import subprocess
 import sys
 import tempfile
+import time
 
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
@@ -74,6 +77,59 @@ def main():
         assert verdict_for(29999, 0, 6000, 'warmup', schema_valid=True)[0] == 'GO'
         assert verdict_for(30000, 0, 6000, 'warmup', schema_valid=True)[0] == 'NO-GO'
         assert verdict_for(1000, 0, 6000, 'warmup', schema_valid=None)[0] == 'NO-GO'
+
+        # --- Phase-2 pins (R8 dup keys, P-1 batches subset, P-3 route enforce, R9 stale lock) ---
+        # R8: duplicate selected_keys rejected (multiset), not silently deduped by set().
+        dup = fixture(cfg); dup['meta']['selected_keys'] = ['real', 'real', 'canary']
+        try:
+            validate_manifest(dup, require_v2=True)
+        except ValueError as e:
+            assert 'duplicate' in str(e), e
+        else:
+            raise AssertionError('R8: duplicate selected_keys admitted')
+
+        # P-1: a batch/presplit key outside selected_keys is refused before any spawn.
+        stray = fixture(cfg); stray['batches'] = [['real', 'ghost']]
+        try:
+            validate_manifest(stray, require_v2=True)
+        except ValueError as e:
+            assert 'selected_keys' in str(e) and 'ghost' in str(e), e
+        else:
+            raise AssertionError('P-1: batch key outside selected_keys admitted')
+        strayp = fixture(cfg); strayp['presplit_keys'] = ['ghost']
+        try:
+            validate_manifest(strayp, require_v2=True)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError('P-1: presplit key outside selected_keys admitted')
+        okb = fixture(cfg); okb['batches'] = [['real', 'canary']]
+        validate_manifest(okb, require_v2=True)         # fully inside selected_keys -> valid
+
+        # P-3: a foreign execution_route is refused AT EXECUTION (validate_profile), not run.
+        foreign = fixture(cfg); foreign['execution']['execution_route'] = 'workflow'
+        try:
+            validate_profile(foreign, cfg, 'c4')
+        except ValueError as e:
+            assert 'execution_route' in str(e), e
+        else:
+            raise AssertionError('P-3: foreign execution_route executed')
+
+        # R9: a crashed holder's lock (dead pid) is reclaimed; a live holder is NOT.
+        fp = manifest['execution']['config_dir_fingerprint']
+        r9 = os.path.join(d, 'r9'); os.makedirs(r9)
+        dead = subprocess.Popen([sys.executable, '-c', 'import sys; sys.exit(0)'])
+        dead.wait()                                     # dead.pid is now a dead PID
+        with open(os.path.join(r9, fp + '.lock'), 'w', encoding='utf-8') as fh:
+            json.dump({'pid': dead.pid, 'ts': time.time()}, fh)
+        with ActiveCallClaim(fp, r9):                   # reclaims the dead-holder lock, then holds it
+            try:
+                with ActiveCallClaim(fp, r9):
+                    pass
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError('R9: reclaimed a LIVE holder lock')
     print('execution_contract_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -1287,6 +1287,13 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
         'max_agents_factor': MAX_AGENTS_FACTOR,
         'max_agents_headroom': MAX_AGENTS_HEADROOM,
         # H255/H811 low-width staggered dispatch: <=MAX_WIDE concurrent units (0 = unbounded).
+        # P-2 (C-12): max_wide/stagger bound INTRA-process dispatch only -- the JS harness's
+        # boundedParallel honours them within one process, but they CANNOT bound cross-process
+        # concurrency (two node processes each max_wide=1 = 2 concurrent), and the serial headless
+        # executor ignores them entirely. The cross-process guarantee is the kernel-backed
+        # execution_contract.ActiveCallClaim (R9): one active model call per config_dir_fingerprint,
+        # so two launches on ONE profile serialise regardless of these hints. They are advisory
+        # dispatch hints, not a cross-process bound -- see execution_contract_selftest's R9/P-2 test.
         'max_wide': MAX_WIDE,
         'stagger_ms': STAGGER_MS,
         # H442 per-card heal budget: caps the heal agent() calls ONE card may spend so a dense

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -1119,11 +1119,15 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
                 # own (see PIPELINE_HISTORY.md fragment-tag-collision entry).
                 fl.append({'skeleton': fsk, 'ls': t.count('<ls'), 'sk': t.count('{#'),
                            'ph': fph, 'fsha': fsha, 'si': si,
-                           # R6: serve a warm slot ONLY when the cached row carries per-sense owners
-                           # (frag-TM v2). A v1 (ownerless) row is a live cache MISS -- re-translated
-                           # rather than stitched under a null owner -- but stays readable for audit.
+                           # R6: serve a warm slot ONLY when the cached row is a valid frag-TM v2 --
+                           # per-sense owners[] whose members are ALL strings (_tm._valid_owners). A
+                           # v1 (ownerless) OR any null-owner row is a live cache MISS (re-translated,
+                           # never stitched under a null owner), but stays readable for audit. This is
+                           # the single boundary where the manifest fragment_tm is built, so it
+                           # guarantees BOTH the JS FRAG_TM and the headless slot carry no null owner.
                            'tm': ({'senses': cached['senses'], 'owners': cached['owners']}
-                                  if (cached and cached.get('owners') and cached.get('senses'))
+                                  if (cached and cached.get('senses')
+                                      and _tm._valid_owners(cached.get('senses'), cached.get('owners')))
                                   else None)})
             if not fl:
                 continue

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -860,7 +860,12 @@ def degenerate_passthrough_card(key, raw, portrait_text, field='russian'):
     return {
         'key1': key,
         'iast': _portrait_key_iast(portrait_text, key),
-        'records': [{'h': None, 'senses': [sense]}],
+        # R7 (C-07): a degenerate stub is a real cross-reference record with no gloss/grammar, NOT a
+        # null owner. Emit honest source-identity values -- h='' (the stub carries no homonym
+        # discriminator, like the 393 h=='' rows) and grammar='' (like the #517
+        # grammar_defaulted_empty population) -- so validate_final_card_schema passes and one xref
+        # stub can no longer make save_and_audit refuse the entire paid window.
+        'records': [{'h': '', 'grammar': '', 'senses': [sense]}],
         'notes': '',
         'degenerate_passthrough': True,
     }

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -1096,7 +1096,12 @@ def build(root, keys, rootmap, budget, lean=False, nws_gate=False,
                 # own (see PIPELINE_HISTORY.md fragment-tag-collision entry).
                 fl.append({'skeleton': fsk, 'ls': t.count('<ls'), 'sk': t.count('{#'),
                            'ph': fph, 'fsha': fsha, 'si': si,
-                           'tm': cached.get('senses') if cached else None})
+                           # R6: serve a warm slot ONLY when the cached row carries per-sense owners
+                           # (frag-TM v2). A v1 (ownerless) row is a live cache MISS -- re-translated
+                           # rather than stitched under a null owner -- but stays readable for audit.
+                           'tm': ({'senses': cached['senses'], 'owners': cached['owners']}
+                                  if (cached and cached.get('owners') and cached.get('senses'))
+                                  else None)})
             if not fl:
                 continue
             frag_n[k] = len(pl)   # raw deterministic fragment count == sense-units the model
@@ -1907,15 +1912,25 @@ async function selfHeal(k) {
         // slot them in at their document position — do NOT re-restore (no {Tn} remain). Tag
         // normalization still applies: an older cache entry harvested before this fix may carry
         // a fabricated tag.
-        // The fragment TM caches SENSES ONLY -- no record context survives it, so these carry
-        // no h/grammar owner. Recorded as unknown rather than invented (C-02 boundary).
-        for (const s of gtm[i]) { applyTag(grp[i].si, s); senses.push(s); owners.push([null, null]) }
+        // R6: a served frag-TM slot is v2 -- it carries the PER-SENSE owner harvested at the fresh
+        // resolve. v1 (ownerless) rows are a serve-time cache MISS (the gview build drops them), so
+        // a served slot restores each sense's real (h, grammar) instead of a null owner.
+        {
+          const cs = (gtm[i] && gtm[i].senses) || []
+          const co = (gtm[i] && gtm[i].owners) || []
+          for (let j = 0; j < cs.length; j++) {
+            applyTag(grp[i].si, cs[j]); senses.push(cs[j])
+            const o = co[j] || [null, null]
+            owners.push([o[0] == null ? null : o[0], o[1] == null ? null : o[1]])
+          }
+        }
         continue
       }
       const card = r.resolved[i]
       if (!card) continue   // an uncached fragment that never resolved — already in missingFragments
       const ph = gph[i] || []
       const fsenses = []
+      const fowners = []
       for (const rec of (card.records || [])) {
         for (const f of RESTORE_SPEC.record) if (typeof rec[f] === 'string') rec[f] = restore(rec[f], ph)
         for (const s of (rec.senses || [])) {
@@ -1924,10 +1939,11 @@ async function selfHeal(k) {
           // C-02: keep the OWNING record's (h, grammar) alongside the sense. This loop used to
           // flatten records->senses and drop `rec`, so the stitch below had nothing left to
           // emit and every promoted row read h: null (403 of the 468 came from this lane).
-          senses.push(s); owners.push([rec.h, rec.grammar]); fsenses.push(s)
+          senses.push(s); owners.push([rec.h, rec.grammar]); fsenses.push(s); fowners.push([rec.h, rec.grammar])
         }
       }
-      if (grp[i].fsha && fsenses.length) fragProv.push({ fsha: grp[i].fsha, senses: fsenses })
+      // R6: emit the PER-SENSE owner into frag_prov so a warm-cache stitch restores ownership.
+      if (grp[i].fsha && fsenses.length) fragProv.push({ fsha: grp[i].fsha, senses: fsenses, owners: fowners })
     }
   }
   if (!senses.length) { if (!FAIL[k]) noteFail(k, 'selfheal-nothing-resolved'); return null }

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -819,6 +819,24 @@ def card_source_profile(raw, portrait_text=None):
     return None
 
 
+_HOMONYM_HEAD_RE = re.compile(r'<div\s+n=')
+
+
+def _degenerate_record_identity(key, raw):
+    """R7: the immutable source-record identity (h, grammar) for a degenerate cross-reference stub,
+    PROVEN from the source rather than defaulted. In this store the homonym head is the source's
+    `<div n="...">` markup (11,208 rows carry one); the 393 h=='' rows are records with NO homonym
+    head. A degenerate stub provably carries none -- the classifier rejects any raw containing
+    `<div` -- so its proven homonym head is '' (the same identity as those 393 rows). grammar is ''
+    (a cross-reference stub has no grammatical description). Returns None (REJECT the pass-through)
+    when the identity cannot be proven FROM THE SOURCE: a residual homonym-head marker means the
+    record is one of several homonyms and a bare xref cannot prove WHICH, so reject rather than
+    fabricate one."""
+    if _HOMONYM_HEAD_RE.search(raw):
+        return None
+    return '', ''
+
+
 def degenerate_passthrough_card(key, raw, portrait_text, field='russian'):
     """Conservative no-LLM lane for cross-reference/supplement stubs.
 
@@ -848,6 +866,10 @@ def degenerate_passthrough_card(key, raw, portrait_text, field='russian'):
     if len(words) > 8 or any((w not in _DEGENERATE_WORDS and n not in _DEGENERATE_WORDS)
                              for w, n in zip(words, norm)):
         return None
+    identity = _degenerate_record_identity(key, raw)
+    if identity is None:
+        return None       # R7: the source-record identity cannot be proven -> reject the pass-through
+    rec_h, rec_grammar = identity
     sense = {
         'tag': 'xref',
         'german': body,
@@ -860,12 +882,13 @@ def degenerate_passthrough_card(key, raw, portrait_text, field='russian'):
     return {
         'key1': key,
         'iast': _portrait_key_iast(portrait_text, key),
-        # R7 (C-07): a degenerate stub is a real cross-reference record with no gloss/grammar, NOT a
-        # null owner. Emit honest source-identity values -- h='' (the stub carries no homonym
-        # discriminator, like the 393 h=='' rows) and grammar='' (like the #517
-        # grammar_defaulted_empty population) -- so validate_final_card_schema passes and one xref
-        # stub can no longer make save_and_audit refuse the entire paid window.
-        'records': [{'h': '', 'grammar': '', 'senses': [sense]}],
+        # R7 (C-07): a degenerate stub is a real cross-reference record. Its (h, grammar) is the
+        # PROVEN source-record identity from _degenerate_record_identity (h = the source homonym
+        # head, '' when the source has none as here; grammar '' for a no-grammar xref) -- NOT a
+        # schema-appeasing default; an unprovable identity was already rejected above. So
+        # validate_final_card_schema passes and one xref stub can no longer make save_and_audit
+        # refuse the entire paid window.
+        'records': [{'h': rec_h, 'grammar': rec_grammar, 'senses': [sense]}],
         'notes': '',
         'degenerate_passthrough': True,
     }
@@ -1613,7 +1636,12 @@ async function agentKill(prompt, opts, skelBytes, budgetMsOverride) {
 // Masked-token multiset of a text: the {Tn} placeholders it carries, order-insensitive.
 // Two texts with equal token multisets restore to identical citation/markup content.
 const tokensOf = t => ((t || '').match(/\\{T\\d+\\}/g) || []).sort().join(' ')
-const cardTokens = card => { let a = []; for (const rec of (card.records || [])) { a = a.concat((rec.grammar || '').match(/\\{T\\d+\\}/g) || []); for (const s of (rec.senses || [])) a = a.concat((s.german || '').match(/\\{T\\d+\\}/g) || []) } return a.sort().join(' ') }
+// C-17: which fields' {Tn} must MATCH the source skeleton for the fragment-fidelity guard is NOT
+// re-typed here -- it is injected from card_fields.js_token_fidelity_spec(), the SAME constant the
+// Python `card_token_multiset` collects from, so the two twins cannot drift (the C-17 defect was
+// the Python lane omitting `grammar` while this JS lane hard-coded rec.grammar + s.german).
+const TOKEN_FIDELITY_SPEC = %(token_fidelity_spec)s
+const cardTokens = card => { let a = []; for (const rec of (card.records || [])) { for (const f of TOKEN_FIDELITY_SPEC.record) a = a.concat((rec[f] || '').match(/\\{T\\d+\\}/g) || []); for (const s of (rec.senses || [])) for (const f of TOKEN_FIDELITY_SPEC.sense) a = a.concat((s[f] || '').match(/\\{T\\d+\\}/g) || []) } return a.sort().join(' ') }
 // Index a returned cards[] by its self-declared key1 (the prompt requires key1 to echo the
 // '=== CARD <key> ===' header). Used to match responses by KEY first, position second —
 // positional-only matching silently misassigns every card after an omitted/reordered one.
@@ -2204,6 +2232,7 @@ return { meta: META, summary, results: out }
         # unmask; both listed three fields while promote read six, and 670 store rows landed
         # with a raw {Tn}. The JS cannot import Python, so the constant is injected instead.
         'restore_spec': card_fields.js_restore_spec(field),
+        'token_fidelity_spec': card_fields.js_token_fidelity_spec(),
         # Language-aware meta + model pin. EN path pins Sonnet 5 explicitly
         # (the bare 'sonnet' alias resolved to 4.6 on a prior run); RU path
         # keeps the 'sonnet' alias unchanged so the autonomous RU runs are untouched.

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -560,12 +560,18 @@ class HeadlessEngine:
                 # later -- it has to survive the flatten.
                 frag_records = []
                 if index < len(cached) and cached[index]:
-                    # The fragment TM caches SENSES ONLY, with no record context, so a
-                    # TM-served fragment genuinely has no `h` to carry. Emit it under an
-                    # unknown owner rather than inventing one -- synthesising an `h` here is
-                    # what the C-02 boundary forbids. This is the residual null source and is
-                    # counted in the summary below.
-                    frag_records = [(None, None, cached[index])]
+                    # R6: a served frag-TM slot is v2 -- it carries the PER-SENSE owner harvested at
+                    # the fresh-resolve run. v1 (ownerless) rows are a serve-time cache MISS (the
+                    # gview build drops them), so a served slot restores each sense's real
+                    # (h, grammar) instead of the C-02 residual null owner that regenerated null-`h`
+                    # rows on every warm run.
+                    slot = cached[index]
+                    c_senses = slot.get('senses') or []
+                    c_owners = slot.get('owners') or []
+                    frag_records = [((c_owners[j] or [None, None])[0] if j < len(c_owners) else None,
+                                     (c_owners[j] or [None, None])[1] if j < len(c_owners) else None,
+                                     [c_senses[j]])
+                                    for j in range(len(c_senses))]
                 elif index in resolved:
                     card = restore_card(resolved[index], self.m['field'],
                                         phs[index] if index < len(phs) else [], unmapped)
@@ -573,8 +579,12 @@ class HeadlessEngine:
                                      record.get('senses') or [])
                                     for record in card.get('records') or []]
                     frag_senses = [sense for _, _, group in frag_records for sense in group]
+                    # R6: carry the PER-SENSE owner into frag_prov so a later warm-cache stitch of
+                    # this fragment restores each sense's (h, grammar) instead of a null owner.
+                    frag_owners = [[rh, rg] for rh, rg, group in frag_records for _ in group]
                     if fragment.get('fsha') and frag_senses:
-                        frag_prov.append({'fsha': fragment['fsha'], 'senses': frag_senses})
+                        frag_prov.append({'fsha': fragment['fsha'], 'senses': frag_senses,
+                                          'owners': frag_owners})
                 for rec_h, rec_grammar, group in frag_records:
                     for sense in group:
                         source_ord = fragment.get('si')

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -33,6 +33,10 @@ EXIT_TIMEOUT = 22
 EXIT_MALFORMED = 23
 EXIT_CONTENT = 24
 
+# R4 (C-15): the hard per-call subprocess ceiling. "NOTHING runs past 3 min (MG)". The bare
+# operator default was 7200 s -- 40x this -- because `budgets.timeout_ceil_ms` was never read.
+HARD_TIMEOUT_MS = 180000
+
 
 def claude_argv_prefix(claude_bin):
     """Return the argv prefix that invokes the Claude CLI directly (Windows-safe).
@@ -288,10 +292,19 @@ def token_multiset(value):
 
 
 def card_token_multiset(card):
+    # C-17: collect {Tn} from EVERY source-mirror field (record.grammar + sense.german), driven
+    # by the one `card_fields.TOKEN_FIDELITY_FIELDS` tuple the JS `cardTokens` also uses. The old
+    # body read `sense.german` only, so a grammar-{Tn} card counted fewer tokens than its skeleton
+    # and was falsely `fragment-fidelity-reject`ed on this lane while JS accepted it.
+    record_fields = [n for lvl, n in card_fields.TOKEN_FIDELITY_FIELDS if lvl == 'record']
+    sense_fields = [n for lvl, n in card_fields.TOKEN_FIDELITY_FIELDS if lvl == 'sense']
     tokens = []
     for record in card.get('records') or []:
+        for name in record_fields:
+            tokens.extend(re.findall(r'\{T\d+\}', record.get(name) or ''))
         for sense in record.get('senses') or []:
-            tokens.extend(re.findall(r'\{T\d+\}', sense.get('german') or ''))
+            for name in sense_fields:
+                tokens.extend(re.findall(r'\{T\d+\}', sense.get(name) or ''))
     return collections.Counter(tokens)
 
 
@@ -299,10 +312,16 @@ def card_token_multiset(card):
 
 
 class HeadlessEngine:
-    def __init__(self, manifest, claude, timeout, runner):
+    def __init__(self, manifest, claude, timeout, runner, max_agents_override=None):
         self.m = manifest
         self.claude = claude
-        self.timeout = timeout
+        budgets = manifest.get('budgets') or {}
+        # R4 (C-15): clamp every subprocess to min(operator, budgets.timeout_ceil_ms, HARD).
+        eff_ms = min(int(timeout) * 1000, HARD_TIMEOUT_MS)
+        ceil_ms = budgets.get('timeout_ceil_ms')
+        if ceil_ms:
+            eff_ms = min(eff_ms, int(ceil_ms))
+        self.timeout = eff_ms / 1000.0
         self.run = runner or run_tree_kill
         self.attempts = []
         self.failures = {}
@@ -310,11 +329,36 @@ class HeadlessEngine:
         self.heal_calls = 0
         self.kill_timeouts = 0
         self.conn_errors = 0
+        # R3 (C-12/C-13): the manifest agent budgets were write-only -- emitted, validated-adjacent,
+        # never read by the executor. Enforce them here. None = unbounded (back-compat). The
+        # `--max-agents` override caps the TOTAL across both lanes and binds even without budgets.
+        self.max_translate_agents = budgets.get('max_translate_agents')
+        self.max_heal_agents = budgets.get('max_heal_agents')
+        self.max_total_agents = budgets.get('max_agents')
+        if max_agents_override is not None:
+            self.max_total_agents = (max_agents_override if self.max_total_agents is None
+                                     else min(self.max_total_agents, max_agents_override))
+        self.budget_stops = 0
 
     def note(self, key, error):
         self.failures[key] = str(error)[:300]
 
+    def _budget_ok(self, heal):
+        """R3: True while another spawn on this lane stays within the manifest agent budgets.
+        Checked BEFORE the counter increments and the subprocess spawns, so `translate_calls` /
+        `heal_calls` can never exceed their ceilings. None = unbounded (back-compat)."""
+        if (self.max_total_agents is not None and
+                self.translate_calls + self.heal_calls >= self.max_total_agents):
+            return False
+        if heal:
+            return self.max_heal_agents is None or self.heal_calls < self.max_heal_agents
+        return self.max_translate_agents is None or self.translate_calls < self.max_translate_agents
+
     def call(self, prompt, label, keys, heal=False):
+        if not self._budget_ok(heal):
+            # R3: a refused call consumes NO spawn and returns a typed stop reason.
+            self.budget_stops += 1
+            return None, 'budget_exceeded:%s' % ('heal' if heal else 'translate')
         argv = claude_argv_prefix(self.claude) + [
                 '-p', '--output-format', 'json', '--json-schema',
                 json.dumps(self.m['output_schema'], ensure_ascii=False, separators=(',', ':')),
@@ -372,6 +416,8 @@ class HeadlessEngine:
             if error:
                 for key in pending:
                     self.note(key, error)
+                if error.startswith('budget_exceeded'):
+                    break                    # R3: retrying/bisecting would only refuse again
                 timed_out = error == 'timeout'
                 if timed_out:
                     break
@@ -383,7 +429,8 @@ class HeadlessEngine:
                     self.note(row['key'], row.get('error', 'unresolved'))
             pending = [key for key in pending if key not in resolved]
         if (pending and len(pending) > 1 and
-                self.m.get('runtime', {}).get('binary_split', True)):
+                self.m.get('runtime', {}).get('binary_split', True) and
+                self._budget_ok(False)):
             mid = (len(pending) + 1) // 2
             for suffix, half in (('A', pending[:mid]), ('B', pending[mid:])):
                 child, _child_pending = self.resolve_group(half, label + '/' + suffix)
@@ -416,6 +463,8 @@ class HeadlessEngine:
             if error:
                 for index in pending:
                     self.note('%s_f%d' % (key, index), error)
+                if error.startswith('budget_exceeded'):
+                    break                    # R3: heal ceiling hit -- stop, do not bisect
                 timed_out = error == 'timeout'
                 if timed_out:
                     break
@@ -433,7 +482,8 @@ class HeadlessEngine:
                 resolved[index] = card
             pending = [index for index in pending if index not in resolved]
         no_bisect = timed_out and self.m.get('runtime', {}).get('kill_timeout_no_bisect', True)
-        if (len(pending) > 1 and not no_bisect and budget['spent'] < budget['max']):
+        if (len(pending) > 1 and not no_bisect and budget['spent'] < budget['max']
+                and self._budget_ok(True)):
             mid = (len(pending) + 1) // 2
             for suffix, half in (('A', pending[:mid]), ('B', pending[mid:])):
                 child, _ = self.heal_group(key, group, half, label + '/' + suffix, budget)
@@ -558,9 +608,9 @@ class HeadlessEngine:
         return rows, healed, len(presplit)
 
 
-def execute(manifest, claude='claude', timeout=7200, runner=None):
+def execute(manifest, claude='claude', timeout=7200, runner=None, max_agents_override=None):
     validate_manifest(manifest, require_v2=False)
-    engine = HeadlessEngine(manifest, claude, timeout, runner)
+    engine = HeadlessEngine(manifest, claude, timeout, runner, max_agents_override)
     try:
         results, healed, presplit = engine.run_all()
     except HardFailure as exc:
@@ -586,6 +636,7 @@ def execute(manifest, claude='claude', timeout=7200, runner=None):
                'null_keys': list(failures), 'partial_keys': [], 'failures': failures,
                'translate_agents_spent': engine.translate_calls,
                'heal_agents_spent': engine.heal_calls,
+               'budget_stops': engine.budget_stops,
                'kill_timeouts': engine.kill_timeouts, 'conn_errors': engine.conn_errors,
                'headless_attempts': engine.attempts}
     output_meta = dict(manifest['meta'])
@@ -608,6 +659,9 @@ def main(argv=None):
     ap.add_argument('--allow-historical-v1', action='store_true',
                     help='read-only/historical replay only; v1 is not a production contract')
     ap.add_argument('--timeout', type=int, default=7200)
+    ap.add_argument('--max-agents', type=int, default=None,
+                    help='R3: hard cap on total model spawns (translate+heal); binds even when '
+                         'the manifest omits budgets, and caps the manifest budget when both set')
     args = ap.parse_args(argv)
     manifest_hash = sha256_path(args.manifest)
     with open(args.manifest, encoding='utf-8') as f:
@@ -616,14 +670,16 @@ def main(argv=None):
         if manifest.get('schema') == SCHEMA_V1:
             if not args.allow_historical_v1:
                 raise ValueError('v1 manifest is historical-only; production requires %s' % SCHEMA_V2)
-            payload, status, code = execute(manifest, args.claude_bin, args.timeout)
+            payload, status, code = execute(manifest, args.claude_bin, args.timeout,
+                                            max_agents_override=args.max_agents)
         else:
             config_dir = os.environ.get('CLAUDE_CONFIG_DIR')
             if not config_dir:
                 raise ValueError('CLAUDE_CONFIG_DIR is required for manifest v2')
             validate_profile(manifest, config_dir, args.only_profile)
             with ActiveCallClaim(manifest['execution']['config_dir_fingerprint']):
-                payload, status, code = execute(manifest, args.claude_bin, args.timeout)
+                payload, status, code = execute(manifest, args.claude_bin, args.timeout,
+                                            max_agents_override=args.max_agents)
     except (OSError, RuntimeError, ValueError) as exc:
         payload, status, code = None, {'classification': 'configuration', 'error': str(exc)}, 2
     status['manifest_sha256'] = manifest_hash

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -652,8 +652,32 @@ class HeadlessEngine:
         return rows, healed, len(presplit)
 
 
+def _validate_fragment_tm(manifest):
+    """R6 execution-time gate: refuse a manifest whose fragment_tm carries any warm slot with
+    invalid/null owners, BEFORE any paid call. The generator's gview already drops v1 (ownerless) and
+    null-owner rows, but a DIRECT / hand-edited manifest bypasses the generator -- so validate here
+    that every non-empty slot is a v2 shape {senses, owners} whose owners are len(senses) [h, grammar]
+    pairs with BOTH members strings (no None). A bare/legacy (ownerless) slot or a null owner is
+    refused rather than stitched under a null owner."""
+    for key, groups in (manifest.get('fragment_tm') or {}).items():
+        for group in groups or []:
+            for slot in group or []:
+                if not slot:
+                    continue                     # None / empty slot = cache miss, fine
+                senses = slot.get('senses') if isinstance(slot, dict) else None
+                owners = slot.get('owners') if isinstance(slot, dict) else None
+                if not (isinstance(senses, list) and isinstance(owners, list)
+                        and len(owners) == len(senses)
+                        and all(isinstance(p, (list, tuple)) and len(p) == 2
+                                and all(isinstance(x, str) for x in p) for p in owners)):
+                    raise ValueError(
+                        'fragment_tm slot for %r has invalid/null owners (refused before any call): %r'
+                        % (key, owners))
+
+
 def execute(manifest, claude='claude', timeout=7200, runner=None, max_agents_override=None):
     validate_manifest(manifest, require_v2=False)
+    _validate_fragment_tm(manifest)      # R6: refuse a null-owner fragment_tm slot BEFORE any call
     engine = HeadlessEngine(manifest, claude, timeout, runner, max_agents_override)
     try:
         results, healed, presplit = engine.run_all()

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -339,9 +339,42 @@ class HeadlessEngine:
             self.max_total_agents = (max_agents_override if self.max_total_agents is None
                                      else min(self.max_total_agents, max_agents_override))
         self.budget_stops = 0
+        # R5 (C-25): the CLI wrapper's usage/cost were parsed then dropped at the call site, so
+        # actual spend was unreconcilable and a priced run ended STOP_COST_UNEVALUABLE. Accumulate.
+        self.usage = {'input_tokens': 0, 'output_tokens': 0, 'cache_read_tokens': 0,
+                      'cache_creation_tokens': 0, 'subagent_tokens': 0,
+                      'observed_cost_usd': 0.0, 'cost_evaluable': True, 'priced_calls': 0,
+                      'missing_usage_calls': 0}
 
     def note(self, key, error):
         self.failures[key] = str(error)[:300]
+
+    def _accumulate_usage(self, wrapper):
+        """R5: fold one CLI wrapper's usage/cost into the running totals. A missing usage or cost
+        field flips `cost_evaluable` False (so a real call is never priced at $0) instead of being
+        silently dropped. `subagent_tokens` is the field the economy pricer reads."""
+        self.usage['priced_calls'] += 1
+        u = wrapper.get('usage') if isinstance(wrapper, dict) else None
+        if isinstance(u, dict):
+            # These are disjoint Claude usage fields; sum them, never overwrite. Prior calls'
+            # totals are retained even when a later call arrives with no usage.
+            self.usage['input_tokens'] += int(u.get('input_tokens') or 0)
+            self.usage['output_tokens'] += int(u.get('output_tokens') or 0)
+            self.usage['cache_read_tokens'] += int(u.get('cache_read_input_tokens') or 0)
+            self.usage['cache_creation_tokens'] += int(u.get('cache_creation_input_tokens') or 0)
+        else:
+            # Retain known telemetry; mark the whole run unpriceable and count the gap.
+            self.usage['cost_evaluable'] = False
+            self.usage['missing_usage_calls'] += 1
+        cost = wrapper.get('total_cost_usd') if isinstance(wrapper, dict) else None
+        if cost is None:
+            self.usage['cost_evaluable'] = False
+        else:
+            # observed_cost_usd stays authoritative (accumulated CLI cost), not recomputed from tokens.
+            self.usage['observed_cost_usd'] += float(cost)
+        self.usage['subagent_tokens'] = (
+            self.usage['input_tokens'] + self.usage['output_tokens']
+            + self.usage['cache_read_tokens'] + self.usage['cache_creation_tokens'])
 
     def _budget_ok(self, heal):
         """R3: True while another spawn on this lane stays within the manifest agent budgets.
@@ -390,11 +423,12 @@ class HeadlessEngine:
                                   'elapsed_ms': elapsed, 'classification': classification})
             raise HardFailure(classification, code, (proc.stderr or proc.stdout or '')[-2000:])
         try:
-            structured, _wrapper = extract_structured(proc.stdout)
+            structured, wrapper = extract_structured(proc.stdout)
         except ValueError as exc:
             self.attempts.append({'label': label, 'keys': keys, 'returncode': 0,
                                   'elapsed_ms': elapsed, 'classification': 'malformed_output'})
             return None, 'malformed_output:%s' % exc
+        self._accumulate_usage(wrapper)     # R5: capture spend instead of discarding it
         self.attempts.append({'label': label, 'keys': keys, 'returncode': 0,
                               'elapsed_ms': elapsed, 'classification': 'success'})
         return structured, None
@@ -637,6 +671,7 @@ def execute(manifest, claude='claude', timeout=7200, runner=None, max_agents_ove
                'translate_agents_spent': engine.translate_calls,
                'heal_agents_spent': engine.heal_calls,
                'budget_stops': engine.budget_stops,
+               'usage': engine.usage,
                'kill_timeouts': engine.kill_timeouts, 'conn_errors': engine.conn_errors,
                'headless_attempts': engine.attempts}
     output_meta = dict(manifest['meta'])

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -106,6 +106,66 @@ def test_card_tokens_include_grammar():
     print('  R2 tokens: card_token_multiset counts grammar+german via card_fields.TOKEN_FIDELITY_FIELDS')
 
 
+def test_cost_telemetry_survives():
+    """R5 (C-25): the CLI wrapper's usage/cost survive into summary['usage']:
+      * a resolving call surfaces its usage/cost (schema-valid card, record `h` present — the test
+        must not embed the C-02 missing-h defect);
+      * multiple calls (retry/split/heal) SUM, never overwrite by the last response;
+      * a measured call + a call missing usage -> known telemetry retained, cost_evaluable False,
+        missing_usage_calls incremented, observed_cost_usd authoritative (accumulated, not recomputed);
+      * a budget refusal (no subprocess) adds neither usage nor cost."""
+    U = {'input_tokens': 100, 'output_tokens': 50,
+         'cache_read_input_tokens': 10, 'cache_creation_input_tokens': 5}   # disjoint fields
+
+    def wrap(cards, usage=U, cost=0.01):
+        w = {'structured_output': {'cards': cards}}
+        if usage is not None:
+            w['usage'] = usage
+        if cost is not None:
+            w['total_cost_usd'] = cost
+        return proc(stdout=json.dumps(w))
+
+    def sequence(seq):
+        def runner(argv, **k):
+            runner.i += 1
+            return seq[min(runner.i - 1, len(seq) - 1)]
+        runner.i = 0
+        return runner
+
+    valid_card = {'key1': 'agni', 'iast': 'agni', 'notes': '',
+                  'records': [{'h': '', 'grammar': '{T1} m.', 'senses': [
+                      {'tag': '1', 'german': '{T1} Feuer', 'russian': '{T1} огонь'}]}]}
+
+    # resolving call surfaces usage/cost (schema-valid card)
+    payload = execute(manifest(), lambda argv, **k: wrap([valid_card], U, 0.0123))[0]
+    assert payload['results'][0]['card'], 'schema-valid card should resolve'
+    u = payload['summary']['usage']
+    assert (u['input_tokens'], u['output_tokens'], u['cache_read_tokens'],
+            u['cache_creation_tokens']) == (100, 50, 10, 5), u
+    assert u['subagent_tokens'] == 165 and u['cost_evaluable'] is True and u['priced_calls'] == 1, u
+    assert abs(u['observed_cost_usd'] - 0.0123) < 1e-9, u
+
+    # (a) two calls SUM, not overwrite (empty cards -> retry to whole_attempts=2)
+    u = execute(manifest(), sequence([wrap([], U, 0.01), wrap([], U, 0.02)]))[0]['summary']['usage']
+    assert u['priced_calls'] == 2 and u['input_tokens'] == 200 and u['subagent_tokens'] == 330, u
+    assert abs(u['observed_cost_usd'] - 0.03) < 1e-9 and u['cost_evaluable'] is True, u
+
+    # (b) measured + missing-usage -> retain telemetry, cost_evaluable False, counter, authoritative cost
+    u = execute(manifest(), sequence([wrap([], U, 0.01), wrap([], usage=None, cost=None)]))[0]['summary']['usage']
+    assert u['input_tokens'] == 100 and u['subagent_tokens'] == 165, u
+    assert u['cost_evaluable'] is False and u['missing_usage_calls'] == 1, u
+    assert abs(u['observed_cost_usd'] - 0.01) < 1e-9, u
+
+    # (c) a budget refusal (no subprocess) adds neither usage nor cost
+    m = manifest(); m['budgets'] = {'max_translate_agents': 1}
+    r = sequence([wrap([], U, 0.05)])
+    u = execute(m, r)[0]['summary']['usage']
+    assert r.i == 1, 'budget should cap to 1 actual spawn, got %d' % r.i
+    assert u['priced_calls'] == 1 and u['input_tokens'] == 100, u
+    assert abs(u['observed_cost_usd'] - 0.05) < 1e-9, u
+    print('  R5 cost: usage/cost sum across calls; missing -> cost_evaluable False + counter; budget refusal adds nothing')
+
+
 def main():
     payload, status, code = execute(manifest(), success_runner)
     assert code == 0 and status['classification'] == 'success'
@@ -332,6 +392,7 @@ console.log(JSON.stringify(restoreCard(card, 'agni')))
     test_translate_budget_binds()
     test_call_timeout_clamped()
     test_card_tokens_include_grammar()
+    test_cost_telemetry_survives()
     print('headless_worker_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -195,6 +195,30 @@ def test_foreign_route_refused_before_any_call():
     print('  P-3 route: foreign execution_route refused before any runner call (runner uncalled)')
 
 
+def test_frag_tm_stitch_retains_owner():
+    """R6 (C-02 residual): a warm frag-TM (v2) stitch restores each sense's (h, grammar) owner
+    instead of a null owner, and heals a fully-cached fragment with ZERO model calls."""
+    m = manifest()
+    key = 'agni'
+    sense = {'tag': '1', 'german': 'Feuer', 'russian': 'огонь'}   # already restored, no {Tn}
+    m['fragment_groups'] = {key: [[{'skeleton': 'Feuer', 'fsha': 'FSHA0', 'si': 0}]]}
+    m['fragment_placeholder_maps'] = {key: [[[]]]}
+    m['fragment_tm'] = {key: [[{'senses': [sense], 'owners': [['2. agni', 'm.']]}]]}
+    m['inputs'] = {key: {'skeleton': 'Feuer', 'portrait': '{}', 'ls': 0, 'sk': 0, 'nws': 0}}
+    m['batches'] = []
+    m['presplit_keys'] = [key]
+
+    def never_runner(argv, **kwargs):
+        raise AssertionError('R6: a fully-cached fragment must NOT call the model')
+
+    payload, _status, _code = execute(m, never_runner)
+    card = payload['results'][0]['card']
+    assert card, 'a fully-cached fragment should stitch a card'
+    rec = card['records'][0]
+    assert rec.get('h') == '2. agni' and rec.get('grammar') == 'm.', rec   # owner restored, not null
+    print('  R6 frag-TM: a v2-served warm stitch retains each sense owner (h/grammar), zero calls')
+
+
 def main():
     payload, status, code = execute(manifest(), success_runner)
     assert code == 0 and status['classification'] == 'success'
@@ -423,6 +447,7 @@ console.log(JSON.stringify(restoreCard(card, 'agni')))
     test_card_tokens_include_grammar()
     test_cost_telemetry_survives()
     test_foreign_route_refused_before_any_call()
+    test_frag_tm_stitch_retains_owner()
     print('headless_worker_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -52,6 +52,60 @@ def success_runner(argv, **kwargs):
     return proc(stdout=json.dumps(wrapper))
 
 
+def _soft_nonresolve_runner():
+    """A runner that always returns a well-formed-but-empty result, so the engine keeps
+    trying to spawn (retries/bisect/heal) -- maximum spawn pressure, no HardFailure."""
+    def runner(argv, **kwargs):
+        runner.n += 1
+        return proc(stdout=json.dumps({'structured_output': {'cards': []}}))
+    runner.n = 0
+    return runner
+
+
+def test_translate_budget_binds():
+    """R3 (C-12/C-13): the manifest agent budget and the --max-agents override cap the ACTUAL
+    spawn count. The 1-key fixture would spawn `whole_attempts`=2 unbounded; a ceiling of 1
+    must cut it to 1, consuming no extra call."""
+    r = _soft_nonresolve_runner()
+    execute(manifest(), r)
+    assert r.n == 2, 'expected 2 unbounded spawns (whole_attempts), got %d' % r.n
+    r = _soft_nonresolve_runner()
+    m = manifest(); m['budgets'] = {'max_translate_agents': 1}
+    execute(m, r)
+    assert r.n == 1, 'manifest budget=1 did not bind: %d spawns' % r.n
+    r = _soft_nonresolve_runner()
+    h.execute(manifest(), claude=sys.executable, runner=r, max_agents_override=1)
+    assert r.n == 1, '--max-agents=1 did not bind: %d spawns' % r.n
+    print('  R3 budget: unbounded=2; manifest ceiling and --max-agents both cap actual spawns to 1')
+
+
+def test_call_timeout_clamped():
+    """R4 (C-15): the timeout handed to subprocess is min(operator, budgets.timeout_ceil_ms, HARD)."""
+    seen = {}
+    def capture_runner(argv, **kwargs):
+        seen['timeout'] = kwargs.get('timeout')
+        return success_runner(argv, **kwargs)
+    execute(manifest(), capture_runner)   # operator default 7200 s -> clamp to HARD (180 s)
+    assert seen['timeout'] == h.HARD_TIMEOUT_MS / 1000.0, 'not clamped to HARD: %r' % seen['timeout']
+    seen.clear()
+    m = manifest(); m['budgets'] = {'timeout_ceil_ms': 45000}
+    execute(m, capture_runner)
+    assert seen['timeout'] == 45.0, 'timeout_ceil_ms not honoured: %r' % seen['timeout']
+    print('  R4 timeout: clamped to min(operator,ceil,180000ms) -> 180.0s then 45.0s')
+
+
+def test_card_tokens_include_grammar():
+    """R2/C-17: card_token_multiset counts {Tn} in record.grammar (not german-only), matching the
+    JS cardTokens, so a grammar-{Tn} card is not falsely fragment-fidelity-rejected. Driven by the
+    one card_fields.TOKEN_FIDELITY_FIELDS tuple the two twins share."""
+    import card_fields as cf
+    card = {'records': [{'grammar': '{T3} {T4}', 'senses': [{'german': '{T1} Feuer'}]}]}
+    ms = dict(h.card_token_multiset(card))
+    assert ms == {'{T1}': 1, '{T3}': 1, '{T4}': 1}, 'grammar tokens missing: %r' % ms
+    assert ('record', 'grammar') in cf.TOKEN_FIDELITY_FIELDS and ('sense', 'german') in cf.TOKEN_FIDELITY_FIELDS
+    print('  R2 tokens: card_token_multiset counts grammar+german via card_fields.TOKEN_FIDELITY_FIELDS')
+
+
 def main():
     payload, status, code = execute(manifest(), success_runner)
     assert code == 0 and status['classification'] == 'success'
@@ -275,6 +329,9 @@ console.log(JSON.stringify(restoreCard(card, 'agni')))
         still_alive = [p for p in pids if _alive(p)]
         assert not still_alive, 'tree PID(s) still alive after kill (orphaned): %s' % still_alive
     print('  D-J tree-kill: parent->child->grandchild all gone (no orphan); timeout bounded + raised once')
+    test_translate_budget_binds()
+    test_call_timeout_clamped()
+    test_card_tokens_include_grammar()
     print('headless_worker_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -166,6 +166,35 @@ def test_cost_telemetry_survives():
     print('  R5 cost: usage/cost sum across calls; missing -> cost_evaluable False + counter; budget refusal adds nothing')
 
 
+def test_foreign_route_refused_before_any_call():
+    """P-3: in the execution flow (validate_profile gates execute), a v2 manifest declaring a
+    foreign route is refused BEFORE execute runs, so the injected model runner is NEVER invoked --
+    not merely that validate_profile() raises in isolation."""
+    import execution_contract as ec
+    called = {'n': 0}
+    def counting_runner(argv, **kwargs):
+        called['n'] += 1
+        return success_runner(argv, **kwargs)
+    with tempfile.TemporaryDirectory() as cfgroot:
+        cfg = os.path.join(cfgroot, 'p'); os.makedirs(cfg)
+        m = manifest()
+        m['schema'] = ec.SCHEMA_V2
+        m['execution'] = {'profile_slot': 'c4',
+                          'config_dir_fingerprint': ec.config_dir_fingerprint(cfg),
+                          'execution_route': 'workflow', 'executor_lane': 'serial',
+                          'validation_method': 'audit', 'model_identifier': m['model']}
+        m['key_provenance'] = {'agni': 'real'}
+        try:                       # replicate headless_worker.main()'s v2 order
+            ec.validate_profile(m, cfg)
+            h.execute(m, claude=sys.executable, runner=counting_runner)   # must NOT be reached
+        except ValueError as e:
+            assert 'execution_route' in str(e), e
+        else:
+            raise AssertionError('P-3: foreign route reached execute')
+    assert called['n'] == 0, 'P-3: runner was called despite a foreign route'
+    print('  P-3 route: foreign execution_route refused before any runner call (runner uncalled)')
+
+
 def main():
     payload, status, code = execute(manifest(), success_runner)
     assert code == 0 and status['classification'] == 'success'
@@ -393,6 +422,7 @@ console.log(JSON.stringify(restoreCard(card, 'agni')))
     test_call_timeout_clamped()
     test_card_tokens_include_grammar()
     test_cost_telemetry_survives()
+    test_foreign_route_refused_before_any_call()
     print('headless_worker_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -219,6 +219,40 @@ def test_frag_tm_stitch_retains_owner():
     print('  R6 frag-TM: a v2-served warm stitch retains each sense owner (h/grammar), zero calls')
 
 
+def test_null_owner_fragment_tm_refused_before_any_call():
+    """R6 execution-time gate: a DIRECT manifest whose fragment_tm slot carries a null owner
+    ([None,'m.'] / ['2. agni',None]) -- or is ownerless (legacy shape) -- is refused BEFORE any paid
+    call, with the runner PROVEN uncalled. The generator's gview drops such rows, but a hand-edited /
+    direct manifest bypasses it, so the executor validates every slot before stitching."""
+    def never_runner(argv, **kwargs):
+        raise AssertionError('runner was called despite a null/ownerless fragment_tm slot')
+    sense = {'tag': '1', 'german': 'Feuer', 'russian': 'огонь'}
+
+    def _mk(owners_or_missing):
+        m = manifest()
+        key = 'agni'
+        slot = {'senses': [sense]}
+        if owners_or_missing is not None:
+            slot['owners'] = owners_or_missing
+        m['fragment_groups'] = {key: [[{'skeleton': 'Feuer', 'fsha': 'F', 'si': 0}]]}
+        m['fragment_placeholder_maps'] = {key: [[[]]]}
+        m['fragment_tm'] = {key: [[slot]]}
+        m['inputs'] = {key: {'skeleton': 'Feuer', 'portrait': '{}', 'ls': 0, 'sk': 0, 'nws': 0}}
+        m['batches'] = []
+        m['presplit_keys'] = [key]
+        return m
+
+    for bad in ([[None, 'm.']], [['2. agni', None]], None):   # null-h, null-grammar, ownerless
+        try:
+            execute(_mk(bad), never_runner)
+        except ValueError as e:
+            assert 'owner' in str(e).lower(), e
+        else:
+            raise AssertionError('a null/ownerless fragment_tm slot (%r) must be refused before any call' % bad)
+    print('  R6 exec-gate: a direct manifest with a null/ownerless fragment_tm slot is refused before '
+          'any call (runner uncalled)')
+
+
 def main():
     payload, status, code = execute(manifest(), success_runner)
     assert code == 0 and status['classification'] == 'success'
@@ -448,6 +482,7 @@ console.log(JSON.stringify(restoreCard(card, 'agni')))
     test_cost_telemetry_survives()
     test_foreign_route_refused_before_any_call()
     test_frag_tm_stitch_retains_owner()
+    test_null_owner_fragment_tm_refused_before_any_call()
     print('headless_worker_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -103,6 +103,23 @@ TRUST_RANK = {TRUST_REVIEWED: 30, TRUST_MACHINE: 20, 'legacy_promoted': 10,
 SUGGEST_SCHEMA = 'pwg.translation_memory.suggest.v1'
 CARD_SCHEMA = 'pwg.translation_memory.v1'
 FRAG_SCHEMA = 'pwg.translation_memory.frag.v1'
+FRAG_SCHEMA_V2 = 'pwg.translation_memory.frag.v2'   # R6: adds a per-sense owners[] array
+
+
+def _valid_owners(senses, owners):
+    """R6: a v2 `owners[]` is a list parallel to `senses`, each element an `[h, grammar]` pair whose
+    members are str-or-None. Malformed/missing owners disqualify a row from live v2 reuse (it stays
+    a v1 row -- audit-readable, never served warm)."""
+    if not isinstance(owners, list) or not isinstance(senses, list):
+        return False
+    if len(owners) != len(senses):
+        return False
+    for pair in owners:
+        if not (isinstance(pair, (list, tuple)) and len(pair) == 2):
+            return False
+        if not all(x is None or isinstance(x, str) for x in pair):
+            return False
+    return True
 PUBLICATION_SCHEMA = 'pwg.translation_memory.publication.v1'
 SCORE_FIELDS = ('score_de_fragment', 'score_sa_headword', 'score_semantic_tag')
 OPTIONAL_SUGGEST_FIELDS = (
@@ -492,9 +509,13 @@ def _normalize_frag_row(row):
     return row
 
 
-def load_frag_tm(lang, path=None, denylist=None):
-    """Return { fsha: {'senses': [...], 'src_key', 'root', ...} } for the fragment sidecar,
-    or {} if none exists. Best reusable row wins (reviewed > machine > legacy; blocked ignored)."""
+def load_frag_tm(lang, path=None, denylist=None, live_only=True):
+    """Return { fsha: {'senses': [...], 'owners': [...], ...} } for the fragment sidecar, or {} if
+    none exists. Best reusable row wins (reviewed > machine > legacy; blocked ignored). R6: by
+    default (`live_only`) only frag-TM v2 rows with a valid per-sense `owners[]` are served; a v1
+    (ownerless) row is readable for historical audit (`live_only=False`) but never live-reusable, so
+    a warm stitch can never regenerate a null-`h` row. A valid v2 row supersedes an ownerless v1 row
+    with the same fsha (it is the only served candidate)."""
     p = frag_tm_path(lang, path)
     out = {}
     if not os.path.exists(p):
@@ -513,9 +534,17 @@ def load_frag_tm(lang, path=None, denylist=None):
             fsha = row.get('fsha')
             # Serve-time fidelity filter: a corrupt/blanked historical row is
             # never handed to the harness, regardless of when it was harvested.
-            if (fsha and fsha not in deny['frags']
+            if not (fsha and fsha not in deny['frags']
                     and frag_senses_sane(row.get('senses'), lang)):
-                by_fsha[fsha].append(_normalize_frag_row(row))
+                continue
+            if live_only and not (row.get('schema') == FRAG_SCHEMA_V2
+                                  and _valid_owners(row.get('senses'), row.get('owners'))):
+                # R6: a v1 (ownerless) or malformed-owners row is readable for historical audit
+                # (live_only=False) but NEVER live-reusable -- a warm stitch must not regenerate a
+                # null-`h` row. A valid v2 row for the same fsha supersedes it here by being the only
+                # served candidate.
+                continue
+            by_fsha[fsha].append(_normalize_frag_row(row))
     for fsha, candidates in by_fsha.items():
         best = best_reusable(candidates)
         if best:
@@ -528,11 +557,27 @@ def build_frags(glob_pattern, lang, out=None):
     append-only fragment sidecar. Idempotent: a fragment already present (by fsha) is never
     duplicated. Returns (path, added, total)."""
     path = frag_tm_path(lang, out)
-    # seen[fsha] == True once a SANE row for that fsha is cached. A fsha whose only
-    # cached rows are corrupt maps to False, so a later good harvest can override it
-    # (previously first-seen-wins locked in the poisoned row). load_frag_tm already
-    # applies the serve-time fidelity filter, so its keys are exactly the sane fshas.
-    seen = {fsha: True for fsha in load_frag_tm(lang, path)}
+    # seen[fsha] = the highest schema version already cached for that fsha (2 = frag-TM v2 with valid
+    # owners, 1 = v1/ownerless). A harvest is skipped only when the cache already holds a version >=
+    # the new one, so a v2 harvest SUPERSEDES a cached v1 (R6) while a v1 re-harvest of a cached v1
+    # is still deduped. Corrupt/blank rows are absent from `seen`, so a later good harvest overrides.
+    seen = {}
+    if os.path.exists(path):
+        with open(path, encoding='utf-8') as _f:
+            for _line in _f:
+                _line = _line.strip()
+                if not _line:
+                    continue
+                try:
+                    _row = json.loads(_line)
+                except json.JSONDecodeError:
+                    continue
+                _fsha = _row.get('fsha')
+                if not _fsha or not frag_senses_sane(_row.get('senses'), lang) or not reusable(_row):
+                    continue      # defect/blocked/suggestion rows are not a real cache hit (overridable)
+                _ver = 2 if (_row.get('schema') == FRAG_SCHEMA_V2
+                             and _valid_owners(_row.get('senses'), _row.get('owners'))) else 1
+                seen[_fsha] = max(seen.get(_fsha, 0), _ver)
     files = sorted(_glob.glob(os.path.join(REPO, glob_pattern)))
     new_rows, added, refused = [], 0, 0
     for fp in files:
@@ -569,32 +614,33 @@ def build_frags(glob_pattern, lang, out=None):
                 owners = fpv.get('owners')       # R6: per-sense [h, grammar]; absent for a v1 emit
                 if not fsha or not senses:
                     continue
+                is_v2 = _valid_owners(senses, owners)   # R6: a valid owners[] promotes the row to v2
                 if not frag_senses_sane(senses, lang):
                     # Never cache a corrupt/blanked fragment (poison guard).
                     refused += 1
                     print('warning: refusing corrupt frag_prov %s (senses fail %s fidelity) in %s'
                           % (fsha[:12], lang, os.path.basename(fp)), file=sys.stderr)
                     continue
-                if seen.get(fsha):
-                    # A sane row is already cached — idempotent skip. (A previously
-                    # cached CORRUPT row maps to False here, so this good row falls
-                    # through and overrides it.)
+                if seen.get(fsha, 0) >= (2 if is_v2 else 1):
+                    # Already cached at a version >= this harvest: idempotent skip. A cached v1 does
+                    # NOT block a v2 harvest (2 > 1 -> supersede, R6); a cached CORRUPT row is absent
+                    # from `seen`, so a good row still overrides it.
                     continue
                 src_key = r.get('key')
                 raw_sha = ((input_hashes.get(src_key) or {}).get('raw_sha256')
                            if src_key else None)
-                seen[fsha] = True
+                seen[fsha] = 2 if is_v2 else 1
                 added += 1
                 new_rows.append({
-                    'schema': FRAG_SCHEMA, 'lang': lang, 'fsha': fsha,
+                    'schema': FRAG_SCHEMA_V2 if is_v2 else FRAG_SCHEMA, 'lang': lang, 'fsha': fsha,
                     'src_key': src_key, 'root': root, 'raw_sha256': raw_sha,
                     'n_senses': len(senses), 'senses': senses,
-                    'owners': owners,          # R6: per-sense [h, grammar] owner (frag-TM v2)
+                    'owners': owners if is_v2 else None,   # R6: v2 carries per-sense [h, grammar]
                     'wf_file': os.path.basename(fp), 'source_wf_file': os.path.basename(fp),
                     'fragment_address_formula': "sha256(lang + '\\x00frag\\x00' + fragment_source)",
                     'splitter_version': 'autosplit_requeue.plan.v1',
                     'trust_level': TRUST_MACHINE, 'gate_status': 'machine_gated',
-                    'gate_version': 'frag_prov_v2' if owners else 'frag_prov_v1',
+                    'gate_version': 'frag_prov_v2' if is_v2 else 'frag_prov_v1',
                     'review_status': 'ai_translated',
                     'reuse_policy': 'auto_exact', 'source_kind': 'frag_prov',
                     'supersedes': None, 'harvested_at': _utc_now(),
@@ -719,8 +765,10 @@ def validate_card_entry(address, row, lang=None):
 def validate_frag_entry(row, lang=None):
     if not isinstance(row, dict):
         return False, 'row is not an object'
-    if row.get('schema') != FRAG_SCHEMA:
+    if row.get('schema') not in (FRAG_SCHEMA, FRAG_SCHEMA_V2):
         return False, 'bad schema'
+    if row.get('schema') == FRAG_SCHEMA_V2 and not _valid_owners(row.get('senses'), row.get('owners')):
+        return False, 'v2 row with malformed owners'
     if lang and row.get('lang') != lang:
         return False, 'wrong lang'
     if not row.get('fsha'):
@@ -1390,7 +1438,8 @@ def _frag_selftest():
     senses = [{'tag': '1', 'german': 'foo <ls>ṚV.</ls>', 'russian': 'фу', 'source_type': 'attested'}]
     wf = {'meta': {'lang': 'ru', 'root': 'zz'}, 'results': [
         {'key': 'zz~~h0_00_pwg00', 'card': {'key1': 'zz', 'records': [{'senses': senses}],
-                                            'frag_prov': [{'fsha': fsha, 'senses': senses}]}},
+                                            'frag_prov': [{'fsha': fsha, 'senses': senses,
+                                                           'owners': [['zz', '']]}]}},
         {'key': 'zz~~h0_01', 'card': None},                       # null card: no frag_prov
     ]}
     en_wf = {'meta': {'lang': 'en', 'root': 'zz'}, 'results': [
@@ -1406,11 +1455,11 @@ def _frag_selftest():
             json.dump({'result': '{"broken"'}, f, ensure_ascii=False)
         sidecar = os.path.join(d, 'frag.ru.jsonl')
         with open(sidecar, 'w', encoding='utf-8') as f:
-            f.write(json.dumps({'schema': 'pwg.translation_memory.frag.v1', 'lang': 'ru',
+            f.write(json.dumps({'schema': FRAG_SCHEMA_V2, 'lang': 'ru', 'owners': [['zz', '']],
                                 'fsha': fsha, 'senses': [{'tag': 'old', 'russian': 'старое'}],
                                 'trust_level': TRUST_MACHINE, 'gate_status': 'legacy_promoted',
                                 'harvested_at': '2026-01-01T00:00:00Z'}, ensure_ascii=False) + '\n')
-            f.write(json.dumps({'schema': 'pwg.translation_memory.frag.v1', 'lang': 'ru',
+            f.write(json.dumps({'schema': FRAG_SCHEMA_V2, 'lang': 'ru', 'owners': [['zz', '']],
                                 'fsha': fsha, 'senses': [{'tag': 'new', 'russian': 'новое'}],
                                 'trust_level': TRUST_REVIEWED, 'gate_status': 'human_reviewed',
                                 'harvested_at': '2026-01-02T00:00:00Z'}, ensure_ascii=False) + '\n')

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -566,6 +566,7 @@ def build_frags(glob_pattern, lang, out=None):
                 continue
             for fpv in card.get('frag_prov') or []:
                 fsha, senses = fpv.get('fsha'), fpv.get('senses')
+                owners = fpv.get('owners')       # R6: per-sense [h, grammar]; absent for a v1 emit
                 if not fsha or not senses:
                     continue
                 if not frag_senses_sane(senses, lang):
@@ -588,11 +589,13 @@ def build_frags(glob_pattern, lang, out=None):
                     'schema': FRAG_SCHEMA, 'lang': lang, 'fsha': fsha,
                     'src_key': src_key, 'root': root, 'raw_sha256': raw_sha,
                     'n_senses': len(senses), 'senses': senses,
+                    'owners': owners,          # R6: per-sense [h, grammar] owner (frag-TM v2)
                     'wf_file': os.path.basename(fp), 'source_wf_file': os.path.basename(fp),
                     'fragment_address_formula': "sha256(lang + '\\x00frag\\x00' + fragment_source)",
                     'splitter_version': 'autosplit_requeue.plan.v1',
                     'trust_level': TRUST_MACHINE, 'gate_status': 'machine_gated',
-                    'gate_version': 'frag_prov_v1', 'review_status': 'ai_translated',
+                    'gate_version': 'frag_prov_v2' if owners else 'frag_prov_v1',
+                    'review_status': 'ai_translated',
                     'reuse_policy': 'auto_exact', 'source_kind': 'frag_prov',
                     'supersedes': None, 'harvested_at': _utc_now(),
                 })

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -108,8 +108,10 @@ FRAG_SCHEMA_V2 = 'pwg.translation_memory.frag.v2'   # R6: adds a per-sense owner
 
 def _valid_owners(senses, owners):
     """R6: a v2 `owners[]` is a list parallel to `senses`, each element an `[h, grammar]` pair whose
-    members are str-or-None. Malformed/missing owners disqualify a row from live v2 reuse (it stays
-    a v1 row -- audit-readable, never served warm)."""
+    members are BOTH strings ('' is valid -- the proven-empty homonym head / defaulted grammar -- but
+    None is NOT: a null member is exactly the C-02 null owner this schema exists to keep out of a warm
+    stitch). Malformed/missing/null-member owners disqualify a row from live v2 reuse; the row stays
+    audit-readable (live_only=False) but is never served warm, so no stitch can restore a null owner."""
     if not isinstance(owners, list) or not isinstance(senses, list):
         return False
     if len(owners) != len(senses):
@@ -117,7 +119,7 @@ def _valid_owners(senses, owners):
     for pair in owners:
         if not (isinstance(pair, (list, tuple)) and len(pair) == 2):
             return False
-        if not all(x is None or isinstance(x, str) for x in pair):
+        if not all(isinstance(x, str) for x in pair):   # BOTH members must be str; None fails
             return False
     return True
 PUBLICATION_SCHEMA = 'pwg.translation_memory.publication.v1'

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -4782,7 +4782,8 @@ def test_defect_fragment_denylist_round_trip():
     sidecar = os.path.join(tmp, 'translation_memory.frag.ru.jsonl')
     with open(sidecar, 'w', encoding='utf-8') as f:
         for fsha in (fsha_good, fsha_bad):
-            f.write(json.dumps({'fsha': fsha, 'senses': senses}) + '\n')
+            f.write(json.dumps({'schema': tm.FRAG_SCHEMA_V2, 'fsha': fsha, 'senses': senses,
+                                'owners': [['x', '']]}) + '\n')   # R6: v2 (live-reusable)
     cache = tm.load_frag_tm('ru', sidecar, denylist=deny_path)
     if fsha_bad in cache:
         fail('denylisted fragment still served by load_frag_tm')
@@ -5085,8 +5086,10 @@ def test_frag_tm_fidelity_gate_and_override():
         blank_senses = [{'tag': '1', 'german': 'bar', 'russian': ''}]
         wf = {'meta': {'lang': 'ru', 'root': 'zz'}, 'results': [
             {'key': 'zz~~h0', 'card': {'key1': 'zz', 'records': [{'senses': good_senses}],
-                                       'frag_prov': [{'fsha': good_fsha, 'senses': good_senses},
-                                                     {'fsha': bad_fsha, 'senses': blank_senses}]}}]}
+                                       'frag_prov': [{'fsha': good_fsha, 'senses': good_senses,
+                                                      'owners': [['zz', '']]},   # R6: v2 (live-reusable)
+                                                     {'fsha': bad_fsha, 'senses': blank_senses,
+                                                      'owners': [['zz', '']]}]}}]}
         with open(os.path.join(d, 'wf_output.sc.zz.json'), 'w', encoding='utf-8') as f:
             json.dump(wf, f, ensure_ascii=False)
         sidecar = os.path.join(d, 'frag.ru.jsonl')
@@ -5523,6 +5526,114 @@ def test_h_reconstructed_regression_guard():
                  'measured count -- an unrelated manifest must not paper over a real drop')
 
 
+def test_card_tokens_twins_agree():
+    """R2/C-17 (closes N-4): the JS `cardTokens` fidelity collector is DRIVEN by the Python-owned
+    card_fields.js_token_fidelity_spec(), so the two twins cannot drift. Proven three ways: the
+    generated JS interpolates the exact spec; cardTokens iterates it (not a hard-coded field list);
+    and changing the Python-owned spec changes the generated JS collector."""
+    import re as _re
+    import gen_opt_harness2 as gh
+    import card_fields as cf
+
+    def _gen():
+        d = tempfile.mkdtemp()
+        rp = os.path.join(d, 'agni~~h0_zz_pw.raw.txt')
+        pp = os.path.join(d, 'agni~~h0_zz_pw.portrait.json')
+        with open(rp, 'w', encoding='utf-8') as f:
+            f.write('=== LAYER: PW ===\n\n{#agni#}¦ m. {%a%}\n— 1〉 Feuer.')
+        with open(pp, 'w', encoding='utf-8') as f:
+            f.write('[]')
+        saved = gh.input_paths
+        gh.input_paths = lambda k, input_dir=None: (rp, pp)
+        try:
+            js, _ = gh.build('zz', ['agni~~h0_zz_pw'], None, 12000, nominal=True,
+                             grammar_on=False, tm_path=None)
+        finally:
+            gh.input_paths = saved
+        return js
+
+    js = _gen()
+    m = _re.search(r'const TOKEN_FIDELITY_SPEC = (\{.*?\})\n', js)
+    if not m:
+        fail('generated JS does not interpolate TOKEN_FIDELITY_SPEC')
+    if m.group(1) != cf.js_token_fidelity_spec():
+        fail('JS TOKEN_FIDELITY_SPEC != card_fields.js_token_fidelity_spec(): %s' % m.group(1))
+    if 'TOKEN_FIDELITY_SPEC.record' not in js or 'TOKEN_FIDELITY_SPEC.sense' not in js:
+        fail('cardTokens is not driven by the interpolated TOKEN_FIDELITY_SPEC')
+    saved = cf.TOKEN_FIDELITY_FIELDS
+    cf.TOKEN_FIDELITY_FIELDS = (('record', 'grammar'), ('sense', 'german'), ('sense', 'tag'))
+    try:
+        m2 = _re.search(r'const TOKEN_FIDELITY_SPEC = (\{.*?\})\n', _gen())
+        if not m2 or '"tag"' not in m2.group(1) or m2.group(1) == m.group(1):
+            fail('JS collector did not follow the Python-owned spec change: %s' % (m2 and m2.group(1)))
+    finally:
+        cf.TOKEN_FIDELITY_FIELDS = saved
+    print('  R2/N-4: JS cardTokens is driven by card_fields.js_token_fidelity_spec() (twins cannot drift)')
+
+
+def test_frag_tm_v2_supersedes_v1():
+    """R6: fragment-TM v2 schema. A v1 (ownerless) row is readable for audit but NEVER live-reusable;
+    a valid v2 row with the same fsha supersedes it; and an existing v1 does NOT block a v2 harvest.
+    Owners count/shape are validated."""
+    import json as _json
+    import translation_memory as tm
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, 'translation_memory.frag.ru.jsonl')
+    sense = {'tag': '1', 'german': 'Feuer', 'russian': 'огонь'}
+    v1 = {'schema': tm.FRAG_SCHEMA, 'lang': 'ru', 'fsha': 'X', 'n_senses': 1, 'senses': [sense],
+          'trust_level': tm.TRUST_MACHINE, 'gate_status': 'machine_gated',
+          'reuse_policy': 'auto_exact', 'source_kind': 'frag_prov'}
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(_json.dumps(v1) + '\n')
+    if tm.load_frag_tm('ru', path) != {}:
+        fail('a v1 (ownerless) row must not be live-served')
+    if 'X' not in tm.load_frag_tm('ru', path, live_only=False):
+        fail('a v1 row must stay readable for historical audit (live_only=False)')
+    wf = os.path.join(d, 'wf_output.zz.json')
+    card = {'key1': 'agni', 'frag_prov': [{'fsha': 'X', 'senses': [sense],
+                                           'owners': [['2. agni', 'm.']]}]}
+    with open(wf, 'w', encoding='utf-8') as f:
+        _json.dump({'meta': {'lang': 'ru', 'root': 'zz'},
+                    'results': [{'key': 'agni', 'card': card}]}, f)
+    saved_repo = tm.REPO
+    tm.REPO = d
+    try:
+        _p, added, _total = tm.build_frags(os.path.basename(wf), 'ru', out=path)
+    finally:
+        tm.REPO = saved_repo
+    if added != 1:
+        fail('an existing v1 must NOT block a v2 harvest (added=%d)' % added)
+    served = tm.load_frag_tm('ru', path)
+    if 'X' not in served or served['X'].get('owners') != [['2. agni', 'm.']]:
+        fail('the v2 row must be live-served with its owners: %r' % served.get('X'))
+    if served['X'].get('schema') != tm.FRAG_SCHEMA_V2:
+        fail('served row must be v2')
+    if not tm._valid_owners([sense], [['h', 'g']]) or tm._valid_owners([sense], [['h']]) \
+            or tm._valid_owners([sense, sense], [['h', 'g']]):
+        fail('_valid_owners count/shape validation is wrong')
+    print('  R6: frag-TM v2 supersedes an ownerless v1; v1 audit-readable, never live-served; owners validated')
+
+
+def test_degenerate_source_identity():
+    """R7: a degenerate card's (h, grammar) is the PROVEN source-record identity, not a schema
+    default; an unprovable identity is REJECTED rather than emitted with a fabricated h."""
+    import gen_opt_harness2 as gh
+    import validate_final_card_schema as vs
+    card = gh.degenerate_passthrough_card('ab~~h0_zz_pw', '=== LAYER: PW ===\n\nvgl. {#agni#}',
+                                          '[]', 'russian')
+    if not card or card['records'][0].get('h') != '' or card['records'][0].get('grammar') != '':
+        fail('a clean single-head xref must prove h="" (no source homonym head): %r' % card)
+    vs.validate_card(card)
+    if gh.degenerate_passthrough_card('ab', '=== LAYER: PW ===\n\nvgl. {#agni#}',
+                                      '[]', 'russian') is None:
+        fail('a bare-root key with a clean stub is a provable identity -- must NOT be rejected')
+    if gh._degenerate_record_identity('ab~~h1_zz_pw', 'vgl. <div n="2"> agni') is not None:
+        fail('a residual homonym head must be rejected (ambiguous owning record)')
+    if gh._degenerate_record_identity('ab~~h0_zz_pw', 'vgl.') != ('', ''):
+        fail('a clean stub must prove ("","")')
+    print('  R7: degenerate (h,grammar) is proven source identity; unprovable identity is rejected')
+
+
 def main():
     tests = [
         test_restore_covers_every_promoted_field,
@@ -5564,6 +5675,9 @@ def main():
         test_no_pwg_source_profile_promotes,
         test_calibration_arm_set_conservative_emit_only,
         test_frag_tm_reuse,
+        test_card_tokens_twins_agree,
+        test_frag_tm_v2_supersedes_v1,
+        test_degenerate_source_identity,
         test_no_fallback_batch_isolation,
         test_cit_split_never_tears_open_span,
         test_cit_split_caps_single_line_monster_sense,

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -2278,26 +2278,35 @@ def test_tm_publication_fixtures_validate():
 
 
 def test_degenerate_passthrough_accounted():
-    """A safely-degenerate cross-reference stub is emitted as an accounted no-LLM row and is
-    excluded from translation lanes; it is never a silent skip."""
+    """A safely-degenerate cross-reference stub is emitted as an accounted, SCHEMA-VALID no-LLM row
+    and is excluded from translation lanes. N-3/R7 (C-07): the card MUST pass
+    validate_final_card_schema (record h + grammar present, not null) so one xref stub can no longer
+    make save_and_audit refuse a whole paid window -- and this assertion must never silently skip on
+    an absent file fixture."""
     import re as _re
     import gen_opt_harness2 as gh
-    from window_common import input_paths, read_text
-    key = 'ab'
-    rp, pp = input_paths(key)
-    if not (os.path.exists(rp) and os.path.exists(pp)):
-        return
-    card = gh.degenerate_passthrough_card(key, read_text(rp), read_text(pp), 'russian')
+    import validate_final_card_schema as vs
+    # Inline stub -> no filesystem dependency, so the schema assertion below can never be skipped.
+    card = gh.degenerate_passthrough_card('ab~~h0_zz_pw', '=== LAYER: PW ===\n\nvgl. {#agni#}',
+                                          '[]', 'russian')
     if not card or not card.get('degenerate_passthrough'):
-        fail('ab fixture should qualify for conservative degenerate pass-through')
-    js, batches = gh.build(key, [key], None, 12000, nominal=True, tm_path=None)
-    meta = json.loads(_re.search(r'const META = (\{.*?\})\n', js, _re.S).group(1))
-    if meta.get('degenerate_passthrough_keys') != [key]:
-        fail('META.degenerate_passthrough_keys must account for the stub key')
-    if batches or meta.get('presplit_keys'):
-        fail('a degenerate pass-through key must not also enter an agent translation lane')
-    if 'const DEGENERATE_RESOLVED' not in js or 'degenerate_passthrough: true' not in js:
-        fail('generated harness must emit explicit degenerate pass-through rows')
+        fail('inline vgl.-stub should qualify for conservative degenerate pass-through')
+    vs.validate_card(card)                     # R7/C-07: raises on any schema violation
+    rec = card['records'][0]
+    if rec.get('h') is None or 'grammar' not in rec:
+        fail('degenerate record must carry a non-null h and a grammar field (RECORD_REQUIRED)')
+    # File-fixture-dependent accounting -- an EXPLICIT conditional, never a silent top-of-function return.
+    from window_common import input_paths, read_text
+    rp, pp = input_paths('ab')
+    if os.path.exists(rp) and os.path.exists(pp):
+        js, batches = gh.build('ab', ['ab'], None, 12000, nominal=True, tm_path=None)
+        meta = json.loads(_re.search(r'const META = (\{.*?\})\n', js, _re.S).group(1))
+        if meta.get('degenerate_passthrough_keys') != ['ab']:
+            fail('META.degenerate_passthrough_keys must account for the stub key')
+        if batches or meta.get('presplit_keys'):
+            fail('a degenerate pass-through key must not also enter an agent translation lane')
+        if 'const DEGENERATE_RESOLVED' not in js or 'degenerate_passthrough: true' not in js:
+            fail('generated harness must emit explicit degenerate pass-through rows')
 
 
 def test_degenerate_passthrough_rejects_glosses():

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -5611,7 +5611,26 @@ def test_frag_tm_v2_supersedes_v1():
     if not tm._valid_owners([sense], [['h', 'g']]) or tm._valid_owners([sense], [['h']]) \
             or tm._valid_owners([sense, sense], [['h', 'g']]):
         fail('_valid_owners count/shape validation is wrong')
-    print('  R6: frag-TM v2 supersedes an ownerless v1; v1 audit-readable, never live-served; owners validated')
+    # null-owner hardening: BOTH members must be strings ('' valid, None fails). A null-owner row is
+    # NOT live-served (so no warm stitch -- JS or headless -- can restore a null owner) but stays
+    # audit-readable, exactly like a v1 row.
+    if not tm._valid_owners([sense], [['', '']]):
+        fail('empty-string owner members must be valid')
+    if tm._valid_owners([sense], [[None, 'g']]) or tm._valid_owners([sense], [['h', None]]):
+        fail('a null owner member ([None,g] / [h,None]) must be rejected')
+    for pair in ([None, 'g'], ['h', None]):
+        npath = os.path.join(d, 'nullowner.frag.ru.jsonl')
+        with open(npath, 'w', encoding='utf-8') as f:
+            f.write(_json.dumps({'schema': tm.FRAG_SCHEMA_V2, 'lang': 'ru', 'fsha': 'N',
+                                 'senses': [sense], 'owners': [pair],
+                                 'trust_level': tm.TRUST_MACHINE, 'gate_status': 'machine_gated',
+                                 'reuse_policy': 'auto_exact'}) + '\n')
+        if tm.load_frag_tm('ru', npath) != {}:
+            fail('a null-owner row %r must NOT be live-served' % pair)
+        if 'N' not in tm.load_frag_tm('ru', npath, live_only=False):
+            fail('a null-owner row %r must stay audit-readable' % pair)
+    print('  R6: frag-TM v2 supersedes v1; null-owner ([None,g]/[h,None]) rejected from live serve, '
+          'audit-readable; owners validated')
 
 
 def test_degenerate_source_identity():


### PR DESCRIPTION
## H1110 Phase 2 — headless fidelity + spend bounds (fix PR)

Closes the 12 defects raised in the Phase-1 audit memo ([`H1110_POST_H1080_AUDIT_MEMO_2026-07-17.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h1110/H1110_POST_H1080_AUDIT_MEMO_2026-07-17.md), merged in #524) plus four adversarial hardenings found during implementation. All changes are scoped to [`RussianTranslation/`](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation).

### Fidelity
- **R2** — grammar-token twin: `card_token_multiset` now counts `grammar`+`german` via the shared `card_fields.TOKEN_FIDELITY_FIELDS`; the JS harness is spec-driven from `card_fields.js_token_fidelity_spec()` (no hand-kept twin).
- **R6** — fragment-TM **v2** (`FRAG_SCHEMA_V2`) with per-sense `owners[]`; v1 stays audit-readable but never live-reusable. `_valid_owners` requires both owner members be strings (empty ok, `None` fails). Warm-cache stitch (JS gview **and** headless) restores each sense owner. **Execution-time gate**: `headless_worker.execute()` refuses any direct/hand-edited manifest whose `fragment_tm` slot carries a null/ownerless owner **before any paid call** — proven runner-uncalled.
- **R7** — degenerate passthrough card uses an immutable source-record identity; if identity is unprovable from source metadata the degenerate pass-through is rejected (no `h=''` schema appeasement).

### Spend bounds
- **R3** — the manifest agent-budget block is now actually enforced by the headless executor (was declared/serialized but never read).
- **R4** — call timeout clamped to `min(operator, manifest-ceiling, 180000ms)` (was a possible 40× breach: 7,200 s runtime default vs the never-consumed 180 s ceiling).
- **R5** — usage/cost summed across calls; a missing-usage call flips `cost_evaluable=False` + counter; a budget-refused call adds nothing; `observed_cost_usd` stays authoritative.
- **R8** — duplicate `selected_keys` rejected via `collections.Counter` (not quadratic `.count()`).
- **R9** — active-call lock is **kernel-backed** (`fcntl.flock` on POSIX, `msvcrt` byte-range lock on Windows), auto-released by the OS on process death; nonblocking contention returns a typed conflict. No PID/TTL/stale-file reclaim.
- **R10** — `--stop-before-promote` writes a durable, atomic, self-hashing `AWAITING_REVIEW` checkpoint **only after a clean audit**; on restart it blocks relaunch + promotion; tamper invalidates; backward-compatible when the flag is absent.

### Contract
- **P-1** batches/presplit ⊆ `selected_keys`; **P-2** `max_wide`/stagger marked advisory (R9 is the cross-process bound); **P-3** a foreign `execution_route` is refused before the injected runner/subprocess is called.
- **item-11 docs**: `AGENTS.md` / `README.md` / `CHANGELOG.md` updated — headless CLI (manifest v2) is the production route; the Max-Workflow lane is forensics-only.

### Gates (offline, on this branch rebased to `612f634e`)
- `window_selftest` **142/142**; `headless_worker_selftest`, `execution_contract_selftest`, `bounded_staged_run_selftest` **PASS**.
- `lang_parity_check` — **0 drift** (53 entries). The 40 verdict hashes drifted by these edits were re-recorded after **human reaffirmation** (C-27): 35 SHARED remain RU=EN; the 5 INTENTIONAL-DIVERGENCE rationales still hold.
- Canonical ruff gate (`--select=E9,F63,F7,F82`) clean; `node --check` OK on all four JS harnesses.

Handoff: [H1110](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1110-Opus_SanskritLexicography_pwg-ru-post-h1080-audit-fix-skills-c4-restart_17.07.26.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
