### PR TITLE
fix(pwg_ru): build-frags glob (C7) + German-as-Latin mask drop (C8) + EN backup collision (C9) (H1418)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2432,6 +2432,18 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H1418 — bug-hunt C7 + C8 + C9 fixed (the last 3 of 9), 21-07-2026 (Opus 4.8 `claude-opus-4-8`).**
+  **C7:** `coordinator.py` `build-frags` hardcoded the default glob while detection honored
+  `PWG_COORDINATOR_DIR` → fragment TM built from the empty default tree under a custom coord dir;
+  unified on `_frag_prov_glob()`. **C8:** `pwg_mask.py` `LATIN_PHRASE` matched German homograph
+  openers (In/Ab/Ex/Sub/Pro), so `{%In den Schlusssatz einfallen%}` was masked+dropped untranslated
+  (1/192,763); guarded with a German-function-word check, `De…` stays Latin. **C9:** `promote_en.py`
+  backup used second-resolution + plain `open('w')` → same-second runs clobbered the earlier `.preEN`
+  copy; fixed to µs+pid+uuid (`_en_backup_path`) + O_EXCL `_fsynced_backup`. Tests: window_selftest
+  `test_frag_prov_glob_honors_coordinator_dir_c7`, `test_pwg_mask_german_homograph_not_latin_c8`;
+  `promote_en --selftest` C9 block. window_selftest OK, promote_en OK, LANG_PARITY 69/69. Delivered by
+  PR (refs issue #632). **All 9 bug-hunt findings (C1–C9) now fixed across 4 PRs.**
+
 - **H1403 — speed & orchestration audit persisted, 20-07-2026 (Fable 5 `claude-fable-5`, 22-agent ultracode workflow).**
   [`PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md):
   9-row bottleneck ledger + 8 recommendations adversarially verified (0 confirmed / 6 weakened /

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,36 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — build-frags glob (C7) + German-as-Latin mask drop (C8) + EN backup collision (C9) (H1418)
+
+- **C7 — `build-frags` built the fragment TM from the wrong tree under a custom coordinator dir.**
+  In [`coordinator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/coordinator.py)
+  `promote_ready`, the `frag_prov` **detection** globbed `paths()['artifacts']` (which honors
+  `PWG_COORDINATOR_DIR` / `--coord-dir`) but the **build-frags** call hardcoded the default-tree
+  glob — so a per-run/worktree coordinator dir detected fragments here yet built the fragment TM
+  from the empty default tree, silently dropping the just-promoted window's fragments. Both sides
+  now use one `_frag_prov_glob()` derived from `paths()['artifacts']`.
+- **C8 — German glosses opening `In…`/`Ab…`/`Ex…`/`Sub…`/`Pro…` were masked as Latin and dropped.**
+  [`pwg_mask.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_mask.py)'s
+  `LATIN_PHRASE` matched German-capitalized homographs of Latin prepositions, so a `{%In den
+  Schlusssatz einfallen%}`-style German gloss was masked to `{Tn}` and never translated —
+  invisibly (restore reinserts the identical German, so the round-trip stayed "100% lossless").
+  Fixed: a homograph opener stays Latin only if **no** German function word follows; `De …` (not a
+  German word) remains an unguarded Latin opener. Measured **1 of 192,763** `{%…%}` spans, now kept
+  inline; genuine Latin (`De accentu comp.`, `In usum Delphini`) still masked.
+- **C9 — the EN store backup could clobber an earlier recovery copy.**
+  [`promote_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_en.py)
+  named the backup with a **second-resolution** timestamp and wrote it with a plain `open('w')`, so
+  two lock-serialized runs in the same second overwrote the earlier `.preEN` backup (defeating the
+  code's own "each run gets its own timestamped backup" promise). Fixed to a µs+pid+uuid name
+  (`_en_backup_path`) plus the RU lane's **O_EXCL** fsynced copier (`_fsynced_backup`, imported —
+  single source).
+- Found by the Opus 4.8 (`claude-opus-4-8`) adversarial bug-hunt review (C7/C8/C9 of
+  [issue #632](https://github.com/gasyoun/SanskritLexicography/issues/632)) — the last of the 9
+  confirmed findings. Selftests: `window_selftest`
+  (`test_frag_prov_glob_honors_coordinator_dir_c7`, `test_pwg_mask_german_homograph_not_latin_c8`)
+  and `promote_en --selftest` (C9 block).
+
 ### Added — speed & orchestration audit: bottleneck ledger + verified action map (H1403)
 
 - [`PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md)

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -94,11 +94,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "Code review 2026-07-04: <ab>lat.</ab>/<ab>griech.</ab> cues are masked to {Tn} in mask() step 1 BEFORE classify_pct runs, so the end-anchored LATIN_CUE regex matched the placeholder, not the cue; measured 33 Latin/Greek cognate glosses across all of PWG (e.g. ignis, uncus, ansa after `lat.`) were being sent for German translation and leaked verbatim into the translator prompt. Fix expands trailing placeholders back to source and strips tags in the classify context window. Masking is stage-0 and runs before any --lang branch, so the fix is identical for RU and EN. Round-trip stays lossless. Pinned by window_selftest.test_pwg_mask_latin_cue_behind_ab_tag.",
+    "note": "Code review 2026-07-04: <ab>lat.</ab>/<ab>griech.</ab> cues are masked to {Tn} in mask() step 1 BEFORE classify_pct runs, so the end-anchored LATIN_CUE regex matched the placeholder, not the cue; measured 33 Latin/Greek cognate glosses across all of PWG (e.g. ignis, uncus, ansa after `lat.`) were being sent for German translation and leaked verbatim into the translator prompt. Fix expands trailing placeholders back to source and strips tags in the classify context window. Masking is stage-0 and runs before any --lang branch, so the fix is identical for RU and EN. Round-trip stays lossless. Pinned by window_selftest.test_pwg_mask_latin_cue_behind_ab_tag. C8 (21-07-2026, Opus 4.8 claude-opus-4-8): the sibling LATIN_PHRASE heuristic matched German-capitalized homographs of Latin prepositions (In/Ab/Ex/Sub/Pro), so a German gloss like 'In der Regel' / 'In den Schlusssatz einfallen' was masked-and-dropped (never translated), invisibly (restore reinserts the identical German, so the round-trip still read 100% lossless). Fixed: a homograph opener stays 'la' only if NO German function word (der/die/den/mit/und/…) follows; 'De …' (not a German word) is an unguarded Latin opener. Measured 1/192,763 real occurrence, now kept inline. Round-trip stays lossless; also stage-0, identical for RU/EN. Pinned by test_pwg_mask_german_homograph_not_latin_c8.",
     "tracking": "",
     "verified_sha256": {
-      "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pwg_mask.py": "31abd637d86fc42db9979e31bb560b67f324147339e623ee9837002d2684e0e8",
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -134,7 +134,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -153,7 +153,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -172,7 +172,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -349,11 +349,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "INTENTIONAL-DIVERGENCE",
-    "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge.",
+    "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge. C9 (21-07-2026, Opus 4.8 claude-opus-4-8): the scripts stay separate, but the EN backup is no longer clobber-prone — it used a second-resolution timestamp + a plain open('w'), so two lock-serialized runs in the SAME second overwrote the earlier .preEN recovery copy (defeating the docstring's per-run-backup promise). Fixed to a µs+pid+uuid name (_en_backup_path) + the RU lane's O_EXCL fsynced copier (_fsynced_backup, imported — single source). Pinned by the C9 block in promote_en.selftest().",
     "tracking": "",
     "verified_sha256": {
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf"
+      "src/promote_en.py": "13c3737579e748e8f5fdf521b9892ecdf166a3609ce779204ee3a36a04b236af"
     }
   },
   {
@@ -372,7 +372,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -391,7 +391,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -410,7 +410,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf"
+      "src/promote_en.py": "13c3737579e748e8f5fdf521b9892ecdf166a3609ce779204ee3a36a04b236af"
     }
   },
   {
@@ -429,7 +429,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -488,7 +488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -512,14 +512,14 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H316 code-hardening pass (2026-07-07). All fixes sit below the --lang branch: stage-0 masking (records feeds both RU and EN lanes), gate shell-out plumbing, and hang guards are language-agnostic by construction. Pinned by test_pwg_mask_bom_source_keeps_first_record, test_pwg_mask_truncated_final_record_not_silent, and the static wiring pin test_subprocess_gate_calls_hardened.",
     "tracking": "",
     "verified_sha256": {
-      "src/pwg_mask.py": "2c7697808e71e26fca3b9501f8effb68f9f3b2ad8d8880dcf78e6328ee659e9a",
+      "src/pwg_mask.py": "31abd637d86fc42db9979e31bb560b67f324147339e623ee9837002d2684e0e8",
       "src/make_edition_cut.py": "5a24d8c96611f50f008689609f8140ef47b02731524dbc255438426b36d306fd",
       "src/preflight_remaining_gates.py": "00386c837b97986c9702abfceed9c29534736c3df3063af202ddfaae6b078b8f",
       "src/release_readiness.py": "db38a870bbc8b5dbe694e706e4a7b9089ba41211a3881ad9a1bd4eb02950c8a9",
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
       "src/pilot/autosplit_requeue.py": "7ada6e0aa8dc8d0be15cf4be725e380929282974cc19fc950690c07b09511448",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -538,7 +538,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -556,7 +556,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -575,7 +575,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -631,8 +631,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/promote_lock.py": "dbbf4e77b39585dabdd3df122143cacc15fedb97ce6c3d12654061e8fe6c11b9",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/promote_en.py": "13c3737579e748e8f5fdf521b9892ecdf166a3609ce779204ee3a36a04b236af",
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -657,7 +657,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -686,7 +686,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "ec9a1c09f8b73574df00c0026b57fb2d28cb636cf95be66f6cc99b106f13e2ee",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -706,7 +706,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -724,8 +724,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "1b54827cee5d653c5bd42c9c90a22051e5cb93bbdae958cd919354bc54aefa9d",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/coordinator.py": "8a8e7bb6cbf313f0fb1097bd72d8fccad1e17d79539f9ecf0a424ca7c87d0b87",
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -762,7 +762,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -820,7 +820,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -839,7 +839,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -858,7 +858,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -878,7 +878,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523",
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -900,7 +900,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -938,7 +938,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/store_path.py": "3a89cce449987ef448939d9e9a326c02e46ffaf4ce346f55aefe3f388cc00590",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf"
+      "src/promote_en.py": "13c3737579e748e8f5fdf521b9892ecdf166a3609ce779204ee3a36a04b236af"
     }
   },
   {
@@ -959,7 +959,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -989,7 +989,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/headless_worker.py": "4e6fc8ab4bdb7fb32e66def36270635ff51f476905d4ca37827115fad3ca66d3",
       "src/pilot/max_account_orchestrator.py": "83173d202fc366b958ce51046bad184476fa3b1b0fd5f93a48791a0a78255a8a",
-      "src/pilot/coordinator.py": "1b54827cee5d653c5bd42c9c90a22051e5cb93bbdae958cd919354bc54aefa9d",
+      "src/pilot/coordinator.py": "8a8e7bb6cbf313f0fb1097bd72d8fccad1e17d79539f9ecf0a424ca7c87d0b87",
       "src/pilot/headless_worker_selftest.py": "8adf980678db843100938045f4057c10d5fb7dc6c2cfe17f936028533e15654c",
       "src/pilot/max_account_orchestrator_selftest.py": "2eddccb237f0159456b5cab65b3282d7e81b8f4f00f7206c9926ee9430e60f6c",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
@@ -1019,7 +1019,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -1038,7 +1038,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -1063,7 +1063,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
       "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -1085,7 +1085,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523",
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1105,7 +1105,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -1160,7 +1160,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "8dc563b46d590ee68d496f563cbc9b3df8b17d31c00e8cb3a6f2e7ca692b39fc",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523"
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c"
     }
   },
   {
@@ -1250,7 +1250,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "89b2a2a64bd438d871ee5c6f3458b71b7a10b35b8751a5a38b1f6ac0863ba757",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf",
+      "src/promote_en.py": "13c3737579e748e8f5fdf521b9892ecdf166a3609ce779204ee3a36a04b236af",
       "src/pilot/tnmask_offline.py": "c857fe425fadbe18c1cdf398892f53b590709048ca66faf94fd05e046730ffea"
     }
   },
@@ -1273,7 +1273,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
       "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
-      "src/pilot/window_selftest.py": "df9cf73edfcf1e3842260105752840f6ebf8951e58f4fc360f92c90fcf556523",
+      "src/pilot/window_selftest.py": "03a7cfafef2b919f70f8db7241b7fbabe9f52486fd1c1904d97baea8d1df776c",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1316,7 +1316,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "H1339 Tier-B report pwg_ru/h1339/H1339_TIER_B_STATUS_2026-07-19.md — port before the first real promote_en run (EN store currently 0 rows; H1209 mini-EN is the first consumer)",
     "verified_sha256": {
-      "src/promote_en.py": "09758e78d1789eeaed9dfd9ef6b6c3089c392e434165b06cd3950e5195a5c4cf"
+      "src/promote_en.py": "13c3737579e748e8f5fdf521b9892ecdf166a3609ce779204ee3a36a04b236af"
     }
   },
   {

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -102,6 +102,15 @@ def paths():
     }
 
 
+def _frag_prov_glob():
+    """C7: the ONE glob both the frag_prov detection and the build-frags call use — derived from
+    paths()['artifacts'], so a custom PWG_COORDINATOR_DIR (per-run / worktree coordinator dir) is
+    honored on both sides. Previously detection honored it but build-frags hardcoded the default
+    tree, so a custom dir detected frag_prov here yet built the fragment TM from the empty default
+    tree, silently dropping the just-promoted window's fragments."""
+    return os.path.join(paths()['artifacts'], '*', 'wf_output*.json')
+
+
 def ensure_dirs():
     p = paths()
     os.makedirs(p['base'], exist_ok=True)
@@ -1651,10 +1660,14 @@ def promote_ready(args):
                                                    'batch_subcards': per.get('subcards'),
                                                    'batch_rows': per.get('rows')})
         run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'build', '--lang', 'ru'])
+        # C7: detection and the build-frags call MUST target the same tree (see _frag_prov_glob).
+        # build_frags joins its --glob with REPO, but this pattern is absolute (coord_dir()
+        # abspath's), so that join is a no-op and both sides resolve to the same coordinator dir.
+        frag_glob = _frag_prov_glob()
         if any('"frag_prov"' in open(fp, encoding='utf-8').read()
-               for fp in glob.glob(os.path.join(paths()['artifacts'], '*', 'wf_output*.json'))):
+               for fp in glob.glob(frag_glob)):
             run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'build-frags',
-                     '--lang', 'ru', '--glob', 'src/pilot/output/coordinator/artifacts/*/wf_output*.json'])
+                     '--lang', 'ru', '--glob', frag_glob])
         run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'validate', '--lang', 'ru'])
     print('promoted %d lease(s)' % len(ready))
 

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -6580,6 +6580,54 @@ def test_h1283_a6_prep_slice_flattens_batches():
     print('  A6: prep_slice flattens every batch key')
 
 
+def test_frag_prov_glob_honors_coordinator_dir_c7():
+    """C7: the coordinator's frag_prov detection AND its build-frags call must both derive their
+    glob from paths()['artifacts'] (honoring PWG_COORDINATOR_DIR), or a custom coord dir (per-run /
+    worktree) detects frag_prov but builds the fragment TM from the empty DEFAULT tree — silently
+    dropping the just-promoted window's fragments."""
+    import coordinator as c
+    old = os.environ.get('PWG_COORDINATOR_DIR')
+    with tempfile.TemporaryDirectory() as d:
+        os.environ['PWG_COORDINATOR_DIR'] = d
+        try:
+            g = os.path.abspath(c._frag_prov_glob())
+            if os.path.abspath(d) not in g:
+                fail('C7: build-frags/detection glob must live under PWG_COORDINATOR_DIR, got %r' % g)
+            if 'wf_output' not in os.path.basename(g):
+                fail('C7: the frag_prov glob must target wf_output*.json, got %r' % g)
+        finally:
+            if old is None:
+                os.environ.pop('PWG_COORDINATOR_DIR', None)
+            else:
+                os.environ['PWG_COORDINATOR_DIR'] = old
+    # regression guard: the hardcoded default glob must never come back
+    src = open(os.path.join(HERE, 'coordinator.py'), encoding='utf-8').read()
+    if "'src/pilot/output/coordinator/artifacts/*/wf_output*.json'" in src:
+        fail('C7: build-frags --glob is hardcoded to the default tree again; use _frag_prov_glob()')
+
+
+def test_pwg_mask_german_homograph_not_latin_c8():
+    """C8: In/Ab/Ex/Sub/Pro are German-capitalized homographs of Latin prepositions, so a German
+    {%..%} gloss like 'In der Regel' / 'In den Schlusssatz einfallen' matched LATIN_PHRASE and was
+    masked-and-dropped (never translated), invisibly (restore reinserts the identical German, so the
+    round-trip selftest still reads 100% lossless). A German function word now keeps such a gloss
+    inline ('de'); a genuine Latin phrase ('De accentu comp.', 'In usum Delphini') stays 'la'."""
+    import pwg_mask as pm
+    de_cases = ['In den Schlusssatz einfallen', 'In der Regel', 'In Verbindung mit etwas',
+                'Ab dem dritten Tag']
+    for c in de_cases:
+        if pm.classify_pct(c, '') != 'de':
+            fail("C8: German gloss %r must classify 'de' (kept inline), got %r"
+                 % (c, pm.classify_pct(c, '')))
+    la_cases = ['De accentu comp.', 'In usum Delphini', 'Ab ovo', 'Ex professo']
+    for c in la_cases:
+        if pm.classify_pct(c, '') != 'la':
+            fail("C8: genuine Latin phrase %r must stay 'la', got %r" % (c, pm.classify_pct(c, '')))
+    # the LATIN_CUE path (an explicit 'lat.'/'griech.' before the span) is unchanged
+    if pm.classify_pct('in aqua', 'das lat.') != 'la':
+        fail('C8: an explicit Latin cue must still force la')
+
+
 def main():
     tests = [
         test_restore_covers_every_promoted_field,
@@ -6739,6 +6787,8 @@ def main():
         test_h1283_a1_pid_alive_and_dirlock_owner,
         test_h1283_a5_max_wide_default_bounded,
         test_h1283_a6_prep_slice_flattens_batches,
+        test_frag_prov_glob_honors_coordinator_dir_c7,
+        test_pwg_mask_german_homograph_not_latin_c8,
     ]
     # Per-test isolation. This used to be a bare `for test in tests: test()`, so the FIRST
     # failure aborted the process and every later test silently never ran. That is not

--- a/RussianTranslation/src/promote_en.py
+++ b/RussianTranslation/src/promote_en.py
@@ -47,6 +47,7 @@ import json
 import os
 import re
 import sys
+import uuid
 from collections import defaultdict
 
 sys.stdout.reconfigure(encoding='utf-8')
@@ -55,6 +56,9 @@ sys.stderr.reconfigure(encoding='utf-8')
 import pipeline_version
 from promote_lock import PromoteClaim, ClaimBusy
 from store_path import canonical_store
+# C9: reuse the RU lane's O_EXCL fsynced copier so an EN backup can never overwrite an existing
+# recovery artifact (single source with promote_final_cards.py, parity with its _fsynced_backup).
+from promote_final_cards import _fsynced_backup
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)
@@ -72,6 +76,15 @@ _KEEP = re.compile(r'[^0-9A-Za-z{}#%]')
 # alias mapping has changed since.
 GEN_MODEL_VERSION = 'claude-sonnet-4-6'      # alias 'sonnet' -> Sonnet 4.6
 JUDGE_MODEL_VERSION = 'claude-opus-4-8'      # alias 'opus'   -> Opus 4.8
+
+
+def _en_backup_path(store):
+    """C9: a collision-resistant `.preEN` backup name — microsecond stamp + pid + uuid, so two
+    lock-serialized runs in the SAME second get distinct names (second-resolution collided, and a
+    plain open('w') then clobbered the earlier recovery copy). Paired with _fsynced_backup's
+    O_EXCL open so an existing backup is never overwritten. Mirrors promote_final_cards._backup_path."""
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%S.%fZ')
+    return '%s.preEN.%s.p%d.%s.bak' % (store, stamp, os.getpid(), uuid.uuid4().hex[:12])
 
 
 def norm_de(g):
@@ -258,6 +271,23 @@ def selftest():
     # idempotent re-run without judge clears the stale judge block
     attach(rows, idx, 0.92, prov=prov)
     assert rows[0]['en_provenance']['judge'] is None, 're-run without --judge resets judge to null'
+    # C9: the backup name must be collision-resistant (two names in the SAME second differ) and the
+    # O_EXCL fsynced copier must refuse an existing destination — so two lock-serialized runs can't
+    # clobber the earlier recovery copy.
+    import tempfile as _tf
+    assert _en_backup_path('/x/store.jsonl') != _en_backup_path('/x/store.jsonl'), \
+        'C9: two backup names generated back-to-back must be unique (µs+pid+uuid)'
+    with _tf.TemporaryDirectory() as _d:
+        _store = os.path.join(_d, 'store.jsonl')
+        open(_store, 'w', encoding='utf-8').write('{}\n')
+        _bak = _en_backup_path(_store)
+        _fsynced_backup(_store, _bak)
+        assert os.path.exists(_bak), 'C9: backup must be written'
+        try:
+            _fsynced_backup(_store, _bak)     # same destination again
+            assert False, 'C9: the O_EXCL backup must refuse an existing destination'
+        except FileExistsError:
+            pass
     print('promote_en selftest OK')
 
 
@@ -332,10 +362,11 @@ def main():
     try:
         with PromoteClaim(args.store, steal=args.steal_lock, **ttl_kwargs):
             if not args.no_backup:
-                stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
-                bak = args.store + '.preEN.%s.bak' % stamp
-                with open(bak, 'w', encoding='utf-8') as f, open(args.store, encoding='utf-8') as src:
-                    f.write(src.read())
+                # C9: collision-resistant name (µs+pid+uuid) + O_EXCL fsynced copy, so two
+                # lock-serialized runs in the SAME second can no longer clobber the earlier recovery
+                # copy — second-resolution + a plain open('w') did exactly that, silently.
+                bak = _en_backup_path(args.store)
+                _fsynced_backup(args.store, bak)
                 print('\nbacked up store -> %s' % os.path.basename(bak))
             # Atomic write: temp file + os.replace so a crash/kill mid-write cannot truncate
             # the tri-lingual store (the "EN layer wiped" scar). Under --no-backup this is the

--- a/RussianTranslation/src/pwg_mask.py
+++ b/RussianTranslation/src/pwg_mask.py
@@ -37,6 +37,13 @@ HEADER_RE = re.compile(r'^<L>([\d.]+)<pc>(.*?)<k1>(.*?)<k2>(.*?)(?:<h>(\d+))?\s*
 DE_CHARS = re.compile(r'[äöüßÄÖÜ]')
 LATIN_CUE = re.compile(r'(lat\.|latein|griech|gr\.)\W{0,4}$', re.I)
 LATIN_PHRASE = re.compile(r'^(De|Ab|Ex|In|Sub|Pro)\s+[a-z]', )  # Latin citation phrase
+# C8: In/Ab/Ex/Sub/Pro are German-capitalized homographs of Latin prepositions, so a German gloss
+# like "In der Regel" / "In den Schlusssatz einfallen" matched LATIN_PHRASE and was masked-and-
+# dropped (never translated). "De" is not a German word, so a "De ..." phrase stays an unguarded
+# Latin opener; a homograph opener stays Latin only if NO German function word follows.
+HOMOGRAPH_LATIN_OPENER = re.compile(r'^(Ab|Ex|In|Sub|Pro)\b')
+DE_FUNCTION = re.compile(r'\b(der|die|das|den|dem|des|ein|eine|einer|einem|einen|und|oder|mit|von'
+                         r'|im|zur|zum|auf|für|nicht|auch|nur|wird|ist|sind|dass|wenn|bei|nach)\b')
 HOMOGRAPH = {'in', 'an', 'un', 'et', 'ut', 'a', 'i'}  # de/lat ambiguous short tokens
 
 
@@ -80,7 +87,11 @@ def classify_pct(content, preceding):
     if LATIN_CUE.search(preceding.strip()):        # "…das lat. " / "griech. "
         return 'la'
     if LATIN_PHRASE.match(content) and not DE_CHARS.search(content):
-        return 'la'
+        # C8: a homograph-opener (In/Ab/Ex/Sub/Pro) phrase carrying a German function word is
+        # German prose, not a Latin citation — fall through so it is kept inline for translation,
+        # never masked+dropped. "De ..." (not a German word) is unaffected and stays Latin.
+        if not (HOMOGRAPH_LATIN_OPENER.match(content) and DE_FUNCTION.search(content)):
+            return 'la'
     toks = [t.strip('.,;') for t in content.lower().split()]
     if toks and all(t in HOMOGRAPH for t in toks) and not DE_CHARS.search(content):
         return 'ambig'


### PR DESCRIPTION
Fixes the last three findings (**C7, C8, C9**) from the Opus 4.8 (`claude-opus-4-8`) adversarial pipeline bug-hunt ([issue #632](https://github.com/gasyoun/SanskritLexicography/issues/632)) — completing all 9 confirmed findings.

## C7 — `build-frags` built the fragment TM from the wrong tree under a custom coordinator dir

In [`coordinator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/coordinator.py) `promote_ready`, the `frag_prov` **detection** globbed `paths()['artifacts']` (which honors `PWG_COORDINATOR_DIR` / `--coord-dir`), but the **build-frags** call hardcoded `--glob 'src/pilot/output/coordinator/artifacts/*/wf_output*.json'`. So a per-run / worktree coordinator dir detected `frag_prov` here yet built the fragment TM from the **empty default tree** — silently dropping the just-promoted window's fragments. Both sides now share one `_frag_prov_glob()` derived from `paths()['artifacts']` (absolute, so `build_frags`' REPO-join is a no-op).

## C8 — German glosses opening `In…`/`Ab…`/`Ex…`/`Sub…`/`Pro…` were masked as Latin and dropped

[`pwg_mask.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_mask.py)'s `LATIN_PHRASE` matched German-capitalized homographs of Latin prepositions, so a German gloss like `{%In den Schlusssatz einfallen%}` was masked to a `{Tn}` placeholder and **never translated**. The loss was invisible: `restore()` reinserts the identical German, so the round-trip selftest still reported "100% lossless".

**Fix:** a homograph opener (`In/Ab/Ex/Sub/Pro`) stays `la` only if **no** German function word (`der/die/den/mit/und/…`) follows; `De …` (not a German word) remains an unguarded Latin opener. Measured against the real `pwg.txt`: **1 of 192,763** `{%…%}` spans was misclassified (`In den Schlusssatz einfallen`) and is now kept inline; genuine Latin (`De accentu comp.`, `In usum Delphini`, `Ab ovo`, `Ex professo`) still masks correctly, and the round-trip stays lossless.

## C9 — the EN store backup could clobber an earlier recovery copy

[`promote_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_en.py) named the backup with a **second-resolution** timestamp (`%Y%m%dT%H%M%SZ`) and wrote it with a plain `open('w')`, so two lock-serialized runs in the **same second** produced the same name and the later one truncated the earlier `.preEN` recovery copy — defeating the code's own "each run gets its own timestamped backup" comment.

**Fix:** a µs+pid+uuid name (`_en_backup_path`) + the RU lane's **O_EXCL** fsynced copier (`_fsynced_backup`, imported — single source), so a name collision is impossible and an existing backup is never overwritten.

## Tests

- `window_selftest.py`: `test_frag_prov_glob_honors_coordinator_dir_c7` (glob lives under `PWG_COORDINATOR_DIR` + regression guard against re-hardcoding), `test_pwg_mask_german_homograph_not_latin_c8` (German homograph glosses → `de`, genuine Latin → `la`).
- `promote_en.py --selftest`: C9 block (two backup names differ within one second; O_EXCL refuses an existing destination).

`window_selftest` **OK**, `promote_en --selftest` **OK**, `lang_parity_check` **69/69 no drift** (C8 → `latin_cue_masking`, C9 → `promotion_scripts_separate`, notes updated).

## Notes for the maintainer

This is the 4th of 4 bug-hunt PRs, all branched off `master`: **C1 → #631**, **C3/C4 → #633**, **C2/C6 → #634**, **C7/C8/C9 → this**. They all touch the shared doc/ledger files (`LANG_PARITY.md`, `CHANGELOG.md`, `.ai_state.md`, `window_selftest.py`), and #634 + this one both add a `from promote_final_cards import …` line to `promote_en.py` — so merging in sequence will need mechanical conflict resolution (keep both import symbols; re-run `python src/pilot/lang_parity_check.py --update-hash <id>` if a hash conflicts). Handoff **H1418**. Happy to rebase/consolidate if you'd prefer one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
