### PR TITLE
fix(pwg_ru): verify+fix audit/mask robustness plausibles P3-P8 (H1422)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -38,6 +38,58 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   (`test_frag_prov_glob_honors_coordinator_dir_c7`, `test_pwg_mask_german_homograph_not_latin_c8`)
   and `promote_en --selftest` (C9 block).
 
+### Fixed — audit/mask robustness plausibles P3–P8, verified and fixed (H1422)
+
+Six LOW-severity PLAUSIBLE findings from the same Opus 4.8 adversarial bug-hunt
+([issue #632](https://github.com/gasyoun/SanskritLexicography/issues/632)) that shipped C1–C9
+above — verified against real code/callers, all six real, all fixed:
+
+- **P3 — the degenerate cross-reference pass-through lane leaked German into the RU/EN field.**
+  [`gen_opt_harness2.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/gen_opt_harness2.py)
+  `degenerate_passthrough_card` assigned `field: body` — the German source text, verbatim — for
+  stubs it correctly identified as untranslatable (`vgl.`/`s.`/`ff.` cross-reference particles).
+  These German tokens are not even covered by `german_residue_scan.py`'s wordlist (it requires
+  3+-letter function words), so the leak was previously undetectable by any existing audit. Now
+  the target field stays empty; the German remains visible via the `german` key for editorial
+  reference.
+- **P4 — sense-tier splitting had no open-span guard, unlike the citation-batch tier.**
+  [`autosplit_requeue.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/autosplit_requeue.py)
+  `_blocks` detected sense boundaries purely from lines matching `_SENSE` ("1)", "2)", …), with no
+  `_span_open` awareness — unlike `_cit_parts` (H155). A multi-line `<ls>`/`{#..#}` citation whose
+  interior contained a `_SENSE`-shaped locator could be torn across two (sub)sense blocks. Fixed
+  by applying the same balanced-span deferral to sense-boundary detection.
+- **P5 — `audit_sense_dupes.norm()` stripped `)`/`〉` but not a trailing `.`.**
+  [`audit_sense_dupes.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/audit_sense_dupes.py):
+  tag `1.` and plain `1` hashed to different buckets, so a real cross-part duplicate with
+  mismatched locator punctuation was missed by the dupe check. Now strips trailing `.`/`)` in
+  any order; an interior period (`caus. 2`) stays untouched.
+- **P6 — `audit_window.run_py`'s subprocess call had no error handling.**
+  [`audit_window.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window.py):
+  a `TimeoutExpired`/`OSError` re-raised straight through `collect_cards`/`root_glue_translated.py`
+  and crashed the whole audit with no report or requeue, even though `main()`'s gate loop already
+  handles a non-`{0,1}` returncode gracefully. Now converts either exception into that same result
+  shape (returncode `124`/`-1`) instead of propagating.
+- **P7 — the EN `MISSING-EN` hard gate treated cross-ref/abbrev residue as translatable prose.**
+  [`audit_window_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window_en.py):
+  `has_gloss` fired on ANY non-empty German prose residue, including a bare cross-reference
+  apparatus (`vgl. {#foo#} fgg.`) that `xref_only()` already recognizes as non-target — hard-failing
+  a sense that was never a translation target the moment its english field was correctly left
+  empty. Now `has_gloss` also requires `not xref_only(g)`.
+- **P8 — EN `MARKUP-LOSS` summed two marker classes before comparing, letting one mask the other.**
+  [`audit_window_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window_en.py):
+  `{%..%}` gloss-wrapper count and `<div>` count were added into one combined number, so a dropped
+  gloss wrapper could be masked by an unrelated `<div>` gained in the english (net count unchanged).
+  Now counts and compares each marker class separately.
+
+LANG_PARITY.md re-verified: `target_field_markup_fidelity_parity_c1` (P3's degenerate lane is
+structurally exempt from the C1 fidelity guard — it bypasses `translateBatch`/`healOnly`
+entirely) and `subprocess_and_bom_hardening_h316` (P6 only adds error handling around the
+existing `encoding='utf-8'`/`timeout=1800` call, both left unchanged) verdicts confirmed to
+still hold; 49 stale hashes re-verified and updated. Selftests: `window_selftest`
+(`test_degenerate_passthrough_no_german_in_target`, `test_sense_split_never_tears_open_span`,
+`test_sense_dupe_norm_strips_trailing_period`, `test_run_py_survives_timeout_and_oserror`,
+`test_p7_missing_en_not_fired_on_xref_only_residue`, `test_p8_markup_loss_not_masked_by_unrelated_div`).
+
 ### Fixed — EN DUP gate false-flags distinct referents (C2) + EN promote {Tn} guard (C6) (H1414)
 
 - **C2 — the EN within-card `DUP` HARD gate false-flagged distinct proper-name senses.**

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -98,7 +98,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "31abd637d86fc42db9979e31bb560b67f324147339e623ee9837002d2684e0e8",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -118,10 +118,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "C1 (bug-hunt review, Opus 4.8 claude-opus-4-8, 21-07-2026). The check keys off TARGET_FIELD (JS) / manifest['field'] (Python) = the per-language field, so it applies identically to ru and en with no language branching. Ported to every off-batch lane the batch accept() H1152 guard never reached: JS heal (stitched-translation-fidelity-reject), headless normalize_batch + selfheal stitch (translation-fidelity-reject / stitched-translation-fidelity-reject), autosplit cmd_merge + stitch_topup (complete-stitch fidelity drift -> reject). Tests: window_selftest test_heal_lane_target_field_fidelity_wired / test_autosplit_stitch_topup_rejects_target_field_drop / test_autosplit_merge_rejects_target_field_drop; headless_worker_selftest test_normalize_batch_translation_fidelity_reject / test_headless_heal_stitch_translation_fidelity_reject.",
     "tracking": "H1412",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
-      "src/pilot/autosplit_requeue.py": "382e52293cea55a0c6b6ebe0adb88639ec4ce8dc08255d11af312e24144bb6c9",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -138,7 +138,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60"
     }
   },
   {
@@ -156,8 +156,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -175,8 +175,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -194,8 +194,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -212,7 +212,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60"
     }
   },
   {
@@ -229,7 +229,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60"
     }
   },
   {
@@ -263,7 +263,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60"
     }
   },
   {
@@ -280,7 +280,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60"
     }
   },
   {
@@ -297,7 +297,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 closes the former divergence: exact model provenance is required across four accounts, so both RU and EN now request and stamp claude-sonnet-5. This prevents account/profile alias resolution from making cross-window provenance incomparable.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60"
     }
   },
   {
@@ -319,8 +319,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
-      "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
-      "src/pilot/audit_window_en.py": "a65478e25e06c50b03a49ad5852ea4582ac00bb6db71c1b2d94f8c1be42f9d64"
+      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
+      "src/pilot/audit_window_en.py": "80eb48b8abbca0d207778c5abcda5de71aa99cf9a553f2a4fd855e7bfb42b3b2"
     }
   },
   {
@@ -338,7 +338,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The denylist append and load_frag_tm filtering are lang-agnostic (fsha encodes lang; requeue_from_audit takes --lang), but the fshas EMITTER lives only in the RU auditor: audit_window_en.py reimplements its gates and does not compute requeue_defect_fshas or write the file, so an EN defect requeue does not auto-denylist its fragments.",
     "tracking": "Uprava/handoffs/archive/H304-Fable_RussianTranslation_coordinator-driver-remake_07.07.26.md (EN-emitter port is the recorded follow-up)",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
+      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2"
     }
@@ -394,8 +394,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -413,8 +413,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H169 (2026-07-04 review, 'broken validators'): the advertised HARD DUP gate was never emitted -- the only within-record duplicate signal was soft SAME-GLOSS, gated on >=3 content words, so a short duplicate ('to go'/'to go') produced zero flags and --strict passed. Classified GAP-being-closed rather than INTENTIONAL-DIVERGENCE: RU's within-record duplicate protection is the cross-part audit_sense_dupes.py gate (already SHARED, see gate_fixes_20260703_ru_only/PR #135) plus the soft, all-senses-only identical_russian_glosses risk in prompt_rule_audit.py (MEDIUM, not high-confidence) -- neither is a pairwise HARD gate. EN now closes that with a real HARD pairwise DUP check; RU getting an equivalent pairwise HARD gate (rather than its current all-or-nothing soft signal) is left as a natural follow-up, not blocking this fix. Pinned by test_en_gate_dup_has_teeth in window_selftest.py. C2 (21-07-2026, Opus 4.8 claude-opus-4-8): the HARD gate keyed on prose(english), which STRIPS {#..#} Sanskrit and <ls>, so two senses distinguished only by their referent ('N. of a serpent-demon {#vAsuki#}' vs '…{#takzaka#}') collapsed to one string and the second was wrongly HARD-DUP'd, failing --strict on faithful output (310 real within-record cases). Fixed to key the DUP seen-dict on the normalized RAW english (referent preserved) while CIRCULAR keeps prose() norm; a true identical-english duplicate is still caught HARD. Pinned by test_en_dup_gate_preserves_sanskrit_referent_c2.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "a65478e25e06c50b03a49ad5852ea4582ac00bb6db71c1b2d94f8c1be42f9d64",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/audit_window_en.py": "80eb48b8abbca0d207778c5abcda5de71aa99cf9a553f2a4fd855e7bfb42b3b2",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -451,8 +451,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -489,7 +489,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9"
     }
   },
@@ -509,9 +509,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -540,9 +540,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/preflight_remaining_gates.py": "00386c837b97986c9702abfceed9c29534736c3df3063af202ddfaae6b078b8f",
       "src/release_readiness.py": "db38a870bbc8b5dbe694e706e4a7b9089ba41211a3881ad9a1bd4eb02950c8a9",
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
-      "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
-      "src/pilot/autosplit_requeue.py": "382e52293cea55a0c6b6ebe0adb88639ec4ce8dc08255d11af312e24144bb6c9",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
+      "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -561,7 +561,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -579,7 +579,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -598,7 +598,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -655,7 +655,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dbbf4e77b39585dabdd3df122143cacc15fedb97ce6c3d12654061e8fe6c11b9",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
       "src/promote_en.py": "5cee9e839a3f32efc2e8bb83a37e7fd6354199b48306bc2b3cdac6c57b7194aa",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -676,11 +676,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H336 (08-07-2026). window_reports.write_reports/write_window_status already took an out_dir parameter (pre-existing --out-dir escape hatch); --window-tag is a thin, lang-agnostic sugar layer over that same parameter computed once in audit_window.py and threaded through unchanged to requeue_from_audit.py/root_window_status.py. Neither RU nor EN branch differently. Pinned by test_audit_window_tag_routing.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
+      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -709,7 +709,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -729,7 +729,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -748,7 +748,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "8a8e7bb6cbf313f0fb1097bd72d8fccad1e17d79539f9ecf0a424ca7c87d0b87",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -785,7 +785,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -804,7 +804,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/stage2_pregate.py": "8f07422d3c416e32d1882f0777d56cc44ba781d19c8097fd9500ddefbfd22945",
-      "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f"
+      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f"
     }
   },
   {
@@ -822,7 +822,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H405 (09-07-2026, resolved same day). Both editions now run the same pregate() module for the mechanical invariants; the difference is only the adapter (RU: subprocess --wf over file pairs; EN: in-process per-sense), not the logic. The partial-adoption (net-new flag types only) is deliberate — the EN auditor already reimplemented LS/SAN/AB/MISSING per-sense with its own thresholds, so pregate contributes exactly the invariants it lacked (<is>, stranded/leaked anchors) rather than duplicating. Verified by a functional test (clean / is-dropped→IS-LOSS / stranded→STRANDED-ANCHOR / ls-dropped→single LS-LOSS not double-flagged) + window_selftest.py green.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "a65478e25e06c50b03a49ad5852ea4582ac00bb6db71c1b2d94f8c1be42f9d64",
+      "src/pilot/audit_window_en.py": "80eb48b8abbca0d207778c5abcda5de71aa99cf9a553f2a4fd855e7bfb42b3b2",
       "src/stage2_pregate.py": "8f07422d3c416e32d1882f0777d56cc44ba781d19c8097fd9500ddefbfd22945"
     }
   },
@@ -843,7 +843,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -861,8 +861,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -880,8 +880,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -900,8 +900,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968",
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -922,8 +922,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -980,9 +980,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -1009,7 +1009,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 Windows readiness uses one language-parameterized manifest and worker contract. Whole-card retries, binary split, fragment TM/restore/fidelity, per-card budgets, timeout-no-bisect, partial stitching, audit-clean subset promotion, staged dispatch, and credential-safe event/census telemetry do not branch on RU/EN. Production policy selects RU no_pwg for the first 100-headword proof; the mechanism preserves EN field/schema behavior.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
       "src/pilot/max_account_orchestrator.py": "12fb8c3bcdc8897e7eaff2285e6d32547b11f047b58921169a9736e37a24aa0c",
       "src/pilot/coordinator.py": "8a8e7bb6cbf313f0fb1097bd72d8fccad1e17d79539f9ecf0a424ca7c87d0b87",
@@ -1039,10 +1039,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H390 Phase 1 (12-07-2026, Opus 4.8 claude-opus-4-8), extended by H818. gen_model is written into language-agnostic run meta and flows through the shared ledger writer and harvester identically for RU/EN; both paths now stamp exact claude-sonnet-5. Pinned by test_ledger_stamps_gen_model in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -1060,8 +1060,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H823, fixes the H255 presplit-cohort loss). Both the citation presplit trigger (_presplit_hit) and the single-card kill budget (killBudgetForCur) are language-independent — they key on <ls>/fragment counts and FRAGS, never on --lang; the same floor + CEIL apply to RU and EN identically. Extends no_fallback_single_kill_budget_and_nominal_key_echo (H220) from no-fallback singles to all singles. Pinned by test_presplit_cite_floor_and_single_ceil.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -1084,9 +1084,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
-      "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
-      "src/pilot/audit_window_en.py": "a65478e25e06c50b03a49ad5852ea4582ac00bb6db71c1b2d94f8c1be42f9d64",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
+      "src/pilot/audit_window_en.py": "80eb48b8abbca0d207778c5abcda5de71aa99cf9a553f2a4fd855e7bfb42b3b2",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -1106,9 +1106,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H960 (15-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes H920's explicitly-deferred accept()-side sense-count consumption. Language-neutral: accept() counts SENSE OBJECTS (records[].senses[]), never a gloss language, and source_senses is sense_count.count_source_senses over the German source markers (identical for the RU and EN lanes — the source is German for both). SOFT by default (SANLOSS_HARD_REJECT=false): a shortfall is telemetry only (no reject/requeue), so live traffic can measure the true drop-vs-false-flag rate before the reject is armed (owner-gated ladder). The shared counter is hardened against the ~4.78%-of-cards cross-reference over-count the naive count carried (gam~~h2_31_pari 2->1, s_ud~~h0_05_pra 4->2, _a_srayatva 2->0); under-counting is the safe direction, never a false shortfall. Pinned by test_h960_accept_sanloss_soft_gate (builds the real harness, extracts the emitted accept()+countOf, asserts soft-keep / surplus-ok / FP-regression / ls-sk-first / armed-hard-reject via accept_sensecount_test.js) plus the 3 cross-reference fixtures in sense_count._selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1128,7 +1128,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -1146,7 +1146,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1152 guard 2 (17-07-2026, Sonnet 4.6 claude-sonnet-4-6), closing H1070's r102 finding (PWG->EN FU1 pilot, vac~~h0_00_pwg00: a {#uc#} span inside a <F> footnote survived the german echo 33/33 but was dropped from english 32/33 -- invisible to the pre-existing check because it never reads the translation field). accept() is lang-parameterized code shared by both lanes (field = 'russian' or 'english', same code path); the new check is symmetric and applies identically to RU and EN generation. Verified against the live RU regression suite: window_selftest.py full run stays green (137/137 baseline, +2 new content-check tests for guards 1/3), and the new/updated fixtures in accept_sensecount_test.js reproduce the exact r102 shape (RED before this change -- proven via git-stash against the pre-fix accept(), the fixture is silently ACCEPTED -- GREEN after). No RU store data touched; this only changes the generation-time accept-path gate for FUTURE generation, never re-validates the 11,605 already-promoted RU rows.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1182,8 +1182,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "EN-only by construction: the RU audit path (audit_window.py + prompt_rule_audit.py) is wired around .merged.md/.raw.txt files and Russian-specific semantic checks, per audit_window_en.py's own module docstring (\"the RU gate ... is wired around ... Russian-specific semantic checks, so the PWG->EN pilot ran with --no-audit. This is the EN sibling\"); XREF-ONLY/NWS-DE-LOCKED are new, EN-only soft flags with no RU counterpart to port -- the RU gate's own dropped_sanskrit_span in prompt_rule_audit.markup_sigla_risks already covers RU's analogous case and was not touched. Pinned by test_h1152_guard3_xref_only_and_nws_de_locked.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "a65478e25e06c50b03a49ad5852ea4582ac00bb6db71c1b2d94f8c1be42f9d64",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968"
+      "src/pilot/audit_window_en.py": "80eb48b8abbca0d207778c5abcda5de71aa99cf9a553f2a4fd855e7bfb42b3b2",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79"
     }
   },
   {
@@ -1251,7 +1251,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/fix_german_connectives.py": "6a5cceb58cd7c989df819703dff777bb635ee979c7178c55ceccce199a3737a8",
       "src/pilot/foreign_literal_guards.py": "e7eaccfb846ff805b585b1c6413ec84b71970dd7fdddfc6abef90fcf04650b93",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
-      "src/pilot/audit_window_en.py": "a65478e25e06c50b03a49ad5852ea4582ac00bb6db71c1b2d94f8c1be42f9d64"
+      "src/pilot/audit_window_en.py": "80eb48b8abbca0d207778c5abcda5de71aa99cf9a553f2a4fd855e7bfb42b3b2"
     }
   },
   {
@@ -1271,7 +1271,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1226: the {Tn} pairing is stamped in the SHARED accept() (runs for both languages) and BOTH promote lanes (promote_final_cards.py RU, promote_en.py EN) carry it to provenance.tnmask, so neither store silently drops the field accept() stamps. Only accept() stamps it: the heal path's acceptFrag hard-rejects fragment {Tn} mismatches, so no un-rejected expansion reaches a healed card. Makes the TNMASK false-flag rate MEASURABLE (H1150 DO_NOT_ARM, denominator 1); TNMASK_HARD_REJECT stays = false — arming is a human @DECIDE. Pinned by window_selftest.test_tnmask_persist_and_offline_detect + tnmask_offline.selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
       "src/promote_en.py": "5cee9e839a3f32efc2e8bb83a37e7fd6354199b48306bc2b3cdac6c57b7194aa",
       "src/pilot/tnmask_offline.py": "c857fe425fadbe18c1cdf398892f53b590709048ca66faf94fd05e046730ffea"
@@ -1295,8 +1295,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
-      "src/pilot/audit_window.py": "fefcfe9abb293338f5a61492a025a31d763f01bdb52495db4a0bbae55356db6f",
-      "src/pilot/window_selftest.py": "12c9283676c03ce71f48ad47cd8aef28c86e6ac8aeb6bf0f06e5b77a7c25b968",
+      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
+      "src/pilot/window_selftest.py": "a767fdcf08d372d5623f6708bc0bd5ed87c98d047192a11c2c85fe2e2967ce79",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1323,7 +1323,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
       "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695"
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60"
     }
   },
   {
@@ -1399,7 +1399,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "f92c937f3e881515ca5abdbe800a40765304a1f3115ad99b86ff35fc0933c695",
+      "src/pilot/gen_opt_harness2.py": "1230fc0c6f5571e9334c38794294b07de5ffd72de0971120194741323b5e9c60",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7"
     }
   },

--- a/RussianTranslation/src/audit_sense_dupes.py
+++ b/RussianTranslation/src/audit_sense_dupes.py
@@ -81,8 +81,16 @@ def find_results(o):
 
 
 def norm(tag):
-    """Normalize a sense tag so 'caus. 2' and plain '2' stay DISTINCT but '2)'=='2'=='2 '."""
-    t = (tag or '').strip().lower().replace('〉', '').rstrip(')').strip()
+    """Normalize a sense tag so 'caus. 2' and plain '2' stay DISTINCT but '2)'=='2'=='2 '=='2.'.
+
+    P5 (H1422): the trailing-punctuation strip covered ')'/'〉' but not '.', so '1.' and '1'
+    hashed to different buckets and a real cross-part duplicate with mismatched locator
+    punctuation was missed. Strips a trailing '.' too, repeatedly with ')'/whitespace so
+    order (e.g. '2.)' or '2).') doesn't matter -- an INTERIOR '.' (e.g. 'caus. 2') is
+    untouched, since only trailing punctuation is stripped."""
+    t = (tag or '').strip().lower().replace('〉', '')
+    while t and t[-1] in ').':
+        t = t[:-1].rstrip()
     return re.sub(r'\s+', ' ', t)
 
 

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -90,11 +90,28 @@ def run_final_schema_gate(results):
 
 def run_py(args, env=None):
     t0 = time.perf_counter()
-    p = subprocess.run([sys.executable] + args, cwd=SRC, capture_output=True,
-                       text=True, encoding='utf-8', env=env, timeout=1800)
-    return {'argv': [sys.executable] + args, 'returncode': p.returncode,
-            'stdout': p.stdout, 'stderr': p.stderr,
-            'seconds': round(time.perf_counter() - t0, 3)}
+    argv = [sys.executable] + args
+    # P6 (H1422): subprocess.run had no try/except -- a TimeoutExpired/OSError re-raised
+    # straight through the caller (collect_cards / root_glue_translated.py) and crashed
+    # the whole audit with no report or requeue. The rest of main() already handles a
+    # non-{0,1} returncode gracefully (gates/'collect'/'glue' each append to `crashed` and
+    # the audit still reports+requeues) -- so on either exception this returns the SAME
+    # shape a normal run does, with a distinguishing returncode: 124 (the conventional
+    # "timed out" exit code) or -1 for any other OSError (missing interpreter, etc.).
+    try:
+        p = subprocess.run(argv, cwd=SRC, capture_output=True,
+                           text=True, encoding='utf-8', env=env, timeout=1800)
+        return {'argv': argv, 'returncode': p.returncode,
+                'stdout': p.stdout, 'stderr': p.stderr,
+                'seconds': round(time.perf_counter() - t0, 3)}
+    except subprocess.TimeoutExpired as e:
+        return {'argv': argv, 'returncode': 124, 'stdout': e.stdout or '',
+                'stderr': (e.stderr or '') + '\nrun_py: TimeoutExpired after %ss' % e.timeout,
+                'seconds': round(time.perf_counter() - t0, 3)}
+    except OSError as e:
+        return {'argv': argv, 'returncode': -1, 'stdout': '',
+                'stderr': 'run_py: OSError: %s' % e,
+                'seconds': round(time.perf_counter() - t0, 3)}
 
 
 def run_py_inproc(args):

--- a/RussianTranslation/src/pilot/audit_window_en.py
+++ b/RussianTranslation/src/pilot/audit_window_en.py
@@ -202,7 +202,13 @@ def audit_sense(german, english):
         soft.append('XREF-ONLY')
     if nws_de_locked(g):
         soft.append('NWS-DE-LOCKED')
-    has_gloss = '{%' in g or bool(prose(g).strip())
+    # P7 (H1422): has_gloss used to fire on ANY non-empty prose residue, including a bare
+    # cross-reference/abbreviation apparatus ('vgl. {#foo#} fgg.') that xref_only() already
+    # recognizes as non-target (soft XREF-ONLY above) -- hard-failing MISSING-EN on a sense
+    # that was never a translation target in the first place. Residual gap not attempted
+    # here: xref_only's WORD regex requires 3+ letters, so a residue of ONLY 1-2 letter
+    # tokens ('s.', 'u.') with no other prose still slips through as has_gloss=True.
+    has_gloss = not xref_only(g) and ('{%' in g or bool(prose(g).strip()))
     if has_gloss and not e.strip():
         hard.append('MISSING-EN')
         return hard, soft
@@ -217,10 +223,14 @@ def audit_sense(german, english):
     if sab > 0 and (sab - oab) >= 2:
         hard.append('AB-LOSS(%d/%d)' % (oab, sab))
 
-    smk = len(GLOSS.findall(g)) + len(DIVTAG.findall(g))
-    omk = len(GLOSS.findall(e)) + len(DIVTAG.findall(e))
-    if smk > 0 and omk < smk:
-        soft.append('MARKUP-LOSS(%d/%d)' % (omk, smk))
+    # P8 (H1422): the two marker classes were summed into one combined count before
+    # comparing, so a dropped {%..%} gloss wrapper could be masked by an unrelated <div>
+    # gained in the english (net count unchanged, e.g. source 2 gloss/0 div vs output
+    # 0 gloss/2 div -- 2 == 2, no flag). Count and compare each class separately.
+    sgl, ogl = len(GLOSS.findall(g)), len(GLOSS.findall(e))
+    sdiv, odiv = len(DIVTAG.findall(g)), len(DIVTAG.findall(e))
+    if (sgl > 0 and ogl < sgl) or (sdiv > 0 and odiv < sdiv):
+        soft.append('MARKUP-LOSS(%d/%d)' % (ogl + odiv, sgl + sdiv))
 
     ep = prose(e)
     if CYR.search(ep):

--- a/RussianTranslation/src/pilot/autosplit_requeue.py
+++ b/RussianTranslation/src/pilot/autosplit_requeue.py
@@ -119,7 +119,21 @@ _SENSE = re.compile(r'^(?:<div[^>]*>)?\s*(?:—\s*)?(?:\d+|[a-zA-Zα-ωΑ-Ω])\s
 def _blocks(raw):
     """(header, [sense/subsense blocks]) or None if <2 boundaries."""
     lines = raw.split('\n')
-    starts = [i for i, l in enumerate(lines) if _SENSE.match(l.strip())]
+    candidates = [i for i, l in enumerate(lines) if _SENSE.match(l.strip())]
+    if len(candidates) < 2:
+        return None
+    # P4 (H1422): a candidate sense boundary is rejected -- not just deferred within a
+    # block, but skipped as a boundary entirely -- if the text since the last ACCEPTED
+    # boundary still has an open <ls>/{#...#} span (see _span_open). Mirrors the guard
+    # _cit_parts/_dense_line_parts already apply at the citation-batch tier (H155); this
+    # repository never had it at the sense tier, so a multi-line citation whose interior
+    # happens to match _SENSE (a "N)"-shaped locator inside the span, not a real new
+    # sense) could tear the span across two blocks.
+    starts = [candidates[0]]
+    for i in candidates[1:]:
+        if _span_open('\n'.join(lines[starts[-1]:i])):
+            continue
+        starts.append(i)
     if len(starts) < 2:
         return None
     header = '\n'.join(lines[:starts[0]]).rstrip()

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -876,7 +876,11 @@ def degenerate_passthrough_card(key, raw, portrait_text, field='russian'):
     sense = {
         'tag': 'xref',
         'german': body,
-        field: body,
+        # P3 (H1422): body is German (plus the {#..#}/<ls>/<ab> markup) -- there is
+        # nothing here to translate, so the target field stays empty rather than
+        # silently carrying verbatim German into the russian/english column. The
+        # German is still visible via the 'german' key above for editorial reference.
+        field: '',
         'equivalence_type': 'explanatory',
         'source_type': 'lexicographic',
         'stratum': '',

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -1697,6 +1697,22 @@ def test_lang_parity_hash_crlf_independent():
             fail('file_sha256 is not CRLF/LF-independent: %s != %s' % (lf_hash, crlf_hash))
 
 
+def test_sense_dupe_norm_strips_trailing_period():
+    """P5 (H1422): norm() stripped a trailing ')'/'〉' but not '.', so tag '1.' and plain
+    '1' hashed to different buckets and a real cross-part duplicate with mismatched
+    locator punctuation ('1.' vs '1)' vs '1') was missed by the dupe check. An INTERIOR
+    period ('caus. 2') must stay distinct from plain '2' -- only trailing punctuation is
+    normalized away."""
+    from audit_sense_dupes import norm
+    for variant in ('1', '1.', '1)', '1 ', '1.)', '1).'):
+        if norm(variant) != '1':
+            fail('norm(%r) = %r, expected \'1\' -- trailing punctuation must normalize '
+                 'identically' % (variant, norm(variant)))
+    if norm('caus. 2') == norm('2'):
+        fail('norm() must keep \'caus. 2\' distinct from plain \'2\' -- an interior period '
+             'is meaningful, only trailing punctuation should be stripped')
+
+
 def test_sense_dupe_batch_override():
     """The cross-part sense-duplicate exemption must be reproducible from the committed
     rootmap_overrides.json, NOT from a gitignored hand-edited rootmap (PROCESS_AUDIT rec 15)."""
@@ -1851,6 +1867,41 @@ def test_en_gate_dup_has_teeth():
             os.remove(report_path)
 
 
+def test_run_py_survives_timeout_and_oserror():
+    """P6 (H1422): audit_window.run_py wrapped subprocess.run with no try/except -- a
+    TimeoutExpired or OSError re-raised straight through collect_cards/root_glue_translated
+    and crashed the whole audit with no report or requeue. main()'s gate loop already
+    handles a non-{0,1} returncode gracefully (appends to `crashed`, still reports+requeues)
+    -- so run_py must convert either exception into that same result shape instead of
+    letting it propagate. Monkeypatches subprocess.run in the audit_window module (no mock
+    lib used elsewhere in this file) to force each exception without a real 1800s wait."""
+    import audit_window as aw
+    real_run = aw.subprocess.run
+
+    def _raise_timeout(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd=a[0] if a else 'x', timeout=1800,
+                                        output='partial out', stderr='partial err')
+
+    def _raise_oserror(*a, **kw):
+        raise OSError('interpreter not found')
+
+    try:
+        aw.subprocess.run = _raise_timeout
+        res = aw.run_py(['fake_script.py'])
+        if res['returncode'] != 124:
+            fail('run_py must return returncode=124 on TimeoutExpired, got %r' % res['returncode'])
+        if not isinstance(res.get('stdout'), str) or not isinstance(res.get('stderr'), str):
+            fail('run_py must still return string stdout/stderr on TimeoutExpired: %r' % res)
+
+        aw.subprocess.run = _raise_oserror
+        res = aw.run_py(['fake_script.py'])
+        if res['returncode'] in (0, 1):
+            fail('run_py must not report a success/soft-fail returncode (0 or 1) on OSError, '
+                 'got %r' % res['returncode'])
+    finally:
+        aw.subprocess.run = real_run
+
+
 def test_ru_gate_fails_loud_on_unparseable_child():
     """H169 defect 2: the RU gate used to recover child-auditor verdicts by regex-scraping
     prose stdout (`| flagged: ...`) — any wording drift in audit_translation.py /
@@ -1922,6 +1973,21 @@ def test_markup_loss_soft_flag_ru():
     kept = risks('{%herfallen über%}', 'нападать на ({%herfallen über%})')
     if any(r['id'] == 'markup_wrapper_dropped' for r in kept):
         fail('markup_wrapper_dropped wrongly fired on a retained side-by-side {%..%} echo')
+
+
+def test_p8_markup_loss_not_masked_by_unrelated_div():
+    """P8 (H1422): MARKUP-LOSS used to sum {%..%} gloss-wrapper and <div> counts into ONE
+    combined number before comparing, so a genuinely dropped gloss wrapper could be masked
+    by an unrelated <div> gained in the english (net count unchanged: source 2 gloss/0 div
+    vs output 0 gloss/2 div -> 2 == 2, no flag). Counting each marker class separately
+    catches this; test_markup_loss_soft_flag_en (below) covers the un-masked ordinary case
+    end-to-end through the CLI."""
+    from audit_window_en import audit_sense
+    _, soft = audit_sense('{%to fall upon%} {%to attack%}',
+                          '<div n="1">to fall upon</div><div n="2">to attack</div>')
+    if not any(f.startswith('MARKUP-LOSS') for f in soft):
+        fail('MARKUP-LOSS must fire when both {%..%} wrappers are dropped, even though an '
+             'unrelated <div> count masks the OLD combined-sum comparison: %r' % soft)
 
 
 def test_markup_loss_soft_flag_en():
@@ -1998,6 +2064,26 @@ def test_h1152_guard3_xref_only_and_nws_de_locked():
     _, soft_san = audit_sense('{%to speak%} {#vac#}', 'to speak {#vac#}')
     if 'NWS-DE-LOCKED' in soft_san:
         fail('NWS-DE-LOCKED wrongly fired on genuine Sanskrit inside a {#..#} span')
+
+
+def test_p7_missing_en_not_fired_on_xref_only_residue():
+    """P7 (H1422): has_gloss used to fire on ANY non-empty prose residue, so a genuinely
+    non-target sense whose German is only a cross-reference apparatus ('Vgl. {#foo#} fgg.')
+    hard-failed MISSING-EN the moment its english field was correctly left empty (there was
+    nothing to translate). The neighboring test above only ever exercises xref rows WITH a
+    non-empty english, which can never trigger MISSING-EN regardless of has_gloss -- this
+    test is the one that actually reproduces the defect."""
+    from audit_window_en import audit_sense
+    hard, soft = audit_sense('Vgl. {#foo#} fgg.', '')
+    if 'MISSING-EN' in hard:
+        fail('MISSING-EN must not fire on a pure cross-reference row with empty english '
+             '(nothing was ever a translation target here): %r' % hard)
+    if 'XREF-ONLY' not in soft:
+        fail('XREF-ONLY should still fire on this row')
+    # CONTROL: a real gloss with empty english IS a genuine MISSING-EN.
+    hard_real, _ = audit_sense('{%to speak%}', '')
+    if 'MISSING-EN' not in hard_real:
+        fail('MISSING-EN must still fire when real gloss prose exists and english is empty')
 
 
 def test_ru_coverage_denominator_not_silently_exempt():
@@ -2531,6 +2617,25 @@ def test_degenerate_passthrough_accounted():
             fail('a degenerate pass-through key must not also enter an agent translation lane')
         if 'const DEGENERATE_RESOLVED' not in js or 'degenerate_passthrough: true' not in js:
             fail('generated harness must emit explicit degenerate pass-through rows')
+
+
+def test_degenerate_passthrough_no_german_in_target():
+    """P3 (H1422): a degenerate cross-reference stub has nothing translatable, so the
+    target-language field must stay empty rather than silently carrying verbatim German
+    (e.g. 'vgl.', 's.', 'ff.' -- particles the german_residue_scan/GERMAN_RESIDUE wordlists
+    do not even cover, so the leak was previously undetectable by any existing audit)."""
+    import gen_opt_harness2 as gh
+    for field in ('russian', 'english'):
+        card = gh.degenerate_passthrough_card('ab~~h0_zz_pw', '=== LAYER: PW ===\n\nvgl. {#agni#}',
+                                              '[]', field)
+        if not card:
+            fail('inline vgl.-stub should qualify for conservative degenerate pass-through')
+        sense = card['records'][0]['senses'][0]
+        if sense.get(field) != '':
+            fail('degenerate pass-through target field %r must be empty, got %r'
+                 % (field, sense.get(field)))
+        if 'vgl' not in sense.get('german', ''):
+            fail('the german field must still carry the original source text for editorial reference')
 
 
 def test_degenerate_passthrough_rejects_glosses():
@@ -4313,6 +4418,37 @@ def test_cit_split_never_tears_open_span():
         if text.count('{#') != text.count('#}'):
             fail('a returned fragment has an unbalanced {#/#} pair — Sanskrit span torn '
                  'across a cut: %r' % text)
+
+
+def test_sense_split_never_tears_open_span():
+    """P4 (H1422): autosplit_requeue._blocks detects sense boundaries purely from lines
+    matching _SENSE ("1)", "2)", ...), with no awareness of an open <ls>/{#...#} span --
+    unlike _cit_parts (H155, see test_cit_split_never_tears_open_span above), which already
+    defers a citation-batch cut until the accumulated text is span-balanced. A citation that
+    spans several lines can contain an interior line shaped like "2)" (a locator INSIDE the
+    span, not a real second sense), which _blocks used to accept as a genuine boundary and
+    tear the span across two (sub)sense blocks. Fixed by applying the same _span_open
+    deferral to sense-boundary detection: a candidate boundary is skipped (merged into the
+    current block) while the text since the last accepted boundary is still open."""
+    import autosplit_requeue as ar
+    raw = (
+        '1) first sense <ls n="a">start of citation\n'
+        '2) middle of citation still open</ls> end of first sense really\n'
+        '3) second real sense\n'
+    )
+    b = ar._blocks(raw)
+    if b is None:
+        fail('fixture should detect 2 real sense boundaries (1+3), got none')
+    header, blocks = b
+    if len(blocks) != 2:
+        fail('interior "2)" locator inside an open <ls> span must not be treated as a real '
+             'sense boundary -- expected 2 blocks, got %d: %r' % (len(blocks), blocks))
+    for blk in blocks:
+        if blk.count('<ls') != blk.count('</ls>'):
+            fail('a sense block has an unbalanced <ls>/</ls> pair — span torn across a '
+                 'sense-tier cut: %r' % blk)
+    if '3) second real sense' not in blocks[-1]:
+        fail('the genuine third sense must survive as its own block: %r' % blocks[-1])
 
 
 def test_cit_split_caps_single_line_monster_sense():
@@ -6832,6 +6968,7 @@ def main():
         test_suggest_tm_does_not_skip_agents,
         test_tm_publication_fixtures_validate,
         test_degenerate_passthrough_accounted,
+        test_degenerate_passthrough_no_german_in_target,
         test_degenerate_passthrough_rejects_glosses,
         test_perf_preflight_small_tm_and_no_tm,
         test_perf_preflight_dense_presplit,
@@ -6865,6 +7002,7 @@ def main():
         test_degenerate_source_identity,
         test_no_fallback_batch_isolation,
         test_cit_split_never_tears_open_span,
+        test_sense_split_never_tears_open_span,
         test_cit_split_caps_single_line_monster_sense,
         test_selfheal_fragment_si_threaded_and_tags_normalized,
         test_heal_lane_target_field_fidelity_wired,
@@ -6889,6 +7027,7 @@ def main():
         test_launch_failure_ledger_rejects_incomplete_entry,
         test_autosplit_topup_targets_and_reassembles,
         test_workflow_payload_nested,
+        test_sense_dupe_norm_strips_trailing_period,
         test_sense_dupe_batch_override,
         test_sense_dupe_cross_level_exempt,
         test_export_translation_dedup,
@@ -6927,12 +7066,15 @@ def main():
         test_nws_fp_suppressed,
         test_en_gate_strict_has_teeth,
         test_en_gate_dup_has_teeth,
+        test_run_py_survives_timeout_and_oserror,
         test_ru_gate_fails_loud_on_unparseable_child,
         test_pwg_mask_latin_cue_behind_ab_tag,
         test_markup_loss_soft_flag_ru,
+        test_p8_markup_loss_not_masked_by_unrelated_div,
         test_markup_loss_soft_flag_en,
         test_en_de_residue_french_guard,
         test_h1152_guard3_xref_only_and_nws_de_locked,
+        test_p7_missing_en_not_fired_on_xref_only_residue,
         test_ru_coverage_denominator_not_silently_exempt,
         test_coverage_gate_multi_layer_and_presplit,
         test_en_residual_coverage_complete,


### PR DESCRIPTION
## Summary
Six LOW-severity PLAUSIBLE findings from the Opus 4.8 adversarial pwg_ru bug-hunt ([issue #632](https://github.com/gasyoun/SanskritLexicography/issues/632); C1–C9 confirmed findings shipped in v1.47.0). Verified each against real code/callers first — all six are real defects, all fixed, one selftest pinned per defect.

- **P3** — `degenerate_passthrough_card` leaked German (`vgl.`/`s.`/`ff.`) verbatim into the RU/EN field for cross-reference stubs; undetectable by `german_residue_scan.py` (its wordlist requires 3+ letters). Target field now stays empty; German still visible via the `german` key.
- **P4** — `autosplit_requeue._blocks` had no open-span guard at the sense tier (unlike `_cit_parts`, H155) — a multi-line `<ls>`/`{#..#}` citation whose interior matched the sense-boundary regex could be torn across two blocks. Same `_span_open` deferral now applied.
- **P5** — `audit_sense_dupes.norm()` stripped `)`/`〉` but not a trailing `.`, so tag `1.` and `1` hashed to different buckets, missing real cross-part duplicates.
- **P6** — `audit_window.run_py` had no error handling around `subprocess.run` — a `TimeoutExpired`/`OSError` crashed the whole audit instead of degrading to the gate-errored path `main()` already handles gracefully (confirmed: a non-`{0,1}` returncode already appends to `crashed` and the audit still reports+requeues).
- **P7** — `audit_window_en.has_gloss` hard-failed `MISSING-EN` on cross-ref-only German residue that `xref_only()` already recognizes as non-target.
- **P8** — `audit_window_en` `MARKUP-LOSS` summed `{%..%}` gloss-wrapper and `<div>` counts before comparing, so a dropped gloss wrapper could be masked by an unrelated `<div>` gain (net count unchanged). Now compared per marker class.

**LANG_PARITY.md**: the two entries whose files I touched with mechanism descriptions close enough to warrant real scrutiny (`target_field_markup_fidelity_parity_c1`, `subprocess_and_bom_hardening_h316`) were re-verified to still hold — P3's degenerate lane structurally bypasses the C1 fidelity guard (never routed through `translateBatch`/`healOnly`), and P6 only adds error handling around the existing hardened `subprocess.run` call (encoding/timeout untouched). All 49 entries whose file bytes changed for unrelated reasons were re-hashed.

Handoff: [H1422](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1422-Sonnet_SanskritLexicography_pwg-audit-mask-robustness-nits_21.07.26.md)

## Test plan
- [x] `python src/pilot/window_selftest.py` → 170/170 passing (6 new tests, one per defect)
- [x] `python src/pilot/lang_parity_check.py` → `LANG PARITY LEDGER: 70 entries, all verdicts complete, no drift`
- [x] `python src/pilot/check_launch_ledger.py --since 2026-07-05` → clean
- [x] `python -m py_compile` on every edited file
- [x] CHANGELOG.md `[Unreleased]` entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)