### PR TITLE
chore(release): 1.50.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.47.0
+version: 1.50.0
 date-released: "2026-07-21"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.50.0] — 21-07-2026
+
 ### Added
 
 - pwg_ru style-research memo [`pwg_ru/STYLE_RESEARCH_DOUBLETS_VL_COMP.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/STYLE_RESEARCH_DOUBLETS_VL_COMP.md)


### PR DESCRIPTION
Promote [Unreleased] (H1306 phase-1 memo + FINDINGS §459) to 1.50.0; CITATION.cff 1.47.0 → 1.50.0. Note: the v1.49.0 section exists only in the GitHub release body, never landed in changelog.md — left as-is, flagged in the H1306 session report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)