### PR TITLE
fix(pwg_ru): port H1152 target-field markup-fidelity guard to every promotable lane (C1, H1412)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2432,6 +2432,19 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H1412 — C1 fix: target-field markup-fidelity guard ported to every promotable lane, 21-07-2026 (Opus 4.8 `claude-opus-4-8`).**
+  From the adversarial pipeline bug-hunt (9 finder groups + per-finding verification): the
+  `<ls>`/`{#..#}` fidelity guard only checked the `german` source-echo on every lane except the JS
+  batch `accept()` (H1152), so a translation-only span drop (german faithful, ru/en short — the
+  live H1070 r102 pattern) was promotable on the heal/presplit stitch, the headless
+  `normalize_batch` (production route) + its selfheal stitch, and both autosplit writers
+  (`cmd_merge` + `stitch_topup`). Added a target-field (`countOfField`/`count_card_field`/
+  `_span_count`) count to all four, rejecting → requeue on drift (also closes C5's `<ls>`-only /
+  non-blocking autosplit gap). Tests: 5 new selftests (window_selftest ×3, headless ×2);
+  window_selftest 160/160, headless PASS, LANG_PARITY 70/70 clean (new SHARED entry
+  `target_field_markup_fidelity_parity_c1`). Delivered by PR; the other 8 confirmed bug-hunt
+  findings (C2–C9) remain open for separate follow-up.
+
 - **H1403 — speed & orchestration audit persisted, 20-07-2026 (Fable 5 `claude-fable-5`, 22-agent ultracode workflow).**
   [`PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md):
   9-row bottleneck ledger + 8 recommendations adversarially verified (0 confirmed / 6 weakened /

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,26 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — target-field markup-fidelity guard ported to every promotable lane (C1 / H1412)
+
+- The `<ls>`/`{#..#}` markup-count fidelity guard now runs over the actual **target-language
+  field** (`russian`/`english`), not only the `german` source-echo, on **every** lane that can
+  promote a card. Previously only the JS batch `accept()` lane carried this check (H1152); the
+  heal/presplit stitch, the headless `normalize_batch` (now the production route) and its
+  selfheal stitch, and both autosplit stitch writers (`cmd_merge` + `stitch_topup`) counted
+  only `german` — so a translation faithful in the German echo but missing a Sanskrit/citation
+  span in the Russian/English column (the live H1070 r102 pattern: german 33/33, english 32/33)
+  was stitched and promoted with the span silently dropped. All off-batch lanes now reject →
+  requeue on a target-field span mismatch. Found by the Opus 4.8 (`claude-opus-4-8`) adversarial
+  bug-hunt review; the autosplit change also closes the `<ls>`-only / non-blocking gap (C5).
+  Selftests: `window_selftest` (`test_heal_lane_target_field_fidelity_wired`,
+  `test_autosplit_stitch_topup_rejects_target_field_drop`,
+  `test_autosplit_merge_rejects_target_field_drop`) and `headless_worker_selftest`
+  (`test_normalize_batch_translation_fidelity_reject`,
+  `test_headless_heal_stitch_translation_fidelity_reject`); classified SHARED in
+  [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md)
+  (`target_field_markup_fidelity_parity_c1`).
+
 ### Added — speed & orchestration audit: bottleneck ledger + verified action map (H1403)
 
 - [`PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md)

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -98,7 +98,30 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
+    }
+  },
+  {
+    "id": "target_field_markup_fidelity_parity_c1",
+    "mechanism": "The <ls>/{#..#} markup-count fidelity guard runs over the actual TARGET-language field (russian/english), not only the german source-echo, on EVERY promotable lane: JS batch accept() (pre-existing, H1152), JS selfHeal/presplit stitch, headless normalize_batch, headless selfheal stitch, and both autosplit stitch writers (cmd_merge + stitch_topup). A span kept in german but dropped from the translation column is rejected/requeued instead of silently promoted.",
+    "files": [
+      "src/pilot/gen_opt_harness2.py",
+      "src/pilot/headless_worker.py",
+      "src/pilot/autosplit_requeue.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "C1 (bug-hunt review, Opus 4.8 claude-opus-4-8, 21-07-2026). The check keys off TARGET_FIELD (JS) / manifest['field'] (Python) = the per-language field, so it applies identically to ru and en with no language branching. Ported to every off-batch lane the batch accept() H1152 guard never reached: JS heal (stitched-translation-fidelity-reject), headless normalize_batch + selfheal stitch (translation-fidelity-reject / stitched-translation-fidelity-reject), autosplit cmd_merge + stitch_topup (complete-stitch fidelity drift -> reject). Tests: window_selftest test_heal_lane_target_field_fidelity_wired / test_autosplit_stitch_topup_rejects_target_field_drop / test_autosplit_merge_rejects_target_field_drop; headless_worker_selftest test_normalize_batch_translation_fidelity_reject / test_headless_heal_stitch_translation_fidelity_reject.",
+    "tracking": "H1412",
+    "verified_sha256": {
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
+      "src/pilot/autosplit_requeue.py": "382e52293cea55a0c6b6ebe0adb88639ec4ce8dc08255d11af312e24144bb6c9",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -115,7 +138,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
     }
   },
   {
@@ -133,8 +156,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -152,8 +175,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -171,8 +194,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -189,7 +212,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
     }
   },
   {
@@ -206,7 +229,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
     }
   },
   {
@@ -240,7 +263,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
     }
   },
   {
@@ -257,7 +280,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
     }
   },
   {
@@ -274,7 +297,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 closes the former divergence: exact model provenance is required across four accounts, so both RU and EN now request and stamp claude-sonnet-5. This prevents account/profile alias resolution from making cross-window provenance incomparable.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
     }
   },
   {
@@ -371,8 +394,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -391,7 +414,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -428,8 +451,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -466,7 +489,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9"
     }
   },
@@ -486,9 +509,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -518,8 +541,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/release_readiness.py": "db38a870bbc8b5dbe694e706e4a7b9089ba41211a3881ad9a1bd4eb02950c8a9",
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
-      "src/pilot/autosplit_requeue.py": "7ada6e0aa8dc8d0be15cf4be725e380929282974cc19fc950690c07b09511448",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/autosplit_requeue.py": "382e52293cea55a0c6b6ebe0adb88639ec4ce8dc08255d11af312e24144bb6c9",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -538,7 +561,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -556,7 +579,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -575,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -632,7 +655,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dbbf4e77b39585dabdd3df122143cacc15fedb97ce6c3d12654061e8fe6c11b9",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
       "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -657,7 +680,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -686,7 +709,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -706,7 +729,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -725,7 +748,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "1b54827cee5d653c5bd42c9c90a22051e5cb93bbdae958cd919354bc54aefa9d",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -762,7 +785,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -820,7 +843,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -838,8 +861,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -857,8 +880,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -877,8 +900,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523",
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -899,8 +922,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -957,9 +980,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -986,11 +1009,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 Windows readiness uses one language-parameterized manifest and worker contract. Whole-card retries, binary split, fragment TM/restore/fidelity, per-card budgets, timeout-no-bisect, partial stitching, audit-clean subset promotion, staged dispatch, and credential-safe event/census telemetry do not branch on RU/EN. Production policy selects RU no_pwg for the first 100-headword proof; the mechanism preserves EN field/schema behavior.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/headless_worker.py": "4e6fc8ab4bdb7fb32e66def36270635ff51f476905d4ca37827115fad3ca66d3",
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
       "src/pilot/max_account_orchestrator.py": "83173d202fc366b958ce51046bad184476fa3b1b0fd5f93a48791a0a78255a8a",
       "src/pilot/coordinator.py": "1b54827cee5d653c5bd42c9c90a22051e5cb93bbdae958cd919354bc54aefa9d",
-      "src/pilot/headless_worker_selftest.py": "8adf980678db843100938045f4057c10d5fb7dc6c2cfe17f936028533e15654c",
+      "src/pilot/headless_worker_selftest.py": "e6dbff6e754dc05fd77fc91a8f182671fb063420563f1454c0eba729a0caf1de",
       "src/pilot/max_account_orchestrator_selftest.py": "2eddccb237f0159456b5cab65b3282d7e81b8f4f00f7206c9926ee9430e60f6c",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
@@ -1016,10 +1039,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H390 Phase 1 (12-07-2026, Opus 4.8 claude-opus-4-8), extended by H818. gen_model is written into language-agnostic run meta and flows through the shared ledger writer and harvester identically for RU/EN; both paths now stamp exact claude-sonnet-5. Pinned by test_ledger_stamps_gen_model in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -1037,8 +1060,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H823, fixes the H255 presplit-cohort loss). Both the citation presplit trigger (_presplit_hit) and the single-card kill budget (killBudgetForCur) are language-independent — they key on <ls>/fragment counts and FRAGS, never on --lang; the same floor + CEIL apply to RU and EN identically. Extends no_fallback_single_kill_budget_and_nominal_key_echo (H220) from no-fallback singles to all singles. Pinned by test_presplit_cite_floor_and_single_ceil.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -1063,7 +1086,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
       "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -1083,9 +1106,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H960 (15-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes H920's explicitly-deferred accept()-side sense-count consumption. Language-neutral: accept() counts SENSE OBJECTS (records[].senses[]), never a gloss language, and source_senses is sense_count.count_source_senses over the German source markers (identical for the RU and EN lanes — the source is German for both). SOFT by default (SANLOSS_HARD_REJECT=false): a shortfall is telemetry only (no reject/requeue), so live traffic can measure the true drop-vs-false-flag rate before the reject is armed (owner-gated ladder). The shared counter is hardened against the ~4.78%-of-cards cross-reference over-count the naive count carried (gam~~h2_31_pari 2->1, s_ud~~h0_05_pra 4->2, _a_srayatva 2->0); under-counting is the safe direction, never a false shortfall. Pinned by test_h960_accept_sanloss_soft_gate (builds the real harness, extracts the emitted accept()+countOf, asserts soft-keep / surplus-ok / FP-regression / ls-sk-first / armed-hard-reject via accept_sensecount_test.js) plus the 3 cross-reference fixtures in sense_count._selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1105,7 +1128,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -1123,7 +1146,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1152 guard 2 (17-07-2026, Sonnet 4.6 claude-sonnet-4-6), closing H1070's r102 finding (PWG->EN FU1 pilot, vac~~h0_00_pwg00: a {#uc#} span inside a <F> footnote survived the german echo 33/33 but was dropped from english 32/33 -- invisible to the pre-existing check because it never reads the translation field). accept() is lang-parameterized code shared by both lanes (field = 'russian' or 'english', same code path); the new check is symmetric and applies identically to RU and EN generation. Verified against the live RU regression suite: window_selftest.py full run stays green (137/137 baseline, +2 new content-check tests for guards 1/3), and the new/updated fixtures in accept_sensecount_test.js reproduce the exact r102 shape (RED before this change -- proven via git-stash against the pre-fix accept(), the fixture is silently ACCEPTED -- GREEN after). No RU store data touched; this only changes the generation-time accept-path gate for FUTURE generation, never re-validates the 11,605 already-promoted RU rows.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1160,7 +1183,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864"
     }
   },
   {
@@ -1248,7 +1271,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1226: the {Tn} pairing is stamped in the SHARED accept() (runs for both languages) and BOTH promote lanes (promote_final_cards.py RU, promote_en.py EN) carry it to provenance.tnmask, so neither store silently drops the field accept() stamps. Only accept() stamps it: the heal path's acceptFrag hard-rejects fragment {Tn} mismatches, so no un-rejected expansion reaches a healed card. Makes the TNMASK false-flag rate MEASURABLE (H1150 DO_NOT_ARM, denominator 1); TNMASK_HARD_REJECT stays = false — arming is a human @DECIDE. Pinned by window_selftest.test_tnmask_persist_and_offline_detect + tnmask_offline.selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
       "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf",
       "src/pilot/tnmask_offline.py": "c857fe425fadbe18c1cdf398892f53b590709048ca66faf94fd05e046730ffea"
@@ -1273,7 +1296,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523",
+      "src/pilot/window_selftest.py": "ce1e9381c8f120db26a3f6c4b4d4b29c300eb736d05242eb656353695e3f4864",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1299,8 +1322,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/card_fields.py": "976c5aa943a35da1691e2ce72e9cb4a14ac53d3bae37f8c68345cc68cb233e2b",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
       "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee",
-      "src/pilot/headless_worker.py": "4e6fc8ab4bdb7fb32e66def36270635ff51f476905d4ca37827115fad3ca66d3",
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757"
+      "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
     }
   },
   {
@@ -1376,8 +1399,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/headless_worker.py": "4e6fc8ab4bdb7fb32e66def36270635ff51f476905d4ca37827115fad3ca66d3"
+      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7"
     }
   },
   {

--- a/RussianTranslation/src/pilot/autosplit_requeue.py
+++ b/RussianTranslation/src/pilot/autosplit_requeue.py
@@ -331,7 +331,10 @@ def topup_fragments(wf_file, lang):
                     owners_by_tag.setdefault(sense.get('tag'), owner)
         cards.append({'orig': orig, 'iast': card.get('iast'), 'notes': card.get('notes', ''),
                       'owners_by_tag': owners_by_tag, 'default_owner': default_owner,
-                      'plan': planrows, 'resolved': resolved, 'missing': missing})
+                      'plan': planrows, 'resolved': resolved, 'missing': missing,
+                      # H1152 parity (C1): source span counts so stitch_topup can reject a
+                      # complete card whose reassembled german OR target field dropped a span.
+                      'src_ls': raw.count('<ls'), 'src_sk': raw.count('{#')})
     return cards
 
 
@@ -359,6 +362,14 @@ def _stitch_tree(tree, field):
         merged.update({kk: vv for kk, vv in extra.items() if vv is not None})
         senses.append(merged)
     return senses, missing_si
+
+
+def _span_count(senses, needle, field):
+    """Count `needle` ('<ls' or '{#') across `field` ('german' or the target field) of a
+    stitched sense list. H1152 parity (C1/C5): the stitch lanes must check BOTH markers on
+    BOTH the german echo AND the translation field, or a translation-only span drop (german
+    faithful, russian/english short) reaches the store the way it can't on the batch lane."""
+    return sum((s.get(field) or '').count(needle) for s in senses)
 
 
 def _stitch_owned_senses(senses, owners):
@@ -424,6 +435,23 @@ def stitch_topup(manifest_cards, got, field):
             continue
         if missing_si:
             still_missing[orig] = missing_fk
+        # H1152 parity (C1): a COMPLETE topup stitch must reproduce the source span counts in BOTH
+        # the german echo AND the target field, or a translation-only span drop is promoted
+        # silently. src_ls/src_sk are stamped by topup_fragments; absent (e.g. a direct unit-test
+        # manifest) => skip, preserving backward compatibility.
+        src_ls, src_sk = c.get('src_ls'), c.get('src_sk')
+        if not missing_si and src_ls is not None and src_sk is not None and (
+                _span_count(senses, '<ls', 'german') != src_ls
+                or _span_count(senses, '{#', 'german') != src_sk
+                or _span_count(senses, '<ls', field) != src_ls
+                or _span_count(senses, '{#', field) != src_sk):
+            still_missing[orig] = missing_fk
+            results.append({'key': orig, 'card': None,
+                            'error': 'topup-merge: complete-stitch fidelity drift '
+                                     '(<ls>/{#..#} span dropped from german or %s)' % field,
+                            'partial': True, 'missing_senses': total_senses,
+                            'total_senses': total_senses})
+            continue
         results.append({'key': orig,
                         'card': {'key1': orig, 'iast': c.get('iast'),
                                  'notes': c.get('notes', ''),
@@ -632,19 +660,34 @@ def cmd_merge(root, lang, task_file):
         if missing_si:
             partial.append(orig)
             missing_frags[orig] = [fk for si in missing_si for fk in senses_map[si].values()]
-        # post-stitch fidelity: reassembled counts vs the source card. Only meaningful on a
-        # COMPLETE card — a partial merge legitimately has fewer <ls> than the source.
+        # post-stitch fidelity vs the source card. Only meaningful on a COMPLETE card — a partial
+        # merge legitimately has fewer spans than the source. H1152 parity (C1/C5): count BOTH
+        # markers (<ls and {#) on BOTH the german echo AND the target field, and REJECT on drift
+        # (was <ls>-only / german-only / non-blocking, so a dropped {#..#} span or a
+        # translation-column drop was promoted with a `fidelity_drift` flag nobody enforced).
         src = read_text(input_paths(orig)[0])
-        got_ls = sum(s['german'].count('<ls') for s in senses)
-        drift = (not missing_si) and got_ls != src.count('<ls')
-        if drift:
-            print('  ! %s fidelity drift: <ls> %d vs source %d' % (orig, got_ls, src.count('<ls')))
+        if not missing_si:
+            src_ls, src_sk = src.count('<ls'), src.count('{#')
+            if (_span_count(senses, '<ls', 'german') != src_ls
+                    or _span_count(senses, '{#', 'german') != src_sk
+                    or _span_count(senses, '<ls', field) != src_ls
+                    or _span_count(senses, '{#', field) != src_sk):
+                print('  ! %s fidelity-reject (complete stitch drift): german <ls>=%d {#=%d, '
+                      '%s <ls>=%d {#=%d vs source <ls>=%d {#=%d'
+                      % (orig, _span_count(senses, '<ls', 'german'),
+                         _span_count(senses, '{#', 'german'), field,
+                         _span_count(senses, '<ls', field), _span_count(senses, '{#', field),
+                         src_ls, src_sk))
+                skipped.append(orig)
+                missing_frags[orig] = [fk for si in senses_map for fk in senses_map[si].values()]
+                results.append({'key': orig, 'card': None,
+                                'error': 'autosplit-merge: complete-stitch fidelity drift '
+                                         '(<ls>/{#..#} span dropped from german or %s)' % field})
+                continue
         row = {'key': orig, 'card': {'key1': orig, 'iast': iast, 'notes': '',
                                      'records': _stitch_owned_senses(senses, owners)},
                'partial': bool(missing_si),
                'missing_senses': len(missing_si), 'total_senses': len(senses_map)}
-        if drift:
-            row['fidelity_drift'] = True       # kept, not dropped — but marked so audits can see it
         results.append(row)
     tag = 'en' if lang == 'en' else 'sc'
     out = os.path.join(REPO, 'wf_output.%s.%s.autosplit.json' % (tag, root))

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -2024,6 +2024,17 @@ async function selfHeal(k) {
       noteFail(k, 'stitched-fidelity-reject: complete heal, but restored <ls>/{# counts drift from source')
       return null
     }
+    // H1152 parity (C1): the counts above run over `german` only (countOf hard-codes s.german),
+    // proving the SOURCE echo is faithful — NOT that the translation preserved its spans. The
+    // batch accept() lane closed this with a target-field count (translation-fidelity-reject);
+    // the heal/presplit lane never did, so a {#..#}/<ls> span kept in `german` but dropped from
+    // russian/english (the live H1070 r102 pattern: german 33/33, english 32/33) was stitched and
+    // promoted with a Sanskrit/citation span silently missing from the translation column. The
+    // presplit lane routes exactly the citation/sense-dense giants most prone to this drop.
+    if (countOfField(stitched, TARGET_FIELD, /<ls\\b/g) !== INPUTS[k].ls || countOfField(stitched, TARGET_FIELD, /\\{#/g) !== INPUTS[k].sk) {
+      noteFail(k, 'stitched-translation-fidelity-reject: complete heal, but target-field <ls>/{# counts drift from source')
+      return null
+    }
   } else {
     stitched.partial = true
     stitched.missing_fragments = missingFragments

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -240,6 +240,21 @@ def count_card(card, needle):
                for sense in record.get('senses') or [])
 
 
+def count_card_field(card, field, needle):
+    """Count `needle` across the card's per-sense TARGET-language field (russian/english).
+
+    H1152 parity (C1): count_card above proves only that the `german` SOURCE echo is faithful.
+    A {#..#}/<ls> span can be dropped from the translation field alone (german 33/33, english
+    32/33 -- the live H1070 r102 pattern) with zero effect on the german count, so a
+    translation-only span drop reached the store on this lane. The JS batch accept() closed
+    this with countOfField(TARGET_FIELD); the headless normalize_batch (now the production
+    route) never did. Same source-occurrence denominator (inp['ls']/inp['sk']) as count_card.
+    """
+    return sum((sense.get(field) or '').count(needle)
+               for record in card.get('records') or []
+               for sense in record.get('senses') or [])
+
+
 def normalize_batch(manifest, keys, structured):
     by_key = {}
     for card in structured['cards']:
@@ -265,8 +280,15 @@ def normalize_batch(manifest, keys, structured):
             card = restore_card(card, manifest['field'],
                                 manifest['placeholder_maps'].get(key, []), unmapped)
             inp = manifest['inputs'][key]
+            field = manifest['field']
             if count_card(card, '<ls') != inp['ls'] or count_card(card, '{#') != inp['sk']:
                 error = 'fidelity-reject'
+                card = None
+            elif (count_card_field(card, field, '<ls') != inp['ls']
+                  or count_card_field(card, field, '{#') != inp['sk']):
+                # H1152 parity (C1): german echo is faithful, but the translation dropped a
+                # span -- requeue instead of promoting a lossy card.
+                error = 'translation-fidelity-reject'
                 card = None
             elif unmapped:
                 # C-42: an out-of-range {Tn} maps nothing and cannot be recovered downstream.
@@ -636,6 +658,15 @@ class HeadlessEngine:
             if ls_count != inp['ls'] or sk_count != inp['sk']:
                 self.note(key, 'stitched-fidelity-reject: <ls> %d/%d, {# %d/%d' %
                           (ls_count, inp['ls'], sk_count, inp['sk']))
+                return None
+            # H1152 parity (C1): the german counts above are the SOURCE echo. Run the same count
+            # over the TARGET field so a translation-only span drop on the headless heal lane is
+            # rejected instead of stitched and promoted (twin of the JS selfHeal check).
+            field = self.m['field']
+            ls_t, sk_t = count_card_field(card, field, '<ls'), count_card_field(card, field, '{#')
+            if ls_t != inp['ls'] or sk_t != inp['sk']:
+                self.note(key, 'stitched-translation-fidelity-reject: %s <ls> %d/%d, {# %d/%d' %
+                          (field, ls_t, inp['ls'], sk_t, inp['sk']))
                 return None
         # C-42: a {Tn} whose index maps nothing used to be written through verbatim on a card
         # that reported success -- that is how `ban_d~~h0_11_ni` and `ban_d~~h0_21_upasam_0`

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -253,6 +253,45 @@ def test_null_owner_fragment_tm_refused_before_any_call():
           'any call (runner uncalled)')
 
 
+def test_normalize_batch_translation_fidelity_reject():
+    """H1152 parity (C1): normalize_batch must reject a card whose `german` echo is faithful but
+    whose TARGET field dropped an <ls>/{#..#} span. Was german-only (count_card), so a
+    translation-column span drop reached the store on the headless production route (the
+    live H1070 r102 pattern: german 33/33, english 32/33). A faithful card still passes."""
+    m = manifest()   # inputs.agni ls=1 sk=0; placeholder_maps.agni=['<ls>RV.</ls>']; field=russian
+    faithful = {'key1': 'agni', 'records': [{'grammar': '', 'senses': [
+        {'tag': '1', 'german': '{T1} Feuer', 'russian': '{T1} огонь'}]}]}
+    dropped = {'key1': 'agni', 'records': [{'grammar': '', 'senses': [
+        {'tag': '1', 'german': '{T1} Feuer', 'russian': 'огонь'}]}]}   # <ls> kept in de, dropped in ru
+    ok = h.normalize_batch(m, ['agni'], {'cards': [faithful]})
+    assert ok[0].get('error') is None and ok[0]['card'], ok
+    bad = h.normalize_batch(m, ['agni'], {'cards': [dropped]})
+    assert bad[0].get('error') == 'translation-fidelity-reject' and bad[0]['card'] is None, bad
+    print('  C1 normalize_batch: german-faithful but target-dropped card -> translation-fidelity-reject')
+
+
+def test_headless_heal_stitch_translation_fidelity_reject():
+    """H1152 parity (C1): the headless selfheal stitch (twin of the JS selfHeal check) must reject
+    a COMPLETE stitched card whose german echo is faithful but whose TARGET field dropped a span.
+    Driven via a warm frag-TM slot (already-restored senses), so no model call is made."""
+    m = manifest()
+    key = 'agni'
+    sense = {'tag': '1', 'german': '<ls>RV.</ls> Feuer', 'russian': 'огонь'}   # de has <ls>, ru drops it
+    m['fragment_groups'] = {key: [[{'skeleton': '<ls>RV.</ls> Feuer', 'fsha': 'FSHA0', 'si': 0}]]}
+    m['fragment_placeholder_maps'] = {key: [[[]]]}
+    m['fragment_tm'] = {key: [[{'senses': [sense], 'owners': [['2. agni', 'm.']]}]]}
+    m['inputs'] = {key: {'skeleton': '<ls>RV.</ls> Feuer', 'portrait': '{}', 'ls': 1, 'sk': 0, 'nws': 0}}
+    m['batches'] = []
+    m['presplit_keys'] = [key]
+
+    def never_runner(argv, **kwargs):
+        raise AssertionError('a fully-cached fragment must NOT call the model')
+
+    payload, _status, _code = execute(m, never_runner)
+    assert payload['results'][0]['card'] is None, payload['results'][0]
+    print('  C1 headless heal: german-faithful, target-dropped complete stitch -> rejected (card None)')
+
+
 def main():
     payload, status, code = execute(manifest(), success_runner)
     assert code == 0 and status['classification'] == 'success'
@@ -483,6 +522,8 @@ console.log(JSON.stringify(restoreCard(card, 'agni')))
     test_foreign_route_refused_before_any_call()
     test_frag_tm_stitch_retains_owner()
     test_null_owner_fragment_tm_refused_before_any_call()
+    test_normalize_batch_translation_fidelity_reject()
+    test_headless_heal_stitch_translation_fidelity_reject()
     print('headless_worker_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -6580,6 +6580,107 @@ def test_h1283_a6_prep_slice_flattens_batches():
     print('  A6: prep_slice flattens every batch key')
 
 
+def test_heal_lane_target_field_fidelity_wired():
+    """H1152 parity (C1): the JS selfHeal COMPLETE-heal branch must run the <ls>/{#..#} count over
+    the TARGET field, not just `german`. The batch accept() lane already did (translation-fidelity-
+    reject); the heal/presplit lane — which routes exactly the citation/sense-dense giants — never
+    did, so a span kept in `german` but dropped from russian/english was stitched and promoted with
+    a silently-missing Sanskrit/citation span (the live H1070 r102 pattern). Static wiring guard on
+    the generated harness for BOTH languages (window_selftest has no JS runtime for the heal path)."""
+    import gen_opt_harness2 as gh
+    raw = ('=== LAYER: PW — Böhtlingk kürzere Fassung ===\n\n'
+           '<hom>1.</hom> √{#gam#}¦ <ls>X. 1</ls>.\n'
+           '<div n="1">— 1〉 {%verlassen%} <ls>Y. 2</ls>.\n')
+    key = 'zz~~synthetic_healfid'
+    d = tempfile.mkdtemp()
+    saved_ip = gh.input_paths
+    try:
+        rp = os.path.join(d, key + '.raw.txt')
+        pp = os.path.join(d, key + '.portrait.json')
+        with open(rp, 'w', encoding='utf-8') as f:
+            f.write(raw)
+        with open(pp, 'w', encoding='utf-8') as f:
+            f.write('[]')
+        gh.input_paths = lambda k, input_dir=None: (rp, pp) if k == key else saved_ip(k)
+        for lang, want_field in (('ru', "const TARGET_FIELD = 'russian'"),
+                                 ('en', "const TARGET_FIELD = 'english'")):
+            js, _ = gh.build('zz', [key], None, 12000, nominal=True, grammar_on=False,
+                             tm_path=None, lang=lang)
+            if want_field not in js:
+                fail('%s heal harness did not set TARGET_FIELD' % lang)
+            if 'stitched-translation-fidelity-reject' not in js:
+                fail('%s heal lane is missing the H1152 target-field fidelity check '
+                     '(stitched-translation-fidelity-reject)' % lang)
+            if 'countOfField(stitched, TARGET_FIELD' not in js:
+                fail('%s heal lane must count <ls>/{#} over the TARGET field of the stitched '
+                     'card, not just german' % lang)
+            # the target check must FOLLOW the german stitched check (i.e. live inside the same
+            # complete-heal branch, never on a partial result).
+            if not (js.index('stitched-fidelity-reject') < js.index('stitched-translation-fidelity-reject')):
+                fail('%s target-field check must follow the german stitched check (complete-heal '
+                     'only)' % lang)
+    finally:
+        gh.input_paths = saved_ip
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_autosplit_stitch_topup_rejects_target_field_drop():
+    """H1152 parity (C1): stitch_topup must REJECT a COMPLETE card whose reassembled `german` echo is
+    faithful but whose target field dropped an <ls>/{#..#} span (source counts stamped by
+    topup_fragments). A faithful card still completes."""
+    import autosplit_requeue as ar
+
+    def card(orig, ru_text):
+        return {'orig': orig, 'iast': 'zz', 'notes': '', 'owners_by_tag': {},
+                'default_owner': ('1', 'm.'), 'src_ls': 1, 'src_sk': 0,
+                'resolved': {'F0': [{'tag': '1', 'german': '<ls>RV.</ls> Feuer',
+                                     'russian': ru_text}]},
+                'plan': [{'s': 0, 'p': 0, 'fsha': 'F0', 'fk': ar.fk_of(orig, 0, 0),
+                          'missing': False}]}
+    res, _ = ar.stitch_topup([card('zz~~drop', 'огонь')], {}, 'russian')          # target drops <ls>
+    if res[0]['card'] is not None or 'fidelity drift' not in (res[0].get('error') or ''):
+        fail('stitch_topup must reject a complete card whose target dropped a span: %r' % res[0])
+    ok, _ = ar.stitch_topup([card('zz~~keep', '<ls>RV.</ls> огонь')], {}, 'russian')  # faithful
+    if not ok[0]['card'] or ok[0].get('partial'):
+        fail('stitch_topup must keep a complete faithful card: %r' % ok[0])
+
+
+def test_autosplit_merge_rejects_target_field_drop():
+    """H1152 parity (C1/C5): cmd_merge (the primary autosplit lane) must REJECT a COMPLETE card whose
+    target field dropped an <ls>/{#..#} span — it was <ls>-only, german-only, and non-blocking (kept
+    the card, only flagged `fidelity_drift`). Behavioral test with a temp manifest/task/source."""
+    import autosplit_requeue as ar
+    orig = 'zz~~h0_00_pwgm'
+    fk = ar.fk_of(orig, 0, 0)
+    d = tempfile.mkdtemp()
+    saved = (ar.manifest_path, ar.input_paths, ar.REPO)
+    try:
+        rawp = os.path.join(d, 'src.raw.txt')
+        with open(rawp, 'w', encoding='utf-8') as f:
+            f.write('<hom>1.</hom> {%Feuer%} <ls>RV. 1,1</ls>.')          # exactly one <ls>, no {#
+        mpath = os.path.join(d, 'manifest.json')
+        with open(mpath, 'w', encoding='utf-8') as f:
+            json.dump({'frags': {fk: {'orig': orig, 's': 0, 'p': 0}}}, f)
+        taskp = os.path.join(d, 'task.json')
+        drop_card = {'key1': orig, 'iast': 'zz', 'records': [{'h': '1', 'grammar': 'm.', 'senses': [
+            {'tag': '1', 'german': '<ls>RV. 1,1</ls> Feuer', 'russian': 'огонь'}]}]}  # ru drops <ls>
+        with open(taskp, 'w', encoding='utf-8') as f:
+            json.dump({'results': [{'key': fk, 'card': drop_card}]}, f)
+        ar.manifest_path = lambda lang, root: mpath
+        ar.input_paths = lambda k, input_dir=None: (rawp, os.path.join(d, k + '.portrait.json'))
+        ar.REPO = d
+        ar.cmd_merge('zzmerge', 'ru', taskp)
+        out = json.load(open(os.path.join(d, 'wf_output.sc.zzmerge.autosplit.json'), encoding='utf-8'))
+        rows = {r['key']: r for r in out['results']}
+        if orig not in rows or rows[orig]['card'] is not None:
+            fail('cmd_merge must null a complete card whose target dropped a span: %r' % rows.get(orig))
+        if 'fidelity drift' not in (rows[orig].get('error') or ''):
+            fail('cmd_merge reject must carry the fidelity-drift error: %r' % rows[orig])
+    finally:
+        ar.manifest_path, ar.input_paths, ar.REPO = saved
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def main():
     tests = [
         test_restore_covers_every_promoted_field,
@@ -6637,6 +6738,9 @@ def main():
         test_cit_split_never_tears_open_span,
         test_cit_split_caps_single_line_monster_sense,
         test_selfheal_fragment_si_threaded_and_tags_normalized,
+        test_heal_lane_target_field_fidelity_wired,
+        test_autosplit_stitch_topup_rejects_target_field_drop,
+        test_autosplit_merge_rejects_target_field_drop,
         test_sense_dense_card_presplit,
         test_kill_gate_wired,
         test_no_fallback_single_gets_ceil_kill_budget,


### PR DESCRIPTION
## What & why

The `<ls>`/`{#..#}` markup-count fidelity guard — which proves a translated card didn't drop a Sanskrit/citation span — ran over the actual **target-language field** (`russian`/`english`) on **only one** of the pipeline's promotable lanes: the JS batch `accept()` (added by H1152). Every other lane counted only the `german` source-echo, so a translation faithful in the German column but missing a span in the Russian/English column — the live **H1070 r102** pattern (`german` 33/33, `english` 32/33) — was stitched and **promoted with the span silently dropped**.

Found by an Opus 4.8 (`claude-opus-4-8`) adversarial bug-hunt review of the pipeline (finding **C1**; the autosplit part also subsumes **C5**).

## The three off-batch lanes fixed

| Lane | File | Before | After |
|---|---|---|---|
| JS selfHeal / **presplit** stitch | [`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py) | `german`-only `countOf` | + `countOfField(stitched, TARGET_FIELD, …)` → `stitched-translation-fidelity-reject` |
| headless `normalize_batch` (**production route**) + selfheal stitch | [`headless_worker.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/headless_worker.py) | `german`-only `count_card` | + `count_card_field(card, field, …)` → `translation-fidelity-reject` |
| autosplit `cmd_merge` + `stitch_topup` | [`autosplit_requeue.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/autosplit_requeue.py) | `<ls>`-only, `german`-only, **non-blocking** (kept + flagged) | both markers, both fields, **rejects** complete-stitch drift (closes C5) |

Every fix is gated to **complete** cards only (a partial legitimately has fewer spans) and rejects → requeue, matching the batch `accept()` invariant. The check keys off the per-language field (`TARGET_FIELD` in JS, `manifest['field']` in Python), so it is language-symmetric — classified **SHARED** in [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md) (`target_field_markup_fidelity_parity_c1`).

## Tests

5 new selftests, all green:

- `window_selftest.py`: `test_heal_lane_target_field_fidelity_wired` (RU+EN static wiring), `test_autosplit_stitch_topup_rejects_target_field_drop`, `test_autosplit_merge_rejects_target_field_drop`
- `headless_worker_selftest.py`: `test_normalize_batch_translation_fidelity_reject`, `test_headless_heal_stitch_translation_fidelity_reject`

`window_selftest` **160/160**, `headless_worker_selftest` **PASS**, `lang_parity_check` **70/70 no drift**, emitted RU harness passes `node --check`.

## Scope

Fixes **C1** (+ **C5**) only. The other 7 confirmed bug-hunt findings (C2–C4, C6–C9) are tracked separately. Handoff **H1412**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
