### PR TITLE
fix(pwg_ru): dead EN card-TM (C3) + rate-limit job-stranding busy-loop (C4) (H1413)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2432,6 +2432,18 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H1413 — bug-hunt C3 + C4 fixed, 21-07-2026 (Opus 4.8 `claude-opus-4-8`).** From the adversarial
+  pipeline review (same batch as C1/H1412). **C3:** `translation_memory.py build --lang en` wrote the
+  EN sense under the store column `'en'` instead of the card field `'english'`, so `tm_card_sane`
+  refused 100% of EN card-TM hits — the EN lane silently re-translated cards it had. Fixed via one
+  `CARD_FIELD` map shared by the card + fragment lanes. **C4:** `max_account_orchestrator.py`
+  rate-limit path called `finish('pending')` without decrementing `attempts`, so after `max_attempts`
+  429s a job was `pending` but unclaimable forever (never `failed`), busy-looping `staged-run`. Fixed
+  via `requeue_rate_limited` (atomic decrement) + a no-progress poll backstop. Tests: window_selftest
+  `test_en_card_tm_serves_english_field_c3`, orchestrator selftest C4 block. window_selftest OK,
+  orchestrator PASS, tm selftest RU+EN OK, LANG_PARITY 69/69. Delivered by PR (refs issue #632).
+  Remaining bug-hunt findings: C2, C6–C9.
+
 - **H1403 — speed & orchestration audit persisted, 20-07-2026 (Fable 5 `claude-fable-5`, 22-agent ultracode workflow).**
   [`PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md):
   9-row bottleneck ledger + 8 recommendations adversarially verified (0 confirmed / 6 weakened /

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,31 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — dead EN card-TM (C3) and rate-limit job-stranding busy-loop (C4) (H1413)
+
+- **C3 — EN whole-card translation memory was 100% dead.** `translation_memory.py build --lang en`
+  wrote each sense's translation under the store **column** name (`FIELD['en']=='en'`) instead of
+  the **card** field name `'english'`, but the serve-side guard (`tm_card_sane`) and the final-card
+  schema require `'english'` — so every EN card-TM hit was silently refused (`sense missing
+  english`) and the EN lane re-translated whole cards it already had (wasted spend; RU was
+  unaffected). Fixed with a single `CARD_FIELD = {'ru': 'russian', 'en': 'english'}` used by both
+  the card builder and the fragment lane (`_FRAG_TRANSLATION_FIELD` now aliases it, so the two
+  can't drift again). Classified SHARED in
+  [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md).
+- **C4 — a rate-limited job could become permanently unclaimable and busy-loop `staged-run`.**
+  `max_account_orchestrator.py` incremented `attempts` at claim time but the 429/rate-limit path
+  called `finish(…, 'pending', …)` without giving the attempt back (unlike `release_db_claims`), so
+  after `max_attempts` rate-limits a job sat `pending` with `attempts == max_attempts` — never
+  re-selected by `claim` (`WHERE attempts < max_attempts`), never marked `failed` — permanently
+  stranded, and `cmd_staged_run` spun on the un-drainable `pending` count. Fixed by treating a 429
+  as a non-defective attempt (`requeue_rate_limited` decrements `attempts` atomically), plus a
+  no-progress poll backstop so any residual unclaimable-but-pending state polls instead of
+  hot-spinning.
+- Found by the Opus 4.8 (`claude-opus-4-8`) adversarial bug-hunt review (findings C3/C4 of
+  [issue #632](https://github.com/gasyoun/SanskritLexicography/issues/632)). Selftests:
+  `window_selftest` (`test_en_card_tm_serves_english_field_c3`) and
+  `max_account_orchestrator_selftest` (C4 rate-limit block).
+
 ### Added — speed & orchestration audit: bottleneck ledger + verified action map (H1403)
 
 - [`PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md)

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -98,7 +98,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -134,7 +134,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -153,7 +153,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -172,7 +172,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -220,10 +220,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "lang is a first-class parameter of the TM address (sha256(lang + ...)); --lang=ru|en both get full reuse.",
+    "note": "lang is a first-class parameter of the TM address (sha256(lang + ...)); --lang=ru|en both get full reuse. C3 (21-07-2026, Opus 4.8 claude-opus-4-8): the reuse was SHARED in address but NOT in the served card — the card-TM builder wrote the EN sense under the store COLUMN name FIELD['en']=='en' instead of the CARD field 'english', so the serve-side tm_card_sane refused 100% of EN card-TM hits ('sense missing english') while RU worked. Fixed by a single CARD_FIELD={'ru':'russian','en':'english'} used by both the card builder and the fragment lane (_FRAG_TRANSLATION_FIELD aliases it), so the two lanes can't drift. Test: window_selftest test_en_card_tm_serves_english_field_c3.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee"
+      "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc"
     }
   },
   {
@@ -372,7 +372,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -391,7 +391,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -429,7 +429,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -488,7 +488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -519,7 +519,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
       "src/pilot/autosplit_requeue.py": "7ada6e0aa8dc8d0be15cf4be725e380929282974cc19fc950690c07b09511448",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -537,8 +537,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H321 (code review 2026-07-04 item #3b): the fragment sidecar is content-addressed on the fragment SOURCE and was harvested append-only first-seen-wins with NO fidelity check, so a hand-edited/corrupt wf_output*.json (blanked or malformed senses) permanently poisoned reuse and a later good harvest of the same fsha could never override it. frag_senses_sane(senses, lang) keys on the CARD-shaped translation field ('russian'/'english') and is applied at BOTH harvest (never cache garbage; a cached-corrupt fsha maps to False so a good row overrides it) and serve (load_frag_tm drops any corrupt historical row). Entirely lang-agnostic — lang is a first-class parameter of frag_address/frag_senses_sane/load_frag_tm/build_frags, no RU/EN branch. Pinned by test_frag_tm_fidelity_gate_and_override. Extends translation_memory_card_and_fragment.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -556,7 +556,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -575,7 +575,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -632,7 +632,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dbbf4e77b39585dabdd3df122143cacc15fedb97ce6c3d12654061e8fe6c11b9",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
       "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -657,7 +657,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -685,8 +685,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
-      "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -706,7 +706,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -725,7 +725,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "1b54827cee5d653c5bd42c9c90a22051e5cb93bbdae958cd919354bc54aefa9d",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -762,7 +762,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -820,7 +820,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -839,7 +839,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -858,7 +858,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -878,7 +878,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523",
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -900,7 +900,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -959,7 +959,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -988,10 +988,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/headless_worker.py": "4e6fc8ab4bdb7fb32e66def36270635ff51f476905d4ca37827115fad3ca66d3",
-      "src/pilot/max_account_orchestrator.py": "83173d202fc366b958ce51046bad184476fa3b1b0fd5f93a48791a0a78255a8a",
+      "src/pilot/max_account_orchestrator.py": "12fb8c3bcdc8897e7eaff2285e6d32547b11f047b58921169a9736e37a24aa0c",
       "src/pilot/coordinator.py": "1b54827cee5d653c5bd42c9c90a22051e5cb93bbdae958cd919354bc54aefa9d",
       "src/pilot/headless_worker_selftest.py": "8adf980678db843100938045f4057c10d5fb7dc6c2cfe17f936028533e15654c",
-      "src/pilot/max_account_orchestrator_selftest.py": "2eddccb237f0159456b5cab65b3282d7e81b8f4f00f7206c9926ee9430e60f6c",
+      "src/pilot/max_account_orchestrator_selftest.py": "6021af7fa4ff0415936e439290dfa7f8196b12afa4fca0a27b8f704841ebf685",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
       "src/pilot/run_observability.py": "eb21e08ba4f0e7ab7ab5dacf9db4e4d0d38234f2d63385157735ca8d7b8ced61",
@@ -1019,7 +1019,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -1038,7 +1038,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -1063,7 +1063,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
       "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -1085,7 +1085,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523",
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1105,7 +1105,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -1160,7 +1160,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f"
     }
   },
   {
@@ -1273,7 +1273,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523",
+      "src/pilot/window_selftest.py": "2b4b36645d1eb5aea276006170c9833a5bacca86c95ba8e3a7558a6f20a7e83f",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1298,7 +1298,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/card_fields.py": "976c5aa943a35da1691e2ce72e9cb4a14ac53d3bae37f8c68345cc68cb233e2b",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee",
+      "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
       "src/pilot/headless_worker.py": "4e6fc8ab4bdb7fb32e66def36270635ff51f476905d4ca37827115fad3ca66d3",
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757"
     }
@@ -1336,7 +1336,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/store_path.py": "3a89cce449987ef448939d9e9a326c02e46ffaf4ce346f55aefe3f388cc00590",
-      "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee",
+      "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
       "src/pilot/ru_coverage.py": "bf08bc3e79a80907dfc7df4e59cead0c026e04cf9cc621359630daecc98b46c3"
     }
   },
@@ -1358,7 +1358,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/bounded_staged_run.py": "096cd639be7f864bc5fc6984c84674a50c13e81e12f6284fbce7185ab328c49c",
       "src/pilot/bounded_supervisor.py": "01610c44d5383420d29f66cb0ef81ae2612c89bff30403cce31816ed6c8f603a",
-      "src/pilot/max_account_orchestrator.py": "83173d202fc366b958ce51046bad184476fa3b1b0fd5f93a48791a0a78255a8a"
+      "src/pilot/max_account_orchestrator.py": "12fb8c3bcdc8897e7eaff2285e6d32547b11f047b58921169a9736e37a24aa0c"
     }
   },
   {
@@ -1397,7 +1397,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
-      "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee",
+      "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9"
     }
   },

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -289,6 +289,23 @@ def park(db_path, account, until, error):
     db.close()
 
 
+def requeue_rate_limited(db_path, job_id, returncode, error, reset_at, attempt_log_path=None):
+    """C4: a rate-limit (429) is an infra throttle, not a defective translation attempt. Return the
+    job to 'pending' AND give back the attempt it consumed at claim time (mirrors
+    release_db_claims' `attempts=max(attempts-1,0)`), so it stays claimable once its account
+    unparks. Without the decrement, a job rate-limited max_attempts times sits 'pending' with
+    attempts==max_attempts — never re-selected by claim (which gates on `attempts < max_attempts`),
+    never marked 'failed', permanently stranded — and cmd_staged_run busy-spins on the
+    un-drainable pending count."""
+    db = connect(db_path)
+    with db:
+        db.execute("UPDATE jobs SET state='pending', returncode=?, error=?, failure_class='rate_limit', "
+                   "attempts=max(attempts-1,0), reset_at=?, "
+                   "attempt_log_path=COALESCE(?,attempt_log_path), finished_at=? WHERE id=?",
+                   (returncode, error, reset_at, attempt_log_path, now_iso(), job_id))
+    db.close()
+
+
 def emit_call_events(events_path, item, idx, manifest_sha256, base):
     """D-I: telemetry for ONE real model call. Emit exactly one call-level 'model_call' event
     (the single latency sample + classification tally for this call, with a stable call_id and
@@ -361,9 +378,9 @@ def run_claimed(db_path, account, config_dir, job, timeout, events_path=None, ru
             reset_text = (proc.stderr or '') + '\n' + (worker_status.get('error') or '')
             until = parse_reset(reset_text)
             park(db_path, account, until, reset_text)
-            finish(db_path, job['id'], 'pending', proc.returncode,
-                   'rate-limited; account parked', 'rate_limit',
-                   attempt_log_path=attempt_log, reset_at=until)
+            requeue_rate_limited(db_path, job['id'], proc.returncode,
+                                 'rate-limited; account parked', until,
+                                 attempt_log_path=attempt_log)
             if events_path:
                 append_event(events_path, stage='dispatch', event='attempt_end',
                              classification='rate_limit', reset_at=until, **event_base)
@@ -926,6 +943,9 @@ def staged_plan_scope(plan, requested_lease_ids=None):
     }
 
 
+STAGED_RUN_IDLE_POLL_SECONDS = 3   # C4: backoff between no-progress staged-run passes (see loop)
+
+
 def cmd_staged_run(args):
     plan = json.load(open(args.plan, encoding='utf-8'))
     scope = staged_plan_scope(plan, args.lease_id)
@@ -983,6 +1003,12 @@ def cmd_staged_run(args):
     completed_before = scoped_job_count(db, lease_scope, "state='done'")
     db.close()
     started = time.monotonic()
+    # C4 backstop: forward progress = a pending job drained or a done window recorded. If a full
+    # pass changes none of (pending, done_unrecorded, completed_before) while accounts are
+    # runnable — e.g. a job that no dispatchable account can claim — the loop must poll, not
+    # hot-spin. The primary C4 fix (requeue_rate_limited decrements attempts) removes the usual
+    # source of an unclaimable-but-pending job; this only guards any residual case.
+    prev_progress_sig = None
     while True:
         db = connect(args.db)
         pending = scoped_job_count(db, lease_scope, "state='pending'")
@@ -1007,6 +1033,13 @@ def cmd_staged_run(args):
                 write_census(args.events, args.census)
                 raise SystemExit('staged-run halted: %d job(s) pending but all accounts parked '
                                  'until %s; rerun with --resume after the reset' % (pending, earliest))
+            # C4 backstop: runnable accounts exist but the previous pass drained nothing — poll
+            # instead of hot-spinning. (`prev_progress_sig` is this pass's entry state; if it
+            # equals the previous pass's entry state, that pass made no progress.)
+            progress_sig = (pending, done_unrecorded, completed_before)
+            if progress_sig == prev_progress_sig:
+                time.sleep(STAGED_RUN_IDLE_POLL_SECONDS)
+            prev_progress_sig = progress_sig
             cmd_run_once(argparse.Namespace(db=args.db, timeout=args.timeout,
                                              events=args.events, run_id=run_id,
                                              claude_bin=args.claude_bin,

--- a/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
@@ -791,6 +791,35 @@ def main():
         assert len(release_calls) == 1 and release_calls[0][1] == 'runtime1'
     print('  runtime integration: reserve batch before workers; retryable worker releases slot')
 
+    with tempfile.TemporaryDirectory() as td:
+        # C4: a rate-limit (429) must NOT consume a retry attempt. With max_attempts=1, one
+        # rate-limit under the OLD behavior left the job 'pending' with attempts==1==max_attempts
+        # — never re-selected by claim (WHERE attempts < max_attempts), never 'failed', so it was
+        # permanently stranded and cmd_staged_run busy-spun on the un-drainable pending count.
+        db = os.path.join(td, 'c4.sqlite')
+        m.main(['--db', db, 'init', '--account', 'acc=' + os.path.join(td, 'acc'),
+                '--skip-profile-check'])
+        out = os.path.join(td, 'rl.json')
+        m.main(['--db', db, 'enqueue', '--external-id', 'rl1', '--max-attempts', '1',
+                '--argv-json', json.dumps([sys.executable, '-c',
+                    'import sys;sys.stderr.write("429 rate limit reset_at=1999999999");sys.exit(21)']),
+                '--cwd', td, '--output', out])
+        m.main(['--db', db, 'run-once', '--timeout', '10'])
+        con = sqlite3.connect(db)
+        state, attempts = con.execute(
+            "select state,attempts from jobs where external_id='rl1'").fetchone()
+        con.execute("update accounts set parked_until=0")
+        con.commit()
+        con.close()
+        assert state == 'pending', 'a rate-limited job must stay pending, got %r' % state
+        assert attempts == 0, ('C4: a rate-limit must not consume an attempt (got attempts=%d) — '
+                               'at max_attempts the job would be permanently unclaimable' % attempts)
+        reclaimed = m.claim(db, 'acc', only_external_ids={'rl1'})
+        assert reclaimed is not None and reclaimed['external_id'] == 'rl1', (
+            'C4: a max_attempts=1 job rate-limited once must remain claimable, not stranded')
+    print('  C4 rate-limit: a 429 returns the job to claimable pending (attempts decremented), '
+          'never a permanently-unclaimable stuck row')
+
     print('max_account_orchestrator_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -90,6 +90,12 @@ from store_path import canonical_store, canonical_sidecar  # noqa: E402
 # failed "store not found" after a successful promotion, aborting the staged-run.
 DEFAULT_STORE = canonical_store(os.path.join(SRC, 'pwg_ru_translated.jsonl'))
 FIELD = {'ru': 'ru', 'en': 'en'}                    # store column holding the translation
+# CARD_FIELD is the per-sense field name on a CARD ('russian'/'english') — distinct from FIELD
+# (the store COLUMN, 'ru'/'en'). C3: the card-TM builder wrote the EN sense under FIELD['en']=='en'
+# instead of 'english', but the serve-side sanity guard (tm_card_sane) and the final-card schema
+# require 'english' — so EVERY EN card-TM hit was silently refused ("sense missing english") and
+# the EN lane re-translated whole cards it already had. Single source, reused below for frags.
+CARD_FIELD = {'ru': 'russian', 'en': 'english'}
 TRUST_REVIEWED = 'reviewed_exact'
 TRUST_MACHINE = 'machine_exact'
 TRUST_SUGGESTION = 'suggestion'
@@ -391,7 +397,10 @@ def reconstruct_cards(store_path, lang):
             sense = {
                 'tag': r.get('sense_tag'),
                 'german': r.get('de') or '',
-                field if lang == 'en' else 'russian': r.get(field),
+                # C3: emit the CARD field name ('russian'/'english'), reading the STORE column
+                # value (r.get(field)). Was `field if lang=='en' else 'russian'`, which put the EN
+                # translation under 'en' — a key the serve-side guard/schema never look at.
+                CARD_FIELD[lang]: r.get(field),
             }
             # B03: optional sense fields are validated WHEN PRESENT by the final-card
             # schema (a present-but-None differentia/equivalence_type is a refusal), so a
@@ -534,7 +543,9 @@ def frag_tm_path(lang, out=None):
 
 # frag_prov senses are CARD-shaped (harvested from wf_output cards), so the
 # translation lives under 'russian'/'english' — NOT the store column names in FIELD.
-_FRAG_TRANSLATION_FIELD = {'ru': 'russian', 'en': 'english'}
+# Same mapping as CARD_FIELD (single source, so the card-TM and fragment-TM lanes can't drift —
+# the C3 divergence is exactly what happens when this is hand-written a second time).
+_FRAG_TRANSLATION_FIELD = CARD_FIELD
 
 
 def frag_senses_sane(senses, lang):

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -6580,6 +6580,47 @@ def test_h1283_a6_prep_slice_flattens_batches():
     print('  A6: prep_slice flattens every batch key')
 
 
+def test_en_card_tm_serves_english_field_c3():
+    """C3: `build --lang en` must write each sense's translation under the CARD field name
+    'english' (not the store COLUMN 'en'), or the serve-side `tm_card_sane` / final-card schema
+    reject every EN card-TM hit ('sense missing english') — 100% of EN whole-card TM silently
+    dead, and the EN lane re-translates cards it already has. The RU path stays correct."""
+    import translation_memory as tm
+    import gen_opt_harness2 as gh
+    d = tempfile.mkdtemp()
+    try:
+        store = os.path.join(d, 'store.en.jsonl')
+        row = {'subcard': 'agni~~h0_00_pwg00', 'iast': 'agni', 'h': '1', 'grammar': '',
+               'sense_tag': '1', 'de': 'Feuer', 'en': 'fire',
+               'provenance': {'input_raw_sha256': 'DEADBEEF'}}
+        with open(store, 'w', encoding='utf-8') as f:
+            f.write(json.dumps(row, ensure_ascii=False) + '\n')
+        built_path, count, _skipped = tm.build(store, 'en', os.path.join(d, 'tm.en.json'))
+        if count != 1:
+            fail('C3: EN card-TM built %d entries from one valid EN store row (expected 1)' % count)
+        entry = next(iter(json.load(open(built_path, encoding='utf-8'))['entries'].values()))
+        sense = entry['card']['records'][0]['senses'][0]
+        if sense.get('english') != 'fire':
+            fail("C3: EN card-TM sense must carry 'english'='fire', got keys %r" % sorted(sense))
+        if 'en' in sense:
+            fail("C3: EN card-TM sense must NOT carry the store-column key 'en': %r" % sense)
+        # the serve-side guard the harness runs on every hit must ACCEPT it (was: refuse it)
+        ok, why = gh.tm_card_sane(entry['card'], 'en', 'english', 'Feuer')
+        if not ok:
+            fail('C3: a valid EN card-TM hit must pass tm_card_sane, got refusal: %s' % why)
+        # RU parity control: the RU path must still key 'russian'
+        rstore = os.path.join(d, 'store.ru.jsonl')
+        rrow = dict(row, ru='огонь'); rrow.pop('en')
+        with open(rstore, 'w', encoding='utf-8') as f:
+            f.write(json.dumps(rrow, ensure_ascii=False) + '\n')
+        rpath, rcount, _ = tm.build(rstore, 'ru', os.path.join(d, 'tm.ru.json'))
+        rsense = next(iter(json.load(open(rpath, encoding='utf-8'))['entries'].values()))['card']['records'][0]['senses'][0]
+        if rsense.get('russian') != 'огонь' or 'ru' in rsense:
+            fail("C3: RU card-TM sense must carry 'russian', not 'ru': %r" % rsense)
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def main():
     tests = [
         test_restore_covers_every_promoted_field,
@@ -6597,6 +6638,7 @@ def main():
         test_translation_memory_addressing,
         test_tm_pre_resolves_cards,
         test_tm_card_sane_rejects_zero_marker_drift,
+        test_en_card_tm_serves_english_field_c3,
         test_generated_harness_strict_key_matching,
         test_tm_auto_no_sidecar_metadata,
         test_suggest_tm_does_not_skip_agents,


### PR DESCRIPTION
Fixes findings **C3** and **C4** from the Opus 4.8 (`claude-opus-4-8`) adversarial pipeline bug-hunt ([issue #632](https://github.com/gasyoun/SanskritLexicography/issues/632)). Two independent, clean deterministic bugs.

## C3 — EN whole-card translation memory was 100% dead

[`translation_memory.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/translation_memory.py) `build --lang en` wrote each sense's translation under the store **column** name (`FIELD['en'] == 'en'`) instead of the **card** field name `'english'`:

```python
field if lang == 'en' else 'russian': r.get(field),   # -> key 'en' for EN
```

But the serve-side sanity guard (`tm_card_sane`, `gen_opt_harness2.py`) and the final-card schema require `'english'`, so **every** EN card-TM hit was refused with `sense missing english` — the EN lane silently re-translated whole cards it already had (wasted spend). RU (`'russian'`) was unaffected, so it went unnoticed.

**Fix:** one `CARD_FIELD = {'ru': 'russian', 'en': 'english'}` (the card field, distinct from `FIELD` the store column), used by both the card builder and the fragment lane (`_FRAG_TRANSLATION_FIELD` now aliases it, so the two can't drift again — the drift is exactly what caused C3).

## C4 — a rate-limited job could strand permanently and busy-loop `staged-run`

[`max_account_orchestrator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/max_account_orchestrator.py) `claim` does `attempts = attempts + 1`, but the 429/rate-limit path called `finish(…, 'pending', …)` which never gives the attempt back (unlike `release_db_claims`, which does `attempts = max(attempts-1, 0)`). After `max_attempts` rate-limits, the job sits `pending` with `attempts == max_attempts` — **never re-selected** by `claim` (`WHERE attempts < max_attempts`), **never** marked `failed` — permanently stranded, and `cmd_staged_run` spins on the un-drainable `pending` count.

**Fix:** a 429 is an infra throttle, not a defective attempt — `requeue_rate_limited` returns the job to `pending` **and** decrements `attempts` atomically, so it stays claimable once its account unparks. Plus a no-progress poll backstop in the staged-run loop so any residual unclaimable-but-pending state polls (`STAGED_RUN_IDLE_POLL_SECONDS`) instead of hot-spinning.

## Tests

- `window_selftest.py`: `test_en_card_tm_serves_english_field_c3` (EN card-TM serves `'english'` and passes `tm_card_sane`; RU parity control).
- `max_account_orchestrator_selftest.py`: C4 block — a `max_attempts=1` job rate-limited once stays `pending` with `attempts == 0` and is **re-claimable**, not stranded.

`window_selftest` **OK**, `max_account_orchestrator_selftest` **PASS**, `translation_memory` selftest **RU+EN OK**, `lang_parity_check` **69/69 no drift** (C3 recorded in the `translation_memory_card_and_fragment` SHARED entry). Handoff **H1413**.

## Scope

C3 + C4 only. Remaining bug-hunt findings (C2, C6–C9) are separate follow-ups; C1 shipped in #631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
