### PR TITLE
fix(M01): propagate the known 52,498-event supersession to its points of use (H1381)

### DIFF
--- a/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md
@@ -1,6 +1,6 @@
 # How to Make the Brill Book — *Digital Sanskrit Lexicography*
 
-_Created: 06-07-2026 · Last updated: 18-07-2026_
+_Created: 06-07-2026 · Last updated: 21-07-2026_
 
 A build plan for a single-authored English monograph at Brill, drawn from work already
 committed across the `sanskrit-lexicon` / `gasyoun` GitHub repos, and coordinated with
@@ -57,7 +57,7 @@ Part II, confirmed by MG:
 > (`observed | derived | inferred | reviewed`), (c) corpus attestation where available,
 > and (d) review provenance. Sanskrit — with **two parallel lexicographic civilizations**
 > (European 1832–1957 and indigenous kośa/Pāṇinian), nineteen centuries of depth, and a
-> 5.6M-token tagged corpus — is the ideal testbed. What is new versus ELEXIS / Lexonomy /
+> 5.7M-token tagged corpus — is the ideal testbed. What is new versus ELEXIS / Lexonomy /
 > TEI-Lex0 is that those standardize *encoding*; this book standardizes *epistemics*:
 > graded, reviewable, corpus-anchored evidence per statement, with the indigenous tradition
 > as first-class data, not exotic noise.
@@ -102,7 +102,7 @@ chapter), **A37** (orthographic drift as a dater — a philology chapter).
 > ✅ **A12 authorship confirmed sole-authored (08-07-2026).** The
 > [OBS-T draft](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/reports/obs_t_paper_draft.md)
 > byline is **Mārcis Gasūns** alone; Jim Funderburk and Dhaval Patel appear only as
-> *correctors within the dataset* (the 50,953 events) and as acknowledgees, not co-authors
+> *correctors within the dataset* (the 52,498 events) and as acknowledgees, not co-authors
 > (contrast the genuinely co-authored A13/A14, correctly excluded). **Ch. 15 = A12 locks;**
 > no swap to A48 needed.
 
@@ -212,7 +212,7 @@ The book's evidentiary base already exists as committed datasets. Highest-value 
 | 5 (A16) | MW block-economy tables/figures (MWS) | 286,561 entries; G5 P 0.86 / R 0.87 | figures 1–3 |
 | 9 (A35) | `mw_etymology.tsv` + oracle (csl-orig) | 9,377 derivations, 10 dicts | derivation-agreement figure |
 | 11/12 (A08/A50) | `<ls>` citation graph (csl-atlas) | 828,505 citations → 912 texts | flagship network figure |
-| 15 (A12) | `correction_events_release.csv` (csl-observatory) | 50,953 events × 43 dicts × 210 correctors | figure + appendix dataset |
+| 15 (A12) | `correction_events_release.csv` (csl-observatory) | 52,498 events × 43 dicts × 208 correctors (released snapshot, 2014-03-18 → 2026-05-30) | figure + appendix dataset |
 | — (data-hub) | [kosha data-v0.1.0](https://github.com/gasyoun/kosha/releases/tag/data-v0.1.0) | 7 datasets, ~718k rows, CC BY-SA | appendix manifest |
 
 **Data blockers (the real critical path — see §9):**
@@ -617,6 +617,21 @@ map. Cited by Ch. 3/5/11/13 (the post-merge numbering of the "Ch. 3/5/12/14" nam
   pass, and two **semantics inversions** were caught and fixed: ch02 §6.2/§6.4 and
   BRILL_PROPOSAL described VEI 69.8 % … SKD 14.1 % as *absence* rates — they are
   **attestation** rates per A40 §4.4 (VEI 2,584-of-3,704 attested).
+
+**Done 21-07-2026 (H1381 execution, Fable 5 `claude-fable-5`):**
+- ✅ **Headline-figure propagation completed — the supersession this log recorded on
+  13-07-2026 (H863) had never reached the two points of use.** §1's corpus size read
+  5.6M-token (a truncation of the §6.1 disclosure's 5,688,416 content tokens, which rounds
+  to 5.7M — not a rival measurement) and §2/§6 still carried the 50,953-event cut that A31
+  §3 and this log's own H863 entry had already declared superseded by the released
+  **52,498-event** snapshot. Fixed here (§1, §2, §6 data table) and in
+  [BRILL_PROPOSAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BRILL_PROPOSAL.md)
+  lines 46/152 — the publisher-facing surface the H1269 red-team's headline-only sweep never
+  read. The §6 row's corrector count was also stale: the released
+  `correction_events_release.csv` (52,498 rows, sha256-pinned) contains **208** unique
+  correctors, not 210 — verified against the CSV itself. Defect class: known-stale-figure
+  left standing (red-team C7, §4.6), not an undiscovered error. Chapter sweep of all 21
+  files under `chapters/`: clean — zero stale figures inherited.
 
 **Still to do** (re-ordered 18-07-2026 per the §10 ruling 4; the old item 2 — "convert A16/A01
 as sample chapters" — was stale, both landed as

--- a/Digital_Sanskrit_Lexicography-BOOK/BRILL_PROPOSAL.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/BRILL_PROPOSAL.md
@@ -1,6 +1,6 @@
 # Book proposal — *Digital Sanskrit Lexicography: The Dictionary as a Layered Evidence Graph*
 
-_Created: 08-07-2026 · Last updated: 18-07-2026_
+_Created: 08-07-2026 · Last updated: 21-07-2026_
 
 Draft proposal for the single-authored monograph **M01**, built to the
 [Brill Book Proposal Guidelines](https://brill.com/fileasset/downloads_products/brill_bookproposal_guidelines.pdf)
@@ -43,7 +43,7 @@ provenance. This book establishes that model and demonstrates it on the richest 
 testbed: **Sanskrit, which uniquely possesses two parallel lexicographic civilizations** —
 the European scholarly dictionaries (1832–1957: Wilson, the Petersburg *Wörterbücher*,
 Monier-Williams, Apte) and the indigenous *kośa* / Pāṇinian tradition — nineteen centuries of
-depth, forty-four digitized dictionaries, and a 5.6-million-token tagged corpus.
+depth, forty-four digitized dictionaries, and a 5.7-million-token tagged corpus.
 
 Where existing standards (ELEXIS, Lexonomy, TEI-Lex0) standardize the *encoding* of
 dictionaries, this book standardizes their **epistemics**: graded, reviewable,
@@ -149,8 +149,8 @@ thesis stated; a roadmap of the book.
   to the historical states; 68.3% of épigraphique headwords are corpus-absent — vocabulary
   invisible to corpus-only methods.
 - **Ch. 14 · Fifty Thousand Corrections** *(← A12, 4/5).* The error typology of twelve years
-  of collaborative maintenance: 50,953 correction events × 43 dicts × 210 correctors — a
-  field-unique dataset. **Sole-authored (confirmed 08-07-2026: byline is Gasūns; Funderburk
+  of collaborative maintenance: 52,498 correction events × 43 dicts × 208 correctors (the
+  released 2014-03-18 → 2026-05-30 snapshot) — a field-unique dataset. **Sole-authored (confirmed 08-07-2026: byline is Gasūns; Funderburk
   and Patel appear as correctors within the dataset and as acknowledgees, not co-authors).**
 
 **Conclusion — *The Evidence Graph as a General Model*** *(new; ~10–15 pp).* FAIR

--- a/Digital_Sanskrit_Lexicography-BOOK/CHANGELOG.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/CHANGELOG.md
@@ -1,11 +1,32 @@
 # Digital Sanskrit Lexicography (Brill monograph) — changelog
 
-_Created: 07-07-2026 · Last updated: 18-07-2026_
+_Created: 07-07-2026 · Last updated: 21-07-2026_
 
 Tracks changes to the book build plan and any future manuscript/front-matter drafts in this
 folder. Registry ID **M01** in [Uprava/ARTICLES.md](https://github.com/gasyoun/Uprava/blob/main/ARTICLES.md).
 
 ## [Unreleased]
+
+### Fixed — 21-07-2026 (H1381, headline-figure propagation: 5.6M→5.7M, 50,953→52,498, 210→208)
+
+- **The known supersession finally propagated to the points of use** (Fable 5
+  `claude-fable-5`; red-team class C7, defect class known-stale-figure-left-standing — the
+  plan's §11 done-log and [BOOK_PLAN.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.meta.md)
+  had recorded the 52,498-event supersession on 13-07-2026 without touching §1/§2/§6):
+  [BOOK_PLAN.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md)
+  §1 corpus size 5.6M→5.7M-token (a truncation of §6.1's 5,688,416 content tokens, not a
+  rival measurement), §2 and the §6 data table 50,953→**52,498** events with the release
+  pin (2014-03-18 → 2026-05-30 snapshot), and
+  [BRILL_PROPOSAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BRILL_PROPOSAL.md)
+  lines 46/152 — the publisher-facing surface, outside everything the H1269 red-team read.
+  A third stale figure in the same rows fixed on CSV evidence: the released
+  `correction_events_release.csv` (sha256-verified against the origin LFS pointer) holds
+  **208** unique correctors, not 210.
+  [ch14](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch14_error_typology.md)'s
+  provenance note made explicitly historical so it no longer describes a live state of the
+  plan. Chapter sweep of all 21 files under `chapters/`: **clean** — zero stale-figure
+  inheritance (converts the red-team's UNMEASURED to MEASURED-CLEAN). Historical records
+  (§11 done-log, metadoc, this changelog, `.ai_state.md`) deliberately untouched.
 
 ### Added — 18-07-2026 (H1240, Ch. 3 + Ch. 11: the last two chapters — 14 of 14 in book form)
 

--- a/Digital_Sanskrit_Lexicography-BOOK/chapters/ch14_error_typology.md
+++ b/Digital_Sanskrit_Lexicography-BOOK/chapters/ch14_error_typology.md
@@ -1,6 +1,6 @@
 # Chapter 14 — Surface, Not Substance: An Error Typology of Twelve Years of Collaborative Correction
 
-_Created: 13-07-2026 · Last updated: 13-07-2026_
+_Created: 13-07-2026 · Last updated: 21-07-2026_
 
 > **Provenance.** This chapter is the book-form version of the article *Surface, Not Substance:
 > A Two-Axis Error Typology of Twelve Years of Correction to the Cologne Digital Sanskrit
@@ -10,8 +10,9 @@ _Created: 13-07-2026 · Last updated: 13-07-2026_
 > the article must remain independently citable, cite that version. Every count and table below
 > is carried over from the article unchanged and is reproducible from the committed corpus
 > ([`correction_events_release.csv`](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/observatory/site/src/data/correction_events_release.csv),
-> CC-BY-4.0). The figures are the released **52,498-event** snapshot (2014–2026); the book's
-> data inventory listed an earlier 50,953-event cut, superseded here. Only the framing has been
+> CC-BY-4.0). The figures are the released **52,498-event** snapshot (2014–2026); an earlier
+> draft of the book's data inventory listed a 50,953-event cut, superseded here and since
+> corrected in the plan itself (21-07-2026). Only the framing has been
 > converted from journal to book form — the abstract and keywords removed, companion-paper
 > labels remapped to this book's chapters, and the collaborative-lexicography literature engaged
 > at the monograph's depth. Section numbering is chapter-internal (§1–§8).


### PR DESCRIPTION
Executes [H1381](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1381-Fable_SanskritLexicography_m01-headline-figure-reconciliation-book-plan_20.07.26.md) (Fable 5 `claude-fable-5`). Closes #658.

## Severity framing — known-stale-figure-left-standing, not an undiscovered error

This is red-team class **C7** ([PORTFOLIO_STATISTICAL_REDTEAM_2026H2.md](https://github.com/gasyoun/Uprava/blob/main/docs/PORTFOLIO_STATISTICAL_REDTEAM_2026H2.md) §4.6), but the book already knew: [BOOK_PLAN.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.md)'s own §11 done-log (H863, 13-07-2026) and [BOOK_PLAN.meta.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BOOK_PLAN.meta.md) both recorded 52,498 as superseding 50,953. The correction was logged but never propagated to the two points of *use*. The 5.6M is a truncation of §6.1's disclosed **5,688,416 content tokens** (rounds to 5.7M) — the same number, not a rival measurement, so nothing needed reconciling, only rounding.

## Changes

- **BOOK_PLAN §1 (line 60):** `5.6M-token` → `5.7M-token`.
- **BOOK_PLAN §2 (line 105):** `50,953` → `52,498` events. The paragraph's authorship argument (Funderburk/Patel as correctors-not-co-authors) is unaffected by the larger count.
- **BOOK_PLAN §6 data table (line 215):** `50,953 events × 43 dicts × 210 correctors` → `52,498 events × 43 dicts × 208 correctors (released snapshot, 2014-03-18 → 2026-05-30)` — release pin in ch14's house phrasing.
- **BOOK_PLAN §11 done-log:** dated H1381 entry appended; the historical H863 entry untouched.
- **[BRILL_PROPOSAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/BRILL_PROPOSAL.md) line 46:** `5.6-million-token` → `5.7-million-token`; **line 152:** `50,953 … × 210` → `52,498 … × 208` with the release pin. **This is the handoff's primary result** — the publisher-facing proposal carried both stale figures and sat outside everything the red-team's headline-only sweep read. The surrounding "field-unique dataset" claim only strengthens with the larger count.
- **[ch14](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/chapters/ch14_error_typology.md) provenance note (lines 13–14):** made explicitly historical ("an earlier draft of the book's data inventory listed…") so it no longer describes a live state of the plan once §6 is fixed. The supersession record itself is preserved.
- **[CHANGELOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/Digital_Sanskrit_Lexicography-BOOK/CHANGELOG.md):** `[Unreleased]` → `### Fixed` entry.

## The 210-vs-208 corrector drift — RESOLVED against the released CSV

The §6 row and BRILL line 152 said **210** correctors; ch14 (lines 25, 137) and the book changelog say **208**. Resolved decisively: the local `correction_events_release.csv` sha256 (`0736b101…`) matches the `origin/main` LFS pointer bit-for-bit; parsing it gives **52,498 rows, 208 unique `corrector` ids, 208 unique `corrector_name` values**. 208 is correct; 210 was a second stale figure riding the same rows. Fixed in this PR per the handoff's step-4 instruction.

## Verification — all 21 chapter files swept (UNMEASURED → MEASURED-CLEAN)

Command: `grep -rnE "5\.6M|5\.6-million|5\.6 million|50,953|50 953" Digital_Sanskrit_Lexicography-BOOK/`

Post-edit result — every remaining hit is a historical record or an explicit supersession note, none a live claim:

```
BOOK_PLAN.md:530        (H863 done-log — historical, deliberately untouched)
BOOK_PLAN.md:624-625    (new H1381 done-log entry naming the old figures as superseded)
BOOK_PLAN.meta.md:105   (metadoc staleness record — untouched)
CHANGELOG.md:10,17-18   (new Fixed entry naming the old figures)
CHANGELOG.md:230        (historical H863 changelog entry — untouched)
chapters/ch14_error_typology.md:14  (supersession note, now explicitly historical)
```

Chapters swept: all **21 files** under `chapters/` (ch00–ch14, 5 bridges, conclusion) — **zero** stale-figure inheritance. Live figures confirmed: 5.7M/5,688,416 in ch00 (×2), ch02 (×5), ch03; 52,498 in ch00 (×2), ch14, bridge_part5. The chapters were drafted from the released figures; only the plan and the proposal lagged.

## Adjacent findings (reported, not fixed — a human should decide)

1. **44-vs-43 dictionary drift inside BRILL_PROPOSAL** (line 46 "forty-four digitized dictionaries" vs line 152 "43 dicts") — red-team §5 item 10 surfacing within a single document. Whether it rides in a follow-up PR or gets its own handoff is a scoping call.
2. **BRILL Ch. 14 title "Fifty Thousand Corrections"** (line 151) — 52,498 still rounds to fifty thousand, so nothing is factually wrong, but the title is anchored to the superseded cut. Retitling an external submission is a human call; not touched.
3. **Whether the corrected figures trigger a full re-read of the Brill proposal** — it was written against the older snapshot and the red-team never read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)