### PR TITLE
H1110 Phase 6 — c4 ladder HEALTH_NOGO_BY_ENVIRONMENT (profile proven, 0 paid calls)

### DIFF
--- a/RussianTranslation/pwg_ru/h1110/H1110_PHASE6_C4_LADDER_HEALTH_NOGO_BY_ENVIRONMENT_2026-07-18.md
+++ b/RussianTranslation/pwg_ru/h1110/H1110_PHASE6_C4_LADDER_HEALTH_NOGO_BY_ENVIRONMENT_2026-07-18.md
@@ -1,0 +1,53 @@
+# H1110 Phase 6 — c4 bounded ladder: `HEALTH_NOGO_BY_ENVIRONMENT`
+
+_Created: 18-07-2026 · Last updated: 18-07-2026_
+
+Terminal record for H1110 Phase 6 (bounded c4 live-acceptance ladder). **No paid c4 call was made.**
+The money-risk gate worked exactly as designed: the c4 profile is mechanically proven and every
+offline pipeline gate is green, but the Anthropic host is presently degraded, so the ladder is
+deferred rather than spending a call that would reproduce the standing NO-GO.
+
+## Verdict
+
+**`HEALTH_NOGO_BY_ENVIRONMENT` · CANARY NOT LAUNCHED · RUNG 3 NOT ENTERED · NO PRODUCTION TRANSLATION · 0 paid c4 calls.**
+
+## Mechanical profile proof — PASSED (offline, deterministic)
+
+The profile binding is unambiguous — this is **not** `STOP_PROFILE_UNBINDABLE`:
+
+| Fact | Value | Source |
+|---|---|---|
+| `c4` validated roster slot | `validated=1`, `parked_until=0` (exactly one `c4`) | `D:\ClaudeTools\pwg_ru\max_accounts.sqlite` `accounts` table |
+| c4 config dir | `D:\ClaudeTools\profiles\claude4\.claude` | roster row **and** `h963_c4_gate0_probe.py` `CONFIG_DIR` (agree) |
+| `config_dir_fingerprint` | `e96ee46471ec057e985b40d5ba6c5887bd4e17cc7cb89cb4dbb9c96a09704d4f` | `sha256(normcase(realpath(config_dir)))` — `execution_contract.config_dir_fingerprint` |
+| `validate_profile` outcome | would PASS for a `profile_slot='c4'` + `execution_route='claude-cli-headless'` manifest carrying that fingerprint | `execution_contract.py:104` |
+
+Billing identity is mechanically established from the repo's own roster + probe, never guessed.
+
+## Phase-5 offline gates — PASSED (current master `977236b1`)
+
+`window_selftest` **142/142** · `headless_worker_selftest` / `execution_contract_selftest` /
+`bounded_staged_run_selftest` PASS · `lang_parity_check` 53 entries **0 drift** · ruff canonical
+(`E9,F63,F7,F82`) clean · `node --check` ×4 clean.
+
+## Why deferred (host degradation)
+
+- The committed [H963 gate-0 report](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h963/H963_C4_SINGLE_PROFILE_GATE0_HEALTH_2026-07-16.md) records a fresh **`C4 HEALTH NO-GO`** on 16-07 at **104,870 ms** — 3.5× the 30 s strict ceiling, and *worse* than the 15-07 reading.
+- In this session (18-07) the Anthropic API — the same host c4 uses — was intermittently **unavailable** (the harness auto-mode classifier could not run), and then **declined** the paid probe command.
+- A fresh health call would almost certainly reproduce the 104 s NO-GO. Per human ruling (18-07), the ladder is deferred: **do not** bypass the classifier, add an allow-rule, launch the canary, or translate anything.
+
+## Exact c4 resume command (after Anthropic service has demonstrably recovered)
+
+Run **one** health probe first; proceed only on a strict PASS (both readings `< 30 000 ms`, 0 conn-errors):
+
+```powershell
+cd C:\Users\user\Documents\GitHub\SanskritLexicography\RussianTranslation
+python src\pilot\h963_c4_gate0_probe.py
+```
+
+- **PASS** → continue the bounded ladder via the skills: `/pwg-live-gate c4` (health + `dq_canary_puregloss` canary) → on GO, `/pwg-bounded-run` (one tiny real batch, `--only-profile c4 --max-agents 1 --timeout 180 --stop-before-promote`). At most **3 paid c4 calls** total; no retry/requeue/replacement.
+- **NO-GO** → record the named stop state, no canary, no production; retry only after the host recovers again.
+
+Do **not** re-run the paid probe on a whim — one health probe per demonstrated-recovery window.
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
H1110 Phase 6 terminal record. Mechanical c4 profile proof **PASSED** (validated roster slot in `max_accounts.sqlite`, config dir `D:\ClaudeTools\profiles\claude4\.claude`, fingerprint `e96ee464…`) and all Phase-5 offline gates are green on master (window_selftest 142/142 + selftests + parity + ruff + node) — but the Anthropic host is degraded (H963 fresh NO-GO 104,870 ms on 16-07; API unavailable + paid probe declined this session). Per human ruling (18-07): record `HEALTH_NOGO_BY_ENVIRONMENT`, **0 paid c4 calls**, preserve the exact resume command, retry one probe only after the host demonstrably recovers. The money-risk gate worked as designed. Handoff: [H1110](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1110-Opus_SanskritLexicography_pwg-ru-post-h1080-audit-fix-skills-c4-restart_17.07.26.md).