### PR TITLE
H1349 wave-3: vidyut-cheda coverage spike → measured NO-GO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,15 +104,16 @@ jobs:
             RussianTranslation/src/pilot/windows100_selftest.py \
             RussianTranslation/src/pilot/run_observability.py \
             RussianTranslation/src/pilot/run_observability_selftest.py
-      - name: Sa->Ru gloss pipeline unit tests (H1349 W1.6 + wave-2 panel scaffold)
+      - name: Sa->Ru gloss pipeline unit tests (H1349 waves 1-3)
         working-directory: RussianTranslation
         run: |
-          # Pure-helper regression tests for the wave-1 defect fixes and the wave-2
-          # precision-panel scaffold (sampler + aggregator). The build_*.py and
-          # saru_gloss_*.py modules import cleanly because their heavy deps (vidyut,
-          # indic_transliteration) are imported lazily inside main()/to_slp1().
+          # Pure-helper regression tests for the wave-1 defect fixes, the wave-2
+          # precision-panel scaffold, and the wave-3 compound-split gate. The
+          # build_*.py and saru_gloss_*.py modules import cleanly because their heavy
+          # deps (vidyut, vidyut.cheda, indic_transliteration) are imported lazily
+          # inside main()/to_slp1().
           pip install pytest
-          pytest tests/test_saru_gloss_pipeline.py tests/test_saru_gloss_wave2.py -q
+          pytest tests/test_saru_gloss_pipeline.py tests/test_saru_gloss_wave2.py tests/test_saru_gloss_wave3.py -q
       - name: Validate research-layer sidecars (capability cards 5, 23)
         working-directory: RussianTranslation
         run: |

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2432,6 +2432,14 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **Sa→Ru gloss layer, wave 3 — coverage spike, vidyut-cheda NO-GO — H1349 W3, 20-07-2026 (Opus 4.8).**
+  `src/build_compound_split.py` (gated vidyut.cheda) recovers 36.4% of the 78,842 unresolved
+  forms, but a 2-judge panel measured those recoveries at 18% gloss precision / 60% wrong
+  (vs wave-2's 85.3%) → **not wired in** (would regress the layer). Root cause: cheda is a
+  running-text segmenter, useless on isolated OOV forms. Recommended path (backlog): DharmaMitra
+  neural segmenter over verse text (kosha `compare_sandhi_methods.py` method C, near-perfect).
+  Finding: `gold/saru_gloss_wave3_cheda_coverage.md`; gate test `tests/test_saru_gloss_wave3.py`.
+  **Wave 4 (pwg_ru/mw_ru TM wiring) is the only remaining H1349 wave; judgment-gated.**
 - **Sa→Ru gloss layer, wave 2 — measured precision — H1349 W2, 20-07-2026 (Opus 4.8).**
   First accuracy measurement (all prior numbers were coverage). New tier×frequency stratified
   sampler + panel aggregator (`src/saru_gloss_sample.py`, `src/saru_gloss_aggregate.py`) run a

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,18 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added — Sa→Ru gloss layer wave-3 coverage spike: vidyut-cheda NO-GO (H1349 W3)
+
+- Measured whether `vidyut.cheda` compound segmentation can recover the 78,842 unresolved
+  forms. `src/build_compound_split.py` applies a strict precision gate (≥2 tokens + every
+  member glossable) and recovers 36.4% (28,673 forms) — but a 2-judge panel scored those
+  recoveries at **18% gloss precision / 60% outright wrong**, vs the wave-2 baseline of 85.3%.
+  **NO-GO: not wired into the rollup** — vidyut-cheda is a running-text segmenter and shatters
+  isolated OOV forms into stem + spurious glossable particle. The 85% layer stays unregressed;
+  recommended path (backlog) is the DharmaMitra neural segmenter over the aligned verse text.
+  Finding: `gold/saru_gloss_wave3_cheda_coverage.md`; gate has a regression test
+  (`tests/test_saru_gloss_wave3.py`, wired into CI).
+
 ### Added — Sa→Ru gloss layer measured precision (H1349 wave 2)
 
 - **First accuracy measurement** of the gloss layer (every prior number was coverage). A

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -4,6 +4,23 @@ _Created: 09-07-2026 · Last updated: 20-07-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
+## 20-07-2026 — Sa→Ru gloss layer, wave-3 coverage spike: vidyut-cheda NO-GO (H1349 W3)
+
+Tried recovering the 78,842 unresolved forms via `vidyut.cheda` compound segmentation
+(D7 reuse). **Measured NO-GO.** A strict gate (≥2 tokens + every member glossable,
+[`src/build_compound_split.py`](src/build_compound_split.py)) recovers 28,673 forms (36.4% of
+unresolved / 55,008 tokens) — but a 2-judge panel (Opus 4.8 `claude-opus-4-8` + Sonnet 5
+`claude-sonnet-5`) on 40 gated recoveries scored segmentation **28% both-correct / 72%
+either-wrong**, gloss **18% both-correct / 60% either-wrong / 40% acceptable**. Against the
+wave-2 baseline (85.3% gloss) that is a catastrophic regression — ~half the recoveries are
+outright wrong. Root cause: vidyut-cheda is a *running-text* segmenter; on isolated OOV forms
+it shatters inflected/dual/plural words into stem + spurious glossable particle (`sahadevaśca`
+→ `sahadeva`+`ca`, head "и"). **Decision: not wired in** — the 85% layer stays unregressed;
+the 78,842 stay an honest coverage gap. Recommended path (backlog): the DharmaMitra **neural**
+segmenter over the aligned *verse text*, which kosha's `compare_sandhi_methods.py` already
+benchmarked as near-perfect and far above vidyut-cheda. Full write-up:
+[`gold/saru_gloss_wave3_cheda_coverage.md`](gold/saru_gloss_wave3_cheda_coverage.md).
+
 ## 20-07-2026 — Sa→Ru gloss layer, measured precision (H1349 wave 2)
 
 First **accuracy** measurement of the gloss layer (every prior number was coverage).

--- a/RussianTranslation/gold/saru_gloss_wave3_cheda_coverage.md
+++ b/RussianTranslation/gold/saru_gloss_wave3_cheda_coverage.md
@@ -1,0 +1,75 @@
+# Sa→Ru gloss layer — wave-3 coverage spike: vidyut-cheda on unresolved forms
+
+_Created: 20-07-2026 · Last updated: 20-07-2026_
+
+Wave 3 (H1349) set out to recover the **78,842 forms no tier resolved**
+(`surface_unresolved.tsv` — 57,101 simplexes + 21,741 long compounds) by compound
+segmentation with **vidyut.cheda** (D7 — reuse, don't build), measured against the
+wave-2 precision baseline. **Verdict: NO-GO.** vidyut-cheda on *isolated* forms is
+too low-precision to wire in; doing so would inject exactly the recovered-but-wrong
+regressions the wave-3 acceptance bar forbids. This document is the measured
+negative result + the recommended path forward.
+
+## What was built
+
+[`src/build_compound_split.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_compound_split.py)
+wraps the offline `vidyut.cheda` Chedaka (kosha `data/vidyut`, the `compare_sandhi_methods.py`
+method-B pattern) and applies a **strict precision gate**: accept a segmentation only if
+it has ≥2 tokens **and every member lemma is already glossable** (in `lemma_glossary`).
+This is the highest-precision gate a spike found (see below).
+
+## Coverage ceiling (the optimistic half)
+
+| gate | forms recovered | % of 78,842 unresolved | tokens |
+|---|--:|--:|--:|
+| "any segment glossable" (naive) | ~37,400 | ~47% | — |
+| **"≥2 tokens AND all members glossable" (shipped gate)** | **28,673** | **36.4%** | 55,008 (39% of 140,667 unresolved tokens) |
+
+## Precision (the disqualifying half)
+
+A 2-judge panel (Opus 4.8 `claude-opus-4-8`, Sonnet 5 `claude-sonnet-5`) scored a
+random 40-item sample of the gated recoveries on two axes — is the **segmentation**
+a correct decomposition, and is the recovered **gloss** right:
+
+| axis | both judges correct | either judge "wrong" | acceptable (neither "wrong") |
+|---|--:|--:|--:|
+| segmentation | 28% | 72% | — |
+| gloss | 18% | 60% | 40% |
+
+Against the **wave-2 baseline** (gloss precision 85.3%, lemmatization 86.1%), this is a
+catastrophic regression: roughly **half** the gated recoveries are outright wrong. Adding
+this tier would trade a measured 85% layer for 36% more coverage at ~18–40% precision — a
+net-negative to the layer's trustworthiness.
+
+## Root cause
+
+vidyut-cheda is a **running-text** segmenter; on an isolated OOV form it has no context and
+routinely **shatters an inflected/dual/plural word into a stem + a spurious "member"** that
+happens to be a real lemma:
+
+- dual/plural endings parsed as particles: `sahadevaśca`→`sahadeva`+`ca`, `-au`→`u` ("и"),
+  so the last-member "head" becomes a stray particle glossed "и"/"идет"/"о";
+- sandhi not reconstructed: `divyakalpa`→`div`+`aj`+`alpa` ("небо+выгнал+мало");
+- meaning inversions: `hīna`→`a`+`hīna` (not-deprived), `sahita`→`ahita` (enemy),
+  `drumavarṣa`→drought.
+
+The strict "all members glossable" gate cannot fix this, because the spurious members
+(`ca`, `u`, `a`, `i`) are themselves glossable function words.
+
+## Decision + path forward
+
+- **NO-GO on wiring vidyut-cheda into the rollup** (isolated-form recovery). The tool +
+  gate are committed for reproducibility and for a running-text application later.
+- **Recommended path (backlog):** kosha's own [`compare_sandhi_methods.py`](https://github.com/gasyoun/kosha/blob/main/scripts/compare_sandhi_methods.py)
+  already benchmarked the **DharmaMitra neural segmenter (method C) as "near-perfect
+  precision, far outperforms vidyut-cheda."** Compound recovery should run a **context-aware
+  neural segmenter over the aligned *verse text*** (which this corpus has — forms trace back
+  to source verses), not vidyut-cheda over isolated forms. That is the shape of a future
+  wave-3.5.
+- The 78,842 unresolved forms therefore stay unresolved for now — an honest coverage gap,
+  not a low-precision patch. Wave-2's measured 85% layer is unregressed.
+
+Evidence: [`saru_gloss_wave3_cheda_sample.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/gold/saru_gloss_wave3_cheda_sample.jsonl)
++ per-judge labels (`saru_gloss_wave3_cheda_labels_opus.jsonl` / `_sonnet.jsonl`).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/gold/saru_gloss_wave3_cheda_labels_opus.jsonl
+++ b/RussianTranslation/gold/saru_gloss_wave3_cheda_labels_opus.jsonl
@@ -1,0 +1,40 @@
+{"id":0,"seg_verdict":"correct","gloss_verdict":"partial","note":"sahadeva+ca legit sandhi split (sahadevaH+ca); but head is particle ca=и, real content Sahadeva survives only in chain"}
+{"id":1,"seg_verdict":"correct","gloss_verdict":"correct","note":"sveta+uzniza = white+turban, real bahuvrihi; gloss белый+тюрбан correct"}
+{"id":2,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"atula=a+tula (incomparable); split a+ula with ula=jackal is spurious, meaning garbled"}
+{"id":3,"seg_verdict":"correct","gloss_verdict":"wrong","note":"triH nizAyAm = thrice in night; split tris+niSA correct but niSA glossed острыми (sharp) instead of night"}
+{"id":4,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"divyakalpa=divya+kalpa; shattered into div+aj+alpa, meaning invented"}
+{"id":5,"seg_verdict":"correct","gloss_verdict":"partial","note":"cintayitum arhasi = you ought to think; cint+arh roots captured; чейн conveys should+think, размышлениях nominalized"}
+{"id":6,"seg_verdict":"wrong","gloss_verdict":"partial","note":"bahu+upakaraNa (noun means/resources); head given as verb root upaskf; help-sense loosely survives"}
+{"id":7,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"aha+ibhya arbitrary split; дни+подданных incoherent, no real compound"}
+{"id":8,"seg_verdict":"correct","gloss_verdict":"correct","note":"tilaSaH kRta = made into pieces; tilaSas+kf correct, в куски+сделал right"}
+{"id":9,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"SokAtiga=Soka+atiga (transcended grief); Suc root for member + atiga glossed 'не внемлющем' wrong"}
+{"id":10,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"subrata=su+vrata (of good vows); svap+ram (sleep+delight) totally spurious"}
+{"id":11,"seg_verdict":"correct","gloss_verdict":"partial","note":"triSiras+man/mata split ok; Trisiras retained but head man=считаю for mata is off"}
+{"id":12,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"pauravAH patronymic plural, single word; pA+u+u shatter into root+particles, garbage"}
+{"id":13,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"Sakra-purogama (led by Indra); shattered into 5 members Sak+f+pA+a+gam, nonsense"}
+{"id":14,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"purI+dvAra = city gate; split pF+i+vf (fill+go+cover) completely wrong"}
+{"id":15,"seg_verdict":"wrong","gloss_verdict":"partial","note":"mahAsena real but +as (быть) is ending mis-parsed as root; head 'есть' misrepresents"}
+{"id":16,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"bhAva+nirvftti; split BU+avani+vft with avani=earth mis-parse of nir-vftti"}
+{"id":17,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"bhAnavIyAH+ca; over-shattered BA+o+i+ca, head is particle ca=и"}
+{"id":18,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"Sata+dhAra (hundred-streamed); split SataDA+f with f spurious from -aH ending"}
+{"id":19,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"avyo vArezu two words (wool, in-filters); split u+vf (particle+cover) unrelated"}
+{"id":20,"seg_verdict":"wrong","gloss_verdict":"partial","note":"cApa+hasta (bow-in-hand); mis-split ca+apahasta drops hand; bow sense garbled in chain"}
+{"id":21,"seg_verdict":"correct","gloss_verdict":"correct","note":"na+ucchvas = not breathing; не+дышит correct"}
+{"id":22,"seg_verdict":"wrong","gloss_verdict":"partial","note":"rAma(name)+ambA; ram root (delight) wrong for Rama; mother retained"}
+{"id":23,"seg_verdict":"correct","gloss_verdict":"correct","note":"AviH kfNoti = makes manifest; Avis+kf correct, явными+сделал right"}
+{"id":24,"seg_verdict":"wrong","gloss_verdict":"partial","note":"prabhAsvant = prabhA+vant suffix (radiant), single derived word; shattered praBA+av+day; сияние survives"}
+{"id":25,"seg_verdict":"wrong","gloss_verdict":"partial","note":"asmad+vAkya (from our words); asmad garbled to a+maT; vac=said keeps speech sense, 'our' lost"}
+{"id":26,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"taijasa=derived from tejas (fiery), single word; split tA+yaj+a nonsense, head a=о"}
+{"id":27,"seg_verdict":"wrong","gloss_verdict":"partial","note":"samrAjau dual of samraj (two sovereigns); u spurious dual ending as head=и; king survives"}
+{"id":28,"seg_verdict":"correct","gloss_verdict":"correct","note":"tAM camUm = that army; tA(tad)+camU correct, эти+войско right"}
+{"id":29,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"paura (citizen) missed entirely; pA+u+as shatter, head 'есть' garbage"}
+{"id":30,"seg_verdict":"correct","gloss_verdict":"correct","note":"mahAn doza = great fault; mah+doza correct, великого+зло right"}
+{"id":31,"seg_verdict":"wrong","gloss_verdict":"partial","note":"azwau angAni = eight limbs; anga=limb right but 'eight' mis-lemmatized as aS/az=достигли"}
+{"id":32,"seg_verdict":"wrong","gloss_verdict":"partial","note":"mokAjina unclear; muc(release) member dubious, ajina=hide/шкуры plausibly the real head"}
+{"id":33,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"puNya+saMbhAra+sandhAyin; shattered into 5, only puNya right, rest garbled"}
+{"id":34,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"druma+varza (tree-rain); mis-split dru+avarza gives avarza=drought, opposite meaning"}
+{"id":35,"seg_verdict":"correct","gloss_verdict":"correct","note":"vfjina+agra both real members; кривое+вначале acceptable (foremost/tip of crookedness)"}
+{"id":36,"seg_verdict":"wrong","gloss_verdict":"partial","note":"yoga+samanvita; split yuj+a+anvi; anvi loosely maps to samanvita, yoga sense loose"}
+{"id":37,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"Aditya+sahita; split a+i+ahita drops sa-, ahita=enemy opposite of sahita=accompanied"}
+{"id":38,"seg_verdict":"wrong","gloss_verdict":"partial","note":"unmukhau dual, single word; u spurious dual ending as head=и; unmukha loosely glossed"}
+{"id":39,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"veda+adhikAra+hIna (deprived of Veda-right); shattered, ahIna=не лишенных is opposite of hIna"}

--- a/RussianTranslation/gold/saru_gloss_wave3_cheda_labels_sonnet.jsonl
+++ b/RussianTranslation/gold/saru_gloss_wave3_cheda_labels_sonnet.jsonl
@@ -1,0 +1,40 @@
+{"id":0,"seg_verdict":"correct","gloss_verdict":"partial","note":"sahadeva+ca real split (sandhi visarga+c->śc); head=ca 'and' is a stray particle, not a true compound head"}
+{"id":1,"seg_verdict":"correct","gloss_verdict":"correct","note":"śveta+uṣṇīṣa, sandhi a+u->o matches; 'white turban' correct bahuvrihi sense"}
+{"id":2,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"a+ula drops the 't' of ātula (true a+tula 'matchless'); head gloss itself flagged '?' (jackal), unrelated"}
+{"id":3,"seg_verdict":"correct","gloss_verdict":"wrong","note":"tris+niśā correct (sandhi s+n->r); but niśā='night' mistranslated as 'sharp' (confused with niśita)"}
+{"id":4,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"div+aj+alpa garbled; true divyakalpa=divya+kalpa; chain 'heaven+drove out+little' is nonsense"}
+{"id":5,"seg_verdict":"correct","gloss_verdict":"correct","note":"cintayitum arhasi is two words, not a compound, but roots cint/arh correctly recovered; 'ought to think' conveyed"}
+{"id":6,"seg_verdict":"wrong","gloss_verdict":"correct","note":"upakaraṇa derives from plain upa+kṛ (no s-augment); 'upaskf' is a different real root wrongly picked, but gloss 'much help' still conveys correct sense"}
+{"id":7,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"aha+ibhya shows no a+i->e sandhi (hiatus kept), implausible boundary; chain 'day+noble' incoherent"}
+{"id":8,"seg_verdict":"correct","gloss_verdict":"correct","note":"tilaśas+kṛ matches source 'tilaśaḥ kṛta' exactly; 'cut into pieces+made' correct"}
+{"id":9,"seg_verdict":"correct","gloss_verdict":"partial","note":"śuc/śoka+atiga plausible root split; atiga='surpassing/overcoming' loosely rendered as 'not heeding'"}
+{"id":10,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"svap+ram does not reconstruct subrata (=su+vrata); 'sleeps+rejoice' unrelated to 'good vow'"}
+{"id":11,"seg_verdict":"correct","gloss_verdict":"correct","note":"triśiras+man, sandhi -as+m->-om matches; 'Trishiras considered/regarded' reasonable"}
+{"id":12,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"pA+u+u garbles paurava/pauravāḥ, doubled meaningless 'u'; chain 'protect+and+and' nonsense"}
+{"id":13,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"garbled decomposition of śakrapurogama; misses real members śakra/puraḥ/gama; chain incoherent"}
+{"id":14,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"pf+i+vf omits the 'd' of purīdvāra entirely, does not reconstruct surface; chain unrelated to 'city gate'"}
+{"id":15,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"mahāsena+as doesn't cleanly reconstruct trailing -sa; 'Mahasena is' is not a coherent compound gloss"}
+{"id":16,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"BU+avani+vf inserts spurious 'avani'(earth); true bhāvanirvṛtti=bhāva+nirvṛtti; chain nonsensical"}
+{"id":17,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"BA+o+i+ca garbled, misses bhānu (sun) entirely; head=ca stray particle, chain incoherent"}
+{"id":18,"seg_verdict":"wrong","gloss_verdict":"partial","note":"wrong boundary śatadhā+ṛ instead of real śata+dhāra ('hundred-edged'); chain vaguely evokes hundred+clashing but literal sense wrong"}
+{"id":19,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"u+vf unrelated to real phrase 'avyo vāreṣu' (sheep-wool sieves); chain 'and+surrounded' unrelated"}
+{"id":20,"seg_verdict":"wrong","gloss_verdict":"partial","note":"wrong boundary ca+apahasta instead of real cāpa+hasta ('bow in hand'); head coincidentally glossed 'bow' but 'hand' lost and 'and' spurious"}
+{"id":21,"seg_verdict":"correct","gloss_verdict":"correct","note":"na+ucchvas, sandhi a+u->o matches; 'not breathing' correct"}
+{"id":22,"seg_verdict":"correct","gloss_verdict":"partial","note":"rāma+ambā dual with correct fem-ā dual shortening before -yoḥ; 'mother' correct but 'ram' mistranslated as verb 'rejoice' instead of name Rāma"}
+{"id":23,"seg_verdict":"correct","gloss_verdict":"correct","note":"āvis+kṛ matches source 'āviḥ kṛṇoti'; 'made manifest' correct"}
+{"id":24,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"av+day does not correspond to the possessive suffix -vant in prabhāsvant; chain incoherent"}
+{"id":25,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"a+maT does not correspond to pronoun stem asmad ('our'); chain 'oh+stole+said' unrelated to 'from our speech'"}
+{"id":26,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"tA+yaj+a is a false etymology; real taijasa derives from tejas, not yaj; head=a stray particle, chain incoherent"}
+{"id":27,"seg_verdict":"wrong","gloss_verdict":"partial","note":"dual ending -au mistaken for separate word 'u'='and'; samrāj='sovereign' correct but ending mistranslated as conjunction"}
+{"id":28,"seg_verdict":"correct","gloss_verdict":"correct","note":"tā+camū matches source 'tāṃ camūm' (sandhi m+c->ṃc); 'that army' correct sense"}
+{"id":29,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"pA+u+as same garbling pattern as id12, doesn't reconstruct paura; chain nonsensical"}
+{"id":30,"seg_verdict":"correct","gloss_verdict":"correct","note":"mah(ān)+doṣa matches 'mahāndoṣa'; 'great evil/fault' correct"}
+{"id":31,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"aS+aNga drops the -ṭā- of aṣṭau, truncates the numeral 'eight'; chain 'attained+body' misses 'eight limbs' sense"}
+{"id":32,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"muc->moka lacks the expected ṣ of mokṣa, incoherent compound sense; likely OCR-mangled mṛgājina ('deerskin'); chain incoherent"}
+{"id":33,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"loses sambhāra/sandhāyin entirely, replaced by unrelated bhū/ras/dhī roots; chain incoherent"}
+{"id":34,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"dru+avarza drops the 'm' of druma, does not reconstruct surface; chain unrelated to 'tree/rain'"}
+{"id":35,"seg_verdict":"correct","gloss_verdict":"correct","note":"vṛjina+agra, sandhi a+a->A matches; 'crooked+top/beginning' reasonable compound sense"}
+{"id":36,"seg_verdict":"wrong","gloss_verdict":"partial","note":"spurious filler 'a'='oh' inserted as a member, missing the sam- prefix of samanvita; 'yoga+follows' loosely conveys 'endowed with'"}
+{"id":37,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"a+i+ahita loses āditya ('sun') entirely and yields ahita ('hostile'), opposite of true sahita ('accompanied by'); chain wrong/inverted"}
+{"id":38,"seg_verdict":"wrong","gloss_verdict":"partial","note":"dual ending -au mistaken for separate word 'u'='and', same pattern as id27; unmukha as 'eager/desirous' plausible secondary sense, but head 'and' spurious"}
+{"id":39,"seg_verdict":"wrong","gloss_verdict":"wrong","note":"wrong boundary turns hīna into ahīna, inverting the meaning (true vedādhikārahīna = 'devoid of right to Veda'); also garbles adhikāra into aDika+f"}

--- a/RussianTranslation/gold/saru_gloss_wave3_cheda_sample.jsonl
+++ b/RussianTranslation/gold/saru_gloss_wave3_cheda_sample.jsonl
@@ -1,0 +1,40 @@
+{"id": 0, "slp1": "sahadevaSca", "sa": "sahadevaśca", "segmentation": "sahadeva+ca", "head_lemma": "ca", "head_gloss": "и", "chain_gloss": "Сахадева + и"}
+{"id": 1, "slp1": "SvetozRIzAH", "sa": "śvetoṣṇīṣāḥ", "segmentation": "Sveta+uzRIza", "head_lemma": "uzRIza", "head_gloss": "тюрбан", "chain_gloss": "белый + тюрбан"}
+{"id": 2, "slp1": "Atula", "sa": "ātula", "segmentation": "a+ula", "head_lemma": "ula", "head_gloss": "Шакала (?)", "chain_gloss": "о + Шакала (?)"}
+{"id": 3, "slp1": "trirniSAyAm", "sa": "trirniśāyām", "segmentation": "tris+niSA", "head_lemma": "niSA", "head_gloss": "острыми", "chain_gloss": "трижды + острыми"}
+{"id": 4, "slp1": "divyakalpa", "sa": "divyakalpa", "segmentation": "div+aj+alpa", "head_lemma": "alpa", "head_gloss": "мало", "chain_gloss": "неба + выгнал + мало"}
+{"id": 5, "slp1": "cintayitumarhasi", "sa": "cintayitumarhasi", "segmentation": "cint+arh", "head_lemma": "arh", "head_gloss": "должен", "chain_gloss": "размышлениях + должен"}
+{"id": 6, "slp1": "bahUpakaraRa", "sa": "bahūpakaraṇa", "segmentation": "bahu+upaskf", "head_lemma": "upaskf", "head_gloss": "окажу помощь", "chain_gloss": "много + окажу помощь"}
+{"id": 7, "slp1": "ahaiBya", "sa": "ahaibhya", "segmentation": "aha+iBya", "head_lemma": "iBya", "head_gloss": "подданных", "chain_gloss": "дни + подданных"}
+{"id": 8, "slp1": "tilaSaHkfta", "sa": "tilaśaḥ kṛta", "segmentation": "tilaSas+kf", "head_lemma": "kf", "head_gloss": "сделал", "chain_gloss": "в куски + сделал"}
+{"id": 9, "slp1": "SokAtigaH", "sa": "śokātigaḥ", "segmentation": "Suc+atiga", "head_lemma": "atiga", "head_gloss": "не внемлющем", "chain_gloss": "скорбит + не внемлющем"}
+{"id": 10, "slp1": "subrata", "sa": "subrata", "segmentation": "svap+ram", "head_lemma": "ram", "head_gloss": "радуются", "chain_gloss": "спит + радуются"}
+{"id": 11, "slp1": "triSiromata", "sa": "triśiromata", "segmentation": "triSiras+man", "head_lemma": "man", "head_gloss": "считаю", "chain_gloss": "Триширас + считаю"}
+{"id": 12, "slp1": "pauravAH", "sa": "pauravāḥ", "segmentation": "pA+u+u", "head_lemma": "u", "head_gloss": "и", "chain_gloss": "Защищайте + и + и"}
+{"id": 13, "slp1": "SakrapurogamAH", "sa": "śakrapurogamāḥ", "segmentation": "Sak+f+pA+a+gam", "head_lemma": "gam", "head_gloss": "отправился", "chain_gloss": "способен + столкнувшись + Защищайте + о + отправился"}
+{"id": 14, "slp1": "purIdvAra", "sa": "purīdvāra", "segmentation": "pF+i+vf", "head_lemma": "vf", "head_gloss": "окруженный", "chain_gloss": "заполнил + идет + окруженный"}
+{"id": 15, "slp1": "mahAsenAsa", "sa": "mahāsenāsa", "segmentation": "mahAsena+as", "head_lemma": "as", "head_gloss": "есть", "chain_gloss": "Махасена + есть"}
+{"id": 16, "slp1": "BAvanirvftti", "sa": "bhāvanirvṛtti", "segmentation": "BU+avani+vft", "head_lemma": "vft", "head_gloss": "происходила", "chain_gloss": "будет + землю + происходила"}
+{"id": 17, "slp1": "BAnavIyASca", "sa": "bhānavīyāśca", "segmentation": "BA+o+i+ca", "head_lemma": "ca", "head_gloss": "и", "chain_gloss": "сияет + о + идет + и"}
+{"id": 18, "slp1": "SataDAraH", "sa": "śatadhāraḥ", "segmentation": "SataDA+f", "head_lemma": "f", "head_gloss": "столкнувшись", "chain_gloss": "на сто частей + столкнувшись"}
+{"id": 19, "slp1": "avyovArezu", "sa": "avyo vāreṣu", "segmentation": "u+vf", "head_lemma": "vf", "head_gloss": "окруженный", "chain_gloss": "и + окруженный"}
+{"id": 20, "slp1": "cApahasta", "sa": "cāpahasta", "segmentation": "ca+apahasta", "head_lemma": "apahasta", "head_gloss": "луком", "chain_gloss": "и + луком"}
+{"id": 21, "slp1": "nocCvasan", "sa": "nocchvasan", "segmentation": "na+ucCvas", "head_lemma": "ucCvas", "head_gloss": "дышит", "chain_gloss": "не + дышит"}
+{"id": 22, "slp1": "rAmAmbayos", "sa": "rāmāmbayos", "segmentation": "ram+ambA", "head_lemma": "ambA", "head_gloss": "мать", "chain_gloss": "радуются + мать"}
+{"id": 23, "slp1": "AviHkfRoti", "sa": "āviḥ kṛṇoti", "segmentation": "Avis+kf", "head_lemma": "kf", "head_gloss": "сделал", "chain_gloss": "явными + сделал"}
+{"id": 24, "slp1": "praBAsvant", "sa": "prabhāsvant", "segmentation": "praBA+av+day", "head_lemma": "day", "head_gloss": "раздает", "chain_gloss": "сияние + на помощь + раздает"}
+{"id": 25, "slp1": "asmadvAkyAt", "sa": "asmadvākyāt", "segmentation": "a+maT+vac", "head_lemma": "vac", "head_gloss": "сказал", "chain_gloss": "о + похитил + сказал"}
+{"id": 26, "slp1": "taijasa", "sa": "taijasa", "segmentation": "tA+yaj+a", "head_lemma": "a", "head_gloss": "о", "chain_gloss": "эти + жертвователя + о"}
+{"id": 27, "slp1": "samrAjAu", "sa": "samrājāu", "segmentation": "samrAj+u", "head_lemma": "u", "head_gloss": "и", "chain_gloss": "царь + и"}
+{"id": 28, "slp1": "tAMcamUm", "sa": "tāṃ camūm", "segmentation": "tA+camU", "head_lemma": "camU", "head_gloss": "войско", "chain_gloss": "эти + войско"}
+{"id": 29, "slp1": "paurAsa", "sa": "paurāsa", "segmentation": "pA+u+as", "head_lemma": "as", "head_gloss": "есть", "chain_gloss": "Защищайте + и + есть"}
+{"id": 30, "slp1": "mahAndoza", "sa": "mahāndoṣa", "segmentation": "mah+doza", "head_lemma": "doza", "head_gloss": "зло", "chain_gloss": "великого + зло"}
+{"id": 31, "slp1": "azwAvaNgAni", "sa": "aṣṭāv aṅgāni", "segmentation": "aS+aNga", "head_lemma": "aNga", "head_gloss": "тело", "chain_gloss": "достигли + тело"}
+{"id": 32, "slp1": "mokAjina", "sa": "mokājina", "segmentation": "muc+ajina", "head_lemma": "ajina", "head_gloss": "шкуры", "chain_gloss": "освобождается + шкуры"}
+{"id": 33, "slp1": "puRyasaMBArasanDAyin", "sa": "puṇyasaṃbhārasandhāyin", "segmentation": "puRya+a+BU+ras+DI", "head_lemma": "DI", "head_gloss": "молитвы", "chain_gloss": "святая + о + будет + затряслась + молитвы"}
+{"id": 34, "slp1": "drumavarza", "sa": "drumavarṣa", "segmentation": "dru+avarza", "head_lemma": "avarza", "head_gloss": "засухи", "chain_gloss": "быстро + засухи"}
+{"id": 35, "slp1": "vfjinAgra", "sa": "vṛjināgra", "segmentation": "vfjina+agra", "head_lemma": "agra", "head_gloss": "вначале", "chain_gloss": "кривое + вначале"}
+{"id": 36, "slp1": "yogasamanvita", "sa": "yogasamanvita", "segmentation": "yuj+a+anvi", "head_lemma": "anvi", "head_gloss": "следует", "chain_gloss": "союзником + о + следует"}
+{"id": 37, "slp1": "Adityasahita", "sa": "ādityasahita", "segmentation": "a+i+ahita", "head_lemma": "ahita", "head_gloss": "враги", "chain_gloss": "о + идет + враги"}
+{"id": 38, "slp1": "unmuKau", "sa": "unmukhau", "segmentation": "unmuKa+u", "head_lemma": "u", "head_gloss": "и", "chain_gloss": "в своем вожделении + и"}
+{"id": 39, "slp1": "vedADikArahIna", "sa": "vedādhikārahīna", "segmentation": "vid+aDika+f+ahIna", "head_lemma": "ahIna", "head_gloss": "не лишенных", "chain_gloss": "знает + выше + столкнувшись + не лишенных"}

--- a/RussianTranslation/src/build_compound_split.py
+++ b/RussianTranslation/src/build_compound_split.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+"""build_compound_split.py — Stage C2: recover DCS+Vidyut+marker-unresolved forms
+by compound segmentation with vidyut.cheda (H1349 wave 3, D7 — reuse, don't build).
+
+The 78,842 forms no tier resolved (`surface_unresolved.tsv`) are dominated by long
+samāsa and sandhi-fused simplexes. vidyut.cheda (the offline Paninian segmenter,
+v0.4.0, reused via the kosha `compare_sandhi_methods.py` method-B pattern) splits a
+form into member tokens, each carrying a lemma.
+
+**Precision gate (the load-bearing choice).** cheda on *isolated* OOV forms is
+low-precision — it happily emits spurious splits (`bax`→`ba`+`x`). A spike (H1349
+W3.2, n=2000) measured: "any segment is glossable" recovers 47% but at low
+precision; **"≥2 tokens AND *every* member lemma is already glossable"** recovers
+~35% and only accepts a compound fully decomposed into known, glossable members.
+This module ships the strict gate; a recovered-but-wrong form counts as a
+regression (wave-3 acceptance), so precision is bought with coverage.
+
+Where the corpus already carries a `+`/`-` morpheme marker (handled upstream by the
+rollup's marker tier), that form never reaches here — so cheda is used ONLY where no
+marker exists (the plan's precedence rule).
+
+Reads   glossary/surface_unresolved.tsv, glossary/lemma_glossary.jsonl
+Writes  glossary/cheda_recovered.tsv  (form_slp1, n, n_tokens, segmentation,
+                                       head_lemma, head_gloss, chain_gloss)
+
+  python build_compound_split.py [kosha_vidyut_dir]
+"""
+import json
+import os
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+G = os.path.normpath(os.path.join(HERE, '..', 'glossary'))
+DEFAULT_VIDYUT = os.path.normpath(os.path.join(
+    HERE, '..', '..', '..', 'kosha', 'data', 'vidyut'))
+
+
+def load_gloss_map(path):
+    """lemma_slp1 -> top Russian gloss (translations[0]); only glossable lemmas."""
+    g = {}
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            r = json.loads(line)
+            tr = r.get('translations') or []
+            if tr:
+                g[r['lemma_slp1']] = tr[0]['ru']
+    return g
+
+
+def gate(tokens, gloss_map):
+    """Accept a segmentation only if it has >=2 tokens and EVERY member lemma is
+    glossable. Returns the lemma list on accept, else None."""
+    if len(tokens) < 2:
+        return None
+    lemmas = [t.lemma for t in tokens]
+    if not all(l and l in gloss_map for l in lemmas):
+        return None
+    return lemmas
+
+
+def main():
+    vidyut_dir = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_VIDYUT
+    from vidyut.cheda import Chedaka        # lazy: keeps the module importable for tests
+    ch = Chedaka(vidyut_dir)
+    gloss_map = load_gloss_map(os.path.join(G, 'lemma_glossary.jsonl'))
+    print(f'[C2] {len(gloss_map)} glossable lemmas', file=sys.stderr)
+
+    inp = os.path.join(G, 'surface_unresolved.tsv')
+    outp = os.path.join(G, 'cheda_recovered.tsv')
+    n = rec = rec_tokens = 0
+    with open(inp, encoding='utf-8') as f, \
+         open(outp, 'w', encoding='utf-8', newline='\n') as out:
+        next(f)
+        out.write('form_slp1\tn\tn_tokens\tsegmentation\thead_lemma\thead_gloss\tchain_gloss\n')
+        for line in f:
+            p = line.rstrip('\n').split('\t')
+            if not p or not p[0]:
+                continue
+            form, freq = p[0], int(p[2]) if len(p) > 2 and p[2].isdigit() else 1
+            n += 1
+            try:
+                tokens = ch.run(form)
+            except Exception:
+                tokens = []
+            lemmas = gate(tokens, gloss_map)
+            if not lemmas:
+                continue
+            head = lemmas[-1]                       # Sanskrit compound head = last member
+            seg = '+'.join(lemmas)
+            chain = ' + '.join(gloss_map[l] for l in lemmas)
+            out.write(f'{form}\t{freq}\t{len(lemmas)}\t{seg}\t{head}\t'
+                      f'{gloss_map[head]}\t{chain}\n')
+            rec += 1
+            rec_tokens += freq
+            if n % 20000 == 0:
+                print(f'  ...{n} unresolved, {rec} recovered', file=sys.stderr)
+    print(f'[C2] {n} unresolved -> cheda gated-recovered {rec} forms '
+          f'({100*rec/n:.1f}%), {rec_tokens} tokens -> {outp}', file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/tests/test_saru_gloss_wave3.py
+++ b/RussianTranslation/tests/test_saru_gloss_wave3.py
@@ -1,0 +1,35 @@
+"""Regression test for the H1349 wave-3 compound-split precision gate.
+
+The gate is the load-bearing decision (a lax gate injected the recovered-but-wrong
+regressions the wave-3 spike measured). No vidyut dep: the Chedaka is imported
+lazily inside main(), and gate() is pure.
+
+Run: `pytest tests/test_saru_gloss_wave3.py` (working dir RussianTranslation).
+"""
+import os
+import sys
+from types import SimpleNamespace as T
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
+
+import build_compound_split as C   # noqa: E402
+
+
+def tok(lemma):
+    return T(lemma=lemma, text=lemma)
+
+
+def test_gate_requires_two_tokens_all_glossable():
+    gm = {'sveta': 'белый', 'uzRIza': 'тюрбан', 'sat': 'сущий', 'AcAra': 'обычай'}
+    # good: 2 members, both glossable
+    assert C.gate([tok('sveta'), tok('uzRIza')], gm) == ['sveta', 'uzRIza']
+    # single token -> rejected (nothing decomposed)
+    assert C.gate([tok('sveta')], gm) is None
+    # a member not glossable -> rejected (the junk-split guard)
+    assert C.gate([tok('sveta'), tok('xyz')], gm) is None
+    # a member with no lemma (None) -> rejected
+    assert C.gate([tok('sveta'), tok(None)], gm) is None
+    # three glossable members -> accepted
+    assert C.gate([tok('sat'), tok('AcAra'), tok('sveta')], gm) == ['sat', 'AcAra', 'sveta']
+    # empty -> rejected
+    assert C.gate([], gm) is None


### PR DESCRIPTION
Wave 3 of the Sa→Ru gloss-layer uplift (handoff [H1349](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1349-Opus_RussianTranslation_saru-gloss-quality-uplift_19.07.26.md)) — a coverage spike with a **measured NO-GO** outcome.

## Question

Can `vidyut.cheda` compound segmentation (D7 — reuse, don't build) recover the **78,842 forms** no dictionary tier resolved, without regressing the wave-2 measured 85% precision?

## Method

`src/build_compound_split.py` wraps the offline Chedaka with a **strict precision gate** (≥2 tokens AND every member lemma already glossable — the highest-precision gate a spike found). It recovers **28,673 forms (36.4% of unresolved / 55,008 tokens)**. A 2-judge panel (Opus 4.8 + Sonnet 5) then scored 40 gated recoveries.

## Result — NO-GO

| axis | both correct | either wrong |
|---|--:|--:|
| segmentation | 28% | 72% |
| gloss | 18% | 60% (40% acceptable) |

Against the wave-2 baseline (**85.3%** gloss), gated cheda recovery is a catastrophic regression — roughly **half** the recoveries are outright wrong. **Root cause:** vidyut-cheda is a *running-text* segmenter; on isolated OOV forms it shatters inflected/dual/plural words into a stem + a spurious *glossable* particle (`sahadevaśca`→`sahadeva`+`ca`, head "и"), so the strict gate can't filter it.

## Decision

**Not wired into the rollup.** The measured 85% layer stays unregressed; the 78,842 forms remain an honest coverage gap rather than a low-precision patch. **Recommended path (backlog):** the DharmaMitra **neural** segmenter over the aligned *verse text* — kosha's own [`compare_sandhi_methods.py`](https://github.com/gasyoun/kosha/blob/main/scripts/compare_sandhi_methods.py) already benchmarked it as near-perfect and far above vidyut-cheda.

Finding: [`gold/saru_gloss_wave3_cheda_coverage.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/gold/saru_gloss_wave3_cheda_coverage.md); panel evidence committed under `gold/`; gate regression test `tests/test_saru_gloss_wave3.py` wired into CI. Numbers in [RESULTS_LOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md). Only wave 4 (pwg_ru/mw_ru TM wiring) remains of H1349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
