### PR TITLE
ci(epistemic): integrity gate on every PR + push to master (H1362 follow-up) — v1.44.0

### DIFF
--- a/.github/workflows/epistemic-integrity.yml
+++ b/.github/workflows/epistemic-integrity.yml
@@ -1,0 +1,79 @@
+# Epistemic-integrity gate — runs on every PR touching the registries/dashboards AND on every
+# push to master. Before H1362 the check (tools/epistemic_integrity_check.py) ran ONLY from the
+# monthly findings-dashboard workflow + the local pre-commit hook, so two PRs that each passed in
+# isolation could both merge and leave duplicate §-numbers on master (the H1350×H1361 §448–451
+# collision, Uprava FINDINGS / REGISTRY_CITATION_IDENTITY_RULING §6). The pull_request run catches
+# most collisions pre-merge; the push:master run is the backstop that catches a slip-through the
+# moment it lands — and opens a tracking issue so a red master is loud, not discovered days later.
+name: epistemic-integrity
+
+on:
+  pull_request:
+    paths: &paths
+      - "FINDINGS.md"
+      - "STALENESS.md"
+      - "RECIPES.md"
+      - "ASSUMPTIONS.md"
+      - "CONTRADICTIONS.md"
+      - "GAPS.md"
+      - "DEAD_ENDS.md"
+      - "GLOSSARY.md"
+      - "epistemic_dashboard/**"
+      - "findings_dashboard/**"
+      - "tools/epistemic_integrity_check.py"
+      - ".github/workflows/epistemic-integrity.yml"
+  push:
+    branches: [master]
+    paths: *paths
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: epistemic-integrity-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Structural integrity check (duplicate §-numbers · heading↔Index parity · next-free marker)
+        # --structural-only is the collision-relevant half and needs no dashboard rebuild, so it is
+        # cheap enough to gate every PR. The full file↔dashboard parity check stays in the monthly
+        # findings-dashboard workflow (it needs the builders to run first).
+        run: python tools/epistemic_integrity_check.py --dir . --structural-only
+
+      - name: Open/refresh a tracking issue when master is red
+        if: failure() && github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "⚠️ Epistemic integrity gate RED on master";
+            const marker = "<!-- epistemic-integrity-gate -->";
+            const sha = context.sha.slice(0, 8);
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `${marker}\nThe structural epistemic-integrity check failed on \`master\` at commit ${sha}.\n\n` +
+              `Most likely a concurrent-merge §-number collision (two PRs green in isolation, colliding once both land — the H1350×H1361 pattern).\n\n` +
+              `- Failing run: ${run}\n- Reproduce locally: \`python tools/epistemic_integrity_check.py --dir .\`\n\n` +
+              `Fix per [REGISTRY_CITATION_IDENTITY_RULING.md](../blob/master/epistemic_dashboard/REGISTRY_CITATION_IDENTITY_RULING.md) rule 4 (later/non-cited claim moves, with a tombstone), then close this issue.`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo, state: "open", per_page: 100,
+            });
+            const hit = existing.data.find(i => i.body && i.body.includes(marker));
+            if (hit) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: hit.number,
+                body: `Still red on \`master\` at ${sha} — ${run}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo, title, body,
+              });
+            }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.43.0
+version: 1.44.0
 date-released: "2026-07-20"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,11 @@ not an error.
 
 ## [Unreleased]
 
+## [1.44.0] — 20-07-2026
+
+### Added
+- **H1362 follow-up: epistemic-integrity gate now runs on every PR + push to master (Opus 4.8 `claude-opus-4-8`).** New [`.github/workflows/epistemic-integrity.yml`](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/workflows/epistemic-integrity.yml) runs `tools/epistemic_integrity_check.py --structural-only` on any PR touching the registries/dashboards **and** on every push to `master`, opening a tracking issue if `master` ever goes red. Before this the check ran only from the monthly `findings-dashboard` workflow + the local pre-commit hook — which is exactly why the concurrent H1350×H1361 §448–451 collision could merge through two isolated-green PRs and sit red on `master` until noticed. Closes the residual follow-up from the [citation-identity ruling](https://github.com/gasyoun/SanskritLexicography/blob/master/epistemic_dashboard/REGISTRY_CITATION_IDENTITY_RULING.md) §6.
+
 ## [1.43.0] — 20-07-2026
 
 ### Added


### PR DESCRIPTION
Closes the residual follow-up from [REGISTRY_CITATION_IDENTITY_RULING.md](https://github.com/gasyoun/SanskritLexicography/blob/master/epistemic_dashboard/REGISTRY_CITATION_IDENTITY_RULING.md) §6.

The epistemic-integrity check ran **only** from the monthly `findings-dashboard` workflow + the local pre-commit hook — so two PRs green in isolation could both merge and leave duplicate §-numbers on `master` (the H1350×H1361 §448–451 collision that left the gate red until I found it via `/next-task`). New [`.github/workflows/epistemic-integrity.yml`](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/workflows/epistemic-integrity.yml):

- runs `epistemic_integrity_check.py --structural-only` on any **PR** touching the registries/dashboards (catches most collisions pre-merge)
- runs it on every **push to master** (the backstop) and **opens a tracking issue** if master goes red, so a slip-through is loud within a minute — not discovered days later

This PR itself exercises the new PR gate. Bundled release **v1.44.0** (changelog + CITATION.cff).

**Remaining human/admin step** (can't be set from committed files): make `epistemic-integrity` a **required** status check + enable *require branches up-to-date before merge* in branch protection, so the second-to-merge PR must re-run against updated master. Model: Opus 4.8 (`claude-opus-4-8`), H1362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)