### PR TITLE
fix(pwg_ru): scope RU style gate and repair H1305 prose

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1073,6 +1073,15 @@ Two live tracks:
 
 ## ✅ Completed (Recent only)
 
+- **RussianTranslation H1305 style-review repair — DONE 19-07-2026 (Codex/GPT-5).**
+  On isolated branch `codex/ru-style-review-fixes`, the RU gate was narrowed to structured
+  `sense.russian` values and one high-precision shared R2/R3 classifier. Complete population
+  audit found 279/20 hard cases and 12/4 ambiguous cases; all 16 legacy over-abbreviations
+  were restored by conflict-safe hash/ordinal reconciliation from the H1305 backup. Store
+  population remains 11,603, conflicts=0, hard violations=0. Timestamped verified backups,
+  live-store TOCTOU hashes, ignored evidence reports, migration fixtures, and TM rebuild are
+  complete; EN behavior remains unchanged.
+
 - **H1268 — A67 negative-results methods paper — DONE 19-07-2026 (Fable 5 `claude-fable-5`).**
   First negative-results paper of the programme drafted at
   [papers/A67_negative_results_computational_sanskrit_lexicography.md](papers/A67_negative_results_computational_sanskrit_lexicography.md)

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2731,3 +2731,35 @@ which sharpen — not overturn — the finding:
 > [SanskritGrammar PR #450](https://github.com/gasyoun/SanskritGrammar/pull/450) (supersedes
 > [#447](https://github.com/gasyoun/SanskritGrammar/pull/447)) · H1310 · 19-07-2026,
 > Opus 4.8 (`claude-opus-4-8[1m]`).
+
+---
+
+### §98. Output gates must audit structured semantic fields, and sample-clean editorial rewrites still require a full-population ambiguity pass
+
+The H1305 RU style gate originally scanned rendered `.merged.md` output and applied
+«вместо»→«вм.» / «в значении»→«в знач.» globally after a clean 60/291 R2 sample and a
+24/24 R3 census. Review exposed two independent false-positive paths. First, rendered
+output contains notes, differentia, source text, headings, and footer metadata that are not
+the translated sense; those fields can contain a trigger even when every Russian sense is
+clean. Second, the R2 sample missed rare quoted, retained, and narrative uses. A complete
+pre-sweep audit measured R2 **279 hard / 12 ambiguous** and R3 **20 hard / 4 ambiguous**.
+
+**Reusable rule.** A gate for a semantic output field must parse the producer's structured
+result and inspect that field directly (`card.records[].senses[].russian` here), aggregating
+back to the original work key only after field-level classification. Rendered documents are
+presentation artifacts, not an audit schema. For style substitutions that can also be
+ordinary prose, use an explicit high-precision cue classifier; surface ambiguous matches as
+warnings and keep them out of defect/requeue output. Before a store-wide apply, audit the
+whole trigger population when it is small enough—an apparently clean random sample does not
+establish absence of rare context classes.
+
+The repair also established the write-safety pattern: reconcile an old backup to the live
+store by a stable non-translation hash plus duplicate ordinal; recognize only original,
+legacy-transformed, or newly scoped values; refuse the whole apply on divergence; create a
+new exclusive timestamped backup on every apply; verify hash + row count; and re-hash the
+live store immediately before atomic replacement. This restored 16 H1305 over-abbreviations
+without overwriting later edits (11,603 rows, 0 conflicts).
+
+> **Source:** [`RussianTranslation/src/ru_style_sweep.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ru_style_sweep.py) +
+> [`RU_STYLE_MECHANICAL.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/RU_STYLE_MECHANICAL.md) ·
+> 19-07-2026, Codex/GPT-5.

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2424,12 +2424,23 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H1305 review findings repaired — EXECUTED 19-07-2026 (Codex/GPT-5).** Isolated branch
+  `codex/ru-style-review-fixes`: `ru_style_sweep.py` now uses one exact high-precision R2/R3
+  classifier for sweep + audit, protects `«…»`/`{%…%}`, and audits only structured
+  `records[].senses[].russian` workflow fields. Ambiguous matches warn without requeue;
+  notes/differentia/German/render metadata are ignored; EN is untouched. Full pre-sweep
+  population review: R2 279 hard + 12 ambiguous; R3 20 hard + 4 ambiguous. Hash/ordinal
+  reconciliation against the H1305 backup restored all 16 ambiguous values, preserved
+  11,603 rows, and found 0 conflicts; post-repair hard violations=0. Every apply now makes
+  and verifies a unique timestamped backup, checks the live hash before atomic replace,
+  and emits ignored JSON evidence. Canonical RU card TM rebuilt + validated (2,476 cards).
+
 - **H1305 mechanical RU style sweep — EXECUTED 19-07-2026 (Sonnet 5 `claude-sonnet-5`).**
   MG's DA-vote (N7/N12 + N4-terseness) ratified four rules, applied store-wide + wired for
   future generation: R1 no letter ё anywhere (whitelist: standalone «всё»/«Всё» only;
   «всё-таки» defaults to е); R2 «вместо»→«вм.» and R3 «в значении»→«в знач.» in editorial
-  metalanguage (measured 0/60 and 0/24 false positives — applied unrestricted, well under
-  the 2% threshold); R4 `ed. Bomb.`→«Бомбейская ред.» in free prose ONLY (282/283
+  metalanguage (the original sampled 0/60 and 0/24 unrestricted decision is superseded by
+  the scoped review repair above); R4 `ed. Bomb.`→«Бомбейская ред.» in free prose ONLY (282/283
   occurrences sit inside `<ls>…</ls>` and were left verbatim — rewriting them breaks
   `pwg_sources.py` source-key resolution; only 1 genuine free-prose occurrence swept).
   Applied to the canonical store (11,603 rows unchanged): 2,029 substitutions across 1,485

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,29 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — scoped RU style gate and conflict-safe H1305 repair
+
+- The `ru_style` workflow gate now audits only structured
+  `card.records[].senses[].russian` values. Rendered Markdown notes, `differentia`, German
+  source text, headings, and footer metadata are excluded. Multiple violating senses still
+  aggregate to one original workflow key; ambiguous R2/R3 matches are diagnostic warnings,
+  never `FLAGGED_JSON` defects. The EN audit path is unchanged.
+- R2/R3 now share one high-precision contextual classifier between rewriting and auditing.
+  Matches inside `«…»` or `{%…%}` are protected; only the ratified correction,
+  replacement-object, and lexical-use cues are hard. A complete re-audit corrected H1305's
+  sampled false-positive claim: of 291 pre-sweep «вместо» occurrences, 279 are hard and 12
+  ambiguous; of 24 «в значении» occurrences, 20 are hard and 4 ambiguous.
+- Added dry-run-by-default `--repair-from` reconciliation against the original H1305 backup.
+  Stable row hashes exclude translation/review/provenance fields and use occurrence ordinals
+  for duplicates. Only original, legacy-swept, or newly scoped values are recognized;
+  divergent later edits fail the entire apply. The canonical repair restored all 16 reviewed
+  ambiguous occurrences with 0 conflicts and preserved the 11,603-row population. Final
+  store audit: 0 hard violations, 12 R2 + 4 R3 warnings.
+- Every apply now makes an exclusive UTC-timestamped backup, verifies its SHA-256 and row
+  count, re-hashes the live store immediately before atomic replacement, and writes an
+  ignored JSON evidence report. Consecutive applies were verified to create distinct backups.
+  The derived RU card translation memory was rebuilt and validated after repair.
+
 ### Added — mechanical RU style sweep: no-ё, terse editorial metalanguage (H1305)
 
 - **Four ratified, deterministic RU style rules applied store-wide and wired for future
@@ -17,11 +40,10 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   **R1** no letter ё anywhere in RU output — write е everywhere; the only exception is the
   standalone token «всё»/«Всё» (disambiguating все/всё); the edge case «всё-таки» defaults
   to е («все-таки») like every other ё-word, per the ruling. **R2** «вместо» → «вм.» and
-  **R3** «в значении» → «в знач.» in editorial metalanguage — measured **0/60** and
-  **0/24** false positives respectively on a hand-classification of the canonical store
-  (every «вместо»/«в значении» hit is editorial apparatus — variant readings, sense
-  specification — never narrative prose), well under the handoff's ~2% restriction
-  threshold, so both apply **unrestricted**. **R4** `ed. Bomb.` → «Бомбейская ред.» in
+  **R3** «в значении» → «в знач.» in editorial metalanguage. The original sampled
+  **0/60** and **0/24** false-positive claim and unrestricted application are superseded by
+  the review fix above: the full population contains 12 ambiguous R2 and 4 ambiguous R3
+  cases, all restored and now non-blocking. **R4** `ed. Bomb.` → «Бомбейская ред.» in
   **free prose only** — 282 of 283 occurrences (221 standalone `<ls>ed. Bomb.</ls>` + 61
   embedded in a longer citation, e.g. `<ls>R. ed. Bomb. 3,69,4</ls>`) sit inside
   `<ls>…</ls>` and were left **verbatim**: [`src/pwg_sources.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_sources.py)'s
@@ -31,10 +53,10 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   swept. The in-`<ls>` population (282 occurrences) is a render-time display concern,
   explicitly out of scope here and NOT covered by [H1307](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1307-Opus_RussianTranslation_pwg-ru-ls-link-enrichment-panini-spr-dhatup_19.07.26.md)
   either — handed off as a PROPOSED follow-up.
-- **Applied to the canonical store** (11,603 rows, row count unchanged — content-only
-  edit): **2,029 substitutions across 1,485 rows** (R1=1,713, R2=291, R3=24, R4=1). A
-  rescan after `--apply` shows **0 residual violations**; the sweep is idempotent (no
-  substitution's output contains its own trigger pattern).
+- **Initially applied to the canonical store** (11,603 rows, row count unchanged): 2,029
+  substitutions across 1,485 rows (R1=1,713, R2=291, R3=24, R4=1). The scoped repair above
+  restored 16 ambiguous R2/R3 values, leaving 2,013 ratified substitutions
+  (R1=1,713, R2=279, R3=20, R4=1) and 0 hard residual violations.
 - **New** [`src/ru_style_sweep.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ru_style_sweep.py)
   (stdlib-only; dry-run default, `--apply`, `--selftest`, `--wf` for the window-gate mode) —
   resolves the store via `store_path.canonical_store` (prints the resolved path before

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -98,7 +98,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -134,7 +134,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -153,7 +153,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -172,7 +172,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -372,7 +372,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -391,7 +391,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -429,7 +429,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -488,7 +488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
       "src/pilot/perf_preflight.py": "56bd55032aa5d6db22d7ba2f59dc05adeca3be3227aecd14780728458bd0b1bb",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -519,7 +519,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "bd9626ca58ca67773ab157140a2b62afff46047ac2294a864783144f629a7d63",
       "src/pilot/audit_window.py": "408865512ccb28f338efb93078858076559978b2d875d8a49b50f2177c6a0049",
       "src/pilot/autosplit_requeue.py": "7ada6e0aa8dc8d0be15cf4be725e380929282974cc19fc950690c07b09511448",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -538,7 +538,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "958b069fc3a88e1032900f44498410fab88646409c9f0ca4e0952272a446cea1",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -556,7 +556,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -575,7 +575,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -615,7 +615,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dbbf4e77b39585dabdd3df122143cacc15fedb97ce6c3d12654061e8fe6c11b9",
       "src/promote_final_cards.py": "f01b9cb8f0b444e7d5be98670908991830eddbbdbe357b2f3e96aa50bce0d6f5",
       "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -640,7 +640,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "062733fd593b4cde4213fcfba2840e19c319da74d0fb5e2eff445bba60520cd6",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -669,7 +669,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "958b069fc3a88e1032900f44498410fab88646409c9f0ca4e0952272a446cea1",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -689,7 +689,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -708,7 +708,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "717a828f7950cf3cac38223dc2b277281143a0536b1f6dca2bd4fb652da0a1aa",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -745,7 +745,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -803,7 +803,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -822,7 +822,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -841,7 +841,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -861,7 +861,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4",
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -883,7 +883,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -942,7 +942,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -1002,7 +1002,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -1021,7 +1021,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -1046,7 +1046,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "408865512ccb28f338efb93078858076559978b2d875d8a49b50f2177c6a0049",
       "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -1068,7 +1068,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "b3fc515249c1bc80b9c90608b3d74f0b30248d45da0a8a2b61910772ce24c744",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4",
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1088,7 +1088,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -1143,7 +1143,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4"
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496"
     }
   },
   {
@@ -1254,9 +1254,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Russian ё-orthography policy and Russian terse editorial metalanguage («вм.», «в знач.», «Бомбейская ред.») have no EN counterpart by construction -- EN output contains no Cyrillic and uses its own English editorial conventions (no ё letter, no «вместо»/«в значении» abbreviation question). Register §4's h178-vote row \"(SHARED)\" annotation is refined here: the GATE WIRING MECHANISM (an RU-only-detector slot added to audit_window.py's existing commands list, alongside translation/stage2_mechanical/coverage/sense_dupes) is SHARED-capable machinery -- a hypothetical 3rd Cyrillic-scripted language could reuse the same gate-list slot -- but the RULES THEMSELVES (R1-R4, the ё-whitelist, the вм./в знач. terse forms) are RU-only INTENTIONAL-DIVERGENCE, not something to port to audit_window_en.py, which this handoff deliberately does not touch.",
     "tracking": "",
     "verified_sha256": {
-      "src/ru_style_sweep.py": "35bb55147149ed4c8824f6001ae406b671dd220b5e9dc8c59d3978ab9614678c",
+      "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
       "src/pilot/audit_window.py": "408865512ccb28f338efb93078858076559978b2d875d8a49b50f2177c6a0049",
-      "src/pilot/window_selftest.py": "6d528a50baa1f8a8c50ed9b7edf153abe0c20480296875ddcb7f16533883a1f4",
+      "src/pilot/window_selftest.py": "082112db2c0876d6cfe5ea2b3737af91c29dd030fb14235c7916e9abfb272496",
       "src/pilot/prompt_rule_audit.py": "913e91862fe08bde42ba9f935533b3acb2fe3db38401a8f903bd7f01cbd4b435",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }

--- a/RussianTranslation/PIPELINE_HISTORY.md
+++ b/RussianTranslation/PIPELINE_HISTORY.md
@@ -15,25 +15,32 @@ MG's DA-sheet vote (N7/N12 + the terseness half of N4) ratified four determinist
 style rules: no letter ё anywhere in output (whitelist: standalone «всё»/«Всё» only,
 disambiguating все/всё — «всё-таки» defaults to е like every other ё-word); «вместо»→«вм.»
 and «в значении»→«в знач.» in editorial metalanguage; `ed. Bomb.` → «Бомбейская ред.» in
-free prose only. The one judgment call was the false-positive measurement before applying
-R2/R3 broadly: sampled 60/291 «вместо» and all 24 «в значении» occurrences by hand — 0%
-false positives on both (every hit was editorial apparatus, never narrative prose), well
-under the handoff's 2% restriction threshold, so both apply unrestricted, no context
-gating needed. `ed. Bomb.` split differently: 282/283 occurrences sit inside `<ls>…</ls>`
+free prose only. H1305 initially sampled 60/291 «вместо» and all 24 «в значении» hits and
+therefore applied R2/R3 unrestricted. The subsequent review re-audited the complete
+population and corrected that claim: **279/291 R2 and 20/24 R3** satisfy the explicit
+high-confidence editorial cues; **12 R2 + 4 R3** are quoted, retained, narrative, or
+otherwise ambiguous and remain natural, diagnostic-only prose. `ed. Bomb.` split
+differently: 282/283 occurrences sit inside `<ls>…</ls>`
 citation spans that `src/pwg_sources.py`'s `source_key()`/`resolve()` key off the exact
 Latin text against PWG's bibliography — rewriting those to Cyrillic breaks source
 resolution outright, so only the 1 genuine free-prose occurrence was swept; the in-`<ls>`
 population is a render-time display concern, handed off (not H1307's shipped scope,
 which is Pāṇini/Spr./DHĀTUP. link enrichment specifically).
 
-Applied to the canonical store (11,603 rows, unchanged row count): 2,029 substitutions
-across 1,485 rows (R1=1,713, R2=291, R3=24, R4=1); a rescan after `--apply` shows 0
-residual violations. Wired for future generation via HARD RULE 9 in `run_pilot_wf.js`'s
+The initial store sweep made 2,029 substitutions across 1,485 rows. The review repair
+matched the original backup to the live 11,603-row store by stable content hash plus
+duplicate ordinal, restored the 16 ambiguous values without overwriting later edits, and
+found zero conflicts. The retained rule population is R1=1,713, R2=279, R3=20, R4=1;
+post-repair audit shows zero hard violations and the expected 12/4 warnings. Every apply
+now uses a distinct verified timestamped backup plus live-store hash checks around atomic
+replacement. Wired for future generation via HARD RULE 9 in `run_pilot_wf.js`'s
 `CONV`/`TR` (auto-inherited by every future `gen_opt_harness2.py`-generated harness, which
 extracts `TR` directly from this file by regex — no separate derivative to keep in sync),
-pinned in `prompt_rule_audit.py`, and enforced by a new `ru_style` gate in
-`audit_window.py` that reuses the sweep's own `scan_violations()` (one detector, two
-callers, can never drift). RU-only by construction (no EN counterpart — see
+pinned in `prompt_rule_audit.py`, and enforced by a `ru_style` gate in `audit_window.py`.
+The gate parses workflow cards and inspects only `records[].senses[].russian`; rendered
+notes/metadata are excluded, and ambiguous matches warn without entering `FLAGGED_JSON`.
+Rewriting and audit use the same classifier while retaining the public
+`scan_violations()` API. RU-only by construction (no EN counterpart — see
 `LANG_PARITY.md` `ru_style_mechanical_yo_terseness`). Full rule table + measurement:
 [`pwg_ru/RU_STYLE_MECHANICAL.md`](pwg_ru/RU_STYLE_MECHANICAL.md).
 

--- a/RussianTranslation/pwg_ru/RU_STYLE_MECHANICAL.md
+++ b/RussianTranslation/pwg_ru/RU_STYLE_MECHANICAL.md
@@ -40,8 +40,8 @@ local-only), as recorded in register §3:
 | id | rule | scope |
 |---|---|---|
 | **R1** | no letter ё anywhere in RU output — write е everywhere | whole `ru` field, whitelist below |
-| **R2** | «вместо» → «вм.» | editorial metalanguage (measured unrestricted, see below) |
-| **R3** | «в значении» → «в знач.» | editorial metalanguage (measured unrestricted, see below) |
+| **R2** | «вместо» → «вм.» | high-confidence editorial contexts only; ambiguous prose is unchanged |
+| **R3** | «в значении» → «в знач.» | high-confidence lexical-use contexts only; ambiguous prose is unchanged |
 | **R4** | `ed. Bomb.` → «Бомбейская ред.» | free prose ONLY, outside any `<ls>…</ls>` span |
 
 **R1 — no-ё whitelist.** Exactly the standalone token «всё»/«Всё» (regex `\bвсё\b`
@@ -54,30 +54,31 @@ preceded by a hyphen, so a hyphenated compound is never mistaken for the standal
 real per the ruling but had zero live instances to sweep); the regex still guards it
 defensively for future content.
 
-## False-positive measurement (BEFORE apply — the judgment call)
+## False-positive measurement (review-corrected full-population audit)
 
-Extracted every occurrence of «вместо», «в значении», and `ed. Bomb.` from the RU field of
-the canonical store (11,603 rows) and hand-classified metalanguage vs. quoted/translated
-prose, per the handoff's ≥50-sample / ≤2%-threshold instruction.
+The original H1305 decision sampled 60 of 291 «вместо» occurrences and reported no prose
+false positives. The review re-audited **all** pre-sweep R2/R3 occurrences and found that
+the sample had missed quoted, retained, narrative, and low-confidence apparatus contexts.
+The unrestricted claim is therefore withdrawn.
 
-| pattern | total occurrences | sample checked | prose (false-positive) | verdict |
+| pattern | pre-sweep population | hard/editorial | ambiguous, unchanged | verdict |
 |---|---:|---:|---:|---|
-| «вместо» | 291 | 60 (random, seed 1305) | **0/60 (0%)** | unrestricted sweep (R2) |
-| «в значении» | 24 | 24 (100%, small population) | **0/24 (0%)** | unrestricted sweep (R3) |
-| `ed. Bomb.` | 283 | 283 (100%, markup-classified) | see split below | prose-only sweep (R4) |
+| «вместо» | 291 | **279** | **12** | contextual R2 only |
+| «в значении» | 24 | **20** | **4** | contextual R3 only |
+| `ed. Bomb.` | 283 | 1 free-prose hit | 282 protected `<ls>` hits | prose-only R4 |
 
-**«вместо» (291 occurrences).** Every sampled hit is editorial apparatus — overwhelmingly
-the fixed pattern «ошибочно/неточно/вероятно вместо X» ("read X instead of Y is an error";
-42/60 carry an explicit error marker), plus other apparatus uses (case-government notes
-like «Вместо <ab>Dat.</ab> также <ab>Instr.</ab>», corrigenda «читать n. вместо m.»,
-variant-reading notes «<ab>v. l.</ab> вместо {#X#}») — **never** ordinary narrative prose
-describing real-world meaning. 0% measured false-positive rate is well under the handoff's
-~2% restriction threshold, so R2 applies to every occurrence unrestricted (no `{%…%}`
-context gating needed).
+R2 is hard only when its ±120-character context carries an explicit correction cue, its
+object begins with the specified markup/editorial qualifier, or its following context uses
+one of the specified reading/replacement formulae. R3 is hard only when its object is
+explicitly marked or its ±80-character context carries a lexical-use cue. An occurrence
+inside `«…»` or `{%…%}` is never abbreviated. The detailed cue lists live beside the shared
+classifier in `src/ru_style_sweep.py` and are pinned by tests.
 
-**«в значении» (24 occurrences, full population checked).** Every occurrence is the
-editorial sense-specification idiom («X в значении Y», "X in the sense of Y" / "X used to
-mean Y") — the exact pattern N12's vote targeted. 0% false positives; R3 applies unrestricted.
+All 16 ambiguous occurrences were reviewed. They include quoted prose («вместо того
+чтобы…»), retained `{%…%}` text, NWS technical narrative (`при māraṇa вместо abhra`), and
+apparatus whose punctuation or wording does not satisfy the high-confidence contract. Even
+where an editor might reasonably abbreviate the latter, the gate leaves it natural and
+non-blocking: precision takes priority over a false defect requeue.
 
 **`ed. Bomb.` (283 occurrences) — markup split, not a prose-vs-metalanguage split.**
 Every occurrence sits either standalone or embedded inside an `<ls>…</ls>` citation span,
@@ -110,7 +111,7 @@ PROPOSED follow-up (see below); it is NOT part of
 shipped scope (that handoff covers Panini/Spr./DHATUP link enrichment specifically, not
 `ed. Bomb.` display) — a future handoff should pick this up explicitly.
 
-## Sweep results (applied)
+## Sweep and review-repair results (applied)
 
 Ran [`src/ru_style_sweep.py --apply`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ru_style_sweep.py)
 against the canonical store (backup verified row-count-match before apply, per the
@@ -119,17 +120,31 @@ handoff's prerequisite 2):
 | rule | substitutions | rows touched |
 |---|---:|---:|
 | R1 no-ё | 1,713 | (of 1,485 total touched rows) |
-| R2 «вместо»→«вм.» | 291 | |
-| R3 «в значении»→«в знач.» | 24 | |
+| R2 «вместо»→«вм.» | 291 initially; **279 retained after review** | |
+| R3 «в значении»→«в знач.» | 24 initially; **20 retained after review** | |
 | R4 `ed. Bomb.` (prose only) | 1 | |
-| **total substitutions** | **2,029** | **1,485 distinct rows** |
+| **total substitutions** | **2,029 initially; 2,013 retained after review** | **1,485 initial distinct rows** |
 
-**Store row count: 11,603 → 11,603 (unchanged, as required — content-only edit).**
-Re-running the auditor (`python src/ru_style_sweep.py`, dry-run) after `--apply` reports
-**0 residual violations** across all four rules — the sweep is idempotent (each
-substitution's output contains none of its own trigger pattern: «вм.» contains no
-«вместо», е-forms contain no ё, «Бомбейская ред.» sits outside `<ls>`, «в знач.» contains
-no «в значении»).
+The review repair reconciled the live store against the original H1305 backup by a stable
+row-content hash plus duplicate ordinal. It restored **16** ambiguous R2/R3 occurrences
+(12 + 4), preserved every later/current-only row, and found **0 conflicts**. Store row count
+remained **11,603 → 11,603**; the post-repair hash is
+`200cde941773a821c94ddc84a2976a645b1eea44b8e596cd954a6c81bac80bb7`.
+The final audit reports **0 hard violations** and the expected 12/4 diagnostic warnings.
+
+Every apply now creates an exclusive UTC-timestamped backup, verifies its SHA-256 and row
+count, and compares the live-store hash both after reading and immediately before atomic
+replacement. The first review-repair backup preserved the legacy-swept store at hash
+`c82a65c4c6159409867ceaa0f4aeb1d637925a0257ff62960c34332562c30488` (11,603 rows).
+The ignored JSON evidence report records before/after hashes, populations, rule counts, all
+16 restored values, ambiguous snippets, and conflicts. The derived RU card translation
+memory was rebuilt and validated after the repair.
+
+The `--wf` gate now parses workflow results and inspects only
+`card.records[].senses[].russian`; notes, differentia, German source text, rendered headings,
+and footer metadata cannot create a style defect. Ambiguous matches are printed under
+`WARNED_JSON` and are never included in `FLAGGED_JSON`. `scan_violations(text) -> list[str]`
+remains the compatibility surface used by existing callers.
 
 ## PROPOSED candidates (routed to H1306 / MG, NOT applied here)
 

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -1207,10 +1207,9 @@ def test_h1302_german_prose_residue_scan():
 
 
 def test_h1305_ru_style_mechanical():
-    # H1305: no-ё / terse editorial metalanguage («вм.», «в знач.») / in-<ls> `ed. Bomb.`
-    # left verbatim (source-resolution safety) -- the audit_window.py `ru_style` gate reuses
-    # ru_style_sweep.scan_violations exactly, so these fixtures pin BOTH the sweep and the gate.
-    from ru_style_sweep import scan_violations, sweep_text
+    # H1305 + review fix: hard style rules inspect structured Russian senses only;
+    # ambiguous narrative R2/R3 prose warns but never enters FLAGGED_JSON.
+    from ru_style_sweep import audit_workflow_results, scan_violations, style_diagnostics, sweep_text
 
     # ё-word flagged (R1)
     if 'R1_yo' not in scan_violations('пришёл поздно'):
@@ -1227,6 +1226,15 @@ def test_h1305_ru_style_mechanical():
     # metalanguage «в значении» flagged (R3)
     if 'R3_vznach' not in scan_violations('употребляется в значении «зуб»'):
         fail('H1305: metalanguage «в значении» not flagged R3_vznach')
+    # Ordinary prose stays natural and is diagnostic-only, not a hard violation.
+    for prose, rule in (
+            ('Он выступил вместо брата.', 'R2_vmesto'),
+            ('«в отдельные случаи [вместо того чтобы быть непрерывным]»', 'R2_vmesto'),
+            ('при māraṇa вместо abhra', 'R2_vmesto'),
+            ('Он понял знак в значении обещания.', 'R3_vznach')):
+        diagnostic = style_diagnostics(prose)
+        if rule in diagnostic['violations'] or rule not in diagnostic['ambiguous_rules']:
+            fail('H1305 review: narrative prose was not classified ambiguous: %s' % prose)
     # `ed. Bomb.` INSIDE <ls>...</ls> (standalone or embedded) is NEVER a violation --
     # rewriting it would break src/pwg_sources.py's citation-key resolution.
     if scan_violations('(так <ls>ed. Bomb.</ls>)'):
@@ -1245,6 +1253,29 @@ def test_h1305_ru_style_mechanical():
         fail('H1305: sweep_text did not apply the terse form / kept in-<ls> siglum verbatim')
     if counts.get('R2_vmesto') != 1 or counts.get('R4_bomb') != 0:
         fail('H1305: sweep_text per-rule counts do not match the expected split')
+
+    # The workflow gate consumes card.records[].senses[].russian directly. Notes,
+    # differentia and German text cannot false-flag an otherwise-clean translation.
+    results = [{
+        'key': 'clean-notes',
+        'card': {'notes': 'Переводчик пришёл.', 'records': [{'senses': [{
+            'german': 'вместо', 'russian': 'чистый текст', 'differentia': 'пришёл',
+        }]}]},
+    }, {
+        'key': 'multi-hard',
+        'card': {'records': [{'senses': [
+            {'russian': 'пришёл'},
+            {'russian': 'ошибочно вместо {#X#}'},
+        ]}]},
+    }, {
+        'key': 'narrative',
+        'card': {'records': [{'senses': [{'russian': 'Он выступил вместо брата.'}]}]},
+    }]
+    _, flagged, warned = audit_workflow_results(results)
+    if flagged != ['multi-hard']:
+        fail('H1305 review: structured workflow flags wrong keys: %r' % flagged)
+    if warned != ['narrative']:
+        fail('H1305 review: ambiguous workflow warning wrong keys: %r' % warned)
 
 
 def test_semantic_review_prioritizer():

--- a/RussianTranslation/src/ru_style_sweep.py
+++ b/RussianTranslation/src/ru_style_sweep.py
@@ -1,358 +1,732 @@
 #!/usr/bin/env python
-r"""ru_style_sweep.py -- H1305 mechanical RU style sweep: no-ё, terse editorial metalanguage.
+r"""Mechanical Russian style rules and the H1305 store-repair utility.
 
-Applies four ratified, deterministic rules (H178 DA-vote 19-07-2026, register rows
-N7/N12/N4-terseness -- see RU_STYLE_MECHANICAL.md for the full ruling text + the
-false-positive measurement that cleared R2/R3 for a BROAD (unrestricted) sweep):
+The hard rules are:
 
-  R1  no letter ё anywhere in RU output -- write е everywhere; the ONLY exception is the
-      standalone word «всё»/«Всё» (kept to disambiguate from «все»/«Все»). A hyphenated
-      compound like «всё-таки» is NOT the exception (it defaults to «все-таки», like
-      every other ё-word) -- the whitelist regex explicitly excludes anything immediately
-      followed/preceded by a letter or hyphen.
-  R2  «вместо» -> «вм.» (editorial metalanguage: variant/replacement readings). Measured
-      0/60 false positives on a random sample of the store's 291 occurrences (all are
-      editorial "read X instead of Y" apparatus, none are narrative prose) -- applied
-      UNRESTRICTED per the handoff's <2% threshold.
-  R3  «в значении» -> «в знач.» (editorial metalanguage: sense specification). Measured
-      0/24 false positives (100% of the store's occurrences hand-classified) -- applied
-      unrestricted.
-  R4  `ed. Bomb.` -> «Бомбейская ред.», but ONLY in free PROSE outside any <ls>...</ls>
-      span. Measured split: 221 standalone <ls>ed. Bomb.</ls> + 61 embedded inside a
-      longer citation (e.g. <ls>R. ed. Bomb. 3,69,4</ls>) = 282 in-<ls> occurrences that
-      MUST stay verbatim Latin (src/pwg_sources.py.source_key()/resolve() key the citation
-      off this exact Latin text against pwgbib.txt -- rewriting it to Cyrillic breaks
-      source resolution), vs. 1 genuine free-prose occurrence outside any <ls> tag. Only
-      that population is swept here; the in-<ls> population is a render-time display
-      concern (counted + handed off in RU_STYLE_MECHANICAL.md, not fixed at the store
-      level).
+* R1: replace ё/Ё with е/Е, except standalone всё/Всё.
+* R2: use вм. for high-confidence editorial uses of вместо.
+* R3: use в знач. for high-confidence lexical uses of в значении.
+* R4: translate ``ed. Bomb.`` only outside ``<ls>...</ls>``.
 
-Reuse (not reinvented -- pattern mirrors the H1302 precedent):
-  - store mode / backup / dry-run-by-default / atomic write: fix_german_connectives.py
-    --store.
-  - canonical store resolution: store_path.canonical_store (worktree-safe -- H805/w06).
-  - --wf window-gate mode (FLAGGED_JSON, audit_window.py wiring): stage2_pregate.py --wf /
-    audit_translation.py --wf (reads the SAME .merged.md rendered output audit_window
-    already consumes for the other RU gates).
+R2/R3 deliberately fail open for ambiguous prose.  The workflow gate inspects only
+structured ``sense.russian`` values; rendered notes and other Markdown are out of scope.
 
-  python src/ru_style_sweep.py                 # dry-run store sweep (default), per-rule counts
-  python src/ru_style_sweep.py --apply          # apply to the canonical store (backs up first)
-  python src/ru_style_sweep.py --selftest       # fixture assertions
-  python src/ru_style_sweep.py --wf wf.json     # window audit gate: FLAGGED_JSON (audit_window.py)
+Usage::
+
+    python src/ru_style_sweep.py                         # store dry-run
+    python src/ru_style_sweep.py --apply                 # safe store apply
+    python src/ru_style_sweep.py --wf wf_output.json     # workflow audit
+    python src/ru_style_sweep.py --repair-from OLD.jsonl # H1305 repair dry-run
+    python src/ru_style_sweep.py --repair-from OLD.jsonl --apply
+    python src/ru_style_sweep.py --selftest
 """
+import argparse
+import collections
+import datetime as dt
+import hashlib
 import json
 import os
 import re
 import shutil
 import sys
+import tempfile
 
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
-HERE = os.path.dirname(os.path.abspath(__file__))     # .../src
+HERE = os.path.dirname(os.path.abspath(__file__))
 if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
 from store_path import canonical_store  # noqa: E402
 
+RT = os.path.dirname(HERE)
+SAMPLES_PER_RULE = 6
+
 # ---------------------------------------------------------------------------
-# R1 -- no-ё, with the «всё»/«Всё» standalone-token whitelist.
+# Shared rule definitions.
 # ---------------------------------------------------------------------------
 YO_CHAR = re.compile('[ёЁ]')
-# Standalone «всё»/«Всё» ONLY: not immediately preceded/followed by a Cyrillic letter or a
-# hyphen, so a hyphenated compound («всё-таки») or a longer word never qualifies -- those
-# default to е like every other ё-word (the ruling's stated edge-case behavior).
 WHITELIST_VSE = re.compile(r'(?<![а-яёА-ЯЁ\-])[Вв]сё(?![а-яёА-ЯЁ\-])')
+
+VMESTO = re.compile(r'\bвместо\b', re.I)
+VZNACH = re.compile(r'\bв\s+значении\b', re.I)
+VMESTO_CAP = re.compile(r'\bВместо\b')
+VMESTO_LOW = re.compile(r'\bвместо\b')
+VZNACH_CAP = re.compile(r'\bВ\s+значении\b')
+VZNACH_LOW = re.compile(r'\bв\s+значении\b')
+
+# A match inside a quoted/retained gloss is prose, never editorial apparatus.
+PROTECTED_PROSE = re.compile(r'\{%.*?%\}|«[^»]*»', re.S)
+R2_CORRECTION_CUE = re.compile(
+    r'ошибочн|опечатк|неверн|неточн|бессмысленн|непонятн|v\.\s*l\.|вариант', re.I)
+R2_OBJECT = re.compile(
+    r'^\s*(?:\{#|<ab\b|<lex\b|'
+    r'(?:прост|втор|предикатив|обычн|употребительн|этого|котор|глагол)\w*)', re.I)
+R2_FOLLOW = re.compile(
+    r'следует\s+(?:читать|поставить)|читает|имеет|поставила', re.I)
+R3_OBJECT = re.compile(r'^\s*(?:\{#|\{%|<ab\b|<lex\b|«)', re.I)
+R3_LEXICAL_CUE = re.compile(
+    r'употреб|слово|форма|термин|здесь|означа|понима|смысл|также|как', re.I)
+
+LS_SPAN = re.compile(r'<ls\b[^>]*>.*?</ls>', re.S)
+BOMB = re.compile(r'ed\.\s*Bomb\.')
+
+RULE_ORDER = ('R4_bomb', 'R2_vmesto', 'R3_vznach', 'R1_yo')
 
 
 def apply_no_yo(text):
-    """Replace every ё/Ё with е/Е, except inside a whitelisted standalone «всё»/«Всё»."""
+    """Replace ё/Ё outside the standalone всё/Всё whitelist."""
     if not text or 'ё' not in text.lower():
         return text, 0
     protected = [(m.start(), m.end()) for m in WHITELIST_VSE.finditer(text)]
-
-    def is_protected(pos):
-        return any(s <= pos < e for s, e in protected)
-
     out = list(text)
     n = 0
-    for m in YO_CHAR.finditer(text):
-        pos = m.start()
-        if is_protected(pos):
+    for match in YO_CHAR.finditer(text):
+        pos = match.start()
+        if any(start <= pos < end for start, end in protected):
             continue
-        out[pos] = 'Е' if m.group(0) == 'Ё' else 'е'
+        out[pos] = 'Е' if match.group(0) == 'Ё' else 'е'
         n += 1
     return ''.join(out), n
 
 
-# ---------------------------------------------------------------------------
-# R2 -- «вместо» -> «вм.» (unrestricted; see docstring for the FP measurement).
-# ---------------------------------------------------------------------------
-VMESTO_CAP = re.compile(r'\bВместо\b')
-VMESTO_LOW = re.compile(r'\bвместо\b')
+def apply_bomb_prose_only(text):
+    """Translate ``ed. Bomb.`` only outside citation spans."""
+    if not text or 'Bomb' not in text:
+        return text, 0
+    out, count, last = [], 0, 0
+    for match in LS_SPAN.finditer(text):
+        segment, changed = BOMB.subn('Бомбейская ред.', text[last:match.start()])
+        count += changed
+        out.extend((segment, match.group(0)))
+        last = match.end()
+    tail, changed = BOMB.subn('Бомбейская ред.', text[last:])
+    count += changed
+    out.append(tail)
+    return ''.join(out), count
+
+
+def _protected_ranges(text):
+    return [(match.start(), match.end()) for match in PROTECTED_PROSE.finditer(text or '')]
+
+
+def _is_protected(ranges, position):
+    return any(start <= position < end for start, end in ranges)
+
+
+def _snippet(text, match, radius=80):
+    start = max(0, match.start() - radius)
+    end = min(len(text), match.end() + radius)
+    return text[start:end].replace('\n', ' ')
+
+
+def _r2_editorial(text, match):
+    ranges = _protected_ranges(text)
+    if _is_protected(ranges, match.start()):
+        return False
+    before = text[max(0, match.start() - 120):match.start()]
+    after = text[match.end():match.end() + 120]
+    return bool(
+        R2_CORRECTION_CUE.search(before + match.group(0) + after)
+        or R2_OBJECT.search(after)
+        or R2_FOLLOW.search(after)
+    )
+
+
+def _r3_editorial(text, match):
+    ranges = _protected_ranges(text)
+    if _is_protected(ranges, match.start()):
+        return False
+    before = text[max(0, match.start() - 80):match.start()]
+    after = text[match.end():match.end() + 80]
+    return bool(
+        R3_OBJECT.search(after)
+        or R3_LEXICAL_CUE.search(before + after)
+    )
+
+
+def _apply_contextual(text, pattern, predicate, lower, upper, rule_id):
+    """Apply a contextual substitution and retain diagnostic ambiguous matches."""
+    if not text:
+        return text, 0, []
+    out, last, count, ambiguous = [], 0, 0, []
+    for match in pattern.finditer(text):
+        out.append(text[last:match.start()])
+        if predicate(text, match):
+            replacement = upper if match.group(0)[:1].isupper() else lower
+            out.append(replacement)
+            count += 1
+        else:
+            out.append(match.group(0))
+            ambiguous.append({
+                'rule': rule_id,
+                'start': match.start(),
+                'snippet': _snippet(text, match),
+            })
+        last = match.end()
+    out.append(text[last:])
+    return ''.join(out), count, ambiguous
+
+
+def _apply_terse_vmesto_detailed(text):
+    return _apply_contextual(text, VMESTO, _r2_editorial, 'вм.', 'Вм.', 'R2_vmesto')
+
+
+def _apply_terse_vznach_detailed(text):
+    return _apply_contextual(text, VZNACH, _r3_editorial, 'в знач.', 'В знач.', 'R3_vznach')
 
 
 def apply_terse_vmesto(text):
-    if not text or 'место' not in text.lower():
-        return text, 0
-    text, c1 = VMESTO_CAP.subn('Вм.', text)
-    text, c2 = VMESTO_LOW.subn('вм.', text)
-    return text, c1 + c2
-
-
-# ---------------------------------------------------------------------------
-# R3 -- «в значении» -> «в знач.» (unrestricted; see docstring for the FP measurement).
-# ---------------------------------------------------------------------------
-VZNACH_CAP = re.compile(r'\bВ\s+значении\b')
-VZNACH_LOW = re.compile(r'\bв\s+значении\b')
+    text, count, _ = _apply_terse_vmesto_detailed(text)
+    return text, count
 
 
 def apply_terse_vznach(text):
-    if not text or 'значени' not in text.lower():
-        return text, 0
-    text, c1 = VZNACH_CAP.subn('В знач.', text)
-    text, c2 = VZNACH_LOW.subn('в знач.', text)
-    return text, c1 + c2
+    text, count, _ = _apply_terse_vznach_detailed(text)
+    return text, count
 
 
-# ---------------------------------------------------------------------------
-# R4 -- `ed. Bomb.` -> «Бомбейская ред.», PROSE ONLY (outside any <ls>...</ls> span).
-# ---------------------------------------------------------------------------
-LS_SPAN = re.compile(r'<ls\b[^>]*>.*?</ls>', re.S)
-BOMB = re.compile(r'ed\.\s*Bomb\.')
-
-
-def apply_bomb_prose_only(text):
-    if not text or 'Bomb' not in text:
-        return text, 0
-    out, n, last = [], 0, 0
-    for m in LS_SPAN.finditer(text):
-        seg = text[last:m.start()]
-        seg, c = BOMB.subn('Бомбейская ред.', seg)
-        n += c
-        out.append(seg)
-        out.append(m.group(0))         # <ls>...</ls> span itself: untouched, verbatim
-        last = m.end()
-    tail = text[last:]
-    tail, c = BOMB.subn('Бомбейская ред.', tail)
-    n += c
-    out.append(tail)
-    return ''.join(out), n
-
-
-# ---------------------------------------------------------------------------
-# Combined sweep + read-only violation scan (the latter is what the audit_window.py
-# `ru_style` gate and the store-mode "0 residual violations" check both reuse).
-# ---------------------------------------------------------------------------
-RULE_ORDER = (
-    ('R4_bomb', apply_bomb_prose_only),
-    ('R2_vmesto', apply_terse_vmesto),
-    ('R3_vznach', apply_terse_vznach),
-    ('R1_yo', apply_no_yo),
-)
+def style_diagnostics(text):
+    """Return the fixed text plus hard and ambiguous rule diagnostics."""
+    counts = {rule: 0 for rule in RULE_ORDER}
+    ambiguous = []
+    text, counts['R4_bomb'] = apply_bomb_prose_only(text)
+    text, counts['R2_vmesto'], found = _apply_terse_vmesto_detailed(text)
+    ambiguous.extend(found)
+    text, counts['R3_vznach'], found = _apply_terse_vznach_detailed(text)
+    ambiguous.extend(found)
+    text, counts['R1_yo'] = apply_no_yo(text)
+    return {
+        'text': text,
+        'counts': counts,
+        'violations': [rule for rule in RULE_ORDER if counts[rule]],
+        'ambiguous': ambiguous,
+        'ambiguous_rules': sorted({item['rule'] for item in ambiguous}),
+    }
 
 
 def sweep_text(text):
-    """Apply R1-R4 in sequence; return (new_text, {rule_id: count})."""
-    counts = {}
-    for rule_id, fn in RULE_ORDER:
-        text, c = fn(text)
-        counts[rule_id] = c
-    return text, counts
+    """Apply hard R1-R4 rules; ambiguous R2/R3 prose is unchanged."""
+    result = style_diagnostics(text)
+    return result['text'], result['counts']
 
 
 def scan_violations(text):
-    """Read-only: which rule tags would fire on `text`? Used by the audit_window.py
-    `ru_style` gate (FLAGGED_JSON on any hit) and by the store-mode auditor (0 residual
-    violations after --apply). Never mutates the input."""
-    if not text:
-        return []
-    _, counts = sweep_text(text)
-    return [rule_id for rule_id, c in counts.items() if c]
+    """Compatibility API: return only hard rule IDs that would change ``text``."""
+    return style_diagnostics(text)['violations']
+
+
+def legacy_sweep_text(text):
+    """Reproduce H1305's original global R2/R3 sweep for safe reconciliation."""
+    counts = {rule: 0 for rule in RULE_ORDER}
+    text, counts['R4_bomb'] = apply_bomb_prose_only(text)
+    text, cap = VMESTO_CAP.subn('Вм.', text)
+    text, low = VMESTO_LOW.subn('вм.', text)
+    counts['R2_vmesto'] = cap + low
+    text, cap = VZNACH_CAP.subn('В знач.', text)
+    text, low = VZNACH_LOW.subn('в знач.', text)
+    counts['R3_vznach'] = cap + low
+    text, counts['R1_yo'] = apply_no_yo(text)
+    return text, counts
 
 
 # ---------------------------------------------------------------------------
-# Store mode.
+# Workflow gate: structured Russian senses only.
 # ---------------------------------------------------------------------------
-SRC = HERE
-SAMPLES_PER_RULE = 6
-
-
-def _iter_store(store):
-    with open(store, encoding='utf-8') as f:
-        for line in f:
-            line = line.strip()
-            if line:
-                yield json.loads(line)
-
-
-def run_store(apply_=False):
-    default_local = os.path.join(SRC, 'pwg_ru_translated.jsonl')
-    store = canonical_store(default_local)
-    print('resolved store  : %s' % store)
-    if not os.path.exists(store):
-        sys.exit('STORE ABSENT: %s' % store)
-    rows = list(_iter_store(store))
-    totals = {rid: 0 for rid, _ in RULE_ORDER}
-    samples = {rid: [] for rid, _ in RULE_ORDER}
-    touched_rows = 0
-    for r in rows:
-        ru = r.get('ru') or ''
-        if not ru:
+def audit_workflow_results(results):
+    rows, flagged, warned = [], [], []
+    for result in results or []:
+        key = result.get('key')
+        if not key:
             continue
-        new, counts = sweep_text(ru)
-        row_total = sum(counts.values())
-        if row_total:
-            touched_rows += 1
-            key = '%s|%s|%s' % (r.get('key1'), r.get('subcard'), r.get('sense_tag'))
-            for rid, c in counts.items():
-                totals[rid] += c
-                if c and len(samples[rid]) < SAMPLES_PER_RULE:
-                    samples[rid].append((key, ru, new))
-            if apply_:
-                r['ru'] = new
-    grand_total = sum(totals.values())
-    print('mode            : %s' % ('APPLY' if apply_ else 'DRY RUN'))
-    print('rows            : %d' % len(rows))
-    print('rows touched    : %d' % touched_rows)
-    print('substitutions   :')
-    for rid, _ in RULE_ORDER:
-        print('  %-12s %d' % (rid, totals[rid]))
-    print('  %-12s %d' % ('TOTAL', grand_total))
-    print()
-    for rid, _ in RULE_ORDER:
-        if samples[rid]:
-            print('--- %s samples (%d shown) ---' % (rid, len(samples[rid])))
-            for key, before, after in samples[rid]:
-                print('  [%s]' % key)
-                print('    before: ...%s...' % before[:160].replace('\n', ' '))
-                print('    after : ...%s...' % after[:160].replace('\n', ' '))
-    if apply_ and grand_total:
-        bak = store + '.h1305.bak'
-        if not os.path.exists(bak):
-            shutil.copyfile(store, bak)
-            print('\nbackup          : %s' % bak)
-        tmp = store + '.tmp'
-        with open(tmp, 'w', encoding='utf-8') as f:
-            for r in rows:
-                f.write(json.dumps(r, ensure_ascii=False) + '\n')
-        os.replace(tmp, store)
-        print('wrote           : %s' % store)
-    elif not apply_:
-        print('\n(dry run -- pass --apply to write)')
-    return grand_total
-
-
-# ---------------------------------------------------------------------------
-# --wf window-gate mode (audit_window.py wiring): reads the SAME .merged.md rendered
-# output the other RU gates (audit_translation.py --wf, stage2_pregate.py --wf) consume.
-# ---------------------------------------------------------------------------
-def cmd_wf(wf_path):
-    pilot = os.path.join(SRC, 'pilot')
-    if pilot not in sys.path:
-        sys.path.insert(0, pilot)
-    import audit_translation as at  # noqa: E402 -- stems_from_wf / IN / OUT shared with the other RU gates
-
-    stems = at.stems_from_wf(wf_path)
-    flagged = []
-    rows = []
-    for stem in stems:
-        outp = os.path.join(at.OUT, stem + '.merged.md')
-        if not os.path.exists(outp):
-            rows.append((stem, 'skip', ['NO-OUTPUT']))
+        card = result.get('card')
+        if not card:
+            rows.append((key, 'skip', ['NO-CARD']))
             continue
-        text = open(outp, encoding='utf-8').read()
-        viols = scan_violations(text)
-        if viols:
-            flagged.append(stem)
-            rows.append((stem, 'FAIL', viols))
+        hard, soft = set(), set()
+        for record in card.get('records') or []:
+            for sense in record.get('senses') or []:
+                diagnostic = style_diagnostics(sense.get('russian') or '')
+                hard.update(diagnostic['violations'])
+                soft.update(diagnostic['ambiguous_rules'])
+        if hard:
+            flagged.append(key)
+            rows.append((key, 'FAIL', sorted(hard)))
+        elif soft:
+            warned.append(key)
+            rows.append((key, 'warn', sorted(soft)))
         else:
-            rows.append((stem, 'ok', []))
-    print('=== ru_style mechanical gate (%d units) ===' % len(stems))
+            rows.append((key, 'ok', []))
+    return rows, sorted(set(flagged)), sorted(set(warned))
+
+
+def cmd_wf(wf_path):
+    import audit_translation as at  # noqa: E402
+
+    with open(wf_path, encoding='utf-8') as stream:
+        results = at.find_results(json.load(stream)) or []
+    rows, flagged, warned = audit_workflow_results(results)
+    print('=== ru_style mechanical gate (%d units) ===' % len(rows))
     print('%-28s %-5s %s' % ('unit', 'st', 'flags'))
-    for stem, st, marks in rows:
-        if st != 'ok':
-            print('%-28s %-5s %s' % (stem[:28], st, ' '.join(marks)))
-    print('\n%s: %d/%d clean, %d hard-flagged'
-          % ('PASS' if not flagged else 'FAIL', len(stems) - len(flagged), len(stems), len(flagged)))
+    for key, status, marks in rows:
+        if status != 'ok':
+            print('%-28s %-5s %s' % (key[:28], status, ' '.join(marks)))
+    print('\n%s: %d/%d clean, %d warned, %d hard-flagged' % (
+        'PASS' if not flagged else 'FAIL',
+        len(rows) - len(flagged) - len(warned), len(rows), len(warned), len(flagged)))
+    print('WARNED_JSON: %s' % json.dumps(warned))
     print('FLAGGED_JSON: %s' % json.dumps(flagged))
     return 0 if not flagged else 1
 
 
 # ---------------------------------------------------------------------------
-# Selftest.
+# Store IO, backups, and repair reconciliation.
+# ---------------------------------------------------------------------------
+MUTABLE_ID_FIELDS = {'ru'}
+
+
+def _is_mutable_identity_field(key):
+    normalized = str(key).lower()
+    return (
+        normalized in MUTABLE_ID_FIELDS
+        or 'review' in normalized
+        or 'evidence' in normalized
+        or 'provenance' in normalized
+    )
+
+
+def _read_rows(path):
+    rows = []
+    with open(path, encoding='utf-8') as stream:
+        for line_number, line in enumerate(stream, 1):
+            if line.strip():
+                try:
+                    rows.append(json.loads(line))
+                except ValueError as exc:
+                    raise ValueError('%s:%d: %s' % (path, line_number, exc)) from exc
+    return rows
+
+
+def _file_sha256(path):
+    digest = hashlib.sha256()
+    with open(path, 'rb') as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b''):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _row_count(path):
+    with open(path, 'rb') as stream:
+        return sum(1 for line in stream if line.strip())
+
+
+def _utc_stamp(now=None):
+    now = now or dt.datetime.now(dt.timezone.utc)
+    return now.strftime('%Y%m%dT%H%M%S%fZ')
+
+
+def _create_verified_backup(store, backup_dir=None, stamp=None):
+    backup_dir = os.path.abspath(backup_dir or os.path.dirname(store))
+    os.makedirs(backup_dir, exist_ok=True)
+    stamp = stamp or _utc_stamp()
+    backup = os.path.join(backup_dir, os.path.basename(store) + '.h1305.' + stamp + '.bak')
+    with open(store, 'rb') as source, open(backup, 'xb') as target:
+        shutil.copyfileobj(source, target, length=1024 * 1024)
+    source_hash = _file_sha256(store)
+    backup_hash = _file_sha256(backup)
+    source_rows = _row_count(store)
+    backup_rows = _row_count(backup)
+    if source_hash != backup_hash or source_rows != backup_rows:
+        raise RuntimeError('backup verification failed: %s' % backup)
+    return {'path': backup, 'sha256': backup_hash, 'rows': backup_rows}
+
+
+def _write_rows_atomic(store, rows, initial_hash, backup_dir=None, stamp=None):
+    if _file_sha256(store) != initial_hash:
+        raise RuntimeError('store changed after read; refusing apply')
+    backup = _create_verified_backup(store, backup_dir=backup_dir, stamp=stamp)
+    tmp = '%s.tmp.%d' % (store, os.getpid())
+    try:
+        with open(tmp, 'x', encoding='utf-8') as stream:
+            for row in rows:
+                stream.write(json.dumps(row, ensure_ascii=False) + '\n')
+        if _file_sha256(store) != initial_hash:
+            raise RuntimeError('store changed before replace; refusing apply')
+        os.replace(tmp, store)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+    return backup
+
+
+def _identity_base(row):
+    stable = {key: value for key, value in row.items() if not _is_mutable_identity_field(key)}
+    payload = json.dumps(stable, ensure_ascii=False, sort_keys=True, separators=(',', ':'))
+    return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+
+
+def _index_rows(rows):
+    seen = collections.Counter()
+    indexed = {}
+    for index, row in enumerate(rows):
+        base = _identity_base(row)
+        ordinal = seen[base]
+        seen[base] += 1
+        indexed[(base, ordinal)] = index
+    return indexed
+
+
+def _row_label(row):
+    return '%s|%s|%s' % (row.get('key1'), row.get('subcard'), row.get('sense_tag'))
+
+
+def reconcile_rows(current_rows, backup_rows):
+    """Rebuild recognized H1305 rows without overwriting divergent later edits."""
+    current_index = _index_rows(current_rows)
+    backup_index = _index_rows(backup_rows)
+    output = [dict(row) for row in current_rows]
+    totals = {rule: 0 for rule in RULE_ORDER}
+    ambiguous_counts = collections.Counter()
+    ambiguous_examples = []
+    conflicts = []
+    restored = []
+    restored_prose = []
+    current_only = []
+
+    for identity, current_pos in current_index.items():
+        current = current_rows[current_pos]
+        current_ru = current.get('ru') or ''
+        if identity in backup_index:
+            original = backup_rows[backup_index[identity]].get('ru') or ''
+            legacy, _ = legacy_sweep_text(original)
+            diagnostic = style_diagnostics(original)
+            desired = diagnostic['text']
+            recognized = {original, legacy, desired}
+            if current_ru not in recognized:
+                conflicts.append({
+                    'row': _row_label(current),
+                    'identity': '%s:%d' % identity,
+                    'reason': 'current ru diverges from original, legacy sweep, and repaired value',
+                    'backup_ru': original,
+                    'legacy_ru': legacy,
+                    'scoped_ru': desired,
+                    'current_ru': current_ru,
+                })
+                continue
+            if legacy != desired:
+                restored_prose.append({
+                    'row': _row_label(current),
+                    'backup_ru': original,
+                    'legacy_ru': legacy,
+                    'scoped_ru': desired,
+                    'current_state': (
+                        'legacy' if current_ru == legacy
+                        else 'scoped' if current_ru == desired
+                        else 'original'),
+                })
+        else:
+            diagnostic = style_diagnostics(current_ru)
+            desired = diagnostic['text']
+            current_only.append(_row_label(current))
+
+        for rule, count in diagnostic['counts'].items():
+            totals[rule] += count
+        for item in diagnostic['ambiguous']:
+            ambiguous_counts[item['rule']] += 1
+            if len(ambiguous_examples) < 100:
+                ambiguous_examples.append({
+                    'row': _row_label(current),
+                    'rule': item['rule'],
+                    'snippet': item['snippet'],
+                })
+        if current_ru != desired:
+            output[current_pos]['ru'] = desired
+            restored.append(_row_label(current))
+
+    backup_only = [
+        _row_label(backup_rows[position])
+        for identity, position in backup_index.items() if identity not in current_index
+    ]
+    return output, {
+        'rule_counts': totals,
+        'ambiguous_counts': dict(sorted(ambiguous_counts.items())),
+        'ambiguous_examples': ambiguous_examples,
+        'changed_rows': restored,
+        'restored_prose': restored_prose,
+        'current_only_rows': current_only,
+        'backup_only_rows': backup_only,
+        'conflicts': conflicts,
+    }
+
+
+def _default_report_path(store, stamp):
+    output_dir = os.path.join(os.path.dirname(store), 'pilot', 'output')
+    os.makedirs(output_dir, exist_ok=True)
+    return os.path.join(output_dir, 'ru_style_repair_%s_%d.json' % (stamp, os.getpid()))
+
+
+def _write_report(path, report):
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, 'x', encoding='utf-8') as stream:
+        json.dump(report, stream, ensure_ascii=False, indent=2)
+        stream.write('\n')
+
+
+def run_repair(backup_path, apply_=False, backup_dir=None, report_path=None):
+    store = canonical_store(os.path.join(HERE, 'pwg_ru_translated.jsonl'))
+    store = os.path.abspath(store)
+    backup_path = os.path.abspath(backup_path)
+    print('resolved store  : %s' % store)
+    print('repair source   : %s' % backup_path)
+    if not os.path.exists(store):
+        raise FileNotFoundError('STORE ABSENT: %s' % store)
+    if not os.path.exists(backup_path):
+        raise FileNotFoundError('REPAIR SOURCE ABSENT: %s' % backup_path)
+
+    stamp = _utc_stamp()
+    initial_hash = _file_sha256(store)
+    current_rows = _read_rows(store)
+    backup_rows = _read_rows(backup_path)
+    repaired_rows, detail = reconcile_rows(current_rows, backup_rows)
+    report = {
+        'schema': 'pwg_ru.ru_style_repair.v1',
+        'created_utc': stamp,
+        'mode': 'apply' if apply_ else 'dry-run',
+        'store': store,
+        'repair_source': backup_path,
+        'before_sha256': initial_hash,
+        'repair_source_sha256': _file_sha256(backup_path),
+        'before_rows': len(current_rows),
+        'repair_source_rows': len(backup_rows),
+        **detail,
+    }
+    print('rows            : %d current / %d repair-source' % (len(current_rows), len(backup_rows)))
+    print('changed rows    : %d' % len(detail['changed_rows']))
+    print('restored prose  : %d reviewed occurrences' % len(detail['restored_prose']))
+    print('current-only    : %d' % len(detail['current_only_rows']))
+    print('backup-only     : %d' % len(detail['backup_only_rows']))
+    print('conflicts       : %d' % len(detail['conflicts']))
+    print('ambiguous       : %s' % (detail['ambiguous_counts'] or '{}'))
+
+    exit_code = 0
+    if detail['conflicts']:
+        exit_code = 2
+        report['after_sha256'] = _file_sha256(store)
+        report['after_rows'] = _row_count(store)
+        print('REFUSED: divergent rows require manual reconciliation', file=sys.stderr)
+    elif apply_:
+        backup = _write_rows_atomic(
+            store, repaired_rows, initial_hash, backup_dir=backup_dir, stamp=stamp)
+        report['apply_backup'] = backup
+        report['after_sha256'] = _file_sha256(store)
+        report['after_rows'] = _row_count(store)
+        print('backup          : %s' % backup['path'])
+        print('backup sha256   : %s' % backup['sha256'])
+        print('wrote           : %s' % store)
+    else:
+        report['after_sha256'] = initial_hash
+        report['after_rows'] = len(current_rows)
+        print('(dry run -- pass --apply to write)')
+
+    report_path = os.path.abspath(report_path or _default_report_path(store, stamp))
+    _write_report(report_path, report)
+    print('report          : %s' % report_path)
+    return exit_code
+
+
+def run_store(apply_=False, backup_dir=None):
+    store = os.path.abspath(canonical_store(os.path.join(HERE, 'pwg_ru_translated.jsonl')))
+    print('resolved store  : %s' % store)
+    if not os.path.exists(store):
+        raise FileNotFoundError('STORE ABSENT: %s' % store)
+    initial_hash = _file_sha256(store)
+    rows = _read_rows(store)
+    totals = {rule: 0 for rule in RULE_ORDER}
+    ambiguous = collections.Counter()
+    samples = {rule: [] for rule in RULE_ORDER}
+    touched = 0
+    for row in rows:
+        original = row.get('ru') or ''
+        diagnostic = style_diagnostics(original)
+        for rule, count in diagnostic['counts'].items():
+            totals[rule] += count
+            if count and len(samples[rule]) < SAMPLES_PER_RULE:
+                samples[rule].append((_row_label(row), original, diagnostic['text']))
+        for item in diagnostic['ambiguous']:
+            ambiguous[item['rule']] += 1
+        if diagnostic['text'] != original:
+            touched += 1
+            if apply_:
+                row['ru'] = diagnostic['text']
+
+    grand_total = sum(totals.values())
+    print('mode            : %s' % ('APPLY' if apply_ else 'DRY RUN'))
+    print('rows            : %d' % len(rows))
+    print('rows touched    : %d' % touched)
+    for rule in RULE_ORDER:
+        print('  %-12s %d' % (rule, totals[rule]))
+    print('  %-12s %d' % ('TOTAL', grand_total))
+    print('ambiguous       : %s' % (dict(ambiguous) or '{}'))
+    if apply_ and grand_total:
+        backup = _write_rows_atomic(store, rows, initial_hash, backup_dir=backup_dir)
+        print('backup          : %s' % backup['path'])
+        print('backup sha256   : %s' % backup['sha256'])
+        print('wrote           : %s' % store)
+    elif not apply_:
+        print('(dry run -- pass --apply to write)')
+    return grand_total
+
+
+# ---------------------------------------------------------------------------
+# Deterministic selftest.
 # ---------------------------------------------------------------------------
 def selftest():
-    # R1: yo -> e, «отвоёвывать» -> «отвоевывать»
-    t, n = apply_no_yo('отвоёвывать')
-    assert t == 'отвоевывать' and n == 1, (t, n)
-    # R1: standalone «всё» is preserved
-    t, n = apply_no_yo('всё хорошо')
-    assert t == 'всё хорошо' and n == 0, (t, n)
-    t, n = apply_no_yo('Всё пропало')
-    assert t == 'Всё пропало' and n == 0, (t, n)
-    # R1 edge case: hyphenated «всё-таки» is NOT whitelisted -> defaults to е
-    t, n = apply_no_yo('всё-таки пришёл')
-    assert t == 'все-таки пришел' and n == 2, (t, n)
-    # R1: a word containing yo elsewhere in the same string is still fixed even when
-    # «всё» sits right next to it (whitelist span is exact, does not leak).
-    t, n = apply_no_yo('она всё ещё ждёт')
-    assert t == 'она всё еще ждет' and n == 2, (t, n)
+    fixed, count = apply_no_yo('она всё ещё ждёт')
+    assert fixed == 'она всё еще ждет' and count == 2, (fixed, count)
+    fixed, count = apply_no_yo('всё-таки пришёл')
+    assert fixed == 'все-таки пришел' and count == 2, (fixed, count)
 
-    # R2: metalanguage «вместо» -> «вм.», case preserved
-    t, n = apply_terse_vmesto('ошибочно вместо {#nyaveSayat#}')
-    assert t == 'ошибочно вм. {#nyaveSayat#}' and n == 1, (t, n)
-    t, n = apply_terse_vmesto('Вместо простого acc.')
-    assert t == 'Вм. простого acc.' and n == 1, (t, n)
+    fixed, count = apply_terse_vmesto('ошибочно вместо {#X#}')
+    assert fixed == 'ошибочно вм. {#X#}' and count == 1, (fixed, count)
+    fixed, count = apply_terse_vmesto('Вместо {#X#} следует читать {#Y#}')
+    assert fixed == 'Вм. {#X#} следует читать {#Y#}' and count == 1, (fixed, count)
+    for prose in (
+            'Он выступил вместо брата.',
+            '«в отдельные случаи [вместо того чтобы быть непрерывным]»',
+            'при māraṇa вместо abhra'):
+        fixed, count = apply_terse_vmesto(prose)
+        assert fixed == prose and count == 0, (fixed, count)
 
-    # R3: «в значении» -> «в знач.»
-    t, n = apply_terse_vznach('С samudA в значении samudAnaya')
-    assert t == 'С samudA в знач. samudAnaya' and n == 1, (t, n)
+    fixed, count = apply_terse_vznach('форма употребляется в значении {#X#}')
+    assert fixed == 'форма употребляется в знач. {#X#}' and count == 1, (fixed, count)
+    prose = 'Он понял знак в значении обещания.'
+    fixed, count = apply_terse_vznach(prose)
+    assert fixed == prose and count == 0, (fixed, count)
 
-    # R4: standalone <ls>ed. Bomb.</ls> is NEVER touched (source-resolution safety)
-    t, n = apply_bomb_prose_only('(так <ls>ed. Bomb.</ls>)')
-    assert t == '(так <ls>ed. Bomb.</ls>)' and n == 0, (t, n)
-    # R4: embedded citation form is NEVER touched either
-    t, n = apply_bomb_prose_only('<ls>R. ed. Bomb. 3,69,4</ls>')
-    assert t == '<ls>R. ed. Bomb. 3,69,4</ls>' and n == 0, (t, n)
-    # R4: genuine free prose OUTSIDE any <ls> IS translated
-    t, n = apply_bomb_prose_only('<ls>Mālatīm.</ls> (ed. Bomb.) 304,1.')
-    assert t == '<ls>Mālatīm.</ls> (Бомбейская ред.) 304,1.' and n == 1, (t, n)
+    fixed, count = apply_bomb_prose_only('<ls>ed. Bomb.</ls> (ed. Bomb.)')
+    assert fixed == '<ls>ed. Bomb.</ls> (Бомбейская ред.)' and count == 1, (fixed, count)
 
-    # combined sweep_text applies all four independently, in one pass
+    results = [{
+        'key': 'clean-notes',
+        'card': {'notes': 'Переводчик пришёл.', 'records': [{
+            'senses': [{'russian': 'чистый текст', 'differentia': 'пришёл'}],
+        }]},
+    }, {
+        'key': 'multi-hard',
+        'card': {'records': [{'senses': [
+            {'russian': 'пришёл'}, {'russian': 'ошибочно вместо {#X#}'},
+        ]}]},
+    }, {
+        'key': 'ambiguous',
+        'card': {'records': [{'senses': [{'russian': 'Он выступил вместо брата.'}]}]},
+    }]
+    _, flagged, warned = audit_workflow_results(results)
+    assert flagged == ['multi-hard'], flagged
+    assert warned == ['ambiguous'], warned
+
+    backup_rows = [
+        {'key1': 'a', 'subcard': 'a~~1', 'sense_tag': '1', 'de': 'x',
+         'ru': 'Он выступил вместо брата.'},
+        {'key1': 'b', 'subcard': 'b~~1', 'sense_tag': '1', 'de': 'y',
+         'ru': 'ошибочно вместо {#X#}'},
+    ]
+    current_rows = []
+    for row in backup_rows:
+        copy = dict(row)
+        copy['ru'] = legacy_sweep_text(row['ru'])[0]
+        current_rows.append(copy)
+    current_rows.append(
+        {'key1': 'c', 'subcard': 'c~~1', 'sense_tag': '1', 'de': 'z', 'ru': 'всё хорошо'})
+    repaired, detail = reconcile_rows(current_rows, backup_rows)
+    assert repaired[0]['ru'] == backup_rows[0]['ru'], repaired[0]
+    assert repaired[1]['ru'] == 'ошибочно вм. {#X#}', repaired[1]
+    assert repaired[2]['ru'] == 'всё хорошо', repaired[2]
+    assert len(detail['current_only_rows']) == 1 and not detail['conflicts'], detail
+    assert len(detail['restored_prose']) == 1, detail['restored_prose']
+    divergent = [dict(row) for row in current_rows]
+    divergent[0]['ru'] = 'поздняя ручная правка'
+    _, detail = reconcile_rows(divergent, backup_rows)
+    assert len(detail['conflicts']) == 1, detail
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store = os.path.join(temp_dir, 'store.jsonl')
+        with open(store, 'w', encoding='utf-8') as stream:
+            stream.write(json.dumps(backup_rows[0], ensure_ascii=False) + '\n')
+        first = _create_verified_backup(store, temp_dir, stamp='one')
+        second = _create_verified_backup(store, temp_dir, stamp='two')
+        assert first['path'] != second['path'] and first['sha256'] == second['sha256']
+        try:
+            _create_verified_backup(store, temp_dir, stamp='one')
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError('backup path reuse did not fail')
+        try:
+            _write_rows_atomic(store, backup_rows, '0' * 64, backup_dir=temp_dir)
+        except RuntimeError as exc:
+            assert 'changed after read' in str(exc), exc
+        else:
+            raise AssertionError('stale store hash did not fail')
+
+        # Simulate a concurrent change after the verified backup but immediately before
+        # replacement. The second live-store hash check must still fail closed.
+        initial = _file_sha256(store)
+        real_hasher = _file_sha256
+        store_hash_calls = [0]
+
+        def simulated_race(path):
+            if os.path.abspath(path) == os.path.abspath(store):
+                store_hash_calls[0] += 1
+                if store_hash_calls[0] >= 3:
+                    return 'f' * 64
+            return real_hasher(path)
+
+        globals()['_file_sha256'] = simulated_race
+        try:
+            try:
+                _write_rows_atomic(store, backup_rows, initial, backup_dir=temp_dir)
+            except RuntimeError as exc:
+                assert 'changed before replace' in str(exc), exc
+            else:
+                raise AssertionError('mid-run store change did not fail')
+        finally:
+            globals()['_file_sha256'] = real_hasher
+
     combined, counts = sweep_text(
-        'ошибочно вместо {#X#}, как читает <ls>ed. Bomb.</ls>. В значении «всё пропало»')
-    assert combined == (
-        'ошибочно вм. {#X#}, как читает <ls>ed. Bomb.</ls>. В знач. «всё пропало»'), combined
-    assert counts['R2_vmesto'] == 1 and counts['R3_vznach'] == 1 and counts['R4_bomb'] == 0, counts
-
-    # scan_violations mirrors sweep_text exactly (read-only, same detectors)
-    assert scan_violations('обычный русский текст без нарушений') == []
-    assert 'R1_yo' in scan_violations('пришёл поздно')
-    assert 'R2_vmesto' in scan_violations('читать вместо этого')
-    assert 'R4_bomb' not in scan_violations('<ls>ed. Bomb.</ls>')  # in-<ls> is not a violation
-
-    # idempotence: re-running the sweep on already-swept text changes nothing
+        'ошибочно вместо {#X#}; форма употребляется в значении {#Y#}; всё хорошо')
     twice, counts2 = sweep_text(combined)
-    assert twice == combined and sum(counts2.values()) == 0, (twice, counts2)
-
+    assert combined == 'ошибочно вм. {#X#}; форма употребляется в знач. {#Y#}; всё хорошо'
+    assert sum(counts.values()) == 2 and twice == combined and not sum(counts2.values())
     print('ru_style_sweep selftest: PASS')
     return True
 
 
 def main():
-    argv = sys.argv[1:]
-    if '--selftest' in argv:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--selftest', action='store_true')
+    parser.add_argument('--wf', metavar='WF_OUTPUT')
+    parser.add_argument('--apply', action='store_true')
+    parser.add_argument('--repair-from', metavar='H1305_BACKUP')
+    parser.add_argument('--backup-dir')
+    parser.add_argument('--report')
+    args = parser.parse_args()
+    if args.selftest:
         selftest()
-        return
-    if '--wf' in argv:
-        i = argv.index('--wf')
-        if i + 1 >= len(argv):
-            sys.exit('usage: python src/ru_style_sweep.py --wf <wf_output.json>')
-        sys.exit(cmd_wf(argv[i + 1]))
-    apply_ = '--apply' in argv
-    run_store(apply_=apply_)
+        return 0
+    if args.wf:
+        if args.apply or args.repair_from:
+            parser.error('--wf cannot be combined with --apply/--repair-from')
+        return cmd_wf(args.wf)
+    if args.repair_from:
+        return run_repair(
+            args.repair_from, apply_=args.apply,
+            backup_dir=args.backup_dir, report_path=args.report)
+    if args.report:
+        parser.error('--report is only valid with --repair-from')
+    run_store(apply_=args.apply, backup_dir=args.backup_dir)
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- audit only structured `card.records[].senses[].russian` values and aggregate by original workflow key
- use one high-precision R2/R3 classifier for rewrite + audit; ambiguous prose warns but never enters `FLAGGED_JSON`
- add conflict-safe `--repair-from`, verified timestamped backups, live-store TOCTOU checks, and ignored JSON evidence
- correct the H1305 measurement/docs and preserve the EN path unchanged

## Canonical store repair
- population: 11,603 -> 11,603 rows
- reviewed restorations: 16 (R2 12, R3 4)
- retained hard population: R2 279, R3 20
- conflicts: 0
- post-repair hard violations: 0
- post-repair SHA-256: `200cde941773a821c94ddc84a2976a645b1eea44b8e596cd954a6c81bac80bb7`
- RU card TM rebuilt and validated: 2,476 cards

## Validation
- `python -m py_compile RussianTranslation/src/ru_style_sweep.py RussianTranslation/src/pilot/window_selftest.py`
- `python RussianTranslation/src/ru_style_sweep.py --selftest`
- `python RussianTranslation/src/pilot/prompt_rule_audit.py --fail-on-missing`
- `python RussianTranslation/src/pilot/lang_parity_check.py` (59 entries, no drift)
- `python RussianTranslation/src/pilot/window_selftest.py` (150/150)
- `git diff --check`

No release is included.