### PR TITLE
fix(russiantranslation): protect store and nominal leases

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -812,6 +812,11 @@ Two live tracks:
 
 ## 🚧 Current Work-In-Progress (WIP)
 
+- **RussianTranslation safety plan — PR 1 implemented locally, PR 2 pending (18-07-2026,
+  Codex/GPT-5; OFFLINE).** First layer protects canonical-store backups and full nominal-lease
+  reservations; focused regressions pass. Work is isolated in
+  `SanskritLexicography-safety-fixes`; no live generation or canonical-store/TM mutation.
+
 - **RussianTranslation PR #498 reconciliation (17-07-2026, Codex/GPT-5).** Isolated worktree;
   no live calls, promotions, store writes, or TM rebuilds. Validation: window tests 131/131 PASS;
   parity 49/49 clean; headless/orchestrator selftests PASS; Ruff fatal PASS; launch ledger 17 complete;

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -812,7 +812,7 @@ Two live tracks:
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- **RussianTranslation safety plan — PR 1 implemented locally, PR 2 pending (18-07-2026,
+- **RussianTranslation safety plan — [PR 1 #547](https://github.com/gasyoun/SanskritLexicography/pull/547) OPEN, PR 2 pending (18-07-2026,
   Codex/GPT-5; OFFLINE).** First layer protects canonical-store backups and full nominal-lease
   reservations; focused regressions pass. Work is isolated in
   `SanskritLexicography-safety-fixes`; no live generation or canonical-store/TM mutation.

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -812,9 +812,16 @@ Two live tracks:
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- **RussianTranslation safety plan — [PR 1 #547](https://github.com/gasyoun/SanskritLexicography/pull/547) OPEN, PR 2 pending (18-07-2026,
+- **RussianTranslation safety plan — [PR 1 #547](https://github.com/gasyoun/SanskritLexicography/pull/547) OPEN; stacked [PR 2 #550](https://github.com/gasyoun/SanskritLexicography/pull/550) OPEN (18-07-2026,
   Codex/GPT-5; OFFLINE).** First layer protects canonical-store backups and full nominal-lease
-  reservations; focused regressions pass. Work is isolated in
+  reservations. The stacked second layer now enforces prepared→running→auditing transitions,
+  ordinary ≤3 runtime, receipt-authorized staged ≤4 runtime, explicit dead-run recovery, and
+  lock-free timed preparation/audit with operation-token CAS. Real simultaneous reservation/cap
+  tests and orchestrator reserve-before-dispatch/release-on-retry tests pass; full window suite is
+  **144/144 PASS**, parity is **53/53 no drift**, promotion/orchestrator selftests, Python AST,
+  tracked JavaScript syntax, and diff hygiene all pass; manually dispatched branch CI
+  [run 29642913707](https://github.com/gasyoun/SanskritLexicography/actions/runs/29642913707) is green.
+  Work is isolated in
   `SanskritLexicography-safety-fixes`; no live generation or canonical-store/TM mutation.
 
 - **RussianTranslation PR #498 reconciliation (17-07-2026, Codex/GPT-5).** Isolated worktree;

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2013,6 +2013,13 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## 🚧 Current Work-In-Progress (WIP)
 
+- **RussianTranslation safety plan PR 1 — implementation complete locally, 18-07-2026
+  (Codex/GPT-5; OFFLINE).** Canonical-store backups are exclusive collision-resistant copies;
+  byte-identical duplicate workflow cards deduplicate while divergent translations/provenance
+  fail closed; nominal leases reserve every canonical input key with legacy migration and
+  unresolved-active fail-closed behavior. Focused promotion + coordinator regression tests pass.
+  No live translation, store mutation, TM rebuild, or H1110/H963 ladder action occurred.
+
 - **H1110 handoff authored, not yet executed (17-07-2026, Codex/GPT-5).** Atomic handoff ID minted
   and the active resume pointer moved from H963 to H1110. No code change, live probe, generation,
   promotion, store mutation or TM rebuild occurred in the authoring session.

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2013,6 +2013,21 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## 🚧 Current Work-In-Progress (WIP)
 
+- **RussianTranslation safety plan PR 2 — [PR #550](https://github.com/gasyoun/SanskritLexicography/pull/550) OPEN, 18-07-2026
+  (Codex/GPT-5; OFFLINE).** Coordinator runtime is now a persisted prepared→running→auditing state
+  machine: standard execution is globally capped at 3; staged execution reaches 4 only with fresh
+  run/lease/profile probe evidence; 5 always fails. `begin-run`, confirmed-dead release/recovery,
+  operation-token CAS, 10-minute preparation and 30-minute audit limits are wired; preflight,
+  generation, normalization, requeue generation, and audit no longer hold the state lock. The
+  four-profile orchestrator writes receipts, reserves batches before worker start, and releases
+  retryable failures. Simultaneous overlap/cap, blocked-subprocess responsiveness, stale-completion,
+  and orchestration tests pass. Final validation: **144/144** window tests, **53/53** parity entries,
+  promotion and max-account orchestrator selftests, Python AST parsing, every tracked JavaScript
+  syntax check, and `git diff --check` all pass; manually dispatched branch CI
+  [run 29642913707](https://github.com/gasyoun/SanskritLexicography/actions/runs/29642913707) is green.
+  No live call, generation, promotion, store write,
+  or TM rebuild occurred.
+
 - **RussianTranslation safety plan PR 1 — [PR #547](https://github.com/gasyoun/SanskritLexicography/pull/547) OPEN, 18-07-2026
   (Codex/GPT-5; OFFLINE).** Canonical-store backups are exclusive collision-resistant copies;
   byte-identical duplicate workflow cards deduplicate while divergent translations/provenance

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2013,7 +2013,7 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- **RussianTranslation safety plan PR 1 — implementation complete locally, 18-07-2026
+- **RussianTranslation safety plan PR 1 — [PR #547](https://github.com/gasyoun/SanskritLexicography/pull/547) OPEN, 18-07-2026
   (Codex/GPT-5; OFFLINE).** Canonical-store backups are exclusive collision-resistant copies;
   byte-identical duplicate workflow cards deduplicate while divergent translations/provenance
   fail closed; nominal leases reserve every canonical input key with legacy migration and

--- a/RussianTranslation/AGENTS.md
+++ b/RussianTranslation/AGENTS.md
@@ -28,6 +28,16 @@ windows. Per-profile call concurrency is serialized by the kernel-backed `Active
 timeout budgets are enforced in `headless_worker.py`, and a `--stop-before-promote` review checkpoint
 gates promotion.
 
+Coordinator state is deliberately split: `claimed`/`prepared`/`requeue_prepared` reserve work but
+consume no model runtime; `begin-run` is the only transition to `running`, and `record-output` moves
+that reservation through `auditing` before releasing it. Ordinary/manual execution is globally
+capped at three running leases. Four is available only inside `max_account_orchestrator.py
+staged-run` after its exact per-profile probe writes a fresh matching receipt; missing, stale,
+failed, or mismatched evidence is a hard refusal, and five is never allowed. Do not call
+`record-output` directly on a merely prepared lease. A dead worker must be returned with
+`release-run --confirm-dead --reason ...`; recover stale `preparing`/`auditing` tokens only with
+`recover-operation --confirm-dead` after confirming the subprocess is gone.
+
 Immediate next operator action: read the live queue in
 [`.ai_state.md`](.ai_state.md) — do NOT take a hardcoded root list from this
 file (an earlier version pinned `sTA` -> `BU` here long after both completed;

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,15 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — canonical-store backup and nominal lease collision safety
+
+- Promotion backups now use exclusive, collision-resistant names and never move or overwrite
+  the live canonical store. Identical recovered workflow cards deduplicate, while divergent
+  translations or generation provenance fail closed before promotion.
+- Nominal coordinator leases persist every canonical input key in `reserved_keys`. Legacy
+  active leases are migrated from claim details or execution manifests; an unresolved active
+  reservation blocks new nominal work instead of permitting an overlapping paid run.
+
 ### Added — H1150 W1-B: offline false-flag rate for `SANLOSS_*`/`TNMASK_*`, with a per-guard arming recommendation
 
 - **Measures; does not arm.** `SANLOSS_HARD_REJECT` and `TNMASK_HARD_REJECT` in

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,24 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added — enforceable coordinator runtime state machine
+
+- Prepared translation leases are now reservations, not runtime. `begin-run` atomically moves a
+  batch to `running`; `record-output` requires that reservation and releases it through `auditing`.
+  Ordinary execution is capped globally at three. A fourth slot exists only for `staged-run` with
+  a fresh, run- and lease-scoped four-profile probe receipt; a fifth lease always fails closed.
+- `release-run --confirm-dead --reason ...` records abandoned attempts and restores their prior
+  prepared state. `recover-operation --confirm-dead` recovers stale preparation/audit tokens, while
+  compare-and-swap completion checks prevent an old subprocess from overwriting newer lease state.
+- Preflight, harness generation, normalization, requeue generation, and audit now run outside the
+  coordinator state lock with explicit 10-minute preparation and 30-minute audit timeouts.
+  Dashboards distinguish reserved and running leases and retain `active_translation_leases` as a
+  one-cycle deprecated alias of the running count.
+- The four-profile orchestrator writes a credential-safe probe receipt, reserves every dispatch
+  batch before workers start, releases retryable/failed workers, and routes successful workers
+  through the required audit transition. Real contention tests also closed the mkdir/`owner.json`
+  lock-creation race that could previously admit two simultaneous claimers.
+
 ### Fixed — canonical-store backup and nominal lease collision safety
 
 - Promotion backups now use exclusive, collision-resistant names and never move or overwrite

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -356,7 +356,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -375,7 +375,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "c3840034737640dd701d772b6f2c25f5b4358c9ca003de561e35c462e4ea03ed",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -413,7 +413,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -472,7 +472,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -503,7 +503,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "bd9626ca58ca67773ab157140a2b62afff46047ac2294a864783144f629a7d63",
       "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/autosplit_requeue.py": "7ada6e0aa8dc8d0be15cf4be725e380929282974cc19fc950690c07b09511448",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -522,7 +522,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "958b069fc3a88e1032900f44498410fab88646409c9f0ca4e0952272a446cea1",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -540,7 +540,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "95797986db7c21210a55c8a13f324514d17110ba07d2f804d000a77a003d5bf3",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -559,7 +559,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -599,7 +599,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dbbf4e77b39585dabdd3df122143cacc15fedb97ce6c3d12654061e8fe6c11b9",
       "src/promote_final_cards.py": "79693cd4517d6c465e88283caf60e3a69affd3850e7b83d6383b8f5d8b8e7a78",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -624,7 +624,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "062733fd593b4cde4213fcfba2840e19c319da74d0fb5e2eff445bba60520cd6",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -653,7 +653,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "958b069fc3a88e1032900f44498410fab88646409c9f0ca4e0952272a446cea1",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -673,7 +673,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -691,8 +691,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "3398bae6db8b6c4836f86a9f62ff0c5d87cf500376e8c94b4a2e6e752026f390",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/coordinator.py": "2573a565070a092a41ec5f6718087864f1dc32ed8c7e3cae00178bd496249f0d",
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -729,7 +729,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -787,7 +787,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -806,7 +806,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -825,7 +825,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -845,7 +845,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e",
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -867,7 +867,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -926,7 +926,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -955,10 +955,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/headless_worker.py": "5022695ffd42d6912bc8d1e2d24c130b744461990afaa89b0f5f13f6ebd57f91",
-      "src/pilot/max_account_orchestrator.py": "39e7a60c0dbd89b6d2d2a8554832c19489f228409aef558062a260844d824635",
-      "src/pilot/coordinator.py": "3398bae6db8b6c4836f86a9f62ff0c5d87cf500376e8c94b4a2e6e752026f390",
+      "src/pilot/max_account_orchestrator.py": "ae74c26b62997f783c395b427cec14e92be4705109bb7320e80a7f5787a22644",
+      "src/pilot/coordinator.py": "2573a565070a092a41ec5f6718087864f1dc32ed8c7e3cae00178bd496249f0d",
       "src/pilot/headless_worker_selftest.py": "8adf980678db843100938045f4057c10d5fb7dc6c2cfe17f936028533e15654c",
-      "src/pilot/max_account_orchestrator_selftest.py": "7380473e18a6523e0cdc4ec831aa745e15e0f608673c06aad8b5a7c8515a564c",
+      "src/pilot/max_account_orchestrator_selftest.py": "df9ca93076dd187240573b043d9a10c9ae87ac94678afa8105ba47125c2fc872",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
       "src/pilot/run_observability.py": "eb21e08ba4f0e7ab7ab5dacf9db4e4d0d38234f2d63385157735ca8d7b8ced61",
@@ -986,7 +986,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -1005,7 +1005,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -1030,7 +1030,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/audit_window_en.py": "c3840034737640dd701d772b6f2c25f5b4358c9ca003de561e35c462e4ea03ed",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -1052,7 +1052,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e",
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1072,7 +1072,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   },
   {
@@ -1127,7 +1127,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "c3840034737640dd701d772b6f2c25f5b4358c9ca003de561e35c462e4ea03ed",
-      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
+      "src/pilot/window_selftest.py": "3ea261fcffc9e6fe4ab432d8b87a4eb0d66282538a6c9a5ac698b33b682aa193"
     }
   }
 ]

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -82,7 +82,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -118,7 +118,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -137,7 +137,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -156,7 +156,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -336,7 +336,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357",
+      "src/promote_final_cards.py": "79693cd4517d6c465e88283caf60e3a69affd3850e7b83d6383b8f5d8b8e7a78",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
     }
   },
@@ -356,7 +356,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -375,7 +375,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "c3840034737640dd701d772b6f2c25f5b4358c9ca003de561e35c462e4ea03ed",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -393,7 +393,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED same day (2026-07-04): PR #140 (feat(provenance): pipeline versioning) added pipeline_version stamping only to promote_final_cards.py; found as a GAP while re-affirming H169's parity re-hash, closed immediately. promote_en.py now calls `pipeline_version.stamp(model_version=gen_model_version)` inside `en_index()`'s per-subcard provenance block, stored as `en_provenance.pipeline` (mirrors RU's `provenance.pipeline`; a distinct field since EN attaches onto an existing RU row rather than owning it). Pinned by an added assertion in `promote_en.selftest()`.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357",
+      "src/promote_final_cards.py": "79693cd4517d6c465e88283caf60e3a69affd3850e7b83d6383b8f5d8b8e7a78",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
     }
   },
@@ -413,7 +413,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -431,7 +431,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 1.1. The layer is derived purely from the sub-card KEY structure, which is identical for RU and EN. promote_en.py ATTACHES english onto the RU-owned row and leaves it otherwise untouched, so EN inherits `layer` for free — no EN-specific code needed. layer_of() pinned by dict_merge.py selftest + a promote_final_cards.selftest assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357",
+      "src/promote_final_cards.py": "79693cd4517d6c465e88283caf60e3a69affd3850e7b83d6383b8f5d8b8e7a78",
       "src/dict_merge.py": "0266e11980e3b8b12d0699665b2051b9f7b8b16ed89d5810adfe5a458e880eea"
     }
   },
@@ -451,7 +451,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357"
+      "src/promote_final_cards.py": "79693cd4517d6c465e88283caf60e3a69affd3850e7b83d6383b8f5d8b8e7a78"
     }
   },
   {
@@ -472,7 +472,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -503,7 +503,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "bd9626ca58ca67773ab157140a2b62afff46047ac2294a864783144f629a7d63",
       "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/autosplit_requeue.py": "7ada6e0aa8dc8d0be15cf4be725e380929282974cc19fc950690c07b09511448",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -522,7 +522,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "958b069fc3a88e1032900f44498410fab88646409c9f0ca4e0952272a446cea1",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -540,7 +540,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "95797986db7c21210a55c8a13f324514d17110ba07d2f804d000a77a003d5bf3",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -559,7 +559,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -597,9 +597,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/promote_lock.py": "dbbf4e77b39585dabdd3df122143cacc15fedb97ce6c3d12654061e8fe6c11b9",
-      "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357",
+      "src/promote_final_cards.py": "79693cd4517d6c465e88283caf60e3a69affd3850e7b83d6383b8f5d8b8e7a78",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -624,7 +624,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "062733fd593b4cde4213fcfba2840e19c319da74d0fb5e2eff445bba60520cd6",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -653,7 +653,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "958b069fc3a88e1032900f44498410fab88646409c9f0ca4e0952272a446cea1",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -673,7 +673,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -691,8 +691,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "ca41cb0055a98171e90031ba3a076ebac66306df0e283b609f4889291f158506",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/coordinator.py": "3398bae6db8b6c4836f86a9f62ff0c5d87cf500376e8c94b4a2e6e752026f390",
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -729,7 +729,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -787,7 +787,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -806,7 +806,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -825,7 +825,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -845,7 +845,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba",
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -867,7 +867,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -904,7 +904,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/store_path.py": "2b3be1415dc7a387717c60574abc36aec9600d7a5c138bf7ac85415aa1b1e152",
-      "src/promote_final_cards.py": "e9a70f11e0387b7cbceb7965b35bb57a1c3599cc59f1ce32131b61a6405ff357",
+      "src/promote_final_cards.py": "79693cd4517d6c465e88283caf60e3a69affd3850e7b83d6383b8f5d8b8e7a78",
       "src/promote_en.py": "4c97e7543390c5f1f7652272e4b7ff49aa7b1df19d8a29aa4975d2aea337407d"
     }
   },
@@ -926,7 +926,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -956,7 +956,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/headless_worker.py": "5022695ffd42d6912bc8d1e2d24c130b744461990afaa89b0f5f13f6ebd57f91",
       "src/pilot/max_account_orchestrator.py": "39e7a60c0dbd89b6d2d2a8554832c19489f228409aef558062a260844d824635",
-      "src/pilot/coordinator.py": "ca41cb0055a98171e90031ba3a076ebac66306df0e283b609f4889291f158506",
+      "src/pilot/coordinator.py": "3398bae6db8b6c4836f86a9f62ff0c5d87cf500376e8c94b4a2e6e752026f390",
       "src/pilot/headless_worker_selftest.py": "8adf980678db843100938045f4057c10d5fb7dc6c2cfe17f936028533e15654c",
       "src/pilot/max_account_orchestrator_selftest.py": "7380473e18a6523e0cdc4ec831aa745e15e0f608673c06aad8b5a7c8515a564c",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
@@ -986,7 +986,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -1005,7 +1005,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -1030,7 +1030,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "89d9999820a6548312257812fb399a70cd95556e51fee02559e76166a1c80680",
       "src/pilot/audit_window_en.py": "c3840034737640dd701d772b6f2c25f5b4358c9ca003de561e35c462e4ea03ed",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -1052,7 +1052,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "910aabcd6db9f7cdf3b78d6fff5692ba2d2eb51f8c33734d64b12b17ee4411e1",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba",
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1072,7 +1072,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   },
   {
@@ -1127,7 +1127,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "c3840034737640dd701d772b6f2c25f5b4358c9ca003de561e35c462e4ea03ed",
-      "src/pilot/window_selftest.py": "fd4bfd46e4778bd7bb7d184e14fd59bd4bb7a2e89904645fae05bdee46724fba"
+      "src/pilot/window_selftest.py": "f6b173ff47de50911b2ad8735ae555010b5a9fb6821ce70481575af0c7d05b5e"
     }
   }
 ]

--- a/RussianTranslation/ORCHESTRATION_4ACCOUNT_MAX.md
+++ b/RussianTranslation/ORCHESTRATION_4ACCOUNT_MAX.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable MD013 MD036 -->
 
-_Created: 12-07-2026 · Last updated: 15-07-2026_
+_Created: 12-07-2026 · Last updated: 18-07-2026_
 
 This dispatcher runs ordinary commands under four isolated profiles. It does not translate by itself or bypass coordinator/audit/promotion gates.
 
@@ -39,6 +39,20 @@ python3 src/pilot/max_account_orchestrator.py --db /var/lib/pwg-ru/max.sqlite re
 python3 src/pilot/max_account_orchestrator.py --db /var/lib/pwg-ru/max.sqlite status
 ```
 
+`run-once` calls coordinator `begin-run` atomically before any manifest-backed worker starts;
+ordinary invocations claim at most three runtime slots. `record-done` is the only successful path
+back through coordinator `record-output` → `auditing`. A retryable or failed worker is returned to
+its previous prepared state with a recorded `release-run --confirm-dead` attempt. If an operator
+must recover manually, first confirm the worker process tree is dead, then use:
+
+```sh
+python3 src/pilot/coordinator.py release-run LEASE_ID --confirm-dead --reason "host restart"
+python3 src/pilot/coordinator.py recover-operation LEASE_ID --confirm-dead
+```
+
+The second command is only for stale `preparing` or `auditing` operation tokens. Late completions
+carry the old operation ID and cannot overwrite the recovered lease.
+
 Install `deploy/pwg-ru-max-orchestrator.{service,timer}` for recurring dispatch. Startup refuses missing or unauthenticated profiles. A rate limit returns the job to pending and parks the account until the parsed epoch, or five hours if no reset is machine-readable. Every attempt gets immutable runner/status logs plus manifest/result hashes. `recover` returns crash-stranded jobs to pending. Promotion remains serialized through `coordinator.py promote-ready --gen-model-version claude-sonnet-5`.
 
 ## Acceptance
@@ -48,6 +62,10 @@ Install `deploy/pwg-ru-max-orchestrator.{service,timer}` for recurring dispatch.
 3. Four disjoint jobs run concurrently.
 4. Kill a dispatch pass, recover, and verify no duplicate promotion.
 5. Record logs, reset behavior, exact model, clean rate, and store delta in the H818 audit.
+
+After both safety PRs merge, the owner-gated H963/H1110 ladder remains the final production test:
+probe → canary → 10 → 20 → four-profile 20. Do not weaken its exactly-once, restart-recovery,
+promotion, audit, or concurrency verdicts to compensate for environmental failures.
 
 ## Windows 100-headword gate
 
@@ -96,7 +114,12 @@ the first profile whose probe fails or exceeds the health ceiling aborts the who
 run (an honest fleet NO-GO), matching acceptance criterion #1. `--drop-unhealthy`
 is the explicit opt-in to instead drop the failing profile, park it, and proceed
 on the healthy subset (still requiring at least one healthy profile). `report`'s
-`probe_latency_ms` becomes a per-profile `name → measured_ms` map. The run then
+`probe_latency_ms` becomes a per-profile `name → measured_ms` map. A successful fleet probe writes
+`probe_receipts/probe_receipt.<run-id>.json` with the run ID, admitted lease IDs, healthy profiles,
+measured latencies, and timestamp. Every dispatch batch presents that receipt to coordinator
+`begin-run`; only this staged path can raise the global runtime ceiling from three to four. A
+missing, failed, stale, future-dated, run-mismatched, lease-mismatched, or incomplete receipt is a
+hard refusal, and a fifth runtime lease is refused in every mode. The run then
 records/audits each window, promotes only its audit-clean subset under the global
 promotion lock, and emits a GO only when the exact headword/subcard census is
 accounted, every window has a positive canonical-store delta, no hard failure or

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -343,6 +343,22 @@ deterministic 10 % sample of clean translated keys. It is NOT the mechanical req
 
 ## Concurrency — run a throttled driver, not N parallel chats
 
+The coordinator enforces this distinction, rather than relying on operator arithmetic:
+
+- `prepared` and `requeue_prepared` leases are durable reserved work and consume zero runtime slots.
+- `coordinator.py begin-run --lease-id ...` atomically reserves runtime before dispatch. Standard
+  mode is globally capped at three; `record-output` is refused unless the lease is `running`.
+- `max_account_orchestrator.py staged-run` may use four only after every admitted profile passes
+  the exact-model probe and the orchestrator writes a fresh receipt scoped to that run and lease
+  set. Missing/failed/stale/mismatched evidence fails closed; no mode admits a fifth lease.
+- Failed/retryable workers use `release-run --confirm-dead --reason ...`. A stale preparation or
+  audit token uses `recover-operation --confirm-dead`; late subprocess completion is rejected by
+  operation ID instead of overwriting the recovered state.
+
+Preparation and audit subprocesses do not hold the global state lock. Their persisted
+`preparing`/`auditing` operation tokens keep `status` and unrelated claims responsive, with a
+10-minute preparation timeout and a 30-minute audit timeout.
+
 **Default to one Workflow window at a time; treat 3-wide as an upper bound, not a target.**
 Each generated harness internally fans out to ~8–14 agents, so N concurrent root-harnesses
 peak at N×~12 Sonnet agents on a single Max session. Slice D launched 18 at once →

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -173,12 +173,14 @@ def load_state():
     state.setdefault('translation_limit', TRANSLATION_LIMIT)
     state.setdefault('preparation_limit', PREPARATION_LIMIT)
     state.setdefault('cap', {})
+    normalize_lease_reservations(state)
     return state
 
 
 def save_state(state):
     p = ensure_dirs()
     expire_stale_leases(state)
+    normalize_lease_reservations(state)
     state['updated_at'] = utc_now()
     atomic_write_json(p['state'], state, indent=1)
     write_dashboard(state)
@@ -221,6 +223,86 @@ def expire_stale_leases(state):
 
 def translation_lease(lease):
     return lease.get('kind') in ('verb', 'nominal')
+
+
+def _validate_reserved_keys(value):
+    if not isinstance(value, list) or not value:
+        return None, 'reserved_keys must be a non-empty list'
+    if any(not isinstance(key, str) or not key for key in value):
+        return None, 'reserved_keys contains an invalid key'
+    if len(value) != len(set(value)):
+        return None, 'reserved_keys contains duplicate keys'
+    return list(value), None
+
+
+def derive_lease_reserved_keys(lease):
+    """Return canonical nominal keys for new and legacy leases, or an explicit error.
+
+    Runtime/safe keys are not sufficient for collision detection because a later candidate is
+    selected by its canonical assembled-card key1. Prefer the persisted reservation, then the
+    claim details, and finally a prepared execution manifest's nominal keymap.
+    """
+    if lease.get('kind') != 'nominal':
+        return [], None
+    if 'reserved_keys' in lease:
+        return _validate_reserved_keys(lease.get('reserved_keys'))
+    details = lease.get('details') or {}
+    if details.get('keys') is not None:
+        return _validate_reserved_keys(details.get('keys'))
+    keymap = details.get('keymap')
+    if isinstance(keymap, dict) and keymap:
+        return _validate_reserved_keys(list(keymap.values()))
+    manifest_path = lease.get('execution_manifest') or lease.get('origin_execution_manifest')
+    if manifest_path:
+        try:
+            with open(manifest_path, encoding='utf-8') as f:
+                manifest = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            return None, 'execution manifest is unreadable: %s' % exc
+        meta = manifest.get('meta') or {}
+        selected = meta.get('selected_keys')
+        keymap = meta.get('nominal_keymap')
+        if isinstance(selected, list) and isinstance(keymap, dict):
+            if any(key not in keymap for key in selected):
+                return None, 'execution manifest nominal_keymap does not cover selected_keys'
+            return _validate_reserved_keys([keymap[key] for key in selected])
+    return None, 'canonical nominal keys cannot be derived from lease details or manifest'
+
+
+def normalize_lease_reservations(state):
+    """Backfill additive reservation state without making read-only status unusable."""
+    for lease in state.get('leases', []):
+        if lease.get('kind') != 'nominal':
+            continue
+        keys, error = derive_lease_reserved_keys(lease)
+        if error:
+            lease['reservation_error'] = error
+        else:
+            lease['reserved_keys'] = keys
+            lease.pop('reservation_error', None)
+
+
+def active_reserved_nominal_keys(state, exclude_lease_id=None, strict=True):
+    """Canonical keys owned by nonterminal nominal leases.
+
+    A new claim must fail closed if any active legacy lease cannot prove its full reservation;
+    otherwise a partially-known batch could overlap silently.
+    """
+    expire_stale_leases(state)
+    normalize_lease_reservations(state)
+    reserved = set()
+    for lease in state.get('leases', []):
+        if (lease.get('kind') != 'nominal' or terminal_state(lease.get('state'))
+                or lease.get('id') == exclude_lease_id):
+            continue
+        error = lease.get('reservation_error')
+        if error:
+            if strict:
+                raise SystemExit('active nominal lease %s has unresolved reservations: %s'
+                                 % (lease.get('id'), error))
+            continue
+        reserved.update(lease.get('reserved_keys') or [])
+    return reserved
 
 
 def active_translation_leases(state):
@@ -339,7 +421,7 @@ def verb_candidates(state, limit=20):
 def nominal_candidates(state, batch_size=12, cards_path=None):
     cards_path = cards_path or os.path.join(SRC, 'assembled_cards.jsonl')
     done = load_store_key1s()
-    leased = active_targets(state)
+    leased = active_reserved_nominal_keys(state)
     keys = []
     if not os.path.exists(cards_path):
         return keys
@@ -350,8 +432,7 @@ def nominal_candidates(state, batch_size=12, cards_path=None):
             row = json.loads(line)
             key = row.get('key1')
             stem = safe_name(key) if key else ''
-            target = 'nominal:%s' % key
-            if (key and key not in done and target not in leased
+            if (key and key not in done and key not in leased
                     and not row.get('quarantined_records')
                     and os.path.exists(os.path.join(HERE, 'input', stem + '.raw.txt'))
                     and os.path.exists(os.path.join(HERE, 'input', stem + '.portrait.json'))):
@@ -417,6 +498,8 @@ def claim(args):
             'artifact_dir': adir,
             'details': details,
         }
+        if args.kind == 'nominal':
+            lease['reserved_keys'] = list(keys)
         os.makedirs(adir, exist_ok=True)
         state['leases'].append(lease)
         save_state(state)
@@ -431,15 +514,20 @@ def register_prepared_lease(lease_id, lane, keys, harness, manifest, preflight_p
         state = load_state()
         if any(lease.get('id') == lease_id for lease in state.get('leases', [])):
             raise SystemExit('lease already exists: %s' % lease_id)
-        active = active_targets(state)
+        keys, key_error = _validate_reserved_keys(list(keys))
+        if key_error:
+            raise SystemExit('invalid nominal reservation: %s' % key_error)
+        active = active_reserved_nominal_keys(state)
         target = 'nominal:%s' % keys[0]
-        if target in active:
-            raise SystemExit('lease target already active: %s' % target)
+        overlap = sorted(set(keys) & active)
+        if overlap:
+            raise SystemExit('nominal lease keys already active: %s' % ','.join(overlap))
         run_keys = [safe_name(k) for k in keys]
         lease = {
             'id': lease_id, 'lane': lane, 'kind': 'nominal', 'owner': owner,
             'target': target, 'state': 'prepared', 'claimed_at': utc_now(),
             'prepared_at': utc_now(), 'artifact_dir': artifact_path or os.path.dirname(manifest),
+            'reserved_keys': list(keys),
             'details': {'keys': keys, 'run_keys': run_keys,
                         'keymap': dict(zip(run_keys, keys))},
             'harness': os.path.abspath(harness),

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -7,6 +7,7 @@ session and feed the full result back through record-output.
 """
 import argparse
 from collections import Counter
+import copy
 import datetime
 import glob
 import json
@@ -16,6 +17,7 @@ import shutil
 import subprocess
 import sys
 import time
+import uuid
 
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
@@ -31,9 +33,20 @@ DASHBOARD_SCHEMA = 'pwg.sla_coordinator.dashboard.v1'
 REGISTRY_SCHEMA = 'pwg.sla_coordinator.artifact.v1'
 DAILY_SCHEMA = 'pwg.sla_coordinator.daily.v1'
 TRANSLATION_LIMIT = 3
+STAGED_TRANSLATION_LIMIT = 4
 PREPARATION_LIMIT = 100
 LEASE_TTL_SECONDS = 6 * 60 * 60
 LOCK_TTL_SECONDS = 10 * 60
+LOCK_META_GRACE_SECONDS = 2
+PREPARE_TIMEOUT_SECONDS = 10 * 60
+AUDIT_TIMEOUT_SECONDS = 30 * 60
+# A single probe authorizes one bounded staged run, whose successive four-window batches can
+# legitimately span hours. It still expires fail-closed before a later operator session.
+PROBE_RECEIPT_MAX_AGE_SECONDS = 6 * 60 * 60
+PROBE_RECEIPT_SCHEMA = 'pwg.runtime_probe_receipt.v1'
+PROBE_MODEL = 'claude-sonnet-5'
+PROBE_POLICY = 'production_v1'
+PROBE_LATENCY_CEILING_MS = 30000
 
 if SRC not in sys.path:
     sys.path.insert(0, SRC)
@@ -140,7 +153,12 @@ class DirLock:
         try:
             meta = json.load(open(meta_path, encoding='utf-8'))
         except (OSError, json.JSONDecodeError):
-            return True
+            # os.mkdir() and owner.json creation are separate operations. A contender can
+            # legitimately observe the directory in that tiny gap; never delete that live lock.
+            try:
+                return time.time() - os.path.getmtime(self.path) > LOCK_META_GRACE_SECONDS
+            except OSError:
+                return False
         created = parse_ts(meta.get('created_at'))
         if not created:
             return True
@@ -154,6 +172,8 @@ def default_state():
         'created_at': utc_now(),
         'updated_at': utc_now(),
         'translation_limit': TRANSLATION_LIMIT,
+        'runtime_limit': TRANSLATION_LIMIT,
+        'runtime_mode': 'standard',
         'preparation_limit': PREPARATION_LIMIT,
         'leases': [],
         'cap': {'weekly_cap_fired': False, 'weekly_cap_cumulative_tokens': None},
@@ -171,6 +191,8 @@ def load_state():
     state.setdefault('schema', STATE_SCHEMA)
     state.setdefault('leases', [])
     state.setdefault('translation_limit', TRANSLATION_LIMIT)
+    state.setdefault('runtime_limit', state.get('translation_limit', TRANSLATION_LIMIT))
+    state.setdefault('runtime_mode', 'standard')
     state.setdefault('preparation_limit', PREPARATION_LIMIT)
     state.setdefault('cap', {})
     normalize_lease_reservations(state)
@@ -181,6 +203,13 @@ def save_state(state):
     p = ensure_dirs()
     expire_stale_leases(state)
     normalize_lease_reservations(state)
+    running = running_translation_leases(state)
+    state['runtime_mode'] = ('staged-probed' if any(
+        lease.get('runtime_mode') == 'staged-probed' for lease in running) else 'standard')
+    state['runtime_limit'] = (max(
+        (int(lease.get('runtime_limit') or TRANSLATION_LIMIT) for lease in running),
+        default=TRANSLATION_LIMIT) if state['runtime_mode'] == 'staged-probed'
+                              else TRANSLATION_LIMIT)
     state['updated_at'] = utc_now()
     atomic_write_json(p['state'], state, indent=1)
     write_dashboard(state)
@@ -305,12 +334,25 @@ def active_reserved_nominal_keys(state, exclude_lease_id=None, strict=True):
     return reserved
 
 
-def active_translation_leases(state):
+def reserved_translation_leases(state):
     expire_stale_leases(state)
     return [
         lease for lease in state.get('leases', [])
         if translation_lease(lease) and not terminal_state(lease.get('state'))
     ]
+
+
+def running_translation_leases(state):
+    expire_stale_leases(state)
+    return [
+        lease for lease in state.get('leases', [])
+        if translation_lease(lease) and lease.get('state') in ('running', 'auditing')
+    ]
+
+
+def active_translation_leases(state):
+    """Deprecated compatibility alias: active now means consuming runtime."""
+    return running_translation_leases(state)
 
 
 def lease_by_id(state, lease_id):
@@ -344,9 +386,9 @@ def registry_event(lease, event_type, data=None):
     append_jsonl(paths()['registry'], rec)
 
 
-def run_cmd(cmd, cwd=REPO, check=True):
+def run_cmd(cmd, cwd=REPO, check=True, timeout=None):
     p = subprocess.run(cmd, cwd=cwd, text=True, encoding='utf-8',
-                       capture_output=True)
+                       capture_output=True, timeout=timeout)
     if check and p.returncode:
         if p.stdout.strip():
             print(p.stdout.rstrip())
@@ -354,6 +396,217 @@ def run_cmd(cmd, cwd=REPO, check=True):
             print(p.stderr.rstrip(), file=sys.stderr)
         raise SystemExit(p.returncode)
     return p
+
+
+def operation_id():
+    return uuid.uuid4().hex
+
+
+def remaining_operation_timeout(deadline, command):
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise subprocess.TimeoutExpired(command, 0)
+    return remaining
+
+
+def begin_operation(lease, expected_states, operation_state, operation_kind):
+    if lease.get('state') not in expected_states:
+        raise SystemExit('%s: cannot begin %s from lease state %r' %
+                         (lease.get('id'), operation_kind, lease.get('state')))
+    token = operation_id()
+    lease['operation_id'] = token
+    lease['operation_kind'] = operation_kind
+    lease['operation_started_at'] = utc_now()
+    lease['operation_previous_state'] = lease.get('state')
+    lease['state'] = operation_state
+    return token
+
+
+def require_operation(lease, token, operation_state):
+    if lease.get('state') != operation_state or lease.get('operation_id') != token:
+        raise SystemExit('%s: stale %s completion refused' %
+                         (lease.get('id'), operation_state))
+
+
+def clear_operation(lease):
+    for key in ('operation_id', 'operation_kind', 'operation_started_at',
+                'operation_previous_state'):
+        lease.pop(key, None)
+
+
+def block_operation(lease_id, token, operation_state, exc):
+    """Record an unexpected long-operation failure if its CAS token still owns the lease."""
+    with DirLock(paths()['lock']):
+        state = load_state()
+        lease = lease_by_id(state, lease_id)
+        if lease.get('state') == operation_state and lease.get('operation_id') == token:
+            if operation_state == 'auditing':
+                lease.setdefault('run_attempts', []).append({
+                    'run_operation_id': lease.get('run_operation_id'),
+                    'run_id': lease.get('run_id'),
+                    'runtime_mode': lease.get('runtime_mode'),
+                    'started_at': lease.get('run_started_at'),
+                    'blocked_at': utc_now(),
+                    'outcome': 'blocked',
+                })
+                for key in ('run_operation_id', 'run_started_at', 'runtime_mode', 'runtime_limit',
+                            'run_id',
+                            'probe_receipt', 'pre_run_state'):
+                    lease.pop(key, None)
+            lease['previous_state'] = operation_state
+            lease['state'] = 'blocked'
+            lease['blocked_at'] = utc_now()
+            lease['operation_error'] = '%s: %s' % (type(exc).__name__, exc)
+            clear_operation(lease)
+            save_state(state)
+            registry_event(lease, 'operation_blocked', {
+                'operation_state': operation_state,
+                'error': lease['operation_error'],
+            })
+
+
+def validate_probe_receipt(receipt_path, lease_ids, run_id, now=None):
+    if not receipt_path:
+        raise SystemExit('staged begin-run requires --probe-receipt')
+    try:
+        with open(receipt_path, encoding='utf-8') as f:
+            receipt = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit('probe receipt is unreadable: %s' % exc)
+    if receipt.get('schema') != PROBE_RECEIPT_SCHEMA or receipt.get('go') is not True:
+        raise SystemExit('probe receipt is missing successful staged evidence')
+    if (receipt.get('model') != PROBE_MODEL
+            or receipt.get('policy') != PROBE_POLICY):
+        raise SystemExit('probe receipt model or policy mismatch')
+    if not run_id or receipt.get('run_id') != run_id:
+        raise SystemExit('probe receipt run ID mismatch')
+    generated = parse_ts(receipt.get('generated_at'))
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    if not generated:
+        raise SystemExit('probe receipt timestamp is missing')
+    age = (now - generated).total_seconds()
+    if age < -60 or age > PROBE_RECEIPT_MAX_AGE_SECONDS:
+        raise SystemExit('probe receipt is stale or future-dated')
+    allowed = set(receipt.get('lease_ids') or [])
+    if not set(lease_ids).issubset(allowed):
+        raise SystemExit('probe receipt lease scope mismatch')
+    healthy = receipt.get('healthy_profiles') or []
+    latencies = receipt.get('probe_latency_ms') or {}
+    if (not healthy or len(set(healthy)) != len(healthy)
+            or set(healthy) != set(latencies)):
+        raise SystemExit('probe receipt profile evidence is incomplete')
+    if any(not isinstance(latencies.get(profile), (int, float))
+           or latencies[profile] < 0
+           or latencies[profile] >= PROBE_LATENCY_CEILING_MS for profile in healthy):
+        raise SystemExit('probe receipt latency evidence is invalid')
+    return receipt
+
+
+def begin_run_leases(state, lease_ids, mode='standard', run_id=None,
+                     probe_receipt=None):
+    lease_ids = list(lease_ids or [])
+    if not lease_ids or len(set(lease_ids)) != len(lease_ids):
+        raise SystemExit('begin-run requires unique lease IDs')
+    leases = [lease_by_id(state, lease_id) for lease_id in lease_ids]
+    if any(lease.get('state') not in ('prepared', 'requeue_prepared') for lease in leases):
+        raise SystemExit('begin-run requires prepared leases')
+    running = running_translation_leases(state)
+    if mode == 'standard':
+        limit = TRANSLATION_LIMIT
+        runtime_mode = 'standard'
+    elif mode == 'staged':
+        receipt = validate_probe_receipt(probe_receipt, lease_ids, run_id)
+        limit = min(STAGED_TRANSLATION_LIMIT, len(receipt['healthy_profiles']))
+        runtime_mode = 'staged-probed'
+    else:
+        raise SystemExit('unknown runtime mode: %s' % mode)
+    if len(running) + len(leases) > limit:
+        raise SystemExit('runtime cap reached (%d)' % limit)
+    started_at = utc_now()
+    for lease in leases:
+        lease['pre_run_state'] = lease['state']
+        lease['state'] = 'running'
+        lease['run_operation_id'] = operation_id()
+        lease['run_started_at'] = started_at
+        lease['runtime_mode'] = runtime_mode
+        lease['runtime_limit'] = limit
+        lease['run_id'] = run_id
+        lease['probe_receipt'] = os.path.abspath(probe_receipt) if probe_receipt else None
+    state['runtime_mode'] = runtime_mode
+    state['runtime_limit'] = limit
+    return leases
+
+
+def begin_run(args):
+    with DirLock(paths()['lock']):
+        state = load_state()
+        leases = begin_run_leases(
+            state, args.lease_id, mode=args.mode, run_id=args.run_id,
+            probe_receipt=args.probe_receipt)
+        save_state(state)
+        for lease in leases:
+            registry_event(lease, 'run_started', {
+                'run_id': lease.get('run_id'),
+                'runtime_mode': lease.get('runtime_mode'),
+                'run_operation_id': lease.get('run_operation_id'),
+            })
+    print('running=%s' % ','.join(lease['id'] for lease in leases))
+
+
+def release_run(args):
+    if not args.confirm_dead or not (args.reason or '').strip():
+        raise SystemExit('release-run requires --confirm-dead and a non-empty --reason')
+    with DirLock(paths()['lock']):
+        state = load_state()
+        lease = lease_by_id(state, args.lease_id)
+        if lease.get('state') not in ('running', 'auditing'):
+            raise SystemExit('%s: no runtime reservation to release' % lease['id'])
+        attempt = {
+            'run_operation_id': lease.get('run_operation_id'),
+            'run_id': lease.get('run_id'),
+            'runtime_mode': lease.get('runtime_mode'),
+            'started_at': lease.get('run_started_at'),
+            'released_at': utc_now(),
+            'reason': args.reason.strip(),
+        }
+        lease.setdefault('run_attempts', []).append(attempt)
+        lease['state'] = lease.get('pre_run_state') or 'prepared'
+        for key in ('run_operation_id', 'run_started_at', 'runtime_mode', 'runtime_limit', 'run_id',
+                    'probe_receipt', 'pre_run_state'):
+            lease.pop(key, None)
+        clear_operation(lease)
+        save_state(state)
+        registry_event(lease, 'run_released', attempt)
+    print('lease %s -> %s' % (lease['id'], lease['state']))
+
+
+def recover_operation(args):
+    if not args.confirm_dead:
+        raise SystemExit('recover-operation requires --confirm-dead')
+    with DirLock(paths()['lock']):
+        state = load_state()
+        lease = lease_by_id(state, args.lease_id)
+        current = lease.get('state')
+        if current not in ('preparing', 'auditing'):
+            raise SystemExit('%s: no recoverable operation' % lease['id'])
+        if current == 'auditing':
+            restored = 'running'
+        else:
+            restored = lease.get('operation_previous_state') or 'claimed'
+        recovery = {
+            'operation_id': lease.get('operation_id'),
+            'operation_kind': lease.get('operation_kind'),
+            'operation_started_at': lease.get('operation_started_at'),
+            'recovered_at': utc_now(),
+            'from_state': current,
+            'to_state': restored,
+        }
+        lease.setdefault('operation_recoveries', []).append(recovery)
+        lease['state'] = restored
+        clear_operation(lease)
+        save_state(state)
+        registry_event(lease, 'operation_recovered', recovery)
+    print('lease %s -> %s' % (lease['id'], lease['state']))
 
 
 def load_store_key1s(store=None):
@@ -453,7 +706,9 @@ def claim(args):
     p = ensure_dirs()
     with DirLock(p['lock']):
         state = load_state()
-        if translation_lease({'kind': args.kind}) and len(active_translation_leases(state)) >= state.get('preparation_limit', PREPARATION_LIMIT):
+        if (translation_lease({'kind': args.kind})
+                and len(reserved_translation_leases(state)) >=
+                state.get('preparation_limit', PREPARATION_LIMIT)):
             raise SystemExit('translation preparation cap reached (%d)' % state.get('preparation_limit', PREPARATION_LIMIT))
         if args.kind == 'verb':
             candidates, worklist = verb_candidates(state)
@@ -577,14 +832,20 @@ def enforce_cost_gate(preflight_path, target, allow_over_cost=False):
 
 
 def prepare(args):
+    if bool(args.profile_slot) != bool(args.config_dir):
+        raise SystemExit('--profile-slot and --config-dir must be supplied together')
     with DirLock(paths()['lock']):
         state = load_state()
         lease = lease_by_id(state, args.lease_id)
+        token = begin_operation(lease, ('claimed',), 'preparing', 'prepare')
+        save_state(state)
+        working = copy.deepcopy(lease)
+    deadline = time.monotonic() + PREPARE_TIMEOUT_SECONDS
+    try:
+        lease = working
         adir = lease.get('artifact_dir') or artifact_dir(args.lease_id)
         os.makedirs(adir, exist_ok=True)
         binding = []
-        if bool(args.profile_slot) != bool(args.config_dir):
-            raise SystemExit('--profile-slot and --config-dir must be supplied together')
         if args.profile_slot:
             binding = ['--profile-slot=%s' % args.profile_slot,
                        '--config-dir=%s' % os.path.abspath(args.config_dir),
@@ -595,14 +856,16 @@ def prepare(args):
             root = lease['target']
             preflight_path = os.path.join(adir, 'preflight.json')
             p = run_cmd([sys.executable, os.path.join(HERE, 'perf_preflight.py'),
-                         root, '--json'])
+                         root, '--json'],
+                        timeout=remaining_operation_timeout(deadline, 'prepare'))
             atomic_write_text(preflight_path, p.stdout)
             enforce_cost_gate(preflight_path, lease.get('target'),
                               allow_over_cost=getattr(args, 'allow_over_cost', False))
             harness = os.path.join(adir, 'run_pilot_wf.%s.js' % lease['id'])
             manifest = os.path.join(adir, 'execution_manifest.%s.json' % lease['id'])
             run_cmd([sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'),
-                     root, '--out=%s' % harness, '--manifest-out=%s' % manifest] + binding)
+                     root, '--out=%s' % harness, '--manifest-out=%s' % manifest] + binding,
+                    timeout=remaining_operation_timeout(deadline, 'prepare'))
         elif lease['kind'] == 'nominal':
             keys = lease.get('details', {}).get('run_keys') or lease.get('details', {}).get('keys') or []
             if not keys:
@@ -611,7 +874,8 @@ def prepare(args):
             root = 'nominal_%s' % lease['id']
             key_arg = ','.join(keys)
             p = run_cmd([sys.executable, os.path.join(HERE, 'perf_preflight.py'),
-                         root, '--nominal', '--no-grammar', '--keys=%s' % key_arg, '--json'])
+                         root, '--nominal', '--no-grammar', '--keys=%s' % key_arg, '--json'],
+                        timeout=remaining_operation_timeout(deadline, 'prepare'))
             atomic_write_text(preflight_path, p.stdout)
             enforce_cost_gate(preflight_path, lease.get('target'),
                               allow_over_cost=getattr(args, 'allow_over_cost', False))
@@ -619,10 +883,19 @@ def prepare(args):
             manifest = os.path.join(adir, 'execution_manifest.%s.json' % lease['id'])
             run_cmd([sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'),
                      root, '--nominal', '--no-grammar', '--keys=%s' % key_arg,
-                     '--out=%s' % harness, '--manifest-out=%s' % manifest] + binding)
+                     '--out=%s' % harness, '--manifest-out=%s' % manifest] + binding,
+                    timeout=remaining_operation_timeout(deadline, 'prepare'))
         else:
             raise SystemExit('prepare is only for verb/nominal translation leases')
+    except BaseException as exc:
+        block_operation(args.lease_id, token, 'preparing', exc)
+        raise
+    with DirLock(paths()['lock']):
+        state = load_state()
+        lease = lease_by_id(state, args.lease_id)
+        require_operation(lease, token, 'preparing')
         lease['state'] = 'prepared'
+        lease['prepared_at'] = utc_now()
         lease['harness'] = harness
         lease['execution_manifest'] = manifest
         lease['origin_execution_manifest'] = os.path.abspath(manifest)
@@ -631,6 +904,7 @@ def prepare(args):
         lease['config_dir'] = os.path.abspath(args.config_dir) if args.config_dir else None
         lease['executor_lane'] = args.executor_lane
         lease['preflight_path'] = preflight_path
+        clear_operation(lease)
         save_state(state)
         registry_event(lease, 'prepared', {'harness': harness, 'manifest': manifest,
                                            'preflight': preflight_path})
@@ -939,92 +1213,124 @@ def recorded_lease_state(state_name, audit_errors, clean_rows, pending=None):
     return 'blocked', False
 
 
+def process_record_output(lease, args):
+    """Normalize and audit a detached lease snapshot without holding the state lock."""
+    base_adir = lease.get('artifact_dir') or artifact_dir(args.lease_id)
+    adir = lease.get('current_artifact_dir') or base_adir
+    os.makedirs(adir, exist_ok=True)
+    wf = os.path.join(adir, 'wf_output.%s.json' % lease['id'])
+    result = normalize_workflow_result(args.workflow_result, wf)
+    if lease.get('kind') == 'nominal':
+        result.setdefault('meta', {})['nominal_keymap'] = lease.get('details', {}).get('keymap') or {}
+        atomic_write_json(wf, result, indent=None)
+    cmd = [sys.executable, os.path.join(HERE, 'audit_window.py'), wf,
+           '--write-requeue', '--out-dir', adir]
+    manifest = lease.get('execution_manifest') or os.path.join(
+        adir, '__missing_execution_manifest__.json')
+    cmd += ['--execution-manifest', manifest]
+    if lease.get('kind') == 'verb':
+        cmd += ['--root', lease['target']]
+    if args.allow_stale:
+        cmd.append('--allow-stale')
+    audit = run_cmd(cmd, check=False, timeout=AUDIT_TIMEOUT_SECONDS)
+    status_path = os.path.join(adir, 'window_status.json')
+    report_path = os.path.join(adir, 'audit_window.report.json')
+    try:
+        status = json.load(open(status_path, encoding='utf-8'))
+    except (OSError, json.JSONDecodeError):
+        status = {}
+    try:
+        report = json.load(open(report_path, encoding='utf-8'))
+    except (OSError, json.JSONDecodeError):
+        report = {}
+    state_name = status.get('state') or ('blocked' if audit.returncode not in (0, 1) else 'unknown')
+    rejected = set(report.get('requeue') or status.get('requeue_keys') or [])
+    clean_payload = clean_result_payload(result, rejected)
+    clean_rows = clean_payload['results']
+    audit_errors = validate_promotable_audit(
+        wf, status, report, state_name, audit.returncode)
+    pending = lease.get('pending_requeue') or empty_pending_requeue()
+    if not audit_errors:
+        try:
+            origin_manifest = ensure_origin_manifest(lease)
+            current_manifest = read_execution_manifest(manifest)
+            latest_pending = pending_from_report(
+                report, report_path, current_manifest['meta'].get('selected_keys') or [])
+            carried = ((lease.get('current_attempt') or {}).get('remaining_pending') or
+                       empty_pending_requeue())
+            if pending_key_set(carried) & set(
+                    current_manifest['meta'].get('selected_keys') or []):
+                raise SystemExit('%s: carried requeue overlaps the current attempt' % lease['id'])
+            pending = merge_pending_requeue(
+                lease, carried, latest_pending, origin_manifest)
+            lease['pending_requeue'] = pending
+        except SystemExit as exc:
+            audit_errors.append(str(exc))
+    lease_state, promotable = recorded_lease_state(
+        state_name, audit_errors, clean_rows, pending)
+    clean_output = None
+    if promotable:
+        clean_output = os.path.join(adir, 'wf_output.clean.%s.json' % lease['id'])
+        atomic_write_json(clean_output, clean_payload, indent=None)
+    lease['audit_state'] = state_name
+    lease['state'] = lease_state
+    lease['wf_output'] = wf
+    lease['clean_output'] = clean_output
+    lease['clean_count'] = len(clean_rows) if promotable else 0
+    lease['clean_output_sha256'] = sha256_file(clean_output) if clean_output else None
+    lease['audit_report'] = report_path
+    lease['status_path'] = status_path
+    lease['audit_returncode'] = audit.returncode
+    lease['audit_errors'] = audit_errors
+    lease['recorded_at'] = utc_now()
+    lease['workflow_result_count'] = len(result.get('results') or [])
+    lease['cost'] = cost_from_transcript(args.transcript_dir)
+    lease['current_artifact_dir'] = adir
+    if lease.get('current_attempt'):
+        lease['current_attempt']['audit_report'] = report_path
+        lease['current_attempt']['audit_report_sha256'] = (
+            sha256_file(report_path) if os.path.exists(report_path) else None)
+        lease['current_attempt']['recorded_at'] = lease['recorded_at']
+    return audit, manifest, adir, pending
+
+
 def record_output(args):
     with DirLock(paths()['lock']):
         state = load_state()
         lease = lease_by_id(state, args.lease_id)
-        base_adir = lease.get('artifact_dir') or artifact_dir(args.lease_id)
-        adir = lease.get('current_artifact_dir') or base_adir
-        os.makedirs(adir, exist_ok=True)
-        wf = os.path.join(adir, 'wf_output.%s.json' % lease['id'])
-        result = normalize_workflow_result(args.workflow_result, wf)
-        if lease.get('kind') == 'nominal':
-            result.setdefault('meta', {})['nominal_keymap'] = lease.get('details', {}).get('keymap') or {}
-            atomic_write_json(wf, result, indent=None)
-        cmd = [sys.executable, os.path.join(HERE, 'audit_window.py'), wf,
-               '--write-requeue', '--out-dir', adir]
-        manifest = lease.get('execution_manifest') or os.path.join(
-            adir, '__missing_execution_manifest__.json')
-        cmd += ['--execution-manifest', manifest]
-        if lease.get('kind') == 'verb':
-            cmd += ['--root', lease['target']]
-        if args.allow_stale:
-            cmd.append('--allow-stale')
-        audit = run_cmd(cmd, check=False)
-        status_path = os.path.join(adir, 'window_status.json')
-        report_path = os.path.join(adir, 'audit_window.report.json')
-        try:
-            status = json.load(open(status_path, encoding='utf-8'))
-        except (OSError, json.JSONDecodeError):
-            status = {}
-        try:
-            report = json.load(open(report_path, encoding='utf-8'))
-        except (OSError, json.JSONDecodeError):
-            report = {}
-        state_name = status.get('state') or ('blocked' if audit.returncode not in (0, 1) else 'unknown')
-        rejected = set(report.get('requeue') or status.get('requeue_keys') or [])
-        clean_payload = clean_result_payload(result, rejected)
-        clean_rows = clean_payload['results']
-        audit_errors = validate_promotable_audit(
-            wf, status, report, state_name, audit.returncode)
-        pending = lease.get('pending_requeue') or empty_pending_requeue()
-        if not audit_errors:
-            try:
-                origin_manifest = ensure_origin_manifest(lease)
-                current_manifest = read_execution_manifest(manifest)
-                latest_pending = pending_from_report(
-                    report, report_path, current_manifest['meta'].get('selected_keys') or [])
-                carried = ((lease.get('current_attempt') or {}).get('remaining_pending') or
-                           empty_pending_requeue())
-                if pending_key_set(carried) & set(
-                        current_manifest['meta'].get('selected_keys') or []):
-                    raise SystemExit('%s: carried requeue overlaps the current attempt' % lease['id'])
-                pending = merge_pending_requeue(
-                    lease, carried, latest_pending, origin_manifest)
-                lease['pending_requeue'] = pending
-            except SystemExit as e:
-                audit_errors.append(str(e))
-        lease_state, promotable = recorded_lease_state(
-            state_name, audit_errors, clean_rows, pending)
-        clean_output = None
-        if promotable:
-            clean_output = os.path.join(adir, 'wf_output.clean.%s.json' % lease['id'])
-            atomic_write_json(clean_output, clean_payload, indent=None)
-        lease['audit_state'] = state_name
-        lease['state'] = lease_state
-        lease['wf_output'] = wf
-        lease['clean_output'] = clean_output
-        lease['clean_count'] = len(clean_rows) if promotable else 0
-        lease['clean_output_sha256'] = sha256_file(clean_output) if clean_output else None
-        lease['audit_report'] = report_path
-        lease['status_path'] = status_path
-        lease['audit_returncode'] = audit.returncode
-        lease['audit_errors'] = audit_errors
-        lease['recorded_at'] = utc_now()
-        lease['workflow_result_count'] = len(result.get('results') or [])
-        lease['cost'] = cost_from_transcript(args.transcript_dir)
-        lease['current_artifact_dir'] = adir
-        if lease.get('current_attempt'):
-            lease['current_attempt']['audit_report'] = report_path
-            lease['current_attempt']['audit_report_sha256'] = (
-                sha256_file(report_path) if os.path.exists(report_path) else None)
-            lease['current_attempt']['recorded_at'] = lease['recorded_at']
+        token = begin_operation(lease, ('running',), 'auditing', 'record-output')
+        save_state(state)
+        working = copy.deepcopy(lease)
+    try:
+        audit, manifest, adir, pending = process_record_output(working, args)
+    except BaseException as exc:
+        block_operation(args.lease_id, token, 'auditing', exc)
+        raise
+    with DirLock(paths()['lock']):
+        state = load_state()
+        lease = lease_by_id(state, args.lease_id)
+        require_operation(lease, token, 'auditing')
+        completed_attempt = {
+            'run_operation_id': working.get('run_operation_id'),
+            'run_id': working.get('run_id'),
+            'runtime_mode': working.get('runtime_mode'),
+            'started_at': working.get('run_started_at'),
+            'recorded_at': working.get('recorded_at'),
+            'outcome': working.get('state'),
+        }
+        working.setdefault('run_attempts', []).append(completed_attempt)
+        for key in ('run_operation_id', 'run_started_at', 'runtime_mode', 'runtime_limit',
+                    'run_id', 'probe_receipt', 'pre_run_state'):
+            working.pop(key, None)
+        clear_operation(working)
+        lease.clear()
+        lease.update(working)
         save_state(state)
         registry_event(lease, 'recorded', {
-            'wf_output': wf,
+            'wf_output': lease['wf_output'],
             'execution_manifest': manifest,
             'artifact_dir': adir,
-            'status': state_name,
+            'status': lease['audit_state'],
             'audit_returncode': audit.returncode,
             'pending_requeue': {
                 'transient': list((pending or {}).get('transient') or []),
@@ -1051,6 +1357,10 @@ def prepare_requeue(args):
         if lease_state not in allowed:
             raise SystemExit('%s: cannot prepare requeue from lease state %r' %
                              (lease['id'], lease_state))
+        token = begin_operation(lease, allowed, 'preparing', 'prepare-requeue')
+        save_state(state)
+        lease = copy.deepcopy(lease)
+    try:
         adir = lease.get('artifact_dir') or artifact_dir(args.lease_id)
         which = 'transient' if args.transient else 'defect'
         origin_manifest = ensure_origin_manifest(lease)
@@ -1123,7 +1433,7 @@ def prepare_requeue(args):
                 atomic_write_text(
                     os.path.join(attempt_dir, 'requeue.defect.fshas.txt'),
                     '\n'.join(sorted(fshas)) + ('\n' if fshas else ''))
-            p = run_cmd(cmd)
+            p = run_cmd(cmd, timeout=PREPARE_TIMEOUT_SECONDS)
             if sha256_file(current_manifest_path) != old_manifest_sha256:
                 raise SystemExit(
                     '%s: previous execution manifest changed during requeue preparation' %
@@ -1175,8 +1485,18 @@ def prepare_requeue(args):
             'selected_keys': requeue_keys,
             'remaining_pending': remaining_pending,
         }
+    except BaseException as exc:
+        block_operation(args.lease_id, token, 'preparing', exc)
+        raise
+    with DirLock(paths()['lock']):
+        state = load_state()
+        fresh = lease_by_id(state, args.lease_id)
+        require_operation(fresh, token, 'preparing')
+        clear_operation(lease)
+        fresh.clear()
+        fresh.update(lease)
         save_state(state)
-        registry_event(lease, 'requeue_prepared', {
+        registry_event(fresh, 'requeue_prepared', {
             'attempt': attempt, 'artifact_dir': attempt_dir,
             'harness': harness, 'manifest': manifest, 'kind': which,
             'selected_keys': requeue_keys,
@@ -1289,7 +1609,9 @@ def daily_close(args):
         'ts': utc_now(),
         'date': today,
         'promoted_leases_today': promoted_today,
-        'active_translation_leases': len(active_translation_leases(state)),
+        'reserved_translation_leases': len(reserved_translation_leases(state)),
+        'running_translation_leases': len(running_translation_leases(state)),
+        'active_translation_leases': len(running_translation_leases(state)),
         'blocked_leases': len([l for l in state.get('leases', []) if l.get('state') == 'blocked']),
         'checks': checks,
         'validation_clean': all(c['returncode'] == 0 for c in checks),
@@ -1304,11 +1626,22 @@ def daily_close(args):
 def write_dashboard(state, daily=None):
     p = ensure_dirs()
     leases = state.get('leases', [])
+    running = running_translation_leases(state)
+    runtime_mode = ('staged-probed' if any(
+        lease.get('runtime_mode') == 'staged-probed' for lease in running) else 'standard')
+    runtime_limit = (state.get('runtime_limit', STAGED_TRANSLATION_LIMIT)
+                     if runtime_mode == 'staged-probed'
+                     else TRANSLATION_LIMIT)
     payload = {
         'schema': DASHBOARD_SCHEMA,
         'generated_at': utc_now(),
         'translation_limit': state.get('translation_limit', TRANSLATION_LIMIT),
-        'active_translation_leases': len(active_translation_leases(state)),
+        'reserved_translation_leases': len(reserved_translation_leases(state)),
+        'running_translation_leases': len(running),
+        'runtime_limit': runtime_limit,
+        'runtime_mode': runtime_mode,
+        # Deprecated compatibility alias for one dashboard cycle.
+        'active_translation_leases': len(running),
         'leases': leases[-30:],
         'ready': [l.get('id') for l in leases if l.get('state') == 'ready'],
         'blocked': [l.get('id') for l in leases if l.get('state') == 'blocked'],
@@ -1326,8 +1659,10 @@ def status(args):
     print('PWG RU SLA coordinator')
     print('state       : %s' % paths()['state'])
     print('leases      : %d' % len(leases))
-    print('active LLM  : %d/%d' % (len(active_translation_leases(state)),
-                                  state.get('translation_limit', TRANSLATION_LIMIT)))
+    print('reserved    : %d' % len(reserved_translation_leases(state)))
+    print('running LLM : %d/%d (%s)' % (
+        len(running_translation_leases(state)), state.get('runtime_limit', TRANSLATION_LIMIT),
+        state.get('runtime_mode', 'standard')))
     for lease in leases[-20:]:
         print('  {id} [{kind}/{lane}] {state} target={target}'.format(**lease))
 
@@ -1354,6 +1689,21 @@ def main(argv=None):
     p.add_argument('--config-dir', help='canonical CLAUDE_CONFIG_DIR bound into manifest v2')
     p.add_argument('--executor-lane', default='serial-whole-card')
     p.set_defaults(func=prepare)
+    br = sub.add_parser('begin-run')
+    br.add_argument('--lease-id', action='append', required=True)
+    br.add_argument('--mode', choices=('standard', 'staged'), default='standard')
+    br.add_argument('--run-id')
+    br.add_argument('--probe-receipt')
+    br.set_defaults(func=begin_run)
+    rr = sub.add_parser('release-run')
+    rr.add_argument('lease_id')
+    rr.add_argument('--confirm-dead', action='store_true')
+    rr.add_argument('--reason', required=True)
+    rr.set_defaults(func=release_run)
+    ro = sub.add_parser('recover-operation')
+    ro.add_argument('lease_id')
+    ro.add_argument('--confirm-dead', action='store_true')
+    ro.set_defaults(func=recover_operation)
     r = sub.add_parser('record-output')
     r.add_argument('lease_id')
     r.add_argument('workflow_result')

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -116,6 +116,62 @@ def atomic_write(path, text):
     atomic_write_text(path, text)
 
 
+def coordinator_command(args, command, check=True):
+    coordinator = os.path.abspath(getattr(
+        args, 'coordinator', os.path.join(os.path.dirname(__file__), 'coordinator.py')))
+    env = os.environ.copy()
+    coord_dir = getattr(args, 'coord_dir', None)
+    if coord_dir:
+        env['PWG_COORDINATOR_DIR'] = os.path.abspath(coord_dir)
+    proc = subprocess.run(
+        [sys.executable, coordinator] + list(command),
+        cwd=os.path.abspath(getattr(args, 'cwd', os.path.dirname(os.path.dirname(__file__)))),
+        env=env, text=True, encoding='utf-8', capture_output=True)
+    if check and proc.returncode:
+        raise SystemExit((proc.stderr or proc.stdout or 'coordinator command failed')[-2000:])
+    return proc
+
+
+def release_db_claims(db_path, jobs, error):
+    """Undo scheduler claims when the coordinator atomically rejects the dispatch batch."""
+    db = connect(db_path)
+    with db:
+        for job in jobs:
+            db.execute(
+                "UPDATE jobs SET state='pending', assigned_acc=NULL, attempts=max(attempts-1,0), "
+                "started_at=NULL, error=? WHERE id=? AND state='in_progress'",
+                (error[-2000:], job['id']))
+    db.close()
+
+
+def release_runtime(args, lease_id, reason):
+    return coordinator_command(
+        args, ['release-run', lease_id, '--confirm-dead', '--reason', reason], check=False)
+
+
+def safe_receipt_name(value):
+    return re.sub(r'[^A-Za-z0-9_.-]+', '_', value)[:120]
+
+
+def write_probe_receipt(coord_dir, run_id, lease_ids, probe_latencies):
+    receipt_dir = os.path.join(os.path.abspath(coord_dir), 'probe_receipts')
+    os.makedirs(receipt_dir, exist_ok=True)
+    path = os.path.join(receipt_dir, 'probe_receipt.%s.json' % safe_receipt_name(run_id))
+    payload = {
+        'schema': PROBE_RECEIPT_SCHEMA,
+        'generated_at': now_iso(),
+        'run_id': run_id,
+        'go': True,
+        'lease_ids': sorted(set(lease_ids)),
+        'healthy_profiles': sorted(probe_latencies),
+        'probe_latency_ms': dict(probe_latencies),
+        'model': EXACT_GEN_MODEL,
+        'policy': PROBE_POLICY,
+    }
+    atomic_write(path, json.dumps(payload, ensure_ascii=False, indent=1) + '\n')
+    return path
+
+
 def parse_reset(text, now=None):
     now = int(now or time.time())
     match = RESET_EPOCH.search(text or '')
@@ -422,8 +478,22 @@ def cmd_import_coordinator(args):
 
 def cmd_recover(args):
     db = connect(args.db)
+    abandoned = scoped_jobs(
+        db, getattr(args, 'only_external_ids', None),
+        "state='in_progress' AND manifest_path IS NOT NULL")
+    db.close()
+    for job in abandoned:
+        proc = release_runtime(args, job['external_id'], 'orchestrator restart recovery')
+        if proc.returncode and 'no runtime reservation to release' not in (proc.stderr + proc.stdout):
+            raise SystemExit('%s: coordinator recovery failed: %s' %
+                             (job['external_id'], proc.stderr or proc.stdout))
+    db = connect(args.db)
+    scope_sql, scope_args = _scope_sql(getattr(args, 'only_external_ids', None))
     with db:
-        changed = db.execute("UPDATE jobs SET state='pending', assigned_acc=NULL, error='recovered after restart' WHERE state='in_progress'").rowcount
+        changed = db.execute(
+            "UPDATE jobs SET state='pending', assigned_acc=NULL, "
+            "error='recovered after restart' WHERE state='in_progress'%s" % scope_sql,
+            scope_args).rowcount
     db.close()
     print('recovered=%d' % changed)
 
@@ -438,10 +508,8 @@ def cmd_record_done(args):
     for job in jobs:
         if not job['manifest_path'] or not os.path.exists(job['output_path']):
             raise SystemExit('%s: completed coordinator job has no result' % job['external_id'])
-        cmd = [sys.executable, os.path.abspath(args.coordinator), 'record-output',
-               job['external_id'], job['output_path']]
-        proc = subprocess.run(cmd, cwd=os.path.abspath(args.cwd), text=True, encoding='utf-8',
-                              capture_output=True)
+        proc = coordinator_command(
+            args, ['record-output', job['external_id'], job['output_path']], check=False)
         if proc.returncode:
             print(proc.stdout, end='')
             print(proc.stderr, end='', file=sys.stderr)
@@ -471,6 +539,16 @@ def cmd_run_once(args):
         only = requested if only is None else set(only) & requested
     if only is not None:
         accounts = [a for a in accounts if a['name'] in only]
+    runtime_mode = getattr(args, 'runtime_mode', 'standard')
+    db = connect(args.db)
+    manifest_pending = scoped_job_count(
+        db, getattr(args, 'only_external_ids', None),
+        "state='pending' AND manifest_path IS NOT NULL")
+    db.close()
+    if manifest_pending:
+        # Do not over-claim scheduler rows that the coordinator must reject. Generic jobs keep
+        # their historical account fan-out because they do not consume translation runtime.
+        accounts = accounts[:4 if runtime_mode == 'staged' else 3]
     work = []
     for acc in accounts:
         job = claim(args.db, acc['name'],
@@ -480,14 +558,40 @@ def cmd_run_once(args):
     if not work:
         print('no runnable jobs')
         return
+    runtime_jobs = [job for _account, job in work if job['manifest_path']]
+    if runtime_jobs:
+        begin = ['begin-run', '--mode', runtime_mode]
+        run_id = getattr(args, 'run_id', None)
+        receipt = getattr(args, 'probe_receipt', None)
+        if run_id:
+            begin += ['--run-id', run_id]
+        if receipt:
+            begin += ['--probe-receipt', receipt]
+        for job in runtime_jobs:
+            begin += ['--lease-id', job['external_id']]
+        try:
+            coordinator_command(args, begin)
+        except SystemExit as exc:
+            release_db_claims(args.db, [job for _account, job in work], str(exc))
+            raise
     claude_bin = getattr(args, 'claude_bin', 'claude')
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(work)) as pool:
         futures = {pool.submit(run_claimed, args.db, acc['name'], acc['config_dir'], job, args.timeout,
                                getattr(args, 'events', None), getattr(args, 'run_id', None), claude_bin):
-                   (acc['name'], job['external_id']) for acc, job in work}
+                   (acc['name'], job) for acc, job in work}
         for future in concurrent.futures.as_completed(futures):
-            acc, external_id = futures[future]
-            print('%s %s -> %s' % (acc, external_id, future.result()))
+            acc, job = futures[future]
+            try:
+                outcome = future.result()
+            except BaseException as exc:
+                outcome = fail_or_retry(args.db, job['id'], 1, str(exc), 'orchestrator')
+            if job['manifest_path'] and outcome != 'done':
+                release = release_runtime(
+                    args, job['external_id'], 'worker outcome %s on profile %s' % (outcome, acc))
+                if release.returncode:
+                    raise SystemExit('%s: runtime release failed: %s' %
+                                     (job['external_id'], release.stderr or release.stdout))
+            print('%s %s -> %s' % (acc, job['external_id'], outcome))
 
 
 def cmd_status(args):
@@ -504,6 +608,7 @@ PROBE_MIN_PAYLOAD_BYTES = 5000           # D-F: repository >=5 KB load-represent
 PROBE_LATENCY_CEILING_MS = 30000         # D-F: health ceiling; a reading over this is NO-GO
 PROBE_POLICY = 'production_v1'
 PROBE_LANE = 'claude-cli-headless/readiness-schema'
+PROBE_RECEIPT_SCHEMA = 'pwg.runtime_probe_receipt.v1'
 # GAP #5 (four-profile): an account dropped by --drop-unhealthy is parked far in the future so the
 # dispatch loop's runnable/claim gates exclude it while the fleet proceeds on the healthy subset.
 # Only the explicit opt-in ever parks this way; the default STOP-on-any-NO-GO path never drops.
@@ -721,11 +826,17 @@ def cmd_staged_run(args):
     if getattr(args, 'max_accounts', 0):
         accounts = accounts[:args.max_accounts]
     run_id = args.run_id or ('win100-' + now_iso().replace(':', '').replace('-', ''))
+    if getattr(args, 'resume', False):
+        cmd_recover(argparse.Namespace(
+            db=args.db, coordinator=args.coordinator, coord_dir=args.coord_dir,
+            cwd=args.cwd, only_external_ids=set(lease_ids)))
     # Probe EVERY validated account (D-K warmup+measured per account; census not inflated). DEFAULT
     # STOP-on-any-NO-GO; --drop-unhealthy opts into proceeding on the healthy subset, parking the
     # dropped accounts so the dispatch loop below claims only survivors.
     probe_latencies = probe_fleet(accounts, args.claude_bin, events_path=args.events,
                                   run_id=run_id, drop_unhealthy=getattr(args, 'drop_unhealthy', False))
+    probe_receipt = write_probe_receipt(
+        args.coord_dir, run_id, lease_ids, probe_latencies)
     if getattr(args, 'drop_unhealthy', False):
         for acc in accounts:
             if acc['name'] not in probe_latencies:
@@ -774,22 +885,25 @@ def cmd_staged_run(args):
                 raise SystemExit('staged-run halted: %d job(s) pending but all accounts parked '
                                  'until %s; rerun with --resume after the reset' % (pending, earliest))
             cmd_run_once(argparse.Namespace(db=args.db, timeout=args.timeout,
-                                            events=args.events, run_id=run_id,
-                                            claude_bin=args.claude_bin,
+                                             events=args.events, run_id=run_id,
+                                             claude_bin=args.claude_bin,
+                                             coordinator=args.coordinator,
+                                             coord_dir=args.coord_dir,
+                                             cwd=args.cwd,
+                                             runtime_mode='staged',
+                                             probe_receipt=probe_receipt,
                                             # dispatch ONLY to the probed, capped/healthy fleet —
                                             # never to a capped-out or dropped (unprobed) account.
                                             only_accounts=set(probe_latencies),
                                             only_profile=getattr(args, 'only_profile', None),
                                             only_external_ids=lease_scope))
         cmd_record_done(argparse.Namespace(db=args.db, coordinator=args.coordinator,
-                                           cwd=args.cwd, only_external_ids=lease_scope))
-        promote_cmd = [sys.executable, os.path.abspath(args.coordinator), 'promote-ready',
-                       '--gen-model-version', 'claude-sonnet-5']
+                                           coord_dir=args.coord_dir, cwd=args.cwd,
+                                           only_external_ids=lease_scope))
+        promote_cmd = ['promote-ready', '--gen-model-version', 'claude-sonnet-5']
         for lease_id in sorted(lease_scope):
             promote_cmd += ['--lease-id', lease_id]
-        promote = subprocess.run(
-            promote_cmd, cwd=os.path.abspath(args.cwd),
-            text=True, encoding='utf-8', capture_output=True)
+        promote = coordinator_command(args, promote_cmd, check=False)
         if promote.returncode and 'no ready leases to promote' not in (promote.stderr + promote.stdout):
             raise SystemExit('promotion failed: %s' % (promote.stderr or promote.stdout)[-1000:])
         db = connect(args.db)
@@ -929,14 +1043,17 @@ def cmd_presplit_canary(args):
 
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__)
+    default_coordinator = os.path.join(os.path.dirname(__file__), 'coordinator.py')
+    default_coord_dir = os.path.join(os.path.dirname(__file__), 'output', 'coordinator')
+    default_cwd = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
     ap.add_argument('--db', default='max_orchestrator.sqlite')
     sub = ap.add_subparsers(dest='cmd', required=True)
     p = sub.add_parser('init'); p.add_argument('--account', action='append', required=True); p.add_argument('--claude-bin', default='claude'); p.add_argument('--skip-profile-check', action='store_true', help=argparse.SUPPRESS); p.set_defaults(func=cmd_init)
     p = sub.add_parser('enqueue'); p.add_argument('--external-id', required=True); p.add_argument('--argv-json', required=True); p.add_argument('--cwd', required=True); p.add_argument('--output', required=True); p.add_argument('--max-attempts', type=int, default=3); p.set_defaults(func=cmd_enqueue)
     p = sub.add_parser('import-coordinator'); p.add_argument('--coord-dir', required=True); p.add_argument('--cwd', required=True); p.add_argument('--lease-id', action='append'); p.add_argument('--max-attempts', type=int, default=3); p.set_defaults(func=cmd_import_coordinator)
-    p = sub.add_parser('recover'); p.set_defaults(func=cmd_recover)
-    p = sub.add_parser('record-done'); p.add_argument('--coordinator', required=True); p.add_argument('--cwd', required=True); p.set_defaults(func=cmd_record_done)
-    p = sub.add_parser('run-once'); p.add_argument('--timeout', type=int, default=7200); p.add_argument('--claude-bin', default='claude'); p.add_argument('--only-profile'); p.set_defaults(func=cmd_run_once)
+    p = sub.add_parser('recover'); p.add_argument('--coordinator', default=default_coordinator); p.add_argument('--coord-dir', default=default_coord_dir); p.add_argument('--cwd', default=default_cwd); p.set_defaults(func=cmd_recover)
+    p = sub.add_parser('record-done'); p.add_argument('--coordinator', default=default_coordinator); p.add_argument('--coord-dir', default=default_coord_dir); p.add_argument('--cwd', default=default_cwd); p.set_defaults(func=cmd_record_done)
+    p = sub.add_parser('run-once'); p.add_argument('--timeout', type=int, default=7200); p.add_argument('--claude-bin', default='claude'); p.add_argument('--only-profile'); p.add_argument('--coordinator', default=default_coordinator); p.add_argument('--coord-dir', default=default_coord_dir); p.add_argument('--cwd', default=default_cwd); p.set_defaults(func=cmd_run_once)
     p = sub.add_parser('status'); p.set_defaults(func=cmd_status)
     p = sub.add_parser('staged-run')
     p.add_argument('--coord-dir', required=True); p.add_argument('--cwd', required=True)

--- a/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
@@ -655,6 +655,60 @@ def main():
         con.close()
     print('  GAP5 recover exactly-once N=4: 2 in_progress -> pending; recorded-done untouched; coordinator_recorded stays 1')
 
+    # Runtime integration: a manifest-backed dispatch batch is reserved atomically before any
+    # worker starts, and a retryable worker explicitly releases its coordinator slot.
+    with tempfile.TemporaryDirectory() as td:
+        db = os.path.join(td, 'runtime.sqlite')
+        m.main(['--db', db, 'init',
+                '--account', 'acc1=' + os.path.join(td, 'a1'),
+                '--account', 'acc2=' + os.path.join(td, 'a2'), '--skip-profile-check'])
+        for n in range(2):
+            m.main(['--db', db, 'enqueue', '--external-id', 'runtime%d' % n,
+                    '--argv-json', json.dumps(['x']), '--cwd', td,
+                    '--output', os.path.join(td, 'runtime%d.json' % n)])
+        con = m.connect(db)
+        with con:
+            con.execute("UPDATE jobs SET manifest_path='fixture.json', manifest_sha256='fixture'")
+        con.close()
+        receipt = m.write_probe_receipt(
+            td, 'runtime-test', ['runtime0', 'runtime1'], {'acc1': 10, 'acc2': 11})
+        receipt_payload = json.load(open(receipt, encoding='utf-8'))
+        assert receipt_payload['schema'] == m.PROBE_RECEIPT_SCHEMA
+        assert receipt_payload['healthy_profiles'] == ['acc1', 'acc2']
+        original_command = m.coordinator_command
+        original_run_claimed = m.run_claimed
+        calls = []
+        reserved = threading.Event()
+
+        def fake_command(args, command, check=True):
+            calls.append(list(command))
+            if command[0] == 'begin-run':
+                reserved.set()
+            return types.SimpleNamespace(returncode=0, stdout='', stderr='')
+
+        def fake_worker(db_path, account, config_dir, job, timeout, events_path=None,
+                        run_id=None, claude_bin='claude'):
+            assert reserved.is_set(), 'worker started before atomic begin-run reservation'
+            outcome = 'done' if job['external_id'] == 'runtime0' else 'pending'
+            m.finish(db_path, job['id'], outcome, 0 if outcome == 'done' else 1)
+            return outcome
+
+        m.coordinator_command = fake_command
+        m.run_claimed = fake_worker
+        try:
+            m.cmd_run_once(m.argparse.Namespace(
+                db=db, timeout=30, events=None, run_id='runtime-test',
+                claude_bin='claude', runtime_mode='staged', probe_receipt=receipt,
+                coordinator='coordinator.py', coord_dir=td, cwd=td))
+        finally:
+            m.coordinator_command = original_command
+            m.run_claimed = original_run_claimed
+        begin_calls = [call for call in calls if call[0] == 'begin-run']
+        release_calls = [call for call in calls if call[0] == 'release-run']
+        assert len(begin_calls) == 1 and begin_calls[0].count('--lease-id') == 2
+        assert len(release_calls) == 1 and release_calls[0][1] == 'runtime1'
+    print('  runtime integration: reserve batch before workers; retryable worker releases slot')
+
     print('max_account_orchestrator_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -2568,6 +2568,88 @@ def test_coordinator_state_dashboard_and_cap():
                 os.environ['PWG_COORDINATOR_DIR'] = old
 
 
+def test_coordinator_nominal_reservations():
+    """Nominal batches own every canonical key, including migrated legacy leases."""
+    import coordinator
+    old_coord = os.environ.get('PWG_COORDINATOR_DIR')
+    old_here = coordinator.HERE
+    old_store = coordinator.promote_final_cards.DEFAULT_STORE
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ['PWG_COORDINATOR_DIR'] = os.path.join(tmp, 'coord')
+        coordinator.HERE = os.path.join(tmp, 'pilot')
+        os.makedirs(os.path.join(coordinator.HERE, 'input'))
+        store = os.path.join(tmp, 'store.jsonl')
+        open(store, 'w', encoding='utf-8').close()
+        coordinator.promote_final_cards.DEFAULT_STORE = store
+        manifest = os.path.join(tmp, 'manifest.json')
+        with open(manifest, 'w', encoding='utf-8') as f:
+            json.dump({'schema': 'pwg.headless_execution_manifest.v1',
+                       'meta': {'selected_keys': ['c_safe'],
+                                'nominal_keymap': {'c_safe': 'c'}}}, f)
+        try:
+            state = coordinator.default_state()
+            state['leases'] = [
+                {'id': 'details-legacy', 'kind': 'nominal', 'state': 'prepared',
+                 'details': {'keys': ['a', 'b']}},
+                {'id': 'manifest-legacy', 'kind': 'nominal', 'state': 'prepared',
+                 'execution_manifest': manifest},
+            ]
+            coordinator.save_state(state)
+            migrated = coordinator.load_state()
+            if migrated['leases'][0].get('reserved_keys') != ['a', 'b']:
+                fail('legacy details.keys reservation was not migrated')
+            if migrated['leases'][1].get('reserved_keys') != ['c']:
+                fail('legacy manifest nominal_keymap reservation was not migrated')
+            if coordinator.active_reserved_nominal_keys(migrated) != {'a', 'b', 'c'}:
+                fail('active nominal reservations did not include every batch key')
+
+            cards = os.path.join(tmp, 'cards.jsonl')
+            with open(cards, 'w', encoding='utf-8') as f:
+                for key in ('b', 'd'):
+                    f.write(json.dumps({'key1': key}) + '\n')
+                    stem = coordinator.safe_name(key)
+                    open(os.path.join(coordinator.HERE, 'input', stem + '.raw.txt'),
+                         'w', encoding='utf-8').close()
+                    open(os.path.join(coordinator.HERE, 'input', stem + '.portrait.json'),
+                         'w', encoding='utf-8').close()
+            if coordinator.nominal_candidates(migrated, batch_size=5, cards_path=cards) != ['d']:
+                fail('nominal candidate selection reused a non-first reserved batch key')
+
+            try:
+                coordinator.register_prepared_lease(
+                    'overlap', 'test', ['b', 'd'], 'harness.js', manifest, 'preflight.json')
+            except SystemExit as exc:
+                if 'already active' not in str(exc):
+                    raise
+            else:
+                fail('overlapping prepared nominal lease was accepted')
+
+            # An unresolved active legacy lease blocks every new nominal claim; terminal history
+            # is harmless and must not freeze the queue forever.
+            state = coordinator.load_state()
+            state['leases'].append({'id': 'unknown', 'kind': 'nominal', 'state': 'prepared'})
+            coordinator.save_state(state)
+            try:
+                coordinator.active_reserved_nominal_keys(coordinator.load_state())
+            except SystemExit as exc:
+                if 'unresolved reservations' not in str(exc):
+                    raise
+            else:
+                fail('unresolved active legacy lease did not fail closed')
+            state = coordinator.load_state()
+            state['leases'][-1]['state'] = 'blocked'
+            coordinator.save_state(state)
+            if coordinator.active_reserved_nominal_keys(coordinator.load_state()) != {'a', 'b', 'c'}:
+                fail('terminal unresolved legacy lease incorrectly blocked reservations')
+        finally:
+            coordinator.HERE = old_here
+            coordinator.promote_final_cards.DEFAULT_STORE = old_store
+            if old_coord is None:
+                os.environ.pop('PWG_COORDINATOR_DIR', None)
+            else:
+                os.environ['PWG_COORDINATOR_DIR'] = old_coord
+
+
 def test_coordinator_fail_closed_audit_states():
     import coordinator
     card = {'key': 'k', 'card': {'key1': 'k'}}
@@ -5678,6 +5760,7 @@ def main():
         test_perf_preflight_partitions_mixed_monster_window,
         test_verb_worklist_excludes_missing_rootmaps,
         test_coordinator_state_dashboard_and_cap,
+        test_coordinator_nominal_reservations,
         test_coordinator_fail_closed_audit_states,
         test_coordinator_promotion_revalidates_artifacts,
         test_coordinator_expired_leases_release_cap,

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import xml.etree.ElementTree as ET
 
 sys.stdout.reconfigure(encoding='utf-8')
@@ -2550,17 +2551,26 @@ def test_coordinator_state_dashboard_and_cap():
                 })
             coordinator.save_state(state)
             loaded = coordinator.load_state()
-            if len(coordinator.active_translation_leases(loaded)) != 3:
-                fail('coordinator must count exactly three active translation leases')
+            if len(coordinator.reserved_translation_leases(loaded)) != 3:
+                fail('coordinator must count exactly three reserved translation leases')
+            if coordinator.running_translation_leases(loaded):
+                fail('prepared leases must not consume runtime slots')
             dash = json.load(open(os.path.join(tmp, 'dashboard.json'), encoding='utf-8'))
             if dash.get('schema') != coordinator.DASHBOARD_SCHEMA:
                 fail('coordinator dashboard schema missing')
-            if dash.get('active_translation_leases') != 3 or dash.get('translation_limit') != 3:
-                fail('coordinator dashboard must expose cap state')
+            if (dash.get('reserved_translation_leases') != 3
+                    or dash.get('running_translation_leases') != 0
+                    or dash.get('active_translation_leases') != 0
+                    or dash.get('runtime_limit') != 3
+                    or dash.get('runtime_mode') != 'standard'):
+                fail('coordinator dashboard must distinguish reserved and running state')
+            coordinator.begin_run_leases(loaded, ['lease0', 'lease1', 'lease2'])
+            if len(coordinator.active_translation_leases(loaded)) != 3:
+                fail('deprecated active alias must equal the running count')
             state['leases'][0]['state'] = 'promoted'
             coordinator.save_state(state)
-            if len(coordinator.active_translation_leases(coordinator.load_state())) != 2:
-                fail('promoted leases must not count against the active LLM cap')
+            if len(coordinator.reserved_translation_leases(coordinator.load_state())) != 2:
+                fail('promoted leases must not count against reserved work')
         finally:
             if old is None:
                 os.environ.pop('PWG_COORDINATOR_DIR', None)
@@ -2641,9 +2651,268 @@ def test_coordinator_nominal_reservations():
             coordinator.save_state(state)
             if coordinator.active_reserved_nominal_keys(coordinator.load_state()) != {'a', 'b', 'c'}:
                 fail('terminal unresolved legacy lease incorrectly blocked reservations')
+
+            barrier = threading.Barrier(2)
+            outcomes = []
+
+            def register_race(lease_id):
+                barrier.wait()
+                try:
+                    coordinator.register_prepared_lease(
+                        lease_id, 'test', ['e', 'f'], 'harness.js', manifest,
+                        'preflight.json')
+                    outcomes.append('accepted')
+                except SystemExit:
+                    outcomes.append('rejected')
+
+            racers = [threading.Thread(target=register_race, args=('race%d' % i,))
+                      for i in range(2)]
+            for racer in racers:
+                racer.start()
+            for racer in racers:
+                racer.join(5)
+            if sorted(outcomes) != ['accepted', 'rejected']:
+                fail('simultaneous overlapping nominal reservations were not serialized')
         finally:
             coordinator.HERE = old_here
             coordinator.promote_final_cards.DEFAULT_STORE = old_store
+            if old_coord is None:
+                os.environ.pop('PWG_COORDINATOR_DIR', None)
+            else:
+                os.environ['PWG_COORDINATOR_DIR'] = old_coord
+
+
+def test_coordinator_runtime_state_machine_and_cas():
+    """Runtime caps, probe authorization, lock responsiveness, and stale completions."""
+    import coordinator
+    from types import SimpleNamespace
+
+    old_coord = os.environ.get('PWG_COORDINATOR_DIR')
+    original_run = coordinator.run_cmd
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ['PWG_COORDINATOR_DIR'] = tmp
+        try:
+            state = coordinator.default_state()
+            for i in range(5):
+                state['leases'].append({
+                    'id': 'run%d' % i, 'kind': 'verb', 'target': 'root%d' % i,
+                    'state': 'prepared', 'artifact_dir': os.path.join(tmp, 'a%d' % i),
+                })
+            coordinator.begin_run_leases(state, ['run0', 'run1', 'run2'])
+            try:
+                coordinator.begin_run_leases(state, ['run3'])
+            except SystemExit as exc:
+                if 'runtime cap' not in str(exc):
+                    raise
+            else:
+                fail('standard runtime accepted a fourth lease')
+
+            state = coordinator.default_state()
+            for i in range(5):
+                state['leases'].append({
+                    'id': 'stage%d' % i, 'kind': 'verb', 'target': 'root%d' % i,
+                    'state': 'prepared', 'artifact_dir': os.path.join(tmp, 's%d' % i),
+                })
+            receipt = os.path.join(tmp, 'receipt.json')
+            with open(receipt, 'w', encoding='utf-8') as f:
+                json.dump({
+                    'schema': coordinator.PROBE_RECEIPT_SCHEMA,
+                    'generated_at': coordinator.utc_now(), 'run_id': 'acceptance-1',
+                    'model': coordinator.PROBE_MODEL, 'policy': coordinator.PROBE_POLICY,
+                    'go': True, 'lease_ids': ['stage%d' % i for i in range(5)],
+                    'healthy_profiles': ['c1', 'c2', 'c3', 'c4'],
+                    'probe_latency_ms': {'c1': 10, 'c2': 11, 'c3': 12, 'c4': 13},
+                }, f)
+            coordinator.begin_run_leases(
+                state, ['stage0', 'stage1', 'stage2', 'stage3'], mode='staged',
+                run_id='acceptance-1', probe_receipt=receipt)
+            try:
+                coordinator.begin_run_leases(
+                    state, ['stage4'], mode='staged', run_id='acceptance-1',
+                    probe_receipt=receipt)
+            except SystemExit as exc:
+                if 'runtime cap' not in str(exc):
+                    raise
+            else:
+                fail('staged runtime accepted a fifth lease')
+            if len(coordinator.running_translation_leases(state)) != 4:
+                fail('fresh four-profile receipt did not authorize four runtime slots')
+            coordinator.save_state(state)
+            coordinator.release_run(SimpleNamespace(
+                lease_id='stage0', confirm_dead=True, reason='selftest worker died'))
+            released = coordinator.load_state()['leases'][0]
+            if released['state'] != 'prepared' or not released.get('run_attempts'):
+                fail('release-run did not restore and record the prepared lease')
+            stale_receipt = os.path.join(tmp, 'stale-receipt.json')
+            stale_payload = json.load(open(receipt, encoding='utf-8'))
+            stale_payload['generated_at'] = (
+                datetime.datetime.now(datetime.timezone.utc) -
+                datetime.timedelta(hours=7)).isoformat(
+                    timespec='seconds').replace('+00:00', 'Z')
+            with open(stale_receipt, 'w', encoding='utf-8') as f:
+                json.dump(stale_payload, f)
+            try:
+                coordinator.validate_probe_receipt(
+                    stale_receipt, ['stage0'], 'acceptance-1')
+            except SystemExit as exc:
+                if 'stale' not in str(exc):
+                    raise
+            else:
+                fail('stale staged probe evidence did not fail closed')
+
+            # Two independent dispatchers racing disjoint batches may both validate against an
+            # empty snapshot, but the state lock must serialize the commit and keep the cap <=3.
+            state = coordinator.default_state()
+            for i in range(5):
+                state['leases'].append({
+                    'id': 'race%d' % i, 'kind': 'verb', 'target': 'root%d' % i,
+                    'state': 'prepared', 'artifact_dir': os.path.join(tmp, 'r%d' % i),
+                })
+            coordinator.save_state(state)
+            barrier = threading.Barrier(2)
+            race_results = []
+
+            def begin_race(lease_ids):
+                barrier.wait()
+                try:
+                    coordinator.begin_run(SimpleNamespace(
+                        lease_id=lease_ids, mode='standard', run_id=None,
+                        probe_receipt=None))
+                    race_results.append('accepted')
+                except SystemExit:
+                    race_results.append('rejected')
+
+            racers = [threading.Thread(target=begin_race, args=(['race0', 'race1', 'race2'],)),
+                      threading.Thread(target=begin_race, args=(['race3', 'race4'],))]
+            for racer in racers:
+                racer.start()
+            for racer in racers:
+                racer.join(5)
+            running = coordinator.running_translation_leases(coordinator.load_state())
+            if len(running) > 3 or sorted(race_results) != ['accepted', 'rejected']:
+                fail('simultaneous begin-run batches exceeded the standard runtime cap')
+
+            # A blocked preparation must not hold the coordinator lock. Recovering it while
+            # the fake subprocess is still alive makes its later completion stale; CAS must
+            # refuse that completion rather than overwrite the recovered lease.
+            state = coordinator.default_state()
+            state['leases'] = [{
+                'id': 'prep', 'kind': 'verb', 'target': 'gam', 'state': 'claimed',
+                'artifact_dir': os.path.join(tmp, 'prep'),
+            }]
+            coordinator.save_state(state)
+            entered = threading.Event()
+            release = threading.Event()
+            errors = []
+
+            def blocking_run(cmd, cwd=coordinator.REPO, check=True, timeout=None):
+                if not 0 < timeout <= coordinator.PREPARE_TIMEOUT_SECONDS:
+                    fail('prepare subprocess did not receive the explicit 10-minute timeout')
+                script = os.path.basename(cmd[1])
+                if script == 'perf_preflight.py':
+                    entered.set()
+                    release.wait(5)
+                    return SimpleNamespace(returncode=0, stdout='{}', stderr='')
+                harness = next(value.split('=', 1)[1] for value in cmd if value.startswith('--out='))
+                manifest = next(value.split('=', 1)[1] for value in cmd
+                                if value.startswith('--manifest-out='))
+                os.makedirs(os.path.dirname(harness), exist_ok=True)
+                open(harness, 'w', encoding='utf-8').close()
+                with open(manifest, 'w', encoding='utf-8') as f:
+                    json.dump({'schema': 'pwg.headless_execution_manifest.v1', 'meta': {}}, f)
+                return SimpleNamespace(returncode=0, stdout='', stderr='')
+
+            coordinator.run_cmd = blocking_run
+
+            def do_prepare():
+                try:
+                    coordinator.prepare(SimpleNamespace(
+                        lease_id='prep', allow_over_cost=False, profile_slot=None,
+                        config_dir=None, executor_lane='serial-whole-card'))
+                except BaseException as exc:
+                    errors.append(exc)
+
+            worker = threading.Thread(target=do_prepare)
+            worker.start()
+            if not entered.wait(5):
+                fail('blocking preparation fixture did not start')
+            with coordinator.DirLock(coordinator.paths()['lock'], wait_seconds=1):
+                if coordinator.load_state()['leases'][0]['state'] != 'preparing':
+                    fail('preparing operation token was not persisted before subprocess launch')
+            coordinator.recover_operation(SimpleNamespace(
+                lease_id='prep', confirm_dead=True))
+            release.set()
+            worker.join(5)
+            if worker.is_alive():
+                fail('blocking preparation fixture did not finish')
+            if not errors or 'stale preparing completion' not in str(errors[0]):
+                fail('stale preparation completion did not fail compare-and-swap')
+            if coordinator.load_state()['leases'][0]['state'] != 'claimed':
+                fail('stale preparation completion overwrote recovered lease state')
+
+            # The same lock/CAS contract applies to the 30-minute audit phase.
+            audit_dir = os.path.join(tmp, 'audit')
+            os.makedirs(audit_dir)
+            audit_manifest = os.path.join(audit_dir, 'manifest.json')
+            with open(audit_manifest, 'w', encoding='utf-8') as f:
+                json.dump({'schema': 'pwg.headless_execution_manifest.v1',
+                           'meta': {'selected_keys': ['k'], 'input_hashes': {}}}, f)
+            result_path = os.path.join(audit_dir, 'result.json')
+            with open(result_path, 'w', encoding='utf-8') as f:
+                json.dump({'results': [{'key': 'k', 'card': {'key1': 'k'}}]}, f)
+            state = coordinator.default_state()
+            state['leases'] = [{
+                'id': 'audit', 'kind': 'verb', 'target': 'gam', 'state': 'prepared',
+                'artifact_dir': audit_dir, 'execution_manifest': audit_manifest,
+            }]
+            coordinator.begin_run_leases(state, ['audit'])
+            coordinator.save_state(state)
+            audit_entered = threading.Event()
+            audit_release = threading.Event()
+            audit_errors = []
+
+            def blocking_audit(cmd, cwd=coordinator.REPO, check=True, timeout=None):
+                if timeout != coordinator.AUDIT_TIMEOUT_SECONDS:
+                    fail('audit subprocess did not receive the explicit 30-minute timeout')
+                adir = cmd[cmd.index('--out-dir') + 1]
+                audit_entered.set()
+                audit_release.wait(5)
+                with open(os.path.join(adir, 'window_status.json'), 'w', encoding='utf-8') as f:
+                    json.dump({'state': 'blocked'}, f)
+                with open(os.path.join(adir, 'audit_window.report.json'),
+                          'w', encoding='utf-8') as f:
+                    json.dump({}, f)
+                return SimpleNamespace(returncode=2, stdout='', stderr='')
+
+            coordinator.run_cmd = blocking_audit
+
+            def do_audit():
+                try:
+                    coordinator.record_output(SimpleNamespace(
+                        lease_id='audit', workflow_result=result_path,
+                        allow_stale=False, transcript_dir=None))
+                except BaseException as exc:
+                    audit_errors.append(exc)
+
+            audit_worker = threading.Thread(target=do_audit)
+            audit_worker.start()
+            if not audit_entered.wait(5):
+                fail('blocking audit fixture did not start')
+            with coordinator.DirLock(coordinator.paths()['lock'], wait_seconds=1):
+                if coordinator.load_state()['leases'][0]['state'] != 'auditing':
+                    fail('auditing operation token was not persisted before subprocess launch')
+            coordinator.recover_operation(SimpleNamespace(
+                lease_id='audit', confirm_dead=True))
+            audit_release.set()
+            audit_worker.join(5)
+            if audit_worker.is_alive():
+                fail('blocking audit fixture did not finish')
+            if not audit_errors or 'stale auditing completion' not in str(audit_errors[0]):
+                fail('stale audit completion did not fail compare-and-swap')
+            if coordinator.load_state()['leases'][0]['state'] != 'running':
+                fail('stale audit completion overwrote recovered runtime state')
+        finally:
+            coordinator.run_cmd = original_run
             if old_coord is None:
                 os.environ.pop('PWG_COORDINATOR_DIR', None)
             else:
@@ -2899,9 +3168,11 @@ def test_coordinator_expired_leases_release_cap():
             ]
             coordinator.save_state(state)
             loaded = coordinator.load_state()
-            active = coordinator.active_translation_leases(loaded)
-            if [l.get('id') for l in active] != ['old-prepared', 'live']:
-                fail('only expired pre-prepare coordinator claims must release the LLM cap')
+            reserved = coordinator.reserved_translation_leases(loaded)
+            if [l.get('id') for l in reserved] != ['old-prepared', 'live']:
+                fail('only expired pre-prepare coordinator claims must release reservations')
+            if coordinator.running_translation_leases(loaded):
+                fail('durable prepared leases must not consume runtime')
             if loaded['leases'][0].get('state') != 'expired':
                 fail('expired coordinator claim must be marked terminal')
             if loaded['leases'][1].get('state') != 'prepared':
@@ -3056,7 +3327,7 @@ def test_coordinator_requeue_attempt_manifests():
 
         fail_once = [True]
 
-        def fake_run(cmd):
+        def fake_run(cmd, **_kwargs):
             out = next(arg.split('=', 1)[1] for arg in cmd if arg.startswith('--out='))
             manifest = next(arg.split('=', 1)[1] for arg in cmd
                             if arg.startswith('--manifest-out='))
@@ -3089,8 +3360,18 @@ def test_coordinator_requeue_attempt_manifests():
             failed_dir = os.path.join(artifacts, 'requeue', 'rq02-transient')
             if os.path.exists(failed_dir) or lease.get('requeue_attempt'):
                 fail('caught generation failure consumed an attempt or left its directory')
+            if lease.get('state') != 'blocked' or 'synthetic generation failure' not in (
+                    lease.get('operation_error') or ''):
+                fail('unexpected requeue generation failure was not recorded as blocked')
             if set(coordinator.pending_key_set(lease['pending_requeue'])) != {'a~~x', 'b~~x'}:
                 fail('caught generation failure changed the pending backlog')
+
+            # Continue the artifact-sequencing half of this selftest from an explicit operator
+            # reset; production blocked states are never retried silently.
+            state = coordinator.load_state()
+            state['leases'][0]['state'] = 'promoted_partial'
+            state['leases'][0].pop('operation_error', None)
+            coordinator.save_state(state)
 
             coordinator.prepare_requeue(SimpleNamespace(
                 lease_id='lease', transient=True, defect=False))
@@ -3297,7 +3578,7 @@ def test_coordinator_mixed_lane_public_state_sequence():
             'transient': [], 'defect': [],
         }]
 
-        def fake_run(cmd, check=True):
+        def fake_run(cmd, cwd=coordinator.REPO, check=True, timeout=None):
             script = os.path.basename(cmd[1]) if len(cmd) > 1 else ''
             if script == 'audit_window.py':
                 spec = audit_specs.pop(0)
@@ -3334,6 +3615,9 @@ def test_coordinator_mixed_lane_public_state_sequence():
             return path
 
         def record(path):
+            state = coordinator.load_state()
+            coordinator.begin_run_leases(state, ['lease'])
+            coordinator.save_state(state)
             coordinator.record_output(SimpleNamespace(
                 lease_id='lease', workflow_result=path, allow_stale=False,
                 transcript_dir=None))
@@ -5761,6 +6045,7 @@ def main():
         test_verb_worklist_excludes_missing_rootmaps,
         test_coordinator_state_dashboard_and_cap,
         test_coordinator_nominal_reservations,
+        test_coordinator_runtime_state_machine_and_cas,
         test_coordinator_fail_closed_audit_states,
         test_coordinator_promotion_revalidates_artifacts,
         test_coordinator_expired_leases_release_cap,

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -36,6 +36,7 @@ import os
 import shutil
 import sys
 import tempfile
+import uuid
 
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
@@ -79,7 +80,7 @@ def load_wf(path):
 
 
 def collect_cards(paths):
-    """sub-card key -> {card, meta, wf_file}. Non-null wins; both-non-null keeps first + logs.
+    """sub-card key -> {card, meta, wf_file}. Non-null wins; exact duplicates collapse.
 
     EN wf files are EXCLUDED: this is the RU bridge (rows_for reads sense['russian']), but
     DEFAULT_GLOB 'wf_output*.json' also matches wf_output.en.* — and those sort BEFORE the
@@ -105,15 +106,25 @@ def collect_cards(paths):
             if not card:
                 null_keys.add(key)
                 continue
-            if key in best:
-                conflicts.append(key)
-                continue                            # keep first-seen non-null
             entry = {'card': card, 'meta': meta, 'wf_file': os.path.basename(path)}
             # carry result-ROW level partial/drift markers (autosplit merge puts them on the
             # row, the selfheal inline path on the card) so provenance can record them
             for m in ('partial', 'missing_senses', 'total_senses', 'fidelity_drift'):
                 if r.get(m):
                     entry[m] = r[m]
+            if key in best:
+                # Recovered/copied workflow artifacts can contain the exact same successful
+                # card.  Collapse those safely, but never choose arbitrarily between different
+                # translations, generation metadata, or partial/drift markers.  wf_file is an
+                # artifact location rather than generation provenance, so it is deliberately
+                # excluded from the equivalence payload.
+                fields = ('card', 'meta', 'partial', 'missing_senses',
+                          'total_senses', 'fidelity_drift')
+                prior = {name: best[key].get(name) for name in fields}
+                current = {name: entry.get(name) for name in fields}
+                if prior != current:
+                    conflicts.append(key)
+                continue
             best[key] = entry
     if en_skipped:
         print('  skipped %d EN wf file(s) (promote_en.py attaches those)' % en_skipped)
@@ -258,11 +269,30 @@ def _atomic_write_rows(path, rows):
 
 
 def _fsynced_backup(source, destination):
-    """Copy, never move, the live store so a later write failure leaves it in place."""
-    with open(source, 'rb') as src, open(destination, 'wb') as dst:
-        shutil.copyfileobj(src, dst, length=1024 * 1024)
-        dst.flush()
-        os.fsync(dst.fileno())
+    """Exclusively copy the live store; never overwrite a prior recovery artifact."""
+    fd = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with open(source, 'rb') as src, os.fdopen(fd, 'wb') as dst:
+            fd = None
+            shutil.copyfileobj(src, dst, length=1024 * 1024)
+            dst.flush()
+            os.fsync(dst.fileno())
+    except BaseException:
+        if fd is not None:
+            os.close(fd)
+        try:
+            os.unlink(destination)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _backup_path(store, merge):
+    """Return a collision-resistant backup path without weakening O_EXCL protection."""
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%S.%fZ')
+    kind = 'premerge' if merge else 'legacy'
+    return '%s.%s.%s.p%d.%s.bak' % (
+        store, kind, stamp, os.getpid(), uuid.uuid4().hex[:12])
 
 
 def validate_store_target(path, init_store=False):
@@ -440,6 +470,23 @@ def selftest():
     best, _conf, nulls = collect_cards([nullf, fullf])
     assert 'p_a~~h5_00_pwg00' in best, 'non-null must win over null for the same key'
     assert nulls == [], 'a key non-null in any file is not a null'
+    # Byte-equivalent recovered artifacts collapse; divergent cards/provenance fail closed.
+    dupf = os.path.join(d, 'wf_output.duplicate.x.json')
+    with open(dupf, 'w', encoding='utf-8') as f:
+        json.dump({'meta': meta, 'results': [
+            {'key': 'p_a~~h5_00_pwg00', 'card': entry['card']}]}, f)
+    best, duplicate_conflicts, _nulls = collect_cards([fullf, dupf])
+    assert len(best) == 1 and duplicate_conflicts == [], \
+        'byte-equivalent workflow cards must deduplicate without a conflict'
+    divergent = os.path.join(d, 'wf_output.divergent.x.json')
+    changed_card = json.loads(json.dumps(entry['card']))
+    changed_card['records'][0]['senses'][0]['russian'] = 'выпить'
+    with open(divergent, 'w', encoding='utf-8') as f:
+        json.dump({'meta': meta, 'results': [
+            {'key': 'p_a~~h5_00_pwg00', 'card': changed_card}]}, f)
+    _best, divergent_conflicts, _nulls = collect_cards([fullf, divergent])
+    assert divergent_conflicts == ['p_a~~h5_00_pwg00'], \
+        'different non-null translations for one key must conflict'
     # EN wf files must NOT shadow RU cards: 'wf_output.en.*' sorts before 'wf_output.sc.*',
     # and its cards carry 'english' not 'russian' -> zero rows -> silent RU loss on rebuild.
     enf = os.path.join(d, 'wf_output.en.x.json')
@@ -496,6 +543,36 @@ def selftest():
         os.replace = real_replace
     assert open(atomic, encoding='utf-8').read() == 'old\n'
     assert not [n for n in os.listdir(d) if n.endswith('.tmp')]
+    # Backups are exclusive, collision-resistant copies. A failed copy leaves both the live
+    # store and any earlier backup untouched and removes its incomplete destination.
+    backup1 = _backup_path(atomic, True)
+    backup2 = _backup_path(atomic, True)
+    assert backup1 != backup2, 'two promotions must never share a backup name'
+    _fsynced_backup(atomic, backup1)
+    _fsynced_backup(atomic, backup2)
+    assert open(backup1, encoding='utf-8').read() == 'old\n'
+    assert open(backup2, encoding='utf-8').read() == 'old\n'
+    try:
+        _fsynced_backup(atomic, backup1)
+    except FileExistsError:
+        pass
+    else:
+        raise AssertionError('backup creation overwrote an existing recovery artifact')
+    real_copyfileobj = shutil.copyfileobj
+    failed_backup = _backup_path(atomic, False)
+    try:
+        shutil.copyfileobj = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OSError('synthetic backup failure'))
+        try:
+            _fsynced_backup(atomic, failed_backup)
+        except OSError:
+            pass
+        else:
+            raise AssertionError('backup copy failure was swallowed')
+    finally:
+        shutil.copyfileobj = real_copyfileobj
+    assert open(atomic, encoding='utf-8').read() == 'old\n'
+    assert not os.path.exists(failed_backup), 'partial backup survived a failed copy'
     print('promote_final_cards selftest OK')
 
 
@@ -650,9 +727,7 @@ def main():
                 # meant a second concurrent promote (even serialized seconds apart by this same
                 # claim) would overwrite the first run's only recovery copy of the pre-merge
                 # store. Each promote now keeps its own backup.
-                stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
-                bak = args.store + ('.premerge.%s.bak' % stamp if args.merge
-                                    else '.legacy.%s.bak' % stamp)
+                bak = _backup_path(args.store, args.merge)
                 _fsynced_backup(args.store, bak)
                 print('\nbacked up prior store -> %s' % os.path.basename(bak))
             # Atomic write: stream to a temp file then os.replace, so a crash/kill mid-write


### PR DESCRIPTION
## What changed

- keep canonical-store backups exclusive and collision-resistant while the live store stays present
- deduplicate byte-equivalent recovered workflow cards and reject divergent translations/provenance
- reserve every canonical key in nominal leases, migrate legacy reservations, and fail closed on unresolved active leases

## Why

The coordinator previously reserved only a nominal batch's first key, allowing overlapping paid work. Promotion backup names had second-level collision risk, and duplicate successful artifacts had no identical-only deduplication rule.

## Validation

- promote_final_cards.py --selftest
- focused coordinator regression set
- window_selftest.py: 143/143 functional tests pass after LANG_PARITY restamp
- lang_parity_check.py: 53 entries, no drift
- AST parse of changed Python files

Offline only: no translation calls, canonical-store mutation, TM rebuild, or live ladder action.