### PR TITLE
fix(pwg_ru): register §7 CONTRADICTIONS pointer (section A, not B)

### DIFF
--- a/RussianTranslation/pwg_ru/H178_DA_VOTE_ISSUE_REGISTER_2026-07-19.md
+++ b/RussianTranslation/pwg_ru/H178_DA_VOTE_ISSUE_REGISTER_2026-07-19.md
@@ -139,7 +139,7 @@ The 10-07-2026 ruling in
 19-07-2026 vote notes (`Caus.` = `кауз.`, `Aor.` "нельзя не переводить", "only
 Latin by ratified unified list"). Logged as a 🔴 row in
 [`CONTRADICTIONS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md)
-(§ B — sources disagree across time); H1303's ratified list is the designated
+(§ A — the project's own policy disagrees with itself across time, row §7); H1303's ratified list is the designated
 resolution path, after which the row graduates to a `D##` decision record.
 
 _Dr. Mārcis Gasūns_


### PR DESCRIPTION
One-line factual fix in [H178_DA_VOTE_ISSUE_REGISTER_2026-07-19.md](https://github.com/gasyoun/SanskritLexicography/blob/h178-register-section-fix/RussianTranslation/pwg_ru/H178_DA_VOTE_ISSUE_REGISTER_2026-07-19.md): the abbreviation contradiction row landed under CONTRADICTIONS section A (§7), not section B as the register's §7 aside claimed. Caught by the H1303 draft-verify agent during the [H1300](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1300-Fable_RussianTranslation_h178-da-vote-processing_19.07.26.md) batch fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)