### PR TITLE
chore(release): 1.56.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.55.0
+version: 1.56.0
 date-released: "2026-07-22"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.56.0] — 22-07-2026
+
 ### Added
 
 - Alexey Vigasin corpus (`literature/md/Alexey_Vigasin/`) — full-text `.mdx` conversions of


### PR DESCRIPTION
## Summary
- Promotes [Unreleased] (Vigasin corpus landing) to 1.56.0, syncs CITATION.cff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)