### PR TITLE
H1349 wave-1: fix Sa→Ru gloss-layer defects (pseudo-roots, homograph trail, vidyut ambiguity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,14 @@ jobs:
             RussianTranslation/src/pilot/windows100_selftest.py \
             RussianTranslation/src/pilot/run_observability.py \
             RussianTranslation/src/pilot/run_observability_selftest.py
+      - name: Wave-1 Sa->Ru gloss pipeline unit tests (H1349 W1.6)
+        working-directory: RussianTranslation
+        run: |
+          # Pure-helper regression tests for the three wave-1 defect fixes; the
+          # build_*.py modules import cleanly because their heavy deps (vidyut,
+          # indic_transliteration) are imported lazily inside main()/to_slp1().
+          pip install pytest
+          pytest tests/test_saru_gloss_pipeline.py -q
       - name: Validate research-layer sidecars (capability cards 5, 23)
         working-directory: RussianTranslation
         run: |

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2432,6 +2432,18 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **Sa→Ru gloss layer, wave-1 defect fixes — H1349 W1.1–W1.3, 20-07-2026 (Opus 4.8).**
+  Fixed three gloss-pipeline defects, each with a regression test wired into CI:
+  pseudo-roots split out of the root layer (`build_dcs_maps.py` →
+  `dcs_lemma2root_unresolved.tsv`, root inventory 3,570→3,147, `root_glossary` 1,853);
+  full homograph trail in `build_rollup_glossaries.py` (`cands[1]`-only → `cands[1:]`,
+  9,521→11,289 rows); vidyut ambiguity trail in `build_vidyut_fallback.py`
+  (`vidyut_ambiguity.tsv`, 5,952 rows). `vidyut`/`indic_transliteration` now imported
+  lazily so the pure helpers are unit-testable (`tests/test_saru_gloss_pipeline.py`, 7
+  passing). Before/after in `RESULTS_LOG.md`; pipeline `glossary/README.md` shrunk to a
+  runbook+pointer at canonical SanskritRussian. Published data NOT regenerated (D8 fences
+  republish). Waves 2–4 (measure precision, coverage via `vidyut.cheda`, pwg_ru TM wiring)
+  remain judgment-gated. Plan: `docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md`.
 - **RussianTranslation safety plan — MERGED 18-07-2026.** PR #547 landed exclusive
   collision-resistant store backups, duplicate/divergence guards, and complete nominal-lease
   reservations; stacked PR #550 landed the persisted runtime state machine, ordinary ≤3 and

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,25 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — Sa→Ru gloss layer wave-1 defects (H1349 W1.1–W1.3)
+
+- **Pseudo-roots (W1.1).** `build_dcs_maps.py` no longer keeps prefixed verb lemmas that
+  fail the root-suffix match as their own roots: the 434 self-mapped `unresolved` rows are
+  split into `dcs_lemma2root_unresolved.tsv`, and `build_rollup_glossaries.py` excludes them
+  from the root layer (root inventory 3,570 → 3,147 distinct keys; `root_glossary` 1,853).
+- **Homograph completeness (W1.2).** The rollup's ambiguity report inspected only the single
+  runner-up `cands[1]`; a genuine 3rd+ homograph was silently dropped. It now records the
+  full trail over `cands[1:]` (9,521 → 11,289 alternate rows across 9,733 forms).
+- **Vidyut ambiguity trail (W1.3).** `build_vidyut_fallback.py` incremented a bare
+  `ambiguous` counter; it now writes the competing `(lemma, pos, n)` candidates to
+  `vidyut_ambiguity.tsv` (5,952 rows over 4,133 forms), mirroring the DCS schema.
+- Each fix carries a regression test in `tests/test_saru_gloss_pipeline.py` (wired into the CI
+  RussianTranslation-gates job); `vidyut`/`indic_transliteration` are now imported lazily so
+  the pure helpers are testable without the heavy deps. Before/after in
+  [RESULTS_LOG.md](RESULTS_LOG.md); the pipeline `glossary/README.md` is now a build runbook
+  pointing at the canonical [gasyoun/SanskritRussian](https://github.com/gasyoun/SanskritRussian)
+  doc. Published data is **not** regenerated (D8 fences republish behind a human GO).
+
 ### Fixed — scoped RU style gate and conflict-safe H1305 repair
 
 - The `ru_style` workflow gate now audits only structured

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -1,8 +1,32 @@
 # RussianTranslation — results log
 
-_Created: 09-07-2026 · Last updated: 12-07-2026_
+_Created: 09-07-2026 · Last updated: 20-07-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
+
+## 20-07-2026 — Sa→Ru gloss layer, wave-1 defect fixes (H1349 W1.1–W1.3)
+
+Three pipeline-defect fixes in the Sa→Ru gloss layer, measured before/after over
+one regenerated two-pass bootstrap (DCS `dcs_full.sqlite` 5.69M tokens + vidyut
+kosha 0.4.0 + `surface_glossary.jsonl`). Fixes + measurement Opus 4.8
+(`claude-opus-4-8`);
+[`src/measure_wave1_delta.py`](src/measure_wave1_delta.py) replays the OLD and NEW
+rule over identical inputs so each row isolates the code change alone. Regressions
+pinned by [`tests/test_saru_gloss_pipeline.py`](tests/test_saru_gloss_pipeline.py)
+(7 passing).
+
+| Defect | Before | After | Note |
+|---|--:|--:|---|
+| W1.1 distinct root keys in lemma→root map | 3,570 | 3,147 | 434 self-mapped pseudo-root rows split out to `dcs_lemma2root_unresolved.tsv` (net −423 distinct keys); `root_glossary` layer now 1,853 roots |
+| W1.2 homograph alternate rows | 9,521 | 11,289 | +1,768 rows; the old code inspected only `cands[1]`, so a genuine 3rd+ homograph was dropped — now the full trail over 9,733 forms |
+| W1.3 vidyut ambiguity rows recorded | 0 | 5,952 | `stats['ambiguous']` was a bare counter (4,133 forms); now a `vidyut_ambiguity.tsv` competitor trail mirroring the DCS schema |
+
+Two-pass bootstrap outcome (regen, fixed pipeline): 40,370 lemmas / 1,853 roots;
+surface-form resolution 43.6 % (DCS) → 58.7 % (+vidyut +marker). The published
+`SanskritRussian` data (still showing 2,021 roots) is **not** regenerated here —
+D8 fences republish behind a human GO; a wave-2-gated republish will drop the root
+count to ~1,853. Accuracy of these glosses is still unmeasured (coverage ≠
+accuracy — wave 2 publishes a per-tier precision figure).
 
 ## 12-07-2026 — E2 sense-genre vs DCS attestation (H833 / H350 backlog #3)
 

--- a/RussianTranslation/glossary/README.md
+++ b/RussianTranslation/glossary/README.md
@@ -1,161 +1,36 @@
-# Sanskrit → Russian glossary (surface · lemma · root)
+# Sanskrit → Russian glossary — generation pipeline (build runbook)
 
-_Created: 01-07-2026 · Last updated: 11-07-2026_
+_Created: 01-07-2026 · Last updated: 20-07-2026_
 
-**🔎 Live searchable glossary + all data:** **[gasyoun/SanskritRussian](https://github.com/gasyoun/SanskritRussian)**
-→ <https://gasyoun.github.io/SanskritRussian/> — type an SLP1 root/word (`gam`, `BU`) or a
-Russian word and browse the ranked translations. The glossary has its own repo because this
-repo's GitHub Pages slot serves the PWG article dashboard (`gh-pages` branch). **This directory
-holds only the generation pipeline** (`../src/build_*.py`) — the data is git-ignored here
-(regenerate locally); the committed data + live site live in that repo.
+**This directory holds only the generation pipeline** (`../src/build_*.py`). The data is
+git-ignored here — regenerate it locally with the runbook below. The committed data, the
+searchable site, and the **canonical documentation** (method, coverage, failure typology,
+accuracy) live in the data repo:
 
-A full inventory of **how every Sanskrit word is rendered into Russian** in the aligned
-corpus, at three granularities:
+> 📖 **Canonical doc:** [gasyoun/SanskritRussian · README.md](https://github.com/gasyoun/SanskritRussian/blob/main/README.md)
+> — three layers (surface · lemma · root), the `√gam` worked example, the coverage table, the
+> failure typology, and the **coverage ≠ accuracy** caveat.
+> 🔎 **Live site:** <https://gasyoun.github.io/SanskritRussian/>
 
-| Layer | Question it answers | Key |
+This repo's own GitHub Pages slot serves the PWG article dashboard (`gh-pages` branch), which
+is why the glossary has its own repo.
+
+## Pipeline scripts (this directory's `../src/`)
+
+| Script | Stage | Emits |
 |---|---|---|
-| **surface form** | how is the *attested form* `gamemahi` translated? | corpus SLP1 form |
-| **lemma / stem** | how is the *stem* `mahāratha` / verb-lemma `saṃgam` translated? | DCS / Vidyut lemma |
-| **root** | how is *√gam* translated across **all** its forms and prefixed verbs? | verb root (dhātu) |
-
-Built from [`RussianTranslation/src/corpus_lexicon.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/corpus_lexicon.jsonl)
-— **1,091,528** word-aligned Saṃskṛta→Russian tokens (SLP1), the alignment asset described in
-[`RENOU.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU.md).
-Scope: **everything, all n ≥ 1** — hapax kept, `kind=translation` **and** `kind=commentary`
-kept (each entry records the split).
-
-## The `gam` example, answered
-
-`root_glossary` for **√gam** aggregates **678 surface forms** across **44 verb lemmas**
-(`gam, āgam, saṃāgam, abhigam, adhigam, upagam, anugam, …`), **7,116 occurrences**, ranked:
-
-> пришел (195) · отправился (176) · ушел (140) · пришли (100) · достигает (99) · явился (92)
-> · ступай (79) · пошел (77) · отправились (77) · идет (73) · удалился (73) · направился (64) …
-
-The four `gamemahi` lines you started from are one surface entry inside this rollup.
-
-## Files
-
-The scripts regenerate these locally; here they are **git-ignored** (the committed copies live
-in [gasyoun/SanskritRussian](https://github.com/gasyoun/SanskritRussian)). The 140 MB raw
-`surface_glossary.jsonl` exceeds GitHub's 100 MB file limit, so it ships (in that repo) as
-`surface_glossary.jsonl.gz` **and** as a per-initial-letter split under `surface/<X>.jsonl`
-(26 parts, max ~22 MB; `cat surface/*.jsonl` reconstructs the whole). `index.html` there is the
-searchable front-end over the root/lemma TSVs.
+| [`build_dcs_maps.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_dcs_maps.py) | B — DCS morphology | `dcs_form2lemma.tsv`, `dcs_lemma2root.tsv`, `dcs_lemma2root_unresolved.tsv` |
+| [`build_surface_glossary.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_surface_glossary.py) | A — surface layer | `surface_glossary.jsonl` / `.tsv` (Layer 1) |
+| [`build_rollup_glossaries.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_rollup_glossaries.py) | D — lemma/root rollup | `lemma_glossary.*`, `root_glossary.*`, `surface_dcs_misses.tsv`, `ambiguity_homographs.tsv` |
+| [`build_vidyut_fallback.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_vidyut_fallback.py) | C — Vidyut fallback | `vidyut_form2lemma.tsv`, `vidyut_ambiguity.tsv` |
+| [`build_ru_gloss_gap_stats.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_ru_gloss_gap_stats.py) | per-dict gap-list (H685) | `ru_gloss_gap_stats.json`, `ru_gloss_gaps.tsv` |
+| [`measure_wave1_delta.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/measure_wave1_delta.py) | wave-1 delta (H1349) | prints the before/after defect-fix table |
 
 Bucket filenames are **case-folded to upper** (`a` and `A` share one file): SLP1 is
 case-significant but Windows' filesystem is case-insensitive, so separate `a`/`A` files would
 collide and truncate. The phonemic distinction is preserved inside each record's `slp1` field.
 
-| File | What |
-|---|---|
-| `surface_glossary.tsv` + `surface/<X>.jsonl` (+ `.jsonl.gz`) | **Layer 1** — 190,838 forms → Ru with counts, registers, works, kinds |
-| `md/surface/<X>.md` | human-readable surface glossary, one file per initial SLP1 letter |
-| `lemma_glossary.jsonl` / `.tsv` + `md/lemma/` | **Layer 2** — 40,370 lemmas → Ru (nouns' stem, verbs' lemma) |
-| `root_glossary.jsonl` / `.tsv` + `md/root/` | **Layer 3** — 2,021 verb roots → Ru (aggregated over lemmas & forms) |
-| `dcs_form2lemma.tsv` | DCS map: 408,660 `form → lemma` pairs (SLP1) |
-| `dcs_lemma2root.tsv` | DCS map: `verb-lemma → root` (via DCS root inventory, longest-suffix) |
-| `vidyut_form2lemma.tsv` | Vidyut fallback: 28,567 DCS-missed forms → lemma/pos |
-| `surface_dcs_misses.tsv` | forms DCS could not lemmatize (stable **input to the Vidyut pass**) |
-| `surface_unresolved.tsv` | forms **no tier** resolved (DCS+Vidyut+marker) — the typology input |
-| `ambiguity_homographs.tsv` | forms whose top DCS lemmas span different POS / are close in count |
-
-Every rollup record carries a `source` field (`dcs` vs `vidyut`) so provenance is auditable.
-
-## Method
-
-The corpus stores **only surface forms** — no lemma. Roots/lemmas are attached by a
-*context-free* join (robust for an aggregate glossary; a per-passage alignment would fight
-270 texts' mismatched ref schemes):
-
-1. **DCS morphology (primary).** [VisualDCS `dcs_full.sqlite`](https://github.com/gasyoun/VisualDCS/tree/main/src/DCS-data-2026)
-   — 5.69M annotated tokens (IAST). Grouped to a `form → lemma` map, transcoded IAST→SLP1
-   (`indic_transliteration.sanscript`). Root for a prefixed verb lemma = the **longest member
-   of DCS's own simple-root inventory** that is a suffix of the lemma (`saṃgam` → `gam`),
-   which sidesteps preverb sandhi (`uddhṛ` ← preverb `ut`, not `ud`).
-2. **Vidyut kosha (fallback).** Forms DCS misses are lemmatized by the Pāṇinian FST
-   (`vidyut.kosha`, v0.4.0). Tinanta → dhātu (root); Subanta → stem.
-3. **Morpheme-marker recovery.** Forms both lexica miss but that carry a corpus boundary
-   mark (`A+gam` = ā+√gam) are split on `[+-]`: the joined string is retried as a form, else
-   the rightmost element is taken when it is a known root/lemma (`source='marker'`).
-4. **Unresolved** forms are kept in Layer 1 and characterised below.
-
-Join keys strip a leading avagraha/apostrophe on both sides (`'gacchat` == `gacchat`).
-Homographs: a form's Ru distribution is attributed to its **highest-count** lemma; alternates
-are logged in `ambiguity_homographs.tsv`, never double-counted.
-
-### Coverage (of 190,838 distinct forms / 1,091,528 tokens)
-
-| Stage | forms resolved | token coverage |
-|---|--:|--:|
-| DCS only | 80,949 (42.4 %) | 79.1 % |
-| + Vidyut fallback | 109,516 (57.4 %) | 86.6 % |
-| + morpheme-marker recovery | 111,996 (58.7 %) | **87.1 %** |
-| unresolved | 78,842 (41.3 %) | 12.9 % |
-
-Distinct-form hit rate is far below token coverage because the misses are the **rare long
-tail** — DCS/Vidyut resolve nearly every common form.
-
-### Per-dictionary RU-gloss coverage & the no-gloss gap-list (H685)
-
-[`../src/build_ru_gloss_gap_stats.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_ru_gloss_gap_stats.py)
-joins each Cologne dictionary's `now-2026` key1 headword list against the three glossary
-layers (surface · lemma · root) over the live corpus and answers "where are the translation
-holes?" — the committed snapshot is
-[`ru_gloss_gap_stats.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/glossary/ru_gloss_gap_stats.json).
-Corpus at measurement: **1,093,391 rows · 191,436 distinct surface keys · hapax rate 58.9 %**
-(token coverage reconciles to 79.1 / 86.5 / 87.1 %, matching the table above within the
-append-only row growth).
-
-| Dict | headwords | any-layer RU gloss | coverage % |
-|---|--:|--:|--:|
-| GRA | 11,108 | 8,526 | **76.8 %** |
-| VEI | 3,704 | 2,346 | **63.3 %** |
-| VCP | 48,636 | 15,313 | 31.5 % |
-| PWG | 106,082 | 27,780 | 26.2 % |
-| AP | 88,867 | 21,386 | 24.1 % |
-| MW | 194,084 | 43,287 | 22.3 % |
-| PWK | 151,349 | 32,430 | 21.4 % |
-| SKD | 40,817 | 6,713 | 16.5 % |
-
-The **gap-list** — dictionary headwords with **no** RU gloss in any layer, ranked by DCS
-corpus frequency — is the direct feeder for the next paid translation window:
-**242,726 gap keys total, 36,974 DCS-attested**. The full list ships as the gitignored
-`ru_gloss_gaps.tsv` (regenerate locally); its highest-value head (top DCS-frequency
-no-gloss keys shared across the most dictionaries) is:
-
-> `tEla` (2109) · `sEnya` (1494) · `vESampAyana` (1326) · `dEtya` (1258) · `dEva` (1226)
-> · `ganDaka` (1192) · `aNgula` (1054) · `SEla` (1036) · `mUzA` (946) · `vESya` (931) …
-
-These are overwhelmingly **vṛddhi-initial derivatives** (`tEla`←taila, `dEtya`←daitya) and
-common realia — high-frequency forms the surface layer misses because the corpus attests
-inflected/sandhi variants, not the bare dictionary headword.
-
-## Failure typology (78,842 unresolved forms · 140,667 tokens)
-
-| Type | forms | tokens | Example | Why it misses |
-|---|--:|--:|---|---|
-| unrecognized simplex | 48,646 | 91,548 | `maratejasi`, `ABArizam` | rare inflection / sandhi-altered stem absent from both lexica |
-| long compound (≥14 chars) | 20,823 | 25,482 | `ADArmikajanAvfta`, `ADUtadvajapawam` | samāsa the FST won't split without a *chedaka* |
-| ends in a known root | 4,695 | 10,267 | `ABAz`, `ABijIvanam` | derived stem, but not a bare lemma either lexicon lists |
-| proper name | 3,094 | 8,945 | `ABIrya` (Абхиры), `ABar` | names/vocatives outside the lexica (Ru gloss capitalised) |
-| morpheme-marker residual | 1,389 | 2,312 | `A-brahma-BuvanAt` | has `+`/`-` marks but rightmost element is itself inflected, not a bare root |
-| short form / particle | 195 | 2,113 | `ABf`, `Ahf` | too short / clitic |
-
-**Join-side edge cases** (handled, not part of the 78,842):
-
-- **Homographs** — 9,521 forms carry ≥2 DCS lemmas of differing POS/near-equal count
-  (`ambiguity_homographs.tsv`). Attributed to the dominant lemma.
-- **Morpheme markers** — corpus forms embedding `+`/`-` marks (`A+gam` = ā+√gam) are now
-  recovered (tier 3, `source='marker'`, 2,480 forms); only 1,389 whose rightmost element is
-  itself inflected remain unresolved.
-- **Avagraha / apostrophe** — leading `'`/`’` normalised away before the join.
-- **Compound-split spacing** — a few corpus forms keep a space (`vācas pati`); these key on the
-  spaced string.
-- **Nominal roots** — Layer 3 (root) is **verbal only**; a noun stem has no verbal root in this
-  pipeline, so nominal lemmas appear at Layer 2 but not Layer 3 by design.
-
-## Regenerate
+## Regenerate (two-pass bootstrap)
 
 From [`RussianTranslation/src/`](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation/src):
 
@@ -167,11 +42,14 @@ python build_vidyut_fallback.py <kosha_dir>   # lemmatize the DCS misses (needs 
 python build_rollup_glossaries.py   # 2nd pass: folds in Vidyut + marker tier -> Layers 2 & 3
 ```
 
-Two-pass bootstrap: the rollup emits the DCS-miss list the Vidyut stage consumes, so run it
-once before Vidyut and once after. `surface_dcs_misses.tsv` is deterministic (snapshotted
-before the Vidyut supplement), so the second pass does not disturb the Vidyut input.
+The rollup emits the DCS-miss list the Vidyut stage consumes, so run it **once before Vidyut
+and once after**. `surface_dcs_misses.tsv` is snapshotted before the Vidyut supplement, so the
+second pass does not disturb the Vidyut input.
 
-Vidyut data: `python -c "import vidyut; vidyut.download_data('vidyut_data')"` then pass
-`vidyut_data/kosha` to the fallback. Transcoding uses `indic_transliteration`; both are pip-installable.
+Vidyut data: `python -c "import vidyut; vidyut.download_data('vidyut_data')"`, then pass
+`vidyut_data/kosha` to the fallback. Transcoding uses `indic_transliteration`; both are
+pip-installable. `vidyut` and `indic_transliteration` are imported **lazily** (inside
+`main()` / `to_slp1()`), so the pure helpers are unit-testable without them installed — see
+[`tests/test_saru_gloss_pipeline.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/tests/test_saru_gloss_pipeline.py).
 
 _Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/build_dcs_maps.py
+++ b/RussianTranslation/src/build_dcs_maps.py
@@ -20,21 +20,24 @@ member of R that is a suffix of the prefixed lemma. Grounded in DCS, not blind s
 import os, sys, sqlite3, collections
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
-from indic_transliteration import sanscript
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_DB = os.path.normpath(os.path.join(
     HERE, '..', '..', '..', 'VisualDCS', 'src', 'DCS-data-2026', 'dcs_full.sqlite'))
 OUT_DIR = os.path.normpath(os.path.join(HERE, '..', 'glossary'))
-os.makedirs(OUT_DIR, exist_ok=True)
 
 _tc = {}
 def to_slp1(s):
-    """IAST -> SLP1 with a memo cache; returns '' on empty/None."""
+    """IAST -> SLP1 with a memo cache; returns '' on empty/None.
+
+    indic_transliteration is imported lazily so this module (and its pure
+    helper derive_lemma2root) can be imported for unit tests without the heavy
+    transliteration dependency installed."""
     if not s:
         return ''
     v = _tc.get(s)
     if v is None:
+        from indic_transliteration import sanscript
         try:
             v = sanscript.transliterate(s, sanscript.IAST, sanscript.SLP1)
         except Exception:
@@ -42,12 +45,48 @@ def to_slp1(s):
         _tc[s] = v
     return v
 
+
+def derive_lemma2root(verb_lemmas, roots_by_len):
+    """Pure lemma->root derivation, split into resolved vs pseudo-root rows.
+
+    verb_lemmas : dict lemma_slp1 -> has_preverb (bool).
+    roots_by_len: root inventory (simple verb lemmas), sorted longest-first.
+
+    Returns (resolved, unresolved, counts):
+      resolved   = [(lemma, root, how)]  how in {'self','suffix'} — real roots.
+      unresolved = [(lemma, lemma, 'unresolved')] — prefixed lemmas for which no
+                   root suffix matched. These self-map, so counting them as roots
+                   inflates the root inventory with pseudo-roots (W1.1); the
+                   caller writes them to a SEPARATE file, out of the root layer.
+      counts     = Counter of how-tags (incl. 'unresolved' = excluded count).
+    """
+    resolved, unresolved = [], []
+    counts = collections.Counter()
+    for ls, has_pre in sorted(verb_lemmas.items()):
+        if not has_pre:
+            resolved.append((ls, ls, 'self'))          # lemma IS a root
+            counts['self'] += 1
+            continue
+        root = ''
+        for r in roots_by_len:
+            if r != ls and ls.endswith(r) and len(r) >= 2:
+                root = r
+                break
+        if root:
+            resolved.append((ls, root, 'suffix'))
+            counts['suffix'] += 1
+        else:
+            unresolved.append((ls, ls, 'unresolved'))  # pseudo-root — not a root
+            counts['unresolved'] += 1
+    return resolved, unresolved, counts
+
 def is_verbal(grammar):
     """DCS grammar string marks a verb by pada codes like '1.P.', '6.Ā.'."""
     return bool(grammar) and ('P.' in grammar or 'Ā.' in grammar)
 
 def main():
     db = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DB
+    os.makedirs(OUT_DIR, exist_ok=True)
     con = sqlite3.connect(db)
 
     # ---- form -> lemma (distinct pairs with occurrence counts) ----
@@ -90,27 +129,24 @@ def main():
           file=sys.stderr)
 
     print('[3/3] deriving lemma -> root (longest root-suffix)...', file=sys.stderr)
+    resolved, unresolved, counts = derive_lemma2root(verb_lemmas, roots_by_len)
+    # Real roots (self + suffix) -> the map the rollup counts as the root layer.
     l2r_path = os.path.join(OUT_DIR, 'dcs_lemma2root.tsv')
-    counts = collections.Counter()
     with open(l2r_path, 'w', encoding='utf-8', newline='\n') as out:
         out.write('lemma_slp1\troot_slp1\thow\n')
-        for ls, has_pre in sorted(verb_lemmas.items()):
-            if not has_pre:
-                out.write(f'{ls}\t{ls}\tself\n')          # lemma IS a root
-                counts['self'] += 1
-                continue
-            root = ''
-            for r in roots_by_len:
-                if r != ls and ls.endswith(r) and len(r) >= 2:
-                    root = r
-                    break
-            if root:
-                out.write(f'{ls}\t{root}\tsuffix\n')
-                counts['suffix'] += 1
-            else:
-                out.write(f'{ls}\t{ls}\tunresolved\n')     # keep lemma as its own root
-                counts['unresolved'] += 1
+        for lemma, root, how in resolved:
+            out.write(f'{lemma}\t{root}\t{how}\n')
+    # W1.1: pseudo-roots (prefixed lemmas that self-map because no root suffix
+    # matched) are split OUT so the rollup no longer counts them as roots. They
+    # stay recorded for audit and remain reachable as lemmas in the lemma layer.
+    unres_path = os.path.join(OUT_DIR, 'dcs_lemma2root_unresolved.tsv')
+    with open(unres_path, 'w', encoding='utf-8', newline='\n') as out:
+        out.write('lemma_slp1\troot_slp1\thow\n')
+        for lemma, root, how in unresolved:
+            out.write(f'{lemma}\t{root}\t{how}\n')
     print(f'      lemma->root: {dict(counts)} -> {l2r_path}', file=sys.stderr)
+    print(f'      excluded {counts["unresolved"]} pseudo-roots -> {unres_path}',
+          file=sys.stderr)
 
 if __name__ == '__main__':
     main()

--- a/RussianTranslation/src/build_rollup_glossaries.py
+++ b/RussianTranslation/src/build_rollup_glossaries.py
@@ -26,8 +26,6 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 G = os.path.normpath(os.path.join(HERE, '..', 'glossary'))
 MD_LEMMA = os.path.join(G, 'md', 'lemma')
 MD_ROOT = os.path.join(G, 'md', 'root')
-os.makedirs(MD_LEMMA, exist_ok=True)
-os.makedirs(MD_ROOT, exist_ok=True)
 
 _ava = re.compile(r"^['’‘]+")
 def norm(k):
@@ -43,6 +41,43 @@ def bucket(s):
     if not s:
         return '_'
     return s[0].upper() if re.match(r'[A-Za-z]', s[0]) else '_other'
+
+
+def parse_lemma2root(lines):
+    """lemma_slp1 -> root_slp1 from a dcs_lemma2root.tsv, EXCLUDING self-mapped
+    `unresolved` pseudo-roots (W1.1). `lines` is any iterable incl. the header
+    row. Robust whether or not build_dcs_maps already split the pseudo-roots into
+    their own file: an `unresolved` how-tag is dropped here regardless."""
+    l2r = {}
+    it = iter(lines)
+    next(it, None)                         # header
+    for line in it:
+        p = line.rstrip('\n').split('\t')
+        if len(p) < 2:
+            continue
+        if len(p) >= 3 and p[2] == 'unresolved':
+            continue                       # pseudo-root -> not a root
+        l2r[p[0]] = p[1]
+    return l2r
+
+
+def homograph_alts(cands):
+    """Every alternate homograph candidate worth recording for a surface form.
+
+    cands: [(lemma, upos, count, source)] sorted by count desc; cands[0] is the
+    primary. Returns [(alt_lemma, alt_upos, alt_count)] for each *later*
+    candidate whose upos differs from the primary OR whose count is >= 50% of the
+    primary's (W1.2 — the full trail; the earlier code inspected only cands[1],
+    so a genuine 3rd+ homograph was silently dropped). Primary attribution is
+    unchanged; only the alternates trail grows."""
+    if len(cands) < 2:
+        return []
+    _plem, pupos, pcnt, _ps = cands[0]
+    out = []
+    for (l2, u2, c2, _s) in cands[1:]:
+        if u2 != pupos or c2 >= 0.5 * pcnt:
+            out.append((l2, u2, c2))
+    return out
 
 
 def load_maps():
@@ -61,13 +96,8 @@ def load_maps():
             f2l[norm(form)].append((lemma, upos, cnt, 'dcs'))
     for k in f2l:
         f2l[k].sort(key=lambda x: -x[2])
-    l2r = {}
     with open(os.path.join(G, 'dcs_lemma2root.tsv'), encoding='utf-8') as f:
-        next(f)
-        for line in f:
-            p = line.rstrip('\n').split('\t')
-            if len(p) >= 2:
-                l2r[p[0]] = p[1]
+        l2r = parse_lemma2root(f)          # W1.1: pseudo-roots excluded from the root layer
     dcs_keys = frozenset(f2l)          # snapshot BEFORE vidyut -> stable DCS-miss detection
     # vidyut fallback: add only for form keys DCS did not resolve
     vpath = os.path.join(G, 'vidyut_form2lemma.tsv')
@@ -165,6 +195,8 @@ def emit(table, path_base, md_dir, key_name, title, extra_lemmas=False):
 
 
 def main():
+    os.makedirs(MD_LEMMA, exist_ok=True)
+    os.makedirs(MD_ROOT, exist_ok=True)
     print('[D] loading DCS maps...', file=sys.stderr)
     f2l, l2r, roots_set, lemmas_set, dcs_keys = load_maps()
     print(f'    {len(f2l)} normalized DCS form keys, {len(l2r)} lemma->root', file=sys.stderr)
@@ -208,12 +240,14 @@ def main():
                     continue
             n_hit += 1
             lemma, upos, lcnt, source = cands[0]
-            # ambiguity: a second candidate of a DIFFERENT upos or within 50% count
-            if len(cands) > 1:
-                l2, u2, c2, _ = cands[1]
-                if u2 != upos or c2 >= 0.5 * lcnt:
+            # ambiguity: EVERY later candidate of a different upos or within 50%
+            # count of the primary (W1.2 — the full homograph trail, not just the
+            # single runner-up). Primary attribution is unchanged; alternates only.
+            alts = homograph_alts(cands)
+            if alts:
+                for l2, u2, c2 in alts:
                     amb.write(f'{slp1}\t{lemma}\t{upos}\t{lcnt}\t{l2}\t{u2}\t{c2}\n')
-                    n_amb += 1
+                n_amb += 1
             # per-form Ru distribution and works
             ru_counts = {t['ru']: t['n'] for t in d['translations']}
             works = collections.Counter()

--- a/RussianTranslation/src/build_vidyut_fallback.py
+++ b/RussianTranslation/src/build_vidyut_fallback.py
@@ -18,7 +18,6 @@ reported in the typology (Stage E).
 import os, sys, collections
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
-from vidyut.kosha import Kosha
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 G = os.path.normpath(os.path.join(HERE, '..', 'glossary'))
@@ -35,20 +34,45 @@ def pos_of(entry):
         return 'ind'
     return 'noun'
 
+
+def pick_primary_and_alts(lp):
+    """Choose the primary (lemma, pos) for a form and list its competitors.
+
+    lp: Counter mapping (lemma, pos) -> n_entries. Primary = most entries, then
+    SHORTEST lemma (prefer the root over a longer derived stem) — identical to
+    the original max(..., key=(cnt, -len)). Returns
+    (primary_lemma, primary_pos, primary_n, alts), where
+    alts = [(lemma, pos, n)] for every non-primary candidate (W1.3 ambiguity
+    trail — the same competitors that only bumped a bare `ambiguous` counter
+    before), or None when lp is empty."""
+    if not lp:
+        return None
+    ranked = sorted(lp.items(), key=lambda kv: (-kv[1], len(kv[0][0])))
+    (plem, ppos), pn = ranked[0]
+    alts = [(lem, pos, n) for (lem, pos), n in ranked[1:]]
+    return plem, ppos, pn, alts
+
 def main():
     kpath = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_KOSHA
     if not os.path.isdir(kpath):
         sys.exit(f'kosha data not found: {kpath}')
+    from vidyut.kosha import Kosha       # lazy: keeps the module importable for unit tests
     k = Kosha(kpath)
 
     inp = os.path.join(G, 'surface_dcs_misses.tsv')
     outp = os.path.join(G, 'vidyut_form2lemma.tsv')
+    ambp = os.path.join(G, 'vidyut_ambiguity.tsv')
     n = hit = 0
     stats = collections.Counter()
     with open(inp, encoding='utf-8') as f, \
-         open(outp, 'w', encoding='utf-8', newline='\n') as out:
+         open(outp, 'w', encoding='utf-8', newline='\n') as out, \
+         open(ambp, 'w', encoding='utf-8', newline='\n') as amb:
         next(f)
         out.write('form_slp1\tlemma_slp1\tpos\tn_entries\n')
+        # W1.3: mirror the DCS ambiguity_homographs.tsv schema so the two tiers'
+        # ambiguity trails are directly comparable.
+        amb.write('form_slp1\tprimary_lemma\tprimary_pos\tprimary_n\t'
+                  'alt_lemma\talt_pos\talt_n\n')
         for line in f:
             p = line.rstrip('\n').split('\t')
             if not p or not p[0]:
@@ -68,16 +92,19 @@ def main():
                 lem = getattr(e, 'lemma', None)
                 if lem:
                     lp[(lem, pos_of(e))] += 1
-            if not lp:
+            picked = pick_primary_and_alts(lp)
+            if picked is None:
                 stats['unresolved'] += 1
                 continue
-            # primary: most entries, then shortest lemma
-            (lemma, pos), cnt = max(lp.items(), key=lambda kv: (kv[1], -len(kv[0][0])))
+            lemma, pos, cnt, alts = picked
             out.write(f'{form}\t{lemma}\t{pos}\t{cnt}\n')
             hit += 1
             stats[pos] += 1
-            if len(lp) > 1:
+            if alts:                       # more than one candidate lemma/pos
                 stats['ambiguous'] += 1
+                for alt_lem, alt_pos, alt_n in alts:
+                    amb.write(f'{form}\t{lemma}\t{pos}\t{cnt}\t'
+                              f'{alt_lem}\t{alt_pos}\t{alt_n}\n')
             if n % 20000 == 0:
                 print(f'  ...{n} misses, {hit} recovered', file=sys.stderr)
     print(f'[C] {n} missed forms -> vidyut recovered {hit} '
@@ -85,6 +112,7 @@ def main():
     print(f'[C] pos: verb={stats["verb"]} noun={stats["noun"]} ind={stats["ind"]}; '
           f'ambiguous={stats["ambiguous"]}', file=sys.stderr)
     print(f'[C] -> {outp}', file=sys.stderr)
+    print(f'[C] ambiguity trail -> {ambp}', file=sys.stderr)
 
 if __name__ == '__main__':
     main()

--- a/RussianTranslation/src/measure_wave1_delta.py
+++ b/RussianTranslation/src/measure_wave1_delta.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""measure_wave1_delta.py — before/after counts for the H1349 wave-1 defect fixes.
+
+Reproducible delta table (D9): replays the OLD and NEW behaviour of each fix over
+the SAME regenerated glossary inputs, so every row isolates the code change alone.
+Reuses the pipeline's own helpers — no logic is re-implemented here.
+
+  W1.1 pseudo-root split : root inventory with vs without the self-mapped pseudo-roots.
+  W1.2 homograph trail   : ambiguity rows the old (cands[1]-only) vs new (all cands[1:]) rule emit.
+  W1.3 vidyut ambiguity  : competitor rows recorded (was a bare counter -> 0 rows).
+
+Run from RussianTranslation/ AFTER a two-pass bootstrap:
+  python src/measure_wave1_delta.py
+Prints a Markdown table to stdout; the numbers feed RESULTS_LOG.md.
+"""
+import json
+import os
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import build_rollup_glossaries as R
+
+G = R.G
+
+
+def count_rows(path):
+    """Data rows in a TSV (excluding the header); 0 if absent."""
+    if not os.path.exists(path):
+        return 0
+    with open(path, encoding='utf-8') as f:
+        return max(0, sum(1 for _ in f) - 1)
+
+
+def main():
+    f2l, l2r, roots_set, lemmas_set, dcs_keys = R.load_maps()
+
+    # --- W1.1: pseudo-root inventory delta -----------------------------------
+    unres_path = os.path.join(G, 'dcs_lemma2root_unresolved.tsv')
+    pseudo = []
+    if os.path.exists(unres_path):
+        with open(unres_path, encoding='utf-8') as f:
+            next(f, None)
+            pseudo = [line.split('\t')[0] for line in f if line.strip()]
+    roots_after = set(l2r.values())                 # unresolved already excluded by load_maps
+    roots_before = roots_after | set(pseudo)         # old behaviour kept the self-maps
+    n_pseudo = len(pseudo)
+
+    # --- W1.2: homograph rows, old rule vs new rule (identical stream) --------
+    old_amb_rows = new_amb_rows = new_amb_forms = 0
+    with open(os.path.join(G, 'surface_glossary.jsonl'), encoding='utf-8') as f:
+        for line in f:
+            nk = R.norm(json.loads(line)['slp1'])
+            cands = f2l.get(nk)
+            if not cands or len(cands) < 2:
+                continue
+            # OLD: inspected only the single runner-up cands[1]
+            _l1, u1, c1, _s1 = cands[0]
+            _l2, u2, c2, _s2 = cands[1]
+            if u2 != u1 or c2 >= 0.5 * c1:
+                old_amb_rows += 1
+            # NEW: every qualifying candidate in cands[1:]
+            alts = R.homograph_alts(cands)
+            if alts:
+                new_amb_rows += len(alts)
+                new_amb_forms += 1
+
+    # --- W1.3: vidyut ambiguity rows -----------------------------------------
+    vidyut_amb_after = count_rows(os.path.join(G, 'vidyut_ambiguity.tsv'))
+
+    # root-glossary layer size (headline context for W1.1)
+    root_gloss = 0
+    rg_path = os.path.join(G, 'root_glossary.jsonl')
+    if os.path.exists(rg_path):
+        with open(rg_path, encoding='utf-8') as f:
+            root_gloss = sum(1 for line in f if line.strip())
+
+    d_inv = len(roots_before) - len(roots_after)
+    rows = [
+        ('W1.1 distinct root keys in lemma->root map', len(roots_before), len(roots_after),
+         f'{n_pseudo} pseudo-root rows split out (net -{d_inv} distinct keys); '
+         f'root_glossary layer now {root_gloss:,}'),
+        ('W1.2 homograph alternate rows', old_amb_rows, new_amb_rows,
+         f'+{new_amb_rows - old_amb_rows} rows; full trail over {new_amb_forms:,} forms'),
+        ('W1.3 vidyut ambiguity rows recorded', 0, vidyut_amb_after,
+         'was a bare counter; now a competitor trail'),
+    ]
+    print('| Defect | Before | After | Note |')
+    print('|---|--:|--:|---|')
+    for name, before, after, note in rows:
+        print(f'| {name} | {before:,} | {after:,} | {note} |')
+
+    # machine-readable echo for the commit body / CI
+    print('\n' + json.dumps({name: {'before': b, 'after': a}
+                             for name, b, a, _ in rows}, ensure_ascii=False))
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/tests/test_saru_gloss_pipeline.py
+++ b/RussianTranslation/tests/test_saru_gloss_pipeline.py
@@ -1,0 +1,114 @@
+"""Regression tests for the wave-1 Sa->Ru gloss-layer defect fixes (H1349 / W1.6).
+
+Each test pins one of the three fixed defects via its extracted pure helper, so
+the suite runs with NO heavy dependency (no DCS sqlite, no vidyut kosha, no
+indic_transliteration) — the three build_*.py modules import cleanly because
+those deps are now imported lazily inside main()/to_slp1().
+
+  Fixture A (W1.1) — a prefixed verb lemma with no root suffix is routed to the
+                     `unresolved` (pseudo-root) bucket, not the root layer.
+  Fixture B (W1.2) — a form with three near-equal lemmas yields >=2 alternates.
+  Fixture C (W1.3) — an ambiguous vidyut form produces its full competitor trail.
+
+Run: `pytest tests/test_saru_gloss_pipeline.py` (working dir RussianTranslation).
+"""
+import collections
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
+
+import build_dcs_maps          # noqa: E402
+import build_rollup_glossaries  # noqa: E402
+import build_vidyut_fallback    # noqa: E402
+
+
+# --- Fixture A · W1.1 pseudo-root split -------------------------------------
+
+def test_pseudo_root_excluded_from_root_layer():
+    """A prefixed verb lemma whose stem is no known root self-maps -> it must
+    land in the unresolved bucket and NOT the resolved (root-layer) rows."""
+    # 'praBU' (pra + BU) has a preverb but no member of the root inventory {gam}
+    # is a suffix of it -> pseudo-root. 'saMgam' resolves to 'gam'. 'gam' is a
+    # simple root (self). Only 'praBU' should be unresolved.
+    verb_lemmas = {'praBU': True, 'saMgam': True, 'gam': False}
+    roots_by_len = sorted({'gam'}, key=len, reverse=True)
+
+    resolved, unresolved, counts = build_dcs_maps.derive_lemma2root(
+        verb_lemmas, roots_by_len)
+
+    resolved_lemmas = {r[0] for r in resolved}
+    unresolved_lemmas = {r[0] for r in unresolved}
+
+    assert 'praBU' in unresolved_lemmas          # prefixed, no root suffix
+    assert 'praBU' not in resolved_lemmas         # -> kept OUT of the root layer
+    assert ('saMgam', 'gam', 'suffix') in resolved   # real derived root, retained
+    assert ('gam', 'gam', 'self') in resolved        # simple root, retained
+    assert counts['unresolved'] == 1                 # the delta-table exclusion count
+    # every unresolved row is a self-map tagged 'unresolved'
+    assert all(lemma == root and how == 'unresolved'
+               for lemma, root, how in unresolved)
+
+
+def test_rollup_parse_lemma2root_drops_unresolved_rows():
+    """The rollup's map loader must exclude any legacy `unresolved` rows so a
+    pseudo-root is never counted as a root even from an un-split file."""
+    lines = [
+        'lemma_slp1\troot_slp1\thow\n',
+        'gam\tgam\tself\n',
+        'saMgam\tgam\tsuffix\n',
+        'praBU\tpraBU\tunresolved\n',
+    ]
+    l2r = build_rollup_glossaries.parse_lemma2root(lines)
+    assert l2r['gam'] == 'gam'
+    assert l2r['saMgam'] == 'gam'
+    assert 'praBU' not in l2r                     # pseudo-root excluded from root layer
+
+
+# --- Fixture B · W1.2 homograph completeness --------------------------------
+
+def test_homograph_emits_all_qualifying_alternates():
+    """Three near-equal lemmas for one form -> at least two alternates recorded,
+    where the old code only ever inspected the single first runner-up."""
+    cands = [
+        ('A', 'NOUN', 100, 'dcs'),   # primary
+        ('B', 'VERB', 90, 'dcs'),    # qualifies: different upos
+        ('C', 'NOUN', 80, 'dcs'),    # qualifies: 80 >= 50% of 100
+    ]
+    alts = build_rollup_glossaries.homograph_alts(cands)
+    assert len(alts) >= 2
+    assert {a[0] for a in alts} == {'B', 'C'}
+
+
+def test_homograph_ignores_minor_same_upos_alternate():
+    """A same-upos candidate below the 50% threshold is not an alternate."""
+    cands = [('A', 'NOUN', 100, 'dcs'), ('D', 'NOUN', 40, 'dcs')]
+    assert build_rollup_glossaries.homograph_alts(cands) == []
+    assert build_rollup_glossaries.homograph_alts([('A', 'NOUN', 100, 'dcs')]) == []
+
+
+# --- Fixture C · W1.3 vidyut ambiguity trail --------------------------------
+
+def test_vidyut_ambiguity_trail_lists_competitors():
+    """An ambiguous form (two candidate lemmas) yields a non-empty alts trail,
+    primary chosen by most-entries-then-shortest-lemma."""
+    lp = collections.Counter({('gam', 'verb'): 3, ('gA', 'verb'): 2})
+    lemma, pos, cnt, alts = build_vidyut_fallback.pick_primary_and_alts(lp)
+    assert (lemma, pos, cnt) == ('gam', 'verb', 3)
+    assert alts == [('gA', 'verb', 2)]
+
+
+def test_vidyut_primary_tiebreak_prefers_shorter_lemma():
+    """Equal entry counts -> the shorter lemma (the root) wins the primary slot."""
+    lp = collections.Counter({('gamana', 'noun'): 2, ('gam', 'verb'): 2})
+    lemma, pos, cnt, alts = build_vidyut_fallback.pick_primary_and_alts(lp)
+    assert lemma == 'gam'                          # shorter wins on a tie
+    assert [a[0] for a in alts] == ['gamana']
+
+
+def test_vidyut_single_candidate_has_no_trail():
+    lp = collections.Counter({('BU', 'verb'): 5})
+    lemma, pos, cnt, alts = build_vidyut_fallback.pick_primary_and_alts(lp)
+    assert (lemma, pos, cnt) == ('BU', 'verb', 5)
+    assert alts == []
+    assert build_vidyut_fallback.pick_primary_and_alts(collections.Counter()) is None


### PR DESCRIPTION
Executes the machine-checkable **wave 1** of the Sa→Ru gloss-layer uplift plan
([docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md),
handoff [H1349](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1349-Opus_RussianTranslation_saru-gloss-quality-uplift_19.07.26.md)).

## Three defect fixes (each with a regression test)

| Defect | Before | After | Fix |
|---|--:|--:|---|
| **W1.1** distinct root keys in lemma→root map | 3,570 | 3,147 | `build_dcs_maps.py` splits the 434 self-mapped `unresolved` prefixed lemmas into `dcs_lemma2root_unresolved.tsv`; `build_rollup_glossaries.py` excludes them from the root layer (`root_glossary` now 1,853). |
| **W1.2** homograph alternate rows | 9,521 | 11,289 | rollup records the full `cands[1:]` trail (was only `cands[1]`, dropping genuine 3rd+ homographs) — over 9,733 forms. |
| **W1.3** vidyut ambiguity rows | 0 | 5,952 | `build_vidyut_fallback.py` writes competing candidates to `vidyut_ambiguity.tsv` (4,133 forms), mirroring the DCS schema, replacing a bare counter. |

Numbers measured over one regenerated two-pass bootstrap (DCS `dcs_full.sqlite` 5.69M tokens + vidyut kosha 0.4.0). [`src/measure_wave1_delta.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/measure_wave1_delta.py) replays the OLD vs NEW rule over identical inputs so each row isolates the code change. Full entry in [RESULTS_LOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md).

## Tests + CI (W1.6)

`tests/test_saru_gloss_pipeline.py` (7 passing) pins all three fixes via extracted pure helpers. `vidyut`/`indic_transliteration` are now imported **lazily** so the modules import without the heavy deps; a new `pytest` step runs the suite in the RussianTranslation-gates job.

## Docs (W1.4)

Pipeline `glossary/README.md` shrunk to a build runbook + full-blob-URL pointer to the canonical [gasyoun/SanskritRussian](https://github.com/gasyoun/SanskritRussian) doc. The canonical-doc caveat + `√gam` count reconciliation land in a companion SanskritRussian PR.

## Fence honored (D8)

Published `SanskritRussian` `.tsv`/`.jsonl` data is **not** regenerated here — republish stays behind a human GO. Waves 2–4 (measure per-tier precision, coverage via `vidyut.cheda`, pwg_ru TM wiring) remain judgment-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)