### PR TITLE
chore(progress-dashboard): H737 — refresh data snapshot (18-07-2026)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ HeadwordLists/heritage_mirror/
 # H813 Sanskrit-in-Numbers module8 fetch cache (zaliznyak-grammar-index TSV,
 # already published as a kosha release asset — fetched on demand, never committed)
 papers/sanskrit_in_numbers/.cache/
+
+# H737: scheduled-task refresh log (written into the main checkout by Task Scheduler)
+findings_dashboard/refresh.log

--- a/findings_dashboard/README.md
+++ b/findings_dashboard/README.md
@@ -30,6 +30,10 @@ is a private repo (network-topology findings) and is deliberately NOT rendered h
 - **This machine** (Task Scheduler, 3rd of month 09:30, task name `SL findings dashboard
   refresh`): the platform probes, which need residential egress; runs the full
   `monthly_refresh.py` pipeline, so it also doubles as a fallback if the Action fails.
+  Definition repaired 18-07-2026 (H737): `StartWhenAvailable` (a missed 09:30 fires at
+  next logon), explicit working directory, log at `findings_dashboard/refresh.log`
+  (gitignored). Still `InteractiveToken` — running while logged off awaits MG's stored
+  credentials (GTD @DO).
 
 A failed collector records `null` and the build continues — a chart simply skips that month.
 

--- a/findings_dashboard/monthly_refresh.py
+++ b/findings_dashboard/monthly_refresh.py
@@ -10,9 +10,18 @@ branches mid-day):
   2. worktree off origin/gh-pages → copy dashboard files into findings/
      → commit → push
 
-Scheduled task (already registered; re-create with):
-  schtasks /Create /SC MONTHLY /D 3 /ST 09:30 /TN "SL findings dashboard refresh" ^
-    /TR "cmd /c python C:\\Users\\user\\Documents\\GitHub\\SanskritLexicography\\findings_dashboard\\monthly_refresh.py >> C:\\Users\\user\\Documents\\GitHub\\SanskritLexicography\\findings_dashboard\\refresh.log 2>&1"
+Scheduled task "SL findings dashboard refresh" (monthly, 3rd, 09:30 local).
+Repaired 18-07-2026 (H737) after the 03-07 run died with 0xC000013A and left no
+log: the definition now sets StartWhenAvailable (a missed 09:30 fires at next
+logon), an explicit WorkingDirectory, no battery blocks, a 2h execution cap,
+and logs to findings_dashboard\\refresh.log (gitignored). Re-create by
+re-registering the XML export, NOT the old /SC one-liner (which loses those
+settings):
+  schtasks /query /tn "SL findings dashboard refresh" /xml > task.xml
+  schtasks /Create /F /TN "SL findings dashboard refresh" /XML task.xml
+LogonType is still InteractiveToken — upgrading to "run whether user is logged
+on or not" requires stored credentials typed at the keyboard (GTD @DO):
+  schtasks /Change /TN "SL findings dashboard refresh" /RU WIN-NJTORH3267V\\user /RP *
 """
 
 import shutil

--- a/progress_dashboard/progress_data.json
+++ b/progress_dashboard/progress_data.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-10",
+  "generated_at": "2026-07-18",
   "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
   "site_url": "https://gasyoun.github.io/SanskritLexicography/",
   "lanes": {
@@ -8,15 +8,15 @@
       "universe": 1882,
       "dcs_attested": 749,
       "promoted": 48,
-      "runnable": 11,
-      "blocked": 690
+      "runnable": 701,
+      "blocked": 0
     },
     "nominal": {
       "measured": true,
-      "candidates": 304,
-      "promoted": 3,
-      "runnable": 283,
-      "pwg_hits": 286,
+      "candidates": 5039,
+      "promoted": 41,
+      "runnable": 4251,
+      "pwg_hits": 4292,
       "medium50_promoted": 2,
       "medium50_total": 50,
       "medium50_status": "paused (kill-gate recalibration, H442/H462)"
@@ -24,10 +24,10 @@
   },
   "store": {
     "measured": true,
-    "senses": 11275,
-    "roots": 147,
+    "senses": 11603,
+    "roots": 254,
     "review": {
-      "ai_translated": 11275
+      "ai_translated": 11603
     },
     "human_reviewed": 0
   },

--- a/progress_dashboard/progress_timeseries.json
+++ b/progress_dashboard/progress_timeseries.json
@@ -7,6 +7,14 @@
       "senses": 11275,
       "roots": 147,
       "coverage_pct": 41.4
+    },
+    {
+      "date": "2026-07-18",
+      "verb_promoted": 48,
+      "verb_dcs_attested": 749,
+      "senses": 11603,
+      "roots": 254,
+      "coverage_pct": 41.4
     }
   ]
 }


### PR DESCRIPTION
Step 3 leg of [H737](https://github.com/gasyoun/Uprava/blob/main/handoffs/H737-Fable_SanskritLexicography_findings-dashboard-refresh-repair_11.07.26.md): [progress_dashboard/progress_timeseries.json](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/progress_timeseries.json) held a single 10-07 snapshot with no refresh trigger. This adds the 18-07 snapshot (senses 11,275→11,603, roots 147→254) built via the documented local `PWG_DATA_ROOT` lane. The standing trigger question (runbook doc line vs scheduled task) is filed as @DECIDE in GTD, not decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)