### PR TITLE
findings+contradictions: kosha A3 morphology audit (H1262)

### DIFF
--- a/CONTRADICTIONS.md
+++ b/CONTRADICTIONS.md
@@ -43,6 +43,18 @@ Blocks: the GasunsDhatu 2026 §2.6 Table 5 / П9 correction (manifest `varga-ser
 ↔ Interlinks: [RECIPES §4](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md) (varga diachrony) is the reproducible pass whose χ² table the prose misread · [GAPS §8](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) is the same epoch-stability question one layer down (collocations vs vargas) · [GLOSSARY "varga"](https://github.com/gasyoun/SanskritLexicography/blob/master/GLOSSARY.md) defines the unit in dispute.
 > **Source:** [FINDINGS §62](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards) · [SanskritGrammar](https://github.com/gasyoun/SanskritGrammar)/[VisualDCS](https://github.com/gasyoun/VisualDCS) · [08-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-08&until=2026-07-09) · `claude-opus-4-8`
 
+### §6. Concordance-Q3 plan set: kosha generated side is `forms` or `inflections` (5× apart)
+🟠 ✍️ **The Concordance-Q3 plan set names two different kosha tables as the generated inflection side, off by 5×.**
+Positions:
+| Source | Value | Evidence loc |
+|--------|-------|--------------|
+| IMPLEMENTATION § W1b deliverable text | `forms` — 1,378,401 rows (426,410 non-heritage) | [morph build report](https://github.com/gasyoun/kosha/blob/main/data/concordance/MORPHOLOGY_ATTESTATION_BUILD_REPORT.md) |
+| ARCHITECTURE § 2 diagram ("6.9M generated") | `inflections` — 6,917,018 rows | same |
+Status: 🟡 provisional pick — A3 (W1b) built on `forms`, the only table with a `source` column, which the trust-ordering / `include_heritage` discipline requires; `inflections` does not distinguish heritage and was NOT folded in. Which table A4 measures is a human call.
+Blocks: the A4 derivation-capture (W2a) generated-side denominator; the architecture diagram's "6.9M" should be corrected to name `inflections`, not propagated forward.
+↔ Interlinks: [FINDINGS §94](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) is the circularity finding (93% DCS-derived generated side) from the same A3 build.
+> **Source:** [H1262](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1262-Opus_kosha_a3_attested_form_join_morphology_audit_18.07.26.md) morphology attestation audit · [kosha](https://github.com/gasyoun/kosha) · [18-07-2026](https://github.com/gasyoun/SanskritLexicography/commits/master?since=2026-07-18&until=2026-07-19) · `claude-opus-4-8`
+
 ## B. A claim overturned (or split) by machine-scale evidence
 *A scholarly charge or a hand-picked exemplar checked against a full machine dataset — the count adjudicates.*
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2607,3 +2607,27 @@ re-read, and 2 were outright `refuted`; a finding's age is not evidence of its s
 > enforcement landed in [PR #530](https://github.com/gasyoun/SanskritLexicography/pull/530) ·
 > [H1110](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1110-Opus_SanskritLexicography_pwg-ru-post-h1080-audit-fix-skills-c4-restart_17.07.26.md) ·
 > 18-07-2026, Opus 4.8 (`claude-opus-4-8`).
+
+### §94. kosha's generated `forms` is 93% DCS-derived, so its attested-form join is a round-trip — only the vidyut-engine subtotal (12.4% attested) carries signal, and A¬G cannot measure engine gaps
+
+**Measured 18-07-2026** (Opus 4.8 `claude-opus-4-8`, H1262, A3 / Concordance-Q3 W1b): joining
+kosha.db `forms` (non-heritage: 426,410 rows) against DCS attested **surface** forms
+(`dcs_full.sqlite token.form`; 381,413 distinct) on `form_key()` equality — the length-preserving
+floor tier — gives AG 401,368 / G¬A 25,042 / **A¬G 2**. The AG looks like 94% coverage, but
+**93.30% of the non-heritage generated side is itself `source='dcs'`** (ingested DCS surface tokens,
+several still carrying `''`-avagraha sandhi markers), so its AG is a **99.99% round-trip**. The only
+research-meaningful subtotal is the **vidyut**-engine one: AG 3,550 / 28,567 = **12.43% attested**,
+25,017 over-generated. Two consequences no downstream wave may forget: (1) any "coverage" headline
+over the full generated side is circular — always split AG by generated-side `source` and quote
+vidyut, never the total; (2) **A¬G is degenerate (=2: `oṃ` plus one German OCR token) and CANNOT
+measure engine gaps from this join**, because the DCS-derived generated forms blanket the attested
+surface set — reported as the finding, not hidden (0 genuine engine gaps, nothing routed to the
+csl-inflect give-back H185). `tense_caveat` follows [§91](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)
+(DCS `Past` lumps aorist + perfect): 16,339 AG rows carry a `Past` attestation. The
+`forms`-vs-`inflections` generated-side table ambiguity is logged separately in
+[CONTRADICTIONS §6](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md).
+
+> **Source:** [morphology-attestation build report](https://github.com/gasyoun/kosha/blob/main/data/concordance/MORPHOLOGY_ATTESTATION_BUILD_REPORT.md)
+> + manifest row `morphology-attestation-audit` ([datasets.json](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json)) ·
+> [H1262](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1262-Opus_kosha_a3_attested_form_join_morphology_audit_18.07.26.md) ·
+> [kosha](https://github.com/gasyoun/kosha) · 18-07-2026, Opus 4.8 (`claude-opus-4-8`).


### PR DESCRIPTION
Two epistemic-registry appends from the kosha A3 morphology-attestation audit (H1262, Concordance-Q3 W1b), executed by Opus 4.8 (`claude-opus-4-8`):

- **[FINDINGS §94]** — kosha's generated `forms` is 93.30% DCS-derived (`source='dcs'`), so joining it against DCS attestation is a 99.99% round-trip. The vidyut-engine subtotal (AG 3,550 / 28,567 = **12.43% attested**) is the only research-meaningful figure; A¬G is degenerate (=2) and cannot measure engine gaps here — reported, not hidden. Cross-links the pre-existing §91 (DCS `Past` lumps aorist+perfect).
- **[CONTRADICTIONS §6]** (group A, source-disagrees-with-itself) — the plan set names two different tables (`forms` 1.38M vs `inflections` 6.9M) as kosha's generated side; A3 built on `forms`; which table A4 measures is a human call. STOP-AND-SURFACE, not resolved.

Registry-only change (no code). Companion to the kosha A3 build PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)