### PR TITLE
docs(findings): reattach §456's orphaned body + regenerate stale dashboards (H1397)

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,6 +1,6 @@
 # FINDINGS — cross-repo empirical registry
 
-_Created: 26-06-2026 · Last updated: 20-07-2026_
+_Created: 26-06-2026 · Last updated: 21-07-2026_
 
 📊 **Live dashboard:** <https://gasyoun.github.io/SanskritLexicography/findings/> —
 importance/section breakdown, staleness flags, monthly time series (§12/§13/§21/§25) and the
@@ -3224,49 +3224,6 @@ lookups.
 
 _↩ **Renumbered §102 → §456** (H1328 collision fix, 20-07-2026): this H1328 finding (PR [#618](https://github.com/gasyoun/SanskritLexicography/pull/618)) reused §102, already held by the DCS `text_sandhied` finding (the incumbent). Per the [citation-identity ruling](epistemic_dashboard/REGISTRY_CITATION_IDENTITY_RULING.md) rule 4, the later claim moves. Caught by the new epistemic-integrity gate ([issue #624](https://github.com/gasyoun/SanskritLexicography/issues/624))._
 
-### §457. DCS covers ~25% of the Poona Dictionary's citation mass but ~78% of DCS's own tokens — the classical core, not PD's encyclopedic breadth; and a siglum prefix-merge fuses MahāBhā. (Mahābhārata) with MahāBh. (Mahābhāṣya)
-
-🔴 First measurement, in this org or the field, of how much of the **Poona Dictionary**'s
-cited source canon the **DCS** corpus holds. Over PD's published letter-`a-` volumes (107,630
-entries, 398,359 citation occurrences), the two coverage numbers point in opposite directions
-and answer different questions:
-
-- **PD-citation-weighted coverage = 25.2 %** — of what PD actually cites, three-quarters
-  points at works DCS does not hold.
-- **DCS-token-weighted coverage = 77.9 %** (2026) / 74.1 % (2021) — of DCS's *own* token
-  mass, ~78 % sits in texts PD cites (the Mahābhārata alone is 1.15 M of DCS's 5.69 M tokens).
-- **Title-level = ~2.4–4.8 %** — DCS holds ~118 of the ~2,445 distinct works PD cites under
-  `a-` alone.
-
-**Reading: DCS is representative of the archaic/classical *core* but not of PD's encyclopedic
-*breadth*.** The residue (75 % of PD's primary citation mass) is four clusters DCS structurally
-lacks: **purāṇas** (Padma 3,506; Brahmāṇḍa 1,857; Bhaviṣya 1,558; a dozen more), the
-**lexicographic tradition** (Vaijayantī, Medinī, Nānārtha), **classical kāvya/nāṭaka** (*no
-Raghuvaṃśa, no Kādambarī, no Śiśupālavadha*), and the **grammatical commentary layer**
-(Mahābhāṣya, the Vārttikas). Corpus work grounded in the high-frequency classical core is
-well-aligned with the lexicographic gold standard; work needing purāṇic/kāvya/kośa breadth
-must supplement DCS. DCS's 2021→2026 growth was concentrated in exactly PD's Vedic core
-(Śatapathabrāhmaṇa 3.7k→144k tokens; +3.8 pp token-weighted coverage).
-
-⚠️ **The reusable gotcha — never prefix-cluster Sanskrit sigla.** `MahāBhā.` (9,337 hits =
-**Mahābhārata**, the epic) and `MahāBh.` (1,934 hits = **Mahābhāṣya**, Patañjali's grammar)
-share a five-character prefix and differ by one vowel-length mark. Any similarity/prefix
-threshold that "normalises spelling variants" will silently fuse the single largest epic with
-the single most important grammatical commentary — one is covered by DCS, the other is
-residue, so the merge corrupts coverage in both directions. Every siglum merge in the
-high-frequency head needs eyes on it, not a threshold. (This is why the crosswalk anchors on
-DCS's bounded 276-text inventory and adjudicates the head by hand rather than clustering.)
-
-> **Source:** report [`reports/PD_DCS_CORPUS_COVERAGE_2026.md`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/reports/PD_DCS_CORPUS_COVERAGE_2026.md)
-> + crosswalk [`data/pd/pd_dcs_text_crosswalk.tsv`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/pd/pd_dcs_text_crosswalk.tsv)
-> + [`pd_siglum_families.tsv`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/pd/pd_siglum_families.tsv)
-> + [`pd_dcs_metrics.json`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/pd/pd_dcs_metrics.json) ·
-> PD source = [`pd.txt`](https://github.com/drdhaval2785/SanskritSpellCheck/blob/master/external_src/pd/pd.txt) (external, read-only) ·
-> DCS = [`VisualDCS` Corpus-Delta 2021–2026](https://github.com/gasyoun/VisualDCS/blob/main/derived-data/Corpus-Delta-2021-2026/per_text_token_delta.csv) ·
-> [H1336](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1336-Opus_csl-atlas_pd-abbrev-vs-dcs-corpus-coverage_19.07.26.md)
-> ([csl-atlas PR #276](https://github.com/sanskrit-lexicon/csl-atlas/pull/276)) — csl-atlas · 20-07-2026, Opus 4.8 (`claude-opus-4-8[1m]`).
-> **Scope caveat:** PD published a–~`apaca-` only (6 of 37+ vols) — this is PD's canon *as exercised under a-*, not its full declared canon.
-
 Measured 20-07-2026 (H1328) by joining the MWderivations `issue15` **uttarapada** (compound
 final-member) index — 19,177 distinct MW-kept finals, classes `UTTARAPADA` + `KRT_STEM_MEMBER`,
 the bound taddhita suffixes `-tva`/`-tā`/`-vat` already excluded upstream — to the DCS Kompozity
@@ -3334,6 +3291,48 @@ whose member-**order** caveat is
 > [H1328](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1328-Opus_VisualDCS_kompozity-mw-uttarapada-join-dict-vs-corpus_19.07.26.md)
 > — VisualDCS · 20-07-2026, Opus 4.8 (`claude-opus-4-8[1m]`).
 
+### §457. DCS covers ~25% of the Poona Dictionary's citation mass but ~78% of DCS's own tokens — the classical core, not PD's encyclopedic breadth; and a siglum prefix-merge fuses MahāBhā. (Mahābhārata) with MahāBh. (Mahābhāṣya)
+
+🔴 First measurement, in this org or the field, of how much of the **Poona Dictionary**'s
+cited source canon the **DCS** corpus holds. Over PD's published letter-`a-` volumes (107,630
+entries, 398,359 citation occurrences), the two coverage numbers point in opposite directions
+and answer different questions:
+
+- **PD-citation-weighted coverage = 25.2 %** — of what PD actually cites, three-quarters
+  points at works DCS does not hold.
+- **DCS-token-weighted coverage = 77.9 %** (2026) / 74.1 % (2021) — of DCS's *own* token
+  mass, ~78 % sits in texts PD cites (the Mahābhārata alone is 1.15 M of DCS's 5.69 M tokens).
+- **Title-level = ~2.4–4.8 %** — DCS holds ~118 of the ~2,445 distinct works PD cites under
+  `a-` alone.
+
+**Reading: DCS is representative of the archaic/classical *core* but not of PD's encyclopedic
+*breadth*.** The residue (75 % of PD's primary citation mass) is four clusters DCS structurally
+lacks: **purāṇas** (Padma 3,506; Brahmāṇḍa 1,857; Bhaviṣya 1,558; a dozen more), the
+**lexicographic tradition** (Vaijayantī, Medinī, Nānārtha), **classical kāvya/nāṭaka** (*no
+Raghuvaṃśa, no Kādambarī, no Śiśupālavadha*), and the **grammatical commentary layer**
+(Mahābhāṣya, the Vārttikas). Corpus work grounded in the high-frequency classical core is
+well-aligned with the lexicographic gold standard; work needing purāṇic/kāvya/kośa breadth
+must supplement DCS. DCS's 2021→2026 growth was concentrated in exactly PD's Vedic core
+(Śatapathabrāhmaṇa 3.7k→144k tokens; +3.8 pp token-weighted coverage).
+
+⚠️ **The reusable gotcha — never prefix-cluster Sanskrit sigla.** `MahāBhā.` (9,337 hits =
+**Mahābhārata**, the epic) and `MahāBh.` (1,934 hits = **Mahābhāṣya**, Patañjali's grammar)
+share a five-character prefix and differ by one vowel-length mark. Any similarity/prefix
+threshold that "normalises spelling variants" will silently fuse the single largest epic with
+the single most important grammatical commentary — one is covered by DCS, the other is
+residue, so the merge corrupts coverage in both directions. Every siglum merge in the
+high-frequency head needs eyes on it, not a threshold. (This is why the crosswalk anchors on
+DCS's bounded 276-text inventory and adjudicates the head by hand rather than clustering.)
+
+> **Source:** report [`reports/PD_DCS_CORPUS_COVERAGE_2026.md`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/reports/PD_DCS_CORPUS_COVERAGE_2026.md)
+> + crosswalk [`data/pd/pd_dcs_text_crosswalk.tsv`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/pd/pd_dcs_text_crosswalk.tsv)
+> + [`pd_siglum_families.tsv`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/pd/pd_siglum_families.tsv)
+> + [`pd_dcs_metrics.json`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/pd/pd_dcs_metrics.json) ·
+> PD source = [`pd.txt`](https://github.com/drdhaval2785/SanskritSpellCheck/blob/master/external_src/pd/pd.txt) (external, read-only) ·
+> DCS = [`VisualDCS` Corpus-Delta 2021–2026](https://github.com/gasyoun/VisualDCS/blob/main/derived-data/Corpus-Delta-2021-2026/per_text_token_delta.csv) ·
+> [H1336](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1336-Opus_csl-atlas_pd-abbrev-vs-dcs-corpus-coverage_19.07.26.md)
+> ([csl-atlas PR #276](https://github.com/sanskrit-lexicon/csl-atlas/pull/276)) — csl-atlas · 20-07-2026, Opus 4.8 (`claude-opus-4-8[1m]`).
+> **Scope caveat:** PD published a–~`apaca-` only (6 of 37+ vols) — this is PD's canon *as exercised under a-*, not its full declared canon.
 ### §458. A Sanskrit dictionary's big letters are big because they head *preverb families* — and testing "entries shrink over publication" needs an outlier-robust estimator, not a parametric regression (encyclopedic dicts have single 300k-char articles)
 
 🔴 **The per-letter law.** Extending [§457](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)'s

--- a/epistemic_dashboard/epistemic.json
+++ b/epistemic_dashboard/epistemic.json
@@ -1,20 +1,20 @@
 {
- "generated_at": "2026-07-20T17:42:33Z",
+ "generated_at": "2026-07-21T10:31:16Z",
  "side": "Sanskrit-data",
  "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
  "core": {
   "key": "FINDINGS",
   "act": "measuring — the settled facts the seven siblings graduate into",
   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md",
-  "total": 115,
+  "total": 116,
   "by_importance": {
-   "3": 19,
+   "3": 20,
    "2": 78,
    "1": 18
   },
   "by_origin": {
    "auto": 0,
-   "human": 115
+   "human": 116
   }
  },
  "layers": [
@@ -241,18 +241,18 @@
    "key": "DEAD_ENDS",
    "act": "abandoning an approach",
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md",
-   "total": 11,
+   "total": 13,
    "by_importance": {
-    "3": 7,
+    "3": 9,
     "2": 3,
     "1": 0
    },
    "by_origin": {
     "auto": 1,
-    "human": 10
+    "human": 12
    },
    "categories": 4,
-   "interlinks": 10,
+   "interlinks": 12,
    "entries": [
     {
      "title": "§1. Body-text / reverse-dict headword mining — abandoned",
@@ -283,6 +283,18 @@
      "importance": null,
      "origin": "human",
      "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#8b-fitting-a-continuous-locus-index-for-the-full-mahābhārata-against-any-free-bulk-e-text---reopened--done-for-all-18-parvans-the-no-free-vulgate-premise-was-refuted-12-07-2026"
+    },
+    {
+     "title": "§11. vidyut.cheda compound segmentation over isolated OOV forms to grow the Sa→Ru gloss layer — measured NO-GO, not wired in",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#11-vidyutcheda-compound-segmentation-over-isolated-oov-forms-to-grow-the-saru-gloss-layer--measured-no-go-not-wired-in"
+    },
+    {
+     "title": "§12. Deriving a safe SANLOSS `count_source_senses` cap from text structure alone — escalated, no safe fix",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#12-deriving-a-safe-sanloss-countsourcesenses-cap-from-text-structure-alone--escalated-no-safe-fix"
     },
     {
      "title": "§4. Bulk-respell of \"typo\" headword-correction lists — abandoned",
@@ -529,19 +541,19 @@
   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/epistemic_dashboard/FINDINGS_VERIFIABILITY_RULING_2026.md"
  },
  "totals": {
-  "rows": 173,
+  "rows": 175,
   "auto": 120,
-  "human": 53,
+  "human": 55,
   "by_importance": {
-   "3": 20,
+   "3": 22,
    "2": 29,
    "1": 8
   },
   "layers": 7,
-  "entry_rows": 59,
+  "entry_rows": 61,
   "candidates": 6,
   "categories": 20,
-  "interlinks": 54,
-  "findings": 115
+  "interlinks": 56,
+  "findings": 116
  }
 }

--- a/findings_dashboard/data.json
+++ b/findings_dashboard/data.json
@@ -1,12 +1,12 @@
 {
- "generated_at": "2026-07-20T17:40:51Z",
+ "generated_at": "2026-07-21T10:30:50Z",
  "stale_days_threshold": 180,
  "counts": {
-  "total": 115,
+  "total": 116,
   "by_importance": {
    "2": 78,
    "1": 18,
-   "3": 19
+   "3": 20
   },
   "stale": 0
  },
@@ -17,7 +17,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-29",
-   "age_days": 21,
+   "age_days": 22,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#1-whitney-accent-mobility-rules-are-machine-encodable"
   },
   {
@@ -26,7 +26,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-14",
-   "age_days": 36,
+   "age_days": 37,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling"
   },
   {
@@ -35,7 +35,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-13",
-   "age_days": 37,
+   "age_days": 38,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#3-the-warnemyr-scrape-union-smears-homonym-classes"
   },
   {
@@ -44,7 +44,7 @@
    "section": "Grammar & morphology data",
    "importance": 1,
    "evidence_date": "2026-06-29",
-   "age_days": 21,
+   "age_days": 22,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#4-pwg-nominal-grammar-compresses-into-335-paradigm-tokens"
   },
   {
@@ -53,7 +53,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 18,
+   "age_days": 19,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#42-whitney-self-contradicts-on-derivative-ī-stem-genpl-accent"
   },
   {
@@ -62,7 +62,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-07-05",
-   "age_days": 15,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents"
   },
   {
@@ -71,7 +71,7 @@
    "section": "Grammar & morphology data",
    "importance": 1,
    "evidence_date": "2026-07-07",
-   "age_days": 13,
+   "age_days": 14,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian"
   },
   {
@@ -80,7 +80,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 26,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#5-the-parallel-corpus-rarely-attests-prefixed-verb-forms"
   },
   {
@@ -89,7 +89,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 26,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#6-no-printed-frequency-dictionary-of-sanskrit-exists"
   },
   {
@@ -98,7 +98,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 26,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations"
   },
   {
@@ -107,7 +107,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 35,
+   "age_days": 36,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#8-unaccented-dcs-cannot-distinguish-present-class-i-from-vi"
   },
   {
@@ -116,7 +116,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06-06",
-   "age_days": 44,
+   "age_days": 45,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#9-dcs-occid-and-sent_id-are-not-unique-keys"
   },
   {
@@ -125,7 +125,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-06",
-   "age_days": 44,
+   "age_days": 45,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#10-dcs-ud-tense-marking-conflates-aorist-and-perfect"
   },
   {
@@ -134,7 +134,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-06",
-   "age_days": 44,
+   "age_days": 45,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#11-dcs-2021-and-2026-vintages-are-not-directly-comparable"
   },
   {
@@ -143,7 +143,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-11",
-   "age_days": 39,
+   "age_days": 40,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword"
   },
   {
@@ -152,7 +152,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 1,
    "evidence_date": "2026-07-01",
-   "age_days": 19,
+   "age_days": 20,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#13-sa-ru-glossary-token-coverage-plateaus-at-866-percent"
   },
   {
@@ -161,7 +161,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-01",
-   "age_days": 19,
+   "age_days": 20,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#14-renou-period-state-tagging-covers-770k-entries-in-8-dicts"
   },
   {
@@ -170,7 +170,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-07",
-   "age_days": 13,
+   "age_days": 14,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards"
   },
   {
@@ -179,7 +179,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-07",
-   "age_days": 13,
+   "age_days": 14,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse"
   },
   {
@@ -188,7 +188,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 26,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#15-pwg-encodes-secondary-stems-inline-not-in-div-markup"
   },
   {
@@ -197,7 +197,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 26,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes"
   },
   {
@@ -206,7 +206,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 26,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#17-pwg-orders-senses-genetically-not-historically"
   },
   {
@@ -215,7 +215,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 26,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#18-vedic-citation-density-separates-the-dictionary-traditions"
   },
   {
@@ -224,7 +224,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 35,
+   "age_days": 36,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#19-skd-and-vcp-carry-essentially-zero-western-markup"
   },
   {
@@ -233,7 +233,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 26,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#20-the-ls-source-map-recognises-724-percent-of-pwg-citations"
   },
   {
@@ -242,7 +242,7 @@
    "section": "Dictionary structure & markup",
    "importance": 1,
    "evidence_date": "2026-07-02",
-   "age_days": 18,
+   "age_days": 19,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#21-pwg-citation-occurrences-track-distinct-references"
   },
   {
@@ -251,7 +251,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 24,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#22-mw-has-no-sense-level-div-markup"
   },
   {
@@ -260,7 +260,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 35,
+   "age_days": 36,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#23-apte-is-three-dictionaries-keys-differ-stem-vs-nominative"
   },
   {
@@ -269,7 +269,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-07",
-   "age_days": 5,
+   "age_days": 6,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#24-about-9-percent-of-typo-corrections-are-collisions"
   },
   {
@@ -278,7 +278,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07",
-   "age_days": 5,
+   "age_days": 6,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#25-a-verified-correction-queue-decays-against-live-csl-orig"
   },
   {
@@ -287,7 +287,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-13",
-   "age_days": 37,
+   "age_days": 38,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#26-citation-density-is-register-bound-not-comparable-raw"
   },
   {
@@ -296,7 +296,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-15",
-   "age_days": 35,
+   "age_days": 36,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#27-sense-granularity-is-a-family-trait-not-a-diachronic-trend"
   },
   {
@@ -305,7 +305,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-03",
-   "age_days": 47,
+   "age_days": 48,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#28-mw-inherited-the-pwg-apparatus-skeleton-not-its-prose"
   },
   {
@@ -314,7 +314,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 24,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index"
   },
   {
@@ -323,7 +323,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-15",
-   "age_days": 35,
+   "age_days": 36,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#30-body-text-headword-mining-is-a-dead-end-386-percent-precision"
   },
   {
@@ -332,7 +332,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 26,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#31-detector-precision-stratifies-by-digitization-quality"
   },
   {
@@ -341,7 +341,7 @@
    "section": "Dictionary structure & markup",
    "importance": 1,
    "evidence_date": "2026-06-17",
-   "age_days": 33,
+   "age_days": 34,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#32-correction-events-concentrate-in-sense-text"
   },
   {
@@ -350,7 +350,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#46-twelve-years-of-corrections-cover-only-1014--of-the-estimated-error-population"
   },
   {
@@ -359,7 +359,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-07-05",
-   "age_days": 15,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1--pwg-is-not-the-sole-spine-of-the-local-layer-universe"
   },
   {
@@ -368,7 +368,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07-11",
-   "age_days": 9,
+   "age_days": 10,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#76-the-mwwordnetsemdom-bridge-is-a-candidate-generator-not-a-classifier"
   },
   {
@@ -422,7 +422,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 24,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#33-indigenous-dictionaries-agree-on-derivation-wilson-is-the-outlier"
   },
   {
@@ -431,7 +431,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 24,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#34-the-e-abbreviation-tag-is-polysemous-across-dicts"
   },
   {
@@ -440,7 +440,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 24,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#35-root-recovery-tiers-err-on-root-form-not-identity"
   },
   {
@@ -449,7 +449,7 @@
    "section": "Encoding & normalization",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 35,
+   "age_days": 36,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily"
   },
   {
@@ -458,7 +458,7 @@
    "section": "Encoding & normalization",
    "importance": 3,
    "evidence_date": "2026-07",
-   "age_days": 5,
+   "age_days": 6,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#100-nfold-earns-sandhi-tolerant-recall-by-fusing-every-nasal-to-n--which-manufactures-false-quotation-matches-unless-every-hit-is-re-verified-on-norm"
   },
   {
@@ -467,7 +467,7 @@
    "section": "Encoding & normalization",
    "importance": 3,
    "evidence_date": "2026-07",
-   "age_days": 5,
+   "age_days": 6,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#102-dcs-sentencetext_sandhied-is-not-reliably-sandhied--some-rows-store-analyzed-word-forms-which-silently-downgrades-verbatim-quotations-to-partial-matches"
   },
   {
@@ -476,7 +476,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06",
-   "age_days": 35,
+   "age_days": 36,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#37-bom-state-is-inconsistent-across-exports"
   },
   {
@@ -485,7 +485,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06-27",
-   "age_days": 23,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#38-injected-boms-crash-the-hw-record-parser"
   },
   {
@@ -494,7 +494,7 @@
    "section": "Encoding & normalization",
    "importance": 1,
    "evidence_date": "2026-06",
-   "age_days": 35,
+   "age_days": 36,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#39-devanagari_to_slp1-mis-routes-retroflex-la"
   },
   {
@@ -503,7 +503,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 24,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#40-gloss-language-spelling-drift-tracks-reform-type-not-age"
   },
   {
@@ -512,7 +512,7 @@
    "section": "Encoding & normalization",
    "importance": 1,
    "evidence_date": "2026-07-05",
-   "age_days": 15,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-practical-russian-transcription-of-sanskrit-names-has-no-safe-reverse-transliteration"
   },
   {
@@ -521,7 +521,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 18,
+   "age_days": 19,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#41-the-sanskrit-dictionary-platform-landscape-probed-live"
   },
   {
@@ -530,7 +530,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#47-heritage-data-is-acquirable-despite-the-anubis-wall--via-a-github-mirror-the-morphology-xml-is-not-in-it"
   },
   {
@@ -539,7 +539,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 18,
+   "age_days": 19,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#43-skdvcp-sensecitation-fusion-is-a-record-type-effect-not-a-dictionary-level-one"
   },
   {
@@ -548,7 +548,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 18,
+   "age_days": 19,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#44-raw-latin-string-tallies-over-gloss-text-include-etymological-false-positives-bopp-lacks-yabh"
   },
   {
@@ -557,7 +557,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 18,
+   "age_days": 19,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#45-siglum-prefix-families-routinely-bundle-several-distinct-works-the-diacritic-stripping-fold-has-poisoned-keys"
   },
   {
@@ -566,7 +566,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#48-vedaweb-20s-resource-export-is-an-async-task-behind-a-pickup-key-not-a-direct-get--and-the-server-went-unresponsive-mid-attempt"
   },
   {
@@ -575,7 +575,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#49-mwheritage-coverage-highlighting-is-a-duplicate-anchor-pattern-not-a-css-class--and-the-mirrors-current-dictionary-is-a-different-scope-asset-than-the-2014-reader-stem-list"
   },
   {
@@ -584,7 +584,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#50-cdsl-display-paths-are-not-uniformly-2020web--and-two-new-digitizations-landed-in-june-2026"
   },
   {
@@ -602,7 +602,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#51-huet-correspondence-predates-this-session-2021--the-morphology-xml-gate-was-already-resolved-in-writing-direct-download-urls-recovered"
   },
   {
@@ -611,7 +611,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#52-heritage-vs-kosha-forms-diff-the-small-raw-overlap-is-mostly-convention--model-difference-and-disagreements-are-two-thirds-lemmatization-policy-not-error"
   },
   {
@@ -620,7 +620,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#53-the-wil-etymology-extractions-affix-field-is-half-noise--wilson-outlier-figures-are-substantially-a-measurement-artifact"
   },
   {
@@ -629,7 +629,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#56-dicos-entry-anchors-nest-three-structural-roles-under-one-html-class--only-one-is-a-true-entry-boundary"
   },
   {
@@ -638,7 +638,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#55-gen_opt_harness2py-output-budget-coarser-wins-on-both-knobs-in-opposite-directions"
   },
   {
@@ -647,7 +647,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#57-samskrtamruz-is-id-addressed-with-no-name-lookup--deep-linking-needs-a-scraped-rootid-table-8-primer-basic-roots-are-absent"
   },
   {
@@ -656,7 +656,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#58-pwg-ru-promoted-store-has-input-level-provenance-but-old-ru-rows-lacked-exact-model-versions"
   },
   {
@@ -674,7 +674,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 17,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#70-pwg_ru-tm-composite-grade-a-is-consensus-gated-57-and-a-reference-free-surface-qe-cannot-detect-wrong-sense"
   },
   {
@@ -683,7 +683,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-07",
-   "age_days": 13,
+   "age_days": 14,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#61-the-reverse-dictionarys-30-sources-split-18-pd-vs-10-in-copyright--the-merged-headword-list-is-not-automatically-publishable"
   },
   {
@@ -692,7 +692,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-08",
-   "age_days": 12,
+   "age_days": 13,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#71-pwg-marks-case-government-explicitly-3853-times-across-3222-senses--a-deterministic-census-not-an-estimate"
   },
   {
@@ -701,7 +701,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-08",
-   "age_days": 12,
+   "age_days": 13,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#72-vedawebs-id_gra-token-field-is-the-grassmann-l-entry-number--no-fuzzy-text-matching-needed-for-a-gravedaweb-crosswalk"
   },
   {
@@ -710,7 +710,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-08",
-   "age_days": 12,
+   "age_days": 13,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#73-vedaweb-20s-cc-by-40-for-everything-claim-is-not-machine-confirmed--only-236-catalog-resources-carry-an-explicit-license-field"
   },
   {
@@ -719,7 +719,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-08",
-   "age_days": 12,
+   "age_days": 13,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#74-the-ls-graph-citation-matrix-is-degenerate-for-mw--its-top-abbreviations-sit-unresolved-use-the-citation-apparatus-siglum-matrix-for-cross-dict-citation-profiles"
   },
   {
@@ -728,7 +728,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-10",
-   "age_days": 10,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#66-the-dcs-ql-frequency-workbooks-slp1-and-length-columns-are-truncated-at-ṣṭhḍh-clusters"
   },
   {
@@ -737,7 +737,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-10",
-   "age_days": 10,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#67-in-pwg-article-size-dwarfs-every-parametric-statistic-you-can-extract-from-the-entry"
   },
   {
@@ -746,7 +746,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-10",
-   "age_days": 10,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#68-the-sanskrit-spellchecker-landscape-one-dormant-demo-one-license-unsettled-543k-wordlist-no-occupant"
   },
   {
@@ -755,7 +755,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-10",
-   "age_days": 10,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#69-hand-transcribed-telemetry-cannot-adjudicate-code-vs-infra--and-a-local-only-ledger-silently-swaps-your-denominator"
   },
   {
@@ -764,7 +764,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-10",
-   "age_days": 10,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#75-the-full-devībhāgavata-purāṇa-sanskrit-is-not-on-gretil--only-the-devigita-fragment-the-complete-mūla-lives-on-sanskritdocumentsorg-without-dbhp_-markers"
   },
   {
@@ -1045,6 +1045,15 @@
    "evidence_date": null,
    "age_days": null,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#457-dcs-covers-25-of-the-poona-dictionarys-citation-mass-but-78-of-dcss-own-tokens--the-classical-core-not-pds-encyclopedic-breadth-and-a-siglum-prefix-merge-fuses-mahābhā-mahābhārata-with-mahābh-mahābhāṣya"
+  },
+  {
+   "n": 458,
+   "title": "A Sanskrit dictionary's big letters are big because they head *preverb families* — and testing \"entries shrink over publication\" needs an outlier-robust estimator, not a parametric regression (encyclopedic dicts have single 300k-char articles)",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#458-a-sanskrit-dictionarys-big-letters-are-big-because-they-head-preverb-families--and-testing-entries-shrink-over-publication-needs-an-outlier-robust-estimator-not-a-parametric-regression-encyclopedic-dicts-have-single-300k-char-articles"
   }
  ]
 }

--- a/findings_dashboard/timeseries.json
+++ b/findings_dashboard/timeseries.json
@@ -40,12 +40,12 @@
    }
   },
   {
-   "date": "2026-07-20",
+   "date": "2026-07-21",
    "source": "build",
    "metrics": {
     "dcs_cdsl_linkage_pct": 81.4,
     "glossary_vidyut_coverage_pct": 86.6,
-    "pwg_citation_coverage_pct": null,
+    "pwg_citation_coverage_pct": 83.6,
     "queue_verdicts": {
      "PASS": 92,
      "DROP": 1,
@@ -68,11 +68,11 @@
     "queue_decay_pct": 0.82
    },
    "registry": {
-    "total": 115,
+    "total": 116,
     "by_importance": {
      "2": 78,
      "1": 18,
-     "3": 19
+     "3": 20
     },
     "stale": 0
    }


### PR DESCRIPTION
## Summary
- H1397 was minted to append the H1328 uttarapada-vs-corpus finding as **§102** to `FINDINGS.md`. On fetch, §102 was already taken by a different (earlier) finding, and the H1328 content had already shipped in PR #618 — renumbered to **§456** by the 20-07-2026 collision fix (issue #624).
- That renumbering only moved the §456 **header** + a tombstone note. The actual finding **body** (Jaccard/strata analysis + Source blockquote) was left orphaned — headerless text sandwiched between §457 and §458, invisible to `epistemic_integrity_check.py`'s heading scan (no `### §` line to collide on) but genuine duplicate/dead content.
- Fix: moved the orphaned body back under its own §456 header. Pure relocation — 42 insertions / 43 deletions, no content change (verified: `git diff` shows only the same lines shifted, nothing added/removed in substance).
- Regenerated `findings_dashboard/data.json` + `timeseries.json` and `epistemic_dashboard/epistemic.json` — both stale (115/116 headings) before this fix, now `116`.
- `python tools/epistemic_integrity_check.py --dir .` now reports full `OK`.

H1397's original scope (append §102) is superseded — the substance already shipped; only the accidental orphan from that shipment needed fixing.

Handoff: [H1397](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1397-Sonnet_SanskritLexicography_findings-uttarapada-dict-vs-corpus-divergence_20.07.26.md)

## Test plan
- [x] `python tools/epistemic_integrity_check.py --dir .` → `OK — 116 distinct FINDINGS headings, Index parity holds, no duplicate §-numbers, dashboards in sync.`
- [x] Confirmed §456/§457/§458 boundaries clean via grep
- [x] `git diff --stat` shows a pure move (no net content change beyond header-date bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)