### PR TITLE
ai-wip: .ai_state — v0.3.0 review-sheet standard shipped

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -46,6 +46,15 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   SanskritGrammar [H1315](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1315-Opus_SanskritGrammar_review-sheets-standard-port_19.07.26.md)
   (+ [H1316](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1316-Opus_SanskritGrammar_apply-voted-precative-w2core-visas_19.07.26.md)
   applying two SG votes found complete-but-unapplied on disk).
+  **SHIPPED (Opus 4.8 `claude-opus-4-8[1m]` finish, 19-07-2026):** [PR #566](https://github.com/gasyoun/SanskritLexicography/pull/566)
+  MERGED (changelog 1.29.0) — the merge reconciled the concurrent [H1311](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1311-Fable_RussianTranslation_renou-pilot-evidence-remake_19.07.26.md)
+  renou-v2 remake (both its evidence panels AND the v0.3.0 config kept); MG's local
+  `review/` folder regenerated on the standard (80/80 marker assertions green). Emitter
+  standard is now the ONE standard in [`/review-sheet`](https://github.com/gasyoun/claude-config/blob/main/commands/review-sheet.md).
+  **Open:** MG votes the 3 ready h178 sheets (→ [H274](https://github.com/gasyoun/Uprava/blob/main/handoffs/H274-Fable_DO_RussianTranslation_pwg_ru_bakeoff_compute_07.07.26.md))
+  + re-votes renou-v2; ports H1314/H1315/H1316 queued. **Release wrinkle:** v1.29.0 was
+  already tagged by H1311, so this work + another session's H1307 entry in `[Unreleased]`
+  need a coordinated v1.30.0 cut (do not cut unilaterally mid-contention).
 
 - **H1300 — h178_da sheet VOTED + processed; 8-handoff fan-out minted H1301–H1308 (19-07-2026, Fable 5 `claude-fable-5`).**
   MG voted the first of the four H178 B-1 bake-off sheets (30 items: **27 approve / 3 reject**;


### PR DESCRIPTION
Refreshes the RussianTranslation `.ai_state.md` H1313 entry to the final shipped state: [PR #566](https://github.com/gasyoun/SanskritLexicography/pull/566) merged, MG's local `review/` regenerated on the v0.3.0 standard, the concurrent H1311 renou-v2 merge reconciled, and the coordinated-v1.30.0 release wrinkle noted. Journal-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)