### PR TITLE
fix(findings-dashboard): H737 — non-null dcs_cdsl_linkage_pct + honest backfill

### DIFF
--- a/findings_dashboard/README.md
+++ b/findings_dashboard/README.md
@@ -1,6 +1,6 @@
 # FINDINGS dashboard
 
-_Created: 02-07-2026 · Last updated: 02-07-2026_
+_Created: 02-07-2026 · Last updated: 18-07-2026_
 
 Recurring visualization of the
 [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
@@ -32,6 +32,13 @@ is a private repo (network-topology findings) and is deliberately NOT rendered h
   `monthly_refresh.py` pipeline, so it also doubles as a fallback if the Action fails.
 
 A failed collector records `null` and the build continues — a chart simply skips that month.
+
+**Backfill note (18-07-2026, H737):** every snapshot before 2026-07-18 recorded
+`dcs_cdsl_linkage_pct: null` because the §12 collector regex never matched its source
+(fixed by H733). The 2026-07-11 snapshot is kept as `source: "backfill"` with the value
+recomputed from the source's git history (81.4%, csl-apidev `ec56968`, unchanged
+2026-07-03→11); the superseded 2026-07-10 bot snapshot (`c91d62a`) had identical inputs.
+No earlier snapshots exist, so nothing else was recoverable.
 
 ## Staleness
 

--- a/findings_dashboard/data.json
+++ b/findings_dashboard/data.json
@@ -1,13 +1,13 @@
 {
- "generated_at": "2026-07-11T07:58:14Z",
+ "generated_at": "2026-07-18T04:13:45Z",
  "stale_days_threshold": 180,
  "counts": {
-  "total": 75,
+  "total": 95,
   "by_importance": {
-   "2": 39,
+   "2": 42,
    "1": 10,
-   "None": 12,
-   "3": 14
+   "None": 27,
+   "3": 16
   },
   "stale": 0
  },
@@ -18,7 +18,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-29",
-   "age_days": 12,
+   "age_days": 19,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#1-whitney-accent-mobility-rules-are-machine-encodable"
   },
   {
@@ -27,7 +27,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-14",
-   "age_days": 27,
+   "age_days": 34,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling"
   },
   {
@@ -36,7 +36,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-13",
-   "age_days": 28,
+   "age_days": 35,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#3-the-warnemyr-scrape-union-smears-homonym-classes"
   },
   {
@@ -45,7 +45,7 @@
    "section": "Grammar & morphology data",
    "importance": 1,
    "evidence_date": "2026-06-29",
-   "age_days": 12,
+   "age_days": 19,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#4-pwg-nominal-grammar-compresses-into-335-paradigm-tokens"
   },
   {
@@ -54,7 +54,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 9,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#42-whitney-self-contradicts-on-derivative-ī-stem-genpl-accent"
   },
   {
@@ -63,7 +63,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-07-05",
-   "age_days": 6,
+   "age_days": 13,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents"
   },
   {
@@ -72,7 +72,7 @@
    "section": "Grammar & morphology data",
    "importance": null,
    "evidence_date": "2026-07-07",
-   "age_days": 4,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian"
   },
   {
@@ -81,7 +81,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 17,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#5-the-parallel-corpus-rarely-attests-prefixed-verb-forms"
   },
   {
@@ -90,7 +90,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 17,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#6-no-printed-frequency-dictionary-of-sanskrit-exists"
   },
   {
@@ -99,7 +99,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 17,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations"
   },
   {
@@ -108,7 +108,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 26,
+   "age_days": 33,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#8-unaccented-dcs-cannot-distinguish-present-class-i-from-vi"
   },
   {
@@ -117,7 +117,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06-06",
-   "age_days": 35,
+   "age_days": 42,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#9-dcs-occid-and-sent_id-are-not-unique-keys"
   },
   {
@@ -126,7 +126,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-06",
-   "age_days": 35,
+   "age_days": 42,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#10-dcs-ud-tense-marking-conflates-aorist-and-perfect"
   },
   {
@@ -135,7 +135,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-06",
-   "age_days": 35,
+   "age_days": 42,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#11-dcs-2021-and-2026-vintages-are-not-directly-comparable"
   },
   {
@@ -144,7 +144,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-11",
-   "age_days": 30,
+   "age_days": 37,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword"
   },
   {
@@ -153,7 +153,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 1,
    "evidence_date": "2026-07-01",
-   "age_days": 10,
+   "age_days": 17,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#13-sa-ru-glossary-token-coverage-plateaus-at-866-percent"
   },
   {
@@ -162,7 +162,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-01",
-   "age_days": 10,
+   "age_days": 17,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#14-renou-period-state-tagging-covers-770k-entries-in-8-dicts"
   },
   {
@@ -171,7 +171,7 @@
    "section": "Corpus & parallel-text data",
    "importance": null,
    "evidence_date": "2026-07-07",
-   "age_days": 4,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards"
   },
   {
@@ -180,7 +180,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-07",
-   "age_days": 4,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse"
   },
   {
@@ -189,7 +189,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 17,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#15-pwg-encodes-secondary-stems-inline-not-in-div-markup"
   },
   {
@@ -198,7 +198,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 17,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes"
   },
   {
@@ -207,7 +207,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 17,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#17-pwg-orders-senses-genetically-not-historically"
   },
   {
@@ -216,7 +216,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 17,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#18-vedic-citation-density-separates-the-dictionary-traditions"
   },
   {
@@ -225,7 +225,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 26,
+   "age_days": 33,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#19-skd-and-vcp-carry-essentially-zero-western-markup"
   },
   {
@@ -234,7 +234,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 17,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#20-the-ls-source-map-recognises-724-percent-of-pwg-citations"
   },
   {
@@ -243,7 +243,7 @@
    "section": "Dictionary structure & markup",
    "importance": 1,
    "evidence_date": "2026-07-02",
-   "age_days": 9,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#21-pwg-citation-occurrences-track-distinct-references"
   },
   {
@@ -252,7 +252,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 15,
+   "age_days": 22,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#22-mw-has-no-sense-level-div-markup"
   },
   {
@@ -261,7 +261,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 26,
+   "age_days": 33,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#23-apte-is-three-dictionaries-keys-differ-stem-vs-nominative"
   },
   {
@@ -270,7 +270,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-07",
-   "age_days": -4,
+   "age_days": 3,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#24-about-9-percent-of-typo-corrections-are-collisions"
   },
   {
@@ -279,7 +279,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07",
-   "age_days": -4,
+   "age_days": 3,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#25-a-verified-correction-queue-decays-against-live-csl-orig"
   },
   {
@@ -288,7 +288,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-13",
-   "age_days": 28,
+   "age_days": 35,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#26-citation-density-is-register-bound-not-comparable-raw"
   },
   {
@@ -297,7 +297,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-15",
-   "age_days": 26,
+   "age_days": 33,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#27-sense-granularity-is-a-family-trait-not-a-diachronic-trend"
   },
   {
@@ -306,7 +306,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-03",
-   "age_days": 38,
+   "age_days": 45,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#28-mw-inherited-the-pwg-apparatus-skeleton-not-its-prose"
   },
   {
@@ -315,7 +315,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 15,
+   "age_days": 22,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index"
   },
   {
@@ -324,7 +324,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-15",
-   "age_days": 26,
+   "age_days": 33,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#30-body-text-headword-mining-is-a-dead-end-386-percent-precision"
   },
   {
@@ -333,7 +333,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 17,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#31-detector-precision-stratifies-by-digitization-quality"
   },
   {
@@ -342,7 +342,7 @@
    "section": "Dictionary structure & markup",
    "importance": 1,
    "evidence_date": "2026-06-17",
-   "age_days": 24,
+   "age_days": 31,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#32-correction-events-concentrate-in-sense-text"
   },
   {
@@ -351,7 +351,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#46-twelve-years-of-corrections-cover-only-1014--of-the-estimated-error-population"
   },
   {
@@ -360,8 +360,26 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-07-05",
-   "age_days": 6,
+   "age_days": 13,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1--pwg-is-not-the-sole-spine-of-the-local-layer-universe"
+  },
+  {
+   "n": 76,
+   "title": "The MW→WordNet→semdom bridge is a candidate generator, not a classifier",
+   "section": "Dictionary structure & markup",
+   "importance": 2,
+   "evidence_date": "2026-07-11",
+   "age_days": 7,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#76-the-mwwordnetsemdom-bridge-is-a-candidate-generator-not-a-classifier"
+  },
+  {
+   "n": 447,
+   "title": "PWG's own closing sense-marker glyph \"〉\" was never recognized by the sense-splitter — ~50% of German senses were silently merged into their first sub-sense",
+   "section": "Dictionary structure & markup",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#447-pwgs-own-closing-sense-marker-glyph--was-never-recognized-by-the-sense-splitter--50-of-german-senses-were-silently-merged-into-their-first-sub-sense"
   },
   {
    "n": 33,
@@ -369,7 +387,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 15,
+   "age_days": 22,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#33-indigenous-dictionaries-agree-on-derivation-wilson-is-the-outlier"
   },
   {
@@ -378,7 +396,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 15,
+   "age_days": 22,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#34-the-e-abbreviation-tag-is-polysemous-across-dicts"
   },
   {
@@ -387,7 +405,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 15,
+   "age_days": 22,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#35-root-recovery-tiers-err-on-root-form-not-identity"
   },
   {
@@ -396,7 +414,7 @@
    "section": "Encoding & normalization",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 26,
+   "age_days": 33,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily"
   },
   {
@@ -405,7 +423,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06",
-   "age_days": 26,
+   "age_days": 33,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#37-bom-state-is-inconsistent-across-exports"
   },
   {
@@ -414,7 +432,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06-27",
-   "age_days": 14,
+   "age_days": 21,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#38-injected-boms-crash-the-hw-record-parser"
   },
   {
@@ -423,7 +441,7 @@
    "section": "Encoding & normalization",
    "importance": 1,
    "evidence_date": "2026-06",
-   "age_days": 26,
+   "age_days": 33,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#39-devanagari_to_slp1-mis-routes-retroflex-la"
   },
   {
@@ -432,7 +450,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 15,
+   "age_days": 22,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#40-gloss-language-spelling-drift-tracks-reform-type-not-age"
   },
   {
@@ -441,7 +459,7 @@
    "section": "Encoding & normalization",
    "importance": 1,
    "evidence_date": "2026-07-05",
-   "age_days": 6,
+   "age_days": 13,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-practical-russian-transcription-of-sanskrit-names-has-no-safe-reverse-transliteration"
   },
   {
@@ -450,7 +468,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 9,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#41-the-sanskrit-dictionary-platform-landscape-probed-live"
   },
   {
@@ -459,7 +477,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#47-heritage-data-is-acquirable-despite-the-anubis-wall--via-a-github-mirror-the-morphology-xml-is-not-in-it"
   },
   {
@@ -468,7 +486,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 9,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#43-skdvcp-sensecitation-fusion-is-a-record-type-effect-not-a-dictionary-level-one"
   },
   {
@@ -477,7 +495,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 9,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#44-raw-latin-string-tallies-over-gloss-text-include-etymological-false-positives-bopp-lacks-yabh"
   },
   {
@@ -486,7 +504,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 9,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#45-siglum-prefix-families-routinely-bundle-several-distinct-works-the-diacritic-stripping-fold-has-poisoned-keys"
   },
   {
@@ -495,7 +513,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#48-vedaweb-20s-resource-export-is-an-async-task-behind-a-pickup-key-not-a-direct-get--and-the-server-went-unresponsive-mid-attempt"
   },
   {
@@ -504,7 +522,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#49-mwheritage-coverage-highlighting-is-a-duplicate-anchor-pattern-not-a-css-class--and-the-mirrors-current-dictionary-is-a-different-scope-asset-than-the-2014-reader-stem-list"
   },
   {
@@ -513,8 +531,17 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#50-cdsl-display-paths-are-not-uniformly-2020web--and-two-new-digitizations-landed-in-june-2026"
+  },
+  {
+   "n": 80,
+   "title": "CORRECTED — the MWScan/2020 `servepdf.php` endpoint is RIGHT (serves 1899); the 1872 first-edition scan coexists on the portal with colliding page numbers",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#80-corrected--the-mwscan2020-servepdfphp-endpoint-is-right-serves-1899-the-1872-first-edition-scan-coexists-on-the-portal-with-colliding-page-numbers"
   },
   {
    "n": 51,
@@ -522,7 +549,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#51-huet-correspondence-predates-this-session-2021--the-morphology-xml-gate-was-already-resolved-in-writing-direct-download-urls-recovered"
   },
   {
@@ -531,7 +558,7 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#52-heritage-vs-kosha-forms-diff-the-small-raw-overlap-is-mostly-convention--model-difference-and-disagreements-are-two-thirds-lemmatization-policy-not-error"
   },
   {
@@ -540,7 +567,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#53-the-wil-etymology-extractions-affix-field-is-half-noise--wilson-outlier-figures-are-substantially-a-measurement-artifact"
   },
   {
@@ -549,7 +576,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#56-dicos-entry-anchors-nest-three-structural-roles-under-one-html-class--only-one-is-a-true-entry-boundary"
   },
   {
@@ -558,7 +585,7 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#55-gen_opt_harness2py-output-budget-coarser-wins-on-both-knobs-in-opposite-directions"
   },
   {
@@ -567,7 +594,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#57-samskrtamruz-is-id-addressed-with-no-name-lookup--deep-linking-needs-a-scraped-rootid-table-8-primer-basic-roots-are-absent"
   },
   {
@@ -576,7 +603,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#58-pwg-ru-promoted-store-has-input-level-provenance-but-old-ru-rows-lacked-exact-model-versions"
   },
   {
@@ -594,7 +621,7 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-03",
-   "age_days": 8,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#70-pwg_ru-tm-composite-grade-a-is-consensus-gated-57-and-a-reference-free-surface-qe-cannot-detect-wrong-sense"
   },
   {
@@ -603,7 +630,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-07",
-   "age_days": 4,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#61-the-reverse-dictionarys-30-sources-split-18-pd-vs-10-in-copyright--the-merged-headword-list-is-not-automatically-publishable"
   },
   {
@@ -612,7 +639,7 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-08",
-   "age_days": 3,
+   "age_days": 10,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#71-pwg-marks-case-government-explicitly-3853-times-across-3222-senses--a-deterministic-census-not-an-estimate"
   },
   {
@@ -621,7 +648,7 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-08",
-   "age_days": 3,
+   "age_days": 10,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#72-vedawebs-id_gra-token-field-is-the-grassmann-l-entry-number--no-fuzzy-text-matching-needed-for-a-gravedaweb-crosswalk"
   },
   {
@@ -630,7 +657,7 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-08",
-   "age_days": 3,
+   "age_days": 10,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#73-vedaweb-20s-cc-by-40-for-everything-claim-is-not-machine-confirmed--only-236-catalog-resources-carry-an-explicit-license-field"
   },
   {
@@ -639,7 +666,7 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-08",
-   "age_days": 3,
+   "age_days": 10,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#74-the-ls-graph-citation-matrix-is-degenerate-for-mw--its-top-abbreviations-sit-unresolved-use-the-citation-apparatus-siglum-matrix-for-cross-dict-citation-profiles"
   },
   {
@@ -648,7 +675,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-10",
-   "age_days": 1,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#66-the-dcs-ql-frequency-workbooks-slp1-and-length-columns-are-truncated-at-ṣṭhḍh-clusters"
   },
   {
@@ -657,7 +684,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-10",
-   "age_days": 1,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#67-in-pwg-article-size-dwarfs-every-parametric-statistic-you-can-extract-from-the-entry"
   },
   {
@@ -666,7 +693,7 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-10",
-   "age_days": 1,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#68-the-sanskrit-spellchecker-landscape-one-dormant-demo-one-license-unsettled-543k-wordlist-no-occupant"
   },
   {
@@ -675,7 +702,7 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-10",
-   "age_days": 1,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#69-hand-transcribed-telemetry-cannot-adjudicate-code-vs-infra--and-a-local-only-ledger-silently-swaps-your-denominator"
   },
   {
@@ -684,8 +711,161 @@
    "section": "External platforms & services",
    "importance": null,
    "evidence_date": "2026-07-10",
-   "age_days": 1,
+   "age_days": 8,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#75-the-full-devībhāgavata-purāṇa-sanskrit-is-not-on-gretil--only-the-devigita-fragment-the-complete-mūla-lives-on-sanskritdocumentsorg-without-dbhp_-markers"
+  },
+  {
+   "n": 78,
+   "title": "DCS 2026 sqlite carries 531,747 sense-annotated tokens (`m_wordsem`) but NO local ID→gloss inventory — gold-scored WSD against MW senses is blocked until the inventory is recovered",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#78-dcs-2026-sqlite-carries-531747-sense-annotated-tokens-m_wordsem-but-no-local-idgloss-inventory--gold-scored-wsd-against-mw-senses-is-blocked-until-the-inventory-is-recovered"
+  },
+  {
+   "n": 77,
+   "title": "Amarakosha and SIL semdom both bolt a formal annex onto a semantic taxonomy — and it is the same ~10% once polysemy is set aside",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#77-amarakosha-and-sil-semdom-both-bolt-a-formal-annex-onto-a-semantic-taxonomy--and-it-is-the-same-10-once-polysemy-is-set-aside"
+  },
+  {
+   "n": 79,
+   "title": "DCS 2021→2026 \"lost lemma\" counts are mostly lemmatization-policy drift — a-privatives now resolve to their bases",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#79-dcs-20212026-lost-lemma-counts-are-mostly-lemmatization-policy-drift--a-privatives-now-resolve-to-their-bases"
+  },
+  {
+   "n": 80,
+   "title": "DCS `text_sandhied` is largely DE-sandhied pada text in the Rāmāyaṇa — and locus joins fail across editions; a text-keyed 3-tier match (exact / consonant-skeleton / fuzzy) recovers it",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#80-dcs-text_sandhied-is-largely-de-sandhied-pada-text-in-the-rāmāyaṇa--and-locus-joins-fail-across-editions-a-text-keyed-3-tier-match-exact--consonant-skeleton--fuzzy-recovers-it"
+  },
+  {
+   "n": 81,
+   "title": "vidyut-cheda 0.4 lemmatizes derivatives to the dhātu ROOT (rāmaḥ → ram) where DCS uses the nominal stem — and over-segments epic verse 1.44×",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#81-vidyut-cheda-04-lemmatizes-derivatives-to-the-dhātu-root-rāmaḥ--ram-where-dcs-uses-the-nominal-stem--and-over-segments-epic-verse-144"
+  },
+  {
+   "n": 82,
+   "title": "MW `<e>` encodes the 1899 print's headword typography (1 = Devanāgarī entry, 2 = roman-only, 3 = run-on compound; letter suffix = continuation record)",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#82-mw-e-encodes-the-1899-prints-headword-typography-1--devanāgarī-entry-2--roman-only-3--run-on-compound-letter-suffix--continuation-record"
+  },
+  {
+   "n": 83,
+   "title": "MW and the Petersburg dictionaries are NOT independent witnesses on inventory or apparatus — do not count their agreement as corroboration; but no shared *error* has ever been found",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#83-mw-and-the-petersburg-dictionaries-are-not-independent-witnesses-on-inventory-or-apparatus--do-not-count-their-agreement-as-corroboration-but-no-shared-error-has-ever-been-found"
+  },
+  {
+   "n": 84,
+   "title": "pwg_ru readiness audit: `[NWS:]` attribution and `{%…%}`-delimiter dropping are NOT audit-contract defects; observed token/cost economy is `not_recoverable`; store-membership ≠ audit-clean",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#84-pwg_ru-readiness-audit-nws-attribution-and--delimiter-dropping-are-not-audit-contract-defects-observed-tokencost-economy-is-not_recoverable-store-membership--audit-clean"
+  },
+  {
+   "n": 88,
+   "title": "The DCS snapshot's UD dependency slice is real but VEDIC-SKEWED — syntax studies get counterexample hunts, not classical norms",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#88-the-dcs-snapshots-ud-dependency-slice-is-real-but-vedic-skewed--syntax-studies-get-counterexample-hunts-not-classical-norms"
+  },
+  {
+   "n": 87,
+   "title": "A curated DCS text→period map EXISTS (consume, don't rebuild) — and the purāṇas carry a measured epic-imitative signature on two independent axes",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#87-a-curated-dcs-textperiod-map-exists-consume-dont-rebuild--and-the-purāṇas-carry-a-measured-epic-imitative-signature-on-two-independent-axes"
+  },
+  {
+   "n": 86,
+   "title": "DCS verbal-feature annotation density collapses for later texts — feats-based diachronic metrics measure ANNOTATION, not language",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#86-dcs-verbal-feature-annotation-density-collapses-for-later-texts--feats-based-diachronic-metrics-measure-annotation-not-language"
+  },
+  {
+   "n": 85,
+   "title": "A clean-looking subset is not promotable evidence when its audit or execution contract failed",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#85-a-clean-looking-subset-is-not-promotable-evidence-when-its-audit-or-execution-contract-failed"
+  },
+  {
+   "n": 86,
+   "title": "Samāsa-type frequency does not exist in any org corpus — and the grammarians' canonical examples are corpus-ghosts (8/58 attested, max freq 147)",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#86-samāsa-type-frequency-does-not-exist-in-any-org-corpus--and-the-grammarians-canonical-examples-are-corpus-ghosts-858-attested-max-freq-147"
+  },
+  {
+   "n": 87,
+   "title": "The roadmap's \"OBS-T κ=0.42\" was a phantom figure — no measured agreement exists for any OBS-T axis",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#87-the-roadmaps-obs-t-κ042-was-a-phantom-figure--no-measured-agreement-exists-for-any-obs-t-axis"
+  },
+  {
+   "n": 89,
+   "title": "MW writes `<ls>` citations in TWO markup shapes and locates them in roman as well as arabic — a literal `<ls>` regex undercounts its apparatus by 28.6%, and case-folding the roman test erases the `L.` hedge",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#89-mw-writes-ls-citations-in-two-markup-shapes-and-locates-them-in-roman-as-well-as-arabic--a-literal-ls-regex-undercounts-its-apparatus-by-286-and-case-folding-the-roman-test-erases-the-l-hedge"
+  },
+  {
+   "n": 90,
+   "title": "A spelling-keyed join onto Whitney's roots union-smears homonyms — one authorial entry lands on every homonym of that spelling, and the rows still read `authorial`",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#90-a-spelling-keyed-join-onto-whitneys-roots-union-smears-homonyms--one-authorial-entry-lands-on-every-homonym-of-that-spelling-and-the-rows-still-read-authorial"
+  },
+  {
+   "n": 91,
+   "title": "DCS has no aorist TENSE value — `feat_tense='Past'` lumps aorist with the perfect; `feat_formation` is what actually separates them",
+   "section": "External platforms & services",
+   "importance": null,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#91-dcs-has-no-aorist-tense-value--feat_tensepast-lumps-aorist-with-the-perfect-feat_formation-is-what-actually-separates-them"
   }
  ]
 }

--- a/findings_dashboard/timeseries.json
+++ b/findings_dashboard/timeseries.json
@@ -2,9 +2,9 @@
  "snapshots": [
   {
    "date": "2026-07-11",
-   "source": "build",
+   "source": "backfill",
    "metrics": {
-    "dcs_cdsl_linkage_pct": null,
+    "dcs_cdsl_linkage_pct": 81.4,
     "glossary_vidyut_coverage_pct": 86.6,
     "pwg_citation_coverage_pct": 83.9,
     "queue_verdicts": {
@@ -35,6 +35,45 @@
      "1": 10,
      "None": 12,
      "3": 14
+    },
+    "stale": 0
+   }
+  },
+  {
+   "date": "2026-07-18",
+   "source": "build",
+   "metrics": {
+    "dcs_cdsl_linkage_pct": 81.4,
+    "glossary_vidyut_coverage_pct": 86.6,
+    "pwg_citation_coverage_pct": 83.9,
+    "queue_verdicts": {
+     "PASS": 92,
+     "DROP": 1,
+     "SCAN-FIRST": 17,
+     "EDITORIAL": 11,
+     "DNF": 1
+    },
+    "queue_pass_by_dict": {
+     "SHS": 29,
+     "YAT": 17,
+     "ACC": 17,
+     "PWG": 10,
+     "MCI": 10,
+     "SKD": 3,
+     "WIL": 3,
+     "PW": 1,
+     "VCP": 1,
+     "GST": 1
+    },
+    "queue_decay_pct": 0.82
+   },
+   "registry": {
+    "total": 95,
+    "by_importance": {
+     "2": 42,
+     "1": 10,
+     "None": 27,
+     "3": 16
     },
     "stale": 0
    }


### PR DESCRIPTION
Executes step 1 of [H737](https://github.com/gasyoun/Uprava/blob/main/handoffs/H737-Fable_SanskritLexicography_findings-dashboard-refresh-repair_11.07.26.md) (from the H733 full-repo audit, area `dashboards`).

- Fresh 2026-07-18 snapshot in [findings_dashboard/timeseries.json](https://github.com/gasyoun/SanskritLexicography/blob/master/findings_dashboard/timeseries.json): `dcs_cdsl_linkage_pct` **81.4** — first non-null value ever in this lane (regex repaired by H733 PR #357, data never regenerated since).
- 2026-07-11 snapshot kept as `source: "backfill"` with the metric recomputed from csl-apidev git history (`ec56968`, readme unchanged 2026-07-03→11); superseded 2026-07-10 bot snapshot had identical inputs. Nothing earlier exists to recover.
- Backfill provenance note added to [findings_dashboard/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/findings_dashboard/README.md).
- [findings_dashboard/data.json](https://github.com/gasyoun/SanskritLexicography/blob/master/findings_dashboard/data.json) regenerated: 95 findings (was 75 on 11-07), 0 stale.

Follow-ups in the same handoff (scheduled-task repair, gh-pages republish, cadence @DECIDE) land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)