### PR TITLE
chore(release): 1.55.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.51.0
-date-released: "2026-07-21"
+version: 1.55.0
+date-released: "2026-07-22"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported
   headword lists, AI-produced Russian translations of Monier-Williams and

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.55.0] - 2026-07-22
+
 ### Fixed — offline control-plane audit and speed hardening (Codex)
 
 - Profile-bound manifest-v2 jobs are now claimed only by their configured account; required slots

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.55.0] — 22-07-2026
+
 ### Fixed
 
 - pwg_ru offline control-plane audit + hardening (Codex Sol `gpt-5.6-sol`, 21-07 audit


### PR DESCRIPTION
Promote [Unreleased] to 1.55.0 in [changelog.md](https://github.com/gasyoun/SanskritLexicography/blob/release-1.55.0/changelog.md) and [RussianTranslation/CHANGELOG.md](https://github.com/gasyoun/SanskritLexicography/blob/release-1.55.0/RussianTranslation/CHANGELOG.md) (the [PR #672](https://github.com/gasyoun/SanskritLexicography/pull/672) Codex control-plane audit + hardening salvage); sync CITATION.cff to 1.55.0 / 2026-07-22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)