### PR TITLE
docs: /ask plan — Sa→Ru gloss-layer quality uplift (H1349)

### DIFF
--- a/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_saru-gloss.md
+++ b/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_saru-gloss.md
@@ -1,0 +1,82 @@
+# ARCHITECTURE — Sa→Ru gloss layer
+
+_Created: 19-07-2026 · Last updated: 19-07-2026_
+
+Index: [PLAN_RussianTranslation_saru-gloss-quality_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md).
+
+## Current pipeline (as-built)
+
+```
+SamudraManthanam verse-aligned Sa↔Ru jsonl
+        │  build_corpus_lexicon.py  (DeepSeek word-alignment)  ── FENCED, out of scope
+        ▼
+src/corpus_lexicon.jsonl  (1,091,528 aligned tokens, SLP1)   ── 290 MB, gitignored
+        │  build_surface_glossary.py
+        ▼
+surface_glossary.jsonl  (190,838 forms → ranked Ru)  =  LAYER 1
+        │
+        │  build_dcs_maps.py ──► dcs_form2lemma.tsv (408,660) + dcs_lemma2root.tsv
+        │  build_vidyut_fallback.py ──► vidyut_form2lemma.tsv (from surface_dcs_misses.tsv)
+        ▼
+build_rollup_glossaries.py  (two-pass bootstrap: rollup → vidyut → rollup)
+        ├─► lemma_glossary.{jsonl,tsv}   (40,370)      =  LAYER 2
+        ├─► root_glossary.{jsonl,tsv}    (2,021)       =  LAYER 3
+        ├─► surface_dcs_misses.tsv   (Vidyut input, stable)
+        ├─► surface_unresolved.tsv   (78,842, final typology)
+        └─► ambiguity_homographs.tsv (9,521 DCS homographs)
+        ▼
+gasyoun/SanskritRussian  (published: data + index.html)  ── data files FENCED
+```
+
+## Resolution tiers (the join that this span validates)
+
+Every form's lemma/root is attached by a **context-free** join (not per-passage), in a strict
+precedence:
+
+1. **DCS morphology (primary)** — `dcs_full.sqlite` (VisualDCS, 5.69 M tokens). Root of a prefixed
+   verb lemma = **longest member of DCS's own simple-root inventory that is a suffix of the lemma**,
+   min length 2 (sidesteps preverb sandhi: `uddhṛ` ← `ut`, not `ud`). `source='dcs'`.
+2. **Vidyut kosha (fallback)** — Pāṇinian FST v0.4.0, only for DCS-missed forms, inserted with a
+   synthetic count of 1 so it always sorts below DCS. Tiebreak: most entries, then shortest lemma.
+   `source='vidyut'`.
+3. **Morpheme-marker recovery** — forms carrying a corpus boundary mark (`A+gam`) split on `[+-]`;
+   joined string retried as a form, else rightmost element if it is a known root/lemma. `source='marker'`.
+4. **Unresolved** — kept in Layer 1, characterised in the failure typology.
+
+Provenance is carried per record (`source` field). **This tiering is exactly what wave 2 measures
+per-tier** — the architecture's central untested assumption is that these three heuristics produce
+correct lemmatization, and no number has ever tested it.
+
+## Component boundaries after this span
+
+| Component | Owns | Changed by |
+|---|---|---|
+| `src/build_*.py` (pipeline) | The four build scripts + the two-pass bootstrap | W1.1–W1.3 (defect fixes), W3.2 (cheda hook) |
+| `gold/` | Sampling, panel, agreement, human protocol | W2.1–W2.4 (new sampler + report **plug into** existing machinery — never rewrite it) |
+| `gasyoun/SanskritRussian` | **Canonical** method/coverage/typology/accuracy doc + published data | W1.4/W1.5 docs only; data FENCED |
+| `RussianTranslation/glossary/README.md` | Build runbook + pointer only (after W1.4) | W1.4 |
+| pwg_ru/mw_ru TM path | Dictionary-card translation lookup | W4.1 (new consumer of the glossary) |
+
+## Data model
+
+- **Surface record** (JSONL): `slp1`, `sa`, ranked `ru` list, `kinds`, `periods`, `genres`,
+  `registers`, sample `works` (SRC_CAP=25). TSV drops period/genre/kind facets.
+- **Lemma/root record** (JSONL): `key`, `ru` (ranked), `n`, `n_total`, `n_forms`, `upos`, `source`,
+  `registers`, `forms`, `lemmas`. TSV drops facets.
+- **New in this span:** `dcs_lemma2root_unresolved.tsv` (W1.1), `vidyut_ambiguity.tsv` (W1.3),
+  `gold/saru_gloss_sample.jsonl` + `gold/saru_gloss_precision_report.md` (W2).
+
+## Build-vs-reuse verdicts (prior-art check, D7)
+
+| Piece | Verdict | Evidence |
+|---|---|---|
+| Samāsa / compound splitter | **REUSE `vidyut.cheda`** | Installed v0.4.0, `import vidyut.cheda` OK. Never write a homegrown splitter. |
+| Segmentation benchmark | **REUSE** `kosha/scripts/compare_sandhi_methods.py` + `kosha/app/segmenter.py` | Sibling repo already compares sandhi methods. |
+| Gold sampling / agreement / protocol | **REUSE** `gold/gold_sample.py`, `gold_agreement.py`, `HUMAN_GOLD_PROTOCOL.md` | Full machinery exists from the alignment precision work (A42/A44). |
+| LLM panel + adversarial verify | **REUSE** the `precision_report.md` pattern | Same shape already ran for `corpus_lexicon` (n=320, 84.4 %). |
+| Transliteration | **REUSE** `indic_transliteration.sanscript` | Already the pipeline's transcoder; `sanskrit-util` consolidation is a separate later cleanup. |
+| `sanskrit_parser` | **DO NOT depend** | Not installed in this environment. |
+
+Nothing in this span is a from-scratch build of an existing asset.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_saru-gloss.md
+++ b/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_saru-gloss.md
@@ -1,0 +1,82 @@
+# IMPLEMENTATION — Sa→Ru gloss layer (wave-1 build sequence)
+
+_Created: 19-07-2026 · Last updated: 19-07-2026_
+
+Index: [PLAN_RussianTranslation_saru-gloss-quality_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md).
+File-level, step-ordered. Each step names the files it touches and its dependency. All pipeline
+work happens in a **worktree off `origin/master`**, never the shared checkout.
+
+## Preconditions (stop-condition check — halt with a note if any absent)
+
+- `../../../VisualDCS/src/DCS-data-2026/dcs_full.sqlite` present.
+- `vidyut` importable, kosha data at `../../../kosha/data/vidyut/kosha`.
+- `src/corpus_lexicon.jsonl` present (290 MB) — needed only if a regen is attempted (it is not in wave 1).
+- `import vidyut.cheda` succeeds (wave 3).
+
+## Wave 1 — ordered steps
+
+### Step 1 — W1.1 pseudo-root fix · `src/build_dcs_maps.py`
+Depends on: nothing.
+- At the root-extraction loop (the `for r in roots_by_len` block, ~line 102–111), the `else` branch
+  writes `f'{ls}\t{ls}\tunresolved\n'`. Redirect these rows to a new `dcs_lemma2root_unresolved.tsv`
+  instead of the main `dcs_lemma2root.tsv`.
+- In `build_rollup_glossaries.py`, when building the root layer, exclude lemmas whose only root is a
+  self-mapped `unresolved` row from the 2,021 root count (they remain in the lemma layer).
+- Emit a count of excluded pseudo-roots to stderr for the delta table.
+
+### Step 2 — W1.2 homograph completeness · `src/build_rollup_glossaries.py`
+Depends on: nothing (independent of Step 1).
+- At the homograph block (~line 211–215, `if u2 != upos or c2 >= 0.5 * lcnt:`), replace the single
+  `cands[1]` inspection with a loop over `cands[1:]`, emitting every candidate that meets the
+  "different upos OR count ≥ 50 % of primary" test to `ambiguity_homographs.tsv`.
+- Keep the primary attribution unchanged (no double-counting); only the alternates trail grows.
+
+### Step 3 — W1.3 Vidyut ambiguity trail · `src/build_vidyut_fallback.py`
+Depends on: nothing.
+- Where `stats['ambiguous']` is incremented (~line 79–80), also append the form + its competing
+  `(lemma, pos, cnt)` candidates to a new `vidyut_ambiguity.tsv` (mirror the DCS
+  `ambiguity_homographs.tsv` schema).
+
+### Step 4 — W1.6 regression tests · `tests/test_saru_gloss_pipeline.py` (new)
+Depends on: Steps 1–3.
+- Fixture A: a prefixed verb lemma with no root suffix → assert it lands in
+  `dcs_lemma2root_unresolved.tsv`, not the root layer.
+- Fixture B: a form with three near-equal lemmas → assert ≥2 alternates in `ambiguity_homographs.tsv`.
+- Fixture C: an ambiguous Vidyut form → assert a row in `vidyut_ambiguity.tsv`.
+- Use the existing committed `src/fixtures/corpus_lexicon.fixture.jsonl` as the seed where possible.
+
+### Step 5 — W1.4 doc consolidation
+Depends on: nothing (parallel with 1–4).
+- In `gasyoun/SanskritRussian` (a separate clone/worktree — docs only, data FENCED): make
+  `README.md` the canonical method/coverage/typology/accuracy doc. Fix the `√gam` counts to one
+  consistent set (regenerate the showcase numbers from current data if present, else pick the
+  README set and correct USE_CASES/SAMPLE to match). Refresh its `.ai_state.md` to v1.1.0 truth.
+- In this repo: shrink `glossary/README.md` to a build runbook (the two-pass bootstrap + script
+  list) + a full-blob-URL pointer to the canonical doc.
+- Give the canonical doc a sibling `.meta.md`.
+
+### Step 6 — W1.5 honesty caveat
+Depends on: Step 5.
+- Add a prominent "**Coverage ≠ accuracy**" block near the top of the canonical README and in
+  `index.html`: state that 87.1 % is a *resolution* rate; the *accuracy* ceiling is the 84.4 %
+  upstream pair precision, compounded by an as-yet-unvalidated lemmatization join; a measured
+  per-tier figure is coming in wave 2.
+
+### Step 7 — delta table + commit
+- Run the two-pass bootstrap locally (rollup → vidyut → rollup) to regenerate the *tsv/jsonl in the
+  worktree ONLY* (gitignored — not published; this proves the fixes, it does not touch SanskritRussian).
+- Write the before/after counts to `RESULTS_LOG.md` (root count, homograph alternates, Vidyut-ambiguity rows).
+- Commit in the worktree; open a PR to `master`; auto-merge.
+
+## Waves 2–4 (sketch — full step lists authored at each wave's start)
+
+- **Wave 2:** `gold/saru_gloss_sample.py` (stratified sampler reusing `gold_sample.py`) →
+  `gold/saru_gloss_panel.py` (panel + adversarial verify, two-part rubric) →
+  `gold/saru_gloss_precision_report.md`.
+- **Wave 3:** `src/build_compound_split.py` wrapping `vidyut.cheda`, benched against
+  `kosha/scripts/compare_sandhi_methods.py`; hook its output into the rollup's marker/rightmost retry;
+  re-measure affected strata.
+- **Wave 4:** a `tm_lookup` module exposing lemma/root glossaries to the pwg_ru/mw_ru card path;
+  smoke test on a known headword; INTERLINKS row flip.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md
+++ b/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md
@@ -1,0 +1,103 @@
+# PLAN — Sa→Ru gloss layer, quality uplift (2026 H2)
+
+_Created: 19-07-2026 · Last updated: 19-07-2026_
+
+**Index / cover doc.** This is the single entry point for the Sa→Ru gloss-layer uplift.
+A fresh agent executes it unattended by reading this file top-to-bottom, then the four
+layer docs it links. Every decision a builder would hit is ruled below — a dangling
+`@DECIDE` in a wave-1 path is a defect here, not a feature.
+
+Execution handoff: [H1349-Opus_RussianTranslation_saru-gloss-quality-uplift_19.07.26](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1349-Opus_RussianTranslation_saru-gloss-quality-uplift_19.07.26.md).
+
+## Goal (one paragraph)
+
+The Sa→Ru gloss layer (three glossaries — 190,838 surface forms / 40,370 lemmas /
+2,021 verb roots — built from `corpus_lexicon.jsonl`, published at
+[gasyoun.github.io/SanskritRussian](https://gasyoun.github.io/SanskritRussian/)) is
+**documented for coverage but never measured for accuracy**. Every published number
+(87.1 % token coverage) is a resolution rate; nothing measures whether a rolled-up gloss
+is *correct*. The upstream alignment is measured at 84.4 % pair precision — that error
+propagates into the rollup and is then compounded by an **unvalidated lemmatization join**
+(≥2-char longest-suffix root rule, Vidyut "most-entries-then-shortest" tiebreak, marker
+recovery), each with known code defects. This span makes the layer **honest, measured,
+and consumable**: fix the defects, publish a per-tier precision figure, attack the largest
+miss classes with *reused* tooling, and wire the glossary into the Tier-1 pwg_ru/mw_ru
+translation-memory path.
+
+## The four layer docs
+
+| Layer | Doc |
+|---|---|
+| Waves, deliverables, non-goals | [ROADMAP_RussianTranslation_saru-gloss_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/ROADMAP_RussianTranslation_saru-gloss_2026H2.md) |
+| Component boundaries, data model, build-vs-reuse | [ARCHITECTURE_RussianTranslation_saru-gloss.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_saru-gloss.md) |
+| File-level, step-ordered build sequence | [IMPLEMENTATION_RussianTranslation_saru-gloss.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_saru-gloss.md) |
+| Acceptance criteria, proof commands, risk register | [VERIFICATION_RussianTranslation_saru-gloss.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/VERIFICATION_RussianTranslation_saru-gloss.md) |
+
+## Decisions taken (Phase-2 interview, 19-07-2026)
+
+| # | Decision | Ruling | Rationale |
+|---|---|---|---|
+| D1 | Scope of "improved" | All four goals, sequenced | Not just one axis — defects, measurement, coverage, downstream, in dependency order. |
+| D2 | Wave order | **Defects → measure → coverage → downstream** | A gold set measured against a defective rollup measures the wrong artifact and must be re-run; fix first. |
+| D3 | Public accuracy claim | **Add an honest "coverage ≠ accuracy" caveat now** | Ship to README + `index.html` in wave 1, citing 84.4 % upstream pair precision as a ceiling, before any measurement. |
+| D4 | Gold annotator | **LLM panel now, human sample slot later** | Same shape as the existing `precision_report.md` (panel + adversarial verify). Explicitly **model-vs-model, NOT gold** per the org gold-provenance audit. |
+| D5 | Gold scope | **Two-axis: tier × frequency stratified** | Per-tier precision (dcs/vidyut/marker) isolates which heuristic fails; frequency stratum gives user-experienced accuracy. |
+| D6 | Annotation rubric | **Lemmatization + top-gloss judged separately** | Two independent verdicts per item, separating pipeline error from corpus/alignment error — you learn *which stage* to fix. |
+| D7 | Compound splitter | **Reuse, do not build** | `vidyut.cheda` v0.4.0 is installed; `kosha/scripts/compare_sandhi_methods.py` already benchmarks segmentation. A homegrown splitter fails the prior-art gate. |
+| D8 | Republish published data after code fixes | **Fix code now, regen+republish in a later GATED pass** | The unattended run lands script fixes + tests + a delta report; touching the published `.tsv`/`.jsonl` is out of scope and needs a human GO. |
+| D9 | Acceptance bar | **Regression tests + a delta report per wave** | Each fix gets a known-bad fixture test; each wave commits a before/after counts table. Machine-checkable, no human mid-run. |
+| D10 | Downstream consumer (wave 4) | **pwg_ru / mw_ru translation memory** | Feeds the Tier-1 RussianTranslation dictionary-card path directly — highest strategic payoff. |
+| D11 | Canonical doc owner | **SanskritRussian owns method/coverage/typology/accuracy; pipeline repo keeps build-only + pointer** | Users land on the data repo; the pipeline README shrinks to a runbook. Canonical doc gets a `.meta.md`. |
+| D12 | Gold execution depth | **Build scaffold + run the LLM panel this run** | Produce a measured per-tier precision this run, labelled model-vs-model; human spot-check left as a `@DO`. Fully unattended. |
+
+## Autonomy contract (verbatim — the unattended-execution rules)
+
+The execution agent runs 5–8 h with no human reachable. It MUST obey the following.
+
+- **On unplanned ambiguity:** apply the plan's marked default, log the call in
+  `RussianTranslation/.ai_state.md` Dev Notes, and continue. Park-and-skip an item ONLY
+  when no default in this plan applies. Never halt the whole run for a single fork.
+- **Commit authority:** waves 1–4 code + doc changes land via a **git worktree → PR →
+  auto-merge**, no confirmation prompt (handoff-scoped autonomy rule; SanskritLexicography
+  is a guarded main-tree repo — a worktree off `origin/master` is mandatory, never commit
+  in the shared checkout).
+- **Stop conditions — halt and leave a note rather than improvise when:** (a) a required
+  input file is absent (`dcs_full.sqlite`, `vidyut` kosha data, `corpus_lexicon.jsonl`);
+  (b) a regeneration would be needed to proceed (D8 fences that off); (c) a change would
+  touch a fenced path (below); (d) a wave's regression tests cannot be made to pass after
+  one genuine fix attempt.
+- **The hard fence — the agent MUST NOT touch:**
+  1. **The published `SanskritRussian` data files** — no writes to `.tsv`/`.jsonl`/`.gz`/`md/`
+     data in `gasyoun/SanskritRussian`. Docs (README, caveat block, `index.html` copy) ARE allowed.
+  2. **`corpus_lexicon.jsonl` and `build_corpus_lexicon.py`** — no re-running the 290 MB
+     DeepSeek alignment, no touching `src/.env` / the API key. Upstream is out of scope and costs money.
+  3. **The `gold/` human-protocol machinery** — reuse `gold_sample.py`, `gold_agreement.py`,
+     `HUMAN_GOLD_PROTOCOL.md` as-is; the new gold set plugs into them, it does not rewrite them.
+  4. **Any Tier-0 / revenue repo** (Systema-Sanscriticum et al.) — wave 4 wires pwg_ru TM
+     inside RussianTranslation only.
+
+## Wave summary (detail in the ROADMAP)
+
+1. **Wave 1 — Defects + honesty.** Fix pseudo-roots (`build_dcs_maps.py:111`), 3rd-homograph
+   blind spot (`build_rollup_glossaries.py:213`), unwritten Vidyut ambiguity
+   (`build_vidyut_fallback.py:79`); consolidate the two README copies to one canonical doc +
+   pointer; add the coverage≠accuracy caveat; each fix gets a regression test.
+2. **Wave 2 — Measure.** Tier × frequency stratified sample; lemmatization + top-gloss rubric;
+   run the LLM panel + adversarial verify; publish a per-tier precision report (model-vs-model),
+   plug into `gold/`.
+3. **Wave 3 — Coverage.** Attack the 48,646 unrecognized simplexes (sandhi-normalization
+   retries) and the 20,823 long compounds via **`vidyut.cheda`** (reuse), measured against the
+   wave-2 baseline.
+4. **Wave 4 — Downstream.** Wire the glossary as a lookup layer into the pwg_ru/mw_ru
+   translation-memory path.
+
+## Autonomy-readiness gate verdict
+
+**PASS.** Every wave-1 deliverable has an architecture spec, ordered implementation steps,
+an acceptance criterion, and identified risks (see the four layer docs). Zero blocking forks
+remain — all twelve decisions are ruled; the one genuinely deferred item (data republish, D8)
+is fenced off with a chosen default (fix-code-only). Prior-art verdicts are recorded (D7):
+nothing scheduled reinvents an existing asset. The autonomy contract covers the plausible
+ambiguities the audit surfaced.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.meta.md
+++ b/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.meta.md
@@ -1,0 +1,38 @@
+# Metadoc — PLAN_RussianTranslation_saru-gloss-quality_2026H2.md
+
+_Created: 19-07-2026 · Last updated: 19-07-2026_
+
+**Subject doc:** [PLAN_RussianTranslation_saru-gloss-quality_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md)
+
+## Purpose
+Execution-ready plan for the Sa→Ru gloss-layer quality uplift — the index a fresh agent reads to
+run waves 1–4 unattended (5–8 h). Produced by `/ask` (heavy up-front interview → layered plan).
+
+## Audience
+The execution agent (Opus 4.8, per handoff H1349) and MG for the gated republish decision (D8).
+
+## Provenance
+- Interview: 19-07-2026, Opus 4.8 (`claude-opus-4-8`), 4 rounds × 4 questions, all ruled.
+- Audit inputs: two Explore agents (data repo `gasyoun/SanskritRussian` + pipeline
+  `RussianTranslation/`), prior-art probe confirming `vidyut.cheda` v0.4.0 + `kosha` segmentation bench.
+- Handoff: [H1349-Opus_RussianTranslation_saru-gloss-quality-uplift_19.07.26](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1349-Opus_RussianTranslation_saru-gloss-quality-uplift_19.07.26.md).
+
+## Ranked improvement backlog (for the plan itself)
+1. After wave 2 lands a real precision number, fold it into the goal paragraph (currently states only the 84.4 % upstream ceiling).
+2. If MG approves the D8 republish, add a wave-1.5 "regen + v2.0.0 release" section.
+3. Wave 4's pwg_ru integration surface may collide with the open safety-plan PRs (#547/#550); revisit the fence once those merge.
+
+## Limitations
+- The autonomy-gate PASS assumes the fenced inputs (`dcs_full.sqlite`, vidyut kosha, corpus_lexicon) are present at run time; the plan makes their absence a stop-condition rather than pre-verifying at authoring time beyond the prior-art probe.
+- Waves 2–4 step lists are sketches; each wave authors its own full step list at start (by design — the plan front-loads decisions, not every keystroke).
+
+## Related docs
+- [[ROADMAP_RussianTranslation_saru-gloss_2026H2]] · [[ARCHITECTURE_RussianTranslation_saru-gloss]] · [[IMPLEMENTATION_RussianTranslation_saru-gloss]] · [[VERIFICATION_RussianTranslation_saru-gloss]]
+- Canonical data/method doc (after W1.4): `gasyoun/SanskritRussian/README.md`
+
+## Revision history
+| Date | Change | By |
+|---|---|---|
+| 19-07-2026 | Created with the plan set (`/ask`) | Opus 4.8 |
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/ROADMAP_RussianTranslation_saru-gloss_2026H2.md
+++ b/RussianTranslation/docs/ROADMAP_RussianTranslation_saru-gloss_2026H2.md
@@ -1,0 +1,91 @@
+# ROADMAP — Sa→Ru gloss layer (2026 H2)
+
+_Created: 19-07-2026 · Last updated: 19-07-2026_
+
+Index: [PLAN_RussianTranslation_saru-gloss-quality_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md).
+Four waves, strict dependency order (D2). Each states what unblocks it.
+
+## Wave 1 — Defects + honesty (unblocks: everything; depends on: nothing)
+
+Fix the three pipeline defects that corrupt the rollup, consolidate documentation, and make the
+public dataset honest about accuracy. Must land before wave 2, because measuring a defective
+rollup wastes the measurement.
+
+Deliverables:
+- **W1.1** — Pseudo-root fix. `build_dcs_maps.py` currently writes a prefixed verb lemma with no
+  matching root-suffix as *its own root* (`ls\tls\tunresolved`), silently inflating the 2,021-root
+  layer with pseudo-roots. Emit these to a separate `dcs_lemma2root_unresolved.tsv` and exclude
+  them from the root layer; recount.
+- **W1.2** — Homograph completeness. `build_rollup_glossaries.py` inspects only the *second*
+  candidate (`cands[1]`); a form with ≥3 near-equal lemmas logs at most one alternate. Iterate all
+  candidates past the primary and emit every qualifying alternate to `ambiguity_homographs.tsv`.
+- **W1.3** — Vidyut ambiguity trail. `build_vidyut_fallback.py` counts ambiguous forms
+  (`stats['ambiguous']`) but never writes them out — the Vidyut tier has no auditable trail
+  comparable to the DCS side. Emit `vidyut_ambiguity.tsv`.
+- **W1.4** — Doc consolidation (D11). Method/coverage/typology/accuracy becomes ONE canonical doc
+  owned by `gasyoun/SanskritRussian`; `RussianTranslation/glossary/README.md` shrinks to a build
+  runbook + a full-blob-URL pointer. Fix the `√gam` count discrepancy (README 195/176/140 vs
+  USE_CASES 196/177/141) and the stale `.ai_state.md` (says v1.0.0, repo is v1.1.0).
+- **W1.5** — Honesty caveat (D3). A prominent "coverage ≠ accuracy" block in the canonical README
+  and `index.html`, citing the 84.4 % upstream pair precision as a ceiling on any rolled-up gloss.
+- **W1.6** — Regression tests (D9). One known-bad fixture test per W1.1–W1.3.
+
+Acceptance: tests green; a `RESULTS_LOG` delta table showing the root-count drop, the added
+homograph alternates, and the new Vidyut-ambiguity row count.
+
+## Wave 2 — Measure accuracy (unblocks: wave 3 baseline; depends on: wave 1)
+
+Produce the first accuracy figure the layer has ever had.
+
+Deliverables:
+- **W2.1** — Stratified sampler (D5): tier (dcs/vidyut/marker) × frequency (high/mid/hapax) +
+  a homograph stratum. Reuse `gold/gold_sample.py` machinery; seed fixed for reproducibility.
+- **W2.2** — Two-part rubric (D6): each sampled entry judged on (a) form→lemma→root attribution
+  correctness, (b) top-ranked Russian gloss acceptability — independently.
+- **W2.3** — LLM panel run (D4, D12): panel + adversarial verification, per the existing
+  `precision_report.md` shape. Output labelled **model-vs-model, NOT gold**.
+- **W2.4** — Per-tier precision report committed under `gold/`, plugged into the existing protocol;
+  a `@DO` row for the human spot-check slot.
+
+Acceptance: `gold/saru_gloss_precision_report.md` exists with a per-tier × per-frequency precision
+table and explicit model-vs-model provenance; `gold_agreement.py`-compatible artifacts present.
+
+## Wave 3 — Coverage on the miss classes (unblocks: nothing downstream; depends on: wave 2)
+
+Reduce the 78,842 unresolved forms, measured against the wave-2 baseline so the gain is a
+*measured accuracy-preserving* gain, not just a coverage bump.
+
+Deliverables:
+- **W3.1** — Simplex recovery: sandhi-normalization retries on the 48,646 unrecognized simplexes
+  (91,548 tokens) before declaring a miss.
+- **W3.2** — Compound splitting via **`vidyut.cheda`** (D7, reuse — installed v0.4.0), evaluated
+  against `kosha/scripts/compare_sandhi_methods.py`'s existing benchmark. Target the 20,823 long
+  compounds (≥14 chars). Splitter output feeds the existing rightmost-element / joined-form retry.
+- **W3.3** — Re-measure the affected strata against wave 2; a form recovered but wrong is a
+  regression, not a win.
+
+Acceptance: coverage delta table + a precision check on a sample of newly-resolved forms showing
+no precision regression vs wave 2.
+
+## Wave 4 — Downstream wiring (depends on: wave 1; independent of 2/3)
+
+Turn the published dataset into a *used* one.
+
+Deliverables:
+- **W4.1** — pwg_ru/mw_ru translation-memory lookup (D10): expose the lemma/root glossaries as a
+  lookup layer the dictionary-card translation path can query for candidate Russian renderings.
+- **W4.2** — Register in [Uprava/PROJECT_INTERLINKS.md](https://github.com/gasyoun/Uprava/blob/main/PROJECT_INTERLINKS.md)
+  as a wired downstream (currently "mostly not yet wired").
+
+Acceptance: a smoke test resolving a known dictionary headword through the TM lookup; the
+INTERLINKS row flipped from planned to wired with the PR link.
+
+## Non-goals (explicit)
+
+- **Regenerating/republishing the `SanskritRussian` data** — D8 fences this to a later gated pass.
+- **Re-running `corpus_lexicon.jsonl`** (the 290 MB DeepSeek alignment) — out of scope, costs money.
+- **A second independent aligner** for the upstream — tracked in `CAPABILITY_OBSERVATORY.md`, not here.
+- **Nominal (noun) roots** — Layer 3 stays verbal-only by design.
+- **Any Tier-0 / revenue-repo integration** — wave 4 is pwg_ru inside RussianTranslation only.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/VERIFICATION_RussianTranslation_saru-gloss.md
+++ b/RussianTranslation/docs/VERIFICATION_RussianTranslation_saru-gloss.md
@@ -1,0 +1,57 @@
+# VERIFICATION — Sa→Ru gloss layer
+
+_Created: 19-07-2026 · Last updated: 19-07-2026_
+
+Index: [PLAN_RussianTranslation_saru-gloss-quality_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md).
+
+## Acceptance criteria + proof commands
+
+### Wave 1
+| Deliverable | Acceptance | Proof |
+|---|---|---|
+| W1.1 pseudo-root fix | Root layer no longer contains self-mapped `unresolved` lemmas; count drops from 2,021 by the excluded number | `pytest tests/test_saru_gloss_pipeline.py -k pseudo_root`; delta row in `RESULTS_LOG.md` |
+| W1.2 homograph completeness | A 3-lemma fixture yields ≥2 alternates | `pytest -k homograph`; `wc -l ambiguity_homographs.tsv` before/after |
+| W1.3 Vidyut trail | `vidyut_ambiguity.tsv` exists and is non-empty after a rollup→vidyut→rollup run | `pytest -k vidyut_ambiguity`; file present |
+| W1.4 doc consolidation | One canonical doc; pipeline README is a runbook+pointer; `√gam` counts consistent across README/USE_CASES/SAMPLE; `.ai_state.md` at v1.1.0 | grep the three files for the `√gam` triple; link-check the pointer |
+| W1.5 caveat | "Coverage ≠ accuracy" block present in canonical README + `index.html` | grep both files |
+| W1.6 tests | All three fixtures green | `pytest tests/test_saru_gloss_pipeline.py` |
+
+### Wave 2
+- `gold/saru_gloss_precision_report.md` exists with a **per-tier × per-frequency** precision table
+  and a separate lemmatization-vs-gloss breakdown.
+- Provenance line states **model-vs-model, NOT gold** (org gold-provenance rule).
+- A `@DO` human-spot-check row exists in [Uprava/GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md).
+- Proof: open the report; confirm the strata cells sum to the sample n; confirm `gold_agreement.py`
+  runs against the produced artifacts without a "no double-reviewed item" hard-fail.
+
+### Wave 3
+- Coverage delta table (forms/tokens recovered) committed.
+- **Precision non-regression:** a sample of newly-resolved forms scored against the wave-2 rubric
+  shows no drop vs the wave-2 tier precision. A recovered-but-wrong form counts as a regression.
+- Proof: `compare_sandhi_methods.py` bench output for the `vidyut.cheda` path; the re-measured strata table.
+
+### Wave 4
+- A smoke test resolves a known dictionary headword through the TM lookup and returns candidate
+  Russian renderings from the glossary.
+- The [Uprava/PROJECT_INTERLINKS.md](https://github.com/gasyoun/Uprava/blob/main/PROJECT_INTERLINKS.md)
+  downstream row for the glossary is flipped from planned to wired with the PR link.
+- Proof: `pytest -k tm_lookup_smoke`; the INTERLINKS diff.
+
+## Risks & spikes register
+
+| Risk | Likelihood | Impact | Mitigation / spike |
+|---|---|---|---|
+| Pseudo-root exclusion (W1.1) drops *legitimate* roots that happen to self-map | Med | Med | Spike: hand-inspect 20 excluded lemmas before finalizing; if any is a true root, tighten the exclusion to "no suffix match AND lemma carries a preverb". |
+| The measured per-tier precision is embarrassingly low (e.g. marker tier < 60 %) | Med | Low (that IS the finding) | Report it honestly; it directly justifies wave 3's re-measurement discipline. Not a blocker. |
+| `vidyut.cheda` splits differ from the corpus's own `+`/`-` marks, causing double-recovery | Med | Med | Prefer the corpus marker when present; use cheda only where no marker exists. Bench on the kosha comparison set first (spike). |
+| Regen in the worktree (Step 7) is slow / OOMs on the 290 MB corpus held in RAM | Low | Med | The rollup does not re-read corpus_lexicon (only surface_glossary.jsonl); if surface regen is needed and OOMs, that is a stop-condition — leave a note, do not stream-refactor unattended. |
+| Panel run (W2.3) hits API limits mid-run | Med | Med | The gold sampler and panel are resumable (append-only, per the existing gold machinery); on limit, park with progress logged. |
+| Wave 4 TM wiring touches the live pwg_ru card pipeline mid-flight (safety-plan PRs #547/#550 open) | Med | High | Wave 4 adds a *read-only lookup consumer*; do not modify the coordinator/runtime that #547/#550 touch. If a collision surfaces, park wave 4 and note it. |
+
+## Spikes to run BEFORE committing to the arch
+
+1. **Excluded-pseudo-root inspection** (W1.1) — 20-sample hand check, ~15 min, before the exclusion is final.
+2. **cheda-vs-corpus-marker agreement** (W3.2) — bench `vidyut.cheda` against the corpus's own marks
+   on a sample, decide precedence, before wiring it into the rollup.
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Layered `/ask` execution plan for the Sa→Ru gloss-layer quality uplift ([H1349](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1349-Opus_RussianTranslation_saru-gloss-quality-uplift_19.07.26.md)).

Docs-only. Adds under `RussianTranslation/docs/`: PLAN index + ROADMAP / ARCHITECTURE / IMPLEMENTATION / VERIFICATION + metadoc.

**Core finding from the audit:** the gloss layer is documented for *coverage* (87.1% tokens) but has NEVER been measured for *accuracy*. The 84.4% upstream alignment precision propagates into an unvalidated lemmatization join with three known code defects.

**Plan (12 rulings, autonomy gate PASS), 4 waves in strict order:**
1. Fix defects (pseudo-roots `build_dcs_maps.py`, 3rd-homograph blind spot, unwritten Vidyut ambiguity) + doc consolidation + coverage≠accuracy caveat, each with a regression test.
2. Publish per-tier precision (LLM panel, model-vs-model, tier × frequency stratified).
3. Coverage on the miss classes via reused `vidyut.cheda`.
4. Wire pwg_ru/mw_ru translation-memory downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)