### PR TITLE
docs(h1110): Phase 6 fresh reading — c4 still NO-GO 18-07 (98.6s)

### DIFF
--- a/RussianTranslation/pwg_ru/h1110/H1110_PHASE6_C4_LADDER_HEALTH_NOGO_BY_ENVIRONMENT_2026-07-18.md
+++ b/RussianTranslation/pwg_ru/h1110/H1110_PHASE6_C4_LADDER_HEALTH_NOGO_BY_ENVIRONMENT_2026-07-18.md
@@ -2,14 +2,15 @@
 
 _Created: 18-07-2026 · Last updated: 18-07-2026_
 
-Terminal record for H1110 Phase 6 (bounded c4 live-acceptance ladder). **No paid c4 call was made.**
-The money-risk gate worked exactly as designed: the c4 profile is mechanically proven and every
-offline pipeline gate is green, but the Anthropic host is presently degraded, so the ladder is
-deferred rather than spending a call that would reproduce the standing NO-GO.
+Terminal record for H1110 Phase 6 (bounded c4 live-acceptance ladder). The money-risk gate worked
+exactly as designed: the c4 profile is mechanically proven and every offline pipeline gate is green,
+but the Anthropic host is degraded. The ladder was first deferred with **0** paid calls; a single
+**confirmation health probe** was later fired (18-07, at the owner's request) and **re-confirmed the
+NO-GO** — so no canary, no batch, no production translation.
 
 ## Verdict
 
-**`HEALTH_NOGO_BY_ENVIRONMENT` · CANARY NOT LAUNCHED · RUNG 3 NOT ENTERED · NO PRODUCTION TRANSLATION · 0 paid c4 calls.**
+**`HEALTH_NOGO_BY_ENVIRONMENT` · CANARY NOT LAUNCHED · RUNG 3 NOT ENTERED · NO PRODUCTION TRANSLATION · 1 confirmation health call (still NO-GO), canary + batch unspent.**
 
 ## Mechanical profile proof — PASSED (offline, deterministic)
 
@@ -35,6 +36,20 @@ Billing identity is mechanically established from the repo's own roster + probe,
 - The committed [H963 gate-0 report](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h963/H963_C4_SINGLE_PROFILE_GATE0_HEALTH_2026-07-16.md) records a fresh **`C4 HEALTH NO-GO`** on 16-07 at **104,870 ms** — 3.5× the 30 s strict ceiling, and *worse* than the 15-07 reading.
 - In this session (18-07) the Anthropic API — the same host c4 uses — was intermittently **unavailable** (the harness auto-mode classifier could not run), and then **declined** the paid probe command.
 - A fresh health call would almost certainly reproduce the 104 s NO-GO. Per human ruling (18-07), the ladder is deferred: **do not** bypass the classifier, add an allow-rule, launch the canary, or translate anything.
+
+## Fresh confirmation reading — 18-07-2026 (one paid probe, at owner's request)
+
+A single c4 health probe was fired 18-07 to check whether Anthropic had recovered. It had **not**:
+
+| Field | Value |
+|---|---|
+| stage / purpose | `probe` / `warmup` (D-K protocol) |
+| **warm-up latency** | **98,625 ms (~98.6 s)** |
+| classification | `success` (schema-valid; `output_bytes=1490`) — **pure-latency**, not auth/connection |
+| model | `claude-sonnet-5` · account `c4` · lane `claude-cli-headless/readiness-schema` |
+| timestamp | `2026-07-18T04:53:24Z` · `run_id=h963-c4-single-profile-gate0-2026-07-16` |
+
+**Verdict: `HEALTH NO-GO`.** Under the strict rule (**either** reading ≥ 30 000 ms ⇒ NO-GO), the warm-up alone at **3.29× the 30 s ceiling** settles it — the measured reading was not reached (the run was cut short) but cannot rescue a NO-GO warm-up. This is **essentially unchanged** from the 16-07 reading (104,870 ms): the c4/Anthropic host remains in the same degraded latency regime **two days on**. Cost: **1 paid c4 call** (the warm-up); canary and batch remain unspent. The ladder stays deferred — retry one probe again after a later window.
 
 ## Exact c4 resume command (after Anthropic service has demonstrably recovered)
 


### PR DESCRIPTION
Appends the 18-07 confirmation probe to the Phase-6 evidence doc: c4 warm-up 98,625 ms (~98.6s), success/pure-latency, HEALTH NO-GO — Anthropic host still degraded (unchanged from 16-07's 104,870 ms). 1 paid c4 call, canary+batch unspent, ladder deferred.