### PR TITLE
H1386: pwg_ru post-H1339 review landing set — resume/crash-recovery + frag-TM fixes, medium50 enabler, prepare-batch (−72% prepare)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Prove bounded PWG→Russian CLI correctness on one profile, then scale + the CDSL article-comparison study
 
-_Created: 09-07-2026 · Last updated: 21-07-2026_
+_Created: 09-07-2026 · Last updated: 22-07-2026_
 
 Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/archive/H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md)):
 
@@ -13,6 +13,20 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 > the root copy. Audited + reconciled 2026-06-26.
 
 ## ➡️ Next Steps (Queue)
+
+- **H1386 EXECUTED (22-07-2026, Fable 5 `claude-fable-5`) — post-H1339 review landing set.**
+  All three confirmed P1s fixed test-first (C1 bounded `--resume` scope-dict bug — recovery
+  matched ZERO jobs; C2 `materialize_requeue` post-audit resume wedge; C3 fragment
+  denylist/unblock re-serve hole + recursive requeue-output harvest glob), D1 medium50
+  enabler (payload v3 `prompt_common` hoist, `WORKFLOW_SCRIPT_CAP` refusal in
+  `inject_payload`, `prep_slice --keys/--chunk N`, `canonical_audit` chunk merge), D2–D5,
+  P3 sweep (P3a/P3i were already fixed by the parallel H1413 wave; P3b–P3h/P3j landed;
+  P3f made the offline bench fully hermetic — `PWG_INPUT_DIR`/`PWG_EVENTS_PATH` sandbox +
+  teardown, honored by all 14 previously hand-copied input-dir sites), plus the OPT
+  prepare-stage batching (`coordinator prepare-batch`, in-process prepare children) with
+  A/B bench evidence. LANG_PARITY entry `h1386_resume_recovery_and_medium50` classifies
+  the whole set (SHARED; EN-lane facts re-checked). P3k fixed in claude-config
+  (`commands/pwg-bounded-run.md` bogus `--max-agents/--timeout 180`).
 
 - **H1306 Phase 1 DONE — style-research memo + ratification sheet emitted; Phase 2 WAITS on MG's
   vote (21-07-2026, Fable 5 `claude-fable-5`).** Memo

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "31abd637d86fc42db9979e31bb560b67f324147339e623ee9837002d2684e0e8",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -133,7 +133,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -169,7 +169,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -188,7 +188,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -207,7 +207,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -407,7 +407,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -426,7 +426,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "73398beb59c272ceb8bbcfdb1649e241a83d4f8447f1aae33c4c3c1e3e5e2862",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -464,7 +464,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -523,7 +523,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -554,7 +554,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -573,7 +573,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -591,7 +591,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -610,7 +610,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -667,7 +667,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -692,7 +692,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -721,7 +721,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -741,7 +741,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -759,8 +759,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "af0028c2296a1ee7a1692ab4ff87eca1252e23f1226df6694629e78062ba1de7",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/coordinator.py": "b31f864f8e8f8dd864140a13aac0625e4d8557340d6e307eb92adc508b706295",
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -797,7 +797,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -855,7 +855,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -874,7 +874,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -893,7 +893,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -913,7 +913,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e",
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -935,7 +935,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -994,7 +994,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -1024,7 +1024,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
       "src/pilot/max_account_orchestrator.py": "38f40e86db49b4294d6d5b789ebc65a84544a25e907eb86cfc0a157023f23038",
-      "src/pilot/coordinator.py": "af0028c2296a1ee7a1692ab4ff87eca1252e23f1226df6694629e78062ba1de7",
+      "src/pilot/coordinator.py": "b31f864f8e8f8dd864140a13aac0625e4d8557340d6e307eb92adc508b706295",
       "src/pilot/headless_worker_selftest.py": "e6dbff6e754dc05fd77fc91a8f182671fb063420563f1454c0eba729a0caf1de",
       "src/pilot/max_account_orchestrator_selftest.py": "6021af7fa4ff0415936e439290dfa7f8196b12afa4fca0a27b8f704841ebf685",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
@@ -1054,7 +1054,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -1073,7 +1073,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -1098,7 +1098,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
       "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
       "src/pilot/audit_window_en.py": "73398beb59c272ceb8bbcfdb1649e241a83d4f8447f1aae33c4c3c1e3e5e2862",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -1120,7 +1120,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e",
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1140,7 +1140,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -1195,7 +1195,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "73398beb59c272ceb8bbcfdb1649e241a83d4f8447f1aae33c4c3c1e3e5e2862",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
     }
   },
   {
@@ -1308,7 +1308,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
       "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
-      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e",
+      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1556,7 +1556,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/bounded_supervisor.py": "225a4cc4153a02b3a3eec848e2529bf1329fb2258f59c317a70b8f6a80226081",
       "src/pilot/max_account_orchestrator.py": "38f40e86db49b4294d6d5b789ebc65a84544a25e907eb86cfc0a157023f23038",
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/coordinator.py": "af0028c2296a1ee7a1692ab4ff87eca1252e23f1226df6694629e78062ba1de7",
+      "src/pilot/coordinator.py": "b31f864f8e8f8dd864140a13aac0625e4d8557340d6e307eb92adc508b706295",
       "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,6 +1,6 @@
 # LANG_PARITY.md — cross-language fix/feature parity ledger
 
-_Created: 04-07-2026 · Last updated: 20-07-2026 (H1339 Tier-B hardening: 9 entries)_
+_Created: 04-07-2026 · Last updated: 22-07-2026 (H1386 post-H1339 review landing set: +1 entry)_
 
 This repo runs the same PWG→Russian and PWG→English translation pipeline through
 shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "31abd637d86fc42db9979e31bb560b67f324147339e623ee9837002d2684e0e8",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -130,10 +130,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "C1 (bug-hunt review, Opus 4.8 claude-opus-4-8, 21-07-2026). The check keys off TARGET_FIELD (JS) / manifest['field'] (Python) = the per-language field, so it applies identically to ru and en with no language branching. Ported to every off-batch lane the batch accept() H1152 guard never reached: JS heal (stitched-translation-fidelity-reject), headless normalize_batch + selfheal stitch (translation-fidelity-reject / stitched-translation-fidelity-reject), autosplit cmd_merge + stitch_topup (complete-stitch fidelity drift -> reject). Tests: window_selftest test_heal_lane_target_field_fidelity_wired / test_autosplit_stitch_topup_rejects_target_field_drop / test_autosplit_merge_rejects_target_field_drop; headless_worker_selftest test_normalize_batch_translation_fidelity_reject / test_headless_heal_stitch_translation_fidelity_reject.",
     "tracking": "H1412",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -150,7 +150,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561"
     }
   },
   {
@@ -168,8 +168,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -187,8 +187,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -206,8 +206,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -224,7 +224,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561"
     }
   },
   {
@@ -241,7 +241,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561"
     }
   },
   {
@@ -258,7 +258,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "lang is a first-class parameter of the TM address (sha256(lang + ...)); --lang=ru|en both get full reuse. C3 (21-07-2026, Opus 4.8 claude-opus-4-8): the reuse was SHARED in address but NOT in the served card — the card-TM builder wrote the EN sense under the store COLUMN name FIELD['en']=='en' instead of the CARD field 'english', so the serve-side tm_card_sane refused 100% of EN card-TM hits ('sense missing english') while RU worked. Fixed by a single CARD_FIELD={'ru':'russian','en':'english'} used by both the card builder and the fragment lane (_FRAG_TRANSLATION_FIELD aliases it), so the two lanes can't drift. Test: window_selftest test_en_card_tm_serves_english_field_c3.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc"
+      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac"
     }
   },
   {
@@ -275,7 +275,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561"
     }
   },
   {
@@ -292,7 +292,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561"
     }
   },
   {
@@ -309,7 +309,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 closes the former divergence: exact model provenance is required across four accounts, so both RU and EN now request and stamp claude-sonnet-5. This prevents account/profile alias resolution from making cross-window provenance incomparable.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561"
     }
   },
   {
@@ -329,10 +329,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED 2026-07-04 (was GAP, task_d29bb788): audited audit_window_en.py against all 3 fixes. (1) multi-layer over-count is N/A -- EN has no analogous raw-marker-vs-card-sense coverage check to carry the bug. (2) the Sanskrit-span leak is already safe -- audit_window_en.py's prose() already scrubs {#..#} spans before residue matching, unlike RU's pre-fix braced_gloss_risks. (3) a REAL EN analogue existed in DE-RESIDUE: 'des' is both a German article and a French partitive article, and gen_fidelity_judge_en.py's own prompt preserves French/Latin literals verbatim -- fixed by extracting LATIN_WORDS/FRENCH_WORDS into a new shared src/pilot/foreign_literal_guards.py imported by both prompt_rule_audit.py and audit_window_en.py, with a French-context guard on the ambiguous 'des' hit. Pinned by test_en_de_residue_french_guard in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/audit_coverage.py": "d3e1966f0ec4cf914f85e3fb5d8336c9f2fc19662717f8300e2d4cab041f3d3f",
+      "src/audit_coverage.py": "a60b8c0ed3b0022a6527a029d1e818cedab3dfcbbb545fc2c78b6a5dd514dcfa",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
-      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
-      "src/pilot/audit_window_en.py": "439d62f7d18df868db9ef41fb3d196c93ec1c1b6e20237e44c679cc12c405aaa"
+      "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
+      "src/pilot/audit_window_en.py": "73398beb59c272ceb8bbcfdb1649e241a83d4f8447f1aae33c4c3c1e3e5e2862"
     }
   },
   {
@@ -350,7 +350,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The denylist append and load_frag_tm filtering are lang-agnostic (fsha encodes lang; requeue_from_audit takes --lang), but the fshas EMITTER lives only in the RU auditor: audit_window_en.py reimplements its gates and does not compute requeue_defect_fshas or write the file, so an EN defect requeue does not auto-denylist its fragments.",
     "tracking": "Uprava/handoffs/archive/H304-Fable_RussianTranslation_coordinator-driver-remake_07.07.26.md (EN-emitter port is the recorded follow-up)",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
+      "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2"
     }
@@ -387,7 +387,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge. C6 (21-07-2026, Opus 4.8 claude-opus-4-8): the SCRIPTS stay separate, but the {Tn}-residue promotion guard is now SHARED — promote_en.py imports TN_RE + UnrestoredPlaceholder from promote_final_cards.py rather than duplicating them, closing the gap where the RU C-01 path refused a card carrying an unrestored {Tn} while the EN attach() silently wrote it into the store. Pinned by the C6 block in promote_en.selftest(). C9 (21-07-2026, Opus 4.8 claude-opus-4-8): the EN backup used a second-resolution timestamp + a plain open('w'), so two lock-serialized runs in the SAME second overwrote the earlier .preEN recovery copy (defeating the docstring's per-run-backup promise). Fixed to a µs+pid+uuid name (_en_backup_path) + the RU lane's O_EXCL fsynced copier (_fsynced_backup, imported — single source). Pinned by the C9 block in promote_en.selftest(). H1425 W3 audit (21-07-2026, Opus 4.8 claude-opus-4-8): confirmed nothing new to share — the shared primitives (TN_RE / UnrestoredPlaceholder / _fsynced_backup) are already imported (C6/C9); the rest of promote_en (norm_de / en_index / match_en / attach) is EN-ATTACH-specific — it attaches an `en` field onto the existing RU store, a different job from promote_final_cards' RU store WRITER — and _en_backup_path's `.preEN` marker is intentionally per-lane. P9 (21-07-2026, Opus 4.8 claude-opus-4-8, H1421): the last shareable primitive is now SHARED too — promote_en.py imports _atomic_write_rows from promote_final_cards.py and its store write is fsync-before-replace durable. The old EN write was a bare open('w') + os.replace: atomic (the rename is all-or-nothing) but NOT durable — a crash/power-loss between the write and the metadata flush could leave a non-durable/truncated store even after the rename, and under --no-backup that write is the ONLY thing between an interrupted write and total loss. As a bonus both lanes now write the store byte-identically ('\\n' newlines; the old EN write CRLF-translated on Windows). Pinned by the P9 block in promote_en.selftest() (fsync-called + round-trip + single-source identity assertion). Adversarial verification note: bug-hunt P1 (merge_store_rows had no better-attempt-wins guard) was ALSO an H1421 item but was already fixed upstream by B08 (H1339) — merge_store_rows is better-attempt-wins with pinned regression selftests — so P1 needed no code change. INTENTIONAL-DIVERGENCE re-affirmed (the scripts stay separate; every low-level store-safety primitive — {Tn} residue, fsynced backup, durable atomic write — is now single-sourced from the RU lane).",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
+      "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
@@ -406,8 +406,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -425,8 +425,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H169 (2026-07-04 review, 'broken validators'): the advertised HARD DUP gate was never emitted -- the only within-record duplicate signal was soft SAME-GLOSS, gated on >=3 content words, so a short duplicate ('to go'/'to go') produced zero flags and --strict passed. Classified GAP-being-closed rather than INTENTIONAL-DIVERGENCE: RU's within-record duplicate protection is the cross-part audit_sense_dupes.py gate (already SHARED, see gate_fixes_20260703_ru_only/PR #135) plus the soft, all-senses-only identical_russian_glosses risk in prompt_rule_audit.py (MEDIUM, not high-confidence) -- neither is a pairwise HARD gate. EN now closes that with a real HARD pairwise DUP check; RU getting an equivalent pairwise HARD gate (rather than its current all-or-nothing soft signal) is left as a natural follow-up, not blocking this fix. Pinned by test_en_gate_dup_has_teeth in window_selftest.py. C2 (21-07-2026, Opus 4.8 claude-opus-4-8): the HARD gate keyed on prose(english), which STRIPS {#..#} Sanskrit and <ls>, so two senses distinguished only by their referent ('N. of a serpent-demon {#vAsuki#}' vs '…{#takzaka#}') collapsed to one string and the second was wrongly HARD-DUP'd, failing --strict on faithful output (310 real within-record cases). Fixed to key the DUP seen-dict on the normalized RAW english (referent preserved) while CIRCULAR keeps prose() norm; a true identical-english duplicate is still caught HARD. Pinned by test_en_dup_gate_preserves_sanskrit_referent_c2.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "439d62f7d18df868db9ef41fb3d196c93ec1c1b6e20237e44c679cc12c405aaa",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/audit_window_en.py": "73398beb59c272ceb8bbcfdb1649e241a83d4f8447f1aae33c4c3c1e3e5e2862",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -444,7 +444,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED same day (2026-07-04): PR #140 (feat(provenance): pipeline versioning) added pipeline_version stamping only to promote_final_cards.py; found as a GAP while re-affirming H169's parity re-hash, closed immediately. promote_en.py now calls `pipeline_version.stamp(model_version=gen_model_version)` inside `en_index()`'s per-subcard provenance block, stored as `en_provenance.pipeline` (mirrors RU's `provenance.pipeline`; a distinct field since EN attaches onto an existing RU row rather than owning it). Pinned by an added assertion in `promote_en.selftest()`.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
+      "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
@@ -463,8 +463,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -482,7 +482,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 1.1. The layer is derived purely from the sub-card KEY structure, which is identical for RU and EN. promote_en.py ATTACHES english onto the RU-owned row and leaves it otherwise untouched, so EN inherits `layer` for free — no EN-specific code needed. layer_of() pinned by dict_merge.py selftest + a promote_final_cards.selftest assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
+      "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
       "src/dict_merge.py": "0266e11980e3b8b12d0699665b2051b9f7b8b16ed89d5810adfe5a458e880eea"
     }
   },
@@ -501,8 +501,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
+      "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03"
     }
   },
   {
@@ -521,9 +521,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -552,9 +552,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/preflight_remaining_gates.py": "00386c837b97986c9702abfceed9c29534736c3df3063af202ddfaae6b078b8f",
       "src/release_readiness.py": "db38a870bbc8b5dbe694e706e4a7b9089ba41211a3881ad9a1bd4eb02950c8a9",
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
-      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
+      "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -572,8 +572,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H321 (code review 2026-07-04 item #3b): the fragment sidecar is content-addressed on the fragment SOURCE and was harvested append-only first-seen-wins with NO fidelity check, so a hand-edited/corrupt wf_output*.json (blanked or malformed senses) permanently poisoned reuse and a later good harvest of the same fsha could never override it. frag_senses_sane(senses, lang) keys on the CARD-shaped translation field ('russian'/'english') and is applied at BOTH harvest (never cache garbage; a cached-corrupt fsha maps to False so a good row overrides it) and serve (load_frag_tm drops any corrupt historical row). Entirely lang-agnostic — lang is a first-class parameter of frag_address/frag_senses_sane/load_frag_tm/build_frags, no RU/EN branch. Pinned by test_frag_tm_fidelity_gate_and_override. Extends translation_memory_card_and_fragment.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -591,7 +591,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -610,7 +610,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -664,10 +664,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H336 (08-07-2026). The claim wraps whichever store path --store points at, and both promote_final_cards.py (RU bridge) and promote_en.py (EN attach) import the identical PromoteClaim class with identical TTL-only (no PID-liveness) staleness semantics and the same --steal-lock override — there is exactly one implementation, not a per-language reimplementation. Pinned by test_promote_claim_contention (pins promote_lock.py's own --selftest into the aggregate suite).",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_lock.py": "dbbf4e77b39585dabdd3df122143cacc15fedb97ce6c3d12654061e8fe6c11b9",
-      "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
+      "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
+      "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -688,11 +688,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H336 (08-07-2026). window_reports.write_reports/write_window_status already took an out_dir parameter (pre-existing --out-dir escape hatch); --window-tag is a thin, lang-agnostic sugar layer over that same parameter computed once in audit_window.py and threaded through unchanged to requeue_from_audit.py/root_window_status.py. Neither RU nor EN branch differently. Pinned by test_audit_window_tag_routing.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
+      "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -715,13 +715,13 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H336 (08-07-2026). append_jsonl_line is a single shared primitive (window_common.py) used identically by every JSONL append site regardless of --lang; the TM denylist stores 'ru'/'en' addresses in the same file with no per-language code path. Pinned by test_denylist_torn_line_warns.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/window_common.py": "083e9aa1a82df34a10561f7cbc93d86e09411f20b7f2120e8d0af9769fbfbec1",
+      "src/pilot/window_common.py": "2d6926ba3a2e99f788641637b2cb6f2f9637ecb7f4e1b1c1561a367c8dd81e93",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
-      "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -741,7 +741,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -759,8 +759,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "81eba949e0fe77e9b2e5ea4e624d5f80aada3fd48e1708f897c0554f2f676666",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/coordinator.py": "af0028c2296a1ee7a1692ab4ff87eca1252e23f1226df6694629e78062ba1de7",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -797,7 +797,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -816,7 +816,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/stage2_pregate.py": "8f07422d3c416e32d1882f0777d56cc44ba781d19c8097fd9500ddefbfd22945",
-      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f"
+      "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2"
     }
   },
   {
@@ -834,7 +834,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H405 (09-07-2026, resolved same day). Both editions now run the same pregate() module for the mechanical invariants; the difference is only the adapter (RU: subprocess --wf over file pairs; EN: in-process per-sense), not the logic. The partial-adoption (net-new flag types only) is deliberate — the EN auditor already reimplemented LS/SAN/AB/MISSING per-sense with its own thresholds, so pregate contributes exactly the invariants it lacked (<is>, stranded/leaked anchors) rather than duplicating. Verified by a functional test (clean / is-dropped→IS-LOSS / stranded→STRANDED-ANCHOR / ls-dropped→single LS-LOSS not double-flagged) + window_selftest.py green.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "439d62f7d18df868db9ef41fb3d196c93ec1c1b6e20237e44c679cc12c405aaa",
+      "src/pilot/audit_window_en.py": "73398beb59c272ceb8bbcfdb1649e241a83d4f8447f1aae33c4c3c1e3e5e2862",
       "src/stage2_pregate.py": "8f07422d3c416e32d1882f0777d56cc44ba781d19c8097fd9500ddefbfd22945"
     }
   },
@@ -855,7 +855,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -873,8 +873,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -892,8 +892,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -912,8 +912,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677",
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -934,8 +934,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -972,7 +972,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/store_path.py": "3a89cce449987ef448939d9e9a326c02e46ffaf4ce346f55aefe3f388cc00590",
-      "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
+      "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
@@ -992,9 +992,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -1021,10 +1021,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 Windows readiness uses one language-parameterized manifest and worker contract. Whole-card retries, binary split, fragment TM/restore/fidelity, per-card budgets, timeout-no-bisect, partial stitching, audit-clean subset promotion, staged dispatch, and credential-safe event/census telemetry do not branch on RU/EN. Production policy selects RU no_pwg for the first 100-headword proof; the mechanism preserves EN field/schema behavior.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
-      "src/pilot/max_account_orchestrator.py": "12fb8c3bcdc8897e7eaff2285e6d32547b11f047b58921169a9736e37a24aa0c",
-      "src/pilot/coordinator.py": "81eba949e0fe77e9b2e5ea4e624d5f80aada3fd48e1708f897c0554f2f676666",
+      "src/pilot/max_account_orchestrator.py": "38f40e86db49b4294d6d5b789ebc65a84544a25e907eb86cfc0a157023f23038",
+      "src/pilot/coordinator.py": "af0028c2296a1ee7a1692ab4ff87eca1252e23f1226df6694629e78062ba1de7",
       "src/pilot/headless_worker_selftest.py": "e6dbff6e754dc05fd77fc91a8f182671fb063420563f1454c0eba729a0caf1de",
       "src/pilot/max_account_orchestrator_selftest.py": "6021af7fa4ff0415936e439290dfa7f8196b12afa4fca0a27b8f704841ebf685",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
@@ -1051,10 +1051,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H390 Phase 1 (12-07-2026, Opus 4.8 claude-opus-4-8), extended by H818. gen_model is written into language-agnostic run meta and flows through the shared ledger writer and harvester identically for RU/EN; both paths now stamp exact claude-sonnet-5. Pinned by test_ledger_stamps_gen_model in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -1072,8 +1072,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H823, fixes the H255 presplit-cohort loss). Both the citation presplit trigger (_presplit_hit) and the single-card kill budget (killBudgetForCur) are language-independent — they key on <ls>/fragment counts and FRAGS, never on --lang; the same floor + CEIL apply to RU and EN identically. Extends no_fallback_single_kill_budget_and_nominal_key_echo (H220) from no-fallback singles to all singles. Pinned by test_presplit_cite_floor_and_single_ceil.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -1095,10 +1095,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/_pilot_gen_merged.py": "1d2ab8504823b0e8bc07c391ffacada034d436da2fd8936484250e58c0672933",
-      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
-      "src/pilot/audit_window_en.py": "439d62f7d18df868db9ef41fb3d196c93ec1c1b6e20237e44c679cc12c405aaa",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
+      "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
+      "src/pilot/audit_window_en.py": "73398beb59c272ceb8bbcfdb1649e241a83d4f8447f1aae33c4c3c1e3e5e2862",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -1118,9 +1118,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H960 (15-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes H920's explicitly-deferred accept()-side sense-count consumption. Language-neutral: accept() counts SENSE OBJECTS (records[].senses[]), never a gloss language, and source_senses is sense_count.count_source_senses over the German source markers (identical for the RU and EN lanes — the source is German for both). SOFT by default (SANLOSS_HARD_REJECT=false): a shortfall is telemetry only (no reject/requeue), so live traffic can measure the true drop-vs-false-flag rate before the reject is armed (owner-gated ladder). The shared counter is hardened against the ~4.78%-of-cards cross-reference over-count the naive count carried (gam~~h2_31_pari 2->1, s_ud~~h0_05_pra 4->2, _a_srayatva 2->0); under-counting is the safe direction, never a false shortfall. Pinned by test_h960_accept_sanloss_soft_gate (builds the real harness, extracts the emitted accept()+countOf, asserts soft-keep / surplus-ok / FP-regression / ls-sk-first / armed-hard-reject via accept_sensecount_test.js) plus the 3 cross-reference fixtures in sense_count._selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1140,7 +1140,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -1158,7 +1158,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1152 guard 2 (17-07-2026, Sonnet 4.6 claude-sonnet-4-6), closing H1070's r102 finding (PWG->EN FU1 pilot, vac~~h0_00_pwg00: a {#uc#} span inside a <F> footnote survived the german echo 33/33 but was dropped from english 32/33 -- invisible to the pre-existing check because it never reads the translation field). accept() is lang-parameterized code shared by both lanes (field = 'russian' or 'english', same code path); the new check is symmetric and applies identically to RU and EN generation. Verified against the live RU regression suite: window_selftest.py full run stays green (137/137 baseline, +2 new content-check tests for guards 1/3), and the new/updated fixtures in accept_sensecount_test.js reproduce the exact r102 shape (RED before this change -- proven via git-stash against the pre-fix accept(), the fixture is silently ACCEPTED -- GREEN after). No RU store data touched; this only changes the generation-time accept-path gate for FUTURE generation, never re-validates the 11,605 already-promoted RU rows.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1194,8 +1194,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "EN-only by construction: the RU audit path (audit_window.py + prompt_rule_audit.py) is wired around .merged.md/.raw.txt files and Russian-specific semantic checks, per audit_window_en.py's own module docstring (\"the RU gate ... is wired around ... Russian-specific semantic checks, so the PWG->EN pilot ran with --no-audit. This is the EN sibling\"); XREF-ONLY/NWS-DE-LOCKED are new, EN-only soft flags with no RU counterpart to port -- the RU gate's own dropped_sanskrit_span in prompt_rule_audit.markup_sigla_risks already covers RU's analogous case and was not touched. Pinned by test_h1152_guard3_xref_only_and_nws_de_locked.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "439d62f7d18df868db9ef41fb3d196c93ec1c1b6e20237e44c679cc12c405aaa",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677"
+      "src/pilot/audit_window_en.py": "73398beb59c272ceb8bbcfdb1649e241a83d4f8447f1aae33c4c3c1e3e5e2862",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e"
     }
   },
   {
@@ -1214,10 +1214,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Validated 18-07-2026 on the RU 3-card slice (v1 exposed the naive-senses equality-gate defect: workers displaced source {Tn} spans into unrestorable card.notes; v2 gates are direction-aligned with accept()). canonical_audit.py is already field-parameterized (reads manifest field, russian/english); wf_template.js still hardcodes the russian target field and a RU controller prompt. The EN variant is owed by the same handoff’s mini-EN step, which must also wire the H1070/H1152 EN guards + audit_window_en gates.",
     "tracking": "H1209 (Uprava/handoffs/H1209-Opus_SanskritLexicography_pwg-ru-controller-worker-canary_17.07.26.md), mini-EN step",
     "verified_sha256": {
-      "src/pilot/h1209/wf_template.js": "3a82285017c5937d9deeab92d7a6ae539e8598287811458b6d3c8af64f486bd3",
-      "src/pilot/h1209/prep_slice.py": "acf9ddda5a76d19d769f4a794ea7f88b6db88a8ae688b44f7f778ac24ecde48d",
+      "src/pilot/h1209/wf_template.js": "e233674cbfdd228afd7c121a0a6d2c97ad047a13af8076c8af8c6e1733a03460",
+      "src/pilot/h1209/prep_slice.py": "d065d685dced6ef237ca9ba65836d0e3426105d563bcde7390a61572bcd9a59c",
       "src/pilot/h1209/build_args.py": "6f245108c60ae7c777c66900c1da4a53670399e949fbc474b6556d6bd0ed3024",
-      "src/pilot/h1209/canonical_audit.py": "30dfb6ab88e692177416eb6d16cd3333dcc83f58c2b6312f096c2f324f85915f"
+      "src/pilot/h1209/canonical_audit.py": "5866af157fd42ae76a903d448a1762a5224411e9842197eed870d21ee36d0315"
     }
   },
   {
@@ -1263,7 +1263,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/fix_german_connectives.py": "6a5cceb58cd7c989df819703dff777bb635ee979c7178c55ceccce199a3737a8",
       "src/pilot/foreign_literal_guards.py": "e7eaccfb846ff805b585b1c6413ec84b71970dd7fdddfc6abef90fcf04650b93",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
-      "src/pilot/audit_window_en.py": "439d62f7d18df868db9ef41fb3d196c93ec1c1b6e20237e44c679cc12c405aaa"
+      "src/pilot/audit_window_en.py": "73398beb59c272ceb8bbcfdb1649e241a83d4f8447f1aae33c4c3c1e3e5e2862"
     }
   },
   {
@@ -1283,8 +1283,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1226: the {Tn} pairing is stamped in the SHARED accept() (runs for both languages) and BOTH promote lanes (promote_final_cards.py RU, promote_en.py EN) carry it to provenance.tnmask, so neither store silently drops the field accept() stamps. Only accept() stamps it: the heal path's acceptFrag hard-rejects fragment {Tn} mismatches, so no un-rejected expansion reaches a healed card. Makes the TNMASK false-flag rate MEASURABLE (H1150 DO_NOT_ARM, denominator 1); TNMASK_HARD_REJECT stays = false — arming is a human @DECIDE. Pinned by window_selftest.test_tnmask_persist_and_offline_detect + tnmask_offline.selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
-      "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
+      "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
       "src/pilot/tnmask_offline.py": "c857fe425fadbe18c1cdf398892f53b590709048ca66faf94fd05e046730ffea"
     }
@@ -1307,8 +1307,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
-      "src/pilot/audit_window.py": "1af028fea51b7b0ca33d2e3df6632e24443f17ce7205098dbccbb11482238d8f",
-      "src/pilot/window_selftest.py": "2c4a00a404801e2bc442c9633964d50cc32e71a9016c1c06a376f696596ad677",
+      "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
+      "src/pilot/window_selftest.py": "b6a452713d4c85db9aa5b5ba88895ce9d3f5f8e5389c4205fa933f67aeecb25e",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1332,10 +1332,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/card_fields.py": "976c5aa943a35da1691e2ce72e9cb4a14ac53d3bae37f8c68345cc68cb233e2b",
-      "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9",
-      "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
+      "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
+      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57"
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561"
     }
   },
   {
@@ -1371,7 +1371,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/store_path.py": "3a89cce449987ef448939d9e9a326c02e46ffaf4ce346f55aefe3f388cc00590",
-      "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
+      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
       "src/pilot/ru_coverage.py": "bf08bc3e79a80907dfc7df4e59cead0c026e04cf9cc621359630daecc98b46c3"
     }
   },
@@ -1391,9 +1391,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/bounded_staged_run.py": "096cd639be7f864bc5fc6984c84674a50c13e81e12f6284fbce7185ab328c49c",
-      "src/pilot/bounded_supervisor.py": "01610c44d5383420d29f66cb0ef81ae2612c89bff30403cce31816ed6c8f603a",
-      "src/pilot/max_account_orchestrator.py": "12fb8c3bcdc8897e7eaff2285e6d32547b11f047b58921169a9736e37a24aa0c"
+      "src/pilot/bounded_staged_run.py": "01ce3b65e6303499937ba891c3478f3ff60bc879296a763af5e97a95e391ecba",
+      "src/pilot/bounded_supervisor.py": "225a4cc4153a02b3a3eec848e2529bf1329fb2258f59c317a70b8f6a80226081",
+      "src/pilot/max_account_orchestrator.py": "38f40e86db49b4294d6d5b789ebc65a84544a25e907eb86cfc0a157023f23038"
     }
   },
   {
@@ -1411,7 +1411,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "a6fff1ec8d97fc6ec6fd59a8da148a2a8cd7002427e4cdcab5997cd3fa0c4b57",
+      "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7"
     }
   },
@@ -1432,8 +1432,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
-      "src/pilot/translation_memory.py": "0ff60624486f72f878bc087af18f2ee199edfe403461a12687cddebb73e105fc",
-      "src/promote_final_cards.py": "00dec19e62712ca07c9c95516ee8462f509223adecd5661884745091b294b4e9"
+      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
+      "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03"
     }
   },
   {
@@ -1468,7 +1468,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/probe_log.py": "6163c8a69bb8be34d14fa066ee4ee7a9f4e437b607f88b3dea25681aaf8edca5"
+      "src/pilot/probe_log.py": "bc5d21b48541c410eaed9b4bccb97619272b4ef542f6ce76257d247303efb067"
     }
   },
   {
@@ -1488,7 +1488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/stage2_pregate.py": "8f07422d3c416e32d1882f0777d56cc44ba781d19c8097fd9500ddefbfd22945",
-      "src/audit_translation.py": "22581af60c24f2871cb372a06ef35c11ae195b8d051e890e81370702f9c6ca44"
+      "src/audit_translation.py": "99d89b13ce7d3ef75b2e4f5f2e79aedc57849e96354997eff995b95ca6f57096"
     }
   },
   {
@@ -1525,6 +1525,45 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/xref_vocab.py": "922940d5ccb4667c361ac15f66f1fcf0a41446419a74aff7feea359585e7c5ec"
+    }
+  },
+  {
+    "id": "h1386_resume_recovery_and_medium50",
+    "mechanism": "H1386 post-H1339 review landing set: C1 bounded --resume passes the lease-id SET to cmd_recover (+_scope_sql dict/str TypeError, None-output window fails loudly); C2 materialize_requeue resumes a post-audit origin with a completed ::rq job; C3 fragment-denylist-aware build_frags seen-scan + recursive '**' requeue-output harvest glob + append-order tiebreak in best_reusable; D1 h1209 payload v3 prompt_common hoist + WORKFLOW_SCRIPT_CAP refusal + prep_slice --keys/--chunk + canonical_audit chunk merge; D2 identity-checked promote-lock reclaim; D3 per-lease store_delta from the batch report; D4 PWG_COORDINATOR_DIR on all bounded coordinator subprocesses; D5 batch-mode --dry-run/--force/--init-store refusal; P3b canonical mw_en_tm resolution; P3c reset-failed origin-lease matching + failed-id messages; P3d/e run_py_inproc KeyboardInterrupt/string-exit semantics; P3f hermetic bench (PWG_INPUT_DIR/PWG_EVENTS_PATH sandbox + teardown); P3g batch null-subcard gate; P3h stale_check v2 execution/provenance cross-check; P3j probe_log falsy-zero clean recovery; OPT coordinator prepare-batch (in-process prepare children).",
+    "files": [
+      "src/pilot/bounded_staged_run.py",
+      "src/pilot/bounded_supervisor.py",
+      "src/pilot/max_account_orchestrator.py",
+      "src/pilot/translation_memory.py",
+      "src/pilot/coordinator.py",
+      "src/promote_final_cards.py",
+      "src/promote_lock.py",
+      "src/pilot/audit_window.py",
+      "src/pilot/window_common.py",
+      "src/pilot/dashboard_events.py",
+      "src/pilot/window_provenance.py",
+      "src/pilot/probe_log.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H1386 (22-07-2026, Fable 5 claude-fable-5). Every fix is language-neutral orchestration/persistence mechanics -- none introduces a --lang branch. Lane facts checked per the handoff: the frag TM half of C3 (build_frags/load_frag_tm/best_reusable) is --lang-parameterized so both lanes get it; the recursive harvest glob + D3 per-lease store_delta + P3g batch gate live in the RU staged/coordinator lane ONLY because the EN promote lane (promote_en.py) by design has no fragment harvest and no batch transaction (its INTENTIONAL-DIVERGENCE ruling is H1425 W3, unchanged); P3b is the EN lane's own seed feed; the h1209 rig (D1) is field-parameterized (payload['field']), so a future EN slice inherits prompt_common/chunking as-is; PWG_INPUT_DIR (P3f) is honored by both audit_window and audit_window_en. Pinned by bounded_staged_run_selftest tests l/m, window_selftest test_h1386_c3_frag_unblock_serves_replacement + test_h1386_d1_medium50_script_size_cap, promote_lock/promote_final_cards selftests, and the h1339_offline_bench deterministic signature (batch == per-lease).",
+    "tracking": "H1386",
+    "verified_sha256": {
+      "src/pilot/bounded_staged_run.py": "01ce3b65e6303499937ba891c3478f3ff60bc879296a763af5e97a95e391ecba",
+      "src/pilot/bounded_supervisor.py": "225a4cc4153a02b3a3eec848e2529bf1329fb2258f59c317a70b8f6a80226081",
+      "src/pilot/max_account_orchestrator.py": "38f40e86db49b4294d6d5b789ebc65a84544a25e907eb86cfc0a157023f23038",
+      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
+      "src/pilot/coordinator.py": "af0028c2296a1ee7a1692ab4ff87eca1252e23f1226df6694629e78062ba1de7",
+      "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
+      "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
+      "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
+      "src/pilot/window_common.py": "2d6926ba3a2e99f788641637b2cb6f2f9637ecb7f4e1b1c1561a367c8dd81e93",
+      "src/pilot/dashboard_events.py": "342dfa7e83ca2b4da78b719ec95126e2fe5a32b2e8d731fee323e3bc44fe7a7e",
+      "src/pilot/window_provenance.py": "2f1240e321004228d94f6bea7ae661a896c4bc93c60f9d47871d248766900d50",
+      "src/pilot/probe_log.py": "bc5d21b48541c410eaed9b4bccb97619272b4ef542f6ce76257d247303efb067"
     }
   }
 ]

--- a/RussianTranslation/pwg_ru/h1339/H1386_PREPARE_BATCH_BENCH_2026-07-22.md
+++ b/RussianTranslation/pwg_ru/h1339/H1386_PREPARE_BATCH_BENCH_2026-07-22.md
@@ -1,0 +1,55 @@
+# H1386 prepare-stage batching — A/B bench evidence (closes the H1339 25% speed target)
+
+_Created: 22-07-2026 · Last updated: 22-07-2026_
+
+Executor: Fable 5 (`claude-fable-5`), [H1386](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1386-Fable_RussianTranslation_pwg-ru-post-h1339-resume-fixes-prepare-speed_20.07.26.md).
+Method: [`src/pilot/h1339_offline_bench.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h1339_offline_bench.py)
+(H1339's committed hermetic bench, now fully sandboxed per H1386 P3f — `PWG_INPUT_DIR` +
+`PWG_EVENTS_PATH` overrides, `finally:` teardown), 2 warmups + **10 measured runs per
+mode**, offline, zero model calls, on the H1386 worktree at `4a3efa99` + the H1386 fixes.
+
+## What changed
+
+`coordinator prepare-batch` (H1386 OPT) prepares N claimed leases in **one** coordinator
+process and runs the two per-lease prepare children (`perf_preflight` cost gate +
+`gen_opt_harness2` harness/manifest generation) **in-process** via
+`audit_window.run_py_inproc` — the H1339 runpy-gates pattern applied to the prepare
+stage, which H1339's own closeout named as the remaining dominant per-lease
+interpreter-spawn cost. 3 interpreter spawns per lease become 0 marginal spawns per
+lease. Per-lease semantics are identical (same operation tokens, same cost gate, same
+artifacts, same state transitions).
+
+## A/B result (5-lease fixture, medians over 10 runs)
+
+| Stage | per-lease (pre-H1386) | prepare-batch (H1386) | Δ median |
+|---|---|---|---|
+| **prepare** | median 11.669 s · p95 15.546 s | median 3.263 s · p95 5.426 s | **−72.0%** |
+| total | median 27.892 s · p95 37.070 s | median 21.763 s · p95 28.639 s | **−22.0%** |
+
+- **Semantic store equality: PROVEN.** Both modes produce the identical deterministic
+  output signature `da1341e6ac11…` on every one of the 10+10 runs (`deterministic: true`,
+  one signature per mode, signatures equal across modes) — same store rows, same TM, same
+  per-lease final states (fx1 promoted 3 clean · fx2 promoted_partial 1 clean +
+  transient/defect backlog · fx3 promoted 2 · fx4 promoted 1 · fx5 promoted 3).
+- **Stage gate:** the H1339 constraint was "ship only stages that clear the 25% stage
+  gate; never weaken a guard to manufacture the last points." Prepare clears at −72.0%
+  with zero guard changes (the cost gate, operation tokens and manifests are the same
+  code, run in-process). Combined with H1339's measured −23.0% pipeline win, the
+  offline-path total is now well past the original ≥25% target.
+- Machine-readable reports: [`h1386_bench_perlease.json`](h1386_bench_perlease.json) ·
+  [`h1386_bench_batch.json`](h1386_bench_batch.json) (committed beside this memo;
+  generated under gitignored `src/pilot/output/` and copied here as evidence).
+
+## Caveats
+
+- The bench's `total` includes stages H1339 already optimized; the −22.0% total here is
+  measured against the *per-lease-prepare* shape on the same H1386 code, not against the
+  pre-H1339 baseline (that comparison was H1339's own PARTIAL −23.0%).
+- `--prepare-mode per-lease` is kept in the bench for future A/B evidence; production
+  callers opt into `prepare-batch` explicitly — `coordinator prepare` is byte-identical
+  in behavior and stays the default single-lease form.
+- In-process children accept the `timeout=` parameter for signature parity but cannot
+  enforce it per child; the prepare stage's own operation deadline
+  (`PREPARE_TIMEOUT_SECONDS`, checked between children) still applies.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/pwg_ru/h1339/h1386_bench_batch.json
+++ b/RussianTranslation/pwg_ru/h1339/h1386_bench_batch.json
@@ -1,0 +1,201 @@
+{
+ "schema": "pwg.h1339_offline_bench.v1",
+ "protocol": {
+  "warmups": 2,
+  "runs": 10,
+  "prepare_mode": "batch"
+ },
+ "python": "3.14.4 (tags/v3.14.4:23116f9, Apr  7 2026, 14:10:54) [MSC v.1944 64 bit (AMD64)]",
+ "platform": "Windows-10-10.0.19045-SP0",
+ "fixture_sha256": "d225ced2f215a5c4492b2657ba43cfef0f8b0d25b13202a5138142e9347e7ac4",
+ "seed_rows": 11600,
+ "stages": {
+  "prepare": {
+   "median_s": 3.263,
+   "p95_s": 5.426,
+   "min_s": 1.82,
+   "max_s": 7.502
+  },
+  "normalize": {
+   "median_s": 0.146,
+   "p95_s": 0.155,
+   "min_s": 0.074,
+   "max_s": 0.25
+  },
+  "audit": {
+   "median_s": 12.108,
+   "p95_s": 17.237,
+   "min_s": 8.558,
+   "max_s": 50.034
+  },
+  "promotion-plan": {
+   "median_s": 0.888,
+   "p95_s": 1.241,
+   "min_s": 0.542,
+   "max_s": 4.938
+  },
+  "store-write": {
+   "median_s": 5.927,
+   "p95_s": 7.281,
+   "min_s": 3.288,
+   "max_s": 20.836
+  },
+  "total": {
+   "median_s": 21.763,
+   "p95_s": 28.639,
+   "min_s": 14.1,
+   "max_s": 78.622
+  }
+ },
+ "runs": [
+  {
+   "prepare": 3.6084435000000212,
+   "normalize": 0.1410037000000557,
+   "audit": 14.794622200000049,
+   "promotion-plan": 0.9481063999999151,
+   "store-write": 5.8661323999999695,
+   "total": 24.410201800000095
+  },
+  {
+   "prepare": 5.425964799999974,
+   "normalize": 0.14944740000009915,
+   "audit": 16.03263449999986,
+   "promotion-plan": 1.1555402999999842,
+   "store-write": 6.679332400000021,
+   "total": 28.287379099999953
+  },
+  {
+   "prepare": 3.437348800000109,
+   "normalize": 0.1297053999999207,
+   "audit": 12.226487800000086,
+   "promotion-plan": 1.1426929000001564,
+   "store-write": 6.518485800000008,
+   "total": 22.312027800000124
+  },
+  {
+   "prepare": 3.0892883999999867,
+   "normalize": 0.1461959000000661,
+   "audit": 11.98912630000018,
+   "promotion-plan": 0.8272656999999981,
+   "store-write": 5.988402999999835,
+   "total": 21.213013600000068
+  },
+  {
+   "prepare": 7.501568499999848,
+   "normalize": 0.24990280000019993,
+   "audit": 50.03448040000012,
+   "promotion-plan": 4.937763600000153,
+   "store-write": 20.8359703000001,
+   "total": 78.62192200000027
+  },
+  {
+   "prepare": 3.9756674000000203,
+   "normalize": 0.14466220000008434,
+   "audit": 17.237068000000136,
+   "promotion-plan": 0.7756412000001092,
+   "store-write": 7.281115099999852,
+   "total": 28.638512700000092
+  },
+  {
+   "prepare": 2.6441632999999456,
+   "normalize": 0.14597249999997075,
+   "audit": 11.795561500000076,
+   "promotion-plan": 1.2413638000000446,
+   "store-write": 5.123130199999878,
+   "total": 19.70882749999987
+  },
+  {
+   "prepare": 2.7250841000000037,
+   "normalize": 0.1505134999999882,
+   "audit": 11.692916000000196,
+   "promotion-plan": 0.5419645000001765,
+   "store-write": 4.448627700000088,
+   "total": 19.017141300000276
+  },
+  {
+   "prepare": 2.5995636999998624,
+   "normalize": 0.15539009999997688,
+   "audit": 10.65817109999989,
+   "promotion-plan": 0.5938219999998182,
+   "store-write": 3.2878957000000355,
+   "total": 16.701020599999765
+  },
+  {
+   "prepare": 1.8195842000000084,
+   "normalize": 0.07380540000008295,
+   "audit": 8.558406399999967,
+   "promotion-plan": 0.781611299999895,
+   "store-write": 3.6477652999999464,
+   "total": 14.099561300000005
+  }
+ ],
+ "deterministic": true,
+ "output_signatures": [
+  "da1341e6ac112bf83c7c521d194f698aa39da067075b636463fa6748c43fb629"
+ ],
+ "last_outputs": {
+  "leases": {
+   "fx1": {
+    "state": "ready",
+    "audit_state": "clean",
+    "clean_count": 3,
+    "pending_requeue": {
+     "transient": [],
+     "defect": []
+    },
+    "final_state": "promoted"
+   },
+   "fx2": {
+    "state": "ready_partial",
+    "audit_state": "needs_requeue",
+    "clean_count": 1,
+    "pending_requeue": {
+     "transient": [
+      "_a_g_ata"
+     ],
+     "defect": [
+      "_a_dikya"
+     ]
+    },
+    "final_state": "promoted_partial"
+   },
+   "fx3": {
+    "state": "ready",
+    "audit_state": "clean",
+    "clean_count": 2,
+    "pending_requeue": {
+     "transient": [],
+     "defect": []
+    },
+    "final_state": "promoted"
+   },
+   "fx4": {
+    "state": "ready",
+    "audit_state": "clean",
+    "clean_count": 1,
+    "pending_requeue": {
+     "transient": [],
+     "defect": []
+    },
+    "final_state": "promoted"
+   },
+   "fx5": {
+    "state": "ready",
+    "audit_state": "clean",
+    "clean_count": 3,
+    "pending_requeue": {
+     "transient": [],
+     "defect": []
+    },
+    "final_state": "promoted"
+   }
+  },
+  "promote_rc": 0,
+  "promote_tail": "promoted 5 lease(s)\n",
+  "store_sha256": "9a2d6daf0fb9887f0140cecafc3b9495dd79267e3ca5fda383a839be73ac4b72",
+  "store_semantic_sha256": "a776afd27eb69eacdfae86d6c990253e7d995f08e5424acdb9d96e5db06bec63",
+  "store_rows": 11715,
+  "tm_sha256": "2ccca227876610a4b18b231920dc4fa550313aab1c901473ab75e1162a64d27b",
+  "signature": "da1341e6ac112bf83c7c521d194f698aa39da067075b636463fa6748c43fb629"
+ }
+}

--- a/RussianTranslation/pwg_ru/h1339/h1386_bench_perlease.json
+++ b/RussianTranslation/pwg_ru/h1339/h1386_bench_perlease.json
@@ -1,0 +1,201 @@
+{
+ "schema": "pwg.h1339_offline_bench.v1",
+ "protocol": {
+  "warmups": 2,
+  "runs": 10,
+  "prepare_mode": "per-lease"
+ },
+ "python": "3.14.4 (tags/v3.14.4:23116f9, Apr  7 2026, 14:10:54) [MSC v.1944 64 bit (AMD64)]",
+ "platform": "Windows-10-10.0.19045-SP0",
+ "fixture_sha256": "d225ced2f215a5c4492b2657ba43cfef0f8b0d25b13202a5138142e9347e7ac4",
+ "seed_rows": 11600,
+ "stages": {
+  "prepare": {
+   "median_s": 11.669,
+   "p95_s": 15.546,
+   "min_s": 4.504,
+   "max_s": 16.502
+  },
+  "normalize": {
+   "median_s": 0.141,
+   "p95_s": 0.166,
+   "min_s": 0.056,
+   "max_s": 0.172
+  },
+  "audit": {
+   "median_s": 10.06,
+   "p95_s": 14.345,
+   "min_s": 5.834,
+   "max_s": 14.755
+  },
+  "promotion-plan": {
+   "median_s": 0.797,
+   "p95_s": 1.534,
+   "min_s": 0.404,
+   "max_s": 1.645
+  },
+  "store-write": {
+   "median_s": 6.175,
+   "p95_s": 8.361,
+   "min_s": 2.065,
+   "max_s": 9.968
+  },
+  "total": {
+   "median_s": 27.892,
+   "p95_s": 37.07,
+   "min_s": 13.955,
+   "max_s": 38.231
+  }
+ },
+ "runs": [
+  {
+   "prepare": 11.168299400000024,
+   "normalize": 0.14189479999993182,
+   "audit": 5.833940299999995,
+   "promotion-plan": 0.40359860000000936,
+   "store-write": 2.065355199999999,
+   "total": 19.20948969999995
+  },
+  {
+   "prepare": 4.504451499999959,
+   "normalize": 0.05599819999997635,
+   "audit": 6.091515600000093,
+   "promotion-plan": 0.40592709999998533,
+   "store-write": 3.302550999999994,
+   "total": 13.954516300000023
+  },
+  {
+   "prepare": 5.939773800000012,
+   "normalize": 0.14946120000001883,
+   "audit": 7.334361199999989,
+   "promotion-plan": 0.6077802000000929,
+   "store-write": 3.430739199999948,
+   "total": 16.854335399999968
+  },
+  {
+   "prepare": 6.340763600000059,
+   "normalize": 0.09272979999991549,
+   "audit": 8.874581700000022,
+   "promotion-plan": 1.534201199999984,
+   "store-write": 9.968367100000023,
+   "total": 25.27644220000002
+  },
+  {
+   "prepare": 15.54604089999998,
+   "normalize": 0.17207110000003922,
+   "audit": 14.151811400000042,
+   "promotion-plan": 1.6445472000000336,
+   "store-write": 8.361019000000056,
+   "total": 38.23094240000012
+  },
+  {
+   "prepare": 16.502233299999943,
+   "normalize": 0.16625070000009146,
+   "audit": 14.75493019999999,
+   "promotion-plan": 0.7109348999999838,
+   "store-write": 5.646834300000137,
+   "total": 37.07024850000016
+  },
+  {
+   "prepare": 9.33940779999989,
+   "normalize": 0.12855089999993652,
+   "audit": 9.449090499999784,
+   "promotion-plan": 0.6735191000000214,
+   "store-write": 4.574002400000154,
+   "total": 23.491051599999764
+  },
+  {
+   "prepare": 12.170493800000031,
+   "normalize": 0.16449999999986176,
+   "audit": 14.345000300000038,
+   "promotion-plan": 0.8824765000001662,
+   "store-write": 7.8471508000000085,
+   "total": 34.52714489999994
+  },
+  {
+   "prepare": 14.269283700000187,
+   "normalize": 0.12637130000007346,
+   "audit": 14.128878299999997,
+   "promotion-plan": 1.0844048000001294,
+   "store-write": 6.702892399999882,
+   "total": 35.22742570000014
+  },
+  {
+   "prepare": 12.188653599999952,
+   "normalize": 0.13951040000006287,
+   "audit": 10.670124199999918,
+   "promotion-plan": 0.9860237000000325,
+   "store-write": 7.509696099999928,
+   "total": 30.507984299999862
+  }
+ ],
+ "deterministic": true,
+ "output_signatures": [
+  "da1341e6ac112bf83c7c521d194f698aa39da067075b636463fa6748c43fb629"
+ ],
+ "last_outputs": {
+  "leases": {
+   "fx1": {
+    "state": "ready",
+    "audit_state": "clean",
+    "clean_count": 3,
+    "pending_requeue": {
+     "transient": [],
+     "defect": []
+    },
+    "final_state": "promoted"
+   },
+   "fx2": {
+    "state": "ready_partial",
+    "audit_state": "needs_requeue",
+    "clean_count": 1,
+    "pending_requeue": {
+     "transient": [
+      "_a_g_ata"
+     ],
+     "defect": [
+      "_a_dikya"
+     ]
+    },
+    "final_state": "promoted_partial"
+   },
+   "fx3": {
+    "state": "ready",
+    "audit_state": "clean",
+    "clean_count": 2,
+    "pending_requeue": {
+     "transient": [],
+     "defect": []
+    },
+    "final_state": "promoted"
+   },
+   "fx4": {
+    "state": "ready",
+    "audit_state": "clean",
+    "clean_count": 1,
+    "pending_requeue": {
+     "transient": [],
+     "defect": []
+    },
+    "final_state": "promoted"
+   },
+   "fx5": {
+    "state": "ready",
+    "audit_state": "clean",
+    "clean_count": 3,
+    "pending_requeue": {
+     "transient": [],
+     "defect": []
+    },
+    "final_state": "promoted"
+   }
+  },
+  "promote_rc": 0,
+  "promote_tail": "promoted 5 lease(s)\n",
+  "store_sha256": "187d80561637f8c1b7e0f25d26bce1053f5ddfceb01c7279026ad6228527a5b9",
+  "store_semantic_sha256": "a776afd27eb69eacdfae86d6c990253e7d995f08e5424acdb9d96e5db06bec63",
+  "store_rows": 11715,
+  "tm_sha256": "fa066c4bf0871afd2d92a9fd3e1cea2f0dd7e025a70cbce2e591b31652ae99b9",
+  "signature": "da1341e6ac112bf83c7c521d194f698aa39da067075b636463fa6748c43fb629"
+ }
+}

--- a/RussianTranslation/src/_pilot_gen_merged.py
+++ b/RussianTranslation/src/_pilot_gen_merged.py
@@ -33,7 +33,8 @@ import nws_split
 from safe_filename import safe_name
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-OUT = os.path.join(HERE, 'pilot', 'input')
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+OUT = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'pilot', 'input')
 
 sys.path.insert(0, os.path.join(HERE, '..', 'research'))
 import root_segment_proto as RS                 # the lossless <div n="p"> root slicer

--- a/RussianTranslation/src/audit_coverage.py
+++ b/RussianTranslation/src/audit_coverage.py
@@ -25,7 +25,8 @@ sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-IN = os.path.join(HERE, 'pilot', 'input')
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+IN = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'pilot', 'input')
 
 LOW, OVER = 0.80, 1.50
 DIVN = re.compile(r'<div n=')

--- a/RussianTranslation/src/audit_sense_dupes.py
+++ b/RussianTranslation/src/audit_sense_dupes.py
@@ -14,7 +14,8 @@ sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
 SKIP = {'gramm-forms', 'header', 'gramm-header', 'grammar', 'paradigm', 'vgl.', 'vgl'}
-INP = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pilot', 'input')
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+INP = os.environ.get('PWG_INPUT_DIR') or os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pilot', 'input')
 # Committed, reproducible batch_of exemptions. The rootmaps under INP are gitignored and
 # regenerated, so a hand-edit there is lost on clone/regen; this tracked file restores it.
 OVERRIDES = os.path.join(os.path.dirname(INP), 'rootmap_overrides.json')

--- a/RussianTranslation/src/audit_translation.py
+++ b/RussianTranslation/src/audit_translation.py
@@ -22,7 +22,8 @@ sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-IN = os.path.join(HERE, 'pilot', 'input')
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+IN = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'pilot', 'input')
 OUT = os.path.join(HERE, 'pilot', 'output')
 
 if HERE not in sys.path:

--- a/RussianTranslation/src/compile_translatable.py
+++ b/RussianTranslation/src/compile_translatable.py
@@ -26,7 +26,8 @@ from safe_filename import safe_name, decode_safe_name
 import nws_split as NS
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-INP = os.path.join(HERE, 'pilot', 'input')
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+INP = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'pilot', 'input')
 OUT = os.path.join(HERE, 'pilot', 'translate')
 
 # ---------------------------------------------------------------- language ID

--- a/RussianTranslation/src/nws_audit_section.py
+++ b/RussianTranslation/src/nws_audit_section.py
@@ -39,7 +39,8 @@ import nws_split as N
 from safe_filename import safe_name
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-INP = os.path.join(HERE, 'pilot', 'input')
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+INP = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'pilot', 'input')
 OUT = os.path.join(HERE, 'pilot', 'output')
 
 BLEED = re.compile(r'^[\s,;]*[^>]*?;\s*[A-ZÀ-ÖØ-ÞĀ-ỿ][^>:]*?\s:\s[\dIVXLCDM]+[A-Za-z]?\s*>\s*')

--- a/RussianTranslation/src/nws_split.py
+++ b/RussianTranslation/src/nws_split.py
@@ -27,7 +27,8 @@ sys.stderr.reconfigure(encoding='utf-8')
 from safe_filename import candidate_names
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-INP = os.path.join(HERE, 'pilot', 'input')
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+INP = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'pilot', 'input')
 OUTP = os.path.join(HERE, 'pilot', 'output')
 
 

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -22,7 +22,8 @@ sys.stderr.reconfigure(encoding='utf-8')
 HERE = os.path.dirname(os.path.abspath(__file__))          # .../src/pilot
 SRC = os.path.dirname(HERE)                                # .../src
 OUT = os.path.join(HERE, 'output')
-INPUT_DIR = os.path.join(HERE, 'input')                    # .../src/pilot/input (portrait sidecars)
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+INPUT_DIR = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'input')  # .../src/pilot/input (portrait sidecars)
 
 sys.path.insert(0, SRC)
 import nws_split

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -149,7 +149,20 @@ def run_py_inproc(args):
                 runpy.run_path(script, run_name='__main__')
             except SystemExit as exc:
                 code = exc.code
-                rc = code if isinstance(code, int) else (0 if code is None else 1)
+                if isinstance(code, int):
+                    rc = code
+                elif code is None:
+                    rc = 0
+                else:
+                    # H1386 P3e: mirror CPython -- sys.exit('<message>') prints the
+                    # message to stderr and exits 1. Pre-fix the diagnosis vanished
+                    # (a crashed entry with EMPTY stderr).
+                    err.write(str(code) + '\n')
+                    rc = 1
+            except KeyboardInterrupt:
+                # H1386 P3d: an operator abort must ABORT the audit, not be recorded as a
+                # crashed gate that pollutes the failure gallery with a phantom crash.
+                raise
             except BaseException:
                 err.write(traceback.format_exc())
                 rc = 3

--- a/RussianTranslation/src/pilot/audit_window_en.py
+++ b/RussianTranslation/src/pilot/audit_window_en.py
@@ -72,7 +72,8 @@ sys.stderr.reconfigure(encoding='utf-8')
 HERE = os.path.dirname(os.path.abspath(__file__))          # .../src/pilot
 SRC = os.path.dirname(HERE)                                # .../src
 OUT = os.path.join(HERE, 'output')
-INPUT_DIR = os.path.join(HERE, 'input')                    # portrait sidecars (H920 source_senses)
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+INPUT_DIR = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'input')  # portrait sidecars (H920 source_senses)
 DEFAULT_MW_TM = os.path.join(SRC, 'mw_en_tm.json')
 
 if HERE not in sys.path:

--- a/RussianTranslation/src/pilot/bounded_staged_run.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run.py
@@ -694,8 +694,12 @@ def run(args):
         # drain loop then sees neither pending nor done-unrecorded and exits at once, stranding
         # the lease forever. Reset in_progress jobs (scoped to this plan) back to pending before
         # the supervisor drains.
+        # H1386 C1: cmd_recover takes the lease-id SET, never the staged_plan_scope dict --
+        # iterating the dict fed its KEYS ('expected_headwords', 'lease_ids', ...) into the
+        # SQL scope, so the recovery UPDATE matched zero jobs and a crashed window was
+        # checkpointed COMPLETED with zero output (mirrors cmd_staged_run's set(lease_ids)).
         mao.cmd_recover(argparse.Namespace(
-            db=args.db, only_external_ids=scope,
+            db=args.db, only_external_ids=set(scope['lease_ids']),
             coordinator=args.coordinator, coord_dir=args.coord_dir, cwd=args.cwd))
 
     sup = build_supervisor(windows, args.checkpoint, ceilings, run_window, audit,

--- a/RussianTranslation/src/pilot/bounded_staged_run.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run.py
@@ -401,26 +401,51 @@ def materialize_requeue(ctx, origin_lease_id, run=None):
         pending = lease.get('pending_requeue') or {}
         kind = ('transient' if pending.get('transient')
                 else 'defect' if pending.get('defect') else None)
-        if kind is None:
-            raise SystemExit('bounded_staged_run: lease %s has no pending requeue backlog '
-                             'to materialise' % origin_lease_id)
-        prep = run(
-            [sys.executable, os.path.abspath(ctx.coordinator), 'prepare-requeue',
-             origin_lease_id, '--%s' % kind],
-            cwd=os.path.abspath(ctx.cwd), text=True, encoding='utf-8', capture_output=True)
-        if prep.returncode:
-            raise SystemExit('bounded_staged_run: prepare-requeue --%s failed for %s: %s'
-                             % (kind, origin_lease_id, (prep.stderr or prep.stdout)[-800:]))
-        with open(ctx.coord_state_path, encoding='utf-8') as f:
-            state = json.load(f)
-        lease = _lease_by_id(state, origin_lease_id) or {}
+        if kind is not None:
+            prep = run(
+                [sys.executable, os.path.abspath(ctx.coordinator), 'prepare-requeue',
+                 origin_lease_id, '--%s' % kind],
+                cwd=os.path.abspath(ctx.cwd), text=True, encoding='utf-8', capture_output=True)
+            if prep.returncode:
+                raise SystemExit('bounded_staged_run: prepare-requeue --%s failed for %s: %s'
+                                 % (kind, origin_lease_id, (prep.stderr or prep.stdout)[-800:]))
+            with open(ctx.coord_state_path, encoding='utf-8') as f:
+                state = json.load(f)
+            lease = _lease_by_id(state, origin_lease_id) or {}
+        # kind None (no preparable backlog): fall through to the H1386 C2 resume check
+        # below instead of raising here -- a promoted_partial whose final lane's attempt
+        # completed and promoted is a crash-resume, not an unmaterialisable backlog.
     if lease.get('state') != 'requeue_prepared':
+        # H1386 C2: a post-audit origin state with a COMPLETED ::rqNN attempt job is a
+        # RESUME, not a wedge. The crash class: the rq item recorded (ready/ready_partial)
+        # or even promoted, then the in-loop promote failed transiently (DirLock busy, the
+        # all-or-nothing batch refusal) or the process died between record and checkpoint,
+        # so --resume re-pulls the checkpointed rq item. Returning the existing attempt job
+        # id lets the drain loop break immediately and the A2 rescue promote land the
+        # recorded-but-unpromoted cards, exactly as it does for plain windows. Pre-fix this
+        # raised on EVERY resume -- a permanent wedge only a hand-run promote could clear.
+        if lease.get('state') in ('ready', 'ready_partial', 'promoted', 'promoted_partial'):
+            rq_id = _completed_requeue_job(ctx, origin_lease_id)
+            if rq_id:
+                return rq_id
         raise SystemExit('bounded_staged_run: lease %s is %r after requeue materialisation '
-                         '(expected requeue_prepared) -- cannot run the rework'
+                         '(expected requeue_prepared, or a post-audit state with a completed '
+                         '::rq attempt job to resume) -- cannot run the rework'
                          % (origin_lease_id, lease.get('state')))
     return mao.cmd_import_requeue(argparse.Namespace(
         db=ctx.db, coord_dir=ctx.coord_dir, cwd=ctx.cwd,
         lease_id=origin_lease_id, max_attempts=2))
+
+
+def _completed_requeue_job(ctx, origin_lease_id):
+    """The most recent COMPLETED requeue-attempt job ('<origin>::rqNN-<kind>') for this
+    origin lease, or None. GLOB (not LIKE) so '_' in lease ids stays literal."""
+    db = mao.connect(ctx.db)
+    row = db.execute(
+        "SELECT external_id FROM jobs WHERE external_id GLOB ? AND state='done' "
+        "ORDER BY id DESC LIMIT 1", (origin_lease_id + '::rq*',)).fetchone()
+    db.close()
+    return row['external_id'] if row else None
 
 
 def make_run_window(ctx):

--- a/RussianTranslation/src/pilot/bounded_staged_run.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run.py
@@ -492,8 +492,16 @@ def make_run_window(ctx):
             failed = mao.scoped_job_count(db, scope, "state='failed'")
             db.close()
             if failed:
-                raise SystemExit('bounded_staged_run: lease %s has %d failed job(s) — fail closed'
-                                 % (lease_id, failed))
+                # H1386 P3c: print the failed jobs' FULL external_ids -- the documented
+                # reset-failed recovery needs the exact '<lease>::rqNN-<kind>' id.
+                db = mao.connect(ctx.db)
+                failed_ids = [j['external_id'] for j in
+                              mao.scoped_jobs(db, scope, "state='failed'")]
+                db.close()
+                raise SystemExit('bounded_staged_run: lease %s has %d failed job(s) '
+                                 '(%s) — fail closed; recover with reset-failed '
+                                 '--lease-id <id> --reason "..."'
+                                 % (lease_id, failed, ', '.join(sorted(failed_ids))))
             if not pending and not done_unrecorded:
                 break
             if pending:

--- a/RussianTranslation/src/pilot/bounded_staged_run.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run.py
@@ -258,6 +258,15 @@ class RunContext:
         return os.path.join(os.path.abspath(self.coord_dir), 'state.json')
 
 
+def _coord_env(ctx):
+    """H1386 D4 (the A7 class, repeated): the env for every coordinator SUBPROCESS this
+    module spawns. Without an explicit PWG_COORDINATOR_DIR the child resolves the DEFAULT
+    coordinator dir, so a bounded run with a non-default --coord-dir (the documented
+    H895-acceptance pattern) would prepare/promote against the wrong coordinator state --
+    a wrong-dir SystemExit mid-drain at best, a same-id foreign lease mutated at worst."""
+    return dict(os.environ, PWG_COORDINATOR_DIR=os.path.abspath(ctx.coord_dir))
+
+
 def _ensure_imported(ctx, lease_id):
     """Import this lease as a scoped job if it is prepared and not already present (mirrors
     cmd_staged_run's to_import filter, scoped to the single lease)."""
@@ -405,7 +414,8 @@ def materialize_requeue(ctx, origin_lease_id, run=None):
             prep = run(
                 [sys.executable, os.path.abspath(ctx.coordinator), 'prepare-requeue',
                  origin_lease_id, '--%s' % kind],
-                cwd=os.path.abspath(ctx.cwd), text=True, encoding='utf-8', capture_output=True)
+                cwd=os.path.abspath(ctx.cwd), env=_coord_env(ctx),
+                text=True, encoding='utf-8', capture_output=True)
             if prep.returncode:
                 raise SystemExit('bounded_staged_run: prepare-requeue --%s failed for %s: %s'
                                  % (kind, origin_lease_id, (prep.stderr or prep.stdout)[-800:]))
@@ -518,7 +528,8 @@ def make_run_window(ctx):
             promote = subprocess.run(
                 [sys.executable, os.path.abspath(ctx.coordinator), 'promote-ready',
                  '--gen-model-version', ctx.gen_model_version, '--lease-id', lease_id],
-                cwd=os.path.abspath(ctx.cwd), text=True, encoding='utf-8', capture_output=True)
+                cwd=os.path.abspath(ctx.cwd), env=_coord_env(ctx),
+                text=True, encoding='utf-8', capture_output=True)
             if promote.returncode and 'no ready leases to promote' not in (
                     promote.stderr + promote.stdout):
                 raise SystemExit('bounded_staged_run: lease %s promotion failed: %s'
@@ -533,7 +544,8 @@ def make_run_window(ctx):
             rescue = subprocess.run(
                 [sys.executable, os.path.abspath(ctx.coordinator), 'promote-ready',
                  '--gen-model-version', ctx.gen_model_version, '--lease-id', lease_id],
-                cwd=os.path.abspath(ctx.cwd), text=True, encoding='utf-8', capture_output=True)
+                cwd=os.path.abspath(ctx.cwd), env=_coord_env(ctx),
+                text=True, encoding='utf-8', capture_output=True)
             if rescue.returncode and 'no ready leases to promote' not in (
                     rescue.stderr + rescue.stdout):
                 raise SystemExit('bounded_staged_run: lease %s post-loop promotion failed: %s'

--- a/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
@@ -503,6 +503,80 @@ def test_k_requeue_materialisation(td):
           'unmaterialisable; audit reads the origin lease; rq-of-rq keeps the true origin: PASS')
 
 
+def test_l_resume_recovers_abandoned_jobs(td):
+    """H1386 C1: --resume must reset THIS plan's abandoned in_progress jobs to pending.
+
+    The pre-fix code passed the whole staged_plan_scope DICT as only_external_ids, so
+    _scope_sql iterated its KEYS ('expected_headwords', 'lease_ids', ...) and the recovery
+    UPDATE matched zero jobs -- a crashed window then checkpointed COMPLETED with zero
+    output while its stuck in_progress job blocked the account for every future claim."""
+    plan = _plan(['no_pwg_w02'])
+    plan_path = os.path.join(td, 'l_plan.json')
+    with open(plan_path, 'w', encoding='utf-8', newline='\n') as f:
+        json.dump(plan, f)
+    coord = os.path.join(td, 'l_coord'); os.makedirs(coord)
+    with open(os.path.join(coord, 'state.json'), 'w', encoding='utf-8', newline='\n') as f:
+        json.dump({'leases': [{'id': 'no_pwg_w02', 'state': 'prepared'}]}, f)
+    db = os.path.join(td, 'l_jobs.sqlite')
+    dbc = mao.connect(db)
+    with dbc:
+        dbc.execute("INSERT INTO accounts(name,config_dir,validated,updated_at) "
+                    "VALUES('acc1',?,1,?)", (td, mao.now_iso()))
+        dbc.execute("INSERT INTO jobs(external_id,cwd,output_path,manifest_path,state) "
+                    "VALUES('no_pwg_w02',?,?,?,'in_progress')",
+                    (td, os.path.join(td, 'l_out.json'), os.path.join(td, 'l_manifest.json')))
+    dbc.close()
+
+    class _NoopSup:
+        def run(self):
+            return {'stop_reason': STOP_CLEAN_TARGET}
+
+    _pf, _rr, _bsup = mao.probe_fleet, mao.release_runtime, bsr.build_supervisor
+    mao.probe_fleet = lambda *a, **k: {'acc1': 10}
+    mao.release_runtime = lambda *a, **k: argparse.Namespace(returncode=0, stdout='', stderr='')
+    bsr.build_supervisor = lambda *a, **k: _NoopSup()
+    try:
+        rc = bsr.run(argparse.Namespace(
+            plan=plan_path, coord_dir=coord, coordinator=os.path.join(HERE, 'coordinator.py'),
+            cwd=td, db=db, checkpoint=os.path.join(td, 'l_cp.json'), lease_id=None,
+            execute=True, resume=True, report=None, run_id='l', events=None,
+            claude_bin='claude', timeout=5, gen_model_version=bsr.DEFAULT_GEN_MODEL_VERSION,
+            only_profile=None, drop_unhealthy=False, stop_before_promote=False,
+            max_windows=None, max_calls=None, max_clean=None, cost_ceiling=None,
+            empty_streak=None, max_accounts=0))
+    finally:
+        mao.probe_fleet, mao.release_runtime, bsr.build_supervisor = _pf, _rr, _bsup
+    assert rc == 0, rc
+    dbc = mao.connect(db)
+    state = dbc.execute("SELECT state FROM jobs WHERE external_id='no_pwg_w02'").fetchone()['state']
+    dbc.close()
+    assert state == 'pending', (
+        'H1386 C1: --resume did not reset the abandoned in_progress job (state=%r)' % state)
+
+    # Defense-in-depth (a): a dict/str scope must be a TypeError, never a silent zero-match.
+    for bad in ({'lease_ids': ['x']}, 'no_pwg_w02'):
+        try:
+            mao._scope_sql(bad)
+            raise AssertionError('_scope_sql accepted a %s scope' % type(bad).__name__)
+        except TypeError:
+            pass
+
+    # Defense-in-depth (b): a NORMAL (non-requeue) window whose run_window returns None must
+    # fail loudly -- never checkpoint COMPLETED with zero output (the crash-recovery hole C1
+    # exposed: recovery matched nothing, the drain saw no jobs, run_window returned None).
+    windows, _ = bsr.scope_windows(plan)
+    sup = bs.BoundedSupervisor(windows, lambda w: None, os.path.join(td, 'l_none_cp.json'),
+                               audit=lambda wf, w: {'clean_count': 0})
+    try:
+        sup.run()
+        raise AssertionError('a None-output normal window checkpointed COMPLETED')
+    except SystemExit:
+        pass
+    assert sup.completed_window_ids == [], sup.completed_window_ids
+    print('  (l) H1386 C1: --resume resets abandoned in_progress jobs; dict/str scope is a '
+          'TypeError; a None-output window fails loudly: PASS')
+
+
 def main():
     with tempfile.TemporaryDirectory() as td:
         test_a_plan_scope(td)
@@ -516,6 +590,7 @@ def main():
         test_i_audit_from_coordinator(td)
         test_j_stop_before_promote_awaiting_review(td)
         test_k_requeue_materialisation(td)
+        test_l_resume_recovers_abandoned_jobs(td)
     print('bounded_staged_run_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
@@ -452,6 +452,13 @@ def test_k_requeue_materialisation(td):
     def fake_prepare(argv, **kw):
         calls.append(argv)
         assert 'prepare-requeue' in argv and '--transient' in argv, argv
+        # H1386 D4 (the A7 class, repeated): every coordinator subprocess must carry THIS
+        # run's coord dir -- without it a non-default --coord-dir run resolves the DEFAULT
+        # coordinator state (wrong-dir SystemExit mid-drain, or a same-id foreign lease
+        # mutated to requeue_prepared).
+        env = kw.get('env') or {}
+        assert env.get('PWG_COORDINATOR_DIR') == os.path.abspath(coord), \
+            'prepare-requeue subprocess missing PWG_COORDINATOR_DIR=%s' % coord
         write_state('requeue_prepared', with_attempt=True)   # what the real command does
         return argparse.Namespace(returncode=0, stdout='', stderr='')
 

--- a/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
@@ -503,6 +503,66 @@ def test_k_requeue_materialisation(td):
           'unmaterialisable; audit reads the origin lease; rq-of-rq keeps the true origin: PASS')
 
 
+def test_m_requeue_resume_after_crash(td):
+    """H1386 C2: a post-audit origin state (ready/ready_partial/promoted/promoted_partial)
+    with a COMPLETED ::rqNN attempt job is a RESUME, not a wedge -- materialize_requeue
+    returns the existing job id and falls through to the drain loop (whose break + A2
+    rescue promote handles recorded-but-unpromoted exactly as for plain windows). Pre-fix,
+    every --resume re-pulled the checkpointed rq item and SystemExit'd permanently."""
+    coord = os.path.join(td, 'm_coord'); os.makedirs(coord)
+    state_path = os.path.join(coord, 'state.json')
+    db = os.path.join(td, 'm_jobs.sqlite')
+    dbc = mao.connect(db)
+    with dbc:
+        dbc.execute("INSERT INTO jobs(external_id,cwd,output_path,manifest_path,state,"
+                    "coordinator_recorded) VALUES('w1::rq01-transient',?,?,?,'done',1)",
+                    (td, os.path.join(td, 'm_out.json'), os.path.join(td, 'm_manifest.json')))
+    dbc.close()
+    ctx = bsr.RunContext(db=db, coord_dir=coord,
+                         coordinator=os.path.join(HERE, 'coordinator.py'),
+                         cwd=td, events=None, run_id='m', probe_latencies={})
+
+    def must_not_run(argv, **kw):
+        raise AssertionError('prepare-requeue must not run on a resumable post-audit lease')
+
+    def write_lease(state_name, pending=None):
+        with open(state_path, 'w', encoding='utf-8', newline='\n') as f:
+            json.dump({'leases': [{'id': 'w1', 'state': state_name,
+                                   'pending_requeue': pending or {'transient': [],
+                                                                  'defect': []}}]}, f)
+
+    # 1. every post-audit state with a completed attempt job resumes to that job id.
+    for state_name in ('ready', 'ready_partial', 'promoted', 'promoted_partial'):
+        write_lease(state_name)
+        rq = bsr.materialize_requeue(ctx, 'w1', run=must_not_run)
+        assert rq == 'w1::rq01-transient', (state_name, rq)
+
+    # 2. genuinely unmaterialisable states stay LOUD even with a completed attempt job.
+    for state_name in ('blocked', 'needs_requeue'):
+        write_lease(state_name)   # empty backlog: nothing preparable
+        try:
+            bsr.materialize_requeue(ctx, 'w1', run=must_not_run)
+            raise AssertionError('%s lease did not fail loudly' % state_name)
+        except SystemExit:
+            pass
+
+    # 3. a post-audit state WITHOUT any completed attempt job is still a loud raise
+    #    (nothing to resume -- the rq item maps to no work at all).
+    db2 = os.path.join(td, 'm_jobs_empty.sqlite')
+    mao.connect(db2).close()
+    ctx2 = bsr.RunContext(db=db2, coord_dir=coord,
+                          coordinator=os.path.join(HERE, 'coordinator.py'),
+                          cwd=td, events=None, run_id='m2', probe_latencies={})
+    write_lease('ready')
+    try:
+        bsr.materialize_requeue(ctx2, 'w1', run=must_not_run)
+        raise AssertionError('ready lease with no attempt job did not fail loudly')
+    except SystemExit:
+        pass
+    print('  (m) H1386 C2: post-audit lease + completed ::rq job resumes to the existing '
+          'job; blocked/no-backlog/no-job stay loud: PASS')
+
+
 def test_l_resume_recovers_abandoned_jobs(td):
     """H1386 C1: --resume must reset THIS plan's abandoned in_progress jobs to pending.
 
@@ -591,6 +651,7 @@ def main():
         test_j_stop_before_promote_awaiting_review(td)
         test_k_requeue_materialisation(td)
         test_l_resume_recovers_abandoned_jobs(td)
+        test_m_requeue_resume_after_crash(td)
     print('bounded_staged_run_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/bounded_supervisor.py
+++ b/RussianTranslation/src/pilot/bounded_supervisor.py
@@ -283,6 +283,19 @@ class BoundedSupervisor:
                         'lease/job for these keys (or rerun attended) before resuming.'
                         % (item.get('id'), item.get('keys')))
 
+                # H1386 C1 defense-in-depth: the same guard for a NORMAL window. run_window
+                # returning None means the drain found no runnable job for the lease (never
+                # imported, already advanced, or crash recovery matched nothing) -- yet the
+                # loop below would checkpoint it COMPLETED with zero model calls, silently
+                # marking its headwords translated when nothing ran.
+                if wf_output is None:
+                    raise SystemExit(
+                        'bounded_supervisor: window %s produced no output -- run_window '
+                        'returned None (no runnable job for the lease: unimported, already '
+                        'advanced, or recovery matched nothing), so checkpointing it '
+                        'COMPLETED would silently drop its headwords untranslated. Recover '
+                        'the lease/job state before resuming.' % item.get('id'))
+
                 # (3) AUDIT — injected report, or the H920 gate helper on a tmp dir.
                 report = self._run_audit(wf_output, item)
 

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -1695,16 +1695,30 @@ def promote_ready(args):
                     fresh['state'] = 'promoted_partial' if has_pending else 'promoted'
                     fresh['promoted_at'] = utc_now()
                     fresh['model_version'] = args.gen_model_version
+                    # H1386 D3: store_delta is the PER-LEASE figure from the batch report
+                    # (its three consumers -- promotion_classification, bad_deltas, the
+                    # windows100 GO gate -- all read it per lease); the bundle-wide
+                    # before/after stays as separate bundle-level context fields.
                     fresh['store_before'] = store_before
                     fresh['store_after'] = store_after
-                    fresh['store_delta'] = store_after - store_before
+                    fresh['store_delta'] = per.get('store_delta',
+                                                   store_after - store_before)
+                    fresh['bundle_store_delta'] = store_after - store_before
                     fresh['promoted_subcards'] = per.get('subcards')
                     fresh['promoted_rows'] = per.get('rows')
+                    fresh['rows_added'] = per.get('rows_added')
+                    fresh['rows_replaced'] = per.get('rows_replaced')
                     save_state(state)
                     registry_event(fresh, 'promoted', {'glob': lease['clean_output'],
                                                        'store_before': store_before,
                                                        'store_after': store_after,
-                                                       'store_delta': store_after - store_before,
+                                                       'store_delta': per.get(
+                                                           'store_delta',
+                                                           store_after - store_before),
+                                                       'bundle_store_delta':
+                                                           store_after - store_before,
+                                                       'rows_added': per.get('rows_added'),
+                                                       'rows_replaced': per.get('rows_replaced'),
                                                        'batch_subcards': per.get('subcards'),
                                                        'batch_rows': per.get('rows')})
         finally:

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -108,7 +108,10 @@ def _frag_prov_glob():
     honored on both sides. Previously detection honored it but build-frags hardcoded the default
     tree, so a custom dir detected frag_prov here yet built the fragment TM from the empty default
     tree, silently dropping the just-promoted window's fragments."""
-    return os.path.join(paths()['artifacts'], '*', 'wf_output*.json')
+    # H1386 C3: '**' (recursive) -- a requeue attempt's corrected wf_output lands two dirs
+    # deep at artifacts/<lease>/requeue/rqNN-<kind>/, which the old single-'*' never
+    # matched, so a rework's fragments were never harvested at all.
+    return os.path.join(paths()['artifacts'], '**', 'wf_output*.json')
 
 
 def ensure_dirs():
@@ -1600,7 +1603,7 @@ def rebuild_ru_translation_memory():
     # so that join is a no-op and both sides resolve to the same coordinator dir.
     frag_glob = _frag_prov_glob()
     if any('"frag_prov"' in open(fp, encoding='utf-8').read()
-           for fp in glob.glob(frag_glob)):
+           for fp in glob.glob(frag_glob, recursive=True)):
         run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'build-frags',
                  '--lang', 'ru', '--glob', frag_glob])
     run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'validate', '--lang', 'ru'])

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -25,8 +25,12 @@ sys.stderr.reconfigure(encoding='utf-8')
 HERE = os.path.dirname(os.path.abspath(__file__))
 SRC = os.path.dirname(HERE)
 REPO = os.path.dirname(SRC)
-# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
-INPUT_DIR = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'input')
+
+def input_dir():
+    """H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+    Resolved PER CALL (never a module constant): callers that rebind HERE (the
+    selftest seam) and env changes must both take effect."""
+    return os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'input')
 OUT = os.path.join(HERE, 'output')
 DEFAULT_COORD_DIR = os.path.join(OUT, 'coordinator')
 ARTIFACT_DIRNAME = 'artifacts'
@@ -759,8 +763,8 @@ def nominal_candidates(state, batch_size=12, cards_path=None):
             stem = safe_name(key) if key else ''
             if (key and key not in done and key not in leased
                     and not row.get('quarantined_records')
-                    and os.path.exists(os.path.join(INPUT_DIR, stem + '.raw.txt'))
-                    and os.path.exists(os.path.join(INPUT_DIR, stem + '.portrait.json'))):
+                    and os.path.exists(os.path.join(input_dir(), stem + '.raw.txt'))
+                    and os.path.exists(os.path.join(input_dir(), stem + '.portrait.json'))):
                 keys.append(key)
             if len(keys) >= batch_size:
                 break

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -25,6 +25,8 @@ sys.stderr.reconfigure(encoding='utf-8')
 HERE = os.path.dirname(os.path.abspath(__file__))
 SRC = os.path.dirname(HERE)
 REPO = os.path.dirname(SRC)
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+INPUT_DIR = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'input')
 OUT = os.path.join(HERE, 'output')
 DEFAULT_COORD_DIR = os.path.join(OUT, 'coordinator')
 ARTIFACT_DIRNAME = 'artifacts'
@@ -757,8 +759,8 @@ def nominal_candidates(state, batch_size=12, cards_path=None):
             stem = safe_name(key) if key else ''
             if (key and key not in done and key not in leased
                     and not row.get('quarantined_records')
-                    and os.path.exists(os.path.join(HERE, 'input', stem + '.raw.txt'))
-                    and os.path.exists(os.path.join(HERE, 'input', stem + '.portrait.json'))):
+                    and os.path.exists(os.path.join(INPUT_DIR, stem + '.raw.txt'))
+                    and os.path.exists(os.path.join(INPUT_DIR, stem + '.portrait.json'))):
                 keys.append(key)
             if len(keys) >= batch_size:
                 break
@@ -901,7 +903,46 @@ def enforce_cost_gate(preflight_path, target, allow_over_cost=False):
                    len(part.get('run_now') or []), len(part.get('defer_monster') or [])))
 
 
-def prepare(args):
+def _run_child_inproc(argv, timeout=None):
+    """H1386 OPT: run a prepare child (perf_preflight / gen_opt_harness2) IN-PROCESS via
+    audit_window.run_py_inproc -- the H1339 runpy-gates pattern applied to the prepare
+    stage, which H1339's own closeout named as the remaining dominant per-lease
+    interpreter-spawn cost. Returns a CompletedProcess-shaped object; mirrors run_cmd's
+    loud failure. `timeout` is accepted for signature parity but not enforceable in-proc
+    -- the caller's between-children operation deadline still applies."""
+    from audit_window import run_py_inproc
+    # run_py_inproc takes [script, *args] -- strip the interpreter that the subprocess
+    # form (run_cmd) needs but runpy must not see.
+    if argv and os.path.normcase(argv[0]) == os.path.normcase(sys.executable):
+        argv = argv[1:]
+    res = run_py_inproc(argv)
+    if res['returncode']:
+        if (res['stdout'] or '').strip():
+            print(res['stdout'].rstrip())
+        if (res['stderr'] or '').strip():
+            print(res['stderr'].rstrip(), file=sys.stderr)
+        raise SystemExit(res['returncode'])
+    return subprocess.CompletedProcess(argv, res['returncode'],
+                                       stdout=res['stdout'], stderr=res['stderr'])
+
+
+def prepare_batch(args):
+    """H1386 OPT: prepare N claimed leases in ONE coordinator process, with the two
+    per-lease children (perf_preflight cost gate + gen_opt_harness2 harness/manifest
+    generation) run in-process -- 3 interpreter spawns per lease become 0 marginal spawns
+    per lease. Per-lease semantics are IDENTICAL to `prepare` (same operation tokens,
+    same cost gate, same artifacts, same state transitions), proven by the
+    h1339_offline_bench deterministic output signature."""
+    for lease_id in args.lease_id:
+        one = argparse.Namespace(
+            lease_id=lease_id, allow_over_cost=getattr(args, 'allow_over_cost', False),
+            profile_slot=args.profile_slot, config_dir=args.config_dir,
+            executor_lane=args.executor_lane)
+        prepare(one, run_child=_run_child_inproc)
+
+
+def prepare(args, run_child=None):
+    run_child = run_child or run_cmd
     if bool(args.profile_slot) != bool(args.config_dir):
         raise SystemExit('--profile-slot and --config-dir must be supplied together')
     with DirLock(paths()['lock']):
@@ -925,17 +966,17 @@ def prepare(args):
         if lease['kind'] == 'verb':
             root = lease['target']
             preflight_path = os.path.join(adir, 'preflight.json')
-            p = run_cmd([sys.executable, os.path.join(HERE, 'perf_preflight.py'),
-                         root, '--json'],
-                        timeout=remaining_operation_timeout(deadline, 'prepare'))
+            p = run_child([sys.executable, os.path.join(HERE, 'perf_preflight.py'),
+                           root, '--json'],
+                          timeout=remaining_operation_timeout(deadline, 'prepare'))
             atomic_write_text(preflight_path, p.stdout)
             enforce_cost_gate(preflight_path, lease.get('target'),
                               allow_over_cost=getattr(args, 'allow_over_cost', False))
             harness = os.path.join(adir, 'run_pilot_wf.%s.js' % lease['id'])
             manifest = os.path.join(adir, 'execution_manifest.%s.json' % lease['id'])
-            run_cmd([sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'),
-                     root, '--out=%s' % harness, '--manifest-out=%s' % manifest] + binding,
-                    timeout=remaining_operation_timeout(deadline, 'prepare'))
+            run_child([sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'),
+                       root, '--out=%s' % harness, '--manifest-out=%s' % manifest] + binding,
+                      timeout=remaining_operation_timeout(deadline, 'prepare'))
         elif lease['kind'] == 'nominal':
             keys = lease.get('details', {}).get('run_keys') or lease.get('details', {}).get('keys') or []
             if not keys:
@@ -943,18 +984,18 @@ def prepare(args):
             preflight_path = os.path.join(adir, 'preflight.json')
             root = 'nominal_%s' % lease['id']
             key_arg = ','.join(keys)
-            p = run_cmd([sys.executable, os.path.join(HERE, 'perf_preflight.py'),
-                         root, '--nominal', '--no-grammar', '--keys=%s' % key_arg, '--json'],
-                        timeout=remaining_operation_timeout(deadline, 'prepare'))
+            p = run_child([sys.executable, os.path.join(HERE, 'perf_preflight.py'),
+                           root, '--nominal', '--no-grammar', '--keys=%s' % key_arg, '--json'],
+                          timeout=remaining_operation_timeout(deadline, 'prepare'))
             atomic_write_text(preflight_path, p.stdout)
             enforce_cost_gate(preflight_path, lease.get('target'),
                               allow_over_cost=getattr(args, 'allow_over_cost', False))
             harness = os.path.join(adir, 'run_pilot_wf.%s.js' % lease['id'])
             manifest = os.path.join(adir, 'execution_manifest.%s.json' % lease['id'])
-            run_cmd([sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'),
-                     root, '--nominal', '--no-grammar', '--keys=%s' % key_arg,
-                     '--out=%s' % harness, '--manifest-out=%s' % manifest] + binding,
-                    timeout=remaining_operation_timeout(deadline, 'prepare'))
+            run_child([sys.executable, os.path.join(HERE, 'gen_opt_harness2.py'),
+                       root, '--nominal', '--no-grammar', '--keys=%s' % key_arg,
+                       '--out=%s' % harness, '--manifest-out=%s' % manifest] + binding,
+                      timeout=remaining_operation_timeout(deadline, 'prepare'))
         else:
             raise SystemExit('prepare is only for verb/nominal translation leases')
     except BaseException as exc:
@@ -1834,6 +1875,15 @@ def main(argv=None):
     p.add_argument('--config-dir', help='canonical CLAUDE_CONFIG_DIR bound into manifest v2')
     p.add_argument('--executor-lane', default='serial-whole-card')
     p.set_defaults(func=prepare)
+    pb = sub.add_parser('prepare-batch')
+    pb.add_argument('lease_id', nargs='+')
+    pb.add_argument('--allow-over-cost', action='store_true',
+                    help='H304 cap-and-defer override: prepare cost-gate-flagged windows '
+                         'anyway (dedicated human-budgeted monster session only)')
+    pb.add_argument('--profile-slot', help='logical profile slot (for example c4; not billing proof)')
+    pb.add_argument('--config-dir', help='canonical CLAUDE_CONFIG_DIR bound into manifest v2')
+    pb.add_argument('--executor-lane', default='serial-whole-card')
+    pb.set_defaults(func=prepare_batch)
     br = sub.add_parser('begin-run')
     br.add_argument('--lease-id', action='append', required=True)
     br.add_argument('--mode', choices=('standard', 'staged'), default='standard')

--- a/RussianTranslation/src/pilot/dashboard_events.py
+++ b/RussianTranslation/src/pilot/dashboard_events.py
@@ -11,7 +11,10 @@ import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 OUT = os.path.join(HERE, 'output')
-EVENT_LOG = os.path.join(OUT, 'dashboard_events.jsonl')
+# H1386 P3f: PWG_EVENTS_PATH lets a hermetic harness (h1339_offline_bench) redirect the
+# events ledger into its sandbox -- a bench audit must never append to the LIVE
+# dashboard_events.jsonl. Unset (production) resolves exactly as before.
+EVENT_LOG = os.environ.get('PWG_EVENTS_PATH') or os.path.join(OUT, 'dashboard_events.jsonl')
 
 
 def utc_now():

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -475,7 +475,14 @@ def parse_args(argv):
     if lang not in ('ru', 'en'):
         die('unknown --lang %r (ru|en)' % lang)
     if lang == 'en' and mw_tm is None:
-        mw_tm = os.path.join(SRC, 'mw_en_tm.json')      # default MW translation-memory feed
+        # H1386 P3b (B04's missed 5th sidecar): the MW seed feed is gitignored, so a
+        # fresh worktree's src/ copy is ABSENT and sanctioned worktree EN runs silently
+        # dropped the MW seed block from every prompt. Resolve through the canonical
+        # main-checkout path exactly like the other four sidecars (note sidecar_rel:
+        # this one lives in src/, not src/pilot/).
+        from store_path import canonical_sidecar as _canon_sidecar
+        mw_tm = _canon_sidecar(os.path.join(SRC, 'mw_en_tm.json'),
+                               sidecar_rel='RussianTranslation/src')
     if tm in ('__default__', '__auto__') or suggest_tm in ('__default__', '__auto__'):
         # B04 (H1339): resolve the default sidecars through translation_memory's canonical
         # resolvers (main-worktree-aware), NOT this checkout's src/pilot -- the sidecars are

--- a/RussianTranslation/src/pilot/h1209/canonical_audit.py
+++ b/RussianTranslation/src/pilot/h1209/canonical_audit.py
@@ -171,14 +171,28 @@ def audit_card(card_in, inp, pmap, wf_row, field):
     return report
 
 
+def merge_slice_results(chunks):
+    """H1386 D1: merge several chunk slice_results (prep_slice --chunk N runs) into ONE
+    audit input -- concatenated in argument order, so the merged audit covers the whole
+    medium50 slice exactly as a single-run slice_result would."""
+    merged = {'slice': [], 'results': [], 'cards_out': []}
+    for ch in chunks:
+        merged['slice'] += list(ch.get('slice') or [])
+        merged['results'] += list(ch.get('results') or [])
+        merged['cards_out'] += list(ch.get('cards_out') or [])
+    return merged
+
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument('slice_result')
+    ap.add_argument('slice_result', nargs='+',
+                    help='one slice_result.json, or several chunk results to merge (H1386 D1)')
     ap.add_argument('manifest')
     ap.add_argument('--out', default=None)
     a = ap.parse_args()
 
-    res = json.load(open(a.slice_result, encoding='utf-8'))
+    res = merge_slice_results([json.load(open(p, encoding='utf-8'))
+                               for p in a.slice_result])
     man = json.load(open(a.manifest, encoding='utf-8'))
     field = man.get('field') or 'russian'                  # EN manifests carry 'english'
     wf_rows = {r['key1']: r for r in res['results']}

--- a/RussianTranslation/src/pilot/h1209/inject_payload.py
+++ b/RussianTranslation/src/pilot/h1209/inject_payload.py
@@ -4,6 +4,11 @@ r"""Inject the slice payload into the controller-worker Workflow template.
 Workflow scripts have no filesystem access, so the payload is embedded as a `const`.
 Building it here (not by hand) keeps the 81 KB JSON out of the tool-call surface.
 
+H1386 D1: the emitted script is hard-checked against WORKFLOW_SCRIPT_CAP (the Workflow
+tool's 512 KB scriptPath ceiling — RUN_LOG 2026-06-29 hit it at 567 KB, at submission,
+with no earlier warning). An over-cap build is REFUSED here with the split remedy
+(`prep_slice.py --chunk N`) instead of dying opaquely at Workflow submission.
+
 Usage: python inject_payload.py <template.js> <slice_args.json> <out_run.js>
 """
 import json
@@ -11,15 +16,32 @@ import sys
 
 sys.stdout.reconfigure(encoding='utf-8')
 
-tpl_path, args_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
-tpl = open(tpl_path, encoding='utf-8').read()
-payload = json.load(open(args_path, encoding='utf-8'))
-# Compact, valid JS literal (JSON is a subset of JS object syntax).
-lit = json.dumps(payload, ensure_ascii=False)
-marker_start = '/*__PAYLOAD__*/ null /*__END__*/'
-if marker_start not in tpl:
-    sys.exit('payload marker not found in template')
-out = tpl.replace(marker_start, lit)
-with open(out_path, 'w', encoding='utf-8', newline='\n') as f:
-    f.write(out)
-print('wrote', out_path, len(out), 'bytes;', len(payload['cards']), 'cards embedded')
+# The Workflow tool's script/scriptPath byte ceiling (maxLength 524288).
+WORKFLOW_SCRIPT_CAP = 512 * 1024
+
+
+def inject(tpl_path, args_path, out_path):
+    tpl = open(tpl_path, encoding='utf-8').read()
+    payload = json.load(open(args_path, encoding='utf-8'))
+    # Compact, valid JS literal (JSON is a subset of JS object syntax).
+    lit = json.dumps(payload, ensure_ascii=False)
+    marker_start = '/*__PAYLOAD__*/ null /*__END__*/'
+    if marker_start not in tpl:
+        sys.exit('payload marker not found in template')
+    out = tpl.replace(marker_start, lit)
+    emitted = len(out.encode('utf-8'))
+    if emitted > WORKFLOW_SCRIPT_CAP:
+        sys.exit(
+            'REFUSED: emitted script is %d bytes > WORKFLOW_SCRIPT_CAP %d (the Workflow '
+            'tool submission ceiling). Split the slice first: re-run prep_slice.py with '
+            '--chunk N (N >= %d) and inject each chunk payload separately.'
+            % (emitted, WORKFLOW_SCRIPT_CAP, emitted // WORKFLOW_SCRIPT_CAP + 1))
+    with open(out_path, 'w', encoding='utf-8', newline='\n') as f:
+        f.write(out)
+    print('wrote', out_path, emitted, 'bytes;', len(payload['cards']), 'cards embedded')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4:
+        sys.exit('usage: inject_payload.py <template.js> <slice_args.json> <out_run.js>')
+    inject(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/RussianTranslation/src/pilot/h1209/prep_slice.py
+++ b/RussianTranslation/src/pilot/h1209/prep_slice.py
@@ -13,8 +13,19 @@ Output: a compact `slice_payload.json` the Workflow tool consumes via `args` (Wo
 scripts have no filesystem access).
 
 Usage:
-  python prep_slice.py <manifest.json> <out_payload.json>
+  python prep_slice.py <manifest.json> <out_payload.json> [--keys k1,k2] [--chunk N]
+
+H1386 D1 (the medium50 start-today enabler): the shared PREAMBLE + GRAMMAR + CONV_TR +
+nws boilerplate (~12 KB) is hoisted into ONE payload-level `prompt_common` (schema v3);
+each card carries only its `card_block`, and the Workflow template assembles
+`prompt_common + card_block` per card (mirroring how gen_opt_harness2 shares PREAMBLE
+across a batch). `--chunk N` splits a big manifest into N cap-sized sub-payloads
+(`<out>.chunk01.json`, ...), each independently runnable; merge the chunk slice_results
+with canonical_audit (it accepts several slice_result files). Pre-fix, a 50-card
+medium50 build duplicated the boilerplate 50x (~612 KB alone) and died only at Workflow
+submission against the 512 KB scriptPath cap.
 """
+import argparse
 import json
 import os
 import re
@@ -23,26 +34,32 @@ import sys
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
+PAYLOAD_SCHEMA = 'h1209.controller_worker_slice.v3'
 
-def reconstruct_prompt(m, key):
-    """Reproduce the exact single-card worker prompt from the manifest components.
+
+def prompt_common(m):
+    """The boilerplate shared by EVERY card's prompt: PREAMBLE + GRAMMAR + CONV_TR + nws.
+    Hoisted once per payload (H1386 D1) -- the per-card assembly is prompt_common +
+    card_block, byte-identical to the v2 per-card prompt."""
+    p = m['prompt']
+    return (p['preamble'] + (p.get('grammar', '') or '') + p['translation']
+            + (p.get('nws_rule', '') or ''))
+
+
+def card_block(m, key):
+    """The per-card tail of the worker prompt.
 
     Mirrors gen_opt_harness2.py:
       cardBlock(k) = GRAMMARS[k] + '\n\n=== CARD k ===\n--- masked German ... ---\n'
                      + skeleton + suggestionBlock(k) + '\n--- portrait (evidence) ---\n' + portrait
-      prompt       = PREAMBLE + GRAMMAR + CONV_TR + nws + cardBlock(k)
     suggestionBlock is empty when no suggestions were resolved (slice has none).
     """
     p = m['prompt']
-    preamble = p['preamble']
-    grammar_top = p.get('grammar', '') or ''
-    conv_tr = p['translation']
-    nws = p.get('nws_rule', '') or ''
     grammars_k = (p.get('grammars', {}) or {}).get(key, '') or ''
     inp = m['inputs'][key]
     skeleton = inp['skeleton']
     portrait = inp.get('portrait', '') or ''
-    card_block = (
+    return (
         grammars_k
         + '\n\n=== CARD ' + key + ' ===\n'
         + '--- masked German (translatable only; {Tn}=masked span) ---\n'
@@ -50,7 +67,12 @@ def reconstruct_prompt(m, key):
         + '\n--- portrait (evidence) ---\n'
         + portrait
     )
-    return preamble + grammar_top + conv_tr + nws + card_block
+
+
+def reconstruct_prompt(m, key):
+    """The exact single-card worker prompt (v2 assembly) -- kept as the identity oracle:
+    prompt_common(m) + card_block(m, key) must equal this, byte for byte."""
+    return prompt_common(m) + card_block(m, key)
 
 
 def placeholder_tokens(text):
@@ -104,51 +126,101 @@ def complexity_features(m, key):
     return feats
 
 
-def main():
-    if len(sys.argv) != 3:
-        sys.exit('usage: prep_slice.py <manifest.json> <out_payload.json>')
-    manifest_path, out_path = sys.argv[1], sys.argv[2]
-    m = json.load(open(manifest_path, encoding='utf-8'))
+def _build_card(m, k):
+    feats = complexity_features(m, k)
+    inp = m['inputs'][k]
+    return {
+        'key1': k,
+        # H1386 D1: card_block ONLY -- the shared boilerplate lives once in prompt_common.
+        'card_block': card_block(m, k),
+        'skeleton_tokens': placeholder_tokens(inp['skeleton']),
+        # v2: the sense gate consumes the H960 cross-reference-hardened source_senses
+        # (shortfall-only, the canonical SAN-LOSS direction) — NEVER the naive `senses`
+        # glyph count (nakzatra: senses=7 counts a PW cross-reference `3〉` as a sense;
+        # gating on equality to it forced workers to displace source spans into
+        # card.notes, an unrestorable field — the v1 slice's 2/3 canonical rejects).
+        'source_senses': inp.get('source_senses'),
+        'ls': inp.get('ls'), 'sk': inp.get('sk'),
+        'placeholder_map': m['placeholder_maps'][k],
+        'complexity': feats,
+    }
+
+
+def _chunk_out_path(out_path, i, n):
+    base, ext = os.path.splitext(out_path)
+    return '%s.chunk%02d%s' % (base, i, ext or '.json')
+
+
+def write_payloads(m, out_path, keys=None, chunk=None, manifest_name=''):
+    """Build and write the v3 payload(s). Returns the list of written paths.
+
+    keys  -- optional explicit subset (order preserved); default: every batch key.
+    chunk -- optional N-way contiguous split into <out>.chunkNN.json sub-payloads,
+             each carrying the same prompt_common + its card subset (H1386 D1)."""
     # A6 (H1283): flatten EVERY key of each batch. Taking only b[0] silently dropped all
     # but the first card of every multi-card batch — invisible on the 1-card/batch canary
     # slice, but on a production medium50 manifest (multi-card batches) every other card
     # vanished with no error. Matches window_selftest's owed-key set ({k for b in batches for k}).
-    keys = [k for b in m['batches'] for k in b]
-    cards = []
-    for k in keys:
-        prompt = reconstruct_prompt(m, k)
-        feats = complexity_features(m, k)
-        inp = m['inputs'][k]
-        cards.append({
-            'key1': k,
-            'prompt': prompt,
-            'skeleton_tokens': placeholder_tokens(inp['skeleton']),
-            # v2: the sense gate consumes the H960 cross-reference-hardened source_senses
-            # (shortfall-only, the canonical SAN-LOSS direction) — NEVER the naive `senses`
-            # glyph count (nakzatra: senses=7 counts a PW cross-reference `3〉` as a sense;
-            # gating on equality to it forced workers to displace source spans into
-            # card.notes, an unrestorable field — the v1 slice's 2/3 canonical rejects).
-            'source_senses': inp.get('source_senses'),
-            'ls': inp.get('ls'), 'sk': inp.get('sk'),
-            'placeholder_map': m['placeholder_maps'][k],
-            'complexity': feats,
-        })
-    payload = {
-        'schema': 'h1209.controller_worker_slice.v2',
-        'source_manifest': os.path.basename(manifest_path),
+    all_keys = [k for b in m['batches'] for k in b]
+    if keys:
+        missing = [k for k in keys if k not in set(all_keys)]
+        if missing:
+            sys.exit('prep_slice: --keys not in the manifest batches: %s' % ','.join(missing))
+        use_keys = list(keys)
+    else:
+        use_keys = all_keys
+    common = prompt_common(m)
+    cards = [_build_card(m, k) for k in use_keys]
+    header = {
+        'schema': PAYLOAD_SCHEMA,
+        'source_manifest': manifest_name,
         'model_worker': m.get('model', 'claude-sonnet-5'),
         'field': m.get('field', 'russian'),
-        'cards': cards,
+        'prompt_common': common,
     }
+    if chunk and chunk > 1:
+        n = min(chunk, len(cards)) or 1
+        per = (len(cards) + n - 1) // n
+        groups = [cards[i * per:(i + 1) * per] for i in range(n)]
+        groups = [g for g in groups if g]
+        paths = []
+        for i, group in enumerate(groups, 1):
+            payload = dict(header, chunk={'index': i, 'of': len(groups)}, cards=group)
+            p = _chunk_out_path(out_path, i, len(groups))
+            with open(p, 'w', encoding='utf-8', newline='\n') as f:
+                json.dump(payload, f, ensure_ascii=False, indent=1)
+                f.write('\n')
+            paths.append(p)
+        return paths
+    payload = dict(header, cards=cards)
     with open(out_path, 'w', encoding='utf-8', newline='\n') as f:
         json.dump(payload, f, ensure_ascii=False, indent=1)
         f.write('\n')
-    for c in cards:
-        print('%-10s prompt=%dB tokens=%d source_senses=%s ls=%s sk=%s complexity=%.2f%s'
-              % (c['key1'], len(c['prompt']), len(c['skeleton_tokens']),
-                 c['source_senses'], c['ls'], c['sk'], c['complexity']['score'],
-                 ' [COMPLEX]' if c['complexity']['complex'] else ''))
-    print('wrote', out_path)
+    return [out_path]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('manifest')
+    ap.add_argument('out_payload')
+    ap.add_argument('--keys', default=None,
+                    help='comma-separated subset of manifest keys to include')
+    ap.add_argument('--chunk', type=int, default=None,
+                    help='split into N cap-sized sub-payloads (<out>.chunkNN.json)')
+    a = ap.parse_args()
+    m = json.load(open(a.manifest, encoding='utf-8'))
+    keys = [k for k in (a.keys or '').split(',') if k] or None
+    paths = write_payloads(m, a.out_payload, keys=keys, chunk=a.chunk,
+                           manifest_name=os.path.basename(a.manifest))
+    for p in paths:
+        payload = json.load(open(p, encoding='utf-8'))
+        for c in payload['cards']:
+            print('%-10s card_block=%dB tokens=%d source_senses=%s ls=%s sk=%s complexity=%.2f%s'
+                  % (c['key1'], len(c['card_block']), len(c['skeleton_tokens']),
+                     c['source_senses'], c['ls'], c['sk'], c['complexity']['score'],
+                     ' [COMPLEX]' if c['complexity']['complex'] else ''))
+        print('wrote %s (%d cards, prompt_common=%dB shared once)'
+              % (p, len(payload['cards']), len(payload['prompt_common'])))
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pilot/h1209/wf_template.js
+++ b/RussianTranslation/src/pilot/h1209/wf_template.js
@@ -7,6 +7,14 @@ export const meta = {
 // Payload (cards: prompt/skeleton_tokens/expected_senses/complexity, plus worker_schema)
 // is injected by inject_payload.py — Workflow scripts have no filesystem access.
 const PAYLOAD = /*__PAYLOAD__*/ null /*__END__*/
+// H1386 D1: v3 payloads hoist the shared preamble/translation/nws boilerplate into ONE
+// prompt_common (the per-card prompt is prompt_common + card_block, assembled below) --
+// a v2 payload (per-card `prompt`, boilerplate duplicated per card) is refused loudly.
+if (!PAYLOAD || PAYLOAD.schema !== 'h1209.controller_worker_slice.v3') {
+  throw new Error('payload schema mismatch: expected h1209.controller_worker_slice.v3, got '
+    + (PAYLOAD && PAYLOAD.schema))
+}
+const PROMPT_COMMON = PAYLOAD.prompt_common
 const CARDS = PAYLOAD.cards
 const WORKER_SCHEMA = PAYLOAD.worker_schema
 
@@ -99,7 +107,7 @@ const AGENT_DEADLINE_MS = 300000
 const withDeadline = (p, ms) => Promise.race([p, new Promise(res => setTimeout(() => res(null), ms))])
 
 async function runWorker(c, feedback) {
-  const prompt = c.prompt + (feedback
+  const prompt = PROMPT_COMMON + c.card_block + (feedback
     ? '\n\n=== CONTROLLER FEEDBACK (fix ONLY these, keep everything else verbatim) ===\n' + feedback : '')
   return await withDeadline(
     agent(prompt, { label: 'worker:' + c.key1, phase: 'Translate', model: 'sonnet', schema: WORKER_SCHEMA }),

--- a/RussianTranslation/src/pilot/h1339_offline_bench.py
+++ b/RussianTranslation/src/pilot/h1339_offline_bench.py
@@ -199,6 +199,10 @@ def install_inputs():
     INPUT_DIR = tempfile.mkdtemp(prefix='h1339bench_input_')
     for name in os.listdir(os.path.join(FIXTURE, 'input')):
         shutil.copy2(os.path.join(FIXTURE, 'input', name), os.path.join(INPUT_DIR, name))
+    # The BENCH process itself must also resolve the sandbox: fake_card's lazy
+    # `import audit_coverage` binds audit_coverage.IN from this env at import time, and
+    # every child inherits it (one_run's explicit env then just makes it visible).
+    os.environ['PWG_INPUT_DIR'] = INPUT_DIR
     return INPUT_DIR
 
 
@@ -313,7 +317,7 @@ def run_cli(argv, env, cwd=REPO, check=True):
     return proc
 
 
-def one_run(tag, keep=False):
+def one_run(tag, keep=False, prepare_mode='batch'):
     """One full pipeline pass in a fresh sandbox. Returns (timings, outputs) dicts."""
     sandbox = tempfile.mkdtemp(prefix='h1339bench_%s_' % tag)
     coord_dir = os.path.join(sandbox, 'coordinator')
@@ -371,10 +375,19 @@ def one_run(tag, keep=False):
             '    save = coordinator.save_state(state)\n'
             'print("injected", len(coordinator.load_state()["leases"]))\n')
     run_cli([inject], env)
-    for lid, _case, _keys in LEASES:
-        run_cli([os.path.join(HERE, 'coordinator.py'), 'prepare', lid,
-                 '--profile-slot', 'bench', '--config-dir', profile_dir,
-                 '--executor-lane', 'serial-whole-card'], env)
+    # H1386 OPT: default 'batch' -- ONE coordinator process prepares the whole batch,
+    # children in-process (was: 3 interpreter spawns per lease -- coordinator +
+    # perf_preflight + gen). 'per-lease' preserves the pre-H1386 shape for A/B evidence.
+    if prepare_mode == 'per-lease':
+        for lid, _case, _keys in LEASES:
+            run_cli([os.path.join(HERE, 'coordinator.py'), 'prepare', lid,
+                     '--profile-slot', 'bench', '--config-dir', profile_dir,
+                     '--executor-lane', 'serial-whole-card'], env)
+    else:
+        run_cli([os.path.join(HERE, 'coordinator.py'), 'prepare-batch']
+                + [lid for lid, _case, _keys in LEASES]
+                + ['--profile-slot', 'bench', '--config-dir', profile_dir,
+                   '--executor-lane', 'serial-whole-card'], env)
     timings['prepare'] = time.perf_counter() - t0
 
     # --- normalize: deterministic wf_output per lease + canonical reorder -------------
@@ -478,6 +491,9 @@ def main():
     ap.add_argument('--runs', type=int, default=10)
     ap.add_argument('--json', help='write the machine-readable report here')
     ap.add_argument('--keep-last', action='store_true', help='keep the last sandbox for inspection')
+    ap.add_argument('--prepare-mode', choices=('batch', 'per-lease'), default='batch',
+                    help="H1386 OPT A/B: 'batch' = one prepare-batch call (production "
+                         "default); 'per-lease' = the pre-H1386 3-spawns-per-lease shape")
     a = ap.parse_args()
 
     install_inputs()
@@ -494,14 +510,15 @@ def main():
 
 def _bench(a, fx_hash):
     for i in range(a.warmups):
-        t, o = one_run('warm%d' % i)
+        t, o = one_run('warm%d' % i, prepare_mode=a.prepare_mode)
         print('warmup %d/%d: total %.2fs (promote rc=%s)' % (
             i + 1, a.warmups, t['total'], o['promote_rc']))
 
     measured, signatures = [], set()
     last_outputs = None
     for i in range(a.runs):
-        t, o = one_run('run%d' % i, keep=(a.keep_last and i == a.runs - 1))
+        t, o = one_run('run%d' % i, keep=(a.keep_last and i == a.runs - 1),
+                       prepare_mode=a.prepare_mode)
         measured.append(t)
         signatures.add(o['signature'])
         last_outputs = o
@@ -532,7 +549,8 @@ def _bench(a, fx_hash):
     if a.json:
         report = {
             'schema': 'pwg.h1339_offline_bench.v1',
-            'protocol': {'warmups': a.warmups, 'runs': a.runs},
+            'protocol': {'warmups': a.warmups, 'runs': a.runs,
+                         'prepare_mode': a.prepare_mode},
             'python': sys.version, 'platform': platform.platform(),
             'fixture_sha256': fx_hash, 'seed_rows': SEED_ROWS,
             'stages': stats, 'runs': measured,

--- a/RussianTranslation/src/pilot/h1339_offline_bench.py
+++ b/RussianTranslation/src/pilot/h1339_offline_bench.py
@@ -62,7 +62,11 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 SRC = os.path.dirname(HERE)
 REPO = os.path.dirname(SRC)
 FIXTURE = os.path.join(HERE, 'fixtures', 'h1339_offline_bench')
-INPUT_DIR = os.path.join(HERE, 'input')
+# H1386 P3f: the bench-session SANDBOX input dir, set by install_inputs() -- NEVER the
+# live shared src/pilot/input/ (fixtures copied there survived the bench and a later
+# production regen silently kept FROZEN fixture bodies for the 12 A-initial keys).
+# Subprocesses see it via PWG_INPUT_DIR (window_common.INP honors the override).
+INPUT_DIR = None
 
 for p in (HERE, SRC):
     if p not in sys.path:
@@ -188,9 +192,14 @@ def fixture_hash():
 
 
 def install_inputs():
-    os.makedirs(INPUT_DIR, exist_ok=True)
+    """H1386 P3f: install the fixtures into a fresh bench-session sandbox dir (returned
+    and stored in INPUT_DIR); the caller tears it down in a finally so a bench run leaves
+    the checkout byte-identical."""
+    global INPUT_DIR
+    INPUT_DIR = tempfile.mkdtemp(prefix='h1339bench_input_')
     for name in os.listdir(os.path.join(FIXTURE, 'input')):
         shutil.copy2(os.path.join(FIXTURE, 'input', name), os.path.join(INPUT_DIR, name))
+    return INPUT_DIR
 
 
 def build_seed_store(path, tm_seed_rows):
@@ -315,6 +324,10 @@ def one_run(tag, keep=False):
         os.makedirs(d)
     env = dict(os.environ,
                PWG_COORDINATOR_DIR=coord_dir, PWG_RU_STORE=store, PWG_RU_TM_DIR=tm_dir,
+               # H1386 P3f: every pipeline subprocess reads the SANDBOX input dir and
+               # appends events to the sandbox ledger -- never the live checkout's.
+               PWG_INPUT_DIR=INPUT_DIR,
+               PWG_EVENTS_PATH=os.path.join(sandbox, 'dashboard_events.jsonl'),
                PYTHONIOENCODING='utf-8')
 
     # --- setup (untimed): seed store incl. the TM-seed key's rows, then build the TM ---
@@ -380,7 +393,13 @@ def one_run(tag, keep=False):
         for key, entry in (manifest.get('tm_resolved') or {}).items():
             if key not in resolved:
                 results.append({'key': key, 'card': entry.get('card')})
-        payload = {'meta': manifest['meta'], 'summary': {'cards': len(results)},
+        # H1386 P3h: mirror production stamping (headless_worker copies execution +
+        # key_provenance from the manifest into the wf meta) -- the stale check now pins
+        # both, so a bare manifest['meta'] would audit stale.
+        payload = {'meta': dict(manifest['meta'],
+                                execution=manifest.get('execution'),
+                                provenance_classes=manifest.get('key_provenance')),
+                   'summary': {'cards': len(results)},
                    'results': sorted(results, key=lambda r: manifest['meta']['selected_keys'].index(r['key'])
                                      if r['key'] in manifest['meta']['selected_keys'] else 999)}
         wf = os.path.join(sandbox, 'wf_output.%s.json' % lid)
@@ -463,9 +482,17 @@ def main():
 
     install_inputs()
     fx_hash = fixture_hash()
-    print('fixture: %d files, content hash %s' % (
-        len(os.listdir(os.path.join(FIXTURE, 'input'))), fx_hash[:16]))
+    print('fixture: %d files, content hash %s (sandbox input dir %s)' % (
+        len(os.listdir(os.path.join(FIXTURE, 'input'))), fx_hash[:16], INPUT_DIR))
+    try:
+        _bench(a, fx_hash)
+    finally:
+        # H1386 P3f: a bench run leaves the checkout byte-identical -- the sandbox input
+        # dir (the only bench artifact outside per-run sandboxes) is always removed.
+        shutil.rmtree(INPUT_DIR, ignore_errors=True)
 
+
+def _bench(a, fx_hash):
     for i in range(a.warmups):
         t, o = one_run('warm%d' % i)
         print('warmup %d/%d: total %.2fs (promote rc=%s)' % (

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -194,6 +194,12 @@ def parse_reset(text, now=None):
 def _scope_sql(only_external_ids):
     if only_external_ids is None:
         return '', ()
+    # H1386 C1 defense-in-depth: iterating a dict yields its keys and a str its characters,
+    # silently degrading the scope to a zero-match (the bounded --resume regression). A scope
+    # must be a set/list/tuple of external ids -- reject the wrong shape loudly.
+    if isinstance(only_external_ids, (dict, str, bytes)):
+        raise TypeError('only_external_ids must be a set/list of external ids, got %s'
+                        % type(only_external_ids).__name__)
     ids = tuple(sorted(set(only_external_ids)))
     if not ids:
         return ' AND 0', ()

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -594,6 +594,15 @@ def cmd_reset_failed(args):
     db = connect(args.db)
     rows = scoped_jobs(db, scope, "state='failed'")
     if not rows:
+        # H1386 P3c: a failed requeue attempt's external_id is '<lease>::rqNN-<kind>' while
+        # the fail-closed drain messages name the ORIGIN lease -- so the documented recovery
+        # command, pasted with the origin id, found nothing for the exact requeue-tombstone
+        # case B18 was built for. Match by origin lease too (still an explicit scope, never
+        # a blanket reset).
+        all_failed = scoped_jobs(db, None, "state='failed'")
+        rows = [j for j in all_failed
+                if coordinator_lease_id(j['external_id']) in scope]
+    if not rows:
         db.close()
         raise SystemExit('no failed job in scope %s' % sorted(scope))
     with db:
@@ -1023,7 +1032,15 @@ def cmd_staged_run(args):
         failed = scoped_job_count(db, lease_scope, "state='failed'")
         db.close()
         if failed:
-            raise SystemExit('staged-run stopped: failed jobs=%d' % failed)
+            # H1386 P3c: name the failed jobs' FULL external_ids -- the reset-failed
+            # recovery needs the exact id (a requeue attempt is '<lease>::rqNN-<kind>').
+            db = connect(args.db)
+            failed_ids = [j['external_id'] for j in
+                          scoped_jobs(db, lease_scope, "state='failed'")]
+            db.close()
+            raise SystemExit('staged-run stopped: failed jobs=%d (%s) -- recover with '
+                             'reset-failed --lease-id <id> --reason "..."'
+                             % (failed, ', '.join(sorted(failed_ids))))
         if not pending and not done_unrecorded:
             break
         if pending:

--- a/RussianTranslation/src/pilot/probe_log.py
+++ b/RussianTranslation/src/pilot/probe_log.py
@@ -155,7 +155,10 @@ def cmd_outcome(a):
     if all(v is None for v in structured.values()):
         import economy_ledger
         kv = economy_ledger.parse_note_kv(getattr(a, 'note', '') or '')
-        recovered = {'cards': kv.get('cards'), 'clean': kv.get('clean') or kv.get('ok'),
+        # H1386 P3j: `or` loses a falsy clean=0 (the B15-motivating degraded-window case,
+        # a REAL all-rejected figure) -- only a genuinely-absent key falls through to ok.
+        recovered = {'cards': kv.get('cards'),
+                     'clean': kv.get('clean') if kv.get('clean') is not None else kv.get('ok'),
                      'agents': kv.get('agents'), 'tokens': kv.get('tokens'),
                      'kill_timeouts': kv.get('kill_timeouts'),
                      'conn_errors': kv.get('conn_errors')}

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -243,17 +243,21 @@ def reusable(row):
 
 
 def best_reusable(rows):
-    candidates = [r for r in rows if reusable(r)]
+    candidates = [(i, r) for i, r in enumerate(rows) if reusable(r)]
     if not candidates:
         return None
-    superseded = {s for r in candidates for s in _as_list(r.get('supersedes')) if s}
-    candidates = [r for r in candidates if not r.get('id') or r.get('id') not in superseded]
+    superseded = {s for _, r in candidates for s in _as_list(r.get('supersedes')) if s}
+    candidates = [(i, r) for i, r in candidates if not r.get('id') or r.get('id') not in superseded]
     if not candidates:
         return None
-    return max(candidates, key=lambda r: (
-        TRUST_RANK.get(r.get('trust_level') or 'legacy_promoted', 10),
-        _entry_time(r),
-    ))
+    # H1386 C3: the input order (== append order for the jsonl sidecars) breaks equal
+    # (trust, timestamp) ties toward the NEWER row -- a same-second replacement harvest of
+    # a denied-then-unblocked fsha must win over the flagged row it supersedes.
+    return max(candidates, key=lambda ir: (
+        TRUST_RANK.get(ir[1].get('trust_level') or 'legacy_promoted', 10),
+        _entry_time(ir[1]),
+        ir[0],
+    ))[1]
 
 
 def load_denylist(path=None):
@@ -624,11 +628,18 @@ def load_frag_tm(lang, path=None, denylist=None, live_only=True):
     return out
 
 
-def build_frags(glob_pattern, lang, out=None):
+def build_frags(glob_pattern, lang, out=None, denylist=None):
     """Harvest per-fragment ground truth from wf_output cards' `frag_prov` channel into the
     append-only fragment sidecar. Idempotent: a fragment already present (by fsha) is never
     duplicated. Returns (path, added, total)."""
     path = frag_tm_path(lang, out)
+    # H1386 C3: an fsha hashes the fragment SOURCE, so a gate-flagged fragment's corrected
+    # rework emits the IDENTICAL fsha. If the seen-scan counted the flagged cached row as a
+    # cache hit, the replacement harvest was deduped forever and a later B12 unblock
+    # re-enabled serving the exact gate-rejected senses the denial existed to block. A
+    # currently-denied fsha is therefore NOT a cache hit -- the replacement appends and the
+    # later harvested_at wins at serve time (best_reusable).
+    deny = load_denylist(denylist)
     # seen[fsha] = the highest schema version already cached for that fsha (2 = frag-TM v2 with valid
     # owners, 1 = v1/ownerless). A harvest is skipped only when the cache already holds a version >=
     # the new one, so a v2 harvest SUPERSEDES a cached v1 (R6) while a v1 re-harvest of a cached v1
@@ -647,10 +658,14 @@ def build_frags(glob_pattern, lang, out=None):
                 _fsha = _row.get('fsha')
                 if not _fsha or not frag_senses_sane(_row.get('senses'), lang) or not reusable(_row):
                     continue      # defect/blocked/suggestion rows are not a real cache hit (overridable)
+                if _fsha in deny['frags']:
+                    continue      # H1386 C3: a denied fsha never blocks its replacement harvest
                 _ver = 2 if (_row.get('schema') == FRAG_SCHEMA_V2
                              and _valid_owners(_row.get('senses'), _row.get('owners'))) else 1
                 seen[_fsha] = max(seen.get(_fsha, 0), _ver)
-    files = sorted(_glob.glob(os.path.join(REPO, glob_pattern)))
+    # H1386 C3: recursive -- a requeue attempt's wf_output lands two dirs deep
+    # (artifacts/<lease>/requeue/rqNN-<kind>/), which a single-* pattern never matched.
+    files = sorted(_glob.glob(os.path.join(REPO, glob_pattern), recursive=True))
     new_rows, added, refused = [], 0, 0
     for fp in files:
         try:

--- a/RussianTranslation/src/pilot/window_common.py
+++ b/RussianTranslation/src/pilot/window_common.py
@@ -11,7 +11,10 @@ import tempfile
 HERE = os.path.dirname(os.path.abspath(__file__))
 SRC = os.path.dirname(HERE)
 REPO = os.path.dirname(SRC)
-INP = os.path.join(HERE, 'input')
+# H1386 P3f: PWG_INPUT_DIR lets a hermetic harness (h1339_offline_bench) point every
+# pipeline stage at a SANDBOX input dir instead of the live shared src/pilot/input/.
+# Unset (production) resolves exactly as before.
+INP = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'input')
 OUT = os.path.join(HERE, 'output')
 # Canonical live production harness (batched + masked, gen_opt_harness2.py).
 # The legacy per-card run_pilot_wf.opt.js is deprecated; consumers point here.

--- a/RussianTranslation/src/pilot/window_provenance.py
+++ b/RussianTranslation/src/pilot/window_provenance.py
@@ -163,6 +163,18 @@ def stale_check(root, workflow_meta, workflow_keys, execution_manifest=None):
             check['errors'].append('workflow rootmap hash does not match execution manifest')
         if workflow_meta.get('input_hashes') != manifest_meta.get('input_hashes'):
             check['errors'].append('workflow input hashes do not match execution manifest')
+        # H1386 P3h: B23 admitted v2 manifests but still verified only v1-era meta. A v2
+        # manifest also binds top-level execution + key_provenance, and PROMOTION trusts
+        # the wf_output-side copies (provenance-class gating + the B20 model-identity
+        # check) -- headless_worker/execution_contract stamp them verbatim from the
+        # manifest, so any drift means a stale/foreign/tampered wf_output.
+        if (execution_manifest or {}).get('schema') == 'pwg.headless_execution_manifest.v2':
+            if workflow_meta.get('execution') != execution_manifest.get('execution'):
+                check['errors'].append(
+                    'workflow execution block does not match execution manifest')
+            if workflow_meta.get('provenance_classes') != execution_manifest.get('key_provenance'):
+                check['errors'].append(
+                    'workflow provenance_classes do not match execution manifest key_provenance')
 
     if manifest_meta is not None:
         _key_coverage(check, workflow_keys, manifest_meta.get('selected_keys') or [],

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -5546,6 +5546,59 @@ def test_defect_fragment_denylist_round_trip():
         fail('transient requeue must never append denylist rows')
 
 
+def test_h1386_c3_frag_unblock_serves_replacement():
+    """H1386 C3: the fragment half of the H304 gate-outcome contract. Deny an fsha, then
+    re-harvest the SAME fsha (rework hashes the fragment SOURCE, so the corrected output
+    emits an identical fsha) with corrected senses, then unblock -- load_frag_tm must serve
+    the NEW senses. Pre-fix, build_frags' seen-scan treated the flagged cached row as a
+    cache hit (never consulting the denylist), the replacement was never appended, and the
+    unblock re-enabled serving the exact gate-rejected senses the denial existed to block.
+    Also pins the recursive harvest glob: a requeue attempt's wf_output lands two dirs deep
+    (artifacts/<lease>/requeue/rqNN-<kind>/), which the old single-* glob never matched."""
+    import translation_memory as tm
+    tmp = tempfile.mkdtemp()
+    deny_path = os.path.join(tmp, 'denylist.jsonl')
+    sidecar = os.path.join(tmp, 'translation_memory.frag.ru.jsonl')
+    fsha = tm.frag_address('ru', 'the fragment source')
+
+    def wf_fixture(path, russian):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w', encoding='utf-8', newline='\n') as f:
+            json.dump({'meta': {'lang': 'ru', 'root': 'c3root', 'input_hashes': {}},
+                       'results': [{'key': 'c3root~~h0', 'card': {
+                           'records': [], 'frag_prov': [{
+                               'fsha': fsha, 'owners': [['h', '']],
+                               'senses': [{'tag': '1', 'german': 'g', 'russian': russian}],
+                           }]}}]}, f, ensure_ascii=False)
+
+    # 1. first harvest caches the (later gate-flagged) senses, one level deep.
+    wf_fixture(os.path.join(tmp, 'artifacts', 'w1', 'wf_output.w1.json'), 'FLAGGED')
+    pattern = os.path.join(tmp, 'artifacts', '**', 'wf_output*.json')
+    _, added, _ = tm.build_frags(pattern, 'ru', out=sidecar, denylist=deny_path)
+    if added != 1:
+        fail('first harvest should cache 1 fragment, got %d' % added)
+    # 2. the gate flags it: fsha denied (H304 defect denial).
+    tm.append_jsonl_line(deny_path, {'schema': 'pwg.translation_memory.denylist.v1',
+                                     'kind': 'fragment', 'fsha': fsha, 'reason': 'defect'})
+    # 3. the corrected --no-tm rework lands TWO dirs deep with the SAME fsha, new senses.
+    wf_fixture(os.path.join(tmp, 'artifacts', 'w1', 'requeue', 'rq01-defect',
+                            'wf_output.w1.json'), 'CORRECTED')
+    _, added2, _ = tm.build_frags(pattern, 'ru', out=sidecar, denylist=deny_path)
+    if added2 < 1:
+        fail('H1386 C3: replacement harvest of a currently-denied fsha was deduped as a '
+             'cache hit -- the corrected senses never reach the sidecar')
+    # 4. promotion unblocks the fsha (clear_denials_for_promotion path).
+    tm.append_unblock((), [fsha], reason='replaced_by_promotion', path=deny_path)
+    # 5. the served row must now be the CORRECTED senses, never the flagged ones.
+    cache = tm.load_frag_tm('ru', sidecar, denylist=deny_path)
+    if fsha not in cache:
+        fail('unblocked fragment missing from load_frag_tm')
+    got = (cache[fsha].get('senses') or [{}])[0].get('russian')
+    if got != 'CORRECTED':
+        fail('H1386 C3: load_frag_tm re-serves the gate-flagged senses (%r) after unblock'
+             % got)
+
+
 def test_write_reports_emits_defect_fsha_file():
     """H304: --write-requeue also persists requeue.defect.fshas.txt so requeue_from_audit
     can denylist the flagged fragments without re-reading the wf_output."""
@@ -7178,6 +7231,7 @@ def main():
         test_h1339_b04_b09_worktree_safe_resolution,
         test_h1339_b10_b19_audit_chain_routing,
         test_h1339_b11_b12_denylist_lifecycle_and_crash_refusal,
+        test_h1386_c3_frag_unblock_serves_replacement,
         test_h1339_b13_b15_telemetry_and_siglum_precision,
         test_every_stitch_emits_record_required,
         test_unmapped_token_is_counted,

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -5546,6 +5546,62 @@ def test_defect_fragment_denylist_round_trip():
         fail('transient requeue must never append denylist rows')
 
 
+def test_h1386_p3d_p3e_run_py_inproc_exit_semantics():
+    """H1386 P3d/P3e: run_py_inproc must mirror CPython for sys.exit('<message>') (message
+    lands in captured stderr, rc=1 -- pre-fix the diagnosis vanished into an empty-stderr
+    crash entry) and must RE-RAISE KeyboardInterrupt (an operator abort inside a gate was
+    recorded as a crashed gate and the audit ran on, polluting the failure gallery)."""
+    from audit_window import run_py_inproc
+    tmp = tempfile.mkdtemp()
+    str_exit = os.path.join(tmp, 'gate_strexit.py')
+    with open(str_exit, 'w', encoding='utf-8', newline='\n') as f:
+        f.write("import sys\nsys.exit('P3E-DIAGNOSIS: missing input file')\n")
+    res = run_py_inproc([str_exit])
+    if res['returncode'] != 1:
+        fail('P3e: a string sys.exit must map to rc=1, got %r' % res['returncode'])
+    if 'P3E-DIAGNOSIS' not in res['stderr']:
+        fail('P3e: the sys.exit message must land in captured stderr, got %r'
+             % res['stderr'][:200])
+    kbd = os.path.join(tmp, 'gate_kbd.py')
+    with open(kbd, 'w', encoding='utf-8', newline='\n') as f:
+        f.write('raise KeyboardInterrupt\n')
+    try:
+        run_py_inproc([kbd])
+        fail('P3d: KeyboardInterrupt inside a gate was swallowed (recorded as a crash)')
+    except KeyboardInterrupt:
+        pass
+
+
+def test_h1386_p3h_stale_check_pins_v2_execution():
+    """H1386 P3h: the v2 branch must cross-check the wf_output's execution /
+    provenance_classes against the manifest's top-level execution / key_provenance --
+    promotion trusts the workflow-side copies (provenance-class gating + the B20
+    model-identity check), so a drifted copy must audit stale, not pass as v1-era-clean."""
+    execu = {'profile_slot': 'c4', 'model_identifier': 'claude-sonnet-5'}
+    prov = {'k1': 'real'}
+    meta = {'root': 'p3h_root', 'selected_keys': ['k1'], 'input_hashes': {},
+            'rootmap_sha256': None, 'nominal': True}
+    manifest = {'schema': 'pwg.headless_execution_manifest.v2', 'meta': dict(meta),
+                'execution': dict(execu), 'key_provenance': dict(prov)}
+    wf_meta = dict(meta, execution=dict(execu), provenance_classes=dict(prov))
+
+    def errs(wf):
+        return stale_check(None, wf, ['k1'], execution_manifest=manifest).get('errors') or []
+
+    matching = errs(wf_meta)
+    if any('execution block' in e or 'provenance_classes' in e for e in matching):
+        fail('P3h: matching v2 execution/provenance flagged as drift: %s' % matching)
+    drifted_exec = errs(dict(wf_meta, execution=dict(execu, model_identifier='claude-opus-4-8')))
+    if not any('execution block' in e for e in drifted_exec):
+        fail('P3h: drifted wf execution block not flagged against the v2 manifest')
+    drifted_prov = errs(dict(wf_meta, provenance_classes={'k1': 'fallback'}))
+    if not any('provenance_classes' in e for e in drifted_prov):
+        fail('P3h: drifted wf provenance_classes not flagged against the v2 manifest')
+    stripped = errs(dict(meta))
+    if not any('execution block' in e for e in stripped):
+        fail('P3h: a wf meta with NO execution copy must not pass the v2 pin')
+
+
 def test_h1386_c3_frag_unblock_serves_replacement():
     """H1386 C3: the fragment half of the H304 gate-outcome contract. Deny an fsha, then
     re-harvest the SAME fsha (rework hashes the fragment SOURCE, so the corrected output
@@ -7331,6 +7387,8 @@ def main():
         test_h1339_b10_b19_audit_chain_routing,
         test_h1339_b11_b12_denylist_lifecycle_and_crash_refusal,
         test_h1386_c3_frag_unblock_serves_replacement,
+        test_h1386_p3d_p3e_run_py_inproc_exit_semantics,
+        test_h1386_p3h_stale_check_pins_v2_execution,
         test_h1339_b13_b15_telemetry_and_siglum_precision,
         test_every_stitch_emits_record_required,
         test_unmapped_token_is_counted,

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -6966,6 +6966,105 @@ def test_h1283_a6_prep_slice_flattens_batches():
     print('  A6: prep_slice flattens every batch key')
 
 
+def test_h1386_d1_medium50_script_size_cap():
+    """H1386 D1: the medium50 start-today enabler. (1) prep_slice hoists the shared
+    preamble/translation/nws boilerplate into ONE payload-level `prompt_common` instead of
+    duplicating ~12 KB into every card's embedded prompt; (2) prep_slice --chunk N splits a
+    big manifest into N cap-sized sub-payloads (--keys subsets); (3) inject_payload hard-
+    refuses an emitted script over WORKFLOW_SCRIPT_CAP; (4) canonical_audit merges several
+    chunk slice_results into one audit. Pre-fix, a 50-card build blew the 512 KB Workflow
+    scriptPath cap at submission with no earlier warning."""
+    import importlib.util as ilu
+    h1209 = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'h1209')
+
+    def load(name):
+        spec = ilu.spec_from_file_location('h1386_' + name, os.path.join(h1209, name + '.py'))
+        mod = ilu.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    prep = load('prep_slice')
+    tmp = tempfile.mkdtemp()
+    boiler = 'B' * 4000
+    keys = ['k%02d' % i for i in range(8)]
+    man = {
+        'model': 'claude-sonnet-5', 'field': 'russian',
+        'batches': [[k] for k in keys],
+        'prompt': {'preamble': boiler, 'grammar': 'G', 'translation': boiler, 'nws_rule': 'N'},
+        'inputs': {k: {'skeleton': 'S-%s {T1}' % k, 'portrait': 'P', 'source_senses': 1,
+                       'ls': 0, 'sk': 0} for k in keys},
+        'placeholder_maps': {k: ['<x/>'] for k in keys},
+    }
+    man_path = os.path.join(tmp, 'man.json')
+    with open(man_path, 'w', encoding='utf-8', newline='\n') as f:
+        json.dump(man, f)
+
+    # (1) single payload: boilerplate hoisted once, cards carry card_block, not prompt.
+    out1 = os.path.join(tmp, 'payload.json')
+    prep.write_payloads(man, out1)
+    payload = json.load(open(out1, encoding='utf-8'))
+    if not (payload.get('prompt_common') or '').startswith(boiler):
+        fail('D1: payload must carry the shared boilerplate once as prompt_common')
+    for c in payload['cards']:
+        if 'prompt' in c:
+            fail('D1: per-card prompt still embeds the shared boilerplate')
+        if boiler in (c.get('card_block') or ''):
+            fail('D1: card_block must not duplicate the shared boilerplate')
+    # the reconstructed per-card prompt must be byte-identical to the v2 assembly.
+    want = prep.reconstruct_prompt(man, 'k00')
+    got = payload['prompt_common'] + payload['cards'][0]['card_block']
+    if got != want:
+        fail('D1: prompt_common + card_block must equal the exact production prompt')
+
+    # (2) a >=4-way chunk: every key exactly once, chunk files share prompt_common.
+    outc = os.path.join(tmp, 'chunked.json')
+    chunk_paths = prep.write_payloads(man, outc, chunk=4)
+    if len(chunk_paths) != 4:
+        fail('D1: --chunk 4 must write 4 sub-payloads, got %d' % len(chunk_paths))
+    seen_keys = []
+    for p in chunk_paths:
+        pc = json.load(open(p, encoding='utf-8'))
+        if pc.get('prompt_common') != payload['prompt_common']:
+            fail('D1: chunk payload missing the shared prompt_common')
+        seen_keys += [c['key1'] for c in pc['cards']]
+    if sorted(seen_keys) != sorted(keys) or len(seen_keys) != len(keys):
+        fail('D1: chunking must cover every key exactly once, got %r' % seen_keys)
+    # --keys subset selection
+    outk = os.path.join(tmp, 'subset.json')
+    prep.write_payloads(man, outk, keys=['k03', 'k05'])
+    pk = json.load(open(outk, encoding='utf-8'))
+    if [c['key1'] for c in pk['cards']] != ['k03', 'k05']:
+        fail('D1: --keys must subset the payload to exactly the named cards')
+
+    # (3) inject_payload refuses an over-cap emitted script.
+    inj = load('inject_payload')
+    if not getattr(inj, 'WORKFLOW_SCRIPT_CAP', None):
+        fail('D1: inject_payload must define WORKFLOW_SCRIPT_CAP')
+    tpl_path = os.path.join(tmp, 'tpl.js')
+    with open(tpl_path, 'w', encoding='utf-8', newline='\n') as f:
+        f.write('const PAYLOAD = /*__PAYLOAD__*/ null /*__END__*/\n')
+    big = os.path.join(tmp, 'big.json')
+    with open(big, 'w', encoding='utf-8', newline='\n') as f:
+        json.dump({'cards': [{'key1': 'x', 'card_block': 'Z' * (inj.WORKFLOW_SCRIPT_CAP + 100)}]}, f)
+    try:
+        inj.inject(tpl_path, big, os.path.join(tmp, 'over.js'))
+        fail('D1: inject_payload accepted a script over WORKFLOW_SCRIPT_CAP')
+    except SystemExit:
+        pass
+    inj.inject(tpl_path, out1, os.path.join(tmp, 'ok.js'))   # a small payload still lands
+
+    # (4) canonical_audit merges several chunk slice_results into one result set.
+    ca = load('canonical_audit')
+    half1 = {'slice': ['k00'], 'results': [{'key1': 'k00', 'would_promote': True}],
+             'cards_out': [{'key1': 'k00', 'card': None}]}
+    half2 = {'slice': ['k01'], 'results': [{'key1': 'k01', 'would_promote': False}],
+             'cards_out': [{'key1': 'k01', 'card': None}]}
+    merged = ca.merge_slice_results([half1, half2])
+    if merged['slice'] != ['k00', 'k01'] or len(merged['results']) != 2 \
+            or len(merged['cards_out']) != 2:
+        fail('D1: canonical_audit must merge chunk slice_results into one audit input')
+
+
 def test_degenerate_xref_vocab_single_source():
     """H1425 W2: the cross-reference / degenerate-passthrough vocabulary is ONE shared frozenset,
     consumed by both the RU generation lane (gen_opt_harness2.degenerate_passthrough_card) and the
@@ -7399,6 +7498,7 @@ def main():
         test_h1420_p10_promote_rebuilds_tm_in_finally,
         test_h1283_a5_max_wide_default_bounded,
         test_h1283_a6_prep_slice_flattens_batches,
+        test_h1386_d1_medium50_script_size_cap,
         test_frag_prov_glob_honors_coordinator_dir_c7,
         test_pwg_mask_german_homograph_not_latin_c8,
     ]

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -4303,9 +4303,16 @@ def test_frag_tm_reuse():
         senses0 = [{'tag': '1', 'german': plan0[0][2][:20], 'russian': 'кэш',
                     'equivalence_type': 'equivalent', 'source_type': 'attested',
                     'stratum': '', 'differentia': ''}]
+        # H1386: the fixture must be a VALID frag-TM v2 row (per-sense owners) -- R6 made a
+        # v1 ownerless row never-live-served, so the old v1 fixture only ever "passed" when
+        # the gam inputs were absent and the test returned early (vacuous in CI; failed on
+        # any second suite run in the same checkout, once earlier tests left the fixtures).
+        owners0 = [['gam', '']]
         with open(os.path.join(d, 'translation_memory.frag.ru.jsonl'), 'w', encoding='utf-8') as f:
-            f.write(json.dumps({'schema': 'pwg.translation_memory.frag.v1', 'lang': 'ru',
-                                'fsha': fsha0, 'src_key': target, 'senses': senses0},
+            f.write(json.dumps({'schema': tm.FRAG_SCHEMA_V2, 'lang': 'ru',
+                                'fsha': fsha0, 'src_key': target, 'senses': senses0,
+                                'owners': owners0, 'trust_level': tm.TRUST_MACHINE,
+                                'gate_status': 'machine_gated', 'reuse_policy': 'auto_exact'},
                                ensure_ascii=False) + '\n')
         js, _batches = gh.build(root, [target], rootmap, 12000, tm_path=tmfile)
 
@@ -4327,8 +4334,11 @@ def test_frag_tm_reuse():
         if filled != [(0, 0)]:
             fail('only the first fragment (the cached one) must be filled, got %s' % filled)
         # the filled slot carries the cached senses; its FRAGS sibling carries the matching fsha
-        if fv[0][0][0]['russian'] != 'кэш':
+        # R6 slot shape: {'senses': [...], 'owners': [...]} (never a bare senses list).
+        if fv[0][0]['senses'][0]['russian'] != 'кэш':
             fail('cached fragment slot must carry the sidecar senses')
+        if fv[0][0]['owners'] != owners0:
+            fail('cached fragment slot must carry the v2 per-sense owners')
         if gv[0][0].get('fsha') != fsha0:
             fail('FRAGS fragment must carry the content address used for the cache lookup')
         # whole-card accounting: reuse happens INSIDE selfHeal, so the card is still owed by a

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -567,6 +567,14 @@ def batch_promote(batch, store, review_status, gen_model_version,
                     line = line.strip()
                     if line:
                         existing_rows.append(json.loads(line))
+        # H1386 D3: per-lease attribution needs the pre-merge per-subcard row counts --
+        # the bundle-wide before/after stamped on every lease made a benign idempotent
+        # replacement indistinguishable from a real landing in the per-lease consumers
+        # (promotion_classification, bad_deltas, the windows100 GO gate).
+        existing_count_by_sub = {}
+        for row in existing_rows:
+            sub = row.get('subcard')
+            existing_count_by_sub[sub] = existing_count_by_sub.get(sub, 0) + 1
         rows_to_write, downgraded = merge_store_rows(existing_rows, all_rows)
         if downgraded:
             raise PromotionContractError(
@@ -597,10 +605,25 @@ def batch_promote(batch, store, review_status, gen_model_version,
             print('backed up prior store -> %s' % os.path.basename(bak))
         _atomic_write_rows(store, rows_to_write)
 
+    # H1386 D3: per-lease rows_added / rows_replaced / store_delta. The bundle is
+    # all-or-nothing (every incoming row landed or we raised above), so these are exact:
+    # a subcard absent from the pre-merge store contributes added rows, a present one
+    # replaces its prior rows, and the net per-lease line-count change is their balance.
+    def _lease_delta(lease_id, best):
+        inc = lease_rows[lease_id]
+        new_subs = {sub for sub in best if sub not in existing_count_by_sub}
+        prior_rows = sum(existing_count_by_sub.get(sub, 0) for sub in best)
+        return {
+            'rows_added': sum(1 for r in inc if r['subcard'] in new_subs),
+            'rows_replaced': sum(1 for r in inc if r['subcard'] not in new_subs),
+            'store_delta': len(inc) - prior_rows,
+        }
+
     report = {'schema': 'pwg.batch_promotion.v1',
               'store_rows_before': before, 'store_rows_after': len(rows_to_write),
-              'leases': {lease_id: {'subcards': len(best),
-                                    'rows': len(lease_rows[lease_id])}
+              'leases': {lease_id: dict({'subcards': len(best),
+                                         'rows': len(lease_rows[lease_id])},
+                                        **_lease_delta(lease_id, best))
                          for lease_id, best in lease_best.items()}}
     print('BATCH PROMOTE: %d lease(s), %d subcard(s), %d sense rows; store %d -> %d rows'
           % (len(batch), len(seen_subs), len(all_rows), before, len(rows_to_write)))
@@ -877,10 +900,21 @@ def selftest():
              for lid, (fp, key) in lease_files.items()]
     rep = batch_promote(batch, bstore, 'ai_translated', SELFTEST_MODEL_VERSION)
     assert rep['leases']['L1']['subcards'] == 1 and rep['leases']['L2']['subcards'] == 1
+    # H1386 D3: PER-LEASE delta figures, not the bundle-wide before/after stamped N times.
+    for lid in ('L1', 'L2'):
+        row = rep['leases'][lid]
+        assert row['rows_added'] == row['rows'] and row['rows_replaced'] == 0, row
+        assert row['store_delta'] == row['rows'], row
     bytes1 = open(bstore, 'rb').read()
     assert b'y~~keep' in bytes1, 'unrelated store row must survive the batch'
     rep2 = batch_promote(batch, bstore, 'ai_translated', SELFTEST_MODEL_VERSION)
     assert open(bstore, 'rb').read() == bytes1, 'batch rerun must be byte-stable/idempotent'
+    # H1386 D3: an idempotent replacement is a per-lease ZERO delta (all rows replaced) --
+    # the benign delta-0 case the windows100 GO gate must see per lease, not bundle-wide.
+    for lid in ('L1', 'L2'):
+        row = rep2['leases'][lid]
+        assert row['rows_added'] == 0 and row['rows_replaced'] == row['rows'], row
+        assert row['store_delta'] == 0, row
     # all-or-nothing: a lease whose clean output diverges from its expectation fails the
     # WHOLE bundle with the store byte-identical.
     bad = [dict(batch[0]), dict(batch[1], expected_subcards=['not~~this'])]
@@ -943,6 +977,14 @@ def main():
     ap.add_argument('--report', help='write the batch per-lease report JSON here')
     args = ap.parse_args()
     if args.batch_manifest:
+        # H1386 D5: flags the batch transaction does not implement are REFUSED, never
+        # silently discarded -- a hand-run `--batch-manifest --dry-run` used to mutate the
+        # canonical store (claim / backup / atomic replace / denylist unblock) with no
+        # warning, because batch_promote ran before the single-mode dry-run check.
+        for flag, name in ((args.dry_run, '--dry-run'), (args.force, '--force'),
+                           (args.init_store, '--init-store')):
+            if flag:
+                sys.exit('REFUSED: %s is not supported with --batch-manifest' % name)
         try:
             batch = json.load(open(args.batch_manifest, encoding='utf-8'))
             report = batch_promote(

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -531,7 +531,7 @@ def batch_promote(batch, store, review_status, gen_model_version,
     `batch` is a list of {'lease_id', 'glob' (ABSOLUTE or repo-relative), 'expected_subcards'}.
     Returns the per-lease report dict (also written to `report_path` when given)."""
     validate_store_target(store)
-    lease_best, lease_rows = {}, {}
+    lease_best, lease_rows, lease_nulls = {}, {}, {}
     all_rows, seen_subs = [], {}
     for item in batch:
         lease_id = item['lease_id']
@@ -540,14 +540,26 @@ def batch_promote(batch, store, review_status, gen_model_version,
         if not paths:
             raise PromotionContractError('%s: no clean output matched %r'
                                          % (lease_id, item['glob']))
-        best, rows, _nulls, _per_root = collect_and_validate(
+        best, rows, nulls, _per_root = collect_and_validate(
             paths, review_status, gen_model_version)
         expected = sorted(item.get('expected_subcards') or [])
+        # H1386 P3g: an entry with no expected_subcards made the subcard-set gate a silent
+        # no-op (the coordinator always supplies it; only a hand-written manifest can omit
+        # it, which is exactly when the gate matters most).
+        if not expected:
+            raise PromotionContractError(
+                '%s: batch entry has no expected_subcards -- refusing a vacuous '
+                'subcard-set gate; supply the lease expectation explicitly' % lease_id)
         got = sorted(best)
-        if expected and got != expected:
+        if got != expected:
             raise PromotionContractError(
                 '%s: clean output subcards %s do not match the lease expectation %s'
                 % (lease_id, got, expected))
+        if nulls:
+            # H1386 P3g: single mode prints these; batch mode silently dropped them.
+            print('%s: null sub-cards skipped: %d (%s)'
+                  % (lease_id, len(nulls), ', '.join(nulls[:10])))
+        lease_nulls[lease_id] = nulls
         for sub in best:
             if sub in seen_subs:
                 raise PromotionContractError(
@@ -622,7 +634,8 @@ def batch_promote(batch, store, review_status, gen_model_version,
     report = {'schema': 'pwg.batch_promotion.v1',
               'store_rows_before': before, 'store_rows_after': len(rows_to_write),
               'leases': {lease_id: dict({'subcards': len(best),
-                                         'rows': len(lease_rows[lease_id])},
+                                         'rows': len(lease_rows[lease_id]),
+                                         'null_subcards': lease_nulls.get(lease_id) or []},
                                         **_lease_delta(lease_id, best))
                          for lease_id, best in lease_best.items()}}
     print('BATCH PROMOTE: %d lease(s), %d subcard(s), %d sense rows; store %d -> %d rows'

--- a/RussianTranslation/src/promote_lock.py
+++ b/RussianTranslation/src/promote_lock.py
@@ -74,13 +74,52 @@ class PromoteClaim:
         except (OSError, json.JSONDecodeError):
             return None
 
-    def _stale(self):
-        meta = self._read()
-        claimed = _parse_ts((meta or {}).get('claimed_at'))
+    def _ts_stale(self, claimed_at):
+        claimed = _parse_ts(claimed_at)
         if not claimed:
             return True                 # unreadable/corrupt claim file -> treat as stale
         age = (datetime.datetime.now(datetime.timezone.utc) - claimed).total_seconds()
         return age > self.ttl_seconds
+
+    def _reclaim(self, judged_claimed_at):
+        """H1386 D2: identity-checked, rename-based reclaim of a claim judged stale.
+
+        The pre-fix read-then-os.remove pair was a TOCTOU: two cross-clone promoters could
+        both judge the crashed run's old claim stale, then the slower one os.remove'd the
+        FASTER one's fresh claim -- both 'held' the lock and the loser's promoted rows
+        vanished (the exact last-writer-wins loss this lock exists to prevent). Instead:
+        atomically rename the claim aside (os.replace), re-read what was actually captured,
+        and verify its claimed_at matches the stale value we judged. Capturing a
+        contender's FRESH claim restores it and loses the reclaim; FileNotFoundError on the
+        rename means another contender already reclaimed -- return True so the caller
+        retries the O_EXCL create and re-evaluates whatever claim now exists."""
+        import uuid
+        aside = self.path + '.reclaimed.' + uuid.uuid4().hex
+        try:
+            os.replace(self.path, aside)
+        except FileNotFoundError:
+            return True                 # another contender already reclaimed it
+        except OSError:
+            return False
+        try:
+            with open(aside, encoding='utf-8') as f:
+                moved = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            moved = {}
+        moved_at = (moved or {}).get('claimed_at')
+        if moved_at != judged_claimed_at and not self._ts_stale(moved_at):
+            # We captured a CONTENDER'S fresh claim (it reclaimed between our read and our
+            # rename) -- restore it and lose the reclaim.
+            try:
+                os.replace(aside, self.path)
+            except OSError:
+                pass
+            return False
+        try:
+            os.remove(aside)
+        except OSError:
+            pass
+        return True
 
     def _try_remove_stale_or_stolen(self):
         if self.steal:
@@ -89,13 +128,11 @@ class PromoteClaim:
             except OSError:
                 pass
             return True
-        if self._stale():
-            try:
-                os.remove(self.path)
-            except OSError:
-                pass
-            return True
-        return False
+        meta = self._read()
+        claimed_at = (meta or {}).get('claimed_at')
+        if not self._ts_stale(claimed_at):
+            return False
+        return self._reclaim(claimed_at)
 
     def __enter__(self):
         while True:
@@ -172,6 +209,28 @@ def selftest():
     with PromoteClaim(store, ttl_seconds=DEFAULT_TTL_SECONDS, steal=True):
         assert True, '--steal-lock must bypass a live claim unconditionally'
     assert not os.path.exists(claim_path(store))
+
+    # H1386 D2: identity-checked reclaim (the read->remove TOCTOU). Promoter A judged the
+    # claim stale, but BETWEEN A's read and A's reclaim a contender already reclaimed and
+    # recreated a FRESH claim. A's reclaim must capture-and-RESTORE the fresh claim (lose
+    # the race), never delete it -- the pre-fix os.remove deleted whatever was there.
+    stale_at = '2000-01-01T00:00:00Z'
+    fresh_contender = {'schema': 'pwg.promote_claim.v1', 'pid': 4242, 'host': 'contender',
+                       'claimed_at': _utc_now()}
+    with open(claim_path(store), 'w', encoding='utf-8') as f:
+        json.dump(fresh_contender, f)
+    a = PromoteClaim(store, ttl_seconds=DEFAULT_TTL_SECONDS)
+    assert a._reclaim(stale_at) is False, 'reclaim must LOSE against a contender fresh claim'
+    survived = json.load(open(claim_path(store), encoding='utf-8'))
+    assert survived.get('pid') == 4242, 'the contender fresh claim must survive a losing reclaim'
+    os.remove(claim_path(store))
+    # A claim matching the judged-stale timestamp is reclaimed; a vanished claim means
+    # another contender won the reclaim (return True -> retry the O_EXCL create).
+    with open(claim_path(store), 'w', encoding='utf-8') as f:
+        json.dump({'schema': 'pwg.promote_claim.v1', 'claimed_at': stale_at}, f)
+    assert a._reclaim(stale_at) is True and not os.path.exists(claim_path(store))
+    assert a._reclaim(stale_at) is True, 'a vanished claim = contender already reclaimed'
+    assert not [p for p in os.listdir(d) if '.reclaimed.' in p], 'reclaim residue left behind'
     print('promote_lock selftest OK')
 
 

--- a/RussianTranslation/src/root_glue_translated.py
+++ b/RussianTranslation/src/root_glue_translated.py
@@ -22,7 +22,8 @@ from safe_filename import safe_name
 import pipeline_version
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-INP = os.path.join(HERE, 'pilot', 'input')
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+INP = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'pilot', 'input')
 OUT = os.path.join(HERE, 'pilot', 'output')
 
 

--- a/RussianTranslation/src/scale_preflight.py
+++ b/RussianTranslation/src/scale_preflight.py
@@ -34,7 +34,8 @@ from safe_filename import safe_name
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 OUT = os.path.join(HERE, 'pilot', 'output')
-INP = os.path.join(HERE, 'pilot', 'input')
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+INP = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'pilot', 'input')
 FREQ = os.path.join(OUT, 'scale_manifest.freq.json')
 PWG = os.path.normpath(os.path.join(HERE, '..', '..', '..', 'csl-orig', 'v02', 'pwg', 'pwg.txt'))
 _DIVP = re.compile(r'^<div n="p">')

--- a/RussianTranslation/src/validate_final_card_schema.py
+++ b/RussianTranslation/src/validate_final_card_schema.py
@@ -19,7 +19,8 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.normpath(os.path.join(HERE, '..'))
 SCHEMA = os.path.join(ROOT, 'schemas', 'pwg_ru_final_card.schema.json')
 DEFAULT_FIXTURE = os.path.join(HERE, 'fixtures', 'final_card_workflow.json')
-PORTRAIT_DIR = os.path.join(HERE, 'pilot', 'input')
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+PORTRAIT_DIR = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'pilot', 'input')
 
 SCHEMA_ID = 'pwg_ru.final_card.schema.v1'
 RESULT_REQUIRED = {'card', 'judge'}

--- a/RussianTranslation/src/verify_root_glue.py
+++ b/RussianTranslation/src/verify_root_glue.py
@@ -41,7 +41,8 @@ import root_segment_proto as RS                       # noqa: E402  segment()/gl
 from safe_filename import safe_name                    # noqa: E402
 
 PWG = os.path.normpath(os.path.join(HERE, '..', '..', '..', 'csl-orig', 'v02', 'pwg', 'pwg.txt'))
-INP = os.path.join(HERE, 'pilot', 'input')
+# H1386 P3f: PWG_INPUT_DIR points a hermetic harness at a sandbox input dir.
+INP = os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'pilot', 'input')
 NAMED_GIANT = ['55166', '21814', '72578']              # bhū + both gam homonyms (the doc's probes)
 DIVP = re.compile(r'^<div n="p">')
 DIVM = re.compile(r'^<div n="m">')

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,48 @@ not an error.
 
 ## [Unreleased]
 
+### Fixed
+
+- pwg_ru post-H1339 review landing set
+  ([H1386](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1386-Fable_RussianTranslation_pwg-ru-post-h1339-resume-fixes-prepare-speed_20.07.26.md),
+  Fable 5 `claude-fable-5`), every fix test-first with a pinned failing regression. Confirmed
+  P1s: C1 — bounded `--resume` passed the staged-plan-scope **dict** to `cmd_recover`, so
+  crash recovery matched ZERO jobs and a crashed window checkpointed COMPLETED with zero
+  output (now the lease-id set; `_scope_sql` rejects dict/str; a None-output window fails
+  loudly); C2 — a requeue item whose origin lease had already recorded/promoted wedged every
+  `--resume` in `materialize_requeue` (post-audit states with a completed `::rq` job now
+  resume to the existing attempt job); C3 — the B12 fragment unblock re-served gate-flagged
+  senses: `build_frags` now treats a currently-denied fsha as not-cached, the harvest glob is
+  recursive (`artifacts/**`) so requeue outputs two dirs deep are harvested at all, and
+  `best_reusable` breaks same-second ties toward the newer row. Also: D2 identity-checked
+  atomic-rename promote-lock reclaim (TOCTOU), D3 per-lease `store_delta` from the batch
+  report (was bundle-wide stamped N times), D4 `PWG_COORDINATOR_DIR` injected into all three
+  bounded coordinator subprocesses (the A7 class), D5 `--batch-manifest` refuses
+  `--dry-run`/`--force`/`--init-store` instead of silently mutating the store, and the P3
+  sweep (P3b canonical `mw_en_tm` resolution, P3c `reset-failed` origin-lease matching +
+  full failed-job ids in fail-closed messages, P3d/P3e `run_py_inproc` KeyboardInterrupt +
+  string-exit semantics, P3g batch null-subcard gate, P3h stale_check v2
+  execution/provenance cross-check, P3j `probe_log` falsy-zero clean recovery).
+
+### Added
+
+- pwg_ru medium50 start-today enabler (H1386 D1): h1209 payload v3 hoists the shared ~12 KB
+  preamble/translation boilerplate into ONE `prompt_common` (was duplicated into every
+  card), `inject_payload.py` hard-refuses an emitted script over `WORKFLOW_SCRIPT_CAP`
+  (512 KB) with the split remedy, `prep_slice.py --keys`/`--chunk N` auto-splits a big
+  manifest into cap-sized sub-payloads, and `canonical_audit.py` merges several chunk
+  slice_results into one audit.
+- pwg_ru prepare-stage batching (H1386 OPT): `coordinator prepare-batch` prepares N claimed
+  leases in ONE coordinator process with the perf_preflight/gen_opt_harness2 children run
+  in-process (the H1339 runpy-gates pattern applied to the prepare stage H1339's closeout
+  named as the remaining dominant spawn cost), A/B-benched against the per-lease shape with
+  semantic-store-equality proven by the bench's deterministic signature.
+- pwg_ru hermetic offline bench (H1386 P3f): `h1339_offline_bench.py` now sandboxes its
+  fixture inputs (`PWG_INPUT_DIR`, honored by all 14 previously hand-copied input-dir
+  sites) and its events ledger (`PWG_EVENTS_PATH`), with a `finally:` teardown — a bench
+  run leaves the checkout byte-identical (previously it froze 12 fixture bodies into the
+  live `src/pilot/input/` and appended to the live `dashboard_events.jsonl`).
+
 ## [1.52.0] — 21-07-2026
 
 ### Added


### PR DESCRIPTION
Executes [H1386](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1386-Fable_RussianTranslation_pwg-ru-post-h1339-resume-fixes-prepare-speed_20.07.26.md) (Fable 5 `claude-fable-5`), the landing list of the 30-agent adversarial review of the H1339 factory-hardening pass. Every fix landed test-first with a pinned failing regression; offline only, zero model calls.

## Confirmed P1s (both verifiers)
- **C1** — bounded `--resume` passed the staged-plan-scope **dict** to `cmd_recover`; `_scope_sql` iterated its keys and crash recovery matched **zero** jobs, so a crashed window checkpointed COMPLETED with zero output. Now the lease-id set (mirrors `cmd_staged_run`); `_scope_sql` rejects dict/str; a None-output window fails loudly instead of checkpointing COMPLETED.
- **C2** — `materialize_requeue` hard-raised on every post-audit origin state, wedging every `--resume` after a crash between record and checkpoint. Post-audit states with a completed `::rqNN` job now resume to the existing attempt job (drain-break + A2 rescue promote); blocked/no-backlog/no-job stay loud.
- **C3** — the B12 fragment unblock re-served gate-flagged senses (the H304 contract, void for fragments): `build_frags` now treats a currently-denied fsha as not-cached, the harvest glob is recursive (`artifacts/**` — requeue outputs two dirs deep were never harvested at all), and `best_reusable` breaks same-second ties toward the newer row.

## Disputed-but-real (D) + P2 sweep (P3)
D2 identity-checked atomic-rename promote-lock reclaim (TOCTOU); D3 per-lease `store_delta`/`rows_added`/`rows_replaced` from the batch report (was bundle-wide × N); D4 `PWG_COORDINATOR_DIR` on all three bounded coordinator subprocesses (A7 class); D5 `--batch-manifest` refuses `--dry-run`/`--force`/`--init-store`; P3b canonical `mw_en_tm` resolution (B04's missed 5th sidecar); P3c `reset-failed` origin-lease matching + full failed-job ids in fail-closed messages; P3d/e `run_py_inproc` KeyboardInterrupt + string-exit semantics; P3g batch null-subcard gate; P3h stale_check v2 execution/provenance cross-check; P3j `probe_log` falsy-zero recovery. (P3a and P3i were already fixed on master by the parallel H1413 wave — verified, not re-done. P3k fixed in claude-config.)

## Medium50 enabler (D1)
h1209 payload v3 hoists the shared ~12 KB boilerplate into ONE `prompt_common`; `inject_payload` hard-refuses scripts over `WORKFLOW_SCRIPT_CAP` (512 KB) with the split remedy; `prep_slice --keys`/`--chunk N`; `canonical_audit` merges chunk slice_results.

## Prepare-stage speed (closes the H1339 25% target)
`coordinator prepare-batch` runs the preflight/gen children in-process: **prepare −72.0% median** (11.669 s → 3.263 s), total −22.0%, 2+10 runs per mode, **identical deterministic output signature** across batch and per-lease — evidence: [H1386_PREPARE_BATCH_BENCH_2026-07-22.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h1339/H1386_PREPARE_BATCH_BENCH_2026-07-22.md). The bench itself is now fully hermetic (P3f): `PWG_INPUT_DIR`/`PWG_EVENTS_PATH` sandbox honored by all 14 previously hand-copied input-dir sites, `finally:` teardown — a bench run leaves the checkout byte-identical.

## Gates (all green locally)
`window_selftest` 180/180 (baseline 157, +regressions for every fix; also un-vacuoused `test_frag_tm_reuse` — its v1 fixture contradicted R6 and only passed when the gam inputs were absent), `lang_parity_check` 73 entries no drift (+`h1386_resume_recovery_and_medium50`), bounded/supervisor/mao/headless/economy/execution/observability selftests, `promote_final_cards --selftest`, `promote_lock --selftest`, `store_path`, `translation_memory` selftest, and the A/B offline bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
