### PR TITLE
H1307: <ls> link enrichment — Panini deep/browse links, Spr. (II) full text, DHATUP. spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,9 @@ jobs:
           python src/pilot/translation_memory.py selftest
           python src/pilot/lang_parity_check.py
           python src/pilot/check_launch_ledger.py --since 2026-07-05
+      - name: Validate <ls> link enrichment (Panini + Spr. (II), H1307)
+        working-directory: RussianTranslation
+        run: python src/pilot/ls_enrichment_selftest.py
       - name: Validate roadmap
         working-directory: RussianTranslation
         run: python src/roadmap_check.py

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2383,6 +2383,22 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H1307 `<ls>` link enrichment — EXECUTED 19-07-2026 (Opus 4.8 `claude-opus-4-8`).**
+  Pāṇini/Spr./DHĀTUP. enrichment on the pwg_ru render layer (MG's N14/N3(b)/N15 vote).
+  Full-form `P. a,p,s` deep links already 100% (25,061/25,061); guarded 2-param/1-param
+  chapter/book browse patterns added (pada 1–4, adhyāya 1–8 guarded — page-refs like
+  `P. II, S. 3` correctly withheld). Every `Spr. (II) N` (8,684, 100% linked) gains an
+  IAST+German full-text tooltip from `indische_sprueche.jsonl` behind a 1st-ed edition
+  guard. `DHĀTUP.`→Palsule = committed acquisition spec (no machine-readable Palsule
+  list exists org-wide; Westergaard gaṇa-level link stays). New `src/spr_fulltext.py`,
+  `src/ls_coverage.py`, `src/pilot/ls_enrichment_selftest.py` (CI-wired); coverage table
+  + spec in [`ABBREVIATIONS_RU.md`](ABBREVIATIONS_RU.md), history in `PIPELINE_HISTORY.md`.
+  URL forms live-verified (ashtadhyayi.com is an SPA → verified vs its backing data repo;
+  boesp bare-`?N` is the only cross-edition form). Coverage computed from pwg.txt
+  (RU store absent locally — Prerequisite 1 substitution); article_site not regenerated
+  (needs the store) — render path unit-verified via `_render()`. All gates green
+  (window_selftest 147/147, parity 55/no-drift, ruff clean).
+
 - **H738 src script hygiene — EXECUTED 18-07-2026 (Fable 5 `claude-fable-5`).** Path
   anchoring + UTF-8 preambles + orphan triage + full CI compile gate; details in the
   [changelog](https://github.com/gasyoun/SanskritLexicography/blob/master/changelog.md) entry.

--- a/RussianTranslation/ABBREVIATIONS_RU.md
+++ b/RussianTranslation/ABBREVIATIONS_RU.md
@@ -1,6 +1,6 @@
 # PWG `<ab>`/`<ls>` abbreviations — tooltips and RU-column purity
 
-_Created: 10-07-2026 · Last updated: 10-07-2026_
+_Created: 10-07-2026 · Last updated: 19-07-2026_
 
 ## Why this exists
 
@@ -133,11 +133,106 @@ lookaround context checks (see their docstrings for the exact mechanism):
   override that. Whether `mw_ru` has the same German/Latin-leak problem is an
   open question, not investigated here.
 
+## `<ls>` link enrichment (Pāṇini · Spr. · DHĀTUP.) — H1307
+
+Three `<ls>` citation classes gain reader-facing enrichment on the pwg_ru
+surfaces (article site now; review sheets via the shared `_render()`/`_ls_tooltip`
+layer). Wired 19-07-2026 (Opus 4.8, `claude-opus-4-8`), born of MG's DA-sheet vote
+(register rows N14 · N3(b) · N15 in
+[H178_DA_VOTE_ISSUE_REGISTER_2026-07-19.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H178_DA_VOTE_ISSUE_REGISTER_2026-07-19.md)).
+All work extends the existing Cologne-port resolver
+[`ls_resolver.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ls_resolver.py)
++ render layer — no second resolver.
+
+### Coverage
+
+| class | total | linked | linked % | tooltip | full-text enriched |
+|---|--:|--:|--:|--:|--:|
+| `P.` (Pāṇini) | 25351 | 25065 | 98.9% | 25349 | — (n/a) |
+| `Spr.` (1st ed) | 13133 | 12953 | 98.6% | 13133 | — (n/a) |
+| `Spr. (II)` (2nd ed) | 8684 | 8684 | 100.0% | 8684 | 8395 |
+| `DHĀTUP.` | 2760 | 2659 | 96.3% | 2760 | — (n/a) |
+
+- **Full-form Pāṇini `P. a,p,s` (3-param):** 25061 / 25061 linked (**100.0%**) — the H1307 DoD target.
+- **`Spr. (II) N` (2nd ed):** 8684 / 8684 linked (**100.0%**), 8395 full-text enriched (96.7% of linked).
+
+_Denominator: full source [`csl-orig/v02/pwg/pwg.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/main/v02/pwg/pwg.txt) — the RU store
+`src/pwg_ru_translated.jsonl` was absent on this machine, so per H1307 Prerequisite 1 the
+count uses the whole PWG corpus (a superset of the RU-translated subset). Recompute against
+the store when present: `python src/ls_coverage.py --md` (raw JSON → gitignored
+`pwg_ru/eval/ls_coverage.json`). Generated 19-07-2026._
+
+### Pāṇini `P.` → ashtadhyayi.com
+
+The full form `P. adhyaya,pada,sutra` deep-links to
+`https://ashtadhyayi.com/sutraani/{adhyaya}/{pada}/{sutra}` (unchanged; the N14
+continuation form `n="P. 2,3,"` + visible `10.` resolves to `/sutraani/2/3/10` by
+concatenation). **URL-form verification:** ashtadhyayi.com is a client-side SPA, so a
+live HTTP 200 proves nothing (an invalid `/9/9/9` also returns 200 with the same shell).
+The form was instead verified against the site's own authoritative backing data repo
+[`ashtadhyayi-com/data`](https://github.com/ashtadhyayi-com/data) (`sutraani/data.txt`:
+fields `a`=adhyaya, `p`=pada, `n`=number; 1.1.14 = निपात एकाजनाङ्), confirming the
+adhyaya/pada/sutra decomposition. **Browse affordance** (MG's N14 "list of sūtras by
+chapter and book"): a 2-param `P. a,p` links to the pāda list `/sutraani/{a}/{p}` and a
+1-param `P. a` to the adhyāya list `/sutraani/{a}` — the site's own browse routes, no
+local sūtra list built. Both patterns are **guarded** to Pāṇini's real ranges (pada 1–4,
+adhyāya 1–8) so ambiguous or non-sūtra forms never mislink: `P. 1,23` (23 is no pada),
+`P. 1,6` (pada 6), and the page-reference form `P. II, S. 3` (Böhtlingk vol. II, Seite 3
+— **not** a sūtra) all correctly stay unlinked.
+
+### `Spr.` / `Spr. (II)` → Indische Sprüche
+
+Edition routing is unchanged and was **live-verified** this session: plain `Spr. N`
+(1st ed) → [boesp1](https://sanskrit-lexicon-scans.github.io/boesp1/app1/?1415) and
+`Spr. (II) N` (2nd ed) → [boesp2](https://sanskrit-lexicon-scans.github.io/boesp2/web1/boesp.html?6145),
+both via a **bare `?N`** query. Verified against the viewers' own `main.js`: boesp2 accepts
+both `?N` and `?verse=N`; boesp1 accepts **only** `?N` — so the resolver's bare-`N` form is
+the single one that works uniformly, and switching to `verse=N` (as one README documents)
+would silently break every 1st-ed link. No resolver change was needed. **Full-text
+enrichment** (MG's N3(b)): every `Spr. (II) N` gains a hover tooltip carrying the saying's
+IAST verse + German translation from the recognized full text
+([`indische_sprueche.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/IndischeSprueche/data/indische_sprueche.jsonl),
+7,537 sayings numbered 1–7878 with 341 numbering gaps), while keeping the boesp2 href.
+**Edition guard** ([PWG#87](https://github.com/sanskrit-lexicon/PWG/issues/87)): the 1st-ed
+`Spr. N` (5,419 sayings) is a *different* edition and is never resolved against the 2nd-ed
+JSONL — `spr_fulltext.second_ed_num()` matches only the `Spr. (II) <digit>` form. The 3.3%
+of linked `Spr. (II)` refs left unenriched fall in the JSONL's numbering gaps (plus one
+lone source-data typo, `Spr. (II) 15802`, beyond the edition's range — it links but cannot
+enrich, never mis-enriches).
+
+### `DHĀTUP.` → Palsule — SPEC'D-NOT-WIRED (acquisition spec)
+
+MG's N15 asks that `DHĀTUP. x,y` citations cite the Palsule list. **Verdict: cannot be
+wired from existing data — spec only.** A local hunt (SanskritGrammar
+[`PALSULE_AUDIT.md`](https://github.com/gasyoun/SanskritGrammar/blob/main/GasunsDhatu_2014/revision-2026/PALSULE_AUDIT.md),
+WhitneyRoots, [kosha datasets.json](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json),
+SanskritLexicography [FINDINGS §63](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md))
+found **no** machine-readable Palsule-numbered dhātupāṭha and **no** Böhtlingk/Westergaard→Palsule
+concordance anywhere in the org. The only machine-readable list is the vidyut dhātupāṭha
+(2,259 dhātus, keyed by gaṇa.sūtra, SLP1) — a *different* numbering. PWG's `DHĀTUP. x,y` is
+Böhtlingk's own gaṇa-arranged edition (x=gaṇa, y=serial-within-gaṇa); Palsule assigns its
+own ~3,690-entry numbering. The current resolver already links `DHĀTUP. x,y` to the
+Westergaard scan viewer at gaṇa level (2,659/2,760 = 96.3%); that stays. **Acquisition spec
+to deliver Palsule references:** (a) digitize Palsule's numbered list from the print source
+(G.B. Palsule, *The Sanskrit Dhātupāṭhas*); (b) build a verified Böhtlingk-`DHĀTUP.`↔vidyut
+gaṇa.sūtra crosswalk; (c) normalize ablaut/citation-form (per FINDINGS §90 and the H328
+negative result: a naive it-stripped join matched only 454/930 Whitney roots). Natural owner:
+article **A39** ([Uprava/ARTICLES.md](https://github.com/gasyoun/Uprava/blob/main/ARTICLES.md)).
+**No fabricated links.**
+
 ## Files touched
 
 * [`RussianTranslation/src/pwg_ab_ru.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_ab_ru.py) — new; the DE→RU editorial-abbreviation map + coverage CLI.
 * [`RussianTranslation/src/iast_to_cyrillic.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/iast_to_cyrillic.py) — new; best-effort IAST→Cyrillic transliterator for `<is>` proper names.
 * [`RussianTranslation/src/pilot/build_article_site.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/build_article_site.py) — `_render()` gained a `lang` parameter; `<ab>`/`<ls>` tooltips; `<is>` Cyrillicization; new `abbreviations.html`/`abbreviations.js` dashboard (`ab_frequency()` + `emit_abbreviations()`).
 * `RussianTranslation/article_site/` — regenerated output (147 roots, 11,275 senses at time of writing).
+
+H1307 `<ls>` link enrichment (19-07-2026):
+
+* [`RussianTranslation/src/ls_resolver.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ls_resolver.py) — guarded Pāṇini 2-param (`/sutraani/a/p`) and 1-param (`/sutraani/a`) chapter/book browse patterns.
+* [`RussianTranslation/src/spr_fulltext.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/spr_fulltext.py) — new; Indische Sprüche 2nd-ed full-text lookup + `Spr. (II)` edition guard, for tooltips.
+* [`RussianTranslation/src/pilot/build_article_site.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/build_article_site.py) — `_ls_tooltip()` (Spr. (II) full text over source title), wired into the html tooltip + md link title.
+* [`RussianTranslation/src/ls_coverage.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ls_coverage.py) — new; per-class `<ls>` coverage counter (store, else pwg.txt).
+* [`RussianTranslation/src/pilot/ls_enrichment_selftest.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/ls_enrichment_selftest.py) — new; fixture selftest, wired into the RussianTranslation CI gates.
 
 _Dr. Mārcis Gasūns_

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -558,7 +558,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H321 (code review 2026-07-04 item #5). ls_resolver resolves an <ls> citation to a scan/hymns URL independent of the translation language (it keys on the citation abbreviation + numbers, never on RU/EN prose), so both language editions' link-targets share it. The anchored _is_rv_prefix and the _warn_swallowed exception surfacing are pure link-resolution correctness, no lang branch. Pinned by test_ls_resolver_rv_av_anchored.",
     "tracking": "",
     "verified_sha256": {
-      "src/ls_resolver.py": "583d0251cfd68e74b3f56b639dd95110477e531e13aa0cc2a67c6d5a8b667480",
+      "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
       "src/pilot/window_selftest.py": "cc131795f8978d9bfb1e6223094eb594e14fe69934c91d520907e6de7940ba57"
     }
   },
@@ -1150,6 +1150,27 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/h1209/prep_slice.py": "acf9ddda5a76d19d769f4a794ea7f88b6db88a8ae688b44f7f778ac24ecde48d",
       "src/pilot/h1209/build_args.py": "6f245108c60ae7c777c66900c1da4a53670399e949fbc474b6556d6bd0ed3024",
       "src/pilot/h1209/canonical_audit.py": "9ae794af290af809caf208caba3b71787bd188f7f3174ebc4af7912ca7ead6f3"
+    }
+  },
+  {
+    "id": "ls_link_enrichment_panini_spr_h1307",
+    "mechanism": "H1307 <ls> link enrichment: Pāṇini P. gains guarded chapter/book browse patterns (2-param a,p -> /sutraani/a/p, 1-param a -> /sutraani/a; pada 1-4 / adhyaya 1-8 guarded so page-refs like 'P. II, S. 3' and bogus 'P. 1,23' never mislink); Spr. (II) N gains a full-text hover tooltip (IAST + German from the Indische Sprüche corpus) via spr_fulltext, with a 1st-ed edition guard (plain Spr. N never resolves against the 2nd-ed corpus); the shared _render()/_ls_tooltip layer carries both.",
+    "files": [
+      "src/ls_resolver.py",
+      "src/spr_fulltext.py",
+      "src/pilot/build_article_site.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H1307 (19-07-2026). The enrichment is render-time and keys only on the citation abbreviation + numbers (P. adhyaya/pada/sutra, Spr. (II) saying number) — never on RU/EN translation prose — so both language editions' <ls> link-targets and tooltips share it with no --lang branch. The Spr. (II) saying text is identical across editions. Pinned by src/pilot/ls_enrichment_selftest.py.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
+      "src/spr_fulltext.py": "446fe8ce8146cfdda3a0cd0b2e6f62c3b76e08cfb872823116549ed3992fe0d5",
+      "src/pilot/build_article_site.py": "41c68f01652e49f66a908d89a16c43877923c92f4d0fb2d447d611aec2a399d7"
     }
   }
 ]

--- a/RussianTranslation/PIPELINE_HISTORY.md
+++ b/RussianTranslation/PIPELINE_HISTORY.md
@@ -1,6 +1,6 @@
 # PWG→RU/EN pipeline — history: solutions, failures, current state
 
-_Created: 04-07-2026 · Last updated: 18-07-2026_
+_Created: 04-07-2026 · Last updated: 19-07-2026_
 
 This is the orientation document for anyone (human or session) who needs the
 **shape** of how this pipeline got here, without reading the full
@@ -8,6 +8,29 @@ This is the orientation document for anyone (human or session) who needs the
 narrated). Read this first; go to `.ai_state.md` for exact dates/PRs/numbers on
 any specific claim below, and to [`src/pilot/RUN_FREQ_MAX.md`](src/pilot/RUN_FREQ_MAX.md)
 for the current operating procedure.
+
+### H1307 — `<ls>` link enrichment: Pāṇini, Spr. (II) full text, DHĀTUP. spec (19-07-2026)
+
+MG's DA-sheet vote (N14/N3(b)/N15) asked that Pāṇini citations link to
+ashtadhyayi.com with browsable chapter/book lists, `Spr. (II)` citations expose the
+recognized full text of *Indische Sprüche*, and `DHĀTUP.` cite the Palsule list. All
+three were done by extending the existing Cologne-port `ls_resolver.py` + `_render()`
+layer (no second resolver): the full-form `P. a,p,s` deep link was already 100%
+(25,061/25,061), and guarded 2-param/1-param patterns add the pāda/adhyāya browse routes
+(pada 1–4, adhyāya 1–8 guarded so page-refs like `P. II, S. 3` never mislink); every
+`Spr. (II) N` (8,684, 100% linked) gains an IAST+German hover tooltip from
+`indische_sprueche.jsonl` behind a 1st-ed edition guard.
+
+Two verification lessons: (1) **ashtadhyayi.com is a client-side SPA** — a live 200
+proves nothing (invalid `/9/9/9` also 200s), so the URL form was verified against the
+site's backing data repo `ashtadhyayi-com/data`, not scraped HTML. (2) The Spr. viewers'
+bare `?N` query is the *only* form that works for **both** editions (boesp1 rejects
+`?verse=N`), so the resolver was correctly left unchanged. `DHĀTUP.` → Palsule exited as
+a committed acquisition spec (no machine-readable Palsule list or Böhtlingk→Palsule
+concordance exists anywhere in the org; the existing Westergaard gaṇa-level link stays).
+Coverage table + spec in
+[`ABBREVIATIONS_RU.md`](ABBREVIATIONS_RU.md); fixture selftest
+`src/pilot/ls_enrichment_selftest.py` in CI.
 
 ### H1209 — controller-worker rig validation and the gate-alignment rule (18-07-2026)
 

--- a/RussianTranslation/src/ls_coverage.py
+++ b/RussianTranslation/src/ls_coverage.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+r"""<ls> link-enrichment coverage over the four H1307 citation classes.
+
+Walks the PWG article corpus, extracts every `<ls n="PFX">VIS</ls>` citation,
+and reports per class -- Pāṇini `P.`, `Spr.` (1st ed), `Spr. (II)` (2nd ed),
+`DHĀTUP.` -- four numbers:
+
+  total              <ls> occurrences of the class
+  linked             resolve to a live-verified href (ls_resolver.generate_href)
+  tooltip'd          have hover text (a pwgbib source title, or the Spr. (II) saying)
+  full_text_enriched carry the recognized full text (Spr. (II) only: saying in the
+                     Indische Sprüche corpus)
+
+DENOMINATOR. The deliverable counts the RU *store*'s occurrences when the store
+(`src/pwg_ru_translated.jsonl`, gitignored) is present on this machine. When it is
+absent (Prerequisite 1 of H1307), the count falls back to the full source
+`../csl-orig/v02/pwg/pwg.txt` -- the whole PWG corpus, a superset of the RU subset
+-- and the substitution is stamped in the report. Pass --store / --pwg to override.
+
+  python src/ls_coverage.py [--store PATH] [--pwg PATH] [--out PATH] [--md]
+
+Raw per-class JSON is written to a gitignored path (default pwg_ru/eval/
+ls_coverage.json); only the aggregate markdown table (--md, also printed) is meant
+to be committed (into ABBREVIATIONS_RU.md).
+"""
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter
+from datetime import date
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import ls_resolver as lsr        # noqa: E402
+import pwg_sources as pwgsrc     # noqa: E402
+import spr_fulltext as spr       # noqa: E402
+
+REPO = os.path.dirname(HERE)                                   # RussianTranslation/
+GH = os.path.normpath(os.path.join(HERE, '..', '..', '..'))    # GitHub/ (csl-orig is a sibling repo)
+STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+PWG = os.path.join(GH, 'csl-orig', 'v02', 'pwg', 'pwg.txt')
+DEFAULT_OUT = os.path.join(REPO, 'pwg_ru', 'eval', 'ls_coverage.json')
+
+_LS = re.compile(r'<ls\b([^>]*)>(.*?)</ls>', re.S)
+_N_ATTR = re.compile(r'\bn\s*=\s*"([^"]*)"')
+
+CLASSES = ['P.', 'Spr.', 'Spr. (II)', 'DHĀTUP.']
+
+
+def classify(n_attr, visible):
+    """Return the H1307 class of one <ls>, or None if it is some other siglum.
+
+    `Spr. (II)` is counted ONLY when a saying NUMBER follows the 2nd-ed marker
+    (`Spr. (II) <digit>`) — this is edition-critical AND excludes the stale-
+    attribute artifact where a 1st-ed continuation ref carries a bled-over
+    `n="Spr. (II)"` but a visible `(I) 1649` (the real edition is 1st); those
+    route to plain `Spr.` where they belong. Tested before plain `Spr.`."""
+    s = re.sub(r'\s+', ' ', ('%s %s' % (n_attr or '', visible or '')).strip())
+    s = re.sub(r'<[^>]+>', '', s)
+    if re.match(r'^Spr\.\s*\(II\)\s*[0-9]', s):
+        return 'Spr. (II)'
+    if re.match(r'^Spr\.', s):
+        return 'Spr.'
+    if re.match(r'^P\.', s):
+        return 'P.'
+    if re.match(r'^DH[ĀA]TUP\.', s):
+        return 'DHĀTUP.'
+    return None
+
+
+def _has_tooltip(n_attr, visible, cls):
+    if cls == 'Spr. (II)' and spr.tooltip(n_attr, visible):
+        return True
+    for cand in (n_attr, pwgsrc.source_key(visible or '')):
+        if cand and pwgsrc.resolve(cand):
+            return True
+    return False
+
+
+def iter_store(store_path):
+    """Yield (n_attr, visible) from every <ls> in the RU store's DE source fields."""
+    with open(store_path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+            except ValueError:
+                continue
+            for fld in ('de', 'de_raw', 'ru'):
+                for m in _LS.finditer(r.get(fld) or ''):
+                    nm = _N_ATTR.search(m.group(1))
+                    yield (nm.group(1) if nm else None), m.group(2)
+
+
+def iter_pwg(pwg_path):
+    """Yield (n_attr, visible) from every <ls> in raw pwg.txt."""
+    with open(pwg_path, encoding='utf-8') as f:
+        for line in f:
+            for m in _LS.finditer(line):
+                nm = _N_ATTR.search(m.group(1))
+                yield (nm.group(1) if nm else None), m.group(2)
+
+
+def compute(pairs):
+    per = {c: Counter() for c in CLASSES}
+    # full-form P. (3-param a,p,s) tracked separately for the DoD metric
+    pfull = Counter()
+    for n_attr, vis in pairs:
+        cls = classify(n_attr, vis)
+        if cls is None:
+            continue
+        c = per[cls]
+        c['total'] += 1
+        url = lsr.generate_href('pwg', n_attr, (vis or '').strip())
+        if url:
+            c['linked'] += 1
+        if _has_tooltip(n_attr, vis, cls):
+            c['tooltip'] += 1
+        if cls == 'Spr. (II)':
+            if spr.second_ed_num(n_attr, vis) is not None and spr.saying(spr.second_ed_num(n_attr, vis)):
+                c['enriched'] += 1
+        if cls == 'P.':
+            s = re.sub(r'\s+', ' ', ('%s %s' % (n_attr or '', vis or '')).strip())
+            s = re.sub(r'<[^>]+>', '', s)
+            if re.match(r'^P\.\s*[0-9]+\s*,\s*[0-9]+\s*,\s*[0-9]+', s):
+                pfull['total'] += 1
+                if url:
+                    pfull['linked'] += 1
+    return per, pfull
+
+
+def pct(num, den):
+    return (100.0 * num / den) if den else 0.0
+
+
+def md_table(per, pfull, source_label):
+    L = []
+    L.append('| class | total | linked | linked % | tooltip | full-text enriched |')
+    L.append('|---|--:|--:|--:|--:|--:|')
+    for c in CLASSES:
+        d = per[c]
+        enr = ('%d' % d['enriched']) if c == 'Spr. (II)' else '— (n/a)'
+        L.append('| `%s` | %d | %d | %.1f%% | %d | %s |' % (
+            c, d['total'], d['linked'], pct(d['linked'], d['total']), d['tooltip'], enr))
+    L.append('')
+    L.append('- **Full-form Pāṇini `P. a,p,s` (3-param):** %d / %d linked (%.1f%%) — the H1307 DoD target.'
+             % (pfull['linked'], pfull['total'], pct(pfull['linked'], pfull['total'])))
+    d2 = per['Spr. (II)']
+    L.append('- **`Spr. (II) N` (2nd ed):** %d / %d linked (%.1f%%), %d full-text enriched (%.1f%% of linked).'
+             % (d2['linked'], d2['total'], pct(d2['linked'], d2['total']),
+                d2['enriched'], pct(d2['enriched'], d2['linked'])))
+    L.append('')
+    L.append('_Denominator: %s. Generated by `src/ls_coverage.py` on %s._'
+             % (source_label, date.today().strftime('%d-%m-%Y')))
+    return '\n'.join(L)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--store', default=STORE)
+    ap.add_argument('--pwg', default=PWG)
+    ap.add_argument('--out', default=DEFAULT_OUT)
+    ap.add_argument('--md', action='store_true', help='print the aggregate markdown table')
+    args = ap.parse_args()
+
+    if os.path.exists(args.store):
+        pairs = iter_store(args.store)
+        source_label = 'RU store `src/pwg_ru_translated.jsonl`'
+        substituted = False
+    elif os.path.exists(args.pwg):
+        pairs = iter_pwg(args.pwg)
+        source_label = ('full source `csl-orig/v02/pwg/pwg.txt` (RU store absent on '
+                        'this machine — SUBSTITUTION per H1307 Prerequisite 1; counts the '
+                        'whole PWG corpus, a superset of the RU-translated subset)')
+        substituted = True
+    else:
+        sys.exit('neither store (%s) nor pwg.txt (%s) is present' % (args.store, args.pwg))
+
+    per, pfull = compute(pairs)
+
+    out = {
+        'generated': date.today().strftime('%d-%m-%Y'),
+        'denominator': source_label,
+        'substituted_pwg_for_store': substituted,
+        'classes': {c: dict(per[c]) for c in CLASSES},
+        'panini_full_form_3param': dict(pfull),
+    }
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, 'w', encoding='utf-8', newline='\n') as f:
+        json.dump(out, f, ensure_ascii=False, indent=2)
+    sys.stderr.write('raw coverage JSON -> %s\n' % args.out)
+
+    table = md_table(per, pfull, source_label)
+    if args.md:
+        print(table)
+    else:
+        sys.stderr.write(table + '\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/ls_resolver.py
+++ b/RussianTranslation/src/ls_resolver.py
@@ -510,9 +510,29 @@ PWG_PATTERNS = [
     LsPattern(r'^(R[.]) *([0-9]+), *([0-9]+)',
               '($2 == "1" || $2 == "2") ? "https://sanskrit-lexicon-scans.github.io/ramayanaschl/?$2,$3,1" : "https://sanskrit-lexicon-scans.github.io/ramayanagorr/?$2,$3,1"',
               ['pw']),
-    # Panini - Ashtadhyayi
+    # Panini - Ashtadhyayi. Full form P. adhyaya,pada,sutra -> deep link to the
+    # sutra. Verified (H1307, 19-07-2026) against the site's own backing data repo
+    # github.com/ashtadhyayi-com/data (sutraani/data.txt: fields a=adhyaya, p=pada,
+    # n=number; e.g. 1.1.14 = 'nipAta ekAjanAG'); ashtadhyayi.com itself is a
+    # client-side SPA whose HTML cannot be scraped, so the URL *form* is what is
+    # verified, not a scraped render.
     LsPattern(r'^(P[.]) *([0-9]+), *([0-9]+), *([0-9]+)',
               'https://ashtadhyayi.com/sutraani/$2/$3/$4'),
+    # Panini chapter-level browse affordance (H1307, MG's N14 ask: "list of sutras
+    # by chapter and book"). A 2-param "P. adhyaya,pada" (no sutra) links to the
+    # pada's own sutra-list browse route /sutraani/{adhyaya}/{pada}; a 1-param
+    # "P. adhyaya" to the adhyaya list /sutraani/{adhyaya}. Both are the same
+    # verified route family as the 3-param deep link (reuse the site's own browse
+    # pages -- build no local sutra list). GUARDED to Panini's real coordinate
+    # ranges (adhyaya 1-8, pada 1-4) so ambiguous 2-number refs like "P. 1,23"
+    # (23 is no pada) do NOT mislink; the trailing (?![0-9]) rejects a pada that
+    # is really the head of a longer number. Placed AFTER the 3-param pattern so a
+    # full a,p,s ref (incl. the n="P. a,p," + visible "s." continuation form)
+    # always wins the deep link first.
+    LsPattern(r'^(P[.]) *([1-8]) *, *([1-4])(?![0-9])',
+              'https://ashtadhyayi.com/sutraani/$2/$3'),
+    LsPattern(r'^(P[.]) *([1-8])(?![0-9,])',
+              'https://ashtadhyayi.com/sutraani/$2'),
     # Rig Veda Pratisthana
     LsPattern(r'^(ṚV[.] PRĀTIŚ[.]) *([0-9]+), *([0-9]+)',
               'rvAvHymnUrl2'),

--- a/RussianTranslation/src/pilot/build_article_site.py
+++ b/RussianTranslation/src/pilot/build_article_site.py
@@ -42,6 +42,7 @@ import ls_resolver as lsr  # noqa: E402  (<ls> citation -> Cologne scan URL; PWG
 import pwg_ab  # noqa: E402  (<ab> grammar/usage abbreviation -> DE/EN expansion, for tooltips)
 import pwg_ab_ru  # noqa: E402  (<ab> -> RU display text for the editorial/cross-ref bucket)
 import pwg_sources as pwgsrc  # noqa: E402  (<ls> siglum -> full source title, for tooltips)
+import spr_fulltext as spr  # noqa: E402  (<ls> Spr. (II) N -> Indische Sprüche full text, for tooltips; H1307)
 import iast_to_cyrillic as i2c  # noqa: E402  (<is> proper name -> Cyrillic, RU column only)
 
 RU_STORE = os.path.join(SRC, 'pwg_ru_translated.jsonl')
@@ -85,6 +86,27 @@ def _ls_title(attrs, visible):
         if r:
             return r
     return None
+
+
+def _ls_tooltip(attrs, visible):
+    """Hover text for one <ls> citation. For a 2nd-edition `Spr. (II) N` citation
+    (H1307) this is the recognized full text of the saying — its IAST verse plus
+    the German translation from the Indische Sprüche corpus — which is far more
+    useful than the bare source title. For every other citation it falls back to
+    the pwgbib source expansion (`_ls_title`). The 1st-edition `Spr. N` form is
+    edition-guarded inside spr_fulltext and never reaches the 2nd-ed corpus.
+
+    Language-independent (the saying/source is the same in the DE/RU/EN editions),
+    so this shared helper is what the review-sheet emitter (H1301) reuses too."""
+    m = _N_ATTR.search(attrs or '')
+    n_attr = m.group(1) if m else None
+    vis = (visible or '').strip()
+    rich = spr.tooltip(n_attr, vis)
+    if rich:
+        return rich
+    return _ls_title(attrs, visible)
+
+
 _AB = re.compile(r'<ab\b[^>]*>(.*?)</ab>', re.S)
 _LEX = re.compile(r'<lex\b[^>]*>(.*?)</lex>', re.S)
 _IS = re.compile(r'<is\b[^>]*>(.*?)</is>', re.S)
@@ -192,7 +214,7 @@ def _render(text, mode, lang=None):
             # quote/space chars that would require quoting.
             vis = m.group(2).strip()
             url = _ls_href(m.group(1), vis)
-            title = _ls_title(m.group(1), vis)
+            title = _ls_tooltip(m.group(1), vis)
             tattr = ' title=%s' % title.replace(' ', '\xa0') if title else ''
             if url:
                 # <a class=ls href=URL title=T target=_blank rel=noopener>VIS</a>
@@ -229,7 +251,15 @@ def _render(text, mode, lang=None):
         def _ls_md(m):
             vis = m.group(2).strip()
             url = _ls_href(m.group(1), vis)
-            return '[%s](%s)' % (vis, url) if url else '[%s]' % vis
+            if not url:
+                return '[%s]' % vis
+            # Carry the Spr. (II) full-text enrichment (H1307) into the md link
+            # title so the md surface has parity with the html tooltip; other
+            # citations stay a plain link to keep the md output unchanged.
+            rich = spr.tooltip(m.group(1), vis)
+            if rich:
+                return '[%s](%s "%s")' % (vis, url, rich.replace('"', "'"))
+            return '[%s](%s)' % (vis, url)
         t = _LS.sub(_ls_md, t)
         t = _AB.sub(lambda m: _ab_display(m.group(1), lang, m.string[:m.start()])[0], t)
         t = _LEX.sub(lambda m: '_%s_' % m.group(1).strip(), t)

--- a/RussianTranslation/src/pilot/ls_enrichment_selftest.py
+++ b/RussianTranslation/src/pilot/ls_enrichment_selftest.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Fixture selftest for the H1307 <ls> link-enrichment (Pāṇini + Spr. (II)).
+
+No network and no RU store are needed. The Pāṇini/edition-guard assertions are
+pure resolver logic; the Spr. (II) full-text lookup uses the tracked, public
+Indische Sprüche corpus (present in a normal checkout) and is skipped-with-note
+only if that file is genuinely absent.
+
+  python src/pilot/ls_enrichment_selftest.py
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = os.path.dirname(HERE)
+sys.path.insert(0, SRC)
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+import ls_resolver as lsr        # noqa: E402
+import spr_fulltext as spr       # noqa: E402
+
+_PANINI = 'https://ashtadhyayi.com/sutraani'
+_BOESP2 = 'sanskrit-lexicon-scans.github.io/boesp2'
+_BOESP1 = 'sanskrit-lexicon-scans.github.io/boesp1'
+
+
+def fail(msg):
+    raise AssertionError(msg)
+
+
+def _href(n_attr, visible):
+    return lsr.generate_href('pwg', n_attr, visible)
+
+
+def test_panini_full_form():
+    """Full 3-param P. adhyaya,pada,sutra -> the sutra deep link."""
+    got = _href('', 'P. 1,1,14')
+    if got != _PANINI + '/1/1/14':
+        fail('P. 1,1,14 -> %r' % got)
+
+
+def test_panini_continuation_ref():
+    """The N14 card's continuation ref: n='P. 2,3,' + visible '10.' -> /2/3/10."""
+    got = _href('P. 2,3,', '10.')
+    if got != _PANINI + '/2/3/10':
+        fail('continuation P. 2,3, + 10. -> %r' % got)
+
+
+def test_panini_chapter_browse():
+    """2-param chapter ref P. 2,3 -> the pada browse route; guarded so a bogus
+    pada like P. 1,23 or an invalid pada P. 1,6 does NOT mislink."""
+    if _href('', 'P. 2,3') != _PANINI + '/2/3':
+        fail('P. 2,3 -> %r' % _href('', 'P. 2,3'))
+    for bad in ('P. 1,6', 'P. 1,23', 'P. 9', 'P. II, S. 3'):
+        if _href('', bad) is not None:
+            fail('%s should NOT link, got %r' % (bad, _href('', bad)))
+
+
+def test_spr_edition_guard():
+    """Plain 1st-ed Spr. N must route to boesp1 and NEVER be resolved against the
+    2nd-ed corpus; 2nd-ed Spr. (II) N routes to boesp2."""
+    first = _href('', 'Spr. 1415')
+    if not first or _BOESP1 not in first:
+        fail('Spr. 1415 (1st ed) -> %r (expected boesp1)' % first)
+    if spr.second_ed_num('', 'Spr. 1415') is not None:
+        fail('1st-ed Spr. 1415 leaked into the 2nd-ed number guard')
+    if spr.second_ed_num('', 'Spr. (I) 200') is not None:
+        fail('Spr. (I) 200 leaked into the 2nd-ed number guard')
+    second = _href('', 'Spr. (II) 5712')
+    if not second or _BOESP2 not in second:
+        fail('Spr. (II) 5712 -> %r (expected boesp2)' % second)
+
+
+def test_spr_second_ed_number():
+    """The 2nd-ed number is extracted for both the inline and continuation forms."""
+    if spr.second_ed_num('', 'Spr. (II) 6145') != 6145:
+        fail('inline Spr. (II) 6145 -> %r' % spr.second_ed_num('', 'Spr. (II) 6145'))
+    if spr.second_ed_num('Spr. (II)', '6145.') != 6145:
+        fail('continuation Spr. (II)+6145. -> %r' % spr.second_ed_num('Spr. (II)', '6145.'))
+
+
+def test_spr_fulltext_lookup():
+    """The Indische Sprüche corpus resolves a known saying to its IAST + German."""
+    if not spr.available():
+        print('  SKIP test_spr_fulltext_lookup: corpus absent on this machine')
+        return
+    rec = spr.saying(6145)
+    if not rec:
+        fail('saying(6145) missing from the corpus')
+    if not rec.get('iast') or not rec.get('translation_de'):
+        fail('saying(6145) lacks iast/translation_de: %r' % rec)
+    tip = spr.tooltip('', 'Spr. (II) 6145')
+    if not tip or not tip.startswith('Spr. (II) 6145:') or 'vipakṣaḥ' not in tip:
+        fail('tooltip(Spr. (II) 6145) -> %r' % tip)
+    # edition guard at the tooltip layer: a 1st-ed ref yields no 2nd-ed tooltip
+    if spr.tooltip('', 'Spr. 1415') is not None:
+        fail('1st-ed Spr. 1415 must not get a 2nd-ed full-text tooltip')
+
+
+def main():
+    tests = [
+        test_panini_full_form,
+        test_panini_continuation_ref,
+        test_panini_chapter_browse,
+        test_spr_edition_guard,
+        test_spr_second_ed_number,
+        test_spr_fulltext_lookup,
+    ]
+    for t in tests:
+        t()
+        print('  ok %s' % t.__name__)
+    print('ls_enrichment_selftest: %d checks passed' % len(tests))
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/spr_fulltext.py
+++ b/RussianTranslation/src/spr_fulltext.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""Indische Sprüche (2nd ed.) full-text lookup for <ls> Spr. (II) enrichment.
+
+H1307 (MG's N3(b) vote): a PWG `<ls>Spr. (II) N</ls>` citation should not only
+link to the boesp2 scan viewer but also expose the saying's own recognized full
+text on hover. This module resolves N -> the 2nd-edition saying record from the
+tracked, public-domain corpus
+    ../../IndischeSprueche/data/indische_sprueche.jsonl
+(7,537 sayings: num, deva, iast, translation_de, ...), registered in the kosha
+manifest as `indische-sprueche` with declared consumer "PWG <ls> citation links".
+
+EDITION GUARD (load-bearing — README + PWG#87): only the 2nd-edition citation
+form `Spr. (II) N` is resolved here. Plain `Spr. N` is 1st-edition numbering
+(a DIFFERENT 5,419-saying edition) and MUST NEVER be looked up against this
+2nd-ed JSONL — `second_ed_num()` returns None for it, so the enrichment layer
+never mis-resolves a 1st-ed citation against 2nd-ed text.
+
+The layer is render-time and language-independent (the saying is the same in the
+DE/RU/EN editions), so it is SHARED per LANG_PARITY.md — build_article_site's
+_render() calls it for every language, and the H1301 review-sheet emitter can
+import the same functions.
+"""
+import json
+import os
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))                 # RussianTranslation/src
+_JSONL = os.path.normpath(os.path.join(
+    HERE, '..', '..', 'IndischeSprueche', 'data', 'indische_sprueche.jsonl'))
+
+# 2nd-edition citation form only. n= attribute + visible text are combined the
+# way ls_resolver.generate_href does (a normalizing space is added between them);
+# we only need the edition marker + number, so a liberal single-space join is safe.
+_SPR_II = re.compile(r'^Spr\.\s*\(II\)\s*([0-9]+)')
+
+_BY_NUM = None
+
+
+def _load():
+    global _BY_NUM
+    if _BY_NUM is not None:
+        return _BY_NUM
+    _BY_NUM = {}
+    if not os.path.exists(_JSONL):
+        # Absent (e.g. a sparse checkout) -> lookups degrade to None, never raise.
+        sys.stderr.write('spr_fulltext: corpus not found at %s — enrichment disabled\n' % _JSONL)
+        return _BY_NUM
+    with open(_JSONL, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+            except ValueError:
+                continue
+            n = r.get('num')
+            if isinstance(n, int):
+                _BY_NUM[n] = r
+    return _BY_NUM
+
+
+def available():
+    """True iff the full-text corpus is present on this machine."""
+    return bool(_load())
+
+
+def saying(n):
+    """The 2nd-ed saying record for number `n`, or None."""
+    try:
+        return _load().get(int(n))
+    except (TypeError, ValueError):
+        return None
+
+
+def second_ed_num(n_attr, visible):
+    """Return the 2nd-edition saying number for a `Spr. (II) N` citation, or None.
+
+    EDITION GUARD: matches ONLY the `Spr. (II)` form. Plain `Spr. N` (1st ed) and
+    `Spr. (I) N` return None, so a 1st-edition citation is never resolved against
+    the 2nd-edition full text."""
+    combined = re.sub(r'\s+', ' ', ('%s %s' % (n_attr or '', visible or '')).strip())
+    combined = re.sub(r'<[^>]+>', '', combined)      # drop any stray inner markup
+    m = _SPR_II.match(combined)
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except ValueError:
+        return None
+
+
+def _oneline(s, limit):
+    """Collapse a verse/prose field to one tooltip-safe line, truncated."""
+    s = (s or '')
+    s = re.sub(r'^\s*[0-9]+[.)]\s*', '', s)          # strip a leading saying number
+    s = s.replace('/', ' ')                           # record-internal line breaks
+    s = re.sub(r'\s+', ' ', s).strip()
+    if len(s) > limit:
+        s = s[:limit].rstrip() + '…'
+    return s
+
+
+def tooltip(n_attr, visible):
+    """Enriched hover text for a `Spr. (II) N` citation, or None when it is not a
+    2nd-ed citation or the saying is absent. Combines the IAST verse and the
+    German translation from the recognized full text.
+
+    Language-independent: the saying text is the same across the DE/RU/EN editions
+    (SHARED per LANG_PARITY.md)."""
+    n = second_ed_num(n_attr, visible)
+    if n is None:
+        return None
+    rec = saying(n)
+    if not rec:
+        return None
+    iast = _oneline(rec.get('iast'), 150)
+    de = _oneline(rec.get('translation_de'), 220)
+    parts = ['Spr. (II) %d' % n]
+    body = ' — '.join(p for p in (iast, de) if p)
+    if body:
+        parts.append(body)
+    return ': '.join(parts)
+
+
+if __name__ == '__main__':
+    for na, vi in [('', 'Spr. (II) 6145'), ('Spr. (II)', '6145.'),
+                   ('', 'Spr. 1415'), ('', 'Spr. (I) 200'), ('', 'Spr. (II) 5712')]:
+        print('%r %r -> num=%s' % (na, vi, second_ed_num(na, vi)))
+        print('   tooltip: %s' % tooltip(na, vi))
+    print('corpus available:', available(), '| entries:', len(_load()))

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,23 @@ not an error.
 
 ## [Unreleased]
 
+### Added
+- **`<ls>` link enrichment — Pāṇini deep/browse links + Spr. (II) full-text tooltips (19-07-2026, Opus 4.8 `claude-opus-4-8`, [H1307](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1307-Opus_RussianTranslation_pwg-ru-ls-link-enrichment-panini-spr-dhatup_19.07.26.md))**:
+  MG's DA-vote (N14/N3(b)/N15) enrichment for three `<ls>` citation classes in the pwg_ru render
+  layer. Pāṇini `P. a,p,s` deep links to [ashtadhyayi.com](https://ashtadhyayi.com) were already
+  100% (25,061/25,061); guarded 2-param/1-param patterns add the pāda/adhyāya browse routes
+  (`/sutraani/a/p`, `/sutraani/a`) — pada 1–4, adhyāya 1–8 guarded so page-refs like `P. II, S. 3`
+  never mislink. Every `Spr. (II) N` (8,684, 100% linked) gains an IAST+German hover tooltip from
+  [`indische_sprueche.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/IndischeSprueche/data/indische_sprueche.jsonl)
+  (7,537 sayings) behind a 1st-edition guard (plain `Spr. N` never resolves against the 2nd-ed corpus).
+  URL forms verified against the ashtadhyayi.com backing data repo (the site is a client-side SPA) and
+  the boesp1/boesp2 viewer JS (bare `?N` is the only form working for both editions). `DHĀTUP.` → Palsule
+  exited as a committed acquisition spec (no machine-readable Palsule list exists org-wide; the Westergaard
+  gaṇa-level link stays). New [`spr_fulltext.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/spr_fulltext.py),
+  [`ls_coverage.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ls_coverage.py),
+  fixture selftest in CI; coverage table + spec in
+  [`ABBREVIATIONS_RU.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ABBREVIATIONS_RU.md).
+
 ## [1.29.0] — 19-07-2026
 
 ### Changed


### PR DESCRIPTION
Executes [H1307](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1307-Opus_RussianTranslation_pwg-ru-ls-link-enrichment-panini-spr-dhatup_19.07.26.md) — MG's DA-vote (N14/N3(b)/N15) `<ls>` link enrichment for the pwg_ru render layer. Extends the existing Cologne-port `ls_resolver.py` + `_render()` layer (no second resolver).

## What changed
- **Pāṇini `P.`** — full-form `P. a,p,s` deep links to [ashtadhyayi.com](https://ashtadhyayi.com) were already 100% (25,061/25,061). Added **guarded** 2-param (`/sutraani/a/p`) and 1-param (`/sutraani/a`) chapter/book browse patterns (MG's N14 "list by chapter and book"). Pada 1–4, adhyāya 1–8 guarded so page-refs like `P. II, S. 3` (Böhtlingk vol II, Seite 3) and bogus `P. 1,23` never mislink. URL form verified against the site's backing data repo [`ashtadhyayi-com/data`](https://github.com/ashtadhyayi-com/data) — the site is a client-side SPA, so a live 200 proves nothing.
- **`Spr. (II) N`** (8,684, 100% linked) — gains an IAST + German full-text hover tooltip from [`indische_sprueche.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/IndischeSprueche/data/indische_sprueche.jsonl) via new `spr_fulltext.py`, behind a **1st-ed edition guard** (plain `Spr. N` never resolves against the 2nd-ed corpus). Resolver URL unchanged — bare `?N` is the only form both boesp viewers accept (verified against their `main.js`; `?verse=N` breaks boesp1).
- **`DHĀTUP.` → Palsule** — committed acquisition **spec**, not wired: no machine-readable Palsule list or Böhtlingk→Palsule concordance exists org-wide. Existing Westergaard gaṇa-level link (96.3%) stays.
- New `ls_coverage.py` (per-class counter, store else pwg.txt), `ls_enrichment_selftest.py` (CI-wired), LANG_PARITY SHARED entry; coverage table + spec in `ABBREVIATIONS_RU.md`, history in `PIPELINE_HISTORY.md`, `[Unreleased]` in `changelog.md`.

## Coverage (denominator = pwg.txt; RU store absent per Prerequisite 1)
| class | total | linked | linked % | full-text enriched |
|---|--:|--:|--:|--:|
| `P.` full-form 3-param | 25061 | 25061 | 100.0% | n/a |
| `Spr. (II)` | 8684 | 8684 | 100.0% | 8395 (96.7%) |
| `DHĀTUP.` | 2760 | 2659 | 96.3% | spec |

## Gates
window_selftest **147/147**, lang_parity **55/no-drift**, ruff clean, ls_enrichment_selftest **6/6**, py_compile clean. article_site not regenerated (needs the local store); render path unit-verified via `_render()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)