### PR TITLE
fix(pwg_ru): verify+fix coordinator concurrency/durability plausibles P2/P10/P11 (H1420)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,33 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — coordinator concurrency/durability plausibles P2/P10/P11 (H1420)
+
+- Three PLAUSIBLE findings from the Opus 4.8 adversarial pwg_ru bug-hunt
+  ([issue #632](https://github.com/gasyoun/SanskritLexicography/issues/632); C1–C9 shipped in
+  v1.47.0), each verified real against the code + callers and fixed in
+  [`coordinator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/coordinator.py),
+  one selftest pinned per defect:
+  - **P2** — `_win32_pid_alive` reported DEAD for *every* `OpenProcess` error except `ERROR_ACCESS_DENIED`
+    (5), contradicting its own fail-safe comment: a transient/unexpected probe error would falsely reclaim a
+    **live** lock into two writers (the A1 double-writer window, H1283). It now leans ALIVE on any error
+    except the definitively-dead `ERROR_INVALID_PARAMETER` (87 = no such pid); the classification is extracted
+    to a pure `_win32_alive_on_openprocess_error` and pinned by
+    `test_h1420_p2_win32_openprocess_error_leans_alive`.
+  - **P10** — `promote_ready` commits the store in one all-or-nothing batch, then rebuilt the RU TM *after* the
+    per-lease state loop; a raise between the store commit and the rebuild (unreadable batch report,
+    no-landed-subcards, a per-lease state error) left store and TM divergent until the next clean run. The
+    rebuild now runs in a `finally` (extracted to `rebuild_ru_translation_memory`), pinned by
+    `test_h1420_p10_promote_rebuilds_tm_in_finally`.
+  - **P11** — `record-output` gated only on `state=='running'`, so after a run was released/recovered and the
+    lease re-run, a stale `workflow_result` from the prior run could record against the new run (silent
+    misattribution). A new optional `--run-id` (the identity sealed at `begin-run`) must now match the running
+    lease's `run_id`; a mismatch is refused before any state is persisted. Pinned by
+    `test_h1420_p11_record_output_binds_run_id`.
+- All three are lang-agnostic coordinator/lock/promotion machinery (no RU/EN divergence); the two
+  `coordinator.py` `LANG_PARITY.md` SHARED entries were re-verified and re-hashed. `window_selftest` 175/175;
+  `lang_parity_check` no drift.
+
 ### Changed — EN/RU convergence W2: shared cross-reference vocabulary + audit reassessment (H1425)
 
 - The cross-reference / degenerate-passthrough vocabulary (`s.`, `vgl.`, `u.`, `Nachträge`, …)

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "31abd637d86fc42db9979e31bb560b67f324147339e623ee9837002d2684e0e8",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -133,7 +133,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -169,7 +169,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -188,7 +188,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -207,7 +207,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -407,7 +407,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -426,7 +426,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "439d62f7d18df868db9ef41fb3d196c93ec1c1b6e20237e44c679cc12c405aaa",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -464,7 +464,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -523,7 +523,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -554,7 +554,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -573,7 +573,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -591,7 +591,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -610,7 +610,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -667,7 +667,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "dbbf4e77b39585dabdd3df122143cacc15fedb97ce6c3d12654061e8fe6c11b9",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
       "src/promote_en.py": "5cee9e839a3f32efc2e8bb83a37e7fd6354199b48306bc2b3cdac6c57b7194aa",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -692,7 +692,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -721,7 +721,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -741,7 +741,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -759,8 +759,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "8a8e7bb6cbf313f0fb1097bd72d8fccad1e17d79539f9ecf0a424ca7c87d0b87",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/coordinator.py": "81eba949e0fe77e9b2e5ea4e624d5f80aada3fd48e1708f897c0554f2f676666",
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -797,7 +797,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -855,7 +855,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -874,7 +874,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -893,7 +893,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -913,7 +913,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96",
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -935,7 +935,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -994,7 +994,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -1024,7 +1024,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
       "src/pilot/max_account_orchestrator.py": "12fb8c3bcdc8897e7eaff2285e6d32547b11f047b58921169a9736e37a24aa0c",
-      "src/pilot/coordinator.py": "8a8e7bb6cbf313f0fb1097bd72d8fccad1e17d79539f9ecf0a424ca7c87d0b87",
+      "src/pilot/coordinator.py": "81eba949e0fe77e9b2e5ea4e624d5f80aada3fd48e1708f897c0554f2f676666",
       "src/pilot/headless_worker_selftest.py": "e6dbff6e754dc05fd77fc91a8f182671fb063420563f1454c0eba729a0caf1de",
       "src/pilot/max_account_orchestrator_selftest.py": "6021af7fa4ff0415936e439290dfa7f8196b12afa4fca0a27b8f704841ebf685",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
@@ -1054,7 +1054,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -1073,7 +1073,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -1098,7 +1098,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
       "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
       "src/pilot/audit_window_en.py": "439d62f7d18df868db9ef41fb3d196c93ec1c1b6e20237e44c679cc12c405aaa",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -1120,7 +1120,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96",
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1140,7 +1140,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -1195,7 +1195,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "439d62f7d18df868db9ef41fb3d196c93ec1c1b6e20237e44c679cc12c405aaa",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96"
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
   {
@@ -1308,7 +1308,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
       "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
-      "src/pilot/window_selftest.py": "15da28341aba3352df065d47c0d73127b490dc2a253a571fdf49f394a0bc4f96",
+      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -118,6 +118,20 @@ def ensure_dirs():
     return p
 
 
+ERROR_INVALID_PARAMETER = 87  # OpenProcess for a nonexistent pid -> definitively dead
+
+
+def _win32_alive_on_openprocess_error(err):
+    # P2 (H1420): OpenProcess failed, so the pid must be ruled alive-or-dead from the error alone.
+    # The ONLY error that definitively proves the pid is gone is ERROR_INVALID_PARAMETER (87 = no
+    # such pid). Everything else -- ERROR_ACCESS_DENIED (5, a live process we merely lack rights to
+    # open), a transient handle/-memory error, or any unexpected code -- must lean ALIVE, so a live
+    # lock-holder is never falsely reported dead and reclaimed into two writers (the A1
+    # double-writer window, H1283). The prior `err == ERROR_ACCESS_DENIED` inverted this: it
+    # reported DEAD for every error except 5 -- the unsafe direction on any transient probe error.
+    return err != ERROR_INVALID_PARAMETER
+
+
 def _win32_pid_alive(pid):
     # A1 (H1283): os.kill(pid, 0) on win32 is GenerateConsoleCtrlEvent(CTRL_C_EVENT), NOT a
     # liveness probe -- it reported a LIVE >600 s promotion-lock holder (whose TM rebuild
@@ -128,16 +142,12 @@ def _win32_pid_alive(pid):
     from ctypes import wintypes
     PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
     STILL_ACTIVE = 259
-    ERROR_ACCESS_DENIED = 5
     k32 = ctypes.WinDLL('kernel32', use_last_error=True)
     k32.OpenProcess.restype = wintypes.HANDLE
     k32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
     h = k32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
     if not h:
-        # A live process we simply lack rights to open (ERROR_ACCESS_DENIED) is still ALIVE;
-        # ERROR_INVALID_PARAMETER (87) = no such pid -> dead. Lean 'alive' on anything else so
-        # a lock is never falsely reclaimed (the A1 failure direction we are closing).
-        return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+        return _win32_alive_on_openprocess_error(ctypes.get_last_error())
     try:
         code = wintypes.DWORD()
         k32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
@@ -1360,6 +1370,19 @@ def record_output(args):
         state = load_state()
         lease = lease_by_id(state, args.lease_id)
         token = begin_operation(lease, ('running',), 'auditing', 'record-output')
+        # P11 (H1420): record-output gates only on state=='running', so after a run is
+        # released/recovered and the lease re-run, a STALE workflow_result from the prior run would
+        # be recorded against the NEW run (silent misattribution -> a zombie run's output promoted).
+        # When the operator carries the run identity (--run-id, sealed at begin-run), require it
+        # match the running lease's run_id; a mismatch is a stale/zombie submission -> refuse before
+        # any state is persisted. Raising here discards begin_operation's in-memory mutation (state
+        # is not saved yet), leaving the on-disk lease 'running' for a correct retry.
+        supplied_run_id = getattr(args, 'run_id', None)
+        if supplied_run_id is not None and supplied_run_id != lease.get('run_id'):
+            raise SystemExit(
+                '%s: record-output --run-id %r does not match the running lease run-id %r '
+                '(stale/zombie run submission refused)' %
+                (args.lease_id, supplied_run_id, lease.get('run_id')))
         save_state(state)
         working = copy.deepcopy(lease)
     try:
@@ -1567,6 +1590,22 @@ def prepare_requeue(args):
     print('harness: %s' % harness)
 
 
+def rebuild_ru_translation_memory():
+    """Rebuild + validate the RU translation memory from the committed canonical store. Must run
+    after any store-mutating promotion -- including from a `finally` -- so a mid-promotion raise
+    can never leave store and TM divergent (P10, H1420)."""
+    run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'build', '--lang', 'ru'])
+    # C7: detection and the build-frags call MUST target the same tree (see _frag_prov_glob).
+    # build_frags joins its --glob with REPO, but this pattern is absolute (coord_dir() abspath's),
+    # so that join is a no-op and both sides resolve to the same coordinator dir.
+    frag_glob = _frag_prov_glob()
+    if any('"frag_prov"' in open(fp, encoding='utf-8').read()
+           for fp in glob.glob(frag_glob)):
+        run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'build-frags',
+                 '--lang', 'ru', '--glob', frag_glob])
+    run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'validate', '--lang', 'ru'])
+
+
 def promote_ready(args):
     if not args.gen_model_version or args.gen_model_version in ('sonnet', 'claude-sonnet'):
         raise SystemExit('exact --gen-model-version is required')
@@ -1631,44 +1670,42 @@ def promote_ready(args):
                  '--batch-manifest', batch_manifest, '--report', batch_report,
                  '--gen-model-version', args.gen_model_version])
         store_after = nonempty_line_count(promote_final_cards.DEFAULT_STORE)
+        # P10 (H1420): the batch promote above is all-or-nothing and raises on failure, so reaching
+        # here means the store IS committed. From this point the RU TM MUST be rebuilt to match the
+        # committed store -- otherwise a raise while reading the batch report or updating per-lease
+        # state leaves store and TM divergent until the next clean run. Rebuild in a `finally` so a
+        # partial-promotion raise still lands a consistent TM.
         try:
-            landed = json.load(open(batch_report, encoding='utf-8'))['leases']
-        except (OSError, KeyError, json.JSONDecodeError) as e:
-            raise SystemExit('batch promotion report unreadable: %s' % e)
-        for lease in ready:
-            per = landed.get(lease['id']) or {}
-            if lease.get('clean_count') and not per.get('subcards'):
-                raise SystemExit('%s: batch promotion landed no subcards for the lease'
-                                 % lease['id'])
-            has_pending = lease_pending[lease['id']]
-            with DirLock(paths()['lock']):
-                state = load_state()
-                fresh = lease_by_id(state, lease['id'])
-                fresh['state'] = 'promoted_partial' if has_pending else 'promoted'
-                fresh['promoted_at'] = utc_now()
-                fresh['model_version'] = args.gen_model_version
-                fresh['store_before'] = store_before
-                fresh['store_after'] = store_after
-                fresh['store_delta'] = store_after - store_before
-                fresh['promoted_subcards'] = per.get('subcards')
-                fresh['promoted_rows'] = per.get('rows')
-                save_state(state)
-                registry_event(fresh, 'promoted', {'glob': lease['clean_output'],
-                                                   'store_before': store_before,
-                                                   'store_after': store_after,
-                                                   'store_delta': store_after - store_before,
-                                                   'batch_subcards': per.get('subcards'),
-                                                   'batch_rows': per.get('rows')})
-        run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'build', '--lang', 'ru'])
-        # C7: detection and the build-frags call MUST target the same tree (see _frag_prov_glob).
-        # build_frags joins its --glob with REPO, but this pattern is absolute (coord_dir()
-        # abspath's), so that join is a no-op and both sides resolve to the same coordinator dir.
-        frag_glob = _frag_prov_glob()
-        if any('"frag_prov"' in open(fp, encoding='utf-8').read()
-               for fp in glob.glob(frag_glob)):
-            run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'build-frags',
-                     '--lang', 'ru', '--glob', frag_glob])
-        run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'validate', '--lang', 'ru'])
+            try:
+                landed = json.load(open(batch_report, encoding='utf-8'))['leases']
+            except (OSError, KeyError, json.JSONDecodeError) as e:
+                raise SystemExit('batch promotion report unreadable: %s' % e)
+            for lease in ready:
+                per = landed.get(lease['id']) or {}
+                if lease.get('clean_count') and not per.get('subcards'):
+                    raise SystemExit('%s: batch promotion landed no subcards for the lease'
+                                     % lease['id'])
+                has_pending = lease_pending[lease['id']]
+                with DirLock(paths()['lock']):
+                    state = load_state()
+                    fresh = lease_by_id(state, lease['id'])
+                    fresh['state'] = 'promoted_partial' if has_pending else 'promoted'
+                    fresh['promoted_at'] = utc_now()
+                    fresh['model_version'] = args.gen_model_version
+                    fresh['store_before'] = store_before
+                    fresh['store_after'] = store_after
+                    fresh['store_delta'] = store_after - store_before
+                    fresh['promoted_subcards'] = per.get('subcards')
+                    fresh['promoted_rows'] = per.get('rows')
+                    save_state(state)
+                    registry_event(fresh, 'promoted', {'glob': lease['clean_output'],
+                                                       'store_before': store_before,
+                                                       'store_after': store_after,
+                                                       'store_delta': store_after - store_before,
+                                                       'batch_subcards': per.get('subcards'),
+                                                       'batch_rows': per.get('rows')})
+        finally:
+            rebuild_ru_translation_memory()
     print('promoted %d lease(s)' % len(ready))
 
 
@@ -1800,6 +1837,9 @@ def main(argv=None):
     r.add_argument('workflow_result')
     r.add_argument('--transcript-dir')
     r.add_argument('--allow-stale', action='store_true')
+    r.add_argument('--run-id',
+                   help='if set, must match the running lease run_id sealed at begin-run '
+                        '(P11: refuses a stale/zombie run recording against a re-leased run)')
     r.set_defaults(func=record_output)
     rq = sub.add_parser('prepare-requeue')
     rq.add_argument('lease_id')

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -6735,6 +6735,163 @@ def test_h1283_a1_pid_alive_and_dirlock_owner():
     print('  A1: pid_alive is a real liveness probe; DirLock spares a foreign-owned lock')
 
 
+def test_h1420_p2_win32_openprocess_error_leans_alive():
+    """P2 (H1420): _win32_alive_on_openprocess_error leans ALIVE on every OpenProcess error except
+    ERROR_INVALID_PARAMETER (87 = no such pid). The prior `err == ERROR_ACCESS_DENIED` reported
+    DEAD for every error but 5, so any transient probe error falsely reclaimed a LIVE lock into two
+    writers (the A1 double-writer window, H1283)."""
+    import coordinator as coord
+    if not coord._win32_alive_on_openprocess_error(5):
+        fail('P2: ERROR_ACCESS_DENIED (5) is a live process we lack rights to open -> ALIVE')
+    if coord._win32_alive_on_openprocess_error(coord.ERROR_INVALID_PARAMETER):
+        fail('P2: ERROR_INVALID_PARAMETER (87) is the only definitively-dead error -> DEAD')
+    for err in (0, 6, 8, 998, 1450):  # success/handle/memory/transient codes -> must lean ALIVE
+        if not coord._win32_alive_on_openprocess_error(err):
+            fail('P2: OpenProcess error %d must lean ALIVE (never falsely reclaim a live lock)' % err)
+    print('  P2: OpenProcess error classification leans alive except no-such-pid (87)')
+
+
+def test_h1420_p11_record_output_binds_run_id():
+    """P11 (H1420): record-output refuses a workflow_result whose --run-id does not match the
+    running lease's sealed run_id (a stale/zombie run recording against a re-leased run), and the
+    on-disk lease stays 'running' for a correct retry. A matching --run-id proceeds."""
+    import coordinator
+    from types import SimpleNamespace
+    old = os.environ.get('PWG_COORDINATOR_DIR')
+    original_run = coordinator.run_cmd
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ['PWG_COORDINATOR_DIR'] = tmp
+        try:
+            adir = os.path.join(tmp, 'run')
+            os.makedirs(adir)
+            manifest = os.path.join(adir, 'manifest.json')
+            with open(manifest, 'w', encoding='utf-8') as f:
+                json.dump({'schema': 'pwg.headless_execution_manifest.v1',
+                           'meta': {'selected_keys': ['k'], 'input_hashes': {}}}, f)
+            result_path = os.path.join(adir, 'result.json')
+            with open(result_path, 'w', encoding='utf-8') as f:
+                json.dump({'results': [{'key': 'k', 'card': {'key1': 'k'}}]}, f)
+
+            def fresh_running_state():
+                state = coordinator.default_state()
+                state['leases'] = [{
+                    'id': 'run', 'kind': 'verb', 'target': 'gam', 'state': 'running',
+                    'artifact_dir': adir, 'execution_manifest': manifest,
+                    'run_operation_id': 'op-X', 'run_id': 'run-X',
+                }]
+                coordinator.save_state(state)
+
+            # A record-output carrying the WRONG run identity is refused before any subprocess runs.
+            fresh_running_state()
+
+            def must_not_run(*a, **k):
+                fail('P11: mismatched --run-id must be refused before the audit subprocess runs')
+            coordinator.run_cmd = must_not_run
+            try:
+                coordinator.record_output(SimpleNamespace(
+                    lease_id='run', workflow_result=result_path, allow_stale=False,
+                    transcript_dir=None, run_id='run-Y'))
+                fail('P11: record-output accepted a stale run-id')
+            except SystemExit as e:
+                if 'run-id' not in str(e):
+                    raise
+            if coordinator.load_state()['leases'][0]['state'] != 'running':
+                fail('P11: a refused record-output must leave the on-disk lease running')
+
+            # The matching run identity proceeds (the lease leaves 'running').
+            fresh_running_state()
+
+            def fake_audit(cmd, cwd=coordinator.REPO, check=True, timeout=None):
+                adir_ = cmd[cmd.index('--out-dir') + 1]
+                with open(os.path.join(adir_, 'window_status.json'), 'w', encoding='utf-8') as f:
+                    json.dump({'state': 'blocked'}, f)
+                with open(os.path.join(adir_, 'audit_window.report.json'), 'w', encoding='utf-8') as f:
+                    json.dump({}, f)
+                return SimpleNamespace(returncode=2, stdout='', stderr='')
+            coordinator.run_cmd = fake_audit
+            coordinator.record_output(SimpleNamespace(
+                lease_id='run', workflow_result=result_path, allow_stale=False,
+                transcript_dir=None, run_id='run-X'))
+            if coordinator.load_state()['leases'][0]['state'] == 'running':
+                fail('P11: a matching --run-id must let record-output proceed')
+            print('  P11: record-output binds a supplied --run-id to the running lease run_id')
+        finally:
+            coordinator.run_cmd = original_run
+            if old is None:
+                os.environ.pop('PWG_COORDINATOR_DIR', None)
+            else:
+                os.environ['PWG_COORDINATOR_DIR'] = old
+
+
+def test_h1420_p10_promote_rebuilds_tm_in_finally():
+    """P10 (H1420): once the batch store commit lands, a raise while reading the batch report or
+    updating per-lease state must NOT skip the RU TM rebuild -- else store and TM diverge. The
+    rebuild runs in a `finally`, so it happens even when per-lease promotion raises."""
+    import coordinator
+    from types import SimpleNamespace
+    old = os.environ.get('PWG_COORDINATOR_DIR')
+    original_run = coordinator.run_cmd
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ['PWG_COORDINATOR_DIR'] = tmp
+        try:
+            adir = os.path.join(tmp, 'artifacts', 'lease')
+            os.makedirs(adir)
+            wf = os.path.join(adir, 'wf.json')
+            clean = os.path.join(adir, 'clean.json')
+            status_path = os.path.join(adir, 'window_status.json')
+            report_path = os.path.join(adir, 'audit_window.report.json')
+            manifest = os.path.join(adir, 'manifest.json')
+            payload = {'results': [{'key': 'k', 'card': {'key1': 'k'}}]}
+            for path, value in ((wf, payload), (clean, payload),
+                                (status_path, {'state': 'clean', 'requeue_keys': []}),
+                                (report_path, {'workflow': wf, 'requeue': [], 'crashed': [],
+                                               'stale_check': {'ok': True}}),
+                                (manifest, {'schema': 'pwg.headless_execution_manifest.v1',
+                                            'meta': {'selected_keys': ['k'], 'input_hashes': {}}})):
+                with open(path, 'w', encoding='utf-8') as f:
+                    json.dump(value, f)
+            state = coordinator.default_state()
+            state['leases'] = [{
+                'id': 'lease', 'kind': 'nominal', 'target': 'n', 'state': 'ready',
+                'artifact_dir': adir, 'wf_output': wf, 'clean_output': clean,
+                'execution_manifest': manifest,
+                'clean_output_sha256': coordinator.sha256_file(clean), 'clean_count': 1,
+                'audit_state': 'clean', 'audit_returncode': 0,
+                'status_path': status_path, 'audit_report': report_path,
+            }]
+            coordinator.save_state(state)
+
+            tm_builds = []
+
+            def fake_run(cmd, cwd=coordinator.REPO, check=True, timeout=None):
+                if '--batch-manifest' in cmd:
+                    # Store commit "succeeds", but the report lists NO subcards for the lease, so
+                    # the per-lease loop raises AFTER the store is committed (the P10 window).
+                    report = cmd[cmd.index('--report') + 1]
+                    with open(report, 'w', encoding='utf-8') as f:
+                        json.dump({'leases': {'lease': {}}}, f)
+                elif 'translation_memory.py' in ' '.join(cmd) and 'build' in cmd:
+                    tm_builds.append(cmd)
+                return SimpleNamespace(returncode=0, stdout='', stderr='')
+            coordinator.run_cmd = fake_run
+            try:
+                coordinator.promote_ready(SimpleNamespace(
+                    gen_model_version='claude-sonnet-5', lease_id=None))
+                fail('P10: promotion with no landed subcards must raise')
+            except SystemExit as e:
+                if 'no subcards' not in str(e):
+                    raise
+            if not tm_builds:
+                fail('P10: the RU TM rebuild must run in a finally even when per-lease promotion raises')
+            print('  P10: promote_ready rebuilds the RU TM in a finally after the store commit')
+        finally:
+            coordinator.run_cmd = original_run
+            if old is None:
+                os.environ.pop('PWG_COORDINATOR_DIR', None)
+            else:
+                os.environ['PWG_COORDINATOR_DIR'] = old
+
+
 def test_h1283_a5_max_wide_default_bounded():
     """A5 (H1283): bounded dispatch is the DEFAULT — the highest throughput-per-effort lever."""
     import gen_opt_harness2 as gh
@@ -7183,6 +7340,9 @@ def main():
         test_grammar_field_restore_behavioral,
         test_h_reconstructed_regression_guard,
         test_h1283_a1_pid_alive_and_dirlock_owner,
+        test_h1420_p2_win32_openprocess_error_leans_alive,
+        test_h1420_p11_record_output_binds_run_id,
+        test_h1420_p10_promote_rebuilds_tm_in_finally,
         test_h1283_a5_max_wide_default_bounded,
         test_h1283_a6_prep_slice_flattens_batches,
         test_frag_prov_glob_honors_coordinator_dir_c7,


### PR DESCRIPTION
Executes [H1420](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1420-Opus_SanskritLexicography_pwg-coordinator-concurrency-plausibles_21.07.26.md): adversarially verify then fix three PLAUSIBLE findings from the Opus 4.8 pwg_ru bug-hunt ([#632](https://github.com/gasyoun/SanskritLexicography/issues/632); C1–C9 shipped in v1.47.0). All three verified **real** against the code + callers in [`coordinator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/coordinator.py); no REFUTED items. One `window_selftest` pin per defect.

## P2 (medium) — `_win32_pid_alive` leaned DEAD on the wrong error set
`return ctypes.get_last_error() == ERROR_ACCESS_DENIED` reported *alive* only for error 5 and *dead* for **every other** `OpenProcess` error — the exact inverse of the adjacent fail-safe comment ("lean 'alive' on anything else so a lock is never falsely reclaimed"). A transient/unexpected probe error ⇒ a **live** lock-holder reported DEAD ⇒ `DirLock.stale()` reclaims a live lock ⇒ two writers on the shared state (the A1 double-writer window, H1283). Now leans **alive** on any error except the definitively-dead `ERROR_INVALID_PARAMETER` (87 = no such pid). Classification extracted to a pure, cross-platform-testable `_win32_alive_on_openprocess_error`.

## P10 (low) — mid-promotion raise left store and TM divergent
`promote_ready` commits the store in one all-or-nothing batch, then rebuilt the RU TM *after* the per-lease state loop. A raise between the store commit and the rebuild — an unreadable batch report, a no-landed-subcards check, or a per-lease state error — left store↔TM divergent until the next clean run. The rebuild now runs in a **`finally`** (extracted to `rebuild_ru_translation_memory`), so a partial promotion still lands a consistent TM. *(The handoff's premise "the per-lease loop commits earlier leases to the store" was refined: since H1339 Phase 3 the store commit is a single batch transaction, not incremental — but the store-commit→TM-rebuild divergence window is real.)*

## P11 (low/medium) — `record-output` misattributes a stale run
`record-output` gated only on `state=='running'`, so after a run was released/recovered and the lease re-run, a stale `workflow_result` from the prior run could record against the new run (silent misattribution — a zombie run's output promoted). A new **optional `--run-id`** (the identity sealed at `begin-run`) must now match the running lease's `run_id`; a mismatch is refused **before any state is persisted** (the raise discards `begin_operation`'s in-memory mutation, leaving the on-disk lease `running` for a correct retry). Backward-compatible: no `--run-id` ⇒ unchanged behaviour.

## Parity + gates
All three are lang-agnostic coordinator/lock/promotion machinery — no RU/EN divergence (checked: `promote_en.py` is a single-pass store-attach with no analogous TM-rebuild loop). The two `coordinator.py` `LANG_PARITY.md` SHARED entries were re-verified (verdicts still hold) and re-hashed, along with the `window_selftest.py`-watching entries whose fingerprint moved.

- `python src/pilot/window_selftest.py` → **175/175 passed**
- `python src/pilot/lang_parity_check.py` → **71 entries, no drift**

Close gate (`window_selftest` green, `lang_parity_check` no drift) satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
