### PR TITLE
chore(release): pwg_ru 1.49.0

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.49.0] - 2026-07-21
+
 ### Fixed — coordinator concurrency/durability plausibles P2/P10/P11 (H1420)
 
 - Three PLAUSIBLE findings from the Opus 4.8 adversarial pwg_ru bug-hunt

--- a/RussianTranslation/CITATION.cff
+++ b/RussianTranslation/CITATION.cff
@@ -16,8 +16,8 @@ authors:
     affiliation: "Институт лингвистических исследований РАН (ИЛИ РАН)"
 repository-code: "https://github.com/gasyoun/SanskritLexicography"
 license: "CC-BY-SA-4.0"
-version: "1.31.0"
-date-released: "2026-07-19"
+version: "1.49.0"
+date-released: "2026-07-21"
 keywords:
   - sanskrit
   - russian


### PR DESCRIPTION
Promotes the pwg_ru `CHANGELOG.md` `[Unreleased]` backlog to **1.49.0** (2026-07-21) and syncs [`RussianTranslation/CITATION.cff`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/CITATION.cff) (`version` + `date-released`). The pwg_ru subsystem changelog was last cut at `[1.31.0]` (2026-07-19); this ships everything accumulated since:

- **H1420** — coordinator concurrency/durability plausibles P2/P10/P11
- **H1421** — durable EN store write (P9 fsync) + P1 verified already-fixed
- **H1425 W1/W2** — EN/RU convergence (shared `card_coverage` + `xref_vocab` kernels + audit reassessment)
- **LANG_PARITY coverage guard** — new language-aware files can't silently escape the ledger

Tag `v1.49.0` + GitHub release follow the merge (default branch is PR-gated). No behaviour change beyond the already-merged feature PRs; this is the changelog/version freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
