### PR TITLE
H741 bucket B: link-check config/workflow overhaul + baseline (73 survivors, goal <100)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1187,6 +1187,25 @@ Two live tracks:
 
 ## ✅ Completed (Recent only)
 
+- [x] **H741 CLOSED — repo-wide dead-link sweep + CI link-check overhaul (22-07-2026, Fable 5
+      `claude-fable-5`).** Full local `markdown-link-check` run (CI config, 559 files): 16,861
+      unique dead links — 15,919 in `literature/md/` ebook conversions, 942 in real surface.
+      Drained to **73 accepted survivors in 21 files** (goal <100).
+      [PR #666](https://github.com/gasyoun/SanskritLexicography/pull/666) fixed 62 links
+      (archive-move repoints → full blob URLs, gitignored delinks, pinned-SHA repoints for
+      PR #540-deleted files, wrong-owner GitHub URLs, external 404s); the config PR rebuilt
+      [link-check.yml](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/workflows/link-check.yml)
+      (find-based, excludes `literature/` + `docs_site/wiki/`) and extended
+      [mlc_config.json](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/mlc_config.json)
+      (private repos, mailto, DOI/publisher bot-blocks, flaky academic hosts, 202 alive).
+      Baseline + survivor classes:
+      [LINK_CHECK_BASELINE_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/LINK_CHECK_BASELINE_2026H2.md).
+      Registry-hygiene residue (40 survivors inside FINDINGS/CONTRADICTIONS/RECIPES/DEAD_ENDS,
+      H706-owned — incl. 22 FINDINGS anchor-slug mismatches and the stale
+      `chore/errata-kochergina-waiting` branch links whose live target is
+      [tree/main/GasunsDhatu_2014/revision-2026](https://github.com/gasyoun/SanskritGrammar/tree/main/GasunsDhatu_2014/revision-2026))
+      is documented in the baseline note, deliberately not edited here.
+
 - [x] **H803 CLOSED — LaukikaNyaya reaches ≥400 target, 404 records (21-07-2026, Sonnet 5
       `claude-sonnet-5`, picked up via `/next-task`).** Fixed `prev_is_prose()` pipeline-wide
       (the 20-07-2026 pass had root-caused this exact bug but explicitly deferred a fix due to

--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -1,7 +1,21 @@
 {
   "ignorePatterns": [
     { "pattern": "^https://gasyoun\\.github\\.io/" },
-    { "pattern": "^https://github\\.com/gasyoun/SanskritLexicography/(blob|tree)/" }
+    { "pattern": "^https://github\\.com/gasyoun/SanskritLexicography/(blob|tree)/" },
+    { "pattern": "^https://github\\.com/gasyoun/(Uprava|claude-config|codex-config|github-spine|claude-memory-store|telegram-sanskrit-corpus|spoken-sanskrit-corpus|indology-archive-research-map|prefaces_ieg|ChatExport|RuWritingStyles-corpus)([/?#]|$)" },
+    { "pattern": "^mailto:" },
+    { "pattern": "^https?://(dx\\.)?doi\\.org/" },
+    { "pattern": "^https?://(www\\.)?(jstor\\.org|sciencedirect\\.com|academia\\.edu|brill\\.com|oed\\.com|webonary\\.org|rapidwords\\.net|loebclassics\\.com|semanticscholar\\.org|degruyter\\.com)([/?#]|$)" },
+    { "pattern": "^https?://(academic|global)\\.oup\\.com/" },
+    { "pattern": "^https?://(dl|cacm)\\.acm\\.org/" },
+    { "pattern": "^https?://id\\.loc\\.gov/" },
+    { "pattern": "^https?://claude\\.ai([/?#]|$)" },
+    { "pattern": "^https://github\\.com/(signup|login)([/?#]|$)" },
+    { "pattern": "^https?://sanskrit\\.uohyd\\.ac\\.in/" },
+    { "pattern": "^https?://(www\\.)?(sanskrit-lexicon|vedaweb)\\.uni-koeln\\.de([/?#]|$)" },
+    { "pattern": "^https?://(www\\.)?sanskrit-linguistics\\.org/" },
+    { "pattern": "^https?://(www\\.)?hss\\.iitb\\.ac\\.in/" },
+    { "pattern": "^https?://mahabharata\\.manipal\\.edu([/?#]|$)" }
   ],
-  "aliveStatusCodes": [200, 206, 429]
+  "aliveStatusCodes": [200, 202, 206, 429]
 }

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -2,7 +2,21 @@ name: Link check
 
 # Markdown link check, moved out of ci.yml (where it consumed ~47 min on every
 # push/PR with continue-on-error, i.e. zero per-push enforcement). Runs weekly
-# plus on manual dispatch; stays advisory (continue-on-error).
+# plus on manual dispatch; stays advisory (continue-on-error), but since H741
+# its output is judged against a stated baseline (LINK_CHECK_BASELINE_2026H2.md)
+# instead of being re-triaged from scratch.
+#
+# H741 changes (see LINK_CHECK_BASELINE_2026H2.md for the full rationale):
+# - explicit find-based invocation instead of the marketplace action, so two
+#   path classes can be EXCLUDED from the sweep:
+#     literature/md/**   third-party converted book texts (H734 territory) —
+#                        15,919 of the 16,861 dead links measured 21-07-2026
+#                        were ebook-internal anchors + decayed bibliographies
+#                        the project does not maintain
+#     docs_site/wiki/**  verbatim copies synced by docs_site/build_site.py
+#                        --sync; their relative links are rewritten at build
+#                        time, so checking the copies is noise
+# - mlc pinned to the version the H741 baseline was measured with.
 
 on:
   schedule:
@@ -22,9 +36,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: actions/setup-node@v4
         with:
-          use-quiet-mode: "yes"
-          use-verbose-mode: "yes"
-          config-file: ".github/mlc_config.json"
+          node-version: 20
+      - run: npm install -g markdown-link-check@3.14.2
+      - name: Check links (excludes literature/ and docs_site/wiki/ — see LINK_CHECK_BASELINE_2026H2.md)
         continue-on-error: true
+        run: |
+          find . -name '*.md' \
+            -not -path './.git/*' \
+            -not -path './literature/*' \
+            -not -path './docs_site/wiki/*' \
+            -print0 \
+            | xargs -0 -n1 markdown-link-check -c .github/mlc_config.json -q -v

--- a/FEATURES_INDEX.md
+++ b/FEATURES_INDEX.md
@@ -142,7 +142,7 @@ column links a real sample headword (or *browse*) to that dictionary's live Colo
 
 | Code | Dictionary | Language | Author | Year | Pages | Repo | Example |
 |---|---|---|---|---:|---:|---|---|
-| MW | Monier-Williams Sanskrit-English Dictionary | Skt→Eng | Monier-Williams | 1899 | 1,333 | [MWS](https://github.com/gasyoun/MWS) | [`a` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/MWScan/2020/web/index.php) |
+| MW | Monier-Williams Sanskrit-English Dictionary | Skt→Eng | Monier-Williams | 1899 | 1,333 | [MWS](https://github.com/sanskrit-lexicon/MWS) | [`a` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/MWScan/2020/web/index.php) |
 | PWG | Grosses Petersburger Wörterbuch | Skt→Ger | Böhtlingk & Roth | 1855 | 4,737 | [PWG](https://github.com/sanskrit-lexicon/PWG) | [`a` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/PWGScan/2020/web/index.php) |
 | PW | Sanskrit-Wörterbuch in kürzerer Fassung | Skt→Ger | Otto Böhtlingk | 1879 | 2,141 | [PWK](https://github.com/sanskrit-lexicon/PWK) | [`a` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/PWScan/2020/web/index.php) |
 | GRA | Wörterbuch zum Rig-Veda | Skt→Ger | Hermann Grassmann | 1873 | 1,775 | [GRA](https://github.com/sanskrit-lexicon/GRA) | [`a` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/GRAScan/2020/web/index.php) |

--- a/LINK_CHECK_BASELINE_2026H2.md
+++ b/LINK_CHECK_BASELINE_2026H2.md
@@ -1,0 +1,72 @@
+# Link-check baseline 2026H2 — what the weekly job's output is judged against
+
+_Created: 22-07-2026 · Last updated: 22-07-2026_
+
+Produced by [H741](https://github.com/gasyoun/Uprava/blob/main/handoffs/H741-Fable_SanskritLexicography_repo-wide-dead-link-sweep_11.07.26.md)
+(repo-wide dead-link sweep, Fable 5 `claude-fable-5`). The weekly
+[link-check workflow](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/workflows/link-check.yml)
+is advisory (`continue-on-error`); this note states the accepted baseline so its
+output is compared against a known state instead of re-triaged from scratch.
+
+## Headline numbers (measured 21/22-07-2026, markdown-link-check 3.14.2)
+
+| Run | Scope | Unique dead links | Files |
+|---|---|---|---|
+| Before (old config, all files) | 559 `.md` files | **16,861** | 289 |
+| — of which `literature/md/` | 34 converted ebooks | 15,919 | 34 |
+| — of which real project surface | 255 files | 942 | 255 |
+| After (new config + exclusions + fix [PR #666](https://github.com/gasyoun/SanskritLexicography/pull/666)) | 480 `.md` files | **73** | 21 |
+
+Goal `<100` met. The audit-era figure of "1,659 dead links" (H733, 11-07-2026)
+under-counted because the CI action was rate-limited and its log truncated; the
+full local run is the honest denominator.
+
+## What was fixed vs. configured away
+
+- **[PR #666](https://github.com/gasyoun/SanskritLexicography/pull/666)** fixed 62
+  real links: archive-move repoints (now full blob URLs), gitignored-target delinks,
+  pinned-SHA repoints for files deleted by
+  [PR #540](https://github.com/gasyoun/SanskritLexicography/pull/540), wrong-owner
+  GitHub URLs (csl-atlas/csl-observatory/csl-standards/sanskrit-util →
+  `sanskrit-lexicon`; SanskritSpellCheck/kosha/WhitneyRoots → `gasyoun`), and
+  genuine external 404s (Wikipedia, TMX 1.4b via Wayback, Speijer/Apte
+  archive.org identifiers).
+- **This PR** configures away the classes that are dead only to an unauthenticated
+  bot, and excludes two path classes from the sweep (below).
+
+## Path exclusions (workflow-level `find … -not -path`)
+
+| Path | Dead links | Why excluded |
+|---|---|---|
+| `literature/md/**` | 15,919 | Third-party converted book texts (ebook-internal `#…xhtml` anchors, never-extracted images, decades-old bibliography URLs). Not project-maintained link surface; the folder's fate is [H734](https://github.com/gasyoun/Uprava/blob/main/handoffs/H734-Fable_SanskritLexicography_literature-copyright-triage_11.07.26.md)'s open Western-cluster ruling. |
+| `docs_site/wiki/**` | ~30 | Verbatim copies synced by [docs_site/build_site.py](https://github.com/gasyoun/SanskritLexicography/blob/master/docs_site/build_site.py) `--sync`; relative links are rewritten at build time, so checking the copies is pure noise. Originals under `RussianTranslation/research/` stay checked. |
+
+## Config ignore-list rationale ([.github/mlc_config.json](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/mlc_config.json))
+
+| Pattern class | Evidence | Why alive despite the status |
+|---|---|---|
+| Private repos: `gasyoun/{Uprava, claude-config, codex-config, github-spine, claude-memory-store, telegram-sanskrit-corpus, spoken-sanskrit-corpus, indology-archive-research-map, prefaces_ieg, ChatExport, RuWritingStyles-corpus}` | 510 unique 404s | GitHub returns 404 to unauthenticated requests for private repos. The org's clickable-links rule *mandates* these full blob URLs; they resolve for every org member. Largest single class. |
+| `mailto:` | 11 | Not HTTP-checkable. |
+| `doi.org`, `dx.doi.org` | 132+ 403/0 | DOIs are persistent identifiers; the resolver bot-blocks HEAD/GET from CI. |
+| Paywalled/bot-blocking publishers: jstor, sciencedirect, academia.edu, brill, oed, oup, acm, degruyter, semanticscholar, loebclassics, webonary, rapidwords, id.loc.gov, claude.ai, github.com/signup | 403/405/202 in bulk; alive in a browser | Standard bot-block behaviour (403, 405 on HEAD, interstitials). Verified alive via serial re-probe with browser UA where possible. |
+| Project-adjacent academic hosts: `sanskrit-lexicon.uni-koeln.de`, `vedaweb.uni-koeln.de`, `sanskrit-linguistics.org` (DCS), `hss.iitb.ac.in` (WSC 2027), `mahabharata.manipal.edu`, `sanskrit.uohyd.ac.in` (Saṁsādhanī) | 403/418/500/0/TLS-altname | Cologne's own server 403s bots; VedaWeb answers 418/500 to checkers; DCS's cert doesn't cover the `www.` alias; the rest time out from CI while being reachable interactively. Cross-reference [Uprava SERVER_OUTAGES.md](https://github.com/gasyoun/Uprava/blob/main/SERVER_OUTAGES.md) before re-probing. |
+| `aliveStatusCodes` gains `202` | doi.org, degruyter, oup, semanticscholar | 202 Accepted is a 2xx success response some publishers return to non-browser agents. |
+
+## Accepted survivors (73 unique, 21 files, measured 22-07-2026)
+
+| Class | Count | Notes |
+|---|---|---|
+| H706-owned epistemic registries ([FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md), [CONTRADICTIONS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md), [RECIPES.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RECIPES.md), [DEAD_ENDS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md)) | 40 | Excluded from H741 edits per the handoff (owned by [H706](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H706-Fable_Uprava_findings-hubs-crosslink-audit_11.07.26.md)). 22 are FINDINGS' own long in-file anchors that mlc's slugifier mismatches (they work on GitHub); the rest are stale branch pointers (`chore/errata-kochergina-waiting` → now [`tree/main/GasunsDhatu_2014/revision-2026`](https://github.com/gasyoun/SanskritGrammar/tree/main/GasunsDhatu_2014/revision-2026)), one `gasyoun/csl-atlas` → `sanskrit-lexicon/csl-atlas` owner fix, one `gasyoun/csl-observatory` → `sanskrit-lexicon/csl-observatory`, and SamudraManthanam `codex/audit-hardening` branch links — all queued as a registry-hygiene follow-up, not silently rewritten here. |
+| Transient `Status: 0` socket flakes | ~28 | github.com / aclanthology.org / arxiv.org / sil.org links the serial re-probe confirmed alive; they wobble per-run under load. Expect a fluctuating handful in any weekly run — treat as noise unless a link repeats across weeks. |
+| Genuinely down externals | 5 | `koshashri-dc.ac.in` (×2, Deccan College PD portal — down at measurement), `darkone23/Heritage_Resources` + two others intermittent. Re-check before repointing; log persistent ones in [SERVER_OUTAGES.md](https://github.com/gasyoun/Uprava/blob/main/SERVER_OUTAGES.md). |
+
+A weekly run reporting **≲75 dead links in these same classes is at baseline** —
+no action needed. New dead links outside these classes are real regressions.
+
+## @DECIDE (vetoable at PR review)
+
+The `<100` threshold and every host added to the permanent ignore list above are
+proposed by this note; MG can veto any row at PR review of the config PR, and any
+later addition to the ignore list should update this table in the same commit.
+
+_Dr. Mārcis Gasūns_

--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,36 @@ not an error.
   sites) and its events ledger (`PWG_EVENTS_PATH`), with a `finally:` teardown — a bench
   run leaves the checkout byte-identical (previously it froze 12 fixture bodies into the
   live `src/pilot/input/` and appended to the live `dashboard_events.jsonl`).
+## [1.53.0] — 22-07-2026
+
+### Added
+
+- [`LINK_CHECK_BASELINE_2026H2.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/LINK_CHECK_BASELINE_2026H2.md)
+  ([H741](https://github.com/gasyoun/Uprava/blob/main/handoffs/H741-Fable_SanskritLexicography_repo-wide-dead-link-sweep_11.07.26.md),
+  Fable 5 `claude-fable-5`): the stated baseline the weekly link-check job is judged against —
+  full-repo measurement 16,861 unique dead links (15,919 in `literature/md/` ebook conversions,
+  942 in real project surface) drained to **73 accepted survivors in 21 files** (goal <100);
+  survivor classes, ignore-list rationale, and path-exclusion rulings documented per row.
+
+### Changed
+
+- Weekly [link-check workflow](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/workflows/link-check.yml)
+  rebuilt (H741): explicit find-based `markdown-link-check@3.14.2` invocation excluding
+  `literature/md/**` (third-party book texts, H734 territory) and `docs_site/wiki/**`
+  (build_site `--sync` copies); [`mlc_config.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/mlc_config.json)
+  gains ignore patterns for the 11 private `gasyoun/*` repos (unauthenticated-404-by-design),
+  `mailto:`, DOI resolvers, bot-blocking publishers, and flaky project-adjacent academic hosts;
+  `aliveStatusCodes` gains 202.
+
+### Fixed
+
+- 62 CI-visible dead links across 31 files
+  ([PR #666](https://github.com/gasyoun/SanskritLexicography/pull/666), H741 bucket A):
+  archive-move relative links → full blob URLs; gitignored-by-design targets delinked;
+  PR #540-deleted gloss-reviews → pinned pre-deletion SHAs; wrong-owner GitHub URLs
+  (csl-atlas / csl-observatory / csl-standards / sanskrit-util / MWS → `sanskrit-lexicon`;
+  SanskritSpellCheck / kosha / WhitneyRoots → `gasyoun`); Wikipedia/TMX/archive.org 404s
+  repointed to verified targets; two broken in-file anchors.
 
 ## [1.52.0] — 21-07-2026
 


### PR DESCRIPTION
Part 2 (final) of [H741](https://github.com/gasyoun/Uprava/blob/main/handoffs/H741-Fable_SanskritLexicography_repo-wide-dead-link-sweep_11.07.26.md). Bucket A was [PR #666](https://github.com/gasyoun/SanskritLexicography/pull/666) (62 mechanical fixes).

**What this does**
- [.github/mlc_config.json](https://github.com/gasyoun/SanskritLexicography/blob/h741-link-check-config/.github/mlc_config.json): ignore the classes that are dead only to an unauthenticated bot — the 11 private `gasyoun/*` repos (the clickable-links rule mandates those URLs; 510 unique 404s), `mailto:`, DOI resolvers, bot-blocking publishers, flaky academic hosts incl. Cologne's own server; `aliveStatusCodes` += 202
- [.github/workflows/link-check.yml](https://github.com/gasyoun/SanskritLexicography/blob/h741-link-check-config/.github/workflows/link-check.yml): find-based `markdown-link-check@3.14.2` excluding `literature/md/**` (15,919 of the 16,861 measured dead links; third-party book texts, [H734](https://github.com/gasyoun/Uprava/blob/main/handoffs/H734-Fable_SanskritLexicography_literature-copyright-triage_11.07.26.md) territory) and `docs_site/wiki/**` (`--sync` copies)
- [LINK_CHECK_BASELINE_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/h741-link-check-config/LINK_CHECK_BASELINE_2026H2.md): the accepted-survivor table (73 unique in 21 files — 40 in H706-owned registries, ~28 verified-alive transients, 5 down externals), per-row ignore rationale, and the **@DECIDE veto note**: the <100 threshold and every ignored host are vetoable here at review
- `FEATURES_INDEX.md` MWS owner fix; changelog **1.53.0**; `.ai_state.md` session record

**Evidence:** final full local run with this config: **73 unique dead links** (was 16,861) — goal <100 met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)