### PR TITLE
docs(findings-dashboard): H737 — repaired scheduled-task definition + gitignored refresh.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ HeadwordLists/heritage_mirror/
 # H813 Sanskrit-in-Numbers module8 fetch cache (zaliznyak-grammar-index TSV,
 # already published as a kosha release asset — fetched on demand, never committed)
 papers/sanskrit_in_numbers/.cache/
+
+# H737: scheduled-task refresh log (written into the main checkout by Task Scheduler)
+findings_dashboard/refresh.log

--- a/findings_dashboard/README.md
+++ b/findings_dashboard/README.md
@@ -30,6 +30,10 @@ is a private repo (network-topology findings) and is deliberately NOT rendered h
 - **This machine** (Task Scheduler, 3rd of month 09:30, task name `SL findings dashboard
   refresh`): the platform probes, which need residential egress; runs the full
   `monthly_refresh.py` pipeline, so it also doubles as a fallback if the Action fails.
+  Definition repaired 18-07-2026 (H737): `StartWhenAvailable` (a missed 09:30 fires at
+  next logon), explicit working directory, log at `findings_dashboard/refresh.log`
+  (gitignored). Still `InteractiveToken` — running while logged off awaits MG's stored
+  credentials (GTD @DO).
 
 A failed collector records `null` and the build continues — a chart simply skips that month.
 

--- a/findings_dashboard/monthly_refresh.py
+++ b/findings_dashboard/monthly_refresh.py
@@ -10,9 +10,18 @@ branches mid-day):
   2. worktree off origin/gh-pages → copy dashboard files into findings/
      → commit → push
 
-Scheduled task (already registered; re-create with):
-  schtasks /Create /SC MONTHLY /D 3 /ST 09:30 /TN "SL findings dashboard refresh" ^
-    /TR "cmd /c python C:\\Users\\user\\Documents\\GitHub\\SanskritLexicography\\findings_dashboard\\monthly_refresh.py >> C:\\Users\\user\\Documents\\GitHub\\SanskritLexicography\\findings_dashboard\\refresh.log 2>&1"
+Scheduled task "SL findings dashboard refresh" (monthly, 3rd, 09:30 local).
+Repaired 18-07-2026 (H737) after the 03-07 run died with 0xC000013A and left no
+log: the definition now sets StartWhenAvailable (a missed 09:30 fires at next
+logon), an explicit WorkingDirectory, no battery blocks, a 2h execution cap,
+and logs to findings_dashboard\\refresh.log (gitignored). Re-create by
+re-registering the XML export, NOT the old /SC one-liner (which loses those
+settings):
+  schtasks /query /tn "SL findings dashboard refresh" /xml > task.xml
+  schtasks /Create /F /TN "SL findings dashboard refresh" /XML task.xml
+LogonType is still InteractiveToken — upgrading to "run whether user is logged
+on or not" requires stored credentials typed at the keyboard (GTD @DO):
+  schtasks /Change /TN "SL findings dashboard refresh" /RU WIN-NJTORH3267V\\user /RP *
 """
 
 import shutil


### PR DESCRIPTION
Step 2 documentation of [H737](https://github.com/gasyoun/Uprava/blob/main/handoffs/H737-Fable_SanskritLexicography_findings-dashboard-refresh-repair_11.07.26.md): the "SL findings dashboard refresh" Windows scheduled task (never completed a run since creation — 0xC000013A, Interactive-only, Temp log purged) was re-registered with StartWhenAvailable, explicit WorkingDirectory, no battery blocks, PT2H cap, and a durable log at findings_dashboard/refresh.log (now gitignored).

- [findings_dashboard/monthly_refresh.py](https://github.com/gasyoun/SanskritLexicography/blob/master/findings_dashboard/monthly_refresh.py) docstring: XML re-registration procedure replaces the stale /SC one-liner; stored-credentials upgrade documented as the pending GTD @DO.
- [findings_dashboard/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/findings_dashboard/README.md) refresh-model section updated to match.

Proof-of-clean-run evidence lands in the handoff close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)