### PR TITLE
fix(pwg_ru): EN DUP gate false-flags distinct referents (C2) + EN promote {Tn} guard (C6) (H1414)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2432,6 +2432,16 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H1414 — bug-hunt C2 + C6 fixed, 21-07-2026 (Opus 4.8 `claude-opus-4-8`).** Same review batch as
+  C1–C4. **C2:** `audit_window_en.py`'s HARD `DUP` gate keyed on `prose(english)` (strips `{#..#}`/
+  `<ls>`), so senses distinguished only by their `{#..#}` referent collapsed and false-flagged under
+  `--strict` (310 real cases); fixed to key on the raw english (CIRCULAR keeps prose-`norm`; true
+  duplicates still caught). **C6:** `promote_en.py` `attach()` wrote `en` with no unrestored-`{Tn}`
+  check; fixed to import + reuse the RU lane's exact `TN_RE`/`UnrestoredPlaceholder` and refuse loudly
+  before any store write. Tests: window_selftest `test_en_dup_gate_preserves_sanskrit_referent_c2`,
+  `promote_en --selftest` C6 block. window_selftest OK, promote_en OK, LANG_PARITY 69/69. Delivered by
+  PR (refs issue #632). Remaining bug-hunt findings: C7, C8, C9.
+
 - **H1403 — speed & orchestration audit persisted, 20-07-2026 (Fable 5 `claude-fable-5`, 22-agent ultracode workflow).**
   [`PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md):
   9-row bottleneck ledger + 8 recommendations adversarially verified (0 confirmed / 6 weakened /

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,29 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — EN DUP gate false-flags distinct referents (C2) + EN promote {Tn} guard (C6) (H1414)
+
+- **C2 — the EN within-card `DUP` HARD gate false-flagged distinct proper-name senses.**
+  [`audit_window_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window_en.py)
+  keyed the duplicate check on `prose(english)`, which **strips** `{#..#}` Sanskrit and `<ls>`
+  citations — so two senses distinguished only by their referent (`N. of a serpent-demon
+  {#vāsuki#}` vs `…{#takṣaka#}`) normalized to one string and the second was reported as a HARD
+  `DUP`, failing `--strict` on faithful output (310 real within-record cases across the EN
+  wf files). Fixed to key the DUP `seen`-dict on the normalized **raw** english (referent
+  preserved), matching the gate's own contract ("the exact same english"); the `CIRCULAR` check
+  keeps prose-`norm`, and a true identical-english duplicate is still caught HARD.
+- **C6 — the EN promote lane had no unrestored-`{Tn}` guard.** `promote_en.py` `attach()` wrote
+  `r['en'] = en` with no residue check, while the RU lane refuses a card carrying a `{Tn}` mask
+  placeholder (`promote_final_cards` C-01 → `UnrestoredPlaceholder`). Fixed by **importing** the
+  RU lane's exact `TN_RE` + `UnrestoredPlaceholder` (single source — a look-alike copy is the
+  drift that C3 was) and refusing loudly, before any backup/store write.
+- Found by the Opus 4.8 (`claude-opus-4-8`) adversarial bug-hunt review (findings C2/C6 of
+  [issue #632](https://github.com/gasyoun/SanskritLexicography/issues/632)). Selftests:
+  `window_selftest` (`test_en_dup_gate_preserves_sanskrit_referent_c2`) and
+  `promote_en --selftest` (C6 refusal block). Recorded in
+  [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md)
+  (`en_dup_hard_gate_20260704`, `promotion_scripts_separate`).
+
 ### Added — speed & orchestration audit: bottleneck ledger + verified action map (H1403)
 
 - [`PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md)

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -98,7 +98,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -134,7 +134,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -153,7 +153,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -172,7 +172,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -297,7 +297,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
-      "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc"
+      "src/pilot/audit_window_en.py": "a65478e25e06c50b03a49ad5852ea4582ac00bb6db71c1b2d94f8c1be42f9d64"
     }
   },
   {
@@ -349,11 +349,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "INTENTIONAL-DIVERGENCE",
-    "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge.",
+    "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge. C6 (21-07-2026, Opus 4.8 claude-opus-4-8): the SCRIPTS stay separate, but the {Tn}-residue promotion guard is now SHARED — promote_en.py imports TN_RE + UnrestoredPlaceholder from promote_final_cards.py rather than duplicating them, closing the gap where the RU C-01 path refused a card carrying an unrestored {Tn} while the EN attach() silently wrote it into the store. Pinned by the C6 block in promote_en.selftest().",
     "tracking": "",
     "verified_sha256": {
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf"
+      "src/promote_en.py": "b4443f2f5f43cb283bde9a98589a1d84e6797462f8231d4edbe1a3ad3fe3d832"
     }
   },
   {
@@ -372,7 +372,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -387,11 +387,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "H169 (2026-07-04 review, 'broken validators'): the advertised HARD DUP gate was never emitted -- the only within-record duplicate signal was soft SAME-GLOSS, gated on >=3 content words, so a short duplicate ('to go'/'to go') produced zero flags and --strict passed. Classified GAP-being-closed rather than INTENTIONAL-DIVERGENCE: RU's within-record duplicate protection is the cross-part audit_sense_dupes.py gate (already SHARED, see gate_fixes_20260703_ru_only/PR #135) plus the soft, all-senses-only identical_russian_glosses risk in prompt_rule_audit.py (MEDIUM, not high-confidence) -- neither is a pairwise HARD gate. EN now closes that with a real HARD pairwise DUP check; RU getting an equivalent pairwise HARD gate (rather than its current all-or-nothing soft signal) is left as a natural follow-up, not blocking this fix. Pinned by test_en_gate_dup_has_teeth in window_selftest.py.",
+    "note": "H169 (2026-07-04 review, 'broken validators'): the advertised HARD DUP gate was never emitted -- the only within-record duplicate signal was soft SAME-GLOSS, gated on >=3 content words, so a short duplicate ('to go'/'to go') produced zero flags and --strict passed. Classified GAP-being-closed rather than INTENTIONAL-DIVERGENCE: RU's within-record duplicate protection is the cross-part audit_sense_dupes.py gate (already SHARED, see gate_fixes_20260703_ru_only/PR #135) plus the soft, all-senses-only identical_russian_glosses risk in prompt_rule_audit.py (MEDIUM, not high-confidence) -- neither is a pairwise HARD gate. EN now closes that with a real HARD pairwise DUP check; RU getting an equivalent pairwise HARD gate (rather than its current all-or-nothing soft signal) is left as a natural follow-up, not blocking this fix. Pinned by test_en_gate_dup_has_teeth in window_selftest.py. C2 (21-07-2026, Opus 4.8 claude-opus-4-8): the HARD gate keyed on prose(english), which STRIPS {#..#} Sanskrit and <ls>, so two senses distinguished only by their referent ('N. of a serpent-demon {#vAsuki#}' vs '…{#takzaka#}') collapsed to one string and the second was wrongly HARD-DUP'd, failing --strict on faithful output (310 real within-record cases). Fixed to key the DUP seen-dict on the normalized RAW english (referent preserved) while CIRCULAR keeps prose() norm; a true identical-english duplicate is still caught HARD. Pinned by test_en_dup_gate_preserves_sanskrit_referent_c2.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/audit_window_en.py": "a65478e25e06c50b03a49ad5852ea4582ac00bb6db71c1b2d94f8c1be42f9d64",
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -410,7 +410,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf"
+      "src/promote_en.py": "b4443f2f5f43cb283bde9a98589a1d84e6797462f8231d4edbe1a3ad3fe3d832"
     }
   },
   {
@@ -429,7 +429,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -488,7 +488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -519,7 +519,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
       "src/pilot/autosplit_requeue.py": "7ada6e0aa8dc8d0be15cf4be725e380929282974cc19fc950690c07b09511448",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -538,7 +538,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -556,7 +556,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -575,7 +575,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -631,8 +631,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/promote_lock.py": "dbbf4e77b39585dabdd3df122143cacc15fedb97ce6c3d12654061e8fe6c11b9",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/promote_en.py": "b4443f2f5f43cb283bde9a98589a1d84e6797462f8231d4edbe1a3ad3fe3d832",
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -657,7 +657,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -686,7 +686,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -706,7 +706,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -725,7 +725,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "1b54827cee5d653c5bd42c9c90a22051e5cb93bbdae958cd919354bc54aefa9d",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -762,7 +762,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -799,7 +799,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H405 (09-07-2026, resolved same day). Both editions now run the same pregate() module for the mechanical invariants; the difference is only the adapter (RU: subprocess --wf over file pairs; EN: in-process per-sense), not the logic. The partial-adoption (net-new flag types only) is deliberate — the EN auditor already reimplemented LS/SAN/AB/MISSING per-sense with its own thresholds, so pregate contributes exactly the invariants it lacked (<is>, stranded/leaked anchors) rather than duplicating. Verified by a functional test (clean / is-dropped→IS-LOSS / stranded→STRANDED-ANCHOR / ls-dropped→single LS-LOSS not double-flagged) + window_selftest.py green.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
+      "src/pilot/audit_window_en.py": "a65478e25e06c50b03a49ad5852ea4582ac00bb6db71c1b2d94f8c1be42f9d64",
       "src/stage2_pregate.py": "8f07422d3c416e32d1882f0777d56cc44ba781d19c8097fd9500ddefbfd22945"
     }
   },
@@ -820,7 +820,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -839,7 +839,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -858,7 +858,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -878,7 +878,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523",
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -900,7 +900,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -938,7 +938,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/store_path.py": "3a89cce449987ef448939d9e9a326c02e46ffaf4ce346f55aefe3f388cc00590",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf"
+      "src/promote_en.py": "b4443f2f5f43cb283bde9a98589a1d84e6797462f8231d4edbe1a3ad3fe3d832"
     }
   },
   {
@@ -959,7 +959,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -1019,7 +1019,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -1038,7 +1038,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -1062,8 +1062,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
-      "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/audit_window_en.py": "a65478e25e06c50b03a49ad5852ea4582ac00bb6db71c1b2d94f8c1be42f9d64",
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -1085,7 +1085,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523",
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1105,7 +1105,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -1159,8 +1159,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "EN-only by construction: the RU audit path (audit_window.py + prompt_rule_audit.py) is wired around .merged.md/.raw.txt files and Russian-specific semantic checks, per audit_window_en.py's own module docstring (\"the RU gate ... is wired around ... Russian-specific semantic checks, so the PWG->EN pilot ran with --no-audit. This is the EN sibling\"); XREF-ONLY/NWS-DE-LOCKED are new, EN-only soft flags with no RU counterpart to port -- the RU gate's own dropped_sanskrit_span in prompt_rule_audit.markup_sigla_risks already covers RU's analogous case and was not touched. Pinned by test_h1152_guard3_xref_only_and_nws_de_locked.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/audit_window_en.py": "a65478e25e06c50b03a49ad5852ea4582ac00bb6db71c1b2d94f8c1be42f9d64",
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5"
     }
   },
   {
@@ -1228,7 +1228,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/fix_german_connectives.py": "6a5cceb58cd7c989df819703dff777bb635ee979c7178c55ceccce199a3737a8",
       "src/pilot/foreign_literal_guards.py": "e7eaccfb846ff805b585b1c6413ec84b71970dd7fdddfc6abef90fcf04650b93",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
-      "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc"
+      "src/pilot/audit_window_en.py": "a65478e25e06c50b03a49ad5852ea4582ac00bb6db71c1b2d94f8c1be42f9d64"
     }
   },
   {
@@ -1250,7 +1250,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf",
+      "src/promote_en.py": "b4443f2f5f43cb283bde9a98589a1d84e6797462f8231d4edbe1a3ad3fe3d832",
       "src/pilot/tnmask_offline.py": "c857fe425fadbe18c1cdf398892f53b590709048ca66faf94fd05e046730ffea"
     }
   },
@@ -1273,7 +1273,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523",
+      "src/pilot/window_selftest.py": "22b2a72b99386dfaeac01cc9f9fb6346e69f105e955f558497ae01bb091a2ae5",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1316,7 +1316,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "H1339 Tier-B report pwg_ru/h1339/H1339_TIER_B_STATUS_2026-07-19.md — port before the first real promote_en run (EN store currently 0 rows; H1209 mini-EN is the first consumer)",
     "verified_sha256": {
-      "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf"
+      "src/promote_en.py": "b4443f2f5f43cb283bde9a98589a1d84e6797462f8231d4edbe1a3ad3fe3d832"
     }
   },
   {

--- a/RussianTranslation/src/pilot/audit_window_en.py
+++ b/RussianTranslation/src/pilot/audit_window_en.py
@@ -288,14 +288,22 @@ def audit_card(result, tm, do_mw):
             # a real duplicate is a real duplicate whether it's one word or ten.
             # SAME-GLOSS (soft): kept as a lower-confidence variant gated on >=3 content
             # words, for callers that only want the historical soft signal.
+            # C2: the DUP key is the normalized RAW english, NOT prose() — prose() strips {#..#}
+            # Sanskrit and <ls> citations, so two senses distinguished ONLY by their referent
+            # ("N. of a serpent-demon {#vAsuki#}" vs "…{#takzaka#}") collapsed to one string and
+            # the second was wrongly HARD-DUP'd, failing --strict on faithful output. The gate's
+            # own contract ("the EXACT same english") requires KEEPING the referent; CIRCULAR
+            # above keeps prose() `norm` (a gloss that is only the transliterated headword IS
+            # circular even with its {#..#} stripped).
+            dup_key = re.sub(r'\s+', ' ', (s.get('english') or '')).strip().lower()
             headerlike = any(hk in tag for hk in HEADERLIKE)
-            if norm and not headerlike:
-                if norm in seen:
-                    hard.append('DUP(=%s)' % seen[norm])
+            if dup_key and not headerlike:
+                if dup_key in seen:
+                    hard.append('DUP(=%s)' % seen[dup_key])
                     if len(words) >= 3:
-                        soft.append('SAME-GLOSS(=%s)' % seen[norm])
+                        soft.append('SAME-GLOSS(=%s)' % seen[dup_key])
                 else:
-                    seen[norm] = tag
+                    seen[dup_key] = tag
             for fl in hard + soft:
                 flags.append((loc, fl))
         if do_mw and tm is not None:

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -665,6 +665,45 @@ def test_h920_en_missing_sense_hard_flag():
             en.INPUT_DIR = old_dir
 
 
+def test_en_dup_gate_preserves_sanskrit_referent_c2():
+    """C2: the EN within-card DUP hard-gate must key on the RAW english, not prose() — prose()
+    strips {#..#} Sanskrit and <ls>, so two senses distinguished ONLY by their referent
+    ('N. of a serpent-demon {#vAsuki#}' vs '…{#takzaka#}') collapsed to one string and the second
+    was wrongly HARD-DUP'd, failing --strict on faithful output (the verifier found 310 such real
+    within-record cases). A TRUE duplicate (identical english) must still be flagged HARD."""
+    import audit_window_en as en
+    with tempfile.TemporaryDirectory() as tmp:
+        old_dir = en.INPUT_DIR
+        en.INPUT_DIR = tmp   # no portraits -> source_senses absent -> MISSING-SENSE gate skipped
+        try:
+            distinct = en.audit_card(
+                {'key': 'zz~~h0_00_pwg00',
+                 'card': {'records': [{'h': 'zz', 'senses': [
+                     {'tag': '1', 'german': '1〉 N. eines Schlangendämons {#vAsuki#}',
+                      'english': 'N. of a serpent-demon {#vAsuki#}'},
+                     {'tag': '2', 'german': '2〉 N. eines Schlangendämons {#takzaka#}',
+                      'english': 'N. of a serpent-demon {#takzaka#}'}]}]}},
+                None, False)
+            if any(f.startswith('DUP') for _, f in distinct['flags']):
+                fail('C2: senses distinguished by their {#..#} referent must NOT be flagged DUP: %r'
+                     % [f for _, f in distinct['flags']])
+            same = en.audit_card(
+                {'key': 'zz~~h1_00_pwg00',
+                 'card': {'records': [{'h': 'zz', 'senses': [
+                     {'tag': '1', 'german': '1〉 N. eines Schlangendämons {#vAsuki#}',
+                      'english': 'N. of a serpent-demon {#vAsuki#}'},
+                     {'tag': '2', 'german': '2〉 N. eines Schlangendämons {#vAsuki#}',
+                      'english': 'N. of a serpent-demon {#vAsuki#}'}]}]}},
+                None, False)
+            dup_flags = [f for _, f in same['flags'] if f.startswith('DUP')]
+            if not dup_flags:
+                fail('C2: two senses with the EXACT same english must still be flagged DUP')
+            if not any(en.is_hard(f) for f in dup_flags):
+                fail('C2: DUP must remain a HARD flag')
+        finally:
+            en.INPUT_DIR = old_dir
+
+
 def test_h960_accept_sanloss_soft_gate():
     """H960: the harness stamps the deterministic (cross-reference-hardened) source_senses into
     each input, and accept() carries the SAN-LOSS shortfall guard — H920's deferred deepest fix.
@@ -6672,6 +6711,7 @@ def main():
         test_h920_sense_shortfall_gate_flags_dropped_sense,
         test_h920_no_pwg_portrait_stamps_source_senses,
         test_h920_en_missing_sense_hard_flag,
+        test_en_dup_gate_preserves_sanskrit_referent_c2,
         test_h960_accept_sanloss_soft_gate,
         test_tnmask_persist_and_offline_detect,
         test_h960_dropped_sanskrit_span,

--- a/RussianTranslation/src/promote_en.py
+++ b/RussianTranslation/src/promote_en.py
@@ -55,6 +55,10 @@ sys.stderr.reconfigure(encoding='utf-8')
 import pipeline_version
 from promote_lock import PromoteClaim, ClaimBusy
 from store_path import canonical_store
+# C6: reuse the RU lane's EXACT {Tn}-residue guard (single source — a look-alike copy is precisely
+# the drift that C3 was). A surviving mask placeholder means restore failed upstream; refuse loudly
+# rather than write it into the canonical store (the RU C-01 path raised; the EN attach silently wrote it).
+from promote_final_cards import TN_RE, UnrestoredPlaceholder
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)
@@ -210,6 +214,12 @@ def attach(rows, idx, threshold, prov=None, judge=None):
         en, how = match_en(norm_de(r.get('de')), idx[sub], threshold)
         stats[how] += 1
         if en is not None:
+            # C6: parity with promote_final_cards' RU-side C-01 guard — never write a card still
+            # carrying a {Tn} mask placeholder into the canonical store.
+            if TN_RE.search(en):
+                raise UnrestoredPlaceholder(
+                    '%s: refusing to promote an EN sense with an unrestored placeholder: %r'
+                    % (sub, en[:80]))
             r['en'] = en
             block = dict(prov.get(sub) or {'model': 'sonnet', 'judge': None})
             if sub in judge:
@@ -258,6 +268,16 @@ def selftest():
     # idempotent re-run without judge clears the stale judge block
     attach(rows, idx, 0.92, prov=prov)
     assert rows[0]['en_provenance']['judge'] is None, 're-run without --judge resets judge to null'
+    # C6: an EN candidate still carrying a {Tn} mask placeholder must be REFUSED (parity with the
+    # RU C-01 UnrestoredPlaceholder guard), never written into the tri-lingual store.
+    bad_rows = [{'subcard': 'p_a~~h0', 'sense_tag': '1', 'de': 'trinken', 'ru': 'пить'}]
+    bad_idx = {'p_a~~h0': [(norm_de('trinken'), 'to drink from a {T3}')]}
+    try:
+        attach(bad_rows, bad_idx, 0.92)
+        assert False, 'C6: a {Tn} residue in the EN candidate must be refused, not attached'
+    except UnrestoredPlaceholder:
+        pass
+    assert 'en' not in bad_rows[0], 'C6: a refused row must carry no partial EN'
     print('promote_en selftest OK')
 
 
@@ -304,7 +324,11 @@ def main():
         print('judge verdicts: %d (from %s); judge model: opus (%s)'
               % (len(judge), os.path.basename(args.judge), args.judge_model_version))
     en_senses = sum(len(v) for v in idx.values())
-    stats = attach(rows, idx, args.threshold, prov=prov, judge=judge)
+    try:
+        stats = attach(rows, idx, args.threshold, prov=prov, judge=judge)
+    except UnrestoredPlaceholder as exc:
+        # C6: refuse loudly, before any backup/store write, exactly like the RU lane.
+        sys.exit('EN promotion refused: %s' % exc)
 
     eligible = len(rows) - stats['no-en-file']
     print('\n=== EN MERGE COVERAGE ===')


### PR DESCRIPTION
Fixes findings **C2** and **C6** from the Opus 4.8 (`claude-opus-4-8`) adversarial pipeline bug-hunt ([issue #632](https://github.com/gasyoun/SanskritLexicography/issues/632)). Both EN-lane, both clean.

## C2 — the EN within-card `DUP` HARD gate false-flagged distinct proper-name senses

[`audit_window_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window_en.py) keyed its duplicate check on `prose(english)`, and `prose()` **strips** `{#..#}` Sanskrit spans and `<ls>` citations. So two senses whose only difference is the referent inside a `{#..#}` span —

```
sense 1: "N. of a serpent-demon {#vāsuki#}"
sense 2: "N. of a serpent-demon {#takṣaka#}"
```

— both normalized to `n. of a serpent-demon`, and the second was reported as a **HARD `DUP`**, failing `--strict` on legitimately distinct senses. Proper-name senses distinguished only by their Sanskrit referent are pervasive in PWG/MW; the review's verifier found **310** real within-record norm-equal-but-raw-distinct cases across the EN `wf_output` files.

**Fix:** key the DUP `seen`-dict on the normalized **raw** english (referent preserved) — the gate's own contract is "two senses share the **exact** same english". The `CIRCULAR` check still uses prose-`norm` (a gloss that is only the transliterated headword is circular even with `{#..#}` stripped), and a true identical-english duplicate is still caught **HARD**.

## C6 — the EN promote lane had no unrestored-`{Tn}` guard

[`promote_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_en.py) `attach()` wrote `r['en'] = en` with no residue check, while the RU lane refuses a card still carrying a `{Tn}` mask placeholder (`promote_final_cards` C-01 → `UnrestoredPlaceholder`; the guard that once kept 670 placeholder rows out of the store). A failed restore would silently write `en = "…to break through a {T3}"` into the canonical tri-lingual store.

**Fix:** **import** the RU lane's exact `TN_RE` + `UnrestoredPlaceholder` (single source — a look-alike copy is precisely the drift that finding C3 was) and refuse loudly, before any backup/store write.

## Tests

- `window_selftest.py`: `test_en_dup_gate_preserves_sanskrit_referent_c2` — distinct `{#..#}` referents are **not** DUP'd; identical english **is** still HARD-DUP'd.
- `promote_en.py --selftest`: a `{Tn}`-bearing EN candidate is refused (`UnrestoredPlaceholder`), no partial attach.

`window_selftest` **OK**, `promote_en --selftest` **OK**, `lang_parity_check` **69/69 no drift** (C2 → `en_dup_hard_gate_20260704`, C6 → `promotion_scripts_separate`). Handoff **H1414**.

## Scope

C2 + C6 only. Remaining bug-hunt findings: C7, C8, C9. (C1 shipped in #631; C3/C4 in #633.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
