### PR TITLE
H1456: PWG per-sense <ls>-loci export for kosha sense-reconciliation

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2503,6 +2503,29 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ✅ Completed (Recent only)
 
+- **H1456 🔴 EXECUTED — PWG per-sense `<ls>`-loci export for kosha sense-reconciliation
+  (22-07-2026, Sonnet 5 `claude-sonnet-5`).** `microstructure.py export_sense_loci` (new
+  command) walks each PWG record's numbered/lettered sense tree (REUSE:
+  `header()`/`split_senses()`/`clean_de()`, no new modeling) and emits
+  `slp1 hom sense_id gloss_de ls_loci` — `ls_loci` = that leaf sense's `<ls>` citations
+  `;`-joined **verbatim** (raw abbrev + locus, unresolved — resolution to a bibliographic
+  source name is kosha step 2's job, reusing the same `pwg_sources.py`). Full run: 123,366
+  records → 189,301 leaf-sense rows, 106,082 distinct headwords, 89.3% non-empty `ls_loci`;
+  byte-identical on re-run (deterministic). `nAgadanta`/`nAgadantaka` smoke test passes
+  exactly per the H1456 goal condition: 1a⊇"Elephantenzahn"+MBH, 1b⊇"Pflock"+PAÑCAT,
+  `nAgadantaka` 1b⊇HIT. **Found + fixed in scope:** PWG Nachträge back-references glue two
+  sense markers directly together with no separating space ("1〉b〉 <ls>…</ls>" — 2,273
+  occurrences in `pwg.txt`); `MARK`'s whitespace-before lookbehind made the second marker
+  invisible, silently misattributing the addendum's locus to the parent sense instead of the
+  referenced one (confirmed live: `nAgadanta`'s KATHĀS. 76,24 addendum was landing on sense
+  '1' instead of '1b', which would have wrongly failed to corroborate the PAÑCAT peg sense).
+  Fixed via a local-only `ADJACENT_MARKERS` space-insertion preprocess inside `leaf_senses()`
+  — never touches the shared `MARK`/`split_senses` used by `sense_node()`/`portrait()`
+  elsewhere in this file, so zero behavior change for any other caller. Output:
+  `src/pwg_sense_loci.tsv` (gitignored, regenerable) + committed
+  `src/pwg_sense_loci.sample.tsv` (500 headword groups, 2,742 rows, deterministic selection,
+  forces in the smoke-test pair). `/handoff-close H1456` next.
+
 - **H1447 🔴 EXECUTED — medium50 c4 live-gated start: LIVE_GO derived, starter STOPPED at
   fleet probe, 0 production calls (22-07-2026, Fable 5 `claude-fable-5`).** Terminal packet:
   [`pwg_ru/h1447/H1447_C4_LIVE_GATE_2026-07-22.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h1447/H1447_C4_LIVE_GATE_2026-07-22.md).

--- a/RussianTranslation/.gitignore
+++ b/RussianTranslation/.gitignore
@@ -87,6 +87,13 @@ src/pilot/output/prompt_rule_audit.md
 # Local API retry ledger
 src/corpus_lexicon.failures.jsonl
 
+# H1456 PWG per-sense <ls>-loci export (microstructure.py export_sense_loci) —
+# full run over all ~123k PWG records, regenerable, not a deliverable (same
+# policy as the other derived tsvs above). The committed sample is the
+# deliverable's reviewable/testable slice — never gitignore that one.
+src/pwg_sense_loci.tsv
+!src/pwg_sense_loci.sample.tsv
+
 # H215 corpus TM TMX export (build_tmx.py) — rights-encumbered (mixes in-copyright
 # named modern RU translations); no public release before per-translator clearance
 # (H215 Slice 5 / /publish-safety-check). Generator + README are committed.

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,23 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added — PWG per-sense `<ls>`-loci export for kosha sense-reconciliation (H1456)
+
+- `microstructure.py export_sense_loci` — new command, reuses the existing
+  `header()`/`split_senses()`/`clean_de()` sense-tree parser (no rewrite). Emits
+  `pwg_sense_loci.tsv` (`slp1 hom sense_id gloss_de ls_loci`, one row per leaf sense;
+  `ls_loci` = that sense's `<ls>` citations `;`-joined verbatim, unresolved) — the sole
+  external input to kosha's
+  [sense-reconciliation plan](https://github.com/gasyoun/kosha/blob/main/docs/PLAN_KOSHA_SENSE_RECONCILIATION_2026H2.md).
+  Full run: 123,366 records → 189,301 rows, 106,082 headwords, 89.3% non-empty `ls_loci`,
+  byte-identical on re-run. Fixed in scope: PWG Nachträge back-references glue two sense
+  markers together with no separating space ("1〉b〉…", 2,273 occurrences), which the
+  shared `MARK` regex's whitespace lookbehind couldn't see — misattributing the addendum's
+  locus to the parent sense; fixed via a local-only preprocess inside the new export path,
+  the shared parser used elsewhere in this file is untouched. `pwg_sense_loci.tsv` is
+  gitignored (regenerable); `pwg_sense_loci.sample.tsv` (500 headwords, 2,742 rows) is
+  committed.
+
 ### Added — plan: finish the Publication-Grade Sa→Ru TM (H215) as three parallel tracks
 
 - `/ask` layered plan for **finishing** [H215](https://github.com/gasyoun/Uprava/blob/main/handoffs/H215-Opus_RussianTranslation_pwg_ru_publication_grade_tm_tmx_and_oral_06.07.26.md)'s

--- a/RussianTranslation/src/microstructure.py
+++ b/RussianTranslation/src/microstructure.py
@@ -12,6 +12,9 @@ Deterministic (no LLM). Turns a flat PWG record into:
 
   python microstructure.py card <key1> [h]
   python microstructure.py sample [N]      first N a-section homonym cards
+  python microstructure.py export_sense_loci [out.tsv] [--limit N]
+      H1456 — per-leaf-sense <ls>-loci export consumed by kosha's sense-
+      reconciliation join (docs/PLAN_KOSHA_SENSE_RECONCILIATION_2026H2.md).
 """
 import json, os, re, sys, collections
 sys.stdout.reconfigure(encoding='utf-8')
@@ -251,6 +254,97 @@ def pretty(p):
         print('  (no corpus attestation)')
 
 
+# ---- H1456: PWG per-sense <ls>-loci export (kosha sense-reconciliation input) ----
+# Contract (ARCHITECTURE_KOSHA_SENSE_RECONCILIATION.md, this export's sole external
+# consumer): one row `slp1 hom sense_id gloss_de ls_loci` per leaf sense, `ls_loci`
+# = that sense's <ls> citations `;`-joined VERBATIM (raw abbrev + locus). Resolving
+# the abbreviation to a bibliographic source name is the *downstream* (kosha step 2)
+# job, reusing this same pwg_sources.py — not done here.
+LS_ATTR = re.compile(r'<ls\b([^>]*)>(.*?)</ls>', re.S)
+
+
+def _cite_clean(s):
+    s = re.sub(r'<lb[^>]*>', ' ', s)
+    s = re.sub(r'<[^>]+>', ' ', s)
+    return re.sub(r'\s+', ' ', s).strip().rstrip('.').strip()
+
+
+def ls_citations(text):
+    """Verbatim <ls> citation strings for one sense segment. A continuation
+    citation like <ls n="PAÑCAT.">252,10</ls> carries its source in the `n=`
+    attribute, not the inner text (PWG convention for repeated-source runs) —
+    reattach it so the citation stays self-contained rather than a bare,
+    sourceless locus."""
+    out = []
+    for attrs, inner in LS_ATTR.findall(text):
+        nm = NATTR_AB.search(attrs)
+        src = _cite_clean(nm.group(1)) if nm else ''
+        loc = _cite_clean(inner)
+        cite = ('%s %s' % (src, loc)).strip() if src else loc
+        if cite:
+            out.append(cite)
+    return out
+
+
+# A PWG Nachträge (supplement) back-reference glues two markers directly
+# together with no separating space — "1〉b〉 <ls>…</ls>." pointing at an
+# EXISTING sense 1b of the main entry (2,273 occurrences in pwg.txt). MARK's
+# lookbehind requires whitespace/—/start before a marker, so the second
+# marker (immediately after the first's closing glyph) is invisible to
+# split_senses and the whole addendum silently falls into sense '1' instead
+# of '1b' — misattributing its <ls> locus to the wrong sense. Insert the
+# missing space so split_senses sees both markers; scoped to this export's
+# own body copy only, never touching the shared split_senses/MARK used by
+# sense_node/portrait elsewhere in this file.
+ADJACENT_MARKERS = re.compile(r'([)〉])(?=(?:\d{1,2}|[a-z])[)〉])')
+
+
+def leaf_senses(buf):
+    """Yield (slp1, hom, sense_id, gloss_de, ls_loci) for one PWG record's
+    numbered/lettered leaf senses. `sense_id` = the microstructure sense path
+    (n + sub, e.g. '1a'/'1b'/'3a'). Note: PWG Nachträge (supplement) entries
+    reference an existing sense by number in their OWN <L> record (e.g. a
+    bare "1〉b〉 <ls>…</ls>" addendum) — such a record contributes an
+    ADDITIONAL row under the same (slp1, hom, sense_id) key, not a merge; a
+    consumer wanting the full loci set for a sense must group by that key."""
+    k1, k2, h = header(buf)
+    if not k1:
+        return
+    slp1 = cg.form_key(k1)
+    body = ADJACENT_MARKERS.sub(r'\1 ', '\n'.join(buf[1:]))
+    for seg in split_senses(body):
+        if seg['n'] == '0':
+            continue  # pre-sense head text — not a numbered/lettered leaf sense
+        sense_id = seg['n'] + (seg['sub'] or '')
+        gloss_de = clean_de(seg['text'])[:200]
+        ls_loci = ';'.join(ls_citations(seg['text']))
+        yield slp1, h, sense_id, gloss_de, ls_loci
+
+
+def cmd_export_sense_loci(args):
+    args = list(args)
+    limit = None
+    if '--limit' in args:
+        i = args.index('--limit')
+        limit = int(args[i + 1])
+        del args[i:i + 2]
+    out_path = args[0] if args else os.path.join(HERE, 'pwg_sense_loci.tsv')
+    n_records = n_rows = 0
+    headwords = set()
+    with open(out_path, 'w', encoding='utf-8', newline='\n') as f:
+        f.write('slp1\thom\tsense_id\tgloss_de\tls_loci\n')
+        for buf in pwg_mask.records(limit):
+            n_records += 1
+            for slp1, hom, sense_id, gloss_de, ls_loci in leaf_senses(buf):
+                f.write('%s\t%s\t%s\t%s\t%s\n' % (slp1, hom, sense_id, gloss_de, ls_loci))
+                n_rows += 1
+                headwords.add(slp1)
+    print('records scanned: %d' % n_records, file=sys.stderr)
+    print('leaf-sense rows: %d' % n_rows, file=sys.stderr)
+    print('distinct headwords (slp1): %d' % len(headwords), file=sys.stderr)
+    print('written: %s' % out_path, file=sys.stderr)
+
+
 def cmd_card(args):
     target = args[0]
     h = args[1] if len(args) > 1 else None
@@ -276,7 +370,9 @@ def cmd_sample(args):
 def main():
     if len(sys.argv) < 2:
         print(__doc__); return
-    {'card': cmd_card, 'sample': cmd_sample}.get(sys.argv[1], lambda *_: print(__doc__))(sys.argv[2:])
+    {'card': cmd_card, 'sample': cmd_sample,
+     'export_sense_loci': cmd_export_sense_loci}.get(
+        sys.argv[1], lambda *_: print(__doc__))(sys.argv[2:])
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pwg_sense_loci.sample.tsv
+++ b/RussianTranslation/src/pwg_sense_loci.sample.tsv
@@ -1,0 +1,2743 @@
+slp1	hom	sense_id	gloss_de	ls_loci
+nAgadanta		1	1〉 m	
+nAgadanta		1a	a〉 Elephantenzahn, Elfenbein H. an. 4,111 . MED. t. 203 . MBH. 12,3630	H. an. 4,111;MED. t. 203;MBH. 12,3630
+nAgadanta		1b	b〉 Pflock in der Wand zum Anhängen von Sachen H. 1011 . H. an. MED. PAÑCAT. 116,19 . 252,10	H. 1011;H. an;MED;PAÑCAT. 116,19;PAÑCAT 252,10
+nAgadanta		2	2〉 f. ( adj. comp. ) N. pr. einer Apsaras R. 2,91,17	R. 2,91,17
+nAgadanta		3	3〉 f. ( adj. comp. )	
+nAgadanta		3a	a〉 N. einer Pflanze, Tiaridium indicum Lehm. H. an. MED. RATNAM. 35 . SUŚR. 1,138,12 . 2,62,6 . 102,9 . 284,8 . 387,16	H. an;MED;RATNAM. 35;SUŚR. 1,138,12;SUŚR 2,62,6;SUŚR. 2, 102,9;SUŚR. 2, 284,8;SUŚR. 2, 387,16
+nAgadanta		3b	b〉 = MED. , welches ŚKDR. und WILS. hier durch Hure erklären: aber H. an. hat statt dessen eine best. Arzeneipflanze	MED;ŚKDR;WILS;H. an
+nAgadanta		1	1〉	
+nAgadanta		1b	b〉 KATHĀS. 76,24	KATHĀS. 76,24
+nAgadantaka		1	1〉 m	
+nAgadantaka		1a	a〉 Elfenbein VARĀH. BṚH. S. 52,62	VARĀH. BṚH. S. 52,62
+nAgadantaka		1b	b〉 Pflock in der Wand zum Anhängen von Sachen AK. 3,4,31,238 . HIT. 27,12 . Schol. zu KĀTY. ŚR. 644,4	AK. 3,4,31,238;HIT. 27,12;KĀTY. ŚR. 644,4
+nAgadantaka		2	2〉 f. N. einer Pflanze, Tragia involucrata L. RATNAM. 69	RATNAM. 69
+A	1	1	1〉 oder wenn man sich auf Etwas besinnt Kār. im BHĀṢYA _zu_ P. 1,1,14 . AK. 3,4,32,1 . ( COL. 3,4,28,1 ). H. an. 7,1 . MED. avy. 3 (statt ist zu lesen). P. 1,1,14 , Sch. ( v. l. ) PRAB. 46 . 4 .⫽print	BHĀṢYA;P. 1,1,14;AK. 3,4,32,1;COL. 3,4,28,1;H. an. 7,1;MED. avy. 3;P. 1,1,14;PRAB. 46;PRAB 4
+A	1	2	2〉 (aber nach COLEBR. ) diess. P. 1,1,14 , Sch	COLEBR;P. 1,1,14
+A	1	3	3〉 MED	MED
+A	1	4	4〉 MED. — ŚĀK. 44,12 und 85,15 , v. l. ist wohl ( s. u. ) für zu lesen; PRAB. 111,15 haben die Scholien gleichfalls st. . — Die Interjection geht nach P. 1,1,14 ( vgl. die Kār. dazu) keine euphonische	MED;ŚĀK. 44,12;ŚĀK 85,15;PRAB. 111,15;P. 1,1,14
+A	2	1	1〉 adv	
+A	2	1a	a〉 her, herzu: ṚV. 1,10,11 . 17,3 . AV. 3,4,5 . 6,35,1 . 18,4,49 . In dieser Bedeutung überaus häufig in Verbindung mit Verben der Bewegung	ṚV. 1,10,11;ṚV. 1, 17,3;AV. 3,4,5;AV 6,35,1;AV 18,4,49
+A	2	1b	b〉 anreihend: dazu, ferner, auch, und: ṚV. 1,83,4 . 24,12 . 3,31,3 . 10,17,10 . 3,16,5 . 2,14,7 . 1,48,16 . 7,2 . 150,1 . 4,11,1 . 12,2	ṚV. 1,83,4;ṚV. 1, 24,12;ṚV 3,31,3;ṚV 10,17,10;ṚV 3,16,5;ṚV 2,14,7;ṚV 1,48,16;ṚV. 1, 7,2;ṚV. 1, 150,1;ṚV 4,11,1;ṚV. 4, 12,2
+A	2	1c	c〉 steigernd und hervorhebend: zumal, ganz, gar; nicht selten dient es nur um auf das Wort, nach welchem es steht, den Nachdruck zu werfen. ṚV. 1,38,10 . 37,6 . 6,45,33 . 59,2 . 2,12,15 . 4,7 . 7,20,2	ṚV. 1,38,10;ṚV. 1, 37,6;ṚV 6,45,33;ṚV. 6, 59,2;ṚV 2,12,15;ṚV 4,7;ṚV 7,20,2;ṚV 1,134,3;ṚV 10,11,6;ṚV. 10, 22,3;AV. 6,33,1;AV 7,22,1;ŚAT. BR. 14,7,2,20;BṚH. ĀR. UP. 4,4,16;ŚAT. BR 9,2,3,44;KENOP. 29;NIR. 3,13;ŚAṂK;KENOP. 19
+A	2	1d	d〉 zur Verstärkung oder näheren Bestimmung verschiedener praepp. dienend; bei ṚV. 9,67,23 . 73,5 . 6 . 2,38,7 . 1,9,3 . S. u. d. Ww	ṚV. 9,67,23;ṚV 73,5;ṚV. 9, 6;ṚV 2,38,7;ṚV 1,9,3
+A	2	2	2〉 praep	
+A	2	2a	a〉 zu — hin, bis an, bis zu, bis auf, bevor: α〉 mit vorang. acc. : [Page1-0582] ṚV. 7,32,4 . 9,66,12 . 54,2 . 8,83,6 . 7,43,4 . — β〉 mit folg. acc. , häufig im ŚAT. BR. in Verbindung mit , wozu ein Ze	ṚV. 7,32,4;ṚV 9,66,12;ṚV. 9, 54,2;ṚV 8,83,6;ṚV 7,43,4;ŚAT. BR;ŚAT. BR 1,6,2,3;ŚAT. BR 2,2,3,3;ŚAT. BR. 2,2, 4,12;ŚAT. BR. 2, 3,4,2;ŚAT. BR 4,1,3,4;ŚAT. BR 11,5,1,4;ŚAT. BR. 11,5,1, 11;P. 2,1,13;P. 2, 3,10;ṚV. 3,53,20;VS. 4,9;AV. 7,59,1;AV 12,4,16;AV 18,3,62;AV 1,14,3;ŚAT. BR. 10,2,1,9;ŚAT. BR 3,1,3,9;ŚAT. BR 12,8,3,17;ŚAT. BR 4,2,4,5;ŚAT. BR 1,5,2,9;ŚAT. BR 2,4,2,21;ŚAT. BR 3,2,1,7;ŚAT. BR 14,4,2,9;BṚH. ĀR. UP. 1,4,4;ŚAT. BR 10,4,4,4;KĀTY. ŚR. 2,2,2;KĀTY. ŚR. 2, 6,9;KĀTY. ŚR 12,4,1;KĀTY. ŚR. 12, 6,18;M. 2,22;M. 2, 167;M. 2, 38;M. 2, 101;M. 2, 108;M. 2, 171;M. 2, 243;M. 2, 244;M 3,279;M 4,137;M 5,88;M. 2, 158;M 6,31;M 9,70;M. 2, 89;M 10,64;M. 2, 91;M. 2, 104;YĀJÑ. 3,23;MBH. 1,4405;BHAG. 8,16;R. 1,6,25;R 2,32,32;R. 2,32, 38;R 3,34,23;R. 3, 46,2;R 4,40,69;R. 4, 58,34;ŚĀK. 2;ŚĀK 26;ŚĀK 71,10;RAGH. 1,90;RAGH. 1, 91;ŚĀK. 54,21;P. 2,1,13;CHĀND. UP. 7,2,1;CHĀND. UP. 7, 8,1;M. 3,247;R. 4,9,106;PAÑCAT. I, 44;AK. 2,6,2,32;KATHĀS. 23,20;KATHĀS 10,208;VID. 54;P. 2,1,13;AMAR. 74;R. 4,37,3;MBH. 1,6965;R. 1,1,12;R 3,69,16;RAGH. 1,5;ŚĀK. 80;ŚĀK 145;VID. 21;HIT. I, 180;M. 9,101;MBH. 3,8333;MUṆḌ. UP. 1,2,3;MBH. 2,531;R. 4,34,16;YĀJÑ. 1,205
+A	2	2b	b〉 von — her, von — aus, von — weg, von — an: α〉 mit folg. abl. : ṚV. 3,56,6 . 7 . 1,92,3 . 17 . 30,21 . AV. 3,3,4 . MBH. 1,3756 . R. 1,5,1 . RAGH. 1,17 . KATHĀS. 24,186 . ( v. l. ) ŚĀK. 121 . 14,19 .	ṚV. 3,56,6;ṚV. 3,56, 7;ṚV 1,92,3;ṚV. 1,92, 17;ṚV. 1, 30,21;AV. 3,3,4;MBH. 1,3756;R. 1,5,1;RAGH. 1,17;KATHĀS. 24,186;ŚĀK. 121;ŚĀK 14,19;KATHĀS. 25,195;KATHĀS 12,191;VID. 130;ŚĀK. CH. 13,6;ṚV. 1,33,7;ṚV 2,17,7;ṚV 1,129,6;ṚV 8,66,6;AV. 4,15,11;MBH. 3,1403;KATHĀS. 2,29;KATHĀS. 2, 28;KATHĀS 4,53;RAGH. 1,5;KATHĀS. 21,122;KATHĀS. 10,69
+A	2	2c	c〉 aus, von, unter, zur Hervorhebung eines Einzelnen unter Mehreren: ṚV. 1,84,9 . 20 . 4,4	ṚV. 1,84,9;ṚV. 1,84, 20;ṚV. 1, 4,4
+A	2	2d	d〉 in, bei, mit dem loc. NIR. 5,5 . ṚV. 1,61,9 . 73,4 . 91,13 . 113,10 . 27,6 . 150,1 . 82,2 . 112,17 . 2,30,1 . 4,11,1 . 5,48,1 . 9,62,8 . 9,110,4 . 73,7 . 10,40,2 . 72,7 . AV. 7,8,1 . 16,4,2	NIR. 5,5;ṚV. 1,61,9;ṚV. 1, 73,4;ṚV. 1, 91,13;ṚV. 1, 113,10;ṚV. 1, 27,6;ṚV 150,1;ṚV 82,2;ṚV 112,17;ṚV 2,30,1;ṚV 4,11,1;ṚV 5,48,1;ṚV 9,62,8;ṚV 9,110,4;ṚV. 9, 73,7;ṚV 10,40,2;ṚV. 10, 72,7;AV. 7,8,1;AV 16,4,2
+A	2	2e	e〉 im comp. mit einem adj. oder partic. etwas, ein wenig, kaum P. 2,2,18 , SAUN. Vārtt. 3. Scheinbar adv. , aber ursprünglich gewiss praep. und zwar in der unter a. aufgeführten Bedeutung: bis zum Gel	P. 2,2,18;SAUN;R. 2,76,4;ŚĀK. 69,2;H. 1239;RAGH. 3,8;RAGH 16,51;AMAR. 89;P. 1,1,14;ŚĀK. 184;DAŚAK;BENF. Chr. 198,23;AK. 2,9,47;BHARTṚ. 3,48;ŚĀK. 176;RAGH. 1,83;P. 1,1,14;P. 1, 4,89;P 2,1,13;P. 2, 3,10;VOP. 1,8;VOP 2,19;AK. 3,4,32,1;COL. 3,4,28,1;H. an. 7,2;MED. avy. 13;P. 6,1,74;P. 6,1, 95;P. 6,1, 126;VOP. 2,5;VOP. 2, 19
+A	2	2	2〉	
+A	2	2a	a〉β〉 bis auf, bis exclusive: der Dvād. besteht nach Abzug ( SĀY. ) des zehnten Tages und der beiden Atirātra aus drei Tryaha AIT. BR. 4,24 . Zu der Verbindung ist nicht ein Zeiltwort der Bewegung (was	SĀY;AIT. BR. 4,24;ŚAT. BR. 11,5,1,4;AIT. BR. 2,13;KĀTY. ŚR. 4,13,16;ṚV. PRĀT. 11,9;M. 10,64
+A	2	2b	b〉α〉	
+A	2	2e	e〉 Z. 6 lies	
+A	3	1	1〉 m. , Śiva PURUṢ. _im_ ŚKDR	PURUṢ;ŚKDR
+A	3	2	2〉 f. Lakṣmī H. 226	H. 226
+A	3	1	3. ¦ m. angeblich auch = und EKĀKṢARĀBHIDHĀNA _im_ AGNI-P. ŚKDR	EKĀKṢARĀBHIDHĀNA;AGNI-P;ŚKDR
+ABIla		1	1〉 adj. Furcht erregend, schrecklich AK. 1,2,2,4 . TRIK. 3,1,7 . 3,381 . H. ś. 87 . an. 3,625 . MED. l. 61 ( ). MBH. 3,388	AK. 1,2,2,4;TRIK. 3,1,7;TRIK. 3, 3,381;H. ś. 87;H an. 3,625;MED. l. 61;MBH. 3,388
+ABIla		2	2〉 n. Schmerz AK. TRIK. 3,3,381 . H. 1371 . H. an. MED	AK;TRIK. 3,3,381;H. 1371;H. an;MED
+ABIra		1	1〉 m. N. pr. eines Volkes MBH. 2,1192 . 1832 . 3,12840 . 14,832 . 16,223 . 270 . R. 4,43,5 . 19 VARĀH. BṚH. S. 14,12 . 18 _in_ Verz. d. B. H. 241 . VP. 189 . 195 . 474 . 481 . PRAB. 88,1 . PAÑCAT. I, 	MBH. 2,1192;MBH. 2, 1832;MBH 3,12840;MBH 14,832;MBH 16,223;MBH. 16, 270;R. 4,43,5;R. 4,43, 19;VARĀH. BṚH. S. 14,12;VARĀH. BṚH. S. 14, 18;Verz. d. B. H. 241;VP. 189;VP 195;VP 474;VP 481;PRAB. 88,1;PAÑCAT. I, 88;LIA. I, 539;LIA. I, 799;LIA. I, II, 589. fgg
+ABIra		2	2〉 m. Kuhhirt AK. 2,9,57 . H. 889 . BURN. Intr. 150 . 424 . Nach M. 10,15 der Sohn eines Brahmanen von einem Ambaṣṭha -Mädchen. H. 522 , Sch. f. AK. 2,6,1,13 . H. 522 . VOP. 5,6	AK. 2,9,57;H. 889;BURN. Intr. 150;BURN. Intr 424;M. 10,15;H. 522;AK. 2,6,1,13;H. 522;VOP. 5,6
+ABIra		3	3〉 Name eines Metrums COLEBR. Misc. Ess. II, 156 (	COLEBR. Misc. Ess. II, 156 (30)
+ABIra		4	4〉 (nämlich ) die Sprache der Ābhīra COLEBR. Misc. Ess. II, 68	COLEBR. Misc. Ess. II, 68
+ABIra		1	1〉 MBH. 16,270 . VARĀH. BṚH. S. 5,38 . 42 . 16,31 . DAŚAR. 2,42 . BHĀG. P. 12,1,36 . Verz. d. Oxf. H. 333,b,15 . 217,b,34 ( sg. ). 338,b,35 . 339,a,2 v. u. 339,b,13 . 45 . 352,b,19 . 204,a,8 . 217,b,1	MBH. 16,270;VARĀH. BṚH. S. 5,38;VARĀH. BṚH. S. 5, 42;VARĀH. BṚH. S 16,31;DAŚAR. 2,42;BHĀG. P. 12,1,36;Verz. d. Oxf. H. 333,b,15;Verz. d. Oxf. H 217,b,34;Verz. d. Oxf. H 338,b,35;Verz. d. Oxf. H 339,a,2 v. u. 339,b,13;Verz. d. Oxf. H. 339,a,2 v. u. 339,b, 45;Verz. d. Oxf. H 352,b,19;Verz. d. Oxf. H 204,a,8;Verz. d. Oxf. H 217,b,12;BHĀG. P. 12,1,27
+ABIra		2	2〉 ( ) Spr. 4897 . GĪT. 1,48	Spr. 4897;GĪT. 1,48
+ABIra		4	4〉 SĀH. D. 432 . — Vgl	SĀH. D. 432
+ABUti		1	1〉 f. Tüchtigkeit, lebendige Wirksamkeit: ṚV. 10,84,6 . AIT. BR. 7,13	ṚV. 10,84,6;AIT. BR. 7,13
+ABUti		2	2〉 m. N. pr. eines Mannes ŚAT. BR. 14,5,5,22 . 7,3,28 = BṚH. ĀR. UP. 2,6,3 . 4,6,3	ŚAT. BR. 14,5,5,22;ŚAT. BR. 14, 7,3,28;BṚH. ĀR. UP. 2,6,3;BṚH. ĀR. UP 4,6,3
+ABaraRa		1	1〉 Schmuck, Schmucksache AK. 2,6,3,3 . H. 650 . ( ) ( ) ( ) Citat beim Sch. zu ŚĀK. 80 . M. 7,219 . 222 . 8,2 . 10,56 . N. 1,12 . 2,10 . R. 1,6,13 . VIŚV. 8,10 . SUŚR. 2,149,15 . ŚĀK. 8,13 . 80 . 185 	AK. 2,6,3,3;H. 650;ŚĀK. 80;M. 7,219;M. 7, 222;M 8,2;M 10,56;N. 1,12;N 2,10;R. 1,6,13;VIŚV. 8,10;SUŚR. 2,149,15;ŚĀK. 8,13;ŚĀK. 8, 80;ŚĀK. 8, 185;HIT. I, 16;ṚT. 1,4;R. 1,9,22;R 6,103,4;PAÑCAT. III, 266
+ABaraRa		2	2〉 Titel verschiedener Werke COLEBR. Misc. Ess. II, 49 . 323	COLEBR. Misc. Ess. II, 49;COLEBR. Misc. Ess. II, 323
+ABaraRa		2	2〉 SIDDH. K. 132,b,2	SIDDH. K. 132,b,2
+ABaradvasu		1	1〉 adj. Güter bringend: ṚV. 5,79,3	ṚV. 5,79,3
+ABaradvasu		2	2〉 m. N. pr. Verz. d. B. H. 57,2 v. u	Verz. d. B. H. 57,2 v. u
+ABicArika		1	1〉 adj. f. auf das Zaubern bezüglich: BṚH. DEV. _in_ Ind. St. 1,120,14	BṚH. DEV;Ind. St. 1,120,14
+ABicArika		2	2〉 n. Zauber KAUŚ. 25 . 47	KAUŚ. 25;KAUŚ 47
+ABijita		1	1〉 adj. unter dem Sternbilde Abhijit geboren P. 4,3,36	P. 4,3,36
+ABijita		2	2〉 patron. f. von P. 5,3,118 . Verz. d. B. H. 55,20	P. 5,3,118;Verz. d. B. H. 55,20
+ABijita		1	¦ Z. 2 lies	
+ABimuKya		1	1〉 die Richtung nach Etwas hin P. 2,1,14 . [Page1-0666] PAÑCAT. I, 370 . SĀH. D. 63,18 . 64,1	P. 2,1,14;PAÑCAT. I, 370;SĀH. D. 63,18;SĀH. D 64,1
+ABimuKya		2	2〉 das nach Etwas hin gerichtete Begehren, Verlangen: P. 8,2,99 , Sch	P. 8,2,99
+ABimuKya		1	1〉 mit acc. (!): Schol. zu KĀTY. ŚR. 16,7,12	KĀTY. ŚR. 16,7,12
+ABimuKya		3	3〉 Geneigtheit, das Zugethansein Spr. 2586	Spr. 2586
+ABimuKya		3	3〉 in den Nachträgen zu streichen, da die Stelle zu	
+ABimuKya		1	1〉 gehört; vgl. Spr. (II) 5708	Spr. (II) 5708
+ABoga		1	1〉 Windung, Krümmung, Wölbung: (könnte auch zu 3. gehören) MBH. 3,9957 . 15,1077 . R. 2,65,3 . BHARTṚ. 1,19 . PRAB. 81,15 . ŚRUT. 40 . MEGH. 89 . (von einem Betttuch) SĀH. D. 42,11 . BALLANTYNE : with	MBH. 3,9957;MBH 15,1077;R. 2,65,3;BHARTṚ. 1,19;PRAB. 81,15;ŚRUT. 40;MEGH. 89;SĀH. D. 42,11;BALLANTYNE
+ABoga		2	2〉 Ausdehnung, Fülle, Mannigfaltigkeit AK. 2,6,3,28 . TRIK. 3,3,55 . H. 1432 . an. 3,117 . MED. g. 29 . ( ) VID. 4 . ŚĀK. 8,1 . ŚĀNTIŚ. 4,20 . BHARTṚ. 3,85	AK. 2,6,3,28;TRIK. 3,3,55;H. 1432;H an. 3,117;MED. g. 29;VID. 4;ŚĀK. 8,1;ŚĀNTIŚ. 4,20;BHARTṚ. 3,85
+ABoga		3	3〉 Schlange: ṚV. 7,94,12	ṚV. 7,94,12
+ABoga		4	4〉 die Anschwellung im Nacken der Brillenschlange, die sogenannte Haube: ( ) MBH. 3,12387 . 16,118 . wird als Varuṇa ʼs Sonnenschirm betrachtet, daher = H. an. MED. — Diese und TRIK. haben noch die Be	MBH. 3,12387;MBH 16,118;H. an;MED;TRIK;WILSON
+ABoga		1	1〉 wohl Gewölbe eines Gemachs KATHĀS. 51,186 . Schol. zu R. 2,65,3 erklärt: . Vgl. 1. u. 2	KATHĀS. 51,186;R. 2,65,3
+ABoga		5	5〉 = Vollgenuss MED. ṇ. 93	MED. ṇ. 93
+ABoga		6	6〉 = (bedeutet Autor nach HAUGHT. ) ŚKDR. the third of the three divisions of a MOLESW. Bei ( vgl. ) heisst es ebend. : the introductory stanza [Page5-1112] of a song. It is distinct from the verses o	HAUGHT;ŚKDR;MOLESW;ebend
+ABu		1	1〉 leer: VS. 16,10 . ṚV. 10,129,3	VS. 16,10;ṚV. 10,129,3
+ABu		2	2〉 leerhändig, karg: ṚV. 10,27,1 . 4 . — Vgl	ṚV. 10,27,1;ṚV. 10,27, 4
+AByudayika		1	1〉 adj	
+AByudayika		1a	a〉 am Ende eines adj. comp. mit dem Aufgange, dem Beginn von dem und dem verbunden: M. 12,88	M. 12,88
+AByudayika		1b	b〉 heilbringend: MṚCCH. 111,5 . Verz. d. B. H. No. 1042	MṚCCH. 111,5;Verz. d. B. H. No. 1042
+AByudayika		2	2〉 n. eine bestimmte Form eines Manenopfers ĀŚV. ŚR. 4,7 . P. 5,4,42, Vārtt. , Sch	ĀŚV. ŚR. 4,7;P. 5,4,42, Vārtt
+AByudayika		1	1〉	
+AByudayika		1b	b〉 Schol. zu KĀTY. ŚR. 7,1,31 . 32	KĀTY. ŚR. 7,1,31;KĀTY. ŚR. 7,1, 32
+AByudayika		2	2〉 Verz. d. Oxf. H. 40,a,14 . Ind. St. 5,299	Verz. d. Oxf. H. 40,a,14;Ind. St. 5,299
+ADAna		1	1〉 das Anlegen, Zulegen, Legen ŚAT. BR. 2,1,4,29 . 11,2,7,33 . KĀTY. ŚR. 5,5,35 . 6,10,9 . 4,10,15 . M. 2,176 . KĀTY. ŚR. 4,11,1 . 8,6,30 . 10,8,6 . Vgl	ŚAT. BR. 2,1,4,29;ŚAT. BR 11,2,7,33;KĀTY. ŚR. 5,5,35;KĀTY. ŚR 6,10,9;KĀTY. ŚR 4,10,15;M. 2,176;KĀTY. ŚR. 4,11,1;KĀTY. ŚR 8,6,30;KĀTY. ŚR 10,8,6
+ADAna		2	2〉 = ( s. d. ): M. 5,168 ( KULL. : ). ( RĀGHAV. : , KULL. : ; gehört viell. zu 3.) 8,209 . (die Sonne wird angeredet) MBH. 3,184 . 8194 . 10663	M. 5,168;KULL;RĀGHAV;KULL;M 8,209;MBH. 3,184;MBH. 3, 8194;MBH. 3, 10663
+ADAna		3	3〉 = Empfängniss Verz. d. B. H. No. 858 ( III ). 862 ( 258,17 ). Ind. St. 1,59,3 v. u. 2,287, N. 2 . MEGH. 3	Verz. d. B. H. No. 858;Verz. d. B. H III;Verz. d. B. H. No 862;Verz. d. B. H 258,17;Ind. St. 1,59,3 v. u. 2,287, N. 2;MEGH. 3
+ADAna		4	4〉 das Niederlegen als Pand, Verpfändung YĀJÑ. 2,238 . 247 . Vgl. 1	YĀJÑ. 2,238;YĀJÑ 247
+ADAna		5	5〉 das Beilegen, Zutheilen, Anwenden: SĀH. D. 10,13 . RAGH. 1,24 . P. 1,3,32 , Sch	SĀH. D. 10,13;RAGH. 1,24;P. 1,3,32
+ADAna		6	6〉 der Ort, an welchen Etwas gelegt wird, in welchem Etwas ruht, sich befindet ŚAT. BR. 14,5,2,1 = BṚH. ĀR. UP. 2,2,1 . Vgl	ŚAT. BR. 14,5,2,1;BṚH. ĀR. UP. 2,2,1
+ADAna		7	7〉 Umfangung, Umfassung: ṚV. 10,94,8	ṚV. 10,94,8
+ADAna		1	1〉 das Drauflegen des Todten Verz. d. Oxf. H. 294,b,18	Verz. d. Oxf. H. 294,b,18
+ADAna		2	2〉 Ind. St. 3,379	Ind. St. 3,379
+ADAna		4	4〉 lies Pfand st. Pand	
+ADAna		5	5〉 das Beibringen MBH. 13,4633 . das Erweisen eines Liebesdienstes MAHĀVĪRAC. 92,16 . so v. a. Kraft mit Geschwindigkeit verbunden KATHĀS. 67,25	MBH. 13,4633;MAHĀVĪRAC. 92,16;KATHĀS. 67,25
+ADAna		7	7〉 lies Zügel oder Pferdegeschirr überh. und füge TBR. 1,6,3,9 hinzu. — Vgl	TBR. 1,6,3,9
+ADAna		1	1〉 das Hinzufügen VĀMANA 1,3,16	VĀMANA 1,3,16
+ADAna		8	8〉 Zaum, Gebiss; s. weiter unten	
+ADAra		1	1〉 Stütze, Stützpunkt, Unterlage (auch bildlich) NIR. 1,13 . MBH. 3,10053 . SUŚR. 2,348,2 . (Dachstuhl) H. 1011 . R. 5,3,77 . 89,39 . HIT. I, 195 . DEV. 11,3 . ŚĀNTIŚ. 2,6 . n. (!) KAIV. UP. _in_ Ind.	NIR. 1,13;MBH. 3,10053;SUŚR. 2,348,2;H. 1011;R. 5,3,77;R. 5, 89,39;HIT. I, 195;DEV. 11,3;ŚĀNTIŚ. 2,6;KAIV. UP;Ind. St. 2,12,9
+ADAra		2	2〉 Rückhalt (?): AV. 12,3,48	AV. 12,3,48
+ADAra		3	3〉 Behälter, Behältniss: YĀJÑ. 3,165 . SUŚR. 1,78,18 . KUMĀRAS. 3,48 . [Page1-0638] PAÑCAT. I, 77 . KUMĀRAS. 6,67 . H. 1096 . YĀJÑ. 3,144 . ŚĀK. 14 . H. 598 . 1365 . SĀH. D. 13,8	YĀJÑ. 3,165;SUŚR. 1,78,18;KUMĀRAS. 3,48;PAÑCAT. I, 77;KUMĀRAS. 6,67;H. 1096;YĀJÑ. 3,144;ŚĀK. 14;H. 598;H 1365;SĀH. D. 13,8
+ADAra		4	4〉 Deich, Damm AK. 1,2,3,28 . H. an. 3,521 . MED. r. 114 . RAGH. 5,6	AK. 1,2,3,28;H. an. 3,521;MED. r. 114;RAGH. 5,6
+ADAra		5	5〉 = H. an. 3,522 . MED. Aus der Verbindung zweier geschiedener, aber auf einander folgender Artikel im AK. entstanden	H. an. 3,522;MED;AK
+ADAra		6	6〉 der Behälter (einer Handlung heisst) (die Beziehung des Locativs) P. 1,4,45 . Auf dieser Stelle beruht die Gleichsetzung von mit H. an. MED. SIDDH. K. 40,b . VOP. 5,30 . in der auf die Endung des n	P. 1,4,45;H. an;MED;SIDDH. K. 40,b;VOP. 5,30;P. 1,1,32;H. an. 4,161
+ADAra		1	1〉 WEBER, RĀMAT. UP. 278 . 321 . 323 . VEDĀNTAS. (Allah.) No. 2 . Unterlage (worauf eine Erscheinung oder Thätigkeit beruht) KAP. 2,42 . Boden —, Gebiet der Wirksamkeit TATTVAS. 45 . Subject, von welc	WEBER, RĀMAT. UP. 278;WEBER, RĀMAT. UP 321;WEBER, RĀMAT. UP 323;VEDĀNTAS. (Allah.) No. 2;KAP. 2,42;TATTVAS. 45;PRATĀPAR. 90,a,7;PRATĀPAR. 90, b,7
+ADAra		3	3〉	
+ADAra		3	3〉 HALĀY. 5,12	HALĀY. 5,12
+ADAra		5	5〉 vgl	
+ADAra		6	6〉 hierher kann ŚĀNTIŚ. 2,6 ( Spr. 2351 ), das unter	ŚĀNTIŚ. 2,6;Spr. 2351
+ADAra		1	1〉 steht, gezogen werden: worauf soll die Liebe gerichtet und die Trauer bezogen werden?	
+ADAra		7	7〉 Teich HALĀY. 3,54 . N. pr. eines Teiches WILSON, Sel. Works 2,23	HALĀY. 3,54;WILSON, Sel. Works 2,23
+ADAra		8	8〉 N. pr. des Verfassers der Ādhārakārikā Verz. d. Oxf. H. 238,b, N. 1 . 353,b,7	Verz. d. Oxf. H. 238,b, N. 1;Verz. d. Oxf. H 353,b,7
+ADava		1	1〉 Aufrüttler, Erreger: ṚV. 10,26,4	ṚV. 10,26,4
+ADava		2	2〉 viell. so v. a. oder die geschüttelte Masse, Mischung: 1,141,3	ṚV 1,141,3
+ADeya		1	1〉 adj	
+ADeya		1a	a〉 niederzulegen, zu deponiren: Pfand YĀJÑ. 2,60	YĀJÑ. 2,60
+ADeya		1b	b〉 was hingelegt wird, dem ein Platz angewiesen wird: TRIK. 3,3,424	TRIK. 3,3,424
+ADeya		1c	c〉 beizulegen, zuzutheilen, zu geben: PAÑCAT. 134,9 . Kār. in P. II, p. 451 . VOP. 4,16	PAÑCAT. 134,9;P. II, p. 451;VOP. 4,16
+ADeya		2	2〉 n. = ; s. und	
+ADeya		1	1〉	
+ADeya		1c	c〉 (wohl zu lesen) Spr. 5122 . was einer Person oder Sache beigelegt wird; n. Prädicat, Aussage. SĀH. D. 725 . 330,16 . PRATĀPAR. 90,a,7 . b,7 . — Vgl	Spr. 5122;SĀH. D. 725;SĀH. D 330,16;PRATĀPAR. 90,a,7;PRATĀPAR. 90, b,7
+ADi	1	1	1〉 Standort, Lage AK. 3,4,108 . H. an. 2,239 . MED. dh. 3	AK. 3,4,108;H. an. 2,239;MED. dh. 3
+ADi	1	2	2〉 Depositum, Pfand AK. H. 882 . H. an. MED. (?) ṚV. 10,109,3 . M. 8,143 . 144 . 145 . 149 . 150 . YĀJÑ. 2,23 . Ind. St. 1,246, N. MIT. 268,9	AK;H. 882;H. an;MED;ṚV. 10,109,3;M. 8,143;M. 8, 144;M. 8, 145;M. 8, 149;M. 8, 150;YĀJÑ. 2,23;Ind. St. 1,246, N;MIT. 268,9
+ADi	1	3	3〉 = nähre Bestimmung, Epitheton u. s. w. TRIK. 3,3,215 . Vgl. 5. und 1,c	TRIK. 3,3,215
+ADi	1	1	1〉 Behälter BHĀG. P. 11,13,33	BHĀG. P. 11,13,33
+ADi	2	1	1〉 Gedanken, Sorge, Seelenleiden AK. 1,1,7,28 . 3,4,100 . H. 312 . 1371 . an. 2,239 . MED. dh. 3 . Fast immer pl. und häufig in Verbindung mit körperliches Leiden. VS. 22,20 . TS. 3,4,7,3 . MBH. 3,195	AK. 1,1,7,28;AK. 1, 3,4,100;H. 312;H 1371;H an. 2,239;MED. dh. 3;VS. 22,20;TS. 3,4,7,3;MBH. 3,195;MBH. 3, 11259;YĀJÑ. 3,63;N. 18,11;R. 3,72,8;ŚĀK. 93;ŚĀK 59;BHARTṚ. 3,34;MBH. 3,69;RAGH. 8,27;RAGH 9,54;KATHĀS. 6,128
+ADi	2	2	2〉 das Nachdenken über das Recht ( ) TRIK. 3,3,215	TRIK. 3,3,215
+ADi	2	3	3〉 Erwartung, Hoffnung TRIK. H. an. MED	TRIK;H. an;MED
+ADi	2	4	4〉 Unglück ( ) AK. 3,4,100 . H. an. MED	AK. 3,4,100;H. an;MED
+ADi	2	5	5〉 ein für den Unterhalt seiner Familie besorgter Mann ( ) TRIK	TRIK
+ADi	2	1	2. ¦ wie von 1. mit . — Vgl. 2	
+ADijYa		1	1〉 gequält, gepeinigt ( )	
+ADijYa		2	2〉 krumm ( ) AJAYAPĀLA _im_ ŚKDR	AJAYAPĀLA;ŚKDR
+ADmAna		1	1〉 das Aufblasen, Aufblähen, Sichaufblähen SUŚR. 1,97,5	SUŚR. 1,97,5
+ADmAna		2	2〉 Bezeichnung mehrerer Krankheiten mit Blähungszuständen SUŚR. 2,44,5 . 194,5 . 200,12 . 202,5 . 1,257,14 . 50,7 . 198,4 . 277,3 . — Vgl	SUŚR. 2,44,5;SUŚR. 2, 194,5;SUŚR. 2, 200,12;SUŚR. 2, 202,5;SUŚR 1,257,14;SUŚR. 1, 50,7;SUŚR. 1, 198,4;SUŚR. 1, 277,3
+ADmAna		1	¦ vgl	
+ADvaryava		1	1〉 adj. zum Adhvaryu ( d. i. YAJURVEDA ) in Beziehung stehend P. 4,3,123 . AV. PARIŚIṢṬA 1 _in_ Ind. St. 1,296,13	YAJURVEDA;P. 4,3,123;AV;PARIŚIṢṬA 1;Ind. St. 1,296,13
+ADvaryava		2	2〉 n. der Dienst beim Opfer; spec. die Function des Adhvaryu gaṇa zu P. 5,1,129 . ṚV. 10,52,2 . VS. 28,19 . ŚAT. BR. 11,5,8,4 . AIT. BR. 5,33 . KĀTY. ŚR. 9,8,9 . 23,5,33 . 24,4,42 . 25,1,6 . NIR. 7,3 	P. 5,1,129;ṚV. 10,52,2;VS. 28,19;ŚAT. BR. 11,5,8,4;AIT. BR. 5,33;KĀTY. ŚR. 9,8,9;KĀTY. ŚR 23,5,33;KĀTY. ŚR 24,4,42;KĀTY. ŚR 25,1,6;NIR. 7,3;MADHUS;Ind. St. 1,16,8;Ind. St. 1, 18,2
+ADvaryava		1	1〉 Verz. d. Oxf. H. 56,a,10	Verz. d. Oxf. H. 56,a,10
+ADvaryava		2	2〉 Verz. d. Oxf. H. 54,b,9	Verz. d. Oxf. H. 54,b,9
+AGAra		1	1〉 Sprengung von Fett in das Opferfeuer: ŚAT. BR. 1,4,4,8 . 5,1 . 2,5,2,19 . 3,4,4,9 . 6,2,2,5 . 11,2,1,5 . KĀTY. ŚR. 1,8,41 . 42 . 3,1,12 . 8,2,30 . ĀŚV. GṚHY. 1,10 . TS. 2,5,11,3 . 3,1,9,2 . 3	ŚAT. BR. 1,4,4,8;ŚAT. BR. 1,4, 5,1;ŚAT. BR 2,5,2,19;ŚAT. BR 3,4,4,9;ŚAT. BR 6,2,2,5;ŚAT. BR 11,2,1,5;KĀTY. ŚR. 1,8,41;KĀTY. ŚR. 1,8, 42;KĀTY. ŚR 3,1,12;KĀTY. ŚR 8,2,30;ĀŚV. GṚHY. 1,10;TS. 2,5,11,3;TS 3,1,9,2;TS. 3,1,9, 3
+AGAra		2	2〉 geklärte Butter H. 407	H. 407
+AGAra		1	1〉 BHĀG. P. 11,27,40	BHĀG. P. 11,27,40
+AGAta		1	1〉 Schläger: Trommelschläger ŚAT. BR. 14,5,4,7 . 7,3,8 = BṚH. ĀR. UP. 2,4,7 . 4,5,8 . Vgl	ŚAT. BR. 14,5,4,7;ŚAT. BR. 14, 7,3,8;BṚH. ĀR. UP. 2,4,7;BṚH. ĀR. UP 4,5,8
+AGAta		2	2〉 Anschlag, Schlag, Verwundung: (ein Elephant) ŚĀK. 32 . gewöhnlich in comp. mit dem, was den Schlag bewirkt oder wogegen der Schlag gerichtet ist: MBH. 2,912 . BHARTṚ. 2,83 . KATHĀS. 13,102 . 21,75 	ŚĀK. 32;MBH. 2,912;BHARTṚ. 2,83;KATHĀS. 13,102;KATHĀS 21,75;KATHĀS 14,12;RĀJA-TAR. 5,463;RĀJA-TAR. 5, 330;MED. k. 224;AMAR. 55;AMAR 7,49;KUMĀRAS. 2,50
+AGAta		3	3〉 Tödtung: YĀJÑ. 3,275 . (so ist zu lesen) BHARTṚ. 2,60	YĀJÑ. 3,275;BHARTṚ. 2,60
+AGAta		4	4〉 Verhaltung (von Harn u. s. w. ) SUŚR. 2,192,5 . 194,19,529,6 . 8 . u. s. w. Vgl	SUŚR. 2,192,5;SUŚR 194,19,529,6;SUŚR. 2,192, 8
+AGAta		5	5〉 Trübsal, Leiden VYUTP. 61	VYUTP. 61
+AGAta		6	6〉 Richtplatz, Schlachthaus TRIK. 2,8,59 . MṚCCH. 161,11 . HIT. IV, 64	TRIK. 2,8,59;MṚCCH. 161,11;HIT. IV, 64
+AGAta		2	2〉 mit Stockschlägen KATHĀS. 54,203	KATHĀS. 54,203
+AGAta		6	6〉 auch BHĀG. P. 11,20,20	BHĀG. P. 11,20,20
+AGAwa		1	1〉 ein zur Begleitung des Tanzes gebrauchtes musik. Instrument, Cymbel oder Klappern: AV. 4,37,4	AV. 4,37,4
+AGAwa		2	2〉 Grenze H. 962 . Vgl	H. 962
+AGAwa		3	3〉 N. einer Pflanze, Achyranthes aspera ( ), RĀJAN. _im_ ŚKDR. Vgl. und	RĀJAN;ŚKDR
+AGAwa		4	4〉 = am Ende einiger compp. P. 3,2,49, Vārtt. 2	P. 3,2,49, Vārtt. 2
+AGAwa		2	2〉 Journ. of the Am. Or. S. 7,42 ( , wo aber gedruckt ist	Journ. of the Am. Or. S. 7,42 (41)
+AGarzaRa		1	1〉 adj. kratzend, reibend	
+AGarzaRa		2	2〉 f. Bürste, Reiber WILS	WILS
+AGrARa		1	1〉 n. das Riechen: KATHĀS. 13,64	KATHĀS. 13,64
+AGrARa		2	2〉 n. Sattheit H. 426	H. 426
+AGrARa		3	3〉 adj. = satt H. 426 , Sch	H. 426
+AGrAta		1	1〉 gerochen MED. t. 87	MED. t. 87
+AGrAta		2	2〉 satt H. 426	H. 426
+AGrAta		3	3〉 = ( ŚKDR. ) MED. — H. an. 3,246 : (?). — Vgl. mit	ŚKDR;MED;H. an. 3,246
+AGrAta		1	¦ (von mit ) n. Bez. einer der 10 Weisen, auf welche eine Eklipse (angeblich) erfolgt, VARĀH. BṚH. S. 5,43 . 50	VARĀH. BṚH. S. 5,43;VARĀH. BṚH. S. 5, 50
+AKaRqala		1	1〉 adj. dass. ṚV. 8,17,12 . NIR. 3,10	ṚV. 8,17,12;NIR. 3,10
+AKaRqala		2	2〉 m. ein Bein. Indra ʼs AK. 1,1,1,40 . H. 2 . 171 . MṚCCH. 86,10 . ŚĀK. 187 . 108,16 . RAGH. 4,83 . KUMĀRAS. 3,11 . MEGH. 15 . Vgl. und ähnliche Beinamen Indra ʼs	AK. 1,1,1,40;H. 2;H 171;MṚCCH. 86,10;ŚĀK. 187;ŚĀK 108,16;RAGH. 4,83;KUMĀRAS. 3,11;MEGH. 15
+AKaRqala		1	¦ m. Bein. Śiva ʼs Verz. d. Oxf. H. 77,b,21 . — adj. ( f. ) Indra gehörig: d. i. Osten VARĀH. BṚH. S. 35,7 . — Welche Bed. hat aber das Wort beim Schol. zu PRAB. 50,12 ?	Verz. d. Oxf. H. 77,b,21;VARĀH. BṚH. S. 35,7;PRAB. 50,12
+AKana		1	1〉 Gräber	
+AKana		2	2〉 Spaten WILS	WILS
+AKanika		1	1〉 Gräber WILS	WILS
+AKanika		2	2〉 Dieb H. an. 4,4 . MED. k. 176	H. an. 4,4;MED. k. 176
+AKanika		3	3〉 Schwein Uṇ. TRIK. 2,5,5 . H. 1288 . an. MED	Uṇ;TRIK. 2,5,5;H. 1288;H an;MED
+AKanika		4	4〉 Maus Uṇ. H. an. MED	Uṇ;H. an;MED
+AKanika		5	5〉 Spaten WILS	WILS
+AKewaka		1	1〉 dass. ŚABDAR. _im_ ŚKDR. PAÑCAT. I, 145 . 60,9 . KATHĀS. 9,74 . 16,6 . 5 . VET. in LA. 6,2	ŚABDAR;ŚKDR;PAÑCAT. I, 145;PAÑCAT. I, 60,9;KATHĀS. 9,74;KATHĀS 16,6;KATHĀS. 16, 5;VET. in LA. 6,2
+AKewaka		2	2〉 Jäger PAÑCAT. I, 432	PAÑCAT. I, 432
+AKewaka		1	1〉 KATHĀS. 52,133 . 59,41 . 63,126 . Wildpark 53,15 . 54,4	KATHĀS. 52,133;KATHĀS 59,41;KATHĀS 63,126;KATHĀS 53,15;KATHĀS 54,4
+AKu		1	1〉 Maus, Ratze ( AK. 2,5,12 . H. 1300 ); Maulwurf ṚV. 9,67,30 . ( s. u. ). VS. 3,57 . 24,26 . 28 . AV. 6,50,1 . TS. 5,5,14,1 . ŚAT. BR. 2,1,1,7 . 6,2,10 . M. 4,126 . 11,159 . 12,62 . MBH. 1,1816 . PAÑ	AK. 2,5,12;H. 1300;ṚV. 9,67,30;VS. 3,57;VS 24,26;VS. 24, 28;AV. 6,50,1;TS. 5,5,14,1;ŚAT. BR. 2,1,1,7;ŚAT. BR. 2, 6,2,10;M. 4,126;M 11,159;M 12,62;MBH. 1,1816;PAÑCAT. I, 175;PAÑCAT. I, 426;PAÑCAT. I, II, 1;KATHĀS. 24,132
+AKu		2	2〉 N. eines Grases, Lipeocercis serrata Trin. , RATNAM. _im_ ŚKDR. KAUŚ. 25 . — Nach H. an. 4,4 bedeutet das Wort noch	RATNAM;ŚKDR;KAUŚ. 25;H. an. 4,4
+AKu		3	3〉 Dieb und	
+AKu		4	4〉 Schwein; nach WILS. noch	WILS
+AKu		5	5〉 Gräber und	
+AKu		6	6〉 Spaten	
+AKyAna		1	1〉 das Erzählen, Berichten: P. 3,3,111 . 8,2,105 . 3,4,59 . 1,4,90 . R. 2,58 in der Unterschr	P. 3,3,111;P 8,2,105;P 3,4,59;P 1,4,90;R. 2,58
+AKyAna		2	2〉 Erzählung, Legende NIR. 5,21 . 7,7 . 11,25 . ŚAT. BR. 13,4,3,2 . 15 . P. 6,2,103 . MBH. 1,18 . 305 . 307 . N. (BOPP) 22,21 . R. 1,1,94 . 4,10 . 44,63 . M. 3,232 . N. 6,9 ( vgl. Z. d. d. m. G. 1,86 	NIR. 5,21;NIR 7,7;NIR 11,25;ŚAT. BR. 13,4,3,2;ŚAT. BR. 13,4,3, 15;P. 6,2,103;MBH. 1,18;MBH. 1, 305;MBH. 1, 307;N. (BOPP) 22,21;R. 1,1,94;R. 1, 4,10;R. 1, 44,63;M. 3,232;N. 6,9;Z. d. d. m. G. 1,86;MBH. 3,1808;P. 4,2,60, Vārtt. 5;VP. 159;LIA. I, 485, N. 2
+AKyAna		1	1〉 KATHĀS. 55,25 . das Auseinandersetzen der Pflichten Spr. 4254 . in der Dramatik das Mittheilen eines vorangegangenen Ereignisses SĀH. D. 500 . 471	KATHĀS. 55,25;Spr. 4254;SĀH. D. 500;SĀH. D 471
+AKyAna		2	2〉 Verz. d. Oxf. H. 54,b,13 . SĀH. D. 560 . — Vgl	Verz. d. Oxf. H. 54,b,13;SĀH. D. 560
+AKyAnaka		1	1〉 n. eine kleine Erzählung PAÑCAT. 72,16 . 188,6	PAÑCAT. 72,16;PAÑCAT 188,6
+AKyAnaka		2	2〉 f. N. eines Metrums, eine Verbindung von und , ŚRUT. 24 . COLEBR. Misc. Ess. II, 124 . 160 ( VI, 3 ) 164 ( VI, 6 )	ŚRUT. 24;COLEBR. Misc. Ess. II, 124;COLEBR. Misc. Ess. II, 160;COLEBR. Misc. Ess VI, 3;COLEBR. Misc. Ess. II, 164;COLEBR. Misc. Ess VI, 6
+AKyAnaka		2	2〉 Ind. St. 8,359. fg	Ind. St. 8,359. fg
+AKyAnaka		1	und ¦ von einander unterschieden DAŚAK. 16,19. fg	DAŚAK. 16,19. fg
+AKyAta		1	1〉 adj. part. praet. pass. von mit ; s. d	
+AKyAta		2	2〉 n. verbum finitum NIR. 1,1 . ṚV. PRĀT. 12,6 . AV. PRĀT. 1,1 . 4,1 . TRIK. 3,3,149 . H. 242 . an. 3,244 . MED. t. 87 . gaṇa zu P. 2,1,72 . Verz. d. B. H. No. 767	NIR. 1,1;ṚV. PRĀT. 12,6;AV. PRĀT. 1,1;AV. PRĀT 4,1;TRIK. 3,3,149;H. 242;H an. 3,244;MED. t. 87;P. 2,1,72;Verz. d. B. H. No. 767
+AKyAta		2	2〉 VS. PRĀT. 5,16 . 6,1 . 8,54	VS. PRĀT. 5,16;VS. PRĀT 6,1;VS. PRĀT 8,54
+AKyAti		1	1〉 Erzählung, Mittheilung, Verbreitung einer Nachricht, Gerücht: KATHĀS. 5,43 . 11,23	KATHĀS. 5,43;KATHĀS 11,23
+AKyAti		2	2〉 Benennung, Name: KATHĀS. 18,15	KATHĀS. 18,15
+ANga	2	1	1〉 adj. das Thema ( gramm. ) betreffend P. 1,1,63 , Sch	P. 1,1,63
+ANga	2	2	2〉 n. ein zarter Körper TRIK. 2,6,20	TRIK. 2,6,20
+ANgika		1	1〉 adj. mit dem Körper, mit den Gliedern bewerkstelligt AK. 1,1,7,16 . H. 283	AK. 1,1,7,16;H. 283
+ANgika		2	2〉 m. Trommelschläger ŚABDAR. _im_ ŚKDR. Wohl falsche Lesart für ; vgl	ŚABDAR;ŚKDR
+ANgika		1	1〉 SĀH. D. 274 . Verz. d. Oxf. H. 200,a,1	SĀH. D. 274;Verz. d. Oxf. H. 200,a,1
+AQaka		1	1〉 m.n. gaṇa zu P. 2,4,31 . SIDDH. K. 249,b,11 . ein best. Hohlmaass, = 4 Prastha = 16 Kuḍava = 64 Pala = 256 Karṣa = 4096 Māṣa (= 216 Kubik — Aṅgula COLEBR. Alg. 3 ) AK. 2,9,89 . H. 886 . an. 3,9 . M	P. 2,4,31;SIDDH. K. 249,b,11;COLEBR. Alg. 3;AK. 2,9,89;H. 886;H an. 3,9;MED. k. 47;SUŚR. 2,175,15;SUŚR. 2, 68,1;SUŚR. 2, 170,12;SUŚR. 2, 229,16. fgg;HESSLER;SUŚR;GARBHOP;Ind. St. 2,71;HIT. Pr. 19;HESSLER;P. 4,1,22;P 5,1,54;VOP. 6,55
+AQaka		2	2〉 f. gaṇa zu P. 4,1,41	P. 4,1,41
+AQaka		2a	a〉 Cajanus indicus Spreng. (die Hülsenfrucht ist ein beliebtes Gemüse) AK. 2,4,4,18 . 3,6,7 . H. 1175 . an. 3,10 . MED. SUŚR. 1,73,9 . 79,21 . 2,64,2 . 77,7 . 185,21 . 489,15	AK. 2,4,4,18;AK. 2, 3,6,7;H. 1175;H an. 3,10;MED;SUŚR. 1,73,9;SUŚR. 1, 79,21;SUŚR 2,64,2;SUŚR. 2, 77,7;SUŚR. 2, 185,21;SUŚR. 2, 489,15
+AQaka		2b	b〉 eine bes. wohlriechende Erde H. 1056	H. 1056
+AQaka		1	1〉 WEBER, JYOT. 78. fgg. Verz. d. Oxf. H. 307,b,2 . VARĀH. BṚH. S. 53,93	WEBER, JYOT. 78. fgg;Verz. d. Oxf. H. 307,b,2;VARĀH. BṚH. S. 53,93
+AQya		1	1〉 wohlhabend, begütert, reich AK. 3,1,10 . H. 357 . ŚAT. BR. 9,5,1,17 . 14,6,11,1 (= BṚH. ĀR. UP. 4,2,1 ). M. 8,169 . MBH. 3,13234 . BHAG. 16,15 . R. 4,7,8 . SUŚR. 1,39,14 . PAÑCAT. V, 8 . VID. 6	AK. 3,1,10;H. 357;ŚAT. BR. 9,5,1,17;ŚAT. BR 14,6,11,1;BṚH. ĀR. UP. 4,2,1;M. 8,169;MBH. 3,13234;BHAG. 16,15;R. 4,7,8;SUŚR. 1,39,14;PAÑCAT. V, 8;VID. 6
+AQya		2	2〉 mit dem instr. oder am Ende eines comp. : an Etwas reich, strotzend von Etwas, mit Etwas reichlich versehen, vermischt, getränkt: VET. 1,15 . PAÑCAT. I, 83 . R. 1,3,7 . N. 25,5 . AK. 2,1,4 . R. 1,7	VET. 1,15;PAÑCAT. I, 83;R. 1,3,7;N. 25,5;AK. 2,1,4;R. 1,73,20;R 3,21,13;R 4,13,30;R 1,5,14;N. 5,38;VET. 1,11;R. 3,23,19;PAÑCAT. V, 41;SUŚR. 2,45,12;SUŚR. 2, 107,14;SUŚR 225,14;SUŚR 244,8;SUŚR 1,22,18;SUŚR 161,2
+AQya		3	3〉 reichlich, in Ueberfülle vorhanden: SUŚR. 2,207,4 . Vgl. . — Vielleicht aus oder (von ) entstanden; es könnte jedoch auch ein etym. Zusammenhang mit und angenommen werden. Dann wäre die urspr. Bed.	SUŚR. 2,207,4
+AQya		1	¦ [ vgl. [Page1-0614]] Z. 14 lies: st	
+AQya		1	¦ Sp. 614, Z. 2 vom Ende lies st. . — Vgl	
+ARi		1	1〉 m. der Zapfen der Achse (der Theil, welcher in der Nabe läuft): ṚV. 1,35,6 . 5,43,8 . 1,63,3 . Hier vielleicht so v. a. auf dem Wagen; NAIGH. 2,17 : im Kampfe. Nach den Lexicographen ( TRIK. 3,3,12	ṚV. 1,35,6;ṚV 5,43,8;ṚV 1,63,3;NAIGH. 2,17;TRIK. 3,3,120;H. 756;H an. 2,132;SĀY;NIR. 6,32
+ARi		2	2〉 der Theil des Beins unmittelbar über dem Knie: SUŚR. 1,348,17 . 345,4	SUŚR. 1,348,17;SUŚR. 1, 345,4
+ARi		3	3〉 m. f. Ecke eines Hauses TRIK. H. an	TRIK;H. an
+ARi		4	4〉 m. f. Grenze diess. — Vgl	
+ASAbanDa		1	1〉 das Band der Hoffnung; das Muthfassen ( ) H. an. 4,149 . MED. dh. 42	H. an. 4,149;MED. dh. 42
+ASAbanDa		2	2〉 Spinngewebe TRIK. 2,5,28 . H. an. MED. — Beide Bedeutungen hat der Dichter MEGH. 10 vor Augen gehabt	TRIK. 2,5,28;H. an;MED;MEGH. 10
+ASa		1	1〉 adj. essend, am Ende eines comp. H. 7 . ŚAT. BR. 2,5,2,16 . KĀTY. ŚR. 5,6,28 . Vgl	H. 7;ŚAT. BR. 2,5,2,16;KĀTY. ŚR. 5,6,28
+ASa		2	2〉 m. das Essen, s	
+ASa		1	¦ (von 1. ) s. 1	
+ASa		1	¦ m. Speise: in der Hoffnung Wind, den Lebensodem der Liebsten des Reisenden, zur Speise zu bekommen, ŚṚṄGĀRARASĀṢṬAKA 3 _bei_ HAEB. 510 . — Vgl	ŚṚṄGĀRARASĀṢṬAKA 3;HAEB. 510
+ASaNkA		1	1〉 Besorgniss, Befürchtung H. 301 . P. 3,4,8 . 3,1,7, Vārtt. 1 . SUŚR. 1,258,19 . BHARTṚ. 3,4 . mit dem abl. KATHĀS. 17,155 . ad ŚĀK. 14 . R. 4,13,9 . beängstigt KATHĀS. 15,95 . comp. mit dem, was man	H. 301;P. 3,4,8;P 3,1,7, Vārtt. 1;SUŚR. 1,258,19;BHARTṚ. 3,4;KATHĀS. 17,155;ŚĀK. 14;R. 4,13,9;KATHĀS. 15,95;P. 6,2,21;MĀDHY.-Rec;BṚH. ĀR. UP. 4,1,3
+ASaNkA		2	2〉 Misstrauen: KATHĀS. 14,56	KATHĀS. 14,56
+ASaNkA		1	1〉 von Furcht ergriffen PAÑCAT. 47,15	PAÑCAT. 47,15
+ASaNkA		2	2〉 KATHĀS. 64,129	KATHĀS. 64,129
+ASara		1	1〉 Feuer MED. r. 115	MED. r. 115
+ASara		2	2〉 ein Rakṣas AK. 1,1,1,55 . H. 187 . MED. — Vgl	AK. 1,1,1,55;H. 187;MED
+ASaya		1	1〉 Lagerstatt, Sitz, Ort AK. 3,3,12 . H. an. 3,480 . MED. y. 72 . ŚAT. BR. 9,1,1,9 . 3,3,4,28 . 5,5,5,6 . MBH. 3,1387 . PAÑCAT. 141,1 . BHAG. 15,8 . KATHĀS. 20,128 . SUŚR. 2,215,17 . In der Medicin di	AK. 3,3,12;H. an. 3,480;MED. y. 72;ŚAT. BR. 9,1,1,9;ŚAT. BR 3,3,4,28;ŚAT. BR 5,5,5,6;MBH. 3,1387;PAÑCAT. 141,1;BHAG. 15,8;KATHĀS. 20,128;SUŚR. 2,215,17;SUŚR. 1,337,21;WHITE 66;SUŚR. 1,14,1;SUŚR. 1, 43,10;SUŚR. 1, 78,16;SUŚR. 1, 257,9;SUŚR. 1, 329,3;SUŚR 2,117,12;SUŚR. 2, 203,7;DAŚAK. 189,11
+ASaya		2	2〉 Ort, Stelle überh. SUŚR. 2,18,4	SUŚR. 2,18,4
+ASaya		3	3〉 der Sitz der Gefühle und Gedanken, Herz, Gemüth AJAYAP. _im_ ŚKDR. YĀJÑ. 3,62 . BHAG. 10,20 . R. 1,4,30 . KATHĀS. 23,33 . 25,165	AJAYAP;ŚKDR;YĀJÑ. 3,62;BHAG. 10,20;R. 1,4,30;KATHĀS. 23,33;KATHĀS 25,165
+ASaya		4	4〉 der im Herzen ruhende Gedanke, Absicht AK. 3,3,20 . H. 1383 . an. 3,481 . MED. y. 72 . KATHĀS. 12,73 . in dieser Absicht MALLIN. _zu_ KUMĀRAS. 6,46 . PAÑCAT. 51,25 . PRAB. 34,1 . KATHĀS. 20,3 . die	AK. 3,3,20;H. 1383;H an. 3,481;MED. y. 72;KATHĀS. 12,73;MALLIN;KUMĀRAS. 6,46;PAÑCAT. 51,25;PRAB. 34,1;KATHĀS. 20,3;KATHĀS 16,41
+ASaya		5	5〉 Gesinnungsweise, Denkweise: dumm KATHĀS. 6,58 (statt ebend. 132 ist wohl auch zu lesen). VID. 44 . KATHĀS. 16,114 . BHARTṚ. 1,80 (auf den Fluss bezogen: ein Behälter von grausigen Thieren). H. an. 	KATHĀS. 6,58;ebend. 132;VID. 44;KATHĀS. 16,114;BHARTṚ. 1,80;H. an. 2,475;MED. l. 2;DHŪRTAS. 67,3
+ASaya		6	6〉 N. einer Pflanze, Artocarpus integrifolia L. ( ), H. an. MED. — AJAYAP. _im_ ŚKDR. hat noch folgg. Bedd. : Eigenthum, geizig; KUSUMĀÑJALI ebend. : ( s. d. ) Schicksal; BALA beim Sch. zu NAIṢ. 2,77 	H. an;MED;AJAYAP;ŚKDR;KUSUMĀÑJALI ebend;BALA;NAIṢ. 2,77
+ASaya		1	1〉 Z. 10 lies WISE st. WHITE	WISE;WHITE
+ASaya		1	1〉 und	
+ASaya		3	3〉 [Page5-1126] ( ) Bette eines Flusses und zugleich Herz Spr. 5158 . KATHĀS. 20,128	Spr. 5158;KATHĀS. 20,128
+ASaya		3	3〉 DAŚAK. _in_ BENF. Chr. 188,1 . sich glücklich fühlend Spr. 1296	DAŚAK;BENF. Chr. 188,1;Spr. 1296
+ASaya		4	4〉 LA. (II) 88,12 . bei dem alle Wünsche zur Ruhe gekommen sind PAÑCAT. III, 189 . adj. KATHĀS. 56,24	LA. (II) 88,12;PAÑCAT. III, 189;KATHĀS. 56,24
+ASaya		5	5〉 in der Yoga -Lehre die Anlage, mit der ein Mensch zur Welt kommt und die eine Folge der Werke in einer vorangehenden Existenz ist, SARVADARŚANAS. 168,16 . SĀH. D. 213,8 . — Vgl	SARVADARŚANAS. 168,16;SĀH. D. 213,8
+ASaya		3	3〉 das Beispiel Spr. 1296 zu streichen; vgl. Spr. (II) 3062 . — [Page7-1712] Vgl. weiter unten	Spr. 1296;Spr. (II) 3062
+ASira	2	1	1〉 adj. gefrässig H. 394 , Sch	H. 394
+ASira	2	2	2〉 m	
+ASira	2	2a	a〉 Feuer Uṇ. 1,52 . H. ś. 168	Uṇ. 1,52;H. ś. 168
+ASira	2	2	2〉 ein Rakṣas Uṇ. H. ś. 36 . — Vgl	Uṇ;H. ś. 36
+ASis	1	1	1〉 Bitte, Bittgebet, Wunsch NAIGH. 3,21 . NIR. 6,8 . ṚV. 1,179,6 . 3,43,2 . 7,17,5 . 10,128,3 . 8,24,23 . 10,67,11 . VS. 2,10 . 6,10 . 17,57 . 19,29 . AV. 14,2,9 . 4,25,7 . 5,24,1 . 26,9 . 8,9,25 . 26	NAIGH. 3,21;NIR. 6,8;ṚV. 1,179,6;ṚV 3,43,2;ṚV 7,17,5;ṚV 10,128,3;ṚV 8,24,23;ṚV 10,67,11;VS. 2,10;VS 6,10;VS 17,57;VS 19,29;AV. 14,2,9;AV 4,25,7;AV 5,24,1;AV. 5, 26,9;AV 8,9,25;AV. 8,9, 26;AV 11,8,27;TS. 3,1,8,3;TS 5,2,2,1;ŚAT. BR. 1,8,1,9;ŚAT. BR 2,1,4,28;ŚAT. BR 1,3,1,26;ŚAT. BR 2,3,4,5;ŚAT. BR 6,5,2,3. fgg;ŚAT. BR 9,2,3,25;ŚAT. BR 4,2,1,22;ŚAT. BR. 4, 5,6,4;NIR. 7,3;KAUŚ. 60;M. 3,252;M 1,84;BHAG. 4,21;BHAG 6,10;MBH. 14,810;KUMĀRAS. 5,76;P. 8,2,104;AK. 3,4,230;H. 272;H an. 2,575;MED. s. 16;ŚĀK. 51,16;P. 8,2,83;ŚĀK. 187;ŚĀK 49,13;R. 2,32,11;R. 2, 55,17;RAGH. 11,5;RAGH 1,44;SĀV. 4,12;R. 2,34,5;R 6,5,17;R 3,35,105;KUMĀRAS. 7,47
+ASis	1	2	2〉 eine der acht Hauptarzeneien ( ) RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+ASis	1	1	1〉 KĀVYĀD. 1,14 . SĀH. D. 471 . Verz. d. Oxf. H. 122,b,16	KĀVYĀD. 1,14;SĀH. D. 471;Verz. d. Oxf. H. 122,b,16
+ASis	1	3	3〉 Bez. des Charakters und der Personalendungen des Precativs KĀTANTRA 3 . 1,15 . 31	KĀTANTRA 3;KĀTANTRA 1,15;KĀTANTRA 31
+ASitaMBava		1	1〉 adj. wovon man satt wird, sättigend P. 3,2,45 . Sch. VOP. 26,59 . = H. an. 5,47 . MED. v. 66	P. 3,2,45;VOP. 26,59;H. an. 5,47;MED. v. 66
+ASitaMBava		2	2〉 das Sattsein, n. P. , Sch. VOP. m. H. an. MED	P;VOP;H. an;MED
+ASleza		1	1〉 m	
+ASleza		1a	a〉 Umschlingung HALĀY. _im_ ŚKDR. MBH. 2,2585 . MEGH. 105 . ( Handschr. : ) VET. 11,5 . AMAR. 15 . 72 . 94 . PAÑCAT. IV, 7 . MEGH. 3	HALĀY;ŚKDR;MBH. 2,2585;MEGH. 105;VET. 11,5;AMAR. 15;AMAR 72;AMAR 94;PAÑCAT. IV, 7;MEGH. 3
+ASleza		1b	b〉 Berührung VOP. 5,30 . [Page1-0726]	VOP. 5,30
+ASleza		2	2〉 f. N. eines Nakṣatra , pl. AV. 19,7,2 . TS. 4,4,10,1 . ( unbest. ob Kürze oder Länge) SUŚR. 1,106,7 . Verz. d. B. H. No. 1266 . Vgl. und	AV. 19,7,2;TS. 4,4,10,1;SUŚR. 1,106,7;Verz. d. B. H. No. 1266
+ASleza		1	1〉	
+ASleza		1a	a〉 BHĀG. P. 10,13,34 . KATHĀS. 64,123	BHĀG. P. 10,13,34;KATHĀS. 64,123
+ASleza		2	2〉 WEBER, Nax. 2,300 . 387 . MBH. 13,3262 ed. Bomb. st. der ed. Calc. VARĀH. BṚH. S. 3,1 . pl. 9,28	WEBER, Nax. 2,300;WEBER, Nax. 2, 387;MBH. 13,3262;ed. Bomb;ed. Calc;VARĀH. BṚH. S. 3,1;VARĀH. BṚH. S 9,28
+ASmana		1	1〉 adj. steinern P. 4,3,143 , Sch. BHAṬṬ. 4,26	P. 4,3,143;BHAṬṬ. 4,26
+ASmana		2	2〉 m. ein Bein. Aruṇa ʼs, des Wagenlenkers der Sonne, TRIK. 1,1,103 . H. ś. 9	TRIK. 1,1,103;H. ś. 9
+ASrama		1	1〉 Einsiedelei, der Aufenthaltsort der Büsser TRIK. 3,3,292 . H. 1001 . an. 3,461 . MED. m. 39 . M. 6,7 . 11,78 . N. 12,71 . DAŚ. 2,7 . R. 1,2,9 . 3,17 . 8,23 . 9,12 . RAGH. 1,35 . 2,67 . MEGH. 1 . 99	TRIK. 3,3,292;H. 1001;H an. 3,461;MED. m. 39;M. 6,7;M 11,78;N. 12,71;DAŚ. 2,7;R. 1,2,9;R. 1, 3,17;R. 1, 8,23;R. 1, 9,12;RAGH. 1,35;RAGH 2,67;MEGH. 1;MEGH 99;N. 9,22;N 17,45;DAŚ. 1,42;R. 2,54,23;R 3,1,2;ŚĀK. 7,10;ŚĀK 28,15;ŚĀK 100,8;VIŚV. 11,10;SUND. 2,24;MBH
+ASrama		2	2〉 ein Stadium im religiösen Leben des Brahmanen, deren es vier giebt: das des Brahmacārin oder Schülers, das des Gṛhastha oder Hausvaters, das des Vānaprastha oder Einsiedlers und endlich das des Bhi	AK. 2,7,3;TRIK;H. 808;H. an;MED;M. 3,2;M 6,1;M. 6, 33;M. 6, 34;M. 6, 87;M 7,17;M 12,97;M 2,230;M 3,77;M. 3, 78;M 3,50;M 6,66;M 7,35;M 8,390;M 12,102;R. 2,106,21;ŚĀK. 63,16;SUŚR. 1,104,20;RAGH. 8,14;PRAB. 97,4;KATHĀS. 24,150;VP. 294. fgg;MED. m. 39;VET. 32,3
+ASrama		3	3〉 eine Hütte, welche man bei feierlichen Gelegenheiten errichtet. VARĀH. BṚH. S. 44,8 . 16	VARĀH. BṚH. S. 44,8;VARĀH. BṚH. S. 44, 16
+ASrama		4	4〉 unter den 11 Schülern Pṛthvīdhara ʼs Verz. d. Oxf. H. 227,b,15 . Wohl nur ein Beiwort, wie AUFRECHT annimmt	Verz. d. Oxf. H. 227,b,15;AUFRECHT
+ASramapada		1	1〉 = 1. N. 12,47 . DRAUP. 8,48 . R. 1,1,50 . 2,25 . 9,30 . VIŚV. 1,5 . 5,24 . ŚĀK. 15	N. 12,47;DRAUP. 8,48;R. 1,1,50;R. 1, 2,25;R. 1, 9,30;VIŚV. 1,5;VIŚV 5,24;ŚĀK. 15
+ASramapada		2	2〉 = 2. VIKR. 82,21 :	VIKR. 82,21
+ASrava	1	1	1〉 adj. gehorsam, sich fügend AK. 3,1,24 . TRIK. 3,3,412 . H. 432 . an. 3,694 . MED. v. 32 . RAGH. 19,49 . DAŚAK. 79,4	AK. 3,1,24;TRIK. 3,3,412;H. 432;H an. 3,694;MED. v. 32;RAGH. 19,49;DAŚAK. 79,4
+ASrava	1	2	2〉 m	
+ASrava	1	2a	a〉 Einwilligung, Versprechen AK. 1,1,4,14 . TRIK. H. 278 . H. an. MED	AK. 1,1,4,14;TRIK;H. 278;H. an;MED
+ASrava	2	1	1〉 Fluss, Strom LALIT. _in_ BURN. Lot. de la b. l. 822	LALIT;BURN;Lot. de la b. l. 822
+ASrava	2	2	2〉 Leiden ( ) H. an. 3,694 . MED. v. 32	H. an. 3,694;MED. v. 32
+ASrava	2	3	3〉 Fehler, Laster BURN. Lot. de la b. l. 795 . 822	BURN;Lot. de la b. l. 795;Lot. de la b. l 822
+ASrayASa		1	1〉 adj. verzehrend womit man in Berührung kommt ( ) H. an. 4,310 . MED. ś. 31	H. an. 4,310;MED. ś. 31
+ASrayASa		2	2〉 m. Feuer AK. 1,1,1,50 . H. 1099 . H. an. MED. HIT. II, 165 . Vgl. R. 2,104,24 . Var	AK. 1,1,1,50;H. 1099;H. an;MED;HIT. II, 165;R. 2,104,24
+ASraya		1	1〉 woran sich Etwas anschliesst, womit Etwas in unmittelbare Berührung tritt, woran sich Etwas lehnt, worauf sich Etwas stützt, woran Etwas haftet P. 3,3,85 . mich verzehrt der Gram wie Feuer Alles wo	P. 3,3,85;R. 2,104,24;RAGH. 9,60;SUŚR. 2,215,19;SĀṂKHYAK. 41;P. 1,1,9;AK. 3,4,156;ŚĀK. 17,4;P. 3,3,85;JAṬĀDH;ŚKDR;P. 3,3,85;TRIK. 3,3,305;HĀR. 266
+ASraya		2	2〉 Sitz, Standort, Behälter AK. 3,4,87 . H. 991 . 10 . PAÑCAT. 211,4 . HIT. 33,13 . Thiere die in Höhlen wohnen M. 7,72 . adj. R. 1,4,31 . VID. 62 . ŚĀK. 176 . SUŚR. 2,251,11 . ( vgl. ebend. und 257,6	AK. 3,4,87;H. 991;H 10;PAÑCAT. 211,4;HIT. 33,13;M. 7,72;R. 1,4,31;VID. 62;ŚĀK. 176;SUŚR. 2,251,11;ebend;SUŚR. 2, 257,6;ŚUK. 38,17;PAÑCAT. 51,20;KATHĀS. 25,43;R. 2,54,18;RAGH. 11,26;RAGH 3,58;R. 3,39,42
+ASraya		3	3〉 Wohnsitz, Zufluchtsstätte, Ruheplatz überh. : ( ŚAṂK. : = ) ŚVETĀŚV. UP. 2,10 . R. 3,56,1 . 4,43,45 . ŚĀNTIŚ. 4,6 . obdachlos R. 1,44,2 . VET. 28,12	ŚAṂK;ŚVETĀŚV. UP. 2,10;R. 3,56,1;R 4,43,45;ŚĀNTIŚ. 4,6;R. 1,44,2;VET. 28,12
+ASraya		4	4〉 Anschluss, Zuflucht, Hilfe, Beistand, Schutz AK. 2,8,1,18 . H. 735 . PAÑCAT. I, 43 . R. 3,55,16 . VET. 32,10 . R. 4,15,19 . 3,31,37 . sich an mich anschliessend BHAG. 7,1 . das eigene Handeln gewäh	AK. 2,8,1,18;H. 735;PAÑCAT. I, 43;R. 3,55,16;VET. 32,10;R. 4,15,19;R 3,31,37;BHAG. 7,1;BHARTṚ. 2,90;R. 3,41,29;RAGH. 12,35;VET. 32,3;HIT. I, 58;BHAG. 4,20
+ASraya		5	5〉 Ausflucht; Ausrede ( ) JAṬĀDH. _im_ ŚKDR	JAṬĀDH;ŚKDR
+ASraya		6	6〉 Anschluss, Wahl, das Ergreifen: durch Anschluss an rationalistische Lehrbücher M. 2,11 . dadurch dass man seinen Aufenthalt in der Fremde nimmt PAÑCAT. I, 185	M. 2,11;PAÑCAT. I, 185
+ASraya		7	7〉 Anschluss, Verbindung, Verknüpfung: (durch eine Reihe, eine Kette von Erzählungen) SĀV. 6,7 . ( vgl. R. 4,6,1 . 5,81,14 ). INDR. 4,9 . = Menge (?) TRIK. 3,3,305	SĀV. 6,7;R. 4,6,1;R 5,81,14;INDR. 4,9;TRIK. 3,3,305
+ASraya		8	8〉 Anschluss, das Beruhen auf Etwas, Bezug, Abhängigkeit ṚV. PRĀT. 11,8 . 34 . wegen seiner Unabhängigkeit von vorgängiger Bestimmung jener beiden 36 . weil sein Lebensunterhalt von ihr abhängt YĀJÑ. 	ṚV. PRĀT. 11,8;ṚV. PRĀT. 11, 34;ṚV. PRĀT. 11, 36;YĀJÑ. 2,48;MBH. 1,309;PAÑCAT. 155,8;SĀṂKHYAK. 12;SĀṂKHYAK 16;SĀṂKHYAK 62;KĀŚ;P. 1,1,56;P. 1,1, 62;P 7,3,31;YĀJÑ. 3,143;RAGH. 3,24
+ASraya		9	9〉 Subject (woran sich das Prädicat anschliesst) ANNAṂBH. _in_ Z. d. d. m. G. 7,291, N. 1	ANNAṂBH;Z. d. d. m. G. 7,291, N. 1
+ASraya		10	10〉 pl. buddh. die fünf Sinnesorgane und das Manas , als Behälter der Objecte ( ), welche vermittelst ihrer Attribute ( ) darin Eingang finden, BURN. Intr. 449 . Vgl. 2	BURN. Intr. 449
+ASraya		4	4〉 SĀH. D. 477 . 471 . Z. 5 falsch aufgefasst; vgl. Spr. 1255	SĀH. D. 477;SĀH. D 471;Spr. 1255
+ASrayaRa		1	1〉 adj. f	
+ASrayaRa		1a	a〉 sich an Etwas anschliessend, seine Zuflucht nehmend: KUMĀRAS. 4,20	KUMĀRAS. 4,20
+ASrayaRa		1b	b〉 Jmd oder Etwas betreffend: VIKR. 51	VIKR. 51
+ASrayaRa		2	2〉 n	
+ASrayaRa		2a	a〉 das sichirgendwohin-Begeben: ŚVETĀŚV. UP. 2,10	ŚVETĀŚV. UP. 2,10
+ASrayaRa		2b	b〉 das Sichanschliessen, das Annehmen, Erwählen: P. 6,1,123 , Sch	P. 6,1,123
+ASrayin		1	1〉 sich an Etwas schliessend, an Etwas haftend: SUŚR. 1,194,15 . SĀṂKHYAK. 43	SUŚR. 1,194,15;SĀṂKHYAK. 43
+ASrayin		2	2〉 auf Etwas sitzend, seinen Wohnsitz habend: RAGH. 6,4 . ( d. i. ) ŚĀK. 78,19 . VID. 59 . RATNĀV. 27,9 ( SĀH. D. 36,14 fälschlich: )	RAGH. 6,4;ŚĀK. 78,19;VID. 59;RATNĀV. 27,9;SĀH. D. 36,14
+ASrayin		2	2〉 VARĀH. BṚH. S. 16,17 . der Platz und was den Platz einnimmt SĀH. D. 265,5 . 721	VARĀH. BṚH. S. 16,17;SĀH. D. 265,5;SĀH. D. 265, 721
+ASreza		1	1〉 m. Umschlinger, N. eines Plagegeistes AV. 8,6,2	AV. 8,6,2
+ASreza		2	2〉 f. pl. = , das siebente Nakṣatra TAITT. BR. 3,1,1,7 . Ind. St. 1,92 . 99	TAITT. BR. 3,1,1,7;Ind. St. 1,92;Ind. St. 1, 99
+ASreza		2	2〉 WEBER, Nax. 2,300 . 303 . 371	WEBER, Nax. 2,300;WEBER, Nax. 2, 303;WEBER, Nax. 2, 371
+ASrita		1	1〉 adj. s. u. mit	
+ASrita		2	2〉 subst. pl. buddh. die durch die 5 Sinne und das Manas ( s. 10.) aufgenommenen Objecte BURN. Intr. 449	BURN. Intr. 449
+ASruta		1	1〉 adj. s. u. mit	
+ASruta		2	2〉 n. = KĀTY. ŚR. 3,2,3. fgg. 5,4,33 . 9,11. fgg. 9,9,17	KĀTY. ŚR. 3,2,3. fgg;KĀTY. ŚR 5,4,33;KĀTY. ŚR. 5, 9,11. fgg;KĀTY. ŚR 9,9,17
+ASruta		1	¦ Z. 1 lies 3,2,6	
+ASu		1	1〉 adj. ὠϰύς , rasch, schnell NIR. 6,1 . 9,9 . Uṇ. 1,1 . H. an. 2,543 . MED. ś. 1 . ṚV. 1,117,9 . 10,107,10 . 119,3 . von Indra 103,1 . vom Winde AV. 10,6,11 . von Vögeln ṚV. 1,118,4 . von den durch d	NIR. 6,1;NIR 9,9;Uṇ. 1,1;H. an. 2,543;MED. ś. 1;ṚV. 1,117,9;ṚV 10,107,10;ṚV. 10, 119,3;ṚV. 10, 103,1;AV. 10,6,11;ṚV. 1,118,4;ṚV. 1, 135,6;ṚV 4,7;ṚV 5,7;VS. 14,23;ŚAT. BR. 5,1,4,8;ṚV. 2,24,13;ŚAT. BR. 4,1,3,3;ŚAT. BR 13,1,2,7;ŚAT. BR 8,2,3,9;ŚAT. BR. 8, 4,1,9;TAITT. UP. 2,8;NAIGH. 2,15;ṚV. 1,84,14;ŚAT. BR. 13,3,6,6;AK. 1,1,1,60;H. 1530;M. 2,168;M 3,15;M. 3, 57;M. 3, 65;M 4,19;M. 4, 71;M. 4, 171;M. 4, 186;M. 4, 243;M 7,12;M 8,22;M. 8, 346;M. 8, 367;M 9,282;M 11,160;M. 11, 241;M. 11, 245;N. 18,16;HIḌ. 3,1;DAŚ. 2,39;SUŚR. 1,121,11;PAÑCAT. I, 225;HIT. I, 1;MEGH. 23;MEGH 40;ṚT. 1,12;ṚT. 1, 26;VID. 174;VID 215;VID 329;P. 3,3,133;R. 3,30,44;Uṇ. 5,57;ŚĀK. 66;HIT. I, 86
+ASu		2	2〉 m	
+ASu		2a	a〉 der Rasche, das Ross NAIGH. 1,14 . ṚV. 2,16,3 . 31,2 . 38,3 . 1,37,14 . 60,5 . AV. 2,14,6 . 4,27,1 . 13,2,2	NAIGH. 1,14;ṚV. 2,16,3;ṚV. 2, 31,2;ṚV. 2, 38,3;ṚV 1,37,14;ṚV. 1, 60,5;AV. 2,14,6;AV 4,27,1;AV 13,2,2
+ASu		2b	b〉 schnellreifender Reis Uṇ. 1,1 . AK. 2,9,15 (es ist entweder oder zu lesen). H. 1168 . an. 2,543 . MED. ś. 1 . ŚAT. BR. 5,3,3,3 . KĀTY. ŚR. 15,4,6 . — Vgl. . Ueber die Etymologie des Wortes s. u	Uṇ. 1,1;AK. 2,9,15;H. 1168;H an. 2,543;MED. ś. 1;ŚAT. BR. 5,3,3,3;KĀTY. ŚR. 15,4,6
+ASu		1	¦ n. N. eines Sāman PAÑCAV. BR. 14,9,9 . 10	PAÑCAV. BR. 14,9,9;PAÑCAV. BR. 14,9, 10
+ASuga		1	1〉 adj. schnell gehend, schnell laufend; von Thieren M. 4,68 . MBH. 1,2630 . 2,1036 . 3,11764 . von Schiffen R. 2,89,17	M. 4,68;MBH. 1,2630;MBH 2,1036;MBH 3,11764;R. 2,89,17
+ASuga		2	2〉 m	
+ASuga		2a	a〉 Wind AK. 1,1,1,57 . 3,4,3,20 . H. 1106 . an. 3,118 . MED. g. 30	AK. 1,1,1,57;AK 3,4,3,20;H. 1106;H an. 3,118;MED. g. 30
+ASuga		2b	b〉 Sonne H. an. Vgl	H. an
+ASuga		2c	c〉 Pfeil AK. 2,8,2,54 . 3,4,3,20 . H. 778 . H. an. MED. MBH. 3,820 . R. 2,35,4 . 3,34,27 . RAGH. 3,54 . 12,91 . DEV. 3,4	AK. 2,8,2,54;AK 3,4,3,20;H. 778;H. an;MED;MBH. 3,820;R. 2,35,4;R 3,34,27;RAGH. 3,54;RAGH 12,91;DEV. 3,4
+ASuga		2d	d〉 N. pr. eines der ersten fünf Anhänger Śākyamuni ʼs VYUTP. 219	VYUTP. 219
+ASuga		1	1〉 TBR. 1,2,1,26	TBR. 1,2,1,26
+ASuheman		1	1〉 zu raschem Lauf angespornt, rasch hineilend: ṚV. 1,116,2	ṚV. 1,116,2
+ASuheman		2	2〉 die Renner antreibend, von Agni : ṚV. 2,1,5 . besonders, wo er als Apāṃ — napāt erscheint, 31,6 . 35,1 . 7,47,2 . TS. 2,4,8,1	ṚV. 2,1,5;ṚV 31,6;ṚV 35,1;ṚV 7,47,2;TS. 2,4,8,1
+ASvAsa		1	1〉 das Aufathmen, Erholung, TRIK. 3,3,442 . H. an. 3,745 . MED. s. 15 . SUŚR. 1,169,9	TRIK. 3,3,442;H. an. 3,745;MED. s. 15;SUŚR. 1,169,9
+ASvAsa		2	2〉 wobei man aufathmet, Trost: KATHĀS. 9,64	KATHĀS. 9,64
+ASvAsa		3	3〉 Abschnitt in einer Erzählung (zum Athemholen) TRIK. H. an. 3,746 . MED. Verz. d. B. H. No. 1355 . — Vgl	TRIK;H. an. 3,746;MED;Verz. d. B. H. No. 1355
+ASvAsa		1	1〉 damit das Herz der Cakravāka aufathmet PRASAṄGĀBH. 15,a	PRASAṄGĀBH. 15,a
+ASvAsa		2	2〉 so v. a. selbst auf einen guten Fürsten kann man sich nicht verlassen Spr. 2620 . kein Vertrauen auf KATHĀS. 57,93 . Muth zugesprochen habend 72,199	Spr. 2620;KATHĀS. 57,93;KATHĀS 72,199
+ASvAsa		3	3〉 SĀH. D. 561 . 568	SĀH. D. 561;SĀH. D 568
+ASvAsana		1	1〉 das Aufathmen — Machen, Beleben: PAÑCAT. 70,21	PAÑCAT. 70,21
+ASvAsana		2	2〉 das Aufheitern, Trösten R. 5,1,9 . MBH. 1,427 . mit dem obj. comp. R. 1,3,32 . 2,24 . 4,61 und MBH. 3,12 in der Unterschr. ŚĀK. 81,21 , v. l	R. 5,1,9;MBH. 1,427;R. 1,3,32;R. 1, 2,24;R. 1, 4,61;MBH. 3,12;ŚĀK. 81,21
+ASvAsana		2	2〉 KATHĀS. 55,65	KATHĀS. 55,65
+ASva		1	1〉 adj. dem Pferde zugehörig, von ihm herrührend u. s. w. : (Pferdegestalt) NIR. 12,10 . SUŚR. 1,194,2 . von Pferden gezogen: P. 4,2,92 , Sch. 4,3,120, Vārtt. 2 , Sch. 4,3,123 , Sch	NIR. 12,10;SUŚR. 1,194,2;P. 4,2,92;P 4,3,120, Vārtt. 2;P 4, 4,3,123
+ASva		2	2〉 n	
+ASva		2a	a〉 ein Trupp Pferde P. 4,2,48 . AK. 2,8,2,16 . H. 1420	P. 4,2,48;AK. 2,8,2,16;H. 1420
+ASva		2b	b〉 = P. 5,1,129 , Sch	P. 5,1,129
+ASva		2	2〉	
+ASva		2c	c〉 N. verschiedener Sāman Ind. St. 3,206,b	Ind. St. 3,206,b
+ASvatTa		1	1〉 adj. f. ( gaṇa zu P. 4,1,41 )	P. 4,1,41
+ASvatTa		1a	a〉 vom heiligen Feigenbaum genommen u. s. w. TS. 2,3,1,5 . AIT. BR. 7,30 . ŚAT. BR. 2,1,4,5 . 4,3,3,6 . 11,5,1,15 . 5,2,1,17 . 3,2,5 . KĀTY. ŚR. 1,3,35 . 15,4,39 . KAUŚ. 15 . 49 . MIT. 147,7 . H. 816	TS. 2,3,1,5;AIT. BR. 7,30;ŚAT. BR. 2,1,4,5;ŚAT. BR 4,3,3,6;ŚAT. BR 11,5,1,15;ŚAT. BR 5,2,1,17;ŚAT. BR. 5, 3,2,5;KĀTY. ŚR. 1,3,35;KĀTY. ŚR 15,4,39;KAUŚ. 15;KAUŚ 49;MIT. 147,7;H. 816
+ASvatTa		1b	b〉 auf die Fruchtzeit des Feigenbaums bezüglich: P. 4,2,5 , Sch	P. 4,2,5
+ASvatTa		2	2〉 n. die Frucht der Ficus religiosa , gaṇa zu P. 4,3,164 . AK. 2,4,1	P. 4,3,164;AK. 2,4,1
+ASvatTa		1	1〉	
+ASvatTa		1b	b〉 lies zum Nakṣatra Aśvattha in Beziehung stehend und vgl. oben u	
+ASvayuja		1	1〉 adj. unter dem Sternbild Aśvayuj geboren P. 4,3,36	P. 4,3,36
+ASvayuja		2	2〉 m. der Monat Āśvina AK. 1,1,3,17 . H. 155 . SUŚR. 1,20,3 . 170,2 . M. 6,15 . YĀJÑ. 3,47	AK. 1,1,3,17;H. 155;SUŚR. 1,20,3;SUŚR. 1, 170,2;M. 6,15;YĀJÑ. 3,47
+ASvayuja		3	3〉 f. ( sc. ) der Vollmondstag [Page1-0727] im Monat Āśvina ŚABDAR. _im_ ŚKDR. ĀŚV. GṚHY. 2,2 . KĀTY. ŚR. 23,4,4 . PĀR. GṚHY. 2,16 . P. 4,3,45 . ein auf diesen Tag fallender Pākayajña ĀŚV. a. a. O. NĀ	ŚABDAR;ŚKDR;ĀŚV. GṚHY. 2,2;KĀTY. ŚR. 23,4,4;PĀR. GṚHY. 2,16;P. 4,3,45;ĀŚV. a. a. O;NĀR;ŚĀṄKH. GṚHY;Z. d. d. m. G. 7,527, N. 2
+ASvayuja		2	2〉 WEBER, Nax. 2,327 . 331 . 333 . 348 . Verz. d. Oxf. H. 46,b,8 . 70,b,1 . VARĀH. BṚH. S. 44,2	WEBER, Nax. 2,327;WEBER, Nax. 2, 331;WEBER, Nax. 2, 333;WEBER, Nax. 2, 348;Verz. d. Oxf. H. 46,b,8;Verz. d. Oxf. H 70,b,1;VARĀH. BṚH. S. 44,2
+ASvayuja		3	3〉 WEBER, Nax. 2,325. fgg. 394 . = Verz. d. Oxf. H. 30,b,6 . 266,b,37	WEBER, Nax. 2,325. fgg;WEBER, Nax. 2, 394;Verz. d. Oxf. H. 30,b,6;Verz. d. Oxf. H 266,b,37
+ASvayuja		4	4〉 adj. zum Monat Āśvayuja in Beziehung stehend: (des Jnpitercyclus) VARĀH. BṚH. S. 8,14	VARĀH. BṚH. S. 8,14
+ASvina	1	1	1〉 adj	
+ASvina	1	1a	a〉 Rossen oder Reitern gleichend: ṚV. 9,86,4 ( vgl	ṚV. 9,86,4
+ASvina	1	1		
+ASvina	1	1b	b〉 den Aśvin gehörig, geweiht VS. 24,3 . AIT. BR. 2,25 . ŚAT. BR. 4,1,5,1 . 5,3,1,8 . 11,5,3,5 . 5,9 . KĀTY. ŚR. 12,6,3 . 6 . 7 . 19,3,2 . ĀŚV. ŚR. 9,2 . TS. 2,1,10,1 . 6,4,9,1	VS. 24,3;AIT. BR. 2,25;ŚAT. BR. 4,1,5,1;ŚAT. BR 5,3,1,8;ŚAT. BR 11,5,3,5;ŚAT. BR. 11,5, 5,9;KĀTY. ŚR. 12,6,3;KĀTY. ŚR. 12,6, 6;KĀTY. ŚR. 12,6, 7;KĀTY. ŚR 19,3,2;ĀŚV. ŚR. 9,2;TS. 2,1,10,1;TS 6,4,9,1
+ASvina	1	2	2〉 m. N. eines Regenmonats (in dem der Vollmond bei dem Sternbilde Aśvinī steht) AK. 1,1,3,17 . H. 155 . COLEBR. Misc. Ess. I, 186 . 193 . VP. 225, N. 19 . Vgl	AK. 1,1,3,17;H. 155;COLEBR. Misc. Ess. I, 186;COLEBR. Misc. Ess. I, 193;VP. 225, N. 19
+ASvina	1	3	3〉 f. Bez. gewisser Brennziegel ( ) TS. 5,3,1,1 . ŚAT. BR. 8,2,1,11 . 10,4,3,15 . KĀTY. ŚR. 17,8,1 . 15 . 11,1 . 12,1 . = P. 4,4,126	TS. 5,3,1,1;ŚAT. BR. 8,2,1,11;ŚAT. BR 10,4,3,15;KĀTY. ŚR. 17,8,1;KĀTY. ŚR. 17,8, 15;KĀTY. ŚR. 17, 11,1;KĀTY. ŚR. 17, 12,1;P. 4,4,126
+ASvina	1	2	2〉 Verz. d. Oxf. H. 284,a,7 v. u. b,12 . 25 . 27 . 35 . 47 . 285,a,8 . 9 . 16 . 21	Verz. d. Oxf. H. 284,a,7 v. u. b,12;Verz. d. Oxf. H. 284,a,7 v. u. b, 25;Verz. d. Oxf. H. 284,a,7 v. u. b, 27;Verz. d. Oxf. H. 284,a,7 v. u. b, 35;Verz. d. Oxf. H. 284,a,7 v. u. b, 47;Verz. d. Oxf. H. 284, 285,a,8;Verz. d. Oxf. H. 284,a,7 v. u. b, 9;Verz. d. Oxf. H. 284,a,7 v. u. b, 16;Verz. d. Oxf. H. 284,a,7 v. u. b, 21
+ASvina	1	4	4〉 n. das Nakṣatra Aśvinī VARĀH. BṚH. S. 7,6 . 15,29 . 98,9	VARĀH. BṚH. S. 7,6;VARĀH. BṚH. S 15,29;VARĀH. BṚH. S 98,9
+ASvineya		1	1〉 patron. von Aśvinau , ein Bein. Sahadeva ʼs, des jüngsten der Pāṇḍava , MBH. 2,1115	MBH. 2,1115
+ASvineya		2	2〉 metron. von , ein Bein. der beiden Aśvin , AK. 1,1,1,47 . H. 181 , Sch	AK. 1,1,1,47;H. 181
+ASvineya		1	1〉 du. Bez. Nakula ʼs und Sahadeva ʼs MBH. 5,4692	MBH. 5,4692
+ATarvaRa		1	1〉 adj. f. von Atharvan oder von den Atharvan herrührend, ihnen gehörig u. s. w. P. 4,3,133 ( vgl. PAT. ). AV. 4,3,7 . 11,4,16 . P. 4,3,133 , Sch. Verz. d. B. H. No. 366 . Ind. St. 1,297 . 2,396 . (ei	P. 4,3,133;PAT;AV. 4,3,7;AV 11,4,16;P. 4,3,133;Verz. d. B. H. No. 366;Ind. St. 1,297;Ind. St 2,396;Ind. St 1,297
+ATarvaRa		2	2〉 m. ein Abkömmling Atharvan ʼs oder der Atharvan , z. B. Dadhyañc ṚV. 1,116,12 . 117,22 . TS. 5,1,4,4 . AV. 6,1,1 . 10,6,20 . 16,8,12 . 19,23,1 . ŚAT. BR. 4,1,5,18 . 6,4,2,3 . 14,1,1,8 . 6,7,1 = BṚH	ṚV. 1,116,12;ṚV. 1, 117,22;TS. 5,1,4,4;AV. 6,1,1;AV 10,6,20;AV 16,8,12;AV 19,23,1;ŚAT. BR. 4,1,5,18;ŚAT. BR 6,4,2,3;ŚAT. BR 14,1,1,8;ŚAT. BR. 14, 6,7,1;BṚH. ĀR. UP. 2,5,16;BṚH. ĀR. UP 3,7,1;Ind. St. 1,84;Ind. St. 1, 87;Ind. St. 1, 217;Ind. St. 1, 291;Ind. St. 1, 295;Ind. St. 1, 384
+ATarvaRa		3	3〉 m. Bezeichnung eines bes. Priesters, dessen Ritual der AV. bildet, Ind. St. 1,296 . 446 . ein mit dem AV. vertrauter Brahman H. an. 4,74	AV;Ind. St. 1,296;Ind. St. 1, 446;AV;H. an. 4,74
+ATarvaRa		4	4〉 m. Hauspriester ( ) H. an. 4,74	H. an. 4,74
+ATarvaRa		5	5〉 m. der Atharva-Veda CHĀND. UP. 7,1,2 . 4 . Ind. St. 1,146 . 266 . P. 4,3,133 , PAT. , Sch. n. = gaṇa zu P. 4,2,38 . AK. 3,3,43	CHĀND. UP. 7,1,2;CHĀND. UP. 7,1, 4;Ind. St. 1,146;Ind. St. 1, 266;P. 4,3,133;PAT;P. 4,2,38;AK. 3,3,43
+ATarvaRa		6	6〉 n. ein Gemach, in welchem der Opferpriester dem Veranstalter eines Opfers das Gelingen desselben meldet, H. 997	H. 997
+ATarvaRa		2	2〉 Bhiṣaj Ind. St. 3,459	Ind. St. 3,459
+ATarvaRa		3	3〉 Spr. 4577	Spr. 4577
+ATarvaRa		5	5〉 Verz. d. Oxf. H. 163,a,1 . 265,b,25 . 270,a,17 . 108,a,20 . eine zum AV. gehörige Schrift: Schol. zu KĀTY. ŚR. 4,11,1 . BHĀG. P. 12,7,4	Verz. d. Oxf. H. 163,a,1;Verz. d. Oxf. H 265,b,25;Verz. d. Oxf. H 270,a,17;Verz. d. Oxf. H 108,a,20;AV;KĀTY. ŚR. 4,11,1;BHĀG. P. 12,7,4
+ATarvaRa		7	7〉 n. N. verschiedener Sāman Ind. St. 3,205,a . — Verz. d. Oxf. H. 7,b,12 . 31,b,12	Ind. St. 3,205,a;Verz. d. Oxf. H. 7,b,12;Verz. d. Oxf. H 31,b,12
+AYjana		2	2〉 f. dass. : R. 2,91,70 . GORR. (2,100, hat st. dessen	R. 2,91,70;GORR. (2,100,71)
+AYjana		1	¦ Z. 1 lies . adj. die Farbe von Augensalbe habend MBH. 5,1708	MBH. 5,1708
+AYjana		2	2〉 nach dem Comm. ( 2,91,77 ed. Bomb. ) ein Kästchen mit Augensalbe	R 2,91,77 ed. Bomb
+AbADa		1	1〉 m. Angriff ṚV. 8,23,3	ṚV. 8,23,3
+AbADa		2	2〉 m. Belästigung, Störung, Unterbrechung, Schaden AK. 1,2,2,3 . P. 6,2,21 . 8,1,10 . MBH. 3,12640 . SUŚR. 2,135,14 . und MBH. 2,223 . 1,3975 . SUŚR. 1,66,8 . 239,9 . adj. f. MBH. 3,16289 . ARJ. 2,17 	AK. 1,2,2,3;P. 6,2,21;P 8,1,10;MBH. 3,12640;SUŚR. 2,135,14;MBH. 2,223;MBH 1,3975;SUŚR. 1,66,8;SUŚR. 1, 239,9;MBH. 3,16289;ARJ. 2,17;HIḌ. 4,12;SUŚR. 2,213,1;SUŚR 1,23,14;M. 4,51;M. 4, 54;P. 6,2,21;SUŚR. 1,70,15;SUŚR. 1, 91,18
+AbADa		3	3〉 f. Segment einer Basis COLEBR. Alg. 70 . Vgl	COLEBR. Alg. 70
+AbADa		2	2〉 füge Pein, Leiden hinzu. = HALĀY. 3,4 . — Vgl	HALĀY. 3,4
+AbadDa		1	1〉 adj. s. u	
+AbadDa		2	2〉 m	
+AbadDa		2a	a〉 ein festes Band MED. dh. 28	MED. dh. 28
+AbadDa		2b	b〉 Schmuck TRIK. 3,3,215 . MED	TRIK. 3,3,215;MED
+AbadDa		2c	c〉 Zuneigung MED. — Vgl	MED
+AbadDa		2	2〉	
+AbadDa		2b	b〉 n. ŚĀṄKH. GṚHY. 2,1	ŚĀṄKH. GṚHY. 2,1
+AbanDa		1	1〉 Band H. an. 3,342 . AMAR. 38	H. an. 3,342;AMAR. 38
+AbanDa		2	2〉 der Riemen, mit dem ein Ochs anʼs Joch oder an den Pflug gebunden wird, AK. 2,9,13 . H. 893	AK. 2,9,13;H. 893
+AbanDa		3	3〉 Schmuck H. an	H. an
+AbanDa		4	4〉 Zuneigung ( , vgl. u	
+AbanDa		1	H. an. — Vgl	H. an
+Abarha		1	1〉 adj. ausreissend s	
+Abarha		2	2〉 m. das Ausreissen SIDDH. K. _zu_ P. 4,4,88	SIDDH. K;P. 4,4,88
+AcAma		1	1〉 Ausspülung des Mundes ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+AcAma		2	2〉 das Wasser, der Schaum von gekochtem Reise AK. 2,9,49 . H. 396 . KĀTY. ŚR. 19,1,22 . YĀJÑ. 3,322	AK. 2,9,49;H. 396;KĀTY. ŚR. 19,1,22;YĀJÑ. 3,322
+AcAra		1	1〉 Wandel, Handlungsweise, Betragen, Benehmen; guter Wandel, gutes Betragen; Herkommen, Brauch, Sitte, Observanz (die Bedeutungen spielen bisweilen so in einander über, dass keine Scheidung möglich is	AK. 3,4,141;AK. 3,4, 151;H. 80;H 843;P. 3,1,10;M. 2,69;M. 2, 12;M 4,155;VP. 300;M. 2,193;YĀJÑ. 1,87;MBH. 3,13760. fgg;R. 6,10,24;P. 3,2,1, Vārtt. 6;M. 3,167;M 10,9;M 4,246;SUŚR. 2,144,6;M. 4,157;BHAG. 9,30;PAÑCAT. I, 437;PRAB. 16,3;PAÑCAT 48,4;BHAG. 3,6;HIḌ. 1,48;R. 1,6,13;SĀV. 6,16;M. 1,107. fgg;M 2,18;YĀJÑ. 1,342;KAUŚ. 1;BHAG. 16,7;M. 3,165;M 1,109;M 5,4;R. 3,23,38;PAÑCAT. V, 33;R. 3,37,5;MBH. 3,13764;R. 1,6,17;P. 8,1,60;AK. 2,7,11;M. 4,145;M. 4, 146;YĀJÑ. 1,15;R. 2,1,16;RAGH. 2,10;RAGH 7,24;R. 3,1,7;NIR. 7,4;ṚV. PRĀT. 3,13;ṚV. PRĀT. 3, 14;ŚĀK. 100;YĀJÑAVALKYAʼs Gesetzbuch
+AcAra		2	2〉 bestimmte Verhaltungsweise, Diät SUŚR. 2,184,8 . Vgl	SUŚR. 2,184,8
+AcAra		3	3〉 Richtschnur: (die Sonne wird angeredet) MBH. 3,166 . — Vgl	MBH. 3,166
+AcAra		1	1〉 Z. 2 vom Ende lies st	
+AcAra		4	4〉 bei den Buddhisten die Erklärung, dass man mit dem vom Lehrer Gesagten einverstanden sei: SARVADARŚANAS. 15,11. fg	SARVADARŚANAS. 15,11. fg
+AcAra		1	¦, n. zu feines Benehmen und n. grobes Benehmen Spr. (II) 156	Spr. (II) 156
+AcArya		1	1〉 m	
+AcArya		1a	a〉 Lehrer, insbes. von einem Brahmanen, der seinen Schüler mit der heiligen Schnur umgürtet und denselben in die heiligen Schriften einführt, VOP. 26,16 . AK. 2,7,7 . TRIK. 3,2,12 . H. 78 . AV. 11,5,1	VOP. 26,16;AK. 2,7,7;TRIK. 3,2,12;H. 78;AV. 11,5,1;ŚAT. BR. 3,6,2,15;ŚAT. BR 10,1,4,10;ŚAT. BR 11,3,3,3;ŚAT. BR. 11,3,3, 6;ŚAT. BR. 11,3,3, 7;ŚAT. BR. 11, 5,4,2;ŚAT. BR. 11,3,3, 12;ŚAT. BR 12,2,2,13;TAITT. UP. 1,3,5;ĀŚV. GṚHY. 3,4;KAUŚ. 92;NIR. 1,4;NIR 7,22;P. 6,2,36;M. 2,140;YĀJÑ. 1,34;M. 2, 145;M. 2, 171;M. 2, 225;M 4,182;M 3,162;TAITT. UP. 1,11,2;P. 1,3,36;H. p. 15;VOP. p. 175
+AcArya		1b	b〉 ein Bein. Droṇa ʼs, des Lehrers der Pāṇḍu , TRIK. 2,8,19 . Vgl. BHAG. 1,2	TRIK. 2,8,19;BHAG. 1,2
+AcArya		2	2〉 f. Lehrerin AK. 2,6,1,14 . H. 524 . SIDDH. K. _zu_ P. 4,1,49 . Vgl. . — Man pflegt adeundus als ursprüngliche Bedeutung von (von mit ) aufzustellen ( vgl. MBH. 14,678 : ); vielleicht liesse sich ab	AK. 2,6,1,14;H. 524;SIDDH. K;P. 4,1,49;MBH. 14,678
+AcAryaka		1	1〉 adj. vom Lehrer kommend P. 4,2,104, Vārtt. 21 , Sch	P. 4,2,104, Vārtt. 21
+AcAryaka		2	2〉 n. Lehreramt: PAÑCAT. III, 268 . RAGH. 12,78 . DAŚAK. 103,13 . MĀLAT. 16,4 ( vgl. SĀH. D. 54,10 )	PAÑCAT. III, 268;RAGH. 12,78;DAŚAK. 103,13;MĀLAT. 16,4;SĀH. D. 54,10
+AcCAdana		1	1〉 das Verdecken, Verhüllen, Verbergen AK. 1,1,2,24 . 3,4,127 . H. an. 4,159 . MED. n. 167 . KĀTY. ŚR. 8,3,12 . VOP. 9,46	AK. 1,1,2,24;AK. 1, 3,4,127;H. an. 4,159;MED. n. 167;KĀTY. ŚR. 8,3,12;VOP. 9,46
+AcCAdana		2	2〉 Bekleidung, Kleidung AK. 2,6,3,17 . 3,4,127 . 133 . 183 . H. 666 , Sch. H. an. MED. P. 4,3,143 . 6,2,170 . M. 3,59 . 9,202 . YĀJÑ. 1,82 . MBH. 2,1252 . 3,14688 . SĀV. 3,20 . R. 2,37,8 . 3,58,24 . P	AK. 2,6,3,17;AK. 2, 3,4,127;AK. 2,6,3, 133;AK. 2,6,3, 183;H. 666;H. an;MED;P. 4,3,143;P 6,2,170;M. 3,59;M 9,202;YĀJÑ. 1,82;MBH. 2,1252;MBH 3,14688;SĀV. 3,20;R. 2,37,8;R 3,58,24;PAÑCAT. 128,20;PAÑCAT 129,8;PAÑCAT 134,22;PAÑCAT 135,7;PAÑCAT. 135, 10;PAÑCAT. 226,17
+AcCAdana		2	2〉 Betttuch: R. 7,37,11	R. 7,37,11
+AcCAdana		3	3〉 = Dachstuhl HALĀY. 2,148	HALĀY. 2,148
+AcCurita		1	1〉 adj. gekratzt, geritzt, gereizt: KATHĀS. 17,35	KATHĀS. 17,35
+AcCurita		2	2〉 n	
+AcCurita		2a	a〉 ein mit den Nägeln hervorgebrachtes Geräusch ( )	
+AcCurita		2b	b〉 lautes Lachen DHAR. _im_ ŚKDR	DHAR;ŚKDR
+AcCuritaka		1a	a〉 eine besondere Art Verletzung durch einen Fingernagel, = TRIK. 3,3,5 . = H. an. 5,1 . [Page1-0608] = MED. k. 224	TRIK. 3,3,5;H. an. 5,1;MED. k. 224
+AcCuritaka		1b	b〉 lautes Lachen AK. 1,1,7,34 . TRIK. H. 298 . H. an. MED	AK. 1,1,7,34;TRIK;H. 298;H. an;MED
+AcamanIya		1	1〉 adj. zum Ausspülen des Mundes dienend: ĀŚV. GṚHY. 4,6	ĀŚV. GṚHY. 4,6
+AcamanIya		2	2〉 n. Wasser zum Ausspülen des Mundes ĀŚV. GṚHY. 1,24 . KAUŚ. 90 . MBH. 3,13662 . 13718 . INDR. 3,2 . VIŚV. 2,16	ĀŚV. GṚHY. 1,24;KAUŚ. 90;MBH. 3,13662;MBH. 3, 13718;INDR. 3,2;VIŚV. 2,16
+AcamanIya		1	1〉 nach NĀR. nicht adj. zu , sondern m. ein Gefäss zum Ausspülen des Mundes	NĀR
+Acamana		1	1〉 das Ausspülen des Mundes AK. 2,7,35 . H. 837 . KULL. _zu_ M. 3,251 und 5,142 . Verz. d. B. H. No. 1022	AK. 2,7,35;H. 837;KULL;M. 3,251;M 5,142;Verz. d. B. H. No. 1022
+Acamana		2	2〉 Wasser zum Ausspülen des Mundes: YĀJÑ. 1,242 . (kann auch zu 1. gezogen werden) 195	YĀJÑ. 1,242;YĀJÑ. 1, 195
+Acamana		1	1〉 Verz. d. Oxf. H. 8,a,37 . 85,a,31 . 267,b,5 . 272,b, No. 644 . 286,a, No. 670 . AV. PRĀT. 4,107 , Sch	Verz. d. Oxf. H. 8,a,37;Verz. d. Oxf. H 85,a,31;Verz. d. Oxf. H 267,b,5;Verz. d. Oxf. H 272,b, No. 644;Verz. d. Oxf. H 286,a, No. 670;AV. PRĀT. 4,107
+Acamana		2	2〉 Verz. d. Oxf. H. 103,b,20 . 24 . WILSON, Sel. Works 2,35	Verz. d. Oxf. H. 103,b,20;Verz. d. Oxf. H. 103,b, 24;WILSON, Sel. Works 2,35
+AcaraRa		1	1〉 Ankunft ṚV. 1,48,3	ṚV. 1,48,3
+AcaraRa		2	2〉 Wandel: MBH. 15,312 . VEDĀNTAS. _in_ BENF. Chr. 219,3	MBH. 15,312;VEDĀNTAS;BENF. Chr. 219,3
+AcaraRa		3	3〉 Karren, Wagen: CHĀND. UP. 8,12,3 . Nach ŚAṂK. m	CHĀND. UP. 8,12,3;ŚAṂK
+AcaraRa		3	3〉 das Thun, Verrichten, Bewerkstelligen: AK. 3,4,18,121 . SĀH. D. 1,5	AK. 3,4,18,121;SĀH. D. 1,5
+Acaritavya		1	1〉 nach hergebrachter Sitte zu verfahren: ŚĀK. 108,22	ŚĀK. 108,22
+Acaritavya		2	2〉 zu thun, zu vollbringen: MBH. 3,15120	MBH. 3,15120
+Acarya		1	1〉 adeundus, zu betreten, zu besuchen: P. 3,1,100, Vārtt. , Sch	P. 3,1,100, Vārtt
+Acarya		2	2〉 zu thun, zu vollbringen: P. 6,1,147 , Sch	P. 6,1,147
+Acita		1	1〉 adj. und	
+Acita		1a	a〉 angesammelt, [Page1-0607] angehäuft, aufgespeichert ( ) H. an. 3,248 . MED. t. 89 . AV. 4,7,5	H. an. 3,248;MED. t. 89;AV. 4,7,5
+Acita		1b	b〉 gefüllt, beladen, besteckt, bespickt H. 1473 . an. MED. ŚAT. BR. 5,4,5,22 . ĀŚV. ŚR. 9,4 . KĀTY. ŚR. 22,11,1 . MBH. 3,11034 . 11572 . R. 3,77,3 . 74,22 . BRAHMA-P. in LA. 53,3 . SUŚR. 2,103,13 . MB	H. 1473;H an;MED;ŚAT. BR. 5,4,5,22;ĀŚV. ŚR. 9,4;KĀTY. ŚR. 22,11,1;MBH. 3,11034;MBH. 3, 11572;R. 3,77,3;R. 3, 74,22;BRAHMA-P. in LA. 53,3;SUŚR. 2,103,13;MBH. 13,3;MBH 3,10255;R. 4,44,55;ST;RAGH. 7,10;KUMĀRAS. 7,61
+Acita		2	2〉 Wagenlast, m. AK. 2,9,88 . TRIK. 3,3,148 . MED. t. 89 . n. H. an. 3,247 . kommt dem Gewicht von 20 Tulā gleich: H. 885	AK. 2,9,88;TRIK. 3,3,148;MED. t. 89;H. an. 3,247;H. 885
+Acita		3	3〉 ein Gewicht von zehn Wagenlasten, n. AK. 2,9,88 . H. an. m. H. 885 . MED. — Als subst. proparox. P. 6,2,146 . am Ende eines adj. comp. f. 4,1,22 ( vgl. 5,1,54 )	AK. 2,9,88;H. an;H. 885;MED;P. 6,2,146;P 4,1,22;P 5,1,54
+Acita		2	2〉 GOBH. 4,6,11	GOBH. 4,6,11
+AdAna	1	1	1〉 das Ansichnehmen, Ergreifen, = H. an. 3,359 . MED. n. 37 . ŚAT. BR. 11,4,2,1 . KĀTY. ŚR. 1,10,9 . 3,6,3 . 4,2,19 . NIR. 7,11 . KUMĀRAS. 5,11 . H. 865	H. an. 3,359;MED. n. 37;ŚAT. BR. 11,4,2,1;KĀTY. ŚR. 1,10,9;KĀTY. ŚR 3,6,3;KĀTY. ŚR 4,2,19;NIR. 7,11;KUMĀRAS. 5,11;H. 865
+AdAna	1	2	2〉 das Fürsichnehmen, Ansichziehen, Empfangen, Wegnehmen, Entziehen AK. 3,4,239 . M. 7,204 . 8,171 . 11,69 . MBH. 2,1205 . M. 8,172 . YĀJÑ. 1,61 . M. 11,15 . RAGH. 4,86 . HIT. IV, 94 . MBH. 3,1211 . d	AK. 3,4,239;M. 7,204;M 8,171;M 11,69;MBH. 2,1205;M. 8,172;YĀJÑ. 1,61;M. 11,15;RAGH. 4,86;HIT. IV, 94;MBH. 3,1211;YĀJÑ. 3,175;M. 11,62;YĀJÑ. 3,235;SUŚR. 2,129,18;SUŚR. 2, 221,1;SUŚR. 2, 190,6;MBH. 3,8501;MBH. 3, 12636
+AdAna	1	3	3〉 Krankheitssymptom RĀJAN. _im_ ŚKDR. — Vgl	RĀJAN;ŚKDR
+AdAna	1	1	1〉 VEDĀNTAS. (Allah.) No. 74	VEDĀNTAS. (Allah.) No. 74
+AdAna	1	2	2〉 WEBER, JYOT. 56 . 58 . 74 . 74	WEBER, JYOT. 56;WEBER, JYOT 58;WEBER, JYOT 74;WEBER, JYOT 74
+AdAna	1	4	4〉 in der Dramatik kurze Angabe der Haupthandlung, = DAŚAR. 1,43 . SĀH. D. 389 . — Vgl	DAŚAR. 1,43;SĀH. D. 389
+AdAna	1	2	2〉 das Nehmen, Anfassen HEM. YOGAŚ. 1,26 . 34 . 38	HEM;YOGAŚ. 1,26;YOGAŚ. 1, 34;YOGAŚ 38
+AdAna	2	1	1〉 das Binden, Fesseln: AV. 6,104,1 . 2 . 3 . 11,9,3	AV. 6,104,1;AV. 6,104, 2;AV. 6,104, 3;AV 11,9,3
+AdAna	2	2	2〉 Pferdeschmuck H. an. 3,358 . MED. n. 37	H. an. 3,358;MED. n. 37
+AdAna	2	1	1〉 (von 3. ) lies das Zerstückeln, Zermalmen	
+AdAna	2	3	3〉 das Binden, Gebundensein: SARVADARŚANAS. 37,11. fgg	SARVADARŚANAS. 37,11. fgg
+AdAra		1	1〉 Anziehung, Anlockung: ṚV. 1,46,5 ?; vgl. 62,11	ṚV. 1,46,5;ṚV. 1, 62,11
+AdAra		2	2〉 N. einer Pflanze, welche der eigentlichen Soma -Pflanze substituirt wird, wo diese nicht zu haben ist: ŚAT. BR. 4,5,10,4 . 5 . 14,1,2,12 . KĀTY. ŚR. 25,12,19 ; vgl. MAHĪDH. _zu_ VS. 37,6	ŚAT. BR. 4,5,10,4;ŚAT. BR. 4,5,10, 5;ŚAT. BR 14,1,2,12;KĀTY. ŚR. 25,12,19;MAHĪDH;VS. 37,6
+AdAra		2	2〉 TBR. 1,4,7,5	TBR. 1,4,7,5
+AdInava		1	1〉 Leiden, Noth ( ) AK. 3,3,29 . H. an. 4,302 . MED. v. 57	AK. 3,3,29;H. an. 4,302;MED. v. 57
+AdInava		2	2〉 Fehler H. 1375 . H. an. MED. HĀR. 196	H. 1375;H. an;MED;HĀR. 196
+AdInava		3	3〉 = ein böser Ausgang (?) H. an. MED. an inflictor of distress WILS	H. an;MED;WILS
+AdIpana		1	1〉 das Anzünden KAUŚ. 80	KAUŚ. 80
+AdIpana		2	2〉 das Aufputzen von Mauern, Fluren u. s. w. bei festlichen Gelegenheiten TRIK. 2,9,13	TRIK. 2,9,13
+AdIpana		1	1〉 BHĀG. P. 3,30,26	BHĀG. P. 3,30,26
+Adadi		1	1〉 verschaffend, gewinnend: ṚV. 8,46,8	ṚV. 8,46,8
+Adadi		2	2〉 wegnehmend, wegschaffend: ṚV. 1,127,6 . 2,24,13	ṚV. 1,127,6;ṚV 2,24,13
+AdarSa		1	1〉 Spiegel AK. 2,6,3,41 . TRIK. 3,3,425 . H. 684 . an. 3,716 . HĀR. 222 . MED. ś. 15 . ŚAT. BR. 14,5,1,9 (= BṚH. ĀR. UP. 2,1,9 .) BṚH. ĀR. UP. 3,9,15 . KĀTY. ŚR. 1,3,41 . MBH. 1,253 . BHAG. 3,38 . R. 	AK. 2,6,3,41;TRIK. 3,3,425;H. 684;H an. 3,716;HĀR. 222;MED. ś. 15;ŚAT. BR. 14,5,1,9;BṚH. ĀR. UP. 2,1,9;BṚH. ĀR. UP. 3,9,15;KĀTY. ŚR. 1,3,41;MBH. 1,253;BHAG. 3,38;R. 3,22,13;R 4,41,31;SUŚR. 2,167,8;SUŚR. 2, 282,1;KATHĀS. 14,53;RAGH. 17,26;KUMĀRAS. 7,22;TRIK;H. an;MED
+AdarSa		2	2〉 Copie eines Werkes H. an. MED. So ist wohl das zur Erklär. gebrauchte zu fassen; WILSON : the original manuscript from which a copy is taken	H. an;MED;WILSON
+AdarSa		3	3〉 N. pr. ein Sohn des 11ten Manu HARIV. 480	HARIV. 480
+AdarSa		4	4〉 N. pr. einer Gegend P. 4,2,124 , Sch. VARĀH. BṚH. S. 14,25 _in_ Verz. d. B. H. 241	P. 4,2,124;VARĀH. BṚH. S. 14,25;Verz. d. B. H. 241
+AdarSa		2	2〉 BHAṬṬOTP. _zu_ VARĀH. BṚH. S. 51,1	BHAṬṬOTP;VARĀH. BṚH. S. 51,1
+AdarSa		5	5〉 das Erblicken Verz. d. Oxf. H. 231,a,23 . eine Wahrnehmung vermittelst des Auges 24. fg	Verz. d. Oxf. H. 231,a,23;Verz. d. Oxf. H 24. fg
+AdarSa		6	6〉 Titel eines Werkes: SARVADARŚANAS. 77,12	SARVADARŚANAS. 77,12
+AdarSa		4	4〉 lies N. pr. eines Berges (nach KAIY. ) PAT. a. a. O. 2,397,b. 6,104,b . Ind. St. 13,359 . WEBER, PRATIJÑĀS. 103,4	KAIY;PAT. a. a. O. 2,397,b. 6,104,b;Ind. St. 13,359;WEBER, PRATIJÑĀS. 103,4
+AdeSa		1	1〉 Bericht, Mittheilung: M. 9,258 . YĀJÑ. 2,304	M. 9,258;YĀJÑ. 2,304
+AdeSa		2	2〉 Anweisung, Vorschrift, Regel: ŚAT. BR. 10,4,5,1 . 14,5,3,11 (= BṚH. ĀR. UP. 2,3,6 .) KĀTY. ŚR. 1,7,28 . TAITT. UP. 1,11,4 . 2,3 . CHĀND. UP. 3,19,1 . in Betreff von diesem folgende Vorschrift KENOP	ŚAT. BR. 10,4,5,1;ŚAT. BR 14,5,3,11;BṚH. ĀR. UP. 2,3,6;KĀTY. ŚR. 1,7,28;TAITT. UP. 1,11,4;TAITT. UP. 1, 2,3;CHĀND. UP. 3,19,1;KENOP. 29;CHĀND. UP. 7,25,1;CHĀND. UP. 7,25, 2;CHĀND. UP 3,5,1;ṚV. PRĀT. 1,22;KĀTY. ŚR. 1,8,38;KĀTY. ŚR 9,5,20;KĀTY. ŚR 25,1,4;KĀTY. ŚR. 25, 3,17;ṚV. PRĀT. 6,4;ĀŚV. GṚHY. 1,4;SUŚR. 1,5,18;SUŚR. 1, 65,16;H. 277;R. 4,25,9;R 1,1,36;PAÑCAT. II, 199;VET. 14,8;VET 29,5;R. 5,68,21;RAGH. 1,92;R. 4,53,11;R 2,29,10;R. 4,53, 11;R 4,4,6;R 3,17,23;PRAB. 33,18
+AdeSa		3	3〉 Vorhersagung ( ) SIDDHĀNTAŚIR. _im_ ŚKDR. MṚCCH. 35,21. fgg. Vgl	SIDDHĀNTAŚIR;ŚKDR;MṚCCH. 35,21. fgg
+AdeSa		4	4〉 ( gramm. ) Substitut, eine substituirte Form, Laut u. s. w. : AV. PRĀT. 1,63 . 2,84 . P. 1,1,48 . 56 . RAGH. 12,58	AV. PRĀT. 1,63;AV. PRĀT 2,84;P. 1,1,48;P. 1,1, 56;RAGH. 12,58
+AdeSa		2	2〉 Lehre VARĀH. BṚH. S. 2,5 . 19 . die Weisen lehren, dass Reichthum das Herz verderbe, Spr. 3142	VARĀH. BṚH. S. 2,5;VARĀH. BṚH. S. 2, 19;Spr. 3142
+AdeSa		4	4〉 ṚV. PRĀT. 16,37	ṚV. PRĀT. 16,37
+AdeSin		1	1〉 adj. anweisend, gebietend: (den Wangen Blässe anweisend) RAGH. 4,68	RAGH. 4,68
+AdeSin		2	2〉 m. Astrolog H. 482 . Vgl. 3	H. 482
+AdeSin		1	¦ (von ) adj. das wofür Etwas substituirt wird, = ebend. 1,135,a	ebend. 1,135,a
+AdiS		1	1〉 das Zielen, Anschlag, Absicht: ṚV. 10,61,3 . 6,4,5 . 8,49,12 . 82,11 . Vgl. auch mit	ṚV. 10,61,3;ṚV 6,4,5;ṚV 8,49,12;ṚV. 8, 82,11
+AdiS		2	2〉 Angabe, Vorschlag: DAŚAK. 109,2 . v. u . WILSON zu d. St. : indication of doubt or suspicion reproved	DAŚAK. 109,2;DAŚAK. 109, v. u;WILSON
+AdiS		3	3〉 Nebenbegriff zu Himmelsgegend in der Formel VS. 6,19	VS. 6,19
+AdiS		2	2〉 es ist zu trennen; vgl. 2	
+AdiS		3	3〉	
+AdibudDa		1	1〉 adj. im Anfange erkannt MĀṆḌ. UP. Kār. 4,92 ; vgl. 98:	MĀṆḌ. UP. Kār. 4,92
+AdibudDa		2	2〉 m. der Ur- Buddha , die höchste Gottheit der nördlichen Buddhisten, BURN. Intr. 117 . 120 . 222 . 230 . 442 . 525 . 581 . 617 . LIA. II, 1084	BURN. Intr. 117;BURN. Intr 120;BURN. Intr 222;BURN. Intr 230;BURN. Intr 442;BURN. Intr 525;BURN. Intr 581;BURN. Intr 617;LIA. II, 1084
+AdikAraRa		1	1〉 Urgrund AK. 1,1,4,6 . ŚAṂK. _zu_ ŚVETĀŚV. UP. 1,5	AK. 1,1,4,6;ŚAṂK;ŚVETĀŚV. UP. 1,5
+AdikAraRa		2	2〉 Analysis, Algebra COLEBR. Alg. 130	COLEBR. Alg. 130
+AdinATa		1	1〉 ein Bein. Ādibuddha ʼs BURN. Intr. 222	BURN. Intr. 222
+AdinATa		2	2〉 N. pr. eines Autors Verz. d. B. H. No. 647	Verz. d. B. H. No. 647
+AdinATa		1	¦ vgl. u	
+Aditeya		1	1〉 Sohn der Aditi : ṚV. 10,88,11 . NIR. 7,29 . 2,13	ṚV. 10,88,11;NIR. 7,29;NIR 2,13
+Aditeya		2	2〉 Gott, Gottheit AK. 1,1,1,3 . H. 88	AK. 1,1,1,3;H. 88
+Aditya		1	1〉 adj	
+Aditya		1a	a〉 der Aditi gehörig, geweiht u. s. w. ; von ihr stammend P. 4,1,85 . TS. 2,2,6,1 . ŚAT. BR. 3,2,3,1 . 6 . 7 . 4,5,1,1 . 5,3,1,4 . KĀTY. ŚR. 4,5,26 . 10,11 . 14 . 15,9,10	P. 4,1,85;TS. 2,2,6,1;ŚAT. BR. 3,2,3,1;ŚAT. BR. 3,2,3, 6;ŚAT. BR. 3,2,3, 7;ŚAT. BR 4,5,1,1;ŚAT. BR 5,3,1,4;KĀTY. ŚR. 4,5,26;KĀTY. ŚR. 4, 10,11;KĀTY. ŚR. 4,5, 14;KĀTY. ŚR 15,9,10
+Aditya		1b	b〉 den Āditya ( s. weiter u. ) gehörig, ihnen zugerechnet, von ihnen stammend P. 4,1,85 . ṚV. 1,105,16 . VS. 13,41 . ŚAT. BR. 6,6,1,2 . 7 . 9 . 4,4,5,19 . BṚH. ĀR. UP. 6,5,3 . CHĀND. UP. 2,24,11 . ṚV.	P. 4,1,85;ṚV. 1,105,16;VS. 13,41;ŚAT. BR. 6,6,1,2;ŚAT. BR. 6,6,1, 7;ŚAT. BR. 6,6,1, 9;ŚAT. BR 4,4,5,19;BṚH. ĀR. UP. 6,5,3;CHĀND. UP. 2,24,11;ṚV. ANUKR
+Aditya		2	2〉 m. Sohn der Aditi :	
+Aditya		2a	a〉 Āditya heissen sieben Götter des himmlischen Lichtes, an deren Spitze Varuṇa steht, welchem deshalb auch vorzugsweise diese Benennung zukommt. ṚV. 9,114,3 ?; vgl. 10,72,8 . 9 . ŚAT. BR. 3,1,3,3 . Ṛ	ṚV. 9,114,3;ṚV 10,72,8;ṚV. 10,72, 9;ŚAT. BR. 3,1,3,3;ṚV. 1,24,13;ṚV. 1,24, 15;ṚV. 1, 25,12;ṚV 2,28,1;ṚV 7,84,4;ṚV. 7, 85,4;NIR. 2,13;TS;SĀY;ṚV. 2,27,1;ROTH;Z. d. d. m. G. 6,68. fgg;ṚV. 2,27,1;ṚV 29,1;ṚV 8,56,1. fgg;AV. 18,4,3;CHĀND. UP. 3,8,1
+Aditya		2b	b〉 sie sind als besondere Götterklasse unterschieden, am häufigsten neben den beiden Ordnungen der Vasu und Rudra oder Marut , aber auch neben den Viśve-Devās , Aṅgiras , Atharvan und Sādhya genannt. 	ṚV. 7,35,14;ṚV. 7,35, 6;ṚV 1,45,1;ṚV 7,51,3;ṚV 10,48,11;ṚV. 10, 125,1;ṚV. 10, 128,9;VS. 2,5;VS 5,11;VS 29,8;AV. 6,68,1;AV. 6, 74,3;AV 9,8,10;AV 10,7,22;ŚAT. BR. 1,5,1,17;ṚV. 2,3,4;AV. 1,9,1;AV 11,6,13;AV 12,3,43;AV. 12,3, 44;AV 8,8,12;AV 19,39,5;TS. 7,3,4,1;TS. 7, 4,6,1;AIT. BR. 6,34;AIT. BR 8,14;ŚAT. BR. 3,5,1,13;ŚAT. BR 4,3,5,19;ŚAT. BR. 4, 4,5,19;ŚAT. BR 6,6,1,11;ŚAT. BR 12,2,2,9;BṚH. ĀR. UP. 1,4,12;M. 3,284;M 11,221;N. 10,24;BHAG. 11,6;BHAG. 11, 22;BRĀHMAṆA;AK. 1,1,1,5;ŚAT. BR. 4,5,7,2;ŚAT. BR 6,1,2,8;ŚAT. BR 11,6,3,5;ŚAT. BR. 11,6,3, 8;BṚH. ĀR. UP. 3,9,5;CHĀND. UP. 3,16,5;MBH. 3,189;MBH. 1,2523. fg;MBH. 1, 4823;HARIV. 175. fgg;HARIV 593. fgg;HARIV 594;MIT. 142,2. fgg;HARIV 11549;HARIV 12456;VP. 122;MBH. 1,2524;MBH 3,3091;BHAG. 10,21;HARIV. 594;MBH. 1,3135;HARIV. 11548;R. 3,20,15;VP. 122;VP 12;PURĀṆA;VP. 234, N
+Aditya		2c	c〉 Āditya als Name der obersten Götter ist zugleich allgemeine Bezeichnung für Götter überhaupt. AK. 1,1,1,3 . TRIK. 3,3,305 . H. 88 , Sch. an. 3,481 . MED. y. 73 . ṚV. 2,1,13 . 10,85,1 . 2 . AV. 19,1	AK. 1,1,1,3;TRIK. 3,3,305;H. 88;H an. 3,481;MED. y. 73;ṚV. 2,1,13;ṚV 10,85,1;ṚV. 10,85, 2;AV. 19,16,2;MBH. 1,2603;MBH 18,215
+Aditya		2d	d〉 Bezeichn. des Sonnengottes (des achten, den sieben andern unebenbürtigen Sohnes der Aditi nach der Mythe ṚV. 10,72,8 . 9 ); Sonne AK. 1,1,2,29 . TRIK. 3,3,305 . H. 95 . an. 3,481 . MED. y. 73 . ṚV.	ṚV. 10,72,8;ṚV. 10,72, 9;AK. 1,1,2,29;TRIK. 3,3,305;H. 95;H an. 3,481;MED. y. 73;ṚV. 1,50,13;ṚV. 1, 163,3;ṚV. 1, 191,9;ṚV 8,90,11;AV. 2,32,1;AV 4,39,6;AV 9,2,15;AV. 9, 8,22;AV 10,3,18;AV 13,2,1;AV. 13,2, 3;AV. 13,2, 28;AV 8,2,15;AIT. BR. 5,28;AIT. BR. 5, 31;ŚAT. BR. 8,7,2,5;ŚAT. BR 10,5,4,14;ŚAT. BR. 10, 6,2,3;ŚAT. BR. 10,5,4, 6;ŚAT. BR. 10,5,4, 9;ŚAT. BR 2,3,1,7;NIR. 7,11;AIT. BR. 5,32;ŚAT. BR. 6,1,2,1;ŚAT. BR. 6, 2,3,2;ŚAT. BR. 6, 3,2,2;ŚAT. BR 7,1,2,5;BṚH. ĀR. UP. 1,3,14;TAITT. UP. 1,5,2;AIT. UP. 1,4;M. 3,76;M 4,37;M. 4, 48;M 7,6;M 9,305;BHAG. 5,16;BHAG 15,12;SĀV. 4,17;INDR. 1,30;N. 1,2;N 10,21;R. 1,1,77;R 4,43,43;R. 4,43, 47;VID. 2;VS. 4,21;VS 1,6;ŚAT. BR. 10,5,4,15;ŚAT. BR 14,6,6,1;BṚH. ĀR. UP. 3,6,1;MBH. 3,7055;Verz. d. B. H. No. 1262;Verz. d. B. H. No 1263;MADHUS;Ind. St. 1,17
+Aditya		2e	e〉 du. N. eines Sternbildes, die 7te Mondstation H. 111 ; vgl	H. 111
+Aditya		2f	f〉 als Synonym von Sonne auch Name der Calotropis gigantea ( s. 9.) ŚKDR	ŚKDR
+Aditya		2g	g〉 N. pr. eines Mannes RĀJA-TAR. 6,345	RĀJA-TAR. 6,345
+Aditya		1	1〉	
+Aditya		1c	c〉 in Beziehung zu Āditya (dem Sonnengott) stehend: Verz. d. Oxf. H. 80,a,6 . Vgl	Verz. d. Oxf. H. 80,a,6
+Aditya		2	2〉	
+Aditya		2a	a〉 Z. 7 vgl. TBR. 1,1,9,1. fgg. auch 10 Āditya werden angenommen; vgl. Ind. St. 5,241	TBR. 1,1,9,1. fgg;Ind. St. 5,241
+Aditya		2b	b〉 die Jaya werden, weil sie bei der Schöpfung ihre Pflichten verabsäumt hatten, von Brahman verflucht unter Anderm auch als Āditya geboren zu werden, Verz. d. Oxf. H. 56,b,25. fgg	Verz. d. Oxf. H. 56,b,25. fgg
+Aditya		2e	e〉 als n. ( sc. ) das unter Aditi stehende Nakṣatra Punarvasu WEBER, Nax. 1,309. fg. VARĀH. BṚH. S. 10,6 . 11,55 . 15,5 . 29 . 32,8 . 98,11	WEBER, Nax. 1,309. fg;VARĀH. BṚH. S. 10,6;VARĀH. BṚH. S 11,55;VARĀH. BṚH. S 15,5;VARĀH. BṚH. S. 15, 29;VARĀH. BṚH. S 32,8;VARĀH. BṚH. S 98,11
+Aditya		2g	g〉 Verz. d. Oxf. H. 212,a, No. 500	Verz. d. Oxf. H. 212,a, No. 500
+Aditya		3	3〉 n. N. eines Sāman Ind. St. 3,205,b	Ind. St. 3,205,b
+Aditya		2	2〉	
+Aditya		2e	e〉 n. ( vgl. Nachträge) SŪRYAS. 8,19	SŪRYAS. 8,19
+AdityavarRa		1	1〉 adj. sonnenfarbig VS. 31,18 . BHAG. 8,9	VS. 31,18;BHAG. 8,9
+AdityavarRa		2	2〉 m. N. pr. eines Mannes Verz. d. B. H. 58,35	Verz. d. B. H. 58,35
+Adizwa		1	1〉 adj. s. u. mit und	
+Adizwa		2	2〉 n	
+Adizwa		2a	a〉 Befehl DHŪRTAS. 67,13	DHŪRTAS. 67,13
+Adizwa		2b	b〉 Ueberbleibsel einer Mahlzeit MED. ṭ. 34	MED. ṭ. 34
+Adizwa		1	¦ m. ( sc. ) Bez. eines best. Bündnisses KĀM. NĪTIS. 9,3 . 15 ; vgl. Spr. 4773	KĀM. NĪTIS. 9,3;KĀM. NĪTIS. 9, 15;Spr. 4773
+Adya	1	1	1〉 adj. f. was zu essen ist, geniessbar; n. Nahrung: AV. 8,2,19 . TS. 2,2,5,6 . ŚAT. BR. 1,8,2,17 . 10,6,2,1 . 13,2,9,8 . 1,3,2,11 . 3,18 . 5,22 . 4,2,1,17 . 13,4,4,8 . PRAŚNOP. 2,11 . M. 5,16 . 24 . 	AV. 8,2,19;TS. 2,2,5,6;ŚAT. BR. 1,8,2,17;ŚAT. BR 10,6,2,1;ŚAT. BR 13,2,9,8;ŚAT. BR 1,3,2,11;ŚAT. BR. 1,3, 3,18;ŚAT. BR. 1,3, 5,22;ŚAT. BR 4,2,1,17;ŚAT. BR 13,4,4,8;PRAŚNOP. 2,11;M. 5,16;M. 5, 24;M. 5, 25;M. 5, 30;M 7,129
+Adya	1	2	2〉 n. Korn RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+Adya	2	1	1〉 adj. f. gaṇa zu P. 4,3,54 . am Ende eines comp. in Bezug auf den Accent gaṇa zu 6,2,131	P. 4,3,54;P 6,2,131
+Adya	2	1a	a〉 am Anfange befindlich, der erste (im Raum, in der Zeit oder in der Ordnung), primitiv AK. 3,2,30 . 3,4,202 . H. 1458 . KĀTY. ŚR. 13,4,18 . 10,2,25 . 16,6,28 . 20,1,5 . 4,15 . 24,3,38 . AV. PRĀT. 3,	AK. 3,2,30;AK 3,4,202;H. 1458;KĀTY. ŚR. 13,4,18;KĀTY. ŚR 10,2,25;KĀTY. ŚR 16,6,28;KĀTY. ŚR 20,1,5;KĀTY. ŚR. 20, 4,15;KĀTY. ŚR 24,3,38;AV. PRĀT. 3,23;M. 3,24;M. 3, 47;M 4,1;M 7,72;M 8,4;M. 8, 333;M 11,265;MBH. 1,22;R. 4,58,29;ŚĀK. 1;ŚĀK 84;HIT. Pr. 6;HIT. Pr 12;HIT. Pr 8,20;RAGH. 1,11;AK. 2,7,12;AK 3,4,212;M. 1,20;ŚRUT. (BR.) 36;M. 1,50;M. 1, 63;M 3,226;M 5,131;M 9,230;N. 3,5;AK. 1,1,1,31;AK. 1, 2,5,8;AK. 1,1, 9,24;AK 2,6,3,21;AK. 2, 3,4,171;H. 3;H 18;H 34
+Adya	2	1b	b〉 unmittelbar vorangehend, am Ende eines comp. : der zehnte ŚRUT. 27 . einem Doppelconsonanten unmittelbar vorangehend 2	ŚRUT. 27
+Adya	2	1c	c〉 voranstehend, einzig in seiner Art, ausgezeichnet: MBH. 1,8130	MBH. 1,8130
+Adya	2	2	2〉 m. pl. eine Klasse von Göttern ( v. l. und ) VP. 263 . HARIV. LANGL. I, 39 ( ed. Calc. 437 : )	VP. 263;HARIV. LANGL. I, 39;ed. Calc. 437
+Adya	2	3	3〉 f. ein Bein. der Durgā ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+Adya	2	1	1〉	
+Adya	2	1c	c〉 Spr. 3684	Spr. 3684
+Adya	2	3	3〉 = MUṆḌAMĀLĀT. 10 _im_ ŚKDR	MUṆḌAMĀLĀT. 10;ŚKDR
+AgAmin		1	1〉 kommend, hinzukommend NIR. 5,11 . 19	NIR. 5,11;NIR. 5, 19
+AgAmin		2	2〉 der da kommen wird, zukünftig Uṇ. 4,7 . gaṇa zu P. 3,3,3 . PAÑCAT. 169,8 . 195,16 . AK. 1,1,3,5 . KATHĀS. 26,65 (fälschlich ). — Vgl	Uṇ. 4,7;P. 3,3,3;PAÑCAT. 169,8;PAÑCAT 195,16;AK. 1,1,3,5;KATHĀS. 26,65
+AgAmin		2	2〉 bevorstehend MBH. 12,8244	MBH. 12,8244
+AgAmin		3	3〉 in der Auguralkunde = wandelbar, beweglich ( Gegens. ) VARĀH. BṚH. S. 96,2	VARĀH. BṚH. S. 96,2
+Agama		1	1〉 adj. hinzukommend, hinzutretend, ergänzend: AV. 6,81,2 . AV. PRĀT. 4,61 . KAUŚ. 23 . superl. gern kommend, schnell kommend: ṚV. 3,58,9 . 4,43,2 . 5,76,2 . 10,15,3 . TAITT. BR. 3,1,1,8	AV. 6,81,2;AV. PRĀT. 4,61;KAUŚ. 23;ṚV. 3,58,9;ṚV 4,43,2;ṚV 5,76,2;ṚV 10,15,3;TAITT. BR. 3,1,1,8
+Agama		2	2〉 m	
+Agama		2a	a〉 Ankunft, das Erscheinen TRIK. 3,3,291 . H. an. 3,461 . MED. m. 39 . R. 2,25,19 . 1,1,39 . 42,26 . 3,16,32 . 4,47,18 . PAÑCAT. III, 45 . RAGH. 14,80 . KATHĀS. 26,11 . MBH. 3,8868 . (ihre Herkunft) M	TRIK. 3,3,291;H. an. 3,461;MED. m. 39;R. 2,25,19;R 1,1,39;R. 1, 42,26;R 3,16,32;R 4,47,18;PAÑCAT. III, 45;RAGH. 14,80;KATHĀS. 26,11;MBH. 3,8868;M. 8,401;R. 4,27,2;N. 21,4;DAŚ. 1,7;ŚĀK. 109;BHAG. 8,18;PAÑCAT. 148,19;CĀṆ. 21;ŚUK. 43,11;BRĀHMAṆ. 1,15;MBH. 2,547;BHAG. 2,14
+Agama		2b	b〉 Hinzutritt, Zusatz NIR. 1,4	NIR. 1,4
+Agama		2c	c〉 Lauf (eines Wassers), Ausfluss: M. 8,252 . [Page1-0597] 9,281 . SUŚR. 2,290,7 . 293,5	M. 8,252;M 9,281;SUŚR. 2,290,7;SUŚR. 2, 293,5
+Agama		2d	d〉 sehr häufig in comp. mit und Wörtern von ähnlicher Bedeutung: Zufluss von Geldern, von Reichthümern; Einkommen, Einkünfte: MBH. 3,88 . HIT. Pr. 18 . MBH. 2,1210 . M. 8,347 . 9,246 . CĀṆ. 85 . BHART	MBH. 3,88;HIT. Pr. 18;MBH. 2,1210;M. 8,347;M 9,246;CĀṆ. 85;BHARTṚ. 2,39;M. 10,115;PAÑCAT. 7,15;PAÑCAT II, 12
+Agama		2e	e〉 mit Ergänzung von oder einem ähnlichen Worte: Zufluss eines Besitzes, bes. das rechtmässige Inbesitzkommen einer Sache: M. 1,81 . 82 . 8,200 . YĀJÑ. 2,27 . 171 . ( SCHL. : praesenti quoque tempori 	M. 1,81;M. 1, 82;M 8,200;YĀJÑ. 2,27;YĀJÑ. 2, 171;SCHL;R. 1,17,8
+Agama		2f	f〉 in comp. mit Zufluss von Kenntnissen, von Wissenschaften KĀṆ. 35 . 37	KĀṆ. 35;KĀṆ 37
+Agama		2g	g〉 mit Ergänzung von oder einem Worte von ähnlicher Bedeutung: Zufluss einer Kenntniss, Kenntniss, Wissen, Nachricht: ( ?) R. 4,35,26 . 6,4,30 . 4,3,2 . MBH. 1,2912 . (nach dem was man davon weiss, ST	R. 4,35,26;R 6,4,30;R 4,3,2;MBH. 1,2912;ST;YĀJÑ. 2,212;STENZLER;YĀJÑ. 2, 92;RAGH. 1,15;RAGH 6,41;BHARTṚ. 2,12;R. 5,87,23
+Agama		2h	h〉 überlieferte Lehre, Vorschrift; Sammlung von solchen Lehren oder Vorschriften, Lehrbuch ( AK. 3,4,89 . TRIK. 3,2,12 . 3,291 . H. an. 3,461 . MED. m. 39 ): M. 12,105 . ( verb. fin. ) MBH. 3,11175 . 	AK. 3,4,89;TRIK. 3,2,12;TRIK. 3, 3,291;H. an. 3,461;MED. m. 39;M. 12,105;MBH. 3,11175;MBH. 3, 1163;MBH. 3, 1030;MBH. 3, 12637;SĀṂKHYAK. 6;SUŚR. 1,24,2;SUŚR 2,10,20;SUŚR. 2, 175,11;SUŚR. 2, 518,7;RAGH. 10,27;PRAB. 85,17;PRAB 29,1;PRAB 51,5;VET. 36,1;DHŪRTAS. 68,15;H. 242;BURN. Intr. 48. fg;BURN. Intr 315;BURN. Intr 317. fg;BURN. Intr 9;GAUḌAPĀDA;Verz. d. B. H. No. 349;Verz. d. B. H. No 352;Ind. St. 2,101;Ind. St. 2, 104;ŚAṂKARA;ebend. 1,469
+Agama		2i	i〉 Suffix AV. PRĀT. 3,77	AV. PRĀT. 3,77
+Agama		2k	k〉 Augment, ein am Anfange, in der Mitte oder am Ende hinzutretender bedeutungsloser Laut P. 3,1,3, Vārtt. u. s. w	P. 3,1,3, Vārtt
+Agama		3	3〉 n. ein Tantra : TANTRAŚĀSTRA _im_ ŚKDR. COLEBR. Misc. Ess. II, 178	TANTRAŚĀSTRA;ŚKDR;COLEBR. Misc. Ess. II, 178
+Agama		1	¦ [ vgl. [Page1-0597]] Das letzte Beispiel u. 2,g gehört zu h; vgl. u	
+Agama		2	2〉	
+Agama		2a	a〉 am Ende eines adj. comp. f. KATHĀS. 56,391	KATHĀS. 56,391
+Agama		2d	d〉 füge noch Erlangung, Erwerb hinzu	
+Agama		2e	e〉 das letzte Beispiel gehört zu	
+Agama		2d	d〉	
+Agama		2f	f〉 das Lernen, Auswendiglernen (beim Lehrer): PAT. _in_ MAHĀBH. 39 . = KAIYY	PAT;MAHĀBH. 39;KAIYY
+Agama		2g	g〉 Kenntnisse, Wissen Spr. 2660 . Das letzte Beispiel gehört zu	Spr. 2660
+Agama		2h	h〉	
+Agama		2h	h〉 = HALĀY. 1,9 . so v. a. Kenntniss des überlieferten Wortlautes Spr. 4919 . der überlieferte Wortlaut der Grammatik [Page5-1091] Ind. St. 5,159. fg. (= MALLIN. ) KIR. 5,18 . 22 (= MALLIN. ). LA. (II	HALĀY. 1,9;Spr. 4919;Ind. St. 5,159. fg;MALLIN;KIR. 5,18;KIR. 5, 22;MALLIN;LA. (II) 87,8
+Agama		60	KATHĀS. 109,75 . Ueberlieferung im Gegens. zu PRAB. 86,14 . von Buddha ʼs Lehre LA. (II) 86,13 . WASSILJEW 64 u. s. w. acht Āgama bei den Jaina WILSON, Sel. Works 1,281	KATHĀS. 109,75;PRAB. 86,14;LA. (II) 86,13;WASSILJEW 64;WILSON, Sel. Works 1,281
+Agama		60i	i〉 zu streichen	
+Agama		60k	k〉 ṚV. PRĀT. 2,11 . 10,14 . 11,6 . 20 . VS. PRĀT. 1,137 . 4,22 . AV. PRĀT. 3,78 . Schol. zu VS. PRĀT. 5,44	ṚV. PRĀT. 2,11;ṚV. PRĀT 10,14;ṚV. PRĀT 11,6;ṚV. PRĀT. 11, 20;VS. PRĀT. 1,137;VS. PRĀT 4,22;AV. PRĀT. 3,78;VS. PRĀT. 5,44
+Agama		60l	l〉 eine best. rhetorische Figur Verz. d. Oxf. H. 208,a,10	Verz. d. Oxf. H. 208,a,10
+Agama		3	3〉 vgl	
+Agamana		1	1〉 das Kommen (auch Wiederkommen) KĀTY. ŚR. 15,2,8 . 19,5,17 . MBH. 1,2876 . N. 3,21 . 21,23 . VIŚV. 8,15 . R. 3,18,13 . PAÑCAT. 194,24 . um nicht wiederzukehren 89,8 . = VID. 215 . Mit dem subj. comp	KĀTY. ŚR. 15,2,8;KĀTY. ŚR 19,5,17;MBH. 1,2876;N. 3,21;N 21,23;VIŚV. 8,15;R. 3,18,13;PAÑCAT. 194,24;PAÑCAT 89,8;VID. 215;R. 1,1,38;R. 1, 3,15;R. 1,1, 35;ŚĀK. 60,18;RAGH. 12,24;KATHĀS. 12,120;VID. 51;PAÑCAT. 214,5;R. 5,59;KATHĀS. 22,106;R. 4,9,29
+Agamana		2	2〉 das Besuchen einer Frau, fleischlicher Umgang: RĀJA-TAR. 5,399	RĀJA-TAR. 5,399
+Agamana		1	1〉 ( INDR. 5,23 ) MBH. 3,1839 . das Eintreffen SĀH. D. 397	INDR. 5,23;MBH. 3,1839;SĀH. D. 397
+Agamana		2	2〉 zu streichen; s. oben	
+Agantu		1	1〉 ankommende, subst. Ankömmling, Fremdling: (mit dem ersten besten Ankömmling) HIT. 18,2 . m. Gast AK. 2,7,33 . H. 499	HIT. 18,2;AK. 2,7,33;H. 499
+Agantu		2	2〉 hinzukommend, sich anhängend, angehängt: VS. PRĀT. 4,7 . KĀTY. ŚR. 3,3,6 . 12,5,1	VS. PRĀT. 4,7;KĀTY. ŚR. 3,3,6;KĀTY. ŚR 12,5,1
+Agantu		3	3〉 von aussen kommend, äusserlich; zustossend, zufällig: NIR. 7,4 . SUŚR. 1,122,11 . 2,1,5 . 17,14 . ( Gegens. ) KAUŚ. 134 . AK. 2,7,48	NIR. 7,4;SUŚR. 1,122,11;SUŚR 2,1,5;SUŚR. 2, 17,14;KAUŚ. 134;AK. 2,7,48
+Agantu		1	1〉 Spr. 2230 . KATHĀS. 61,94	Spr. 2230;KATHĀS. 61,94
+Agantu		3	3〉 Verz. d. Oxf. H. 316,b,5	Verz. d. Oxf. H. 316,b,5
+Agantuka		1	1〉 = 1: HIT. 70,10 . DHŪRTAS. 89,12 . KATHĀS. 24,231 . von Vieh: von selbst herbeikommend, verirrt YĀJÑ. 2,163	HIT. 70,10;DHŪRTAS. 89,12;KATHĀS. 24,231;YĀJÑ. 2,163
+Agantuka		2	2〉 = 2. ĀŚV. ŚR. 9,7 :	ĀŚV. ŚR. 9,7
+Agantuka		3	3〉 = 3. TRIK. 3,1,20 . SUŚR. 1,96,8 . 275,6 . 2,1,4 . eine Lesart, die sich gleichsam eingeschlichen hat, auf keiner besondern Autorität beruht, MALLIN. _zu_ KUMĀRAS. 6,46	TRIK. 3,1,20;SUŚR. 1,96,8;SUŚR. 1, 275,6;SUŚR 2,1,4;MALLIN;KUMĀRAS. 6,46
+Agastya	1	1	1〉 den Weisen Agasti betreffend u. s. w. gaṇa zu P. 4,2,80 . MBH. 1,442 . 3,4085	P. 4,2,80;MBH. 1,442;MBH 3,4085
+Agastya	1	2	2〉 von der Pflanze Agasti grandiflorum herrührend: SUŚR. 1,223,11	SUŚR. 1,223,11
+Agastya	1	2	2〉 auch = Agasti grandiflorum MED. j. 37	MED. j. 37
+Agati		1	1〉 Ankunft (auch Wiederkunft), das Kommen ṚV. 2,5,6 . VS. 20,13 . YĀJÑ. 3,170 . das Entstehen: R. 2,110,1	ṚV. 2,5,6;VS. 20,13;YĀJÑ. 3,170;R. 2,110,1
+Agati		2	2〉 Zufall DAŚAK. _in_ BENF. Chr. 193,9	DAŚAK;BENF. Chr. 193,9
+Agati		1	1〉 Ankunft ŚIŚ. 9,43 . Entstehung Verz. d. Oxf. H. 312,a, No. 745, Z. 21 . so v. a. indem das, woran er gerade denkt, hinzukommt, sich hinzugesellt SĀH. D. 132,7	ŚIŚ. 9,43;Verz. d. Oxf. H. 312,a, No. 745, Z. 21;SĀH. D. 132,7
+Agati		2	2〉 zu streichen, da das Wort auch hier das Herkommen, Herstammen (eines Dinges) bedeutet. BENFEY giebt das Wort durch concern wieder, eben so übersetzt er ( s. oben u. 2. )	BENFEY
+AgnIDrIya		1	1〉 adj. im Āgnīdhra ( n. ) befindlich	
+AgnIDrIya		2	2〉 m	
+AgnIDrIya		2a	a〉 nämlich , das im Āgnīdhra befindliche Feuer AIT. BR. 5,34 . ŚAT. BR. 9,2,3,26 . 3,5,3,4 . 6,1,28 . 2,20 . 21 . 4,4,2,8 . KĀTY. ŚR. 6,9,9 . 8,6,33 . CHĀND. UP. 2,24,7 . (so ist mit der ed. Calc. zu 	AIT. BR. 5,34;ŚAT. BR. 9,2,3,26;ŚAT. BR 3,5,3,4;ŚAT. BR. 3, 6,1,28;ŚAT. BR. 3,5, 2,20;ŚAT. BR. 3,5,3, 21;ŚAT. BR 4,4,2,8;KĀTY. ŚR. 6,9,9;KĀTY. ŚR 8,6,33;CHĀND. UP. 2,24,7;ed. Calc;P. 3,4,16;ĀŚV. ŚR. 4,10
+AgnIDrIya		2b	b〉 nämlich , der Feuerheerd im Āgnīdhra : ŚAT. BR. 7,1,2,12 . 14 . 9,4,3,4 . KĀTY. ŚR. 8,6,16 . 10,6,15 . ĀŚV. ŚR. 5,3 . 7	ŚAT. BR. 7,1,2,12;ŚAT. BR. 7,1,2, 14;ŚAT. BR 9,4,3,4;KĀTY. ŚR. 8,6,16;KĀTY. ŚR 10,6,15;ĀŚV. ŚR. 5,3;ĀŚV. ŚR. 5, 7
+AgnIDra		1	1〉 adj. vom Feueranzünder ( ) herrührend, ihm gehörig: ṚV. 2,36,4 . KĀTY. ŚR. 9,12,15	ṚV. 2,36,4;KĀTY. ŚR. 9,12,15
+AgnIDra		2	2〉 m	
+AgnIDra		2a	a〉 Feueranzünder (so v. a. ), ein in gewissen Opferhandlungen fungirender Priester: AIT. BR. 6,10 . 3 . ŚAT. BR. 1,8,1,41 . 4,3,5,9 . 4,2,18 . 5,5,1,8 . u. s. w. KĀTY. ŚR. 10,2,19 . 21 . 26,7,3 . ĀŚV.	AIT. BR. 6,10;AIT. BR. 6, 3;ŚAT. BR. 1,8,1,41;ŚAT. BR 4,3,5,9;ŚAT. BR. 4, 4,2,18;ŚAT. BR 5,5,1,8;KĀTY. ŚR. 10,2,19;KĀTY. ŚR. 10,2, 21;KĀTY. ŚR 26,7,3;ĀŚV. ŚR. 1,4;ĀŚV. ŚR 4,1;ĀŚV. ŚR 5,5;ĀŚV. ŚR. 5, 19;ĀŚV. ŚR 9,4;HARIV. 11363;AK. 2,7,17
+AgnIDra		2b	b〉 N. pr. ein Sohn des Manu Svāyaṃbhuva HARIV. 415	HARIV. 415
+AgnIDra		3	3〉 f. die Sorge um das heilige Feuer H. 814	H. 814
+AgnIDra		4	4〉 n	
+AgnIDra		4a	a〉 der Raum des Agnīdh. ein Feueraltar sammt Umfassung P. 4,3,120, Vārtt. 5 . ( ). 5,4,37, Vārtt. 6 . AIT. BR. 2,36 . 1,23 . 30 . 5,22 . ŚAT. BR. 3,6,1,23. fgg. 3,11 . 9,2,16. fgg. 4,3,4,11 . 5,1,5,6.	P. 4,3,120, Vārtt. 5;P 5,4,37, Vārtt. 6;AIT. BR. 2,36;AIT. BR 1,23;AIT. BR. 1, 30;AIT. BR 5,22;ŚAT. BR. 3,6,1,23. fgg;ŚAT. BR. 3,6, 3,11;ŚAT. BR. 3, 9,2,16. fgg;ŚAT. BR 4,3,4,11;ŚAT. BR 5,1,5,6. fgg;ŚAT. BR. 5, 4,3,6;KĀTY. ŚR. 6,10,14;KĀTY. ŚR 8,6,22;KĀTY. ŚR. 8, 7,7
+AgnIDra		4b	b〉 das Geschäft des Agnīdh : ŚAT. BR. 4,3,4,24 . 3,6,1,29 . KĀTY. ŚR. 9,8,14 . 24,4,46 . — Vgl. und	ŚAT. BR. 4,3,4,24;ŚAT. BR 3,6,1,29;KĀTY. ŚR. 9,8,14;KĀTY. ŚR 24,4,46
+AgnIDra		2	2〉	
+AgnIDra		2b	b〉 N. pr. eines Sohnes des Priyavrata BHĀG. P. 5,1,25 . 34 . 2,1. fgg	BHĀG. P. 5,1,25;BHĀG. P. 5,1, 34;BHĀG. P. 5, 2,1. fgg
+Agneya		1	1〉 adj. f	
+Agneya		1a	a〉 dem Feuer oder Feuergotte gehörig, geweiht, ähnlich P. 4,2,30 . 8, Vārtt. VOP. 7,19 . VS. 24,6 . AIT. BR. 1,1 . ŚAT. BR. 1,6,3,23 . 24 . 11,5,4,12 . 13,7,1,3 . KĀTY. ŚR. 8,8,27 . 10,9,17 . ĀŚV. ŚR.	P. 4,2,30;P. 4,2, 8, Vārtt;VOP. 7,19;VS. 24,6;AIT. BR. 1,1;ŚAT. BR. 1,6,3,23;ŚAT. BR. 1,6,3, 24;ŚAT. BR 11,5,4,12;ŚAT. BR 13,7,1,3;KĀTY. ŚR. 8,8,27;KĀTY. ŚR 10,9,17;ĀŚV. ŚR. 9,4;M. 9,310;MBH. 2,1154;YĀJÑ. 3,287;R. 3,35,45;VIŚV. 6,1;PAÑCAT. 84,18;VID. 48;SĀH. D. 2,10;VP. 284;MṚCCH. 49,18
+Agneya		1b	b〉 der Agnāyī gehörig, geweiht P. 6,3,35, Vārtt. 3 , Sch	P. 6,3,35, Vārtt. 3
+Agneya		2	2〉 m	
+Agneya		2a	a〉 ein Bein. Skanda ʼs MBH. 3,14630 . Vgl. Ind. St. 1,269	MBH. 3,14630;Ind. St. 1,269
+Agneya		2b	b〉 ein Bein. Agastya ʼs H. 123 . Vgl	H. 123
+Agneya		2c	c〉 m. pl. N. pr. eines Volkes MBH. 3,15256	MBH. 3,15256
+Agneya		3	3〉 f	
+Agneya		3a	a〉 Agni ʼs Gemahlin H. 1100 . JAṬĀDH. _im_ ŚKDR. [Page1-0601] Vgl	H. 1100;JAṬĀDH;ŚKDR
+Agneya		3b	b〉 Gemahlin Ūru ʼs (Tochter Agni ʼs?) HARIV. 73	HARIV. 73
+Agneya		3c	c〉 die von Agni beschützte Weltgegend, der Süd-Osten H. 169 , Sch. JAṬĀDH. _im_ ŚKDR	H. 169;JAṬĀDH;ŚKDR
+Agneya		4	4〉 n	
+Agneya		4a	a〉 Blut H. 621	H. 621
+Agneya		4b	b〉 geklärte Butter, angeblich nach P. ŚKDR	P;ŚKDR
+Agneya		4c	c〉 Gold RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+Agneya		4d	d〉 N. pr. einer Gegend ŚABDAR. _im_ ŚKDR. Vgl	ŚABDAR;ŚKDR
+Agneya		1	1〉	
+Agneya		1a	a〉 Verz. d. Oxf. H. 98,b,7 . 105,a,14	Verz. d. Oxf. H. 98,b,7;Verz. d. Oxf. H 105,a,14
+Agneya		1c	c〉 südöstlich: VARĀH. BṚH. S. 27,2 . 54,97 . 59,13 . 87,20 . 31 . 43 . 24,23	VARĀH. BṚH. S. 27,2;VARĀH. BṚH. S 54,97;VARĀH. BṚH. S 59,13;VARĀH. BṚH. S 87,20;VARĀH. BṚH. S. 87, 31;VARĀH. BṚH. S. 87, 43;VARĀH. BṚH. S 24,23
+Agneya		3	3〉	
+Agneya		3c	c〉 mit und ohne VARĀH. BṚH. S. 5,82 . 11,11 . 14,8 . 24,33 . 53,118 . 60,2 . 88,43 . 95,21 . WEBER, RĀMAT. UP. 303. fg. — [Page5-1092]	VARĀH. BṚH. S. 5,82;VARĀH. BṚH. S 11,11;VARĀH. BṚH. S 14,8;VARĀH. BṚH. S 24,33;VARĀH. BṚH. S 53,118;VARĀH. BṚH. S 60,2;VARĀH. BṚH. S 88,43;VARĀH. BṚH. S 95,21;WEBER, RĀMAT. UP. 303. fg
+Agneya		4	4〉	
+Agneya		4e	e〉 das Nakṣatra Kṛttikā VARĀH. BṚH. S. 8,2 . 14,1 . 32 . 32,12	VARĀH. BṚH. S. 8,2;VARĀH. BṚH. S 14,1;VARĀH. BṚH. S. 14, 32;VARĀH. BṚH. S 32,12
+Agneya		4f	f〉 N. eines Sāman Ind. St. 3,204,b	Ind. St. 3,204,b
+Agneya		4	4〉	
+Agneya		4e	e〉 (Nachträge) SŪRYAS. 8,18	SŪRYAS. 8,18
+AgnimAruta		1	1〉 adj. dem Agni und Marut gehörig VS. 24,7 . NIR. 7,23 . P. 6,3,28 , Sch	VS. 24,7;NIR. 7,23;P. 6,3,28
+AgnimAruta		2	2〉 m. ein Bein. Agastya ʼs H. 123 . Vgl. und	H. 123
+AgnimAruta		3	3〉 n. (mit Ergänzung von ) Litanei an A. und die M. AIT. BR. 3,35 . 5,3 . 15 . ŚAT. BR. 1,7,4,4 . 4,5,1,8 . KĀTY. ŚR. 18,6,17 . ĀŚV. ŚR. 7,1 . — Vgl. über die Form P. 7,3,21 . 6,3,28	AIT. BR. 3,35;AIT. BR 5,3;AIT. BR. 5, 15;ŚAT. BR. 1,7,4,4;ŚAT. BR 4,5,1,8;KĀTY. ŚR. 18,6,17;ĀŚV. ŚR. 7,1;P. 7,3,21;P 6,3,28
+AgrahAyaRa		1	1〉 m. = P. 5,4,36, Vārtt. 5 . RĀYAM. _zu_ AK. 1,1,3,14 . ŚKDR	P. 5,4,36, Vārtt. 5;RĀYAM;AK. 1,1,3,14;ŚKDR
+AgrahAyaRa		2	2〉 f. gaṇa zu P. 4,1,41	P. 4,1,41
+AgrahAyaRa		2a	a〉 ( sc. ) der Vollmondstag im Monat Agrahāyaṇa P. 4,2,22 . 3,50 . 5,4,110 . H. 150 . Am Ende eines adv. comp. oder P. 5,4,110 . VOP. 6,68	P. 4,2,22;P. 4, 3,50;P 5,4,110;H. 150;P. 5,4,110;VOP. 6,68
+AgrahAyaRa		2b	b〉 ein bes. Pākayajña NĀR. _zu_ ŚĀṄKH. GṚHY. 1,1 . in Z. d. d. m. G. 7,527, N. 2	NĀR;ŚĀṄKH. GṚHY. 1,1;Z. d. d. m. G. 7,527, N. 2
+AgrahAyaRa		2c	c〉 N. eines Sternbildes AK. 1,1,2,24 . S	AK. 1,1,2,24
+AgrahAyaRa		2	2〉	
+AgrahAyaRa		2a	a〉 ŚĀṄKH. ŚR. 3,15,2 . GṚHY. 4,17 . GOBH. 3,9,1 . 4,8,1	ŚĀṄKH. ŚR. 3,15,2;GṚHY. 4,17;GOBH. 3,9,1;GOBH 4,8,1
+AgrahAyaRa		2b	b〉 Verz. d. Oxf. H. 30,b,5 . 266,b,37	Verz. d. Oxf. H. 30,b,5;Verz. d. Oxf. H 266,b,37
+Agraha		1	1〉	
+Agraha		1a	a〉 Ergreifung ( ) H. an. 3,761 . MED. h. 13	H. an. 3,761;MED. h. 13
+Agraha		1b	b〉 Angriff ( ) diess	
+Agraha		1c	c〉 Gunst, Zuneigung ( ) TRIK. 3,3,456 . H. an. MED. MALL. _zu_ KUMĀRAS. 5,7	TRIK. 3,3,456;H. an;MED;MALL;KUMĀRAS. 5,7
+Agraha		1d	d〉 = TRIK. = MED. = (aus einem verlesenen entstanden) H. an. Die Bedeutung moralische Kraft, Muth scheint das Wort KATHĀS. 25,99 ( ) zu haben. BROCKHAUS : der Vater führte ihn darauf aus dem Tempelhof	TRIK;MED;H. an;KATHĀS. 25,99;BROCKHAUS
+Agraha		1	¦ [ vgl. [Page1-0601]] KATHĀS. 25,99 hat die Bedeutung das Beharren bei Etwas, das Bestehen auf Etwas	KATHĀS. 25,99
+Agraha		1	1〉	
+Agraha		1d	d〉 das Halten an Etwas, Bestehen auf Etwas, Versessensein auf Etwas, Grille, Hartnäckigkeit: Spr. 3504 . KATHĀS. 63,176 . ŚUK. (Pet. Hdschr.) 13,b . 16,a . mit Beharrlichkeit, in seiner Hartnäckigkeit	Spr. 3504;KATHĀS. 63,176;ŚUK. (Pet. Hdschr.) 13,b;ŚUK. (Pet. Hdschr.) 16,a;Spr. 1616;Spr 3683;KATHĀS. 25,99;KATHĀS 54,197;KATHĀS 78,78;KATHĀS 90,22;RĀJA-TAR. 5,441
+Agraha		1a	a〉 zu streichen und in der Folge	
+Agraha		2	2〉	
+Agraha		3	3〉	
+Agraha		4	4〉 st	
+Agraha		4b	b〉	
+Agraha		4c	c〉	
+Agraha		4d	d〉 zu setzen. Statt ist in MED. ohne Zweifel zu lesen. — Vgl	MED
+AgrayaRa		1	1〉 m	
+AgrayaRa		1a	a〉 nämlich , der Erstling, eine Soma -Libation beim Agniṣṭoma : VS. 7,20 . 13,58 . 18,20 . TS. 6,4,11,1 . AIT. BR. 3,1 . ŚAT. BR. 4,1,1,1. fgg. 3,3,2. fgg. 5,21 . KĀTY. ŚR. 9,2,15 . 5,21 . ĀŚV. ŚR. 6,	VS. 7,20;VS 13,58;VS 18,20;TS. 6,4,11,1;AIT. BR. 3,1;ŚAT. BR. 4,1,1,1. fgg;ŚAT. BR. 4, 3,3,2. fgg;ŚAT. BR. 4,1, 5,21;KĀTY. ŚR. 9,2,15;KĀTY. ŚR. 9, 5,21;ĀŚV. ŚR. 6,9;ŚAT. BR. 4,5,5,8;ŚAT. BR. 4,5,5, 12
+AgrayaRa		1b	b〉 eine bes. Form Agni ʼs: MBH. 3,14188. fgg	MBH. 3,14188. fgg
+AgrayaRa		2	2〉 f. , näml. , Erstlingsopfer, ein NĀR. _zu_ ŚĀṄKH. GṚHY. 1,1 _in_ Z. d. d. m. G. 7,527, N. 2	NĀR;ŚĀṄKH. GṚHY. 1,1;Z. d. d. m. G. 7,527, N. 2
+AgrayaRa		3	3〉 n. Erstlingsopfer von Früchten am Ende der Regenzeit: AIT. BR. 7,9 . ŚAT. BR. 2,4,3,14 . KĀTY. ŚR. 1,2,11 . 4,5,2 . 6,1 . ĀŚV. ŚR. 2,9 . 12,8 . GṚHY. 2,2 . KAUŚ. 22 . ŚĀṄKH. BR. _in_ Ind. St. 2,288	AIT. BR. 7,9;ŚAT. BR. 2,4,3,14;KĀTY. ŚR. 1,2,11;KĀTY. ŚR 4,5,2;KĀTY. ŚR. 4, 6,1;ĀŚV. ŚR. 2,9;ĀŚV. ŚR 12,8;GṚHY. 2,2;KAUŚ. 22;ŚĀṄKH. BR;Ind. St. 2,288;Ind. St. 2, 299. fg;M. 6,10;LOIS;MBH. 3,14188;R. 3,22,6;ŚAT. BR. 2,4,3,1;ŚAT. BR 5,2,3,9;ŚAT. BR 12,3,5,7;YĀJÑ. 1,125;MUṆḌ. UP. 1,2,3
+AgrayaRa		3	3〉 BHĀG. P. 10,20,48 . Verz. d. Oxf. H. 266,b,38	BHĀG. P. 10,20,48;Verz. d. Oxf. H. 266,b,38
+AhAra		1	1〉 adj	
+AhAra		1a	a〉 herbeiholend, verschaffend: KAUŚ. 61 . ( d. h. nicht regelmässig dieser Beschäftigung obliegend, sondern nur gelegentlich; im andern Falle soll die Form gebraucht werden) P. 3,2,11 , Sch. Vgl	KAUŚ. 61;P. 3,2,11
+AhAra		1b	b〉 der die Absicht hat herbeizuholen, allaturus: SĀV. 4,23 . 5,68 . MBH. 1,3222 . fem. MBH. 4,455 : . Vgl. . [Page1-0748]	SĀV. 4,23;SĀV 5,68;MBH. 1,3222;MBH. 4,455
+AhAra		2	2〉 m. TRIK. 3,5,4	TRIK. 3,5,4
+AhAra		2a	a〉 das Herbeinehmen, Herbeiholen H. an. 3,520 . MED. r. 115 . KĀTY. ŚR. 25,11,7 . 14,34 . (leicht herbeizuschaffen) R. 2,31,26	H. an. 3,520;MED. r. 115;KĀTY. ŚR. 25,11,7;KĀTY. ŚR. 25, 14,34;R. 2,31,26
+AhAra		2b	b〉 das Beiziehen, Anwenden KĀTY. ŚR. 16,1,3	KĀTY. ŚR. 16,1,3
+AhAra		2c	c〉 das Zusichnehmen von Nahrung; Nahrung ( P. 3,3,19 , Sch. ) AK. 2,9,56 . TRIK. 3,2,27 . H. 423 . an. 3,250 . MED. SUŚR. 1,4,13 . HIT. Pr. 24 . Nahrung zu sich nehmen, essen MBH. 1,8118 . 3,7092 . 15	P. 3,3,19;AK. 2,9,56;TRIK. 3,2,27;H. 423;H an. 3,250;MED;SUŚR. 1,4,13;HIT. Pr. 24;MBH. 1,8118;MBH 3,7092;MBH 15,145;SĀV. 6,17;N. 11,27;R. 4,13,18;R. 4, 44,26;PAÑCAT. 191,16;HIT. 38,8;VIKR. 65,1;VID. 45;H. 58;PAÑCAT. 77,12;CHĀND. UP. 7,26,2;MBH. 3,13985;M. 11,77;R. 3,39,40;VIŚV. 9,19;N. 12,45;SĀV. 1,5;BHAG. 6,17;R. 5,21,21;HIT. 26,16;M. 11,257;M 198;MBH. 3,16143;MBH 14,2763;R. 1,48,31;ŚAT. BR. 14,6,11,4;BṚH. ĀR. UP. 4,2,3;M. 5,105;M 6,3;R. 3,5,3;SUŚR. 1,119,6;SUŚR. 1, 240,2;SUŚR. 1, 247,16;SUŚR 2,4,3;SUŚR. 2, 170,13;HIT. I, 79;HIT. I, 18,9;VID. 181
+AhAra		1	1〉	
+AhAra		1b	b〉 Schol. zu VS. PRĀT. 3,57 . 4,8 . — Vgl	VS. PRĀT. 3,57;VS. PRĀT 4,8
+AhAra		2	2〉	
+AhAra		2c	c〉 HEM. YOGAŚ. 3,79 . 86 . 149	HEM;YOGAŚ. 3,79;YOGAŚ. 3, 86;YOGAŚ. 3, 149
+AhArya		1	1〉 adj	
+AhArya		1a	a〉 herbeizuholen, herbeizuschaffen: ĀŚV. ŚR. 6,10 . KĀTY. ŚR. 2,6,11 . SĀṂKHYAK. 32 . M. 8,202	ĀŚV. ŚR. 6,10;KĀTY. ŚR. 2,6,11;SĀṂKHYAK. 32;M. 8,202
+AhArya		1b	b〉 auszuziehen, zu entfernen SUŚR. 1,92,18	SUŚR. 1,92,18
+AhArya		1c	c〉 was immer wieder entfernt werden kann, zufällig, äusserlich TRIK. 3,1,20 . ad. ŚĀK. 94 . der etwas Ausserliches, die Tracht, die Verzierungen betreffende Theil einer theatralischen Darstellung H. 2	TRIK. 3,1,20;ŚĀK. 94;H. 283
+AhArya		2	2〉 m. ( sc. ) eine bes. Art Verband SUŚR. 1,55,14	SUŚR. 1,55,14
+AhArya		3	3〉 n	
+AhArya		3a	a〉 was mit Ausziehen zu behandeln ist, das Ausziehen SUŚR. 1,14,19 . 28,9 . 29,7	SUŚR. 1,14,19;SUŚR. 1, 28,9;SUŚR. 1, 29,7
+AhArya		3b	b〉 Ausrüstung, Geräthe: AV. 9,1,32 . 6,18	AV. 9,1,32;AV. 9, 6,18
+AhArya		1	1〉	
+AhArya		1a	a〉 Ind. St. 8,80 . KATHĀS. 108,180 . 110,37 ; vgl. 107,86	Ind. St. 8,80;KATHĀS. 108,180;KATHĀS 110,37;KATHĀS 107,86
+AhArya		1c	c〉 KĀM. NĪTIS. 3,10 . Schol. SĀH. D. 274 . Verz. d. Oxf. H. 200,a,2	KĀM. NĪTIS. 3,10;SĀH. D. 274;Verz. d. Oxf. H. 200,a,2
+AhArya		3	3〉	
+AhArya		3b	b〉 setze Zurüstung, Aufwartung, lies 9,1,23 und füge bei TBR. 2,1,2,12	TBR. 2,1,2,12
+AhArya		3c	c〉 Nahrung (= Schol. ; vgl. ) BHĀG. P. 10,86,14 . 11,25,28	BHĀG. P. 10,86,14;BHĀG. P 11,25,28
+AhAva		1	1〉 Eimer, Trog, Schüssel NIR. 5,26 . ṚV. 6,7,2 . 10,101,5 . 112,6 . 1,34,8 . Tränke in der Nähe eines Brunnens P. 3,3,74 . AK. 1,2,3,26 . H. 1092 . Sch. zu ŚĀK. 39	NIR. 5,26;ṚV. 6,7,2;ṚV 10,101,5;ṚV 112,6;ṚV 1,34,8;P. 3,3,74;AK. 1,2,3,26;H. 1092;ŚĀK. 39
+AhAva		2	2〉 Anruf DHAR. _im_ ŚKDR. Bez. einer liturgischen Formel ( ) AIT. BR. 2,33 . 38 . 3,23 . ohne Anwendung des Anrufs 37 . ĀŚV. ŚR. 5,9 . 10 . 18	DHAR;ŚKDR;AIT. BR. 2,33;AIT. BR. 2, 38;AIT. BR 3,23;AIT. BR. 3, 37;ĀŚV. ŚR. 5,9;ĀŚV. ŚR. 5, 10;ĀŚV. ŚR. 5, 18
+AhAva		3	3〉 Kampf DHAR. _im_ ŚKDR. Vgl	DHAR;ŚKDR
+AhAva		4	4〉 falsche Lesart für PAÑCAT. I, 458 ; vgl. Bull. hist.-phil. VIII, 129 oder Mél. asiat. I, 296 . — In der [Page1-0749] ersten Bed. von mit , in den beiden andern von ; nach P. auch in der ersten Bed.	PAÑCAT. I, 458;Bull. hist.-phil. VIII, 129;Mél. asiat. I, 296;P
+AhAva		2	2〉 Z. 2. fg. lies 2,23. 33. 38, streiche bis 37 und vgl. dagegen mit	
+Aha	1	1	1〉 des Vorwurfs	
+Aha	1	2	2〉 des Befehls H. an. 7,52 . MED. avy. 90	H. an. 7,52;MED. avy. 90
+Aha	1	3	3〉 ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+Ahanana		1	1〉 das Anschlagen, Aufschlagen: KĀTY. ŚR. 8,2,18	KĀTY. ŚR. 8,2,18
+Ahanana		2	2〉 das Schlagen, Schlachten eines Thieres AV. 12,5,39 . 47	AV. 12,5,39;AV. 12,5, 47
+Ahanas		1	1〉 schwellend, strotzend: da wurde sie schwellend, strotzend von Milch ṚV. 2,13,1 . vom gährenden, schäumenden Soma : 9,75,5 . 10,125,2	ṚV. 2,13,1;ṚV 9,75,5;ṚV 10,125,2
+Ahanas		2	2〉 geil, üppig: ṚV. 5,42,13 . 10,10,8 . 6 ; vgl. NIR. 4,15 . 5,2 . — Auf den möglichen Zusammenhang mit und ist schon u. hingewiesen worden. Wollte man das Wort von den übrigen trennen, so liesse es s	ṚV. 5,42,13;ṚV 10,10,8;ṚV. 10,10, 6;NIR. 4,15;NIR 5,2
+Ahanas		1	¦ [ vgl. [Page1-0746]] Z. 6 lies: st	
+Ahanas		1	¦ Z. 6 lies st. . und pflegt man auf zurückzuführen	
+Ahara		1	1〉 adj. der herbeizutragen pflegt, am Ende eines comp. P. 3,2,11 . Sch. RAGH. 1,49 . Vgl	P. 3,2,11;RAGH. 1,49
+Ahara		2	2〉 m. Zustandebringung, Vollbringung (eines Opfers): MBH. 2,664	MBH. 2,664
+Ahara		3	3〉 das Einathmen, die eingeathmete Luft H. 1368	H. 1368
+AharaRa		1	1〉 adj. fortnehmend, entwendend, s	
+AharaRa		2	2〉 n	
+AharaRa		2a	a〉 das Ergreifen, Herbeiholen H. an. 3,520 . MED. r. 115 . KĀTY. ŚR. 4,14,3 . 6 . 22,6,9 . 9,1,7 . 16,5,10 . 25,3,10 . PRAB. 64,13 . SĀṂKHYAK. 32 . ŚĀK. 7,9	H. an. 3,520;MED. r. 115;KĀTY. ŚR. 4,14,3;KĀTY. ŚR. 4,14, 6;KĀTY. ŚR 22,6,9;KĀTY. ŚR 9,1,7;KĀTY. ŚR 16,5,10;KĀTY. ŚR 25,3,10;PRAB. 64,13;SĀṂKHYAK. 32;ŚĀK. 7,9
+AharaRa		2b	b〉 das Ausziehen, Entfernen SUŚR. 1,23,15 . 25,2 . 16 . 26,18 . 100,11 . 2,3,16	SUŚR. 1,23,15;SUŚR. 1, 25,2;SUŚR. 1,23, 16;SUŚR. 1, 26,18;SUŚR. 1, 100,11;SUŚR 2,3,16
+AharaRa		2c	c〉 das Zustandebringen, Vollbringen (eines Opfers): MBH. 14,2072	MBH. 14,2072
+Ahartar		1	1〉 Herbeiholer, Bringer, Verschaffer TS. 6,2,4,2 . 3 . ŚAT. BR. 1,3,3,10 . NIR. 7,26 . MBH. 3,10886 . R. 5,95,34	TS. 6,2,4,2;TS. 6,2,4, 3;ŚAT. BR. 1,3,3,10;NIR. 7,26;MBH. 3,10886;R. 5,95,34
+Ahartar		2	2〉 Bringer, Veranlasser: MBH. 14,1797 . VIKR. 139	MBH. 14,1797;VIKR. 139
+Ahartar		3	3〉 Vollbringer (eines Opfers): MBH. 1,2021 . N. (BOPP) 12,45 . 81	MBH. 1,2021;N. (BOPP) 12,45;N. (BOPP) 12, 81
+Ahata		1	1〉 adj. s. u. mit	
+Ahata		2	2〉 m. Trommel MED. t. 90	MED. t. 90
+Ahata		3	3〉 n. ein altes oder neues Kleid MED. t. 90 . Vgl. und	MED. t. 90
+Ahava		1	1〉 (von = mit ) Ausforderung; Kampf, Streit P. 3,3,73 . NAIGH. 2,17 . AK. 2,8,2,74 . TRIK. 3,3,412 . H. 796 . an. 3,694 . MED. v. 31 . ṚV. 2,23,11 . 1,155,6 . 6,47,1 . 10,150,5 . M. 5,95 . 98 . 7,89 .	P. 3,3,73;NAIGH. 2,17;AK. 2,8,2,74;TRIK. 3,3,412;H. 796;H an. 3,694;MED. v. 31;ṚV. 2,23,11;ṚV 1,155,6;ṚV 6,47,1;ṚV 10,150,5;M. 5,95;M. 5, 98;M 7,89;M 11,119;BHAG. 1,31;ARJ. 10,67;R. 1,1,68;R. 1,1, 79;R. 1, 23,9;SUŚR. 1,7,18;SUŚR. 1, 12,11;MBH. 14,1791;MBH. 14, 324;R. 3,68,27;MBH. 3,15260;RAGH. 7,64;MBH. 14,1772;ARJ. 8,2
+Ahava		2	2〉 (von mit ) Opfer TRIK. H. an. MED	TRIK;H. an;MED
+Ahava		1	1〉 MĀRK. P. 18,36 . KATHĀS. 60,202 . Kampfplatz 116,53 . so v. a. kämpfe mit mir BHĀG. P. 10,66,6	MĀRK. P. 18,36;KATHĀS. 60,202;KATHĀS 116,53;BHĀG. P. 10,66,6
+Ahava		1	¦ Z. 1 lies st	
+Ahika		1	1〉 der niedersteigende Knoten ( ) TRIK. 1,1,94 . H. 121 . HĀR. 37	TRIK. 1,1,94;H. 121;HĀR. 37
+Ahika		2	2〉 ein Bein. des Grammatikers Pāṇini TRIK. 2,7,24	TRIK. 2,7,24
+AhlAda		1	1〉 Freude: PAÑCAT. V, 46 . IV, 7 . adv. 207,13	PAÑCAT. V, 46;PAÑCAT IV, 7;PAÑCAT 207,13
+AhlAda		2	2〉 patron. des Para TS. 5,6,5,3 . Könnte Verwechselung mit oder Schreibfehler sein	TS. 5,6,5,3
+AhlAda		1	1〉 Spr. 3489	Spr. 3489
+Ahnika		1	1〉 adj. was an einem Tage vollbracht wird P. 5,1,79 , Sch. TRIK. 3,3,4 . H. 255 . an. 3,9 . MED. k. 48 . was täglich vollbracht wird: MBH. 3,10772 . R. 1,25,4 . die täglich zu bestimmten Stunden zu be	P. 5,1,79;TRIK. 3,3,4;H. 255;H an. 3,9;MED. k. 48;MBH. 3,10772;R. 1,25,4;RAGHUNANDANA;ŚKDR
+Ahnika		2	2〉 n	
+Ahnika		2a	a〉 eine täglich zu einer bestimmten Zeit zu vollbringende religiöse Handlung TRIK. H. an. MED. MBH. 3,10905 . 15524 . R. 1,25,2 . 3,74,2 . = ( s. u	TRIK;H. an;MED;MBH. 3,10905;MBH. 3, 15524;R. 1,25,2;R 3,74,2
+Ahnika		1	GILD. Bibl. 465 . 469 . Verz. d. B. H. No. 1030 . ebend. No. 1029	GILD. Bibl. 465;GILD. Bibl 469;Verz. d. B. H. No. 1030;ebend. No. 1029
+Ahnika		1b	b〉 ein Tagewerk, was an einem Tage gelesen werden kann, Abschnitt, Kapitel TRIK. 3,2,25 . H. 255 . H. an. MED. in zerfällt unter andern PATAÑJALI ʼs MAHĀBHĀṢYA Z. f. d. K. d. M. 7,163 . Verz. d. B. H.	TRIK. 3,2,25;H. 255;H. an;MED;PATAÑJALI;MAHĀBHĀṢYA;Z. f. d. K. d. M. 7,163;Verz. d. B. H. No. 720
+Ahnika		1c	c〉 Speise H. an. HĀR. 264 . MED	H. an;HĀR. 264;MED
+Ahnika		1	1〉 was am Tage geschieht, — erfolgt: (so die ed. Bomb. ) MBH. 5,3814 . was täglich vollbracht wird: Verz. d. Oxf. H. 291,a, No. 702 . die tägliche Nahrung R. 7,62,4	ed. Bomb;MBH. 5,3814;Verz. d. Oxf. H. 291,a, No. 702;R. 7,62,4
+Ahnika		2	2〉	
+Ahnika		2a	a〉 Verz. d. Oxf. H. 22,b,24 . 275,a,3 v. u. 276,b,39 . 277,a,15 v. u. 285,b. No. 669 . 286,a, No. 670 . Tagesgeschäft KATHĀS. 53,64 ; vgl. 42	Verz. d. Oxf. H. 22,b,24;Verz. d. Oxf. H 275,a,3 v. u. 276,b,39;Verz. d. Oxf. H 277,a,15 v. u. 285,b. No. 669;Verz. d. Oxf. H 286,a, No. 670;KATHĀS. 53,64;KATHĀS 42
+Ahnika		2b	b〉 Verz. d. Oxf. H. 228,b, No. 560	Verz. d. Oxf. H. 228,b, No. 560
+Ahnika		2d	d〉 Titel zweier Werke über die täglich zu beobachtenden religiösen Verrichtungen HALL 21 . 205 . — Vgl	HALL 21;HALL 205
+Ahuti		1	1〉 f. Opferspende, sowohl die Gabe als das Geben. Dem ältern Sprachgebrauch ist auch die Bedeutung Anrufung, somit die Ableitung von nicht fremd. Bei der nahen Verwandtschaft beider Bedeutungen lässt 	H. 821;ṚV. 1,31,5;ṚV 93,3;ṚV 105,5;ṚV 135,8;ṚV 3,28,3;ṚV. 3,28, 6;ṚV 7,66,19;ṚV 8,19,5;ṚV. 8,19, 18;ṚV 10,52,2;AV. 3,22,4;AV 7,70,1;AV 10,5,43;AV. 10, 8,35;AV 11,10,5;AV. 11,10, 26;AV 12,1,13;AV 19,4,1;TS. 5,1,3,4;TS 2,2,2,5;TS. 2, 3,9,3;TS 3,4,10,1;AIT. BR. 1,2;AIT. BR 2,13;AIT. BR. 2, 14;AIT. BR 5,28;ŚAT. BR. 1,4,4,1;ŚAT. BR 7,2,10;ŚAT. BR 2,3,1,22. fgg;ŚAT. BR 3,5,1,22;ŚAT. BR 11,3,2,1;ŚAT. BR 5,6,3. fgg;ĀŚV. ŚR. 2,2;ĀŚV. ŚR 6,9;KĀTY. ŚR. 3,3,29;KĀTY. ŚR 14,5,1;KĀTY. ŚR 20,1,20;KĀTY. ŚR 25,1,3;BṚH. ĀR. UP. 3,1,8;M. 3,76;M 11,119;M 2,106;M 5,104;YĀJÑ. 3,71;MBH. 3,14131;MBH 14,2700;R. 4,10,21;RAGH. 1,53;RAGH. 1, 82;ŚAT. BR. 4,3,4,5;ŚAT. BR 11,2,6,13;ŚAT. BR 11,2,1,6
+Ahuti		2	2〉 m. N. pr. eines Marut HARIV. 11547	HARIV. 11547
+AhvAna		1	1〉 das Anrufen, Herbeirufen, Aufruf AK. 1,1,5,9 . 3,4,18,126 . 27,209 . H. 261 . AK. 1,1,7,15 . P. 8,2,84 , Sch. MBH. 1,691 . PAÑCAT. III, 44 . HIT. 128,5	AK. 1,1,5,9;AK 3,4,18,126;AK. 3,4, 27,209;H. 261;AK. 1,1,7,15;P. 8,2,84;MBH. 1,691;PAÑCAT. III, 44;HIT. 128,5
+AhvAna		2	2〉 das Anrufen, Herbeirufen einer Gottheit M. 9,126 . MBH. 1,4391 . 4861 . 3,14140 . 15146 . 17076 . 1,4394 . 15,830	M. 9,126;MBH. 1,4391;MBH. 1, 4861;MBH 3,14140;MBH. 3, 15146;MBH. 3, 17076;MBH 1,4394;MBH 15,830
+AhvAna		3	3〉 Aufforderung zum Kampf R. 4,13,40 . 14,10	R. 4,13,40;R. 4, 14,10
+AhvAna		4	4〉 Aufforderung vor Gericht zu erscheinen MṚCCH. 143,3 . MIT. 8	MṚCCH. 143,3;MIT. 8
+AhvAna		5	5〉 Bezeichnung einer liturgischen Formel ( s. 2.) ĀŚV. ŚR. 5,10 . 9,6	ĀŚV. ŚR. 5,10;ĀŚV. ŚR 9,6
+AhvAna		6	6〉 Benennung, Name ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+AhvAna		1	1〉 HALĀY. 1,154 . das Herbeirufen, Citiren (eines Geistes) KATHĀS. 73,277	HALĀY. 1,154;KATHĀS. 73,277
+AhvAna		6	6〉 HALĀY. 1,152	HALĀY. 1,152
+Ahvaya		1	1〉 Wette bei Thierkämpfen M. 8,7 ; vgl. 9,223	M. 8,7;M 9,223
+Ahvaya		2	2〉 Benennung, Name AK. 1,1,5,8 . H. 260 . AK. 2,4,3,31 . 3,6,2,14 . meist am Ende eines adj. comp. und namentlich da, wo ein sonst gangbares Wort, das zugleich Name (einer Pflanze u. s. w. ) ist, als 	AK. 1,1,5,8;H. 260;AK. 2,4,3,31;AK 3,6,2,14;R. 1,4,1;SUŚR. 2,20,18;SUŚR. 2, 25,15;SUŚR. 2, 101,10;SUŚR. 2, 222,6;ebend;AK. 2,4,2,35;AK. 2,4,2, 45;H. 225;H 245;R. 4,51,38;MBH. 3,9;MBH. 3, 1348;KATHĀS. 15,6;MBH. 3,35
+AjAna		1	1〉 Geburt, Abkunft, Art: VS. 31,17 ( vgl. TAITT. ĀR. 10,1,12 ). 33,72 . ŚAT. BR. 3,1,3,4 . ein Gott von Geburt ( Gegens. ) ŚAT. BR. 14,7,1,35 = BṚH. ĀR. UP. 4,3,33 . = TAITT. UP. 2,8 . 10	VS. 31,17;TAITT. ĀR. 10,1,12;TAITT. ĀR 33,72;ŚAT. BR. 3,1,3,4;ŚAT. BR. 14,7,1,35;BṚH. ĀR. UP. 4,3,33;TAITT. UP. 2,8;TAITT. UP. 2, 10
+AjAna		2	2〉 Geburtsort (nach MAHĪDH. ) VS. 33,72	MAHĪDH;VS. 33,72
+AjAneya		1	1〉 adj. f. von edler Abkunft: Pferde KĀTY. ŚR. 22,2,23 . MBH. 2,1733 . 1835 . Am Ende eines comp. von der und der Abkunft, Art: buddh. SCHIEFNER, Lebensb. 326 ( . Vgl	KĀTY. ŚR. 22,2,23;MBH. 2,1733;MBH. 2, 1835;SCHIEFNER, Lebensb. 326 (96)
+AjAneya		2	2〉 m. ein Pferd von edler Race AK. 2,8,2,12 . H. 1234 . DRAUP. 7,10 . AŚVATANTRA _im_ ŚKDR. Vgl	AK. 2,8,2,12;H. 1234;DRAUP. 7,10;AŚVATANTRA;ŚKDR
+Aja		1	1〉 adj. von Ziegen herrührend, caprinus: ĀŚV. GṚHY. 1,19 . SUŚR. 1,174,20 . 2,13,1 . R. 2,91,66	ĀŚV. GṚHY. 1,19;SUŚR. 1,174,20;SUŚR 2,13,1;R. 2,91,66
+Aja		2	2〉 m. Geier H. ś. 194	H. ś. 194
+Aja		3	3〉 N. pr. Verz. d. B. H. 61,5 ( pl. )	Verz. d. B. H. 61,5
+Aja		4	4〉 n	
+Aja		4a	a〉 das unter Aja Ekapād stehende Nakṣatra Pūrvabhadrapadā VARĀH. BṚH. S. 10,17 . 15,23 . 23,9 . 32,12	VARĀH. BṚH. S. 10,17;VARĀH. BṚH. S 15,23;VARĀH. BṚH. S 23,9;VARĀH. BṚH. S 32,12
+Aja		4b	b〉 = Schol. zu R. 2,55,17 ; vgl. u	R. 2,55,17
+Aja		5	5〉	
+Aji		1	1〉 Wettlauf, Wettkampf, Kampf überh. NAIGH. 2,17 . NIR. 9,23 . AK. 2,8,2,74 . 3,4,34 . 95 . H. 797 . an. 2,66 . MED. j. 3 . SIDDH. K. 251,a,6 . ( ) ṚV. 5,35,7 . 6,24,6 . 7,98,4 . 4,20,3 . 16,19 . 17,9	NAIGH. 2,17;NIR. 9,23;AK. 2,8,2,74;AK. 2, 3,4,34;AK. 2,8,2, 95;H. 797;H an. 2,66;MED. j. 3;SIDDH. K. 251,a,6;ṚV. 5,35,7;ṚV 6,24,6;ṚV 7,98,4;ṚV 4,20,3;ṚV. 4, 16,19;ṚV. 4, 17,9;ṚV. 4, 42,5;ṚV. 4, 58,10;AV. 2,14,5;AV 6,92,2;BRĀHMAṆA;AIT. BR. 2,25;AIT. BR 4,27;ŚAT. BR. 2,4,3,4;ŚAT. BR 5,1,1,3;ŚAT. BR. 5,1, 4,1;ŚAT. BR. 5,1,4, 15;ŚAT. BR 6,1,2,12;ŚAT. BR 7,1,2,1;KĀTY. ŚR. 14,3,21;ĀŚV. ŚR. 9,9;CHĀND. UP. 1,3,5;ŚAT. BR. 5,1,5,10;ŚAT. BR. 5,1,5, 28;ŚAT. BR 11,1,2,13;MBH. 3,772;ARJ. 10,74;R. 1,29,3;R 3,26,18;R. 3, 59,24;RAGH. 12,45;MBH. 3,16479
+Aji		2	2〉 Rennbahn: ṚV. 4,24,8 . AV. 13,2,4 . ebener Boden AK. 3,4,34 . H. an. 2,66 . MED. j. 3	ṚV. 4,24,8;AV. 13,2,4;AK. 3,4,34;H. an. 2,66;MED. j. 3
+Aji		3	3〉 Tadel ( ) ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+Aji		4	4〉 Augenblick H. an	H. an
+Aji		1	1〉 wer die von ihm als Menschen geforderte Arbeit thut und beim Wettlauf (bildlich) bis zur äussersten Grenze läuft, der thut seiner Pflicht Genüge, MBH. 5,4509 . im Kampfe Spr. 3969 . VARĀH. BṚH. S. 	MBH. 5,4509;Spr. 3969;VARĀH. BṚH. S. 43,2;MBH. 5,7229
+Ajya	1	1	1〉 Opferschmalz; die am Feuer zerlassene und gereinigte Butter, welche in die Flamme gegossen oder zum Schmälzen und Salben verwendet wird, AK. 2,9,51 . 52 . 7,23 . H. 407 . 832 . Das Wort findet sich	AK. 2,9,51;AK. 2,9, 52;AK. 2, 7,23;H. 407;H 832;ṚV;SĀY;AIT. BR. 1,3;ṚV. 10,79,5;ṚV 88,4;ṚV 53,2;ṚV 90,6;ṚV 122,7;ṚV 130,3;VS. 20,20;VS 2,8;VS. 2, 9;VS. 2, 13;VS 5,35;AV. 6,114,3;AV 9,2,1;AV 10,29,5;AV 12,4,34;AV 13,1,53;AV 19,27,5;TS. 2,2,9,4;AIT. BR. 1,3;ŚAT. BR. 1,2,1,22;ŚAT. BR 2,4,3,10;ŚAT. BR 3,5,2,1;KĀTY. ŚR. 2,7,7;KĀTY. ŚR 15,3,28;KAUŚ. 90;KAUŚ 67;BṚH. ĀR. UP. 6,3,1;P. 8,1,63;BHAG. 9,16;R. 3,9,33;R 6,92,13;SUŚR. 1,16,11;SUŚR 2,159,8;RAGH. 7,17;ŚAT. BR. 1,7,2,10;ŚAT. BR 9,3,2,4;AIT. BR. 2,14;ĀŚV. GṚHY. 1,4;ĀŚV. GṚHY. 1, 23;PĀR. GṚHY. 2,1;KĀTY. ŚR. 19,4,25;KAUŚ. 6;ŚAT. BR. 1,5,3,4;ŚAT. BR. 1,5,3, 5;ŚAT. BR. 1, 9,2,7;ŚAT. BR 11,4,1,15
+Ajya	1	2	2〉 in weiterem Sinne auch das statt des eigentlichen Opferschmalzes verwendete Oel, Milch u. s. w. : GṚHYASAṂGR. 2,2	GṚHYASAṂGR. 2,2
+Ajya	1	3	3〉 Name einer bestimmten Litanei ( oder ): AIT. BR. 2,37 . 31 . 36 . 38 . SĀY. in der Einl. zu AIT. BR. ŚAT. BR. 10,1,2,7 . 13,5,1,8	AIT. BR. 2,37;AIT. BR. 2, 31;AIT. BR. 2, 36;AIT. BR. 2, 38;SĀY;AIT. BR;ŚAT. BR. 10,1,2,7;ŚAT. BR 13,5,1,8
+Ajya	1	4	4〉 Terpentin AJAYAPĀLA _im_ ŚKDR	AJAYAPĀLA;ŚKDR
+Ajya	1	1	1. ¦ [ vgl. [Page1-0611]] letzte Zeile lies: {1,18} st. {1,8}	
+Ajya	1	3	3〉 genauer	
+Ajya	1	3a	a〉 ein gewisses Śastra bei der Frühspende und zwar je eines für den Hotar und seine drei Gehilfen ŚĀṄKH. BR. 14,1	ŚĀṄKH. BR. 14,1
+Ajya	1	3b	b〉 das in demselben enthaltene Sūkta ŚĀṄKH. BR. 20,2	ŚĀṄKH. BR. 20,2
+Ajya	1	3c	c〉 ein mit jenem Śastra verbundenes Stotra PAÑCAV. BR. 19,7,5 . 20,8,1 . 14,7 . d. h. die Ājya-Stotra enthalten den Pañcadaśa-Stoma SĀY. _zu_ AIT. BR. 2,36	PAÑCAV. BR. 19,7,5;PAÑCAV. BR 20,8,1;PAÑCAV. BR. 20, 14,7;SĀY;AIT. BR. 2,36
+Ajyapa		1	1〉 adj. das Opferschmalz trinkend VS. 21,40 . 46 . 47 . 58 . 28,11 . ŚAT. BR. 1,4,2,17 . 5,3,23 . 7,3,11 . 9,1,10 . 2,2,3,20	VS. 21,40;VS. 21, 46;VS. 21, 47;VS. 21, 58;VS 28,11;ŚAT. BR. 1,4,2,17;ŚAT. BR. 1, 5,3,23;ŚAT. BR. 1, 7,3,11;ŚAT. BR. 1, 9,1,10;ŚAT. BR 2,2,3,20
+Ajyapa		2	2〉 m. pl. die Manen ( ) der Vaiśya , Söhne Pulastya ʼs M. 3,197 . 198 . Kardama ʼs VP. 321, N. 84, N. 10	M. 3,197;M. 3, 198;VP. 321, N. 84, N. 10
+AkANkzA		1	1〉 Verlangen, Wunsch AK. 1,1,7,27 . SUŚR. 2,212,2 . AMAR. 41	AK. 1,1,7,27;SUŚR. 2,212,2;AMAR. 41
+AkANkzA		2	2〉 das Erfordern einer Ergänzung (zur Vervollständigung des Sinnes): SĀH. D. 8,20 . 17 . BHĀṢĀP. 81 . 83 . Vgl	SĀH. D. 8,20;SĀH. D. 8, 17;BHĀṢĀP. 81;BHĀṢĀP 83
+AkANkzA		1	1〉 Spr. 2213 . SĀH. D. 479	Spr. 2213;SĀH. D. 479
+AkANkzA		2	2〉 Verz. d. Oxf. H. 177,b. No. 403	Verz. d. Oxf. H. 177,b. No. 403
+AkASa		1	1〉 Licht, Helle; s. u	
+AkASa		2	2〉 freier Raum: AIT. BR. 3,42 . ŚAT. BR. 3,3,2,19 . 4,6,8,17 . 7,1,2,23 . 10,5,2,11 . 13,5,1,15 . 8,1,10 . 14,3,5,6 (= BṚH. ĀR. UP. 2,3,4 ). BṚH. ĀR. UP. 1,4,3 . ( ) MBH. 3,12552 . 15267 . N. 14,10 . 	AIT. BR. 3,42;ŚAT. BR. 3,3,2,19;ŚAT. BR 4,6,8,17;ŚAT. BR 7,1,2,23;ŚAT. BR 10,5,2,11;ŚAT. BR 13,5,1,15;ŚAT. BR. 13, 8,1,10;ŚAT. BR 14,3,5,6;BṚH. ĀR. UP. 2,3,4;BṚH. ĀR. UP. 1,4,3;MBH. 3,12552;MBH. 3, 15267;N. 14,10;COLEBR. Misc. Ess. I, 386
+AkASa		3	3〉 Luftraum, die freie Luft, Aether NAIGH. 1,3 . AK. 1,1,2,2 . 3,4,1,2 . H. 163 . ŚAT. BR. 10,6,3,2 . 14,7,1,19 (= BṚH. ĀR. UP. 4,3,19 ). 5,5,4 . 6,6,1 . 7,10 (= BṚH. 2,5,10 . 3,7,12 ). TAITT. UP. 1,3	NAIGH. 1,3;AK. 1,1,2,2;AK 3,4,1,2;H. 163;ŚAT. BR. 10,6,3,2;ŚAT. BR 14,7,1,19;BṚH. ĀR. UP. 4,3,19;ŚAT. BR 5,5,4;ŚAT. BR 6,6,1;ŚAT. BR 7,10;BṚH. 2,5,10;BṚH 3,7,12;TAITT. UP. 1,3,1;M. 1,75;M 10,104;YĀJÑ. 3,144;BHAG. 13,32;R. 1,44,23;R 3,29,7;R 4,31,23;R. 4, 38,34;R 6,70,29;BHARTṚ. 3,89;M. 1,76;M 3,90;M 4,184;N. 19,22;SUŚR. 1,91,13;SUŚR. 1, 151,3;R. 2,33,8;R 1,44,5;R 1,38,7;R 4,44,61;MBH. 3,10909;RAGH. 1,78;VID. 112;KATHĀS. 20,179;PAÑCAT. 114,21;Verz. d. B. H. 193 (28);Verz. d. B. H No. 905;ŚĀK. 77,1;ŚĀK 97,1;KATHĀS. 25,214;MṚCCH. 32,18;MṚCCH 40,8;ŚĀK. 31,7;ŚĀK 41,23;ŚĀK 52,16;ŚĀK 101,5;ŚĀK 59,6;ŚĀK. 31,7;COLEBR. Misc. Ess. I, 243;COLEBR. Misc. Ess. I, 268;COLEBR. Misc. Ess. I, 275;COLEBR. Misc. Ess. I, 373;COLEBR. Misc. Ess. I, 398;MÜLLER;Z. d. d. m. G. 2,19. fg;BURN. Intr. 497;Lot. de la b. l. 515;WILS;CHĀND. UP. 7,12,2
+AkASa		3	3〉 ( vgl. Sp. 587, Z	
+AkASa		17	SĀH. D. 425 . Hiernach [Page5-1087] wird das nicht hinter der Bühne gesprochen, sondern der auf der Bühne befindliche Schauspieler thut nur so, als wenn er Etwas hörte und das Gehörte wiederholte	SĀH. D. 425
+AkASa		3	3〉 (Nachträge); zu vgl. noch DAŚAR. 1,60 . SĀH. D. 513	DAŚAR. 1,60;SĀH. D. 513
+AkASaga		1	1〉 adj. f. im Luftraum sich bewegend, — sich befindend R. 2,33,8 . 1,38,7 . 44,5	R. 2,33,8;R 1,38,7;R. 1, 44,5
+AkASaga		2	2〉 m. Vogel MBH. 5,7287	MBH. 5,7287
+AkASarakzin		1	¦ ( + ) m. Wärter auf einer Mauer RĀJADHARMA _im_ ŚKDR	RĀJADHARMA;ŚKDR
+AkASarakzin		2	2〉 in den Nachträgen	
+AkASavARI		1	1〉 f. eine Stimme vom Himmel TRIK. 2,8,26 [Page1-0588], im Inhaltsverz. Vgl. VID. 112	TRIK. 2,8,26;VID. 112
+AkASavARI		2	2〉 m. N. pr. Verfasser eines HANUMATSTOTRA Z. d. d. m. G. 2,342, No. 200,d	HANUMATSTOTRA;Z. d. d. m. G. 2,342, No. 200,d
+AkASeSa		1	1〉 Gebieter des Luftraums, ein Bein. Indra ʼs	
+AkASeSa		2	2〉 in der Gerichtsspr. eine hilflose Person (die nur über die Luft zu verfügen hat), ein Kind, ein Weib, ein Armer oder Kranker WILS	WILS
+AkASeSa		2	2〉 M. 4,184	M. 4,184
+AkAlika		1	1〉 adj. f	
+AkAlika		1a	a〉 keinen Zeitraum ausfüllend, nur einen Augenblick während, momentan P. 5,1,114 . auch , f. Vārtt. M. 4,103 . 105 . 118 . P. 5,1,114 , Sch	P. 5,1,114;M. 4,103;M. 4, 105;M. 4, 118;P. 5,1,114
+AkAlika		1b	b〉 nicht zur rechten, gewöhnlichen Zeit eintreffend: MṚCCH. 76,5 ( vgl	MṚCCH. 76,5
+AkAlika		2	KUMĀRAS. 3,34	KUMĀRAS. 3,34
+AkAlika		2	2〉 f. Blitz H. 1105 . Vgl. u. s. w. — Die Grammatiker leiten das Wort in der ersten Bedeutung von ab, indem sie wahrscheinlich in der Bedeutung von ein wenig auffassen	H. 1105
+AkAlika		1	1〉	
+AkAlika		1a	a〉 KULL. _zu_ M. 4,103 fasst das Wort in der Bed. von bis zur selben Zeit ( 2. + ) des folgenden Tages während	KULL;M. 4,103
+AkAlika		1b	b〉 KĀLIKĀ-P. 31 _im_ ŚKDR	KĀLIKĀ-P. 31;ŚKDR
+AkAravant		1	1〉 mit einer Gestalt versehen, verkörpert: KATHĀS. 17,50	KATHĀS. 17,50
+AkAravant		2	2〉 wohlgeformt: N. 5,5	N. 5,5
+Akalana		1	1〉 das Binden	
+Akalana		2	2〉 das Zählen TRIK. 3,3,230 . H. an. 4,159 . MED. n. 166	TRIK. 3,3,230;H. an. 4,159;MED. n. 166
+Akalana		3	3〉 das Wünschen H. an. MED	H. an;MED
+Akalpa		1	1〉 Anwendung, Anfügung ( ) TRIK. 3,3,274 . H. an. 3,440 . MED. p. 15	TRIK. 3,3,274;H. an. 3,440;MED. p. 15
+Akalpa		2	2〉 Schmuck, Putz, Zierath AK. 2,6,3,1 . TRIK. H. 635 . an. 3,439 . MED. MBH. 3,13373 . RAGH. 17,22 . 18,51 . SĀH. D. 54,12 . 17	AK. 2,6,3,1;TRIK;H. 635;H an. 3,439;MED;MBH. 3,13373;RAGH. 17,22;RAGH 18,51;SĀH. D. 54,12;SĀH. D. 54, 17
+Akalpa		3	3〉 Krankheit, Unwohlsein VIKR. (LENZ) 93,16 . Falsche Lesart für	VIKR. (LENZ) 93,16
+Akalpa		2	2〉 GĪT. 6,11 . DAŚAK. _in_ BENF. Chr. 195,5 . BHĀG. P. 10,5,9 . 41,40	GĪT. 6,11;DAŚAK;BENF. Chr. 195,5;BHĀG. P. 10,5,9;BHĀG. P. 10, 41,40
+Akalpaka		1	1〉 Sehnsucht TRIK. 3,2,28 . H. an. 4,3	TRIK. 3,2,28;H. an. 4,3
+Akalpaka		2	2〉 Freude H. an	H. an
+Akalpaka		3	3〉 Ohnmacht H. an	H. an
+Akalpaka		4	4〉 Finsterniss H. an	H. an
+Akalpaka		5	5〉 Knoten H. an. — MED. k. 175	H. an;MED. k. 175
+Akara		1	1〉 Ueberschütter, Anfüller: ṚV. 3,51,3 . 5,34,4 . 8,33,5	ṚV. 3,51,3;ṚV 5,34,4;ṚV 8,33,5
+Akara		2	2〉 Anhäufung, Ansammlung, Fülle, Menge H. 1411 , Sch. an. 3,522 . MED. r. 113 . R. 5,17,18 . 4,14,18 . 3,22,25 . VIKR. 9 . BHARTṚ. 2,65 . 88 . um Anhäufung zu verhüten SUŚR. 2,299,18	H. 1411;H an. 3,522;MED. r. 113;R. 5,17,18;R 4,14,18;R 3,22,25;VIKR. 9;BHARTṚ. 2,65;BHARTṚ. 2, 88;SUŚR. 2,299,18
+Akara		3	3〉 = P. 3,3,118 , Sch. Mine AK. 2,3,7 . H. 1036 . an. 3,522 . MED. r. 113 (lies ). M. 7,62 . 8,419 . 11,63 . YĀJÑ. 3,242 . RAGH. 3,18 . (so ist zu lesen) KAṆĀDA _in_ Z. d. d. m. G. 6,16,31 . MBH. 3,16	P. 3,3,118;AK. 2,3,7;H. 1036;H an. 3,522;MED. r. 113;M. 7,62;M 8,419;M 11,63;YĀJÑ. 3,242;RAGH. 3,18;KAṆĀDA;Z. d. d. m. G. 6,16,31;MBH. 3,16302;R. 1,36,13;HIT. Pr. 44;R. 4,40,26;HIT. 27,6;VARĀH. BṚH. S;Verz. d. B. H. 249 (82);MBH. 3,1657;MBH. 3, 16215
+Akara		4	4〉 N. pr. eines Landes VARĀH. BṚH. S. _in_ Verz. d. B. H. 241 ( . — Die Bedeutung ( MED. ) der beste beruht wohl auf einseitiger Auffassung. — Vgl	VARĀH. BṚH. S;Verz. d. B. H. 241 (12);MED
+Akara		3	3〉 Mine, Fundgrube bildlich so v. a. Geburtsstätte, Herkunft: Spr. 3672 . in den entsprechenden Minen d. i. im Drama SĀH. D. 174,1 . am Ende von Personennamen WASSILJEW 268	Spr. 3672;SĀH. D. 174,1;WASSILJEW 268
+Akara		4	4〉 VARĀH. BṚH. S. 14,12 . = das heutige Khandéṣ	VARĀH. BṚH. S. 14,12
+Akara		5	5〉 Titel eines Werkes Verz. d. Oxf. H. 277,b,35 . — Vgl	Verz. d. Oxf. H. 277,b,35
+Akarza		1	1〉 Ansichziehung H. an. 3,731 . MED. ṣ. 31 . (?) KĀTY. ŚR. 13,3,20 . PRAB. 61,16	H. an. 3,731;MED. ṣ. 31;KĀTY. ŚR. 13,3,20;PRAB. 61,16
+Akarza		2	2〉 das Spannen des Bogens H. an. 3,730 . MED. ṣ. 30	H. an. 3,730;MED. ṣ. 30
+Akarza		3	3〉 Krampf WILS	WILS
+Akarza		4	4〉 Würfelspiel (das Ansichziehen der Würfel vor dem Wurf) AK. 3,4,223 . H. an. MED. MBH. 2,2116	AK. 3,4,223;H. an;MED;MBH. 2,2116
+Akarza		5	5〉 Würfel AK. H. an. MED	AK;H. an;MED
+Akarza		6	6〉 Spielbrett diess	
+Akarza		7	7〉 Sinnesorgan H. an. MED	H. an;MED
+Akarza		8	8〉 N. pr. eines Fürsten MBH. 2,1270	MBH. 2,1270
+Akarza		1	1〉 BHĀG. P. 10,9,3	BHĀG. P. 10,9,3
+Akarza		9	9〉 MBH. 5,1541 unter den Sachen, die in einem Hause nicht fehlen dürfen; der Schol. ergänzt . Vielleicht Magnet ( vgl. )	MBH. 5,1541
+Akarza		1	1〉 das Schleppen: eines Steines CARAKA 1,7	CARAKA 1,7
+AkarzaRa		1	1〉 n. das Ansichziehen, Herbeiziehen MED. ṣ. 31 . MBH. 1,7109 . 2,915 . MṚCCH. 47,9 . 10 . PAÑCAT. 258,22 . HIT. III, 92 . VID. 338 . KATHĀS. 20,195 . 24,119 . 25,152 . 204 . als Zauberkunst Verz. d. 	MED. ṣ. 31;MBH. 1,7109;MBH 2,915;MṚCCH. 47,9;MṚCCH. 47, 10;PAÑCAT. 258,22;HIT. III, 92;VID. 338;KATHĀS. 20,195;KATHĀS 24,119;KATHĀS 25,152;KATHĀS. 25, 204;Verz. d. B. H. No. 904
+AkarzaRa		2	2〉 f. ein Stäbchen (mit einem Haken) zum Ansichziehen eines Astes mit Früchten, Blumen u. s. w. ŚKDR	ŚKDR
+AkarzaRa		1	1〉 das Herbeiziehen eines Abwesenden (durch Zauberei) Verz. d. Oxf. H. 94,a,13 . 97,b,21 . 98,a. 6 und N. 1 . das Ziehen an den Haaren MĀRK. P. 85,74 . VENĪS. _in_ SĀH. D. 147,14 . — Vgl	Verz. d. Oxf. H. 94,a,13;Verz. d. Oxf. H 97,b,21;Verz. d. Oxf. H. 97, 98,a. 6;N. 1;MĀRK. P. 85,74;VENĪS;SĀH. D. 147,14
+AkarzaRa		1	¦ n. Anziehung SŪRYAS. 2,8 . das Spannen: eines Bogens CARAKA 1,7	SŪRYAS. 2,8;CARAKA 1,7
+Akarzaka		1	1〉 adj. an sich anziehend, = ( v. l. ) P. 5,2,64	P. 5,2,64
+Akarzaka		2	2〉 m. Magnet ŚABDAM. _im_ ŚKDR	ŚABDAM;ŚKDR
+Akarzaka		3	3〉 f. N. pr. einer Stadt KATHĀS. 3,53	KATHĀS. 3,53
+Akarzin		1	1〉 adj. an sich ziehend	
+Akarzin		1b	b〉 f. = WILS	WILS
+Akarzin		1	¦ vgl	
+Akfti		1	1〉 Bestandtheil: ṚV. 10,85,5 . ( adj. ) 1,164,12	ṚV. 10,85,5;ṚV 1,164,12
+Akfti		2	2〉 Form, Gestalt, äussere Erscheinung AK. 3,4,164 . TRIK. 3,3,147 . H. an. 3,249 . MED. t. 94 . KĀTY. ŚR. 1,3,39 . 9,2,13 . 26,1,20 . ŚVETĀŚV. UP. 6,6 . M. 11,52 . N. 5,9 . 12,13 . HIḌ. 2,2 . HIT. 34,	AK. 3,4,164;TRIK. 3,3,147;H. an. 3,249;MED. t. 94;KĀTY. ŚR. 1,3,39;KĀTY. ŚR 9,2,13;KĀTY. ŚR 26,1,20;ŚVETĀŚV. UP. 6,6;M. 11,52;N. 5,9;N 12,13;HIḌ. 2,2;HIT. 34,20;VID. 43;R. 4,9,46;R 1,13,26;BRĀHMAṆ. 1,28;ŚĀK. 19;ŚĀK 80,7;VID. 105;VID 260;H. an;MED;VAIJ;KIR. 1,36
+Akfti		3	3〉 Art, Unterart, Species TRIK. H. an. MED. SUŚR. 2,17,14 . 16 . 49,8 . 164,11 . ṚV. PRĀT. 18,4 . Vgl	TRIK;H. an;MED;SUŚR. 2,17,14;SUŚR. 2,17, 16;SUŚR. 2, 49,8;SUŚR. 2, 164,11;ṚV. PRĀT. 18,4
+Akfti		4	4〉 ein Metrum von 88 Silben ṚV. PRĀT. 16,56 . 59 . KĀTY. ANUKR. 4,12 . COLEBR. Misc. Ess. II, 163	ṚV. PRĀT. 16,56;ṚV. PRĀT. 16, 59;KĀTY. ANUKR. 4,12;COLEBR. Misc. Ess. II, 163
+Akfti		5	5〉 m. N. pr. eines Mannes MBH. 2,1165 . — Vgl	MBH. 2,1165
+AkrIqa		1	1〉 m. Spiel, Scherz: MBH. 1,4649 . KUMĀRAS. 2,43	MBH. 1,4649;KUMĀRAS. 2,43
+AkrIqa		2	2〉 m.n. Spielplatz, Lusthain, Garten AK. 2,4,1,3 ( m. ein königlicher öffentlicher Garten). H. 1112 ( m. , nach den Sch. m.n. ). MBH. 3,11358 . 14866 . R. 3,61,7 . 4,40,36 . m. MBH. 3,11370 . 14867 . 	AK. 2,4,1,3;H. 1112;MBH. 3,11358;MBH. 3, 14866;R. 3,61,7;R 4,40,36;MBH. 3,11370;MBH. 3, 14867;R. 5,9,10;R 6,73,38;MBH. 3,10823
+AkrIqa		3	3〉 m. N. pr. ein Sohn Karutthāma ʼs HARIV. 1835	HARIV. 1835
+AkramaRa		1	1〉 adj. heranschreitend, beschreitend VS. 25,3 . 6	VS. 25,3;VS. 25, 6
+AkramaRa		2	2〉 n. das Beschreiten, Auftreten, Aufsteigen, Aufstieg: AV. 5,30,7 . 13,1,43 . TS. 7,5,8,5 . NIR. 6,17 . R. 2,42,19 . 31,5 . das (feindliche) Betreten des Landes KULL. _zu_ M. 7,207 . mit dem subj. co	AV. 5,30,7;AV 13,1,43;TS. 7,5,8,5;NIR. 6,17;R. 2,42,19;R. 2, 31,5;KULL;M. 7,207;KATHĀS. 18,46;H. an. 3,762
+AkramaRa		2	2〉 das Angreifen: KATHĀS. 101,51	KATHĀS. 101,51
+Akranda		1a	a〉 AK. 3,4,93	AK. 3,4,93
+Akranda		1b	b〉 AK. H. an. 3,327 . MED. d. 21	AK;H. an. 3,327;MED. d. 21
+Akranda		1c	c〉 MED	MED
+Akranda		1d	d〉 NAIGH. 2,17 . H. 799 . AK. H. an. ( st. zu lesen ). MED. — Eine Stelle im MANU (7,207) hat Veranlassung gegeben, noch andere Bedeutungen aufzustellen. Hier heisst es: bedeutet hier allem Anschein n	NAIGH. 2,17;H. 799;AK;H. an;MED;MANU (7,207);KULL;AK;H. an;MED;DHAR;ŚKDR
+Akranda		1	1〉 der natürliche Freund eines im Kriege begriffenen Fürsten; zieht ein Fürst inʼs Feld, so heisst sein unmittelbarer Nachbar, der ihm in den Rücken fällt, ; der unmittelbar an den gränzende Fürst ist	KĀM. NĪTIS. 8,17;KĀM. NĪTIS. 8, 43;KĀM. NĪTIS. 8, 46;M. 7,207;VARĀH. BṚH. S. 16,7;VARĀH. BṚH. S 104,61;VARĀH. BṚH. S 17,6. fgg
+Akranda		2	2〉 Freund, Beschützer überh. : adj. ( f. ) keinen Freund —, keinen Beschützer habend: (der Schol. fasst das Wort als loc. und erklärt es durch ) (als Beschützer, als Gatten) MBH. 1,6568 . 3,13859 . De	MBH. 1,6568;MBH 3,13859;MBH. 1,6568;MBH 3,13859;MED
+AkroSa		1	1〉 das Anrufen, Erfüllen einer Gegend mit seinem Geschrei: R. 4,9,19	R. 4,9,19
+AkroSa		2	2〉 Anfahrung, Schmähung, Beschimpfung, Tadel H. 272 . NIR. 4,2 . P. 6,2,158 . AK. 1,1,5,15 . ( subj. ) R. 2,106,28 . ( obj. ) — YĀJÑ. 2,302 . mit dem obj. comp. : R. 3,59,9 . 4,30 in der Unterschr. YĀ	H. 272;NIR. 4,2;P. 6,2,158;AK. 1,1,5,15;R. 2,106,28;YĀJÑ. 2,302;R. 3,59,9;R. 3, 4,30;YĀJÑ. 2,232
+AkroSa		3	3〉 N. pr. eines Fürsten MBH. 2,1188 . Z. f. d. K. d. M. 3,185 . 190	MBH. 2,1188;Z. f. d. K. d. M. 3,185;Z. f. d. K. d. M. 3, 190
+AkroSa		1	1〉 s. u	
+AkroSa		2	2〉 Spr. 3679	Spr. 3679
+AkulIkar		1	1〉 mit Etwas erfüllen: R. 4,41,29	R. 4,41,29
+AkulIkar		2	2〉 in Verwirrung bringen: PAÑCAT. V, 25 . KATHĀS. 19,66 . — Davon n. das Verwirren, = P. 7,2,54 , Sch	PAÑCAT. V, 25;KATHĀS. 19,66;P. 7,2,54
+Akula		1	1〉 adj. f. AK. 2,8,2,67 . 3,2,21 . 4,192 . TRIK. 3,3,380 . H. 366 . 1472	AK. 2,8,2,67;AK. 2, 3,2,21;AK. 2,8, 4,192;TRIK. 3,3,380;H. 366;H 1472
+Akula		1a	a〉 erfüllt, voll überhäuft von Etwas; mit dem instr. : MBH. 2,475 . R. 3,63,4 . (von Pflichten gegen ihn) ŚĀK. 94 . gewöhnlich am Ende eines comp. R. 1,19,11 . 2,46,17 . 50,9 . 3,74,8 . VIŚV. 4,12 . R	MBH. 2,475;R. 3,63,4;ŚĀK. 94;R. 1,19,11;R 2,46,17;R. 2, 50,9;R 3,74,8;VIŚV. 4,12;R. 3,17,18;VIŚV. 6,18;AMAR. 81;BHARTṚ. 2,4;BHARTṚ 3,11;N. 4,18;N 16,11;R. 4,50,14;HIT. 18,11;VID. 107;VID 179;VID 50;KATHĀS. 1,43;PAÑCAT. 9,11;HIT. 42,14;HIT I, 204
+Akula		1b	b〉 in Verwirrung oder Unordnung gerathen, aus seinem natürlichen Zustande gebracht, verwirrt ( übertr. ): R. 3,58,45 . 5,54,1 . VIŚV. 5,1 . R. 5,21,15 . ( N. pr. eines Flusses) 2,46,28 . BHAG. 2,1 . M	R. 3,58,45;R 5,54,1;VIŚV. 5,1;R. 5,21,15;R 2,46,28;BHAG. 2,1;MṚCCH. 130,8;MBH. 3,17304;KATHĀS. 12,183;KATHĀS 13,161;R. 1,1,52;R 3,79,1;ŚĀK. 106;ŚUK. 43,18;ŚĀK. 32,2;VID. 29
+Akula		2	2〉 [Page1-0589] n. eine mit Menschen angefüllte, eine bewohnte Gegend: R. 3,43,34 . — Wird von abgeleitet, scheint uns aber eher von mit abzustammen. — Vgl	R. 3,43,34
+Akula		1	1〉	
+Akula		1b	b〉 KATHĀS. 108,44 . wild und ron Spr. 4553	KATHĀS. 108,44;Spr. 4553
+Akula		3	3〉 n. Verwirrung: verwirrt KATHĀS. 78,94 . 106,149	KATHĀS. 78,94;KATHĀS 106,149
+AkulatA		1	1〉 Fülle, Menge: SĀH. D. 64,13. fgg. BALLANTYNE : perplexity about smoke, etc. — perplexity about dust, etc	SĀH. D. 64,13. fgg;BALLANTYNE
+AkulatA		2	2〉 Verwirrung: MBH. 3,401 . mit dem instr. comp. : AMAR. 72	MBH. 3,401;AMAR. 72
+AkulatA		1	¦ [ vgl. [Page1-0589]] Das Beispiel u. 1. gehört zu 2	
+AkulatA		1	1〉 das Beispiel gehört zu	
+AkulatA		2	2〉	
+AkulatA		2	2〉 Spr. 632	Spr. 632
+Akulatva		1	1〉 Fülle, Menge: MBH. 3,13711	MBH. 3,13711
+Akulatva		2	2〉 Verwirrung, Verwirrtheit: KATHĀS. 19,60 . BHARTṚ. 1,17	KATHĀS. 19,60;BHARTṚ. 1,17
+Akulatva		2	2〉 ŚIŚ. 9,42	ŚIŚ. 9,42
+Akzepa		1	1〉 Ansichreissung, Ansichziehung, Zukkung TRIK. 3,3,274 . H. an. 3,439 . MED. p. 15 . SUŚR. 1,254,2 . KUMĀRAS. 7,95	TRIK. 3,3,274;H. an. 3,439;MED. p. 15;SUŚR. 1,254,2;KUMĀRAS. 7,95
+Akzepa		2	2〉 Andeutung: the primary meaningʼs hinting something else ( BALLANTYNE ) SĀH. D. 11,20 . [Page1-0593] Vgl. 12,3 und	BALLANTYNE;SĀH. D. 11,20;SĀH. D 12,3
+Akzepa		3	3〉 Anlegung, Auftragung: KUMĀRAS. 7,17	KUMĀRAS. 7,17
+Akzepa		4	4〉 Fortwerfung, Aufgebung, das Fahrenlassen: KUMĀRAS. 1,14 . BHARTṚ. 3,29 ( bedeutet hier wohl umgewandelt, umgestimmt, was wir hier wegen des u. 2. mit 3. Gesagten erwähnen)	KUMĀRAS. 1,14;BHARTṚ. 3,29
+Akzepa		5	5〉 das Hinausziehen, Aushalten (eines Lautes): ṚV. PRĀT. 3,1	ṚV. PRĀT. 3,1
+Akzepa		6	6〉 Schmähung, Verschmähung, Vorwurf AK. 1,1,5,13 . TRIK. 3,2,28 . 3,274 . H. 272 . an. MED. adv. PAÑCAT. 24,12	AK. 1,1,5,13;TRIK. 3,2,28;TRIK. 3, 3,274;H. 272;H an;MED;PAÑCAT. 24,12
+Akzepa		7	7〉 Zweifel, Ironie SUŚR. 2,559,5 . = H. an. MED	SUŚR. 2,559,5;H. an;MED
+Akzepa		2	2〉 SĀH. D. 315 . 700 . in der Dramatik: DAŚAR. 1,38 . PRATĀPAR. 40,a,3 . SĀH. D. 276,15	SĀH. D. 315;SĀH. D 700;DAŚAR. 1,38;PRATĀPAR. 40,a,3;SĀH. D. 276,15
+Akzepa		4	4〉 das Abnehmen —, Entfernen des [Page5-1089] Siegels KATHĀS. 102,134	KATHĀS. 102,134
+Akzepa		6	6〉 Spr. 1434 . BHĀG. P. 10,55,17 . harte Worte 12,6,22 . 2079 . verächtlich 2639 . LA. (II) 90,5 . so v. a. mit verächtlichen Seitenblicken BHĀG. P. 10,32,6	Spr. 1434;BHĀG. P. 10,55,17;BHĀG. P 12,6,22;BHĀG. P 2079;BHĀG. P 2639;LA. (II) 90,5;BHĀG. P. 10,32,6
+Akzepa		7	7〉 lies: in der Rhetorik Einwurf, Einwendung, eine Erklärung, dass man mit Etwas nicht einverstanden sei, insbes. Berichtigung der eigenen Rede: KĀVYĀD. 2,120 . AGNI-P. beim Schol. zu KĀVYĀD. 2,120 . 	KĀVYĀD. 2,120;AGNI-P;KĀVYĀD. 2,120;KĀVYA-PR. 157,16. fgg;SĀH. D. 714;KUVALAY. 93,a (114,a);PRATĀPAR. 95,b,4
+Akzepa		8	8〉 Herausforderung (zum Streit) KATHĀS. 66,65	KATHĀS. 66,65
+Akzepaka		1	1〉 adj. schmähend, tadelnd H. an. 4,3 . MED. k. 176	H. an. 4,3;MED. k. 176
+Akzepaka		2	2〉 m. Convulsion SUŚR. 1,254,2 ( s. u. 1.). 16 . 357,19 . 2,32,6 . 42,16 . 95,10 . = und H. an. MED	SUŚR. 1,254,2;SUŚR. 1,254, 16;SUŚR. 1, 357,19;SUŚR 2,32,6;SUŚR. 1, 42,16;SUŚR. 1, 95,10;H. an;MED
+Akzepya		1	1〉 wogegen man einen Einwurf zu erheben hat, womit man sich nicht einverstanden erklären kann KĀVYĀD. 2,120	KĀVYĀD. 2,120
+Akzepya		2	2〉 herauszufordern (zum Spiel, zum Kampf) KATHĀS. 121,90	KATHĀS. 121,90
+Akzika		1	1〉 adj	
+Akzika		1a	a〉 = oder P. 4,4,2 , Sch. eine durch Würfelspiel entstandene Schuld M. 8,159 . Einsatz beim Würfelspiel WILS	P. 4,4,2;M. 8,159;WILS
+Akzika		1b	b〉 = gaṇa zu P. 5,1,50	P. 5,1,50
+Akzika		2	2〉 m. Morinda tinctoria , ein kleiner Baum, RATNAM. _im_ ŚKDR. SUŚR. 1,190,3 . Vgl. , 1. am Ende	RATNAM;ŚKDR;SUŚR. 1,190,3
+Akzika		7	bereitet: SUŚR. 1,190,3 . f. ein solches Getränk CARAKA 1,27 , v. l. (für ) und MADAN. 8,65	SUŚR. 1,190,3;CARAKA 1,27;MADAN. 8,65
+AlAna		1	1〉 n. der Pfosten, an den ein Elephant gebunden wird, AK. 2,8,2,9 . TRIK. 2,8,39 . H. 1230 . MED. n. 39 . R. 5,52,12 . MṚCCH. 20,12 . RAGH. 4,81 . ŚĀNTIŚ. 1,22 . BHARTṚ. 3,82 . Nach NĪLAK. _zu_ AK. be	AK. 2,8,2,9;TRIK. 2,8,39;H. 1230;MED. n. 39;R. 5,52,12;MṚCCH. 20,12;RAGH. 4,81;ŚĀNTIŚ. 1,22;BHARTṚ. 3,82;NĪLAK;AK;RAGH. 4,69;RAGH 1,71;MED. n. 39;RĀJAN;ŚKDR;SIDDH. K. 249,a,9
+AlAna		2	2〉 m. N. pr. eines Dieners von Śiva VYĀḌI _zu_ H. 210	VYĀḌI;H. 210
+AlAna		1	1〉 (= Schol. ) Spr. 834 . adj. KATHĀS. 52,118 . 72,195 . der Strick, mit dem der Elephant angebunden wird, MĀLAV. 76 . adj. KATHĀS. 112,62	Spr. 834;KATHĀS. 52,118;KATHĀS 72,195;MĀLAV. 76;KATHĀS. 112,62
+AlApa		1	1〉 Rede, Gespräch, Mittheilung AK. 1,1,5,16 . H. 274 . AV. 11,8,25 . R. 5,14,10 . ŚĀK. 8,21 . PRAB. 63,9 . 104,11 . PAÑCAT. 46,12 . Sch. zu ŚĀK. 31,7 . (ein Kind) KATHĀS. 17,66 . BRAHMA-P. in LA. 53,1	AK. 1,1,5,16;H. 274;AV. 11,8,25;R. 5,14,10;ŚĀK. 8,21;PRAB. 63,9;PRAB 104,11;PAÑCAT. 46,12;ŚĀK. 31,7;KATHĀS. 17,66;BRAHMA-P. in LA. 53,19;DHŪRTAS. 89,2;HIT. 21,4;HIT 25,17;HIT 26,22;KATHĀS. 19,30;KATHĀS 21,52;VP;SĀH. D. 2,14;AMAR. 97;ŚRUT. 39
+AlApa		2	2〉 bei den Mathematikern das Stellen der Frage COLEBR. Alg. 187	COLEBR. Alg. 187
+AlApa		1	1〉 Spr. 778 . KATHĀS. 66,20 . 72,245 . Erzählung 54,81 . Unterhaltung 66,116 . 119 . vom Gesange der Vögel: 69,7 . 81,88 . nom. abstr. von 90,48 . Sp. 703, Z. 2 streiche adj. und vgl. Spr. 2628 . — Vg	Spr. 778;KATHĀS. 66,20;KATHĀS 72,245;KATHĀS 54,81;KATHĀS 66,116;KATHĀS. 66, 119;KATHĀS 69,7;KATHĀS 81,88;KATHĀS 90,48;Spr. 2628
+AlApin		1	1〉 adj. redend, sprechend: BHARTṚ. 2,44	BHARTṚ. 2,44
+AlApin		2	2〉 f. eine aus einem Kürbiss ( oder heisst die Flaschengurke) verfertigte Laute As. Res. 9,453	As. Res. 9,453
+AlIQa		1	1〉 adj. s. mit	
+AlIQa		2	2〉 m. N. pr. eines Mannes gaṇa zu P. 4,1,123	P. 4,1,123
+AlIQa		3	3〉 n. eine bes. Stellung beim Schiessen, bei der das rechte Bein vorgestellt, das linke gebogen wird, AK. 2,8,2,53 . H. 777 . MED. ḍh. 7 . MALLIN. _zu_ KUMĀRAS. 3,70 . RAGH. 3,52	AK. 2,8,2,53;H. 777;MED. ḍh. 7;MALLIN;KUMĀRAS. 3,70;RAGH. 3,52
+Ala		1	1〉 n	
+Ala		1a	a〉 Laich oder Ausspritzungen giftiger Thiere SUŚR. 2,257,17 . 296,13 . 297,20 . KAUŚ. 51 . Vgl. 1. und	SUŚR. 2,257,17;SUŚR. 2, 296,13;SUŚR. 2, 297,20;KAUŚ. 51
+Ala		1b	b〉 gelber Arsenik, Auripigment AK. 2,9,104 . H. 1059 . an. 2,474 . SUŚR. 2,109,12 . 298,4 . 325,16 . Vgl. 2. und	AK. 2,9,104;H. 1059;H an. 2,474;SUŚR. 2,109,12;SUŚR. 2, 298,4;SUŚR. 2, 325,16
+Ala		1c	c〉 Verstümmelung von in	
+Ala		2	2〉 adj. nicht klein ( ) H. an. Diese Bed. des Wortes hat man in ( s. d. ) gesucht	H. an
+Ala		3	3〉 m. N. pr. eines Affen KATHĀS. 57,136	KATHĀS. 57,136
+AlaBana		1	1〉 das Anfassen, Berühren BHĀG. P. 10,29,46	BHĀG. P. 10,29,46
+AlaBana		2	2〉 das Schlachten (eines Opferthieres) BHĀG. P. 11,5,13	BHĀG. P. 11,5,13
+AlamBa		1	1〉 das Anfassen, Ergreifen, Berührung VYUTP. 120 . ĀŚV. GṚHY. 1,15 . M. 2,179 . YĀJÑ. 3,157	VYUTP. 120;ĀŚV. GṚHY. 1,15;M. 2,179;YĀJÑ. 3,157
+AlamBa		2	2〉 das Abreissen, Ausreissen (von Pflanzen): M. 11,144	M. 11,144
+AlamBa		3	3〉 das Tödten des ergriffenen Thieres AK. 2,8,2,84 . H. 371 . AIT. BR. 2,3 . ŚAT. BR. 3,7,3,4 . 5 . 13,3,8,5 . MBH. 14,2820 . MEGH. 46	AK. 2,8,2,84;H. 371;AIT. BR. 2,3;ŚAT. BR. 3,7,3,4;ŚAT. BR. 3,7,3, 5;ŚAT. BR 13,3,8,5;MBH. 14,2820;MEGH. 46
+AlamBa		1	¦ vgl	
+AlamBana		1	1〉 das Anfassen, Berühren KĀTY. ŚR. 9,3,19 . 4,9 . 17,3,16 . 18,6,8	KĀTY. ŚR. 9,3,19;KĀTY. ŚR. 9, 4,9;KĀTY. ŚR 17,3,16;KĀTY. ŚR 18,6,8
+AlamBana		2	2〉 das Tödten, Schlachten KĀTY. ŚR. 8,8,15 . 20,4,2	KĀTY. ŚR. 8,8,15;KĀTY. ŚR 20,4,2
+AlamBana		1	¦ vgl	
+Alamba		1	1〉 adj. herabhängend: R. 3,22,17	R. 3,22,17
+Alamba		2	2〉 m	
+Alamba		2a	a〉 woran Etwas hängt, woran man sich festhält, sich stützt, Stütze (auch übertr. ): ( d. i. ) śikya heisst dass, woran die Last hängt H. 364 . VID. 239 . ŚĀNTIŚ. 3,2 . MBH. 3,1541 . R. 1,44,2 . VIŚV. 	H. 364;VID. 239;ŚĀNTIŚ. 3,2;MBH. 3,1541;R. 1,44,2;VIŚV. 13,23;R. 5,7,58;R 4,63,23;R 3,40,28;VET. 28,12;KATHĀS. 12,175;R. 5,73,6
+Alamba		2b	b〉 eine senkrechte Linie WILS. Vgl	WILS
+Alamba		2c	c〉 N. pr. eines Muni MBH. 2,109	MBH. 2,109
+Alamba		3	3〉 f. N. einer Pflanze mit giftigem Blatte SUŚR. 2,251,16	SUŚR. 2,251,16
+Alamba		2	2〉	
+Alamba		2a	a〉 RĀJA-TAR. 5,310 . Spr. 2158 . KATHĀS. 67,106 . so v. a. Wüstheit des Kopfes SĀH. D. 222 . — Vgl	RĀJA-TAR. 5,310;Spr. 2158;KATHĀS. 67,106;SĀH. D. 222
+Alambana		1	1〉 das sich — auf — Etwas — Stützen P. 8,3,68	P. 8,3,68
+Alambana		2	2〉 das Stützen, Erhalten: MEGH. 4	MEGH. 4
+Alambana		3	3〉 Stütze, Haltpunkt: R. 5,3,64 . ( ) PAÑCAT. I, 34 . übertr. Fundament, Grundlage KAṬHOP. 2,17 . Grund, Veranlassung: PRAB. 71,7 ( Sch. 1: = ). In der Rhetorik ist der eigentliche Grund der Gefühlser	R. 5,3,64;PAÑCAT. I, 34;KAṬHOP. 2,17;PRAB. 71,7;SĀH. D. 32,7;SĀH. D. 32, 9;SĀH. D 29,6;SĀH. D 61,18;SĀH. D 76,22;VP. 653;WILS;BURN. Intr. 449
+Alambana		3	3〉 Verz. d. Oxf. H. 229,a,28 . 17. fgg. f. so v. a. Wüstheit des Kopfes SĀH. D. 222 . Ueber die bei den Buddhisten vgl. SARVADARŚANAS. 20,3. fgg. — Vgl	Verz. d. Oxf. H. 229,a,28;Verz. d. Oxf. H 17. fgg;SĀH. D. 222;SARVADARŚANAS. 20,3. fgg
+Alambin	1	1	1〉 an Etwas hängend, sich auf Etwas stützend: ( d. i. ) AK. 2,10,30 . ( ) PAÑCAT. I, 160 . RAGH. 12,85	AK. 2,10,30;PAÑCAT. I, 160;RAGH. 12,85
+Alambin	1	2	2〉 umhüllt: ( ) KUMĀRAS. 5,78	KUMĀRAS. 5,78
+Alambin	1	3	3〉 abhängend von: (von Wolken, die durch den Wind getrieben werden) MBH. 3,9924	MBH. 3,9924
+Alambin	1	4	4〉 von dem Etwas abhängt, eine Stütze seiend, unterstützend: HIT. Pr. 19	HIT. Pr. 19
+Alambin	1	1	1〉 KATHĀS. 65,195 . herabhängend ṚT. 6,24	KATHĀS. 65,195;ṚT. 6,24
+AleKana		1	1〉 adj. kratzend, scharrend; malend	
+AleKana		2	2〉 m. N. pr. eines Lehrers in Ritualsachen ĀŚV. ŚR. 6,10 . Davon patron. [Page1-0705] gaṇa zu P. 4,1,112	ĀŚV. ŚR. 6,10;P. 4,1,112
+AleKana		3	3〉 f. Pinsel WILS	WILS
+AleKana		4	4〉 n. das Kratzen, Scharren P. 6,1,142 . Sch	P. 6,1,142
+Ali	1	1	1〉 Scorpion H. 1211 . Ind. St. 2,260	H. 1211;Ind. St. 2,260
+Ali	1	2	2〉 Biene Sch. zu AK. und angeblich HĀR. ŚKDR. — Vgl	AK;HĀR;ŚKDR
+Ali	1	2	2〉 hierher stellt BENFEY PAÑCAT. I, 203 , wo aber anzunehmen ist	BENFEY;PAÑCAT. I, 203
+Ali	2	1	1〉 Freundin eines Frauenzimmers AK. 2,6,1,12 . 3,4,200 . TRIK. 3,3,381 . H. 529 . an. 2,475 . MED. l. 3 . Die von den Schol. zu AK. aufgeführte Form erscheint KUMĀRAS. 5,83 . SĀH. D. 71,11 . AMAR. 23 	AK. 2,6,1,12;AK. 2, 3,4,200;TRIK. 3,3,381;H. 529;H an. 2,475;MED. l. 3;AK;KUMĀRAS. 5,83;SĀH. D. 71,11;AMAR. 23
+Ali	2	2	2〉 Streifen, Strich, Linie, Zug AK. 2,4,1,4 . 3,4,200 . H. 1423 . H. an. MED. die Linie, die eine Strasse bildet, AMAR. 89 . ( acc. pl. ) PRAB. 101,17 . mit der Länge: PAÑCAT. 203,6 . KUMĀRAS. 6,49 . 	AK. 2,4,1,4;AK. 2, 3,4,200;H. 1423;H. an;MED;AMAR. 89;PRAB. 101,17;PAÑCAT. 203,6;KUMĀRAS. 6,49;MEGH. 79
+Ali	2	3	3〉 Damm AK. 2,1,14 . TRIK. 3,3,381 . H. 965 . H. an. MED	AK. 2,1,14;TRIK. 3,3,381;H. 965;H. an;MED
+Ali	2	4	4〉 kleiner Graben VYUTP. 102	VYUTP. 102
+Ali	2	5	5〉 Verwandtschaftsreihe, Reihenfolge in der Abstammung ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+Ali	2	1	1〉 HALĀY. 2,332	HALĀY. 2,332
+Ali	2	2	2〉 Spr. 4965 . HALĀY. 4,36	Spr. 4965;HALĀY. 4,36
+Ali	2	3	3〉 HALĀY. 3,54	HALĀY. 3,54
+Ali	3	1	1〉 unnütz, zwecklos ( ) H. an. 2,475	H. an. 2,475
+Ali	3	2	2〉 von lauterer Gesinnungsweise ( ) H. an. MED. l. 2	H. an;MED. l. 2
+AliNga		1	1〉 Umarmung DAŚAK. _in_ BENF. Chr. 201,14	DAŚAK;BENF. Chr. 201,14
+AliNga		2	2〉 = m. Trommel Sch. zu AK. 1,1,7,5	AK. 1,1,7,5
+AliNgya		1	1〉 adj. zu umfassen	
+AliNgya		2	2〉 m	
+AliNgya		2a	a〉 eine bes. Art Trommel AK. 1,1,7,5 . H. 293 , Sch. ŚABDĀRṆ. _im_ ŚKDR. R. 5,13,47 . Vgl. und	AK. 1,1,7,5;H. 293;ŚABDĀRṆ;ŚKDR;R. 5,13,47
+AliNgya		2b	b〉 N. pr. gaṇa zu P. 4,2,82	P. 4,2,82
+Alocana		1	1〉 das Sehen: P. 8,1,25 . 3,2,60 . das Wahrnehmen (der Sinnesorgane): [Page1-0706] SĀṂKHYAK. 28	P. 8,1,25;P 3,2,60;SĀṂKHYAK. 28
+Alocana		2	2〉 das Erwägen, Ueberlegen: H. 741 . auch f. R. 5,14,38 :	H. 741;R. 5,14,38
+Aloka		1	1〉 das Sehen, Blicken, Hinsehen, Ansehen, Erblicken, Anblick AK. 3,4,3 . 3,3,31 , v. l. H. an. 3,7 . MED. k. 47 . ŚĀNTIŚ. 4,6 . MṚCCH. 14,13 . KUMĀRAS. 7,46 . dessen Anblick reinigt KATHĀS. 10,204 . Ś	AK. 3,4,3;AK 3,3,31;H. an. 3,7;MED. k. 47;ŚĀNTIŚ. 4,6;MṚCCH. 14,13;KUMĀRAS. 7,46;KATHĀS. 10,204;ŚĀK. 9;MEGH. 38;MEGH 83;VIKR. 109;YĀJÑ. 3,141;YĀJÑ. 3, 157;ŚĀK. 32;RAGH. 1,84;MEGH. 3;KATHĀS. 18,15;SĀH. D. 70,21;RAGH. 7,6;KUMĀRAS. 7,57;RAGH 15,78;VIKR. 11;VIKR 109
+Aloka		2	2〉 Licht, heller Schein, Schein AK. 3,4,3 . H. 101 . H. an. MED. R. 4,50,25 . 51,23 . MBH. 1,5438 . 3,817 . nicht einmal einen Schimmer, eine Spur von Rāma R. 2,47,2 . MBH. 1,1475 . 29	AK. 3,4,3;H. 101;H. an;MED;R. 4,50,25;R. 4, 51,23;MBH. 1,5438;MBH 3,817;R. 2,47,2;MBH. 1,1475;MBH. 1, 29
+Aloka		3	3〉 Lobpreis, Schmeichelei H. an. MED. HĀR. 149 . RAGH. 2,9	H. an;MED;HĀR. 149;RAGH. 2,9
+Aloka		4	4〉 Abschnitt, Kapitel Verz. d. B. H. No. 819 . 823	Verz. d. B. H. No. 819;Verz. d. B. H. No 823
+Aloka		1	1〉 KATHĀS. 104 . 83	KATHĀS. 104;KATHĀS 83
+Aloka		1	1〉	
+Aloka		2	2〉 Spr. 3937	Spr. 3937
+Aloka		2	2〉 KATHĀS. 73,281 . 75,50 . 91,57 . DAŚAK. _in_ BENF. Chr. 186,15 . Spr. 3582 . (ein brennendes Licht) MBH. 13,2947 . dass. 4677 . 4726 . Verz. d. Oxf. H. 230,b,27. fgg. in dunklen Welten MBH. 13,3261	KATHĀS. 73,281;KATHĀS 75,50;KATHĀS 91,57;DAŚAK;BENF. Chr. 186,15;Spr. 3582;MBH. 13,2947;MBH. 13, 4677;MBH. 13, 4726;Verz. d. Oxf. H. 230,b,27. fgg;MBH. 13,3261;NĪLAK;VARĀH. BṚH. S. 106,1
+Aloka		5	5〉 Titel eines Werkes, = HALL 38 . — Vgl	HALL 38
+AlokanIya		1	1〉 sichtbar; davon nom. abstr. KUMĀRAS. 2,24 :	KUMĀRAS. 2,24
+AlokanIya		2	2〉 in Erwägung zu ziehen, zu beachten R. 4,44,36	R. 4,44,36
+Alu		1	1〉 m	
+Alu		1a	a〉 Eule ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+Alu		1b	b〉 eine Art Ebenholz ( ) RĀJAN. _im_ ŚKDR. Vgl. schwarzes Ebenholz	RĀJAN;ŚKDR
+Alu		2	2〉 f. ein kleines Wassergefäss AK. 2,9,31 . TRIK. 3,3,380 . H. an. 2,475 . MED. l. 3 . H. 1021 . 1025	AK. 2,9,31;TRIK. 3,3,380;H. an. 2,475;MED. l. 3;H. 1021;H 1025
+Alu		3	3〉 n	
+Alu		3a	a〉 Floss, Nachen TRIK. H. an. MED. HIT. III, 52	TRIK;H. an;MED;HIT. III, 52
+Alu		3b	b〉 Name einer Wurzel TRIK. H. an. MED. VYUTP. 134 . Vgl	TRIK;H. an;MED;VYUTP. 134
+Alu		3	3〉	
+Alu		3a	a〉 vgl. Spr. 4194	Spr. 4194
+Alu		3b	b〉 Wurzelknolle überh: vgl	
+Aluka		1	1〉 m	
+Aluka		1a	a〉 eine Art Ebenholz ( ) RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+Aluka		1b	b〉 ein Bein. Śeṣa ʼs H. 1307	H. 1307
+Aluka		2	2〉 n	
+Aluka		2a	a〉 die essbare Wurzel von Amorphophallus campanulatus Bl. RĀJAN. _im_ ŚKDR. SUŚR. 2,457,16 . =	RĀJAN;ŚKDR;SUŚR. 2,457,16
+Aluka		2b	b〉 = RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+Aluka		1	¦ vgl. f. eine best. Wurzel BHĀVAPR. _im_ ŚKDR	BHĀVAPR;ŚKDR
+Aluka		1	¦ n. s. oben u	
+Am		1	1〉 der Einwilligung AK. 3,5,16 . TRIK. 3,4,2 (wohl zu lesen; vgl. 1. ). H. 1540 . an. 7,2 . MED. avy. 50 . H. 1540 , Sch	AK. 3,5,16;TRIK. 3,4,2;H. 1540;H an. 7,2;MED. avy. 50;H. 1540
+Am		2	2〉 der Erinnerung (wenn man sich auf Etwas besinnt) H. an. MED. MṚCCH. 2,8 . 47, ult. 153,14 . 160,21 . ŚĀK. CH. 43, ult. 91,9 . 151,12 . VIKR. 58,17 . [Page1-0668] — Vgl. 1	H. an;MED;MṚCCH. 2,8;MṚCCH 47, ult. 153,14;MṚCCH 160,21;ŚĀK;CH. 43, ult. 91,9;CH. 43, 151,12;VIKR. 58,17
+AmAvAsya		1	1〉 adj	
+AmAvAsya		1a	a〉 zum Neumond oder dessen Feier gehörig ŚAT. BR. 1,6,2,6 . 8,3,4 . AIT. BR. 1,1	ŚAT. BR. 1,6,2,6;ŚAT. BR. 1, 8,3,4;AIT. BR. 1,1
+AmAvAsya		1b	b〉 an einem Neumond geboren P. 4,3,30	P. 4,3,30
+AmAvAsya		2	2〉 n. (nämlich ) das Neumondsopfer ŚAT. BR. 11,1,3,1. fgg. ĀŚV. ŚR. 12,6 . KĀTY. ŚR. 4,5,26 . 25,4,37 . 46 . 7,4 . ŚAT. BR. 11,1,5,4	ŚAT. BR. 11,1,3,1. fgg;ĀŚV. ŚR. 12,6;KĀTY. ŚR. 4,5,26;KĀTY. ŚR 25,4,37;KĀTY. ŚR. 25,4, 46;KĀTY. ŚR. 25, 7,4;ŚAT. BR. 11,1,5,4
+AmAvAsya		1	1〉	
+AmAvAsya		1a	a〉 GOBH. 1,5,6	GOBH. 1,5,6
+AmAvAsya		2	2〉 WEBER, JYOT. 85	WEBER, JYOT. 85
+Ama	1	1	1〉 adj. f. ὠμός , Gegens. H. an. 2,315 . MED. m. 2	H. an. 2,315;MED. m. 2
+Ama	1	1a	a〉 roh, ungekocht: ṚV. 1,162,10 . AV. 4,17,4 . 5,29,6 . 8,6,23 . M. 4,223 . YĀJÑ. 1,286 . R. 4,40,31 . SUŚR. 1,176,16 . halbgeröstet KĀTY. ŚR. 5,3,2 . Im Veda besonders von der Kuh, welche im Gegensat	ṚV. 1,162,10;AV. 4,17,4;AV 5,29,6;AV 8,6,23;M. 4,223;YĀJÑ. 1,286;R. 4,40,31;SUŚR. 1,176,16;KĀTY. ŚR. 5,3,2;ṚV. 3,30,14;ṚV 1,62,9;ṚV. 1, 180,3;ṚV 2,40,2;ṚV 4,3,9;ṚV 6,72,4;ṚV 8,78,7;TS. 6,5,6,4;ŚAT. BR. 2,2,4,15;ŚAT. BR 14,9,3,10
+Ama	1	1b	b〉 ungebrannt, von einem Gefäss AV. 5,31,1 . MBH. 3,1215 . PAÑCAT. III, 13 . HIT. IV, 63 . MṚCCH. 47,9 . Vgl	AV. 5,31,1;MBH. 3,1215;PAÑCAT. III, 13;HIT. IV, 63;MṚCCH. 47,9
+Ama	1	1c	c〉 unreif, von Früchten AK. 2,4,1,15 . H. 1130 . SUŚR. 1,215,20 . von Geschwüren und dgl. : SUŚR. 1,62,11 . 63,3 . 2,105,18 . 224,7	AK. 2,4,1,15;H. 1130;SUŚR. 1,215,20;SUŚR. 1,62,11;SUŚR. 1, 63,3;SUŚR 2,105,18;SUŚR. 2, 224,7
+Ama	1	1d	d〉 unverdaut, von krankhafter Ausleerung SUŚR. 2,429,4 . 7	SUŚR. 2,429,4;SUŚR. 2,429, 7
+Ama	1	2	2〉 n	
+Ama	1	2a	a〉 der Zustand des Rohseins SUŚR. 1,186,9	SUŚR. 1,186,9
+Ama	1	2b	b〉 Verdauungslosigkeit, cruditas SUŚR. 2,488,6 . 489,2 . 490,9 . Bezeichnung einer acuten Form von Dysenterie WISE 335 . SUŚR. 2,430,20 . vollständiger 21 . der damit Behaftete 10 . Aus den obigen Ste	SUŚR. 2,488,6;SUŚR. 2, 489,2;SUŚR. 2, 490,9;WISE 335;SUŚR. 2,430,20;SUŚR. 2,430, 21;SUŚR. 2,430, 10;ŚKDR;H. an. 2,315;MED. m. 2;RĀJAN;ŚKDR
+Ama	1	1	1〉	
+Ama	1	1b	b〉 VARĀH. BṚH. S. 53,94	VARĀH. BṚH. S. 53,94
+Ama	1	1e	e〉 zart, fein (= Schol. ): adj. BHĀG. P. 3,31,27	BHĀG. P. 3,31,27
+Ama	1	2	2〉	
+Ama	1	2b	b〉 Spr. 890	Spr. 890
+Ama	1	3	3〉 m. N. pr. eines Sohnes des Kṛṣṇa BHĀG. P. 10,61,13	BHĀG. P. 10,61,13
+AmantraRa		1	1〉 das Anreden, Anrede, Anruf AK. 3,4,32,5 . ( COL. 3,4,28,5 ). H. 261 . ŚAT. BR. 6,6,2,5 . SĀH. D. (1828) 177,18 .⫽print_change	AK. 3,4,32,5;COL. 3,4,28,5;H. 261;ŚAT. BR. 6,6,2,5;SĀH. D. (1828) 177,18
+AmantraRa		2	2〉 das Begrüssen ( ) JAṬĀDH. _im_ ŚKDR	JAṬĀDH;ŚKDR
+AmantraRa		3	3〉 das Einladen YĀJÑ. 1,112 . MBH. 2,1243 . PAÑCAT. 34,17 . 236,20 . VOP. 25,22	YĀJÑ. 1,112;MBH. 2,1243;PAÑCAT. 34,17;PAÑCAT 236,20;VOP. 25,22
+AmantraRa		4	4〉 das Bereden, Befragen, Berathen AV. 8,10,7 . KĀTY. ŚR. 5,9,27	AV. 8,10,7;KĀTY. ŚR. 5,9,27
+AmantraRa		1	1〉 DAŚAR. 1,43 . SĀH. D. 172,15	DAŚAR. 1,43;SĀH. D. 172,15
+AmantraRa		3	3〉 der Brahmanen Festtag ist eine Einladung zum Schmause VṚDDHA-CĀṆ. 12,13	VṚDDHA-CĀṆ. 12,13
+AmantraRa		5	5〉 Mahlstatt KĀṬH. 8,7	KĀṬH. 8,7
+Amantrita		1	1〉 adj. s. u. mit	
+Amantrita		2	2〉 n. Anrede, der Vocativ VS. PRĀT. 2,17 . AV. PRĀT. 1,81 . im Vocativ der Einzahl 2,47 . ṚV. PRĀT. 1,18 . P. 2,3,48 . 1,2 . 6,1,198 . 8,1,8 . 19 . 55 . 72 . 73	VS. PRĀT. 2,17;AV. PRĀT. 1,81;AV. PRĀT 2,47;ṚV. PRĀT. 1,18;P. 2,3,48;P. 2, 1,2;P 6,1,198;P 8,1,8;P. 8,1, 19;P. 8,1, 55;P. 8,1, 72;P. 8,1, 73
+Amarda		1	1〉 das Zausen, Jmd-Zusetzen: ( ) ŚĀK. 173 . MBH. 15,237	ŚĀK. 173;MBH. 15,237
+Amarda		2	2〉 N. pr. einer Stadt Verz. d. B. H. No. 1242	Verz. d. B. H. No. 1242
+Amarda		1	¦ Druck KATHĀS. 100,44 . — Vgl	KATHĀS. 100,44
+AmayAvin		1	1〉 krank P. 5,2,122, Vārtt. 3 . AK. 2,6,2,9 . H. 459 . TS. 3,2,3,3 . 2,1,1,3 . KĀṬH. 27,4 u. s. w. KĀTY. ŚR. 23,1,16	P. 5,2,122, Vārtt. 3;AK. 2,6,2,9;H. 459;TS. 3,2,3,3;TS 2,1,1,3;KĀṬH. 27,4;KĀTY. ŚR. 23,1,16
+AmayAvin		2	2〉 an schlechter Verdauung leidend M. 3,7 . YĀJÑ. 3,210 . Davon nom. abstr. M. 11,51	M. 3,7;YĀJÑ. 3,210;M. 11,51
+Amaya		1	1〉 m	
+Amaya		1a	a〉 Schaden, Beschädigung; s. und	
+Amaya		1b	b〉 Krankheit AK. 2,6,2,2 . H. 463 . im Veda nur am Ende von compp. ŚAT. BR. 13,3,8,4 . 3 . KĀTY. ŚR. 20,3,14 . 16 . YĀJÑ. 3,245 . BHAG. 17,9 . R. 4,44,83 . SUŚR. 1,58,13 . 185,20 . 239,14 . 2,430,11 .	AK. 2,6,2,2;H. 463;ŚAT. BR. 13,3,8,4;ŚAT. BR. 13,3,8, 3;KĀTY. ŚR. 20,3,14;KĀTY. ŚR. 20,3, 16;YĀJÑ. 3,245;BHAG. 17,9;R. 4,44,83;SUŚR. 1,58,13;SUŚR. 1, 185,20;SUŚR. 1, 239,14;SUŚR 2,430,11;ŚĀNTIŚ. 2,10;PAÑCAT. I, 408;RAGH. 19,48
+Amaya		1c	c〉 schlechte Verdauung HĀR. 141 . Vgl. 1. 2,b	HĀR. 141
+Amaya		2	2〉 n. N. einer Arzeneipflanze, Costus speciosus ( ), RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+Amaya		1	1〉	
+Amaya		1b	b〉 eine Pest BHĀG. P. 10,74,53	BHĀG. P. 10,74,53
+AmlikA		1	1〉 = 1. ŚABDAM. _im_ ŚKDR	ŚABDAM;ŚKDR
+AmlikA		2	2〉 = 2. RĀYAM. _zu_ AK. 2,4,2,24 . ŚKDR	RĀYAM;AK. 2,4,2,24;ŚKDR
+Amoda		1	1〉 adj. f. erfreuend, erheiternd: ŚAT. BR. 4,3,2,13 . KĀTY. ŚR. 9,13,29 . 10,3,8 . 6,9	ŚAT. BR. 4,3,2,13;KĀTY. ŚR. 9,13,29;KĀTY. ŚR 10,3,8;KĀTY. ŚR. 10, 6,9
+Amoda		2	2〉 m	
+Amoda		2a	a〉 Freude, Heiterkeit AK. 1,1,4,2 . 3,4,94 . TRIK. 3,3,203 . H. 316 . an. 3,327 . MED. d. 21 . R. 1,34,13	AK. 1,1,4,2;AK. 1, 3,4,94;TRIK. 3,3,203;H. 316;H an. 3,327;MED. d. 21;R. 1,34,13
+Amoda		2b	b〉 Wohlgeruch AK. 1,1,4,19 . TRIK. H. 1390 . H. an. MED. BHARTṚ. 1,37 . 96 . RAGH. 1,43 . AMAR. 58 . 91 . ṚT. 1,28 . MEGH. 32 . PRAB. 60,6 . KATHĀS. 8,10 . VET. 6,9 . DHŪRTAS. 69,4 . am Ende eines adj	AK. 1,1,4,19;TRIK;H. 1390;H. an;MED;BHARTṚ. 1,37;BHARTṚ. 1, 96;RAGH. 1,43;AMAR. 58;AMAR 91;ṚT. 1,28;MEGH. 32;PRAB. 60,6;KATHĀS. 8,10;VET. 6,9;DHŪRTAS. 69,4;BHARTṚ. 1,39;BHARTṚ. 1, 40
+Amoda		1	¦ [ vgl. [Page1-0672]] Z. 2 lies: {6,5} st. {6,9}	
+Amoda		1	1〉 Z. 2 lies 6,5 st. 6,9	
+Amoda		2	2〉	
+Amoda		2a	a〉 Freude an Spr. 3719	Spr. 3719
+Amoda		2c	c〉 Titel eines Commentars HALL 201	HALL 201
+Amodin		1	1〉 adj. am Ende eines comp. einen Wohlgeruch von dem und dem habend: BHARTṚ. 1,42 . voc. f. ŚRUT. 42	BHARTṚ. 1,42;ŚRUT. 42
+Amodin		2	2〉 m. ein Parfum für den Mund AK. 1,1,4,20 . H. 1391	AK. 1,1,4,20;H. 1391
+Amodin		1	1〉 RĀJA-TAR. 5,357 . KATHĀS. 123,51	RĀJA-TAR. 5,357;KATHĀS. 123,51
+AmrAtaka		1	1〉 dass. AK. 2,4,2,8 . H. 1152 . MBH. 1,7584 . 3,11567 . R. 3,17,7 . SUŚR. 1,210,16 . 156,4 . 2,289,9 . 479,21 . 489,6	AK. 2,4,2,8;H. 1152;MBH. 1,7584;MBH 3,11567;R. 3,17,7;SUŚR. 1,210,16;SUŚR. 1, 156,4;SUŚR 2,289,9;SUŚR. 2, 479,21;SUŚR. 2, 489,6
+AmrAtaka		2	2〉 = RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+AmrAtaka		3	3〉 N. pr. eines Berges R. 4,44,23 , v. l	R. 4,44,23
+AmuKa		1	1〉 Beginn TRIK. 3,2,30	TRIK. 3,2,30
+AmuKa		2	2〉 Vorspiel, Einleitung SĀH. D. 131,15 . TRIK. MṚCCH. 5,8	SĀH. D. 131,15;TRIK;MṚCCH. 5,8
+AmuKa		2	2〉 DAŚAR. 3,5. fgg. ( vgl. S	DAŚAR. 3,5. fgg
+AmuKa		27	PRATĀPAR. 23,a,5 . SĀH. D. 279 . 282 . 286	PRATĀPAR. 23,a,5;SĀH. D. 279;SĀH. D 282;SĀH. D 286
+AnAha		1	1〉 Verstopfung des Leibes AK. 2,6,2,6 . H. 471 . SUŚR. 1,32,2 . 82,5 . 97,11 . 366,7 . 2,44,15 . 256,19 . MBH. 3,10334	AK. 2,6,2,6;H. 471;SUŚR. 1,32,2;SUŚR. 1, 82,5;SUŚR. 1, 97,11;SUŚR. 1, 366,7;SUŚR 2,44,15;SUŚR. 2, 256,19;MBH. 3,10334
+AnAha		2	2〉 Länge AK. 2,6,3,16 . H. 1431	AK. 2,6,3,16;H. 1431
+AnadDa		1	1〉 adj. s. u	
+AnadDa		2	2〉 n. ein mit Fell bezogenes musikalisches Instrument, Trommel u. s. w. AK. 1,1,7,4 . TRIK. 3,3,214 . H. 287 . an. 3,342 . MED. dh. 27	AK. 1,1,7,4;TRIK. 3,3,214;H. 287;H an. 3,342;MED. dh. 27
+Anaka		1	1〉 Bez. verschiedener Arten von Trommeln, = AK. 1,1,7,6 . 3,4,1,3 . H. an. 3,8 . MED. k. 46 . = AK. 3,4,1,3 . H. 293 . H. an. MED. = H. an. MED. BHAG. 1,13 . HARIV. 1924	AK. 1,1,7,6;AK 3,4,1,3;H. an. 3,8;MED. k. 46;AK. 3,4,1,3;H. 293;H. an;MED;H. an;MED;BHAG. 1,13;HARIV. 1924
+Anaka		2	2〉 Donnerwolke H. an. MED. — Vielleicht von 2	H. an;MED
+Anaka		1	¦ vgl	
+Ananda		1	1〉 m	
+Ananda		1a	a〉 Lust, Wonne; Wollust AK. 1,1,4,3 . 3,5,10 . H. 316 . ṚV. 9,113,6 . 11 . VS. 19,8 . 30,6 . 20 . 20,9 . AV. 9,7,23 . 10,2,9 . 11,7,26 . 8,24 . TS. 5,7,19,1 . ŚAT. BR. 10,3,5,13 . 14 . 6,2,2,6 . 14,5,	AK. 1,1,4,3;AK. 1, 3,5,10;H. 316;ṚV. 9,113,6;ṚV. 9,113, 11;VS. 19,8;VS 30,6;VS. 30, 20;VS 20,9;AV. 9,7,23;AV 10,2,9;AV 11,7,26;AV. 11, 8,24;TS. 5,7,19,1;ŚAT. BR. 10,3,5,13;ŚAT. BR. 10,3,5, 14;ŚAT. BR 6,2,2,6;ŚAT. BR 14,5,1,22;ŚAT. BR. 14,5, 4,11;ŚAT. BR. 14, 6,10,5;BṚH. ĀR. UP. 2,1,79;BṚH. ĀR. UP. 2, 4,11;BṚH. ĀR. UP 4,1,6;BṚH. ĀR. UP. 4,3,9;MĀṆḌ. UP. 5;TAITT. UP. 2,4;TAITT. UP. 2, 5;TAITT. UP. 2, 8;R. 1,1,17;RAGH. 12,62;HIT. 42,8;ŚĀK. 81;VID. 51;VEDĀNTAS;BENF. Chr. 209,20;SĀṂKHYAK. 28;KATHĀS. 14,23;ŚAT. BR. 14,6,9,34;BṚH. ĀR. UP. 3,9,28;TAITT. UP. 1,6,2;WILS;AK;ŚKDR;R. 2,47,10;R 4,19,14;R 5,18,3;R 6,7,18
+Ananda		1b	b〉 N. des 48sten Jahres im Jupiter — Cyclus KĀLAS. 354	KĀLAS. 354
+Ananda		1c	c〉 ein Bein. Śiva ʼs ŚIV	ŚIV
+Ananda		1d	d〉 N. pr. der 6te der 9 weissen Bala H. 698	H. 698
+Ananda		1e	e〉 N. pr. ein Vetter und eifriger Anhänger Śākyamuni ʼs, Sammler der Sūtra , LALIT. 2 . u. s. w. BURN. Intr. 45 . 76, N. 1 . 197 . 205 . 392 . 535 . 578 . Lot. de la b. l. 130. fgg. 297 . LIA. II, Anh	LALIT. 2;BURN. Intr. 45;BURN. Intr 76, N. 1;BURN. Intr 197;BURN. Intr 205;BURN. Intr 392;BURN. Intr 535;BURN. Intr 578;Lot. de la b. l. 130. fgg;Lot. de la b. l 297;LIA. II, Anh. II. fg;SCHIEFNER, Lebensb. 237 (7). 245 (15). 264 (34)
+Ananda		2	2〉 f. N. einer Pflanze ( ) RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+Ananda		3	3〉 gaṇa zu P. 4,1,41 . N. einer Pflanze ( vulg. ) ŚABDAC. _im_ ŚKDR	P. 4,1,41;ŚABDAC;ŚKDR
+Ananda		4	4〉 n. s. u. 1,a	
+Ananda		1	1〉	
+Ananda		1a	a〉 als n. MBH. 13,1092 . KULĀRṆAVAT. _in_ Verz. d. Oxf. H. 91,b,5. fgg. In der Dramatik das Eintreffen des Gewünschten, = SĀH. D. 399	MBH. 13,1092;KULĀRṆAVAT;Verz. d. Oxf. H. 91,b,5. fgg;SĀH. D. 399
+Ananda		1b	b〉 Verz. d. Oxf. H. 332,a,5	Verz. d. Oxf. H. 332,a,5
+Ananda		1e	e〉 N. pr. eines der 5 Lokeśvara bei den Buddhisten WILSON, Sel. Works 2,23	WILSON, Sel. Works 2,23
+Ananda		1f	f〉 N. pr. eines Lehrers (fehlerhaft für ) WILSON, Sel. Works 1,214 . eines Dichters Verz. d. Oxf. H. 167,a,37 . Verfassers des Mādhavānala 157,b, No. 340	WILSON, Sel. Works 1,214;Verz. d. Oxf. H. 167,a,37;Verz. d. Oxf. H 157,b, No. 340
+Ananda		1h	h〉 N. pr. einer Oertlichkeit Verz. d. Oxf. H. 339,a,3	Verz. d. Oxf. H. 339,a,3
+Ananda		1	¦ m. N. pr. eines Śrāvaka HEM. YOGAŚ. 3,151	HEM;YOGAŚ. 3,151
+Anandakanda		1	1〉 die Wurzel der Wonne WEBER, RĀMAT. UP. 324 . Verz. d. Oxf. H. 28,b,35	WEBER, RĀMAT. UP. 324;Verz. d. Oxf. H. 28,b,35
+Anandakanda		2	2〉 m. N. pr. eines Autors HALL 19	HALL 19
+Anandakanda		3	3〉 m. Titel eines medicinischen Werkes Verz. d. Oxf. H. 319,b, No. 759	Verz. d. Oxf. H. 319,b, No. 759
+Anandakanda		4	4〉 N. pr. einer Oertlichkeit Verz. d. Oxf. H. 154,a,16	Verz. d. Oxf. H. 154,a,16
+Anandana		1	1〉 Erheiterung: (kann auch adj. sein) HIT. I, 204	HIT. I, 204
+Anandana		2	2〉 freundlicher Empfang, freundlicher Gruss AK. 3,3,7 . H. 731	AK. 3,3,7;H. 731
+AnandavarDana		1	1〉 adj. die Wonne vermehrend R. 1,1,17 . 2,45,7	R. 1,1,17;R 2,45,7
+AnandavarDana		2	2〉 m. N. pr. eines Dichters RĀJA-TAR. 5,34	RĀJA-TAR. 5,34
+AnandavarDana		2	2〉 Verz. d. Oxf. H. 123,b,20 . Vgl	Verz. d. Oxf. H. 123,b,20
+Anandin		1	¦ (wie eben) adj. wonnig, lusterfüllt, glückselig: AV. 4,15,16 . 38,4 . ŚAT. BR. 14,4,3,28 (= BṚH. ĀR. UP. 1,5,19 .) KAUŚ. 70 . 40 . CHĀND. UP. 7,10,1 . TAITT. UP. 2,7 . MBH. 2,609 . R. 6,11,45	AV. 4,15,16;AV. 4, 38,4;ŚAT. BR. 14,4,3,28;BṚH. ĀR. UP. 1,5,19;KAUŚ. 70;KAUŚ 40;CHĀND. UP. 7,10,1;TAITT. UP. 2,7;MBH. 2,609;R. 6,11,45
+Anandin		1	1〉 adj. froh LA. (II) 88,6 . erfreuend: KATHĀS. 106,109	LA. (II) 88,6;KATHĀS. 106,109
+Anandin		2	2〉 m. N. pr. eines Mannes Verz. d. Oxf. H. 255,a, N. 1	Verz. d. Oxf. H. 255,a, N. 1
+Anandita		1	1〉 adj. s. u. mit	
+Anandita		2	2〉 m. N. pr. eines Mannes LALIT. 289	LALIT. 289
+Anaquha		1	1〉 adj. vom Stier stammend, taurinus: ŚAT. BR. 7,3,2,1 . KĀTY. ŚR. 4,8,3 . 7,6,1 . KAUŚ. 67 . YĀJÑ. 1,279 . PĀR. GṚHY. 2,1	ŚAT. BR. 7,3,2,1;KĀTY. ŚR. 4,8,3;KĀTY. ŚR 7,6,1;KAUŚ. 67;YĀJÑ. 1,279;PĀR. GṚHY. 2,1
+Anaquha		2	2〉 n. N. pr. eines Tīrtha HARIV. 5334	HARIV. 5334
+Anarta		1	1〉 Bühne ( ) AK. 3,4,66 . H. an. 3,245 . MED. t. 91	AK. 3,4,66;H. an. 3,245;MED. t. 91
+Anarta		2	2〉 Kampf AK. H. an. MED	AK;H. an;MED
+Anarta		3	3〉 N. pr. eines Landes und der Bewohner derselben ( m. pl. ) auf der Halbinsel Guzerat , mit der Hauptstadt Kuśasthalī , AK. H. an. MED. AV. PARIŚ. _in_ Verz. d. B. H. No. 366 . VARĀH. BṚH. S. ebend. 	AK;H. an;MED;AV. PARIŚ;Verz. d. B. H. No. 366;VARĀH. BṚH. S;ebend. No. 849;MBH. 2,997;MBH 3,622;MBH. 3, 631;MBH. 3, 12582;R. 4,43,13;VP. 190;HARIV. 5163;HARIV. 642. fgg;VP. 354. fg;HARIV. 1751;LIA. I, 626;LIA. I, II, 791;MED;H. an
+Anarta		3	3〉 als Volksname VARĀH. BṚH. S. 5,80 . 14,17 . 16,31 . der Fürst der Ānarta 14,33	VARĀH. BṚH. S. 5,80;VARĀH. BṚH. S 14,17;VARĀH. BṚH. S 16,31;VARĀH. BṚH. S 14,33
+Anava		1	1〉 adj. den Leuten zugethan, leutselig (?): ṚV. 8,63,4	ṚV. 8,63,4
+Anava		2	2〉 m. Mann, Leute (Fremde und Unbekannte): ṚV. 6,62,9 . 7,18,13 . Bezeichnung eines fremden Volksstammes überh. : ṚV. 8,4,1 . In SV. I, 5,2,3,2 scheint das Wort verdorbene Lesart zu sein; vgl. AV. 2,2	ṚV. 6,62,9;ṚV 7,18,13;ṚV. 8,4,1;SV. I, 5,2,3,2;AV. 2,22,1
+Anila		1	1〉 adj. vom Winde stammend u. s. w	
+Anila		2	2〉 f. N. der 15ten Mondstation H. 112	H. 112
+Anila		3	3〉 n. das unter dem Gotte des Windes stehende Nakṣatra Svāti VARĀH. BṚH. S. 71,10 . 98,4	VARĀH. BṚH. S. 71,10;VARĀH. BṚH. S 98,4
+Antara		1	1〉 adj. im Innern befindlich, innerlich: (= Schol. ) UTTARARĀMAC. 26,11. fg. BHAṬṬ. 5,83	UTTARARĀMAC. 26,11. fg;BHAṬṬ. 5,83
+Antara		2	2〉 m	
+Antara		2a	a〉 ein im Innern des Hauses —, des Palastes Angestellter (= Schol. ) MBH. 12,3090 . 3346	MBH. 12,3090;MBH. 12, 3346
+Antara		2b	b〉 ein innerhalb des Landes Wohnender, ein Eingeborener, Landeskind: MBH. 12,3913	MBH. 12,3913
+Anulomya		1	1〉 adj. in der natürlichen oder geraden Ordnung entstanden: ( Sch. : ) UŚANAS _in_ DĀY. 108,9 . 109,5	UŚANAS;DĀY. 108,9;DĀY 109,5
+Anulomya		2	2〉 n	
+Anulomya		2a	a〉 die Richtung nach dem Strich der Haare, gerade oder natürliche Ordnung (von oben nach unten, von vorn nach hinten) M. 10,5 . 13 . YĀJÑ. 2,183 . 207 . 286 . P. 3,4,64	M. 10,5;M. 10, 13;YĀJÑ. 2,183;YĀJÑ. 2, 207;YĀJÑ. 2, 286;P. 3,4,64
+Anulomya		2b	b〉 günstige Richtung, geeignete Disposition, Geneigtheit P. 3,2,20 . 5,4,63 . SUŚR. 1,250,4 . 30,5	P. 3,2,20;P 5,4,63;SUŚR. 1,250,4;SUŚR. 1, 30,5
+Anulomya		2c	c〉 das Bringen in die richtige Lage SUŚR. 1,26,18	SUŚR. 1,26,18
+AnupUrva		1	1〉 n. Reihenfolge von vorn nach hinten: der Reihe nach M. 2,41 . SĀV. 4,11 . VIŚV. 7,15 . 10,9 . R. 5,73,2 . 74,14	M. 2,41;SĀV. 4,11;VIŚV. 7,15;VIŚV 10,9;R. 5,73,2;R. 5, 74,14
+AnupUrva		2	2〉 f. dass. AK. 2,7,36 . H. 1504 . MBH. 1,7190 . R. 3,70,20 . der Reihe nach M. 3,23 . MBH. 1,2964 . 3,11081 (p. 572). 12296 . 13929 . R. 2,90,6 . 101,11 . 4,54,20 . 2,91,39	AK. 2,7,36;H. 1504;MBH. 1,7190;R. 3,70,20;M. 3,23;MBH. 1,2964;MBH 3,11081 (p. 572). 12296;MBH. 3, 13929;R. 2,90,6;R. 2, 101,11;R 4,54,20;R 2,91,39
+AnupUrva		2	2〉 Z. 2 lies . Das letzte Beispiel gehört zu . da hier mit der ed. Bomb. zu lesen ist. Nach den indischen Grammatikern ist f. zu	ed. Bomb
+Anupadika		1	1〉 = P. 4,4,37	P. 4,4,37
+Anupadika		2	2〉 = gaṇa zu P. 4,2,60	P. 4,2,60
+Ap		1	1〉 erreichen, einholen; act. : ṚV. 1,33,10 . 100,15 . 24,6 . 7,99,2 . AV. 9,2,24 . 3,13,2 . 2,11,1 . TS. 5,1,3,4 . ŚAT. BR. 14,4,3,34 (= BṚH. ĀR. UP. 1,5,23 .) BṚH. ĀR. UP. 1,5,21 . CHĀND. UP. 8,1,4 .	ṚV. 1,33,10;ṚV. 1, 100,15;ṚV 24,6;ṚV 7,99,2;AV. 9,2,24;AV 3,13,2;AV 2,11,1;TS. 5,1,3,4;ŚAT. BR. 14,4,3,34;BṚH. ĀR. UP. 1,5,23;BṚH. ĀR. UP. 1,5,21;CHĀND. UP. 8,1,4;RAGH. 8,24;NALOD. 2,22;BHAṬṬ. 6,59;ṚV. 10,114,7;BHAṬṬ. 1,21
+Ap		2	2〉 erlangen, gewinnen, in Besitz nehmen, auf sich laden, erleiden; act. : ṚV. 4,1,9 . 23,2 . 8,59,7 . 10,95,13 . AV. 4,11,9 . 38,3 . 9,2,19 . 5,22 . ŚAT. BR. 4,6,9,20 . 3,9,4,13 . 6,2,2,31 . 9,5,2,3 .	ṚV. 4,1,9;ṚV. 4, 23,2;ṚV 8,59,7;ṚV 10,95,13;AV. 4,11,9;AV. 4, 38,3;AV 9,2,19;AV. 9, 5,22;ŚAT. BR. 4,6,9,20;ŚAT. BR 3,9,4,13;ŚAT. BR 6,2,2,31;ŚAT. BR 9,5,2,3;ŚAT. BR 12,2,2,8;AIT. UP. 4,6;HIT. Pr. 29;M. 1,63;M 8,143;M 3,95;M. 3, 129;M. 3, 283;M 9,161;M 11,8;M. 11, 28;M 4,229;M. 4, 230;M 5,166;M. 5, 165;M 8,81;M 9,29;M. 9, 137;M 30;M 8,40;M. 8, 316;BHAG. 3,2;MBH. 1,4977;ŚĀK. 12;KATHĀS. 15,130;R. 1,14,29;RAGH. 7,51;MBH. 2,1227;MBH 3,38;M. 4,167;N. 10,11;M. 8,128;M. 8, 368;M. 8, 369;MBH. 3,1046;MBH. 3, 14244;RAGH. 9,79;M. 8,188;ṚV. 9,108,4;ṚV. 9, 10,5;ṚV 2,34,7;TS. 2,5,11,4
+Ap		3	3〉 pass. refl. sein Ziel, sein Ende erreichen, voll werden: TS. 2,5,8,3 . — partic	TS. 2,5,8,3
+Ap		1	1〉 erreicht, ereilt, getroffen: ŚAT. BR. 8,2,3,14 . BṚH. ĀR. UP. 3,1,3	ŚAT. BR. 8,2,3,14;BṚH. ĀR. UP. 3,1,3
+Ap		2	2〉 erlangt, empfangen, in Besitz genommen H. an. 2,158 . MED. t. 3 . ŚAT. BR. 1,6,3,26 . 1,1,14 . 15 . 14,7,1,21 (= BṚH. ĀR. UP. 4,3,21 ). ŚVETĀŚV. UP. 1,11 . M. 9,143 . R. 3,3,15 . H. 881 . DHŪRTAS. 	H. an. 2,158;MED. t. 3;ŚAT. BR. 1,6,3,26;ŚAT. BR 1,1,14;ŚAT. BR. 1, 15;ŚAT. BR 14,7,1,21;BṚH. ĀR. UP. 4,3,21;ŚVETĀŚV. UP. 1,11;M. 9,143;R. 3,3,15;H. 881;DHŪRTAS. 96,5;KATHĀS. 22,29;KATHĀS 25,54;KATHĀS 21,26
+Ap		3	3〉 erreicht habend, hinanreichend, sich erstreckend [Page1-0650] über ŚAT. BR. 1,1,1,21 . 10,6,3,2	ŚAT. BR. 1,1,1,21;ŚAT. BR 10,6,3,2
+Ap		4	4〉 reichlich, voll: M. 7,79 . N. 5,43 . 26,38 ( BOPP ). VIŚV. 3,24 . R. 2,30,35	M. 7,79;N. 5,43;N 26,38;BOPP;VIŚV. 3,24;R. 2,30,35
+Ap		5	5〉 zu einer Sache geeignet, geschickt, zuverlässig; m. eine geeignete Person, Gewährsmann AK. 2,8,1,13 . H. 734 . an. 2,158 . MED. t. 3 . M. 7,80 . 190 . 8,63 . 294 . R. 1,7,18 . BHARTṚ. 1,52 . RAGH. 	AK. 2,8,1,13;H. 734;H an. 2,158;MED. t. 3;M. 7,80;M. 7, 190;M 8,63;M. 8, 294;R. 1,7,18;BHARTṚ. 1,52;RAGH. 5,39;RAGH 3,12;PAÑCAT. 43,8;PAÑCAT III, 38;SUŚR. 1,240,3;SUŚR. 1,240, 4;SUŚR 2,90,15;SUŚR. 2, 185,9;ŚĀK. 97;SĀṂKHYAK. 4;SĀṂKHYAK 5;RAGH. 11,42;COLEBR. Misc. Ess. I, 303;SĀṂKHYAK. 5;SĀṂKHYAK 6;KAPILA;Z. d. d. m. G. 7,303, N. 4;SĀH. D. 10,9;H. 242;GAUḌAPĀDA;SĀṂKHYAK. 4
+Ap		6	6〉 nahe stehend, verwandt, befreundet, vertraut; m. Verwandter, Freund, Vertrauter ( vgl. ) MED. t. 3 ( ). M. 2,109 . 8,64 . YĀJÑ. 1,28 . 2,71 . RAGH. 12,52 . M. 5,101 . DEV. 1,19 . — Vgl. . — caus. ;	MED. t. 3;M. 2,109;M 8,64;YĀJÑ. 1,28;YĀJÑ 2,71;RAGH. 12,52;M. 5,101;DEV. 1,19;P. 6,4,57;VOP. 26,215
+Ap		1	1〉 erreichen lassen: ( ungramm. aor. für ; in der Mādhy. - Rec. : von ) BṚH. ĀR. UP. 4,5,14	BṚH. ĀR. UP. 4,5,14
+Ap		2	2〉 Jmd Etwas erlangen lassen: CHĀND. UP. 1,1,6	CHĀND. UP. 1,1,6
+Ap		3	3〉 Jmd Etwas abgeben, zu fühlen geben: KATHĀS. 17,32	KATHĀS. 17,32
+Ap		4	4〉 = DHĀTUP. 34,32 . — desid. P. 7,4,55 . VOP. 19,10 . zu erreichen, zu erlangen streben: AV. 9,5,12 . ŚAT. BR. 10,1,2,1 . 12,1,1,1 . 13,1,2,9 . MBH. 1,1090 . 2,1007 . 3,13191 . ved. ṚV. 1,100,5 : . —	DHĀTUP. 34,32;P. 7,4,55;VOP. 19,10;AV. 9,5,12;ŚAT. BR. 10,1,2,1;ŚAT. BR 12,1,1,1;ŚAT. BR 13,1,2,9;MBH. 1,1090;MBH 2,1007;MBH 3,13191;ṚV. 1,100,5
+Ap		1	1〉 wen oder was man zu haben wünscht, begehrt, erwünscht, genehm, lieb: M. 2,48 . N. 3,2 . 12,15 . R. 1,4,18 . 4,28,3 . P. 1,4,27 . MEGH. 112 . VID. 93 . ŚĀK. 62 . N. 1,4 . R. 4,27,22 . VIŚV. 3,1 . MB	M. 2,48;N. 3,2;N 12,15;R. 1,4,18;R 4,28,3;P. 1,4,27;MEGH. 112;VID. 93;ŚĀK. 62;N. 1,4;R. 4,27,22;VIŚV. 3,1;MBH. 3,161;AK. 2,9,57;H. 1505;BHAṬṬ. 2,28;VIŚV. 5,18;RAGH. 1,79;RAGH 3,1;RAGH. 3, 5;KATHĀS. 22,170;VID. 247
+Ap		2	2〉 von einer Autorität festgesetzt, anerkannt: Sch. zu VARARUCI 10,2 _in_ LASSEN, Institutt. 7 . — desid. vom caus. zu erreichen streben: ŚAT. BR. 2,6,3,11 . — bis zu Etwas reichen, erreichen ŚAT. BR.	VARARUCI 10,2;LASSEN, Institutt. 7;ŚAT. BR. 2,6,3,11;ŚAT. BR. 7,4,1,43;ŚAT. BR 9,1,2,16;ŚAT. BR 13,6,2,20;ŚAT. BR. 9,5,2,3;ŚAT. BR 1,1,1,15;ŚAT. BR. 1,1,1, 21;ŚAT. BR 10,1,3,8;ŚAT. BR. 10,1,3, 10;ŚAT. BR. 10, 4,3,6;MBH. 2,534;MBH 3,14458;MBH 2,632;M. 5,136;M 12,105;YĀJÑ. 1,111;YĀJÑ 3,110;R. 1,38,1;MBH. 1,6469;R. 2,35,19;M. 5,156;MBH. 5,17;AK. 3,2,3;AK. 3,2, 61;VIŚV. 15,11;M. 7,204
+Ap		1	1〉 erreichen, betreten: ( mitact. Bed. ) KAṬHOP. 2,3 . MBH. 1,5875 . KATHĀS. 1,27 . auf Jmd stossen, Jmd antreffen: KATHĀS. 3,46	KAṬHOP. 2,3;MBH. 1,5875;KATHĀS. 1,27;KATHĀS. 3,46
+Ap		2	2〉 erlangen, empfangen, sich zu Eigen machen, gewinnen, erleiden, sich zuziehen: CHĀND. UP. 8,8,4 . VIŚV. 7,19 . M. 7,118 . 9,217 . 2,160 . 5,54 . 7,207 ( ). 8,156 . R. 3,35,16 . 1,1,86 . 7,18 . 3,4,1	CHĀND. UP. 8,8,4;VIŚV. 7,19;M. 7,118;M 9,217;M 2,160;M 5,54;M 7,207;M 8,156;R. 3,35,16;R 1,1,86;R. 3, 7,18;R 3,4,18;R 1,1,38;VIŚV. 8,17;MBH. 2,989;M. 4,76;M. 4, 94;M 2,9;M 6,80;M 2,9;MBH. 2,2590;MBH 1,7714;MBH 2,627;VIŚV. 12,20;N. 14,19;N 19,29;VID. 153;ŚĀK. 82;M. 9,147;MBH. 3,490;RAGH. 3,33;M. 2,116;MBH. 3,1763;KATHĀS. 2,46;R. 5,37,13;M. 5,161;M 12,69;M 9,91;PAÑCAT. 106,3;RAGH. 18,34;MBH. 14,597;M. 7,86;VIŚV. 8,18;R. 1,17,6;KATHĀS. 12,195;M. 9,209;ŚĀK. 25,1;ŚIŚUP. 5,40
+Ap		1	1〉 auf Etwas stossen, antreffen: R. 4,44,71	R. 4,44,71
+Ap		2	2〉 erlangen, gewinnen, auf sich laden, erleiden: MBH. 2,866 . R. 3,55,40 . YĀJÑ. 1,212 . R. 3,66,16 . 2,67,7 . 5,87,21 . MBH. 3,16595 . 10449 . 5,7079 . KATHĀS. 4,96 . ARJ. 5,5 . — hinaufreichen, erre	MBH. 2,866;R. 3,55,40;YĀJÑ. 1,212;R. 3,66,16;R 2,67,7;R 5,87,21;MBH. 3,16595;MBH. 3, 10449;MBH 5,7079;KATHĀS. 4,96;ARJ. 5,5;ŚAT. BR. 2,6,2,16;ŚAT. BR 13,5,4,14;ŚAT. BR. 13,5,4, 23;TS. 6,6,11,5;ŚAT. BR. 11,3,2,1;ŚAT. BR 12,4,3,3;ŚAT. BR. 12, 9,3,13;TAITT. UP. 1,8;ŚAT. BR. 6,2,2,10;ŚAT. BR 11,5,2,9;ŚAT. BR 4,3,2,13;AIT. BR. 2,16;KAUŚ. 68;KAUŚ 140
+Ap		1	1〉 erreichen, gewinnen: ṚV. 1,76,1 . TS. 7,3,1,4 . ŚAT. BR. 2,1,4,8	ṚV. 1,76,1;TS. 7,3,1,4;ŚAT. BR. 2,1,4,8
+Ap		2	2〉 ein Ende machen, genug sein lassen: MBH. 15,1073 . — part. erfüllt, zum Abschluss gebracht, das volle Maass habend, ein hohes Maass erreichend, geräumig, vollständig, voll, hinreichend, genügend: [	MBH. 15,1073;MUṆḌ. UP. 3,2,2;RAGH. 6,44;KUMĀRAS. 7,26;KUMĀRAS 3,54;MBH. 15,186;RAGH. 18,46;RAGH 15,18;RAGH 17,17;BHAG. 1,10;M. 7,76;MBH. 3,13505;M. 3,40;YĀJÑ. 3,250;R. 5,25,20;R. 5, 81,24;R. 5,25, 42;R 2,38,10;N. (BOPP) 11,8;M. 11,7;VIKR. 11,11;MBH. 3,13541;R. 2,31,23;R 6,36,21;R 5,35,46;R 3,42,26;R 3,44,30;R. 3, 35,25;R. 3, 51,7;RAGH. 10,26;PRAB. 75,2;R. 1,21,13;R 3,28,15;R. 3, 42,25;MBH. 3,11281;AK. 2,9,57;H. 1505;RAGH. 16,28
+Ap		1	1〉 verlangen, fordern, wünschen: M. 8,161 . MBH. 3,11368 . 1,5515 . 4,503 . 2,563	M. 8,161;MBH. 3,11368;MBH 1,5515;MBH 4,503;MBH 2,563
+Ap		2	2〉 zu erhalten wünschen, in Acht nehmen, schützen: MBH. 3,17327 . 4,2246 . 480 . 3,14899 . 4,1008	MBH. 3,17327;MBH 4,2246;MBH. 4, 480;MBH 3,14899;MBH 4,1008
+Ap		3	3〉 Jmd beizukommen suchen, auf Jmd oder Etwas lauern, nachstellen: MBH. 3,632 . 11454 . 15723 . — zusammenfassen, zusammennehmen: KAUŚ. 90	MBH. 3,632;MBH. 3, 11454;MBH. 3, 15723;KAUŚ. 90
+Ap		1	1〉 erreichen, treffen; an einen Ort gelangen; auf Jmd oder Etwas stossen, Jmd oder Etwas antreffen: AV. 1,30,1 . 17,1,28 . 29 . 4,9,4 . 11,1,22 . 12,3,45 . ŚAT. BR. 8,6,2,13 . 4,5,6,5 . 5,5,3,1 . 12,5	AV. 1,30,1;AV 17,1,28;AV. 17,1, 29;AV 4,9,4;AV 11,1,22;AV 12,3,45;ŚAT. BR. 8,6,2,13;ŚAT. BR 4,5,6,5;ŚAT. BR 5,5,3,1;ŚAT. BR 12,5,2,9. fgg;TAITT. UP. 2,9;CHĀND. UP. 4,9,1;BṚH. ĀR. UP. 8,9,1;M. 11,263;N. 12,7;DAŚ. 2,3;R. 3,22,37;R 1,1,86;R 2,54,8;ŚĀK. 55,21;RAGH. 1,48;VID. 81;VID 186;VID 223;VID 246;VID 282;P. 3,4,20;R. 1,77,20;VID. 25;VID 100;BHAṬṬ. 5,96;BHAṬṬ. 15,70;YĀJÑ. 3,142;BHAṬṬ. 15,106
+Ap		2	2〉 erlangen, gewinnen, sich zuziehen, auf sich laden, erleiden; act. : [Page1-0653] AV. 3,20,9 . TS. 2,6,6,5 . ŚAT. BR. 2,4,4,6 . 3,2,1,39 . M. 3,277 . 2,95 . 3,176 . 10,128 . 4,14 . 6,96 . 8,420 . 12	AV. 3,20,9;TS. 2,6,6,5;ŚAT. BR. 2,4,4,6;ŚAT. BR 3,2,1,39;M. 3,277;M 2,95;M 3,176;M 10,128;M 4,14;M 6,96;M 8,420;M 12,116;M. 12, 126;M 8,343;M 12,19;M 7,42;M 10,127;M 5,164;M 9,30;M 5,38;M 8,364;M 9,291;M. 9, 71;M 8,355;M 11,261;M 8,225;M. 8, 319;M. 8, 354;M 9,287;M 8,270;N. 1,10;N 10,12;N 11,17;N. 11, 28;N 24,47;R. 1,1,85;R 3,35,6;VIŚV. 5,19;VIŚV 14,19;VIŚV 15,19;RAGH. 12,37;RAGH. 12, 65;KATHĀS. 5,27;KATHĀS 13,64;VID. 42;VID 59;VID 95;PRAB. 84,15;N. 4,8;N 3,6;BHAG. 16,13;MBH. 1,1734;MBH 3,1046;MBH. 3, 1352;MBH. 3, 8254;MBH. 3, 13536;R. 1,39,7;R 2,21,28;R 4,34,28;M. 12,85;R. 1,17,6
+Ap		3	3〉 gramm. in eine Form, einen Laut ( acc. ) übergehen: und das Wort geht in über SIDDH. K. _zu_ P. 5,4,118 . VOP. 2,25	SIDDH. K;P. 5,4,118;VOP. 2,25
+Ap		4	4〉 intrans. reichen bis P. 5,2,8 . AK. 2,6,3,21	P. 5,2,8;AK. 2,6,3,21
+Ap		5	5〉 sich finden, vorhanden sein: AV. 4,19,2 . in der Gramm. in Folge einer Regel Geltung erhalten, sich aus einer Regel ergeben: KĀŚ. _zu_ P. 1,1,56 . 4 , Sch. In derselben Bed. auch pass. : 50 , Sch. 	AV. 4,19,2;KĀŚ;P. 1,1,56;P. 1,1, 4;P. 1,1, 50
+Ap		1	1〉 erreicht, getroffen, angetroffen: KĀTY. ŚR. 22,6,16 . 17 . M. 11,246 . HIT. 20,15 . 42,13 . weil ein erreichtes Object ist (in ) P. 2,3,12, Vārtt. 3 , Sch	KĀTY. ŚR. 22,6,16;KĀTY. ŚR. 22,6, 17;M. 11,246;HIT. 20,15;HIT 42,13;P. 2,3,12, Vārtt. 3
+Ap		2	2〉 erlangt, gewonnen, sich zugezogen, auf sich geladen AK. 3,2,54 . TRIK. 3,3,172 . H. 1490 . R. 1,3,5 . VIŚV. 8,17 . VID. 66 . 333 . ( ) M. 9,194 . MBH. 1,6175 . HIT. Pr. 34 . I, 179 . AK. 2,9,4 . M.	AK. 3,2,54;TRIK. 3,3,172;H. 1490;R. 1,3,5;VIŚV. 8,17;VID. 66;VID 333;M. 9,194;MBH. 1,6175;HIT. Pr. 34;HIT I, 179;AK. 2,9,4;M. 11,122;R. 4,13,39;P. 1,2,44;M. 8,299;R. 1,7,13;AK. 2,8,2,85;VID. 284;P. 2,2,4;AK. 3,6,43
+Ap		3	3〉 erreicht oder getroffen habend, an einem Orte angelangt seiend: AV. 9,7,22 . ŚAT. BR. 5,3,4,13 . KAṬHOP. 6,18 . wir haben ein Tausend erreicht, sind ein Tausend voll geworden CHĀND. UP. 4,5,1 . DRA	AV. 9,7,22;ŚAT. BR. 5,3,4,13;KAṬHOP. 6,18;CHĀND. UP. 4,5,1;DRAUP. 8,37;DAŚ. 2,12;RAGH. 12,96;VID. 246;KĀTY. ŚR. 17,4,18;SUŚR. 2,64,9;SUŚR. 2,64, 10;VIŚV. 9,5;HIT. I, 139;MBH. 18,296
+Ap		4	4〉 erlangt habend, sich zugezogen —, auf sich geladen —, erlitten — ŚAT. BR. 2,4,4,6 . M. 7,2 . — 9,24 . 10,99 . 9,313 . 5,40 . [Page1-0654] 8,198 . 300 . 342 . ( vgl. P. 2,1,24 ) 7,93 . — MBH. 1,5918	ŚAT. BR. 2,4,4,6;M. 7,2;M 9,24;M 10,99;M 9,313;M 5,40;M 8,198;M. 8, 300;M. 8, 342;P. 2,1,24;M 7,93;MBH. 1,5918;MBH. 1, 10887;N. 9,20;N 13,47;DAŚ. 2,41;DAŚ. 2, 47
+Ap		5	5〉 gekommen, angelangt, da seiend: M. 8,79 . 3,105 . 112 . MBH. 3,2154 . N. 23,16 . 26,31 . INDR. 1,12 . VID. 43 . 143 . 177 . 300 . M. 7,165 . 4,96 . 9,307 . MBH. 3,2191 . CĀṆ. 11 . Citat bei MALLIN.	M. 8,79;M 3,105;M. 3, 112;MBH. 3,2154;N. 23,16;N 26,31;INDR. 1,12;VID. 43;VID 143;VID 177;VID 300;M. 7,165;M 4,96;M 9,307;MBH. 3,2191;CĀṆ. 11;MALLIN;RAGH. 3,28;N. 1,11;VID. 233;VID 77;N. 5,15;N 8,12;N 13,17;PAÑCAT. 71,24;HIT. I, 44;HIT. I, 22,1;N. 2,7;BRĀHMAṆ. 1,28;N. 12,36
+Ap		6	6〉 zum Abschluss, zur Reife gelangt, fertig: dessen Process nicht beendigt ist YĀJÑ. 2,243 . ein Mädchen, das noch nicht mannbar ist, M. 9,88	YĀJÑ. 2,243;M. 9,88
+Ap		7	7〉 gramm. in Folge einer Regel Geltung habend: P. 1,1,34 , Sch. oder s. u. . medic. indicirt: SUŚR. 2,7,2 . — Die Lexicographen kennen noch zwei Bedeutungen:	P. 1,1,34;SUŚR. 2,7,2
+Ap		8	8〉 gestellt ( ) AK. 3,2,36	AK. 3,2,36
+Ap		9	9〉 schicklich H. 743 . — caus. ( gerund. oder P. 6,4,57 , Sch. VOP. 26,215 )	H. 743;P. 6,4,57;VOP. 26,215
+Ap		1	1〉 Jmd oder Etwas wohin ( acc. oder Ortsadv. ) gelangen lassen, treiben, führen, bringen, befördern; act. : CHĀND. UP. 4,5,1 . MBH. 1,818 . 1850 . 2998 . 4,1664 . ARJ. 4,23 . R. 2,40,11 . 4,62,19 . PA	CHĀND. UP. 4,5,1;MBH. 1,818;MBH. 1, 1850;MBH. 1, 2998;MBH 4,1664;ARJ. 4,23;R. 2,40,11;R 4,62,19;PAÑCAT. 114,23;PAÑCAT 115,3;KATHĀS. 10,189;KATHĀS 22,179;VID. 34;P. 1,3,36;R. 2,39,10;MBH. 3,13289;ŚAT. BR. 1,8,1,16;MBH. 4,1739;MBH. 4, 1748;MBH 14,242;KATHĀS. 25,214;KATHĀS 4,76;PRAB. 18,7;RAGH. 14,60;M. 8,43
+Ap		2	2〉 Jmd ( acc. ) Etwas ( acc. ) erlangen lassen: MBH. 2,171 . ( acc. ) KATHĀS. 2,69 . R. 4,34,25 . PAÑCAT. 102,4 . RĀJA-TAR. 5,424	MBH. 2,171;KATHĀS. 2,69;R. 4,34,25;PAÑCAT. 102,4;RĀJA-TAR. 5,424
+Ap		3	3〉 erlangen: R. 1,21,8 . — desid. zu erreichen suchen, streben: TS. 5,4,3,1 . ŚAT. BR. 1,4,2,13 (die Hdschr. : ). 4,1,1,21 . Vgl	R. 1,21,8;TS. 5,4,3,1;ŚAT. BR. 1,4,2,13;ŚAT. BR 4,1,1,21
+Ap		1	1〉 einen Ort ( acc. ) erreichen, auf Jmd stossen, Jmd finden, sich zu Jmd begeben: VIŚV. 15,1 . MBH. _in_ BENF. Chr. 70,54 . mit act. Bedeutung: MBH. 1,5874 . 3,1833 . 1850 . R. 1,1,30 . 2,42,13 . 101	VIŚV. 15,1;MBH;BENF. Chr. 70,54;MBH. 1,5874;MBH 3,1833;MBH. 3, 1850;R. 1,1,30;R 2,42,13;R. 2, 101,10;R 3,11,8;R. 3, 23,26;R. 3, 74,27;R. 1, 27,9
+Ap		2	2〉 wiedererlangen, erlangen, sich zuziehen: R. 1,1,80 . MBH. _in_ BENF. Chr. 54,11	R. 1,1,80;MBH;BENF. Chr. 54,11
+Ap		3	3〉 nachgehen, nachahmen: RAGH. 4,22	RAGH. 4,22
+Ap		4	4〉 intrans. kommen, anlangen; part. angekommen, angelangt: R. 3,75,2 . 4,39,20 . (heimgekehrt) 2,57,27 . DAŚ. 1,13 . R. 4,26,24 . 5,35,14	R. 3,75,2;R 4,39,20;R 2,57,27;DAŚ. 1,13;R. 4,26,24;R 5,35,14
+Ap		1	1〉 einen Ort erreichen: R. 2,52,76 . 87 . [Page1-0655] mit act. Bed. 3,30,1 . 73,10	R. 2,52,76;R. 2,52, 87;R 3,30,1;R. 3, 73,10
+Ap		2	2〉 erlangen: MBH. 2,1616 . N. (BOPP) 19,28	MBH. 2,1616;N. (BOPP) 19,28
+Ap		3	3〉 angekommen, angelangt R. 1,18,6 . 4,2,16 . 39,34 . — reichen bis zu, erreichen: ŚAT. BR. 6,7,4,11 . 8,1,4,1 . 7,2,14 . 3,6 . CHĀND. UP. 5,10,3 . — desid. s. . — hinzukommen, nahen: R. 3,75,17	R. 1,18,6;R 4,2,16;R. 4, 39,34;ŚAT. BR. 6,7,4,11;ŚAT. BR 8,1,4,1;ŚAT. BR. 8, 7,2,14;ŚAT. BR. 8,1, 3,6;CHĀND. UP. 5,10,3;R. 3,75,17
+Ap		1	1〉 erreichen, gelangen zu, antreffen: ŚAT. BR. 9,2,3,13 . 23 . 29 . MUṆḌ. UP. 3,2,5 . RAGH. 7,42 . R. 6,109,1 . KATHĀS. 2,2 . 20,39 . PAÑCAT. III, 49 . VID. 23 . BHAṬṬ. 6,68 . mit pass. Bed. : HIT. I,	ŚAT. BR. 9,2,3,13;ŚAT. BR. 9,2,3, 23;ŚAT. BR. 9,2,3, 29;MUṆḌ. UP. 3,2,5;RAGH. 7,42;R. 6,109,1;KATHĀS. 2,2;KATHĀS 20,39;PAÑCAT. III, 49;VID. 23;BHAṬṬ. 6,68;HIT. I, 4;N. 13,16;P. 2,3,12, Vārtt. 3;R. 3,42,6;R. 3, 18,2;MBH. 3,2852;SUŚR. 2,64,8
+Ap		2	2〉 erlangen, sich zuziehen: M. 12,74 . PAÑCAT. II, 21 . 201 . KATHĀS. 23,15 . (als Gewinn aufgefasst; vgl. RAGH. 3,38 ) MBH. 2,1227 . ŚĀNTIŚ. 4,17 . PAÑCAT. I, 344 . 347 . mit pass. Bed. : R. 4,17,20 	M. 12,74;PAÑCAT. II, 21;PAÑCAT 201;KATHĀS. 23,15;RAGH. 3,38;MBH. 2,1227;ŚĀNTIŚ. 4,17;PAÑCAT. I, 344;PAÑCAT. I, 347;R. 4,17,20;BRĀHMAṆ. 1,23;N. 18,8
+Ap		3	3〉 angelangt, gekommen: M. 3,99 . 9,141 . INDṚ. 5,4 . HIḌ. 2,24 . 4,27 . R. 1,20,5 . 41,28 . 4,2,20 . ŚĀK. 61,7 . BHAṬṬ. 6,100 . R. 3,22,4 . 42,6 . 2,77,1 . 4,27,2 . ARJ. 3,18 . MBH. 3,2566 . VID. 202	M. 3,99;M 9,141;INDṚ. 5,4;HIḌ. 2,24;HIḌ 4,27;R. 1,20,5;R. 1, 41,28;R 4,2,20;ŚĀK. 61,7;BHAṬṬ. 6,100;R. 3,22,4;R. 3, 42,6;R 2,77,1;R 4,27,2;ARJ. 3,18;MBH. 3,2566;VID. 202;R. 6,93,13;ŚAT. BR. 2,2,2,7
+Ap		1	1〉 erreichen, anlangen bei: MBH. 1,5243 . 4,22 . 1,4708 . 3,1883 . R. 3,68,7	MBH. 1,5243;MBH 4,22;MBH 1,4708;MBH 3,1883;R. 3,68,7
+Ap		2	2〉 angelangt, gekommen R. 2,65,11 . DAŚ. 1,11	R. 2,65,11;DAŚ. 1,11
+Ap		1	1〉 erreichen, gelangen zu: DRAUP. 8,16 . R. 2,55,21 . MBH. 3,408	DRAUP. 8,16;R. 2,55,21;MBH. 3,408
+Ap		2	2〉 erlangen: R. 4,3,27	R. 4,3,27
+Ap		3	3〉 anlangen, kommen: MBH. 3,11366	MBH. 3,11366
+Ap		1	1〉 erreichen: MBH. 3,2337	MBH. 3,2337
+Ap		2	2〉 erlangen: MBH. 1,5188	MBH. 1,5188
+Ap		3	3〉 hinzukommen: MBH. 3,14378	MBH. 3,14378
+Ap		1	1〉 hindurchreichen, durchdringen, erfüllen, ausfüllen: AV. 8,9,20 . 12,3,5 . 28 . 13,2,30 . 17,1,13 . ŚAT. BR. 3,8,3,33 . 10,4,2,4 . MBH. 3,12883 . P. 5,2,7 . RAGH. 18,39 . BHAṬṬ. 7,56 . 15,22 . VOP. 	AV. 8,9,20;AV 12,3,5;AV. 12,3, 28;AV 13,2,30;AV 17,1,13;ŚAT. BR. 3,8,3,33;ŚAT. BR 10,4,2,4;MBH. 3,12883;P. 5,2,7;RAGH. 18,39;BHAṬṬ. 7,56;BHAṬṬ 15,22;VOP. 23,31;M. 12,124;BHAG. 10,16;M. 12,14;M. 12, 24;ŚĀK. 1;P. 3,4,56
+Ap		2	2〉 reichen bis ( P. 5,2,8 . AK. 2,6,3,21 ) H. 678 . — partic	P. 5,2,8;AK. 2,6,3,21;H. 678
+Ap		1	1〉 durchdrungen, erfüllt, angefüllt H. 1473 . ŚVETĀŚV. UP. 4,10 . BHAG. 11,20 . R. 1,35,15 . 37,17 . 3,39,12 . 4,31,25 . SUŚR. 2,173,18 . PAÑCAT. III, 38 . 171,1 . PRAB. 44,8 . M. 5,128	H. 1473;ŚVETĀŚV. UP. 4,10;BHAG. 11,20;R. 1,35,15;R. 1, 37,17;R 3,39,12;R 4,31,25;SUŚR. 2,173,18;PAÑCAT. III, 38;PAÑCAT 171,1;PRAB. 44,8;M. 5,128
+Ap		2	2〉 eingenommen, in Besitz genommen: MBH. 14,299 . 304 . 306 . Vgl. 308 . PAÑCAT. 227,11 . PRAB. 116,7 . Sch. :	MBH. 14,299;MBH. 14, 304;MBH. 14, 306;MBH. 14, 308;PAÑCAT. 227,11;PRAB. 116,7
+Ap		3	3〉 in Besitz gelangt, befriedigt: AIT. BR. 4,4 . — sich bis wohin erstrecken: bis inclusive: P. 2,1,134 , Sch. SIDDH. K. _zu_ 1,14 . — Vgl. fgg	AIT. BR. 4,4;P. 2,1,134;SIDDH. K;P. 2, 1,14
+Ap		1	1〉 erlangen: AV. 9,5,15 . 10,9,6 . 13,2,15 . MBH. 3,7068 . 13940 . 5,445 . R. 3,2,28 . ( SCHLEGEL : tu universum perficis, WEST. : permeare, complecti) BHAG. 11,10 . RAGH. 17,17	AV. 9,5,15;AV 10,9,6;AV 13,2,15;MBH. 3,7068;MBH. 3, 13940;MBH 5,445;R. 3,2,28;SCHLEGEL;WEST;BHAG. 11,10;RAGH. 17,17
+Ap		2	2〉 vollenden, erfüllen: ŚAT. BR. 11,5,6,2 . 8,4,2 . 4 . 12,3,3,5 . KĀTY. ŚR. 22,2,17 . 25,8,18 . 12,20 . ŚAT. BR. 10,4,1,10	ŚAT. BR. 11,5,6,2;ŚAT. BR. 11, 8,4,2;ŚAT. BR. 11,5,6, 4;ŚAT. BR 12,3,3,5;KĀTY. ŚR. 22,2,17;KĀTY. ŚR 25,8,18;KĀTY. ŚR. 25, 12,20;ŚAT. BR. 10,4,1,10
+Ap		3	3〉 heranreichen: AV. 12,3,45	AV. 12,3,45
+Ap		1	1〉 vollendet, beendigt, zu Ende gegangen M. 5,88 . 11,81 ( ). R. 3,49,27 . RAGH. 3,65 . VID. 270 . (erschöpft) VIKR. 159 . MBH. 16,83 . KĀTY. ŚR. 24,6,26 . KATHĀS. 22,234	M. 5,88;M 11,81;R. 3,49,27;RAGH. 3,65;VID. 270;VIKR. 159;MBH. 16,83;KĀTY. ŚR. 24,6,26;KATHĀS. 22,234
+Ap		2	2〉 vollendet, geschickt: MBH. 14,2561 . — caus	MBH. 14,2561
+Ap		1	1〉 erreichen oder erlangen lassen: ŚAT. BR. 2,3,3,16	ŚAT. BR. 2,3,3,16
+Ap		2	2〉 zu Ende führen, vollbringen, vollführen: M. 8,420 . 11,158 . MBH. 1,6885 . 8103 . R. 1,61,22 . KATHĀS. 22,234 . RAGH. 17,24 . ( s. P. 6,4,57 ) R. 2,25,44 . RAGH. 2,23 . MBH. 3,9911 . R. 4,29,25 . M	M. 8,420;M 11,158;MBH. 1,6885;MBH. 1, 8103;R. 1,61,22;KATHĀS. 22,234;RAGH. 17,24;P. 6,4,57;R. 2,25,44;RAGH. 2,23;MBH. 3,9911;R. 4,29,25;M. 2,228;M 237;MBH. 3,9907;R. 1,11,17;H. 127;RAGH. 8,72;KATHĀS. 20,196;MADHUS;Ind. St. 1,19
+Ap		1	1〉 zu erreichen oder zu erlangen wünschen, begehren: begehrt, erwünscht: R. 3,5,22	R. 3,5,22
+Ap		2	2〉 zu vollenden streben: ŚAT. BR. 12,4,1,10 . — desid. vom caus. zu vollbringen suchen: ŚAT. BR. 14,4,3,34 = BṚH. ĀR. UP. 1,5,23 . Vgl. MBH. 1,6872 . [Page1-0657] — caus. dazu vollenden, nachher zu St	ŚAT. BR. 12,4,1,10;ŚAT. BR. 14,4,3,34;BṚH. ĀR. UP. 1,5,23;MBH. 1,6872;KĀTY. ŚR. 24,6,26;BHAG. 4,33;ŚĀK. 105;PAT;P. 8,3,58;MBH. 1,8139
+Ap		1	¦ [ vgl. [Page1-0650]] Z. 19 v. u. lies st	
+Ap		4	4〉 vollständig: PAÑCAV. BR. 23,1,2 . ŚĀṄKH. ŚR. 15,3,14 . TS. 6,2,6,1 . — caus	PAÑCAV. BR. 23,1,2;ŚĀṄKH. ŚR. 15,3,14;TS. 6,2,6,1
+Ap		1	1〉 gebracht BHĀG. P. 10,19,13 . — desid. herbeiholen PAÑCAV. BR. 20,3,2 . partic	BHĀG. P. 10,19,13;PAÑCAV. BR. 20,3,2
+Ap		1	1〉 M. 3,231 . 4,156 . 9,59 . — Z. 3 lies st	M. 3,231;M 4,156;M 9,59
+Ap		1	1〉 Weise stossen auf Vorzüge und Mängel Spr. 838 . wurde entdeckt, — gefunden KATHĀS. 106,26 . — vgl. . — desid. vgl. . — partic. : genug MBH. 5,7302. fg. eine hinreichende Anzahl von Augen habend (= 	Spr. 838;KATHĀS. 106,26;MBH. 5,7302. fg;HARIV. 3964;DAŚAK;BENF. Chr. 185,10;HARIV. 6525;Spr. 3940;P. 3,4,66;Spr. 2179;TRIK. 3,3,167;MED. t. 128;H. an. 3,276;HALĀY. 2,171;HALĀY 4,33;HALĀY 5,3;Spr. 3368
+Ap		9	9〉 MED. t. 32 . HALĀY. 4,61 . DAŚAK. _in_ BENF. Chr. 188,4 . — caus. vorbringen, melden, verkünden: R. 7,103,10 . — , wohl alle Flüssigkeiten sind schliesslich Wasser NIR. 1,16 . — vgl. . [Page5-1108]	MED. t. 32;HALĀY. 4,61;DAŚAK;BENF. Chr. 188,4;R. 7,103,10;NIR. 1,16;KATHĀS. 120,97
+Ap		1	1〉 in etwas Anderem eingeschlossen, einbegriffen BHĀṢĀP. 67 . so v. a. fällt unter den Begriff der Vergänglichkeit TARKAS. 41 . — caus. erfüllt Spr. 3836 . — , partic	BHĀṢĀP. 67;TARKAS. 41;Spr. 3836
+Ap		1	1〉 da die Herrlichkeit des Goldes im Meru selbst zum Abschluss gekommen ist ( d. i. Andern nicht zu Gute kommt), so will er mir nicht gefallen, Spr. 2526 . vollständig, vollzählig 523 . v. l. um Etwas	Spr. 2526;Spr 523;ṚV. PRĀT. 13,13
+Ap		2	2〉 ṚV. PRĀT. 10,1	ṚV. PRĀT. 10,1
+Ap		3	3〉 Jmd abthun, Jmd den Garaus machen: KATHĀS. 48,67 . (so ist zu schreiben) BHĀG. P. 7,8,51 . — pass. zum Schluss gelangen, das Endziel erreichen BHĀG. P. 11,16,44 . = Schol. — Vgl	KATHĀS. 48,67;BHĀG. P. 7,8,51;BHĀG. P. 11,16,44
+Ap		2	2〉 Z. 6 M. 1,63 ist von schützen gemeint. — partic. dividirt SŪRYAS. 1,52. fg. 60 . 2,28. fg. 57 . 61. fg. 64 . 3,10. fg. 22 . — durch Division erhalten SŪRYAS. 2,32 . 3,9 . 12,59	M. 1,63 ist;SŪRYAS. 1,52. fg;SŪRYAS. 1, 60;SŪRYAS 2,28. fg;SŪRYAS. 2, 57;SŪRYAS. 2, 61. fg;SŪRYAS. 2, 64;SŪRYAS 3,10. fg;SŪRYAS. 3, 22;SŪRYAS. 2,32;SŪRYAS 3,9;SŪRYAS 12,59
+Ap		2	2〉 mit infin. bekommen zu: Spr. (II) 7515 . — partic	Spr. (II) 7515
+Ap		4	4〉 so v. a. versehen mit R. ed. Bomb. 1,7,8 . — desid. s. . — caus	R. ed. Bomb. 1,7,8
+Ap		1	1〉 KAUṢ. UP. 2,15 . — Z. 3 so v. a. erstreckt sich auf Jedes, gehört zu Jedem; vgl. PAT. a. a. O. 1,48,b . erstreckt sich auf 2,317,a	KAUṢ. UP. 2,15;PAT. a. a. O. 1,48,b;PAT. a. a. O 2,317,a
+ApAta		1	1〉 adj. auf Etwas losstürzend, sich an Etwas machend: M. 11,9 . KULL. : =	M. 11,9;KULL
+ApAta		2	2〉 m. das Heranstürzen, Andrang: ŚĀK. 32 , v. l. HIḌ. 2,9 . RAGH. 12,76 . KUMĀRAS. 2,45 . KATHĀS. 22,202 . 19,50 . 25,112 . 4,8 . MEGH. 49 . das Hineinstürzen: inʼs Feuer YĀJÑ. 3,154 . ARJ. 7,10 . = T	ŚĀK. 32;HIḌ. 2,9;RAGH. 12,76;KUMĀRAS. 2,45;KATHĀS. 22,202;KATHĀS 19,50;KATHĀS 25,112;KATHĀS 4,8;MEGH. 49;YĀJÑ. 3,154;ARJ. 7,10;TRIK. 3,3,149;H. an. 3,243;MED. t. 87
+ApAta		3	3〉 m. das Sicheinstellen, Sichereignen, zum-Vorschein-Kommen: SĀH. D. 10,19	SĀH. D. 10,19
+ApAta		4	4〉 beim ersten Ansatz, sofort, ohne Weiteres: MADHUS. _in_ Ind. St. 1,23,3 . v. u . VEDĀNTAS. 1,10 . Comm. 13,13 . 25,2 v. u. 26,3 v. u . Sch. in der Einl. zu NYĀYA-S. 4,71 . SĀH. D. (1828) 273,3 . 8 	MADHUS;Ind. St. 1,23,3;Ind. St. 1,23, v. u;VEDĀNTAS. 1,10;VEDĀNTAS 13,13;VEDĀNTAS 25,2 v. u. 26,3 v. u;NYĀYA-S. 4,71;SĀH. D. (1828) 273,3;SĀH. D. ( 1828) 273, 8;TRIK. 3,3,149;MED. t. 87;H. an. 3,243
+ApAta		5	5〉 m. das zum-Sturz-Bringen ŚABDAC. _im_ ŚKDR	ŚABDAC;ŚKDR
+ApAta		1	1〉 zu streichen; vgl	
+ApAta		2	2〉 so v. a. die zudringlichen Blicke der Menschen Spr. 2745	Spr. 2745
+ApAta		3	3〉 füge das Eintreffen hinzu. KATHĀS. 108,51 . Spr. 1615 . SARVADARŚANAS. 119,7 . 129,12 . 132,8 . 147,20	KATHĀS. 108,51;Spr. 1615;SARVADARŚANAS. 119,7;SARVADARŚANAS 129,12;SARVADARŚANAS 132,8;SARVADARŚANAS 147,20
+ApAta		4	4〉 sofort, vom ersten Augenblick an Spr. 361 . 2775 . PAÑCAT. _in_ Gött. gel. Anz. 1860, S. 735	Spr. 361;Spr 2775;PAÑCAT;Gött. gel. Anz. 1860, S. 735
+ApAta		4	4〉 am Anfange im Gegensatz zu Spr. (II) 6419 ( Conj. )	Spr. (II) 6419
+ApIna		1	1〉 adj. s. u	
+ApIna		2	2〉 n. Euter AK. 2,9,73 . H. 1272 . RAGH. 2,18	AK. 2,9,73;H. 1272;RAGH. 2,18
+ApIqa		1	1〉 m	
+ApIqa		1a	a〉 das Zusammendrücken: SUŚR. 2,201,21	SUŚR. 2,201,21
+ApIqa		1b	b〉 ein auf dem Scheitel getragener Kranz AK. 2,6,3,38 . 3,4,238 . H. 654 . MBH. 3,12234 . 1,7314 . R. 2,48,11 . 93,12 . 6,18,2 . 19,9 . 86,9 . N. 12,76 . RAGH. 18,28 . Häufig am Ende von Personennamen	AK. 2,6,3,38;AK. 2, 3,4,238;H. 654;MBH. 3,12234;MBH 1,7314;R. 2,48,11;R. 2, 93,12;R 6,18,2;R. 6, 19,9;R. 6, 86,9;N. 12,76;RAGH. 18,28
+ApIqa		2	2〉 f. N. eines Metrums COLEBR. Misc. Ess. II, 165	COLEBR. Misc. Ess. II, 165
+ApIqa		1	1〉	
+ApIqa		1a	a〉 Leibkneifen MBH. 6,2524	MBH. 6,2524
+ApIqa		1b	b〉 HARIV. 3849	HARIV. 3849
+ApIqa		2	2〉 ist gleichfalls masc. Ind. St. 8,348. fgg. — Vgl	Ind. St. 8,348. fgg
+ApIta		1	1〉 adj. gelblich	
+ApIta		2	2〉 n. ein schwefelhaltiges Mineral ( ) RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+ApUpika	1	1	1〉 adj. sich mit dem Verkauf von Kuchen abgebend P. 4,4,51 , Sch. AK. 2,9,28 . gewohnt Kuchen zu essen P. 4,4,61 , Sch. ein Verehrer von Kuchen 4,3,96 , Sch. dem es zuträglich ist Kuchen zu essen 4,4,	P. 4,4,51;AK. 2,9,28;P. 4,4,61;P 4,3,96;P 4,4,65
+ApUpika	1	2	2〉 n. ein Haufen Kuchen P. 4,2,47 , Sch. 39, Vārtt. 3 , Sch. AK. 3,3,40 . H. 1418	P. 4,2,47;P. 4, 39, Vārtt. 3;AK. 3,3,40;H. 1418
+ApUraRa		1	1〉 adj. anfüllend NIR. 7,28 . HIT. Pr. 19	NIR. 7,28;HIT. Pr. 19
+ApUraRa		2	2〉 m. N. pr. eines Nāga MBH. 1,1551	MBH. 1,1551
+ApUraRa		3	3〉 n. das Anfüllen: PAÑCAT. 96,20	PAÑCAT. 96,20
+ApUraRa		1	¦ [ vgl. [Page1-0661]] Die 3te Bed. ist viell. zu streichen, da in dem angeführten Beispiele eben so gut angenommen werden kann	
+ApUraRa		3	3〉 Spr. 4606 ( Conj. ). PAÑCAT. 96,20 kann auch angenommen werden	Spr. 4606;PAÑCAT. 96,20
+ApaRika		1	1〉 adj. mit dem Markte in Verbindung stehend, = P. 4,3,75 , Sch. = 4,4,47 , Sch	P. 4,3,75;P 4,4,47
+ApaRika		2	2〉 m	
+ApaRika		2a	a〉 Handelsmann AK. 2,9,79 . H. 867	AK. 2,9,79;H. 867
+ApaRika		2b	b〉 das Pachtgeld für einen Markt P. 4,4,50 , Sch	P. 4,4,50
+ApaRika		1	¦ [ vgl. [Page1-0657]] Z. 2 lies:	
+ApaRika		1	¦ Z. 2 lies	
+ApagA		1	1〉 Fluss AK. 1,2,3,29 . H. 1080 . MBH. 1,7896 . N. 12,26 . R. 2,47,17 . 48,8 . 55,13 . 4,40,19 . 20 . 41,20 . 44,79 . 60,13 . SUŚR. 2,173,20 . PAÑCAT. I, 6 . ŚĀK. 167 . RAGH. 9,22 . ŚIŚUP. 3,72	AK. 1,2,3,29;H. 1080;MBH. 1,7896;N. 12,26;R. 2,47,17;R. 2, 48,8;R. 2, 55,13;R 4,40,19;R. 4,40, 20;R. 4, 41,20;R. 4, 44,79;R. 4, 60,13;SUŚR. 2,173,20;PAÑCAT. I, 6;ŚĀK. 167;RAGH. 9,22;ŚIŚUP. 3,72
+ApagA		2	2〉 N. pr. eines Flusses MBH. 3,6038 . — Wohl eine Steigerung von hinunterfliessend; vgl. und	MBH. 3,6038
+Apana		1	1〉 das Erreichen, Erlangen (von ), s	
+Apana		2	2〉 Pfeffer ŚABDAC. _im_ ŚKDR	ŚABDAC;ŚKDR
+Apana		1	¦ adj. bringend, herbeiführend BHĀG. P. 10,82,44	BHĀG. P. 10,82,44
+Apanika		1	1〉 Saphir Uṇ. 2,46	Uṇ. 2,46
+Apanika		2	2〉 ein Kirāta ebend	ebend
+Apas		1	1〉 eine religiöse Handlung Uṇ. 4,209	Uṇ. 4,209
+Apas		2	2〉 Wasser	
+Apas		3	3〉 Sünde UṆĀDIK. _im_ ŚKDR. — Vgl. 2	UṆĀDIK;ŚKDR
+Apas		2	2〉 die Aufstellung dieser Bed. beruht vielleicht darauf, dass man an als acc. pl. ( s. oben u. ) oder als erstem Gliede eines comp. Anstoss nahm	
+Apatika		1	1〉 adj. vom Schicksal kommend Uṇ. 2,46	Uṇ. 2,46
+Apatika		2	2〉 m. Falke ebend	ebend
+Apatti		1	1〉 das Eintreten in ein Verhältniss, Umwandlung in H. an. 3,250 . MED. t. 95 . AV. PRĀT. 3,57 . 1,68 . KĀTY. ŚR. 4,3,19 . 23,2,17 . 26,4,7 . ŚAṂK. _in_ WIND. Sancara 152 . Z. d. d. m. G. 7,300, N. 4 .	H. an. 3,250;MED. t. 95;AV. PRĀT. 3,57;AV. PRĀT 1,68;KĀTY. ŚR. 4,3,19;KĀTY. ŚR 23,2,17;KĀTY. ŚR 26,4,7;ŚAṂK;WIND. Sancara 152;Z. d. d. m. G. 7,300, N. 4;BURN. Intr. 291, N. 3
+Apatti		2	2〉 Unfall, Unglück, Noth ( ) MED. YĀJÑ. 3,42 . VET. 30,9	MED;YĀJÑ. 3,42;VET. 30,9
+Apatti		3	3〉 Fehler, Versehen ( ) H. an. — Vgl	H. an
+Apatti		1	1〉 ṚV. PRĀT. 6,9 . VS. PRĀT. 1,42 . 4,146 . 161 . SARVADARŚANAS. 13,1 . 4 . 7 . 9 . 25,21 . Füge noch hinzu das Gerathen in	ṚV. PRĀT. 6,9;VS. PRĀT. 1,42;VS. PRĀT 4,146;VS. PRĀT. 4, 161;SARVADARŚANAS. 13,1;SARVADARŚANAS. 13, 4;SARVADARŚANAS. 13, 7;SARVADARŚANAS. 13, 9;SARVADARŚANAS 25,21
+ApfcCya		1	1〉 zu begrüssen, zu verehren: ṚV. 1,60,2	ṚV. 1,60,2
+ApfcCya		2	2〉 lobenswerth: ṚV. 1,64,13	ṚV. 1,64,13
+ApiSala		1	1〉 adj. von Āpiśali herrührend: P. 6,2,36 , Sch	P. 6,2,36
+ApiSala		2	2〉 m. ein Schüler Āpiśali ʼs ebend. KĀŚ. _zu_ 7,3,95	ebend;KĀŚ;P 7,3,95
+ApiSala		2	2〉 PAT. _in_ Ind. St. 5,134	PAT;Ind. St. 5,134
+ApiSala		1	¦, ( sc. ) PAT. a. a. O. 4,16,b	PAT. a. a. O. 4,16,b
+ApiYjara		1	1〉 adj. f. röthlich RAGH. 16,51	RAGH. 16,51
+ApiYjara		2	2〉 n. Gold RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+ApiYjara		1	1〉 KATHĀS. 104,89	KATHĀS. 104,89
+Apluta		1	1〉 part. praet. pass. von mit ( s. d. )	
+Apluta		2	2〉 m. = H. an. 3,244 . MED. t. 88 . — Die Bedeutung Bad H. an. beruht auf einem blossen Druckfehler (für ), da das m. , welches Geschlecht H. angiebt, diese Bedeutung unmöglich haben kann	H. an. 3,244;MED. t. 88;H. an;H
+Apta		1	1〉 m	
+Apta		1a	a〉 ein Arhant H. 25	H. 25
+Apta		1b	b〉 N. pr. eines Nāga MBH. 1,1553	MBH. 1,1553
+Apta		2	2〉 f. Haarwulst ( ) JAṬĀDH. _im_ ŚKDR	JAṬĀDH;ŚKDR
+Apta		3	3〉 n	
+Apta		3a	a〉 Quotient	
+Apta		3b	b〉 equation of a degree WILS. — Die andern Bedeutungen des Wortes s. u	WILS
+Apti		1	1〉 Erreichung, das Treffen, mit dem gen. des subj. TS. 2,5,11,5 . ŚAT. BR. 5,2,1,2 . 9,1,1,44 . BṚH. ĀR. UP. 3,1,3	TS. 2,5,11,5;ŚAT. BR. 5,2,1,2;ŚAT. BR 9,1,1,44;BṚH. ĀR. UP. 3,1,3
+Apti		2	2〉 Erlangung, Gewinnung H. an. 2,158 . MED. t. 3 . TS. 5,1,3,4 . ŚAT. BR. 13,3,1,4 . MĀṆD. UP. 9 . KAṬHOP. 2,11 . 1,14 . MBH. 14,2620 . R. 4,21,30 . PAÑCAT. II, 45 . KATHĀS. 25,182	H. an. 2,158;MED. t. 3;TS. 5,1,3,4;ŚAT. BR. 13,3,1,4;MĀṆD. UP. 9;KAṬHOP. 2,11;KAṬHOP 1,14;MBH. 14,2620;R. 4,21,30;PAÑCAT. II, 45;KATHĀS. 25,182
+Apti		3	3〉 Verbindung H. an. MED. = TRIK. 3,3,148	H. an;MED;TRIK. 3,3,148
+Apti		4	4〉 pl. Name von zwölf Opfersprüchen, welche [Page1-0662] mit ( VS. 9,20 ) beginnen ŚAT. BR. 5,2,1,1 . 2 . — Vgl. und	VS. 9,20;ŚAT. BR. 5,2,1,1;ŚAT. BR. 5,2,1, 2
+ApyAyana		1	1〉 adj. Fülle, Beleibtheit verleihend SUŚR. 1,231,5 . übertr. Fülle, Wohlergehen verleihend: MBH. 3,6002	SUŚR. 1,231,5;MBH. 3,6002
+ApyAyana		2	2〉 n	
+ApyAyana		2a	a〉 das Vollmachen, Fettmachen SUŚR. 1,2,19 . das Sättigen, Befriedigen (der Götter durch Opfer): M. 3,211 . Mittel zum Fett- oder Starkwerden, Stärkung: ŚAT. BR. 1,6,4,11 . das Gedeihenmachen, Mittel 	SUŚR. 1,2,19;M. 3,211;ŚAT. BR. 1,6,4,11;M. 3,213;M. 3, 203;AK. 3,4,118
+ApyAyana		2b	b〉 Schwellung ( näml. des Soma) heissen gewisse mit den Pflanzen oder dem Saft vorgenommene Handlungen, z. B. das Begiessen mit Wasser, ŚAT. BR. 3,4,3,12. fgg. KĀTY. ŚR. 7,6,28 . 8,2,34 . 9,5,2 . 9 . 	ŚAT. BR. 3,4,3,12. fgg;KĀTY. ŚR. 7,6,28;KĀTY. ŚR 8,2,34;KĀTY. ŚR 9,5,2;KĀTY. ŚR. 9,5, 9;SĀY;AIT. BR. 1,26
+ApyAyana		2	2〉	
+ApyAyana		2a	a〉 Sättigung, Befriedigung VARĀH. BṚH. S. 5,14	VARĀH. BṚH. S. 5,14
+ApyAyana		2b	b〉 Bez. einer best. an einem Zauberspruche vorgenommenen Cerimonie ŚĀRADĀT. _in_ SARVADARŚANAS. 171,4 = Verz. d. Oxf. H. 98,b,26	ŚĀRADĀT;SARVADARŚANAS. 171,4;Verz. d. Oxf. H. 98,b,26
+ApyAyana		3	3〉 f. Bez. einer Arterie im Nabelstrang: MĀRK. P. 11,11	MĀRK. P. 11,11
+Aqambara		1	1〉 Trommel AK. 2,8,2,76 . H. 799 . MED. r. 249 . (sic) R. 5,13,51 . Vgl. den folg. Artikel	AK. 2,8,2,76;H. 799;MED. r. 249;R. 5,13,51
+Aqambara		2	2〉 ein Trompetenstoss, als Zeichen zum Angriff AK. 3,4,170 . H. an. 4,239	AK. 3,4,170;H. an. 4,239
+Aqambara		3	3〉 Elephantengebrüll AK. H. an. MED	AK;H. an;MED
+Aqambara		4	4〉 Stolz ( ) H. an. MED	H. an;MED
+Aqambara		5	5〉 Beginn TRIK. 3,2,18 . Diese und die vorangehende Bedeutung sind ursprünglich wohl nur eine gewesen, da und leicht verwechselt werden konnten	TRIK. 3,2,18
+Aqambara		6	6〉 Zorn SVĀMIN _im_ ŚKDR	SVĀMIN;ŚKDR
+Aqambara		7	7〉 Freude ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+Aqambara		8	8〉 Augenwimpern MED	MED
+Aqambara		1	1〉 eine Art Trommel: (= Schol. ) MBH. 7,2914 . (= Schol. ) 2487 . ŚAT. BR. 14,8,12,1 . SĀY. hat getrennt, da er durch erklärt; an der entsprechenden Stelle BṚH. ĀR. UP	MBH. 7,2914;MBH. 7, 2487;ŚAT. BR. 14,8,12,1;SĀY;BṚH. ĀR. UP
+Aqambara		9	9〉 Lärm: Spr. 1624 . Vgl	Spr. 1624
+Aqambara		10	10〉 Lärm so v. a. lärmvolles Benehmen, das Posaunen (in übertr. Bed. ), vieles Reden, Wortschwall: Schol. zu NAIṢ. 5,61 . SĀH. D. 627 . RĀJA-TAR. 2,125	NAIṢ. 5,61;SĀH. D. 627;RĀJA-TAR. 2,125
+Aqambara		11	11〉 Gewirre: (= Schol. ) UTTARARĀMAC. 36,12 . KATHĀS. 26,89 . Wortschwall als Erkl. von MALLIN. _zu_ ŚIŚ. 2,27 . dass. PRATĀPAR. 19,b,4 . dass. VĪR. 20,a,1 . SĀH. D. 243,2 . = HALĀY. 5,55	UTTARARĀMAC. 36,12;KATHĀS. 26,89;MALLIN;ŚIŚ. 2,27;PRATĀPAR. 19,b,4;VĪR. 20,a,1;SĀH. D. 243,2;HALĀY. 5,55
+Aqambara		12	12〉 N. pr. eines Wesens im Gefolge Skanda ʼs (neben ) MBH. 9,2541	MBH. 9,2541
+Aqambara		1	1〉 MBH. 9,2676	MBH. 9,2676
+Aqi		1	1〉 = AK. 2,5,25	AK. 2,5,25
+Aqi		2	2〉 ein bes. Fisch RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+Aqi		1	1〉 ein best. Vogel ( vgl. ) MĀRK. P. 9,10 . 13 . 15 . ( adj. ) der Kampf zwischen dem Āḍi und dem Vaka d. i. zwischen Vasiṣṭha und Viśvāmitra (die in diese Vögel verwandelt worden waren) 8,270 . 9,32 	MĀRK. P. 9,10;MĀRK. P. 9, 13;MĀRK. P. 9, 15;MĀRK. P 8,270;MĀRK. P 9,32;HARIV. 11100
+ArADana		1	1〉 adj. für sich gewinnend, günstig stimmend: KUMĀRAS. 6,73 . [Page1-0687] KATHĀS. 17,97	KUMĀRAS. 6,73;KATHĀS. 17,97
+ArADana		2	2〉 n	
+ArADana		2a	a〉 das Vollbringen, inʼs-Werk-Setzen AK. 3,4,128 . H. an. 4,158 . ŚĀK. 12,1	AK. 3,4,128;H. an. 4,158;ŚĀK. 12,1
+ArADana		2b	b〉 das Kochen H. an. MED. n. 167	H. an;MED. n. 167
+ArADana		2c	c〉 das Erlangen AK. H. an. MED. BHARTṚ. 3,5	AK;H. an;MED;BHARTṚ. 3,5
+ArADana		2d	d〉 das für-sich-Gewinnen, günstig-Stimmen, das darauf gerichtete Handeln AK. H. an. MED. MBH. 1,419 . N. 5,20 . KATHĀS. 17,26 . BHAG. 7,22 . KUMĀRAS. 1,59 . KATHĀS. 5,86 . R. 5,43,2 . PRAB. 70,1 . KAT	AK;H. an;MED;MBH. 1,419;N. 5,20;KATHĀS. 17,26;BHAG. 7,22;KUMĀRAS. 1,59;KATHĀS. 5,86;R. 5,43,2;PRAB. 70,1;KATHĀS. 21,140;KATHĀS. 21, 142
+ArADana		3	3〉 f. = 2,d. H. 497	H. 497
+ArADana		2	2〉	
+ArADana		2c	c〉 das Beispiel gehört zu	
+ArADana		2d	d〉; vgl	
+ArADana		2d	d〉 Spr. 801 . 4106	Spr. 801;Spr 4106
+ArADana		3	3〉 HALĀY. 1,129	HALĀY. 1,129
+ArADya		1	¦ (von im caus. mit ) adj. der günstig zu stimmen ist, der zu befriedigen ist: KATHĀS. 21,140 . BHARTṚ. 2,3 . ( Sch. : = ) PRAB. 22,9 . 23,10 . BHARTṚ. 3,78 . PAÑCAT. I, 45 . 72 . 77	KATHĀS. 21,140;BHARTṚ. 2,3;PRAB. 22,9;PRAB 23,10;BHARTṚ. 3,78;PAÑCAT. I, 45;PAÑCAT. I, 72;PAÑCAT. I, 77
+ArADya		1	1〉 adj. R. 7,6,2 . KATHĀS. 115,89 . auch was man sich angelegen sein lassen soll: Spr. 3934 . 3935	R. 7,6,2;KATHĀS. 115,89;Spr. 3934;Spr 3935
+ArADya		2	2〉 m. pl. N. einer Secte Verz. d. Oxf. H. 248,a,10 . WILSON, Sel. Works 1,225	Verz. d. Oxf. H. 248,a,10;WILSON, Sel. Works 1,225
+ArAma		1	1〉 Ergötzen, Lust: ŚAT. BR. 14,7,1,15 = BṚH. ĀR. UP. 4,3,14 . adj. TAITT. UP. 1,6,2 . BHAG. 3,16 . BHARTṚ. 3,88 . sich an der Einsamkeit ergötzend, allein YĀJÑ. 3,58 . ŚAT. BR. 11,5,7,1 . Vgl	ŚAT. BR. 14,7,1,15;BṚH. ĀR. UP. 4,3,14;TAITT. UP. 1,6,2;BHAG. 3,16;BHARTṚ. 3,88;YĀJÑ. 3,58;ŚAT. BR. 11,5,7,1
+ArAma		2	2〉 Ort der Ergötzung, Garten AK. 2,4,1,2 . H. 1111 . M. 8,262 . 264 . 11,61 . YĀJÑ. 2,154 . MBH. 1,4348 . R. 2,52,91 . 59,12 . SUŚR. 1,353,20 . MṚCCH. 79,23 . BURN. Intr. 23 . Verz. d. B. H. No. 903 .	AK. 2,4,1,2;H. 1111;M. 8,262;M. 8, 264;M 11,61;YĀJÑ. 2,154;MBH. 1,4348;R. 2,52,91;R. 2, 59,12;SUŚR. 1,353,20;MṚCCH. 79,23;BURN. Intr. 23;Verz. d. B. H. No. 903;MBH. 3,8327
+ArAma		1	1〉 adj. Spr. 4094 . adj. 4698	Spr. 4094;Spr 4698
+ArAma		2	2〉 Baumgarten ŚĀṄKH. GṚHY. 5,3,1 . VARĀH. BṚH. S. 55,1 . 56,1 . DAŚAK. _in_ BENF. Chr. 197,17 . KATHĀS. 61,296 . KATHĀS. 68,41	ŚĀṄKH. GṚHY. 5,3,1;VARĀH. BṚH. S. 55,1;VARĀH. BṚH. S 56,1;DAŚAK;BENF. Chr. 197,17;KATHĀS. 61,296;KATHĀS. 68,41
+ArAma		3	3〉 ein best. Metrum Ind. St. 8,410 . — Vgl	Ind. St. 8,410
+ArAt		1	1〉 aus der Ferne, von fern; fern, fernhin; fern von, mit dem abl. ( P. 2,2,29 ) AK. 3,4,32,4 . H. an. 7,21 . MED. avy. 28 . aus weiter Ferne ṚV. 1,129,9 . 164,43 . 10,27,19 . AV. 6,32,1 . 8,2,9 . 12 .	P. 2,2,29;AK. 3,4,32,4;H. an. 7,21;MED. avy. 28;ṚV. 1,129,9;ṚV 164,43;ṚV 10,27,19;AV. 6,32,1;AV 8,2,9;AV. 8,2, 12;VS. 19,84;AV. 1,19,1;AV 6,30,2;KĀTY. ŚR. 21,3,19;ṚV. 10,131,7;AV. 2,3,6;AV 8,1,12;AV 10,1,1;AV. 10, 31,11;AV. 10, 56,6;MBH. 3,246;MBH 1,6447;MBH. 1, 7292;MBH. 1, 7157;KATHĀS. 22,194;KATHĀS 25,185;MADHUS;Ind. St. 1,15,7
+ArAt		2	2〉 in der Nähe VOP. 5,22 . AK. H. an. MED. RAGH. 2,10 . 5,13 . Diese Bedeutung geben die Comm. dem Worte öfters auch in den oben u. 1. aufgeführten Stellen aus den Veden	VOP. 5,22;AK;H. an;MED;RAGH. 2,10;RAGH 5,13
+ArAt		3	3〉 sogleich, alsobald: ( Sch. : = ) PRAB. 72,13 . KATHĀS. 26,135 . ŚĀK. 126 . — Vgl	PRAB. 72,13;KATHĀS. 26,135;ŚĀK. 126
+ArAt		2	2〉 GĪT. 1,37	GĪT. 1,37
+ArAt		3	3〉 KATHĀS. 65,32	KATHĀS. 65,32
+ArAt		1	¦ N. pr. eines Dorfes der Bāhīka ; davon adj. ( f. und ) PAT. a. a. O. 4,72,b	PAT. a. a. O. 4,72,b
+Ara	2	1	1〉 Erz, , m.n. H. 1047 . m. H. an. 2,395 . n. Sch. zu AK. 2,9,97 . ŚKDR. Vgl	H. 1047;H. an. 2,395;AK. 2,9,97;ŚKDR
+Ara	2	2	2〉 n. Eisenrost RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+Ara	2	3	3〉 n. Spitze, Ecke Sch. zu ĀNANDAL. ŚKDR	ĀNANDAL;ŚKDR
+Ara	2	4	4〉 m. N. eines Baumes, = , vulg. RATNAM. _im_ ŚKDR	RATNAM;ŚKDR
+Ara	2	5	5〉 N. eines Sees KAUṢ. UP. _in_ Ind. St. 1,396 . 398. fg. Vgl. 1. 4	KAUṢ. UP;Ind. St. 1,396;Ind. St. 1, 398. fg
+Ara	2	1	1〉 BHĀG. P. 10,41,20	BHĀG. P. 10,41,20
+Ara	2	3	3〉 Stachel (so v. a. , vgl. auch ) Comm. TS. 1,394	TS. 1,394
+Ara	3	1	1〉 = Ἄρης , der Planet Mars TRIK. 3,3,330 . H. 116 . an. 2,395 . MED. r. 7 . HORĀŚ. _in_ Z. f. d. K. d. M. 4,318 . Ind. St. 2,261 . 283. fg	TRIK. 3,3,330;H. 116;H an. 2,395;MED. r. 7;HORĀŚ;Z. f. d. K. d. M. 4,318;Ind. St. 2,261;Ind. St. 2, 283. fg
+Ara	3	2	2〉 der Planet Saturn TRIK. H. an. MED	TRIK;H. an;MED
+Ara	3	1	1〉 VARĀH. BṚH. S. 9,38 . 17,14 . 28,21	VARĀH. BṚH. S. 9,38;VARĀH. BṚH. S 17,14;VARĀH. BṚH. S 28,21
+Ara	3	1	3. ¦, die ed. Bomb. richtig	ed. Bomb
+AraBawa		1	1〉 m. ein unternehmender, beherzter Mensch H. 285 , Sch. Vgl	H. 285
+AraBawa		2	2〉 f. die Darstellung übernatürlicher und schauervoller Ereignisse auf dem Theater: SĀH. D. 169,7. fg. H. 285	SĀH. D. 169,7. fg;H. 285
+AraBawa		2	2〉 DAŚAR. 2,52 . PRATĀPAR. 10,a,7 . Verz. d. Oxf. H. 208,a,35	DAŚAR. 2,52;PRATĀPAR. 10,a,7;Verz. d. Oxf. H. 208,a,35
+AraRyaka		1	1〉 adj. = , angebl. nur in Verbindung mit und P. 4,2,129, Vārtt. 1. 2 . MBH. 15,532 . R. 2,36,6 . Milch von Waldthieren YĀJÑ. 1,170 . heisst sowohl das ganze 3te Buch des MBH. , als auch die 1ste Abth	P. 4,2,129, Vārtt. 1. 2;MBH. 15,532;R. 2,36,6;YĀJÑ. 1,170;MBH;R
+AraRyaka		2	2〉 m. Waldbewohner, Einsiedler VYUTP. 37 . MBH. 3,1129 . ŚĀK. 46 . RAGH. 5,15	VYUTP. 37;MBH. 3,1129;ŚĀK. 46;RAGH. 5,15
+AraRyaka		3	3〉 n. für das Studium in der Einsamkeit der Wildniss bestimmt oder aus derselben hervorgegangen, Bezeichnung einer den BRĀHMAṆA verwandten Schriftgattung, ĀRUṆ. UP. _in_ Ind. St. 2,179 . M. 4,123 . YĀ	BRĀHMAṆA;ĀRUṆ. UP;Ind. St. 2,179;M. 4,123;YĀJÑ. 1,145;YĀJÑ 3,110;YĀJÑ. 3, 309;MBH. 1,258;MBH 5,6014;ŚAT. BR
+AraRyaka		1	1〉 nach P. 4,2,129 in Verbindung mit , nach KĀTY. auch in Verbindung mit den 6 aufgezählten Wörtern. Verz. d. Oxf. H. 13,b,19 . Waldbewohner TARKAS. 49	P. 4,2,129;KĀTY;Verz. d. Oxf. H. 13,b,19;TARKAS. 49
+AraRyaka		3	3〉 ŚĀṄKH. GṚHY. 6,1 . 2 . Ind. St. 3,276 . 392. fg. Verz. d. Oxf. H. 56,a,10 . 12 . 378 . 393,b, No. 91 . — Vgl	ŚĀṄKH. GṚHY. 6,1;ŚĀṄKH. GṚHY. 6, 2;Ind. St. 3,276;Ind. St. 3, 392. fg;Verz. d. Oxf. H. 56,a,10;Verz. d. Oxf. H. 56,a, 12;Verz. d. Oxf. H. 56,a, 378;Verz. d. Oxf. H 393,b, No. 91
+Arakza		1	1〉 adj. bewacht, beschützt, = ŚABDAR. zu bewachen, = VIŚVA _im_ ŚKDR	ŚABDAR;VIŚVA;ŚKDR
+Arakza		2	2〉 m. Schutz, Wache, = H. an. 3,729 . M. 2,204 . R. 5,75,2 . 10,22 . 2,88,19 . Auch f. ŚĀNTIŚ. 3,5 ; ( l. )	H. an. 3,729;M. 2,204;R. 5,75,2;R. 5, 10,22;R 2,88,19;ŚĀNTIŚ. 3,5
+Arakza		3	3〉 m. die Gegend, wo die beiden Erhöhungen auf der Stirn des Elephanten zusammenstossen ( ), TRIK. 2,8,37 . die Gegend unterhalb dieser beiden Erhöhungen ( ) H. 1226 . an. 3,729	TRIK. 2,8,37;H. 1226;H an. 3,729
+Arakza		2	2〉 (so die ed. Bomb. ) MBH. 5,5409	ed. Bomb;MBH. 5,5409
+AramBa		1	1〉 das in-Angriff-Nehmen, das an-Etwas-Gehen, die auf Etwas gerichtete Willensäusserung, Beginnen, Unternehmen: BHAG. 14,12 . 3,4 . PAÑCAT. III, 130 . 92,3 . M. 11,64 . Cit. bei MALLIN. _zu_ RAGH. 3,2	BHAG. 14,12;BHAG 3,4;PAÑCAT. III, 130;PAÑCAT. III, 92,3;M. 11,64;MALLIN;RAGH. 3,28;M. 2,71;HIT. Pr. 14;R. 5,77,9;R 3,51,25;P. 1,1,69;MEGH. 25;VIKR. 32,16;KĀTY. ŚR. 1,1,4;SUŚR. 1,147,9;KĀTY. ŚR 3,4;KĀTY. ŚR 8,1;KĀTY. ŚR 22,6,19;KĀTY. ŚR 1,4,1;KĀTY. ŚR 4,1,26;KĀTY. ŚR 24,7,28;M. 12,32;R. 4,30,15;PAÑCAT. 172,25;BHAG. 12,16;RAGH. 1,15;P. 1,3,68;KĀŚ;P 4,1,79;AK. 3,4,142;MBH. 15,812;CĀṆ. 67;M. 7,209;ADBH. BR;Ind. St. 1,40;MEGH. 55;MEGH 72
+AramBa		2	2〉 Anfang, Beginn: ŚAT. BR. 3,1,3,24 . 6,2,2,38 . 4,1,5 . 7,3,1,35 . 9,3,2,4 . KĀTY. ŚR. 1,4,4 . 4,5,22 . MEGH. 37 . AK. 3,4,32,6 . MADHUS. _in_ Ind. St. 1,23,13 . mit dem inf. Etwas beginnen PAÑCAT. 	ŚAT. BR. 3,1,3,24;ŚAT. BR 6,2,2,38;ŚAT. BR. 6, 4,1,5;ŚAT. BR 7,3,1,35;ŚAT. BR 9,3,2,4;KĀTY. ŚR. 1,4,4;KĀTY. ŚR 4,5,22;MEGH. 37;AK. 3,4,32,6;MADHUS;Ind. St. 1,23,13;PAÑCAT. 10,11;AK. 3,3,26;AK 2,7,12;TRIK. 3,2,18;H. 1510;TRIK. 3,2,30;AK;H. an. 3,451;MED. bh. 10;TRIK. 3,3,284;H. an;MED;TRIK;H. an. 3,450;MED;H. an;MED
+AramBa		2	2〉 MEGH. 85 . DAŚAK. _in_ BENF. Chr. 198,22 . Bez. des ersten Grades in den Mysterien der Śākta Verz. d. Oxf. H. 91,b,40 . in den Zuständen des Yoga ( ) 235,b,24 . 26 . in der Dramatik Bez. des ersten	MEGH. 85;DAŚAK;BENF. Chr. 198,22;Verz. d. Oxf. H. 91,b,40;Verz. d. Oxf. H 235,b,24;Verz. d. Oxf. H. 235,b, 26;SĀH. D. 324. fg
+AramBa		1	1〉 so v. a. der Bau eines Hauses Spr. (II) 2192 . (so v. a. ohne ein Haus zu bauen) KAP. 4,12	Spr. (II) 2192;KAP. 4,12
+AramBaRa		1	1〉 das Anfassen, Ergreifen, Gebrauchen: (? besondere Bezeichnung, ŚAṂK. : = ) CHĀND. UP. 6,1,4	ŚAṂK;CHĀND. UP. 6,1,4
+AramBaRa		2	2〉 Ort des Anfassens; Handhabe: ṚV. 10,81,2 . AIT. BR. 2,35 . KĀTY. ŚR. 14,1,13 . — Vgl	ṚV. 10,81,2;AIT. BR. 2,35;KĀTY. ŚR. 14,1,13
+AramaRa		1	1〉 Stillstand, Ruheplatz: TS. 6,5,11,4 . ŚAT. BR. 4,2,1,19	TS. 6,5,11,4;ŚAT. BR. 4,2,1,19
+AramaRa		2	2〉 das Sichvergnügen ŚAṂK. _zu_ BṚH. ĀR. UP. 4,3,14	ŚAṂK;BṚH. ĀR. UP. 4,3,14
+Arava		1	1〉 Geschrei, Geheul, Gekrächz P. 3,3,50 . AK. 1,1,6,2 . H. 1400 . R. 4,50,23 . 1,26,14 . VID. 51 . Vgl	P. 3,3,50;AK. 1,1,6,2;H. 1400;R. 4,50,23;R 1,26,14;VID. 51
+Arava		2	2〉 N. pr. eines Volkes VARĀH. BṚH. S. 14,16 _in_ Verz. d. B. H. 241	VARĀH. BṚH. S. 14,16;Verz. d. B. H. 241
+Arava		1	¦ Arabien Verz. d. Oxf. H. 339,a,3 . 33 . f. die arabische Sprache GAṆAPATIMUHŪRTA _im_ ŚKDR	Verz. d. Oxf. H. 339,a,3;Verz. d. Oxf. H. 339,a, 33;GAṆAPATIMUHŪRTA;ŚKDR
+Arava		1	1〉 füge Laut, Geräusch hinzu. KATHĀS. 20,226 . 70,69 . Spr. 2401 . PAÑCAT. 165,8 . — s. u	KATHĀS. 20,226;KATHĀS 70,69;Spr. 2401;PAÑCAT. 165,8
+Ardra		1	1〉 adj. f. kann mit zusammenges. werden gaṇa zu P. 1,4,74	P. 1,4,74
+Ardra		1a	a〉 feucht, nass ( Gegens. ) AK. 3,2,55 . TRIK. 3,1,8 . H. 1492 . MED. r. 7 . ṚV. 1,116,4 . 2,13,6 . TS. 6,2,11,2 . 4,1,5 . ŚAT. BR. 1,3,3,4 . 6,3,23 . 41 . 3,2,3,10 . 8,5,10 . u. s. w. 14,4,2,13 . M. 	AK. 3,2,55;TRIK. 3,1,8;H. 1492;MED. r. 7;ṚV. 1,116,4;ṚV 2,13,6;TS. 6,2,11,2;TS. 6, 4,1,5;ŚAT. BR. 1,3,3,4;ŚAT. BR. 1, 6,3,23;ŚAT. BR. 1,3,3, 41;ŚAT. BR 3,2,3,10;ŚAT. BR. 3, 8,5,10;ŚAT. BR 14,4,2,13;M. 4,76;P. 5,4,139;M. 6,23;YĀJÑ. 3,52;MBH. 14,53;SUŚR. 1,36,5;SUŚR. 1, 105,5;ŚĀK. 8,14;ŚĀK. 8, 69;VIŚV. 6,9;MEGH. 84;BHARTṚ. 1,38;BHARTṚ. 1, 26;MṚCCH. 143,25;KUMĀRAS. 7,14;R. 3,22,23;HIḌ. 4,55;ŚĀK. 31;MEGH. 44;HĀR. 196;PRAB. 80,1;R. 6,92,59
+Ardra		1b	b〉 frisch; von Pflanzen, Holz, Gliedern u. s. w. saftig, grün, lebendig: AV. 1,32,3 . ŚAT. BR. 1,3,4,1 . 9,2,2,3 . 7 . R. 4,9,94 . 2,84,17 . SUŚR. 1,118,18 . 217,9 . [Page1-0695] 218,4 . 2,36,20 . 276	AV. 1,32,3;ŚAT. BR. 1,3,4,1;ŚAT. BR 9,2,2,3;ŚAT. BR. 9,2,2, 7;R. 4,9,94;R 2,84,17;SUŚR. 1,118,18;SUŚR. 1, 217,9;SUŚR 218,4;SUŚR 2,36,20;SUŚR 276,21;ĀŚV. GṚHY. 1,11;M. 12,101;YĀJÑ. 3,38;MBH. 14,671;ŚAT. BR. 14,5,4,10;ŚAT. BR. 14, 7,3,11;BṚH. ĀR. UP. 2,4,10;BṚH. ĀR. UP 4,5,11;P. 4,2,90
+Ardra		1c	c〉 frisch, neu: AMAR. 2 . KATHĀS. 21,113 . ad MEGH. 112 . PRAB. 94,8 . 10	AMAR. 2;KATHĀS. 21,113;MEGH. 112;PRAB. 94,8;PRAB. 94, 10
+Ardra		1d	d〉 sanft, weich, gefühlvoll, warm: PAÑCAT. 101,24 . KATHĀS. 22,65 . MEGH. 91 . RĀJA-TAR. 5,194 . PAÑCAT. 8,19 . VIKR. 72 . KATHĀS. 9,63 . RAGH. 2,11 . VID. 124 . AMAR. 4 . ad MEGH. 18	PAÑCAT. 101,24;KATHĀS. 22,65;MEGH. 91;RĀJA-TAR. 5,194;PAÑCAT. 8,19;VIKR. 72;KATHĀS. 9,63;RAGH. 2,11;VID. 124;AMAR. 4;MEGH. 18
+Ardra		2	2〉 m.n. gaṇa zu P. 2,4,31 . Wohl gleichdeutend mit	P. 2,4,31
+Ardra		3	3〉 m. N. pr. ein Grossohn Pṛthus HARIV. 669. fg. VP. 361	HARIV. 669. fg;VP. 361
+Ardra		4	4〉 f. das vierte Nakṣatra AV. 19,7,2 . TS. 4,4,10,1 . TAITT. BR. 3,1,1,4 . das sechste H. 110 . COLEBR. Misc. Ess. II, 332 . VP. 226, N. 21 . MED. r. 7 . (Kürze!) VET. 16,19 . — Vgl. , wo als nom. abs	AV. 19,7,2;TS. 4,4,10,1;TAITT. BR. 3,1,1,4;H. 110;COLEBR. Misc. Ess. II, 332;VP. 226, N. 21;MED. r. 7;VET. 16,19
+Ardra		1	1〉	
+Ardra		1c	c〉 adv. : KATHĀS. 77,77	KATHĀS. 77,77
+Ardra		1d	d〉 Spr. 4746 . Vgl	Spr. 4746
+Ardra		2	2〉 m. pl. wohl frischer Ingwer HARIV. 8445 . Lies gleichbedeutend st. gleichdeutend	HARIV. 8445
+Ardra		4	4〉 WEBER, JYOT. 37. fg. 95 . Nax. 1,310 . 2,300 . 303 . 315 ( pl. ). 323 . 370 . MBH. 13,3259 . VARĀH. BṚH. S. 9,12 . 26 . 10,1 . 11,55 ( pl. )	WEBER, JYOT. 37. fg;WEBER, JYOT 95;Nax. 1,310;Nax 2,300;Nax. 2, 303;Nax. 2, 315;WEBER, Nax 323;WEBER, Nax 370;MBH. 13,3259;VARĀH. BṚH. S. 9,12;VARĀH. BṚH. S. 9, 26;VARĀH. BṚH. S 10,1;VARĀH. BṚH. S 11,55
+Ardra		1	¦ Feuchtigkeit, feuchte Masse: HARIV. 4083 ; vgl. KUMĀRAS. 7,23	HARIV. 4083;KUMĀRAS. 7,23
+Ardraka	2	1	1〉 adj. unter dem Sternbild Ārdrā geboren P. 4,3,28	P. 4,3,28
+Ardraka	2	2	2〉 m. N. pr. ein Sohn Vasumitra ʼs VP. 471	VP. 471
+ArjIkIya		1	1〉 m. dass. : ṚV. 8,53,11	ṚV. 8,53,11
+ArjIkIya		2	2〉 f. übertragen auf irdische Flüsse: ṚV. 10,75,5 . Nach NIR. 9,26 N. des Flusses Vipāś . Vgl. ROTH, Zur L. u. G. d. W. 137. fg	ṚV. 10,75,5;NIR. 9,26;ROTH, Zur L. u. G. d. W. 137. fg
+Arjava		1	1〉 n. gaṇa zu P. 5,1,122 . Geradheit, gerade Richtung: SĀH. D. 40,5 . Meist in übertr. Bed. gerades, redliches, offenes Benehmen CHĀND. UP. 3,17,4 . M. 11,222 . BHAG. 13,7 . MBH. 3,1119 . 14,296 . R. 	P. 5,1,122;SĀH. D. 40,5;CHĀND. UP. 3,17,4;M. 11,222;BHAG. 13,7;MBH. 3,1119;MBH 14,296;R. 2,52,16;R. 2, 113,16;R 3,58,42;R 4,51,28;HIT. II, 112
+Arjava		2	2〉 adj. (!) in [Page1-0692] der Bed. von KATHĀS. 22,115 :	KATHĀS. 22,115
+Arjava		3	3〉 m. N. pr. eines Lehrers VĀYU-P. _in_ VP. 278, N. 12	VĀYU-P;VP. 278, N. 12
+Arjava		1	1〉 gerades, offenes, rechtschaffenes Benehmen Spr. 5057 . gegen alle Geschöpfe 5194 . 1125 . Vgl	Spr. 5057;Spr 5194;Spr 1125
+Arjava		3	3〉 vgl. Verz. d. Oxf. H. 55,a,4	Verz. d. Oxf. H. 55,a,4
+Arka		1	1〉 zur Sonne in Beziehung stehend, solar: ein Sonnentag WEBER, JYOT. 41 . BHĀG. P. 11,22,31	WEBER, JYOT. 41;BHĀG. P. 11,22,31
+Arka		2	2〉 von der Calotropis gigantea kommend: VARĀH. BṚH. S. 50,25	VARĀH. BṚH. S. 50,25
+Arogya		1	¦ (von 2. ) n. Freisein von Krankheit, Gesundheit AK. 2,6,2,1 . TRIK. 3,3,322 . H. 474 . ŚVETĀŚV. UP. 2,13 . MBH. 3,13101 . 17359 . R. 1,15,13 . SUŚR. 2,163,5 . PRAB. 99,5 . M. 2,127 . R. 2,52,30 . 4,	AK. 2,6,2,1;TRIK. 3,3,322;H. 474;ŚVETĀŚV. UP. 2,13;MBH. 3,13101;MBH. 3, 17359;R. 1,15,13;SUŚR. 2,163,5;PRAB. 99,5;M. 2,127;R. 2,52,30;R 4,55,14;BHARTṚ. 3,34;ŚIV
+Arogya		1	1〉 n. MBH. 13,358 . (als Gruss) Spr. 698 . Verz. d. Oxf. H. 87,a,33 . 58,a,46 . 284,a,10 v. u. [Page5-1118]	MBH. 13,358;Spr. 698;Verz. d. Oxf. H. 87,a,33;Verz. d. Oxf. H 58,a,46;Verz. d. Oxf. H 284,a,10 v. u
+Arogya		2	2〉 f. N. der Dākṣāyaṇī in Vaidyanātha Verz. d. Oxf. H. 39,b,18 . v. l	Verz. d. Oxf. H. 39,b,18
+Aroha		1	1〉 (der Etwas besteigt) Reiter, ein zu Wagen fahrender Mann: HARIV. 13464 . R. 6,73,34 . gewöhnlich im comp. mit dem Vehikel: R. 3,57,23 . 5,83,2 . DRAUP. 8,7 . R. 6,19,10 . AK. 2,8,2,27 . DRAUP. 8,22	HARIV. 13464;R. 6,73,34;R. 3,57,23;R 5,83,2;DRAUP. 8,7;R. 6,19,10;AK. 2,8,2,27;DRAUP. 8,22;R. 3,4,110;VID. 25;AK. 2,8,2,28;H. an. 3,762;MED. h. 14
+Aroha		2	2〉 das Besteigen, Erklimmen H. an. 3,762 . MED. h. 14 . R. 2,1,20 . ŚĀK. 96,3 , v. l. des Scheiterhaufens KATHĀS. 25,142 . Vgl	H. an. 3,762;MED. h. 14;R. 2,1,20;ŚĀK. 96,3;KATHĀS. 25,142
+Aroha		3	3〉 das hochhinaus — Wollen: Uebermuth KATHĀS. 1,30	KATHĀS. 1,30
+Aroha		4	4〉 Erhöhung, Hebung, Höhe TRIK. 3,3,456 . H. 1431 . H. an. MED. AK. 2,4,1,10 . P. 3,3,87 , Sch. sich an einem Berge erhebend R. 5,73,6	TRIK. 3,3,456;H. 1431;H. an;MED;AK. 2,4,1,10;P. 3,3,87;R. 5,73,6
+Aroha		5	5〉 Haufen, Berg: R. 1,5,14	R. 1,5,14
+Aroha		6	6〉 die schwellenden Hüften oder nates eines Frauenzimmers AK. 3,4,240 . TRIK. H. 608 . H. an. MED. ϰαλλίπυγος N. 5,29 . 10,22 . VIŚV. 13,8 . R. 2,95,2 . BRAHMA-P. in LA. 50,18	AK. 3,4,240;TRIK;H. 608;H. an;MED;N. 5,29;N 10,22;VIŚV. 13,8;R. 2,95,2;BRAHMA-P. in LA. 50,18
+Aroha		7	7〉 Länge ( ) AK. 2,6,3,16 . TRIK. H. an. MED. VYUTP. 74	AK. 2,6,3,16;TRIK;H. an;MED;VYUTP. 74
+Aroha		8	8〉 ein bes. Maas H. an	H. an
+Aroha		9	9〉 das Herabsteigen ( ) MED	MED
+Aroha		1	1〉 so heisst auch eine Pflanze, die auf einer anderen wächst. KĀṬH. 26,3 . zu mir heraufgestiegen (bildlich) BHĀG. P. 11,14,44	KĀṬH. 26,3;BHĀG. P. 11,14,44
+Aroha		2	2〉 bildlich RĀJA-TAR. 5,310 . ein aufsteigendes Verhältniss, Aufschwung, Zunahme; = SĀH. D. 249,19	RĀJA-TAR. 5,310;SĀH. D. 249,19
+Aroha		6	6〉 BHĀG. P. 10,6,16 . so v. a. Schooss 7,18 . 8,44 . — Vgl	BHĀG. P. 10,6,16;BHĀG. P 7,18;BHĀG. P 8,44
+Aroha		1	1〉 Z. 5 lies AK. st. R	AK;R
+Aroha		2	2〉 das Aufsteigen in übertragener Bed. VĀMANA 3,1,12	VĀMANA 3,1,12
+ArohaRa		1	1〉 das Aufsteigen, Besteigen H. 1510 . an. 4,75 . MED. ṇ. 91 . AV. 5,30,7 . ŚAT. BR. 2,3,3,16 . KĀTY. ŚR. 2,3,15 . 29 . 18,3,5 . 25,6,9 . KUMĀRAS. 1,39 . MEGH. 61 . MBH. 1,372 . VIŚV. 10,26 . SUŚR. 1,	H. 1510;H an. 4,75;MED. ṇ. 91;AV. 5,30,7;ŚAT. BR. 2,3,3,16;KĀTY. ŚR. 2,3,15;KĀTY. ŚR. 2,3, 29;KĀTY. ŚR 18,3,5;KĀTY. ŚR 25,6,9;KUMĀRAS. 1,39;MEGH. 61;MBH. 1,372;VIŚV. 10,26;SUŚR. 1,98,10;R. 1,3,26;R. 1,3, 36;ŚĀK. 96,3;PAÑCAT. 203,1;MBH. 2,1281;R. 3,76,28
+ArohaRa		2	2〉 das Wachsen (der Pflanzen) H. an. 4,74 . MED. ṇ. 91	H. an. 4,74;MED. ṇ. 91
+ArohaRa		3	3〉 Gefährt, Wagen: TS. 5,6,21,1 . ŚAT. BR. 3,3,3,15 . 4,25 . KĀTY. ŚR. 22,2,27	TS. 5,6,21,1;ŚAT. BR. 3,3,3,15;ŚAT. BR. 3,3, 4,25;KĀTY. ŚR. 22,2,27
+ArohaRa		4	4〉 eine erhöhte Bühne zum Tanz: MBH. 14,282	MBH. 14,282
+ArohaRa		5	5〉 Treppe, Leiter AK. 2,2,17 . H. 1013 . H. an. MED. R. 5,14,14	AK. 2,2,17;H. 1013;H. an;MED;R. 5,14,14
+ArohaRa		1	1〉 VARĀH. BṚH. S. 93,6 . — Vgl	VARĀH. BṚH. S. 93,6
+Arohaka		1	1〉 Reiter: PAÑCAT. 129,18	PAÑCAT. 129,18
+Arohaka		2	2〉 Baum H. ś. 172	H. ś. 172
+Arohaka		3	3〉 Backe Ind. St. 5,370 . 374	Ind. St. 5,370;Ind. St. 5, 374
+Arohin		1	1〉 von mit , besteigend, erklimmend: PAÑCAT. III, 264	PAÑCAT. III, 264
+Arohin		2	2〉 von , = gaṇa zu P. 5,2,136	P. 5,2,136
+Arohin		1	1〉 lies ersteigen machend, hinaufführend und vgl. Spr. 2879	Spr. 2879
+Aropa		1	¦ (von im caus. mit ) m. das Aufladen, Aufbürden; Beziehen auf Etwas, Uebertragung: das Aufbürden [Page1-0690] von Fehlern, obgleich gute Eigenschaften da sind, AK. 1,1,7,24 . Sch. zu ŚĀK. 35 . VEDĀNT	AK. 1,1,7,24;ŚĀK. 35;VEDĀNTAS. 4,9;BĀLAB. 17;SĀH. D. 12,19;SĀH. D 13,2;SĀH. D. 13, 6;BALLANTYNE
+Aropa		1	1〉 Uebertragung KAP. 1,153 . SARVADARŚANAS. 151,9 . 167,1 . SĀH. D. 273 . 669 . 671 . Identificirung PRATĀPAR. 96,1 ; vgl	KAP. 1,153;SARVADARŚANAS. 151,9;SARVADARŚANAS 167,1;SĀH. D. 273;SĀH. D 669;SĀH. D 671;PRATĀPAR. 96,1
+Aropa		2	2〉 Verdeckung —, Verfinsterung eines Planeten durch einen andern VARĀH. BṚH. S. 9,19	VARĀH. BṚH. S. 9,19
+Aropa		3	3〉 Bez. einer der 10 Weisen, auf welche eine Eklipse erfolgt, VARĀH. BṚH. S. 5,43	VARĀH. BṚH. S. 5,43
+Aropa		2	2〉	
+Aropa		3	3〉 diese Bedd. u. zu stellen	
+Aropa		2	2〉	
+Aropa		3	3〉 an beiden Stellen wird gelesen	
+AropaRa		1	1〉 das Besteigenlassen: (einer Frau) KATHĀS. 17,84 . 20,17	KATHĀS. 17,84;KATHĀS 20,17
+AropaRa		2	2〉 das Auflegen: RAGH. 7,25 . KUMĀRAS. 7,88	RAGH. 7,25;KUMĀRAS. 7,88
+AropaRa		3	3〉 das Aufsteigenlassen, zum-Himmel-Befördern, den-Tod-Bringen: R. 5,15,46	R. 5,15,46
+AropaRa		5	5〉 das Spannen (des Bogens): R. 1,66,27 . 33,9	R. 1,66,27;R. 1, 33,9
+AropaRa		5	5〉 KATHĀS. 71,79	KATHĀS. 71,79
+AropaRa		6	6〉 das Aufstellen, Aufrichten KATHĀS. 61,35	KATHĀS. 61,35
+AropaRa		7	7〉 das Uebertragen SĀH. D. 114,8 . 671	SĀH. D. 114,8;SĀH. D. 114, 671
+AropaRa		8	8〉 =	
+AropaRa		3	3〉 VARĀH. BṚH. S. 5,49	VARĀH. BṚH. S. 5,49
+AropaRa		8	8〉 diese Bed. u. zu stellen	
+AropaRa		5	5〉 richtiger das Beziehen des Bogens mit der Sehne; vgl. 1. mit caus	
+AropaRa		3	3〉	
+AropaRa		8	8〉 zu streichen, da der Text in dieser Bed. hat	
+Artava		1	1〉 adj	
+Artava		1a	a〉 zu den Jahreszeiten, Zeitabschnitten gehörig, ihnen angemessen P. 5,1,105 . H. an. 3,694 . MED. v. 32 . R. 2,30,16 . 3,35,9 . KUMĀRAS. 4,18 . f. VIKR. 13 . RAGH. 8,36 . KATHĀS. 25,169 . ( s. auch d	P. 5,1,105;H. an. 3,694;MED. v. 32;R. 2,30,16;R 3,35,9;KUMĀRAS. 4,18;VIKR. 13;RAGH. 8,36;KATHĀS. 25,169;P. 6,2,9
+Artava		1b	b〉 zur Periode der Weiber gehörig: SUŚR. 1,43,18	SUŚR. 1,43,18
+Artava		2	2〉 m. Jahresabschnit, eine Zusammenfassung mehrerer Jahreszeiten AV. 3,10,9 . 10 . 5,28,2 . 13 . 10,6,18 . 7,5 . 11,3,17 . 6,17 . 7,20 . 15,6,6 . 17,6 . 16,8,18 . TS. 7,2,6,1 . 3 . VS. 22,28 . KAUṢ. U	AV. 3,10,9;AV. 3,10, 10;AV 5,28,2;AV. 5,28, 13;AV 10,6,18;AV. 10, 7,5;AV 11,3,17;AV. 11, 6,17;AV 7,20;AV 15,6,6;AV 17,6;AV 16,8,18;TS. 7,2,6,1;TS. 7,2,6, 3;VS. 22,28;KAUṢ. UP;Ind. St. 1,402
+Artava		3	3〉 f. Stute RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+Artava		4	4〉 n	
+Artava		4a	a〉 die monatliche Reinigung AK. 2,6,1,21 . TRIK. 3,3,411 . H. 536 . an. 3,695 . MED. v. 32 . ŚAT. BR. 14,9,4,12 = BṚH. ĀR. UP. 6,4,13 . SUŚR. 1,44,8 . 18 . 49,12 . M. 4,40 . ( ) 3,48 . MBH. 1,2384 . A	AK. 2,6,1,21;TRIK. 3,3,411;H. 536;H an. 3,695;MED. v. 32;ŚAT. BR. 14,9,4,12;BṚH. ĀR. UP. 6,4,13;SUŚR. 1,44,8;SUŚR. 1,44, 18;SUŚR. 1, 49,12;M. 4,40;M 3,48;MBH. 1,2384;M. 3,46. fgg;SUŚR. 1,48,14;SUŚR. 2,257,8;SUŚR. 2,257, 16
+Artava		4b	b〉 Blume TRIK. 3,3,411 . H. an. 3,695 . MED. v. 32	TRIK. 3,3,411;H. an. 3,695;MED. v. 32
+Artimant		1	1〉 adj. leidend: SUŚR. 1,120,1	SUŚR. 1,120,1
+Artimant		2	2〉 N. pr. einer Schlange MBH. 1,2188	MBH. 1,2188
+Aru		1	1〉 m	
+Aru		1a	a〉 Eber	
+Aru		1b	b〉 Krebs	
+Aru		1c	c〉 N. einer Baumes ( Lagerstroemia regina Roxb. nach WILS. ) MED. r. 8	WILS;MED. r. 8
+Aru		2	2〉 f. Wasserkrug ( s. ) Sch. zu AK. 2,9,31	AK. 2,9,31
+AruRi		1	1〉 des Uddālaka , eines vielgenannten Brāhmaṇa -Lehrers, eines Sohnes des Aruṇa Aupaveśi und Vaters des Śvetaketu , ŚAT. BR. 1,1,2,11 . 2,3,1,31 . 34 . 3,3,4,19 . 4,5,7,9 . 5,5,5,14 . 11,2,6,12 . 4,1,	ŚAT. BR. 1,1,2,11;ŚAT. BR 2,3,1,31;ŚAT. BR. 2,3,1, 34;ŚAT. BR 3,3,4,19;ŚAT. BR 4,5,7,9;ŚAT. BR 5,5,5,14;ŚAT. BR 11,2,6,12;ŚAT. BR. 11, 4,1,1;ŚAT. BR. 11, 5,3,1;ŚAT. BR 12,2,2,13;AIT. BR. 8,7;BṚH. ĀR. UP. 3,7,1;MBH. 1,684. fgg;MBH. 1, 695
+AruRi		2	2〉 des Auddālaki ( ŚAṂK. : = ), d. i. Śvetaketu ʼs KAṬHOP. 1,11 . Vgl	ŚAṂK;KAṬHOP. 1,11
+AruRi		3	3〉 des Suparṇeya , eines Sohnes Pragāpati ʼs, TAITT. ĀR. 10,79	TAITT. ĀR. 10,79
+AruRi		4	4〉 des Vainateya , eines Sohnes der Vinatā , MBH. 1,2548 . 2160 . HARIV. 12469 . 14175	MBH. 1,2548;MBH. 1, 2160;HARIV. 12469;HARIV 14175
+AruRi		1	¦ pl. BHĀG. P. 10,87,18 . — Vgl	BHĀG. P. 10,87,18
+Aruh		1	1〉 adj. besteigend, s	
+Aruh		2	2〉 f. Auswuchs, Schössling: AV. 13,1,9	AV. 13,1,9
+Aruha		1	1〉 adj. aufspringend, besteigend: R. 5,12,31	R. 5,12,31
+Aruha		2	2〉 m. Besteigung, s	
+Aruha		2	2〉 lies st	
+Aruja		1	1〉 adj. zerbrechend: ṚV. 8,45,13	ṚV. 8,45,13
+Aruja		2	2〉 N. pr. eines Rakṣas im Gefolge des Rāvaṇa MBH. 3,16365	MBH. 3,16365
+Aruja		1	1〉 ṚV. 3,45,2 . MBH. 13,1978 . HARIV. 6881	ṚV. 3,45,2;MBH. 13,1978;HARIV. 6881
+Arya		1	1〉 m. f. der zu den Treuen, Ergebenen Gehörige, d. h. der Mann des eigenen Stammes; zuweilen auch wohl gedacht als der den Volksgöttern des Stammes Treue; N. , mit welchem die indischen wie die iranis	ṚV. 1,51,8;ṚV 130,8;ṚV 156,5;ṚV 4,26,2;ṚV 8,24,27;ṚV 10,83,1;ṚV 1,59,2;ṚV. 1, 117,21;ṚV 2,11,18;ṚV. 2,11, 19;ṚV 6,18,3;ṚV 7,5,6;ṚV 8,92,1;ṚV 10,138,3;VĀLAKH. 3,9;AV. 4,20,4;AV. 4,20, 8;AV 19,32,8;AV. 19, 62,1;VS. 14,30;NIR. 2,2;AIT. BR. 8,25;KĀTY. ŚR. 13,3,7;KĀTY. ŚR. 13,3, 8;KĀTY. ŚR 4,14,1;M. 10,45;M. 10, 57;M. 10, 67;M. 10, 73;M 7,69;YĀJÑ. 2,294;MBH. 14,2137;AK. 1,1,7,14;H. 333;H 379;H an. 2,345;R. 3,24,9;M. 8,75;M. 8, 179;M. 8, 395;PAÑCAT. I, 86;N. 12,16;HIḌ. 4,30;BRĀHMAṆ. 2,28;ŚĀK. 3,6;ŚĀK. 3, 11;ŚĀK. 3, 15;ŚĀK 4,11;ŚĀK. 4, 16;BHARATA;ŚĀK. 1;HIT. 8,19;HIT 45,1;HIT 18,16;PAÑCAT. 32,8
+Arya		1a	a〉 der Gebieter H. 359 (nach ŚKDR. ; vgl. 1	H. 359;ŚKDR
+Arya		2		
+Arya		2b	b〉 der Freund AJAYAP. _im_ ŚKDR	AJAYAP;ŚKDR
+Arya		2c	c〉 der Vaiśya H. 864 ( vgl. 2. )	H. 864
+Arya		2d	d〉 Buddha H. 232	H. 232
+Arya		2e	e〉 buddh. ein Mann, der über die vier Grundwahrheiten nachgedacht hat und sein Betragen darnach richtet ( Gegens. ), BURN. Intr. 290. fg	BURN. Intr. 290. fg
+Arya		2f	f〉 ein Sohn des Manu Sāvarṇa HARIV. 465	HARIV. 465
+Arya		2	2〉 adj. f. und ( ved. ) arisch: die arischen Gemeinen, Stämme ṚV. 1,77,3 . 96,31 . 103,3 . 3,34,9 . 10,49,3 . 9,63,5 . 14 . arische Herrschaft auf Erden verbreitend 10,65,11 . 11,4 . 43,4 . [Page1-069	ṚV. 1,77,3;ṚV. 1, 96,31;ṚV. 1, 103,3;ṚV 3,34,9;ṚV 10,49,3;ṚV 9,63,5;ṚV. 9,63, 14;ṚV 10,65,11;ṚV 11,4;ṚV 43,4;ṚV. 6,60,6;ṚV 6,33,3;ṚV 7,83,1;ṚV 10,69,6;M. 2,207;R. 3,2,13;R 5,36,66;R 2,115,6;R 6,16,72;SĀṂKHYAK. 71;R. 3,2,23;ŚĀK. 21;ŚĀK. 80,23;AK. 2,7,2;ŚABDAR;ŚKDR;AJAYA;ŚKDR
+Arya		3	3〉 f	
+Arya		3a	a〉 f. zu 1; s. daselbst	
+Arya		3b	b〉 ein Bein. der Pārvatī TRIK. 1,1,51 . H. 203 . an. 2,346 . HARIV. 3270	TRIK. 1,1,51;H. 203;H an. 2,346;HARIV. 3270
+Arya		3c	c〉 ein bes. Metrum (aus 12 + 18 und 12 + 17 Moren bestehend) H. an. 2,346 . ŚRUT. 4 . COLEBR. Misc. Ess. II, 72 . 153 . SĀṂKHYAK. 71 . HORĀŚ. _in_ Ind. St. 2,277 . — Vgl	H. an. 2,346;ŚRUT. 4;COLEBR. Misc. Ess. II, 72;COLEBR. Misc. Ess. II, 153;SĀṂKHYAK. 71;HORĀŚ;Ind. St. 2,277
+Arya		1	1〉 Z. 12. fg. streiche die Stelle aus AIT. BR. und vgl	AIT. BR
+Arya		1a	a〉 entspricht häufig unserm Herr, so z. B. VARĀH. BṚH. S. 51,23	VARĀH. BṚH. S. 51,23
+Arya		1c	c〉 HALĀY. 2,415	HALĀY. 2,415
+Arya		1f	f〉 N. pr. eines Mannes Verz. d. Oxf. H. 371,b, No. 248	Verz. d. Oxf. H. 371,b, No. 248
+Arya		1g	g〉 ein Wächter im Gynaeceum HALĀY. 5,28	HALĀY. 5,28
+Arya		3	3〉	
+Arya		3c	c〉 eine Āryā -Strophe: KATHĀS. 52,158 . 53,31 . 56,358	KATHĀS. 52,158;KATHĀS 53,31;KATHĀS 56,358
+Arya		3d	d〉 Titel zweier im Āryā -Metrum verfasster Schriftchen HALL 146 . 151	HALL 146;HALL 151
+Aryaka		1	1〉 m	
+Aryaka		1a	a〉 ein ehrenwerther, ehrwürdiger Mann R. 5,61,15	R. 5,61,15
+Aryaka		1b	b〉 Grossvater ŚABDAM. _im_ ŚKDR. MBH. 1,5026 . R. 2,72,5 . 6 . 4,57,6	ŚABDAM;ŚKDR;MBH. 1,5026;R. 2,72,5;R. 2,72, 6;R 4,57,6
+Aryaka		1c	c〉 N. pr. der Sohn eines Kuhhirten, der zuletzt König wurde, MṚCCH. 35,22 . 107,17	MṚCCH. 35,22;MṚCCH 107,17
+Aryaka		1d	d〉 N. pr. eines Nāga MBH. 1,1552 . 5,3639. fgg	MBH. 1,1552;MBH 5,3639. fgg
+Aryaka		2	2〉 f	
+Aryaka		2a	a〉 oder VOP. 4,7 . eine ehrenwerthe, ehrwürdige Frau ŚKDR	VOP. 4,7;ŚKDR
+Aryaka		2b	b〉 ein bes. Nakṣatra ŚĀNT. 1,21	ŚĀNT. 1,21
+Aryaka		3	3〉 n. eine den Manen geltende Ceremonie ( ) TRIK. 2,7,7	TRIK. 2,7,7
+Aryaka		1	1〉	
+Aryaka		1a	a〉 voc. pl. BHĀG. P. 11,6,35	BHĀG. P. 11,6,35
+Aryaka		1e	e〉 N. pr. eines Volkes im südlichen Indien VARĀH. BṚH. S. 14,15	VARĀH. BṚH. S. 14,15
+Aryaka		2	2〉	
+Aryaka		2b	b〉 = Schol. zu ŚĀNT. 1,21	ŚĀNT. 1,21
+AryamiSra		1	¦ ( + ) m. pl. eine Versammlung achtbarer Männer TRIK. 3,1,24 . als Anrede: R. 2,82,18 . MṚCCH. 1,10 . von einer Person als Ausdruck grosser Hochachtung: PRAB. 25,2	TRIK. 3,1,24;R. 2,82,18;MṚCCH. 1,10;PRAB. 25,2
+AryamiSra		1	1〉	
+AryamiSra		1b	b〉	
+AryasaMGa		1	1〉 Gesammtheit der Priesterschaft, Geistlichkeit (auch ) VYUTP. 123	VYUTP. 123
+AryasaMGa		2	2〉 N. pr. eines berühmten Philosophen, Stifters der Schule der Yogācāra , BURN. Intr. 450 . 540 . LIA. II, 460 . Er wird auch und genannt; vgl. Mél. asiat. II, 172	BURN. Intr. 450;BURN. Intr 540;LIA. II, 460;Mél. asiat. II, 172
+Arza		1	1〉 adj. f. von den Ṛṣi ( d. h. den Liedverfassern des Veda oder andern alten Weisen) herrührend, sie betreffend, archaistisch: M. 3,21 (= MBH. 1,2962 ). YĀJÑ. 1,59 . M. 3,29 . MBH. 3,8525 . R. 2,28,16	M. 3,21;MBH. 1,2962;YĀJÑ. 1,59;M. 3,29;MBH. 3,8525;R. 2,28,16;R 6,102,34;Ind. St. 1,68;Ind. St 2,19;P. 2,4,58;NĪLAK;N. 7,3;ṚV. PRĀT. 2,27;ṚV. PRĀT. 2, 28;ṚV. PRĀT 11,10;ṚV. PRĀT. 11, 29
+Arza		2	2〉 m. (mit Ergänz. von oder ) die von den Ṛṣi eingesetzte Heirathsweise (wobei nach M. 3,29 der Vater der Braut vom Bräutigam einen Stier und eine Kuh oder auch zwei von jedem empfängt) M. 3,53 . 9,19	M. 3,29;M. 3,53;M 9,196;M 3,38
+Arza		3	3〉 n	
+Arza		3a	a〉 die Rede eines Ṛṣi , der Liedestext, Veda NIR. 6,27 . 13,9 . ṚV. PRĀT. 11,28 . 29 . M. 12,106 . MBH. 3,1167	NIR. 6,27;NIR 13,9;ṚV. PRĀT. 11,28;ṚV. PRĀT. 11, 29;M. 12,106;MBH. 3,1167
+Arza		3b	b〉 heilige Abstammung: Sch. zu LĀṬY. _in_ Ind. St. 1,51 . YĀJÑ. 1,53 . ST. : die entsprossen ist von einem Manne, der nicht gleichen Namen und gleiche Familie hat	LĀṬY;Ind. St. 1,51;YĀJÑ. 1,53;ST
+Arza		3c	c〉 der Ṛṣi — Ursprung (eines Liedes), Autorschaft Verz. d. B. H. No. 142 . — Vgl. und	Verz. d. B. H. No. 142
+Arza		1	1〉 SĀH. D. 560	SĀH. D. 560
+Arza		2	2〉 ĀŚV. GṚHY. 1,6,4	ĀŚV. GṚHY. 1,6,4
+ArzaBa		1	¦ (von ) adj. vom Stier herrührend ŚAT. BR. 14,9,4,17 (= BṚH. ĀR. UP. 6,4,18 .) M. 9,50 . N. einer bestimmten Strecke der Mondbahn VP. 226, N. 21	ŚAT. BR. 14,9,4,17;BṚH. ĀR. UP. 6,4,18;M. 9,50;VP. 226, N. 21
+ArzaBa		1	1〉 adj. MBH. 6,2261 ( ed. Calc. )	MBH. 6,2261;ed. Calc
+ArzaBa		2	2〉 m. patron. von Ṛṣabha BHĀG. P. 5,14,41 . 11,2,14	BHĀG. P. 5,14,41;BHĀG. P 11,2,14
+ArzaBa		3	3〉 n	
+ArzaBa		3a	a〉 N. eines Sāman Ind. St. 3,206,a	Ind. St. 3,206,a
+ArzaBa		3b	b〉 ein best. Metrum Ind. St. 8,357	Ind. St. 8,357
+Arzeya		1	1〉 adj. von den Ṛṣi stammend, aus altheiligem Geschlecht: ( , imperat. von 1. ) ṚV. 9,97,51 . VS. 7,46 . 21,61 . AV. 11,1,25 . 16 . 26 . 33 . 35 . 12,4,2 . 12 . 16,8,10 . TS. 3,4,8,7 . ŚAT. BR. 1,4,2,	ṚV. 9,97,51;VS. 7,46;VS 21,61;AV. 11,1,25;AV. 11,1, 16;AV. 11,1, 26;AV. 11,1, 33;AV. 11,1, 35;AV 12,4,2;AV. 12,4, 12;AV 16,8,10;TS. 3,4,8,7;ŚAT. BR. 1,4,2,3;ŚAT. BR. 1,4, 5,19;ŚAT. BR 12,4,4,7;KĀTY. ŚR. 25,3,17;KAUŚ. 55;KAUŚ 63;KAUŚ 67;CHĀND. UP. 1,3,9;WEBER, Lit. 72;WEBER, Lit 73. fg;Ind. St. 1,42;Ind. St. 1, 45;Ind. St. 1, 49;Ind. St. 1, 54
+Arzeya		2	2〉 n. heilige Abstammung: AIT. BR. 7,26 . KĀTY. ŚR. 3,2,7 — 10 . ŚAT. BR. 1,4,2,5 . 6,2,3,10 . ĀŚV. ŚR. 4,1	AIT. BR. 7,26;KĀTY. ŚR. 3,2,7;KĀTY. ŚR. 3,2, 10;ŚAT. BR. 1,4,2,5;ŚAT. BR 6,2,3,10;ĀŚV. ŚR. 4,1
+Arzeya		1	1〉 wenn es nicht ein Ṛṣi -Name ist VS. PRĀT. 4,157 . und Namen von Sāman Ind. St. 3,206,a	VS. PRĀT. 4,157;Ind. St. 3,206,a
+Arzeya		2	2〉 Z. 2 lies 7,25 st. 7,26	
+As	2	1	1〉 sitzen, sich setzen DHĀTUP. 24,11 . ṚV. 7,55,6 . 32,2 . AV. 18,3,70 . 10,10,12 . AIT. BR. 7,27 . ŚAT. BR. 2,3,2,4 . 5 . 9,1,2,14 . 4,6,6,1—5 . BṚH. ĀR. UP. 2,4,4 . M. 2,203 . 204 . MBH. 3,10036 . R	DHĀTUP. 24,11;ṚV. 7,55,6;ṚV. 7, 32,2;AV. 18,3,70;AV 10,10,12;AIT. BR. 7,27;ŚAT. BR. 2,3,2,4;ŚAT. BR. 2,3,2, 5;ŚAT. BR 9,1,2,14;ŚAT. BR 4,6,6,1—5;BṚH. ĀR. UP. 2,4,4;M. 2,203;M. 2, 204;MBH. 3,10036;R. 1,50,10;ŚĀK. 101,10;R. 2,30,14;R 3,49,9;H. 492;M. 1,1;M 2,195;M. 2, 196;M 3,3;M. 3, 189;M. 3, 219;M 4,43;M 6,49;M 7,91;M 8,2;M. 8, 10;M 11,111;MBH. 1,2215;MBH. 1, 3287;SUND. 3,3;R. 1,4,13;R. 1, 31,31;HIT. 29,12;M. 2,193;N. 12,49;VIKR. 27,16;R. 4,10,7;R 1,72,15;MEGH. 53;KATHĀS. 26,265
+As	2	2	2〉 sich aufhalten, wohnen, seinen Wohnsitz aufschlagen: ṚV. 1,20,6 . 9,15,2 . 10,17,4 . 2,41,5 . 10,107,10 . VS. 17,75 . AV. 11,8,10 . 32 . 4,34,4 . 18,2,48 . CHĀND. UP. 4,2,4 . MBH. 3,12723 . (!) 129	ṚV. 1,20,6;ṚV 9,15,2;ṚV 10,17,4;ṚV 2,41,5;ṚV 10,107,10;VS. 17,75;AV. 11,8,10;AV. 11,8, 32;AV 4,34,4;AV 18,2,48;CHĀND. UP. 4,2,4;MBH. 3,12723;MBH. 3, 12991;MBH 1,674;MBH 2,104;MBH 5,256;MBH 3,14465;KATHĀS. 25,68;VID. 290;BRAHMA-P. 52,2;BHAṬṬ. 4,6;BHAṬṬ 8,79;VOP. 5,7;P. 1,4,51, Vārtt. 2;CĀT. 1;ṚV. 9,113,11;ṚV 6,51,12;AV. 18,4,40
+As	2	3	3〉 sitzen bleiben, stillsitzen, verweilen, verbleiben, aushalten, verharren; sowohl mit dem Begriff der Unthätigkeit als mit dem der Ausdauer oder der ruhigen Würde: ṚV. 1,48,6 . 2,43,3 . AV. 1,14,1 .	ṚV. 1,48,6;ṚV 2,43,3;AV. 1,14,1;AIT. BR. 7,15;ŚAT. BR. 9,3,1,15;R. 3,9,32;BRAHMA-P. 56,8;M. 3,141;ŚAT. BR. 14,6,10,1;BṚH. ĀR. UP. 4,1,1;M. 7,172;ṚV. 6,10,6;ṚV. 6, 47,9;ṚV 9,10,7;ŚAT. BR. 4,6,4,4;ŚAT. BR. 4,6, 8,19;ŚAT. BR 14,1,1,3;TS. 7,2,6,2;TS. 7,1,4,1;AIT. BR. 2,19;ŚAT. BR. 4,5,1,12;ŚAT. BR. 4,5, 9,1;ŚAT. BR 5,5,5,13;ŚAT. BR 11,5,5,1;N. 7,3
+As	2	4	4〉 einer Handlung fortwährend obliegen, in einem Zustande oder Verhältnisse verharren, sich längere Zeit hindurch darin befinden, anhalten, dauern; die Ergänzung ist mannigf. Art:	
+As	2	4a	a〉 ein mit dem praed. congruirendes partic. , adj. oder subst. : ṚV. 10,65,7 . 71,11 . 2,13,4 . ŚAT. BR. 1,8,3,6 . TAITT. UP. 3,10,5 . BHAG. 3,6 . PAÑCAT. 9,8 . 31,4 . HIT. 47,14 . 67,18 . 87,15 . 129	ṚV. 10,65,7;ṚV. 10, 71,11;ṚV 2,13,4;ŚAT. BR. 1,8,3,6;TAITT. UP. 3,10,5;BHAG. 3,6;PAÑCAT. 9,8;PAÑCAT 31,4;HIT. 47,14;HIT 67,18;HIT 87,15;HIT 129,15;DHŪRTAS. 81,6;PAÑCAT. 36,20;PAÑCAT 226,22;PAÑCAT 89,10;PAÑCAT 237,1;HIT. 91,1;ŚĀK. 100,21;VET. 4,11;RĀJA-TAR. 5,99;RĀJA-TAR. 5, 480;M. 5,158;M 11,255;N. 17,37;BHAG. 2,61;N. 16,26;MBH. 1,674;VIKR. 86,14;RĀJA-TAR. 5,3
+As	2	4b	b〉 ein gerund. auf ( ) oder er halte den Feind eingeschlossen M. 7,195 . hängt der Leichnam schon da VET. 5,11 . verhielten sich aus Furcht ganz still BHAṬṬ. 5,95 . er ist mit dem Melken der Kühe besc	M. 7,195;VET. 5,11;BHAṬṬ. 5,95;P. 1,4,51, Vārtt. 1;R. 4,57,23;R. 4, 56,24;R. 4,56,20
+As	2	4c	so können und auch als wirkliche acc. aufgefasst werden	
+As	2	4c	c〉 ein adv. : (er verhält sich ganz ruhig) MBH. 3,1248 . PAÑCAT. 21,10 . HIT. 57,17 . (gehabe dich wohl) R. 2,16,19 . VIKR. 65,17 . wer befindet sich wohl? BHARTṚ. 2,49 . ŚĀK. 66,16 . (in diesen Verhä	MBH. 3,1248;PAÑCAT. 21,10;HIT. 57,17;R. 2,16,19;VIKR. 65,17;BHARTṚ. 2,49;ŚĀK. 66,16;R. 5,57,15;BHAG. 2,54
+As	2	4d	d〉 ein instr. : befindet sich ganz wohl PAÑCAT. 107,2 . bei dem man sich ruhiges Herzens fühlt, wenn man ihm [Page1-0731] ein Geschäft übertragen hat, I, 106	PAÑCAT. 107,2;PAÑCAT I, 106
+As	2	4e	e〉 ein dat. : möge die gute Führung redlicher Leute wie eine Neuvermählte euerm Herzen zur Freude gereichen und zwar dauernd HIT. I, 207	HIT. I, 207
+As	2	5	5〉 sich legen, ein Ende nehmen: PAÑCAT. 106,19 . (es ist Zeit ein Ende zu machen mit der Aufzählung der Untugenden der Weiber) IV, 61 . AMAR. 97 . DAŚAK. 185, ult. genug! nicht so! nicht so! HIT. 122,	PAÑCAT. 106,19;PAÑCAT IV, 61;AMAR. 97;DAŚAK. 185, ult;HIT. 122,19;HIT 127,15
+As	2	6	6〉 die Form ṚV. 1,109,7 : ist eine unregelm. Schreibung und zu 1. zu ziehen; man vgl. oben u. 4,b und den Wechsel zwischen Formen von und in SV. II, 3,1,7,2 . 4,2,1,10 . 5,2,3,2 und die entsprechenden	ṚV. 1,109,7;SV. II, 3,1,7,2;SV. II, 4,2,1,10;SV. II, 5,2,3,2;ṚV
+As	2	1	1〉 adj	
+As	2	1a	a〉 der gesessen oder gewohnt hat: P. 3,4,76 , Sch	P. 3,4,76
+As	2	1b	b〉 gesessen oder gewohnt worden: ebend	ebend
+As	2	1c	c〉 dem man obliegt: R. 2,71,35 . 1,3,4	R. 2,71,35;R 1,3,4
+As	2	2	2〉 n	
+As	2	2a	a〉 das Sitzen, Sichsetzen: SĀH. D. 68,18 . schlechte, unschickliche Art zu sitzen MBH. 3,14669	SĀH. D. 68,18;MBH. 3,14669
+As	2	2b	b〉 der Ort, an dem man gesessen oder gewohnt hat: Sch. zu P. 3,4,76 . 2,2,13 . 3,68 . VOP. 5,27 . 26,130 . R. 2,58,10 . — caus. sitzen heissen: P. 1,3,88 , Sch. — desid. P. 1,3,62 , Sch. — mit dem acc	P. 3,4,76;P 2,2,13;P. 2, 3,68;VOP. 5,27;VOP 26,130;R. 2,58,10;P. 1,3,88;P. 1,3,62;P. 1,4,46;VOP. 5,2
+As	2	1	1〉 einen Sitz ( acc. ) einnehmen, auf Etwas liegen oder sich legen (von Thieren): R. 2,81,11 . MBH. 1,858 . MṚCCH. 115,21 . ŚĀK. 81,1 . RAGH. 4,74 . 12,85 . 6,10 . BHAṬṬ. 15,97 . VIKR. 59,2 . MEGH. 77	R. 2,81,11;MBH. 1,858;MṚCCH. 115,21;ŚĀK. 81,1;RAGH. 4,74;RAGH 12,85;RAGH 6,10;BHAṬṬ. 15,97;VIKR. 59,2;MEGH. 77;R. 2,93,17;RAGH. 2,17;R. 5,57,6
+As	2	2	2〉 seinen Aufenthalt irgendwo haben oder nehmen, bewohnen, seinen Sitz haben (auch vom Herrscher) oder aufschlagen, (eine Wohnung) beziehen: ṚV. 10,94,9 . MBH. 1,854 . R. 2,99,11 . ŚĀK. 80,22 . KATHĀS	ṚV. 10,94,9;MBH. 1,854;R. 2,99,11;ŚĀK. 80,22;KATHĀS. 6,108;R. 6,2,34;BHARTṚ. 1,67;R. 3,36,14;R. 3, 54,5;R 4,9,53;R. 4, 58,23;BHAṬṬ. 1,5;M. 7,77;RAGH. 1,95;RAGH. 15,93;MBH. 3,11856
+As	2	3	3〉 auf oder in Etwas ( acc. ) treten, betreten, antreten (einen Weg, eine Stellung, Beruf, Amt): in die Schuhe fahrend KATHĀS. 3,52 . MBH. 3,13330 . 16908 . (Lebensstadium) VIKR. 82,21 . MĀLAV. 13,14 	KATHĀS. 3,52;MBH. 3,13330;MBH. 3, 16908;VIKR. 82,21;MĀLAV. 13,14
+As	2	4	4〉 auf Etwas oder Jmd ruhen, lasten, vom Auge, einer Bewegung der Hand, u. s. w. : RAGH. 2,52 . MBH. 3,14669 . um die ein Streit obwaltet DHŪRTAS. 92,2	RAGH. 2,52;MBH. 3,14669;DHŪRTAS. 92,2
+As	2	5	5〉 in einem ehelichen Verhältnisse mit Jmd leben: MBH. 1,7265	MBH. 1,7265
+As	2	6	6〉 über Etwas gestellt sein, herrschen: ṚV. 1,25,9 . — caus. einen Sitz einnehmen lassen: BHAṬṬ. 2,46 . — desid. hinaufzusteigen im Begriff sein: BHAṬṬ. 8,38	ṚV. 1,25,9;BHAṬṬ. 2,46;BHAṬṬ. 8,38
+As	2	1	1〉 einen Sitz ( acc. ) mit einem Andern zugleich einnehmen: RAGH. 13,52	RAGH. 13,52
+As	2	2	2〉 bewohmen: R. 6,4,52 . — desid. einen Platz einnehmen wollen: ( d. i. ) BHAṬṬ. 14,16	R. 6,4,52;BHAṬṬ. 14,16
+As	2	1	1〉 dabeisitzen, umsitzen, mit dem acc. : ŚAT. BR. 1,3,1,12 . 17 . MBH. 2,405 . 15,575 . 3,3071 . ŚĀK. 33,3 . MBH. 3,243 . R. 5,45,12 . RAGH. 1,56 . med. mit pass. Bedeutung: MBH. 3,7040 . RAGH. ed. Ca	ŚAT. BR. 1,3,1,12;ŚAT. BR 17;MBH. 2,405;MBH 15,575;MBH 3,3071;ŚĀK. 33,3;MBH. 3,243;R. 5,45,12;RAGH. 1,56;MBH. 3,7040;RAGH. ed. Calc. 1,57
+As	2	2	2〉 sich setzen, sobald sich ein Anderer gesetzt hat; mit dem acc. der Person, der man es nachthut: RAGH. 2,24	RAGH. 2,24
+As	2	3	3〉 mit einer religiösen Handlung ( acc. ) beschäftigt sein, eine Andacht verrichten: (sic! v. l. ) MBH. 3,2256 . R. 2,50,34 . 53,1 . — Vgl. . — sich auf Etwas ( acc. ) setzen: ṚV. 7,2,11 . — (abgesond	MBH. 3,2256;R. 2,50,34;R. 2, 53,1;ṚV. 7,2,11;SĀH. D. 44,2;ŚIŚUP. 2,42;MBH. 1,6026;R. 2,33,3;BHAG. 9,9;KUMĀRAS. 2,13;SĀṂKHYAK. 20;VID. 63;M. 7,158;YĀJÑ. 1,344;AK. 2,8,1,10;H. 732;AK. 2,8,1, 155;AK. 2,8,1, 177;AK. 2,8,1, 180;AK. 2,8,1, 211;BHAG. 6,9;MBH. 3,1035;MBH. 3, 1041;MBH 15,214;R. 2,59,17;Ind. St. 2,286;PAÑCAT. 86,12
+As	2	1	1〉 daneben sitzen, sich daneben setzen, neben Jmd ( acc. ) sitzen oder sich setzen (als Zeichen der Unterordnung und Dienstbereitheit): ŚAT. BR. 2,3,2,4 . 1,3,4,15 . 3,2,3,16 . 3,2,5 . 9,3,7 . AV. 10,	ŚAT. BR. 2,3,2,4;ŚAT. BR 1,3,4,15;ŚAT. BR 3,2,3,16;ŚAT. BR. 3, 3,2,5;ŚAT. BR. 3, 9,3,7;AV. 10,7,21
+As	2	7	CHĀND. UP. 5 . 24,5 . M. 3,189 . 4,154 . MBH. 1,6320 . R. 2,91,52 . 3,4,1 . 2 . (mit pass. Bed. ) 2,100,29 . [Page1-0733] ( pass. ) MBH. 3,16167 . P. 3,4,72 , Sch	CHĀND. UP. 5;CHĀND. UP 24,5;M. 3,189;M 4,154;MBH. 1,6320;R. 2,91,52;R 3,4,1;R. 3,4, 2;R 2,100,29;MBH. 3,16167;P. 3,4,72
+As	2	2	2〉 sitzen: ( ) M. 2,103 . R. 3,49,29	M. 2,103;R. 3,49,29
+As	2	3	3〉 einen Platz einnehmen, sich aufhalten: M. 5,93 . R. 1,36,1	M. 5,93;R. 1,36,1
+As	2	4	4〉 beiwohnen, an Etwas Theil nehmen: M. 3,104 . MBH. 14,2871	M. 3,104;MBH. 14,2871
+As	2	5	5〉 sich nähern, sich irgend wohin begeben: ŚAT. BR. 14,9,4,2 . MBH. 1,3845 . 3,16883 . BHAṬṬ. 5,107 . 7,89 . gelangen zur Wahrheit YĀJÑ. 3,192	ŚAT. BR. 14,9,4,2;MBH. 1,3845;MBH 3,16883;BHAṬṬ. 5,107;BHAṬṬ 7,89;YĀJÑ. 3,192
+As	2	6	6〉 belagern: ŚAT. BR. 3,4,4,4	ŚAT. BR. 3,4,4,4
+As	2	7	7〉 einer Sache obliegen, dabei bleiben, sich mit Etwas zu thun machen, ausführen, ausüben: ṚV. 10,154,1 . AV. 10,10,32 . 5,17,17 . 10,6,31 . 10,31 . R. 1,1,93 . 4,24,11 . 3 . 1,34,20 . 2,35,27 . SUŚR.	ṚV. 10,154,1;AV. 10,10,32;AV 5,17,17;AV 10,6,31;AV. 10, 10,31;R. 1,1,93;R 4,24,11;R. 4,24, 3;R 1,34,20;R 2,35,27;SUŚR. 1,14,11;MBH. 2,1309;VIŚV. 13,16;MBH. 2,428;MBH 1,1890;MBH 3,8072;M. 2,222;M 7,223;R. 4,10,6;R. 4,10, 10;R. 4,10, 24;DAŚ. 2,32;MṚCCH. 56,3;DAŚAK;BENF. Chr. 184,3;MBH. 1,668;MBH 3,5051;R. 2,67,11
+As	2	1	MBH. 3,4078 . M. 11,42 . R. 3,9,20	MBH. 3,4078;M. 11,42;R. 3,9,20
+As	2	8	8〉 sich unterziehen, erleiden: MBH. 3,15634 . M. 11,183	MBH. 3,15634;M. 11,183
+As	2	9	9〉 ausharren, in einer Thätigkeit oder einem Zustande verharren: ( WEST. : excubias agere) R. 1,32,6 . mit einem partic. praes. : ŚAT. BR. 3,9,3,11 . 4,5,9,3 . BHAG. 12,6 . mit einem gerund. auf oder 	WEST;R. 1,32,6;ŚAT. BR. 3,9,3,11;ŚAT. BR 4,5,9,3;BHAG. 12,6;R. 1,44,1;R 4,53,11;R 5,32,23
+As	2	10	10〉 erwartend dabeisitzen, erwarten; zuwarten; das Zuwarten, Nachsehen haben: ṚV. 2,162,12 . ŚAT. BR. 1,9,2,12 . 27 . 2,1,3,9 . ( Gegens. ) 6,7,1,39 . KĀTY. ŚR. 25,6,13 . MBH. 3,1215	ṚV. 2,162,12;ŚAT. BR. 1,9,2,12;ŚAT. BR. 1,9,2, 27;ŚAT. BR 2,1,3,9;ŚAT. BR 6,7,1,39;KĀTY. ŚR. 25,6,13;MBH. 3,1215
+As	2	11	11〉 ehrend oder dienend nahen, verehren; Ehre erzeigen; sich anhänglich zeigen: ṚV. 1,36,7 . 9,86,39 . 7,33,14 . 10,109,7 . 151,4 . 153,1 . VS. 40,9 . AV. 10,8,22 . 11,5,9 . 3,10,3 . 10,7,27 . 18,4,36	ṚV. 1,36,7;ṚV 9,86,39;ṚV 7,33,14;ṚV 10,109,7;ṚV. 10, 151,4;ṚV. 10, 153,1;VS. 40,9;AV. 10,8,22;AV 11,5,9;AV 3,10,3;AV 10,7,27;AV 18,4,36;ŚAT. BR. 10,3,5,3;ŚAT. BR. 10, 6,2,10;CHĀND. UP. 4,2,2;BHAG. 12,2;BHAG 9,15;MBH. 3,924;MBH. 3, 5014;MBH. 3, 8102;MBH. 3, 8169;MBH. 3, 8220;MBH. 3, 10826;MBH 1,2902;MBH. 1, 5777;N. 26,31;R. 3,77,11
+As	2	12	12〉 ehren, achten, anerkennen: ṚV. 10,121,2 . 191,2 . AV. 11,4,11 . darum sollst du mich achten ( d. h. mit folgen), indem du ein Schiff zurüstest ŚAT. BR. 1,8,1,4 . 5 . wie man, wenn ein Höherer zum 	ṚV. 10,121,2;ṚV. 10, 191,2;AV. 11,4,11;ŚAT. BR. 1,8,1,4;ŚAT. BR. 1,8,1, 5;ŚAT. BR 2,3,1,8;BHARTṚ. 3,52;AK. 3,2,51
+As	2	13	13〉 achten so v. a. dafür halten, dafür erkennen: AV. 11,8,5 . 10,10,26 . VS. 32,14 ( vgl. damit AV. 6,108,4 , wo dem gleichsteht). ŚAT. BR. 10,2,6,19 . 3,4,5 . so meinen die Ś. 4,5,1 . 5,2,20 . 6,3,1	AV. 11,8,5;AV 10,10,26;VS. 32,14;AV. 6,108,4;ŚAT. BR. 10,2,6,19;ŚAT. BR. 10, 3,4,5;Ś. 4,5,1;Ś 5,2,20;Ś 6,3,1;Ś. 6,3, 2;Ś 11,4,4,9—12;Ś 12,2,3,3;Ś 14,4,2,22;Ś. 14, 5,1,2;BṚH. ĀR. UP. 1,4,10;BṚH. ĀR. UP 2,1,2;TAITT. UP. 1,6,2
+As	2	14	14〉 anwenden, gebrauchen: SUŚR. 2,187,19 . 196,8 . for the sake of which indication is subservient SĀH. D. 19,6	SUŚR. 2,187,19;SUŚR. 2, 196,8;SĀH. D. 19,6
+As	2	1	1〉 umsitzen, umgeben, umlagern; mit dem acc. : CHĀND. UP. 5,24,5 . 6,15,1 . N. 1,11 . MBH. 2,280 . R. 1,7,5 . 3,17,28 . 4,22,4 . 31,31 . KUMĀRAS. 2,38 . PAÑCAT. I, 271 . ( pass. Bed. ) R. 2,69,6	CHĀND. UP. 5,24,5;CHĀND. UP 6,15,1;N. 1,11;MBH. 2,280;R. 1,7,5;R 3,17,28;R 4,22,4;R. 4, 31,31;KUMĀRAS. 2,38;PAÑCAT. I, 271;R. 2,69,6
+As	2	2	2〉 auf Etwas sitzen: ( KULL. : = ) M. 2,75	KULL;M. 2,75
+As	2	3	3〉 umwohnen: MBH. 3,10412	MBH. 3,10412
+As	2	4	4〉 beiwohnen, an Etwas Theil nehmen: MBH. 4,574 . ARJ. 8,21	MBH. 4,574;ARJ. 8,21
+As	2	5	5〉 Jmd dienend nahen, Ehre erzeigen, verehren: (ergänze: sagte der Weise) R. 1,34,39 . M. 7,37 . BHAG. 9,22 . 12,1 . 3 . MBH. 3,11056 (p. 571) . R. 3,77,12 . pass. : RAGH. 10,63	R. 1,34,39;M. 7,37;BHAG. 9,22;BHAG 12,1;BHAG. 12, 3;MBH. 3,11056 (p. 571);R. 3,77,12;RAGH. 10,63
+As	2	1	1〉 bei einander sitzen: R. 2,105,1	R. 2,105,1
+As	2	2	2〉 einer Sache gemeinschaftlich obliegen, in Gemeinschaft ausüben, verrichten: R. 2,87,19 . von einer einzelnen Person: 4,10,24 . GṚHYASAṂGR. 2,67	R. 2,87,19;R 4,10,24;GṚHYASAṂGR. 2,67
+As	2	3	3〉 in Gemeinschaft Jmd Ehre erzeigen, verehren: MBH. 3,5067 . MṚCCH. 33,4 . pass. mit einem sing. : RAGH. 8,14	MBH. 3,5067;MṚCCH. 33,4;RAGH. 8,14
+As	2	1	1〉 herumsitzen, sich um Jmd ( acc. ) sammeln: ṚV. 9,73,3 . 10,179,2 . 8,31,1 . 9,86,1 . ŚAT. BR. 1,3,3,8	ṚV. 9,73,3;ṚV 10,179,2;ṚV 8,31,1;ṚV 9,86,1;ŚAT. BR. 1,3,3,8
+As	2	2	2〉 sitzen bleiben, unthätig bleiben: ṚV. 7,20,7 . 3,9,3 . 8,8,8	ṚV. 7,20,7;ṚV 3,9,3;ṚV 8,8,8
+As	2	3	3〉 sich ausschliessen von ( acc. ), supersedere: ṚV. 10,40,7 . — sich gegen Etwas ( acc. ) setzen ŚAT. BR. 3,6,2,20 . [Page1-0735]	ṚV. 10,40,7;ŚAT. BR. 3,6,2,20
+As	2	1	1〉 zusammensitzen, um Etwas ( acc. ) oder Jmd versammelt sein, sich versammeln: ṚV. 7,1,4 . 10,95,7 . 3,9,7 . AV. 12,2,51 . 13,2,27 . MBH. 2,304 . 379 . 3,10474 . 1,2104 . mit dem instr. : SĀV. 6,27	ṚV. 7,1,4;ṚV 10,95,7;ṚV 3,9,7;AV. 12,2,51;AV 13,2,27;MBH. 2,304;MBH. 2, 379;MBH 3,10474;MBH 1,2104;SĀV. 6,27
+As	2	2	2〉 sitzen: M. 2,101 . 102 . R. 2,111,8 . VIŚV. 11,11	M. 2,101;M. 2, 102;R. 2,111,8;VIŚV. 11,11
+As	2	3	3〉 zur Berathung zusammensitzen, Rath halten: AV. 7,12,3 . sie beriethen sich über V. und wurden über ihn nicht einig ŚAT. BR. 10,6,1,1	AV. 7,12,3;ŚAT. BR. 10,6,1,1
+As	2	4	4〉 es mit Jmd ( acc. ) oder Etwas aufnehmen, gewachsen sein, widerstehen: MBH. 3,372 . 14,822 . R. 5,36,50 . Vgl. — . — es mit Jmd aufnehmen, Jmd gewachsen sein, widerstehen: MBH. 3,17314 . 1904 . R. 	MBH. 3,372;MBH 14,822;R. 5,36,50;MBH. 3,17314;MBH. 3, 1904;R. 3,42,23;R 5,68,19;MBH. 14,1830
+As	2	1	1〉 act. : (= ) R. 7,44,18 . Am Schluss hinzuzufügen: dass das schöne Hügelpaar der Brüste ohne Stütze festsitzt Spr. 5328	R. 7,44,18;Spr. 5328
+As	2	2	2〉 KATHĀS. 112,102 . ( = Schol. ) R. 7,35,64 . hätte zu	KATHĀS. 112,102;R. 7,35,64
+As	2	4	4〉	
+As	2	4c	c〉 gestellt werden müssen	
+As	2	3	3〉 KATHĀS. 52,36 . 53	KATHĀS. 52,36;KATHĀS 53
+As	2	4	4〉	
+As	2	4a	a〉 im letzten [Page5-1129] Beispiele ist, wie wie schon durch das Ausrufungszeichen andeuteten, eine falsche Form; die richtige wäre	
+As	2	4b	b〉 flogen häufig KĀṬH. 36,7 . 34,8	KĀṬH. 36,7;KĀṬH 34,8
+As	2	4c	c〉 wie es ihm gerade ergeht, so mag es ihm ergehen Spr. 2086 . besteht nicht mehr 3843	Spr. 2086;Spr 3843
+As	2	4e	e〉 lies möge eure Klugheit wie eine Neuvermählte lange dem Herzen Redlicher zur Freude gereichen und vgl. Spr. 4721	Spr. 4721
+As	2	4f	f〉 ein nom. act. im loc. : BHĀG. P. 10,82,6	BHĀG. P. 10,82,6
+As	2	5	5〉 bedeutet so v. a. es unterbleibe, mag unbesprochen bleiben, ich will Nichts davon wissen; vgl. noch Spr. 406 . 3737 . 4710 . KATHĀS. 74,85 . 94,27 . imperat. mit so dass: so v. a. so dass von den a	Spr. 406;Spr 3737;Spr 4710;KATHĀS. 74,85;KATHĀS 94,27;KATHĀS 67,23;KATHĀS. 121,99;ṢAḌV. BR. 2,4
+As	2	1	1〉 act. : VARĀH. BṚH. S. 79,14	VARĀH. BṚH. S. 79,14
+As	2	3	3〉 so v. a. lässt sich nicht beweisen SARVADARŚANAS. 118,8 ; vgl. 135,2 v. u	SARVADARŚANAS. 118,8;SARVADARŚANAS 135,2 v. u
+As	2	7	7〉 über Jmd ( acc. ) —, höher als Jmd sitzen BHĀG. P. 10,78,23. fg	BHĀG. P. 10,78,23. fg
+As	2	3	3〉 richtig ed. Bomb. R. 7,34,32. fg. Spr. 4420 , v. l. für	ed. Bomb;R. 7,34,32. fg;Spr. 4420
+As	2	1	1〉 unbetheiligt sein u. s. w. : MĀLATĪM. 2,12 . BHĀG. P. 10,73,23 . 11,10,7 . Asket WILSON, Sel. Works 1,169. fg	MĀLATĪM. 2,12;BHĀG. P. 10,73,23;BHĀG. P 11,10,7;WILSON, Sel. Works 1,169. fg
+As	2	2	2〉 bei Seite lassen, übergehen: SARVADARŚANAS. 100,9	SARVADARŚANAS. 100,9
+As	2	1	1〉 R. 7,6,45 . umlagern MBH. 13,1808	R. 7,6,45;MBH. 13,1808
+As	2	3	3〉 zum Aufenthaltsort haben MBH. 5,6054 . Spr. 4321 . 1814 . MBH. 13,1808	MBH. 5,6054;Spr. 4321;Spr 1814;MBH. 13,1808
+As	2	7	7〉 WEBER, RĀMAT. UP. 356,4 . so v. a. pflegt Umgang mit einem Guten Spr. 5224	WEBER, RĀMAT. UP. 356,4;Spr. 5224
+As	2	8	8〉 so v. a. Weib sein R. 7,87,27	R. 7,87,27
+As	2	9	9〉 Spr. 3770	Spr. 3770
+As	2	10	10〉 ruhig abwarten Spr. 5236 . MBH. 3,258	Spr. 5236;MBH. 3,258
+As	2	11	11〉 wer einem Habenichts dient Spr. 3635 . Ind. St. 8,378 . pflegt Spr. 4917 . — Vgl. fg. , fg. , . — umlagern (einen Feind) MBH. 15,236	Spr. 3635;Ind. St. 8,378;Spr. 4917;MBH. 15,236
+As	2	5	5〉 Spr. 1655 . MBH. 12,12550	Spr. 1655;MBH. 12,12550
+As	2	6	6〉 Etwas ruhig ansehen: Spr. 4375 . — Vgl. fgg	Spr. 4375
+As	2	2	2〉 wie arme Schlucker dasitzen Spr. 4895	Spr. 4895
+As	2	3	3〉 R. 7,106,7 . = Schol	R. 7,106,7
+As	2	5	5〉 einer Sache obliegen: R. 7,76,17	R. 7,76,17
+As	2	6	6〉 achten auf Etwas, anerkennen: Spr. 3816	Spr. 3816
+As	2	4	4〉 SARVADARŚANAS. 19,6 . 48,10 . 82,18 . 108,12. fg	SARVADARŚANAS. 19,6;SARVADARŚANAS 48,10;SARVADARŚANAS 82,18;SARVADARŚANAS 108,12. fg
+As	2	9	9〉 (so ed. Bomb. ) MBH. 3,10580	ed. Bomb;MBH. 3,10580
+As	3	1	1〉 abl. (mit ) von Mund zu Mund, aus unmittelbarer Nähe: ṚV. 7,99,7	ṚV. 7,99,7
+As	3	2	2〉 instr. adv. gebraucht in Bedd. , welche mit coram nahe zusammentreffen: vor und von Angesicht, mündlich; persönlich, gegenwärtig, leibhaftig; daher NAIGH. 2,16 unter den Wörten für nahe aufgezählt.	NAIGH. 2,16;ṚV. 6,16,9;ṚV 7,16,9;ṚV 1,76,4;ṚV. 1, 129,5;ṚV 10,115,3;ṚV 2,1,14;ṚV 5,23,1;ṚV 6,3,4;ṚV 4,5,10;ṚV 5,17,2;ṚV. 5,17, 5;ṚV 6,32,1;ṚV 1,140,2;ṚV. 1, 152,6;ṚV 168,2;ṚV 10,1,3;ṚV 20,3;ṚV 40,6;ṚV 67,10
+AsAdana		1	1〉 das Niedersetzen, Niederlegen KĀTY. ŚR. 5,4,28 . 8,32 . 6,2,5 . 9,6,4 . 10,9,29 . 15,9,3	KĀTY. ŚR. 5,4,28;KĀTY. ŚR. 5, 8,32;KĀTY. ŚR 6,2,5;KĀTY. ŚR 9,6,4;KĀTY. ŚR 10,9,29;KĀTY. ŚR 15,9,3
+AsAdana		2	2〉 das auf-Jmd-Losgehen, Bekriegen: MBH. 2,808	MBH. 2,808
+AsAdana		3	3〉 das Stossen auf, Gelangen zu, Theilhaftwerden SĀH. D. 328,16	SĀH. D. 328,16
+AsAra		1	1〉 Umschliessung des Feindes ( ) AK. 2,8,2,64 . TRIK. 3,3,329 . H. an. 3,521 . MED. r. 114	AK. 2,8,2,64;TRIK. 3,3,329;H. an. 3,521;MED. r. 114
+AsAra		2	2〉 Platzregen AK. 1,1,2,13 . TRIK. H. 165 . H. an. MED. VIKR. 57,19 . MEGH. 17 . MBH. 1,1300 . RAGH. 13,29 . BHARTṚ. 1,46 . AMAR. 54 . MEGH. 44 . KATHĀS. 22,226 . [Page1-0739] 11,49	AK. 1,1,2,13;TRIK;H. 165;H. an;MED;VIKR. 57,19;MEGH. 17;MBH. 1,1300;RAGH. 13,29;BHARTṚ. 1,46;AMAR. 54;MEGH. 44;KATHĀS. 22,226;KATHĀS 11,49
+AsAra		3	3〉 das Heer des Bundesgenossen TRIK. H. 790 . H. an. MED	TRIK;H. 790;H. an;MED
+AsAra		4	4〉 Mundvorrath (?): PAÑCAT. III, 39 . 48	PAÑCAT. III, 39;PAÑCAT. III, 48
+AsAra		2	2〉 HARIV. 4585 . BHĀG. P. 10,83,27 . Hagel 76,11 . Schol. — Vgl	HARIV. 4585;BHĀG. P. 10,83,27;BHĀG. P 76,11
+AsAra		3	3〉 genauer ein durch mehrere zwischenliegende Länder getrennter Fürst, der im Fall eines Krieges ein natürlicher Bundesgenosse ist, KĀM. NĪTIS. 8,17 . 43 . 46 . 11,15 . 16 . 13,71 . 87 . 15,5 . Hierhe	KĀM. NĪTIS. 8,17;KĀM. NĪTIS. 8, 43;KĀM. NĪTIS. 8, 46;KĀM. NĪTIS 11,15;KĀM. NĪTIS. 11, 16;KĀM. NĪTIS 13,71;KĀM. NĪTIS. 13, 87;KĀM. NĪTIS 15,5
+AsAra		4	4〉 aufgeführten Stellen, so dass	
+AsAra		4	4〉 ganz zu streichen und st. dessen zu setzen ist: ein best. Metrum KĀVYĀD. 1,37	KĀVYĀD. 1,37
+AsAra		2	2〉 KATHĀS. 26,32 . 38,125 (hier falsch zerlegt)	KATHĀS. 26,32;KATHĀS 38,125
+AsPota		1	1〉 m. N. verschiedener Pflanzen:	
+AsPota		1a	a〉 Calotropis gigantea ( s. 9.) AK. 2,4,2,61 . H. an. 3,246 . MED. t. 92 . SUŚR. 2,109,8 . 281,7 . 325,8 . 21	AK. 2,4,2,61;H. an. 3,246;MED. t. 92;SUŚR. 2,109,8;SUŚR. 2, 281,7;SUŚR. 2, 325,8;SUŚR. 2,109, 21
+AsPota		1b	b〉 Bauhinia variegata L. H. an. MED	H. an;MED
+AsPota		1c	c〉 = ( vulg. ) ŚABDAC. _im_ ŚKDR. Echites dichotoma Roxb. WILS	ŚABDAC;ŚKDR;WILS
+AsPota		2	2〉 f. N. verschiedener Pflanzen:	
+AsPota		2a	a〉 Jasminum Sambac Ait. , ein Strauch, AK. 2,4,2,50 . H. an. MED. SUŚR. 2,50,2 . 389,9 . ROXB. Fl. ind. 1,88 . Vgl	AK. 2,4,2,50;H. an;MED;SUŚR. 2,50,2;SUŚR. 2, 389,9;ROXB;Fl. ind. 1,88
+AsPota		2b	b〉 Clitoria ternatea Lin. AK. 2,4,3,22 . H. an. MED. Vgl	AK. 2,4,3,22;H. an;MED
+AsPota		2c	c〉 Echites frutescens Roxb. ( ) RĀJAN. _im_ ŚKDR. Echites dichotoma Roxb. ( vulg. ) RĀJAV. _im_ ŚKDR	RĀJAN;ŚKDR;RĀJAV;ŚKDR
+AsPota		1	1〉 VARĀH. BṚH. S. 55,22	VARĀH. BṚH. S. 55,22
+AsPowa		1	1〉 m	
+AsPowa		1a	a〉 das Zittern, sich-Hinundherbewegen: (zwei einander gegenüberstehende Kämpfer) MBH. 2,900 . 3,11141 ( vgl. 11139 : )	MBH. 2,900;MBH 3,11141;MBH. 3, 11139
+AsPowa		1b	b〉 = ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+AsPowa		2	2〉 f. = 1. ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+AsPowa		1	1〉	
+AsPowa		1a	a〉 lies das Hinundherbewegen: SĀH. D. 98,7 . — Vgl	SĀH. D. 98,7
+AsPowa		2	2〉 lies	
+AsPowa		1	1〉	
+AsPowa		1a	a〉	
+AsPowana		1	1〉 n	
+AsPowana		1a	a〉 das Zittern, sich-Hinundherbewegen: R. 5,10,13 . SUŚR. 2,313,13	R. 5,10,13;SUŚR. 2,313,13
+AsPowana		1b	b〉 das Aufblühen	
+AsPowana		1c	c〉 das Versiegeln DHAR. _im_ ŚKDR	DHAR;ŚKDR
+AsPowana		2	2〉 f. Bohrer (zum Durchbohren von Perlen u. s. w. ) AK. 2,10,34 . H. 909	AK. 2,10,34;H. 909
+AsPowana		1	1〉	
+AsPowana		1a	a〉 BHĀG. P. 10,18,12 . auch trans. das Zitternmachen, Hinundherbewegen: MBH. 12,4265 . das Recken VARĀH. BṚH. S. 78,4	BHĀG. P. 10,18,12;MBH. 12,4265;VARĀH. BṚH. S. 78,4
+AsTA		1	1〉 Rücksicht, Bedacht, Sorge TRIK. 3,3,195 . H. an. 2,212 . MED. th. 3 . KAṬHOP. 1,28 , v. l. mit dem loc. : BHARTṚ. 3,53 . 2,96 . HIT. I, 41 . RAGH. 10,44 . KATHĀS. 24,138 . darauf kommt es nicht an 	TRIK. 3,3,195;H. an. 2,212;MED. th. 3;KAṬHOP. 1,28;BHARTṚ. 3,53;BHARTṚ 2,96;HIT. I, 41;RAGH. 10,44;KATHĀS. 24,138;KUMĀRAS. 6,12;KUMĀRAS. 6, 63;RAGH. 2,57;AK. 3,4,90;H. an;MED
+AsTA		2	2〉 Einwilligung, Versprechen H. 278	H. 278
+AsTA		3	3〉 Vertrauen, Hoffnung: adj. KATHĀS. 25,25 . f. DAŚAK. _in_ BENF. Chr. 200,6 . RĀJA-TAR. 5,245	KATHĀS. 25,25;DAŚAK;BENF. Chr. 200,6;RĀJA-TAR. 5,245
+AsTA		4	4〉 Stütze TRIK. H. an. MED	TRIK;H. an;MED
+AsTA		5	5〉 Versammlung AK. 3,4,90 . H. 481 . H. an. MED	AK. 3,4,90;H. 481;H. an;MED
+AsTA		6	6〉 Aufenthalt H. 1498 . BHARTṚ. 1,93 . Wohl nur eine Variante von	H. 1498;BHARTṚ. 1,93
+AsTA		7	7〉 Zustand: AK. 3,3,2 . ŚUK. 39,12 . Ebenfalls nur fehlerhaft für , wie auch H. 1497 an der entsprechenden Stelle des AK. hat	AK. 3,3,2;ŚUK. 39,12;H. 1497;AK
+AsTA		1	1〉 nach dem Walde geht unser Sinnen und Trachten Spr. 1966	Spr. 1966
+AsTA		3	3〉 mit Zuversicht Spr. 920 . KATHĀS. 81,113 . 87,24 . 30,97 . 55,22 . 4,12 . 52,168 . 56,36 . 403 . 69,86 . 119,188 . 120,7	Spr. 920;KATHĀS. 81,113;KATHĀS 87,24;KATHĀS 30,97;KATHĀS 55,22;KATHĀS 4,12;KATHĀS 52,168;KATHĀS 56,36;KATHĀS. 56, 403;KATHĀS 69,86;KATHĀS 119,188;KATHĀS 120,7
+AsTA		3	3〉 Verlass auf ( loc. ) Spr. (II) 7558	Spr. (II) 7558
+AsTAna		1	1〉 n	
+AsTAna		1a	a〉 Standort, Ort, Unterlage VS. 11,21 . 38 . AV. 1,23,3 . 32,2 . 6,77,1 . ŚAT. BR. 5,5,5,14 . 11,5,5,8 . Vgl	VS. 11,21;VS. 11, 38;AV. 1,23,3;AV. 1, 32,2;AV 6,77,1;ŚAT. BR. 5,5,5,14;ŚAT. BR 11,5,5,8
+AsTAna		1b	b〉 Versammlung AK. 2,7,15 . H. 481 . Audienzsaal des Königs: KATHĀS. 21,17 . 24,47 . 21,38 . 18,28 . BROCKHAUS : Thron. n. Versammlungszimmer H. 997 . Verz. d. B. H. 172,3	AK. 2,7,15;H. 481;KATHĀS. 21,17;KATHĀS 24,47;KATHĀS 21,38;KATHĀS 18,28;BROCKHAUS;H. 997;Verz. d. B. H. 172,3
+AsTAna		2	2〉 f. TRIK. 3,5,21 . Versammlung AK. 2,7,15 . 3,4,90 . PRAB. 102,10 . in den Audienzsaal Kuvera ʼs DAŚAK. 117,3 v. u	TRIK. 3,5,21;AK. 2,7,15;AK 3,4,90;PRAB. 102,10;DAŚAK. 117,3 v. u
+AsTAna		1	1〉	
+AsTAna		1b	b〉 Empfang bei einem Fürsten, Audienzsaal eines Fürsten HALĀY. 4,93 . RĀJA-TAR. 5,35 . KATHĀS. 44,82 . 45,1 . 50,106 . 53,28 . 36 . 42 . 44 . 49 . 54 . 56 . 65 . 54,137 . 56,358 . 59,24 . 26 . 66,64	HALĀY. 4,93;RĀJA-TAR. 5,35;KATHĀS. 44,82;KATHĀS 45,1;KATHĀS 50,106;KATHĀS 53,28;KATHĀS. 53, 36;KATHĀS. 53, 42;KATHĀS. 53, 44;KATHĀS. 53, 49;KATHĀS. 53, 54;KATHĀS. 53, 56;KATHĀS. 53, 65;KATHĀS 54,137;KATHĀS 56,358;KATHĀS 59,24;KATHĀS. 59, 26;KATHĀS 66,64
+AsTApita		1	1〉 adj. s. u. mit im caus	
+AsTApita		2	2〉 mit dem Ton auf der ersten Silbe gaṇa zu P. 6,2,146	P. 6,2,146
+Asa	3	1	1〉 Sitz s	
+Asa	3	2	2〉 n. Gesäss: [Page1-0736] CHĀND. UP. 1,6,7	CHĀND. UP. 1,6,7
+Asa	3	3	3〉 Nähe (?), s	
+AsaMsAra		1	1〉 adj. beständigem Wandel unterworfen: KATHĀS. 5,103	KATHĀS. 5,103
+AsaMsAra		2	2〉 adv. so lange der beständige Wandel der Welt besteht, bis zum Ende der Welt RĀJA-TAR. 5,119	RĀJA-TAR. 5,119
+AsaMsAra		1	1〉 zu streichen, da an der angeführten Stelle nach KERN [Page5-1130] ( und werden in Hdschrr. oft verwechselt) so lange die Welt besteht zu lesen ist	KERN
+AsaMsAra		2	2〉 so lange die Welt besteht, von Anfang der Welt an Spr. 401 . 3743	Spr. 401;Spr 3743
+AsaNga		1	1〉 m	
+AsaNga		1a	a〉 das Anhaften, Anhaken, Anhängen (auch in übertr. Bed. ) AK. 3,3,2 . ŚĀK. 32 . KUMĀRAS. 5,9 . ( ) DHŪRTAS. 92,8 . KATHĀS. 12,90 . VID. 269 . PAÑCAT. V, 83 . BHAG. 4,20 . PRAB. 61,14 . SĀH. D. 79,20	AK. 3,3,2;ŚĀK. 32;KUMĀRAS. 5,9;DHŪRTAS. 92,8;KATHĀS. 12,90;VID. 269;PAÑCAT. V, 83;BHAG. 4,20;PRAB. 61,14;SĀH. D. 79,20
+AsaNga		1b	b〉 das sich-an-Jmd-Anhängen, Nachstellung: ŚAT. BR. 1,1,2,3 . 3,1,5 . 4,4,8 . 6,1,11 . 5,2,3,5	ŚAT. BR. 1,1,2,3;ŚAT. BR. 1, 3,1,5;ŚAT. BR. 1, 4,4,8;ŚAT. BR. 1, 6,1,11;ŚAT. BR 5,2,3,5
+AsaNga		1c	c〉 N. pr. eines Mannes ṚV. 8,1,32 . 33	ṚV. 8,1,32;ṚV. 8,1, 33
+AsaNga		2	2〉 n. eine bes. wohlriechende Erde ( ) RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+AsaNga		3	3〉 adj. und adv. = ununterbrochen JAṬĀDH. _im_ ŚKDR. — Vgl	JAṬĀDH;ŚKDR
+AsaNga		1	1〉	
+AsaNga		1a	a〉 KATHĀS. 61,168 . Spr. 915 . ( adj. ) 4608 . PAÑCAT. V, 83 ist zu streichen, da dieses in + zu zerlegen ist	KATHĀS. 61,168;Spr. 915;Spr 4608;PAÑCAT. V, 83
+AsaYjana		1	1〉 das Anhängen, Anhaken: AIT. BR. 5,11 . KĀTY. ŚR. 25,10,14 . ŚĀK. 32 , v. l	AIT. BR. 5,11;KĀTY. ŚR. 25,10,14;ŚĀK. 32
+AsaYjana		2	2〉 Henkel, Haken ŚAT. BR. 6,7,1,17 . 19 . 21	ŚAT. BR. 6,7,1,17;ŚAT. BR. 6,7,1, 19;ŚAT. BR. 6,7,1, 21
+Asadana		1	1〉 das Sitzen	
+Asadana		2	2〉 Sitz: KĀTY. ŚR. 25,7,8	KĀTY. ŚR. 25,7,8
+Asakti		1	1〉 das an-Etwas-Hängen ( übertr. ): ŚUK. 40,1	ŚUK. 40,1
+Asakti		2	2〉 das sich — an — Jmd — Anhängen, Nachstellung: ṚV. 10,85,28 . — adv. geflissentlich: ŚAT. BR. 9,5,1,16 . 17 . — Vgl. d. folg. W	ṚV. 10,85,28;ŚAT. BR. 9,5,1,16;ŚAT. BR. 9,5,1, 17
+Asakti		1	1〉 Spr. 3935 . KATHĀS. 53,87 . 61,141	Spr. 3935;KATHĀS. 53,87;KATHĀS 61,141
+Asakti		2	2〉 adv. zusammenhängend, ununterbrochen: PAÑCAV. BR. 6,6,10 . Dieselbe Bed. wird wohl auch für die aus ŚAT. BR. angeführte Stelle anzunehmen sein	PAÑCAV. BR. 6,6,10;ŚAT. BR
+Asakti		1	1〉 in eig. Bed. RĀJA-TAR. 3,98 . in übertr. Bed. Spr. (II) 12 . An beiden Stellen am Ende eines adj. comp	RĀJA-TAR. 3,98;Spr. (II) 12
+Asana	1	1	1〉 n	
+Asana	1	1a	a〉 das Sitzen, Sichsetzen: KĀTY. ŚR. 4,15,33 . 7,5,8 . 16,1,29 . 25,4,7 . M. 6,22 . 7,220 . 11,180 . 224 . N. 2,4 . M. 8,281 . 357 . die Art und Weise des Sitzens bildet einen Bestandtheil der achtgli	KĀTY. ŚR. 4,15,33;KĀTY. ŚR 7,5,8;KĀTY. ŚR 16,1,29;KĀTY. ŚR 25,4,7;M. 6,22;M 7,220;M 11,180;M. 11, 224;N. 2,4;M. 8,281;M. 8, 357;AK. 2,7,39;H. 82;PRAB. 97,15;MADHUS;Ind. St. 1,22
+Asana	1	84	Arten des Sitzens erwähnt; s. und	
+Asana	1	84b	b〉 das Haltmachen (im Feldzuge), Beziehen eines Lagers AK. 2,8,1,18 . H. 735 . an. 2,357 . MED. n. 36 . M. 7,160 — 162 . 166 . YĀJÑ. 1,346 . PAÑCAT. 12,21 . 153,9 . HIT. 119,17	AK. 2,8,1,18;H. 735;H an. 2,357;MED. n. 36;M. 7,160;M. 7, 162;M. 7, 166;YĀJÑ. 1,346;PAÑCAT. 12,21;PAÑCAT 153,9;HIT. 119,17
+Asana	1	84c	c〉 das Sichaufhalten, Wohnen: M. 6,59 . 2,215	M. 6,59;M 2,215
+Asana	1	84d	d〉 Sitz, Platz AK. 2,6,3,40 . 7,45 . 3,4,171 . 187 . H. 684 . H. an. MED. KĀTY. ŚR. 1,8,27 . 7,4,32 . 9,9 . 12,4,15 . 25,4,47 . KAUŚ. 3 . TAITT. UP. 1,11,3 . M. 3,208 . KUMĀRAS. 7,12 . BHAG. 6,11 . VI	AK. 2,6,3,40;AK. 2,6, 7,45;AK. 2, 3,4,171;AK. 2,6,3, 187;H. 684;H. an;MED;KĀTY. ŚR. 1,8,27;KĀTY. ŚR 7,4,32;KĀTY. ŚR. 7, 9,9;KĀTY. ŚR 12,4,15;KĀTY. ŚR 25,4,47;KAUŚ. 3;TAITT. UP. 1,11,3;M. 3,208;KUMĀRAS. 7,12;BHAG. 6,11;VIŚV. 2,2;M. 3,99;M 4,154;R. 3,18,29;N. 5,4;M. 2,202;M. 2, 119;ebend;RAGH. 2,6;ŚĀK. 28,8;ŚĀK 63,16;RAGH. 3,1;N. 3,15;M. 4,69;R. 3,67,1;R. 3, 15,12;P. 6,2,151;INDR. 2,20;H. 61;M. 5,94;M 7,141
+Asana	1	84e	e〉 Widerrist des Elephanten, der Sitz des Führers, AK. 2,8,2,7 . H. 1224 . H. an. MED	AK. 2,8,2,7;H. 1224;H. an;MED
+Asana	1	2	2〉 f. P. 3,3,107 , Sch. VOP. 26,194 . Aufenthalt AK. 3,3,21 . H. 1498	P. 3,3,107;VOP. 26,194;AK. 3,3,21;H. 1498
+Asana	1	3	3〉 f	
+Asana	1	3a	a〉 Aufenthalt MED. n. 37	MED. n. 37
+Asana	1	3b	b〉 Sitz: KAUŚ. 3	KAUŚ. 3
+Asana	1	3c	c〉 Bude, Laden H. an. 3,358 . MED	H. an. 3,358;MED
+Asana	1	1	1〉	
+Asana	1	1a	a〉 DAŚAK. _in_ BENF. Chr. 180,22 . Art und Weise des Sitzens (in der Askese) VEDĀNTAS. (Allah.) No. 127 . 130 . Verz. d. Oxf. H. 11,a, N. 1. fgg. 94,a, N. 2 . 102,b,12. fgg. 233,b,7 . 234,a,14. fgg. 2	DAŚAK;BENF. Chr. 180,22;VEDĀNTAS. (Allah.) No. 127;VEDĀNTAS. (Allah.) No 130;Verz. d. Oxf. H. 11,a, N. 1. fgg;Verz. d. Oxf. H 94,a, N. 2;Verz. d. Oxf. H 102,b,12. fgg;Verz. d. Oxf. H 233,b,7;Verz. d. Oxf. H 234,a,14. fgg;Verz. d. Oxf. H 236,a,31. fgg
+Asana	1	1d	d〉 Thron RĀJA-TAR. 4,309	RĀJA-TAR. 4,309
+Asana	1	1e	e〉 der Theil des Pferderückens, auf dem der Reiter sitzt, VARĀH. BṚH. S. 93,1 . 3 . — Vgl	VARĀH. BṚH. S. 93,1;VARĀH. BṚH. S. 93, 3
+Asana	1	1	1〉	
+Asana	1	1a	a〉 über die verschiedenen Arten des Sitzens HEM. YOGAŚ. 4,123. fgg	HEM;YOGAŚ. 4,123. fgg
+Asanda		1	1〉 m. ein Beiname Viṣṇu ʼs H. ś. 74 . MED. d. 20 (verdruckt )	H. ś. 74;MED. d. 20
+Asanda		2	2〉 f. ein aus Holz oder Flechtwerk gemachter Sessel, Stuhl, Lehnstuhl AK. 3,6,9 . H. 684 . HĀR. 209 . MED. AV. 14,2,65 . 15,3,2. fgg. VS. 8,56 . 19,16 . 86 . TS. 7,5,8,5 . AIT. BR. 8,5 . ŚAT. BR. 5,4,	AK. 3,6,9;H. 684;HĀR. 209;MED;AV. 14,2,65;AV 15,3,2. fgg;VS. 8,56;VS 19,16;VS. 19, 86;TS. 7,5,8,5;AIT. BR. 8,5;ŚAT. BR. 5,4,4,1;ŚAT. BR. 5, 2,1,22;ŚAT. BR. 5, 5,3,7;ŚAT. BR 6,7,1,12. fgg;ŚAT. BR 12,8,3,4. fgg;ŚAT. BR 14,1,3,8. fgg;KĀTY. ŚR. 26,2,8. fgg;KĀTY. ŚR 13,3,2. fgg;KĀTY. ŚR 16,5,5;KAUṢ. UP;Ind. St. 1,397;ŚAT. BR. 12,8,3,4
+Asatti		1	1〉 Anschluss, unmittelbare Verbindung H. an. 3,250 . MED. t. 95 . der Worte in einem Satze SĀH. D. 8,17 . 22	H. an. 3,250;MED. t. 95;SĀH. D. 8,17;SĀH. D. 8, 22
+Asatti		2	2〉 Erlangung H. an. MED	H. an;MED
+Asatti		1	1〉 BHĀṢĀP. 81 . 82 . 63	BHĀṢĀP. 81;BHĀṢĀP 82;BHĀṢĀP 63
+Asatti		3	3〉 das in-die-Enge-Kommen, Verlegenheit, ein Zustand, in dem man keinen Rath weiss: MBH. 12,1878 . = NĪLAK	MBH. 12,1878;NĪLAK
+Asava	2	1	1〉 das Abkochen; Destillation H. 905	H. 905
+Asava	2	2	2〉 Decoct, Abguss, Liquor, häufig ein mit Zucker oder Lauge gemischter Trank SUŚR. 1,70,10 . 145,13 . 163,9 . 10 . 190,6 . MBH. 16,30 . M. 11,95 ( n. als copul. comp. gedeutet). (von den Lexicographen	SUŚR. 1,70,10;SUŚR. 1, 145,13;SUŚR. 1, 163,9;SUŚR. 1,163, 10;SUŚR. 1, 190,6;MBH. 16,30;M. 11,95;SUŚR. 1,190,8;R. 5,12,42;R. 5, 14,44;R. 5,12, 24;SUŚR. 1,190,15;SUŚR. 1, 229,1;SUŚR. 1, 237,21;SUŚR. 1, 238,4;SUŚR. 1,238, 5;SUŚR 2,52,10;SUŚR. 1, 73,11;VIŚV. 3,2;VIKR. 107;ŚĀNTIŚ. 1,29;KATHĀS. 21,8;PRAB. 19,12;DHŪRTAS. 83,7;YĀJÑ. 3,37;AK. 2,10,42;H. 704;RĀJAN;ŚKDR;HĀR. 170;KUMĀRAS. 1,31
+Asava	2	2	2〉 ŚĀRṄG. SAṂH. _in_ Verz. d. Oxf. H. 315,a, No. 748 . Spr. 3179 . 820 . — Vgl	ŚĀRṄG. SAṂH;Verz. d. Oxf. H. 315,a, No. 748;Spr. 3179;Spr 820
+Asecana	1	1	1〉 das Aufgiessen, Eingiessen KĀTY. ŚR. 9,5,4 . 6,2 . 15,9,4 . 25,12,12	KĀTY. ŚR. 9,5,4;KĀTY. ŚR. 9, 6,2;KĀTY. ŚR 15,9,4;KĀTY. ŚR 25,12,12
+Asecana	1	2	2〉 der Ort des Aufgiessens, Behälter von Flüssigkeiten: ṚV. 1,162,13 . ŚAT. BR. 2,1,4,5 . KĀTY. ŚR. 4,8,5	ṚV. 1,162,13;ŚAT. BR. 2,1,4,5;KĀTY. ŚR. 4,8,5
+AsevA		1	1〉 dass. : P. 3,4,56 , Sch	P. 3,4,56
+AsevA		2	2〉 Verkehr, Umgang: mit der es schwer zu verkehren ist ( ) R. 3,23,15	R. 3,23,15
+Asevin		1	1〉 besuchend, sich aufhaltend in: KATHĀS. 71,95	KATHĀS. 71,95
+Asevin		2	2〉 betreibend, sich hingebend einer Sache: RĀJA-TAR. 5,207	RĀJA-TAR. 5,207
+Askanda		1	1〉 das Aufspringen, Besteigen: KATHĀS. 26,36	KATHĀS. 26,36
+Askanda		2	2〉 Angriff oder Angreifer VS. 30,18	VS. 30,18
+Askanda		2	2〉 Angriff: Spr. 167 . RĀJA-TAR. 8,2633 . Streiche die Worte oder Angreifer VS. 30,18 und füge hinzu	Spr. 167;RĀJA-TAR. 8,2633;VS. 30,18
+Askanda		3	3〉 ein best. Würfel VS. 30,18 . TS. 4,3,3,2 . KĀṬH. 39,7	VS. 30,18;TS. 4,3,3,2;KĀṬH. 39,7
+Askanda		4	4〉 eine best. Recitationsweise LĀṬY. 4,1,5 . 6,6,19	LĀṬY. 4,1,5;LĀṬY 6,6,19
+Askandana		1	1〉 Angriff, = MALLIN. _zu_ KUMĀRAS. 3,71 . Kampf AK. 2,8,2,72 . H. 797 . an. 4,161 . MED. n. 168	MALLIN;KUMĀRAS. 3,71;AK. 2,8,2,72;H. 797;H an. 4,161;MED. n. 168
+Askandana		2	2〉 das Anfahren mit Worten ( ) H. an. MED	H. an;MED
+Askandana		3	3〉 das Trocknen ( ) H. an. MED	H. an;MED
+Askandana		1	1〉 Angriff: der Angriff auf dich KATHĀS. 49,125	KATHĀS. 49,125
+Askandin		1	1〉 auf Jmd springend: RAGH. 17,52	RAGH. 17,52
+Askandin		2	2〉 (vom caus. ) fliessen lassend, spendend: KATHĀS. 24,87	KATHĀS. 24,87
+Askandin		3	3〉 angreifend; s	
+Askandin		2	2〉 (wegen der Cäsur besser ) Spr. (II) 5934	Spr. (II) 5934
+Aspada		2	2〉 Geschäft AK. 3,4,96 . H. an. MED	AK. 3,4,96;H. an;MED
+Aspada		1	1〉 (die Seele) hat ein endloses Gebiet wie der Himmel TATTVAS. 17 . der Palast eines Fürsten RĀJA-TAR. 5,235 . Aufenthaltsort KATHĀS. 58,111 . 75,128 . [Page5-1132] 68,17 . ein Ort für RĀJA-TAR. 5,44 	TATTVAS. 17;RĀJA-TAR. 5,235;KATHĀS. 58,111;KATHĀS 75,128;KATHĀS 68,17;RĀJA-TAR. 5,44;KATHĀS. 56,308;Spr. 5184;Spr 3278;KATHĀS. 60,9;KATHĀS 61,329
+Aspada		2	2〉 Bez. des 10ten astrologischen Hauses VARĀH. BṚH. 9,2 . 4 . 10,1 . 25 (, 6	VARĀH. BṚH. 9,2;VARĀH. BṚH. 9, 4;VARĀH. BṚH 10,1;VARĀH. BṚH 25 (23), 6
+AsrAva		1	1〉 das Fliessen, Ausfluss H. an. 4,136 . MED. d. 43 . SUŚR. 1,8,11 . 83,10 . 84,5. fgg. 2,60,13 . 235,7 . 1,155,2 . 2,307,3 . 4	H. an. 4,136;MED. d. 43;SUŚR. 1,8,11;SUŚR. 1, 83,10;SUŚR. 1, 84,5. fgg;SUŚR 2,60,13;SUŚR 235,7;SUŚR 1,155,2;SUŚR 2,307,3
+AsrAva		2	2〉 ein Körperschaden, Gebrechen AV. 1,2,4 . 2,3,3 . Vgl. und 2	AV. 1,2,4;AV 2,3,3
+AsrAva		1	1〉 Eiterung: Spr. 4444 . — Vgl	Spr. 4444
+Asrava		1	1〉 der Schaum auf kochendem Reise H. ś. 94	H. ś. 94
+Asrava		2	2〉 Leiden AK. 3,3,29 . Fehler, Gebrechen H. 1375	AK. 3,3,29;H. 1375
+Asrava		3	3〉 bei den Jaina das was den im Körper befindlichen Geist auf die äusseren Objecte lenkt COLEBR. Misc. Ess. I, 382 . — Vgl. 2. und 10	COLEBR. Misc. Ess. I, 382
+Asrava		3	3〉 bei den Jaina der Einfluss der Aussenwelt auf den Menschen SARVADARŚANAS. 36,14. fgg. 38,20. fgg. 39,16 (wo st. zu lesen ist). 43,16 . 20 ; vgl. WILSON, Sel. Works 1,310	SARVADARŚANAS. 36,14. fgg;SARVADARŚANAS 38,20. fgg;SARVADARŚANAS 39,16;SARVADARŚANAS 43,16;SARVADARŚANAS. 43, 20;WILSON, Sel. Works 1,310
+Asrava		3	3〉 (Nachträge) HEM. YOGAŚ. 4,55. fgg. 73. fgg. 80	HEM;YOGAŚ. 4,55. fgg;YOGAŚ. 4, 73. fgg;YOGAŚ. 4, 80
+AstAra		1	1〉 Ausbreitung (von mit ), s	
+AstAra		2	2〉 in ( AK. 2,7,16 . H. 480 . MBH. 2,1787 ) Mitglied einer Versamlung scheint eher mit als mit in Verbindung zu stehen; vgl	AK. 2,7,16;H. 480;MBH. 2,1787
+AstAra		1	¦, DURGĀD. _zu_ NIR. 5,22 erklärt ṚV. 10,43,5 durch . Vgl	DURGĀD;NIR. 5,22;ṚV. 10,43,5
+AstIka		1	1〉 m. N. pr. eines alten Weisen, eines Sohnes des und der Jaratkāru , der beim grossen Schlangenopfer einen Theil derselben rettete, TRIK. 2,8,21 . MBH. 1,1634. fgg. 1929. fg. HARIV. 11233 . ein Beina	TRIK. 2,8,21;MBH. 1,1634. fgg;MBH. 1, 1929. fg;HARIV. 11233;ŚABDAR;ŚKDR
+AstIka		2	2〉 adj. Āstīka betreffend, über ihn handelnd MBH. 1,304 . 1023 . 1027 . oder heisst ein Abschnitt im 1sten Buch des MBH., Kap. 13 — 58	MBH. 1,304;MBH. 1, 1023;MBH. 1, 1027;MBH., Kap. 13;MBH., Kap 58
+AstIka		1	1〉 Verz. d. Oxf. H. 24,b,39 . 40 . 268,a,36	Verz. d. Oxf. H. 24,b,39;Verz. d. Oxf. H. 24,b, 40;Verz. d. Oxf. H 268,a,36
+Astara		1	1〉 Decke, Teppich (auch von ausgebreiteten Blumen, Blättern u. s. w. ) H. 680 . ŚĀNTIŚ. 2,19 . KATHĀS. 22,196	H. 680;ŚĀNTIŚ. 2,19;KATHĀS. 22,196
+Astara		2	2〉 N. pr. eines Mannes Verz. d. B. H. No. 166	Verz. d. B. H. No. 166
+AstaraRa	1	1	1〉 n. = 1. AK. 2,8,2,10 . H. 680 , Sch. AV. 15,3,7 . AIT. BR. 8,5 . KAUŚ. 64 . ĀŚV. GṚHY. 2,3 . MBH. 1,131 . R. 3,49,15 . MBH. 3,15142 . INDR. 5,3 . R. 2,32,9 . 4,25,29 . 33,25 . 5,13,54 . 6,99,13 . Ś	AK. 2,8,2,10;H. 680;AV. 15,3,7;AIT. BR. 8,5;KAUŚ. 64;ĀŚV. GṚHY. 2,3;MBH. 1,131;R. 3,49,15;MBH. 3,15142;INDR. 5,3;R. 2,32,9;R 4,25,29;R. 4, 33,25;R 5,13,54;R 6,99,13;ŚĀK. 33,2;PAÑCAT. I, 190;PAÑCAT 36,12;RAGH. 6,64
+AstaraRa	1	2	2〉 f. gaṇa zu P. 4,1,41	P. 4,1,41
+Astika		1	1〉 adj. der an die Wahrheit der Ueberlieferung [Page1-0742] glaubt, gläubig ( Gegens. und ) P. 4,4,60 . H. 490 . MBH. 1,3088 . 225 . 3,13782 . 14512 . R. 2,109,37 . YĀJÑ. 1,267 . SUŚR. 1,123,20 . PRAB	P. 4,4,60;H. 490;MBH. 1,3088;MBH. 1, 225;MBH 3,13782;MBH. 3, 14512;R. 2,109,37;YĀJÑ. 1,267;SUŚR. 1,123,20;PRAB. 27,9;MADHUS;Ind. St. 1,13;R. 2,109,36;SIDDH. K;P. 4,4,60
+Astika		2	2〉 falsche Form für im ŚKDR. und bei WILSON	ŚKDR;WILSON
+Asura		1	1〉 adj. f. nach der doppelten Bedeutung von	
+Asura		1a	a〉 geistig, göttlich: ṚV. 3,29,11 . von Varuṇa 5,85,5 . ( vgl. P. 4,4,124 ) VS. 11,69 . AV. 3,22,4	ṚV. 3,29,11;ṚV 5,85,5;P. 4,4,124;VS. 11,69;AV. 3,22,4
+Asura		1b	b〉 zu den bösen Geistern gehörig, ihnen geweiht, asurisch, dämonisch: ṚV. 5,40,5 . 9 . 10,131,4 . VS. 19,34 . AV. 8,5,9 . ŚAT. BR. 5,3,2,2 . 4,1,9 . 13,8,1,5 . 2,1 . KĀTY. ŚR. 1,10,14 . CHĀND. UP. 8,8	ṚV. 5,40,5;ṚV. 5,40, 9;ṚV 10,131,4;VS. 19,34;AV. 8,5,9;ŚAT. BR. 5,3,2,2;ŚAT. BR. 5, 4,1,9;ŚAT. BR 13,8,1,5;ŚAT. BR. 13,8, 2,1;KĀTY. ŚR. 1,10,14;CHĀND. UP. 8,8,5;M. 3,21;M. 3, 24;M. 3, 25;M 9,197;M 3,31;M 11,20;ARJ. 10,30;BHAG. 16,7;BHAG 7,15;BHAG 9,12;BHAG 16,4;BHAG. 16, 20;PRAB. 113,19;MBH. 3,765;DAŚ. 1,2;DAŚAK. 64,3 v. u
+Asura		2	2〉 m	
+Asura		2a	a〉 = ein Asura , gaṇa zu P. 5,4,38 . f. AV. 1,24,1 . 2 . 7,38,2 . AIT. BR. 2,22 (dieselbe Belegstelle ist aus Versehen u. 4,a angegeben worden)	P. 5,4,38;AV. 1,24,1;AV. 1,24, 2;AV 7,38,2;AIT. BR. 2,22
+Asura		2b	b〉 = ( s. u. 1, ŚKDR. Bei dieser Heirathsform erkauft der Bräutigam die Braut, indem er nach M. 3,31 den Verwandten und der Braut soviel giebt, als er vermag	ŚKDR;M. 3,31
+Asura		2c	c〉 pl. die Sterne der südlichen Hemisphäre SŪRYAS. KĀLAS. 355 . HAUGHTON	SŪRYAS;KĀLAS. 355;HAUGHTON
+Asura		2d	d〉 ein Fürst der Asura (eines Kriegerstammes) gaṇa zu P. 5,3,117 ; vgl. Vārtt. 2 zu 4,1,177	P. 5,3,117;Vārtt. 2 zu 4,1,177
+Asura		3	3〉 f	
+Asura		3a	a〉 Chirurgie VAIDY. und ŚABDAC. _im_ ŚKDR	VAIDY;ŚABDAC;ŚKDR
+Asura		3b	b〉 schwarzer Senf, Sinapis ramosa Roxb. , AK. 2,9,19 . H. 419	AK. 2,9,19;H. 419
+Asura		4	4〉 n	
+Asura		4a	a〉 Blut H. 621	H. 621
+Asura		4b	b〉 schwarzes Salz ( ) RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+Asura		1	1〉	
+Asura		1a	a〉 auch KĀṬH. 16,7 . TS. 4,1,9,2	KĀṬH. 16,7;TS. 4,1,9,2
+Asura		1b	b〉 ( Gegens. ) ṚV. PRĀT. 16,2 . Ind. St. 8,230 . 232 . ĀŚV. GṚHY. 1,6,6 . eines Schule (wohl von ) Ind. St. 3,259	ṚV. PRĀT. 16,2;Ind. St. 8,230;Ind. St. 8, 232;ĀŚV. GṚHY. 1,6,6;Ind. St. 3,259
+Asura		2	2〉	
+Asura		2a	a〉 KĀṬH. 11,5 . WEBER, RĀMAT. UP. 297	KĀṬH. 11,5;WEBER, RĀMAT. UP. 297
+Asura		3	3〉	
+Asura		3c	c〉 ( sc. ) Bez. des penis ( ) oder vielmehr der Harnröhre BHĀG. P. 4,25,52 . 29,14 . vulva BURN	BHĀG. P. 4,25,52;BHĀG. P. 4, 29,14;BURN
+AsutIvala		1	1〉 Opferpriester, (wohl der Soma -Trankbereiter) TRIK. 3,3,381 . H. 818 . 5,44 . 45 . MED. l. 168	TRIK. 3,3,381;H. 818;H. an 5,44;H. an. 5, 45;MED. l. 168
+AsutIvala		2	2〉 ein Bereiter oder Verkäufer von berauschenden Getränken TRIK. H. 901 . H. an	TRIK;H. 901;H. an
+AsutIvala		3	3〉 der mit Sclavinnen Handel treibt (!), MED	MED
+AsutIvala		1	¦ [ vgl. [Page1-0739]] Die 3te Bedeutung ist zu streichen, da MED. l. 168 offenbar nur Druckfehler für ist	MED. l. 168
+AsutIvala		3	3〉 zu streichen, da a. a. O. gewiss nur Druckfehler für ist	
+AsvAda		1	1〉 adj. kostend, schmeckend: M. 11,9	M. 11,9
+AsvAda		2	2〉 m	
+AsvAda		2a	a〉 das Kosten, Genuss (auch in übertr. Bed. ): H. 424 . KUMĀRAS. 3,32 . KATHĀS. 25,105 . VID. 278 . SĀH. D. 27,2 . HIT. I, 145 . das Küssen des Mundes YĀJÑ. 3,229	H. 424;KUMĀRAS. 3,32;KATHĀS. 25,105;VID. 278;SĀH. D. 27,2;HIT. I, 145;YĀJÑ. 3,229
+AsvAda		2b	b〉 der an einer Sache haftende Geschmack (auch in übertr. Bed. ): PAÑCAT. 263,22 . 61,11 . 200,7 . R. 4,61,28 . PAÑCAT. I, 429 . HIT. IV, 76 . MEGH. 42 . HIḌ. 1,20	PAÑCAT. 263,22;PAÑCAT 61,11;PAÑCAT 200,7;R. 4,61,28;PAÑCAT. I, 429;HIT. IV, 76;MEGH. 42;HIḌ. 1,20
+AsvAda		1	1〉 zu streichen und die Stelle unter	
+AsvAda		2	2〉	
+AsvAda		2a	a〉 zu setzen; vgl. u	
+AsvAda		2	2〉	
+AsvAda		2a	a〉 Verz. d. Oxf. H. 231,a,23 . 25 . VEDĀNTAS. (Allah.) No. 139	Verz. d. Oxf. H. 231,a,23;Verz. d. Oxf. H. 231,a, 25;VEDĀNTAS. (Allah.) No. 139
+AsvAda		2b	b〉 wie Honig schmeckend MBH. 13,4429	MBH. 13,4429
+AsyA		1	1〉 das Sitzen SUŚR. 2,142,20	SUŚR. 2,142,20
+AsyA		2	2〉 Aufenthalt AK. 3,3,21 . H. 1498 . an. 2,345 . MED. y. 5 . Vgl. 6	AK. 3,3,21;H. 1498;H an. 2,345;MED. y. 5
+AsyA		3	3〉 Zustand: H. 1497 . Vgl. 7	H. 1497
+Asya		1	1〉 Mund, Maul, Rachen NIR. 1,9 . AK. 2,6,2,40 . H. 572 . 1237 . H. an. 2,345 . MED. y. 5 . ṚV. 1,38,14 . 61,3 . 5,12,1 . 7,15,1 . 102,3 . 1,162,8 . 2,1,13 . 10,39,13 . VS. 2,11 . AV. 6,56,3 . 139,2 . 	NIR. 1,9;AK. 2,6,2,40;H. 572;H 1237;H. an. 2,345;MED. y. 5;ṚV. 1,38,14;ṚV. 1, 61,3;ṚV 5,12,1;ṚV 7,15,1;ṚV. 7, 102,3;ṚV 1,162,8;ṚV 2,1,13;ṚV 10,39,13;VS. 2,11;AV. 6,56,3;AV. 6, 139,2;AV. 6,56, 4;AV 7,56,8;AV. 7, 70,4;AV 6,76,2;AV 9,8,3;ŚAT. BR. 11,1,6,7;ŚAT. BR 12,7,3,20;ŚAT. BR 14,4,1,9;BṚH. ĀR. UP. 1,3,8;KĀTY. ŚR. 6,3,31;KĀTY. ŚR 15,5,22;CHĀND. UP. 5,18,2;P. 1,3,20;M. 1,94;M. 1, 95;M 4,117;M 5,130;M. 5, 141;M 8,271;INDR. 1,6;N. 12,13;MBH. 3,1566;R. 3,73,19;SUŚR. 1,100,8;SUŚR. 1, 115,11;SUŚR. 1, 156,14;SUŚR. 1, 210,20;MBH. 2,2178;R. 3,61,19;R 5,17,29;ŚṚṄGĀRAT. 1;YĀJÑ. 3,199
+Asya		2	2〉 ein Theil des Mundes, insofern er bei der Aussprache eines Lautes betheiligt ist; das Organ, mit dem ein Laut ausgesprochen wird: VS. PRĀT. 1,43 . P. 1,1,9 . (Kehle, Gaumen, Kopf, Zähne, Lippen, Na	VS. PRĀT. 1,43;P. 1,1,9;PAÑCAT. V, 44;KĀŚ;P. 1,1,9;H. an. 3,245;MED. y. 5
+Asya		3	3〉 Mündung, Oeffnung, z. B. einer Wunde SUŚR. 2,7,18 . — Vgl. 3. und	SUŚR. 2,7,18
+Asya		1	1〉 Z. 10 stelle ŚṚṄGĀRAT. 1 (= Spr. 1970 ) in die folgende Zeile nach 3,199. — Vgl	ŚṚṄGĀRAT. 1;Spr. 1970
+At		1b	adv	
+At		1	1〉 darauf, dann, da: ṚV. 1,148,4 . 164,47 . 127,5 . 148,4 . 7,64,3 . 8,52,5 . Besonders häufig im Nachsatz nach und oft verstärkt durch eine der Partikeln . 1,115,4 . 8,21,14 . 1,32,4 . 51,4 . 87,5 . 	ṚV. 1,148,4;ṚV 164,47;ṚV 127,5;ṚV 148,4;ṚV 7,64,3;ṚV 8,52,5;ṚV 1,115,4;ṚV 8,21,14;ṚV 1,32,4;ṚV. 1, 51,4;ṚV. 1, 87,5;ṚV. 1, 140,5;ṚV 8,82,15;AV. 10,10,10;NIR. 6,8
+At		2	2〉 einfach anreihend: dann, ferner, auch, und: ṚV. 7,66,11 . 1,18,8 . 71,3 . 116,10 . 10,82,2 . AV. 3,21,10 . 4,3,3 . 4 . 9,8 . 20,1 . 7,70,2 . 10,9,8	ṚV. 7,66,11;ṚV 1,18,8;ṚV. 1, 71,3;ṚV. 1, 116,10;ṚV 10,82,2;AV. 3,21,10;AV 4,3,3;AV. 4,3, 4;AV. 4, 9,8;AV. 4, 20,1;AV 7,70,2;AV 10,9,8
+At		3	3〉 am schwächsten erscheint die Bedeutung, wenn das Wort am Anfange eines demonstrativen Nachsatzes steht nur um diesen deutlich hervorzuheben: der sich allein für unwiderstehlich hielt, dem erstand e	ṚV. 5,52,3;ṚV 1,67,8
+At		4	4〉 nach einem Fragewort: (wie) dann, (wie, ob) doch; wie sonst häufig u. s. w. : ṚV. 1,33,1 . 4,23,6 . 30,7	ṚV. 1,33,1;ṚV 4,23,6;ṚV. 4, 30,7
+AtAra		1	1〉 das Anlanden Ind. St. 2,41	Ind. St. 2,41
+AtAra		2	2〉 = ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+AtaNka		1	1〉 körperliches Leiden AK. 3,4,10 . H. 462 . an. 3,8 . MED. k. 49 . SUŚR. 1,30,15 . 81,5 . 89,13 . YĀJÑ. 3,245 . Fieber RĀJAN. _im_ ŚKDR. Titel eines medic. Werkes Z. d. d. m. G. 2,338 ( No. 143 )	AK. 3,4,10;H. 462;H an. 3,8;MED. k. 49;SUŚR. 1,30,15;SUŚR. 1, 81,5;SUŚR. 1, 89,13;YĀJÑ. 3,245;RĀJAN;ŚKDR;Z. d. d. m. G. 2,338;Z. d. d. m. G. 2, No. 143
+AtaNka		2	2〉 Leiden der Seele, Unruhe, Besorgniss, Furcht AK. H. 301 . H. an. MED. VIKR. 41,20 . SĀH. D. 71,2 . PRAB. 43,5 . adv. ad. ŚĀK. 14 . MBH. 2,1944 . RAGH. 1,63 . DEV. 12,30 . f. MBH. 2,285 (kann auch z	AK;H. 301;H. an;MED;VIKR. 41,20;SĀH. D. 71,2;PRAB. 43,5;ŚĀK. 14;MBH. 2,1944;RAGH. 1,63;DEV. 12,30;MBH. 2,285
+AtaNka		2a	a〉 Pein ( )	
+AtaNka		2b	b〉 Furcht	
+AtaNka		3	3〉 der Laut einer Trommel H. an. MED	H. an;MED
+AtaNka		1	¦ vgl	
+AtaNka		2	2〉 Furcht vor dem Tode (das vorangehende ist als Correlativ zu aufzufassen) HEM. YOGAŚ. 4,60	HEM;YOGAŚ. 4,60
+AtaYcana		1	1〉 Mittel zum Gerinnen, coagulum, Lab. — [Page1-0616]	
+AtaYcana		2	2〉 geronnene Milch; die sich darin absondernde Flüssigkeit, Zieger: ( ) TS. 2,5,3,5 . ŚAT. BR. 3,3,3,2 . 11,1,4,1 . KĀTY. ŚR. 7,8,8 . 25,4,38 . Nach den Lexicographen:	TS. 2,5,3,5;ŚAT. BR. 3,3,3,2;ŚAT. BR 11,1,4,1;KĀTY. ŚR. 7,8,8;KĀTY. ŚR 25,4,38
+AtaYcana		2a	a〉 = AK. 3,4,118 . H. an. 4,160 . MED. n. 166 . SVĀMIN erklärt: das Bestreuen von geschmolzenem Golde u. s. w. mit einer andern Substanz (zum Oxydiren); SĀRAS. : das dazu geeignete Pulver; SUBHŪTI : d	AK. 3,4,118;H. an. 4,160;MED. n. 166;SVĀMIN;SĀRAS;SUBHŪTI;RĀYAM
+AtaYcana		2b	b〉 Eile ( ) AK. H. an. in MED. ist wohl nur Druckfehler für =	AK;H. an;MED
+AtaYcana		2c	c〉 das Fettmachen ( ) AK. H. an. MED	AK;H. an;MED
+AtaYcana		2d	d〉 das Befördern H. an	H. an
+AtarpaRa		1	1〉 Befriedigung ( ) MED. ṇ. 91	MED. ṇ. 91
+AtarpaRa		2	2〉 das Anstreichen von Mauern u. s. w. bei Festlichkeiten ( ) MED	MED
+AtarpaRa		2	2〉 TRIK. 2,9,13	TRIK. 2,9,13
+AtiTeya	1	1	1〉 adj. f. für einen Gast bestimmt, gastlich, gastfreundschaftlich P. 4,4,104 . AK. 2,7,33 . M. 3,18 . ŚĀK. 7,11 . RAGH. 12,25 . 5,2 . KUMĀRAS. 5,31	P. 4,4,104;AK. 2,7,33;M. 3,18;ŚĀK. 7,11;RAGH. 12,25;RAGH 5,2;KUMĀRAS. 5,31
+AtiTeya	1	2	2〉 f. gastfreundliche Aufnahme H. 499 (nach den Sch. auch n. )	H. 499
+AtiTeya	1	1	1〉 gastfreundschaftlich KATHĀS. 72,376 . 86,30 . 87,51	KATHĀS. 72,376;KATHĀS 86,30;KATHĀS 87,51
+AtiTeya	1	3	3〉 n. Gastfreundschaft, gastfreundliche Aufnahme HALĀY. 2,204 . Hierher gehört M. 3,18	HALĀY. 2,204;M. 3,18
+AtiTya	1	1	1〉 adj. für einen Gast bestimmt, gastlich P. 5,4,26 . AK. 2,7,33 . H. an. 3,482 . MED. y. 72 . AIT. BR. 1,15 . , näml. , KĀTY. ŚR. 2,7,15 . 17 . 4,5,10	P. 5,4,26;AK. 2,7,33;H. an. 3,482;MED. y. 72;AIT. BR. 1,15;KĀTY. ŚR. 2,7,15;KĀTY. ŚR. 2,7, 17;KĀTY. ŚR 4,5,10
+AtiTya	1	2	2〉 m. Gast H. 499 , Sch. H. an. MED	H. 499;H. an;MED
+AtmADIna		1	1〉 ( viell. auf die Seele bezüglich, [Page1-0626] oder ist etwa ein lebendes Wesen zu lesen?)	
+AtmADIna		2	2〉 Sohn	
+AtmADIna		3	3〉 Bruder der Frau	
+AtmADIna		4	4〉 Narr im Drama H. an. 4,161 . — Vgl. und	H. an. 4,161
+AtmArAma		1	1〉 adj. im eigenen Selbst Freude findend Spr. 3313 . BHĀG. P. 10,73,23 . 83,39	Spr. 3313;BHĀG. P. 10,73,23;BHĀG. P. 10, 83,39
+AtmArAma		2	2〉 m. N. pr. eines Autors Verz. d. Oxf. H. 233,b, No. 566	Verz. d. Oxf. H. 233,b, No. 566
+AtmaBAva		1	1〉 das Sein, das Dasein der Seele ŚVETĀŚV. UP. 1,2	ŚVETĀŚV. UP. 1,2
+AtmaBAva		2	2〉 das Selbst, die eigene Person BURN. Lot. de la b. l. 411	BURN;Lot. de la b. l. 411
+AtmaBAva		3	3〉 Körper ibid	
+AtmaBAva		2	2〉 Spr. 4054	Spr. 4054
+AtmaBU		1	1〉 Brahman ʼs AK. 1,1,1,11 . TRIK. 3,3,284 . H. 213 . an. 3,451 . MED. bh. 11 . ŚĀK. 186 . KUMĀRAS. 2,53	AK. 1,1,1,11;TRIK. 3,3,284;H. 213;H an. 3,451;MED. bh. 11;ŚĀK. 186;KUMĀRAS. 2,53
+AtmaBU		2	2〉 Viṣṇu ʼs H. 217 . ŚABDAR. _im_ ŚKDR. RAGH. 10,21	H. 217;ŚABDAR;ŚKDR;RAGH. 10,21
+AtmaBU		3	3〉 Śiva ʼs ŚABDAR. ŚĀK. 194 . ŚIV	ŚABDAR;ŚĀK. 194;ŚIV
+AtmaBU		4	4〉 des Liebesgottes AK. 1,1,1,21 . TRIK. 3,3,284 . H. 229 , Sch. H. an. MED	AK. 1,1,1,21;TRIK. 3,3,284;H. 229;H. an;MED
+AtmaBU		4	4〉 als Bez. des Liebesgottes ( BHĀG. P. 11,26,14 ) so v. a. im Herzen entstehend; vgl	BHĀG. P. 11,26,14
+AtmaGoza		1	1〉 Krähe AK. 2,5,20 . H. 1322 . HĀR. 84	AK. 2,5,20;H. 1322;HĀR. 84
+AtmaGoza		2	2〉 Hahn ŚABDAC. _im_ ŚKDR	ŚABDAC;ŚKDR
+Atmagati		1	1〉 das Leben des Geistes NIR. 3,12 . 12,38	NIR. 3,12;NIR 12,38
+Atmagati		2	2〉 der Gang des eigenen Selbst: von selbst, ohne Zuthun eines Andern ŚĀK. 104,14	ŚĀK. 104,14
+Atmahan		1	1〉 adj	
+Atmahan		1a	a〉 der seine Seele tödtet, nicht an die Wohlfahrt der Seele denkt ĪŚOP. 3	ĪŚOP. 3
+Atmahan		1b	b〉 der sich umʼs Leben bringt, ein Selbstmörder MBH. 1,6839	MBH. 1,6839
+Atmahan		2	2〉 m. Aufseher eines Heiligthums ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+Atmahan		1	1〉	
+Atmahan		1a	a〉 BHĀG. P. 11,20,17	BHĀG. P. 11,20,17
+Atmaja		1	1〉 m. Sohn (aus dem Selbst des Vaters entstanden) AK. 2,6,1,27 . H. 542 . NIR. 3,6 . M. 7,14 . INDR. 1,11 . R. 1,1,51 . 2,39,6 . HIT. 42,21 . KATHĀS. 19,69 . Nachkomme: wird Viśvāmitra genannt VIŚV. 7	AK. 2,6,1,27;H. 542;NIR. 3,6;M. 7,14;INDR. 1,11;R. 1,1,51;R 2,39,6;HIT. 42,21;KATHĀS. 19,69;VIŚV. 7,5;VIŚV 13,5;BRĀHMAṆ. 2,20;R. 2,39,29
+Atmaja		2	2〉 f	
+Atmaja		2a	a〉 Tochter AK. H. SĀV. 4,14 . N. 12,71 . R. 1,1,69 . 3,3,18 . 5,27,5 . ŚĀK. 14,13 . RAGH. 13,78 . KATHĀS. 25,290 . VID. 100	AK;H;SĀV. 4,14;N. 12,71;R. 1,1,69;R 3,3,18;R 5,27,5;ŚĀK. 14,13;RAGH. 13,78;KATHĀS. 25,290;VID. 100
+Atmaja		2b	b〉 die Vernunft ( ) ŚABDAR. _im_ ŚKDR. — Vgl	ŚABDAR;ŚKDR
+Atmaja		1	¦ adj. von selbst entstanden: (so die ed. Bomb. ) MBH. 12,12449	ed. Bomb;MBH. 12,12449
+AtmakAma		1	1〉 sich selbst liebend, Eigenliebe besitzend R. 2,70,10	R. 2,70,10
+AtmakAma		2	2〉 den Allgeist liebend ŚAT. BR. 14,7,1,21 . 2,8 = BṚH. ĀR. UP. 4,3,21 . 4,6	ŚAT. BR. 14,7,1,21;ŚAT. BR. 14,7, 2,8;BṚH. ĀR. UP. 4,3,21;BṚH. ĀR. UP. 4, 4,6
+Atman		1	1〉 Hauch: ṚV. 10,92,13 . 34,7 . 7,87,2 . 10,168,4	ṚV. 10,92,13;ṚV. 10, 34,7;ṚV 7,87,2;ṚV 10,168,4
+Atman		2	2〉 Seele, als Princip von Leben und Empfindung, im nächsten Gegensatz zum Leibe AK. 1,1,4,7 . 3,4,35 . 209 . TRIK. 1,1,114 . H. 1366 . an. 2,258 . MED. n. 38 . ṚV. 1,162,20 . AV. 1,18,3 . 7,57,1 . TS.	AK. 1,1,4,7;AK. 1, 3,4,35;AK. 1,1,4, 209;TRIK. 1,1,114;H. 1366;H an. 2,258;MED. n. 38;ṚV. 1,162,20;AV. 1,18,3;AV 7,57,1;TS. 1,1,10,12;ṚV. 1,164,4;ṚV 10,16,3;ṚV. 10, 107,7;ṚV 8,3,24;ṚV 1,149,3;AV. 5,9,7;AV. 5, 5,7;AV 6,53,2;AV 11,8,31;VS. 11,20;TS. 2,3,11,1;ŚAT. BR. 4,6,1,1;ŚAT. BR 14,3,2,5;ṚV. 1,115,1;ṚV 7,101,7;ṚV 9,6,8;ṚV. 9, 2,10;ŚAT. BR. 10,4,2,3;BHAG. 9,5;HIT. I, 151
+Atman		3	3〉 das Selbst, die eigene Person; häufig für das pron. refl. : ṚV. 9,113,1 . 10,163,5 . SV. II, 5,2,8,5 . AV. 9,5,30 . 5,29,6 . 3,15,7 . 29,8 . 4,12,2 . 20,5 . AIT. BR. 2,3 . 6,35 . ŚAT. BR. 3,9,1,3 .	ṚV. 9,113,1;ṚV 10,163,5;SV. II, 5,2,8,5;AV. 9,5,30;AV 5,29,6;AV 3,15,7;AV. 3, 29,8;AV 4,12,2;AV. 4, 20,5;AIT. BR. 2,3;AIT. BR 6,35;ŚAT. BR. 3,9,1,3;ŚAT. BR 10,6,5,3;ŚAT. BR 14,9,4,26;KĀTY. ŚR. 2,6,14;TS. 5,1,9,6;ŚAT. BR. 3,1,3,27;ŚAT. BR 2,5,3,4;ŚAT. BR 4,5,4,5;ŚAT. BR 1,8,1,42;ŚAT. BR 3,1,4,6;ŚAT. BR 5,2,1,2;M. 4,254;M 9,45;M. 9, 130;M 10,28;M 8,84;SĀV. 7,14;BRĀHMAṆ. 3,11;N. 22,16;VET. 33,10;N. 11,11;N 12,64;BRĀHMAṆ. 1,32;ŚĀK. 19,1;ŚĀK 32,12;ŚĀK 66,18;N. 11,8;M. 7,213;M. 7, 170;N. 9,17;R. 1,1,74;ŚĀK. 25,4;ŚĀK 7,20;MĀLAV. 50;R. 1,66,22;RAGH. 10,61;M. 6,49;M 7,46;N. 2,7;RAGH. 3,35;M. 7,46;M. 1,14;DAŚ. 1,29;R. 3,20,2;RAGH. 1,79;RAGH. 1, 87;M. 7,57;M. 7, 76;N. 20,31;R. 1,7,17;R 2,64,28;MBH. 1,6086;KATHĀS. 18,275;M. 6,12;M. 6, 25;M. 6, 38;RAGH. 2,41;MBH. 1,2485;N. 6,11;N 18,8;M. 9,12;MBH. 3,10966;N. 19,8;R. 2,21,8;ŚĀK. 88;ŚĀK 98,9;RAGH. 1,88;M. 7,212;KATHĀS. 13,52;RAGH. 1,44;MBH. 2,1542;RAGH. 7,38;M. 9,2;ŚĀK. 151;ŚĀK 92;BRĀHMAṆ. 2,3;BRĀHMAṆ. 2,18;HIḌ. 4,14;P. 6,3,6;MBH. 17,25;R. 4,5,9;R 5,89,47;ŚĀK. 6,17;HIT. III, 37;KAIY;P. 6,3,5;M. 1,60;R. 1,9,64;M. 7,39;R. 1,2,24;M. 3,188;M 6,86;M 4,145;M. 4, 146;M 10,110;N. 23,23;N 21,25;R. 1,1,32;N. 20,25;MEGH. 44;RAGH. 1,68
+Atman		4	4〉 Wesen, Natur, Eigenthümlichkeit AK. 3,4,112 . H. 1376 . an. 2,259 . MED. n. 38 . ṚV. 10,97,11 . SĀH. D. 6,18 . Besonders häufig am Ende von adj. compp. : dessen Wesen die That ist M. 1,22 . 53 . 5,	AK. 3,4,112;H. 1376;H an. 2,259;MED. n. 38;ṚV. 10,97,11;SĀH. D. 6,18;M. 1,22;M. 1, 53;M 5,3;M 12,2;R. 1,1,29;R. 1, 23,7;M. 7,27;M 2,2;BHAG. 4,40;MEGH. 41
+Atman		5	5〉 die Person, die sich im Leib als Einheit darstellt; der Leib im Gegens. zu den Gliedern: VS. 19,92 . 93 . 12,4 . 20,7 . 10 . ŚAT. BR. 9,5,2,16 . 12,2,3,6 . 7,2,2,8 . 3,1,44	VS. 19,92;VS. 19, 93;VS 12,4;VS 20,7;VS. 19, 10;ŚAT. BR. 9,5,2,16;ŚAT. BR 12,2,3,6;ŚAT. BR 7,2,2,8;ŚAT. BR. 7, 3,1,44
+Atman		6	6〉 Körper AK. 3,4,112 . H. an. 2,258 . MED. n. 39 . RAGH. 1,14 . KULL. erklärt ohne Noth durch Körper M. 12,12 :	AK. 3,4,112;H. an. 2,258;MED. n. 39;RAGH. 1,14;KULL;M. 12,12
+Atman		7	7〉 Verstand, Intelligenz AK. 3,4,112 . TRIK. 3,3,230 . H. an. 2,258 . MED. n. 39 . von geringem Verstande N. 15,13 . 10,29	AK. 3,4,112;TRIK. 3,3,230;H. an. 2,258;MED. n. 39;N. 15,13;N 10,29
+Atman		8	8〉 die Persönlichkeit in ausgezeichnetem Sinne, das höchste persönliche Lebensprincip, Weltseele, Allgeist ( u. s. w. , syn. mit ) AK. 3,4,112 . H. an. 2,258 . MED. n. 39 . [Page1-0623] AV. 10,8,44 . 	AK. 3,4,112;H. an. 2,258;MED. n. 39;AV. 10,8,44;VS. 32,11;ŚAT. BR. 14,5,5,15;BṚH. ĀR. UP. 2,5,15;ŚAT. BR. 14, 7,1,6;BṚH. ĀR. UP. 4,3,7;NIR. 7,4;NIR 14,1;M. 1,15;M 12,24;UPANIṢAD;Ind. St
+Atman		9	9〉 Fürsorge ( ) AK. 3,4,112 . H. an. 2,258 . MED. n. 38	AK. 3,4,112;H. an. 2,258;MED. n. 38
+Atman		10	10〉 Festigkeit AK. H. an. MED	AK;H. an;MED
+Atman		11	11〉 Sonne	
+Atman		12	12〉 Feuer	
+Atman		13	13〉 Wind H. an	H. an
+Atman		14	14〉 Sohn ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+Atman		15	15〉 DHAR. _im_ ŚKDR. — In den ältern Schriften findet man das von nicht selten nach und gleich einem kurzen abgeworfen: ( Bed. 8.) KAṬHOP. 3,12 . DRAUP. 5,9 . MBH. 1,7537 . 2,2113 . 2521 . 3,12526 . 1	DHAR;ŚKDR;KAṬHOP. 3,12;DRAUP. 5,9;MBH. 1,7537;MBH 2,2113;MBH. 2, 2521;MBH 3,12526;MBH 1,4016;MBH. 1, 6713
+Atman		3	3〉 als pron. reflex. stets im sg. ohne Rücksicht auf die Zahl des Subjects; auf Lebloses bezogen: SĀH. D. 12,12 . auf das grammatische, nicht auf das logische Subject bezogen: (= Schol. ) BHĀG. P. 9,8	SĀH. D. 12,12;BHĀG. P. 9,8,3
+Atman		5	5〉 so v. a. Rumpf WEBER, Nax. 2,314 . Ind. St. 9,18 . 36	WEBER, Nax. 2,314;Ind. St. 9,18;Ind. St. 9, 36
+Atman		6	6〉 Gold im Gewicht des eigenen Körpers WEBER, RĀMAT. UP. 356	WEBER, RĀMAT. UP. 356
+Atman		16	16〉 abgekürzt so v. a. Verz. d. Oxf. H. 394,b,3	Verz. d. Oxf. H. 394,b,3
+AtmanIna		1	1〉 adj. f. = P. 5,1,9 . 6,4,169 . VOP. 7,19 . 22 . dem Selbst zukommend, eigen: PRAB. 95,4 . Sch. 1: = , Sch. 2: =	P. 5,1,9;P 6,4,169;VOP. 7,19;VOP. 7, 22;PRAB. 95,4
+AtmanIna		2	2〉 m	
+AtmanIna		2a	a〉 Sohn	
+AtmanIna		2b	b〉 ein lebendes Wesen ( )	
+AtmanIna		2c	c〉 Bruder der Frau	
+AtmanIna		2d	d〉 Narr im Drama ( , wohl wegen seines vertrauten Verhältnisses zum König) Ajaya im ŚKDR. — Vgl. und	ŚKDR
+AtmanIna		1	1〉 der eigenen Person entsprechend BHAṬṬ. 2,48	BHAṬṬ. 2,48
+AtmasAt		1	1〉 auf sich legen: YĀJÑ. 3,54 ; vgl. M. 6,25 :	YĀJÑ. 3,54;M. 6,25
+AtmasAt		2	2〉 sich zu Eigen machen, an sich bringen, für sich gewinnen: MBH. 3,493 . 496 . R. 4,28,9 . BHARTṚ. 3,34 . RAGH. 8,2 . HIT. IV, 37	MBH. 3,493;MBH. 3, 496;R. 4,28,9;BHARTṚ. 3,34;RAGH. 8,2;HIT. IV, 37
+AtmasAt		2	2〉 sich gleich machen: sich gleich macht so v. a. in Staub —, in Erde verwandelt KULL. _zu_ M. 8,251 . so v. a. in sich zurückziehend BHĀG. P. 12,4,4	KULL;M. 8,251;BHĀG. P. 12,4,4
+AtmasaMBava		1	1〉 Sohn MBH. 1,6651 . R. 2,74,10 . 5,18,27 . 6,6,26 . 65,34 . RAGH. 3,21 . 11,57 . 17,8	MBH. 1,6651;R. 2,74,10;R 5,18,27;R 6,6,26;R. 6, 65,34;RAGH. 3,21;RAGH 11,57;RAGH 17,8
+AtmasaMBava		2	2〉 f. Tochter R. 3,20,22 . — Vgl	R. 3,20,22
+AtmavIra		1	1〉 ein mächtiger Mann, = H. an. 4,239 . = MED. r. 250	H. an. 4,239;MED. r. 250
+AtmavIra		2	2〉 Sohn H. an	H. an
+AtmavIra		3	3〉 Bruder der Frau H. an. MED	H. an;MED
+AtmavIra		4	4〉 der Narr im Drama diess. — Vgl. und	
+AtmayAjin		1	1〉 für sich selbst opfernd ŚAT. BR. 11,2,6,13	ŚAT. BR. 11,2,6,13
+AtmayAjin		2	2〉 sich selbst zum Opfer bringend: M. 12,91	M. 12,91
+Atmayoni		1	1〉 Brahman ʼs H. 6 . an. 4,162 . MED. n. 169 . ŚVETĀŚV. UP. 6,16 . ŚAṂK. :	H. 6;H an. 4,162;MED. n. 169;ŚVETĀŚV. UP. 6,16;ŚAṂK
+Atmayoni		2	2〉 Śiva ʼs ŚIV	ŚIV
+Atmayoni		3	3〉 des Liebesgottes H. 229 , Sch. an. 4,162 . MED. KUMĀRAS. 3,70	H. 229;H an. 4,162;MED;KUMĀRAS. 3,70
+AtmodBava		1	1〉 m. Sohn RAGH. 18,11 . Vgl	RAGH. 18,11
+AtmodBava		2	2〉 f. Glycine debilis Roxb. ( ), eine Fabacee, RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+Atmya		1	1〉 einer Person angehörig, persönlich; s	
+Atmya		2	2〉 am Ende eines comp. (das und das) Wesen habend: CHĀND. UP. 6,8,7 . ŚAṂK. hat st. dessen	CHĀND. UP. 6,8,7;ŚAṂK
+Atmya		1	¦ Nebenform zu in einer Legende TBR. 3,2,8,11	TBR. 3,2,8,11
+Atreya		1	1〉 adj. f. von Atri herrührend: (nämlich ṚV. 5,51,11. fgg. ) ĀŚV. GṚHY. 3,4 . COLEBR. Misc. Ess. I, 16, N. 74 . WEBER, Lit. 86 — 89 . Ind. St. 1,71 . 73 . 2,16 . 177	ṚV. 5,51,11. fgg;ĀŚV. GṚHY. 3,4;COLEBR. Misc. Ess. I, 16, N. 74;WEBER, Lit. 86;WEBER, Lit 89;Ind. St. 1,71;Ind. St. 1, 73;Ind. St 2,16;Ind. St. 2, 177
+Atreya		2	2〉 m	
+Atreya		2a	a〉 Abkömmling des Atri P. 4,1,122 , Sch. VOP. 7,1 . 5 . TRIK. 3,3,305 . H. an. 3,481 . MED. y. 73 . ŚAT. BR. 14,5,5,21 . 7,3,27 (= BṚH. ĀR. UP. 2,6,3 . 4,6,3 ). HARIV. 477 . 481 . COLEBR. Misc. Ess. I	P. 4,1,122;VOP. 7,1;VOP. 7, 5;TRIK. 3,3,305;H. an. 3,481;MED. y. 73;ŚAT. BR. 14,5,5,21;ŚAT. BR. 14, 7,3,27;BṚH. ĀR. UP. 2,6,3;BṚH. ĀR. UP 4,6,3;HARIV. 477;HARIV 481;COLEBR. Misc. Ess. I, 16;COLEBR. Misc. Ess. I, 296;COLEBR. Misc. Ess. I, II, 48;WEBER, Lit. 98;WEBER, Lit 148;WEBER, Lit 216;WEBER, Lit 218;WEBER, Lit 235;WEBER, Lit 237;Verz. d. B. H. 58;Verz. d. B. H. No 59;Verz. d. B. H. No 194;Verz. d. B. H. No 366;Verz. d. B. H. No 940;Verz. d. B. H. No 941;Verz. d. B. H. No 947;Verz. d. B. H. No 987;Verz. d. B. H. No 1006;Ind. St. 1,21;Ind. St. 1, 71;Ind. St. 1, 263;Ind. St 2,32;Ind. St 1,228;Ind. St. 1, 269;P. 4,1,117;P. 4,1,110;P. 2,4,65;MBH. 3,971;VP. 196
+Atreya		2b	b〉 m. Bezeichnung eines Priesters, der mit dem Sadasya in nächster Beziehung steht: AIT. BR. 7,7 . ŚAT. BR. 4,3,4,21 . KĀTY. ŚR. 10,2,21 . Vielleicht wurde zu diesem Amte immer ein Abkömmling des Atri	AIT. BR. 7,7;ŚAT. BR. 4,3,4,21;KĀTY. ŚR. 10,2,21
+Atreya		2c	c〉 ein Bein. Śiva ʼs ŚIV	ŚIV
+Atreya		2d	d〉 m. Lymphe H. 620	H. 620
+Atreya		3	3〉 f	
+Atreya		3a	a〉 ein weiblicher Nachkomme des Atri P. 2,4,65	P. 2,4,65
+Atreya		3b	b〉 ein menstruirendes Weib AK. 2,6,1,20 . TRIK. 3,3,305 . H. 535 . an. 3,481 . MED. y. 73 . ŚAT. BR. 1,4,5,13 . Nach SĀY. ein nach einer Fehlgeburt menstruirendes Weib (oder diejenige, bei welcher in 	AK. 2,6,1,20;TRIK. 3,3,305;H. 535;H an. 3,481;MED. y. 73;ŚAT. BR. 1,4,5,13;SĀY;M. 11,87;YĀJÑ. 3,251;KULL
+Atreya		3c	c〉 N. pr. eines Flusses TRIK. 3,3,305 . H. an. 3,481 . MED. y. 73 . MBH. 2,374 . = Tistā (der letzte unmittelbare Zufluss der Gaṅgā aus Norden) LIA. I, 60, N. 1	TRIK. 3,3,305;H. an. 3,481;MED. y. 73;MBH. 2,374;LIA. I, 60, N. 1
+Atreya		1	1〉 in ist adj. von 2,a〉; vgl. Ind. St. 3,396	Ind. St. 3,396
+Atreya		2	2〉	
+Atreya		2a	a〉 pl. als N. eines Volksstammes MBH. 6,376 = VP. 196	MBH. 6,376;VP. 196
+Atreya		4	4〉 n. N. zweier Sāman Ind. St. 3,205,a	Ind. St. 3,205,a
+AvAha		1	1〉 das Heirathen VYUTP. 219	VYUTP. 219
+AvAha		2	2〉 N. pr. ein Sohn Śvaphalka ʼs HARIV. 1918 . 2085	HARIV. 1918;HARIV 2085
+AvAha		1	¦ wohl Einladung zum Schmause in der Stelle: MBH. 13,3232 . Vgl. im Pāli , welches BURNOUF. _in_ Lot. de la b. l. 470 durch faire des conjurations und détourner des conjurations, WEBER aber in Ind. St	MBH. 13,3232;BURNOUF;Lot. de la b. l. 470;WEBER;Ind. St. 3,156
+AvAhana		1	1〉 n. das Auffordern zum Kommen, Einladen: VIŚV. 10,10 . das Feuer, bei welchem die Aufforderung gesprochen wird, YĀJÑ. 1,250	VIŚV. 10,10;YĀJÑ. 1,250
+AvAhana		2	2〉 f. eine best. Verbindung der Hände: ŚKDR	ŚKDR
+AvAhana		1	1〉 VARĀH. BṚH. S. 48,19 . BHĀG. P. 11,27,13 . Verz. d. Oxf. H. 85,b,18 . 103,b,20	VARĀH. BṚH. S. 48,19;BHĀG. P. 11,27,13;Verz. d. Oxf. H. 85,b,18;Verz. d. Oxf. H 103,b,20
+AvApa		1	1〉 adj. ausstreuend, werfend: MBH. 1,7073 . Vgl	MBH. 1,7073
+AvApa		2	2〉 m	
+AvApa		2a	a〉 das Ausstreuen, MED. p. 14 . das Hinwerfen, H. an. 3,439	MED. p. 14;H. an. 3,439
+AvApa		2b	b〉 das Aussäen: NĀRADA _in_ MIT. 9,10	NĀRADA;MIT. 9,10
+AvApa		2c	c〉 das Hinzustreuen, Beimischung, z. B. von untergeordneten Stoffen in eine Arzenei SUŚR. 2,16,15 . 54,11 . 99,8 . 221,15	SUŚR. 2,16,15;SUŚR. 2, 54,11;SUŚR 99,8;SUŚR 221,15
+AvApa		2d	d〉 Einstreuung, Einschiebung in Formeln, Liedern u. s. w. : ĀŚV. ŚR. 7,5 . 2 . 11,1 . KĀTY. ŚR. 24,1,12 . 13 . SĀH. D. 10,5	ĀŚV. ŚR. 7,5;ĀŚV. ŚR. 7, 2;ĀŚV. ŚR 11,1;KĀTY. ŚR. 24,1,12;KĀTY. ŚR. 24,1, 13;SĀH. D. 10,5
+AvApa		2e	e〉 das Ausstellen von Geräthen ( ) MED. p. 14 . H. an. 3,439 ( )	MED. p. 14;H. an. 3,439
+AvApa		2f	f〉 ein besonderer Trank ( ) H. an. 3,438 . — [Page1-0710]	H. an. 3,438
+AvApa		2g	g〉 Gefäss ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+AvApa		2h	h〉 ein am Handgelenk getragenes Armband H. 663 . auch n. nach dem Sch. MBH. 14,2241 . R. 6,92,15 . Vgl	H. 663;MBH. 14,2241;R. 6,92,15
+AvApa		2i	i〉 = AK. 1,2,3,29 . H. 1095 . an. 3,438 . MED. p. 14	AK. 1,2,3,29;H. 1095;H an. 3,438;MED. p. 14
+AvApa		2k	k〉 unebener Boden AJAYA _im_ ŚKDR	AJAYA;ŚKDR
+AvApa		2l	l〉 die Angelegenheiten mit dem Feinde, H. 715 . SĀH. D. 35,18 ( die Ausg. von 1828, p. 40, l. 7 richtig: ). DAŚAK. 187,2 . ŚIŚUP. 2,88	H. 715;SĀH. D. 35,18;die Ausg. von 1828, p. 40, l. 7;DAŚAK. 187,2;ŚIŚUP. 2,88
+AvApa		2m	m〉 Hauptopfer ( ) angeblich nach der SMṚTI ŚKDR	SMṚTI;ŚKDR
+AvApa		1	1〉 zu streichen, da hier die Bed	
+AvApa		2	2〉	
+AvApa		2h	h〉 hat. BENFEY giebt die Bed. Bogen	BENFEY
+AvApa		2	2〉	
+AvApa		2c	c〉 Zusatz, Hinzufügung WEBER, JYOT. 55. fg	WEBER, JYOT. 55. fg
+AvApa		2d	d〉 ŚĀṄKH. ŚR. 1,16,3 . 12,1,9 . n. heisst bei Bildung eines Stoma die Ṛc eines Tṛca , welche mehr als dreimal wiederholt wird, LĀṬY. 4,4,2 . 3 . 6,5,2 . PĀR. GṚHY. 1,5,5	ŚĀṄKH. ŚR. 1,16,3;ŚĀṄKH. ŚR 12,1,9;LĀṬY. 4,4,2;LĀṬY. 4,4, 3;LĀṬY 6,5,2;PĀR. GṚHY. 1,5,5
+AvApa		1	¦ Saatfeld: so v. a. in diesem Jammerthal BHĀG. P. 4,22,13	BHĀG. P. 4,22,13
+Avaha		1	1〉 adj. f. herbeiführend, bewirkend; in comp. mit dem obj. : BRAHMA-P. 52,17 . ŚVETĀŚV. UP. 2,8 . M. 8,347 . BHAG. 3,35 . R. 1,14,44 . 4,9,18 . RĀJA-TAR. 5,344 . VET. 5,9 . ŚVETĀŚV. UP. 6,6 . M. 11,70	BRAHMA-P. 52,17;ŚVETĀŚV. UP. 2,8;M. 8,347;BHAG. 3,35;R. 1,14,44;R 4,9,18;RĀJA-TAR. 5,344;VET. 5,9;ŚVETĀŚV. UP. 6,6;M. 11,70;YĀJÑ. 1,356;BRĀHMAṆ. 2,5;R. 1,4,5;R 3,17,17;PAÑCAT. I, 463;PAÑCAT. I, III, 5;HIT. I, 172;BRAHMA-P. 49,1;R. 1,23,13;R 4,49,10;ŚĀNTIŚ. 1,20;R. 6,74,39;PAÑCAT. V, 62;RAGH. 14,5;KATHĀS. 15,111;AK. 1,1,4,5;RĀJA-TAR. 5,223;RĀJA-TAR. 5, 399
+Avaha		2	2〉 m. N. eines der siehen Winde HARIV. 12787 . BRAHMĀṆḌA-P. beim Sch. zu ŚĀK. 165 . einer der sieben Zungen des Feuers COLEBR. Misc. Ess. I, 190, N	HARIV. 12787;BRAHMĀṆḌA-P;ŚĀK. 165;COLEBR. Misc. Ess. I, 190, N
+Avaha		1	1〉 mit dem acc. : BHĀG. P. 9,11,17 . v. l. beim Schol. — Vgl	BHĀG. P. 9,11,17
+Avantika		1	1〉 adj. aus Avanti stammend u. s. w. : VARĀH. BṚH. S. 85 _in_ Verz. d. B. H. 249 . m. pl. N. einer buddhistischen Schule BURN. Intr. 446 . Lot. de la b. l. 357 ( ). Die Kürze (durch das Versmaass gesi	VARĀH. BṚH. S. 85;Verz. d. B. H. 249;BURN. Intr. 446;Lot. de la b. l. 357;SĀH. D;LASSEN, Institt. 35
+Avantika		2	2〉 f. N. pr. der Tochter eines Brahmanen KATHĀS. 16,21	KATHĀS. 16,21
+Avantika		1	1〉 VARĀH. BṚH. S. 5,64 . 86,2 . Verz. d. Oxf. H. 328,b,3 v. u. 217,b,12 . 208,a,32	VARĀH. BṚH. S. 5,64;VARĀH. BṚH. S 86,2;Verz. d. Oxf. H. 328,b,3 v. u;Verz. d. Oxf. H 217,b,12;Verz. d. Oxf. H 208,a,32
+Avantya		1	1〉 adj. f. aus dem Lande Avanti kommend, dort seiend: ( ) SUŚR. 1,172,9	SUŚR. 1,172,9
+Avantya		2	2〉 m. ein Fürst oder ein Bewohner von Avanti P. 4,1,171 , Sch. MBH. 2,1114 . HARIV. 5016 . 5497 . 8020 . 8099 . — MBH. 2,1915 . m. pl. 3,15253 . VP. 418, N. 20 . Nach M. 10,21 sind die Āvantya die Nac	P. 4,1,171;MBH. 2,1114;HARIV. 5016;HARIV 5497;HARIV 8020;HARIV 8099;MBH. 2,1915;MBH 3,15253;VP. 418, N. 20;M. 10,21
+Avantya		1	¦ aus Avanti stammend: BHĀG. P. 11,23,31 . 12,6,77 . 78 . 80	BHĀG. P. 11,23,31;BHĀG. P 12,6,77;BHĀG. P. 12,6, 78;BHĀG. P. 12,6, 80
+Avapana		1	1〉 n. das Hinstreuen, Hinwerfen, Auflegen: ŚAT. BR. 8,7,2,18 . 9,4,2,27 . KĀTY. ŚR. 8,8,9 . 16,6,23	ŚAT. BR. 8,7,2,18;ŚAT. BR 9,4,2,27;KĀTY. ŚR. 8,8,9;KĀTY. ŚR 16,6,23
+Avapana		1b	b〉 das Einstreuen, Einschieben ŚAT. BR. 8,6,2,3 . 10,1,2,9 . KĀTY. ŚR. 25,14,14	ŚAT. BR. 8,6,2,3;ŚAT. BR 10,1,2,9;KĀTY. ŚR. 25,14,14
+Avapana		1c	c〉 capacitas, Geräumigkeit: MBH. 1,3576	MBH. 1,3576
+Avapana		1d	d〉 Gefäss P. 4,1,42 . AK. 2,9,33 . H. 1026 . VS. 23,10 . 9 (= MBH. 3,17352. fg. ). NIR. 3,20 . Vgl. , das als Würfelbecher aufzufassen ist	P. 4,1,42;AK. 2,9,33;H. 1026;VS. 23,10;VS. 23, 9;MBH. 3,17352. fg;NIR. 3,20
+Avapana		2	2〉 f. Gefäss: (von der Erde) AV. 12,1,61	AV. 12,1,61
+Avapana		1	1〉	
+Avapana		1d	d〉 TBR. 1,1,6,8	TBR. 1,1,6,8
+Avapana		1e	e〉 Saatfeld (in übertr. Bed. ) BHĀG. P. 10,80,45 . 87,20	BHĀG. P. 10,80,45;BHĀG. P. 10, 87,20
+AvaraRa		1	1〉 adj. bedeckend, verhüllend: RAGH. 14,71	RAGH. 14,71
+AvaraRa		2	2〉 n	
+AvaraRa		2a	a〉 das Verdecken, Verhüllen (auch in übertr. Bed. ) VOP. 8,63 . SUŚR. 2,148,2 . deren Trachten darauf gerichtet ist, von den Wolken verhüllt zu werden, RAGH. 10,47 . P. 4,4,62 , Sch. SUŚR. 2,250,16 . 	VOP. 8,63;SUŚR. 2,148,2;RAGH. 10,47;P. 4,4,62;SUŚR. 2,250,16;VEDĀNTA;ŚKDR
+AvaraRa		2b	b〉 das Verschliessen, Hemmen, Unterbrechen VOP. 14 . M. 3,163 . SUŚR. 2,38,4 . RAGH. 5,13	VOP. 14;M. 3,163;SUŚR. 2,38,4;RAGH. 5,13
+AvaraRa		2c	c〉 Hülle, Decke, Gewand (auch in übertr. Bed. ): MBH. 1,131 . ŚĀK. 70 . KIRĀT. 5,25 . MBH. 1,87 . verhüllt, verborgen RAGH. 19,16	MBH. 1,131;ŚĀK. 70;KIRĀT. 5,25;MBH. 1,87;RAGH. 19,16
+AvaraRa		2d	d〉 Alles was zum Schutze dient: R. 6,99,33 . CĀṆ. 76 . (kann auch zu c. gehören) MBH. 1,2802	R. 6,99,33;CĀṆ. 76;MBH. 1,2802
+AvaraRa		2e	e〉 Schild H. 783 . R. 3,32,30 . MBH. 1,1158	H. 783;R. 3,32,30;MBH. 1,1158
+AvaraRa		2f	f〉 was zum Verschliessen dient, Riegel, Schloss: verschlossen ( ) RAGH. 16,7	RAGH. 16,7
+AvaraRa		2	2〉	
+AvaraRa		2a	a〉 zum Schluss zu vergleichen: VEDĀNTAS. (Allah.) No. 36	VEDĀNTAS. (Allah.) No. 36
+AvaraRa		2c	c〉 BHĀG. P. 11,6,16 . WEBER, RĀMAT. UP. 301. fgg. 327 . Verz. d. Oxf. H. 231,a,1 v. u. und fgg. SARVADARŚANAS. 117,9 . 11 . fünf Āvaraṇa bei den Jaina WILSON, Sel. Works 1,310 . SARVADARŚANAS. 38 . 29	BHĀG. P. 11,6,16;WEBER, RĀMAT. UP. 301. fgg;WEBER, RĀMAT. UP 327;Verz. d. Oxf. H. 231,a,1 v. u;SARVADARŚANAS. 117,9;SARVADARŚANAS. 117, 11;WILSON, Sel. Works 1,310;SARVADARŚANAS. 38;SARVADARŚANAS 29,15. fgg
+AvaraRa		2e	e〉 ŚIŚ. 9,66 . — Vgl	ŚIŚ. 9,66
+AvaraRa		2	2〉	
+AvaraRa		2c	c〉 Spr. (II) 7491	Spr. (II) 7491
+Avarta		1	1〉 m	
+Avarta		1a	a〉 Wendung, Windung, = H. an. 3,245 . MED. t. 91 . R. 6,19,44 . SĀH. D. 64,12 . SUŚR. 1,343,11 . 258,13 . ( s. d. ) verdickter Mangosaft, wohl deshalb so genannt, weil er in gewundener Form erscheint	H. an. 3,245;MED. t. 91;R. 6,19,44;SĀH. D. 64,12;SUŚR. 1,343,11;SUŚR. 1, 258,13
+Avarta		1b	b〉 Wirbel, Strudel (auch in übertr. Bed. ) AK. 1,2,3,6 . H. 1076 . H. an. 3,244 . MED. ŚAT. BR. 12,9,2,4 . KAUŚ. 18 . ŚVETĀŚV. UP. 1,5 . MBH. 3,9955 . 15,422 . 16,141 . R. 2,46,28 . 50,12 . 59,29 . 3,	AK. 1,2,3,6;H. 1076;H. an. 3,244;MED;ŚAT. BR. 12,9,2,4;KAUŚ. 18;ŚVETĀŚV. UP. 1,5;MBH. 3,9955;MBH 15,422;MBH 16,141;R. 2,46,28;R. 2, 50,12;R. 2, 59,29;R 3,31,45;R 4,44,73;R 5,50,16;RAGH. 6,52;MEGH. 29;KATHĀS. 26,10;KATHĀS. 26, 11;CHĀND. UP. 4,15,6;BHARTṚ. 1,76;PAÑCAT. I, 204;DEV. 1,40;TRIK. 3,3,148;H. an. 3,245;MED. t. 91
+Avarta		1c	c〉 Wirbel des Haupthaars: KAUŚ. 124 . R. 5,32,12 . zwischen den Augenbrauen: AK. 3,4,52 . beim Pferde: H. 1236 . N. (BOPP) 19,14	KAUŚ. 124;R. 5,32,12;AK. 3,4,52;H. 1236;N. (BOPP) 19,14
+Avarta		1d	d〉 du. die beiden Verliefungen im Stirnbein über den Augenbrauen SUŚR. 1,351,2	SUŚR. 1,351,2
+Avarta		1e	e〉 ein Ort, an dem eine Menge Menschen dicht zusammengedrängt wohnen; auf diese Weise [Page1-0708] ist das Wort wohl in und aufzufassen; vgl. auch PRAB. 88,2 : und oben u. b	PRAB. 88,2
+Avarta		1f	f〉 eine Art Edelstein ( s. ) RĀJAN. _im_ ŚKDR. Vgl	RĀJAN;ŚKDR
+Avarta		1g	g〉 N. einer bestimmten und personificirten Wolkenform: ŚKDR. Vgl	ŚKDR
+Avarta		2	2〉 f. N. pr. eines Flusses HARIV. 7995 . 8052 ( — )	HARIV. 7995;HARIV 8052
+Avarta		3	3〉 n. ein bes. Mineral ( ) RĀJAN. _im_ ŚKDR. — Vgl	RĀJAN;ŚKDR
+Avarta		1	1〉 m. nom. act. das Drehen: (so die neuere Ausg. ) HARIV. 4424	HARIV. 4424
+Avarta		1a	a〉 KATHĀS. 61,279	KATHĀS. 61,279
+Avarta		1b	b〉 R. 7,110,2	R. 7,110,2
+Avarta		1c	c〉 Haarwirbel überh. : ŚĀṄKH. GṚHY. 1,5,9 . Ind. St. 5,370	ŚĀṄKH. GṚHY. 1,5,9;Ind. St. 5,370
+Avarta		1h	h〉 N. eines best. Kometen VARĀH. BṚH. S. 11,50 . — Vgl	VARĀH. BṚH. S. 11,50
+Avartaka		1	1〉 m	
+Avartaka		1a	a〉 ein best. giftiges Insect SUŚR. 2,287,14	SUŚR. 2,287,14
+Avartaka		1b	b〉 = 1,g: KUMĀRAS. 2,20 ( MALLIN. : ). MEGH. 6 . Nach WILS. _zu_ VP. 230 heissen oder diejenigen Wolken, welche man für die von Indra abgeschnittenen Flügel der Berge hält und die am Ende eines jeden 	KUMĀRAS. 2,20;MALLIN;MEGH. 6;WILS;VP. 230;MALLIN;ŚIŚ. 15,107
+Avartaka		2	2〉 f. N. einer rankenden Pflanze ( u. s. w. ; in Kokaṇa : ) RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+Avartaka		1	¦ vgl	
+Avartana		1	1〉 adj. umwendend. sich herwendend: TS. 3,3,10,1	TS. 3,3,10,1
+Avartana		2	2〉 n	
+Avartana		2a	a〉 das Umwenden, Rückkehren VYUTP. 158 . ṚV. 10,19,4 . 5	VYUTP. 158;ṚV. 10,19,4;ṚV. 10,19, 5
+Avartana		2b	b〉 das Buttern	
+Avartana		2c	c〉 das Schmelzen von Metallen Sch. zu AK. _im_ ŚKDR	AK;ŚKDR
+Avartana		2d	d〉 die Zeit, wann die Sonne den Schatten nach Osten zu werfen beginnt, ŚKDR	ŚKDR
+Avartana		3	3〉 f. Schmelztiegel ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+Avartana		2	2〉	
+Avartana		2d	d〉 Mittag WEBER, JYOT. 51	WEBER, JYOT. 51
+Avartana		2e	e〉 Jahr MBH. 13,5229 . 5282	MBH. 13,5229;MBH. 13, 5282
+Avartana		3	3〉 vgl	
+Avartana		4	4〉 m. N. pr. eines Upadvīpa in Jambudvīpa BHĀG. P. 5,19,31	BHĀG. P. 5,19,31
+Avartana		5	5〉 f. Bez. einer best. Zauberkunst R. 7,88,20	R. 7,88,20
+AvasaTa		1	1〉 Wohnplatz, Herberge H. 991 . AV. 9,6,7 . ŚAT. BR. 2,3,1,8 . 9 . 3,9,2,7 . 9,4,2,11 . 12,4,4,6 . 14,7,1,43 (= BṚH. ĀR. UP. 4,3,37 .) KĀTY. ŚR. 8,9,28 . 18,6,3 . KAUŚ. 11 . CHĀND. UP. 4,1,1 . AIT. UP	H. 991;AV. 9,6,7;ŚAT. BR. 2,3,1,8;ŚAT. BR. 2,3,1, 9;ŚAT. BR 3,9,2,7;ŚAT. BR 9,4,2,11;ŚAT. BR 12,4,4,6;ŚAT. BR 14,7,1,43;BṚH. ĀR. UP. 4,3,37;KĀTY. ŚR. 8,9,28;KĀTY. ŚR 18,6,3;KAUŚ. 11;CHĀND. UP. 4,1,1;AIT. UP. 3,12;M. 3,107;M 4,151;MBH. 1,5775;MBH 3,10783;MBH. 3, 14812;MBH. 3, 14850;MBH 14,281;MBH. 14, 565. fg;R. 1,1,31;R. 1, 9,58;R. 1, 12,10;R 2,56,15;R. 2,56, 26;R. 2, 91,41;R 5,25,6;HIT. 27,11;RAGH. 8,14;H. 994
+AvasaTa		2	2〉 eine bes. Gelübde ( ) UṆĀDIK. _im_ ŚKDR	UṆĀDIK;ŚKDR
+AvasaTa		3	3〉 ein bes. Werk über das Āryā -Metrum ( ) ebend	ebend
+AvasaTa		1	¦ vgl	
+AvasaTya		1	1〉 adj. im Hause befindlich: Verz. d. B. H. No. 139	Verz. d. B. H. No. 139
+AvasaTya		2	2〉 m. das im Hause gepflegte heilige Feuer: MBH. 3,14181 . Verz. d. B. H. No. 1065 . 1067 . 1090	MBH. 3,14181;Verz. d. B. H. No. 1065;Verz. d. B. H. No 1067;Verz. d. B. H. No 1090
+AvasaTya		3	3〉 = P. 5,4,23 . n. nach dem Sch. m. eine Wohnung für Schüler oder Asketen H. 994	P. 5,4,23;H. 994
+AvasaTya		4	4〉 n. die Anlegung des häuslichen Feuers PĀR. GṚHY. 1,2 _in_ Z. d. d. m. G. 7,530	PĀR. GṚHY. 1,2;Z. d. d. m. G. 7,530
+Avawya		1	1〉 patron. von , f. und P. 4,1,75 . 17	P. 4,1,75;P. 4,1, 17
+Avawya		2	2〉 n. nom. abstr. von 3. + P. 5,1,121	P. 5,1,121
+AveSa		1	1〉 das Sichanfügen, Anschliessen: KĀTY. ŚR. 22,3,51	KĀTY. ŚR. 22,3,51
+AveSa		2	2〉 das Hineingehen, Eindringen: [Page1-0714] BĀLAB. 6 . sehr häufig von Gemüthszuständen, die den ganzen Menschen in Besitz nehmen: MBH. 1,585 . 3,398 . ŚĀK. CH. 90,1 . PRAB. 89,1 . 96,11 . 12 . BHART	BĀLAB. 6;MBH. 1,585;MBH 3,398;ŚĀK. CH. 90,1;PRAB. 89,1;PRAB 96,11;PRAB. 96, 12;BHARTṚ. 1,88;VID. 172;KATHĀS. 25,230;KATHĀS 22,113;SĀH. D. 57,2;RAGH. 5,19;ST
+AveSa		3	3〉 das Eindringen von bösen Geistern, Besessensein H. 321 . Verz. d. B. H. No. 903	H. 321;Verz. d. B. H. No. 903
+AveSa		4	4〉 Stolz, Hochmuth TRIK. 3,2,19 . H. 1499 . — Vgl	TRIK. 3,2,19;H. 1499
+AveSa		2	2〉 das Hineintreten in ein Haus Spr. 5319 . KATHĀS. 65,230	Spr. 5319;KATHĀS. 65,230
+AveSa		3	3〉 Verz. d. Oxf. H. 322,b,32 . PRATĀPAR. 53,b,4	Verz. d. Oxf. H. 322,b,32;PRATĀPAR. 53,b,4
+AveSa		5	5〉 das Hängen an (= Schol. ): BHĀG. P. 11,20,13	BHĀG. P. 11,20,13
+AveSana		1	1〉 das Hineindringen H. an. 4,160 . MED. n. 168	H. an. 4,160;MED. n. 168
+AveSana		2	2〉 das Besessensein TRIK. 3,3,230 . MED. SĀH. D. 68,1	TRIK. 3,3,230;MED;SĀH. D. 68,1
+AveSana		3	3〉 Zorn DHAR. _im_ ŚKDR	DHAR;ŚKDR
+AveSana		4	4〉 Werkstatt AK. 2,2,7 . TRIK. H. 1000 . H. an. MED. M. 9,265	AK. 2,2,7;TRIK;H. 1000;H. an;MED;M. 9,265
+AveSana		5	5〉 Hof um den Mond oder die Sonne ( ) H. an	H. an
+AveSana		5	5〉 richtiger	
+AveSika		1	1〉 adj. eigenthümlich TRIK. 3,1,22	TRIK. 3,1,22
+AveSika		2	2〉 m.f.n. Gast AK. 2,7,33 . H. 499	AK. 2,7,33;H. 499
+AveSika		3	3〉 n. gastfreundliche Aufnahme, Gastfreundschaft H. 499	H. 499
+Avega		1	1〉 m. die aus der Aufgeregtheit hervorgehende Unruhe und Hast H. 322 . SĀH. D. 64,13 . ŚĀK. 39,13 . 105,14 . PRAB. 92,8 . AMAR. 83 . KATHĀS. 5,101 . 15,16 . 25,112 . PRAB. 91,13 . KATHĀS. 21,82 . 97 .	H. 322;SĀH. D. 64,13;ŚĀK. 39,13;ŚĀK 105,14;PRAB. 92,8;AMAR. 83;KATHĀS. 5,101;KATHĀS 15,16;KATHĀS 25,112;PRAB. 91,13;KATHĀS. 21,82;KATHĀS. 21, 97;MṚCCH. 168,22;ŚĀK. CH. 156,1
+Avega		2	2〉 f. N. einer Pflanze, ( beng. und , hind. ) AK. 2,4,52 . RĀJAN. _im_ ŚKDR. Nach VOIGT (und ROXB. ) ist beng. Argyreia speciosa Sweet. und Argyreia argentea Chois. Es ist eine schöne Winde	AK. 2,4,52;RĀJAN;ŚKDR;VOIGT;ROXB
+Avega		1	1〉 SĀH. D. 237 . 381	SĀH. D. 237;SĀH. D 381
+Avft		1	1〉 das Sichherwenden, Umwenden; Einkehr: ṚV. 3,42,3 . ( ) 5,46,1 . 2,36,6	ṚV. 3,42,3;ṚV 5,46,1;ṚV 2,36,6
+Avft		2	2〉 Wendung des Ganges, Weges; Lauf, Gang, Richtung: AV. 10,5,37 . VS. 2,26 . 12,8 . AV. 6,77,3 . 10,7,4 . TS. 5,2,1,3 . ŚAT. BR. 4,6,7,21	AV. 10,5,37;VS. 2,26;VS 12,8;AV. 6,77,3;AV 10,7,4;TS. 5,2,1,3;ŚAT. BR. 4,6,7,21
+Avft		3	3〉 Wendung einer Handlung; Vorgang, Folge von Verrichtungen: ŚAT. BR. 4,6,8,20 . 2,5,1,18 . 3,5 . 6,2,1,39 . damit soll man dasselbe vornehmen, was mit einem wirklichen Menschenleibe AIT. BR. 7,2 . 34	ŚAT. BR. 4,6,8,20;ŚAT. BR 2,5,1,18;ŚAT. BR. 2,5, 3,5;ŚAT. BR 6,2,1,39;AIT. BR. 7,2;AIT. BR. 7, 34;M. 2,66;KĀTY. ŚR. 2,2,4;KĀTY. ŚR 16,7,6;KĀTY. ŚR 26,6,20;ĀŚV. ŚR. 5,11;ĀŚV. ŚR 6,13;ŚAT. BR. 14,9,4,18;BṚH. ĀR. UP. 6,4,19;BṚH. ĀR. UP. 6,3,1;ĀŚV. GṚHY. 1,11;YĀJÑ. 3,2;M. 3,248;M. 3, 214
+Avft		4	4〉 Reihenfolge, Ordnung AK. 2,7,36 . H. 1504 . ŚAT. BR. 13,1,7,2 . 12,2,2,12 . — Vgl	AK. 2,7,36;H. 1504;ŚAT. BR. 13,1,7,2;ŚAT. BR 12,2,2,12
+Avft		3	3〉 vgl. Ind. St. 5,410 . — Vgl	Ind. St. 5,410
+Avft		1	¦ vgl. oben	
+Avftti		1	1〉 das Sichherwenden, Einkehren; Umkehr, Wiederkehr TS. 6,1,8,2 . ŚAT. BR. 14,9,1,18 . 11,6,2,4 . BṚH. ĀR. UP. 6,2,15 . YĀJÑ. 3,194 . MBH. 14,525 . BHAG. 8,23 . KATHĀS. 14,64 . KUMĀRAS. 6,77	TS. 6,1,8,2;ŚAT. BR. 14,9,1,18;ŚAT. BR 11,6,2,4;BṚH. ĀR. UP. 6,2,15;YĀJÑ. 3,194;MBH. 14,525;BHAG. 8,23;KATHĀS. 14,64;KUMĀRAS. 6,77
+Avftti		2	2〉 Wiederholung: KĀTY. ŚR. 1,7,9 . 5,11,16 . 7,9,13 . 16,5,24 . MADHUS. _in_ Ind. St. 1,20,13 . ebend. 19,13	KĀTY. ŚR. 1,7,9;KĀTY. ŚR 5,11,16;KĀTY. ŚR 7,9,13;KĀTY. ŚR 16,5,24;MADHUS;Ind. St. 1,20,13;ebend. 19,13
+Avftti		3	3〉 Wendung des Ganges; Lauf, Richtung: ŚAT. BR. 12,2,3,13 . 1,8,2,4 . KĀTY. ŚR. 1,7,26 . ( ) ARJ. 5,6 . RAGH. 2,18 . von der Sonnenwende KĀTY. ŚR. 6,1,2 . RAGH. 8,33	ŚAT. BR. 12,2,3,13;ŚAT. BR 1,8,2,4;KĀTY. ŚR. 1,7,26;ARJ. 5,6;RAGH. 2,18;KĀTY. ŚR. 6,1,2;RAGH. 8,33
+Avftti		4	4〉 Vorgang, Hergang: KAUŚ. 72	KAUŚ. 72
+Avftti		1	1〉 keine Furcht vor einer Wiederkehr auf diese Erde Spr. 4094	Spr. 4094
+Avftti		2	2〉 VS. PRĀT. 4,19 . Ind. St. 8,428 . 442 . 446 . SĀH. D. 640 . 258,12 . Streiche am Ende ebend. 19,13 und vgl	VS. PRĀT. 4,19;Ind. St. 8,428;Ind. St. 8, 442;Ind. St. 8, 446;SĀH. D. 640;SĀH. D 258,12;ebend. 19,13
+Avftti		5	5〉 Wiederholung als eine best. rhetorische Figur (= ) KĀVYĀD. 2,116. fgg. ; vgl	KĀVYĀD. 2,116. fgg
+Avid		1	1〉 Vorwissen, Bekanntsein: ŚAT. BR. 1,9,1,8 . 10,3,5,16 . TS. 5,1,9,6	ŚAT. BR. 1,9,1,8;ŚAT. BR 10,3,5,16;TS. 5,1,9,6
+Avid		2	2〉 technische Bezeichnung der mit und beg. Formeln in VS. 10,9 . ŚAT. BR. 5,2,5,31	VS. 10,9;ŚAT. BR. 5,2,5,31
+AvidDa		1	1〉 partic. s. u	
+AvidDa		2	2〉 krumm AK. 3,2,21 . TRIK. 3,3,214 . H. 1456 . an. 3,342 . MED. dh. 28	AK. 3,2,21;TRIK. 3,3,214;H. 1456;H an. 3,342;MED. dh. 28
+AvidDa		3	3〉 falsch, betrügerisch HĀR. 201	HĀR. 201
+AvidDa		4	4〉 thöricht ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+Avika		1	1〉 adj	
+Avika		1a	a〉 vom Schafe herrührend: M. 2,41 . MBH. 2,1848 . R. 5,14,2 . M. 5,8 . YĀJÑ. 1,170 . SUŚR. 1,174,20 . 175,21 . 177,15 . 193,21 . 2,91,2	M. 2,41;MBH. 2,1848;R. 5,14,2;M. 5,8;YĀJÑ. 1,170;SUŚR. 1,174,20;SUŚR. 1, 175,21;SUŚR. 1, 177,15;SUŚR 193,21;SUŚR 2,91,2
+Avika		1b	b〉 wollen M. 10,87 . SUŚR. 1,65,13	M. 10,87;SUŚR. 1,65,13
+Avika		2	2〉 n. wollener Zeug, wollenes Gewand ŚAT. BR. 14,5,3,10 (= BṚH. ĀR. UP. 2,3,6 ). KĀTY. ŚR. 22,4,20 . M. 5,120 . YĀJÑ. 1,186 . R. 3,49,44 . wollene Decke H. 670 . m. nach HALĀY. _im_ ŚKDR	ŚAT. BR. 14,5,3,10;BṚH. ĀR. UP. 2,3,6;KĀTY. ŚR. 22,4,20;M. 5,120;YĀJÑ. 1,186;R. 3,49,44;H. 670;HALĀY;ŚKDR
+Avika		1	1〉	
+Avika		1b	b〉 M. 2,41 . — Vgl	M. 2,41
+Avis		1a	a〉 mit und offenbar werden, — sein, erscheinen, vor Augen sein: ṚV. 1,146,4 . 31,3 . 9,79,5 . 10,107,1 . AV. 12,1,60 . ŚAT. BR. 11,5,1,5 . 1,6,17 . 6,3,1,22 . 10,5,3,3 . ŚĀK. 111 . RAGH. 9,55 . SĀH. D	ṚV. 1,146,4;ṚV. 1, 31,3;ṚV 9,79,5;ṚV 10,107,1;AV. 12,1,60;ŚAT. BR. 11,5,1,5;ŚAT. BR. 11, 1,6,17;ŚAT. BR 6,3,1,22;ŚAT. BR 10,5,3,3;ŚĀK. 111;RAGH. 9,55;SĀH. D. 54,10;KATHĀS. 1,29;PRAB. 86,4;DEV. 1,48;HIT. 63,12;VIKR. 8;MEGH. 21
+Avis		1b	b〉 mit offenbar machen, aufdecken, sehen lassen, zeigen: ṚV. 1,123,10 . 10,27,24 . 5,83,3 . 1,86,9 . 116,12 . 123,6 . 124,4 . 5,2,9 . AV. 4,20,5 . 6,123,2 . 12,4,29 . 30 . ŚAT. BR. 13,8,1,10 . 3,9,3,2	ṚV. 1,123,10;ṚV 10,27,24;ṚV 5,83,3;ṚV 1,86,9;ṚV. 1, 116,12;ṚV. 1, 123,6;ṚV. 1, 124,4;ṚV 5,2,9;AV. 4,20,5;AV 6,123,2;AV 12,4,29;AV. 12,4, 30;ŚAT. BR. 13,8,1,10;ŚAT. BR 3,9,3,23;ŚAT. BR 4,2,1,18;ŚAT. BR. 4,2, 2,12;NIR. 4,16;SĀH. D. 15,20;SĀH. D 60,17;H. 1478;M. 11,226;ŚĀK. 77;ŚĀK 80;ŚĀK 26,17;RAGH. 10,53;KUMĀRAS. 7,35;MBH. 1,6547;ŚAT. BR. 10,5,3,10
+Avis		1a	a〉 ŚIŚ. 10,19 . Diese Trennung vom Verbum getadelt in der BHĀGAVṚTTI ; vgl. UJJVAL. _zu_ UṆĀDIS. 2,109	ŚIŚ. 10,19;BHĀGAVṚTTI;UJJVAL;UṆĀDIS. 2,109
+Avis		1b	b〉 MBH. 1,6547 ist. adj. = Spr. 292 . — compar. BHĀG. P. 11,7,21	MBH. 1,6547;Spr. 292;BHĀG. P. 11,7,21
+Avya		1	1〉 zum Schafgeschlecht gehörig TS. 2,2,6,3	TS. 2,2,6,3
+Avya		2	2〉 wollen: ( viell. zu lesen) ĀŚV. GṚHY. 1,19	ĀŚV. GṚHY. 1,19
+Avya		1	¦ [ vgl. [Page1-0714]] Z. 2. Alle Handschriften und der Scholiast NĀRĀYAṆA lesen	NĀRĀYAṆA
+Avya		2	2〉 alle Hdschrr. und auch der Schol. NĀRĀYAṆA lesen	NĀRĀYAṆA
+AwRAra		1	1〉 patron. von ; so heisst Para : ŚAT. BR. 13,5,4,4 . TS. 5,6,5,3 . PAÑCAV. BR. 25,16	ŚAT. BR. 13,5,4,4;TS. 5,6,5,3;PAÑCAV. BR. 25,16
+AwRAra		2	2〉 NIR. 1,14 von DURGA durch wanderlustig erklärt	NIR. 1,14;DURGA
+Awavika		1	1〉 Waldbewohner MBH. 2,1119 . 3,15255 . M. 9,257	MBH. 2,1119;MBH 3,15255;M. 9,257
+Awavika		2	2〉 Förster SĀH. D. 37,1 . Vgl	SĀH. D. 37,1
+Awavika		1	¦ adj. zum Walde in Beziehung stehend: ein aus Waldbewohnern bestehendes Heer Spr. 4463 . m. Waldbewohner KĀM. NĪTIS. 13,29 . 14,22 . VARĀH. BṚH. S. 16,13 . 36,3	Spr. 4463;KĀM. NĪTIS. 13,29;KĀM. NĪTIS 14,22;VARĀH. BṚH. S. 16,13;VARĀH. BṚH. S 36,3
+Awika		1	1〉 adj. rüstig zum Wandern ( vgl. ) Ind. St. 1,255, N. 4	Ind. St. 1,255, N. 4
+Awika		2	2〉 f. N. pr. die Frau von Uṣasti CHĀND. UP. 1,10,1	CHĀND. UP. 1,10,1
+Awika		1	¦ s	
+Awopa		1	1〉 das Sichaufblähen, Anschwellen, Anschwellung; vom Schweife des Pfaues: MBH. 3,11587 . von der sog. Haube der Brillenschlange: PAÑCAT. I, 229 = III, 83 . 174,11 . von schweren Wolken: PAÑCAT. 93,8 .	MBH. 3,11587;PAÑCAT. I, 229;PAÑCAT III, 83;PAÑCAT 174,11;PAÑCAT. 93,8;ŚIŚ. 3,74
+Awopa		2	2〉 Aufgeblasenheit des Leibes, Flatulenz SUŚR. 1,81,21 . 97,11 . 2,21,16 . 195,11 . 224,7	SUŚR. 1,81,21;SUŚR. 1, 97,11;SUŚR 2,21,16;SUŚR. 2, 195,11;SUŚR. 2, 224,7
+Awopa		3	3〉 Aufgeblasenheit, Stolz TRIK. 3,2,19 . H. 1499 . MṚCCH. 87,4 . PAÑCAT. 46,4 . adv. MṚCCH. 96,20 . 138,13 . 146,2 . HIT. 58,15	TRIK. 3,2,19;H. 1499;MṚCCH. 87,4;PAÑCAT. 46,4;MṚCCH. 96,20;MṚCCH 138,13;MṚCCH 146,2;HIT. 58,15
+Awopa		1	1〉 BHĀG. P. 5,9,19 . adv. so v. a. Fülle, Menge 14,11 . adj. ( ) 12,8,19 . = Schol. an allen drei Stellen. ( Conj. ) Spr. 1614	BHĀG. P. 5,9,19;BHĀG. P 14,11;BHĀG. P 12,8,19;Spr. 1614
+Awopa		3	3〉 Verz. d. Oxf. H. 354,b,9 . — Vgl	Verz. d. Oxf. H. 354,b,9
+Awopa		3	3〉 pl. Spr. (II) 2158	Spr. (II) 2158
+AyAma		1	1〉 Spannung Dehnung ṚV. PRĀT. 3,1 ( s. u	ṚV. PRĀT. 3,1
+AyAma		5	VS. PRĀT. 1,31 . TAITT. PRĀT. 2,10 . SUŚR. 1,254,12 . 13	VS. PRĀT. 1,31;TAITT. PRĀT. 2,10;SUŚR. 1,254,12;SUŚR. 1,254, 13
+AyAma		2	2〉 das Anhalten, Hemmen: H. 83 . M. 2,75 . 83 . 6,69 . 70 . 72 . 11,141 . 199 . 201 . 248 . MBH. 3,165 . 14,1337 . BHAG. 4,29 . SUŚR. 1,98,11 . PRAB. 8,14 . 97,15	H. 83;M. 2,75;M. 2, 83;M 6,69;M. 6, 70;M. 6, 72;M 11,141;M. 11, 199;M. 11, 201;M. 11, 248;MBH. 3,165;MBH 14,1337;BHAG. 4,29;SUŚR. 1,98,11;PRAB. 8,14;PRAB 97,15
+AyAma		3	3〉 Ausdehnung, Länge P. 5,1,19, Kār. AK. 2,6,3,16 . H. 1431 . P. 2,1,16 . 5,4,83 . SUŚR. 1,125,18 . 126,11 . ĀŚV. GṚHY. 4,2 . KĀTY. ŚR. 8,6,17 . [Page1-0677] R. 1,40,18 . 6,1,44 . 5,9,50 . MEGH. 58 . 	P. 5,1,19, Kār;AK. 2,6,3,16;H. 1431;P. 2,1,16;P 5,4,83;SUŚR. 1,125,18;SUŚR. 1, 126,11;ĀŚV. GṚHY. 4,2;KĀTY;ŚR. 8,6,17;R. 1,40,18;R 6,1,44;R 5,9,50;MEGH. 58;R. 3,22,12
+AyAma		1	¦ RĀJA-TAR. 5,165 fehlerhaft für , wie die ed. Calc. liest. — Vgl	RĀJA-TAR. 5,165;ed. Calc
+AyAma		1	1〉 = ebend. 1,192,b	ebend. 1,192,b
+AyAmin		1	1〉 von mit P. 3,2,142	P. 3,2,142
+AyAmin		2	2〉 von gaṇa zu P. 5,2,136	P. 5,2,136
+AyAmin		1	1〉 anhaltend, hemmend; s	
+AyAmin		2	2〉 lang (örtlich und zeitlich): DAŚAK. _in_ BENF. Chr. 201,11 . Spr. 1928	DAŚAK;BENF. Chr. 201,11;Spr. 1928
+AyAna		1	1〉 das Herankommen ṚV. 8,22,18 . MBH. 3,11029 (p. 570) . NALOD. 2,63	ṚV. 8,22,18;MBH. 3,11029 (p. 570);NALOD. 2,63
+AyAna		2	2〉 natürliche Anlage, Natur ( ) JAṬĀDH. _im_ ŚKDR. Vgl	JAṬĀDH;ŚKDR
+AyAsa		1	1〉 Anstrengung der körperlichen oder geistigen Kräfte VS. 39,11 . MBH. 3,74 . SUŚR. 1,72,8 . 80,5 . 127,1 . 290,5 . 551,20 . PAÑCAT. I, 421 . ŚĀK. 37 . KATHĀS. 21,30 . SĀH. D. 74,4 . er machte R. zu s	VS. 39,11;MBH. 3,74;SUŚR. 1,72,8;SUŚR. 1, 80,5;SUŚR. 1, 127,1;SUŚR. 1, 290,5;SUŚR. 1, 551,20;PAÑCAT. I, 421;ŚĀK. 37;KATHĀS. 21,30;SĀH. D. 74,4;MBH. 14,825;BHAG. 18,24;PRAB. 92,13;SUŚR. 2,211,8;DRAUP. 6,3;DAŚ. 2,19;HIT. I, 143;KATHĀS. 20,195;P. 8,1,13
+AyAsa		2	2〉 die aus der Anstrengung hervorgehende Ermüdung, Abspannung H. 320 . R. 6,7,1 . DAŚ. 2,70 . MBH. 15,310 . R. 2,69,3 . 5,72,1 . 2,25,1 . ADBH. BR. _in_ Ind. St. 1,39,3 v. u. Sch. =	H. 320;R. 6,7,1;DAŚ. 2,70;MBH. 15,310;R. 2,69,3;R 5,72,1;R 2,25,1;ADBH. BR;Ind. St. 1,39,3 v. u
+AyAsa		1	1〉 Spr. 997 ( pl. ). RĀJA-TAR. 5,174 (nach der Lesart der ed. Calc. ). 191 . adj. keine Anstrengung verursachend KATHĀS. 119 . 184 . den Ohren wehe thuend R. 7,21,13 . Z. 4 lies ŚĀK. 37,23 st. ŚĀK. 37	Spr. 997;RĀJA-TAR. 5,174;ed. Calc;RĀJA-TAR 191;KATHĀS. 119;KATHĀS 184;R. 7,21,13;ŚĀK. 37,23;ŚĀK. 37
+AyAsa		2	2〉 R. 3,55,17 . VARĀH. BṚH. S. 104,5	R. 3,55,17;VARĀH. BṚH. S. 104,5
+AyAsa		1	1〉 Z. 2 lies {191} st. {191}	
+AyAsa		1	1〉 Z. 2 lies 191 st. 191	
+AyAta		1	1〉 adj. s. u	
+AyAta		2	2〉 n. Uebermaass: KIRĀT. 5,23	KIRĀT. 5,23
+AyAti		1	1〉 f. Herbeikunft PRAŚNOP. 3,12 , v. l. ( s. Ind. St. 1,449 )	PRAŚNOP. 3,12;Ind. St. 1,449
+AyAti		2	2〉 m. N. pr. ein Sohn Nahuṣa ʼs MBH. 1,3155 . HARIV. 1600 . VP. 413	MBH. 1,3155;HARIV. 1600;VP. 413
+Aya		1	1〉 Anlauf, Eintreffen: ṚV. 2,38,10 . CHĀND. UP. 7,9,1	ṚV. 2,38,10;CHĀND. UP. 7,9,1
+Aya		2	2〉 Einkünfte, Einkommen ( Gegens. ) P. 5,1,47 . M. 8,419 . YĀJÑ. 1,321 . 326 . MBH. 2,201. fg. 3,8599. fg. 14701 . R. 2,1,19 . MṚCCH. 33,4 . PAÑCAT. I, 179 . HIT. II, 91 . NALOD. 1,13 . 2,63 . 3,52	P. 5,1,47;M. 8,419;YĀJÑ. 1,321;YĀJÑ. 1, 326;MBH. 2,201. fg;MBH 3,8599. fg;MBH. 3, 14701;R. 2,1,19;MṚCCH. 33,4;PAÑCAT. I, 179;HIT. II, 91;NALOD. 1,13;NALOD 2,63;NALOD 3,52
+Aya		3	3〉 Wächter im Gynaeceum HALĀY. _im_ ŚKDR	HALĀY;ŚKDR
+Aya		4	4〉 astrol. das eilfte Haus Ind. St. 2,281 . 285	Ind. St. 2,281;Ind. St. 2, 285
+Aya		1	1〉 das Hinzutreten (eines Lautes; Gegens. ) ṚV. PRĀT. 14,1	ṚV. PRĀT. 14,1
+Aya		4	4〉 VARĀH. BṚH. S. 41,9 . 98,18 . 100,1 . 103,11	VARĀH. BṚH. S. 41,9;VARĀH. BṚH. S 98,18;VARĀH. BṚH. S 100,1;VARĀH. BṚH. S 103,11
+Aya		5	5〉 Art, Weise (= Schol. ): auf hunderterlei Weise gehen sie Reichthümern nach MBH. 13,7602 . Könnte auch durch Einnahme, Mittel zu Geld zu gelangen übersetzt werden	MBH. 13,7602
+Aya		6	6〉 = Würfel und in dieser Bed. Bez. der Zahl vier WEBER, JYOT. 48 . v. l	WEBER, JYOT. 48
+Aya		7	7〉 in ŚĀṄKH. ŚR. 6,1,22 . Schol. zu 7,9,1 . 16,7 . 8,7,1 Bez. gewisser liturgischer Einschiebsel	ŚĀṄKH. ŚR. 6,1,22;ŚĀṄKH. ŚR 7,9,1;ŚĀṄKH. ŚR. 7, 16,7;ŚĀṄKH. ŚR 8,7,1
+Ayana		1	¦ (von mit ) n. das Kommen: ṚV. 10,142,8 . VS. 22,7 . AV. 6,122,2	ṚV. 10,142,8;VS. 22,7;AV. 6,122,2
+Ayana		2	2〉	
+Ayana		2c	c〉	
+Ayana		2d	d〉: Schol. zu SŪRYAS. 4,24. fg	SŪRYAS. 4,24. fg
+Ayasa		1	1〉 adj. f. ehern, metallen, eisern: ṚV. 1,52,8 . 56,3 . 80,12 . 10,96,3 . 4 . 113,5 . 1,58,8 . 2,20,8 . 7,3,7 . 15,14 . 95,1 . 10,101,8 . 8,29,3 . ŚAT. BR. 13,2,2,16 . 19 . 3,4,5 . KĀTY. ŚR. 20,7,5 . 	ṚV. 1,52,8;ṚV. 1, 56,3;ṚV. 1, 80,12;ṚV 10,96,3;ṚV. 10,96, 4;ṚV. 10, 113,5;ṚV 1,58,8;ṚV 2,20,8;ṚV 7,3,7;ṚV. 7, 15,14;ṚV. 7, 95,1;ṚV 10,101,8;ṚV 8,29,3;ŚAT. BR. 13,2,2,16;ŚAT. BR. 13,2,2, 19;ŚAT. BR. 13, 3,4,5;KĀTY. ŚR. 20,7,5;KĀTY. ŚR 15,5,21;AIT. UP. 4,5;M. 8,315;M. 8, 372;YĀJÑ. 3,259;MBH. 1,582;MBH 3,689;MBH. 3, 14999;R. 1,67,5;R 2,20,43;R 3,21,17;R. 3, 28,23;R 5,41,23;R. 5, 56,121;VIŚV. 8,10
+Ayasa		2	2〉 f. ein eisernes Netz (als Rüstung) H. 769	H. 769
+Ayasa		3	3〉 n	
+Ayasa		3a	a〉 Eisen BHARATA _zu_ AK. 2,9,98 . RĀJAN. _im_ ŚKDR. YĀJÑ. 1,305 . RAGH. 17,63 . KUMĀRAS. 6,55 . Kann überall als Gegenstand von Eisen aufgefasst werden	BHARATA;AK. 2,9,98;RĀJAN;ŚKDR;YĀJÑ. 1,305;RAGH. 17,63;KUMĀRAS. 6,55
+Ayasa		3b	b〉 Blasinstrument: KĀTY. ŚR. 21,3,7	KĀTY. ŚR. 21,3,7
+Ayasa		1	1〉 die Farbe des Eisens habend MBH. 5,1709	MBH. 5,1709
+Ayasa		3	3〉	
+Ayasa		3a	a〉 Alles was aus Eisen gemacht ist VARĀH. BṚH. S. 50,26	VARĀH. BṚH. S. 50,26
+Ayatana		1a	a〉 vom Platze des heiligen Feuers, von der Feuerstätte: KĀTY. ŚR. 4,8,24 . ĀŚV. ŚR. 12,6 . GṚHY. 4,2 . 6	KĀTY. ŚR. 4,8,24;ĀŚV. ŚR. 12,6;GṚHY. 4,2;GṚHY 6
+Ayatana		1b	b〉 von Heiligthümern AK. 2,2,6 . CHĀND. UP. 7,24,2 . R. 2,25,4 . 7 . 3,23,37 . PRAB. 43,6 . R. 1,44,55 . PAÑCAT. 199,12 . 14 . 10,4 . M. 4,46 . 8,248 . N. (BOPP) 25,7 . R. 1,5,13 . 77,12 . SUŚR. 1,134	AK. 2,2,6;CHĀND. UP. 7,24,2;R. 2,25,4;R. 2,25, 7;R 3,23,37;PRAB. 43,6;R. 1,44,55;PAÑCAT. 199,12;PAÑCAT. 199, 14;PAÑCAT 10,4;M. 4,46;M 8,248;N. (BOPP) 25,7;R. 1,5,13;R. 1, 77,12;SUŚR. 1,134,18;PRAB. 33,5;INDR. 5,10;VET. 6,12;PAÑCAT. 32,23;R. 1,12,35;R 4,37,33
+Ayatana		1c	c〉 Scheune ( STENZLER ) YĀJÑ. 2,154	STENZLER;YĀJÑ. 2,154
+Ayatana		1d	d〉 bei den Buddhisten heissen die 5 Sinne und das Manas die sechs innern [Page1-0675] Sitze ( ), die den 5 Sinnen entsprechenden Eigenschaften der Dinge (Schall u. s. w. ) so wie das Gesetz ( ) — die 	BURN. Intr. 501;BURN. Intr 488;BURN. Intr 635
+Ayatana		1b	b〉 ṢAḌV. BR. 5,1 . ŚĀṄKH. GṚHY. 4,12 . = HALĀY. 2,138	ṢAḌV. BR. 5,1;ŚĀṄKH. GṚHY. 4,12;HALĀY. 2,138
+Ayatana		1d	d〉 WASSILJEW 240. fg. 244. fg. 252 . SARVADARŚANAS. 23,11. fgg	WASSILJEW 240. fg;WASSILJEW 244. fg;WASSILJEW 252;SARVADARŚANAS. 23,11. fgg
+Ayatana		1	¦, ein Gegenstand des Gelächters VĀMANA 1,3,17	VĀMANA 1,3,17
+Ayati		1	1〉 Ausdehnung, Länge TRIK. 3,3,148 . H. an. 3,249 . MED. t. 93 . VIŚVA _im_ ŚKDR. Vgl	TRIK. 3,3,148;H. an. 3,249;MED. t. 93;VIŚVA;ŚKDR
+Ayati		2	2〉 Ausstreckung der Hand nach Etwas, Annahme, = TRIK. = DHAR. _im_ ŚKDR. KATHĀS. 24,119 . BROCKHAUS : (der Priester) nahm ein würdevolles Ansehen an ( vgl. u. 5.), und nach weiteren Geschenken begieri	TRIK;DHAR;ŚKDR;KATHĀS. 24,119;BROCKHAUS
+Ayati		3	3〉 Zusammenhang, Verbindung: ṚV. 1,139,9 . ( v. l. , s. Ind. St. 1,449, N. ) PRAŚNOP. 3,12 . = ŚAṂK. zu d. St. = H. an. MED. VIŚVA _im_ ŚKDR	ṚV. 1,139,9;Ind. St. 1,449, N;PRAŚNOP. 3,12;ŚAṂK;H. an;MED;VIŚVA;ŚKDR
+Ayati		4	4〉 Folge, Zukunft AK. 2,8,1,29 . 3,4,21,152 . TRIK. H. 162 . H. an. MED. M. 4,70 . häufig in Verbindung mit 7,163 . 169 . 178 . 179 . MBH. 2,2107 . 3,1412 . R. 5,76,16 (wo für zu lesen ist). 90,1 . MB	AK. 2,8,1,29;AK 3,4,21,152;TRIK;H. 162;H. an;MED;M. 4,70;M 7,163;M. 7, 169;M. 7, 178;M. 7, 179;MBH. 2,2107;MBH 3,1412;R. 5,76,16;R. 5, 90,1;MBH. 3,14799;R. 2,106,19;M. 7,208;R. 4,14,32;PAÑCAT. III, 113;R. 3,44,11
+Ayati		5	5〉 Ansehen, Majestät AK. 3,4,74 . H. an. MED. — (?) TRIK	AK. 3,4,74;H. an;MED;TRIK
+Ayati		6	6〉 N. pr. eine Tochter Meru ʼs VP. 82 . 85, N. 11	VP. 82;VP 85, N. 11
+Ayati		4	4〉 auf die Länge, auf lange Zeit Spr. 3142 . so v. a. für die Folge erspriesslich R. 7,83,8	Spr. 3142;R. 7,83,8
+Ayati		5	5〉 Spr. 1840 . Hierher wohl die u	Spr. 1840
+Ayati		2	2〉 aufgeführte Stelle KATHĀS. 24,119	KATHĀS. 24,119
+Ayatti		1	1〉 Abhängigkeit ( ) H. an. 3,249 . MED. t. 94 . VIŚVA _im_ ŚKDR. VOP. 7,85	H. an. 3,249;MED. t. 94;VIŚVA;ŚKDR;VOP. 7,85
+Ayatti		2	2〉 Anhänglichkeit ( ) H. an. MED. VIŚVA	H. an;MED;VIŚVA
+Ayatti		3	3〉 Kraft, Macht ( ) diess	
+Ayatti		4	4〉 Tag diess. ( MED. st. )	MED
+Ayatti		5	5〉 Grenze H. an. VIŚVA	H. an;VIŚVA
+Ayatti		6	6〉 das Schlafen	
+Ayatti		7	7〉 Länge	
+Ayatti		8	8〉 Majestät	
+Ayatti		9	9〉 Zukunft DHAR. _im_ ŚKDR. — Vgl	DHAR;ŚKDR
+Ayavasa		1	1〉 Weideplatz, Futterplatz: TS. 5,2,8,2	TS. 5,2,8,2
+Ayavasa		2	2〉 N. pr. nach SĀY. ṚV. 1,122,15 : ; der Vers ist aber offenbar mangelhaft überliefert	SĀY;ṚV. 1,122,15
+AyoDana		1	1〉 Kampf, Schlacht AK. 2,8,2,72 . H. 796 . an. 4,158 . MED. n. 165 . MBH. 1,584 . RAGH. 6,42 . 5,71	AK. 2,8,2,72;H. 796;H an. 4,158;MED. n. 165;MBH. 1,584;RAGH. 6,42;RAGH 5,71
+AyoDana		2	2〉 Todtschlag ( ) H. an. MED	H. an;MED
+AyoDana		3	3〉 Kampfplatz: MBH. 3,16445 . DRAUP. 8,30 . R. 3,32,32 . 6,105,18 . 108,4	MBH. 3,16445;DRAUP. 8,30;R. 3,32,32;R 6,105,18;R. 6, 108,4
+Ayoga		1	1〉 Anstellung an ein Geschäft, Beschäftigung, = TRIK. 3,3,55 . H. an. 3,117 . MED. g. 29 . R. 5,17,15	TRIK. 3,3,55;H. an. 3,117;MED. g. 29;R. 5,17,15
+Ayoga		2	2〉 eine Darbringung von Wohlgerüchen und Kränzen H. an. MED	H. an;MED
+Ayoga		3	3〉 Ufer, H. an. (!) MED	H. an;MED
+Ayoga		4	4〉 Gespann: mit 12 bespannt ŚĀṄKH. ŚR. 3,18,10 . KĀṬH. 15,2	ŚĀṄKH. ŚR. 3,18,10;KĀṬH. 15,2
+Ayoga		5	5〉 HARIV. 4501 . 4507 . 4503 . Nach dem Schol. Berühmtheit: =	HARIV. 4501;HARIV 4507;HARIV 4503
+Ayogava		1	1〉 dem Stamme der Ayogu angehörig: heisst Marutta Āvikṣita ŚAT. BR. 13,5,4,6	ŚAT. BR. 13,5,4,6
+Ayogava		2	2〉 N. einer Mischkaste, angeblich der durch Vermischung eines Śūdra mit einer Vaiśyā Entsprungenen H. 897 . KĀTY. ŚR. 22,1,38 . M. 10,12 . 16 . 26 . YĀJÑ. 1,94 . M. 10,48 . f. 15 . 35	H. 897;KĀTY. ŚR. 22,1,38;M. 10,12;M. 10, 16;M. 10, 26;YĀJÑ. 1,94;M. 10,48;M. 10, 15;M. 10, 35
+Ayogava		2	2〉 vgl. MBH. 13,2574 . 2582 . 2587 . Z. 4 lies 20,1,38 st. 22,1,38	MBH. 13,2574;MBH. 13, 2582;MBH. 13, 2587
+Ayu		1	1〉 adj. lebendig, beweglich: ṚV. 9,23,4 . 107,14 . 2,5,5 . ( vgl. ŚAT. BR. 9,4,1,8 ) VS. 18,39 . Hierher dürfte auch gehören ṚV. 1,162,1 ( 5,41,2 ?): , wo die Comm. das Wort auf den Wind deuten, NIR. 	ṚV. 9,23,4;ṚV. 9, 107,14;ṚV 2,5,5;ŚAT. BR. 9,4,1,8;VS. 18,39;ṚV. 1,162,1;ṚV 5,41,2;NIR. 9,3;SĀY;ṚV. 10,5,6;VS. 15,63
+Ayu		2	2〉 m	
+Ayu		2a	a〉 lebendes Wesen, Mensch; häufig collect. die Gesammtheit der Lebenden, Menschheit NIR. 10,41 . NAIGH. 2,2 . ṚV. 1,58,3 . 60,3 . 31,2 . 117,25 . 2,32,2 . 20,2 . 1,31,11 . 130,6 . 3,59,9 . 8,39,10 . 1	NIR. 10,41;NAIGH. 2,2;ṚV. 1,58,3;ṚV. 1, 60,3;ṚV. 1, 31,2;ṚV. 1, 117,25;ṚV 2,32,2;ṚV. 2, 20,2;ṚV 1,31,11;ṚV. 1, 130,6;ṚV 3,59,9;ṚV 8,39,10;ṚV 15,5;ṚV 1,174,6;ṚV 3,7,8;ṚV 4,7,4;ṚV 23,8;ṚV 38,4;ṚV 7,4,3;ṚV 8,3,16;ṚV 9,10,6;ṚV 15,7;ṚV 19,3;ṚV 23,2;ṚV 64,23;ṚV 107,17;VĀLAKH. 4,1;ṚV. 1,96,2;MBH. 3,11193
+Ayu		2b	b〉 Sohn, Nachkomme; collect. Nachkommenschaft: [Page1-0678] ṚV. 1,114,8 . 104,4 . 4,2,18 . 5,41,19 . ; 1,122,4 . 10,20,7	ṚV. 1,114,8;ṚV. 1, 104,4;ṚV 4,2,18;ṚV 5,41,19;ṚV 1,122,4;ṚV 10,20,7
+Ayu		2c	c〉 Āyu , das Kind des Purūravas und der Urvaśī ( MBH. 1,3149. fg. 3,12408 . HARIV. 1372 . 8813 ; vgl. Āyus ), ist: der Sohn schlechthin, das aus den Reibhölzern geborene Feuer VS. 5 , ? 2 ; vgl. ṚV. 1	MBH. 1,3149. fg;MBH 3,12408;HARIV. 1372;HARIV 8813;VS. 5;VS 2;ṚV. 1,31,11;ŚAT. BR. 3,4,1,22
+Ayu		2d	d〉 N. pr. α〉 eines von Indra Verfolgten: ṚV. 1,53,10 . 2,14,7 . VĀLAKH. 5,1 . — β〉 eines von Indra Beschützten: (hier wäre eine appell. Auffassung zulässig) ṚV. 10,49,5 . — γ〉 des Liedverfassers von V	ṚV. 1,53,10;ṚV 2,14,7;VĀLAKH. 5,1;ṚV. 10,49,5;VĀLAKH. 5;VĀLAKH 5,1;HARIV. 189;MBH. 3,13174
+Ayu		2	2〉	
+Ayu		2c	c〉 KĀṬH. 8,10 . Verz. d. Oxf. H. 50,a,29	KĀṬH. 8,10;Verz. d. Oxf. H. 50,a,29
+Ayu		2d	d〉γ〉 lies VĀLAKH. 4 . — ζ〉 Āyu Kāṇva Ind. St. 3,206,a . — η〉 ein Sohn Kṛṣṇa ʼs BHĀG. P. 10,61,17	VĀLAKH. 4;Ind. St. 3,206,a;BHĀG. P. 10,61,17
+AyuDa		1	1〉 n. Waffe P. 3,3,58, Vārtt. 4 . AK. 2,8,2,50 . 3,4,181 . TRIK. 2,8,50 . H. 773 (nach dem Sch. ?auch m. ). ṚV. 1,39,2 . 61,13 . 92,1 . 2,30,9 . Weiber machte der Dāsa zu seinen Waffen ( d. h. nahm si	P. 3,3,58, Vārtt. 4;AK. 2,8,2,50;AK. 2, 3,4,181;TRIK. 2,8,50;H. 773;ṚV. 1,39,2;ṚV. 1, 61,13;ṚV. 1, 92,1;ṚV 2,30,9;ṚV 5,30,9;ṚV 10,84,1;ṚV. 10, 108,5;ṚV 120,5;ṚV 9,90,1;ṚV 61,30;ṚV 76,2;ṚV 57,2;SV;ṚV 8,6,3;AV. 6,133,2;AV 11,9,1;VS. 16,14;VS. 16, 51;ŚAT. BR. 5,3,5,30;TS. 5,7,2,3;M. 7,93;DRAUP. 9,1;R. 3,71,2;RAGH. 3,63;M. 7,92;MBH. 1,3289;MBH 3,643;M. 5,99;M 7,75;M. 7, 90;M. 7, 192;M 8,113;BHAG. 10,28;ARJ. 3,39;R. 1,5,10;R. 1,5, 17;VIŚV. 5,5
+AyuDa		2	2〉 n. Geräthe überhaupt: AV. 10,10,18 . AIT. BR. 7,19 . KAUŚ. 43	AV. 10,10,18;AIT. BR. 7,19;KAUŚ. 43
+AyuDa		3	3〉 n. pl. nach NAIGH. 1,12 so v. a. Wasser; vielleicht durch falsche Deutung von ṚV. 5,30,9 ( s. u	NAIGH. 1,12;ṚV. 5,30,9
+AyuDa		1		
+AyuDa		4	4〉 n. Gold zu Schmucksachen ( ) H. 1046 . — Vgl	H. 1046
+Ayurveda		1	1〉 Śalya , Chirurgie	
+Ayurveda		2	2〉 Śālākya , die Lehre von den Krankheiten des Kopfs und seiner Organe	
+Ayurveda		3	3〉 Kāyacikitsā , die Behandlung der Krankheiten, welche den ganzen Leib afficiren	
+Ayurveda		4	4〉 Bhūtavidyā , die Heilung der Seelenkrankheiten, die auf dämonischen Einflüssen beruhend gedacht werden	
+Ayurveda		5	5〉 Kaumārabhṛtya , Behandlung der Kinder	
+Ayurveda		6	6〉 Agadatantra , die Lehre von den Gegengiften	
+Ayurveda		7	7〉 Rāsāyanatantra , die Lehre von den Elixiren	
+Ayurveda		8	8〉 Vājīkaraṇatantra , die Lehre von der Stärkung der Zeugungskraft, SUŚR. 1,2,4. fgg. 3,5 . 122,14 . MBH. 2,442 . HARIV. 1539 . 1532 . CĀṆ. 103 . VP. 284 . ein Upaveda MADHUS. _in_ Ind. St. 1,13,14 . 	SUŚR. 1,2,4. fgg;SUŚR. 1, 3,5;SUŚR. 1, 122,14;MBH. 2,442;HARIV. 1539;HARIV 1532;CĀṆ. 103;VP. 284;MADHUS;Ind. St. 1,13,14;Ind. St. 1, 20,28;Ind. St. 1, 21,1;Verz. d. B. H. No. 931;Verz. d. B. H N. 941;Verz. d. B. H No. 974
+Ayurveda		1	¦ Spr. 3714 . Verz. d. Oxf. H. 7,b,13 . 22,a,40 . 86,a,17 . 277,b,41 . 309,b,16 . 311,a,9 u. s. w. 8. WEBER, Nax. 2,281 . Verz. d. Oxf. H. 311,a,23 . Ind. St. 3,280	Spr. 3714;Verz. d. Oxf. H. 7,b,13;Verz. d. Oxf. H 22,a,40;Verz. d. Oxf. H 86,a,17;Verz. d. Oxf. H 277,b,41;Verz. d. Oxf. H 309,b,16;Verz. d. Oxf. H 311,a,9;WEBER, Nax. 2,281;Verz. d. Oxf. H. 311,a,23;Ind. St. 3,280
+Ayus	2	1	1〉 Leben, sowohl Lebenskraft, Gesundheit als Lebensdauer; langes Leben AK. 2,8,2,88 . H. 1369 . ṚV. 1,10,11 . 25,12 . 34,11 . 37,15 . 44,6 . 93,3 . [Page1-0681] 96,8 . 113,17 . 23,24 . 24,11 . 66,1 . 	AK. 2,8,2,88;H. 1369;ṚV. 1,10,11;ṚV 25,12;ṚV 34,11;ṚV 37,15;ṚV 44,6;ṚV 93,3;ṚV 96,8;ṚV 113,17;ṚV 23,24;ṚV 24,11;ṚV 66,1;ṚV. 1, 89,8;ṚV 2,41,17;ṚV. 2, 27,10;ṚV. 2, 38,5;ṚV 3,17,3;ṚV 4,4,7;ṚV 7,23,2;ṚV 10,16,5;ṚV. 10, 27,7;ṚV. 10, 51,7;VS. 4,15;VS. 4, 28;VS 5,27;AV. 1,35,1;AV 6,63,1;AV 3,31,1;AV 8,2,23;TS. 1,1,10,2;TS 5,1,5,7;TS 6,5,2,1;ŚAT. BR. 1,8,3,16;ŚAT. BR 2,1,3,4;CHĀND. UP. 2,11,2;BṚH. ĀR. UP. 2,1,10;ŚAT. BR. 3,1,1,4;ŚAT. BR 8,7,3,11;TAITT. UP. 2,3;CHĀND. UP. 2,24,6;PĀR. GṚHY. 2,2;ŚAT. BR. 11,1,6,6;AIT. BR. 8,7;ṚV. 6,2,5;VS. 19,37;TS. 3,2,6,3;ŚAT. BR. 13,1,1,4;KAṬHOP. 1,23;M. 3,186;ŚAT. BR. 11,1,6,6;PAÑCAT. II, 82;M. 1,83;PAÑCAT. 187,10;BHARTṚ. 3,50;MṚCCH. 1,18;M. 4,1;M 5,169;M 6,33;MBH. 1,974;KATHĀS. 14,80;KATHĀS. 14, 81;M. 4,27;M. 4, 76;M. 4, 78;M. 4, 94;M. 4, 230;R. 3,75,25;R. 3,75, 26;PAÑCAT. Pr. 10;SĀV. 2,25;M. 4,157;M 7,136;M 4,42;R. 2,105,19;M. 4,41;M. 4, 237;RAGH. 12,48;M. 4,218;M 11,40;M 4,189;R. 2,105,18;R 2,2,6;M. 4,156;R. 5,2,42;PAÑCAT. 9,4;PAÑCAT 52,15;PAÑCAT 187,7;RAGH. 3,69;PAÑCAT. 78,8;R. 3,30,9;SĀH. D. 13,9;Verz. d. B. H. No. 857 (255,8). 869;R. 3,55,20;R. 3, 45,22;PAÑCAT. 24,18;HIT. I, 69;SĀV. 2,23;KATHĀS. 14,80
+Ayus	2	2	2〉 lebendige Kraft überhaupt: ṚV. 3,1,5 . VS. 7,23	ṚV. 3,1,5;VS. 7,23
+Ayus	2	3	3〉 Lebensfeier (vollständig ), Name einer Begehung, welche neben und einen Bestandtheil der sechstägigen Abhiplava Feier bildet, als deren drittes und fünftes Tagewerk: TS. 7,4,1,1 . ŚAT. BR. 12,2,2,1	TS. 7,4,1,1;ŚAT. BR. 12,2,2,12;ŚAT. BR 13,5,4,3;KĀTY. ŚR. 24,1,9;KĀTY. ŚR 23,1,16;KĀTY. ŚR 24,6,19;AIT. BR. 4,15;ĀŚV. ŚR. 9,1;ĀŚV. ŚR 10,3;R. 1,13,45
+Ayus	2	4	4〉 ein nach NAIGH. 2,7 . — Vgl. 2. und	NAIGH. 2,7
+Ayus	2	1	1〉 drei Menschenalter hindurch TBR. 3,10,11,3 . das Alter nach 50 Jahren, die Zeit vor 50 TBR. 1,3,10,7 . Comm	TBR. 3,10,11,3;TBR. 1,3,10,7
+Ayus	2	3	3〉 vgl. WEBER, Nax. 2,282 . In dieser Bed. als masc. behandelt, ausser in der Verbindung und , z. B. ĀŚV. ŚR. 12,6,17	WEBER, Nax. 2,282;ĀŚV. ŚR. 12,6,17
+Ayus	2	5	5〉 N. eines Sāman Ind. St. 3,201,a . desgl. 206,a . — Vgl	Ind. St. 3,201,a;Ind. St 206,a
+Ayuta		1	1〉 adj. s. u. mit	
+Ayuta		2	2〉 n. halbgeschmolzene Butter: AIT. BR. 1,3	AIT. BR. 1,3
+Ayuzmant		1	1〉 adj	
+Ayuzmant		1a	a〉 lebenskräftig, gesund, dem ein langes Leben bevorsteht AK. 3,1,6 . H. 479 , Sch. MED. t. 186 . VS. 34,52 . 35,17 . AV. 3,9,3 . 6,47,1 . 2 . 14,1,45 . 19,27,8 . SUŚR. 1,123,19 . M. 3,263 . MBH. 1,24	AK. 3,1,6;H. 479;MED. t. 186;VS. 34,52;VS 35,17;AV. 3,9,3;AV 6,47,1;AV. 6,47, 2;AV 14,1,45;AV 19,27,8;SUŚR. 1,123,19;M. 3,263;MBH. 1,2472;N. 16,25;TS. 2,2,3,2;ŚAT. BR. 13,8,4,8;ŚAT. BR. 13,8,4, 9;AV. 3,31,8;AV 8,2,13;M. 2,125;R. 4,22,30;P. 8,2,83;ŚAT. BR. 12,2,1,9;BHARATA;ŚĀK. 5,2;MBH. 3,725;MBH. 3, 752;N. (BOPP) 15,12;ŚĀK. 5,2;ŚĀK 95,1;ŚĀK 96,2;ŚĀK 97,4;ŚĀK. 97, 15;VIKR. 86,14;ŚĀK. 50,2;MEGH. 99;DHŪRTAS. 76,12;P. 5,3,14, Vārtt
+Ayuzmant		1b	b〉 dauernd: AV. 6,98,2	AV. 6,98,2
+Ayuzmant		1c	c〉 alt: ĀŚV. GṚHY. 4,6	ĀŚV. GṚHY. 4,6
+Ayuzmant		2	2〉 m	
+Ayuzmant		2a	a〉 N. des 3ten unter den 27 Yoga MED. t. 186	MED. t. 186
+Ayuzmant		2b	b〉 ein Stern (the Yoga -star) im 3ten Mondhause KĀLAS. 74 . 356	KĀLAS. 74;KĀLAS 356
+Ayuzmant		2c	c〉 N. pr. ein Sohn Uttānapāda ʼs HARIV. 62 . VP. 86, N. 1 ( Āyuṣmanta ). Saṃhrāda ʼs 147 ( vgl. N	HARIV. 62;VP. 86, N. 1;VP 147 ( vgl. N. 1)
+Ayuzmant		1	1〉	
+Ayuzmant		1b	b〉 das Leben hindurch während: Spr. 1973	Spr. 1973
+Ayuzwoma		1	¦ ( + ) m. P. 8,3,83 ; s. u. 3	P. 8,3,83
+Ayuzwoma		3	3〉	
+Ayuzya		1	1〉 adj. f. lebengebend, das Leben kräftigend, gesund gaṇa zu P. 5,1,111, Vārtt. 2 . ŚAT. BR. 11,7,1,2 . 4,2,2 . 12 . 15 . M. 1,106 . 3,106 . 4,13 . MBH. 1,2309 . 2,236 ( f. ). R. 1,1,95 . 44,63	P. 5,1,111, Vārtt. 2;ŚAT. BR. 11,7,1,2;ŚAT. BR. 11, 4,2,2;ŚAT. BR. 11,7,1, 12;ŚAT. BR. 11,7,1, 15;M. 1,106;M 3,106;M 4,13;MBH. 1,2309;MBH 2,236;R. 1,1,95;R. 1, 44,63
+Ayuzya		2	2〉 n	
+Ayuzya		2a	a〉 Lebenskraft, Lebensfülle: AV. 2,29,1 . 19,26,4 . VS. 34,50 . ŚAT. BR. 6,7,4,1 . 2 . M. 2,52 . R. 1,4,22 . PAÑCAT. I, 129 = II, 41 . oder P. 2,3,73	AV. 2,29,1;AV 19,26,4;VS. 34,50;ŚAT. BR. 6,7,4,1;ŚAT. BR. 6,7,4, 2;M. 2,52;R. 1,4,22;PAÑCAT. I, 129;PAÑCAT II, 41;P. 2,3,73
+Ayuzya		2b	b〉 Belebung; so heisst eine nach der Geburt eines Kindes zu vollziehende Ceremonie PĀR. GṚHY. 1,16 _in_ Z. d. d. m. G. 7,531 . — Vgl	PĀR. GṚHY. 1,16;Z. d. d. m. G. 7,531
+Ayuzya		1	1〉 langes Leben verleihend VS. PRĀT. 8,39 . VARĀH. BṚH. S. 48,74	VS. PRĀT. 8,39;VARĀH. BṚH. S. 48,74
+Ayuzya		2	2〉	
+Ayuzya		2a	a〉 füge noch langes Leben und Spr. 2052 ( Gegens. ). WEBER, RĀMAT. UP. 357 hinzu	Spr. 2052;WEBER, RĀMAT. UP. 357
+AzAQa		1	1〉 m	
+AzAQa		1a	a〉 N. eines Monats (in dem der Vollmond beim Sternbilde Aṣāḍhā steht) AK. 1,1,3,16 . TRIK. 1,1,111 . H. 154 . an. 3,188 . MED. ḍh. 6 . SUŚR. 1,20,5 . MEGH. 2 . KATHĀS. 26,4 . RĀJA-TAR. 5,296 . VP. 225	AK. 1,1,3,16;TRIK. 1,1,111;H. 154;H an. 3,188;MED. ḍh. 6;SUŚR. 1,20,5;MEGH. 2;KATHĀS. 26,4;RĀJA-TAR. 5,296;VP. 225, N. 19
+AzAQa		1b	b〉 ein Stab aus Palāśa - Holz, den ein Schüler bei besondern Gelübden trägt, AK. 2,7,45 . H. 815 . H. an. MED. KUMĀRAS. 5,30 . = P. 5,1,110	AK. 2,7,45;H. 815;H. an;MED;KUMĀRAS. 5,30;P. 5,1,110
+AzAQa		1c	c〉 N. pr. eines Fürsten MBH. 1,2699	MBH. 1,2699
+AzAQa		1d	d〉 das Malaya -Gebirge H. 1029 . H. an. MED	H. 1029;H. an;MED
+AzAQa		2	2〉 f. = ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+AzAQa		3	3〉 ( sc. ) Vollmondstag im Monat Āṣāḍha MED. ḍh. 7 . KĀTY. ŚR. 5,3,1 . — Vgl	MED. ḍh. 7;KĀTY. ŚR. 5,3,1
+AzAQa		1	1〉	
+AzAQa		1a	a〉 LĀṬY. 10,5,18 . Ind. St. 5,297 . VARĀH. BṚH. S. 5,77 . 7,17 . 24,4 . 25,1 . Verz. d. Oxf. H. 285,a,19 . RĀJA-TAR. 5,126	LĀṬY. 10,5,18;Ind. St. 5,297;VARĀH. BṚH. S. 5,77;VARĀH. BṚH. S 7,17;VARĀH. BṚH. S 24,4;VARĀH. BṚH. S 25,1;Verz. d. Oxf. H. 285,a,19;RĀJA-TAR. 5,126
+AzAQa		2	2〉 MBH. 13,3276 . 3278 ; die ed. Bomb. an beiden Stellen richtig	MBH. 13,3276;MBH. 13, 3278;ed. Bomb
+AzAQa		3	3〉 WEBER, JYOT. 64 . ŚĀṄKH. ŚR. 2,5,7 . 6,1 . 2 . BR. 1,3 . VARĀH. BṚH. S. 26,1 . 14 . 27,6 . in der Unterschr. von Adhy. 26	WEBER, JYOT. 64;ŚĀṄKH. ŚR. 2,5,7;ŚĀṄKH. ŚR. 2, 6,1;ŚĀṄKH. ŚR. 2,5, 2;ŚĀṄKH BR. 1,3;VARĀH. BṚH. S. 26,1;VARĀH. BṚH. S. 26, 14;VARĀH. BṚH. S 27,6
+AzAQa		4	4〉 adj. zum Monat Āṣāḍha in Beziehung stehend: (des Jupitercyclus) VARĀH. BṚH. S. 8,11	VARĀH. BṚH. S. 8,11
+AzAQa		2	2〉 SŪRYAS. 9,14 . dieses oder 8,16	SŪRYAS. 9,14;SŪRYAS 8,16
+AzAQaka		1	1〉 der Monat Āṣāḍha ŚKDR. ohne Ang. einer Aut. Vgl	ŚKDR
+AzAQaka		2	2〉 N. pr. eines Elephantenführers KATHĀS. 13,8 ( ?)	KATHĀS. 13,8
+BA	1	1	1〉 scheinen, leuchten; erscheinen DHĀTUP. 24,43 . ṚV. 2,2,2 . 5,44,12 . 6,65,2 . 7 . 9 . 3 . TBR. 3,11,7,3 . ŚAT. BR. 14,4,3 . 33 . 1,17 . 11 . 8,3,9 . ĀŚV. ŚR. 11 . 6 . KAṬHOP. 5,15 (= MUṆḌ. UP. 2,2 	DHĀTUP. 24,43;ṚV. 2,2,2;ṚV 5,44,12;ṚV 6,65,2;ṚV. 6,65, 7;ṚV. 6,65, 9;ṚV. 6,65, 3;TBR. 3,11,7,3;ŚAT. BR. 14,4,3;ŚAT. BR. 14,4, 33;ŚAT. BR. 14, 1,17;ŚAT. BR. 14,4, 11;ŚAT. BR 8,3,9;ĀŚV. ŚR. 11;ĀŚV. ŚR 6;KAṬHOP. 5,15;MUṆḌ. UP. 2,2;MUṆḌ. UP. 2, 10;ŚVETĀŚV. UP. 6,14;MAITRYUP. 6,16;TBR. 3,1,1,1;Z. f. d. K. d. M. 7,266;Spr. 3521;PRAB. 98,2;VARĀH. BṚH. S. 30,32;Verz. d. Oxf. H. 238,b,5;ARJ. 1,2;N. 13,27;KATHĀS. 44,147;KATHĀS 43,215;KIR. 5,20;CHĀND. UP. 4,14,2;CHĀND. UP. 4, 9,2;MBH. 3,2701;MBH 7,2235;MBH 2,1800;Spr. 1851;Spr 2949;Spr 3119;MBH. 13,4867;MBH 3,10058;R. 1,30,15;R 2,71,22;R. 2, 72,19;R. 2, 94,7;MBH. 3,11602;SUŚR. 1,23;SUŚR. 1, 4;RAGH. 3,18;BHĀG. P. 4,28,44;MBH. 3,2502. fg;MBH 3,7153. fg;MBH 6,3447;R. 2,23,3;R. 2, 93,11;RAGH. 2,16;RAGH. 2, 4;RAGH. 2, 1;RAGH 12,26;VARĀH. BṚH. S. 16;VARĀH. BṚH. S 16;Spr. 4150;KATHĀS. 48,99;RĀJA-TAR. 2,127;RĀJA-TAR 5,94;VET. in LA. (II) 4,6;BHĀG. P. 1,2,32;Verz. d. Oxf. H. 249,a, N. 3;VEDĀNTAS. (Allah.) No. 37;R. 2,83,14;Spr. 3576;KATHĀS. 27,2;BRAHMA-P. in LA. (II) 54,6;R. 1,4,30;BĀLAB. 17;BHAṬṬ. 8,2;BHĀG. P. 3,23,18;BHĀG. P 9,11,32;ŚABDAM;ŚKDR;HIḌ. 1;HIḌ 10;MBH
+BA	1	2	2〉 erscheinen machen, zeigen, offenbaren BHAṬṬ. 15,111 . v. l. — stark —, stärker scheinen, — glänzen: AV. 10,3,17 . R. 2,42,12 . 59,11 . — , impers. SIDDH. K. 163,a,13 . — scheinen nach ( acc. ): ṚV.	BHAṬṬ. 15,111;AV. 10,3,17;R. 2,42,12;R. 2, 59,11;SIDDH. K. 163,a,13;ṚV. 3,6,7;KAṬHOP. 5,15;MUṆḌ. UP. 2,2,10;ŚVETĀŚV. UP. 6,14;GHAT. 10;MBH. 5,1856;MBH 7,1622;MBH 12,7416;ṚV. 1,154,6;VS. 6,3;HARIV. 13100;MBH. 3,10094;RĀJA-TAR. 3,427;BHĀG. P. 3,12,48;BHĀG. P. 3, 32,28;BHĀG. P 4,24,60;BHĀG. P 3,8,22;ṚV. 1,48,9;ṚV. 1, 49,4;ṚV 50,4;ṚV 2,4,6;ṚV 5,76,1;ṚV 7,10,1;ṚV 10,45,4;AV. 13,2,2;TBR. 3,10,1,1;Spr. 5020;BHĀG. P. 4,9,62;BHAṬṬ. 9,36;R. GORR. 4,31,18;BHĀG. P. 8,7,24;MBH. 2,1333;MBH 3,13701;MBH 4,1806;MBH 5,1708;HARIV. 12549;R. 1,15,19;DAŚ. 1,17;SUŚR. 1,123,6;MṚCCH. 76,9;RAGH. 3,33;RAGH 5,15;RAGH. 5, 70;RAGH 13,14;VIKR. 142;MĀLAV. 43;RĀJA-TAR. 3,240;BHĀG. P. 1,2,31;BHAṬṬ. 7,8;HARIV. 3909;BHAṬṬ. 7,66;KATHĀS. 50,7;H. 101;MBH. 11,723;M. 1,7;BHĀG. P. 8,19,4;BHĀG. P. 1,11,20;BHĀG. P 8,6,5;BHĀG. P 6,5,22;M. 5,44;M 2,10;M 5,113;MBH. 8,3141;RAGH. 11,66;KATHĀS. 25,227
+BA	1	1	1〉 hervorleuchten; leuchten, scheinen: ṚV. 1,121,7 . AIT. BR. 4,9 . TS. 6,6,8,4 . TBR. 3,10,1,1 . AV. 18,4,14 . 3,65 . MBH. 8,1685 . 14,748 . 3,10054 . erscheinen: R. 2,103,43 ( 111,50 GORR. ). ( ) 6,	ṚV. 1,121,7;AIT. BR. 4,9;TS. 6,6,8,4;TBR. 3,10,1,1;AV. 18,4,14;AV. 18, 3,65;MBH. 8,1685;MBH 14,748;MBH 3,10054;R. 2,103,43;R. 2, 111,50 GORR;R 6,2,30;MBH. 4,321;ŚĀṄKH. ŚR. 2,6,3;MBH. 3,47;MBH 12,4936;R. 1,25,1;R. 1, 33,2;R 2,6,10;R. 2, 47,1;R. 2, 52,1;R. 2, 34,35;KATHĀS. 33,127;KATHĀS 34,143;KATHĀS 37,79;RAGH. 3,2;R. 1,36,1;R. 1, 20,19;R. GORR. 2,11,17;AK. 1,1,3,3;AK. 1, 3,5,19;TRIK. 1,1,103;H. 138;HALĀY. 1,111;R. 2,13,12;ŚĀK. 46,8;PRAB. 116,15;ITIH;SĀY;ṚV. 1,125,1;HARIV. 7071;Spr. 2968;RAGH. 2,1;VARĀH. BṚH. S. 48,23;VARĀH. BṚH. S 59,12;VID. 124;HIT. 21,22;HIT 23,5;VET. in LA. (II) 30,15;VET. in LA. (II) 30, 16;R. 1,26,1;R. 1, 27,1 GORR;R. 1, 45,5;R 2,86,21;SĀV. 5,80;R. 1,28,35;R. 1, 47,19;LA. (II) 91,13;SUŚR. 1,118,4;MBH. 1,1091;R. 2,77,4;R. 2, 79,1;VARĀH. BṚH. S. 43,19;KATHĀS. 30,144;VET. in LA. (II) 28,14;KĀTY. ŚR. 415,9;Spr. 2625;Verz. d. B. H. No. 1022;VP. 266, N. 1;MBH. 1,2584
+BA	1	2	2〉 erleuchten: TAITT. UP. 1,4,3 . — Vgl. fgg. — bescheinen: TBR. 1,2,1,7 . — erscheinen, sichtbar sein: MBH. 3,10055	TAITT. UP. 1,4,3;TBR. 1,2,1,7;MBH. 3,10055
+BA	1	1	1〉 scheinen auf ( acc. ), bescheinen: LĀṬY. 1,12,5	LĀṬY. 1,12,5
+BA	1	2	2〉 erscheinen, zu sein scheinen: DAŚAK. _in_ BENF. Chr. 187,22 . MBH. 3,1930 . R. 2,60,8 . 88,17 . ŚĀK. 110,17 . MĀLAV. 82 . PRAB. 48,11 . DRAUP. 4,4 . ARJ. 4,39 . MBH. 1,7260 . Einschieb. nach R. 2,5	DAŚAK;BENF. Chr. 187,22;MBH. 3,1930;R. 2,60,8;R. 2, 88,17;ŚĀK. 110,17;MĀLAV. 82;PRAB. 48,11;DRAUP. 4,4;ARJ. 4,39;MBH. 1,7260;R. 2,56,13;R. 2, 72,11;R. 2, 104,12;R 3,52,42;ŚĀK. 42;ŚĀK 174;RAGH. 2,47;KUMĀRAS. 5,38;KUMĀRAS 6,54;Spr. 1973;Spr 3014;Spr 3039;Spr 3959;RĀJA-TAR. 3,418;RĀJA-TAR 4,382;RĀJA-TAR 5,257;RĀJA-TAR 6,118;BHĀG. P. 5,17,20;PAÑCAT. 190,12;MBH. 4,381;Spr. 5133;R. 2,59,18;R. 2, 76,9;R. 2, 88,5;HIT. 86,12;MBH. 4,304
+BA	1	3	3〉 erscheinen, sich zeigen, sich darbieten; mit dem gen. und acc. der Person: GHAṬ. 15 . MBH. 1,1273 . 10,797 . RĀJA-TAR. 3,84 . so v. a. stellte sich nicht ein bei den Göttern MBH. 10,800 . so v. a. 	GHAṬ. 15;MBH. 1,1273;MBH 10,797;RĀJA-TAR. 3,84;MBH. 10,800;MBH 8,1969;MBH 12,104;ed. Bomb;MBH 5,2412;R. 1,55,17;R. 1, 56,17 GORR;R. 1, 5,7289
+BA	1	4	4〉 in Jmds Geiste klar erscheinen, dem Geiste gegenwärtig werden, zum Bewusstsein kommen, einleuchten, begriffen werden, einfallen; mit dem acc. der Person: [Page5-0233] so v. a. wurde ihm offenbart N	NIR. 4,6;CHĀND. UP. 6,7,2;KAṬHOP. 2,6;R. 2,60,14;MBH. 3,11069 (S. 571). 1,696;MBH. 1, 739;MBH 3,13510;MBH 12,1878;ed. Bomb;HARIV. 9972;R. 2,62,4;R. GORR. 1,67,17
+BA	1	5	5〉 gut scheinen, gefallen: PAÑCAT. 66,19 . 78,12 . 151,1 . KULL. _zu_ M. 3,11 (S. 178, Z. . mit dem acc. der Person VIKR. 43,18 . SIDDH. K. _zu_ P. 2,3,2 . — Vgl. . — erscheinen, zu sein scheinen: MBH	PAÑCAT. 66,19;PAÑCAT 78,12;PAÑCAT 151,1;KULL;M. 3,11 (S. 178, Z. 1);VIKR. 43,18;SIDDH. K;P. 2,3,2;MBH. 9,3507
+BA	1	1	1〉 dass. : MBH. 1,8095	MBH. 1,8095
+BA	1	2	2〉 in Jmds Geiste klar erscheinen, dem Geiste gegenwärtig werden, zum Bewusstsein kommen: MBH. 3,10781	MBH. 3,10781
+BA	1	1	1〉 erscheinen, erglänzen, glänzen; erscheinen wie, scheinen zu sein; zum Vorschein kommen: ṚV. 1,92,9 . 95,11 . 113,15 . 17 . 19 . 2,8,4 . 23,15 . 6,5,5 . 4,51,1 . 7,77,5 . 10,6,1 . VS. 12,15 . TBR. 1	ṚV. 1,92,9;ṚV. 1, 95,11;ṚV 113,15;ṚV. 1, 17;ṚV. 1, 19;ṚV 2,8,4;ṚV 23,15;ṚV 6,5,5;ṚV 4,51,1;ṚV 7,77,5;ṚV 10,6,1;VS. 12,15;TBR. 1,4,10,7;TS. 1,6,5,1;TS. 1, 7,5,1;KAṬHOP. 5,15;MUṆḌ. UP. 2,2,10;ŚVETĀŚV. UP. 6,14;PRAB. 107,19;MAITRYUP. 6,24;HARIV. 4027;SĀH. D. 17,21;VARĀH. BṚH. S. 30,33;PAÑCAR. 1,4,5;PAÑCAR. 1, 7,83;MĀRK. P. 107,6;ŚIŚ. 9,26;KATHĀS. 34,251;R. 2,72,20;R. 2, 114,13;Spr. 3052;Spr 1518;Spr 2311;MALLIN;KUMĀRAS. 3,26;BHĀG. P. 1,14,39;Spr. 1012;VARĀH. BṚH. S. 19,14;KATHĀS. 27,1;R. 3,9,12;MBH. 1,5771;MBH 3,4024;MBH 4,1867;MBH 7,1105;MBH 14,2185;RAGH. 13,52;RAGH. 13, 53;VARĀH. BṚH. S. 12,9;RĀJA-TAR. 5,355;BHĀG. P. 3,18,19;PRAB. 13,13;Verz. d. Oxf. H. 238,b,34;BĀLAB. 19;MBH. 14,2659;CHĀND. UP. 8,4,2;VEDĀNTAS. (Allah.) No. 124;BHĀG. P. 8,3,4;KATHĀS. 23,10;H. 139;HALĀY. 1,111;ŚABDAR;ŚKDR;ŚĀK. 115;RAGH. 5,69;RAGH. 5, 72;RAGH 7,2
+BA	1	2	2〉 bescheinen, beleuchten: ṚV. 9,97,32 . 6,68,9 . erleuchten VS. 14,8 . [Page5-0234] AV. 13,2,10 . 28 . 42 . 17,1,16 . MBH. 3,10658 . — wer in seinem Hause dir hell macht d. i. Feuer entzündet ṚV. 1,7	ṚV. 9,97,32;ṚV 6,68,9;VS. 14,8;AV. 13,2,10;AV. 13,2, 28;AV. 13,2, 42;AV 17,1,16;MBH. 3,10658;ṚV. 1,71,6;ṚV. 7,5,2;AV. 13,2,42;HARIV. 13100;MUṆḌ. UP. 3,1,10;ŚAṂK;TBR. 3,10,1,1;MBH. 5,3830;HARIV. 16081;MBH. 12,6812;R. 5,14,13;R 2,91,55;MBH. 7,789;MBH. 12,12401;ed. Bomb;HIḌ. 1,10
+BA	1	1	1〉 füge eine glänzende Erscheinung sein, eine hervorragende Stellung einnehmen hinzu. KATHĀS. 73,23 . glänzend, leuchtend BHĀG. P. 10,13,48 . — erscheinen BHĀG. P. 11,2,38 . — , glänzend BHĀG. P. 12,9	KATHĀS. 73,23;BHĀG. P. 10,13,48;BHĀG. P. 11,2,38;BHĀG. P. 12,9,23;BHĀG. P 10,82,46;BHĀG. P. 10, 84,24;Ind. St. 9,144;R. 7,32,57;BHĀG. P. 10,69,38;R. 7,69,38
+BA	1	1	1〉 erglänzen so v. a. einen Glanz erhalten, schmuck erscheinen: zu BHARTṚ. 1,38	BHARTṚ. 1,38
+BA	1	1	1〉 bei klarem Tagesanbruch MBH. 5,7603	MBH. 5,7603
+BA	2	1	1〉 f. Schein, Glanz, Licht VS. 30,12 . ŚAT. BR. 9,4,1,9 . 11,8,3,11 . Der nom. lautet wahrscheinlich , da die ältere Sprache die Wurzeln auf in unverkürzter Form als Nomina zu gebrauchen pflegt; vgl. 	VS. 30,12;ŚAT. BR. 9,4,1,9;ŚAT. BR 11,8,3,11
+BA	2	2	2〉 m. die Sonne TRIK. 1,1,99 ; es könnte auch gemeint sein. — Vgl	TRIK. 1,1,99
+BARqIra		1	1〉 N. pr. eines hohen Nyagrodha -Baumes auf dem Govardhana in Vṛndāvana ; = JAṬĀDH. _im_ ŚKDR. HARIV. 3114 . 3614 . 3749 . GĪT. 6,12 . ( Kṛṣṇa ) PAÑCAR. 4,8,59 . 103 . Vgl	JAṬĀDH;ŚKDR;HARIV. 3114;HARIV 3614;HARIV 3749;GĪT. 6,12;PAÑCAR. 4,8,59;PAÑCAR 103
+BARqIra		2	2〉 N. pr. eines Dānava KATHĀS. 47,16	KATHĀS. 47,16
+BARqIra		1	1〉 BHĀG. P. 10,19,13 . 22	BHĀG. P. 10,19,13
+BARqa		1	1〉 m. = Thespesia populneoides Wall. RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+BARqa		2	2〉 f. gaṇa zu P. 4,4,41 . viell. = Rubia Munjista Roxb. SUŚR. 2,175,1 . Vgl. und	P. 4,4,41;SUŚR. 2,175,1
+BARqa		3	3〉 n	
+BARqa		3a	a〉 Topf, Gefäss, Schüssel, Kasten, Kästchen, Geräthe AK. 2,9,33 . 3,4,11,46 . H. 1026 . an. 2,125 . MED. ḍ. 21 . VAIJ. beim Schol. zu ŚIŚ. 3,76 . M. 4,65 . 10,52 . BHĀG. P. 4,14,41 . Spr. 1994 . SUŚR.	AK. 2,9,33;AK 3,4,11,46;H. 1026;H an. 2,125;MED. ḍ. 21;VAIJ;ŚIŚ. 3,76;M. 4,65;M 10,52;BHĀG. P. 4,14,41;Spr. 1994;SUŚR. 1,109,6;SUŚR 2,189,7;SUŚR. 2, 244,7;HIT. 115,1;HIT. 115, 7;HIT. 115, 8;BHĀG. P. 1,18,34;M. 5,112;MBH. 13,5501;MĀRK. P. 15,26;KATHĀS. 49,143;ŚAṂK;BṚH. ĀR. UP. S. 254;M. 7;M 132;SUŚR. 1,163,19;ŚĀRṄG. SAṂH. 2,9,15;M. 8,289;M 327;RĀJA-TAR. 1,238;Spr. 5417;MĀRK. P. 51,38;HIT. 85,14. fg;M. 11,147;PAÑCAT. 36,16;VṚDDHA-CĀṆ. 11,7;HIT. 91,15;HIT. 91, 16;VYUTP. 209;M. 8,405;VARĀH. BṚH. S. 51,28;MṚCCH. 26,9;KATHĀS. 24,133;RĀJA-TAR. 5,84;M. 9,271;P. 3,1,20;MBH. 2,1836;R. 2,89,16;MBH. 3,11043;R. 3,6,4;R. 3, 62,23;HARIV. 14118;HARIV 4426;BHĀG. P. 4,4,6;VARĀH. BṚH. S. 10,10;VARĀH. BṚH. S 42,8;VARĀH. BṚH. S. 42, 11;VARĀH. BṚH. S. 42, 12;MĀRK. P. 134;MĀRK. P 63;R. 1,4,21;MBH. 2,60;RĀJA-TAR. 3,443;MBH. 5,7631;SĀV. 3,1;R. 2,79,6;MBH. 13,517;MBH 3,14674;MBH. 12,8793
+BARqa		3b	b〉 insbes, Pferdegeschirr, Pferdeverzierung AK. 3,4,11,46 . H. an. MED. VAIJ. adj. MBH. 7,1217 . 6,781 . R. GORR. 2,125,14 . adj. MBH. 4,1781 . 5,5262 . 7,77 . HARIV. 4429 . R. 6,35,12	AK. 3,4,11,46;H. an;MED;VAIJ;MBH. 7,1217;MBH 6,781;R. GORR. 2,125,14;MBH. 4,1781;MBH 5,5262;MBH 7,77;HARIV. 4429;R. 6,35,12
+BARqa		3c	c〉 Schmuck überh. H. an. MED. HĀR. 260 . VAIJ. MBH. 4,2158 . R. 2,78,17. fg	H. an;MED;HĀR. 260;VAIJ;MBH. 4,2158;R. 2,78,17. fg
+BARqa		3d	d〉 = ein musikalisches Instrument: M. 10,49	M. 10,49
+BARqa		3e	e〉 Waare; = AK. 3,4,11,46 . = H. an. = MED. = VAIJ. NĀRADA _in_ MIT. ŚKDR. M. 8,405 . 399 . 9,331 . YĀJÑ. 2,197 . PAÑCAT. 7,17 . Spr. 1276 . 2222 . KATHĀS. 43,73 . ŚIŚ. 3,76	AK. 3,4,11,46;H. an;MED;VAIJ;NĀRADA;MIT;ŚKDR;M. 8,405;M. 8, 399;M 9,331;YĀJÑ. 2,197;PAÑCAT. 7,17;Spr. 1276;Spr 2222;KATHĀS. 43,73;ŚIŚ. 3,76
+BARqa		3f	f〉 Flussbett H. an	H. an
+BARqa		3g	g〉 (von ) Possenreisserei AJAYAP. _im_ ŚKDR. HALĀY. 2,213 . — Vgl. (auch HIT. 64,19 )	AJAYAP;ŚKDR;HALĀY. 2,213;HIT. 64,19
+BARqa		3	3〉	
+BARqa		3a	a〉 Kübel PAÑCAT. 62,25 . Vgl	PAÑCAT. 62,25
+BARqa		3d	d〉 vgl	
+BARqa		3e	e〉 Waare KATHĀS. 54,125 ( m. pl. ). Kapital 57,144	KATHĀS. 54,125;KATHĀS 57,144
+BARqaka		1	1〉 m.n. SIDDH. K. 249,a,1 . Kästchen: KATHĀS. 24,163	SIDDH. K. 249,a,1;KATHĀS. 24,163
+BARqaka		2	2〉 f	
+BARqaka		2a	a〉 Geräthe: VYUTP. 209	VYUTP. 209
+BARqaka		2b	b〉 = , s	
+BARqaka		1	1〉 Topf KATHĀS. 61,93 . Vgl	KATHĀS. 61,93
+BARqaka		3	3〉 am Ende eines adj. comp. Waare KATHĀS. 52,318	KATHĀS. 52,318
+BARqavAdya		3	3〉	
+BARqavAdya		3d	d〉 BHAR. NĀṬYAŚ. 34,33	BHAR. NĀṬYAŚ. 34,33
+BAdra		1	1〉 m. ( sc. ) = AK. 1,1,3,17 . H. 155 . RĀJA-TAR. 6,365 . Verz. d. Oxf. H. 284,b,10 . 23 . 38 . 46 . 285,a,4. fgg	AK. 1,1,3,17;H. 155;RĀJA-TAR. 6,365;Verz. d. Oxf. H. 284,b,10;Verz. d. Oxf. H. 284,b, 23;Verz. d. Oxf. H. 284,b, 38;Verz. d. Oxf. H. 284,b, 46;Verz. d. Oxf. H 285,a,4. fgg
+BAdra		2	2〉 f. ( sc. ) Vollmondstag im Monat Bhādra As. Res. III, 290	As. Res. III, 290
+BAdrapada		1	1〉 m. ein Monat der Regenzeit (August-September) AK. 1,1,3,17 . H. 154 . Schol. zu KĀTY. ŚR. 566,7 . 892,6 . SUŚR. 1,20,3 . VARĀH. BṚH. S. 5,79 . 8,13 . 21,10 . 11 . RĀJA-TAR. 2,18 . 6,114 . Verz. d. 	AK. 1,1,3,17;H. 154;KĀTY. ŚR. 566,7;KĀTY. ŚR 892,6;SUŚR. 1,20,3;VARĀH. BṚH. S. 5,79;VARĀH. BṚH. S 8,13;VARĀH. BṚH. S 21,10;VARĀH. BṚH. S. 21, 11;RĀJA-TAR. 2,18;RĀJA-TAR 6,114;Verz. d. B. H. 134,b,7 v. u;Verz. d. Oxf. H. 284,b,11;Verz. d. Oxf. H. 284,b, 34;Verz. d. Oxf. H. 284,b, 40;Verz. d. Oxf. H. 284,b, 42;Verz. d. Oxf. H 285,a,15;Journ. of the Am. Or. S. 7,27,6
+BAdrapada		2	2〉 f. = ; pl. AK. 1,1,2,24 . du. SŪRYAS. 8,16 . H. 115 , v. l. VP. 226, N. 21 . COLEBR. Misc. Ess. II, 343 . (!) ŚKDR. angeblich nach dem JYOTIṢA. Vgl	AK. 1,1,2,24;SŪRYAS. 8,16;H. 115;VP. 226, N. 21;COLEBR. Misc. Ess. II, 343;ŚKDR;JYOTIṢA
+BAdrapada		3	3〉 f. der Vollmondstag im Monat Bhādrapada PADDH. _zu_ KĀTY. ŚR. 451,18	PADDH;KĀTY. ŚR. 451,18
+BAga	1	1	1〉 m. P. 7,3,52 , Sch	P. 7,3,52
+BAga	1	1a	a〉 Theil, Antheil, zugeschiedenes Eigenthum, Loos, namentlich gutes oder glückliches Loos; = TRIK. 3,3,65 . H. 1434 . = an. 2,39 . MED. g. 13 . ṚV. 1,123,3 . 135,2 . 156,5 . 183,4 . 2,36,4 . 1,161,6 .	TRIK. 3,3,65;H. 1434;H an. 2,39;MED. g. 13;ṚV. 1,123,3;ṚV. 1, 135,2;ṚV 156,5;ṚV 183,4;ṚV 2,36,4;ṚV 1,161,6;ṚV 3,60,1;ṚV 2,38,5;ṚV 4,54,2;ṚV 8,89,1;ṚV 10,85,21;ṚV. 10,85, 16;ṚV. 10,85, 4;ṚV. 10, 66,2;AV. 8,1,1;ṚV. 10, 71,6;AV. 5,19,13;AV 9,4,5;AV. 9, 5,2;AV 11,1,5;AV 14,1,33;VS. 14,24;VS 17,13;AIT. BR. 2,7;AIT. BR 7,26;ŚAT. BR. 1,6,1,1;ŚAT. BR. 1, 7,4,18;ŚAT. BR. 1, 9,2,35;ŚAT. BR 8,4,2,2;AIT. BR. 1,4;AIT. BR. 1, 17;TBR. 1,3;TBR 10,6;AIT. BR. 2,18;ŚĀṄKH. ŚR. 1,12,9;KAUŚ. 72;TS. 5,6,4,2;NIR. 12,1;P. 1,4,90;M. 9,131;M. 9, 143;M. 9, 204;M. 9, 211;M 215;YĀJÑ. 2;YĀJÑ 114;MBH. 1,1715;MBH 13,3197;R. 2,43,5;Spr. 3569;ŚĀK. 193;MBH. 14,280;MBH. 14, 2730;R. 1,60,10;R. 1,60, 11;R. GORR. 1,68,10;RAGH. 5,9;RAGH 10,46;KATHĀS. 36,77;KATHĀS 46,221. fg;Journ. of the Am. Or. S. 7,27,19;Journ. of the Am. Or. S. 7,27, 28;Journ. of the Am. Or. S. 7,27, 4;MBH. 5,2244;MBH. 5, 2243;MBH. 5, 2245;MBH. 5, 2246;CHĀND. UP. 8,1,5;MBH. 1,4529;MBH 3,8850;R. GORR. 1,15,21;KATHĀS. 28,89;SUŚR. 2,13,17;VOP. 8,11;VOP. 8, 139;KATHĀS. 3,68;M. 7,130;M 8,33;M. 8, 35;M 10,118;SŪRYAS. 1,17;SŪRYAS 2,15;AK. 1,1,2,17;AK. 1, 2,9,90;R. 6,73,35;H. 141;M. 4,1;M 5,169;M 6,33;VARĀH. BṚH. S. 25,2;VARĀH. BṚH. S. 25, 3;ŚVETĀŚV. UP. 5,9;M. 8,140;YĀJÑ. 2,37;YĀJÑ 180;YĀJÑ 125;TS. 7,1,5,5;AV. 12,2,35;PAÑCAR. 1,14,50;VOP. 8,132;VET. in LA. (II) 10,21
+BAga	1	1b	b〉 Theil so v. a. Platz, Stelle, Gegend: = TRIK. H. an. MED. Schol. zu P. 1,2,29 . 30 . SUŚR. 1,27,1 . nach oben treibend d. i. zum Brechen reizend 144,14 . nach unten ausleerend 19 . nach oben und un	TRIK;H. an;MED;P. 1,2,29;P. 1,2, 30;SUŚR. 1,27,1;SUŚR 144,14;SUŚR 19;SUŚR 145,3;SUŚR 135,20;VIKR. 26;MBH. 13,5364;MBH 1,6960;MBH 13,1436;R. 2,54,3;ŚĀK. 90;PRAB. 79,6;KĀM. NĪTIS. 16,1;KATHĀS. 34,145;KATHĀS 37,13;KATHĀS 47,50;ŚĀK. 80;ŚĀK 83;RAGH. 18,46;R. 1,60,20;HALĀY. 5,41;HALĀY 2,373;HALĀY 5,6
+BAga	1	1c	c〉 am Ende eines adj. comp. ( f. ) die Stelle von — vertretend ( vgl. ): [Page5-0236] ( st. dessen KĀTY. ŚR. ) LĀṬY. 8,3,6 . 8	KĀTY. ŚR;LĀṬY. 8,3,6
+BAga	1	1d	d〉 Zähler eines Bruchs COLEBR. Alg. 13	COLEBR. Alg. 13
+BAga	1	1e	e〉 Grad, der 360ste Theil eines Kreises SŪRYAS. 1,28 . 3,17 . 4,6 . 7,10 . 8,9 . 10 . 11 . 21 . 12,59 . 68 . 75 . 13,6 . 14,5	SŪRYAS. 1,28;SŪRYAS 3,17;SŪRYAS 4,6;SŪRYAS 7,10;SŪRYAS 8,9;SŪRYAS. 8, 10;SŪRYAS. 8, 11;SŪRYAS. 8, 21;SŪRYAS 12,59;SŪRYAS. 12, 68;SŪRYAS. 12, 75;SŪRYAS 13,6;SŪRYAS 14,5
+BAga	1	1f	f〉 eine halbe Rupie H. an. MED. P. 5,1,49 , Sch	H. an;MED;P. 5,1,49
+BAga	1	1g	g〉 in der Stelle: schlage ihn in die Flucht PAÑCAT. 232,16 . 18 vielleicht fehlerhaft für (von )	PAÑCAT. 232,16;PAÑCAT. 232, 18
+BAga	1	1h	h〉 N. pr. eines Fürsten ( VP. statt dessen ) VP. 471, N. 35	VP;VP. 471, N. 35
+BAga	1	1i	i〉 N. pr. eines Flusses, aus dessen Vereinigung mit dem Flusse Candra die Candrabhāgā entsteht, LIA. I. Anh. XLI. — In der Stelle: MBH. 7,75 hat die neuere Ausg. st	LIA. I. Anh. XLI;MBH. 7,75
+BAga	1	2	2〉 n. N. eines Sāman Ind. St. 3,227,b . — Vgl. (auch R. 1,19,6 . SŪRYAS. 2,62 )	Ind. St. 3,227,b;R. 1,19,6;SŪRYAS. 2,62
+BAga	1	1	1〉	
+BAga	1	1g	g〉 Z. 1 lies	
+BAgaDeya		1	1〉 n. Antheil, Theil, Gebühr, Eigenthum ṚV. 3,28,4 . 8,85,8 . 10,52,1 . 114 . 3 . VĀLAKH. 11,1 . AV. 6,111,1 . 116,2 . 7,79,1 . 11,1,29 . 12,2,1 . 53 . 18,2,31 . PAÑCAV. BR. 24,18,2 . ŚAT. BR. 1 . 5,1	ṚV. 3,28,4;ṚV 8,85,8;ṚV 10,52,1;ṚV. 10,52, 114;ṚV. 10,52, 3;VĀLAKH. 11,1;AV. 6,111,1;AV. 6, 116,2;AV 7,79,1;AV 11,1,29;AV 12,2,1;AV. 12,2, 53;AV 18,2,31;PAÑCAV. BR. 24,18,2;ŚAT. BR. 1;ŚAT. BR 5,1,26;ŚAT. BR 9,2,35;ŚAT. BR 2,4,3,5;ŚAT. BR 11;ŚAT. BR 7;ŚAT. BR 4,2;ŚAT. BR 12,7,3,6;AIT. BR. 1,3;AIT. BR 2,7;AIT. BR 3,13;TBR. 2,1,1;TBR. 2,1, 1;TS. 5,4,10,5;TS. 5, 5,9,2;NIR. 9,31;M. 3,245. fg;MBH. 3,2277;ŚĀK. 27,5;RAGH. 1,50;MBH. 2,1702;MBH. 2, 1704;AK. 1,1,4,6;H. 1379;H an. 4,227;MED. y. 124;HALĀY. 1,126;MBH. 1,7222;MBH 13,7597;AK. 2,8,1,27;H. 745;H. an;MED;HALĀY. 2,278;MED
+BAgaDeya		2	2〉 adj. ; f. ved. P. 4,1,30 . als Theil gebührend: VS. 6,24	P. 4,1,30;VS. 6,24
+BAgaDeya		1	1〉 Los, Schicksal: adj. dessen Schicksal sich nimmer wendet, ein Unglücksvogel VIKR. 55,10 . Z. 10 lies ( ) st. ( )	VIKR. 55,10
+BAgavata		1	1〉 adj. f. zu Bhagavant ( Viṣṇu Kṛṣṇa ) in Beziehung stehend, von ihm herrührend u. s. w. MBH. 12,12718 . 14,1587 . HARIV. 4430 . 4455 . BHĀG. P. 1,6,29 . 5,24,3 . 1,4,2 . ( d. i. ) Verz. d. Oxf. H. 2	MBH. 12,12718;MBH 14,1587;HARIV. 4430;HARIV 4455;BHĀG. P. 1,6,29;BHĀG. P 5,24,3;BHĀG. P 1,4,2;Verz. d. Oxf. H. 255,b,13;Verz. d. Oxf. H No. 815;BHĀG. P. 1,7,8;Verz. d. B. H. 448;Verz. d. Oxf. H. 8,a 11;BHĀG. P. 1,1,3;BHĀG. P 2,8,28;Verz. d. Oxf. H. 8,a,1;Verz. d. Oxf. H 59,a,37;Verz. d. Oxf. H 65,a,38;Verz. d. Oxf. H 75,a,2;Verz. d. Oxf. H 101,b,41;Verz. d. Oxf. H 104,a,8;Verz. d. Oxf. H 113,b,31;Verz. d. Oxf. H 163,a,6;Verz. d. Oxf. H 182,b,41;Verz. d. Oxf. H 185,b,39;Verz. d. Oxf. H 279,a,2;VP. 284;PAÑCAR. 2,7,28. fg;MĀRK. P. S. 659;MĀRK. P. S. Z 3;Verz. d. Oxf. H. 63,b,14;Verz. d. Oxf. H 80,a,6;Verz. d. Oxf. H 79,b. fgg;MBH. 12,12818;HARIV. 4431;HARIV 4449;VARĀH. BṚH. S. 15,20;BHĀG. P. 1,2,18;BHĀG. P. 1, 4,9;BHĀG. P. 1, 13,9;BHĀG. P 3,1,24;BHĀG. P 9,5,20;Verz. d. B. H. No. 452;Verz. d. Oxf. H. 10,a,6;Verz. d. Oxf. H 248,a,14;Verz. d. Oxf. H. 248,a, 17;PAÑCAR. 2,2;PAÑCAR. 2, 14;WEBER, RĀMAT. UP. 277;HALL;VĀSAVAD. 53;LIA. II. 962;LIA. II. N 1095;LIA. II. N 6;BHĀG. P. 1,12,17;BHĀG. P. 1,12, 32;BHĀG. P 5,1,6;Verz. d. B. H. No. 1318;P. 2,4,11
+BAgavata		2	2〉 m. N. pr. eines Fürsten VP. 471 . — Vgl	VP. 471
+BAgavata		2	2〉 BHĀG. P. 12,1,16	BHĀG. P. 12,1,16
+BAgika		1	1〉 adj. f. P. 5,1,49 . einen Theil bildend: SUŚR. 2,13,17 . wohl ein auf hundert, ein Procent; ein auf zwanzig, fünf Procent Schol. zu P. einen halben Theil erhaltend YĀJÑ. 2 . 134 ; st. dessen wohl r	P. 5,1,49;SUŚR. 2,13,17;P;YĀJÑ. 2;YĀJÑ 134
+BAgika		2	2〉 m. N. pr. eines Mannes RĀJA-TAR. 8,1230 . 1656 . 1667 . 1673 . 1816 . 1924	RĀJA-TAR. 8,1230;RĀJA-TAR. 8, 1656;RĀJA-TAR. 8, 1667;RĀJA-TAR. 8, 1673;RĀJA-TAR. 8, 1816;RĀJA-TAR. 8, 1924
+BAgya	2	1	1〉 adj	
+BAgya	2	1a	a〉 (von ) = zu theilen VOP. 26,12	VOP. 26,12
+BAgya	2	1b	b〉 oxyt. = auf einen Antheil Ansprüche habend gaṇa zu P. 5,1,66	P. 5,1,66
+BAgya	2	1c	c〉 parox. = P. 5,1,49 . ein von Hundert, ein Procent, ein von zwanzig, fünf Procent Sch	P. 5,1,49
+BAgya	2	1d	d〉 glücklich: MBH. 1,4886	MBH. 1,4886
+BAgya	2	2	2〉 n. sg. und pl. Loos, Schicksal (bedingt durch die Werke des vorangegangenen Lebens); gutes oder glückliches Loos; Glück, Wohlfahrt; = AK. 1,1,4,6 . H. 1379 . HALĀY. 1,126 . = AK. 3,1,24,157 . H. an	AK. 1,1,4,6;H. 1379;HALĀY. 1,126;AK. 3,1,24,157;H. an. 2,374;MED. y. 42;MBH. 1,3904;R. 2,27,4;R. 2,27, 5;Spr. 3129;Spr 3637;ŚĀK. 92;PAÑCAT. ed. orn. 4,25;ed. Bomb;MBH. 13,6636;MṚCCH. 98,11;SĀṂKHYAK. 50;LASSEN;MṚCCH. 157,16;ŚĀK. 126;VARĀH. BṚH. S. 24,27;VARĀH. BṚH. S 27,6;HIT. 10,10;Spr. 5349;Spr 1475;Spr 3100;Spr 3965;RAGH. 19,24;PAÑCAR. 1,6,32;ŚĀK. 93;KATHĀS. 20,19;Spr. 1648;MĀRK. P. 62,19;MBH. 3,2735;Spr. 4805;Spr 634;RAGH. 3,13;Journ. of the Am. Or. S. 7,6, Śl. 18;RAGH. 8,46;RĀJA-TAR. 1,198;Spr. 2586;Spr 435;BHĀG. P. 3,15,38;MBH. 1,4705;MBH 4,638;R. 3,72,27;R 2,53,24;RĀJA-TAR. 5,385;BENFEY;ed. Calc
+BAj		1	1〉 adj. am Ende eines comp. P. 3,2,62	P. 3,2,62
+BAj		1a	a〉 theilhabend an, betheiligt bei, berechtigt an; theilhaftig, besitzend, zu geniessen habend, sich einer Sache erfreuend, empfindend, sich hingebend: ŚĀṄKH. BR. 16,6. fgg. GOBH. 4,3,18 . AIT. BR. 5,2	ŚĀṄKH. BR. 16,6. fgg;GOBH. 4,3,18;AIT. BR. 5,24;AIT. BR 2,25;MBH. 4,202;M. 8,305;M 9,155;RAGH. 3,44;KĀM. NĪTIS. 2,10;VARĀH. BṚH. S. 19,13;VARĀH. BṚH. S 5,98;M. 1,109;Spr. 3161;MBH. 1,6655;PAÑCAR. 1,14,114;YĀJÑ. 2,60;Spr. 3589;M. 2,139;KUMĀRAS. 7,28;RAGH. 10,21;MAITRYUP. 4,3;M. 8,386;R. 2,23,29;KĀM. NĪTIS. 2,35;MĀRK. P. 114,20;BHĀG. P. 3,9,4;Verz. d. Oxf. H. 249,a,15;YĀJÑ. 2,237;YĀJÑ 1,65;YĀJÑ 179;Verz. d. Oxf. H. 91,b,14;BHĀG. P. 2,3,22;Spr. 4230;Spr. 181;VARĀH. BṚH. S. 18,6;VARĀH. BṚH. S 47,5;MAITRYUP. 6,21;R. 6,1,36;Spr. 2519;PAÑCAT. 55,1;KIR. 5,23;KATHĀS. 22,259;KATHĀS 48,137;Spr. 5209;DHŪRTAS. in LA. 96,12;RAGH. 3,35;Spr. 372;PAÑCAR. 3,5,23;MBH. 2,567;BHĀG. P. 3,33,5;Spr. 4733;Spr 4132;R. 4,21,36
+BAj		1b	b〉 einen Theil von Etwas bildend, gehörig zu: ṚV. PRĀT. 1,18 . 6,15 . 7,2 . 11,3 . 2,31 . 5,10 . 1,7 . 18,17	ṚV. PRĀT. 1,18;ṚV. PRĀT 6,15;ṚV. PRĀT 7,2;ṚV. PRĀT 11,3;ṚV. PRĀT 2,31;ṚV. PRĀT 5,10;ṚV. PRĀT 1,7;ṚV. PRĀT 18,17
+BAj		1c	c〉 verbunden mit: [Page5-0241] MBH. 2,636 . KUMĀRAS. 2,7 . ṚT. 4,4 . (so ist zu lesen mit K. ) PRAB. 109,13 . DHŪRTAS. in LA. 68,12 . AK. 1,1,7,29 . mit Genuss verbunden, genossen werdend Spr. 1991 . 	MBH. 2,636;KUMĀRAS. 2,7;ṚT. 4,4;PRAB. 109,13;DHŪRTAS. in LA. 68,12;AK. 1,1,7,29;Spr. 1991;BHĀṢĀP. 46;P. II, S. 462;Spr. 1087
+BAj		1d	d〉 innehabend, einnehmend (einen Sitz, Platz), bewohnend, wohnend in, an: RAGH. 5,3 . 19,39 . Spr. 116 . RAGH. 15,2 . NAIGH. 22,44 . mit dem acc. : (wohl zu lesen) MĀRK. P. 102,8	RAGH. 5,3;RAGH 19,39;Spr. 116;RAGH. 15,2;NAIGH. 22,44;MĀRK. P. 102,8
+BAj		1e	e〉 hingehend zu: RAGH. 12,35 . in den Schooss kommend so v. a. zufallend KIR. 5,52	RAGH. 12,35;KIR. 5,52
+BAj		1f	f〉 verehrend: BHAG. 9,30 . RAGH. 11,2	BHAG. 9,30;RAGH. 11,2
+BAj		2	2〉 Angelegenheit: BHAṬṬ. 3,21 . — Vgl. (auch LĀṬY. 6,2,23 . 7,20 )	BHAṬṬ. 3,21;LĀṬY. 6,2,23;LĀṬY. 6, 7,20
+BAj		1	1〉 mit gen. : reiche —, vornehme Männer VARĀH. BṚH. S. 68,64	VARĀH. BṚH. S. 68,64
+BAjana		1	1〉 n. proparox. Stellvertretung; instr. an der Stelle von: ŚAT. BR. 3,3,3,11 . 1,8,1,40 . Am Ende eines comp. ( oxyt. ) n. Stellvertreter, vertretend, gleichgeltend, gleichbedeutend ŚAT. BR. 2,3,1,23 	ŚAT. BR. 3,3,3,11;ŚAT. BR 1,8,1,40;ŚAT. BR. 2,3,1,23;ŚAT. BR. 2, 4,2,13;ŚAT. BR 3,3,2,4;ŚAT. BR 3,4,2,15;ŚAT. BR. 3,4,2, 3;ŚAT. BR. 3,4,2, 22;AIT. BR. 1,22;AIT. BR 6,3;ŚĀṄKH. GṚHY. 6,3;ŚAT. BR. 2,6,1,15
+BAjana		2	2〉 am Ende eines adj. comp. ( f. )	
+BAjana		2a	a〉 theilhabend an, theilhaft, berechtigt zu: AIT. BR. 2,18 . ŚĀṄKH. BR. 10,6 . 13,2 . ŚAT. BR. 6,6,1,11 . ŚĀṄKH. BR. 10,4 . ( MIT. 3,3,a,2 v. u. ) YĀJÑ. 3,6 . R. GORR. 2,64,8 . dessen Gunst er erfahre	AIT. BR. 2,18;ŚĀṄKH. BR. 10,6;ŚĀṄKH. BR 13,2;ŚAT. BR. 6,6,1,11;ŚĀṄKH. BR. 10,4;MIT. 3,3,a,2 v. u;YĀJÑ. 3,6;R. GORR. 2,64,8;BHĀG. P. 4,14,33
+BAjana		2b	b〉 gehörig zu, in Beziehung stehend zu: AIT. BR. 1,10 . 3 . 18 . ŚAT. BR. 2,4,4,20	AIT. BR. 1,10;AIT. BR. 1, 3;AIT. BR. 1, 18;ŚAT. BR. 2,4,4,20
+BAjana		3	3〉 n. das Dividiren COLEBR. Alg. 8	COLEBR. Alg. 8
+BAjana		4	4〉 Gefäss AK. 2,9,33 . TRIK. 3,3,250 . H. 1026 . MED. n. 101 . HĀR. 138 . HALĀY. 2,172 . M. 3,202 . 4,65 . 10,54 . YĀJÑ. 1,230 . MBH. 7,2159 . 12,3252 . R. 1,53,4 . SUŚR. 1,158,16 ( ). 237,1 . 2,221,6	AK. 2,9,33;TRIK. 3,3,250;H. 1026;MED. n. 101;HĀR. 138;HALĀY. 2,172;M. 3,202;M 4,65;M 10,54;YĀJÑ. 1,230;MBH. 7,2159;MBH 12,3252;R. 1,53,4;SUŚR. 1,158,16;SUŚR 237,1;SUŚR 2,221,6;SUŚR. 2, 353,6;RAGH. 5,22;Spr. 2398;MĀRK. P. 34,101;KATHĀS. 3,47;PRAB. 59,3;SUŚR. 1,74,19;SUŚR 2,341,2;MĀRK. P. 15,26;KATHĀS. 45,131;M. 11,147;R. 3,4,49;SUŚR. 2,50,17;SUŚR. 2, 73,6;ŚĀK. 44,1;BURN. Intr. 261, N. 2;HARIV. 4485;KATHĀS. 45,228;TRIK;MED;ŚAṂK;WIND. Sancara 125;VEDĀNTAS. (Allah.) No. 144;SĀH. D. 56,15;VID. 4;Spr. 2424;Spr 5160;KATHĀS. 34,205;Spr. 2451;Spr 5282;Spr 2978;Spr 1657;Spr 4445;ŚUK. in LA. (II) 35,10;HARIV. 1028;PAÑCAR. 4,3,31;Verz. d. Oxf. H. 263,a. 3;Spr. 1576;KATHĀS. 36;KATHĀS 106;Spr. 3023;Spr 2069;DHŪRTAS. in LA. 78,17;MĀLAV. 12,18;RĀJA-TAR. 4,511;RĀJA-TAR 3,102;HARIV. 4369;Spr. 4863;Spr
+BAjana		5	5〉 n. ein best. Maass, = Āḍhaka = 64 Pala ŚĀRṄG. SAṂH. 1,1,20 . Verz. d. Oxf. H. 307,b,9	ŚĀRṄG. SAṂH. 1,1,20;Verz. d. Oxf. H. 307,b,9
+BAjana		6	6〉 m. N. pr. eines Mannes gaṇa zu P. 4,1,104 . Davon patron. ebend. : pl. gaṇa zu 2,4,67 . — Vgl	P. 4,1,104;ebend;P 2,4,67
+BAjana		1	1〉 (so die ed. Bomb. ) MBH. 3,15815	ed. Bomb;MBH. 3,15815
+BAjana		4	4〉 in übertr. Bed. : (richtig) HEM. YOGAŚ. 3,63	HEM;YOGAŚ. 3,63
+BAjin		1	1〉 theilhabend an, theilhaftig CHĀND. UP. 3,9,2. fgg. KUMĀRAS. 6,74 . ŚATR. 1,22 . Vgl	CHĀND. UP. 3,9,2. fgg;KUMĀRAS. 6,74;ŚATR. 1,22
+BAjin		2	2〉 verbunden mit: KĀM. NĪTIS. 8,46 . WEBER, RĀMAT. UP. 308	KĀM. NĪTIS. 8,46;WEBER, RĀMAT. UP. 308
+BAkUwa		1	1〉 ein best. Fisch ( vgl. )	
+BAkUwa		2	2〉 N. pr. eines Berges H. an. 3,166 . MED. ṭ. 52	H. an. 3,166;MED. ṭ. 52
+BAkta	1	1	1〉 dem regelmässig Speise gereicht wird P. 4,4,68	P. 4,4,68
+BAkta	1	2	2〉 zur Speise sich eignend P. 4,4,100 . Sch	P. 4,4,100
+BAkta	2	1	1〉 adj. f. untergeordnet, secundär ( Gegens. ) ŚAṂK. _zu_ KAṬHOP. 1,1 . Schol. zu KAṆ. 7,2,5 . 6 . TITHYĀDIT. _im_ ŚKDR	ŚAṂK;KAṬHOP. 1,1;KAṆ. 7,2,5;KAṆ. 7,2, 6;TITHYĀDIT;ŚKDR
+BAkta	2	2	2〉 m. Bez. einer Viṣṇu itischen und Śiva itischen Secte, die Gläubigen, Frommen WILSON, Sel. Works I, 15 . 17 . 250. fgg. ; vgl. 2,a. b	WILSON, Sel. Works I, 15;WILSON, Sel. Works I, 17;WILSON, Sel. Works I, 250. fgg
+BAkta	2	1	1〉 SĀH. D. 342,16 . — a follower BENFEY nach RAGH. 11,2 ; hier ist aber =	SĀH. D. 342,16;BENFEY;RAGH. 11,2
+BAktva		1	1〉	
+BAktva		1a	a〉: PAT. a. a. O. 2,339,b	PAT. a. a. O. 2,339,b
+BAkuri		1	1〉 ein zur Erkl. von erfundenes Wort: ŚAT. BR. 9,4,1,9	ŚAT. BR. 9,4,1,9
+BAkuri		2	2〉 patron. PRAVARĀDHY. _in_ Verz. d. B. H. 58,27 ( d. i. )	PRAVARĀDHY;Verz. d. B. H. 58,27
+BAlANka		1	1〉 adj. mit einem (Grosses ankündenden) Zeichen auf der Stirn versehen H. an. 3,77. fg. MED. k. 133	H. an. 3,77. fg;MED. k. 133
+BAlANka		2	2〉 m	
+BAlANka		2a	a〉 Cyprinus Rohita TRIK. 1,2,16 . H. an. MED. HĀR. 235	TRIK. 1,2,16;H. an;MED;HĀR. 235
+BAlANka		2b	b〉 Schildkröte	
+BAlANka		2c	c〉 Bein. Śiva ʼs	
+BAlANka		2d	d〉 ein best. Gemüse H. an. MED	H. an;MED
+BAla		1	1〉 Stirn AK. 3,4,1 . 17 . TRIK. 2,7,15 . H. 573. fg. an. 2,504 . MED. l. 42 . Spr. 3044 . 2386 . RĀJA-TAR. 2,89 . 1,2 . 3,1 . SĀH. D. 42,20 . 60,1 . PAÑCAR. 1,14,16 . 2,2,21 . 5,24 . Verz. d. Oxf. H. 	AK. 3,4,1;AK. 3,4, 17;TRIK. 2,7,15;H. 573. fg;H an. 2,504;MED. l. 42;Spr. 3044;Spr 2386;RĀJA-TAR. 2,89;RĀJA-TAR 1,2;RĀJA-TAR 3,1;SĀH. D. 42,20;SĀH. D 60,1;PAÑCAR. 1,14,16;PAÑCAR 2,2,21;PAÑCAR. 2, 5,24;Verz. d. Oxf. H. 242,a (No. 593. fgg.);Verz. d. Oxf. H 249,a,5;ŚĀRṄG. SAṂH. 3,8,28;ŚĀRṄG. SAṂH. 3, 10,5;Journ. of the Am. Or. S. 6,502, Śl. 1;Journ. of the Am. Or. S 7,11, Śl. 40;TRIK. 2,6;TRIK. 2, 29
+BAla		2	2〉 Glanz H. an. MED. Inschr. in Journ. of the Am. Or. S. 6,505, Śl. 16 . — Vgl	H. an;MED;Journ. of the Am. Or. S. 6,505, Śl. 16
+BAlacandra		1	1〉 Bein. Gaṇeśa ʼs (den Mond auf seiner [Page5-0257] Stirn habend) GAṆEŚOPAP. _in_ Journ. of the Am. Or. S. 6,526 (	GAṆEŚOPAP;Journ. of the Am. Or. S. 6,526 (7)
+BAlacandra		2	2〉 N. pr. eines Lehrers Verz. d. B. H. No. 1045	Verz. d. B. H. No. 1045
+BAma	1	1	1〉 Schein, Licht, Strahl H. an. 2,330 . MED. m. 21 . VIŚVA _bei_ UJJVAL. ṚV. 5,2,10 . 3,26,6 . 6,6,3 . 10,3,4 . 5	H. an. 2,330;MED. m. 21;VIŚVA;UJJVAL;ṚV. 5,2,10;ṚV 3,26,6;ṚV 6,6,3;ṚV 10,3,4;ṚV. 10,3, 5
+BAma	1	2	2〉 die Sonne H. an. MED. VIŚVA a. a. O	H. an;MED;VIŚVA a. a. O
+BAma	2	1	1〉 m. Grimm, Wuth, Zorn NAIGH. 2 . 13 . TRIK. 1,1 . 128 . H. an. 2,330 . MED. m. 21 . VIŚVA _bei_ UJJVAL. _zu_ UṆĀDIS. 1,139 . ṚV. 1,165,8 . 5,32,4 . 10,83,4 . ( die Hdschrr. ) AV. 14,2,35 . 18,4,82 .	NAIGH. 2;NAIGH 13;TRIK. 1,1;TRIK. 1, 128;H. an. 2,330;MED. m. 21;VIŚVA;UJJVAL;UṆĀDIS. 1,139;ṚV. 1,165,8;ṚV 5,32,4;ṚV 10,83,4;AV. 14,2,35;AV 18,4,82;VS. 18,4;VS 20,6;VS 21,39;VS. 21, 56;ŚAT. BR. 12,7,1,7
+BAma	2	2	2〉 f	
+BAma	2	2a	a〉 eine leidenschaftliche Frau ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+BAma	2	2b	b〉 = N. pr. einer der Frauen Kṛṣṇa ʼs KATHĀS. 39,197	KATHĀS. 39,197
+BAmin	1	1	1〉 adj. scheinend, glänzend NIR. 14,25 . ṚV. 1,77,1 . 84,16 . Häufig das fem. in der Bed. glänzend, schön, von Frauen gebraucht MBH. 1,2625 . 6524 . 3,16190 ( ed. Bomb. ). 4,503 . 14,1505 . R. 2,25,35	NIR. 14,25;ṚV. 1,77,1;ṚV. 1, 84,16;MBH. 1,2625;MBH. 1, 6524;MBH 3,16190;ed. Bomb;MBH 4,503;MBH 14,1505;R. 2,25,35;R 91,18;RAGH. 8,28;ed. Calc;BHĀG. P. 9,18,6;MBH. 1,1192;MBH 13,6552;MBH 14,629;MBH. 14, 631;R. 2,26,38;GĪT. 12,6;KUMĀRAS. 5,38;BHĀG. P. 3,20,34;BHĀG. P 8,9,6;HALĀY. 2,326;RĀJAN;ŚKDR
+BAmin	1	2	2〉 f. N. pr. der Tochter eines Gandharva MĀRK. P. 128,7	MĀRK. P. 128,7
+BAmin	1	1	1〉 KATHĀS. 75,137 . 101,230	KATHĀS. 75,137;KATHĀS 101,230
+BAnavIya		1	1〉 adj. von der Sonne kommend: MAITRYUP. 6,31	MAITRYUP. 6,31
+BAnavIya		2	2〉 n. das rechte Auge H. 576	H. 576
+BAnu		1	1〉 m	
+BAnu		1a	a〉 Schein, Licht, Strahl NAIGH. 1,9 . AK. 1,1,2,35 . 3,4,18,107 . H. 100 . an. 2,277 . MED. n. 14 . HALĀY. 1,39 . VAIJ. beim Schol. zu ŚIŚ. 1,27 . ṚV. 1,92,1 . 2,2,8 . 8,4 . 16,4 . 3,21,4 . 61,7 . 4,1	NAIGH. 1,9;AK. 1,1,2,35;AK 3,4,18,107;H. 100;H an. 2,277;MED. n. 14;HALĀY. 1,39;VAIJ;ŚIŚ. 1,27;ṚV. 1,92,1;ṚV 2,2,8;ṚV 8,4;ṚV 16,4;ṚV 3,21,4;ṚV 61,7;ṚV 4,1,17;ṚV 13,2;ṚV 45,1;ṚV 5,37,1;ṚV 10,75,3;ṚV 1,36,3;ṚV. 1, 87,6;ṚV. 1, 92,2;ṚV 97,5;ṚV 143,3;ṚV 6,64,2;AV. 18,3,29;AV 19,7,2;VS. 11,54;VS 12,32;M. 8,132;LIṄGA-P;MUIR, ST. IV, 325;ŚIŚ. 1,27
+BAnu		1b	b〉 Sonne AK. 1,1,2,32 . 3,4,18,107 . H. 95 . H. an. MED. HĀR. 11 . HALĀY. 1,36 . VAIJ. a. a. O. MBH. 1,1103 . SUŚR. 1,20,12 . Spr. 2037 . MEGH. 35 . SŪRYAS. 1,36 . 39 . 3,48 . 9,9 . 12,24 . MĀRK. P. 7	AK. 1,1,2,32;AK 3,4,18,107;H. 95;H. an;MED;HĀR. 11;HALĀY. 1,36;VAIJ. a. a. O;MBH. 1,1103;SUŚR. 1,20,12;Spr. 2037;MEGH. 35;SŪRYAS. 1,36;SŪRYAS. 1, 39;SŪRYAS 3,48;SŪRYAS 9,9;SŪRYAS 12,24;MĀRK. P. 77,1;LIṄGA-P;MUIR, ST. IV, 325;ŚIŚ. 1,27;Verz. d. Oxf. H. 33,a,24
+BAnu		1c	c〉 pl. die Āditya , Kinder des Bhānu , HARIV. 148 . 12480 . VP. 120 . PAÑCAR. 3,4,12 . die Götter im 3ten Manvantara HARIV. 425 . sg. N. eines best. Āditya WEBER, RĀMAT. UP. 304 . 313	HARIV. 148;HARIV 12480;VP. 120;PAÑCAR. 3,4,12;HARIV. 425;WEBER, RĀMAT. UP. 304;WEBER, RĀMAT. UP 313
+BAnu		1d	d〉 Tag H. an	H. an
+BAnu		1e	e〉 König; Herr DHAR. _im_ ŚKDR	DHAR;ŚKDR
+BAnu		1f	f〉 = Śiva VAIJ. a. a. O	VAIJ. a. a. O
+BAnu		1g	g〉 N. pr. eines Devagandharva MBH. 1,2555 . eines Sohnes des Kṛṣṇa 2,56 . HARIV. 9183 . VP. 591 . N. pr. eines Yādava HARIV. 8472 . des Vaters des 15ten Arhant ʼs der gegenwärtigen Avasarpiṇī H. 37 . 	MBH. 1,2555;MBH 2,56;HARIV. 9183;VP. 591;HARIV. 8472;H. 37;BHĀG. P. 9;BHĀG. P 12,10;Verz. d. Oxf. H. 206,b,10;Verz. d. Oxf. H. 206,b, 12;Verz. d. Oxf. H 248,a,2;HALL;VĀSAVAD. 45
+BAnu		2	2〉 f	
+BAnu		2a	a〉 = ŚABDAR. _im_ ŚKDR. ein schönes Weib WILSON	ŚABDAR;ŚKDR;WILSON
+BAnu		2b	b〉 N. pr. einer Tochter Dakṣa ʼs. Gattin Dharma ʼs ( Manu ʼs) und Mutter der Bhānu ( Āditya ), HARIV. 145 . 148 . 12449 . 12480 . VP. 119. fg. Mutter des Devaṛṣabha BHĀG. P. 6,6,4 . 5 . N. pr. einer T	HARIV. 145;HARIV 148;HARIV 12449;HARIV 12480;VP. 119. fg;BHĀG. P. 6,6,4;BHĀG. P. 6,6, 5;HARIV. 9184;BHĀG. P. 7,2,19;ed. Bomb
+BAnu		1	1〉	
+BAnu		1g	g〉 eines Sohnes des Kṛṣṇa BHĀG. P. 10,61,10 . 90,33 . eines Schülers des Śaṃkarācārya LA. (II) 87,17	BHĀG. P. 10,61,10;BHĀG. P. 10, 90,33;LA. (II) 87,17
+BAnu		1h	h〉 Titel der Kapitel im [Page5-1657] Wörterbuch eines unbekannten Verfassers: Verz. d. Oxf. H. 194,a,20. fgg	Verz. d. Oxf. H. 194,a,20. fgg
+BAnumant		1	1〉 adj	
+BAnumant		1a	a〉 leuchtend, scheinend, strahlend: Agni ṚV. 5,1,4 . 6,4,6 . MBH. 1,6604 . R. 5,11,3 . MBH. 1,1430 . 1433 . 7209 . 4,1010 . 1323 . 7,4641 . 8,2950 . 13,1839 ( ) 3505 . 14,2315 . 1,1433 . 3,15696 . 14,	ṚV. 5,1,4;ṚV 6,4,6;MBH. 1,6604;R. 5,11,3;MBH. 1,1430;MBH. 1, 1433;MBH. 1, 7209;MBH 4,1010;MBH. 1, 1323;MBH 7,4641;MBH 8,2950;MBH 13,1839;MBH. 1, 3505;MBH 14,2315;MBH 1,1433;MBH 3,15696;MBH 14,780;HARIV. 13146
+BAnumant		1b	b〉 das Wort enthaltend ŚĀṄKH. ŚR. 11,13,15	ŚĀṄKH. ŚR. 11,13,15
+BAnumant		2	2〉 m	
+BAnumant		2a	a〉 die Sonne HALĀY. 1,36 . ŚABDAR. _im_ ŚKDR. MBH. 1,3665 . 14,892 . RAGH. 6,36 . KUMĀRAS. 3,65 . ṚT. 5,2 . VARĀH. BṚH. S. 30,10 . Spr. 1045	HALĀY. 1,36;ŚABDAR;ŚKDR;MBH. 1,3665;MBH 14,892;RAGH. 6,36;KUMĀRAS. 3,65;ṚT. 5,2;VARĀH. BṚH. S. 30,10;Spr. 1045
+BAnumant		2b	b〉 N. pr. eines Mannes mit dem patron. Aupamanyava SV. VAṂŚA-BR. _in_ Ind. St. 4,372 . eines Streiters auf Seiten der Kuru (nach dem Schol. ein Sohn Kaliṅga ʼs) MBH. 6,2268 . eines Sohnes des Kuśadhva	SV;VAṂŚA-BR;Ind. St. 4,372;MBH. 6,2268;VP. 390;BHĀG. P. 9,13,21;BHĀG. P 12,10;BHĀG. P. 12, 11;BHĀG. P 23,16
+BAnumant		3	3〉 f. n. pr. Verz. d. Oxf. H. 101,b,2 . einer Tochter des Aṅgiras MBH. 3,14124 . MĀRK. P. 52 . 21 . des Kṛtavīrya und Gemahlin des Ahaṃyāti MBH. 1,3768 . einer Tochter des Yādava Bhānu HARIV. 8472. fg	Verz. d. Oxf. H. 101,b,2;MBH. 3,14124;MĀRK. P. 52;MĀRK. P 21;MBH. 1,3768;HARIV. 8472. fgg;HARIV 8159;VARARUCI;ŚKDR;Verz. d. Oxf. H. 135,a (No. 254)
+BAnumant		2	2〉	
+BAnumant		2b	b〉 ein Sohn Kṛṣṇa ʼs BHĀG. P. 10,61,10	BHĀG. P. 10,61,10
+BAnumant		1	¦, f. heisst die Ṭīkā des Cakradatta zu Suśruta	
+BArAkrAnta		1	1〉 adj. überladen: Spr. 4626 . CHANDOM. 97	Spr. 4626;CHANDOM. 97
+BArAkrAnta		2	2〉 f. ein best. Metrum, 4 Mal – – – –, ⏑ ⏑ ⏑ ⏑ ⏑ –, ⏑ – ⏑ ⏑ – – – CHANDOM. 97 ; vgl	CHANDOM. 97
+BAra		1	1〉 Bürde, Tracht, Last H. 364 . = *⁾ an. 2,444 . MED. r. 73 . HALĀY. 4,73 . ṚV. 1,31,3 . 152,3 . 3,56,2 . 4,5,6 . 7,34,7 . AV. 9,3,24 . VS. 23,26 . AIT. BR. 4,13 . ŚAT. BR. 2,1,4,26 . 12,2,4,10 . TS. 	H. 364;H an. 2,444;MED. r. 73;HALĀY. 4,73;ṚV. 1,31,3;ṚV. 1, 152,3;ṚV 3,56,2;ṚV 4,5,6;ṚV 7,34,7;AV. 9,3,24;VS. 23,26;AIT. BR. 4,13;ŚAT. BR. 2,1,4,26;ŚAT. BR 12,2,4,10;TS. 6,2,5,1;Spr. 255;Spr 1570;R. 1,9,57;KATHĀS. 37,155;SUŚR. 1,341,19;BHĀG. P. 2,3,21;Spr. 4638;Spr 4919;MBH. 2,1866;AK. 2,9,88;KATHĀS. 44,132;KATHĀS. 44, 76;MBH. 3,1892;MBH 16,283;HARIV. 2894;HARIV 2916;HARIV 2898;BHĀG. P. 9,24,58;KATHĀS. 38,90;Spr. 242;HALĀY
+BAra		1a	a〉 mit dem obj. : ŚĀṄKH. ŚR. 17,6,6 . SUŚR. 1,13,15 . KATHĀS. 44,77 . R. 1,4,21 . MBH. 3,12712 . ŚĀK. 101 . VARĀH. BṚH. S. 32,1 . VID. 209 . Spr. 1005 . RAGH. 2,18 . ŚRUT. 28 . GĪT. 1,39 . PRAB. 40,3 	ŚĀṄKH. ŚR. 17,6,6;SUŚR. 1,13,15;KATHĀS. 44,77;R. 1,4,21;MBH. 3,12712;ŚĀK. 101;VARĀH. BṚH. S. 32,1;VID. 209;Spr. 1005;RAGH. 2,18;ŚRUT. 28;GĪT. 1,39;PRAB. 40,3;MEGH. 80;Spr. 1530;Spr 1843;SUŚR. 1,53,6;MĀRK. P. 8,187;RAGH. 14,68
+BAra		1b	b〉 mit dem subj. : MBH. 1,8012 . GĪT. 5,20 . die Last eines Fürsten KATHĀS. 39,237 . Last für die Erde BHĀG. P. 1,15,26 . so viel wie ein Kochtopf trägt, fasst MBH. 3,16851	MBH. 1,8012;GĪT. 5,20;KATHĀS. 39,237;BHĀG. P. 1,15,26;MBH. 3,16851
+BAra		2	2〉 Last so v. a. schwere Arbeit, Arbeit, Mühe überh. : MBH. 1,6034 . KATHĀS. 28,89 . (so liest die ed. Bomb. ) MBH. 6,2579 . für das Schicksal ist keine Arbeit zu schwer (so ist zu übersetzen) Spr. 14	MBH. 1,6034;KATHĀS. 28,89;ed. Bomb;MBH. 6,2579;Spr. 1401;Spr 744;R. 1,12,4;RĀJA-TAR. 5,171;RĀJA-TAR 173;RĀJA-TAR 171. fg;MBH. 1,2918;MBH 5,2414;MBH. 5, 2416;MBH. 5, 6;MBH. 5, 4922;Spr. 2044;PAÑCAR. 1,14,45
+BAra		3	3〉 Last so v. a. Masse, Menge; in Verbindung mit Wörtern, die Haar bedeuten, H. 568 . DAŚ. 1,27 . 34 . R. 2,28,13 . Verz. d. Oxf. H. 46,a,41 . PAÑCAR. 1,14,63 . 2,4,3 ( vgl. GĪT. 12,26 ). so v. a. der	H. 568;DAŚ. 1,27;DAŚ. 1, 34;R. 2,28,13;Verz. d. Oxf. H. 46,a,41;PAÑCAR. 1,14,63;PAÑCAR 2,4,3;GĪT. 12,26;MEGH. 54;HARIV. 12083;HARIV 8787;VIKR. 85;HARIV. 2199;MĀRK. P. 45,15;PAÑCAR. 1,14,92;CAURAP. 33
+BAra		4	4〉 Last als best. Gewicht = 20 Tulā = 2000 Pala (etwa 140 Pfund) AK. 2,9,87 . H. 885 . H. an. MED. Verz. d. Oxf. H. 307,b,11 . SUŚR. 2,175,16 . ŚĀRṄG. SAṂH. 1,1,23 . BHAṬṬ. 15,54 . PAÑCAT. 99,25 . HAR	AK. 2,9,87;H. 885;H. an;MED;Verz. d. Oxf. H. 307,b,11;SUŚR. 2,175,16;ŚĀRṄG. SAṂH. 1,1,23;BHAṬṬ. 15,54;PAÑCAT. 99,25;HARIV. 6905;HARIV 15046;HARIV 15336
+BAra		5	5〉 Bein. Viṣṇu ʼs MED. — Vgl	MED
+BAra		4	4〉 HARIV. 15041 , wo mit der neueren Ausg. st. zu lesen ist. KATHĀS. 103,184	HARIV. 15041;KATHĀS. 103,184
+BAradvAja		1	1〉 adj. f. von Bharadvāja herrührend, stammend, zu ihm in Beziehung stehend u. s. w. ŚAT. BR. 10,4,2,19 . 14,5,5,20 . 21 . 6,10,11 . ĀŚV. ŚR. 7,6 . 12,11 . 12 . NIR. 6,30 . WEBER, Nax. 2,392,2 . ŚĀṄKH	ŚAT. BR. 10,4,2,19;ŚAT. BR 14,5,5,20;ŚAT. BR. 14,5,5, 21;ŚAT. BR. 14, 6,10,11;ĀŚV. ŚR. 7,6;ĀŚV. ŚR 12,11;ĀŚV. ŚR. 12, 12;NIR. 6,30;WEBER, Nax. 2,392,2;ŚĀṄKH. ŚR. 14,32,12;ŚĀṄKH. ŚR 16,11,10;ṚV. 6;ŚĀṄKH. ŚR 10,11,21;AIT. BR. 8,3;Ind. St. 3,227,b;Ind. St 1,80;Verz. d. Oxf. H. 121,b (No. 214). 239,b (No. 580). 264,a,16;Verz. d. Oxf. H. 121,b (No. 214). 239, 356,a,5;Verz. d. Oxf. H 20;Ind. St. 3,246, N
+BAradvAja		2	2〉 m	
+BAradvAja		2a	a〉 patron. gaṇa zu P. 4,1,104 . TRIK. 3,3,86 . H. an. 4,56 . MED. j. 34 . MBH. 12,5249. fgg. Verz. d. Oxf. H. 53,a,22 . 54,b,10 . 80,a,12 . 82,a,13 . 276,b,17 . Śūṣa Vāhneya Ind. St. 4,373 . Śaunahotr	P. 4,1,104;TRIK. 3,3,86;H. an. 4,56;MED. j. 34;MBH. 12,5249. fgg;Verz. d. Oxf. H. 53,a,22;Verz. d. Oxf. H 54,b,10;Verz. d. Oxf. H 80,a,12;Verz. d. Oxf. H 82,a,13;Verz. d. Oxf. H 276,b,17;Ind. St. 4,373;Ind. St 1,281;Ind. St 280;Ind. St 440;Ind. St 454;P. 4,1,117;TRIK;MED;MBH. 6,3590;ŚKDR;H. an;ŚABDAR;ŚKDR;TAITT. PRĀT. 2,5;P. 7,2,63;P. 2,4,84, Vārtt
+BAradvAja		2b	b〉 pl. N. pr. eines Volkes ( vgl. ) VP. 196	VP. 196
+BAradvAja		2c	c〉 der Planet Mars ŚKDR. nach dem Grahayajñatattva	ŚKDR
+BAradvAja		2d	d〉 Lerche ( vgl. ) H. an. PAÑCAT. 157,3	H. an;PAÑCAT. 157,3
+BAradvAja		3	3〉 f	
+BAradvAja		3a	a〉 ein best. Vogel PĀR. GṚHY. 1,19	PĀR. GṚHY. 1,19
+BAradvAja		3b	b〉 die wilde Baumwollenstaude AK. 2,4,4,4 . MED. RATNAM. 171	AK. 2,4,4,4;MED;RATNAM. 171
+BAradvAja		3c	c〉 N. pr. eines Flusses MBH. 6,336 ( VP. 183 )	MBH. 6,336;VP. 183
+BAradvAja		4	4〉 n	
+BAradvAja		4a	a〉 Knochen H. 625	H. 625
+BAradvAja		4b	b〉 N. pr. einer Gegend P. 4,2,145 , v. l. für	P. 4,2,145
+BAradvAja		2	2〉	
+BAradvAja		2a	a〉 in ṚV. ANUKR. führen dieses patron. Ṛjiśvan , Garga , Nara , Pāyu , Vasu , Śāsa , Śirimbiṭha , Śunahotra , Sapratha , Suhotra und die Rātri ( f. )	ṚV. ANUKR
+BAradvAja		2d	d〉 BHĀG. P. 10,15,13	BHĀG. P. 10,15,13
+BAraka		1	¦ (von ) m. Bürde, Tracht, Last: M. 11,133 . KATHĀS. 44,76 . adj. 26,156 . — Vgl	M. 11,133;KATHĀS. 44,76;KATHĀS 26,156
+BAraka		4	4〉	
+BAratItIrTa		1	1〉 m. N. pr. eines Lehrers Verz. d. Oxf. H. 222,a,13 . 263,b,42 . Verz. d. B. H. No. 625 . 629 . HALL 98 . Vgl	Verz. d. Oxf. H. 222,a,13;Verz. d. Oxf. H 263,b,42;Verz. d. B. H. No. 625;Verz. d. B. H. No 629;HALL 98
+BAratItIrTa		2	2〉 n. N. pr. eines heiligen Badeplatzes Verz. d. Oxf. H. 73,b,24	Verz. d. Oxf. H. 73,b,24
+BArata		1	1〉 adj. ( f. ) gaṇa zu P. 4,1,86	P. 4,1,86
+BArata		1a	a〉 Bez. des Agni , vielleicht so v. a. kriegerisch; nach SĀY. der von Ṛtvij ( Bharata ) stammende oder Träger (des Opfers). ṚV. 2,7,1 . 5 . 4,25,4 . 6,16,19 . TS. 2,5,9,1 . ŚAT. BR. 1,4,2,2 . ĀŚV. ŚR.	SĀY;ṚV. 2,7,1;ṚV. 2,7, 5;ṚV 4,25,4;ṚV 6,16,19;TS. 2,5,9,1;ŚAT. BR. 1,4,2,2;ĀŚV. ŚR. 1,2;TRIK. 1,1,67
+BArata		1b	b〉 von Bharata stammend: . MBH. 1,371 . 3122 . HARIV. 3040 . 4035 . VP. _bei_ MUIR, ST. I, 187 . 5 . ṚV. 3,53,12 . so heissen Devaśravas und Devarāta 23,2 . subst. ein Nachkomme des Bharata ( f. ) gaṇ	MBH. 1,371;MBH. 1, 3122;HARIV. 3040;HARIV 4035;VP;MUIR, ST. I, 187;MUIR, ST. I, N 5;ṚV. 3,53,12;ṚV. 3, 23,2;P. 5,3,117;P 4,1,178;HIḌ. 1,7;BRĀHMAṆ. 2,36;SĀV. 3,22;N. 1,6;N. 1, 3;N. 1, 1;N 12,87;TAITT. ĀR. 1,27,2;MBH. 1,3122;MBH 5,923;HARIV. 12;HARIV 1723;MBH. 5,7283;MBH. 5, 955
+BArata		1c	c〉 den Bharata gehörig, ihnen zukommend . MBH. 1,534 . 3,1930 . 4,1241 . 6,4548 . 7,28 . 1,3122	MBH. 1,534;MBH 3,1930;MBH 4,1241;MBH 6,4548;MBH 7,28;MBH 1,3122
+BArata		1d	d〉 der Kampf —, die Schlacht der Bharata ʼs P. 4,2,56 . Sch. ( oxyt. ). MBH. 6,5769 . HARIV. 9800 . Z. d. d. m. G. 8,537 . 34 . 41 . subst. : (= Schol. ) MBH. 12,1716 . RĀJA-TAR. 1,49	P. 4,2,56;MBH. 6,5769;HARIV. 9800;Z. d. d. m. G. 8,537;Z. d. d. m. G. 8, 34;Z. d. d. m. G. 8, 41;MBH. 12,1716;RĀJA-TAR. 1,49
+BArata		1e	e〉 und subst. n. die Erzählung von den Bharata ʼs, von ihrem Kampfe: MBH. 1,2233 . Spr. 340 . MBH. 1,19 . 18,210 (wo mit der ed. Bomb. st. zu lesen ist). BHĀG. P. 1,4,25 . subst. n. TRIK. 3,3,175. fg.	MBH. 1,2233;Spr. 340;MBH. 1,19;MBH 18,210;ed. Bomb;BHĀG. P. 1,4,25;TRIK. 3,3,175. fg;H. an. 3,284;MED. t. 139;ĀŚV. GṚHY. 3,4,4;MBH. 1,52;MBH. 1, 96;MBH. 1, 101;MBH 13,6069;MBH 18,209;MBH. 18, 211;HARIV. 16140;PRAB. 101,7;Verz. d. Oxf. H. 125,a,35;Verz. d. Oxf. H 163,a,6;Verz. d. Oxf. H 266,a,38;Z. d. d. m. G. 8,537,22;LA. (II) 100,6 v. u;Ind. St. 8,413, N. 1;Verz. d. B. H. No. 1025
+BArata		1f	f〉 N. pr. eines Sees ŚATR. 1,60	ŚATR. 1,60
+BArata		1g	g〉 oder n. mit Ergänzung desselben: Bharata ʼs Varṣa d. i. Indien AK. 2,1,6 . TRIK. 2,1,2 . 3,3,175. fg. H. 691 . 947 , Sch. H. an. MED. MBH. 6,201 . SŪRYAS. 12,39 . 70 . 71 . VARĀH. BṚH. S. 14,1 . VP	AK. 2,1,6;TRIK. 2,1,2;TRIK 3,3,175. fg;H. 691;H 947;H. an;MED;MBH. 6,201;SŪRYAS. 12,39;SŪRYAS. 12, 70;SŪRYAS. 12, 71;VARĀH. BṚH. S. 14,1;VP. 165;VP 174. fgg;BHĀG. P. 1,16,13;BHĀG. P 3,1,20;BHĀG. P 5,4,9;BHĀG. P. 5, 17,11;BHĀG. P. 5, 19,9;MĀRK. P. 53,41;PAÑCAR. 1,1,67;PAÑCAR 2,2,62;Verz. d. Oxf. H. 41,a,32;ŚATR. 1,292;Verz. d. Oxf. H. 259,a,5
+BArata		1h	h〉 Bhāratavarṣa bewohnend: BHĀG. P. 5,19,10 . 17	BHĀG. P. 5,19,10;BHĀG. P. 5,19, 17
+BArata		1i	i〉 Bez. einer best. Stilart TRIK. 3,3,175 . H. 285 . H. an. MED. PRATĀPAR. 10,a,7 . 24,a,5 . DAŚAR. 2,55 . 57 . 3,4 . 5 . SĀH. D. 285 . Verz. d. Oxf. H. 208,a,35	TRIK. 3,3,175;H. 285;H. an;MED;PRATĀPAR. 10,a,7;PRATĀPAR 24,a,5;DAŚAR. 2,55;DAŚAR. 2, 57;DAŚAR 3,4;DAŚAR. 3, 5;SĀH. D. 285;Verz. d. Oxf. H. 208,a,35
+BArata		2	2〉 m. Schauspieler ( vgl. ) JAṬĀDH. _im_ ŚKDR	JAṬĀDH;ŚKDR
+BArata		3	3〉 f	
+BArata		3a	a〉 nach NAIGH. 1,11 . AK. 1,1,5,1 . TRIK. 3,3,175 . H. 241 . H. an. MED. (= und ) und HALĀY. 1,8 so v. a. . Eine der Götterfrauen, welche namentlich unter den Āprī -Gottheiten neben Iḷā und Sarasvatī 	NAIGH. 1,11;AK. 1,1,5,1;TRIK. 3,3,175;H. 241;H. an;MED;HALĀY. 1,8;ṚV. 1,22,10;ṚV. 1, 142,9;ṚV. 1, 188,8;ṚV 2,1,11;ṚV. 2, 3,8;ṚV 3,4,8;ṚV. 3, 62,3;ṚV 9,5,8;ṚV 10,110,7;NIR. 8,13;TBR. 1,5,11,1;TBR. 1,5,11, 2;TBR. ebend;PAÑCAR. 1,11,34;PAÑCAR 12,56;MBH. 3,2421;MBH 4,913;MBH 5,7434;HARIV. 5769;DAŚ. 2,37;RAGH. 10,37;KUMĀRAS. 6,79;Spr. 2658;VARĀH. BṚH. S. 2,3;VID. 114;KATHĀS. 26,256;KATHĀS 38,68;KATHĀS 27,56;RĀJA-TAR. 1,12
+BArata		3b	b〉 Wachtel TRIK. 2,5,29 . 3,3,175 . H. an. MED. Verz. d. H. B. No. 897	TRIK. 2,5,29;TRIK 3,3,175;H. an;MED;Verz. d. H;B. No. 897
+BArata		3c	c〉 N. pr. eines Flusses MBH. 3,14232	MBH. 3,14232
+BArata		4	4〉 m. (die Rede) N. pr. eines Lehrers Verz. d. Oxf. H. 227,b,16 . 251,b,22 . WILSON, Sel. Works I, 202. fg. — Vgl	Verz. d. Oxf. H. 227,b,16;Verz. d. Oxf. H 251,b,22;WILSON, Sel. Works I, 202. fg
+BArata		1	1〉	
+BArata		1b	b〉 Z. 4 nach 23,2 hinzuzufügen: Aśvamedha Bhārata Verfasser von ṚV. 5,27	ṚV. 5,27
+BArata		1i	i〉 SĀH. D. 410	SĀH. D. 410
+BArata		5	5〉 m. Bez. der im Süden des Meru scheinenden Sonne Ind. St. 10,268 . 275	Ind. St. 10,268;Ind. St. 10, 275
+BArata		4	4〉 lies N. eines der zehn auf Schüler Śaṃkarācārya ʼs zurückgeführten Bettelorden, dessen Mitglieder das Wort ihrem Namen beifügen	
+BAravAha		1	1〉 nom. ag. eine Last tragend, Lastträger AK. 2,10,15 . H. 363 . HĀR. 163 . demjenigen, der eine Last trägt, soll man den Weg räumen, MBH. 3,10621	AK. 2,10,15;H. 363;HĀR. 163;MBH. 3,10621
+BAravAha		2	2〉 f. Indigo RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+BArava		1	1〉 n. Bogensehne TRIK. 2,8,51	TRIK. 2,8,51
+BArava		2	2〉 f. Basilienkraut ŚABDĀRTHAK. _bei_ WILSON	ŚABDĀRTHAK;WILSON
+BArga		1	1〉 m. ein Fürst der Bharga P. 4,1,178 . N. pr. eines Sohne des Pratardana HARIV. 1587 . st. dessen ( d. i. die neuere Ausg. ) 1741 . N. pr. eines Fürsten, der sonst Bharga genannt wird. VP. 409 ( MUIR	P. 4,1,178;HARIV. 1587;HARIV 1741;VP. 409;MUIR, ST. I, 52, N. 31;MBH. 6,358;ed. Bomb;VP. 190
+BArga		2	2〉 f	
+BArga		2a	a〉 eine Fürstin der Bharga P. 4,1,178	P. 4,1,178
+BArga		2b	b〉 Clerodendrum Siphonanthus R. Br. AK. 2,4,3,8 . RATNAM. 37 . SUŚR. 1,138,12 . 139,4 . 145,18 . 2,80,17 . 104,21 . 276,3 . 285,12 . — Vgl	AK. 2,4,3,8;RATNAM. 37;SUŚR. 1,138,12;SUŚR. 1, 139,4;SUŚR. 1, 145,18;SUŚR 2,80,17;SUŚR. 2, 104,21;SUŚR. 2, 276,3;SUŚR. 2, 285,12
+BArga		2	2〉	
+BArga		2b	b〉 wohl fehlerhaft für	
+BArgava		1	1〉 adj. f. von Bhaṛgu stammend, herrührend, ihm gehörend MBH. 1,865 . HARIV. 1597 . 1753 . Ind. St. 8,276 . TAITT. UP. 3,6 . Verz. d. Oxf. H. 266,b,18 . Ind. St. 3,227,b . (das Nomen) Ind. St. 4,330 .	MBH. 1,865;HARIV. 1597;HARIV 1753;Ind. St. 8,276;TAITT. UP. 3,6;Verz. d. Oxf. H. 266,b,18;Ind. St. 3,227,b;Ind. St. 4,330;Verz. d. Oxf. H. 8,a,10;Verz. d. B. H. 127, N;MADHUS;Ind. St. 1,18,21;BURNOUF;BHĀG. P. I, LXXVII;P. 2,4,65;VOP. 7,14;AIT. BR. 8,21;ŚAT. BR. 4,1,5,1;MBH. 1,870;MBH. 1, 1928;MBH 13,207;R. 1,70,31;R 2,110,19. fg;R. 2, 119,19 GORR;ŚĀṄKH. BR. 22,4;PAÑCAV. BR. 14,9,32;Ind. St. 3,459;Ind. St 1,193;MBH. 13,1545;MBH 1,1117;R. 1,61,13;R. 1,61, 17;R. 1,51,11;R. 1, 52,11 GORR;TRIK. 3,3,302;TRIK. 3,3, 418;H. 848;H an. 3,707;MED. v. 45;MBH. 5,7012;MBH. 5, 7022;MBH. 5, 7308;R. 1,74,17;Spr. 323;RAGH. 11,46;Verz. d. Oxf. H. 59,a,30;MĀRK. P. 110,35;ĀŚV. ŚR. 12,10;Ind. St. 7,467;KĀTY. ŚR. 15,4,1;PAÑCAV. BR. 14,3,23;PAÑCAV. BR. 14, 9,19;PAÑCAV. BR. 14,3, 39;PRAŚNOP. 1,1;HARIV. 1597;HARIV 1741;HARIV 1753;R;Verz. d. B. H. 121;ed. Bomb;Spr. 2292;Verz. d. B. H. 54,3 v. u. 55,1;Verz. d. B. H. 54,3 v. u. 55, 90 (21). 93 (54);Verz. d. Oxf. H. 32,a,23;Verz. d. Oxf. H. 32, b,7;Verz. d. Oxf. H 80,a,15;Verz. d. Oxf. H 101,b,17;Verz. d. Oxf. H 310,a,24;Verz. d. Oxf. H 138,a (No. 270). 279,a,3;Verz. d. Oxf. H 351,a,25;MĀRK. P. 57,35;DAŚAK. 162,11;Journ. of the Am. Or. S. 6,508, Śl. 12;MBH. 7,9527;MBH 14,200
+BArgava		2	2〉 m	
+BArgava		2a	a〉 patron. Śukra ʼs, des Lehrers der Daitya , der Planet Venus, AK. 1,1,2,26 . TRIK. 3,3,418 . H. 119 . H. an. MED. HALĀY. 1,48 . R. GORR. 2,40,10 . 5,73,53 . KĀM. NĪTIS. 14,63 . SŪRYAS. 2,8 . 56 . 7,	AK. 1,1,2,26;TRIK. 3,3,418;H. 119;H. an;MED;HALĀY. 1,48;R. GORR. 2,40,10;R. GORR 5,73,53;KĀM. NĪTIS. 14,63;SŪRYAS. 2,8;SŪRYAS. 2, 56;SŪRYAS 7,23;SŪRYAS 9,3;VARĀH. BṚH. S. 18,5;VARĀH. BṚH. S 28,1;Verz. d. Oxf. H. 100,a,8
+BArgava		2b	b〉 pl. die Nachkommen des Bhṛgu (die sonst heissen) HARIV. 1790 . MBH. 5,6048 . N. eines Volksstammes MBH. 6,358 ( VP. 190 ). MĀRK. P. 57,43	HARIV. 1790;MBH. 5,6048;MBH. 6,358;VP. 190;MĀRK. P. 57,43
+BArgava		2c	c〉 ein Bogenschütze, ein guter Bogenschütze (wie es Paraśurāma war) = und TRIK. H. an. MED. Man beachte, dass MBH. 7,9527 und 14,200 vor (als Namen von Śiva ) steht	TRIK;H. an;MED;MBH. 7,9527;MBH 14,200
+BArgava		2d	d〉 Elephant TRIK. H. an. MED	TRIK;H. an;MED
+BArgava		3	3〉 f	
+BArgava		3a	a〉 ein weiblicher Nachkomme des Bhṛgu P. 2,4,65 . VOP. 7,14 . Devayāni MBH. 1,3217 . BHĀG. P. 9,19,2 . 28	P. 2,4,65;VOP. 7,14;MBH. 1,3217;BHĀG. P. 9,19,2;BHĀG. P. 9,19, 28
+BArgava		3b	b〉 Bein. der Lakṣmī H. ś. 76 (wo st. wohl so zu lesen ist). H. an. MED	H. ś. 76;H. an;MED
+BArgava		3c	c〉 Bein. der Pārvatī TRIK. H. an. MED	TRIK;H. an;MED
+BArgava		3d	d〉 = Panicum Dactylon AK. 2,4,5,24 . TRIK. MED. HĀR. 93 . = H. an. ŚABDAR. _im_ ŚKDR. = RĀJAN. _im_ ŚKDR. — Vgl	AK. 2,4,5,24;TRIK;MED;HĀR. 93;H. an;ŚABDAR;ŚKDR;RĀJAN;ŚKDR
+BArgava		1	1〉 adj. Bhārgava d. i. Śukra gehörend: R. 7,80,3 . In ṚV. ANUKR. führen das patron. Bhārgava : Iṭa , Kali , Kṛtnu , Gṛtsamada , Cyavana , Jamadagni , Nema , Prayoga , Vena , Somāhuti und Syūmaraśmi . 	R. 7,80,3;ṚV. ANUKR;R. 7,80,7
+BArgava		2	2〉	
+BArgava		2a	a〉 R. 7,93,18	R. 7,93,18
+BArika		1	1〉 adj. eine Last bildend; schwer; so heisst eine Form der Elephantiasis SUŚR. 1,291,16	SUŚR. 1,291,16
+BArika		2	2〉 m. Lastträger AK. 2,10,15 . H. 363 . HĀR. 163 . RĀJA-TAR. 5,204 . Holzträger KATHĀS. 37,56	AK. 2,10,15;H. 363;HĀR. 163;RĀJA-TAR. 5,204;KATHĀS. 37,56
+BArika		2	2〉 KATHĀS. 57,7 . 12 . 14	KATHĀS. 57,7;KATHĀS. 57, 12;KATHĀS. 57, 14
+BArika		1	1〉 Verdauung CARAKA 1,7 . Kopf 17	CARAKA 1,7;CARAKA 1, 17
+BAruRqa		1	1〉 m. ein best. Vogel MBH. 6,265 . 12,3357 . 3519 . 6326 . Vgl	MBH. 6,265;MBH 12,3357;MBH. 12, 3519;MBH. 12, 6326
+BAruRqa		2	2〉 n	
+BAruRqa		2a	a〉 Name eines Sāman MBH. 1,2882 . Ind. St. 2,54, N	MBH. 1,2882;Ind. St. 2,54, N
+BAruRqa		2b	b〉 N. pr. eines Waldes R. 2,71,5	R. 2,71,5
+BAryAru		1	1〉 der Vater eines mit einem fremden Weibe erzeugten Sohnes	
+BAryAru		2	2〉 eine Art Gazelle	
+BAryAru		3	3〉 N. pr. eines Berges H. an. 3,585 . MED. r. 193	H. an. 3,585;MED. r. 193
+BAryAwika		1	1〉 ein unter dem Pantoffel seines Weibes stehender Mann H. an. 4,26 . MED. k. 205	H. an. 4,26;MED. k. 205
+BAryAwika		2	2〉 eine Art Gazelle ( ) MED	MED
+BAryAwika		3	3〉 N. pr. eines Muni ( ) H. an	H. an
+BArya		1	1〉 adj. zu tragen; zu hegen, zu pflegen, zu ernähren: jeder der von einem Andern seinen Lebensunterhalt empfängt, Diener, familiaris: TS. 5,5,2,5 . ŚAT. BR. 2,3,2 . 18 . 4,7 . 4 . 6,7,21 . 10,3,5,9 . 	TS. 5,5,2,5;ŚAT. BR. 2,3,2;ŚAT. BR. 2,3, 18;ŚAT. BR 4,7;ŚAT. BR. 4, 4;ŚAT. BR 6,7,21;ŚAT. BR 10,3,5,9;HARIV. 8831;AIT. BR. 1,29
+BArya		2	2〉 m. Söldling, Soldat: P. 3,1,112 . Sch	P. 3,1,112
+BArya		3	3〉 f. Gattin VOP. 26 . 20 . AK. 2,6,1,6 . H. 513 . HĀR. 145 . HALĀY. 2,339 . AIT. BR. 7,1 . ŚAT. BR. 14,6,7,1 . 7,3,1 . KĀTY. ŚR. 20,8,24 . 25,4,35 . ŚĀṄKH. GṚHY. 2,16 . 5,9 . [Page5-0256] KAUŚ. 89 . 	VOP. 26;VOP 20;AK. 2,6,1,6;H. 513;HĀR. 145;HALĀY. 2,339;AIT. BR. 7,1;ŚAT. BR. 14,6,7,1;ŚAT. BR. 14, 7,3,1;KĀTY. ŚR. 20,8,24;KĀTY. ŚR 25,4,35;ŚĀṄKH. GṚHY. 2,16;ŚĀṄKH. GṚHY 5,9;KAUŚ. 89;KAUŚ 141;MBH. 1,4199;M. 3,4;M. 3, 7;M. 3, 77;M 6,3;MBH. 13,2530;R. 1,8,25;Spr. 2038. fgg;Spr 1373;Spr 4658. fgg;Spr 5150;ŚĀK. 90,22;VID. 333;M. 2,131;M 9,120;P. 6,2,69;P. 2,2,31;AK. 2,6,1,38;H. 519;MĀRK. P. 72,9;Spr. 2040;RAGH. 1,55;HALĀY. 3,34
+BArya		1	1〉 BHĀG. P. 10,86,43	BHĀG. P. 10,86,43
+BAs	1	1	1〉 Schein, Licht, Glanz (auch Strahl nach den Lexicogrr. ) AK. 1,1,2,35 . 3,4,30,232 . H. 100 . an. 1,16 . MED. s. 6 . HALĀY. 1,38 . ṚV. 1,45,8 . 46,10 . 2,4,5 . 4,5,1 . 7,9 . 6,1,11 . 4,6 . 7,8,2 . 8	AK. 1,1,2,35;AK 3,4,30,232;H. 100;H an. 1,16;MED. s. 6;HALĀY. 1,38;ṚV. 1,45,8;ṚV. 1, 46,10;ṚV 2,4,5;ṚV 4,5,1;ṚV. 4, 7,9;ṚV 6,1,11;ṚV. 6, 4,6;ṚV 7,8,2;ṚV 8,1,28;ṚV. 8, 23,11;ṚV 10,3,1;VS. 13,39;VS 17,72;AV. 7,14,2;TBR. 1,1,3,12;ŚAT. BR. 1,9,3,10;ŚAT. BR 14,7,1,10;ŚAT. BR. 14, 8,8,1;PAÑCAV. BR. 10,2,6;KĀṬH. 34,8;CHĀND. UP. 1,6,5;KAṬHOP. 5,15;BHAG. 11,12;HARIV. 14181;MBH. 14,118;MBH 7,2143;MBH 6,2940;MBH 8,3392;HARIV. 1331;HARIV 14994;R. 4,44,119;KUMĀRAS. 7,3;VARĀH. BṚH. S. 30,32;PRAB. 107,19;BHAG. 11,30;Spr. 3349;ŚAṂK;BṚH. ĀR. UP. S. 237;PRASAṄGĀBH. 15,a;MBH. 1,7294;MBH 6,133;MBH 12,3760;MBH 13,3499;HARIV. 8289;RAGH. 9,17;KUMĀRAS. 7,35;MEGH. 79;ṚT. 1,17;ṚT. 1, 24;ṚT 3,21;MĀRK. P. 96,36;NAIṢ. 22,43;KĀVYĀD. 2,99
+BAs	1	2	2〉 Machtglanz, Macht, Majestät H. an. MED	H. an;MED
+BAs	1	3	3〉 Wunsch ( ) DHAR. _im_ ŚKDR	DHAR;ŚKDR
+BAs	1	1	1〉 f. TBR. 1,2,1,7 . ( pl. ) ṚT. 6,33 . RĀJA-TAR. 5,343 . NALOD. 1,17	TBR. 1,2,1,7;ṚT. 6,33;RĀJA-TAR. 5,343;NALOD. 1,17
+BAs	2	1	1〉 scheinen, leuchten: VS. 12,32 . MBH. 1,4852 . 2,433 . 3,11862 . 4,1326 . 12,7857 . HARIV. 5724 . med. : NIR. 6,25 . 32 . MBH. 3,12299 . 4,1461 . 6,2603 . 7,633 . 14,670 . HARIV. 3584 . 5034 = 5561 	VS. 12,32;MBH. 1,4852;MBH 2,433;MBH 3,11862;MBH 4,1326;MBH 12,7857;HARIV. 5724;NIR. 6,25;NIR. 6, 32;MBH. 3,12299;MBH 4,1461;MBH 6,2603;MBH 7,633;MBH 14,670;HARIV. 3584;HARIV 5034;HARIV 5561;HARIV 14994;R. 2,78,7;R 5,28,17;RAGH. ed. Calc. 7,21;ST;KUMĀRAS. 6,11;BHAṬṬ. 10,61;BHAṬṬ 14,83;HARIV. 11759
+BAs	2	2	2〉 med. erscheinen, zur Vorstellung kommen, deutlich werden, einleuchten, begriffen werden: Spr. 1080 . in wessen Geiste taucht nicht der Zweifel auf? 2101 . Verz. d. Oxf. H. 266,a,26 . KUSUM. 45,4 . 	Spr. 1080;Spr 2101;Verz. d. Oxf. H. 266,a,26;KUSUM. 45,4;BĀLAB. 18;VEDĀNTAS. (Allah.) No. 125;AṢṬĀV. 2,7;AṢṬĀV. 2, 8;AṢṬĀV. 2, 9;AṢṬĀV 15,14;NĪLAK. 56,89;P. 7,4,3;MAITRYUP. 6,7;MBH. 3,1668;MBH. 3, 11861;MBH 6,3179;MBH. 6, 5111;MBH 8,556;MBH 11,721;MBH 13,7375;HARIV. 1318;HARIV 1324;HARIV 1331;HARIV 6548;HARIV 13249;R. 5,11,2;R. 5, 14,32;RAGH. 9,17;SŪRYAS. 13,12;KATHĀS. 29,40;VID. 3;MĀRK. P. 16,85;MĀRK. P 63,6;MĀRK. P 97,14;LA. (II) 89,12;Verz. d. Oxf. H. 28,b,17;Journ. of the Am. Or. S. 6,504, Śl. 14;VEDĀNTAS. (Allah.) No. 112;BHAG. 15,6;BHAG. 15, 12;MBH. 3,182;MBH 9,2010;Verz. d. Oxf. H. 222,b,27;ebend;MBH. 2,1334;MBH 7,7619;KATHĀS. 45,12;MĀRK. P. 65,5;ŚATR. 2,659;BHAṬṬ. 15,42;BHAṬṬ. 15, 111;BĀLAB. 4;Verz. d. Oxf. H. 238,b,19;MBH. 5,1091;MBH 1,1253;BHĀG. P. 5,23,2;MBH. 12,13221;Spr. 678;SUŚR. 1,104,7;R. 1,35,16;BHĀG. P. 4,21,41;BHĀG. P. 4, 29,69;BHĀG. P 5,26,28;BĀLAB. 17;Verz. d. Oxf. H. 181,b, No. 413;VEDĀNTAS. (Allah.) No. 94;ŚAṂK;BṚH. ĀR. UP. S. 16;MBH. 3,1674;MBH 12,8345;ed. Bomb;MBH 13,4088;ŚAṂK;BṚH. ĀR. UP. S. 60;BHĀG. P. 5,1,8;BHĀG. P. 5,1, 30;VEDĀNTAS. (Allah.) No. 112;MBH. 4,1776;MBH 5,2525;MBH 7,6672;ed. Bomb;MBH. 7, 7601;MBH. 7, 7605;ed. Bomb;MBH 12,13361;R. 4,2,9;R 5,20,18;SUŚR. 1,54,16;KATHĀS. 35,112;KATHĀS 45,312;ŚIŚ. 9,37;SUŚR. 1,326,3;MBH. 2,1313;MBH 8,204;RAGH. 7,40;RAGH. 7, 60;RAGH 14,12;RAGH 16,41;KUMĀRAS. 7,3;KATHĀS. 45,339;NIR. 7,23;MĀRK. P. 105,18;MBH. 1,1241;R. 3,29,10;ed. Bomb;MBH. 13,7302;MBH 5,728;HARIV. 2051;VARĀH. BṚH. S. 30,20;VARĀH. BṚH. S 32,21;VARĀH. BṚH. S 43,3;PAÑCAR. 4,3,30;MALLIN;KUMĀRAS. 1,2;MṚCCH. 86,18;MṚCCH 159,2;RAGH. 7,16;Spr. 466;HARIV. 590;MED. t. 25;ŚAT. BR. 3,1,3,11;Verz. d. Oxf. H. 72,a,24;MBH. 3,5005;MBH. 3, 17090;MBH 8,2202;HARIV. 6618;HARIV 9013;MBH. 4,238;MBH. 1,6532;R. 4,43,50;MBH. 9,2052;MBH 4,1776;RĀJA-TAR. 4,380;RĀJA-TAR 6,327;Spr. 4232;VEDĀNTAS. (Allah.) No. 23;AṢṬĀV. 15,14;NĪLAK. 222;KATHĀS. 6,143;AV. 13,4,7;AV 19,26,23;ŚATR. 1,35;Spr. 595;R. 2,13,10;MBH. 8,4667;MBH. 12,13912
+BAs	2	1	2. ¦ mit vgl. . — caus. vollkommen erleuchten, — erhellen KATHĀS. 103,206 . — , KATHĀS. 74,187 . 93,17 . — caus. erleuchten, erhellen 53,168 . — , KATHĀS. 83,15	KATHĀS. 103,206;KATHĀS. 74,187;KATHĀS 93,17;KATHĀS 53,168;KATHĀS. 83,15
+BAsa		1	1〉 m. = Licht, Glanz H. an. 2,585 . MED. s. 6 . VIŚVA _im_ ŚKDR. KATHĀS. 35,21 . am Ende eines adj. comp. : MBH. 7,74 . 8,2889 . ( die neuere Ausg. ) von Viṣṇu HARIV. 14119	H. an. 2,585;MED. s. 6;VIŚVA;ŚKDR;KATHĀS. 35,21;MBH. 7,74;MBH 8,2889;HARIV. 14119
+BAsa		2	2〉 m. ein best. Raubvogel, = MED. = AK. 3,4,14,60 . H. 1338 . H. an. HALĀY. 2,92 . = H. an. VIŚVA. = ders. = Schol. zu MBH. 1,5277 . — ADBH. BR. 6,8 _in_ Ind. St. 1,40 . M. 11,135 . YĀJÑ. 1,127 . 3,27	MED;AK. 3,4,14,60;H. 1338;H. an;HALĀY. 2,92;H. an;VIŚVA;MBH. 1,5277;ADBH. BR. 6,8;Ind. St. 1,40;M. 11,135;YĀJÑ. 1,127;YĀJÑ 3,272;MBH. 1,5277. fg;MBH 6,62. fg;MBH 12,1315;HARIV. 3390;R. 4,58,30;SUŚR. 1,24,7;SUŚR. 1, 75,1;SUŚR. 1, 108,3;SUŚR. 1, 202,13;VĀGBH. 1,6,50;BHĀG. P. 3,10,23;BHĀG. P 5,24,6;BHĀG. P 8,10,10;PAÑCAT. 157,3;Verz. d. B. H. No. 897;Verz. d. Oxf. H. 86,b,37;ebend. 354,a,32;Verz. d. B. H. 193,13;MBH. 1,2620. fg;HARIV. 222. fg;R. 3,20,18. fg;VP. 148;MĀRK. P. 104;MĀRK. P 8
+BAsa		3	3〉 m. Kuhstall, Kuhhürde ( ) VIŚVA	VIŚVA
+BAsa		4	4〉 m. oxyt. N. eines Sāman TBR. 1,2,4,3 . n. Ind. St. 3,227,b . AIT. BR. 4,19 . PAÑCAV. BR. 14,11,14 . LĀṬY. 4,7,1 . 6,12,5 . ĀŚV. ŚR. 8,6	TBR. 1,2,4,3;Ind. St. 3,227,b;AIT. BR. 4,19;PAÑCAV. BR. 14,11,14;LĀṬY. 4,7,1;LĀṬY 6,12,5;ĀŚV. ŚR. 8,6
+BAsa		5	5〉 m. N. pr. eines Mannes RĀJA-TAR. 8,1431 . 1476 . 1480 . 1482 u. s. w. eines dramatischen Dichters ( vgl. ) HALL in der Einl. zu VĀSAV. 14 . 20 . Verz. d. Oxf. H. 124,a,42 . b,18 . 142,a,14 . SARASV	RĀJA-TAR. 8,1431;RĀJA-TAR. 8, 1476;RĀJA-TAR. 8, 1480;RĀJA-TAR. 8, 1482;HALL;VĀSAV. 14;VĀSAV 20;Verz. d. Oxf. H. 124,a,42;Verz. d. Oxf. H. 124, b,18;Verz. d. Oxf. H 142,a,14;SARASVATĪKAṆṬHĀBH. ebend. 511,c;KATHĀS. 44,25;KATHĀS. 44, 143;KATHĀS 45,379;KATHĀS 47,25
+BAsa		6	6〉 m. N. pr. eines Berges MBH. 14,1174	MBH. 14,1174
+BAsa		7	7〉 f	
+BAsa		7a	a〉 die Urmutter der Bhāsa s. u. 2	
+BAsa		7b	b〉 N. pr. einer Tochter der Prādhā MBH. 1,2554	MBH. 1,2554
+BAsa		8	8〉 n. s. u. 4. — Vgl	
+BAsa		2	2〉 PAT. a. a. O. 4,88,a	PAT. a. a. O. 4,88,a
+BAsaka		1	1〉 adj. (vom caus. von 2. ) am Ende eines comp. erscheinen [Page5-0275] machend VEDĀNTAS. (Allah.) No. 91	VEDĀNTAS. (Allah.) No. 91
+BAsaka		2	2〉 m. N. pr. eines dramatischen Dichters ( vgl. ) MĀLAV. 3,12 , v. l. Verz. d. Oxf. H. 135,b, N. HALL in der Einl. zu VĀSAV. 14. fg	MĀLAV. 3,12;Verz. d. Oxf. H. 135,b, N;HALL;VĀSAV. 14. fg
+BAsaka		1	1〉 beleuchtend, machend dass man erkennt; davon nom. abstr. n. SARVADARŚANAS. 94,5	SARVADARŚANAS. 94,5
+BAsanta		1	1〉 adj. glänzend, schön H. an. 3,285 . MED. t. 140	H. an. 3,285;MED. t. 140
+BAsanta		2	2〉 m	
+BAsanta		2a	a〉 die Sonne H. an	H. an
+BAsanta		2b	b〉 der Mond UṆĀDIK. _im_ ŚKDR	UṆĀDIK;ŚKDR
+BAsanta		2c	c〉 Stern, Sternbild ( ) H. an	H. an
+BAsanta		2d	d〉 der Vogel H. an. MED	H. an;MED
+BAsanta		3	3〉 f. Sternbild, ein Nakṣatra UṆĀDIK. _im_ ŚKDR	UṆĀDIK;ŚKDR
+BAskarIya		1	1〉 adj. von Bhāskara herrührend Z. d. d. m. G. 2,339 (162, . Verz. d. B. H. No. 828 . Ind. St. 2,253	Z. d. d. m. G. 2,339 (162,c);Verz. d. B. H. No. 828;Ind. St. 2,253
+BAskarIya		2	2〉 m. ein Schüler des Bhāskara : SĀY. _in_ Verz. d. Oxf. H. 168,b, N. KULL. _zu_ M. 1,8 . 15	SĀY;Verz. d. Oxf. H. 168,b, N;KULL;M. 1,8;M 15
+BAskara		1	1〉 adj. scheinend, leuchtend, glänzend TRIK. 3,3,176 . NIR. 6,25 . Spr. 3159 ( v. l. und ). MBH. 6,280 ( v. l. ). Die adj. Bed. des Wortes steht demnach nicht sicher	TRIK. 3,3,176;NIR. 6,25;Spr. 3159;MBH. 6,280
+BAskara		2	2〉 m	
+BAskara		2a	a〉 die Sonne AK. 1,1,2,30 . 3,4,13,51 . H. 97 . an. 3,584 . MED. r. 192 . HALĀY. 1,35 . TAITT. ĀR. 10,1,7 . M. 2,48 . YĀJÑ. 1,33 . MBH. 6,2380 . 7,3884 . 7874 . 7938 . INDR. 1,30 . HARIV. 8980 . R. 1,	AK. 1,1,2,30;AK 3,4,13,51;H. 97;H an. 3,584;MED. r. 192;HALĀY. 1,35;TAITT. ĀR. 10,1,7;M. 2,48;YĀJÑ. 1,33;MBH. 6,2380;MBH 7,3884;MBH. 7, 7874;MBH. 7, 7938;INDR. 1,30;HARIV. 8980;R. 1,14,25;R. 1, 55,25;R. 1, 65,14;R 2,52,2;R. 2, 83,9;R 4,43,50;RAGH. 11,7;RAGH 12,25;KUMĀRAS. 6,49;Spr. 552;SŪRYAS. 1,9;SŪRYAS 2,58;SŪRYAS 3,45;SŪRYAS 4,9;SŪRYAS 11,6;SŪRYAS 12,67;VARĀH. BṚH. S. 12,14;MĀRK. P. 105,16;HIT. 106,10;HARIV. 14109;R. GORR. 2,8,60;MBH. 14,195
+BAskara		2b	b〉 Feuer H. an. MED	H. an;MED
+BAskara		2c	c〉 Held DHAR. _im_ ŚKDR	DHAR;ŚKDR
+BAskara		2d	d〉 (als N. der [Page5-0276] Sonne) Calotropis gigantea ( ) RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+BAskara		2d	d〉 N. pr. verschiedener Manner (unter Andern eines berühmten Astronomen) SAṂSK. K. 185,a,10 . WEBER, JYOT. 100. fg. Verz. d. B. H. No. 828. fgg. 842. fgg. Verz. d. Oxf. H. 22,a,40 . 131,b,3 . 150,b,31	SAṂSK. K. 185,a,10;WEBER, JYOT. 100. fg;Verz. d. B. H. No. 828. fgg;Verz. d. B. H. No 842. fgg;Verz. d. Oxf. H. 22,a,40;Verz. d. Oxf. H 131,b,3;Verz. d. Oxf. H 150,b,31;Verz. d. Oxf. H 199,b, No. 471;Verz. d. Oxf. H 255,b, N. 5;Verz. d. Oxf. H 258,b,13;Verz. d. Oxf. H 322,a, No. 764;Verz. d. Oxf. H 327,a, No. 774;Verz. d. Oxf. H. 327, 341,a;H. 872;HALL 120;HALL 25;HALL 26;HALL 78;HALL 81;HALL 186;NĪLAK. 9;HALL 86
+BAskara		3	3〉 n	
+BAskara		3a	a〉 Gold RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+BAskara		3b	b〉 N. pr. eines Tīrtha Verz. d. Oxf. H. 67,a,32 . — Vgl	Verz. d. Oxf. H. 67,a,32
+BAskari		1	1〉 der Planet Saturn Ind. St. 2,284,4	Ind. St. 2,284,4
+BAskari		2	2〉 N. pr. eines Muni MBH. 12,1599	MBH. 12,1599
+BAsura		1	1〉 adj	
+BAsura		1a	a〉 leuchtend, glänzend P. 3,2,161 . VOP. 26,151 . RĀJA-TAR. 4,583 . Spr. 919 , v. l. 3159 , v. l. RAGH. 5,30 . VARĀH. BṚH. S. 44,28 . KATHĀS. 25,238 . 35,21 . 152 . 38,50 . KIR. 5,5 . SUŚR. 2,319,5 . 	P. 3,2,161;VOP. 26,151;RĀJA-TAR. 4,583;Spr. 919;Spr 3159;RAGH. 5,30;VARĀH. BṚH. S. 44,28;KATHĀS. 25,238;KATHĀS 35,21;KATHĀS. 35, 152;KATHĀS 38,50;KIR. 5,5;SUŚR. 2,319,5;HARIV. 985;MBH. 5,7266;MBH 9,2490;MBH 15,880;MBH 18,83;HARIV. 13117;Verz. d. Oxf. H. 247,b,36;Spr. 3406
+BAsura		1b	b〉 furchtbar H. ś. 87 . Wohl fehlerhaft	H. ś. 87
+BAsura		2	2〉 m	
+BAsura		2a	a〉 Krystall TRIK. 2,9,28	TRIK. 2,9,28
+BAsura		2b	b〉 Held DHAR. _im_ ŚKDR	DHAR;ŚKDR
+BAsura		3	3〉 n. Costus speciosus oder arabicus ( ) RĀJAN. _im_ ŚKDR. — Vgl	RĀJAN;ŚKDR
+BAsvant		1	1〉 adj. scheinend, leuchtend, glänzend; = TRIK. 3,3,176 . = MED. t. 138 . ṚV. 1,92,7 . 113,4 . NAIGH. 1,8 . Sonne ṚV. 10,37,8 . Augen ŚAT. BR. 7,5,2,12 . KĀTY. ŚR. 4,14,3 . VS. 15,63 . AIT. BR. 4,23 .	TRIK. 3,3,176;MED. t. 138;ṚV. 1,92,7;ṚV. 1, 113,4;NAIGH. 1,8;ṚV. 10,37,8;ŚAT. BR. 7,5,2,12;KĀTY. ŚR. 4,14,3;VS. 15,63;AIT. BR. 4,23;TS. 4,3,11,3;NIR. 2,6;NAIGH. 1,13;CHĀND. UP. 7,11,2;MAITRYUP. 6,5;M. 1,77;M 4,243;MBH. 2,289;MBH. 2, 1892;MBH 3,10592;MBH 4,48;MBH 7,3784;MBH. 7, 9633;BHAG. 2,11;HARIV. 595;HARIV 935;HARIV 1331;HARIV 5185;HARIV 10995;R. 1,44,30;R 2,83,6;R. GORR. 2,100,16;R. GORR 5,32,32;KUMĀRAS. 6,60;Spr. 865;VARĀH. BṚH. S. 43,6;PAÑCAR. 2,4,21;KATHĀS. 29,182;KATHĀS 35,18;KATHĀS 38,25;MĀRK. P. 101,19;PRAB. 15,5;PRAB 21,4;PRAB 81,11;BHĀṢĀP. 40
+BAsvant		2	2〉 m	
+BAsvant		2a	a〉 die Sonne AK. 1,1,2,30 . TRIK. H. 98 . an. 2,182 . MED. HALĀY. 1,35 . RAGH. 16,44 . KĀM. NĪTIS. 5,74 . Spr. 517 . 1172 . 2625 . KATHĀS. 19,106 . MĀRK. P. 77,35 . 37 . 105,2 . DHŪRTAS. in LA. 74,1	AK. 1,1,2,30;TRIK;H. 98;H an. 2,182;MED;HALĀY. 1,35;RAGH. 16,44;KĀM. NĪTIS. 5,74;Spr. 517;Spr 1172;Spr 2625;KATHĀS. 19,106;MĀRK. P. 77,35;MĀRK. P. 77, 37;MĀRK. P 105,2;DHŪRTAS. in LA. 74,1
+BAsvant		2b	b〉 Held ŚKDR. u. WILSON angeblich nach MED	ŚKDR;WILSON;MED
+BAsvant		2c	c〉 Glanz, Licht; = H. an. ; wohl fehlerhaft für	H. an
+BAsvant		3	3〉 f	
+BAsvant		3a	a〉 die Residenz des Sonnengottes ŚABDĀRTHAK. _bei_ WILSON	ŚABDĀRTHAK;WILSON
+BAsvant		3b	b〉 Titel einer Schrift COLEBR. Misc. Ess. II, 354 ; vgl. . — Vgl	COLEBR. Misc. Ess. II, 354
+BAsvara		1	1〉 adj. f. leuchtend, glänzend P. 3,2,175 . VOP. 26,156 . MED. t. 138 . ŚAT. BR. 14,9,1,17 . MAITRYUP. 6,17 . ARJ. 10,2 ( v. l. ). MBH. 1,1006 . 3118 ( v. l. ). 8290 . 2,81 . 283 . 6,1849 . HARIV. 933	P. 3,2,175;VOP. 26,156;MED. t. 138;ŚAT. BR. 14,9,1,17;MAITRYUP. 6,17;ARJ. 10,2;MBH. 1,1006;MBH. 1, 3118;MBH. 1, 8290;MBH 2,81;MBH. 2, 283;MBH 6,1849;HARIV. 9330;R. 1,30,8;SUŚR. 2,350,5;Spr. 919;Spr 3159;KĀM. NĪTIS. 1,63;KATHĀS. 35,155;HARIV. 8971;PAÑCAR. 3,15,2;KATHĀS. 21,72;KATHĀS 25,186;KATHĀS 35,38;HARIV. 1605;R. 1,23,14;R. 1, 57,14;R. 1, 64,7;R. 1, 73,34;TARKAS. 13
+BAsvara		2	2〉 m	
+BAsvara		2a	a〉 die Sonne ŚKDR. WILS	ŚKDR;WILS
+BAsvara		2b	b〉 Tag RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+BAsvara		2c	c〉 N. pr. eines Trabanten des Sonnengottes, den er Skanda überlässt, MBH. 9,2533 . eine buddh. Gottheit LALIT. 57 (statt der zwei Namen Prabhāvyūha und Bhāsvara bei FOUCAUX hat die ed. Calc. 49,6 )	MBH. 9,2533;LALIT. 57;FOUCAUX;ed. Calc. 49,6
+BAsvara		3	3〉 n. Costus arabicus oder speciosus ( ) ŚABDAC. _im_ ŚKDR. — Vgl. und	ŚABDAC;ŚKDR
+BAvAwa		1	1〉 = Affect	
+BAvAwa		2	2〉 ein Verliebter H. an. 3,167 . MED. ṭ. 51 . [Page5-0264]	H. an. 3,167;MED. ṭ. 51
+BAvAwa		3	3〉 Schauspieler MED	MED
+BAvAwa		4	4〉 = H. an. MED. dress, decoration WILSON	H. an;MED;WILSON
+BAva		1	1〉 das Werden, Sein, Stattfinden; = AK. 3,4,27,209 . H. an. 2,533 . MED. v. 20 . HALĀY. 5,64 . ŚVETĀŚV. UP. 5,14 . BHAG. 2 . 16 . KĀTY. ŚR. 4,3 . 24 . MBH. 3,2228 . das Bestehen Spr. 4662 . SŪRYAS. 7,	AK. 3,4,27,209;H. an. 2,533;MED. v. 20;HALĀY. 5,64;ŚVETĀŚV. UP. 5,14;BHAG. 2;BHAG 16;KĀTY. ŚR. 4,3;KĀTY. ŚR. 4, 24;MBH. 3,2228;Spr. 4662;SŪRYAS. 7,24;HARIV. 12591;Spr. 2809;M. 2,124;ṚV. PRĀT. 5,28;ṚV. PRĀT 1,14;ṚV. PRĀT 2,4;ṚV. PRĀT 4,35;ṚV. PRĀT 11,19;ṚV. PRĀT. 11, 24;ṚV. PRĀT 13,14;ṚV. PRĀT 15,7;P. 3,1,40;P 5,1,59;P 8,2,3;KĀŚ;P. 1,1,56;NIR. 1,1;NIR 2;NIR 12;NIR 13;ṚV. PRĀT. 12,5;P. 2,3,37;P 3,1,24;H. an;MED;P. 3,1,66;P. 3, 4,69;VOP. 24,1;VOP. 24, 6;VOP 8,33;P. 3,1,107;P. 3, 2,45;P. 3, 3,18;VOP. 26,1;AK. 3,6,2,15;P. 5,1,119;P 4,4,144;H. an;KĀTY. ŚR. 22,4,27;KĀTY. ŚR 1,6,5;M. 5,60;M 10,93;MAITRYUP. 6,27;BHAG. 4,10;BHAG 8,5;BHAG 11,49;MBH. 4,55;HARIV. 9226;ŚĀK. 12,12;MĀLAV. 19,5;Spr. 1891;Spr 2840;Spr 5209;KĀM. NĪTIS. 7,21;MEGH. 92;SĀṂKHYAK. 17,19;RAGH. 2,11;RAGH 3,32;RAGH. 3, 62;AK. 3,4,29,225;KATHĀS. 13,94;PAÑCAT. 33,16;PRAB. 105,15;LA. (II) 22,19;NIR. 7,28;NIR 12,19;KĀTY. ŚR. 9,1,8;KĀTY. ŚR. 9, 5,13;KĀTY. ŚR. 38,25;KĀTY. ŚR 32,11;KĀTY. ŚR 117,23;M. 9,17;R. 1,17,33;Spr. 3528;PAÑCAT. 243,13;R. 1,34,15
+BAva		2	2〉 Benehmen, Betragen, Gebahren; = AK. H. an. MED. HALĀY. 5,64 . VIKR. 102 . SĀH. D. 41,18 . Spr. 3319 . BRAHMA-P. in LA. (II) 54,13	AK;H. an;MED;HALĀY. 5,64;VIKR. 102;SĀH. D. 41,18;Spr. 3319;BRAHMA-P. in LA. (II) 54,13
+BAva		3	3〉 Zustand, Lage, Verhältniss: NIR. 7,3 . MBH. 12,8199 . R. 2,64,54 . so v. a. im Alter Spr. 1774 , v. l. 245 . 461 . 493 . 3412 . 3430 . 3682 . euphem. für er stirbt SUŚR. 2,87,9 . ( d. i. ) SUŚR. 1,	NIR. 7,3;MBH. 12,8199;R. 2,64,54;Spr. 1774;Spr 245;Spr 461;Spr 493;Spr 3412;Spr 3430;Spr 3682;SUŚR. 2,87,9;SUŚR. 1,150,14;SĀṂKHYAK. 40;SĀṂKHYAK 43;SĀṂKHYAK 52;Verz. d. Oxf. H. 259,a,24;COLEBR. Misc. Ess. I, 264;BHAG. 10,5;BALL;TATTVAS. 41;Ind. St. 1,47,15. fgg;PAÑCAT. V, 44;ŚKDR;JĀTARATNA;KOṢṬHĪPRADĪPA
+BAva		4	4〉 das wahre Verhältniss, die Wahrheit: (so die neuere Ausg. st. ) HARIV. 1279 . Bei der anderen [Page5-0259] Lesart müsste man die Bedeutung Fähigkeit annehmen	HARIV. 1279
+BAva		5	5〉 Art und Weise zu sein, Natur, Wesen; = AK. H. 1376 . H. an. MED. BHAG. 9,11 . Spr. 2443 ( vgl. HARIV. 8332. fg. ). 4045 (zugleich Sinn). 4672 . 5009 . (so ist st. zu lesen; die Scholien: ) so v. a.	AK;H. 1376;H. an;MED;BHAG. 9,11;Spr. 2443;HARIV. 8332. fg;HARIV 4045;HARIV 4672;HARIV 5009;MBH. 13,1878;Spr. 3304;Spr 560;KĀŚ;P. 1,1,56
+BAva		6	6〉 Gemüthszustand, Gesinnung, Meinung, Denkart, Gefühl; = AK. H. 1383 . H. an. MED. HALĀY. sind Cit. beim Schol. zu ŚĀK. 13,12 . R. 2,22,16 . M. 8,25 . R. GORR. 2,1,23 . 6,100,1 . RAGH. 2,26 . 43 . KĀ	AK;H. 1383;H. an;MED;HALĀY;ŚĀK. 13,12;R. 2,22,16;M. 8,25;R. GORR. 2,1,23;R. GORR 6,100,1;RAGH. 2,26;RAGH. 2, 43;KĀM. NĪTIS. 12,15;RĀJA-TAR. 3,274;RĀJA-TAR 4,409;RĀJA-TAR 5,262;KĀM. NĪTIS. 11,29;KĀM. NĪTIS 18,3;M. 12,81;BHĀG. P. 6,18,26;N. 8,18;R. 2,88,5;R. 2, 96,12 GORR;SŪRYAS. 1,5;Spr. 1597;ŚĀK. 25,7;M. 4,234;VIKR. 89;HARIV. 1641;Spr. 4807;HIḌ. 2,27;MBH. 3,2347;R. 1,22,14;R. 1, 66,19;R 3,49,56;R. GORR. 2,10,28;R. SCHL. 1,3,11;M. 2,97;R. 2,59,20;MBH. 15,748;R. GORR. 2,10,28;Spr. 2041;Spr 4723;BHAG. 17,16;KĀM. NĪTIS. 2,31;SĀH. D. 51,3;SĀH. D 7,1;SĀH. D. 7, 7;SĀH. D 50,12;SĀH. D. 50, 19;SĀH. D 51,10;PRATĀPAR. 55,a,5;SĀH. D. 76,12;SĀH. D 22,12;Verz. d. B. H. No. 824;Verz. d. B. H. No. H 295;AK. 1,1,7,32;MĀRK. P. 106,60;H. 509;AK. 1,1,7,21;HALĀY. 1,90;H. an;MED;TRIK. 3,3,419
+BAva		7	7〉 Voraussetzung, Vermuthung: M. 4,65 . AṢṬĀV. 1,13	M. 4,65;AṢṬĀV. 1,13
+BAva		8	8〉 Sinn einer Rede, = ( s. oben u. 6.) Spr. 4045 . Verz. d. Oxf. H. 243,b,4 . ( s. bes. ) und ( s. bes. ). am Schlusse einer Erklärung in Commentaren unzählige Male	Spr. 4045;Verz. d. Oxf. H. 243,b,4
+BAva		9	9〉 das Gefühl der Liebe, Zuneigung: MBH. 3,75 . 196 . 12,4268 . (contemplandi facultate praediti SCHL. ) BHAG. 10,8 . fasste Liebe zu ihr MBH. 1,3817 . 3,909 . MATSYOP. 11 . RAGH. 6,36 . [Page5-0260] 	MBH. 3,75;MBH. 3, 196;MBH 12,4268;SCHL;BHAG. 10,8;MBH. 1,3817;MBH 3,909;MATSYOP. 11;RAGH. 6,36;KATHĀS. 49,249;KATHĀS 17,127;MĀRK. P. 74,31;ŚĀK. 34;ŚĀK 26,17;ŚĀK 86,14;MĀLAV. 38;KUMĀRAS. 5,58;BHĀG. P. 9,14,23;BRAHMA-P. in LA. (II) 57,10;KUMĀRAS. 6,95;PAÑCAR. 4,2,20;DHŪRTAS. in LA. 73,15;R. 2,27,22;MBH. 5,7071
+BAva		10	10〉 der Sitz der Gefühle, das Herz, Gemüth; = AK. 3,4,27,209 . H. an. MED. HALĀY. 5,64 . ŚVETĀŚV. UP. 5,14 . MBH. 1,6014 . 12,4263 . Spr. 4930 . M. 4,227 . 6,43 . 80 . 7,171 . Spr. 1350 . VṚDDHA-CĀṆ. 	AK. 3,4,27,209;H. an;MED;HALĀY. 5,64;ŚVETĀŚV. UP. 5,14;MBH. 1,6014;MBH 12,4263;Spr. 4930;M. 4,227;M 6,43;M 80;M 7,171;Spr. 1350;VṚDDHA-CĀṆ. 8,10;VṚDDHA-CĀṆ. 8, 11;R. 2,21,16;Spr. 2042;Spr 4653;LA. (II) 87,5;Spr 5313
+BAva		11	11〉 das Seiende, Ding, = TRIK. 3,2,21 . 3,419 . MED. = H. an. jedes Ding vergeht KAP. 1,44 . 81 . AṢṬĀV. 18,42 . MUṆḌ. UP. 2,1,1 . MAITRYUP. 6,25 . M. 6,80 . 12,24 . BHAG. 7,12 . MBH. 1,39 . 3,9969 . 	TRIK. 3,2,21;TRIK. 3, 3,419;MED;H. an;KAP. 1,44;KAP. 1, 81;AṢṬĀV. 18,42;MUṆḌ. UP. 2,1,1;MAITRYUP. 6,25;M. 6,80;M 12,24;BHAG. 7,12;MBH. 1,39;MBH 3,9969;MBH 13,2850;R. 2,94,18;SUŚR. 2,370,1;AṢṬĀV. 7,4;AṢṬĀV 14,1;VARĀH. BṚH. S. 42,14;KATHĀS. 25,42;RĀJA-TAR. 4,498;Spr. 3519;Spr 4087;BHĀG. P. 1,2,33;BHĀG. P 6,1,41;PRAB. 15,4;KUSUM. 39,2;RAGH. 3,41
+BAva		12	12〉 Wesen, Geschöpf; = TRIK. 3,3,419 . H. an. MED. so v. a. Pflanzen und Thiere Spr. 4067 . (= Schol. ) (so die ed. Bomb. ) MBH. 3,15853	TRIK. 3,3,419;H. an;MED;Spr. 4067;ed. Bomb;MBH. 3,15853
+BAva		13	13〉 im Drama ein kluger, gescheidter Mann AK. 1,1,7,12 . H. 372 . H. an. MED. HALĀY. 1,99 . ein in Ansehen stehender Mann TRIK. 3,3,419 . so v. a. gnädiger Herr ( vgl. und 2.) MṚCCH. 43,14 . 21 . MĀLA	AK. 1,1,7,12;H. 372;H. an;MED;HALĀY. 1,99;TRIK. 3,3,419;MṚCCH. 43,14;MṚCCH. 43, 21;MĀLAV. 3,8;MĀLATĪM. 2,13;MĀLATĪM. 2, 21
+BAva		14	14〉 N. des 8ten (42sten) Jahres im 60jährigen Jupitercyclus VARĀH. BṚH. S. 8,31 . WEBER, JYOT. 98 . Verz. d. Oxf. H. 331,b, No. 782 . Journ. of the Am. Or. S. 6,180	VARĀH. BṚH. S. 8,31;WEBER, JYOT. 98;Verz. d. Oxf. H. 331,b, No. 782;Journ. of the Am. Or. S. 6,180
+BAva		15	15〉 ein astrologisches Haus Ind. St. 2,256. fg. 275. fg. 281 . Verz. d. B. H. No. 876 . 868 . 876 . 857 . 869 . 883	Ind. St. 2,256. fg;Ind. St. 2, 275. fg;Ind. St. 2, 281;Verz. d. B. H. No. 876;Verz. d. B. H 868;Verz. d. B. H 876;Verz. d. B. H 857;Verz. d. B. H 869;Verz. d. B. H 883
+BAva		16	16〉 N. des 27sten Kalpa ( s. 2,d.) Verz. d. Oxf. H. 52,a,3	Verz. d. Oxf. H. 52,a,3
+BAva		17	17〉 = N. pr. des Verfassers des Bhāvaprakāśa Verz. d. Oxf. H. 309,b, No. 743 . — Die indischen Lexicographen kennen noch folgende Bedd. : und H. an. MED. H. an. DHAR. _im_ ŚKDR. DHAR. ANEKĀRTHAK. _im_	Verz. d. Oxf. H. 309,b, No. 743;H. an;MED;H. an;DHAR;ŚKDR;DHAR;ANEKĀRTHAK;ŚKDR;SUŚR. 1,113,5;SUŚR. 1, 147,7;KĀTY. ŚR. 122,12;KĀTY. ŚR. 122, 13;NĪLAK. 33
+BAva		13	13〉 SĀH. D. 171,17 . VIKR. 3,11	SĀH. D. 171,17;VIKR. 3,11
+BAva		4	4〉 am Anfange eines comp. = ( d. i. ) in Wirklichkeit Spr. (II) 5875 . Am Ende des Artikels ist zu streichen	Spr. (II) 5875
+BAvaka		1	1〉 adj	
+BAvaka		1a	a〉 Etwas werden [Page5-0261] lassend, bewirkend: MBH. 1,7615 . Verz. d. Oxf. H. 219,b, No. 524	MBH. 1,7615;Verz. d. Oxf. H. 219,b, No. 524
+BAvaka		1b	b〉 Jmdes Wohl befördernd: MBH. 12,2325 . 3326	MBH. 12,2325;MBH. 12, 3326
+BAvaka		1c	c〉 sich einbildend, vorstellend: AṢṬĀV. 18,42	AṢṬĀV. 18,42
+BAvaka		1d	d〉 einen Sinn für das Schöne habend DAŚAK. 1,2 ; st. dessen Verz. d. Oxf. H. 203,a, No. 484	DAŚAK. 1,2;Verz. d. Oxf. H. 203,a, No. 484
+BAvaka		2	2〉 m. = Gefühl, Affect ŚKDR. und WILSON angeblich nach HALĀY. ; vgl. 1	ŚKDR;WILSON;HALĀY
+BAvaka		1	1〉	
+BAvaka		1d	d〉 einen poetischen Sinn habend SĀH. D. 121,12 . Z. 2 lies DAŚAR. st. DAŚAK	SĀH. D. 121,12;DAŚAR;DAŚAK
+BAvamiSra		1	1〉 im Drama so v. a. gnädiger Herr; im Prākrit ŚĀK. 73,4 . 74,8 ; vgl. 13	ŚĀK. 73,4;ŚĀK 74,8;ŚĀK 13
+BAvamiSra		2	2〉 N. pr. des Verfassers des Bhāvaprakāśa ŚKDR. VII, S. 12 . WILSON in der 1ten Auflage des Wört. XXXIX. Auch und genannt	ŚKDR. VII, S. 12;WILSON in der 1ten Auflage des Wört. XXXIX
+BAvanIya		1	1〉 zur Erscheinung zu bringen, ins Werk zu setzen NĪLAK. 27, N., Z. 9 . 17	NĪLAK. 27, N., Z. 9;NĪLAK. 27, N 17
+BAvanIya		2	2〉 vorzustellen: NĪLAK. 27, N., Z. 5 . zu vergegenwärtigen, vor Augen zu haben Spr. 1314 . zu vermuthen, anzunehmen KULL. _zu_ M. 2,231	NĪLAK. 27, N., Z. 5;Spr. 1314;KULL;M. 2,231
+BAvanIya		3	3〉 zu belehren: (so ed. Bomb. ) MBH. 12,4012	ed. Bomb;MBH. 12,4012
+BAvanIya		1	¦ vgl	
+BAvana		2	2〉	
+BAvana		2c	c〉 mit loc. seine Phantasie beschäftigen mit, seine Gedanken richten auf Spr. (II) 4481 . Bei den Jaina scheint das Wort richtige Vorstellung, richtiger Begriff zu bedeuten; vgl. HEM. YOGAŚ. 1,19 . 25	Spr. (II) 4481;HEM;YOGAŚ. 1,19;YOGAŚ. 1, 25;YOGAŚ 4,54;YOGAŚ. 4, 109;YOGAŚ. 4, 121;YOGAŚ 1,28;YOGAŚ 4,63;YOGAŚ. 4, 66;YOGAŚ. 4, 68;YOGAŚ. 4, 70;YOGAŚ. 4, 72;YOGAŚ. 4, 77;YOGAŚ. 4, 84;YOGAŚ. 4, 90;YOGAŚ. 4, 105;YOGAŚ. 4, 108
+BAvana	1	1	1〉 adj. f	
+BAvana	1	1a	a〉 bewirkend, bildend, zur Erscheinung bringend: MBH. 14,1037 . SĀV. 1,11 . BHĀG. P. 1,10,2 . GHAT. 6	MBH. 14,1037;SĀV. 1,11;BHĀG. P. 1,10,2;GHAT. 6
+BAvana	1	1b	b〉 fördernd, Jmdes Heil bewirkend: Śiva (= Schol. ) MBH. 12,10374 . 3,14640 . R. 1,62,5 . den Geschöpfen Heil bringend BHAG. 9,5 . 10,15 . MBH. 1,928 . 2779 . 6,220 . 14,624 . R. 3,34,35 . SŪRYAS. 12,	MBH. 12,10374;MBH 3,14640;R. 1,62,5;BHAG. 9,5;BHAG 10,15;MBH. 1,928;MBH. 1, 2779;MBH 6,220;MBH 14,624;R. 3,34,35;SŪRYAS. 12,9;SŪRYAS. 12, 12;MĀRK. P. 106,56;HARIV. 14456;HARIV 14507;MBH. 13,1359;SUND. 3,32;MBH. 1,4389;MBH 9,2744;MBH 14,1365;HARIV. 7063;BHĀG. P. 3,4,22;MBH. 2,416;MĀRK. P. 107,7;HARIV. 1318;R. 4,44,120;PAÑCAR. 1,1,23;MBH. 2,2293
+BAvana	1	1c	c〉 sich einbildend, vorstellend: AṢṬĀV. 14,1	AṢṬĀV. 14,1
+BAvana	1	1d	d〉 lehrend: MBH. 14,949 . Vgl	MBH. 14,949
+BAvana	1	2	2〉 m. N. des 22ten Kalpa ; s. u. 2,d	
+BAvana	1	3	3〉 f. ( ) und n	
+BAvana	1	3a	a〉 das Bewirken, in-die-Erscheinung-Bringen; n. NIR. 7,25 . ist ein , insofern aus Erde Bilder von Brahman geformt werden, BHĀG. P. 3,26,46 . SĀH. D. 76,14 . das Bewirken durch Worte ist Verordnung MA	NIR. 7,25;BHĀG. P. 3,26,46;SĀH. D. 76,14;MADHUS;Ind. St. 1,14,13;Verz. d. Oxf. H. 219,b, No. 524;KUSUM. 55,15;KUSUM 57,1
+BAvana	1	3b	b〉 das Fördern: [Page5-0262] (= Schol. ) MBH. 12,3587	MBH. 12,3587
+BAvana	1	3c	c〉 Vergegenwärtigung, Einbildung, Vorstellung; Voraussetzung, Vermuthung; = H. 1373 . = H. an. 3,396 . = MED. n. 101 . n. NĪLAK. 18 . GĪT. 6,5 . BHAG. 2,66 . MBH. 12,13072 . 1,7834 . Spr. 1241 . 2119 	H. 1373;H. an. 3,396;MED. n. 101;NĪLAK. 18;GĪT. 6,5;BHAG. 2,66;MBH. 12,13072;MBH 1,7834;Spr. 1241;Spr 2119;Spr 3732;Spr 5229;BHĀG. P. 1;BHĀG. P 8,31;BHĀG. P 7,2,25;PRAB. 93,18;Verz. d. Oxf. H. 230,a,32;GĪT. 4,2;TARKAS. 54;AṢṬĀV. 12,7;AṢṬĀV 18,63;ŚAṂK;BṚH. ĀR. UP. S. 182;KĀTY. ŚR. 38,15;KĀTY. ŚR 117,23;KĀTY. ŚR. 117, 122;KĀTY. ŚR. 117, 1;VEDĀNTAS. (Allah.) No. 38;VP. 654;P. 3,2,85;HALĀY. 89;Spr. 4179;ŚAṂK;BṚH. ĀR. UP. S. 65;BṚH. ĀR. UP. S 113;BHĀG. P. 3,28,31;KULL;M. 1,9;M 2,83;KATHĀS. 43,88;MĀRK. P. 104,39
+BAvana	1	3d	d〉 das Feststellen, Erweisen: wenn Theilung geleugnet wird, so soll man sich von ihr überzeugen durch Verwandte u. s. w. ( ST. ) YĀJÑ. 2,149	ST;YĀJÑ. 2,149
+BAvana	1	3e	e〉 in der Math. f. the accomplishing a thing by combination HAUGHT. composition WILS	HAUGHT;WILS
+BAvana	1	3f	f〉 in der Med. Sättigung eines trockenen Pulvers mit Flüssigkeit: ŚĀRṄG. SAṂH. 2,6,1	Med;ŚĀRṄG. SAṂH. 2,6,1
+BAvana	1	3g	g〉 am Ende eines adj. comp. Natur, Wesen ( vgl. ): WEBER, RĀMAT. UP. 337 . In der Folge entspricht diesem	WEBER, RĀMAT. UP. 337
+BAvana	1	3h	h〉 = ( vgl. ) MED	MED
+BAvana	1	4	4〉 f	
+BAvana	1	4a	a〉 Titel einer Upaniṣad Ind. St. 3,326	Ind. St. 3,326
+BAvana	1	4b	b〉 Krähe ( )	
+BAvana	1	4c	c〉 Wasser ( ) H. an	H. an
+BAvana	1	5	5〉 n	
+BAvana	1	5a	a〉 = die Frucht der Dillenia speciosa RĀJAN. _im_ ŚKDR	RĀJAN;ŚKDR
+BAvana	1	5b	b〉 N. pr. eines Waldes ( viell. in [ ] + zu zerlegen; vgl. 2. ) HARIV. 8955	HARIV. 8955
+BAvana	1	1	1〉	
+BAvana	1	1b	b〉 UTTARARĀMAC. 27,20 (36, als Beiw. Brahman ʼs könnte auch Schöpfer der Geschöpfe bedeuten, also auch zu	UTTARARĀMAC. 27,20 (36,11)
+BAvana	1	1a	a〉 gestellt werden	
+BAvana	1	3	3〉	
+BAvana	1	3e	e〉 das Finden; vgl. und	
+BAvarUpa		1	1〉 adj. real, wirklich bestehend ŚAṂK. _zu_ BṚH. ĀR. UP. S. 40 . NĪLAK. 247	ŚAṂK;BṚH. ĀR. UP. S. 40;NĪLAK. 247
+BAvarUpa		2	2〉 Titel einer Schrift Verz. d. B. H. No. 684	Verz. d. B. H. No. 684
+BAvika		1	1〉 adj. f	
+BAvika		1a	a〉 real, wirklich bestehend KUSUM. 25,19 . WILSON, SĀṂKHYAK. S. 180	KUSUM. 25,19;WILSON, SĀṂKHYAK. S. 180
+BAvika		1b	b〉 gefühlvoll, ausdrucksvoll: MĀLAV. 5	MĀLAV. 5
+BAvika		2	2〉 n	
+BAvika		2a	a〉 lebhafte Schilderung eines vorgestellten Objectes, so dass man glaubt dasselbe vor Augen zu haben: PRATĀPAR. 101,a,5 . KUVALAY. 153,a . SĀH. D. 751 . Verz. d. Oxf. H. 208,b,24	PRATĀPAR. 101,a,5;KUVALAY. 153,a;SĀH. D. 751;Verz. d. Oxf. H. 208,b,24
+BAvika		2b	b〉 = affectvolle Sprache PRATĀPAR. 67,a,9	PRATĀPAR. 67,a,9
+BAvin		1	1〉 adj. werdend, seiend, zu sein pflegend: HARIV. 3805 . Am Ende eines comp. zu eins werdend, zuerst seiend ṚV. PRĀT. 3,8 . Diener seiend RAGH. 11,49 . Cit. bei MALLIN. _zu_ KUMĀRAS. 7,94 . in verschi	HARIV. 3805;ṚV. PRĀT. 3,8;RAGH. 11,49;MALLIN;KUMĀRAS. 7,94;MALLIN;KUMĀRAS. 1,7
+BAvin		1b	b〉 zukünftig, bevorstehend, sein müssend UṆĀDIS. 4,8 . gana zu P. 3,3,3 . RAGH. 8,77 . 18,30 . Spr. 1718 . VIKR. 87,1 . SŪRYAS. 12,8 . 9 . 12 . KĀM. NĪTIS. 10,28 . Spr. 2463 . KATHĀS. 19,77 . 25,83 . 	UṆĀDIS. 4,8;P. 3,3,3;RAGH. 8,77;RAGH 18,30;Spr. 1718;VIKR. 87,1;SŪRYAS. 12,8;SŪRYAS. 12, 9;SŪRYAS. 12, 12;KĀM. NĪTIS. 10,28;Spr. 2463;KATHĀS. 19,77;KATHĀS 25,83;KATHĀS 30,67;KATHĀS 32,192;KATHĀS 45,141;MĀRK. P. 94,12;AK. 2,8,2,71;H. 802;H 53;P. 1,1,45;HARIV. 734;Spr. 4117;Spr 4663;Spr 4810;PAÑCAT. I, 417;MBH. 1,4888;Spr. 244;Spr 245;MBH. 12,8047;MBH 1,515;MBH. 3,13062;MBH. 3, 14262;MBH 13,4645;HARIV. 5806;MEGH. 42;MEGH 57;Spr. 64;Spr 2342;Spr 4270;KATHĀS. 25,84;KATHĀS 39,128;KATHĀS 42,21;MĀRK. P. 63,21;Verz. d. Oxf. H. 55,a,42;HIT. 86,12;Z. d. d. m. G. 14,572,14
+BAvin		1c	c〉 am Ende eines comp. im Besitz von Etwas seiend: MBH. 13,6669	MBH. 13,6669
+BAvin		1d	d〉 wie Jmd sein müsste: ( = Schol. ) HARIV. 11190	HARIV. 11190
+BAvin		1e	e〉 in (von ) zu Hari Zuneigung habend VOP. 6,9	VOP. 6,9
+BAvin		2	2〉 m	
+BAvin		2a	a〉 jeder Vocal mit Ausnahme des a und d VS. PRĀT. 1,46 . 3,21 . 55 . 4,33 . 45 . 7,9 . Vielleicht deshalb so genannt, weil sie einer Veränderung, dem Uebergange in die entsprechenden Halbvocale, unter	VS. PRĀT. 1,46;VS. PRĀT 3,21;VS. PRĀT. 3, 55;VS. PRĀT 4,33;VS. PRĀT. 4, 45;VS. PRĀT 7,9
+BAvin		2b	b〉 Bez. der 4ten Kaste, der Śūdra , in Plakṣadvīpa u. s. w. VP. _bei_ MUIR, ST. I, 191 ( VP. 198 )	VP;MUIR, ST. I, 191;VP. 198
+BAvin		3	3〉 f	
+BAvin		3a	a〉 ein schönes ( vgl. ) Weib AK. 2,6,1,3 . INDR. 5,37 . HIḌ. 4,30 . SUND. 4,24 . N. 5,11 . 11,28 . 32 . 16,32 . 17,15 . 27 . 18,17 . MBH. 1,905 . 968 . 3,16190 (nach der Lesart der ed. Bomb. ). 4,76 .	AK. 2,6,1,3;INDR. 5,37;HIḌ. 4,30;SUND. 4,24;N. 5,11;N 11,28;N. 11, 32;N 16,32;N 17,15;N. 17, 27;N 18,17;MBH. 1,905;MBH. 1, 968;MBH 3,16190;ed. Bomb;MBH 4,76;MBH 5,6030;MBH. 5, 7014;MBH. 5, 7328;MBH 14,730;HARIV. 6696;HARIV 7070;HARIV 9074;R. GORR. 1,66,1;R. GORR 3,53,39;R. GORR 6,99,56;MĀRK. P. 63,62;MĀRK. P 74,47;MĀRK. P 114,24
+BAvin		3b	b〉 N. pr. einer der Mütter im Gefolge des Skanda MBH. 9,2629 . der Tochter eines Gandharva MĀRK. P. 128,11 . 17 . 22 . — Vgl	MBH. 9,2629;MĀRK. P. 128,11;MĀRK. P. 128, 17;MĀRK. P. 128, 22
+BAvin		1	¦ fördernd in	
+BAvitAtman		1	1〉 adj. s. u. 1. caus	
+BAvitAtman		5	5〉	
+BAvitAtman		2	2〉 m. Bez. des 15ten Muhūrta Ind. St. 10,296	Ind. St. 10,296
+BAvuka		1	1〉 adj. f. P. 3,2,154 . VOP. 26,146	P. 3,2,154;VOP. 26,146
+BAvuka		1a	a〉 werdend: TS. 1,7,1,6 . ŚAT. BR. 7 . 3,2,14 . 13,1,9,6 . 8 . 2,2,2. fgg. TBR. 3,8,13,2 . 23,1 . 2. KĀṬH. 28,8 . Häufig am Ende eines comp. nach einem adv. auf P. 3,2,57 ; vgl. ( u. )	TS. 1,7,1,6;ŚAT. BR. 7;ŚAT. BR 3,2,14;ŚAT. BR 13,1,9,6;ŚAT. BR. 13,1,9, 8;ŚAT. BR. 13, 2,2,2. fgg;TBR. 3,8,13,2;TBR. 3,8, 23,1;KĀṬH. 28,8;P. 3,2,57
+BAvuka		1b	b〉 Sinn für das Schöne habend BHĀG. P. 1,1,3 . Verz. d. Oxf. H. 203,a, No. 484 ( v. l. )	BHĀG. P. 1,1,3;Verz. d. Oxf. H. 203,a, No. 484
+BAvuka		2	2〉 m. im Drama der Schwester Mann H. 332 . HALĀY. 1,99	H. 332;HALĀY. 1,99
+BAvuka		3	3〉 n	
+BAvuka		3a	a〉 Wohlfahrt AK. 1,1,4,4 . H. 86 . HALĀY. 1,122	AK. 1,1,4,4;H. 86;HALĀY. 1,122
+BAvuka		3b	b〉 affectvolle Sprache: PRATĀPAR. 70,a,2 ( 67,a,9 st. dessen )	PRATĀPAR. 70,a,2;PRATĀPAR 67,a,9
+BAvya		1	1〉 adj. P. 3,1,123	P. 3,1,123
+BAvya		1a	a〉 was geschehen muss: Spr. 1509 . 2085 . gegenwärtig ( vgl. ) oder zukünftig AV. 13,1,54 . 19,6,4 . zukünftig HARIV. 485 . KUVALAY. 153,a . Schol. zu KĀTY. ŚR. 122,2 . die Stelle des fut. von vertret	Spr. 1509;Spr 2085;AV. 13,1,54;AV 19,6,4;HARIV. 485;KUVALAY. 153,a;KĀTY. ŚR. 122,2;HARIV. 478;MBH. 4,927;MBH. 4, 928;ed. Bomb;MBH 15,838;BHĀG. P. 8,13,31;BHĀG. P 9,22,47;MĀRK. P. 108,24;M. 5,150;YĀJÑ. 1,225;MBH. 3,13702;ARJ. 10,74;R. 6,7,3;Spr. 611;Spr 4387;Spr 4776;KATHĀS. 17,60;KATHĀS 25,32;KATHĀS 38,136;KATHĀS 39,43;BHĀG. P. 4,1,30;MĀRK. P. 76;MĀRK. P 44;PAÑCAT. 20,3;PAÑCAT 36,14;PAÑCAT 186,10;KUSUM. 7,10;VOP. 26,6;MBH. 4,926;KATHĀS. 28,186;P. 7,2,68;Spr. 808
+BAvya		1b	b〉 zu Stande zu bringen, zu bewerkstelligen, zu bewirken, zu thun: KUMĀRAS. 3,18 . BHĀG. P. 3,5,36 . (so die ed. Bomb. ) u. s. w. 4,30,28	KUMĀRAS. 3,18;BHĀG. P. 3,5,36;ed. Bomb;BHĀG. P 4,30,28
+BAvya		1c	c〉 zu empfinden: [Page5-0266] KATHĀS. 26,71	KATHĀS. 26,71
+BAvya		1d	d〉 vorzustellen, was man sich vorstellt: AṢṬĀV. 18,63	AṢṬĀV. 18,63
+BAvya		1e	e〉 zu überführen: M. 8,60	M. 8,60
+BAvya		1f	f〉 zu erweisen, zu beweisen: YĀJÑ. 2,171	YĀJÑ. 2,171
+BAvya		1g	g〉 nach den Comm. = NIR. 9,10 ; vielleicht zu verehren: ṚV. 1,126,1	NIR. 9,10;ṚV. 1,126,1
+BAvya		2	2〉 m. N. pr. eines Fürsten (= und anderer Autt. ) VP. 463, N. 10 . — Vgl	VP. 463, N. 10
+BAvya		1	¦ so v. a. was gut geheissen —, für gut befunden wird: Z. d. d. m. G. 27,46 . leicht zu fassen —, errathen VĀMANA 3,2,9	Z. d. d. m. G. 27,46;VĀMANA 3,2,9
+BAvyatva		1	1〉	
+BAvyatva		1d	d〉 SARVADARŚANAS. 124,12 . 15	SARVADARŚANAS. 124,12;SARVADARŚANAS. 124, 15
+BAwwa		1	1〉 ein Anhänger des Bhaṭṭa ( Kumārilabhaṭṭa ) MADHUS. _in_ Ind. St. 1,14,13 . VEDĀNTAS. (Allah.) No. 88 . Verz. d. B. H. No. 626 . 721 . 823 . Verz. d. Oxf. H. 255,b, N. 5 . 270,b,22 . Z. d. d. m. G. 	MADHUS;Ind. St. 1,14,13;VEDĀNTAS. (Allah.) No. 88;Verz. d. B. H. No. 626;Verz. d. B. H. No 721;Verz. d. B. H. No 823;Verz. d. Oxf. H. 255,b, N. 5;Verz. d. Oxf. H 270,b,22;Z. d. d. m. G. I, 200
+BAwwa		2	2〉 pl. N. pr. eines Volkes RĀJA-TAR. 1,314	RĀJA-TAR. 1,314
+BAz	1	1	1〉 Jmd [Page5-0267] reden machen, zu sprechen veranlassen: P. 1,4,52, Vārtt. 3 , Sch. MĀRK. P. 75,22	P. 1,4,52, Vārtt. 3;MĀRK. P. 75,22
+BAz	1	2	2〉 sagen, sprechen: MBH. 5,1698	MBH. 5,1698
+BAz	1	1	1〉 Jmd ( acc. ) nachrufen, zurufen ŚAT. BR. 5,4,1,9 . M. 3,30 . reden —, sprechen zu ( acc. ) R. GORR. 2,2,3 . BHĀG. P. 3,21,33 . sich unterhalten mit ( acc. ) R. 2,50,36 ( 47,27 GORR. ). antworten R.	ŚAT. BR. 5,4,1,9;M. 3,30;R. GORR. 2,2,3;BHĀG. P. 3,21,33;R. 2,50,36;R. 2, 47,27 GORR;R. GORR. 2,37,1;R. GORR 3,3,2;BHĀG. P. 7,7,1;MBH. 12,3286
+BAz	1	2	2〉 bekennen: M. 11,228 . MBH. 13,5538	M. 11,228;MBH. 13,5538
+BAz	1	3	3〉 Jmds ( acc. ) Worten trauen: MBH. 5,1966 . — In der Stelle HARIV. 10969 ist zum vorhergehenden acc. zu ziehen; die neuere Ausg. liest aber st. . Vgl. . — caus	MBH. 5,1966;HARIV. 10969
+BAz	1	1	1〉 sich unterhalten mit ( acc. ) R. ed. Bomb. 2,50,50 ( st. die anderen Ausgg. )	R. ed. Bomb. 2,50,50
+BAz	1	2	2〉 lesen, als Erkl. von Schol. zu ŚĀK. 17,4 . — schmähen: KUMĀRAS. 5,83 . — anreden, sprechen zu ( acc. ) VS. 23,23 . LĀTY. 3,3,3 . M. 2,128 . 11,223 . N. 3,11 . SUND. 1,15 . BRĀHMAṆ. 3,1 . N. 3,16 . 	ŚĀK. 17,4;KUMĀRAS. 5,83;VS. 23,23;LĀTY. 3,3,3;M. 2,128;M 11,223;N. 3,11;SUND. 1,15;BRĀHMAṆ. 3,1;N. 3,16;MBH. 1,5289;MBH. 1, 6181;MBH 3,2425;MBH 4,515;HARIV. 4913;R. 2,9,19;R. 2, 12,48;R. 2, 78,23;R. 2, 92,2;MṚCCH. 158,16;KATHĀS. 35,63;BHĀG. P. 3,14,32;MBH. 3,16758;MBH 14,2891;Verz. d. Oxf. H. 238,b,2;MBH. 8,2170;MBH. 8, 52;MBH 13,511;DAŚAK. 116,2;HARIV. 11034 (S. 790);MBH. 3,15603;R. 2,18,3;M. 4,57;M 8,355;MBH. 13,6644;RĀJA-TAR. 3,19;Spr. 2851;BHĀG. P. 6,2,1;BHĀG. P. 6, 17,36;N. 7,15;R. 2,37,1;BHĀG. P. 8,6,30;MBH. 12,13839;HARIV. 10353;ed. Bomb;MBH. 13,809;R. 1,28,13;M. 11,103;NIR. 2,2;NIR 5,1;N. 3,3;R. 1,60,1;R. 1,60, 2;R. 1, 64,9;Spr. 1280;KATHĀS. 7,4;KATHĀS 15,83;KATHĀS 43,121;KATHĀS 45,5;KATHĀS 49,72;RĀJA-TAR. 6,55;MBH. 3,2549;MBH 12,6363;R. 2,85,8;MBH. 3,12697;KĀM. NĪTIS. 17,23;MBH. 12,8345;MBH 7,6672;ed. Bomb;MBH. 1,74;MBH. 1, 6562;MBH 3,2765;MBH 4,60;MBH 12,308;R. 1,43,26;R. 1, 44,5;R. 1, 45,5 GORR;R 2,49,13;SĀH. D. 59,17;Spr. 1230;MBH. 13,501;KATHĀS. 17,84;HARIV. 8409;Spr. 396;BHAṬṬ. 3,51;SUŚR. 1,128,9;MBH. 18,66;RAGH. 6,82;RAGH 14,44;MĀRK. P. 82,35;MBH. 3,15169;R. 4,1,31;MBH. 13,4485;MBH. 13, 4489;MBH. 6,31;MBH. 6, 4850;HARIV. 6952;HARIV 9057;R. GORR. 2,108,37;R. GORR 4,10,23;R. GORR 6,16,1;BHĀG. P. 6,14,16;MBH. 1,4198;MBH 13,4589;MBH. 13,7302;PAÑCAR. 4,3,30
+BAz	1	1	1〉 Jmd ( acc. ) zusprechen, zureden, admonere MBH. 1,4287 . 7,2539 . HARIV. 7324	MBH. 1,4287;MBH 7,2539;HARIV. 7324
+BAz	1	2	2〉 anreden R. 5,38,20	R. 5,38,20
+BAz	1	3	3〉 aussprechen, erklären: GṚHYASAṂGR. 2,18 . (so die neuere Ausg. ) u. s. w. HARIV. 4219 . lehren KĀŚ. _zu_ P. 1,2,57 . MIT. 268,11 . — Vgl. fgg. — sprechen: MBH. 1,3012 . 6677 . 2,1397 . 13,2422 . HA	GṚHYASAṂGR. 2,18;HARIV. 4219;KĀŚ;P. 1,2,57;MIT. 268,11;MBH. 1,3012;MBH. 1, 6677;MBH 2,1397;MBH 13,2422;HARIV. 10336;R. 3,51,25;R 4,63,6;R 5,90,39;Spr. 5385;KĀM. NĪTIS. 8,28;BHĀG. P. 3,16,16;BHĀG. P 9,21,14;MBH. 13,3476;HARIV. 7061;MBH. 3,16669;MBH 4,241;HARIV. 12173;R. 2,98,17;R. 2, 107,7 GORR;BHAG. 2,54;R. 2,96,14;Spr. 2513;BHĀG. P. 2,3,25;VARĀH. BṚH. S. 46,97;Spr. 3871;MBH. 5,41;BHĀG. P. 5,9,9;BHĀG. P 8,16;BHĀG. P. 8, 13;BHĀG. P 9,4,10;Verz. d. Oxf. H. 65,a,26;R. 4,62,2;MBH. 3,11829;MBH 12,383;MBH 14,2886;R. 2,79,16;VARĀH. BṚH. S. 68,7;MBH. 3,2282;HARIV. 11874;BHĀG. P. 3,11,14;SUŚR. 1,13,14;MBH. 3,2599;MBH. 12,5836;MBH 5,568;MBH. 5, 41;MBH 3,14266;HARIV. 11872;N. 2,19;N 18,13;N 19,1;MBH. 1,5294;MBH 2,2696;MBH 3,2370;MBH. 3, 2419;MBH. 3, 2422;MBH. 3, 2425;MBH 5,7005;MBH 6,2184;R. 1,8,29;R 2,35,23;R. 2, 57,27;R. 2, 66,2;R. GORR. 1,74,15;R. GORR 2,74,17;KATHĀS. 16,20;KATHĀS 27,85;KATHĀS 28,154;BHĀG. P. 1,15,2;BHĀG. P 8,12,14;PAÑCAT. 193,13;BHAṬṬ. 5,39;MBH. 5,7124;MBH. 5, 7145;R. 2,57,29;HARIV. 9621;R. 4,27,21;MBH. 13,6338;ŚRUT. 6;RĀJA-TAR. 6,327;R. 5,68,1
+BAz	1	1	1〉 schmähen: (= Schol. ) MBH. 5,4234 . HARIV. 7500 . MBH. 13,2156	MBH. 5,4234;HARIV. 7500;MBH. 13,2156
+BAz	1	2	2〉 einen Wechsel zulassend, so und auch anders sein könnend: NIR. 10,17 . KAUŚ. 141 . P. 7,3,25 . 8,1,74 . SIDDH. K. _zu_ P. 7,2,10 . — Vgl. . — sprechen zu: MBH. 12,12367	NIR. 10,17;KAUŚ. 141;P. 7,3,25;P 8,1,74;SIDDH. K;P. 7,2,10;MBH. 12,12367
+BAz	1	1	1〉 sich unterhalten, sprechen mit: MBH. 5,7473 . R. 3,68,40 . MBH. 1,5190 . LĀṬY. 3,3,16 . GOBH. 1,4,2 . M. 8,55 . MBH. 5,5411 ( ed. Bomb. ). R. 2,85,14 . BHĀG. P. 6,18,47 . R. GORR. 1,2,22 . Verz. d.	MBH. 5,7473;R. 3,68,40;MBH. 1,5190;LĀṬY. 3,3,16;GOBH. 1,4,2;M. 8,55;MBH. 5,5411;ed. Bomb;R. 2,85,14;BHĀG. P. 6,18,47;R. GORR. 1,2,22;Verz. d. Oxf. H. 231,a,2;KĀTY. ŚR. 7,5,7;MBH. 1,5292;R. 2,52,86;R. 2,52, 23 GORR;R 6,71,19;R. 6, 97,7;SUŚR. 1,109,9;KATHĀS. 10,35;KATHĀS 29,80;KATHĀS 45,301;PAÑCAR. 1,7,1;PAÑCAR. 1,7, 15;PAÑCAR. 1,7, 63;PAÑCAR. 1,7, 67;PAÑCAT. 36,13 (32,19 ed. orn.). 37,21 (34,5 ed. orn.). 240,13;HIT. 14,20;BHĀG. P. 1,6,38;Spr. 3098;HIT. 63,18;HIT 64,12;HIT 133,6;KAUṢ. UP. 2,4;MBH. 3,16731;ed. Bomb;MBH 13,4807;Spr. 2165;Spr 2517;BHĀG. P. 3,24,26;PAÑCAT. 112,23
+BAz	1	2	2〉 einstimmen R. 1,67,15 ( 69,16 GORR. )	R. 1,67,15;R. 1, 69,16 GORR
+BAz	1	3	3〉 Jmd ( acc. ) bereden: HIT. 57,6	HIT. 57,6
+BAz	1	4	4〉 hersagen: (Lesart der neneren Ausg. ) HARIV. 11872 . = Schol. (ohne !) zu Viṣṇu gerichtet hersagend PAÑCAR. 3,14,25 . — Vgl. u. s. w. — caus	HARIV. 11872;PAÑCAR. 3,14,25
+BAz	1	1	1〉 sich mit Jmd ( instr. ) unterhalten MBH. 5,5411 ( st. ed. Bomb. ). Jmd ( acc. ) anreden: R. 5,56,96	MBH. 5,5411;ed. Bomb;R. 5,56,96
+BAz	1	2	2〉 Jmd bereden, Jmd gute Worte geben v. l. für Spr. 2459 . — s. . — Jmd anreden, begrüssen R. GORR. 2,4,8	Spr. 2459;R. GORR. 2,4,8
+BAz	1	1	1〉 Jmd zu sprechen veranlassen wohl so v. a. Jmd zu denken [Page5-1658] geben, in Unruhe versetzen R. 7,35,7 . — zu Jmd ( acc. ) sprechen, mit Jmd reden R. 7,15,25 . — zusagen, versprechen KATHĀS. 55,	R. 7,35,7;R. 7,15,25;KATHĀS. 55,4;KATHĀS 121,58;KATHĀS. 121, 83
+BAz	1	1	1〉 BHĀG. P. 10,85,2	BHĀG. P. 10,85,2
+BAz	1	3	3〉 ( die ältere Ausg. ) UTT80,10. fg. . ( 103,4. fg. )	UTT80,10. fg;UTTARARĀMAC 103,4. fg
+BAz	1	2	2〉 KĀTANTRA 2,1,28	KĀTANTRA 2,1,28
+BAzA		1	1〉 Rede, Sprache AK. 1,1,5,1 . H. 241 . HALĀY. 1,8 . M. 8,164 . BHĀG. P. 5,6,6 . MBH. 13,502 . adj. 1,8060 . ihre Sprache annehmend 4,280 . Verkehrssprache, in der älteren Zeit im Gegens. zur vedische	AK. 1,1,5,1;H. 241;HALĀY. 1,8;M. 8,164;BHĀG. P. 5,6,6;MBH. 13,502;MBH 1,8060;MBH 4,280;NIR. 1,4;NIR. 1, 5;P. 3,2,108;P 6,1,181;P. 8,4,45;Z. d. d. m. G. 7,168;Z. d. d. m. G. 7, 599;MBH. 2,2040;M. 9,332;Spr. 1245;MBH. 1,7582;SĀH. D. 642;KĀM. NĪTIS. 18;KĀM. NĪTIS 37;KATHĀS. 5,129;KAURAP. 19;Journ. asiat. IVe S. T. XI, 472;NAIṢ. 22,47;DHŪRTAS. in LA. 67,7;Verz. d. Oxf. H. 181,a. No. 412;MUIR, ST. II, 57;ŚUK. in LA. (II) 33,6
+BAzA		2	2〉 Beschreibung, Definition: BHAG. 2 . 54	BHAG. 2;BHAG 54
+BAzA		3	3〉 bei den Juristen Klage ŚKDR. nach MIT. und VYAVAHĀRAT. DHŪRTAS. in LA. 90,4	ŚKDR;MIT;VYAVAHĀRAT;DHŪRTAS. in LA. 90,4
+BAzA		4	4〉 Bez. einer Rāgiṇī ŚKDR. und WILSON angeblich nach HĀR. — Vgl	ŚKDR;WILSON;HĀR
+BAzA		3	3〉 hierher wohl PAÑCAT. 167,6	PAÑCAT. 167,6
+BAzaRa		1	1〉 das Reden, Sprechen, Schwatzen: Rede: AK. 1,1,5,17 . HALĀY. 1,150 . MBH. 5,5813 . R. 2,105,1 . Spr. 310 , v. l. 4167 . 5149 . VṚDDHA-CĀṆ. 3,2 . 15,19 . Spr. im 4ten Th. BHĀG. P. 5,2,6 . M. 11,69 . 	AK. 1,1,5,17;HALĀY. 1,150;MBH. 5,5813;R. 2,105,1;Spr. 310;Spr 4167;Spr 5149;VṚDDHA-CĀṆ. 3,2;VṚDDHA-CĀṆ 15,19;Spr;BHĀG. P. 5,2,6;M. 11,69;NIR. 5,2;SUŚR. 1;SUŚR 192,9;MALLIN;KUMĀRAS. 4,9;M. 8,101;KATHĀS. 27;KATHĀS 119;BHĀG. P. 7,1,17;Spr. 4243;ŚĀK. 9,6;SUŚR. 1,69,17;Verz. d. Oxf. H. 216,b,43;SĀH. D. 39,8
+BAzaRa		2	2〉 der Ausdruck der Befriedigung nach Erreichung des Zieles (im Drama) PRATĀPAR. 22,b,3	PRATĀPAR. 22,b,3
+BAzaRa		2	2〉 = freundliche Worte, Geschenke u. s. w. SĀH. D. 402	SĀH. D. 402
+BAzya		1	1〉 das Reden, Sprechen SUŚR. 1,237,15 . 2,477,20 . VĀGBH. 1,7,57	SUŚR. 1,237,15;SUŚR 2,477,20;VĀGBH. 1,7,57
+BAzya		2	2〉 ein Schriftwerk in gewöhnlicher Sprache VS. PRĀT. 1,19 . Verz. d. B. H. 92,4 . ĀŚV. GṚHY. 3,4,4 . ŚĀṄKH. GṚHY. 4,10 . HARIV. 8007	VS. PRĀT. 1,19;Verz. d. B. H. 92,4;ĀŚV. GṚHY. 3,4,4;ŚĀṄKH. GṚHY. 4,10;HARIV. 8007
+BAzya		3	3〉 Erklärungsschrift, Commentar, insbes. zu einem Sūtra H. 254 . MBH. 2,453 ( vgl. HARIV. 14079 ). 1312 . 13,4303 . VARĀH. BṚH. S. 15,1 . ŚIŚ. 2,24 . LA. (II) 87,16 . Verz. d. Oxf. H. 258,b,18 . GAUḌA	H. 254;MBH. 2,453;HARIV. 14079;MBH. 2, 1312;MBH 13,4303;VARĀH. BṚH. S. 15,1;ŚIŚ. 2,24;LA. (II) 87,16;Verz. d. Oxf. H. 258,b,18;GAUḌAP;SĀṂKHYAK. 69;ROSEN;ṚV. 2,1,3;Verz. d. Oxf. H. 257,b,14;Verz. d. Oxf. H 255,b,17;Verz. d. Oxf. H 104,a,9;SVĀMIN;ŚKDR;RĀJA-TAR. 4,635;P. 1,2,32 (Th. II);Verz. d. B. H. No. 757;UJJVAL;UṆĀDIS. 2,23
+BAzya		4	4〉 eine Art Haus ( ) ŚKDR. nach der MĀDHAVĪ _bei_ MATHUREŚA	ŚKDR;MĀDHAVĪ;MATHUREŚA
+BEkza		1	1〉 adj. und ) gaṇa zu P. 4,3,73 . von Almosen lebend MBH. 1,7777	P. 4,3,73;MBH. 1,7777
+BEkza		2	2〉 n	
+BEkza		2a	a〉 das Betteln, Bettel: M. 6,55 . 10,116 . YĀJÑ. 3,42 . 281 . MṚCCH. 53,13 . KĀM. NĪTIS. 2,22 . [Page5-0378] Spr. 2279 . 2726 . Verz. d. Oxf. H. 85,a,19 . betteln gehen, betteln GOBH. 2,10,38 . KAUŚ. 	M. 6,55;M 10,116;YĀJÑ. 3,42;YĀJÑ. 3, 281;MṚCCH. 53,13;KĀM. NĪTIS. 2,22;Spr. 2279;Spr 2726;Verz. d. Oxf. H. 85,a,19;GOBH. 2,10,38;KAUŚ. 57;M. 2,48;M. 2, 49;M. 2, 182;M 6,55;M 11,122;YĀJÑ. 1,29;MBH. 1,702;R. 2,43,4;DHŪRTAS. in LA. 76,4;BRĀHMAṆ. 1,2
+BEkza		2b	b〉 Erbetteltes, erbettelte Speise, Almosen P. 4,2,38 . VOP. 7,19 . AK. 2,7,46 . H. 1415 . KAUŚ. 10 . PĀR. GṚHY. 2,4 . GOBH. 2,10,42 . ŚĀṄKH. GṚHY. 2,6 . MBH. 1,702 . M. 4,5 . 11,123 . 2,183 . 6,27 . 2	P. 4,2,38;VOP. 7,19;AK. 2,7,46;H. 1415;KAUŚ. 10;PĀR. GṚHY. 2,4;GOBH. 2,10,42;ŚĀṄKH. GṚHY. 2,6;MBH. 1,702;M. 4,5;M 11,123;M 2,183;M 6,27;M 2,51;M 5,129;YĀJÑ. 1,187;BHAG. 2,5;MBH. 1,7268;MBH 14,1277;M. 2,188;ebend;MBH. 1,701;Spr. 270;Spr 1754
+BEkzaka		2	2〉	
+BEkzaka		2b	b〉 R. 7,59,2,28	R. 7,59,2,28
+BEma		1	1〉 adj. f. zu Bhīma in Beziehung stehend: ( s. ) Verz. d. Oxf. H. 154,a,5 . f. subst. dass. ŚKDR. As. Res. III, 272 . WILSON, Sel. Works I, 203. fgg. 203 . Davon nom. abstr. MATSYA-P. _im_ ŚKDR	Verz. d. Oxf. H. 154,a,5;ŚKDR;As. Res. III, 272;WILSON, Sel. Works I, 203. fgg;WILSON, Sel. Works I, 203;MATSYA-P;ŚKDR
+BEma		2	2〉 m. patron. , pl. MBH. 3,10268 ( Schol. ). 7,4069 . HARIV. 5243 . 7663 . 8814 . f. Bhīma ʼs Tochter, patron. der Damayantī N. 1,12 . 7,13 . 12,6	MBH. 3,10268;MBH 7,4069;HARIV. 5243;HARIV 7663;HARIV 8814;N. 1,12;N 7,13;N 12,6
+BErava	1	1	1〉 adj. grausig AK. 1,1,7,19 . H. 303 . an. 3,708 . MED. v. 46 . HALĀY. 4,20 . [Page5-0379] R. 1,26,14 . KATHĀS. 10,77 . Verz. d. Oxf. H. 59,a,1 . MBH. 1,215 . Wunde SUŚR. 1,83,19 . 2,388,5 . MBH. 1,1	AK. 1,1,7,19;H. 303;H an. 3,708;MED. v. 46;HALĀY. 4,20;R. 1,26,14;KATHĀS. 10,77;Verz. d. Oxf. H. 59,a,1;MBH. 1,215;SUŚR. 1,83,19;SUŚR 2,388,5;MBH. 1,1213;MBH. 1, 6278;MBH 4,1525;MBH 4,1525;MBH 10,392;ed. Bomb;HIḌ. 4,20;R. 6,9,21;VARĀH. BṚH. S. 30,6;VARĀH. BṚH. S 39,5;R. 6,9,22;HARIV. 5599;MBH. 4,1396;MBH 14,2471;RĀJA-TAR. 1,368;MBH. 2,2690;MBH. 2, 2695;MBH 8,63;ed. Bomb;VARĀH. BṚH. S. 30,3;R. 6,11,36;R. 6, 70,29
+BErava	1	2	2〉 m	
+BErava	1	2a	a〉 eine Form Śiva ʼs TRIK. 1,1,44 . H. 198 . H. an. MED. LA. (II) 87,7 . PRAB. 59,7 . Verz. d. Oxf. H. 69,b, N. 2 . 88,a,23 . 91,b,6 . 101,a,31 . b,8 . 13 . 17 . 238,b,16 . 309,b,27 . 320,a,2 . BURN. 	TRIK. 1,1,44;H. 198;H. an;MED;LA. (II) 87,7;PRAB. 59,7;Verz. d. Oxf. H. 69,b, N. 2;Verz. d. Oxf. H 88,a,23;Verz. d. Oxf. H 91,b,6;Verz. d. Oxf. H 101,a,31;Verz. d. Oxf. H. 101, b,8;Verz. d. Oxf. H. 101,a, 13;Verz. d. Oxf. H. 101,a, 17;Verz. d. Oxf. H 238,b,16;Verz. d. Oxf. H 309,b,27;Verz. d. Oxf. H 320,a,2;BURN. Intr. 551;WILSON, Sel. Works I, 21;RĀJA-TAR. 1,311;BRAHMAVAIV. P;Verz. d. Oxf. H. 25,b, N. 5;ŚKDR;WILS;ŚAṂKARAVIJAYA;Verz. d. Oxf. H. 250,a,18. fgg;TANTRASĀRA;ŚKDR;VĀMANA-P;ŚKDR;Verz. d. B. H. No. 1302;Verz. d. Oxf. H. 95,a,46;Verz. d. Oxf. H 104,a,11;Verz. d. Oxf. H 108,b,24;Verz. d. Oxf. H 299,a, No. 729;Verz. d. Oxf. H. 257,a,2
+BErava	1	2b	b〉 ein den Bhairava darstellender Mann WILSON, Sel. Works I, 258	WILSON, Sel. Works I, 258
+BErava	1	2c	c〉 ein Śivagaṇādhipa KĀLIKĀ-P. 44 _im_ ŚKDR	KĀLIKĀ-P. 44;ŚKDR
+BErava	1	2d	d〉 ein Sohn Śiva ʼs von der Tārāvatī , der Gattin Candraśekhara ʼs, Königs von Karavīrapura , KĀLIKĀ-P. 49 _im_ ŚKDR	KĀLIKĀ-P. 49;ŚKDR
+BErava	1	2e	e〉 N. pr. eines Nāga MBH. 1,2158 . eines Yakṣa Verz. d. Oxf. H. 18,b,38	MBH. 1,2158;Verz. d. Oxf. H. 18,b,38
+BErava	1	2f	f〉 N. pr. eines Mannes HALL 173 . Verz. d. Oxf. H. 101,b,13 . Autors des Pheṭkāriṇītantra 98,b,35 . eines Lehrers der Haṭhavidyā 233,b,38 . zweier Fürsten 137,b, No. 267 . 273,a, No. 648 . eines Jäger	HALL 173;Verz. d. Oxf. H. 101,b,13;Verz. d. Oxf. H 98,b,35;Verz. d. Oxf. H 233,b,38;Verz. d. Oxf. H 137,b, No. 267;Verz. d. Oxf. H 273,a, No. 648;HIT. 34,18
+BErava	1	2g	g〉 N. pr. eines Flusses ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+BErava	1	2h	h〉 Bez. eines Rāga (einer musikalischen Weise) H. an. As. Res. III, 73 . 77 ; vgl. c	H. an;As. Res. III, 73;As. Res. III, 77
+BErava	1	3	3〉 f	
+BErava	1	3a	a〉 eine best. Form der Durgā H. 206 . HALĀY. 1,17 . Verz. d. Oxf. H. 88,a,23 . 93,b,13. fgg. 96,b,5 . 94,a,40 . 92,a, N. 1 . 95,a,47 ( Verz. d. B. H. No. 1335 ). 94,b,24 . 93,b,12 . 94,b,10 . 94,a,40 	H. 206;HALĀY. 1,17;Verz. d. Oxf. H. 88,a,23;Verz. d. Oxf. H 93,b,13. fgg;Verz. d. Oxf. H 96,b,5;Verz. d. Oxf. H 94,a,40;Verz. d. Oxf. H 92,a, N. 1;Verz. d. Oxf. H 95,a,47;Verz. d. B. H. No. 1335;Verz. d. Oxf. H 94,b,24;Verz. d. Oxf. H 93,b,12;Verz. d. Oxf. H 94,b,10;Verz. d. Oxf. H 94,a,40
+BErava	1	3b	b〉 ein zwölfjähriges Mädchen, welches bei der Durgā -Feier diese Göttin vertritt, ANNADĀKALPA _im_ ŚKDR. u. . WILSON, Sel. Works I, 257. fg	ANNADĀKALPA;ŚKDR;WILSON, Sel. Works I, 257. fg
+BErava	1	3c	c〉 Bez. einer Ragiṇī ( vgl. 2,h.) As. Res. III, 77 . GĪT. Einl. VIII. 37,5	As. Res. III, 77;GĪT. Einl. VIII;GĪT 37,5
+BErava	2	1	1〉 adj. f. zu Bhairava in Beziehung stehend: Verz. d. B. H. No. 963	Verz. d. B. H. No. 963
+BErava	2	2	2〉 n. so v. a. s. u. 1. 2,a. d. i. und Verz. d. Oxf. H. 109,a,20. fgg	Verz. d. Oxf. H. 109,a,20. fgg
+BEzaja		1	1〉 m	
+BEzaja		1a	a〉 Perdix chinensis JAṬĀDH. _im_ ŚKDR	JAṬĀDH;ŚKDR
+BEzaja		1b	b〉 pl. oxyt. , pl. zum patron. gaṇa zu P. 4,2,111	P. 4,2,111
+BEzaja		2	2〉 n. angeblich = Arzenei ŚKDR. und WILSON	ŚKDR;WILSON
+BEzajya		1	1〉 m. patron. von gaṇa zu P. 4,1,105	P. 4,1,105
+BEzajya		2	2〉 n	
+BEzajya		2a	a〉 heilende Wirkung, heilende Thätigkeit VS. 20,3 . TS. 6,4,9,2 . ŚAT. BR. 12,8,2,16 . 3,2 . ŚĀṄKH. BR. 5,1 . KĀTY. ŚR. 15,7,34 . auf Heilung bezügliche Begehung (im Ritual) KAUŚ. 25	VS. 20,3;TS. 6,4,9,2;ŚAT. BR. 12,8,2,16;ŚAT. BR. 12,8, 3,2;ŚĀṄKH. BR. 5,1;KĀTY. ŚR. 15,7,34;KAUŚ. 25
+BEzajya		2b	b〉 = Heilmittel, Arzenei P. 5,4,23 . AK. 2,6,2,1 . H. 473 . HALĀY. 2,458 . NIR. 10,7 . 25 . ŚAT. BR. 12,7,1,12 . SUŚR. 1,159,4 . ŚĀRṄG. SAṂH. 1,2,1 . 2 . Verz. d. B. H. No. 973 . Spr. 1742 . 4676 . 13	P. 5,4,23;AK. 2,6,2,1;H. 473;HALĀY. 2,458;NIR. 10,7;NIR. 10, 25;ŚAT. BR. 12,7,1,12;SUŚR. 1,159,4;ŚĀRṄG. SAṂH. 1,2,1;ŚĀRṄG. SAṂH. 1,2, 2;Verz. d. B. H. No. 973;Spr. 1742;Spr 4676;Spr 1365;VYUTP. 211
+BI	1	1	1〉 erschrecken ( trans. ), schrecken, einschüchtern [Page5-0293] P. 1,3,68 . 7,3,40 . VOP. 18,19 . AIT. BR. 3,20 . ŚAT. BR. 9,1,1,6 . 14 . MBH. 7,6825 . 7995 . R. 6,13,23 . BHAṬṬ. 5,58 . 8,42 . 14,78 	P. 1,3,68;P 7,3,40;VOP. 18,19;AIT. BR. 3,20;ŚAT. BR. 9,1,1,6;ŚAT. BR. 9,1,1, 14;MBH. 7,6825;MBH. 7, 7995;R. 6,13,23;BHAṬṬ. 5,58;BHAṬṬ 8,42;BHAṬṬ 14,78;BHAṬṬ 15,36;MBH. 1,185;MBH. 1, 1480;MBH 2,1433;MBH 5,2717;HARIV. 6454;BHĀG. P. 7,5,18;AIT. BR. 3,26;MṚCCH. 85,20;MBH. 1,996;MBH. 1, 8285;MBH 4,1448;Spr. 5195;KATHĀS. 5,81;KATHĀS 27,177;DAŚAK;BENF. Chr. 193,15
+BI	1	2	2〉 dass. Sch. zu P. 6,1,56 . 7,3,40 . VOP. 18,18	P. 6,1,56;P 7,3,40;VOP. 18,18
+BI	1	3	3〉 Jmd mit Etwas schrecken: Sch. zu P. 1,3,68 . 6,1,56 . 7,3,40 . VOP. 18,18 . ( v. l. ) MEGH. 62 . BHAṬṬ. 5,41 . — insens. P. 6,4,115 , Sch. — s. . — caus. schrecken, einschüchtern: KĀṬH. 34,9 . — s.	P. 1,3,68;P 6,1,56;P 7,3,40;VOP. 18,18;MEGH. 62;BHAṬṬ. 5,41;P. 6,4,115;KĀṬH. 34,9;BHAṬṬ. 6,2;ed. Bomb;MBH. 6,2630;ed. Bomb;MBH. 14,269;MĀRK. P. 71,13;ṚV. 1,80,12;ṚV 8,68,8;TS. 3,2,5,2;Spr. 5195;Spr 2776;MBH. 5,5359;MBH 8,2015;R. 5,38,10
+BI	1	1	1〉 (sic) BHĀG. P. 10,9,11	BHĀG. P. 10,9,11
+BI	1	2	2〉 lies	
+BI	1	3	3〉 KATHĀS. 106,126	KATHĀS. 106,126
+BI	1	1	1. ¦ Sp. 293, Z. 14 lies intens	
+BIluka		1	1〉 adj. = furchtsam, feig P. 3,2,174 . VOP. 26,163 . AK. 3,1,26 . H. 365 . Spr. 4628 , v. l. sich scheuend vor KATHĀS. 32,53	P. 3,2,174;VOP. 26,163;AK. 3,1,26;H. 365;Spr. 4628;KATHĀS. 32,53
+BIluka		2	2〉 m. Bär ( vgl. und ) ŚABDAR. _im_ ŚKDR	ŚABDAR;ŚKDR
+BIma		1	1〉 adj. f. furchtbar, schrecklich P. 3,4,74 . AK. 1,1,7,20 . TRIK. 3,1,7 . H. 302 . an. 2,331 . MED. m. 21 ( Druckfehler für ). HALĀY. 4,20 . VIŚVA _bei_ UJJVAL. ṚV. 1,36,20 . 55,1 . 140,6 . 4,20,6 . 	P. 3,4,74;AK. 1,1,7,20;TRIK. 3,1,7;H. 302;H an. 2,331;MED. m. 21;HALĀY. 4,20;VIŚVA;UJJVAL;ṚV. 1,36,20;ṚV. 1, 55,1;ṚV. 1, 140,6;ṚV 4,20,6;ṚV 6,3,3;ṚV 10,109,4;ṚV 1,154,2;ṚV 2,33,11;ṚV 4,16,14;ṚV 7,19,1;ṚV 6,18,10;ṚV. 6, 31,5;AV. 3,25,1;AV 8,1,10;AV 12,4,41;AIT. BR. 7,17;TS. 4,4,11,2;ARJ. 2,2;INDR. 1,14;SUND. 4,17;MBH. 1,1167;MBH 5,7364;DAŚ. 1,14;RAGH. 1,16;RAGH 3,54;RAGH 12,72;Spr. 2051;Spr 2475;Spr 2776;DHŪRTAS. in LA. 66,15;BHAG. 1,15;MBH. 12,4259;RAGH. 3,57;RAGH. ed. Calc. 3,59;VS. 16,40;Ind. St. 2,41
+BIma		2	2〉 m	
+BIma		2a	a〉 eine Art Sauerampfer ( ) H. an. MED	H. an;MED
+BIma		2b	b〉 N. des Rudra ĀŚV. GṚHY. 4,8,19 . = AK. 1,1,1,30 . TRIK. 3,3,301 . H. 195 . H. an. MED. HALĀY. 1,12 . VIŚVA a. a. O. eine der acht Formen Śiva ʼs VP. 58 . MĀRK. P. 52,7 . Verz. d. Oxf. H. 54,a,1 . N	ĀŚV. GṚHY. 4,8,19;AK. 1,1,1,30;TRIK. 3,3,301;H. 195;H. an;MED;HALĀY. 1,12;VIŚVA a. a. O;VP. 58;MĀRK. P. 52,7;Verz. d. Oxf. H. 54,a,1;VP. 121, N. 17;BHĀG. P. 6,6,17
+BIma		2c	c〉 N. pr. eines Devagandharva MBH. 1,2551 . eines der Deva Yajñamuṣ 3,14166 . eines Dānava 12,8261 . KATHĀS. 47,16 . eines Vidyādhara 46,60 . eines Sohnes des Rākṣasa Kumbhakarṇa Verz. d. Oxf. H. 64,a	MBH. 1,2551;MBH 3,14166;MBH 12,8261;KATHĀS. 47,16;KATHĀS 46,60;Verz. d. Oxf. H. 64,a,36;Verz. d. Oxf. H 78,b,15
+BIma		2d	d〉 N. pr. verschiedener Männer: eines Vaidarbha AIT. BR. 7,34 . N. 1,5 . HARIV. 1989 . 6590 . eines Sohnes des Īlina MBH. 1,3708 . des zweiten Sohnes des Pāṇḍu ( vgl. ) TRIK. 3,3,301 . H. 707 . H. an.	AIT. BR. 7,34;N. 1,5;HARIV. 1989;HARIV 6590;MBH. 1,3708;TRIK. 3,3,301;H. 707;H. an;MED;VIŚVA a. a. O;DRAUP. 5,20;HIḌ. 4,18;HIḌ. 4, 19;MBH. 1,4772;VP. 437;VP 459;HARIV. 1415;VP. 398;BHĀG. P. 9,15,3;HARIV. 5242. fgg;Verz. d. Oxf. H. 149,a,23;REINAUD, Mém. sur lʼInde 211;REINAUD, Mém. sur lʼInde 247;REINAUD, Mém. sur lʼInde 271;Journ. of the Am. Or. S. 7,39;ŚUK. in LA. (II) 37,1;COLEBR. Misc. Ess. II, 49;Verz. d. Oxf. H. 124,a,44;Verz. d. Oxf. H 378,a,10;MBH. 2,335
+BIma		3	3〉 f	
+BIma		3a	a〉 Peitsche ŚABDAM. _im_ ŚKDR	ŚABDAM;ŚKDR
+BIma		3b	b〉 ein best. Parfum ( ) ŚABDAC. _im_ ŚKDR	ŚABDAC;ŚKDR
+BIma		3c	c〉 eine Form der Durgā H. ś. 52 . ŚABDAR. _im_ ŚKDR. HARIV. LANGL. I, 511 . Verz. d. Oxf. H. 39,b,27 ( ). HIOUEN-THSANG I, 124 . KÖPPEN II. 30	H. ś. 52;ŚABDAR;ŚKDR;HARIV. LANGL. I, 511;Verz. d. Oxf. H. 39,b,27;HIOUEN-THSANG I, 124;KÖPPEN II. 30
+BIma		3d	d〉 N. pr. einer Apsaras R. 2,91,17 . ed. Bomb	R. 2,91,17;ed. Bomb
+BIma		3e	e〉 N. pr. verschiedener Flüsse MBH. 3,14232 . 6,329 ( VP. 183 ). LIA. t. 168	MBH. 3,14232;MBH 6,329;VP. 183;LIA. t. 168
+BIma		3f	f〉 N. pr. einer Localität RĀJA-TAR. 2,135 (in Verbindung mit , also ohne Zweifel der Durgā geheiligt). N. pr. einer Stadt HIOUEN-THSANG II, 243 . — Vgl	RĀJA-TAR. 2,135;HIOUEN-THSANG II, 243
+BImabala		1	1〉 adj. eine furchtbare Kraft besitzend	
+BImabala		2	2〉 m. N. pr. eines der Söhne des Dhṛtarāṣṭra MBH. 1,2733 . 4546 . eines der Deva Yajñamuṣ 3,14166 ( in und zu zerlegen)	MBH. 1,2733;MBH. 1, 4546;MBH 3,14166


### PR DESCRIPTION
## Summary
- `microstructure.py export_sense_loci` — new command, reuses the existing sense-tree parser (`header()`/`split_senses()`/`clean_de()`), no rewrite.
- Emits `pwg_sense_loci.tsv` (`slp1  hom  sense_id  gloss_de  ls_loci`) — the sole external input to kosha's [sense-reconciliation plan](https://github.com/gasyoun/kosha/blob/main/docs/PLAN_KOSHA_SENSE_RECONCILIATION_2026H2.md) ([H1455](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1455-Sonnet_kosha_corpus-attestation-per-sense-join_22.07.26.md) is the consumer).
- Full run: 123,366 PWG records → 189,301 leaf-sense rows, 106,082 distinct headwords, 89.3% non-empty `ls_loci`; byte-identical on re-run (deterministic).
- Smoke test passes exactly per the [H1456](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1456-Sonnet_RussianTranslation_pwg-sense-loci-export_22.07.26.md) goal condition: `nAgadanta` 1a⊇"Elephantenzahn"+MBH, 1b⊇"Pflock"+PAÑCAT; `nAgadantaka` 1b⊇HIT.
- **Found + fixed in scope:** PWG Nachträge back-references glue two sense markers together with no separating space (`"1〉b〉 <ls>…</ls>"`, 2,273 occurrences in `pwg.txt`) — invisible to the shared `MARK` regex's whitespace-before lookbehind, silently misattributing the addendum's locus to the parent sense instead of the one it actually refers to. Fixed via a local-only preprocess inside the new `leaf_senses()` path only; the shared `MARK`/`split_senses` used by `sense_node()`/`portrait()` elsewhere in this file is untouched (verified `card` command output unchanged).
- `pwg_sense_loci.tsv` is gitignored (regenerable, 28 MB); `pwg_sense_loci.sample.tsv` (500 headword groups, 2,742 rows, forces in the smoke-test pair) is committed as the reviewable/testable sample.

## Test plan
- [x] `python -m py_compile microstructure.py`
- [x] Existing `card`/`sample` commands still produce identical output (no regression to shared parser)
- [x] Full export: 123,366 records, 189,301 rows, all 5 columns, 0 malformed rows
- [x] Re-run determinism: byte-identical diff
- [x] `nAgadanta`/`nAgadantaka` smoke test matches the H1456 goal condition exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)