### PR TITLE
docs(pwg): /ask layered plan — PWG data layers (H1350)

### DIFF
--- a/docs/ARCHITECTURE_SanskritLexicography_PWG_DATA_LAYERS.md
+++ b/docs/ARCHITECTURE_SanskritLexicography_PWG_DATA_LAYERS.md
@@ -1,0 +1,100 @@
+_Created: 19-07-2026 · Last updated: 19-07-2026_
+
+# ARCHITECTURE — PWG data layers
+
+Cover: [PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md).
+
+## 1. Anatomy of a PWG card — the model this wave formalises
+
+A PWG record is the span `<L>…<LEND>` in [`csl-orig/v02/pwg/pwg.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/pwg/pwg.txt) — 123,366 records. Its markup vocabulary (measured, [`csl-atlas/data/parse-rules/pwg.json`](https://github.com/gasyoun/csl-atlas/blob/main/data/parse-rules/pwg.json)):
+
+| Tag | Role | Count | Parse adequacy |
+|-----|------|-------|----------------|
+| `<L>` / `<LEND>` | record boundary | 123,366 | clean |
+| `<k1>` / `<k2>` | headword keys (Devanāgarī / SLP1) | per record | clean |
+| `<h>` | homograph number | 6,499 | clean |
+| `<hom>` | homonym marker | 82 | clean |
+| `<lex>` | grammar / part-of-speech | 131,189 | clean |
+| `<div>` | sense division | 113,613 | clean |
+| `<ls>` | literature citation | 772,567 | **lossy** (72.4% recognised) |
+| `<ab>` | abbreviation (diasystem) | 185,563 | partial |
+| `<is>` | inflected/stem surface | 53,947 | surfaced, not dropped |
+| `{#…#}` | SLP1 → IAST Sanskrit | inline | clean |
+| `{%…%}` | German-vs-Latin gloss | inline | clean |
+| `〉` | **sense-closing glyph** | 87,680 | **historically unparsed** |
+| `[Page…]` / `<pc>` | volume/column locus | per record | clean |
+
+Three descriptions of this anatomy exist and are **reused, not rebuilt**:
+
+- **Pedagogical** — [`EntryAnatomy/README.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/EntryAnatomy/README.md), 24 named elements, human-facing.
+- **Machine-measured** — the parse-rules `pwg.json` above, every tag with counts + MDF adequacy.
+- **Working parser** — [`RussianTranslation/src/microstructure.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/microstructure.py), flat record → Apresjan "lexicographic portrait" (homonym-keyed card, grammar, diasystem, numbered/lettered sense tree), validated by [`schemas/pwg_ru_lexicographic_portrait.schema.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/schemas/pwg_ru_lexicographic_portrait.schema.json).
+
+W1.1 (`PWG_CARD_ANATOMY.md`) is the **index + measured crosswalk** over these three — a coverage matrix showing, per anatomy element, which of the three describes it and where they diverge. The three stay as-is.
+
+## 2. Build-vs-reuse verdict per piece (prior-art check — `/prior-art` evidence)
+
+| Piece | Verdict | Consume, don't rebuild |
+|-------|---------|------------------------|
+| Card anatomy description | **reuse ×3** | The three above. New doc only crosswalks them. |
+| Record splitter / masker | **reuse** | [`pwg_mask.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_mask.py) (`<L>…<LEND>` split, `{Tn}` masking, 123,365/123,366 lossless round-trip). |
+| Portrait parser | **reuse** | `microstructure.py`. The JSON Schema extension (W1.3) formalises *its* output. |
+| `<ab>` resolver | **reuse** | [`pwg_ab.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_ab.py) (791 abbreviations from `pwgab_input.txt`). |
+| `<ls>` resolver | **extend** | [`pwg_sources.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_sources.py) (`pwgbib.txt`, ~2.7k) + [`ls_resolver.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ls_resolver.py) (1266 ln). W1.6 mines the unrecognised tail against these; no new resolver. |
+| `<pc>` page/column | **reuse** | [`pwg_page_index.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_page_index.py). (Note the open `page=(column+1)//2` per-volume-offset `@DO`.) |
+| Sense records | **extend** | [`csl-atlas/data/lexico/senses_pwg.jsonl`](https://github.com/gasyoun/csl-atlas/blob/main/data/lexico/senses_pwg.jsonl) (`senseId`, `parserFamily`, `splitConfidence`, `sanskritAnchors`). |
+| Xref edges | **extend** | `csl-atlas/data/lexico/xref_edges.csv` + [`scripts/lexico/m3_xrefs.py`](https://github.com/gasyoun/csl-atlas/blob/main/scripts/lexico/m3_xrefs.py). |
+| Government / Rektion | **extend** | The H1308 government index (~3,853 markings / ~3,222 senses, [FINDINGS §71](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)). |
+| OntoLex sidecar | **extend** | [`export_lod.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/export_lod.py) `de-lexicon`, emitting `pwg_de_lexicon.ttl` (H772, [PWG_PLUS_GERMAN_ENRICHMENT.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_PLUS_GERMAN_ENRICHMENT.md)). |
+| Formal grammar (RNG) | **NEW** — the one genuine gap | No DTD/XSD/RNG exists anywhere in csl-orig (audit-confirmed). Only the TEI header references `tei_all.rnc`. This is net-new and non-duplicative. |
+| Defect-report packaging | **reuse pattern** | The [`NWS_ERRATUM_EMAIL.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/NWS_ERRATUM_EMAIL.md) precedent + [/cologne-correction-queue](https://github.com/gasyoun/claude-config/blob/main/commands/cologne-correction-queue.md) change-file format. |
+
+**Nothing scheduled rebuilds an existing asset.** The single NEW component is the RelaxNG grammar.
+
+## 3. Component boundaries
+
+```
+csl-orig/v02/pwg/pwg.txt   (READ-ONLY source, 123,366 records)
+        │
+        ├─▶ pwg_mask.py ──▶ microstructure.py ──▶ portrait (JSON)
+        │                        │
+        │                        ├─▶ [W1.3] pwg_portrait.schema.json  ──▶ pwg_portrait_validation.json
+        │                        └─▶ [W1.4] corrected 〉-splitter      ──▶ sense_glyph_audit.json
+        │                                                                 + pwg_ru_glyph_quarantine.jsonl (side file)
+        ├─▶ [W1.2] pwg_markup.rnc (NEW) ──▶ pwg_markup_validation.json (typed failure buckets)
+        │                                          │
+        │                                          └─▶ [W1.9] csl-corrections change files (STAGED, no PR)
+        │
+        ├─▶ [W1.6] ls_source_map + pwgbib ──▶ citations layer (≥85% recognised)
+        ├─▶ [W1.7] senses / xref / government layers
+        │
+        └─▶ [W1.8] export_lod.py de-lexicon ──▶ pwg_de_lexicon.ttl
+                   (entry/<key1>/de nodes on shared lemma/<key1> spine — additive, German never mutated)
+```
+
+The `lemma/<key1>` spine (SLP1 `form_key`) is the join key for every layer — **not** the Russian, **not** the presence of a PWG record. A headword with no PWG record still gets its other-layer nodes; the German node is emitted only when a PWG record exists.
+
+## 4. Data model — new/changed artifacts
+
+| Artifact | Path | Shape |
+|----------|------|-------|
+| Anatomy reference | `docs/PWG_CARD_ANATOMY.md` | Markdown: element × source coverage matrix + divergence notes |
+| RNG grammar | `RussianTranslation/schemas/pwg_markup.rnc` | RelaxNG compact syntax over the `<L>…<LEND>` tag language |
+| Markup validation | `RussianTranslation/reports/pwg_markup_validation.json` | `{record_id, status: pass|fail, failure_type, span}` per record |
+| Portrait validation | `RussianTranslation/reports/pwg_portrait_validation.json` | same shape, over the parsed portrait |
+| `〉` audit | `RussianTranslation/reports/pwg_sense_glyph_audit.json` | per-record merged-sense count + store-contamination totals |
+| Quarantine marker | `RussianTranslation/reports/pwg_ru_glyph_quarantine.jsonl` | `{key1, senseId, reason}` — **side file, store untouched** |
+| Citations layer | extend `csl-atlas/data/lexico/senses_pwg.jsonl` / a `pwg_citations.jsonl` | `{key1, ls_raw, resolved_source, confidence}` |
+| Xref edges | extend `csl-atlas/data/lexico/xref_edges.csv` | `{src_key1, redirect_type: s|vgl, tgt_key1, resolved: bool}` |
+| Government layer | extend the H1308 index | `{key1, senseId, case, kind: single|variation}` |
+| OntoLex graph | `RussianTranslation/release/fixture/pwg_de_lexicon.ttl` | additive properties on `entry/<key1>/de` |
+| Staged defects | `csl-corrections/…/batch_pending/` change files | change-file format per correction-workflow.md |
+
+## 5. Key risks (full register in the verification doc)
+
+- **R1 — the `〉` re-segmentation over-corrects.** Mitigation: the ≤50-card LLM sanity check (W1.5) + a deterministic diff against the first-2500 fix already verified in [FINDINGS §447](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).
+- **R2 — RNG can't express a genuinely-irregular but valid record**, inflating false failures. Mitigation: the 100%-parse-or-typed-bucket bar treats "unexpected but attested" as its own bucket, not a defect; a human reviews buckets before any change file ships.
+- **R3 — citation resolver plateaus below 85%.** Mitigation: D8 accepts ~85–90% as the honest ceiling; the tail is catalogued as a typed gap, not forced.
+- **R4 — shared-tree contention** on `csl-atlas` (external actor commits mid-session). Mitigation: csl-atlas edits go through a worktree off `origin/main`; PRs, never direct pushes to a live tree.
+
+_Dr. Mārcis Gasūns_

--- a/docs/IMPLEMENTATION_SanskritLexicography_PWG_DATA_LAYERS.md
+++ b/docs/IMPLEMENTATION_SanskritLexicography_PWG_DATA_LAYERS.md
@@ -1,0 +1,87 @@
+_Created: 19-07-2026 · Last updated: 19-07-2026_
+
+# IMPLEMENTATION — PWG data layers (wave-1, file-level, step-ordered)
+
+Cover: [PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md). Architecture: [ARCHITECTURE_SanskritLexicography_PWG_DATA_LAYERS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/ARCHITECTURE_SanskritLexicography_PWG_DATA_LAYERS.md).
+
+**Setup (do first).** Work in a fresh worktree off `origin/master`: `git worktree add -b feat/pwg-data-layers ../SanskritLexicography-pwg-dl origin/master`. All Python scripts open outputs `encoding='utf-8'`, call `sys.stdout/stderr.reconfigure(encoding='utf-8')`, write no BOM, and are saved as `.py` files (never inline). Every step commits `ai-wip:` on completion.
+
+---
+
+### Step 1 — W1.1 canonical anatomy reference (no dependencies)
+
+- **Read** the three sources (architecture §1). **Write** `docs/PWG_CARD_ANATOMY.md`: for each of the 24 pedagogical elements, a row giving `{element, pedagogical?, parse-rules tag+count?, portrait field?, divergence note}`.
+- **Derive the coverage matrix** with a throwaway script `RussianTranslation/src/build_anatomy_crosswalk.py` that reads `csl-atlas/data/parse-rules/pwg.json` (counts) and the portrait schema (fields) and emits the matrix as a markdown table to stdout; paste into the doc. Do **not** re-parse pwg.txt for counts — read the measured census.
+- **Acceptance:** every tag in `pwg.json` appears in the matrix with its count; every one of the 24 elements is mapped or explicitly marked "pedagogical-only".
+
+### Step 2 — W1.2 RelaxNG grammar + validation run
+
+- **Write** `RussianTranslation/schemas/pwg_markup.rnc` — a RelaxNG compact grammar for the `<L>…<LEND>` tag language (element inventory from Step 1). Model the paired spans (`<ls> <ab> <is> <lex> <lang> {#…#} {%…%}`), the record header (`<L>/<pc>/<k1>/<k2>/<h>`), and the `〉` sense-close.
+- **Write** `RussianTranslation/src/validate_pwg_markup.py`: for each of the 123,366 records, attempt validation; on failure, classify into a typed bucket (`malformed-span`, `unknown-tag`, `glyph-class`, `unbalanced-delim`, `unexpected-but-attested`). Emit `RussianTranslation/reports/pwg_markup_validation.json`.
+- **Guard (FINDINGS §129/§130):** no record is silently dropped — every record is `pass` or lands in exactly one bucket. Assert `sum(buckets)+passes == 123366`.
+- **Acceptance:** the assert holds; zero `unclassified`. See [VERIFICATION](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/VERIFICATION_SanskritLexicography_PWG_DATA_LAYERS.md) V2.
+
+### Step 3 — W1.3 JSON Schema over the portrait
+
+- **Extend** `RussianTranslation/schemas/pwg_ru_lexicographic_portrait.schema.json` (or add `pwg_portrait_structural.schema.json`) to cover the full sense tree + apparatus, not just the RU fields.
+- **Write** `RussianTranslation/src/validate_pwg_portrait.py` running `microstructure.py` over all records → validate → emit `reports/pwg_portrait_validation.json` (same bucket discipline).
+- **Acceptance:** 100% parse-or-bucket; the schema is referenced by the existing `validate_portrait_schema.py` harness.
+
+### Step 4 — W1.4 `〉` full measure + quarantine (store untouched)
+
+- **Write** `RussianTranslation/src/audit_sense_glyph.py`:
+  1. re-segment all 123,366 records with the **corrected** splitter that recognises `〉` (the FINDINGS §447 fix; verify it matches the first-2500 audit in `_audit_micro.py`);
+  2. for each record, count senses under the old (merged) vs corrected segmentation;
+  3. join to the RU store **read-only** (`pwg_ru_translated.jsonl`) to find rows whose `senseId` was produced against merged segmentation;
+  4. emit `reports/pwg_sense_glyph_audit.json` (totals + per-record deltas) and `reports/pwg_ru_glyph_quarantine.jsonl` (one row per contaminated store row).
+- **Fence:** open the store `'r'` only. Never write `pwg_ru_translated.jsonl` or a rebuilt sibling (FINDINGS §9). Quarantine is the side file alone.
+- **Acceptance:** the audit reports a single contamination number with a CI, and the quarantine file's row count equals the audit's contaminated-row total.
+
+### Step 5 — W1.5 bounded LLM sanity check (skippable)
+
+- **Write** `RussianTranslation/src/sanity_glyph_resegment.py`: stratified ≤50-card sample; ask DeepSeek (`--backend openai`, **no Anthropic key**) whether the corrected segmentation reads correctly vs the German. Emit a small verdict JSON + a one-line agreement rate.
+- **On no backend / network:** log "sanity check skipped — no backend" to `.ai_state.md` Dev Notes and continue (stop condition (b), not a halt).
+- **Acceptance:** either an agreement rate is reported, or the skip is logged. Never blocks.
+
+### Step 6 — W1.6 citation coverage extension
+
+- **Write** `RussianTranslation/src/extend_ls_coverage.py`: collect the currently-unrecognised `<ls>` tail; match against `pwg_sources.py`'s `pwgbib.txt` + the Verzeichniss patterns; add new patterns to `ls_source_map.json` (or a sidecar `ls_source_map_ext.json`). Recompute recognition rate.
+- **No LLM, no synthesised sources** (D8). Unresolvable tail → `reports/pwg_ls_unresolved.tsv` as a typed gap for a human bibliographer.
+- **Acceptance:** recognition ≥85% OR a written explanation of why the ceiling is lower, with the unresolved tail catalogued. (Baseline 72.4%, FINDINGS §20.)
+
+### Step 7 — W1.7 sense / xref / government layers
+
+- **Senses:** extend `csl-atlas/data/lexico/senses_pwg.jsonl` with the corrected segmentation from Step 4 (via a csl-atlas worktree — R4).
+- **Xrefs:** `RussianTranslation/src/resolve_xrefs.py` — resolve `s.`/`vgl.` redirects where the target `key1` is deterministically identifiable; emit `{src,type,tgt,resolved}` to extend `xref_edges.csv`. Unresolved stay `resolved:false` (never guessed).
+- **Government:** extend the H1308 index with any senses the corrected segmentation newly exposes.
+- **Acceptance:** each layer's row count and resolved-fraction reported; no fabricated targets.
+
+### Step 8 — W1.8 OntoLex rollup
+
+- **Extend** `RussianTranslation/src/export_lod.py de-lexicon` to attach citations (W1.6), corrected senses (W1.4), xref edges (W1.7), and government (W1.7) as new properties on `entry/<key1>/de`. Regenerate `release/fixture/pwg_de_lexicon.ttl`.
+- **Fence:** additive only — the German lemma/text nodes are never altered, only new sibling properties added.
+- **Acceptance:** the TTL parses (rdflib), node count grows by the expected layer cardinality, and a spot query for a known headword (e.g. `agni`) returns the new properties. See VERIFICATION V8.
+
+### Step 9 — W1.9 defect staging (csl-corrections only)
+
+- **Write** `RussianTranslation/src/stage_pwg_defects.py`: read the failure buckets from Steps 2/3/4 + the 12 PWG SanskritSpellCheck typos; emit **change files** in the csl-corrections change-file format into `csl-corrections/.../batch_pending/` (via a csl-corrections worktree).
+- **Fence:** commit change files to csl-corrections **only**. Open **no** PR to csl-orig; merge nothing. Write a `PWG_DEFECTS_STAGED.md` manifest listing every staged item for MG's later [/cologne-batch-pr](https://github.com/gasyoun/claude-config/blob/main/commands/cologne-batch-pr.md).
+- **Acceptance:** N change files staged, N rows in the manifest, zero csl-orig writes, zero PRs opened to a maintainer repo.
+
+### Step 10 — W1.10 hub sync + release
+
+- **FINDINGS:** append the `〉` contamination number, the RNG-gap-now-filled note, and the citation-coverage delta (SanskritLexicography FINDINGS for data, Uprava FINDINGS for infra) via [/findings-append](https://github.com/gasyoun/claude-config/blob/main/commands/findings-append.md).
+- **PROJECT_INTERLINKS:** register `pwg_de_lexicon.ttl`'s new layers as consumable; **SHARED_CODE:** register `validate_pwg_markup.py` + the RNG grammar as the canonical PWG markup validator.
+- **CHANGELOG** entry under `[Unreleased]`, then [/cut-release](https://github.com/gasyoun/claude-config/blob/main/commands/cut-release.md).
+- **GTD:** `@DECIDE` row for MG to review the staged defects + run the batch PR; `@DECIDE` for the Wave-3 requeue budget.
+- **`.ai_state.md`:** move finished items to Completed, point Next Steps at Wave 2.
+- **Deliver:** push the SanskritLexicography branch, open PR, auto-merge + delete branch.
+
+## Ambiguity defaults (apply + log, never block)
+
+- Malformed record that fits no bucket → new `unexpected-but-attested` bucket, logged.
+- csl-atlas push rejected → retry via `/branch-contention-recover`; if unresolved, stage the csl-atlas layer changes as a patch file in the SL repo and log a `@DECIDE`.
+- Citation ceiling < 85% → accept, catalogue the tail, log the reason.
+- Store join ambiguity (a `senseId` maps to multiple segmentations) → mark `ambiguous` in the quarantine file, never guess.
+
+_Dr. Mārcis Gasūns_

--- a/docs/PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md
+++ b/docs/PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md
@@ -1,0 +1,70 @@
+_Created: 19-07-2026 · Last updated: 19-07-2026_
+
+# PLAN — PWG data layers: card anatomy, formal schema, four extraction layers, German-side enrichment
+
+**Repo:** [SanskritLexicography](https://github.com/gasyoun/SanskritLexicography) · **Subject:** PWG (Petersburger Wörterbuch / Böhtlingk–Roth) data layers · **Span:** 2026 H2 · **Handoff:** [H1350](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1350-Sonnet_SanskritLexicography_pwg-data-layers-anatomy-schema-extract_19.07.26.md)
+
+This is the cover/index for a `/ask`-grade layered plan: a single unattended 5–8 h execution run that (1) reconciles the three existing PWG-card anatomy descriptions into one canonical reference, (2) authors the first-ever **formal** PWG grammar (RelaxNG over raw markup + JSON Schema over the parsed portrait) and runs it over all 123,366 records, (3) extends four extraction layers — citations, sense structure, cross-references, government — onto the existing OntoLex sidecar, and (4) turns the byproduct markup defects into staged csl-corrections change files (never a csl-orig PR).
+
+The four layer docs this points at:
+
+- **Roadmap** — [ROADMAP_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/ROADMAP_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md)
+- **Architecture** — [ARCHITECTURE_SanskritLexicography_PWG_DATA_LAYERS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/ARCHITECTURE_SanskritLexicography_PWG_DATA_LAYERS.md)
+- **Implementation** — [IMPLEMENTATION_SanskritLexicography_PWG_DATA_LAYERS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/IMPLEMENTATION_SanskritLexicography_PWG_DATA_LAYERS.md)
+- **Verification** — [VERIFICATION_SanskritLexicography_PWG_DATA_LAYERS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/VERIFICATION_SanskritLexicography_PWG_DATA_LAYERS.md)
+
+---
+
+## 1. Goal (one paragraph)
+
+Make the anatomy of a PWG card a **formally specified, machine-validated, queryable** object, and route the enrichment additively onto the German original — never into the German source text. Today the card's structure is described in three unreconciled places (a 24-element pedagogical list, a machine-measured tag census, and a working parser), enforced only by ad-hoc Python validators with no grammar. This wave produces one canonical anatomy reference, two real schemas that classify every record as pass-or-typed-failure, four extended extraction layers rolled into the existing OntoLex graph, and a staged (not shipped) set of upstream defect reports. The German markup in `csl-orig` is **read-only** throughout; "enrich the German" here means additive sidecar annotation on the shared `lemma/<key1>` spine (the PWG++ pattern, [H772](https://github.com/gasyoun/Uprava/blob/main/handoffs/README.md)), plus a formal grammar that describes the German markup without altering it.
+
+## 2. Decisions taken (Phase-2 interview rulings)
+
+Every fork a builder would hit was ruled up front. The execution agent trusts these without re-deriving them.
+
+| # | Decision | Ruling | Rationale |
+|---|----------|--------|-----------|
+| D1 | What "enrich the German" means | **Sidecar overlay + formal PWG schema + anatomy synthesis doc.** No new text into csl-orig. | Additive annotation is zero-risk and already has infrastructure ([`export_lod.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/export_lod.py), H772). The formal schema *describes* the German markup; it does not modify it. |
+| D2 | Extraction targets for this wave | **All four:** citations `<ls>`, sense structure + the `〉` fallout, cross-references (`s.`/`vgl.`), grammar/government (Rektion). | Each extends a partially-built asset rather than starting cold; together they cover the card's full apparatus. |
+| D3 | What the RU pass feeds back | **Markup defects + sense-segmentation disagreements + OCR/text errors.** Not "keep the wall". | The translation pass reads every word; its byproduct defects are the highest-signal source-quality feed that exists. Bucket C has been 0 forever — this opens it. |
+| D4 | Upstream delivery contract | **csl-corrections change files only.** No csl-orig PR; no auto-merge to any maintainer repo. MG runs [/cologne-batch-pr](https://github.com/gasyoun/claude-config/blob/main/commands/cologne-batch-pr.md) later. | csl-corrections takes agent commits (audit trail); csl-orig and maintainer-repo merges stay MG `@DECIDE`. Reconciles the "agent-gated" preference with the standing read-only rule. |
+| D5 | Formal schema target | **Both** — RelaxNG over raw `<L>…<LEND>` markup **and** JSON Schema over the `microstructure.py` portrait. | RNG (source-facing) drives the upstream defect reports and matches the TEI header's `tei_all.rnc` lineage; JSON (internal) proves the parse is complete. |
+| D6 | `〉` sense audit depth | **Full measure + quarantine, no requeue.** | Bounds the blast radius (how many RU-store rows were translated against merged segmentation) without spending scarce generation budget or colliding with the paused nominal lane / [H1209](https://github.com/gasyoun/Uprava/blob/main/handoffs/README.md) canary. |
+| D7 | Sidecar overlay shape | **Extend the existing OntoLex graph** (`entry/<key1>/de` nodes on the `lemma/<key1>` spine). | One coherent, queryable graph; reuses `export_lod.py`; consistent with [LOD_GRAPH.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LOD_GRAPH.md). |
+| D8 | `<ls>` citation coverage method | **Extend `ls_source_map` + `pwgbib` resolver deterministically.** No LLM resolution of the tail. | Auditable, no synthesised sources (avoids the "repaired ≠ synthesised" trap, [FINDINGS §94/§95](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)). Realistic ceiling ~85–90%. |
+| D9 | Wave-1 scope | **Everything in one long unattended run**, internally sub-ordered (anatomy doc → schemas → `〉` audit → extraction layers → defect staging). | The whole plan is deterministic-first, so it can run start-to-finish without a human. |
+| D10 | Doc home | **`SanskritLexicography/docs/`** — co-located with `EntryAnatomy/`, `RussianTranslation/`, and FINDINGS. | Ownership clarity; the code these docs describe lives here. |
+| D11 | Anatomy doc role | **Index + crosswalk; keep the three originals.** | Preserves each source's audience (teaching / machine / parser); adds a measured coverage matrix on top. |
+| D12 | Generation budget | **Deterministic-first, with ONE bounded ≤50-card LLM sanity check** of the `〉` re-segmentation via DeepSeek (`--backend openai`, **no Anthropic key, ever**). | Keeps the run essentially offline; the single model step is gated and its network risk is isolated. |
+| D13 | Schema pass-bar | **100% parse OR typed failure bucket; zero unclassified drops.** | The failure buckets *are* the upstream defect reports; a silent drop hides a complementary class ([FINDINGS §129/§130](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)). |
+
+## 3. The autonomy contract (verbatim — governs the unattended run)
+
+No human is reachable for 5–8 h. The execution agent is bound by the following:
+
+**Ambiguity policy — default-and-log, never block.** On any unplanned ambiguity: pick the plan's marked default, or failing that the most conservative / read-only option; log the decision + rationale under `## 🧠 Dev Notes & Hypotheses` in [`.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/.ai_state.md); press on. Never stall waiting for a human. Anything genuinely unresolvable is parked as a typed `@DECIDE` row — never acted on destructively.
+
+**Stop conditions.** Halt (commit progress, write a resume note, stop) only on: (a) a git push rejection that `/branch-contention-recover` cannot resolve; (b) the single ≤50-card LLM sanity check failing to run (no backend / network) — skip that step, log it, continue with the rest; (c) any operation that would require writing to `csl-orig` or merging a maintainer-repo PR — park it, never do it. No other condition stops the run.
+
+**Commit authority.** Per the handoff-scoped autonomy rule, H1350 authorizes commit → PR → merge **within SanskritLexicography** (author in a worktree off `origin/master`, push branch, open PR, auto-merge + delete branch). csl-corrections receives **change-file commits only** (its own PR/merge is a later human step). No exception.
+
+**The fence — never touch (verbatim):**
+1. **`csl-orig` is read-only.** Only `git log` / `git show`. Every source defect becomes a csl-corrections change file — never an edit, commit, or PR to csl-orig.
+2. **No new csl-orig PR; no auto-merge to any maintainer repo** (csl-orig, csl-corrections, csl-devanagari). Those stay MG `@DECIDE`.
+3. **Never mutate the RU store.** `pwg_ru_translated.jsonl` and its `.enriched`/`.quarantine` siblings are not rewritten. The `〉` audit quarantines by writing a **separate marker file**, never by rebuilding the store (supersede-mode rebuild once wiped overlays — [FINDINGS §9](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)). *[Agent-applied conservative default, derived from the standing FINDINGS §9 rule — not an explicit interview ruling, but load-bearing.]*
+4. **Do not launch the paused generation lanes** (nominal medium50, promote/requeue) and do not collide with the H1209 canary. This wave triggers no generation lane. *[Agent-applied conservative default, same basis.]*
+
+## 4. Autonomy-readiness gate verdict
+
+**PASS.** Every wave-1 deliverable has an architecture spec, ordered implementation steps, an acceptance criterion, and identified risks (see the four layer docs). Zero blocking forks remain — all 13 decisions above are ruled, and the two non-selected fence items are applied as conservative read-only defaults consistent with standing rules. Prior-art verdicts are recorded in the architecture doc (build-vs-reuse per piece); nothing scheduled rebuilds an existing asset. The autonomy contract covers the plausible ambiguities the audit surfaced (missing backend, malformed records, contention on the shared tree).
+
+## 5. Starter line (paste into a fresh chat, then walk away)
+
+```
+Read C:\Users\user\Documents\GitHub\SanskritLexicography\docs\PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md and execute it.
+```
+
+Run as Sonnet 5 (`claude-sonnet-5`) or higher; `cd C:\Users\user\Documents\GitHub` first. The handoff [H1350](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1350-Sonnet_SanskritLexicography_pwg-data-layers-anatomy-schema-extract_19.07.26.md) names the scope; this PLAN carries everything else.
+
+_Dr. Mārcis Gasūns_

--- a/docs/PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.meta.md
+++ b/docs/PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.meta.md
@@ -1,0 +1,31 @@
+_Created: 19-07-2026 · Last updated: 19-07-2026_
+
+# Metadoc — PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2
+
+**Purpose.** Companion record for the `/ask`-grade layered plan that turns PWG card anatomy into a formally specified, machine-validated, queryable object and routes enrichment additively onto the German original (never into csl-orig source text).
+
+**Audience.** The unattended execution agent running [H1350](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1350-Sonnet_SanskritLexicography_pwg-data-layers-anatomy-schema-extract_19.07.26.md); MG for the Wave-2 upstream gate; any future session extending the PWG data layers.
+
+**Provenance.** Authored 19-07-2026 by Opus 4.8 (`claude-opus-4-8`) via `/ask` (4 interview rounds, 16 rulings). Execution handoff minted as H1350 for Sonnet 5 (`claude-sonnet-5`). Audit basis: three Explore sweeps over SanskritLexicography, Uprava hubs, and csl-atlas parse-rules (19-07-2026).
+
+**The five docs.**
+- Cover — [PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md)
+- [ROADMAP](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/ROADMAP_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md) · [ARCHITECTURE](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/ARCHITECTURE_SanskritLexicography_PWG_DATA_LAYERS.md) · [IMPLEMENTATION](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/IMPLEMENTATION_SanskritLexicography_PWG_DATA_LAYERS.md) · [VERIFICATION](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/VERIFICATION_SanskritLexicography_PWG_DATA_LAYERS.md)
+
+**Ranked improvement backlog.**
+1. When Wave-1 lands, add measured numbers (contamination %, citation coverage delta, failure-bucket counts) back into this plan's §4 and the ARCHITECTURE risk register.
+2. If the RNG spike (S1) forces the fallback (sense structure in JSON only), record it here and in ARCHITECTURE §2.
+3. Cross-link the shipped anatomy reference from [EntryAnatomy/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/EntryAnatomy/README.md) and csl-atlas's MICROSTRUCTURE docs so the three originals point up to the crosswalk.
+4. Feed the citation-coverage work into papers A27 (serialization standard) and A33 (sense ordering); feed the `〉` contamination number into A52 (failure taxonomy).
+
+**Limitations.**
+- The plan is deterministic-first; the single LLM step (W1.5) is a sanity check, not a decision-maker. Sense-segmentation *disagreements* (Wave 2) need a stronger evidence bar than this run applies.
+- Wave 3 (requeue contaminated cards) is deliberately out of scope — it needs a generation budget the autonomy contract can't guarantee.
+- The "agent-gated" upstream preference was reconciled to "csl-corrections staging only, MG merges" — a narrower reading than the raw interview answer, chosen to respect the standing csl-orig read-only rule.
+
+**Related docs.** [PWG_LAYER_COMBINATIONS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/PWG_LAYER_COMBINATIONS.md) · [PWG_PLUS_GERMAN_ENRICHMENT.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_PLUS_GERMAN_ENRICHMENT.md) · [LOD_GRAPH.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LOD_GRAPH.md) · [FINDINGS §447 / §20 / §71 / §9](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).
+
+**Revision history.**
+- 19-07-2026 — created alongside the PLAN (H1350 minted). Opus 4.8 (`claude-opus-4-8`).
+
+_Dr. Mārcis Gasūns_

--- a/docs/ROADMAP_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md
+++ b/docs/ROADMAP_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md
@@ -1,0 +1,44 @@
+_Created: 19-07-2026 · Last updated: 19-07-2026_
+
+# ROADMAP — PWG data layers 2026 H2
+
+Cover: [PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md).
+
+Wave 1 is the whole unattended run, internally ordered so each step de-risks the next and the earliest steps need no gates. Waves 2–3 are human-gated follow-ons that this run only *stages*, never ships.
+
+## Wave 1 — the unattended run (deterministic-first, one bounded LLM check)
+
+Ordered; each step states what unblocks it. Full file-level steps in [IMPLEMENTATION_SanskritLexicography_PWG_DATA_LAYERS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/IMPLEMENTATION_SanskritLexicography_PWG_DATA_LAYERS.md).
+
+| # | Deliverable | Unblocked by | Gate |
+|---|-------------|--------------|------|
+| W1.1 | **Canonical anatomy reference** — [`docs/PWG_CARD_ANATOMY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/PWG_CARD_ANATOMY.md): index + measured crosswalk over the 24-element pedagogical list, the parse-rules tag census, and the microstructure portrait. | nothing (opener) | none |
+| W1.2 | **RelaxNG grammar** `schemas/pwg_markup.rnc` over raw `<L>…<LEND>`, + validator run over all 123,366 records → typed failure catalogue `reports/pwg_markup_validation.json`. | W1.1 (element inventory) | none |
+| W1.3 | **JSON Schema** extension over the parsed portrait + validator run → `reports/pwg_portrait_validation.json`. | W1.2 (shared tag vocabulary) | none |
+| W1.4 | **`〉` full measure + quarantine** — re-segment all records with the corrected splitter, measure RU-store contamination, write `reports/pwg_sense_glyph_audit.json` + a **separate** quarantine marker `reports/pwg_ru_glyph_quarantine.jsonl` (store untouched). | W1.3 (portrait sense tree) | none |
+| W1.5 | **LLM sanity check** — ≤50-card DeepSeek spot-check of the `〉` re-segmentation vs human judgement (`--backend openai`, no Anthropic key). Skippable on no-backend. | W1.4 | bounded, isolated |
+| W1.6 | **Citation layer** — extend `ls_source_map` + `pwgbib` resolver; recompute `<ls>` recognition; target ≥85%. | W1.1 | none |
+| W1.7 | **Sense / xref / government layers** — extend `senses_pwg.jsonl`, `xref_edges.csv` (resolve `s.`/`vgl.` where deterministic), government index. | W1.4, W1.6 | none |
+| W1.8 | **OntoLex rollup** — attach W1.4/W1.6/W1.7 as new properties on `entry/<key1>/de`; regenerate `pwg_de_lexicon.ttl` via `export_lod.py`. | W1.6, W1.7 | none |
+| W1.9 | **Defect staging** — turn the RNG/portrait/`〉` failure buckets + OCR hits into **csl-corrections change files** (no csl-orig PR). | W1.2, W1.3, W1.4 | staged only |
+| W1.10 | **Hub sync + release** — FINDINGS/PROJECT_INTERLINKS/SHARED_CODE rows, CHANGELOG entry, `/cut-release`, GTD `@DECIDE` rows for the staged defects. | all above | none |
+
+## Wave 2 — human-gated upstream (staged by W1.9, shipped later by MG)
+
+- MG reviews the staged csl-corrections change files, runs [/cologne-batch-pr](https://github.com/gasyoun/claude-config/blob/main/commands/cologne-batch-pr.md) → one consolidated PR to csl-orig at most ~monthly.
+- Sense-segmentation disagreements (an editorial claim about Böhtlingk, higher evidence bar) get a separate review sheet before any are proposed.
+
+## Wave 3 — requeue the `〉`-contaminated RU cards (budget-gated)
+
+- Regenerate the quarantined RU rows against the corrected segmentation. Deferred out of this run because requeue burns generation budget and must not collide with the paused nominal lane / H1209 canary. Triggered only after the Wave-1 contamination number is known and a budget is authorized.
+
+## Non-goals (explicit)
+
+- **No edit, commit, or PR to `csl-orig`.** Ever.
+- **No rewrite of the RU store**; the `〉` audit only quarantines via a side file.
+- **No LLM resolution of citations or synthesised sources** — deterministic resolver only.
+- **No launch of the paused nominal/promote/requeue lanes.**
+- **No rewrite of the three existing anatomy docs** — the new reference indexes them.
+- **No requeue of contaminated cards in this run** (that is Wave 3).
+
+_Dr. Mārcis Gasūns_

--- a/docs/VERIFICATION_SanskritLexicography_PWG_DATA_LAYERS.md
+++ b/docs/VERIFICATION_SanskritLexicography_PWG_DATA_LAYERS.md
@@ -1,0 +1,43 @@
+_Created: 19-07-2026 · Last updated: 19-07-2026_
+
+# VERIFICATION — PWG data layers
+
+Cover: [PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md). Implementation: [IMPLEMENTATION_SanskritLexicography_PWG_DATA_LAYERS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/IMPLEMENTATION_SanskritLexicography_PWG_DATA_LAYERS.md).
+
+## Acceptance criteria per deliverable
+
+| ID | Deliverable | Acceptance criterion | Proof command / flow |
+|----|-------------|----------------------|----------------------|
+| V1 | Anatomy reference | Every parse-rules tag appears in the crosswalk with its count; all 24 pedagogical elements mapped or marked pedagogical-only. | `python RussianTranslation/src/build_anatomy_crosswalk.py --check` exits 0; manual diff of the matrix against `pwg.json` tag list. |
+| V2 | RelaxNG grammar | `passes + Σ buckets == 123366`; zero `unclassified`. | `python RussianTranslation/src/validate_pwg_markup.py --assert-total`; inspect `reports/pwg_markup_validation.json` totals block. |
+| V3 | Portrait JSON Schema | 100% parse-or-bucket; validated by the existing `validate_portrait_schema.py`. | `python RussianTranslation/src/validate_pwg_portrait.py --assert-total`. |
+| V4 | `〉` audit + quarantine | One contamination number with a CI; quarantine row count == audit contaminated-row total; **store byte-identical before/after**. | `sha256` of `pwg_ru_translated.jsonl` unchanged across the step; `python -c "…"` comparing the two counts. |
+| V5 | LLM sanity check | An agreement rate is reported, OR a skip is logged in `.ai_state.md`. | Read `reports/pwg_glyph_sanity.json` or the Dev-Notes skip line. |
+| V6 | Citation coverage | Recognition ≥85%, or a written ceiling explanation with the unresolved tail catalogued. | `python RussianTranslation/src/extend_ls_coverage.py --report` prints old→new %; `reports/pwg_ls_unresolved.tsv` exists. |
+| V7 | Sense/xref/government layers | Row counts + resolved-fraction reported; zero fabricated xref targets (all unresolved carry `resolved:false`). | `grep -c 'resolved.*false'` sanity; count deltas logged. |
+| V8 | OntoLex rollup | TTL parses under rdflib; node count grows by expected cardinality; a known headword returns the new properties. | `python -c "import rdflib; g=rdflib.Graph(); g.parse('release/fixture/pwg_de_lexicon.ttl'); print(len(g))"`; SPARQL spot query on `agni`. |
+| V9 | Defect staging | N change files in `batch_pending/` == N manifest rows; **zero csl-orig writes; zero maintainer-repo PRs opened**. | `git -C csl-orig status` clean & untouched; `gh pr list` shows no new PR to csl-orig/csl-corrections; manifest count == file count. |
+| V10 | Hub sync + release | FINDINGS/PROJECT_INTERLINKS/SHARED_CODE rows present; CHANGELOG entry; release cut; GTD `@DECIDE` rows added. | `git log` shows the hub commits; `gh release view` shows the new tag. |
+
+## Global invariants (must hold at run end)
+
+- **INV-1 — csl-orig untouched.** `git -C csl-orig status --porcelain` is empty; no commit authored to csl-orig by this run.
+- **INV-2 — RU store immutable.** `pwg_ru_translated.jsonl` (+ `.enriched`, `.quarantine`) sha256 identical to run start.
+- **INV-3 — no maintainer-repo merge.** No PR merged into csl-orig / csl-corrections / csl-devanagari by the agent.
+- **INV-4 — no paused lane launched.** No nominal/promote/requeue generation run triggered; no collision with the H1209 canary.
+- **INV-5 — no unclassified drops.** Both validation reports account for all 123,366 records.
+- **INV-6 — no synthesised sources.** Every citation resolution traces to `pwgbib.txt`/Verzeichniss; no LLM-guessed source in the citation layer.
+
+## Risks & spikes register
+
+| ID | Risk | Likelihood | Mitigation / spike |
+|----|------|-----------|--------------------|
+| R1 | `〉` re-segmentation over-corrects | med | Diff against the verified first-2500 fix (`_audit_micro.py`) **before** the full run; the ≤50-card sanity check (V5) is the second signal. Spike: run Step 4 on the first 2500 first, confirm it reproduces FINDINGS §447's numbers, then release to full. |
+| R2 | RNG flags valid-but-irregular records as failures | med | The `unexpected-but-attested` bucket absorbs these; a human reviews buckets before any change file ships (Wave 2 gate). No change file is auto-generated from that bucket. |
+| R3 | Citation resolver plateaus < 85% | med | Accepted per D8; catalogue the tail. Not a run failure. |
+| R4 | csl-atlas shared-tree contention | med | Worktree off `origin/main` + PR; never a direct push. If rejected, stage as a patch in SL and `@DECIDE`. |
+| R5 | DeepSeek backend unavailable | high | V5 is skippable by design; the run does not depend on it. |
+| R6 | Store join ambiguity in the `〉` audit | low | Mark `ambiguous`, never guess (INV-6 spirit). |
+| S1 | **Spike before committing to RNG:** confirm RelaxNG can express the `〉`-terminated sense structure at all. | — | 1-hour spike on 100 records; if RNG can't express it cleanly, fall back to expressing sense structure in the JSON Schema only and RNG covers spans/tags — log the decision. |
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
`/ask`-grade layered plan for the PWG data-layers wave: card anatomy synthesis, first formal PWG schema (RelaxNG + JSON Schema), four extraction layers (citations / sense+〉 / xrefs / government), German-side additive enrichment, and staged (not shipped) csl-corrections defect reports.

- **Cover:** [PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/plan/pwg-data-layers/docs/PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md)
- ROADMAP · ARCHITECTURE · IMPLEMENTATION · VERIFICATION + metadoc
- 16 interview rulings; deterministic-first unattended run; **csl-orig read-only** throughout.
- Execution handoff: H1350 (Sonnet 5).

Docs-only. No code, no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)