### PR TITLE
H1421: durable EN promotion store write (P9 fsync); verify P1 already-fixed

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -28,6 +28,22 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   `Fr.`…) cannot take fixed token→RU mappings — incl. a latent wrong-render trap in the existing
   `W.` → «слово» mapping (store has `W.` with n="Wange").
 
+- **H1421 🔴 EXECUTED — bug-hunt plausibles P1/P9 verify+fix (21-07-2026, Opus 4.8 `claude-opus-4-8`).**
+  Adversarial verify-then-fix of the two PLAUSIBLE findings from the Opus pwg_ru bug-hunt.
+  **P9 (real → fixed):** [`promote_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_en.py)'s
+  tri-lingual store write was a bare `open('w')` + `os.replace` — atomic but NOT fsynced, so a
+  crash/power-loss between the write and the metadata flush could leave a non-durable/truncated
+  store (under `--no-backup` the ONLY guard against total loss). Now reuses the RU lane's fsynced
+  `_atomic_write_rows` (single-sourced import from
+  [`promote_final_cards.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_final_cards.py)),
+  pinned by a new P9 block in `promote_en.selftest()` (fsync-called + round-trip + single-source
+  identity). **P1 (real but ALREADY FIXED → no code change):** the missing better-attempt-wins guard
+  on `merge_store_rows` was already resolved upstream by **B08 (H1339)** — complete > partial /
+  fewer-missing-fragments precedence, with pinned regression selftests. Close gate green:
+  `window_selftest` **173/173**, both promote selftests OK, `lang_parity_check` no drift.
+  `promotion_scripts_separate` ledger note records the SHARED `_atomic_write_rows` reuse;
+  [issue #632](https://github.com/gasyoun/SanskritLexicography/issues/632) commented. PR + merge same pass.
+
 - **H1339 🔴 EXECUTED — PWG→RU factory hardening + measured speed Phase B (20-07-2026, Fable 5 `claude-fable-5`).**
   Tier-B adjudication vs `90b2ff21`: **21/21 STILL REPRODUCED** (44 finder/adversarial-verifier
   agents, zero disagreements; three H1283 refutations stand; the `card_fields.py` conflict

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -37,6 +37,24 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   `coordinator.py` `LANG_PARITY.md` SHARED entries were re-verified and re-hashed. `window_selftest` 175/175;
   `lang_parity_check` no drift.
 
+### Fixed — EN promotion store write is now durable (fsync-before-replace); P1 verified already-fixed (H1421)
+
+- **P9 (bug-hunt plausible, now fixed):** [`promote_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_en.py)'s
+  tri-lingual store write was a bare `open('w')` + `os.replace` — **atomic but not durable**: a
+  crash/power-loss between the write and the metadata flush could leave a non-durable/truncated
+  store even after the rename (and under `--no-backup` that write is the ONLY thing between an
+  interrupted write and total loss). It now reuses the RU lane's fsynced `_atomic_write_rows`
+  (imported from [`promote_final_cards.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_final_cards.py) —
+  `flush()`+`os.fsync()` before `os.replace`), single-sourcing the store writer across both lanes
+  (as a bonus both now write `\n` newlines; the old EN write CRLF-translated on Windows). Pinned by
+  a new P9 block in `promote_en.selftest()` (fsync-called + round-trip + single-source identity).
+  The `promotion_scripts_separate` LANG_PARITY note records the SHARED reuse.
+- **P1 (bug-hunt plausible, verified already-fixed):** the concern that `merge_store_rows` replaced
+  by sub-card unconditionally — silently downgrading a complete store card when an older/partial
+  `wf_output` is re-promoted — was **already resolved upstream by B08 (H1339)**: `merge_store_rows`
+  is better-attempt-wins (complete > partial, fewer missing fragments win, ties favour the incoming
+  attempt) with pinned regression selftests. No code change needed; recorded for the audit trail.
+
 ### Changed — EN/RU convergence W2: shared cross-reference vocabulary + audit reassessment (H1425)
 
 - The cross-reference / degenerate-passthrough vocabulary (`s.`, `vgl.`, `u.`, `Nachträge`, …)

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -384,11 +384,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "INTENTIONAL-DIVERGENCE",
-    "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge. C6 (21-07-2026, Opus 4.8 claude-opus-4-8): the SCRIPTS stay separate, but the {Tn}-residue promotion guard is now SHARED — promote_en.py imports TN_RE + UnrestoredPlaceholder from promote_final_cards.py rather than duplicating them, closing the gap where the RU C-01 path refused a card carrying an unrestored {Tn} while the EN attach() silently wrote it into the store. Pinned by the C6 block in promote_en.selftest(). C9 (21-07-2026, Opus 4.8 claude-opus-4-8): the EN backup used a second-resolution timestamp + a plain open('w'), so two lock-serialized runs in the SAME second overwrote the earlier .preEN recovery copy (defeating the docstring's per-run-backup promise). Fixed to a µs+pid+uuid name (_en_backup_path) + the RU lane's O_EXCL fsynced copier (_fsynced_backup, imported — single source). Pinned by the C9 block in promote_en.selftest(). H1425 W3 audit (21-07-2026, Opus 4.8 claude-opus-4-8): confirmed nothing new to share — the shared primitives (TN_RE / UnrestoredPlaceholder / _fsynced_backup) are already imported (C6/C9); the rest of promote_en (norm_de / en_index / match_en / attach) is EN-ATTACH-specific — it attaches an `en` field onto the existing RU store, a different job from promote_final_cards' RU store WRITER — and _en_backup_path's `.preEN` marker is intentionally per-lane. The one remaining shareable primitive is the fsynced atomic store write (_atomic_write_rows) — promote_en's own write lacks the fsync (bug-hunt P9), already tracked under H1421, not this handoff. INTENTIONAL-DIVERGENCE re-affirmed.",
+    "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge. C6 (21-07-2026, Opus 4.8 claude-opus-4-8): the SCRIPTS stay separate, but the {Tn}-residue promotion guard is now SHARED — promote_en.py imports TN_RE + UnrestoredPlaceholder from promote_final_cards.py rather than duplicating them, closing the gap where the RU C-01 path refused a card carrying an unrestored {Tn} while the EN attach() silently wrote it into the store. Pinned by the C6 block in promote_en.selftest(). C9 (21-07-2026, Opus 4.8 claude-opus-4-8): the EN backup used a second-resolution timestamp + a plain open('w'), so two lock-serialized runs in the SAME second overwrote the earlier .preEN recovery copy (defeating the docstring's per-run-backup promise). Fixed to a µs+pid+uuid name (_en_backup_path) + the RU lane's O_EXCL fsynced copier (_fsynced_backup, imported — single source). Pinned by the C9 block in promote_en.selftest(). H1425 W3 audit (21-07-2026, Opus 4.8 claude-opus-4-8): confirmed nothing new to share — the shared primitives (TN_RE / UnrestoredPlaceholder / _fsynced_backup) are already imported (C6/C9); the rest of promote_en (norm_de / en_index / match_en / attach) is EN-ATTACH-specific — it attaches an `en` field onto the existing RU store, a different job from promote_final_cards' RU store WRITER — and _en_backup_path's `.preEN` marker is intentionally per-lane. P9 (21-07-2026, Opus 4.8 claude-opus-4-8, H1421): the last shareable primitive is now SHARED too — promote_en.py imports _atomic_write_rows from promote_final_cards.py and its store write is fsync-before-replace durable. The old EN write was a bare open('w') + os.replace: atomic (the rename is all-or-nothing) but NOT durable — a crash/power-loss between the write and the metadata flush could leave a non-durable/truncated store even after the rename, and under --no-backup that write is the ONLY thing between an interrupted write and total loss. As a bonus both lanes now write the store byte-identically ('\\n' newlines; the old EN write CRLF-translated on Windows). Pinned by the P9 block in promote_en.selftest() (fsync-called + round-trip + single-source identity assertion). Adversarial verification note: bug-hunt P1 (merge_store_rows had no better-attempt-wins guard) was ALSO an H1421 item but was already fixed upstream by B08 (H1339) — merge_store_rows is better-attempt-wins with pinned regression selftests — so P1 needed no code change. INTENTIONAL-DIVERGENCE re-affirmed (the scripts stay separate; every low-level store-safety primitive — {Tn} residue, fsynced backup, durable atomic write — is now single-sourced from the RU lane).",
     "tracking": "",
     "verified_sha256": {
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "5cee9e839a3f32efc2e8bb83a37e7fd6354199b48306bc2b3cdac6c57b7194aa"
+      "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
   {
@@ -445,7 +445,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "5cee9e839a3f32efc2e8bb83a37e7fd6354199b48306bc2b3cdac6c57b7194aa"
+      "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
   {
@@ -666,7 +666,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/promote_lock.py": "dbbf4e77b39585dabdd3df122143cacc15fedb97ce6c3d12654061e8fe6c11b9",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "5cee9e839a3f32efc2e8bb83a37e7fd6354199b48306bc2b3cdac6c57b7194aa",
+      "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
       "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
     }
   },
@@ -973,7 +973,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/store_path.py": "3a89cce449987ef448939d9e9a326c02e46ffaf4ce346f55aefe3f388cc00590",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "5cee9e839a3f32efc2e8bb83a37e7fd6354199b48306bc2b3cdac6c57b7194aa"
+      "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
   {
@@ -1285,7 +1285,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
       "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/promote_en.py": "5cee9e839a3f32efc2e8bb83a37e7fd6354199b48306bc2b3cdac6c57b7194aa",
+      "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
       "src/pilot/tnmask_offline.py": "c857fe425fadbe18c1cdf398892f53b590709048ca66faf94fd05e046730ffea"
     }
   },
@@ -1351,7 +1351,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "H1339 Tier-B report pwg_ru/h1339/H1339_TIER_B_STATUS_2026-07-19.md — port before the first real promote_en run (EN store currently 0 rows; H1209 mini-EN is the first consumer)",
     "verified_sha256": {
-      "src/promote_en.py": "5cee9e839a3f32efc2e8bb83a37e7fd6354199b48306bc2b3cdac6c57b7194aa"
+      "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
   {

--- a/RussianTranslation/src/promote_en.py
+++ b/RussianTranslation/src/promote_en.py
@@ -56,10 +56,13 @@ sys.stderr.reconfigure(encoding='utf-8')
 import pipeline_version
 from promote_lock import PromoteClaim, ClaimBusy
 from store_path import canonical_store
-# C6/C9: reuse the RU lane's EXACT guards (single source — a look-alike copy is precisely the drift
-# that C3 was). TN_RE + UnrestoredPlaceholder refuse a card with an unrestored {Tn} placeholder;
-# _fsynced_backup is the O_EXCL fsynced copier so an EN backup can never overwrite a recovery copy.
-from promote_final_cards import TN_RE, UnrestoredPlaceholder, _fsynced_backup
+# C6/C9/P9: reuse the RU lane's EXACT guards (single source — a look-alike copy is precisely the
+# drift that C3 was). TN_RE + UnrestoredPlaceholder refuse a card with an unrestored {Tn}
+# placeholder; _fsynced_backup is the O_EXCL fsynced copier so an EN backup can never overwrite a
+# recovery copy; _atomic_write_rows is the fsync-before-replace store writer (H1421 P9), so the EN
+# store write is as durable as the RU one — not merely atomic.
+from promote_final_cards import (
+    TN_RE, UnrestoredPlaceholder, _fsynced_backup, _atomic_write_rows)
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)
@@ -305,6 +308,30 @@ def selftest():
             assert False, 'C9: the O_EXCL backup must refuse an existing destination'
         except FileExistsError:
             pass
+    # P9 (H1421): the EN store write now reuses the RU lane's fsynced _atomic_write_rows (single
+    # source) rather than a bare open('w')+os.replace with no fsync — a crash/power-loss between
+    # the write and the rename can no longer leave a non-durable/truncated tri-lingual store. Pin
+    # that the exact writer main() calls fsyncs BEFORE it renames, and round-trips the rows.
+    import promote_final_cards as _pfc
+    assert _atomic_write_rows is _pfc._atomic_write_rows, \
+        'P9: the EN store writer must BE the RU lane primitive (single source, not a look-alike copy)'
+    fsynced = []
+    real_fsync = os.fsync
+
+    def _spy_fsync(fd):
+        fsynced.append(fd)
+        return real_fsync(fd)
+    os.fsync = _spy_fsync
+    try:
+        with _tf.TemporaryDirectory() as _d:
+            _s = os.path.join(_d, 'store.jsonl')
+            _atomic_write_rows(_s, [{'subcard': 'p_a~~h0', 'ru': 'пить', 'en': 'to drink'}])
+            assert fsynced, 'P9: the EN store write must fsync before os.replace (durability)'
+            _back = [json.loads(l) for l in open(_s, encoding='utf-8') if l.strip()]
+            assert _back == [{'subcard': 'p_a~~h0', 'ru': 'пить', 'en': 'to drink'}], \
+                'P9: rows must round-trip through the durable writer'
+    finally:
+        os.fsync = real_fsync
     print('promote_en selftest OK')
 
 
@@ -389,14 +416,14 @@ def main():
                 bak = _en_backup_path(args.store)
                 _fsynced_backup(args.store, bak)
                 print('\nbacked up store -> %s' % os.path.basename(bak))
-            # Atomic write: temp file + os.replace so a crash/kill mid-write cannot truncate
-            # the tri-lingual store (the "EN layer wiped" scar). Under --no-backup this is the
-            # ONLY thing standing between an interrupted write and total loss.
-            tmp = args.store + '.tmp'
-            with open(tmp, 'w', encoding='utf-8') as f:
-                for row in rows:
-                    f.write(json.dumps(row, ensure_ascii=False) + '\n')
-            os.replace(tmp, args.store)
+            # Durable atomic write: the RU lane's _atomic_write_rows — mkstemp temp,
+            # fh.flush() + os.fsync() BEFORE os.replace (H1421 P9). The old bare
+            # open('w')+os.replace was atomic but NOT durable: a crash/power-loss between the
+            # write and the metadata flush could leave a non-durable/truncated store even after
+            # the rename. Under --no-backup this write is the ONLY thing standing between an
+            # interrupted write and total loss, so it must be genuinely durable. Single-sourced
+            # with the RU bridge, so both lanes write the store byte-identically ('\n' newlines).
+            _atomic_write_rows(args.store, rows)
             print('wrote tri-lingual store -> %s (%d rows, %d now carry en)'
                   % (os.path.relpath(args.store, ROOT), len(rows), stats['attached']))
             print('NEXT: re-run `python src/annotate_dcs_freq.py` to (re)attach the dcs_freq block.')


### PR DESCRIPTION
Executes handoff **H1421** — adversarially verify + fix the two PLAUSIBLE findings (P1, P9) from the Opus 4.8 (`claude-opus-4-8`) pwg_ru bug-hunt ([issue #632](https://github.com/gasyoun/SanskritLexicography/issues/632); C1–C9 already shipped in v1.47.0).

## P9 (real → fixed): EN promotion store write was not durable

[`promote_en.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/promote_en.py)'s tri-lingual store write was a bare `open('w')` + `os.replace` — **atomic but NOT durable**. A crash/power-loss between the write and the metadata flush could leave a non-durable/truncated store even after the rename, and under `--no-backup` that write is the ONLY thing standing between an interrupted write and total loss (the module's own comment says so). The RU lane already writes through the fsynced `_atomic_write_rows` (`flush()` + `os.fsync()` before `os.replace`); the EN lane did not.

**Fix:** `promote_en.py` now imports and reuses `promote_final_cards._atomic_write_rows` for the store write — the same single-source import path C6/C9 already established (`TN_RE`, `UnrestoredPlaceholder`, `_fsynced_backup`). Both promotion lanes now share the durable writer, so the store is written byte-identically (`\n` newlines; the old EN write CRLF-translated on Windows).

**Pinned** by a new P9 block in `promote_en.selftest()`: asserts the writer `main()` calls fsyncs before it renames, round-trips the rows, and IS the RU-lane primitive (single-source identity — no look-alike copy, the C3 drift lesson). The SHARED reuse is recorded in the `promotion_scripts_separate` `LANG_PARITY.md` note (6 pinned hashes re-verified).

## P1 (real, but already fixed upstream → no code change)

The finding — `merge_store_rows` replaced by sub-card **unconditionally**, so re-promoting an older/partial `wf_output` over a complete stored card silently downgraded it — was **already resolved by B08 (H1339)**. At `origin/master`, `merge_store_rows` is better-attempt-wins (complete > partial, fewer missing fragments win, ties favour the incoming attempt) with pinned regression selftests (`promote_final_cards.selftest`). Verified reproduced against the handoff-cited code, confirmed already-fixed against current `master`; recorded for the audit trail, no change made.

## Close gate (all green)

- `python src/pilot/window_selftest.py` → **173/173 passed**
- `python src/promote_en.py --selftest` → OK (incl. new P9 pin)
- `python src/promote_final_cards.py --selftest` → OK (B08 better-attempt-wins pins)
- `python src/pilot/lang_parity_check.py` → 72 entries, all verdicts complete, **no drift**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
