### PR TITLE
H1308: one-click case-government (Rektion) index + PW capitalized-marker gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,9 @@ jobs:
         working-directory: RussianTranslation
         run: |
           python src/mfs_baseline.py --selftest
+          python src/government_census.py selftest
           python src/government_sidecar.py --selftest
+          python src/pilot/build_article_site.py --selftest
           python research/build_observatory.py --check
       - name: LOD graph acceptance (fixture-only, H350/E7)
         working-directory: RussianTranslation

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -26,6 +26,18 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   ```
   Opus 4.8 (`claude-opus-4-8`); working dir `C:\Users\user\Documents\GitHub\SanskritLexicography\RussianTranslation`; tell the session where MG dropped the XLS.
 
+- **H1308 🔴 EXECUTED — one-click case-government (Rektion) index + PW capitalized-marker
+  gap closed (19-07-2026, Opus 4.8 `claude-opus-4-8`).** DA-vote N2 (`vas~~h0_zz_pw00|samava`):
+  made `government_census.py` marker regexes case-insensitive (new `_cases()` normaliser) so
+  the PW `zz_pw*` capitalized stratum `(<ab>Instr.</ab>)` — 0 of 1,123 store rows caught
+  before, incl. the N2 card — is now extracted; store government rows **508 → 1,756**, raw
+  `pwg.txt` ceiling **3,853 → 3,905**. New `government.html` via `emit_government()` in the
+  site builder: case chips → every governing card (Instr. one-click = 218 cards incl.
+  vas/samava), `#g=<safe>` full-entry deep-links, honest floor-vs-ceiling banner, cross-linked
+  with `abbreviations.html`. `census_stats.json` re-frozen, sidecar regenerated (local).
+  SHARED in LANG_PARITY; selftests in CI. Dataset export deliberately NOT registered (254
+  lemmas mid-drain vs 1,476-entry ceiling — would ship misleadingly partial). PR + gh-pages
+  deploy in the same pass.
 - **H1305 🔴 EXECUTED — mechanical RU style sweep, no-ё + terse editorial metalanguage
   (19-07-2026, Sonnet 5 `claude-sonnet-5`).** See `## ✅ Completed` below for the full
   summary; rule table + measurement in

--- a/RussianTranslation/ABBREVIATIONS_RU.md
+++ b/RussianTranslation/ABBREVIATIONS_RU.md
@@ -24,6 +24,22 @@ An audit of `RussianTranslation/src/pwg_ru_translated.jsonl` (11,275 rows,
 occurrences in the RU field (99.99%) were still verbatim German/Latin**, across
 265 distinct tokens.
 
+## Case government (Rektion) — owned by government.html, not this dashboard (H1308)
+
+MG's DA-vote row **N2** (19-07-2026, card `vas~~h0_zz_pw00|samava`) asked a
+different question of the same `<ab>` markup: given a sense carrying
+`(<ab>Instr.</ab>)`, *can I find every card with Instr. government in one click?*
+That is **card retrieval**, not token frequency — so it lives on its own page, the
+[government (Rektion) index](https://gasyoun.github.io/SanskritLexicography/government.html)
+(case chips Instr./Loc./Gen./Acc./Dat./Abl. → every card governing that case, with
+an honest floor-vs-ceiling coverage banner), NOT inside this abbreviations
+dashboard. Ruling: **two pages, cross-linked** — `abbreviations.html` stays
+token-frequency oriented, `government.html` is card-retrieval oriented; merging
+would bury N2's one-click ask. Extractor: `government_census.extract_government()`,
+now case-insensitive so the PW `zz_pw*` capitalized stratum (`(<ab>Instr.</ab>)`,
+1,116 rows previously invisible) is captured alongside the PWG lowercase one. See
+[H1308](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1308-Opus_RussianTranslation_pwg-ru-valency-government-index_19.07.26.md).
+
 ## Architecture decision: fix at RENDER TIME, not in the data store
 
 The translated JSONL store (`pwg_ru_translated.jsonl`) keeps the `<ab>`/`<is>`

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,6 +1,6 @@
 # LANG_PARITY.md — cross-language fix/feature parity ledger
 
-_Created: 04-07-2026 · Last updated: 18-07-2026 (H1209 controller-worker rig GAP entry)_
+_Created: 04-07-2026 · Last updated: 19-07-2026 (H1308 government-index page SHARED entry)_
 
 This repo runs the same PWG→Russian and PWG→English translation pipeline through
 shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
@@ -589,10 +589,27 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "H335 (08-07-2026). The census reads raw pwg.txt below any --lang branch and never touches RU/EN translation code; the government-marker regexes operate on the German source markup shared by both editions. Read-only over the source; selftest-gated. Re-verified 12-07-2026 after H778 (#384) added a source_sha16-gated JSON sidecar freeze/cache layer (build_sidecar/write_sidecar/load_sidecar/census_or_load) plus a `freeze` CLI subcommand around the same run_census() function — still no --lang branch, verdict unchanged.",
+    "note": "H335 (08-07-2026). The census reads raw pwg.txt below any --lang branch and never touches RU/EN translation code; the government-marker regexes operate on the German source markup shared by both editions. Read-only over the source; selftest-gated. Re-verified 12-07-2026 after H778 (#384) added a source_sha16-gated JSON sidecar freeze/cache layer (build_sidecar/write_sidecar/load_sidecar/census_or_load) plus a `freeze` CLI subcommand around the same run_census() function — still no --lang branch, verdict unchanged. Re-verified 19-07-2026 (H1308, Opus 4.8 claude-opus-4-8): the PAREN/CASE/MIT/CONNECTOR regexes were made case-INSENSITIVE so the PW zz_pw* CAPITALIZED stratum ((<ab>Instr.</ab>)) extracts alongside the PWG lowercase one, matched case tokens normalised to lowercase via the new _cases() helper. Both extract_government() (store de fields) and run_census() (raw pwg.txt) share the change; the raw ceiling rose 3853->3905 markers (the +52 are sentence-initial 'Mit dem <ab>...</ab>' prose government the lowercase regex missed). Still operates only on the shared German source markup below any --lang branch; verdict unchanged.",
     "tracking": "",
     "verified_sha256": {
-      "src/government_census.py": "bf421d8fd743767c891ea1633f47e6526e88aef2c93d3a73437fc9ac749dafb1"
+      "src/government_census.py": "0a004740cc6ba9407c292fef015b07b60fcd62cd82b6252f08fc49a00de6d6d8"
+    }
+  },
+  {
+    "id": "government_index_page_h1308",
+    "mechanism": "H1308 one-click government (Rektion) retrieval page: government_index()/government_meta()/emit_government() in build_article_site.py apply government_census.extract_government() over each sense's DE source text to produce government.html (case chips Instr./Loc./Gen./Acc./Dat./Abl. + variation bucket -> every card governing that case), an honest floor-vs-ceiling coverage banner, and index.html #g=<safe> deep-links to the full entry.",
+    "files": [
+      "src/pilot/build_article_site.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H1308 (19-07-2026, Opus 4.8 claude-opus-4-8). government_index() reads s['de_raw'] (the German SOURCE sense text, identical across the RU and EN editions) via the shared extract_government() — the same authoritative reference set ab_frequency()/ls_stats() use — and marker spans render through the shared _render() layer. No RU/EN branch anywhere in the government surface; a future EN site build would show the identical government index. Language-neutral analysis layer, exactly like the H775 government sidecar precedent. Pinned by build_article_site.py --selftest (selftest_government).",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/build_article_site.py": "09ce9d51e88bcfdebfb86ac74b86d57317faa6f182922041a212b96871b24987"
     }
   },
   {
@@ -1186,7 +1203,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
       "src/spr_fulltext.py": "446fe8ce8146cfdda3a0cd0b2e6f62c3b76e08cfb872823116549ed3992fe0d5",
-      "src/pilot/build_article_site.py": "41c68f01652e49f66a908d89a16c43877923c92f4d0fb2d447d611aec2a399d7"
+      "src/pilot/build_article_site.py": "09ce9d51e88bcfdebfb86ac74b86d57317faa6f182922041a212b96871b24987"
     }
   },
   {

--- a/RussianTranslation/PIPELINE_HISTORY.md
+++ b/RussianTranslation/PIPELINE_HISTORY.md
@@ -9,6 +9,29 @@ narrated). Read this first; go to `.ai_state.md` for exact dates/PRs/numbers on
 any specific claim below, and to [`src/pilot/RUN_FREQ_MAX.md`](src/pilot/RUN_FREQ_MAX.md)
 for the current operating procedure.
 
+### H1308 — one-click case-government (Rektion) index + PW capitalized-marker gap closed (19-07-2026)
+
+MG's DA-sheet vote row **N2** (card `vas~~h0_zz_pw00|samava`) asked whether case
+government (`(<ab>Instr.</ab>)`) is structurally recoverable and whether he can find
+**all cards with Instr. government in one click**. Recoverability was largely solved prior
+art (H335 census, H338 extractor, H775 sidecar), but three things were missing: a search
+surface, live coverage, and — the real bug — the **PW `zz_pw*` supplement stratum**, which
+writes case names CAPITALIZED (`(<ab>Instr.</ab>)`) while the extractor's regexes were
+lowercase-only. Measured 19-07: the shipped extractor caught **0 of 1,123** store rows
+carrying a capitalized marker, INCLUDING the N2 exemplar card itself. Fix: made the
+`PAREN/CASE/MIT/CONNECTOR` regexes in `government_census.py` case-insensitive with a new
+`_cases()` lowercase-normaliser (one change serves both `extract_government()` over the
+store and `run_census()` over raw `pwg.txt`); selftest pins updated. Store government rows
+rose **508 → 1,756** (614 → 2,129 markers); the raw `pwg.txt` ceiling rose **3,853 → 3,905**
+(the +52 are sentence-initial "Mit dem `<ab>…</ab>`" prose government the lowercase regex
+missed). New surface: `government.html`/`government.js` via `emit_government()` in the site
+builder — case chips (Instr. leads, per N2) → every governing card, `#g=<safe>` deep-links
+to the full entry, and an honest floor-vs-ceiling banner. Instr. one-click returns **218
+cards including vas/samava** (verified end-to-end). Two pages, cross-linked:
+`abbreviations.html` stays token-frequency oriented, `government.html` is card-retrieval
+oriented. `census_stats.json` re-frozen; sidecar regenerated (1,756 rows, local). SHARED in
+`LANG_PARITY.md` (extraction reads `de` below the `--lang` branch); selftests wired into CI.
+
 ### H1305 — mechanical RU style sweep: no-ё, terse editorial metalanguage (19-07-2026)
 
 MG's DA-sheet vote (N7/N12 + the terseness half of N4) ratified four deterministic RU

--- a/RussianTranslation/src/census_stats.json
+++ b/RussianTranslation/src/census_stats.json
@@ -1,28 +1,28 @@
 {
   "schema": "pwg_ru.government_census.v1",
-  "generated": "12-07-2026",
+  "generated": "19-07-2026",
   "pipeline_version": "1.1.0",
   "source": "pwg.txt",
   "source_sha16": "430c910f8b0c9229",
   "census": {
     "n_entries": 123366,
     "n_units": 288991,
-    "entries_with": 1476,
-    "units_with": 3222,
+    "entries_with": 1490,
+    "units_with": 3244,
     "kinds": {
-      "mit-phrase": 1504,
+      "mit-phrase": 1556,
       "paren-single": 2309,
       "paren-nongov": 68,
       "paren-variation": 40
     },
     "cases": {
       "mit-phrase": {
-        "gen": 318,
-        "acc": 635,
-        "loc": 197,
-        "abl": 120,
-        "dat": 108,
-        "instr": 125,
+        "acc": 650,
+        "gen": 338,
+        "abl": 124,
+        "loc": 200,
+        "dat": 110,
+        "instr": 133,
         "nom": 1
       },
       "paren-single": {
@@ -62,10 +62,10 @@
       }
     },
     "pos_gov_entries": {
-      "unknown": 427,
-      "adj": 327,
-      "nominal": 241,
-      "indecl": 64,
+      "adj": 333,
+      "nominal": 246,
+      "unknown": 429,
+      "indecl": 65,
       "verb": 417
     },
     "pos_entries_all": {
@@ -107,6 +107,13 @@
       ],
       [
         [
+          "55166",
+          "BU"
+        ],
+        43
+      ],
+      [
+        [
           "21814",
           "gam"
         ],
@@ -114,10 +121,10 @@
       ],
       [
         [
-          "55166",
-          "BU"
+          "15071",
+          "kar"
         ],
-        42
+        40
       ],
       [
         [
@@ -125,13 +132,6 @@
           "viS"
         ],
         39
-      ],
-      [
-        [
-          "15071",
-          "kar"
-        ],
-        38
       ],
       [
         [
@@ -152,14 +152,14 @@
           "27838",
           "jYA"
         ],
-        30
+        32
       ],
       [
         [
           "36484",
           "DA"
         ],
-        29
+        30
       ],
       [
         [
@@ -250,9 +250,9 @@
           "54756",
           "BAz"
         ],
-        20
+        21
       ]
     ],
-    "n_hits": 3921
+    "n_hits": 3973
   }
 }

--- a/RussianTranslation/src/government_census.py
+++ b/RussianTranslation/src/government_census.py
@@ -42,13 +42,27 @@ GOV_CASES = ("acc", "loc", "instr", "gen", "dat", "abl")
 NONGOV_CASES = ("nom", "voc")
 ALL_CASES = GOV_CASES + NONGOV_CASES
 
+# Case markers are matched case-INSENSITIVELY (H1308): the PWG stratum writes them
+# lowercase (``(<ab>instr.</ab>)``) while the PW ``zz_pw*`` supplement stratum writes
+# them CAPITALIZED (``(<ab>Instr.</ab>)``, ``(<ab>Loc.</ab>)`` …). Before this, the
+# lowercase-only regexes extracted 0 of the 1,116 store rows carrying a capitalized
+# marker (incl. the N2 acceptance card ``vas~~h0_zz_pw00|samava``). The matched case
+# token is normalised to lowercase everywhere it is compared or stored (see
+# ``_cases()``); the raw ``span`` preserves the source capitalisation for display.
 _AB = r"<ab>(?:%s)\.</ab>" % "|".join(ALL_CASES)
 PAREN_RE = re.compile(
-    r"\(\s*(" + _AB + r"(?:\s*(?:,|und|oder)\s*" + _AB + r")*)\s*\)"
+    r"\(\s*(" + _AB + r"(?:\s*(?:,|und|oder)\s*" + _AB + r")*)\s*\)",
+    re.IGNORECASE,
 )
-CASE_RE = re.compile(r"<ab>(%s)\.</ab>" % "|".join(ALL_CASES))
-CONNECTOR_RE = re.compile(r"\b(und|oder)\b")
-MIT_RE = re.compile(r"\bmit (?:dem |der )?(" + _AB + r")")
+CASE_RE = re.compile(r"<ab>(%s)\.</ab>" % "|".join(ALL_CASES), re.IGNORECASE)
+CONNECTOR_RE = re.compile(r"\b(und|oder)\b", re.IGNORECASE)
+MIT_RE = re.compile(r"\bmit (?:dem |der )?(" + _AB + r")", re.IGNORECASE)
+
+
+def _cases(group):
+    """Case tokens in a matched group, normalised to the lowercase canonical form so
+    ``Instr``/``instr`` collapse to one bucket downstream (H1308)."""
+    return [c.lower() for c in CASE_RE.findall(group)]
 LS_RE = re.compile(r"<ls\b[^>]*>.*?</ls>", re.S)
 LEX_RE = re.compile(r"<lex>([^<]+)</lex>")
 SENSE_SPLIT_RE = re.compile(r"\d+〉")
@@ -72,17 +86,17 @@ def extract_government(text):
     text_nols = LS_RE.sub("", text or "")
     hits = []
     for m in PAREN_RE.finditer(text_nols):
-        cases = CASE_RE.findall(m.group(1))
+        cases = _cases(m.group(1))
         if all(c in NONGOV_CASES for c in cases):
             continue
-        connectors = sorted(set(CONNECTOR_RE.findall(m.group(1))))
+        connectors = sorted(set(c.lower() for c in CONNECTOR_RE.findall(m.group(1))))
         kind = "paren-single" if len(cases) == 1 else "paren-variation"
         hits.append({
             "cases": cases, "variation": len(cases) > 1,
             "connector": "/".join(connectors), "kind": kind, "span": m.group(0),
         })
     for m in MIT_RE.finditer(text_nols):
-        cases = CASE_RE.findall(m.group(1))
+        cases = _cases(m.group(1))
         hits.append({
             "cases": cases, "variation": False, "connector": "",
             "kind": "mit-phrase", "span": m.group(0),
@@ -135,8 +149,8 @@ def scan_entry(header, entry_lines):
     for unit, text in sense_units(entry_lines):
         text_nols = LS_RE.sub("", text)
         for m in PAREN_RE.finditer(text_nols):
-            cases = CASE_RE.findall(m.group(1))
-            connectors = sorted(set(CONNECTOR_RE.findall(m.group(1))))
+            cases = _cases(m.group(1))
+            connectors = sorted(set(c.lower() for c in CONNECTOR_RE.findall(m.group(1))))
             kind = "paren-single" if len(cases) == 1 else "paren-variation"
             if all(c in NONGOV_CASES for c in cases):
                 kind = "paren-nongov"
@@ -148,7 +162,7 @@ def scan_entry(header, entry_lines):
                 "snippet": m.group(0),
             })
         for m in MIT_RE.finditer(text_nols):
-            cases = CASE_RE.findall(m.group(1))
+            cases = _cases(m.group(1))
             hits.append({
                 "L": header.get("L", ""), "k1": header.get("k1", ""),
                 "h": header.get("h", ""), "pos": pos, "unit": unit,
@@ -364,6 +378,10 @@ FIXTURE = """<L>1<pc>1-1<k1>snih<k2>snih<h>1
 <hom>1.</hom> {#sTA#}¦, {#ti/zWati#} <ls>DHĀTUP. 22,30</ls>.
 <div n="1"> 1〉 {%stehen bleiben bei%} (<ab>loc.</ab>): {#q#} <ls>MBH. 2,2</ls>. <lex>adj.</lex> {#sTita#}.
 <LEND>
+
+<L>4<pc>1-4<k1>vas<k2>vas<h>0
+<div n="m">— <ab>Caus.</ab> {#prativAsita#} {%gehüllt in%} (<ab>Instr.</ab>).
+<LEND>
 """
 
 
@@ -375,23 +393,27 @@ def selftest():
         path = tf.name
     try:
         r = run_census(path)
-        assert r["n_entries"] == 3, r
-        assert r["kinds"].get("paren-single") == 2, r          # snih (loc.) + sTA (loc.)
+        assert r["n_entries"] == 4, r
+        # snih (loc.) + sTA (loc.) + vas CAPITALIZED (Instr.) — H1308 case-insensitive
+        assert r["kinds"].get("paren-single") == 3, r
         assert r["kinds"].get("paren-variation") == 1, r       # (loc. und gen.)
         assert r["kinds"].get("mit-phrase") == 1, r            # mit dem instr.
         assert r["kinds"].get("paren-nongov") == 1, r          # (voc.); (pl.) never matches
         assert r["cases"]["paren-variation"] == {"loc+gen": 1}, r
-        assert r["entries_with"] == 2, r                       # snih + sTA; deva's voc is nongov
-        # sTA: no root sign, DHĀTUP head line, body <lex>adj.</lex> must NOT win
-        assert r["pos_gov_entries"] == {"verb": 2}, r
-        assert r["units_with"] == 3, r  # snih div2.s1 (both parens) + snih div3 (mit) + sTA div1.s1
+        # vas's capitalized (Instr.) is normalised to lowercase in the case bucket
+        assert r["cases"]["paren-single"].get("instr") == 1, r
+        assert r["entries_with"] == 3, r                       # snih + sTA + vas; deva's voc is nongov
+        # sTA: no root sign, DHĀTUP head line, body <lex>adj.</lex> must NOT win;
+        # vas card has no √/DHĀTUP/<lex> on its head line -> "unknown"
+        assert r["pos_gov_entries"] == {"verb": 2, "unknown": 1}, r
+        assert r["units_with"] == 4, r  # snih div2.s1 (both parens) + snih div3 (mit) + sTA div1.s1 + vas head
 
         # H778 sidecar round-trip: freeze -> fresh read -> stale on source change
         sc = path + ".census.json"
         data = write_sidecar(path, sc, generated="01-01-2026")
         assert data["schema"] == SIDECAR_SCHEMA and data["source_sha16"] == source_sha16(path)
         cached, why = load_sidecar(sc, path)
-        assert why == "cached" and cached["n_entries"] == 3, (why, cached)
+        assert why == "cached" and cached["n_entries"] == 4, (why, cached)
         got, origin = census_or_load(path, sc)
         assert origin == "cached" and got["kinds"].get("mit-phrase") == 1, (origin, got)
         # mutate the source -> SHA differs -> sidecar rejected, live scan instead
@@ -432,6 +454,28 @@ def selftest_extract_government():
     assert extract_government("{%Gott%} (<ab>pl.</ab>) <ls>ṚV. 1,1,1</ls>. (<ab>voc.</ab>) auch so.") == []
     # <ls> spans are stripped first -> a stray case token inside a siglum never matches.
     assert extract_government("<ls>loc. 1,1</ls> plain text") == []
+
+    # H1308: capitalized PW zz_pw* markers extract identically, case-normalised to lowercase.
+    cap = extract_government("{%etwas%} (<ab>Instr.</ab>): {#v#} <ls>MBH. 3,3</ls>.")
+    assert cap == [{"cases": ["instr"], "variation": False, "connector": "",
+                    "kind": "paren-single", "span": "(<ab>Instr.</ab>)"}], cap
+    # capitalized variation keeps the und/oder connector and lowercases both cases.
+    cap_var = extract_government("(<ab>Loc.</ab> und <ab>Gen.</ab>)")
+    assert cap_var[0]["cases"] == ["loc", "gen"] and cap_var[0]["variation"] is True, cap_var
+    assert cap_var[0]["connector"] == "und", cap_var
+    # capitalized (<ab>Voc.</ab>) is still non-government -> excluded.
+    assert extract_government("(<ab>Voc.</ab>) auch so.") == [], "cap voc must be nongov"
+    # capitalized mit-phrase (prose government).
+    cap_mit = extract_government("mit dem <ab>Instr.</ab> {#x#}")
+    assert cap_mit == [{"cases": ["instr"], "variation": False, "connector": "",
+                        "kind": "mit-phrase", "span": "mit dem <ab>Instr.</ab>"}], cap_mit
+    # N2 acceptance card (vas~~h0_zz_pw00|samava): the exact de must yield the Instr. hit,
+    # while the non-case <ab>Caus.</ab> earlier in the same sentence is ignored.
+    n2 = extract_government(
+        "<div n=\"m\">— <ab>Caus.</ab> {#prativAsita#} {%gehüllt in%} "
+        "[Page6-043-a] (<ab>Instr.</ab>).")
+    assert n2 == [{"cases": ["instr"], "variation": False, "connector": "",
+                   "kind": "paren-single", "span": "(<ab>Instr.</ab>)"}], n2
     print("extract_government selftest: OK")
 
 

--- a/RussianTranslation/src/pilot/build_article_site.py
+++ b/RussianTranslation/src/pilot/build_article_site.py
@@ -44,6 +44,7 @@ import pwg_ab_ru  # noqa: E402  (<ab> -> RU display text for the editorial/cross
 import pwg_sources as pwgsrc  # noqa: E402  (<ls> siglum -> full source title, for tooltips)
 import spr_fulltext as spr  # noqa: E402  (<ls> Spr. (II) N -> Indische Sprüche full text, for tooltips; H1307)
 import iast_to_cyrillic as i2c  # noqa: E402  (<is> proper name -> Cyrillic, RU column only)
+import government_census as govc  # noqa: E402  (<ab> case-government extractor; powers government.html, H1308)
 
 RU_STORE = os.path.join(SRC, 'pwg_ru_translated.jsonl')
 OUT_DIR = os.path.join(REPO, 'article_site')
@@ -319,6 +320,86 @@ def ab_frequency(model):
             'bucket': 'translated' if ru_vis else ('latin' if res else 'unresolved'),
         })
     return rows
+
+
+def _safe(s):
+    """URL-/filename-safe slug for a root (matches the roots/<safe>.js convention)."""
+    return re.sub(r'[^A-Za-z0-9_.~-]', '_', s or '')
+
+
+# Fixed case order for the government chips (retrieval oriented): the N2 ask is
+# "one click -> all Instr.-governing cards", so Instr. leads.
+GOV_CASE_ORDER = ('instr', 'loc', 'gen', 'acc', 'dat', 'abl')
+GOV_CASE_LABEL = {'instr': 'Instr.', 'loc': 'Loc.', 'gen': 'Gen.',
+                  'acc': 'Acc.', 'dat': 'Dat.', 'abl': 'Abl.'}
+
+
+def government_index(model):
+    """Per-sense case-government (Rektion) rows for the government.html retrieval
+    surface (H1308). Reuses ``government_census.extract_government`` over the DE
+    (source) sense text — the same authoritative reference set ``ab_frequency`` and
+    ``ls_stats`` read (RU/EN mirror the same government markers). One row per
+    (subcard, sense) that governs >=1 CORE case (acc/loc/instr/gen/dat/abl);
+    nom/voc-only citation-form notes are excluded by the extractor. Marker spans are
+    rendered through ``_render`` so the page shows the tooltip'd ``<span class=ab>``,
+    never raw ``<ab>`` markup. The extractor is case-insensitive, so BOTH the PWG
+    lowercase stratum (``(<ab>instr.</ab>)``) and the PW ``zz_pw*`` capitalized
+    stratum (``(<ab>Instr.</ab>)``) are captured (the N2 card vas~~h0_zz_pw00|samava
+    lives in the latter)."""
+    rows = []
+    for r in model:
+        for sc in r['subcards']:
+            for s in sc['senses']:
+                hits = govc.extract_government(s.get('de_raw'))
+                if not hits:
+                    continue
+                cases = sorted({c for h in hits for c in h['cases'] if c in govc.GOV_CASES})
+                if not cases:
+                    continue
+                markers = [{
+                    'cases': [c for c in h['cases'] if c in govc.GOV_CASES],
+                    'kind': h['kind'], 'variation': h['variation'],
+                    'span_html': _render(h['span'], 'html', 'de'),
+                } for h in hits]
+                rows.append({
+                    'root': r['root'], 'safe': _safe(r['root']), 'iast': r['iast'],
+                    'key': sc['key'], 'sub_iast': sc['iast'] or sc['h'] or sc['key'],
+                    'tag': str(s['tag']), 'sense_html': s['de_html'],
+                    'cases': cases, 'has_variation': any(h['variation'] for h in hits),
+                    'markers': markers,
+                })
+    return rows
+
+
+def government_meta(rows):
+    """Coverage numbers for the government.html banner — the FLOOR the extractor
+    reaches — plus the raw ``pwg.txt`` CEILING read from the frozen census sidecar
+    (H778 ``census_stats.json``), so the banner states floor-vs-ceiling honestly.
+    All numbers computed, never hand-typed."""
+    per_case = collections.Counter()
+    for row in rows:
+        for c in row['cases']:
+            per_case[c] += 1                 # one count per row governing that case
+    meta = {
+        'rows': len(rows),
+        'markers': sum(len(r['markers']) for r in rows),
+        'lemmas': len({r['root'] for r in rows}),
+        'variation_rows': sum(1 for r in rows if r['has_variation']),
+        'per_case': {c: per_case.get(c, 0) for c in GOV_CASE_ORDER},
+    }
+    # Raw pwg.txt ceiling + provenance from the frozen census sidecar.
+    try:
+        sc = json.load(open(os.path.join(SRC, 'census_stats.json'), encoding='utf-8'))
+        cen = sc.get('census', {})
+        kinds = cen.get('kinds', {})
+        meta['ceiling_markers'] = sum(n for k, n in kinds.items() if k != 'paren-nongov')
+        meta['ceiling_entries'] = cen.get('entries_with')
+        meta['ceiling_units'] = cen.get('units_with')
+        meta['census_generated'] = sc.get('generated')
+    except Exception:
+        meta['ceiling_markers'] = meta['ceiling_entries'] = None
+        meta['ceiling_units'] = meta['census_generated'] = None
+    return meta
 
 
 def _root_of(key1):
@@ -683,7 +764,7 @@ a.ls:hover{text-decoration:underline;border-bottom-color:transparent}
    wait. contain-intrinsic-size keeps the scrollbar stable. */
 .sub,.sense,.leaf{content-visibility:auto;contain-intrinsic-size:auto 320px}
 </style></head><body><div id="wrap">
-<nav id="side"><h1>PWG статьи</h1><a href="abbreviations.html" style="display:block;font-size:12px;color:var(--mut);margin:-4px 0 10px 6px">📖 словарь сокращений</a><input id="q" placeholder="фильтр корней…"><div id="list"></div></nav>
+<nav id="side"><h1>PWG статьи</h1><a href="abbreviations.html" style="display:block;font-size:12px;color:var(--mut);margin:-4px 0 2px 6px">📖 словарь сокращений</a><a href="government.html" style="display:block;font-size:12px;color:var(--mut);margin:0 0 10px 6px">⚖ управление (Rektion)</a><input id="q" placeholder="фильтр корней…"><div id="list"></div></nav>
 <main id="main"><div id="arthead"></div><div id="artbody" class="lang-ru"><p class="na">Загрузка…</p></div></main></div>
 <script src="articles.js"></script>
 <script>
@@ -787,7 +868,19 @@ document.getElementById('main').addEventListener('click',function(e){
  var b=e.target.closest?e.target.closest('.tab'):null;if(!b)return;lang=b.getAttribute('data-lang');applyLang();
 });
 q.oninput=function(){renderList(q.value.toLowerCase());};
-renderList('');if(A.roots.length){renderList('');renderRoot(A.roots[0]);}
+// Deep-link: government.html / abbreviations.html open a full entry via
+// index.html#g=<safe> (H1308 V4 — clickable full-entry links). Fall back to the
+// first root when the hash is absent or names no known root.
+function rootByHash(){
+ var m=(location.hash||'').match(/^#g=(.+)$/); if(!m)return null;
+ var safe=decodeURIComponent(m[1]);
+ for(var i=0;i<A.roots.length;i++){if(A.roots[i].safe===safe||A.roots[i].root===safe)return A.roots[i];}
+ return null;
+}
+function openHash(){var r=rootByHash(); if(r){cur=r.root;renderList(q.value.toLowerCase());renderRoot(r);window.scrollTo(0,0);}}
+window.addEventListener('hashchange',openHash);
+renderList('');
+if(A.roots.length){var start=rootByHash()||A.roots[0];cur=start.root;renderList('');renderRoot(start);}
 </script></body></html>
 """
 
@@ -818,7 +911,7 @@ tr:hover td{background:var(--card)}
 .ru{color:var(--fg)}.ru.na{color:var(--mut);font-style:italic}
 .count{text-align:right;font-variant-numeric:tabular-nums}
 </style></head><body><div id="wrap">
-<a class="back" href="index.html">← к статьям</a>
+<a class="back" href="index.html">← к статьям</a> <a class="back" href="government.html" style="margin-left:14px">⚖ управление (Rektion)</a>
 <h1>Словарь сокращений PWG</h1>
 <div class="summary" id="summary">Загрузка…</div>
 <input id="q" placeholder="фильтр по сокращению / расшифровке…">
@@ -867,6 +960,113 @@ render('');
 """
 
 
+GOVERN_HTML = r"""<!doctype html><html lang="ru"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PWG — управление (Rektion)</title>
+<style>
+:root{--bg:#fff;--fg:#1a1a1a;--mut:#6a6a6a;--line:#e4e4e4;--accent:#7a1f1f;--card:#fafafa}
+@media(prefers-color-scheme:dark){:root{--bg:#161616;--fg:#e8e8e8;--mut:#9a9a9a;--line:#333;--accent:#e6928a;--card:#1e1e1e}}
+*{box-sizing:border-box}body{margin:0;font:15px/1.55 -apple-system,Segoe UI,Roboto,sans-serif;color:var(--fg);background:var(--bg)}
+#wrap{max-width:1040px;margin:0 auto;padding:20px 24px 60px}
+a{color:var(--accent)}
+h1{font-size:24px;margin:4px 0 4px}
+.nav{font-size:13px;color:var(--mut);margin-bottom:10px}
+.nav a{text-decoration:none;margin-right:14px}
+.summary{color:var(--mut);font-size:13px;margin:6px 0 12px;line-height:1.6}
+.summary b{color:var(--fg)}
+.caveat{font-size:12px;color:var(--mut);background:var(--card);border-left:3px solid var(--accent);padding:8px 12px;border-radius:0 6px 6px 0;margin:10px 0 16px;line-height:1.55}
+.chips{display:flex;flex-wrap:wrap;gap:8px;margin:10px 0 8px}
+.chip{cursor:pointer;font-size:13px;padding:5px 12px;border:1px solid var(--line);border-radius:16px;background:var(--bg);color:var(--fg);user-select:none;white-space:nowrap}
+.chip:hover{border-color:var(--accent)}
+.chip.on{background:var(--accent);color:#fff;border-color:var(--accent)}
+.chip .n{font-variant-numeric:tabular-nums;opacity:.75;font-size:11px;margin-left:5px}
+#q{width:100%;max-width:360px;padding:7px 10px;border:1px solid var(--line);border-radius:6px;background:var(--bg);color:var(--fg);margin:6px 0 12px}
+.count-line{font-size:12px;color:var(--mut);margin:2px 0 10px}
+table{width:100%;border-collapse:collapse;font-size:13.5px}
+th,td{text-align:left;padding:6px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+th{color:var(--mut);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.03em;position:sticky;top:0;background:var(--bg)}
+tr:hover td{background:var(--card)}
+.hw{white-space:nowrap;font-weight:600}
+.hw a{text-decoration:none}
+.hw a:hover{text-decoration:underline}
+.sub{font-family:ui-monospace,monospace;font-size:11.5px;color:var(--mut);white-space:nowrap}
+.tag{display:inline-block;font-size:10px;color:var(--mut);border:1px solid var(--line);border-radius:8px;padding:0 6px;margin-right:5px}
+.sense{color:var(--fg);max-width:460px}
+.gov{white-space:nowrap}
+.casebadge{display:inline-block;font-size:10px;background:var(--accent);color:#fff;border-radius:8px;padding:1px 7px;margin:1px 2px 1px 0;letter-spacing:.02em}
+.casebadge.var{background:#a04000}
+.ab{border-bottom:1px dotted var(--mut)}
+.na{color:var(--mut);font-style:italic}
+</style></head><body><div id="wrap">
+<div class="nav"><a href="index.html">← к статьям</a><a href="abbreviations.html">📖 словарь сокращений</a></div>
+<h1>Управление (Rektion) в PWG</h1>
+<div class="summary" id="summary">Загрузка…</div>
+<div class="caveat" id="caveat"></div>
+<div class="chips" id="chips"></div>
+<input id="q" placeholder="фильтр по заголовку / значению / под-карте…">
+<div class="count-line" id="countline"></div>
+<table><thead><tr><th>Заголовок</th><th>Под-карта</th><th>Значение (DE)</th><th>Управление</th></tr></thead>
+<tbody id="rows"></tbody></table>
+</div>
+<script src="government.js"></script>
+<script>
+var ROWS=window.GOV_ROWS||[], META=window.GOV_META||{per_case:{}};
+var CASE_ORDER=['instr','loc','gen','acc','dat','abl'];
+var CASE_LABEL={instr:'Instr.',loc:'Loc.',gen:'Gen.',acc:'Acc.',dat:'Dat.',abl:'Abl.'};
+var tbody=document.getElementById('rows'), q=document.getElementById('q'), chipbox=document.getElementById('chips');
+var active=null; // active case chip ('instr'...), 'var', or null=all
+function esc(x){return x==null?'':(''+x);}
+function matchesCase(r){ if(active==null)return true; if(active==='var')return r.has_variation; return r.cases.indexOf(active)>=0; }
+function matchesText(r,f){ if(!f)return true;
+ return (r.iast||'').toLowerCase().indexOf(f)>=0||(r.sense_html||'').toLowerCase().indexOf(f)>=0
+  ||(r.key||'').toLowerCase().indexOf(f)>=0||(r.sub_iast||'').toLowerCase().indexOf(f)>=0; }
+function govHtml(r){
+ var seen={}, order=[]; r.cases.forEach(function(c){if(!seen[c]){seen[c]=1;order.push(c);}});
+ var badges=order.map(function(c){return '<span class="casebadge">'+esc(CASE_LABEL[c]||c)+'</span>';}).join('');
+ if(r.has_variation)badges+='<span class="casebadge var" title="вариативное управление (und/oder)">вар.</span>';
+ var spans=r.markers.map(function(m){return m.span_html;}).join(' ');
+ return '<div class="gov">'+badges+'</div><div style="margin-top:3px">'+spans+'</div>';
+}
+function render(){
+ var f=(q.value||'').toLowerCase(); tbody.innerHTML=''; var n=0;
+ ROWS.forEach(function(r){
+  if(!matchesCase(r)||!matchesText(r,f))return; n++;
+  var tr=document.createElement('tr');
+  // sense_html / span_html are this builder's own generated, escaped markup
+  // (via _render) -> injected as HTML; only plain-text fields go through esc().
+  tr.innerHTML='<td class="hw"><a href="index.html#g='+encodeURIComponent(r.safe)+'" title="открыть полную статью">'+esc(r.iast)+'</a></td>'
+   +'<td class="sub">'+esc(r.key)+'</td>'
+   +'<td class="sense"><span class="tag">'+esc(r.tag)+'</span>'+(r.sense_html||'<span class="na">—</span>')+'</td>'
+   +'<td>'+govHtml(r)+'</td>';
+  tbody.appendChild(tr);
+ });
+ document.getElementById('countline').innerHTML='Показано <b>'+n+'</b> из '+ROWS.length+' карточек с управлением'
+  +(active?(' · фильтр: <b>'+(active==='var'?'вариативное':CASE_LABEL[active])+'</b>'):'');
+}
+function buildChips(){
+ var pc=META.per_case||{}; var html='<span class="chip'+(active==null?' on':'')+'" data-c="">все<span class="n">'+ROWS.length+'</span></span>';
+ CASE_ORDER.forEach(function(c){ var n=pc[c]||0; if(!n)return;
+  html+='<span class="chip'+(active===c?' on':'')+'" data-c="'+c+'">'+CASE_LABEL[c]+'<span class="n">'+n+'</span></span>'; });
+ if(META.variation_rows)html+='<span class="chip'+(active==='var'?' on':'')+'" data-c="var">вариативное<span class="n">'+META.variation_rows+'</span></span>';
+ chipbox.innerHTML=html;
+ var chips=chipbox.querySelectorAll('.chip');
+ for(var i=0;i<chips.length;i++){chips[i].onclick=function(){var c=this.getAttribute('data-c');active=c===''?null:c;buildChips();render();};}
+}
+var ceil = META.ceiling_markers?(' Потолок сырого <i>pwg.txt</i> (только PWG-слой, без PW <i>zz_pw*</i>): <b>'+META.ceiling_markers+'</b> помет управления в <b>'+META.ceiling_entries+'</b> статьях (перепись '+esc(META.census_generated)+').'):'';
+document.getElementById('summary').innerHTML=
+ '<b>'+META.rows+'</b> карточек несут явную помету управления (<b>'+META.markers+'</b> помет, <b>'+META.lemmas+'</b> корней). '
+ +'Нажмите падеж ниже — получите <b>все</b> карточки с этим управлением в один клик.'+ceil;
+document.getElementById('caveat').innerHTML=
+ '⚠️ Это <b>нижняя граница</b>, а не «всё управление». Извлекаются только пометы, явно размеченные тегом <code>&lt;ab&gt;</code> '
+ +'(в круглых скобках <code>(&lt;ab&gt;Instr.&lt;/ab&gt;)</code> или в прозе <code>mit dem &lt;ab&gt;…&lt;/ab&gt;</code>), в обоих регистрах — '
+ +'строчном (слой PWG) и прописном (слой-добавление PW <code>zz_pw*</code>). Управление, выраженное только прозой без тега, '
+ +'и продолжения многопадежных <code>mit</code>-оборотов сюда не попадают — поэтому число занижено, но не завышено.';
+q.oninput=render;
+buildChips(); render();
+</script></body></html>
+"""
+
+
 def emit_abbreviations(model):
     """abbreviations.html + abbreviations.js — the site-wide abbreviation
     dashboard (per-article tooltips live inline in each root's rendered HTML;
@@ -881,6 +1081,25 @@ def emit_abbreviations(model):
     with open(os.path.join(OUT_DIR, 'abbreviations.html'), 'w', encoding='utf-8', newline='\n') as f:
         f.write(ABBREV_HTML)
     return rows
+
+
+def emit_government(model):
+    """government.html + government.js — the one-click case-government (Rektion)
+    RETRIEVAL surface (H1308, DA-vote N2). Abbreviations.html is token-frequency
+    oriented; this page is card-retrieval oriented: click a case chip -> every card
+    governing that case. Rows/meta are computed from the DE source senses, so the
+    page carries an honest floor-vs-ceiling coverage banner (never 'all government')."""
+    rows = government_index(model)
+    meta = government_meta(rows)
+    with open(os.path.join(OUT_DIR, 'government.js'), 'w', encoding='utf-8', newline='\n') as f:
+        f.write('window.GOV_ROWS=')
+        json.dump(rows, f, ensure_ascii=False)
+        f.write(';\nwindow.GOV_META=')
+        json.dump(meta, f, ensure_ascii=False)
+        f.write(';\n')
+    with open(os.path.join(OUT_DIR, 'government.html'), 'w', encoding='utf-8', newline='\n') as f:
+        f.write(GOVERN_HTML)
+    return rows, meta
 
 
 def emit(model):
@@ -935,13 +1154,56 @@ def emit(model):
     with open(os.path.join(OUT_DIR, 'index.html'), 'w', encoding='utf-8', newline='\n') as f:
         f.write(INDEX_HTML)
     ab_rows = emit_abbreviations(model)
+    emit_government(model)
     return ab_rows
+
+
+def selftest_government():
+    """Fixture selftest for government_index / government_meta (H1308) — no store,
+    no network. Pins the N2 acceptance card and the floor-coverage arithmetic."""
+    model = [
+        {'root': 'vas', 'iast': 'vas', 'subcards': [
+            {'key': 'vas~~h0_zz_pw00', 'h': '0', 'iast': 'vas', 'senses': [
+                make_sense('samava',
+                           '<div n="m">— <ab>Caus.</ab> {#prativAsita#} {%gehüllt in%} '
+                           '[Page6-043-a] (<ab>Instr.</ab>).', None, None, None, ''),
+                make_sense('1', '{%plain gloss, no government%} <ls>MBH. 1,1</ls>.',
+                           None, None, None, ''),
+            ]}]},
+        {'root': 'snih', 'iast': 'snih', 'subcards': [
+            {'key': 'snih~~h0', 'h': '1', 'iast': 'snih', 'senses': [
+                make_sense('2', '{%sich heften auf%} (<ab>loc.</ab> und <ab>gen.</ab>): {#z#}',
+                           None, None, None, ''),
+            ]}]},
+    ]
+    rows = government_index(model)
+    # vas|samava (CAPITALIZED Instr.) + snih (loc.+gen. variation) = 2 rows; the
+    # plain-gloss vas sense governs nothing and is dropped.
+    assert len(rows) == 2, rows
+    by_key = {(r['key'], r['tag']): r for r in rows}
+    n2 = by_key[('vas~~h0_zz_pw00', 'samava')]                 # the N2 acceptance card
+    assert n2['cases'] == ['instr'], n2                         # capitalized Instr. captured
+    assert n2['safe'] == 'vas' and n2['iast'] == 'vas', n2
+    span = n2['markers'][0]['span_html']
+    assert 'class=ab' in span and '<ab>' not in span, span     # rendered via _render, not raw
+    sn = by_key[('snih~~h0', '2')]
+    assert sn['cases'] == ['gen', 'loc'] and sn['has_variation'] is True, sn
+    meta = government_meta(rows)
+    assert meta['rows'] == 2 and meta['lemmas'] == 2, meta
+    assert meta['per_case']['instr'] == 1 and meta['per_case']['loc'] == 1, meta
+    assert meta['per_case']['gen'] == 1 and meta['variation_rows'] == 1, meta
+    print('build_article_site government selftest: OK')
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--root', help='debug: print one root and exit')
+    ap.add_argument('--selftest', action='store_true',
+                    help='run the government_index/meta fixture selftest and exit')
     args = ap.parse_args()
+    if args.selftest:
+        selftest_government()
+        return
     model = build_model()
     if args.root:
         r = next((x for x in model if x['root'] == args.root), None)

--- a/RussianTranslation/src/pwg_ab.py
+++ b/RussianTranslation/src/pwg_ab.py
@@ -34,6 +34,15 @@ def table():
     global _AB
     if _AB is None:
         _AB = {}
+        if not os.path.exists(AB):
+            # The pwgab tooltip source lives in the sibling csl-pywork repo, which is
+            # not checked out in every environment (CI runs only this repo). A missing
+            # OPTIONAL tooltip table must degrade to "no expansion", never crash the
+            # site build (H1308): resolve() then returns None and <ab> tags render
+            # without a hover title. Warn once so a genuinely misconfigured local run
+            # stays visible.
+            sys.stderr.write('pwg_ab: table source not found (%s); <ab> tooltips disabled\n' % AB)
+            return _AB
         for line in open(AB, encoding='utf-8'):
             if '\t' not in line:
                 continue

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,25 @@ not an error.
 
 ## [Unreleased]
 
+### Added
+- **One-click case-government (Rektion) index + PW capitalized-marker gap closed (19-07-2026, Opus 4.8 `claude-opus-4-8`, [H1308](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1308-Opus_RussianTranslation_pwg-ru-valency-government-index_19.07.26.md))**:
+  answers DA-vote row N2 (card `vas~~h0_zz_pw00|samava`) — a searchable government surface plus
+  the fix for the PW `zz_pw*` supplement stratum, which writes case markers CAPITALIZED
+  (`(<ab>Instr.</ab>)`) that the lowercase-only extractor missed entirely (0 of 1,123 store
+  rows, incl. the N2 card). Made the marker regexes in
+  [`government_census.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/government_census.py)
+  case-insensitive (new `_cases()` lowercase-normaliser; one change serves both
+  `extract_government()` over the store and `run_census()` over raw `pwg.txt`). Store
+  government rows **508 → 1,756** (614 → 2,129 markers); raw `pwg.txt` ceiling **3,853 → 3,905**
+  (the +52 are sentence-initial "Mit dem `<ab>…</ab>`" prose government previously missed).
+  New `government.html`/`government.js` via `emit_government()` in
+  [`build_article_site.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/build_article_site.py):
+  case chips → every governing card (Instr. one-click returns 218 cards incl. vas/samava),
+  `index.html#g=<safe>` deep-links to the full entry, honest floor-vs-ceiling coverage banner;
+  cross-linked with the abbreviations dashboard. `census_stats.json` re-frozen; government
+  sidecar regenerated (local-only). SHARED in LANG_PARITY; census + site-builder selftests
+  wired into CI.
+
 ### Changed
 - **LaukikaNyaya phrase-tier recall broadened — 151 → 240 records (19-07-2026, Sonnet 5 `claude-sonnet-5`, [H803](https://github.com/gasyoun/Uprava/blob/main/handoffs/H803-Sonnet_SanskritLexicography_laukika-nyaya-jacob-ingest_12.07.26.md) continuation)**:
   the non-`न्याय` phrase-tier headword gate in [`build_laukika_nyaya.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/LaukikaNyaya/tools/build_laukika_nyaya.py)


### PR DESCRIPTION
Executes [H1308](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1308-Opus_RussianTranslation_pwg-ru-valency-government-index_19.07.26.md) — DA-vote row **N2** (card `vas~~h0_zz_pw00|samava`): make PWG case government (Rektion) searchable in one click, and fix the PW `zz_pw*` supplement stratum the extractor was blind to. Opus 4.8 (`claude-opus-4-8`).

## What was broken
The government extractor's regexes were **lowercase-only**. The PW `zz_pw*` supplement stratum writes case markers CAPITALIZED (`(<ab>Instr.</ab>)` vs PWG's `(<ab>instr.</ab>)`), so the extractor caught **0 of 1,123** store rows carrying a capitalized marker — *including the N2 acceptance card itself*.

## Changes
- **`government_census.py`** — `PAREN`/`CASE`/`MIT`/`CONNECTOR` regexes made case-insensitive; new `_cases()` normalises matched tokens to lowercase (one change serves both `extract_government()` over the store and `run_census()` over raw `pwg.txt`). Selftest pins updated (capitalized fixture + exact N2 card assertion).
- **`build_article_site.py`** — `government_index()` / `government_meta()` / `emit_government()` → `government.html` + `government.js`. Case chips (Instr. leads, per N2) → every governing card; `index.html#g=<safe>` deep-links to the full entry; honest floor-vs-ceiling coverage banner; cross-linked with `abbreviations.html`. Fixture selftest `--selftest` added and wired into CI.
- **`census_stats.json`** re-frozen; **`LANG_PARITY.md`** SHARED classification + new entry; **ABBREVIATIONS_RU / PIPELINE_HISTORY / changelog** updated.

## Measured (19-07-2026, live store 11,603 rows)
| metric | before | after |
|---|---|---|
| store rows with government | 508 | **1,756** |
| government markers | 614 | **2,129** |
| capitalized rows caught | 0 | **1,053** |
| raw `pwg.txt` ceiling (markers) | 3,853 | **3,905** |

The raw ceiling rose by **+52** — all `mit-phrase`: 50 sentence-initial "Mit dem `<ab>gen.</ab>`" + 2 capitalized case tokens — genuine prose government the case-sensitive regex under-counted. Reported honestly rather than suppressed.

## Acceptance (N2)
Clicking **Instr.** returns **218 cards including `vas`/`samava`** — verified end-to-end by driving the real page script with a DOM shim (not just the data). `extract_government()` on the N2 card's `de` now returns the `(<ab>Instr.</ab>)` hit.

## Coverage is a FLOOR
The banner, docs, and this PR all state it: only government explicitly `<ab>`-tagged (parenthesized or `mit`-prose, both case-forms) is extracted; prose-only government and multi-case `mit` continuations are not. All explicitly-tagged government, never "all government".

## Dataset registration — NOT registered this pass (deliberate)
No `kosha/datasets.json` row. The store spans **254 lemmas mid-drain** against a raw-PWG ceiling of **1,476** marker-bearing entries (PW stratum uncounted on top), so a `de`-only export would ship as a misleading partial. Verdict per the handoff default: register only once the drain completes. `pwg_government.jsonl` stays local/gitignored.

## gh-pages
`government.html` deployed to the orphan `gh-pages` branch in the same pass (`.nojekyll` preserved). Live: https://gasyoun.github.io/SanskritLexicography/government.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)