### PR TITLE
chore(release): v1.19.0 - H739 interactive gloss-review sheets

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.18.1
+version: 1.19.0
 date-released: "2026-07-18"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.19.0] — 18-07-2026
+
 ### Added
 
 - **article-comparison gloss-review goes interactive (H739).** The four finalist words'


### PR DESCRIPTION
Promote [Unreleased] to [1.19.0] - 18-07-2026 (the H739 gloss-review deliverable, [PR #540](https://github.com/gasyoun/SanskritLexicography/pull/540)) and sync [CITATION.cff](https://github.com/gasyoun/SanskritLexicography/blob/master/CITATION.cff) to 1.19.0. Tag + GitHub release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)