### PR TITLE
pwg_ru offline control-plane audit + hardening (Codex 21-07, stranded branch salvaged onto the H1386 landing set)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Repository documentation, PWG→Russian bounded CLI restart & housekeeping
 
-_Created: 09-07-2026 · Last updated: 19-07-2026_
+_Created: 09-07-2026 · Last updated: 21-07-2026_
 
 Keep the SanskritLexicography data/research workspace documented and its git
 state tidy.
@@ -37,11 +37,13 @@ Two live tracks:
   priority pool if MG authorizes it. Full plan:
   [PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md).
 
-- **RussianTranslation H1339 — PWG→RU factory hardening + measured speed Phase B
-  (Fable 5 `claude-fable-5`, queued 19-07-2026).** Current-master Tier-B revalidation,
-  real unattended requeue materialisation, and a ≥25% frozen offline prepare→audit→promote
-  speed target under unchanged concurrency/store-safety gates. Resume:
-  `Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H1339-Fable_SanskritLexicography_pwg-ru-factory-hardening-speed-phase-b_19.07.26.md and execute it.`
+- **RussianTranslation H1437 — bounded cohort scheduler + promotion ledger (Fable 5,
+  queued 21-07-2026; hard-gated on H1386).** The current offline Codex hardening pass closed
+  profile-bound claims, fail-open audit inputs, cost-schema drift, repeated checkout discovery,
+  repeated promotion-store scans, and per-card output-directory scans. H1437 owns the remaining
+  P0 attempt/run/result binding, promotion reconciliation, campaign ledger, then measured 1/2/3-
+  profile cohort execution. It must stop after every phase for Codex review. Resume:
+  [`H1437`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1437-Fable_RussianTranslation_bounded-wave-barrier-promotion-ledger_21.07.26.md).
 
 - **H1110 — 🔴 EXECUTED 18-07-2026 (Opus 4.8 `claude-opus-4-8[1m]`): Phases 1–6 COMPLETE, paid c4 ladder DEFERRED.**
   Audit + fixes + skills/goals all merged green: Phase 1 audit (#524) + Phase 2 fixes (#530, `window_selftest`
@@ -1205,6 +1207,15 @@ Two live tracks:
       `chore/errata-kochergina-waiting` branch links whose live target is
       [tree/main/GasunsDhatu_2014/revision-2026](https://github.com/gasyoun/SanskritGrammar/tree/main/GasunsDhatu_2014/revision-2026))
       is documented in the baseline note, deliberately not edited here.
+- [x] **RussianTranslation offline pipeline hardening + speed pass COMPLETE (21-07-2026,
+      Codex/GPT-5).** Audited the prepared-lease→headless worker→audit→promotion/TM path on fresh
+      `origin/master`; fixed scheduler profile binding, corrupt/missing audit fail-open paths,
+      nested/unevaluable cost telemetry, repeated Git checkout discovery, repeated 26 MB store
+      scans, and repeated case-exact output-directory scans. Frozen H1339 one-run smoke retained
+      the exact output signature and improved **17.842→11.354 s (−36.4%)**; the full offline gate
+      is green (`window_selftest` 176/176, LANG_PARITY 72 clean). No generation, live probe,
+      promotion, canonical-store/TM mutation, or paid call. Remaining P0 work is phase-gated in
+      [H1437](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1437-Fable_RussianTranslation_bounded-wave-barrier-promotion-ledger_21.07.26.md).
 
 - [x] **H803 CLOSED — LaukikaNyaya reaches ≥400 target, 404 records (21-07-2026, Sonnet 5
       `claude-sonnet-5`, picked up via `/next-task`).** Fixed `prev_is_prose()` pipeline-wide

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -3398,3 +3398,27 @@ a Petersburg-tradition fact, not a Sanskrit-encyclopedic-dictionary one. PD is u
 ⚠️ **Reusable rules.** Never consume the fused/separable split as a register property of SKD-vs-VCP — the "units" are different objects (SKD *iti*-micro-segments, 2.88/record, vs VCP mostly whole-record `lumped-proxy` blobs, 1.31/record) detected by different instruments (curated names + `ity`-regex vs the `<name>0` siglum regex), and the ≥20-non-whitespace-chars fusion threshold makes "fused" quasi-monotone in unit length. Corollary for prose: the committed corpus stats *invert* the "short SKD entry vs long VCP commentary" story ([`dictionary-coverage.json`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/dictionary-coverage.json): SKD meanChars 531 > VCP 493, medians 221 > 162, and VCP has MORE records, 50,135 > 42,531 — VCP's discursive register is a tail phenomenon, maxChars 312,261). Any segmenter for indigenous citation formulas must split *name-aware* (keep `iti <name>` together), not on bare `iti`.
 
 > **Source:** hostile referee pass [papers/A30_review_fable5.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A30_review_fable5.md) (M1–M5) + model-labelled sample [papers/A30_SKD_ITI_ADJUDICATION_MODEL_PASS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/papers/A30_SKD_ITI_ADJUDICATION_MODEL_PASS.md), verified against csl-atlas `origin/main` `a56444f` ([`build-r2-kosa-fusion.mjs`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/scripts/build-r2-kosa-fusion.mjs), [`build-r2-source-anchors.mjs`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/scripts/build-r2-source-anchors.mjs), [`r2_kosa_fusion_sample.json`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/lexico/r2_kosa_fusion_sample.json)) · [H1382](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1382-Fable_SanskritLexicography_a30-hostile-referee-pass-skd-vcp_20.07.26.md) ([PR #662](https://github.com/gasyoun/SanskritLexicography/pull/662)) — SanskritLexicography · 21-07-2026, Fable 5 (`claude-fable-5`).
+
+### §462. On Windows, repeated repository discovery can dominate a Python pipeline: cache checkout identity, not mutable path overrides
+
+⚠️ **Reusable performance gotcha.** A small PWG→Russian preflight launched **88 Git subprocesses**
+only to rediscover the same main-worktree identity; those launches consumed **4.50 s of 5.29 s**.
+The safe cache boundary is narrower than “cache the resolved store path”: cache only the immutable
+checkout relationship, keyed by normalized absolute directory, for the life of the process. Keep
+`PWG_RU_STORE` / TM environment overrides outside that cache so test and operator overrides remain
+live, and never cache a blank/failed Git lookup as “not a linked worktree” — one transient failure
+would otherwise pin the process to a worktree-local store. The same audit found two unnecessary
+scans of the 26 MB canonical JSONL around promotion even though the atomic child transaction already
+reported exact before/after row counts; consuming the validated receipt avoids reopening the store
+without weakening the audit trail.
+
+The frozen H1339 smoke fixture kept the exact output signature
+`da1341e6ac112bf83c7c521d194f698aa39da067075b636463fa6748c43fb629` while the combined safe wins
+reduced one-run total time **17.842→11.354 s (−36.4%)**. Treat that as a smoke result, not a stable
+benchmark: `warmups=0`, `runs=1`. A further case-exact lookup fix snapshots output-directory names
+once after collection instead of rebuilding `set(os.listdir(...))` for every card; it landed after
+the frozen comparison and is therefore excluded from the percentage.
+
+> **Source:** [`docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md) +
+> [`RussianTranslation/src/store_path.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/store_path.py) +
+> [`RussianTranslation/src/pilot/coordinator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/coordinator.py) — offline Codex audit, 21-07-2026; no live/model/promotion/store call.

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -27,6 +27,11 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   A/B bench evidence. LANG_PARITY entry `h1386_resume_recovery_and_medium50` classifies
   the whole set (SHARED; EN-lane facts re-checked). P3k fixed in claude-config
   (`commands/pwg-bounded-run.md` bogus `--max-agents/--timeout 180`).
+- **H1437 — Fable 5 bounded-cohort hardening, QUEUED 21-07-2026; hard-gated on H1386.** First
+  close automated result/attempt/run binding, atomic promotion receipt + startup reconciliation,
+  and a campaign-wide probe/model-call ledger; only then build a barrier-tested 1/2/3-profile
+  cohort scheduler. Fable 5 must stop after every phase for Codex inspection/correction. Handoff:
+  [`H1437-Fable_RussianTranslation_bounded-wave-barrier-promotion-ledger_21.07.26.md`](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1437-Fable_RussianTranslation_bounded-wave-barrier-promotion-ledger_21.07.26.md).
 
 - **H1306 Phase 1 DONE — style-research memo + ratification sheet emitted; Phase 2 WAITS on MG's
   vote (21-07-2026, Fable 5 `claude-fable-5`).** Memo
@@ -2489,6 +2494,17 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   ([SamudraManthanam #16](https://github.com/gasyoun/SamudraManthanam/issues/16)).
 
 ## ✅ Completed (Recent only)
+
+- **Codex pipeline hardening/speed review COMPLETE, 21-07-2026 (OFFLINE).** On a collision-isolated
+  fresh-master branch, the end-to-end control-plane audit fixed wrong-account manifest claims,
+  missing/corrupt audit evidence being treated as clean, current nested cost telemetry (including
+  explicit unevaluable/invalid values), repeated Git checkout resolution, duplicate full-store
+  row scans during promotion, and per-card case-exact directory scans. Frozen H1339 smoke output
+  stayed byte-signature-identical while total time fell **17.842→11.354 s (−36.4%, one-run smoke)**;
+  all offline checks pass (`window_selftest` 176/176; LANG_PARITY 72/72). No paid/model call,
+  live probe, promotion, store write, or TM rebuild. Audit:
+  [`../docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md`](../docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md);
+  residual P0/cohort work: [H1437](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1437-Fable_RussianTranslation_bounded-wave-barrier-promotion-ledger_21.07.26.md).
 
 - **H1418 — bug-hunt C7 + C8 + C9 fixed (last 3 of 9), 21-07-2026 (Opus 4.8 `claude-opus-4-8`).**
   **C7:** `coordinator.py` `build-frags` hardcoded the default glob while detection honored

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,8 +10,6 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
-## [1.50.0] - 2026-07-21
-
 ### Fixed — offline control-plane audit and speed hardening (Codex)
 
 - Profile-bound manifest-v2 jobs are now claimed only by their configured account; required slots
@@ -26,8 +24,9 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
   output-directory snapshot per audit,
   and promotion receipt row counters remove repeated Git launches, directory scans, and two full
   26 MB store scans. On the frozen H1339 fixture, the one-run offline smoke retained the exact
-  output signature while total time fell 17.842→11.354 s (−36.4%). Full gates: 176/176 window
-  tests and 72/72 language-parity entries clean. See
+  output signature while total time fell 17.842→11.354 s (−36.4%). Full gates at landing (after
+  rebase onto the merged H1386 set): 180/180 window tests twice under random hash seeds and
+  73/73 language-parity entries clean. See
   [`../docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md`](../docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md).
 
 ## [1.49.0] - 2026-07-21

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,26 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.50.0] - 2026-07-21
+
+### Fixed — offline control-plane audit and speed hardening (Codex)
+
+- Profile-bound manifest-v2 jobs are now claimed only by their configured account; required slots
+  are selected before concurrency slicing and unavailable/parked/unprobed/busy owners fail loudly.
+  Valid active jobs in older SQLite queues are crash-safely backfilled; corrupt/unreadable active
+  manifests remain unclaimable but retryable after repair, and fail before the dispatch poll loop.
+- Missing or corrupt coordinator/Workflow evidence and a crashed sense-shortfall detector now
+  fail the bounded run before checkpointing instead of becoming a synthetic zero-clean success.
+  Current `summary.usage` cost telemetry is read at its real schema path; explicit unevaluable,
+  negative, NaN, and infinite figures remain fail-closed.
+- Cached immutable main-worktree discovery (without caching Git failures), one case-exact
+  output-directory snapshot per audit,
+  and promotion receipt row counters remove repeated Git launches, directory scans, and two full
+  26 MB store scans. On the frozen H1339 fixture, the one-run offline smoke retained the exact
+  output signature while total time fell 17.842→11.354 s (−36.4%). Full gates: 176/176 window
+  tests and 72/72 language-parity entries clean. See
+  [`../docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md`](../docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md).
+
 ## [1.49.0] - 2026-07-21
 
 ### Fixed — coordinator concurrency/durability plausibles P2/P10/P11 (H1420)

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "31abd637d86fc42db9979e31bb560b67f324147339e623ee9837002d2684e0e8",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -133,7 +133,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -169,7 +169,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -188,7 +188,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -207,7 +207,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -407,7 +407,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -426,7 +426,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "73398beb59c272ceb8bbcfdb1649e241a83d4f8447f1aae33c4c3c1e3e5e2862",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -464,7 +464,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -523,7 +523,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -554,7 +554,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -573,7 +573,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -591,7 +591,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -610,7 +610,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -667,7 +667,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -692,7 +692,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "687f9861e3dbcc3ec10f730330cd83a88348f8ef59d3a17383950c77e7bd03d2",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -721,7 +721,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -741,7 +741,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -759,8 +759,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "b31f864f8e8f8dd864140a13aac0625e4d8557340d6e307eb92adc508b706295",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -797,7 +797,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -855,7 +855,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -874,7 +874,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -893,7 +893,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -913,7 +913,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60",
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -935,7 +935,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -971,7 +971,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H805, root-fix for the H255 w06 store loss). The resolver is language-independent; both promotion paths import the SAME store_path.canonical_store and default --store to its result, so neither RU nor EN can silently drop promotions into a discarded worktree store. Strengthens promotion_claim_file_h336: both paths now lock the SAME canonical store path across worktrees. Deterministic selftest: python src/store_path.py --selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/store_path.py": "3a89cce449987ef448939d9e9a326c02e46ffaf4ce346f55aefe3f388cc00590",
+      "src/store_path.py": "4967ab7ea748da995367fd0520f89f4bf9a39b84c428310314291b85be26f73c",
       "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
@@ -994,7 +994,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -1023,10 +1023,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/headless_worker.py": "bc43daf54de2d9065d55a2d77a7b49c51303bcfdc4d0ac5cb7ed362e3936d4c7",
-      "src/pilot/max_account_orchestrator.py": "38f40e86db49b4294d6d5b789ebc65a84544a25e907eb86cfc0a157023f23038",
-      "src/pilot/coordinator.py": "b31f864f8e8f8dd864140a13aac0625e4d8557340d6e307eb92adc508b706295",
+      "src/pilot/max_account_orchestrator.py": "03a59329720faa2cdbb56dd71284128ef3db62e301fb650cf51d4a2d4fec3a68",
+      "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
       "src/pilot/headless_worker_selftest.py": "e6dbff6e754dc05fd77fc91a8f182671fb063420563f1454c0eba729a0caf1de",
-      "src/pilot/max_account_orchestrator_selftest.py": "6021af7fa4ff0415936e439290dfa7f8196b12afa4fca0a27b8f704841ebf685",
+      "src/pilot/max_account_orchestrator_selftest.py": "41d1060b729d2f2507224ee0c072b07437c01f2285405f528c70ab8bf7df40af",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
       "src/pilot/run_observability.py": "eb21e08ba4f0e7ab7ab5dacf9db4e4d0d38234f2d63385157735ca8d7b8ced61",
@@ -1054,7 +1054,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/window_reports.py": "bebcc79826bc74d676be5861f961c8aac3aa2f793f41bbe757c4fc02f0eb8720",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -1073,7 +1073,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -1098,7 +1098,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
       "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
       "src/pilot/audit_window_en.py": "73398beb59c272ceb8bbcfdb1649e241a83d4f8447f1aae33c4c3c1e3e5e2862",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -1120,7 +1120,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60",
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1140,7 +1140,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -1195,7 +1195,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "73398beb59c272ceb8bbcfdb1649e241a83d4f8447f1aae33c4c3c1e3e5e2862",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60"
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c"
     }
   },
   {
@@ -1308,7 +1308,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
       "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",
-      "src/pilot/window_selftest.py": "dc25dd1ee42f28307fbdb6a96eff2b2bd6f239280bb86019cf619ef0c8e9aa60",
+      "src/pilot/window_selftest.py": "e1f72d0b48a3df8fb57521f363ff6e7c713632d541b59536bba56d301bb82a7c",
       "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1370,7 +1370,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/store_path.py": "3a89cce449987ef448939d9e9a326c02e46ffaf4ce346f55aefe3f388cc00590",
+      "src/store_path.py": "4967ab7ea748da995367fd0520f89f4bf9a39b84c428310314291b85be26f73c",
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
       "src/pilot/ru_coverage.py": "bf08bc3e79a80907dfc7df4e59cead0c026e04cf9cc621359630daecc98b46c3"
     }
@@ -1391,9 +1391,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/bounded_staged_run.py": "01ce3b65e6303499937ba891c3478f3ff60bc879296a763af5e97a95e391ecba",
-      "src/pilot/bounded_supervisor.py": "225a4cc4153a02b3a3eec848e2529bf1329fb2258f59c317a70b8f6a80226081",
-      "src/pilot/max_account_orchestrator.py": "38f40e86db49b4294d6d5b789ebc65a84544a25e907eb86cfc0a157023f23038"
+      "src/pilot/bounded_staged_run.py": "ab9b060041449bacb6c1e81d18dad30387536002a7c9b95de1b549c0cb0ab927",
+      "src/pilot/bounded_supervisor.py": "d23e508463d5bca4e161e9a20769221186d85e7a68ef5c8e3878125997478446",
+      "src/pilot/max_account_orchestrator.py": "03a59329720faa2cdbb56dd71284128ef3db62e301fb650cf51d4a2d4fec3a68"
     }
   },
   {
@@ -1488,7 +1488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/stage2_pregate.py": "8f07422d3c416e32d1882f0777d56cc44ba781d19c8097fd9500ddefbfd22945",
-      "src/audit_translation.py": "99d89b13ce7d3ef75b2e4f5f2e79aedc57849e96354997eff995b95ca6f57096"
+      "src/audit_translation.py": "0c8bb16fb854f18f31ca0838bc18e436eb0e75f55a28ff0e8f1336c09dcb7016"
     }
   },
   {
@@ -1552,11 +1552,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1386 (22-07-2026, Fable 5 claude-fable-5). Every fix is language-neutral orchestration/persistence mechanics -- none introduces a --lang branch. Lane facts checked per the handoff: the frag TM half of C3 (build_frags/load_frag_tm/best_reusable) is --lang-parameterized so both lanes get it; the recursive harvest glob + D3 per-lease store_delta + P3g batch gate live in the RU staged/coordinator lane ONLY because the EN promote lane (promote_en.py) by design has no fragment harvest and no batch transaction (its INTENTIONAL-DIVERGENCE ruling is H1425 W3, unchanged); P3b is the EN lane's own seed feed; the h1209 rig (D1) is field-parameterized (payload['field']), so a future EN slice inherits prompt_common/chunking as-is; PWG_INPUT_DIR (P3f) is honored by both audit_window and audit_window_en. Pinned by bounded_staged_run_selftest tests l/m, window_selftest test_h1386_c3_frag_unblock_serves_replacement + test_h1386_d1_medium50_script_size_cap, promote_lock/promote_final_cards selftests, and the h1339_offline_bench deterministic signature (batch == per-lease).",
     "tracking": "H1386",
     "verified_sha256": {
-      "src/pilot/bounded_staged_run.py": "01ce3b65e6303499937ba891c3478f3ff60bc879296a763af5e97a95e391ecba",
-      "src/pilot/bounded_supervisor.py": "225a4cc4153a02b3a3eec848e2529bf1329fb2258f59c317a70b8f6a80226081",
-      "src/pilot/max_account_orchestrator.py": "38f40e86db49b4294d6d5b789ebc65a84544a25e907eb86cfc0a157023f23038",
+      "src/pilot/bounded_staged_run.py": "ab9b060041449bacb6c1e81d18dad30387536002a7c9b95de1b549c0cb0ab927",
+      "src/pilot/bounded_supervisor.py": "d23e508463d5bca4e161e9a20769221186d85e7a68ef5c8e3878125997478446",
+      "src/pilot/max_account_orchestrator.py": "03a59329720faa2cdbb56dd71284128ef3db62e301fb650cf51d4a2d4fec3a68",
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/coordinator.py": "b31f864f8e8f8dd864140a13aac0625e4d8557340d6e307eb92adc508b706295",
+      "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
       "src/promote_final_cards.py": "72e276422c5624d0849178c581f3267220050f5490cc09771b73ee7329dcef03",
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/pilot/audit_window.py": "3ef6a0ef43d12578733a8db72dafe4aa31d5a457c220a4abfacdc605417817f2",

--- a/RussianTranslation/src/audit_translation.py
+++ b/RussianTranslation/src/audit_translation.py
@@ -32,15 +32,20 @@ if HERE not in sys.path:
 from safe_filename import safe_name  # noqa: E402
 
 
-def _exact_exists(directory, name):
-    """Case-exact existence (Windows os.path.exists is case-insensitive)."""
+def _directory_names(directory):
+    """One case-exact directory snapshot; callers keep it scoped to a single audit run."""
     try:
-        return name in set(os.listdir(directory))
+        return set(os.listdir(directory))
     except OSError:
-        return False
+        return set()
 
 
-def merged_output_path(stem, out_dir=None):
+def _exact_exists(directory, name, names=None):
+    """Case-exact existence (Windows os.path.exists is case-insensitive)."""
+    return name in (_directory_names(directory) if names is None else names)
+
+
+def merged_output_path(stem, out_dir=None, exact_names=None):
     """B19 (H1339): resolve a wf key's merged output with the DUAL lookup the rest of the
     pipeline already uses (audit_window.quarantine / window_reports / run_real_test).
 
@@ -51,7 +56,7 @@ def merged_output_path(stem, out_dir=None):
     Returns the resolved path, or None when neither form exists."""
     out_dir = out_dir or OUT
     for name in (safe_name(stem) + '.merged.md', stem + '.merged.md'):
-        if _exact_exists(out_dir, name):
+        if _exact_exists(out_dir, name, exact_names):
             return os.path.join(out_dir, name)
     return None
 
@@ -67,9 +72,9 @@ def body(t):
     return t.split('===\n\n', 1)[1] if '===\n\n' in t else t
 
 
-def audit_unit(stem):
+def audit_unit(stem, out_names=None):
     rawp = os.path.join(IN, stem + '.raw.txt')
-    outp = merged_output_path(stem)          # B19: dual lookup, not a verbatim join
+    outp = merged_output_path(stem, exact_names=out_names)  # B19: dual lookup
     if not os.path.exists(rawp):
         return stem, None, ['NO-RAW']
     if outp is None:
@@ -130,8 +135,11 @@ def main():
     print('=== translation fidelity audit (%d units) ===' % len(stems))
     print('%-24s %-10s %-10s %-5s %s' % ('unit', 'ls s/o', 'san s/o', 'ru', 'flags'))
     fails = []
+    # H1430: case-exact lookup used to rebuild set(os.listdir(OUT)) up to twice per card.
+    # Snapshot only after collection has finished and keep it local to this audit invocation.
+    out_names = _directory_names(OUT)
     for s in stems:
-        stem, nums, flags = audit_unit(s)
+        stem, nums, flags = audit_unit(s, out_names=out_names)
         if nums is None:
             print('%-24s %s' % (stem[:24], ' '.join(flags)))
             fails.append(stem)

--- a/RussianTranslation/src/pilot/bounded_staged_run.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run.py
@@ -61,6 +61,7 @@ none. Model authored by Opus 4.8 (claude-opus-4-8[1m]) for handoff H963.
 """
 import argparse
 import json
+import math
 import os
 import sys
 
@@ -163,15 +164,28 @@ def _window_cost_usd(lease, wf_summary):
     falls back to a recorded numeric cost on the lease. Returns None — NOT 0 — when neither is
     available (the common case: H911 found run-event tokens 'not_recoverable'), so a cost
     ceiling fails the run closed rather than silently under-counting."""
-    tokens = (wf_summary or {}).get('subagent_tokens')
-    if isinstance(tokens, (int, float)) and not isinstance(tokens, bool):
+    summary = wf_summary if isinstance(wf_summary, dict) else {}
+    usage = summary.get('usage') if isinstance(summary.get('usage'), dict) else {}
+    if usage.get('cost_evaluable') is False:
+        return None
+    observed = usage.get('observed_cost_usd')
+    if (isinstance(observed, (int, float)) and not isinstance(observed, bool)
+            and math.isfinite(observed) and observed >= 0):
+        return observed
+    # Current headless workers put usage under summary.usage.  Preserve the old flat field
+    # for historical Workflow artifacts written before the headless envelope was introduced.
+    tokens = usage.get('subagent_tokens', summary.get('subagent_tokens'))
+    if (isinstance(tokens, (int, float)) and not isinstance(tokens, bool)
+            and math.isfinite(tokens) and tokens >= 0):
         return tokens * el.PRICE['input'] / 1e6
     cost = lease.get('cost') if isinstance(lease, dict) else None
-    if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+    if (isinstance(cost, (int, float)) and not isinstance(cost, bool)
+            and math.isfinite(cost) and cost >= 0):
         return cost
     if isinstance(cost, dict):
         usd = cost.get('est_cost_usd') if not cost.get('error') else None
-        if isinstance(usd, (int, float)) and not isinstance(usd, bool):
+        if (isinstance(usd, (int, float)) and not isinstance(usd, bool)
+                and math.isfinite(usd) and usd >= 0):
             return usd
     return None
 
@@ -191,11 +205,18 @@ def audit_from_coordinator(coord_state_path, wf_output, window):
     try:
         with open(coord_state_path, encoding='utf-8') as f:
             coord_state = json.load(f)
-    except (OSError, ValueError, TypeError):
-        coord_state = {}
+    except (OSError, ValueError, TypeError) as exc:
+        raise RuntimeError('coordinator state is unreadable: %s: %s'
+                           % (coord_state_path, exc)) from exc
+    if not isinstance(coord_state, dict):
+        raise RuntimeError('coordinator state is not a JSON object: %s' % coord_state_path)
     # H1339 A4: a requeue work-item audits its ORIGIN lease -- the rq item's own id
     # ('rq-NNN-<origin>') is a supervisor bookkeeping id, never a coordinator lease.
-    lease = _lease_by_id(coord_state, window.get('origin') or window['id']) or {}
+    lease_id = window.get('origin') or window['id']
+    lease = _lease_by_id(coord_state, lease_id)
+    if not isinstance(lease, dict):
+        raise RuntimeError('coordinator lease %s is missing from %s'
+                           % (lease_id, coord_state_path))
     pending = lease.get('pending_requeue') or {}
     requeue_keys = [k for k in (list(pending.get('transient') or []) +
                                 list(pending.get('defect') or [])) if k]
@@ -208,11 +229,21 @@ def audit_from_coordinator(coord_state_path, wf_output, window):
     wf_summary = {}
     try:
         with open(wf_output, encoding='utf-8') as f:
-            wf_summary = (json.load(f).get('summary') or {})
-    except (OSError, ValueError, TypeError):
-        wf_summary = {}
-    calls = int((wf_summary.get('translate_agents_spent') or 0) +
-                (wf_summary.get('heal_agents_spent') or 0))
+            wf_payload = json.load(f)
+        if not isinstance(wf_payload, dict):
+            raise TypeError('top level is not an object')
+        if 'summary' not in wf_payload or not isinstance(wf_payload['summary'], dict):
+            raise TypeError('summary is missing or is not an object')
+        wf_summary = wf_payload['summary']
+    except (OSError, ValueError, TypeError, AttributeError) as exc:
+        raise RuntimeError('workflow output is unreadable: %s: %s'
+                           % (wf_output, exc)) from exc
+    call_parts = [wf_summary.get('translate_agents_spent'),
+                  wf_summary.get('heal_agents_spent')]
+    if any(not isinstance(value, int) or isinstance(value, bool) or value < 0
+           for value in call_parts):
+        raise RuntimeError('workflow summary has invalid call counters: %s' % wf_output)
+    calls = sum(call_parts)
     return {
         'requeue_keys': requeue_keys,
         'satisfied_keys': satisfied,

--- a/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
@@ -300,6 +300,18 @@ def test_i_audit_from_coordinator(td):
     assert rep['satisfied_keys'] == [], rep
     assert rep['calls'] == 5, rep                                    # 4 + 1
     assert rep['cost'] is not None and rep['cost'] > 0, rep          # priced from tokens
+    with open(wf, 'w', encoding='utf-8') as f:
+        json.dump({'summary': {'translate_agents_spent': 1, 'heal_agents_spent': 0,
+                               'usage': {'subagent_tokens': 2_000_000,
+                                         'observed_cost_usd': 0.42,
+                                         'cost_evaluable': True}}}, f)
+    nested = bsr.audit_from_coordinator(coord_state_path, wf, {'id': 'no_pwg_w02'})
+    assert nested['cost'] == 0.42 and nested['calls'] == 1, nested
+    assert bsr._window_cost_usd({}, {'usage': {
+        'subagent_tokens': 2_000_000, 'cost_evaluable': False}}) is None
+    for invalid in (-1, float('nan'), float('inf')):
+        assert bsr._window_cost_usd({}, {'usage': {
+            'observed_cost_usd': invalid, 'cost_evaluable': True}}) is None
     # a zero-delta requeue window: the pending key is satisfied-not-failed
     with open(coord_state_path, 'w', encoding='utf-8') as f:
         json.dump({'leases': [{'id': 'no_pwg_w02', 'state': 'promoted', 'clean_count': 0,
@@ -307,7 +319,34 @@ def test_i_audit_from_coordinator(td):
                                'pending_requeue': {'transient': ['t~~h0_zz_pw'], 'defect': []}}]}, f)
     rep2 = bsr.audit_from_coordinator(coord_state_path, wf, {'id': 'no_pwg_w02', 'requeue': True})
     assert rep2['satisfied_keys'] == ['t~~h0_zz_pw'] and rep2['requeue_keys'] == [], rep2
-    print('  (i) audit_from_coordinator reads clean/requeue/satisfied/calls/cost from the lease: PASS')
+    for index, malformed_payload in enumerate((
+            {}, {'summary': None}, {'summary': []},
+            {'summary': {'translate_agents_spent': -1, 'heal_agents_spent': 0}})):
+        malformed_wf = os.path.join(td, 'malformed-wf-%d.json' % index)
+        with open(malformed_wf, 'w', encoding='utf-8', newline='\n') as f:
+            json.dump(malformed_payload, f)
+        try:
+            bsr.audit_from_coordinator(
+                coord_state_path, malformed_wf, {'id': 'no_pwg_w02', 'requeue': True})
+            raise AssertionError('malformed workflow summary/call counters were accepted')
+        except RuntimeError as exc:
+            assert 'workflow' in str(exc), exc
+    for bad_state, bad_wf, message in (
+            (os.path.join(td, 'missing-state.json'), wf, 'state'),
+            (coord_state_path, os.path.join(td, 'missing-wf.json'), 'output')):
+        try:
+            bsr.audit_from_coordinator(bad_state, bad_wf, {'id': 'no_pwg_w02'})
+            raise AssertionError('missing %s was accepted' % message)
+        except RuntimeError as exc:
+            assert message in str(exc), exc
+    with open(coord_state_path, 'w', encoding='utf-8') as f:
+        json.dump({'leases': []}, f)
+    try:
+        bsr.audit_from_coordinator(coord_state_path, wf, {'id': 'no_pwg_w02'})
+        raise AssertionError('missing coordinator lease was accepted')
+    except RuntimeError as exc:
+        assert 'lease no_pwg_w02 is missing' in str(exc), exc
+    print('  (i) audit_from_coordinator reads current usage and fails closed on missing artifacts: PASS')
 
 
 def test_j_stop_before_promote_awaiting_review(td):

--- a/RussianTranslation/src/pilot/bounded_supervisor.py
+++ b/RussianTranslation/src/pilot/bounded_supervisor.py
@@ -407,9 +407,38 @@ class BoundedSupervisor:
         try:
             with open(wf_output, encoding='utf-8') as f:
                 payload = json.load(f)
-        except (OSError, ValueError, TypeError):
-            return {'requeue_keys': [], 'clean_count': 0, 'cost': 0, 'satisfied_keys': []}
-        results = payload.get('results') or []
+        except (OSError, ValueError, TypeError) as exc:
+            # A missing/corrupt result is not an empty successful window. Returning a zeroed
+            # report here let an uncapped supervisor checkpoint the item as completed and later
+            # finish with STOP_CLEAN_TARGET despite having no auditable evidence.
+            raise RuntimeError(
+                'bounded_supervisor: default audit cannot read workflow output %r: %s'
+                % (wf_output, exc)) from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError(
+                'bounded_supervisor: default audit workflow output is not an object: %r'
+                % wf_output)
+        results = payload.get('results')
+        if not isinstance(results, list) or not results:
+            raise RuntimeError(
+                'bounded_supervisor: default audit requires a non-empty results list: %r'
+                % wf_output)
+        result_keys = []
+        for index, row in enumerate(results):
+            if (not isinstance(row, dict) or not isinstance(row.get('key'), str)
+                    or not row['key'].strip()):
+                raise RuntimeError(
+                    'bounded_supervisor: default audit result %d has no valid key: %r'
+                    % (index, wf_output))
+            result_keys.append(row['key'])
+        if len(set(result_keys)) != len(result_keys):
+            raise RuntimeError(
+                'bounded_supervisor: default audit result keys are not unique: %r' % wf_output)
+        expected_keys = item.get('keys') or item.get('subcards') or []
+        if expected_keys and set(result_keys) != set(expected_keys):
+            raise RuntimeError(
+                'bounded_supervisor: default audit result keys do not match window %s'
+                % item.get('id'))
         null_keys = [r.get('key') for r in results
                      if isinstance(r, dict) and r.get('key') and r.get('card') is None]
         defect_keys = []
@@ -417,8 +446,13 @@ class BoundedSupervisor:
             from sense_count import scan_sense_shortfall
             short = scan_sense_shortfall(results, self._ensure_input_dir())
             defect_keys = [s['key'] for s in short if s.get('key')]
-        except Exception:
-            defect_keys = []
+        except Exception as exc:
+            # The fallback exists specifically to enforce the H920 detector. If that detector
+            # crashes, treating its output as an empty defect set silently disables the gate and
+            # counts affected non-null cards clean. Preserve the pre-audit checkpoint instead.
+            raise RuntimeError(
+                'bounded_supervisor: default sense-shortfall gate crashed for %r: %s'
+                % (wf_output, exc)) from exc
         requeue = sorted(set(null_keys) | set(defect_keys))
         clean = sum(1 for r in results
                     if isinstance(r, dict) and r.get('key')

--- a/RussianTranslation/src/pilot/bounded_supervisor_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_supervisor_selftest.py
@@ -16,6 +16,7 @@ cases is exercised end to end:
       index/budget/backlog with NO completed window re-run
   (g) an already-promoted requeue key with zero store-delta is satisfied-not-failed
   (h) the offline default H920 auditor requeues a null card hermetically (no live gen)
+  (n) the offline default auditor fails closed on unreadable/empty output or a crashed sense gate
 
   python src/pilot/bounded_supervisor_selftest.py
 """
@@ -401,6 +402,62 @@ def test_m_calls_clean_survive_restart(td):
     print('  (m) call/clean counters persist across a checkpoint resume: PASS')
 
 
+def test_n_default_audit_fail_closed(td):
+    """The fallback auditor must never turn missing/corrupt evidence or a detector crash into
+    a zero-clean completed window. Either case would let an uncapped supervisor drain to the
+    misleading STOP_CLEAN_TARGET state with no trustworthy audit."""
+    plan = make_plan(1)
+
+    missing = os.path.join(td, 'missing-wf-output.json')
+    cp_missing = os.path.join(td, 'n-missing.json')
+    sup = BoundedSupervisor(plan, lambda _window: missing, cp_missing)
+    try:
+        sup.run()
+        raise AssertionError('unreadable workflow output must fail the fallback audit closed')
+    except RuntimeError as exc:
+        assert 'cannot read workflow output' in str(exc), exc
+    assert not os.path.exists(cp_missing), 'a failed audit must not checkpoint the window complete'
+
+    for index, payload in enumerate(({}, {'results': []}, {'results': [{}]},
+                                     {'results': [{'key': 'wrong', 'card': None}]})):
+        malformed = os.path.join(td, 'n-structural-%d.json' % index)
+        checkpoint = os.path.join(td, 'n-structural-%d.checkpoint.json' % index)
+        with open(malformed, 'w', encoding='utf-8', newline='\n') as f:
+            json.dump(payload, f)
+        sup = BoundedSupervisor(plan, lambda _window, path=malformed: path, checkpoint)
+        try:
+            sup.run()
+            raise AssertionError('structurally empty/mismatched workflow output was accepted')
+        except RuntimeError as exc:
+            assert 'default audit' in str(exc), exc
+        assert not os.path.exists(checkpoint), 'invalid result structure must not checkpoint'
+
+    wf = os.path.join(td, 'n-valid.json')
+    with open(wf, 'w', encoding='utf-8', newline='\n') as f:
+        json.dump({'meta': {}, 'results': [
+            {'key': 'k_0', 'card': {'records': [{'senses': [{'gloss': 'x'}]}]}},
+        ]}, f)
+    import sense_count
+    original_scan = sense_count.scan_sense_shortfall
+    cp_gate = os.path.join(td, 'n-gate.json')
+    try:
+        def crashed_gate(_results, _input_dir):
+            raise ValueError('synthetic detector crash')
+
+        sense_count.scan_sense_shortfall = crashed_gate
+        sup = BoundedSupervisor(plan, lambda _window: wf, cp_gate,
+                                input_dir=tempfile.mkdtemp(prefix='bs_gate_input_'))
+        try:
+            sup.run()
+            raise AssertionError('a crashed sense gate must fail the fallback audit closed')
+        except RuntimeError as exc:
+            assert 'sense-shortfall gate crashed' in str(exc), exc
+        assert not os.path.exists(cp_gate), 'a crashed gate must not checkpoint the window complete'
+    finally:
+        sense_count.scan_sense_shortfall = original_scan
+    print('  (n) default audit unreadable/empty/key-mismatch/gate-crash paths fail closed: PASS')
+
+
 def main():
     with tempfile.TemporaryDirectory() as td:
         test_a_window_count(td)
@@ -416,6 +473,7 @@ def main():
         test_k_cost_fail_closed(td)
         test_l_cost_unevaluable_harmless_without_ceiling(td)
         test_m_calls_clean_survive_restart(td)
+        test_n_default_audit_fail_closed(td)
     print('bounded_supervisor_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -1709,7 +1709,6 @@ def promote_ready(args):
             batch.append({'lease_id': lease['id'],
                           'glob': os.path.abspath(source),
                           'expected_subcards': sorted({row.get('key') for row in clean_rows})})
-        store_before = nonempty_line_count(promote_final_cards.DEFAULT_STORE)
         batch_dir = ready[0].get('artifact_dir') or paths()['artifacts']
         batch_manifest = os.path.join(batch_dir, 'batch_promotion.manifest.json')
         batch_report = os.path.join(batch_dir, 'batch_promotion.report.json')
@@ -1717,7 +1716,6 @@ def promote_ready(args):
         run_cmd([sys.executable, os.path.join(SRC, 'promote_final_cards.py'),
                  '--batch-manifest', batch_manifest, '--report', batch_report,
                  '--gen-model-version', args.gen_model_version])
-        store_after = nonempty_line_count(promote_final_cards.DEFAULT_STORE)
         # P10 (H1420): the batch promote above is all-or-nothing and raises on failure, so reaching
         # here means the store IS committed. From this point the RU TM MUST be rebuilt to match the
         # committed store -- otherwise a raise while reading the batch report or updating per-lease
@@ -1725,9 +1723,19 @@ def promote_ready(args):
         # partial-promotion raise still lands a consistent TM.
         try:
             try:
-                landed = json.load(open(batch_report, encoding='utf-8'))['leases']
-            except (OSError, KeyError, json.JSONDecodeError) as e:
+                batch_payload = json.load(open(batch_report, encoding='utf-8'))
+                if not isinstance(batch_payload, dict):
+                    raise TypeError('top level is not an object')
+                landed = batch_payload['leases']
+                store_before = batch_payload['store_rows_before']
+                store_after = batch_payload['store_rows_after']
+            except (OSError, KeyError, TypeError, json.JSONDecodeError) as e:
                 raise SystemExit('batch promotion report unreadable: %s' % e)
+            if (batch_payload.get('schema') != 'pwg.batch_promotion.v1'
+                    or not isinstance(landed, dict)
+                    or any(not isinstance(value, int) or isinstance(value, bool) or value < 0
+                           for value in (store_before, store_after))):
+                raise SystemExit('batch promotion report has invalid schema/store counters')
             for lease in ready:
                 per = landed.get(lease['id']) or {}
                 if lease.get('clean_count') and not per.get('subcards'):

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -33,7 +33,8 @@ CREATE TABLE IF NOT EXISTS accounts (
 CREATE TABLE IF NOT EXISTS jobs (
   id INTEGER PRIMARY KEY AUTOINCREMENT, external_id TEXT UNIQUE NOT NULL,
   argv_json TEXT NOT NULL DEFAULT '[]', cwd TEXT NOT NULL, output_path TEXT NOT NULL,
-  manifest_path TEXT, manifest_sha256 TEXT, result_sha256 TEXT, attempt_log_path TEXT,
+  manifest_path TEXT, manifest_sha256 TEXT, profile_slot TEXT,
+  result_sha256 TEXT, attempt_log_path TEXT,
   failure_class TEXT, reset_at INTEGER,
   coordinator_recorded INTEGER NOT NULL DEFAULT 0,
   state TEXT NOT NULL DEFAULT 'pending', assigned_acc TEXT, attempts INTEGER NOT NULL DEFAULT 0,
@@ -44,6 +45,17 @@ CREATE INDEX IF NOT EXISTS jobs_state_id ON jobs(state, id);
 """
 RATE_LIMIT = re.compile(r"rate.?limit|usage limit|too many requests|429", re.I)
 RESET_EPOCH = re.compile(r"(?:reset(?:s|_at)?|parked_until)[^0-9]{0,20}([0-9]{10})", re.I)
+
+
+def _profile_slot_from_manifest(manifest_path):
+    """Return a validated v2 profile slot, or None for unreadable/invalid legacy input."""
+    try:
+        with open(manifest_path, encoding='utf-8') as f:
+            manifest = json.load(f)
+        validate_manifest(manifest, require_v2=True)
+        return manifest['execution']['profile_slot']
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
 
 
 def is_rate_limited(worker_status, stderr):
@@ -92,6 +104,7 @@ def connect(path):
     existing = {row[1] for row in db.execute('PRAGMA table_info(jobs)')}
     for name, declaration in (
             ('manifest_path', 'TEXT'), ('manifest_sha256', 'TEXT'),
+            ('profile_slot', 'TEXT'),
             ('result_sha256', 'TEXT'), ('attempt_log_path', 'TEXT'),
             ('failure_class', 'TEXT'), ('reset_at', 'INTEGER'),
             ('coordinator_recorded', 'INTEGER NOT NULL DEFAULT 0')):
@@ -100,6 +113,16 @@ def connect(path):
     account_cols = {row[1] for row in db.execute('PRAGMA table_info(accounts)')}
     if 'validated' not in account_cols:
         db.execute('ALTER TABLE accounts ADD COLUMN validated INTEGER NOT NULL DEFAULT 0')
+    # Existing production databases may predate the profile_slot column. Recheck claim-relevant
+    # NULL rows on every connection so a crash after ALTER but before backfill cannot strand them.
+    # Historical completed rows are never reopened. Invalid active manifests receive an empty
+    # sentinel so an unrelated healthy scope does not reparse them on every connect(). cmd_run_once
+    # explicitly retries falsey bindings in its own scope, preserving repair-and-resume recovery.
+    for row in db.execute(
+            "SELECT id,manifest_path FROM jobs WHERE manifest_path IS NOT NULL "
+            "AND profile_slot IS NULL AND state IN ('pending','in_progress')"):
+        profile_slot = _profile_slot_from_manifest(row['manifest_path']) or ''
+        db.execute('UPDATE jobs SET profile_slot=? WHERE id=?', (profile_slot, row['id']))
     db.commit()
     return db
 
@@ -240,8 +263,9 @@ def _claim_tx(db, account, now, only_external_ids=None):
         return None
     scope_sql, scope_args = _scope_sql(only_external_ids)
     job = db.execute(
-        "SELECT * FROM jobs WHERE state='pending' AND attempts < max_attempts%s "
-        "ORDER BY id LIMIT 1" % scope_sql, scope_args).fetchone()
+        "SELECT * FROM jobs WHERE state='pending' AND attempts < max_attempts "
+        "AND (manifest_path IS NULL OR profile_slot=?)%s ORDER BY id LIMIT 1"
+        % scope_sql, (account,) + scope_args).fetchone()
     if not job:
         db.rollback()
         return None
@@ -497,15 +521,16 @@ def cmd_import_coordinator(args):
                 raise SystemExit('%s: %s' % (lease['id'], exc))
             if manifest['meta'].get('lang') != 'ru':
                 raise SystemExit('%s: H818 production default is RU only' % lease['id'])
+            profile_slot = manifest['execution']['profile_slot']
             keys = set(manifest['meta']['selected_keys'])
             overlap = keys & occupied
             if overlap:
                 raise SystemExit('%s: key overlap with queued/done job: %s' %
                                  (lease['id'], ','.join(sorted(overlap))))
             output = os.path.join(lease['artifact_dir'], 'workflow_result.headless.%s.json' % lease['id'])
-            db.execute('INSERT INTO jobs(external_id,cwd,output_path,manifest_path,manifest_sha256,max_attempts) VALUES(?,?,?,?,?,?)',
+            db.execute('INSERT INTO jobs(external_id,cwd,output_path,manifest_path,manifest_sha256,profile_slot,max_attempts) VALUES(?,?,?,?,?,?,?)',
                        (lease['id'], os.path.abspath(args.cwd), output, manifest_path,
-                        sha256_path(manifest_path), args.max_attempts))
+                        sha256_path(manifest_path), profile_slot, args.max_attempts))
             occupied.update(keys)
             added += 1
     db.close()
@@ -546,6 +571,7 @@ def cmd_import_requeue(args):
         raise SystemExit('%s: %s' % (args.lease_id, exc))
     if manifest['meta'].get('lang') != 'ru':
         raise SystemExit('%s: H818 production default is RU only' % args.lease_id)
+    profile_slot = manifest['execution']['profile_slot']
     external_id = '%s%s%02d-%s' % (args.lease_id, RQ_ID_SEP, number, kind)
     db = connect(args.db)
     existing = {row['external_id'] for row in db.execute('SELECT external_id FROM jobs')}
@@ -569,9 +595,9 @@ def cmd_import_requeue(args):
     output = os.path.join(adir, 'workflow_result.headless.%s.rq%02d-%s.json'
                           % (args.lease_id, number, kind))
     with db:
-        db.execute('INSERT INTO jobs(external_id,cwd,output_path,manifest_path,manifest_sha256,max_attempts) VALUES(?,?,?,?,?,?)',
+        db.execute('INSERT INTO jobs(external_id,cwd,output_path,manifest_path,manifest_sha256,profile_slot,max_attempts) VALUES(?,?,?,?,?,?,?)',
                    (external_id, os.path.abspath(args.cwd), output, manifest_path,
-                    sha256_path(manifest_path), args.max_attempts))
+                    sha256_path(manifest_path), profile_slot, args.max_attempts))
     db.close()
     print('imported=1 %s' % external_id)
     return external_id
@@ -688,11 +714,23 @@ def cmd_run_once(args):
         accounts = [a for a in accounts if a['name'] in only]
     runtime_mode = getattr(args, 'runtime_mode', 'standard')
     db = connect(args.db)
-    manifest_pending = scoped_job_count(
-        db, getattr(args, 'only_external_ids', None),
-        "state='pending' AND manifest_path IS NOT NULL")
+    scope_sql, scope_args = _scope_sql(getattr(args, 'only_external_ids', None))
+    manifest_rows = [dict(row) for row in db.execute(
+        "SELECT external_id,manifest_path,profile_slot,attempts,max_attempts FROM jobs "
+        "WHERE state='pending' AND manifest_path IS NOT NULL%s ORDER BY id" % scope_sql,
+        scope_args)]
+    # A falsey binding is the durable invalid-legacy sentinel. Retry only the selected scope so a
+    # repaired manifest can recover, without making every unrelated connect() reopen the bad file.
+    for row in manifest_rows:
+        if not row['profile_slot']:
+            repaired_slot = _profile_slot_from_manifest(row['manifest_path'])
+            if repaired_slot:
+                row['profile_slot'] = repaired_slot
+                db.execute('UPDATE jobs SET profile_slot=? WHERE external_id=?',
+                           (repaired_slot, row['external_id']))
+    db.commit()
     db.close()
-    if manifest_pending:
+    if manifest_rows:
         # Do not over-claim scheduler rows that the coordinator must reject. Generic jobs keep
         # their historical account fan-out because they do not consume translation runtime.
         # B16 (H1339): filter to CLAIM-ELIGIBLE accounts (validated + unparked -- the exact
@@ -703,6 +741,35 @@ def cmd_run_once(args):
         # account) never fired -- the bounded drain spun to its iteration ceiling instead.
         now_ts = int(time.time())
         accounts = [a for a in accounts if a['validated'] and a['parked_until'] <= now_ts]
+        missing_binding = [row['external_id'] for row in manifest_rows if not row['profile_slot']]
+        if missing_binding:
+            raise SystemExit('pending manifest job(s) have no valid profile binding: %s'
+                             % ','.join(missing_binding))
+        exhausted = [row['external_id'] for row in manifest_rows
+                     if row['attempts'] >= row['max_attempts']]
+        if exhausted:
+            raise SystemExit('pending manifest job(s) exhausted attempts: %s'
+                             % ','.join(exhausted))
+        required_slots = {row['profile_slot'] for row in manifest_rows}
+        eligible_slots = {account['name'] for account in accounts}
+        unavailable = sorted(required_slots - eligible_slots)
+        if unavailable:
+            raise SystemExit('pending manifest profile(s) have no eligible/probed account: %s'
+                             % ','.join(unavailable))
+        placeholders = ','.join('?' for _ in required_slots)
+        db = connect(args.db)
+        busy_rows = list(db.execute(
+            "SELECT assigned_acc,external_id FROM jobs WHERE state='in_progress' "
+            "AND assigned_acc IN (%s) ORDER BY id" % placeholders,
+            tuple(sorted(required_slots))))
+        db.close()
+        if busy_rows:
+            detail = ','.join('%s:%s' % (row['assigned_acc'], row['external_id'])
+                              for row in busy_rows)
+            raise SystemExit('pending manifest profile(s) are busy with active job(s): %s' % detail)
+        # Filter before the 3/4 concurrency slice. Otherwise alphabetically earlier accounts that
+        # own no pending job can cut a required later slot out of the dispatch pass forever.
+        accounts = [account for account in accounts if account['name'] in required_slots]
         accounts = accounts[:4 if runtime_mode == 'staged' else 3]
     work = []
     for acc in accounts:

--- a/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import builtins
 import json
 import os
 import sqlite3
@@ -39,6 +40,98 @@ def main():
     assert scope['expected_windows'] == 1 and scope['expected_headwords'] == 1
     print('  staged plan scope: prepared lease alone supplies the GO denominators')
 
+    # Schema migration reads historical manifests once, when profile_slot is added. Corrupt
+    # legacy rows stay NULL/unclaimable but must not be reopened on every scheduler connection.
+    with tempfile.TemporaryDirectory() as td:
+        legacy_db = os.path.join(td, 'legacy.sqlite')
+        legacy_schema = m.SCHEMA.replace(
+            'manifest_path TEXT, manifest_sha256 TEXT, profile_slot TEXT,',
+            'manifest_path TEXT, manifest_sha256 TEXT,')
+        assert legacy_schema != m.SCHEMA
+        con = sqlite3.connect(legacy_db)
+        con.executescript(legacy_schema)
+        valid_path = os.path.join(td, 'valid-manifest.json')
+        corrupt_path = os.path.join(td, 'corrupt-manifest.json')
+        with open(valid_path, 'w', encoding='utf-8') as f:
+            json.dump({'schema': 'pwg.headless_execution_manifest.v2',
+                       'model': 'claude-sonnet-5',
+                       'meta': {'lang': 'ru', 'selected_keys': ['legacy-key']},
+                       'execution': {'profile_slot': 'acc1',
+                                     'config_dir_fingerprint': config_dir_fingerprint(td),
+                                     'execution_route': 'claude-cli-headless',
+                                     'executor_lane': 'serial-whole-card',
+                                     'validation_method': 'audit_window+final_schema',
+                                     'model_identifier': 'claude-sonnet-5'},
+                       'key_provenance': {'legacy-key': 'real'}}, f)
+        with open(corrupt_path, 'w', encoding='utf-8') as f:
+            f.write('{')
+        for external_id, manifest_path in (
+                ('legacy-valid', valid_path), ('legacy-corrupt', corrupt_path)):
+            con.execute(
+                'INSERT INTO jobs(external_id,cwd,output_path,manifest_path) VALUES(?,?,?,?)',
+                (external_id, td, os.path.join(td, external_id + '.json'), manifest_path))
+        con.commit()
+        con.close()
+        migrated = m.connect(legacy_db)
+        assert migrated.execute(
+            "SELECT profile_slot FROM jobs WHERE external_id='legacy-valid'").fetchone()[0] == 'acc1'
+        assert migrated.execute(
+            "SELECT profile_slot FROM jobs WHERE external_id='legacy-corrupt'").fetchone()[0] == ''
+        now = m.now_iso()
+        for account in ('acc1', 'acc2'):
+            migrated.execute(
+                'INSERT INTO accounts(name,config_dir,validated,updated_at) VALUES(?,?,1,?)',
+                (account, os.path.join(td, account), now))
+        migrated.commit()
+        migrated.close()
+        # A healthy scoped run must not reopen the unrelated corrupt sentinel.
+        original_open = builtins.open
+        original_claim = m.claim
+        attempted = []
+        try:
+            def reject_corrupt_cross_scope(path, *args, **kwargs):
+                if os.path.abspath(os.fspath(path)) == os.path.abspath(corrupt_path):
+                    raise AssertionError('unrelated corrupt manifest was reparsed')
+                return original_open(path, *args, **kwargs)
+
+            def observe_claim(db_path, account, only_external_ids=None):
+                attempted.append((account, frozenset(only_external_ids or ())))
+                return None
+
+            builtins.open = reject_corrupt_cross_scope
+            m.claim = observe_claim
+            m.cmd_run_once(types.SimpleNamespace(
+                db=legacy_db, timeout=30, runtime_mode='standard', only_accounts=None,
+                only_external_ids={'legacy-valid'}))
+        finally:
+            builtins.open = original_open
+            m.claim = original_claim
+        assert attempted == [('acc1', frozenset({'legacy-valid'}))], attempted
+        with open(corrupt_path, 'w', encoding='utf-8') as f:
+            json.dump({'schema': 'pwg.headless_execution_manifest.v2',
+                       'model': 'claude-sonnet-5',
+                       'meta': {'lang': 'ru', 'selected_keys': ['restored-key']},
+                       'execution': {'profile_slot': 'acc2',
+                                     'config_dir_fingerprint': config_dir_fingerprint(td),
+                                     'execution_route': 'claude-cli-headless',
+                                     'executor_lane': 'serial-whole-card',
+                                     'validation_method': 'audit_window+final_schema',
+                                     'model_identifier': 'claude-sonnet-5'},
+                       'key_provenance': {'restored-key': 'real'}}, f)
+        original_claim = m.claim
+        try:
+            m.claim = lambda db_path, account, only_external_ids=None: None
+            m.cmd_run_once(types.SimpleNamespace(
+                db=legacy_db, timeout=30, runtime_mode='standard', only_accounts=None,
+                only_external_ids={'legacy-corrupt'}))
+        finally:
+            m.claim = original_claim
+        reopened = sqlite3.connect(legacy_db)
+        assert reopened.execute(
+            "SELECT profile_slot FROM jobs WHERE external_id='legacy-corrupt'").fetchone()[0] == 'acc2'
+        reopened.close()
+    print('  profile-slot migration: bad cross-scope sentinel stays cold; scoped repair revalidates')
+
     with tempfile.TemporaryDirectory() as td:
         scoped_db = os.path.join(td, 'scope.sqlite')
         m.main(['--db', scoped_db, 'init', '--account', 'acc=' + os.path.join(td, 'acc'),
@@ -60,6 +153,105 @@ def main():
             con, {'current'}, "state='done' AND coordinator_recorded=0")] == ['current']
         con.close()
     print('  staged scope: unrelated failed/history jobs excluded from claims and counts')
+
+    # A profile-bound v2 manifest is a scheduler constraint, not merely a worker-time check.
+    # Register accounts in the opposite order from the manifest owner and ask the wrong account
+    # first: it must not reserve the paid job. Generic argv jobs intentionally remain portable.
+    with tempfile.TemporaryDirectory() as td:
+        bound_db = os.path.join(td, 'profile-bound.sqlite')
+        acc1_dir = os.path.join(td, 'acc1')
+        acc2_dir = os.path.join(td, 'acc2')
+        m.main(['--db', bound_db, 'init',
+                '--account', 'acc2=' + acc2_dir, '--account', 'acc1=' + acc1_dir,
+                '--skip-profile-check'])
+        coord = os.path.join(td, 'coord')
+        artifacts = os.path.join(coord, 'artifacts', 'bound-acc1')
+        os.makedirs(artifacts)
+        manifest_path = os.path.join(artifacts, 'execution_manifest.json')
+        with open(manifest_path, 'w', encoding='utf-8') as f:
+            json.dump({'schema': 'pwg.headless_execution_manifest.v2',
+                       'model': 'claude-sonnet-5',
+                       'meta': {'lang': 'ru', 'selected_keys': ['bound-key']},
+                       'execution': {'profile_slot': 'acc1',
+                                     'config_dir_fingerprint': config_dir_fingerprint(acc1_dir),
+                                     'execution_route': 'claude-cli-headless',
+                                     'executor_lane': 'serial-whole-card',
+                                     'validation_method': 'audit_window+final_schema',
+                                     'model_identifier': 'claude-sonnet-5'},
+                       'key_provenance': {'bound-key': 'real'}}, f)
+        with open(os.path.join(coord, 'state.json'), 'w', encoding='utf-8') as f:
+            json.dump({'leases': [{'id': 'bound-acc1', 'state': 'prepared',
+                                   'artifact_dir': artifacts,
+                                   'execution_manifest': manifest_path}]}, f)
+        m.main(['--db', bound_db, 'import-coordinator', '--coord-dir', coord,
+                '--cwd', td, '--lease-id', 'bound-acc1'])
+        con = sqlite3.connect(bound_db)
+        assert con.execute(
+            "select profile_slot from jobs where external_id='bound-acc1'").fetchone()[0] == 'acc1'
+        con.close()
+        assert m.claim(bound_db, 'acc2') is None, 'wrong account claimed an acc1-bound manifest'
+        try:
+            m.cmd_run_once(types.SimpleNamespace(
+                db=bound_db, timeout=30, runtime_mode='standard',
+                only_accounts={'acc2'}, only_external_ids={'bound-acc1'}))
+            raise AssertionError('missing eligible owner must fail before a dispatch poll loop')
+        except SystemExit as exc:
+            assert 'no eligible/probed account: acc1' in str(exc), exc
+
+        m.main(['--db', bound_db, 'enqueue', '--external-id', 'generic',
+                '--argv-json', json.dumps(['x']), '--cwd', td,
+                '--output', os.path.join(td, 'generic.json')])
+        generic = m.claim(bound_db, 'acc2')
+        assert generic is not None and generic['external_id'] == 'generic'
+        m.finish(bound_db, generic['id'], 'done', 0)
+        bound = m.claim(bound_db, 'acc1')
+        assert bound is not None and bound['external_id'] == 'bound-acc1'
+    print('  profile-bound claims: wrong/missing owner refused loudly; generic job remains portable')
+
+    # Required profile selection happens before the standard three-account concurrency slice.
+    # Otherwise acc4 is permanently hidden behind three alphabetically earlier idle accounts.
+    with tempfile.TemporaryDirectory() as td:
+        slice_db = os.path.join(td, 'profile-slice.sqlite')
+        m.main(['--db', slice_db, 'init'] + [
+            part for n in range(1, 5)
+            for part in ('--account', 'acc%d=%s' % (n, os.path.join(td, 'a%d' % n)))
+        ] + ['--skip-profile-check'])
+        con = m.connect(slice_db)
+        with con:
+            con.execute(
+                'INSERT INTO jobs(external_id,cwd,output_path,manifest_path,profile_slot) '
+                'VALUES(?,?,?,?,?)', ('late-slot', td, os.path.join(td, 'late.json'),
+                                     os.path.join(td, 'manifest.json'), 'acc4'))
+        con.close()
+        original_claim = m.claim
+        attempted = []
+        try:
+            def observe_claim(db_path, account, only_external_ids=None):
+                attempted.append(account)
+                return None
+
+            m.claim = observe_claim
+            m.cmd_run_once(types.SimpleNamespace(
+                db=slice_db, timeout=30, runtime_mode='standard', only_accounts=None,
+                only_external_ids={'late-slot'}))
+        finally:
+            m.claim = original_claim
+        assert attempted == ['acc4'], attempted
+        con = m.connect(slice_db)
+        with con:
+            con.execute(
+                "INSERT INTO jobs(external_id,cwd,output_path,state,assigned_acc) "
+                "VALUES(?,?,?,'in_progress','acc4')",
+                ('unrelated-active', td, os.path.join(td, 'busy.json')))
+        con.close()
+        try:
+            m.cmd_run_once(types.SimpleNamespace(
+                db=slice_db, timeout=30, runtime_mode='standard', only_accounts=None,
+                only_external_ids={'late-slot'}))
+            raise AssertionError('busy required profile must fail before a bounded poll loop')
+        except SystemExit as exc:
+            assert 'acc4:unrelated-active' in str(exc), exc
+    print('  profile-bound dispatch: late slot selected before slice; busy owner fails loudly')
 
     with tempfile.TemporaryDirectory() as td:
         db = os.path.join(td, 'q.sqlite')
@@ -750,7 +942,10 @@ def main():
                     '--output', os.path.join(td, 'runtime%d.json' % n)])
         con = m.connect(db)
         with con:
-            con.execute("UPDATE jobs SET manifest_path='fixture.json', manifest_sha256='fixture'")
+            con.execute("UPDATE jobs SET manifest_path='fixture.json', manifest_sha256='fixture', "
+                        "profile_slot='acc1' WHERE external_id='runtime0'")
+            con.execute("UPDATE jobs SET manifest_path='fixture.json', manifest_sha256='fixture', "
+                        "profile_slot='acc2' WHERE external_id='runtime1'")
         con.close()
         receipt = m.write_probe_receipt(
             td, 'runtime-test', ['runtime0', 'runtime1'], {'acc1': 10, 'acc2': 11})

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3870,6 +3870,7 @@ def test_coordinator_mixed_lane_public_state_sequence():
     old_coord = os.environ.get('PWG_COORDINATOR_DIR')
     original_run = coordinator.run_cmd
     original_store = coordinator.promote_final_cards.DEFAULT_STORE
+    original_count = coordinator.nonempty_line_count
     with tempfile.TemporaryDirectory() as tmp:
         os.environ['PWG_COORDINATOR_DIR'] = tmp
         store = os.path.join(tmp, 'store.jsonl')
@@ -3938,6 +3939,8 @@ def test_coordinator_mixed_lane_public_state_sequence():
                 report_arg = cmd[cmd.index('--report') + 1]
                 batch_spec = json.load(open(batch_arg, encoding='utf-8'))
                 leases_out = {}
+                with open(store, encoding='utf-8') as f:
+                    before = sum(1 for line in f if line.strip())
                 with open(store, 'a', encoding='utf-8') as f:
                     for item in batch_spec:
                         subs = item.get('expected_subcards') or []
@@ -3947,6 +3950,9 @@ def test_coordinator_mixed_lane_public_state_sequence():
                                                         'rows': len(subs)}
                 with open(report_arg, 'w', encoding='utf-8') as f:
                     json.dump({'schema': 'pwg.batch_promotion.v1',
+                               'store_rows_before': before,
+                               'store_rows_after': before + sum(
+                                   row['rows'] for row in leases_out.values()),
                                'leases': leases_out}, f)
             return SimpleNamespace(returncode=0, stdout='', stderr='')
 
@@ -3988,6 +3994,8 @@ def test_coordinator_mixed_lane_public_state_sequence():
             coordinator.save_state(state)
 
         coordinator.run_cmd = fake_run
+        coordinator.nonempty_line_count = lambda _path: (_ for _ in ()).throw(
+            AssertionError('coordinator must use transaction report counts, not rescan store'))
         try:
             record(result_file('initial.json', ['a~~x', 'b~~x']))
             lease = coordinator.load_state()['leases'][0]
@@ -4008,6 +4016,8 @@ def test_coordinator_mixed_lane_public_state_sequence():
             lease = coordinator.load_state()['leases'][0]
             if lease['state'] != 'promoted_partial':
                 fail('mixed backlog promotion did not remain promoted_partial')
+            if (lease.get('store_before'), lease.get('store_after'), lease.get('store_delta')) != (0, 1, 1):
+                fail('promotion did not persist transaction-reported store counts')
 
             set_attempt(2, 'defect', 'b~~x', coordinator.empty_pending_requeue())
             record(result_file('retry-b.json', ['b~~x']))
@@ -4017,12 +4027,17 @@ def test_coordinator_mixed_lane_public_state_sequence():
                 fail('final clean defect retry did not drain the pending backlog')
             coordinator.promote_ready(SimpleNamespace(
                 gen_model_version='claude-sonnet-5', lease_id=['lease']))
-            if coordinator.load_state()['leases'][0]['state'] != 'promoted':
+            final_lease = coordinator.load_state()['leases'][0]
+            if final_lease['state'] != 'promoted':
                 fail('drained mixed retry sequence did not finish promoted')
+            if (final_lease.get('store_before'), final_lease.get('store_after'),
+                    final_lease.get('store_delta')) != (1, 2, 1):
+                fail('second promotion did not use transaction-reported store counts')
             if audit_specs:
                 fail('mixed-lane integration did not consume every planned audit')
         finally:
             coordinator.run_cmd = original_run
+            coordinator.nonempty_line_count = original_count
             coordinator.promote_final_cards.DEFAULT_STORE = original_store
             if old_coord is None:
                 os.environ.pop('PWG_COORDINATOR_DIR', None)
@@ -6383,6 +6398,16 @@ def test_h1339_b10_b19_audit_chain_routing():
         fail('dual lookup must still find the verbatim form')
     if at.merged_output_path('absent', out_dir=d) is not None:
         fail('a genuinely missing output must resolve to None')
+    # H1430: one per-audit name snapshot preserves exact-case behavior and is not global/stale.
+    snap = at._directory_names(d)
+    if at.merged_output_path('MITRA', out_dir=d, exact_names=snap) is not None:
+        fail('snapshot lookup accepted the wrong filename case')
+    with open(os.path.join(d, 'fresh.merged.md'), 'w', encoding='utf-8') as f:
+        f.write('x')
+    if at.merged_output_path('fresh', out_dir=d, exact_names=snap) is not None:
+        fail('an existing per-audit snapshot unexpectedly changed after collection')
+    if not at.merged_output_path('fresh', out_dir=d, exact_names=at._directory_names(d)):
+        fail('a fresh audit snapshot missed a file created by collection')
     # B19 wiring: both defect sites route through the shared resolver.
     for fname in ('audit_translation.py', 'stage2_pregate.py'):
         text = open(os.path.join(SRC, fname), encoding='utf-8').read()
@@ -6988,7 +7013,9 @@ def test_h1420_p10_promote_rebuilds_tm_in_finally():
                     # the per-lease loop raises AFTER the store is committed (the P10 window).
                     report = cmd[cmd.index('--report') + 1]
                     with open(report, 'w', encoding='utf-8') as f:
-                        json.dump({'leases': {'lease': {}}}, f)
+                        json.dump({'schema': 'pwg.batch_promotion.v1',
+                                   'store_rows_before': 10, 'store_rows_after': 11,
+                                   'leases': {'lease': {}}}, f)
                 elif 'translation_memory.py' in ' '.join(cmd) and 'build' in cmd:
                     tm_builds.append(cmd)
                 return SimpleNamespace(returncode=0, stdout='', stderr='')

--- a/RussianTranslation/src/store_path.py
+++ b/RussianTranslation/src/store_path.py
@@ -30,6 +30,7 @@ with no trace of w06 except the RUN_LOG record. See
 The default is loss-safety: a worktree run persists to the canonical store unless it *opts out*
 by setting `$PWG_RU_STORE` to a scratch path.
 """
+import functools
 import os
 import subprocess
 import sys
@@ -42,32 +43,69 @@ STORE_REL = 'RussianTranslation/src/pwg_ru_translated.jsonl'
 
 
 def _git(start_dir, *args):
-    """Run `git -C <start_dir> <args>` and return stripped stdout ('' on any failure)."""
-    return subprocess.run(
+    """Run `git -C <start_dir> <args>` and return stripped stdout.
+
+    Failure must raise: callers may cache successful checkout identity, but must never cache a
+    transient Git failure as the loss-unsafe conclusion that a linked worktree is standalone.
+    """
+    proc = subprocess.run(
         ['git', '-C', start_dir, *args],
         stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
         encoding='utf-8', errors='replace',
-    ).stdout.strip()
+    )
+    if proc.returncode:
+        raise subprocess.CalledProcessError(proc.returncode, proc.args)
+    output = proc.stdout.strip()
+    if not output:
+        raise RuntimeError('git returned an empty repository path')
+    return output
 
 
-def main_worktree_root(start_dir):
+@functools.lru_cache(maxsize=64)
+def _main_worktree_root_cached(start_dir):
     """Return the MAIN worktree toplevel if `start_dir` is inside a LINKED worktree, else None.
 
     A linked worktree's git common-dir is `<MAIN>/.git` while its own toplevel is the linked
     directory; the MAIN checkout's common-dir is `<TOP>/.git` (its parent == the toplevel). So
     `dirname(common-dir) != toplevel` iff we are in a linked worktree.
     """
-    try:
-        common = _git(start_dir, 'rev-parse', '--path-format=absolute', '--git-common-dir')
-        top = _git(start_dir, 'rev-parse', '--show-toplevel')
-    except Exception:
-        return None
-    if not common or not top:
-        return None
+    common = _git(start_dir, 'rev-parse', '--path-format=absolute', '--git-common-dir')
+    top = _git(start_dir, 'rev-parse', '--show-toplevel')
     main = os.path.dirname(os.path.normpath(common))
     if os.path.normpath(main) == os.path.normpath(top):
         return None            # this IS the main checkout
     return main                # a linked worktree -> the main root
+
+
+def _has_git_marker(start_dir):
+    """Cheap error-path check: is this directory nested under a .git file/directory?"""
+    current = os.path.abspath(start_dir)
+    while True:
+        if os.path.exists(os.path.join(current, '.git')):
+            return True
+        parent = os.path.dirname(current)
+        if parent == current:
+            return False
+        current = parent
+
+
+def main_worktree_root(start_dir):
+    """Resolve once per normalized directory for the lifetime of this Python process.
+
+    Canonical store/sidecar helpers are hot during harness construction.  On Windows each
+    uncached lookup launches two Git processes, so the old implementation spent seconds
+    repeatedly rediscovering an immutable property of the checkout.
+    """
+    normalized = os.path.normcase(os.path.abspath(start_dir))
+    try:
+        return _main_worktree_root_cached(normalized)
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        # Non-git directories legitimately fall back to the local path. Inside a checkout, however,
+        # an unresolved identity must fail closed: using local_default for even one linked-worktree
+        # store write recreates the H255 loss mode. Exceptions are not cached, so a retry can recover.
+        if _has_git_marker(normalized):
+            raise RuntimeError('cannot resolve Git worktree identity for %s' % normalized) from exc
+        return None
 
 
 def canonical_store(local_default, store_rel=STORE_REL):
@@ -119,6 +157,55 @@ def selftest():
         lp = os.path.join(d, 'pwg_ru_translated.jsonl')
         assert canonical_store(lp) == lp, canonical_store(lp)
         assert main_worktree_root(d) is None
+    # 2b. repeated/lexically-equivalent paths share one cached Git resolution.
+    _original_git = globals()['_git']
+    calls = []
+    try:
+        _main_worktree_root_cached.cache_clear()
+        globals()['_git'] = lambda start, *args: (
+            calls.append((start, args)) or
+            (os.path.join(start, '.git') if '--git-common-dir' in args else start))
+        probe = os.path.join('scratch', 'checkout')
+        assert main_worktree_root(probe) is None
+        assert main_worktree_root(os.path.join(probe, '.')) is None
+        assert len(calls) == 2, calls
+    finally:
+        globals()['_git'] = _original_git
+        _main_worktree_root_cached.cache_clear()
+    # 2c. a transient Git failure is not cached as a standalone-worktree result.
+    calls = []
+    try:
+        _main_worktree_root_cached.cache_clear()
+        marker_root = tempfile.mkdtemp(prefix='store_path_linked_')
+        linked = os.path.join(marker_root, 'linked')
+        main = os.path.join(marker_root, 'main')
+        os.makedirs(linked)
+        os.makedirs(main)
+        with open(os.path.join(linked, '.git'), 'w', encoding='utf-8') as f:
+            f.write('gitdir: synthetic')
+
+        def fail_once_then_linked(start, *args):
+            calls.append((start, args))
+            if len(calls) == 1:
+                raise OSError('synthetic transient Git failure')
+            return (os.path.join(main, '.git') if '--git-common-dir' in args else
+                    linked)
+
+        globals()['_git'] = fail_once_then_linked
+        try:
+            main_worktree_root(linked)
+            raise AssertionError('a Git failure inside a checkout must fail closed')
+        except RuntimeError as exc:
+            assert 'cannot resolve Git worktree identity' in str(exc), exc
+        assert main_worktree_root(linked) == main
+        assert main_worktree_root(linked) == main
+        assert len(calls) == 3, calls
+    finally:
+        globals()['_git'] = _original_git
+        _main_worktree_root_cached.cache_clear()
+        if 'marker_root' in locals():
+            import shutil
+            shutil.rmtree(marker_root)
     # 3. inside a LINKED worktree -> resolve to the MAIN checkout store (H818 D-E: this is the
     # resolution translation_memory.DEFAULT_STORE now shares with promote_final_cards, so a
     # worktree run's post-promotion TM rebuild targets the MAIN store, not a vanishing local one).

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,23 @@ not an error.
 
 ## [Unreleased]
 
+### Fixed
+
+- pwg_ru offline control-plane audit + hardening (Codex Sol `gpt-5.6-sol`, 21-07 audit
+  [`docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md);
+  stranded branch salvaged, rebased onto the merged H1386 landing set and re-gated by Fable 5
+  `claude-fable-5`): profile-bound manifest-v2 claim binding (an account can no longer claim a
+  manifest bound to another profile; unavailable/parked/unprobed/busy owners fail loudly),
+  corrupt/missing audit evidence and a crashed sense-shortfall detector fail the bounded run
+  before checkpointing (was a synthetic zero-clean success), cost telemetry read at its real
+  `summary.usage` schema path with unevaluable/negative/NaN/infinite figures fail-closed, and
+  store-path/promotion perf (cached immutable main-worktree discovery, one case-exact
+  output-dir snapshot per audit, receipt row counters instead of two full 26 MB store scans —
+  frozen-fixture smoke 17.842→11.354 s, −36.4%, identical output signature; FINDINGS §462).
+  Union of this branch + the H1386 set re-gated green: `window_selftest` 180/180 twice under
+  random hash seeds, `lang_parity_check` 73 entries no drift (38 hashes re-affirmed post-rebase),
+  orchestrator/bounded/supervisor/headless/promote/store_path selftests all PASS.
+
 ## [1.54.0] — 22-07-2026
 
 ### Fixed

--- a/docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md
+++ b/docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md
@@ -86,7 +86,9 @@ semantics to drift.
    [`run_claimed`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/max_account_orchestrator.py#L333).
    **Disposition:** fixed on the repair branch. Imported jobs persist `profile_slot`; manifest jobs
    are claimable only by that account; old valid v2 rows are backfilled; invalid rows stay
-   unclaimable. A reverse-order regression protects the contract.
+   unclaimable. Required owners are selected before the concurrency slice, and a missing,
+   unprobed, parked, busy, or attempt-exhausted owner now stops loudly instead of polling forever.
+   Reverse-order, late-roster-slot, missing-owner, and migration regressions protect the contract.
 
 2. **Recorded output is not bound to the worker attempt at ingestion.** The scheduler records a
    result hash, but `record-done` checks only that the path exists and omits the coordinator run ID.
@@ -161,8 +163,9 @@ semantics to drift.
 
 An instrumented Windows profile found canonical path resolution launched 88 Git subprocesses in a
 small preflight (4.50 s of 5.29 s). Caching checkout identity per normalized directory is process-
-local and semantics-preserving; environment store/TM overrides remain outside the cache. Promotion
-also scanned the 26 MB canonical store twice although its receipt already had exact row counts.
+local and semantics-preserving; environment store/TM overrides remain outside the cache, and Git
+failures are deliberately not cached. Promotion also scanned the 26 MB canonical store twice
+although its receipt already had exact row counts.
 
 The frozen H1339 fixture was run once before and once after (`warmups=0`, `runs=1`, identical
 Python/platform/fixture). This is a smoke comparison, not a statistical benchmark, but the output
@@ -178,10 +181,11 @@ signature was exactly identical:
 | Store write | 4.270 s | 1.989 s | -53.4% |
 | **Total** | **17.842 s** | **11.354 s** | **-36.4%** |
 
-Next low-risk speed work is to snapshot directory names once per audit rather than rebuilding
-`set(os.listdir(...))` per card. Higher-risk work is to avoid full harness rebuilds per preflight
-partition, cache TM/denylist reads by file signature, move scans outside the claim lock, and add
-cohort dispatch.
+The final low-risk pass also snapshots directory names once per audit rather than rebuilding
+`set(os.listdir(...))` per card; that landed after the frozen comparison above, so its incremental
+effect is deliberately not included in the −36.4% claim. Higher-risk work is to avoid full harness
+rebuilds per preflight partition, cache TM/denylist reads by file signature, move scans outside the
+claim lock, and add cohort dispatch.
 
 ## Verification specification
 

--- a/docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md
+++ b/docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md
@@ -1,0 +1,210 @@
+# Pipeline audit: PWG Russian translation
+
+**Auditor:** Codex (GPT-5), with three independent read-only audit passes  
+**Audit date:** 2026-07-21 (Europe/Moscow)  
+**Repository:** `gasyoun/SanskritLexicography`  
+**Immutable audit base:** [`50c6c5aa5d622a878b4966e1fee1a75e4b359a90`](https://github.com/gasyoun/SanskritLexicography/tree/50c6c5aa5d622a878b4966e1fee1a75e4b359a90)  
+**Repair branch:** `codex/rt-pipeline-hardening-20260721`  
+**Scope:** `RussianTranslation`, from prepared lease through headless execution, audit,
+promotion, translation-memory rebuild, checkpoint/resume, and offline tests.  
+**Not exercised:** paid Claude generation, live account probes, canonical-store promotion,
+network APIs, publication export, or deployment. The audit used source inspection, temporary
+fixtures, and hermetic self-tests only.
+
+## Executive assessment
+
+The content gates and deterministic regression coverage are strong, but the control plane is not
+yet transactionally closed end to end. The highest risks sit between otherwise well-tested stages:
+an account could claim a manifest bound to another profile; a worker result can be replaced after
+its hash was recorded but before ingestion; a store commit can outlive its receipt and translation-
+memory rebuild; and campaign cost/call limits omit some paid calls. Several error paths also turned
+unreadable artifacts into empty reports.
+
+The audited path is usable for bounded attended work after the repairs on this branch, but
+unattended multi-profile scale-out should wait for the remaining P0 attempt-binding,
+promotion-reconciliation, and campaign-ledger work. The current “bounded staged” driver probes a
+fleet but drains one lease synchronously, so extra profiles mostly add probe cost, not throughput.
+
+## Actual production call graph
+
+```text
+no_pwg_scale_plan.py
+  -> perf_preflight.py + gen_opt_harness2.py
+  -> coordinator.register_prepared_lease()
+
+bounded_staged_run.py --execute
+  -> probe_fleet()                         # paid readiness calls
+  -> BoundedSupervisor.run()               # one lease/window, synchronous
+     -> max_account_orchestrator.import-coordinator/import-requeue
+     -> max_account_orchestrator.run-once
+        -> coordinator begin-run
+        -> run_claimed()
+           -> headless_worker.py
+              -> validate_manifest()/validate_profile()/ActiveCallClaim
+              -> Claude CLI batches, retries, splits and healing
+              -> workflow result + status artifacts
+     -> max_account_orchestrator.record-done
+        -> coordinator record-output
+           -> normalize_workflow_result()
+           -> audit_window.py
+              -> collect + schema + NWS + semantic + sense + style gates
+           -> clean output + ready/ready_partial/needs_requeue state
+     -> coordinator promote-ready
+        -> promote_final_cards.py --batch-manifest
+           -> claim + backup + canonical-store replace + denylist + report
+        -> per-lease coordinator state update
+        -> RU TM build/build-frags/validate
+     -> outer audit/accounting/checkpoint
+```
+
+`max_account_orchestrator.py staged-run` is a second monolithic entry point over much of the same
+path. Maintaining both has allowed runtime-mode, coordinator-directory, accounting, and resume
+semantics to drift.
+
+## Capability and ownership map
+
+| Concern | Owning component | Current behavior | Audit verdict |
+|---|---|---|---|
+| Lease preparation | [`coordinator.py`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/coordinator.py) | Reserves inputs and emits sealed manifests | Strong gates; preflight parse failures can fail open |
+| Profile contract | [`execution_contract.py`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/execution_contract.py) | Validates v2 route/profile/model at worker start | Correct, but was enforced after scheduler claim |
+| Fleet dispatch | [`max_account_orchestrator.py`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/max_account_orchestrator.py#L217) | SQLite claims, one active job/account, threaded workers | Profile and result/run binding were incomplete |
+| Bounded stop/resume | [`bounded_supervisor.py`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/bounded_supervisor.py#L244) | Window/call/clean/cost/empty bounds, replace checkpoint | Some inputs failed open; checkpoint not fsync-durable |
+| Live staged wrapper | [`bounded_staged_run.py`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/bounded_staged_run.py#L179) | Probes once, drains one lease, promotes, audits | Serial despite a fleet; usage-path drift |
+| Content audit | [`audit_window.py`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/audit_window.py) | Parallel deterministic gates and requeue artifacts | Exception/report and quarantine semantics need hardening |
+| Canonical promotion | [`promote_final_cards.py`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/promote_final_cards.py#L509) | Batch merge and atomic store replacement | Receipt/TM/coordinator state are outside the transaction |
+| Translation memory | [`translation_memory.py`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/translation_memory.py) | Rebuilt and validated after promotion | Correct target resolution; repeated sidecar loads cost time |
+| Observability | [`run_observability.py`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/run_observability.py) | Append-only events and census | Not the single atomic source for campaign spend |
+
+## Ranked findings and repair disposition
+
+### P0 — fix before unattended scale-out
+
+1. **Scheduler claim ignored manifest profile binding.** The claim transaction selected the first
+   pending row without filtering `execution.profile_slot`; validation occurred only after an
+   attempt was consumed. Reverse queue/account order could burn all attempts as configuration
+   failures. Base evidence: [`_claim_tx`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/max_account_orchestrator.py#L217) and
+   [`run_claimed`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/max_account_orchestrator.py#L333).
+   **Disposition:** fixed on the repair branch. Imported jobs persist `profile_slot`; manifest jobs
+   are claimable only by that account; old valid v2 rows are backfilled; invalid rows stay
+   unclaimable. A reverse-order regression protects the contract.
+
+2. **Recorded output is not bound to the worker attempt at ingestion.** The scheduler records a
+   result hash, but `record-done` checks only that the path exists and omits the coordinator run ID.
+   An old or replaced file can be audited under a newer attempt. Evidence:
+   [`result_sha256` recording](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/max_account_orchestrator.py#L388),
+   [`cmd_record_done`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/max_account_orchestrator.py#L632), and
+   [optional run guard](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/coordinator.py#L1373).
+   **Disposition:** open. Persist the run/attempt ID, re-hash immediately before ingestion, require
+   `--run-id` for automated jobs, and compare result execution/provenance with the sealed manifest.
+
+3. **Store commit, receipt, coordinator state, and TM rebuild are not one recoverable
+   transaction.** The canonical store is replaced before the non-atomic report write, and
+   reconciliation begins only after the child returns. A crash can leave a committed store, a
+   `ready` lease, and stale TM. Evidence:
+   [`os.replace`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/promote_final_cards.py#L598),
+   [report write](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/promote_final_cards.py#L621), and
+   [coordinator invocation](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/coordinator.py#L1669).
+   **Disposition:** open. Write an atomic fsynced receipt with before/after store hashes and make
+   startup/promotion reconcile receipt, store, lease state, and TM idempotently.
+
+4. **Cost/call ceilings do not cover the campaign.** Readiness probes occur before the supervisor
+   ledger; failed/malformed calls can lack usage; limits are checked after a complete window.
+   Evidence: [`probe call site`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/bounded_staged_run.py#L665) and
+   [post-window accounting](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/bounded_supervisor.py#L268).
+   **Disposition:** partially fixed. Current worker `summary.usage.observed_cost_usd` and nested
+   tokens are now read correctly. One atomic campaign ledger must still reserve before every
+   probe/model spawn.
+
+### P1 — correctness, recovery, and throughput
+
+5. **Missing/corrupt audit inputs could become zero-progress completion.** The live wrapper replaced
+   unreadable coordinator/output JSON and a missing lease with empty dictionaries, then checkpointed
+   the window as completed. Base evidence: [`audit_from_coordinator`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/bounded_staged_run.py#L179).
+   **Disposition:** fixed on the repair branch; these paths now raise before checkpointing.
+
+6. **Default audit failures could produce an all-clean synthetic report.** An unreadable Workflow
+   payload or a crashed sense gate was converted to empty defects. **Disposition:** fixed on the
+   repair branch; both fail closed and have a no-checkpoint regression.
+
+7. **Bounded resume and custom coordinator routing have known local fixes not integrated into the
+   audit base.** Normal windows returning `None` could complete silently; scope recovery passed the
+   wrong object; direct promotion/requeue subprocesses could lose `PWG_COORDINATOR_DIR`. Fixes exist
+   on the active dirty local branch `h1386-post-h1339-review-fixes` (`d46ccc6d`, `3e119790`).
+   **Disposition:** do not duplicate or cherry-pick from an active dirty worktree; reconcile those
+   focused commits after its owner finishes.
+
+8. **Bounded staging is serial.** One supervisor item is one lease and `run_window` blocks through
+   dispatch, audit, and promotion. Up to four profiles are probed, but only one lease is drained
+   before the next item. Evidence: [`one-lease runner`](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/bounded_staged_run.py#L414) and
+   [synchronous supervisor](https://github.com/gasyoun/SanskritLexicography/blob/50c6c5aa5d622a878b4966e1fee1a75e4b359a90/RussianTranslation/src/pilot/bounded_supervisor.py#L268).
+   **Disposition:** open, assigned to the Fable 5 handoff after P0 prerequisites. Dispatch a bounded
+   cohort, audit per lease, then perform one batch promotion/TM rebuild per accepted wave.
+
+9. **Safety parses fail open.** Queued-manifest parse failures are ignored when deriving occupied
+   keys; malformed canonical-store rows can be skipped; required preflight parse failures can
+   proceed without a blocking price. **Disposition:** open; partial censuses and malformed required
+   artifacts must fail with exact file/line diagnostics.
+
+10. **Parked-account checks are wider than the dispatch allow-list.** A healthy excluded account
+    can mask that all admitted accounts are parked, causing a hot loop. **Disposition:** open; count
+    only the probed/admitted fleet.
+
+### P2 — durability, performance, and maintenance
+
+11. Critical replace-based writers do not consistently flush/fsync files and parent directories.
+12. Promotion and coordinator subprocesses lack operation deadlines and process-tree timeouts.
+13. Threaded audit exceptions can escape before a blocked report is written; NWS quarantine can
+    mutate global output before the whole audit accepts.
+14. Documentation mixes historical Max Workflow instructions with the headless production route.
+
+## Performance evidence
+
+An instrumented Windows profile found canonical path resolution launched 88 Git subprocesses in a
+small preflight (4.50 s of 5.29 s). Caching checkout identity per normalized directory is process-
+local and semantics-preserving; environment store/TM overrides remain outside the cache. Promotion
+also scanned the 26 MB canonical store twice although its receipt already had exact row counts.
+
+The frozen H1339 fixture was run once before and once after (`warmups=0`, `runs=1`, identical
+Python/platform/fixture). This is a smoke comparison, not a statistical benchmark, but the output
+signature was exactly identical:
+`da1341e6ac112bf83c7c521d194f698aa39da067075b636463fa6748c43fb629`.
+
+| Stage | Before | After | Change |
+|---|---:|---:|---:|
+| Prepare | 4.862 s | 5.153 s | +6.0% (single-run noise) |
+| Normalize | 0.094 s | 0.056 s | -40.4% |
+| Audit | 8.616 s | 4.156 s | -51.8% |
+| Promotion plan | 0.748 s | 0.364 s | -51.3% |
+| Store write | 4.270 s | 1.989 s | -53.4% |
+| **Total** | **17.842 s** | **11.354 s** | **-36.4%** |
+
+Next low-risk speed work is to snapshot directory names once per audit rather than rebuilding
+`set(os.listdir(...))` per card. Higher-risk work is to avoid full harness rebuilds per preflight
+partition, cache TM/denylist reads by file signature, move scans outside the claim lock, and add
+cohort dispatch.
+
+## Verification specification
+
+1. Mutate a completed output after its recorded hash; `record-done` must refuse before audit.
+2. Begin run A, release, begin run B, then submit A's output; run binding must refuse while B stays
+   running.
+3. Fault-inject after store replace but before report write; restart must reconcile TM and lease
+   state without duplicate promotion.
+4. Under `max_calls=0/1/3`, count probes, malformed calls, retries, failures, and successes in one
+   ledger and prove the bound is never exceeded.
+5. Feed missing, malformed, and over-ceiling preflight through both preparation entry points; all
+   must refuse unless an audited override exists.
+6. Block two or three fake profile workers on a barrier; prove peak concurrency, deterministic
+   store bytes, exact per-window accounting, one promotion/TM rebuild per wave, and crash-safe
+   resume without re-launching completed work.
+7. Make each threaded audit gate raise; require a complete blocked report and requeue-all with no
+   global quarantine mutation.
+
+## Recommended sequence
+
+1. Land the current fail-closed/profile-binding/path-cache/store-scan repairs.
+2. Reconcile the focused H1386 resume/routing commits after that worktree is no longer active.
+3. Implement attempt/result/run binding.
+4. Add the atomic promotion receipt and startup reconciliation.
+5. Add the campaign-wide call/cost reservation ledger.
+6. Only then implement Fable 5's cohort scheduler and measure 1/2/3-profile scaling.


### PR DESCRIPTION
Salvage of the stranded `codex/rt-pipeline-hardening-20260721` branch — authored by Codex Sol (`gpt-5.6-sol`) 21-07 ~23:30 local in its own worktree, never pushed (the session then claimed and landed H1386 via [PR #667](https://github.com/gasyoun/SanskritLexicography/pull/667) instead, leaving this complementary work orphaned). Rebased, reconciled and re-gated by Fable 5 (`claude-fable-5`).

## What this lands

- **Independent 3-pass control-plane audit** — [docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md](https://github.com/gasyoun/SanskritLexicography/blob/codex/rt-pipeline-hardening-20260721/docs/PIPELINE_AUDIT_pwg_ru_2026-07-21.md) (210 lines, base `50c6c5aa`): a defect set disjoint from the H1386 30-agent review — attempt-binding, claim/profile binding, promotion reconciliation, campaign cost-ledger gaps.
- **Fixes for its own findings**: profile-bound manifest-v2 claim binding (an account can no longer claim a manifest bound to another profile; unavailable/parked/unprobed/busy owners fail loudly); corrupt/missing audit evidence and a crashed sense-shortfall detector fail the bounded run *before* checkpointing (was a synthetic zero-clean success); cost telemetry read at its real `summary.usage` path, unevaluable/negative/NaN/inf fail-closed.
- **Measured perf** ([FINDINGS §462](https://github.com/gasyoun/SanskritLexicography/blob/codex/rt-pipeline-hardening-20260721/FINDINGS.md)): cached immutable main-worktree discovery (88 git subprocesses → cached; 4.50 s of a 5.29 s preflight), one case-exact output-dir snapshot per audit, receipt row counters instead of two full 26 MB store scans — frozen-fixture smoke **17.842 → 11.354 s (−36.4%)** with the exact output signature retained.

## Reconciliation notes (dual-run adjudication)

- Overlaps H1386 in **files**, not in **defects** — all code files auto-merged cleanly on rebase; only the two `.ai_state.md` journals (both-sides-append, both kept) and 37 pure hash-line hunks in [LANG_PARITY.md](https://github.com/gasyoun/SanskritLexicography/blob/codex/rt-pipeline-hardening-20260721/RussianTranslation/LANG_PARITY.md) conflicted (verified zero non-hash conflict content; 38 entries re-affirmed via `--update-hash` on the union).
- Codex's RT-changelog section carried a `[1.50.0] — 21-07` header for a version that already shipped with different content — moved under `[Unreleased]`; gate figures updated from its pre-merge 176/72 to the as-landing union numbers.

## Gates (union of this branch + merged H1386 set)

- `window_selftest` **180/180**, twice, under random hash seeds
- `lang_parity_check` **73 entries, no drift**
- `max_account_orchestrator` / `bounded_staged_run` / `bounded_supervisor` / `headless_worker` / `promote_final_cards --selftest` / `store_path --selftest` — all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)