### PR TITLE
chore(release): 1.57.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.56.0
+version: 1.57.0
 date-released: "2026-07-22"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.57.0] — 22-07-2026
+
 ### Fixed
 
 - **`bounded_staged_run.py` CLI: `--claude-bin` was dereferenced but never defined** — the


### PR DESCRIPTION
Promote [Unreleased] to [1.57.0] — 22-07-2026 (H1447 c4 live-gate packet + prepared medium50 plan; bounded_staged_run CLI --claude-bin fix) and sync CITATION.cff. Tag + GitHub release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)