### PR TITLE
docs: backfill metadocs for 11 docs incl. RussianTranslation roadmaps (H968)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.21.0
+version: 1.22.0
 date-released: "2026-07-18"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/FEATURES_INDEX.meta.md
+++ b/FEATURES_INDEX.meta.md
@@ -1,0 +1,86 @@
+# FEATURES_INDEX.meta.md — metadoc for `FEATURES_INDEX.md`
+
+_Created: 18-07-2026 · Last updated: 18-07-2026_
+
+This is a **metadoc** — a document *about* a document. Its subject is
+[FEATURES_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md).
+It does not duplicate the subject's content; it records everything *around* it. Kept per the
+standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`).
+
+## Subject
+- **Document:** [FEATURES_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md)
+- **Purpose:** The clickable, capability-first inventory of every working asset across the
+  ~85-repo Sanskrit Lexicon org — 44 dictionaries, 21 interfaces, 43 data assets, 14 tools,
+  4 external stacks, 11 learner drill sets. Answers "what exists at all?" as distinct from
+  `REUSE_INDEX.md`'s "don't rebuild — consume this."
+- **Audience:** Every fresh session in any repo of the org that needs to check prior art
+  before building — this is the org-root CLAUDE.md's linked answer to "see what already
+  EXISTS." Also the canonical source for the generated `features_index.html` interactive
+  artifact.
+- **Format / contract:** Stable IDs per category (`A`–`F` data · `G`–`K` interfaces · `L`–`M`
+  tools · `P` drills; dictionaries use their code), running numbers that never restart or
+  shift, size-tier markers (🟢/🟡/⚪), an "Intro" first-introduced month/year column. This
+  Markdown file is the canonical source — `build_features_index_html.py` generates
+  `features_index.html` from it; never hand-edit the HTML.
+
+## Provenance
+- **Created:** 18-07-2026 (handoff H968, Sonnet 5 `claude-sonnet-5`) — this metadoc. The
+  subject document itself dates to 04-07-2026 per its own header.
+- **Next hardening:** none scheduled — this is a high-churn hub, hardened continuously by
+  whichever session adds an asset; no dedicated hardening pass planned.
+
+## Improvement backlog (ranked)
+
+| # | Improvement | Why | Status |
+|---|---|---|---|
+| 1 | Keep the Markdown/HTML pair in sync on every edit | The doc's own contract states the HTML is generated and must never drift — a session editing the table without re-running `build_features_index_html.py` silently breaks the interactive artifact | parked — process discipline, not a one-off task; enforce on every edit |
+| 2 | Re-verify sizes/counts against source repos periodically | The doc's own caveat: "Sizes and counts are approximate; re-verify against a source repo before a large change" | parked — no scheduled cadence; do opportunistically |
+| 3 | Extend coverage as new asset families land (e.g. the ACC×NCC works-catalogue crosswalk once [ROADMAP_ACC_NCC.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_ACC_NCC.md) P3 ships) | New durable data/interface/tool assets should register here per the org's "post-work hub sync" reflex | parked — triggered by the producing session, not this metadoc |
+
+## Known limitations / caveats
+- This is a **high-churn, actively-referenced** doc (last updated 14-07-2026 per its header,
+  ten days after creation) — any read of it should be treated as a snapshot, not a frozen
+  reference; check "Last updated" before citing a count in a paper.
+- Two linked companion hubs ([`SHARED_CODE.md`](https://github.com/gasyoun/github-spine/blob/main/SHARED_CODE.md),
+  [`PROJECT_INTERLINKS.md`](https://github.com/gasyoun/Uprava/blob/main/PROJECT_INTERLINKS.md))
+  live in **private** repos (`github-spine`, `Uprava`) — a reader without access to those
+  repos sees dead links for the "who owns this code" / "who feeds whom" cross-references.
+- The ID scheme is running-number-within-category, not stable-across-categories — e.g. `E43`
+  appears twice in the table read during this metadoc's authoring (kosha corpus sandhi
+  programme and the code-duplication census both carry `E43`), which looks like a duplicate-ID
+  defect worth a closer look by whoever next edits this table.
+
+## Intended use / known misuse
+- **For:** the first stop before building a parser/transcoder/dataset in ANY repo of the org
+  — the org CLAUDE.md's "check prior art before building" rule routes here specifically for
+  "what already EXISTS."
+- **Misuse:** treating a listed asset's size/count as exact without re-verifying against its
+  source repo (explicitly flagged approximate); hand-editing `features_index.html` instead of
+  editing this Markdown file and regenerating.
+
+## Maintenance & sunset plan
+- Owner: whoever adds a new durable asset anywhere in the org (distributed ownership by
+  convention, not a single maintainer) — the org's "post-work hub sync" reflex names this file
+  as one of the hubs to update after any deliverable.
+- Sunset: none planned — this is a permanent living inventory; it only shrinks if an asset is
+  deprecated, in which case the row is struck/annotated, not deleted (mirroring FINDINGS.md's
+  append-only discipline for its own numbering, though this file's IDs are per-category not
+  fully append-only).
+
+## Deprecation status
+`active` — continuously maintained hub.
+
+## Related documents
+- [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) — the sibling empirical-findings registry (this doc = what exists; FINDINGS = what we've learned about it).
+- [ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.md) — cites this doc's L1 dictionary count directly.
+- [features_index.html](https://github.com/gasyoun/SanskritLexicography/blob/master/features_index.html) — the generated interactive artifact.
+- [build_features_index_html.py](https://github.com/gasyoun/SanskritLexicography/blob/master/build_features_index_html.py) — the generator; never hand-edit the HTML output.
+- [Uprava/REUSE_INDEX.md](https://github.com/gasyoun/Uprava/blob/main/REUSE_INDEX.md) — companion "don't rebuild — consume this" doc.
+
+## Revision history
+
+| Date | Event | Who |
+|---|---|---|
+| 18-07-2026 | Metadoc created (backfill sweep) | Sonnet 5 (`claude-sonnet-5`), H968 |
+
+_Dr. Mārcis Gasūns_

--- a/FINDINGS.meta.md
+++ b/FINDINGS.meta.md
@@ -1,0 +1,91 @@
+# FINDINGS.meta.md — metadoc for `FINDINGS.md`
+
+_Created: 18-07-2026 · Last updated: 18-07-2026_
+
+This is a **metadoc** — a document *about* a document. Its subject is
+[FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).
+It does not duplicate the subject's content; it records everything *around* it. Kept per the
+standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`).
+
+Note: `FINDINGS.md` is on the org's `EXEMPT_EXACT` list for the authorship-time genre-coverage
+hook (it is a named hub registry, not a genre-named doc the hook flags) — this metadoc exists
+because the org CLAUDE.md's "substantially edit an important doc → keep its `<name>.meta.md`"
+convention applies independently of that hook, and this handoff (H968) was explicitly scoped
+to cover it.
+
+## Subject
+- **Document:** [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
+- **Purpose:** The cross-repo, evidence-backed empirical registry for Sanskrit-lexicon **data**
+  facts — dictionary structure, encoding, corpus, morphology, per-dict tooling gotchas —
+  expensive to re-discover, easy to get wrong by assumption. Currently 2,269 lines, ~448
+  findings.
+- **Audience:** Every session working on Sanskrit-lexicon data in any repo — the org CLAUDE.md
+  routes "rely on a premise / hit a contradiction" work here (Sanskrit-data side) as opposed
+  to [Uprava/FINDINGS.md](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md) (infra/
+  process side).
+- **Format / contract:** Append-only `§N` numbering — a new finding always takes the next free
+  number (currently §448) regardless of section; refuted/superseded findings are struck with
+  a reason, never renumbered or reused. Schema per finding: `###` heading, bold claim,
+  `Evidence:`, `Implication:`, blockquoted `Source` with `— repo · date`. Colour-dot importance
+  label (🔴/🟠/🟡) on both the claim line and its Index entry. An Index section at the top
+  lists every finding as a clickable anchor, grouped by topic area.
+
+## Provenance
+- **Created:** 18-07-2026 (handoff H968, Sonnet 5 `claude-sonnet-5`) — this metadoc. The
+  subject document itself dates to 26-06-2026 per its own header.
+- **Next hardening:** none scheduled — this is the org's highest-churn Sanskrit-data hub,
+  appended to continuously by design ("living document — appended on a regular basis").
+
+## Improvement backlog (ranked)
+
+| # | Improvement | Why | Status |
+|---|---|---|---|
+| 1 | Keep the Index section's anchor list in sync with the §N headings as new findings are appended | A drifted Index (missing entries, wrong importance dots) defeats the "stable citation" contract the doc promises | parked — process discipline enforced per-append, not a one-off task |
+| 2 | Periodic staleness sweep — some findings reference counts/measurements that may drift as source data (csl-orig, DCS vintages) changes upstream | The doc itself warns findings are "expensive to re-discover and easy to get wrong by assumption" but does not carry an automated staleness check the way the live dashboard does for §12/§13/§21/§25/§41 | parked — the [findings_dashboard/](https://github.com/gasyoun/SanskritLexicography/tree/master/findings_dashboard) monthly refresh already covers the time-series subset; a fuller sweep is unscoped |
+| 3 | Resolve any accumulating cross-references to renumbered findings (e.g. §72/§73 noted elsewhere as "renumbered from §63/§64 on 11-07-2026") | Renumbering-on-supersession is explicitly disallowed by the doc's own rule ("never reuse its number") — any observed renumbering note elsewhere in the org is worth auditing against this file's actual current numbering | parked — needs a dedicated cross-repo grep pass, not scoped to this metadoc backfill |
+
+## Known limitations / caveats
+- This is a **2,269-line, ~448-entry, continuously-appended** file — this metadoc's author
+  read only the header and the Index's first ~100 lines (grammar/morphology, corpus, dict-
+  structure, etymology, encoding sections); it does not audit every individual finding's
+  current accuracy.
+- Distinct scope from three sibling docs the subject itself calls out: `PILOT_LESSONS.md`
+  (CI/CD process, github-spine), `SHARED_CODE.md` (who-owns-what code, github-spine), and
+  `Uprava/FINDINGS.md` (non-Sanskrit infra/process gotchas) — a finding filed in the wrong one
+  of these four is a recurring miscategorization risk the doc's own header exists to prevent.
+- The live dashboard (linked at the top of the subject) covers only a subset of findings
+  (importance/section breakdown, staleness flags for §12/§13/§21/§25/§41) — most individual
+  findings have no automated freshness signal.
+
+## Intended use / known misuse
+- **For:** checking whether a non-obvious Sanskrit-data gotcha (encoding collision, markup
+  quirk, corpus limitation) has already been measured before re-deriving it; citing a stable
+  `§N` anchor in a paper or another doc.
+- **Misuse:** filing a non-Sanskrit infra/process finding here instead of `Uprava/FINDINGS.md`;
+  reusing or renumbering a struck finding's `§N` instead of appending a new number; citing a
+  finding's numeric claim without checking whether it has since been struck/superseded.
+
+## Maintenance & sunset plan
+- Owner: every session that measures a non-obvious Sanskrit-data fact — distributed by
+  convention, not a single maintainer. The doc's own header states the append reflex is
+  mandatory ("if you discovered it by running something, it belongs here").
+- Sunset: none planned — this is a permanent, append-only living registry; individual findings
+  are struck (never deleted) on supersession, but the file itself has no end state.
+
+## Deprecation status
+`active` — continuously appended hub, currently at §448.
+
+## Related documents
+- [Uprava/FINDINGS.md](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md) — the infra/process-side sibling registry; do not cross-file.
+- [github-spine/PILOT_LESSONS.md](https://github.com/gasyoun/github-spine/blob/main/PILOT_LESSONS.md) — CI/CD process lessons, explicitly out of this doc's scope.
+- [github-spine/SHARED_CODE.md](https://github.com/gasyoun/github-spine/blob/main/SHARED_CODE.md) — code-ownership registry, explicitly out of this doc's scope.
+- [findings_dashboard/](https://github.com/gasyoun/SanskritLexicography/tree/master/findings_dashboard) — the live dashboard generator, refreshed monthly.
+- [FEATURES_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md) — the sibling "what exists" inventory (this doc = what we've learned about it).
+
+## Revision history
+
+| Date | Event | Who |
+|---|---|---|
+| 18-07-2026 | Metadoc created (backfill sweep) | Sonnet 5 (`claude-sonnet-5`), H968 |
+
+_Dr. Mārcis Gasūns_

--- a/HERITAGE_INRIA_ROADMAP.meta.md
+++ b/HERITAGE_INRIA_ROADMAP.meta.md
@@ -1,0 +1,76 @@
+# HERITAGE_INRIA_ROADMAP.meta.md — metadoc for `HERITAGE_INRIA_ROADMAP.md`
+
+_Created: 18-07-2026 · Last updated: 18-07-2026_
+
+This is a **metadoc** — a document *about* a document. Its subject is
+[HERITAGE_INRIA_ROADMAP.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HERITAGE_INRIA_ROADMAP.md).
+It does not duplicate the subject's content; it records everything *around* it. Kept per the
+standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`).
+
+## Subject
+- **Document:** [HERITAGE_INRIA_ROADMAP.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HERITAGE_INRIA_ROADMAP.md)
+- **Purpose:** Tracks reuse of Gérard Huet's Sanskrit Heritage Platform (sanskrit.inria.fr) —
+  access reality (bot-walled site, GitHub mirror), the LGPLLR×BY-SA rights resolution, and a
+  6-phase integration plan (morphology databanks, MW↔Heritage crosswalk, frequency tables,
+  DICO gloss layer, segmenter service).
+- **Audience:** Sessions touching Heritage-derived assets in kosha, HeadwordLists, csl-atlas,
+  or SanskritSpellCheck; anyone re-checking the Huet outreach/rights status.
+- **Format / contract:** Numbered phases (0–6) each with consumer/gate/status columns; a
+  rulings section; an execution log pointing at the handoffs that did the work. Status cells
+  update in place as phases land.
+
+## Provenance
+- **Created:** 18-07-2026 (handoff H968, Sonnet 5 `claude-sonnet-5`).
+- **Next hardening:** none scheduled — revisit when Phase 3 (frequency tables) or Phase 6
+  (segmenter-as-service) is picked up.
+
+## Improvement backlog (ranked)
+
+| # | Improvement | Why | Status |
+|---|---|---|---|
+| 1 | Phase 3 — ingest `DATA/*.tsv` pada/compound/transition frequencies, diff against VisualDCS M1–M8 and `corpus_lexicon`, register in PROJECT_INTERLINKS | Explicitly queued in the subject ("⬜ queued, own H###") — cheapest remaining phase, mirror-only, no gate | parked — needs its own H### mint when picked up |
+| 2 | Phase 6 — segmenter-as-service cross-validation vs DharmaMitra GPU morphology | Queued in the subject; unlocks a second morphology witness for csl-atlas/RussianTranslation | parked — needs its own H### mint when picked up |
+| 3 | Transcribe Gérard Huet's exact reply wording (attribution phrasing, conditions) into this repo | Subject flags this explicitly as "not transcribed into this repo yet" — a rights-precision gap | parked — needs the actual email text located first |
+| 4 | kosha ingest of Heritage's 928k surplus forms (flagged as Phase 4 follow-on, explicitly "not built") | Left as a GTD `@DECIDE`, not built, per the subject's own phase-4 row | parked — MG `@DECIDE`, tracked in GTD |
+
+## Known limitations / caveats
+- The current morphology XML databanks are **not** in the GitHub mirror — they require either
+  a manual browser download (past the Anubis bot-wall) or a local Platform install; Phase 1's
+  "done" status is explicitly the mirror-fallback path, not the human-downloaded export.
+- `DATA/mw_index.rem` (OCaml `Marshal` binary) was never decoded and is out of scope per the
+  subject's own inventory note.
+- Phase 4's 78.3% agreement figure between Heritage and kosha forms is measured against a
+  small raw overlap (94,264 of ~1M+410k forms); most of that low overlap is attributed to
+  engine-surplus and lemmatization-policy differences, not error — don't over-read it as a
+  precision number without re-reading the hand-adjudication note in the subject.
+
+## Intended use / known misuse
+- **For:** checking rights status before using any Heritage-derived asset, and finding which
+  phase (if any) already covers a given Heritage integration need before rebuilding it.
+- **Misuse:** treating "Phases 1–5 done" as "everything from Heritage is ingested" — several
+  explicit follow-ons (kosha surfacing, kosha ingest of surplus forms) are flagged done-but-
+  not-built and sit as GTD `@DECIDE` rows, not completed work.
+
+## Maintenance & sunset plan
+- Owner: whoever next works Heritage-derived data (SanskritLexicography/HeadwordLists side).
+  No dedicated maintainer assigned.
+- Sunset: once Phases 3 and 6 land (or are explicitly deprioritized), this roadmap is fully
+  executed and becomes a historical record of the integration — retitle rather than delete,
+  since it also documents the LGPLLR×BY-SA rights ruling other sessions may need to cite.
+
+## Deprecation status
+`active` — Phases 0–2, 4–5 done; Phases 3 and 6 queued with no handoff minted yet.
+
+## Related documents
+- [SAMSAADHANII_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/SAMSAADHANII_INDEX.md) — companion external-stack roadmap (the SCL side, first mature external computational-Sanskrit stack).
+- [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) — §41 (Anubis bot-wall), §47 (GitLab also walled), §49/§52/§54 (execution findings) referenced throughout the subject.
+- [HeadwordLists/HERITAGE_MIRROR_INVENTORY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/HERITAGE_MIRROR_INVENTORY.md) — the mirror contents inventory.
+- [Uprava/GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md) — carries the kosha-ingest `@DECIDE`.
+
+## Revision history
+
+| Date | Event | Who |
+|---|---|---|
+| 18-07-2026 | Metadoc created (backfill sweep) | Sonnet 5 (`claude-sonnet-5`), H968 |
+
+_Dr. Mārcis Gasūns_

--- a/ROADMAP_ACC_NCC.meta.md
+++ b/ROADMAP_ACC_NCC.meta.md
@@ -1,0 +1,74 @@
+# ROADMAP_ACC_NCC.meta.md — metadoc for `ROADMAP_ACC_NCC.md`
+
+_Created: 18-07-2026 · Last updated: 18-07-2026_
+
+This is a **metadoc** — a document *about* a document. Its subject is
+[ROADMAP_ACC_NCC.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_ACC_NCC.md).
+It does not duplicate the subject's content; it records everything *around* it. Kept per the
+standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`).
+
+## Subject
+- **Document:** [ROADMAP_ACC_NCC.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_ACC_NCC.md)
+- **Purpose:** Specifies and tracks the ACC (Aufrecht's *Catalogus Catalogorum*) × NCC (*New
+  Catalogus Catalogorum*) catalogue-of-works crosswalk build — decisions locked, phased plan
+  P0–P5, rights resolution, and current status per phase.
+- **Audience:** Whoever picks up the P2 adjudication gate or a downstream P3–P5 phase (kosha
+  consumer work); also the reference for "why is this asset dual-licensed" questions.
+- **Format / contract:** Numbered phases (P0–P5) each with a deliverable and status marker
+  (✅ DONE / BLOCKED / queued); a decisions-locked table; a rights section. New phase status
+  updates edit the status cell in place, they do not fork the doc.
+
+## Provenance
+- **Created:** 18-07-2026 (handoff H968, Sonnet 5 `claude-sonnet-5`).
+- **Next hardening:** none scheduled — update opportunistically when P2 unblocks or a later
+  phase lands.
+
+## Improvement backlog (ranked)
+
+| # | Improvement | Why | Status |
+|---|---|---|---|
+| 1 | Unblock P2 adjudication ([Draft PR #264](https://github.com/gasyoun/SanskritLexicography/pull/264)) — MG vote on the full 49,019-row sheet | Doc has said "BLOCKED on MG's vote" since 09-07-2026; the whole P3–P5 chain is gated on this one human decision | parked — MG `@DECIDE`, tracked in Uprava GTD, not this metadoc's job to chase |
+| 2 | MG re-verify the local NCC dump isn't stale before the Su→Ha gap is frozen (§4 of the subject) | Explicitly flagged in the subject as a pre-freeze condition, not yet done | parked — MG `@DECIDE` |
+| 3 | Once P2 clears, fold the realized P3 (kosha `works` table) status back into this doc rather than leaving it as a forward-looking deliverable description | Keeps the roadmap from drifting into a stale plan once work ships | parked — depends on item 1 |
+
+## Known limitations / caveats
+- The doc's own Tier-A/B exact+nasal-fold match counts (8,413 / +2,041/+2,047) are frozen at
+  the 03–06-07-2026 measurement; re-verify before citing in a paper if NCC/ACC source files
+  change upstream in csl-orig or VisualDCS.
+- Rights section states NCC = CC BY-NC 4.0 and ACC = CC BY-SA 4.0, dual-licensed per field —
+  any consumer must preserve this split, never flatten to one license.
+- The whole downstream chain (P3 kosha consumption, P4 surfaces, P5 release) is inert until
+  the P2 human vote lands; treat "queued" status literally, not as "in progress."
+
+## Intended use / known misuse
+- **For:** orienting a session that picks up P2 adjudication, or any kosha-side session
+  building the `works` table consumer, on what the crosswalk asset contains and where its
+  rights boundary sits.
+- **Misuse:** treating the Tier C/D fuzzy-match candidate counts as accepted matches — they
+  are unadjudicated candidates by design (full-fuzzy manufactures false joins); only P2's
+  `works_crosswalk.tsv` output, once produced, is a citable join.
+
+## Maintenance & sunset plan
+- Owner: whoever next works the ACC/NCC works-catalogue asset (SanskritLexicography or
+  kosha side). No dedicated maintainer assigned.
+- Sunset: once P5 (release, DOI) ships and the asset is frozen, this roadmap becomes a
+  historical record — retitle its status line "archived: see the release" rather than
+  deleting it, since it documents the rights-resolution reasoning that a release note alone
+  would not carry.
+
+## Deprecation status
+`active` — P0/P1 done, P2 blocked on a pending human decision, P3–P5 not started.
+
+## Related documents
+- [FEATURES_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md) — the works-catalogue asset, once shipped, belongs in the Data assets table here.
+- [kosha/data/SOURCES.md](https://github.com/gasyoun/kosha/blob/main/data/SOURCES.md) — the consumption-pattern precedent P3 follows.
+- [Uprava/GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md) — carries the P2 `@DECIDE`/Waiting-on-Me row.
+- [docs/permissions/NCC_permission_2026-06-25.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/permissions/NCC_permission_2026-06-25.md) — the formal rights record §5 of the subject summarizes.
+
+## Revision history
+
+| Date | Event | Who |
+|---|---|---|
+| 18-07-2026 | Metadoc created (backfill sweep) | Sonnet 5 (`claude-sonnet-5`), H968 |
+
+_Dr. Mārcis Gasūns_

--- a/ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.meta.md
+++ b/ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.meta.md
@@ -1,0 +1,81 @@
+# ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.meta.md — metadoc for `ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.md`
+
+_Created: 18-07-2026 · Last updated: 18-07-2026_
+
+This is a **metadoc** — a document *about* a document. Its subject is
+[ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.md).
+It does not duplicate the subject's content; it records everything *around* it. Kept per the
+standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`).
+
+## Subject
+- **Document:** [ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.md)
+- **Purpose:** The org's central publications roadmap — a DH-standards review of csl-atlas
+  (gaps G1–G8 against FAIR/CLARIN/ELEXIS norms), the "evidence-graded lexicography" research
+  thesis (Part II, including the Apresyan/ACL methodological lineage added 14-07-2026), the
+  P1–P6 paper pipeline feeding a planned book, and a quarter-by-quarter 12-month roadmap
+  (Q3 2026 → Q2 2027).
+- **Audience:** Anyone deciding what paper/dataset work to pick up next in the Tier-1 research
+  track; explicitly named in the repo's own `CLAUDE.md` as "the orientation document for how
+  this repo connects to the broader project."
+- **Format / contract:** Part I (gap review) / Part II (thesis) / Part III (paper table
+  P1–P6) / Part IV (quarterly roadmap) / Part V (risks). Quarterly sections get checked off /
+  annotated in place as work lands; new gaps append to the G-table, never renumber existing
+  ones (same append-only discipline as FINDINGS.md).
+
+## Provenance
+- **Created:** 18-07-2026 (handoff H968, Sonnet 5 `claude-sonnet-5`).
+- **Next hardening:** none scheduled — revisit at each quarter boundary (next: Q4 2026,
+  Oct 2026) when the roadmap's own quarterly checklist is due for a status pass.
+
+## Improvement backlog (ranked)
+
+| # | Improvement | Why | Status |
+|---|---|---|---|
+| 1 | G1 FAIR sprint — Zenodo DOI + CITATION.cff across atlas/standards/VisualDCS/observatory, ORCID registered | Flagged High severity; Q3 2026 roadmap item 1; blocks every paper citing a dataset DOI | parked — Q3 2026 roadmap item, no handoff minted yet |
+| 2 | G2 TEI Lex-0 pilot (MW + SKD sample, schema-validated) | Flagged High severity; reviewers will ask "where is the TEI?" | parked — Q4 2026 roadmap item 3 |
+| 3 | G4 double-keying / κ reporting for the community review pool | Flagged High severity — single-reviewer bottleneck makes reviewed claims' reliability unmeasurable | parked — Q3 2026 roadmap item 3 |
+| 4 | P1 submission to IJL | First paper in the pipeline, gates the book proposal (needs 2 published/under-review chapters) | parked — Q3 2026 roadmap item 4, tracked in ARTICLES.md as its own Axx |
+
+## Known limitations / caveats
+- The Part II thesis (evidence-graded lexicography) and Part III paper pipeline are the
+  scholarly spine — but every P1–P6 submission date in the roadmap table is a *plan*, not a
+  commitment; check [Uprava/ARTICLES.md](https://github.com/gasyoun/Uprava/blob/main/ARTICLES.md)
+  for the actual current readiness score of each Axx before assuming a Q-date holds.
+- Several G-gaps (G4 single-reviewer bottleneck, G8 bus-factor-1 on the atlas and 65/76 org
+  repos) are structural, not fixable by one session — the roadmap names mitigations, not full
+  fixes.
+- This doc explicitly does **not** own statistics/measurement scope — that's
+  [ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.md),
+  which *feeds* this roadmap's papers with numbers. Don't duplicate census work here.
+
+## Intended use / known misuse
+- **For:** deciding what publication-track work is next, understanding why csl-atlas's
+  architecture looks the way it does (the boundary-rules / evidence-label design choices are
+  explained here), and citing the Apresyan/ACL methodological framing for the monograph.
+- **Misuse:** treating the roadmap's quarterly dates as deadlines rather than sequencing —
+  the doc itself frames Q1–Q2 2027 as "mostly writing, not building" *if* the Q3–Q4 2026
+  infrastructure sprint lands on time; slippage cascades and should be re-planned, not ignored.
+
+## Maintenance & sunset plan
+- Owner: whoever is driving the Tier-1 research/publication track (per the org's priority
+  tiers). No single named maintainer.
+- Sunset: superseded only when the 12-month window (through Q2 2027) closes and a successor
+  roadmap is authored — archive with a pointer to the successor rather than deleting, since
+  the Part I gap review and Part II thesis remain citable reference material past the window.
+
+## Deprecation status
+`active` — Q3 2026 items in progress, later quarters not yet started.
+
+## Related documents
+- [ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.md) — the measurement counterpart that feeds this roadmap's papers with numbers.
+- [Uprava/ARTICLES.md](https://github.com/gasyoun/Uprava/blob/main/ARTICLES.md) — the actual P1–P6/Axx readiness tracker.
+- [FEATURES_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md) — asset inventory the paper pipeline draws data from.
+- [../CLAUDE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/CLAUDE.md) — names this doc as the repo's orientation document for the broader project.
+
+## Revision history
+
+| Date | Event | Who |
+|---|---|---|
+| 18-07-2026 | Metadoc created (backfill sweep) | Sonnet 5 (`claude-sonnet-5`), H968 |
+
+_Dr. Mārcis Gasūns_

--- a/ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.meta.md
+++ b/ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.meta.md
@@ -1,0 +1,78 @@
+# ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.meta.md — metadoc for `ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.md`
+
+_Created: 18-07-2026 · Last updated: 18-07-2026_
+
+This is a **metadoc** — a document *about* a document. Its subject is
+[ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.md).
+It does not duplicate the subject's content; it records everything *around* it. Kept per the
+standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`).
+
+## Subject
+- **Document:** [ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.md)
+- **Purpose:** The org-wide "what statistics can we compute over all ~85 repos, in what
+  order" measurement roadmap — a 7-layer counting register (L1–L7, each stat marked
+  ✅/◐/○) feeding the publications roadmap, a public observatory, internal QA, and product
+  analytics.
+- **Audience:** Whoever is asked "has X already been counted org-wide" before running a new
+  census script; explicitly the deconfliction point against re-measuring something already ✅.
+- **Format / contract:** "Part 0 — the counting register" is the living scoreboard (7 layers,
+  each row: Statistic / Count-status / Where); later parts (not fully read in this pass) carry
+  the sequencing plan. Status symbols (✅ computed · ◐ partial · ○ not started) update in
+  place as work lands — this is the doc's core contract, don't restructure the table shape.
+
+## Provenance
+- **Created:** 18-07-2026 (handoff H968, Sonnet 5 `claude-sonnet-5`).
+- **Next hardening:** none scheduled — revisit whenever a census item flips status, per the
+  doc's own "drive every ○ and ◐ to ✅" framing.
+
+## Improvement backlog (ranked)
+
+| # | Improvement | Why | Status |
+|---|---|---|---|
+| 1 | L1 "Definition typology (synonym vs equivalent vs encyclopedic)" — ○ not started | Flagged as an "ATLAS_FAIR micro-gap" in the subject's own L1 table, ties directly to the publications roadmap's Part I microstructure gap list | parked — no handoff minted yet |
+| 2 | L2 "Form→lemma ambiguity rate" — ○ not started | Named directly in the subject's L2 table as the one remaining morphology-layer gap | parked — no handoff minted yet |
+| 3 | L3 "Meter / prosody statistics" — ○ not started | Named in the subject's L3 table; natural home is SanskritKaraoke per the "Where" column | parked — no handoff minted yet, likely SanskritKaraoke-side work |
+| 4 | L3 "Vedic accent coverage" — ○ not started, pending VedaWeb reuse | Explicitly gated on VedaWeb M13 in the subject's own table | parked — depends on [ROADMAP_VEDAWEB_REUSE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_VEDAWEB_REUSE.md) Phase 2/6 landing first |
+
+## Known limitations / caveats
+- Only Part 0 (L1–L3 of 7 layers) was read closely when this metadoc was authored — L4–L7
+  (translation, review/QA, publication, and any further layers) exist in the doc but were not
+  individually audited here; a future metadoc pass should extend the backlog once those
+  sections are read.
+- Counts in the register are dated "as of the 06–12-07-2026 census re-measure" per the doc's
+  own caveat — re-verify before citing in a paper if it has been more than a few weeks.
+- This doc is explicitly **not** the publications roadmap (that's
+  [ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.md))
+  and not the asset inventory (that's `FEATURES_INDEX.md`) — it is specifically the
+  measurement-scoping layer between them.
+
+## Intended use / known misuse
+- **For:** checking whether an org-wide statistic has already been computed before running a
+  new census script — the doc's whole point is "don't recompute, check the register first."
+- **Misuse:** treating a ✅ status as permanently current without checking the census
+  re-measure date, or treating a ◐ partial as ✅ (several rows are explicitly partial with a
+  named remaining scope, e.g. sense/polysemy distribution at 11/44 dicts).
+
+## Maintenance & sunset plan
+- Owner: whoever runs org-wide census/statistics work (closely tied to csl-observatory).
+  No single named maintainer.
+- Sunset: the doc's own framing is "the year is: finish the census... land it as a citable
+  observatory + FAIR release set + a methods chapter" — sunset trigger is that methods
+  chapter shipping, at which point this roadmap becomes historical planning material.
+
+## Deprecation status
+`active` — L1–L3 partially computed per the register; full L1–L7 sweep not yet complete.
+
+## Related documents
+- [ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.md) — the publications roadmap this one feeds.
+- [FEATURES_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md) — "what assets exist"; this doc answers "what statistics can we compute over them."
+- [Uprava/DATA_LAYERS_CENSUS.md](https://github.com/gasyoun/Uprava/blob/main/DATA_LAYERS_CENSUS.md) — "what large data sits uncounted on disk," the sibling hub this doc distinguishes itself from.
+- [ROADMAP_VEDAWEB_REUSE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_VEDAWEB_REUSE.md) — gates the L3 Vedic accent coverage row.
+
+## Revision history
+
+| Date | Event | Who |
+|---|---|---|
+| 18-07-2026 | Metadoc created (backfill sweep) | Sonnet 5 (`claude-sonnet-5`), H968 |
+
+_Dr. Mārcis Gasūns_

--- a/ROADMAP_VEDAWEB_REUSE.meta.md
+++ b/ROADMAP_VEDAWEB_REUSE.meta.md
@@ -1,0 +1,76 @@
+# ROADMAP_VEDAWEB_REUSE.meta.md — metadoc for `ROADMAP_VEDAWEB_REUSE.md`
+
+_Created: 18-07-2026 · Last updated: 18-07-2026_
+
+This is a **metadoc** — a document *about* a document. Its subject is
+[ROADMAP_VEDAWEB_REUSE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_VEDAWEB_REUSE.md).
+It does not duplicate the subject's content; it records everything *around* it. Kept per the
+standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`).
+
+## Subject
+- **Document:** [ROADMAP_VEDAWEB_REUSE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_VEDAWEB_REUSE.md)
+- **Purpose:** Tracks reuse of VedaWeb 2.0 (Universität zu Köln) data across the org — a
+  5-phase plan (bulk export, WhitneyRoots accent validation, GRA crosswalk, meter/translation
+  rights triage, plus a queued segmenter-service phase) with the feed landing in VisualDCS.
+- **Audience:** Sessions consuming VedaWeb-derived data (WhitneyRoots accent rules,
+  RussianTranslation's Elizarenkova witness, SanskritKaraoke meter seeds, PWG German gloss
+  witness) or checking VedaWeb licensing before a new use.
+- **Format / contract:** Phase 0–4 (all done) + a still-queued follow-on ("Phase 2:
+  WhitneyRoots accent-validation run") — each phase carries an executable one-line handoff
+  starter (`Read <path> and execute it.`) per the org's session-starters contract. Any new
+  phase gets the same starter-line treatment.
+
+## Provenance
+- **Created:** 18-07-2026 (handoff H968, Sonnet 5 `claude-sonnet-5`).
+- **Next hardening:** none scheduled — this roadmap is functionally complete; revisit only if
+  a new VedaWeb layer is proposed.
+
+## Improvement backlog (ranked)
+
+| # | Improvement | Why | Status |
+|---|---|---|---|
+| 1 | Downstream a–f accent-mobility emission into ZALIZNYAK_INDEX, gated on Phase 2's per-cell GO/NO-GO | Explicitly named in the subject's "Dependency order" section as the one still-open follow-on outside this roadmap's own scope | parked — tracked as its own follow-on, not owned by this doc |
+
+## Known limitations / caveats
+- All 5 named phases (0–4) are marked done; the doc is close to fully executed — treat it as
+  near-final reference material, not an active work queue, aside from the one flagged
+  follow-on above.
+- Rights note: only 2/36 VedaWeb catalog resources originally carried an explicit `license`
+  field; the blanket "CC BY 4.0" framing was an unverified assumption at triage time, later
+  confirmed in writing by VedaWeb (Kölligan/Reinöhl) for all 4 candidate meter/translation
+  layers — cite the confirmation (§ Phase 4), not the original assumption, if provenance
+  matters.
+- Advisory-only constraint: VedaWeb-derived signal must never be written into reviewed/human
+  data (spines, `headword_index.tsv`, app data) — the doc calls this out explicitly as "the
+  I/VI accent-collapse lesson."
+
+## Intended use / known misuse
+- **For:** finding what VedaWeb data already exists as a registered feed before re-scraping
+  the API, and citing the correct CC BY 4.0 attribution + rights-confirmation trail for any
+  VedaWeb-derived layer used in a paper or export.
+- **Misuse:** re-running the Phase 0/1 API probe or bulk export from scratch — the feed is
+  already landed under `VisualDCS/non-derived/vedaweb/`; consume it, don't rebuild it.
+
+## Maintenance & sunset plan
+- Owner: whoever next touches VedaWeb-derived data (VisualDCS side owns the feed; this repo
+  owns the roadmap doc). No dedicated maintainer.
+- Sunset: once the one remaining follow-on (accent-mobility emission) lands or is explicitly
+  deprioritized, this roadmap is fully executed — retitle as archived/historical rather than
+  deleting, since it is the authoritative record of the VedaWeb rights-confirmation trail.
+
+## Deprecation status
+`active` (functionally near-complete — see backlog item 1 for the one open thread).
+
+## Related documents
+- [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) — §1 (API probe), §72/§73 (renumbered GRA crosswalk and rights findings) cited throughout the subject.
+- [VisualDCS/non-derived/vedaweb/](https://github.com/gasyoun/VisualDCS/tree/main/non-derived/vedaweb) — the landed feed this roadmap describes.
+- [WhitneyRoots crosswalk/accent_rules.json](https://github.com/gasyoun/WhitneyRoots/blob/main/crosswalk/accent_rules.json) — the first downstream consumer.
+- [RussianTranslation/ZALIZNYAK_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ZALIZNYAK_INDEX.md) — the accent-axis emission target for the still-open follow-on.
+
+## Revision history
+
+| Date | Event | Who |
+|---|---|---|
+| 18-07-2026 | Metadoc created (backfill sweep) | Sonnet 5 (`claude-sonnet-5`), H968 |
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/RESEARCH_CAPABILITY_ROADMAP_2026-07-09.meta.md
+++ b/RussianTranslation/RESEARCH_CAPABILITY_ROADMAP_2026-07-09.meta.md
@@ -1,0 +1,79 @@
+# RESEARCH_CAPABILITY_ROADMAP_2026-07-09.meta.md — metadoc for `RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md`
+
+_Created: 18-07-2026 · Last updated: 18-07-2026_
+
+This is a **metadoc** — a document *about* a document. Its subject is
+[RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md).
+It does not duplicate the subject's content; it records everything *around* it. Kept per the
+standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`).
+
+## Subject
+- **Document:** [RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md)
+- **Purpose:** A 30-card, ranked research-capability programme for `pwg_ru` — turns the H335
+  capability audit's four questions into falsifiable, measurable research cards (Claim / Data
+  / Metric / Acceptance / Dependency flag), anchored to an ACL method spine (word alignment,
+  MT/QE, bitext mining, WSD, BLI, annotation reliability, etc.).
+- **Audience:** Whoever picks up the next `pwg_ru` capability-hardening card — each card is
+  self-contained enough to hand to a fresh session.
+- **Format / contract:** Additive to three existing docs it names as its baseline
+  (`PIPELINE_CAPABILITY_AUDIT_2026-07-08.md`, `ACL_TM_CROSSWALK_MEMO.md`,
+  `DECISIONS_PIPELINE_CAPABILITY_H335.md`) — never restates them. Cards are numbered and keep
+  a fixed 5-field contract (Claim/Data/Metric/Acceptance/Dependency flag); new cards append,
+  existing cards' numbers should not be reused if one is dropped.
+
+## Provenance
+- **Created:** 18-07-2026 (handoff H968, Sonnet 5 `claude-sonnet-5`) — this metadoc. The
+  subject document itself dates to 09-07-2026 per its own header (same day for created/updated
+  — authored in one pass, not yet revisited).
+- **Next hardening:** none scheduled — cards get picked up individually as `pwg_ru` capacity
+  allows; no batch revisit planned.
+
+## Improvement backlog (ranked)
+
+| # | Improvement | Why | Status |
+|---|---|---|---|
+| 1 | Card 1 (COMET-QE calibration) — needs a frozen human A/B/C gold slice before it can run | Explicitly flagged `needs gold sample` in the card itself; blocks validating/replacing the `tm_grade.py` proxy | parked — no gold slice built yet, no handoff minted |
+| 2 | Card 3 (BLI evaluation of `corpus_lexicon`) — needs a 300-item Sa→Ru gold set | Same gold-sample dependency as card 1; this roadmap and [ROADMAP_ACL_LESSONS_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_ACL_LESSONS_2026.md) B1 describe overlapping BLI-evaluation work — worth reconciling which doc owns the actual build before both are separately picked up | parked — see cross-doc overlap note below |
+| 3 | This doc and `research/ROADMAP_ACL_LESSONS_2026.md` / `research/ROADMAP_CEILING_2026.md` were authored the same week (08–09-07-2026) with visibly overlapping scope (BLI, WSD, COMET-QE all appear in more than one) — a consolidation pass would prevent divergent card numbering for the same underlying work | Three near-simultaneous roadmaps in the same subsystem risk drifting out of sync as cards get picked off independently | parked — needs a human decision on which doc is canonical for BLI/WSD before consolidating |
+
+## Known limitations / caveats
+- This metadoc's author read roughly the first third of the doc (ACL method spine + cards
+  1–6 of 30) — the remaining ~24 cards were not individually audited; treat the backlog above
+  as a sample, not exhaustive coverage of every card's status.
+- Several cards share the `needs gold sample` dependency flag and no gold sample currently
+  exists per the doc's own text — most of the roadmap is blocked on that one shared
+  prerequisite until a gold-annotation session runs.
+- Visible overlap with `research/ROADMAP_ACL_LESSONS_2026.md`'s B1 (BLI evaluation) and
+  `research/ROADMAP_CEILING_2026.md`'s C1 (in-context WSD) — this doc's cards 3–4 cover
+  similar ground under different card numbering. Not yet resolved which is authoritative.
+
+## Intended use / known misuse
+- **For:** picking the next `pwg_ru` research-hardening task in priority order, with each
+  card's acceptance threshold pre-defined so the work is falsifiable, not open-ended.
+- **Misuse:** starting a `needs gold sample` card without first building the gold set —
+  several cards are silently blocked on that shared prerequisite even though nothing in the
+  doc marks them "blocked" at the top level.
+
+## Maintenance & sunset plan
+- Owner: whoever is driving `pwg_ru` research-capability work (RussianTranslation subsystem).
+  No dedicated maintainer.
+- Sunset: superseded once the overlap with the two `research/ROADMAP_*_2026.md` docs is
+  reconciled (see backlog item 3) — at that point either this doc absorbs them or is folded
+  into whichever survives as canonical.
+
+## Deprecation status
+`active` — cards not yet individually triaged as done/in-progress/blocked at the doc level.
+
+## Related documents
+- [ROADMAP_ACL_LESSONS_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_ACL_LESSONS_2026.md) — overlapping BLI/WSD scope, see backlog item 3.
+- [ROADMAP_CEILING_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_CEILING_2026.md) — overlapping WSD scope, see backlog item 3.
+- [REVIEW_AND_ROADMAP.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/REVIEW_AND_ROADMAP.md) — the higher-level `pwg_ru` build retrospective and phase plan this roadmap's cards feed into.
+- [RussianTranslation/PIPELINE_HISTORY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_HISTORY.md) — required prior reading before touching `pwg_ru` code, per the repo's own CLAUDE.md.
+
+## Revision history
+
+| Date | Event | Who |
+|---|---|---|
+| 18-07-2026 | Metadoc created (backfill sweep) | Sonnet 5 (`claude-sonnet-5`), H968 |
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/REVIEW_AND_ROADMAP.meta.md
+++ b/RussianTranslation/REVIEW_AND_ROADMAP.meta.md
@@ -1,0 +1,87 @@
+# REVIEW_AND_ROADMAP.meta.md — metadoc for `REVIEW_AND_ROADMAP.md`
+
+_Created: 18-07-2026 · Last updated: 18-07-2026_
+
+This is a **metadoc** — a document *about* a document. Its subject is
+[REVIEW_AND_ROADMAP.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/REVIEW_AND_ROADMAP.md).
+It does not duplicate the subject's content; it records everything *around* it. Kept per the
+standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`).
+
+## Subject
+- **Document:** [REVIEW_AND_ROADMAP.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/REVIEW_AND_ROADMAP.md)
+- **Purpose:** The candid retrospective + phased forward plan (A–D) for the `pwg_ru` pipeline
+  (PWG → corpus-attested Russian edition) — what was built, what's good, what's honestly bad
+  (unmeasured precision, flat sense-bag microstructure, the frequency-first pivot), and the
+  roadmap from proving the output through publication.
+- **Audience:** Anyone picking up `pwg_ru` work — this is the single-document orientation for
+  "what state is this pipeline actually in," distinct from the deeper theory/methodology
+  companions it names.
+- **Format / contract:** §1 What was built (pipeline diagram) → §2 What is good → §3 What is
+  bad / honest weaknesses → §4 Roadmap (Phase A–D) → §5 Immediate plan (frequency-first
+  tranche). Companion docs are named at the top, not restated. Machine-readable companions
+  (`roadmap/scientific_hardening.json`, `roadmap/quality_gates.jsonl`) are the canonical
+  phase/gate record — this Markdown file is the human-readable narrative, validated against
+  those JSON/JSONL files via `python src/roadmap_check.py`.
+
+## Provenance
+- **Created:** 18-07-2026 (handoff H968, Sonnet 5 `claude-sonnet-5`) — this metadoc. The
+  subject document itself dates to 09-07-2026 per its own header, describing a build the
+  header's title labels "(2026-06-16)".
+- **Next hardening:** none scheduled — revisit when Phase A (corpus-first re-harvest of the
+  216 a-section cards) completes, since §3's "honest weaknesses" list is keyed to that not-yet-
+  done state.
+
+## Improvement backlog (ranked)
+
+| # | Improvement | Why | Status |
+|---|---|---|---|
+| 1 | Phase A — corpus-first re-harvest + re-translate the 216 a-section cards | Explicitly named "the immediate next action" in §3; the a-section cards are still the OLD provisional translations from before the corpus lexicon existed | parked — no handoff minted at time of this metadoc; check `.ai_state.md` for current status before assuming still pending |
+| 2 | Gold standard + precision/recall with Wilson CIs (Phase B item 1) | §3 flags "Precision is unmeasured... the single most important gap before any print claim" | parked — Phase B, sequenced after Phase A |
+| 3 | Lexicographic microstructure (sense tree, homonym `h`-keying, `equivalence_type`, diasystem labels — Phase B item 2) | §3: "Cards are still a flat sense-bag... The Apresyan 'portrait' is on paper," not built | parked — Phase B |
+| 4 | Reconcile this doc's frequency-first pivot ordering with the card-level research roadmaps ([RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md), `research/ROADMAP_ACL_LESSONS_2026.md`, `research/ROADMAP_CEILING_2026.md`) | Four `pwg_ru`-adjacent roadmap docs authored within days of each other risk sequencing conflicts if not read together | parked — needs a human decision on canonical sequencing owner |
+
+## Known limitations / caveats
+- §3's weaknesses list is a point-in-time honest assessment (dated 09-07-2026 in the header,
+  describing a 2026-06-16 build) — re-check `.ai_state.md` and `CHANGELOG.md` in
+  `RussianTranslation/` before assuming any listed weakness (e.g. "precision is unmeasured")
+  still holds; this metadoc does not re-verify current pipeline state.
+- The doc explicitly separates itself from four companion docs
+  (`METHODOLOGY_REVIEW.md`, `APRESJAN.md`, `HARVEST.md`, `failures/FAILURE_GALLERY.md`,
+  `CHANGELOG.md`) — reading this doc alone gives the roadmap but not the theoretical grounding
+  or the failure-mode detail.
+- Cost tracking in §3 ("~30% over estimate, ~$49 vs ~$37") is specific to the a-section run;
+  do not extrapolate that overrun ratio to the full-PWG scale-up without re-measuring on a
+  representative sample, per the doc's own caveat.
+
+## Intended use / known misuse
+- **For:** orienting a fresh session on `pwg_ru`'s actual current state and honest gaps before
+  making a claim about pipeline quality or picking the next phase to work.
+- **Misuse:** citing §2's "what is good" list as a print-quality claim — the doc itself states
+  in §3 that precision is unmeasured and no gold standard exists yet, so quality claims are
+  provisional until Phase B lands.
+
+## Maintenance & sunset plan
+- Owner: whoever is driving the `pwg_ru` pipeline (RussianTranslation subsystem). No
+  dedicated maintainer named in the doc.
+- Sunset: superseded when Phase D (publish: TEI Lex-0/OntoLex export, CITATION.cff, edition
+  freeze) ships — at that point this becomes a historical retrospective rather than an active
+  roadmap; archive with a pointer to the published edition rather than deleting.
+
+## Deprecation status
+`active` — Phase A explicitly named as the immediate next action, not yet complete as of this
+metadoc's authoring.
+
+## Related documents
+- [METHODOLOGY_REVIEW.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/METHODOLOGY_REVIEW.md) — the 5-lens external review companion.
+- [APRESJAN.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/APRESJAN.md) — the theoretical grounding companion.
+- [HARVEST.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/HARVEST.md) — the harvest-layer companion.
+- [RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md) — the card-level research programme this roadmap's phases feed into.
+- [PIPELINE_HISTORY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_HISTORY.md) — required prior reading before touching `pwg_ru` code.
+
+## Revision history
+
+| Date | Event | Who |
+|---|---|---|
+| 18-07-2026 | Metadoc created (backfill sweep) | Sonnet 5 (`claude-sonnet-5`), H968 |
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/research/ROADMAP_ACL_LESSONS_2026.meta.md
+++ b/RussianTranslation/research/ROADMAP_ACL_LESSONS_2026.meta.md
@@ -1,0 +1,83 @@
+# ROADMAP_ACL_LESSONS_2026.meta.md — metadoc for `ROADMAP_ACL_LESSONS_2026.md`
+
+_Created: 18-07-2026 · Last updated: 18-07-2026_
+
+This is a **metadoc** — a document *about* a document. Its subject is
+[ROADMAP_ACL_LESSONS_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_ACL_LESSONS_2026.md)
+("Roadmap B"). It does not duplicate the subject's content; it records everything *around*
+it. Kept per the standing "one metadoc per important document" convention
+(`~/.claude/CLAUDE.md`).
+
+## Subject
+- **Document:** [ROADMAP_ACL_LESSONS_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_ACL_LESSONS_2026.md)
+- **Purpose:** "Roadmap B" — maps three ACL-adjacent literatures (BLI evaluation, sense-
+  benchmark/WordNet lineage, Lexical Linked Data) onto layers `pwg_ru` already has, with a
+  ground-truth section correcting naive assumptions (OntoLex already exists as a flat export,
+  per-sense dating exists as a Renou proxy, DCS genre is per-lemma not per-sense) and a
+  ruled decision log from an 08-07-2026 MG session.
+- **Audience:** Whoever picks up B1 (BLI evaluation), B2 (sense-benchmark), or B3 (LLOD
+  upgrade) work on `pwg_ru`'s interoperability exports.
+- **Format / contract:** Explicitly complementary to
+  [ROADMAP_CEILING_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_CEILING_2026.md)
+  ("Roadmap A") and
+  [ACL_ANTHOLOGY_MONITOR.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ACL_ANTHOLOGY_MONITOR.md)
+  — the doc states explicitly "complement, don't duplicate." A ground-truth section, three
+  ranked work items (B1/B2/B3), a phasing table (Wave 0/1/2), and a decision log at the
+  bottom (never edited retroactively — new decisions append as new rows).
+
+## Provenance
+- **Created:** 18-07-2026 (handoff H968, Sonnet 5 `claude-sonnet-5`) — this metadoc. The
+  subject document itself dates to 08-07-2026 per its own header.
+- **Next hardening:** none scheduled — revisit at the "Wave 2 (after ~50% coverage)" trigger
+  named in the doc's own phasing table.
+
+## Improvement backlog (ranked)
+
+| # | Improvement | Why | Status |
+|---|---|---|---|
+| 1 | B3 milestones 1–3 (real IRIs via w3id.org, `vartrans` sense-links, PROV-O provenance) | Named "Wave 1 (parallel with translation)" — the doc calls this a "quick win," deterministic edits to one exporter + its selftest | parked — Wave 1, no handoff minted at time of this metadoc |
+| 2 | IndoWordNet rights check before the B2 synset crosswalk | Doc flags "Rights first" — IndoWordNet's license is restrictive; needs a Samsaadhanii/Kulkarni contact check before building | parked — Wave 1, `@DECIDE` on composition pending the license quote |
+| 3 | B1 gold set + P@1/MRR scoring for `corpus_lexicon` | Named "Wave 2 (after ~50% coverage)" — sequenced deliberately after translation coverage, not a Wave-0/1 item | parked — Wave 2, coverage-gated |
+| 4 | Reconcile with [RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md), which independently proposes overlapping BLI-evaluation work (its cards 2–3) one day later | Two sibling roadmaps under different numbering schemes describing the same B1/BLI work risks drift | parked — needs a human decision on which doc owns the actual BLI build task |
+
+## Known limitations / caveats
+- The doc's own "Ground truth" section is itself a correction of an earlier, more pessimistic
+  reading of what `pwg_ru` already has (e.g. "OntoLex already exists... Upgrade, not
+  stand-up") — treat the Ground truth section as the current authoritative baseline, not the
+  original framing it corrects.
+- Wave-gating (Wave 0 now / Wave 1 parallel-with-translation / Wave 2 after ~50% coverage)
+  means B1/B2's headline gold-set work is intentionally not startable yet; check translation
+  coverage in `RussianTranslation/.ai_state.md` before assuming Wave 2 is unlocked.
+- Overlaps with `RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md` (see backlog item 4) — this doc
+  and that one were not obviously cross-referenced against each other at authoring time.
+
+## Intended use / known misuse
+- **For:** understanding what ACL-literature-informed upgrade path exists for `pwg_ru`'s
+  interoperability exports (OntoLex/TEI Lex-0) and sense-evaluation benchmarks before
+  proposing a new one from scratch.
+- **Misuse:** starting B1/B2 gold-set work before the Wave-2 coverage gate — the doc
+  deliberately sequences model/benchmark phases after ~50% translation coverage, not before.
+
+## Maintenance & sunset plan
+- Owner: whoever drives `pwg_ru` ACL-literature-informed research work. No dedicated
+  maintainer.
+- Sunset: superseded once B1–B3 all land, or folded into
+  [ACL_ANTHOLOGY_MONITOR.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ACL_ANTHOLOGY_MONITOR.md)
+  if that becomes the standing complement doc's permanent home for this material.
+
+## Deprecation status
+`active` — Wave 0 in progress per the doc's phasing, Waves 1–2 not started.
+
+## Related documents
+- [ROADMAP_CEILING_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_CEILING_2026.md) — "Roadmap A," the explicit companion this doc cross-references.
+- [ACL_ANTHOLOGY_MONITOR.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ACL_ANTHOLOGY_MONITOR.md) — the standing complement doc named at the top of the subject.
+- [RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md) — overlapping BLI-evaluation scope, see backlog item 4.
+- [REVIEW_AND_ROADMAP.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/REVIEW_AND_ROADMAP.md) — the higher-level pipeline roadmap this feeds into.
+
+## Revision history
+
+| Date | Event | Who |
+|---|---|---|
+| 18-07-2026 | Metadoc created (backfill sweep) | Sonnet 5 (`claude-sonnet-5`), H968 |
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/research/ROADMAP_CEILING_2026.meta.md
+++ b/RussianTranslation/research/ROADMAP_CEILING_2026.meta.md
@@ -1,0 +1,82 @@
+# ROADMAP_CEILING_2026.meta.md — metadoc for `ROADMAP_CEILING_2026.md`
+
+_Created: 18-07-2026 · Last updated: 18-07-2026_
+
+This is a **metadoc** — a document *about* a document. Its subject is
+[ROADMAP_CEILING_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_CEILING_2026.md)
+("Roadmap A"). It does not duplicate the subject's content; it records everything *around*
+it. Kept per the standing "one metadoc per important document" convention
+(`~/.claude/CLAUDE.md`).
+
+## Subject
+- **Document:** [ROADMAP_CEILING_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_CEILING_2026.md)
+- **Purpose:** "Roadmap A" — an honest ceiling analysis of what the PWG→RU dictionary
+  *cannot* answer without an external model or dated corpus bolted on (in-context WSD,
+  sense chronology, frequency outside DCS, modern etymology, register/pragmatics, scholarly
+  consensus, citation residue, cross-lingual vocabulary), with each of 8 items (C1–C8) ruled
+  by MG on 08-07-2026 as BUILD / PARTIAL / STAYS-OUT, plus the bolt-on named for each.
+- **Audience:** Whoever needs to know, before making a claim, whether `pwg_ru` can actually
+  answer a given question (e.g. "which sense is live in this passage") or whether that
+  requires an explicitly named external bolt-on.
+- **Format / contract:** A single ceiling-item table (C1–C8: Verdict + bolt-on), a phasing
+  section (Wave 0/1/2), and a decision log (MG rulings, 08-07-2026) at the bottom — the
+  decision log is append-only, ruled forks are not re-litigated without a new MG session.
+
+## Provenance
+- **Created:** 18-07-2026 (handoff H968, Sonnet 5 `claude-sonnet-5`) — this metadoc. The
+  subject document itself dates to 08-07-2026 per its own header.
+- **Next hardening:** none scheduled — revisit at the "Wave 2 (after ~50% translation
+  coverage)" trigger named in the doc's own phasing table.
+
+## Improvement backlog (ranked)
+
+| # | Improvement | Why | Status |
+|---|---|---|---|
+| 1 | C2 Phase 1 — join each sense's `<ls>` citations to `ls_source_map.json`'s date/period/renou fields for a per-sense attestation window | Named "Wave 1 (parallel with translation, cheap derivables)" — deterministic, no external dependency | parked — Wave 1, no handoff minted at time of this metadoc |
+| 2 | C4 — KEWA normalization + join using the already-OCRed KEWA index | Rights are unlocked (MG holds written Mayrhofer permission); the index already exists on disk — this is a "locate + quote terms verbatim, then join" task, not new acquisition | parked — Wave 1; GTD `@DO` to locate/quote the permission terms verbatim before publication-tier use |
+| 3 | C8 — DharmaMitra license-gated probe + outreach draft | Named Wave 1; rights-gated, so gated on `/license-gated-ingest` + `/outreach-draft` completing first | parked — Wave 1, rights-gated |
+| 4 | C1 embedding-WSD baseline + gold set (Wave 2) | Sequenced deliberately after ~50% translation coverage per the doc's own phasing — the highest-value ceiling item (in-context WSD) but intentionally not startable yet | parked — Wave 2, coverage-gated |
+
+## Known limitations / caveats
+- Every C-item verdict (BUILD / PARTIAL / STAYS-OUT / STAYS-PROXY / MEASURE+SHRINK / PROBE)
+  was a human ruling on 08-07-2026, not a technical default — re-litigating a verdict (e.g.
+  "why can't we just build C6 consensus-meaning resolution") needs a new MG session, not a
+  unilateral re-read of the ceiling table.
+- C3 ("Frequency outside DCS") is explicitly "STAYS PARTIAL forever" by design — DCS is a
+  sample, and the doc is explicit that widening it (GRETIL ingestion) "never closes the
+  inference gap." Do not read future GRETIL work as eventually promoting C3 to BUILD.
+- Overlaps with `ROADMAP_ACL_LESSONS_2026.md`'s B1 (BLI, adjacent to but distinct from this
+  doc's C1 WSD) — the two roadmaps share a phasing rhythm (Wave 0/1/2) and were authored the
+  same day, but cover different ceiling items; cross-check both before assuming either is
+  exhaustive for "what pwg_ru's research programme covers."
+
+## Intended use / known misuse
+- **For:** checking, before publishing a claim from `pwg_ru`, whether the dictionary alone
+  supports it or whether it needs an explicitly named external bolt-on (and what that bolt-on
+  is) per the C1–C8 table.
+- **Misuse:** treating a "PARTIAL" or "STAYS PROXY" verdict as eventually resolvable to full
+  coverage — several items (C3, C5) are explicitly permanent ceilings by the ruling, not
+  temporary gaps.
+
+## Maintenance & sunset plan
+- Owner: whoever drives `pwg_ru`'s research-capability work. No dedicated maintainer.
+- Sunset: individual C-items get struck/updated as their bolt-ons land (e.g. C4 once KEWA
+  join ships); the doc as a whole sunsets only if a future ruling session revisits and
+  re-rules the ceiling wholesale.
+
+## Deprecation status
+`active` — Wave 0 in progress per the doc's phasing, Waves 1–2 not started.
+
+## Related documents
+- [ROADMAP_ACL_LESSONS_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_ACL_LESSONS_2026.md) — "Roadmap B," the explicit companion this doc cross-references.
+- [ls_source_map.json](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ls_source_map.json) — the per-work dating source C2 Phase 1 joins against.
+- [LEARNER_APPARATUS_SPEC.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/LEARNER_APPARATUS_SPEC.md) — documents the KEWA dhātu-form join gotcha referenced under C4.
+- [REVIEW_AND_ROADMAP.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/REVIEW_AND_ROADMAP.md) — the higher-level pipeline roadmap this feeds into.
+
+## Revision history
+
+| Date | Event | Who |
+|---|---|---|
+| 18-07-2026 | Metadoc created (backfill sweep) | Sonnet 5 (`claude-sonnet-5`), H968 |
+
+_Dr. Mārcis Gasūns_

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,11 @@ not an error.
 
 ## [Unreleased]
 
+## [1.22.0] — 18-07-2026
+
+### Added
+- **H968 — 11 metadocs backfilled for hook-flagged genre-named docs (18-07-2026, Sonnet 5 `claude-sonnet-5`)**: sibling `<name>.meta.md` companions authored for every currently-missing metadoc in scope — [FEATURES_INDEX.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.meta.md), [FINDINGS.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.meta.md), [HERITAGE_INRIA_ROADMAP.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/HERITAGE_INRIA_ROADMAP.meta.md), [ROADMAP_ACC_NCC.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_ACC_NCC.meta.md), [ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.meta.md), [ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.meta.md), [ROADMAP_VEDAWEB_REUSE.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_VEDAWEB_REUSE.meta.md), and three RussianTranslation roadmaps ([RESEARCH_CAPABILITY_ROADMAP_2026-07-09.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESEARCH_CAPABILITY_ROADMAP_2026-07-09.meta.md), [REVIEW_AND_ROADMAP.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/REVIEW_AND_ROADMAP.meta.md), [research/ROADMAP_ACL_LESSONS_2026.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_ACL_LESSONS_2026.meta.md), [research/ROADMAP_CEILING_2026.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_CEILING_2026.meta.md)). Each carries purpose/audience/format, a ranked improvement backlog with real owners (`H###` or `parked — <reason>`), known limitations read from the actual subject text, deprecation status, and related-doc links; two cross-doc overlaps were surfaced (BLI-evaluation work duplicated across `RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md` and `research/ROADMAP_ACL_LESSONS_2026.md`) as backlog items rather than silently resolved.
+
 ## [1.21.0] — 18-07-2026
 
 ### Changed


### PR DESCRIPTION
## Summary
- Adds sibling `<name>.meta.md` companions for 11 previously-uncovered, load-bearing docs: `FEATURES_INDEX.md`, `FINDINGS.md`, `HERITAGE_INRIA_ROADMAP.md`, `ROADMAP_ACC_NCC.md`, `ROADMAP_ATLAS_FAIR_PUBLICATIONS_2026_2027.md`, `ROADMAP_STATISTICS_ORG_CENSUS_2026_2027.md`, `ROADMAP_VEDAWEB_REUSE.md`, plus three `RussianTranslation/` roadmaps (`RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md`, `REVIEW_AND_ROADMAP.md`, `research/ROADMAP_ACL_LESSONS_2026.md`, `research/ROADMAP_CEILING_2026.md`).
- Each metadoc: purpose/audience/format, a ranked improvement backlog with real owners (`H###` or `parked — <reason>`, never invented handoff numbers), known limitations read from the actual subject text, deprecation status, and related-doc links.
- Surfaces two cross-doc overlaps (BLI-evaluation work duplicated across `RESEARCH_CAPABILITY_ROADMAP_2026-07-09.md` and `research/ROADMAP_ACL_LESSONS_2026.md`) as backlog items for a human to reconcile, rather than silently resolving them.
- Bumps `changelog.md` to 1.22.0 and `CITATION.cff` to match, per the repo's changelog/release-coupling convention.

## Test plan
- [x] All 11 subject docs read in full/substantial part before authoring their metadoc.
- [x] Creation dates sourced from `git log --follow --diff-filter=A` per doc.
- [x] All links are full `blob` URLs against `master` (not relative).
- [x] No new metadoc has an unowned open backlog row.