### PR TITLE
docs(RussianTranslation): full-audit improvement umbrella plan (2026 H2)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Prove bounded PWG→Russian CLI correctness on one profile, then scale + the CDSL article-comparison study
 
-_Created: 09-07-2026 · Last updated: 22-07-2026_
+_Created: 09-07-2026 · Last updated: 23-07-2026_
 
 Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/archive/H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md)):
 
@@ -13,6 +13,13 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 > the root copy. Audited + reconciled 2026-06-26.
 
 ## ➡️ Next Steps (Queue)
+
+- **Full-audit improvement umbrella (23-07-2026, `/ask`).** PLAN:
+  [`docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.md).
+  Wave-1 offline (no paid gen, no store write): **H1553** Track A H1403 residues ·
+  **H1554** Track B promotion-receipt scaffold · **H1555** Track C docs register ·
+  **H1556** Track D editorial dry-run (best-effort). Wave-2 = fresh health GO then
+  medium50 drain. Track E = existing H1457/H1458 + Sa→Ru gloss PLAN (no new handoff).
 
 - **medium50 serial-c4 RESUME — prepared plan parked, needs a FRESH health PASS first
   (22-07-2026, Fable 5 `claude-fable-5`, H1447 terminal).** H1447 derived a mechanical

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,20 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added — full-audit improvement umbrella plan (2026 H2)
+
+- `/ask` layered plan after a full RussianTranslation audit: offline wave-1 portfolio
+  (H1403 production residues · promotion-receipt scaffold · docs umbrella), then
+  health-gated drain, then existing TM/gloss/editorial programmes. Docs under `docs/`:
+  [PLAN](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.md)
+  (+ `.meta.md`),
+  [ROADMAP](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/ROADMAP_RussianTranslation_full_audit_improvement_2026H2.md),
+  [ARCHITECTURE](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_full_audit_improvement.md),
+  [IMPLEMENTATION](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_full_audit_improvement.md),
+  [VERIFICATION](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/VERIFICATION_RussianTranslation_full_audit_improvement.md).
+- Indexes (does not supersede) the pubgrade-TM and Sa→Ru gloss `/ask` plans. Wave-1 fences:
+  no paid generation, no live store mutation. One handoff per track (A–E).
+
 ### Added — PWG per-sense `<ls>`-loci export for kosha sense-reconciliation (H1456)
 
 - `microstructure.py export_sense_loci` — new command, reuses the existing

--- a/RussianTranslation/README.md
+++ b/RussianTranslation/README.md
@@ -1,6 +1,6 @@
 # RussianTranslation — Sanskrit dictionaries into Russian, at scale
 
-_Created: 28-06-2026 · Last updated: 11-07-2026_
+_Created: 28-06-2026 · Last updated: 23-07-2026_
 
 This directory holds two independent machine-translation efforts that bring the
 great 19th-century Sanskrit dictionaries to Russian readers, plus the
@@ -124,6 +124,14 @@ forced the change):
 | 11 | 07-05→06 | TM industrialization: mined tier (97% precision gate, 10,132 pairs), A/B/C grading, TMX 1.4b export |
 | 12 | 07-05→06 | Re-glue research track: addenda typology, learner scores, and the bake-off verdict — synthesize-first does not beat re-glue |
 | 13 | 07-06 | Multi-agent orchestration post-mortem → `synth_dispatch.py` guards (output-file liveness, kill-guard, sealed outputs) |
+
+## Improvement programme (post-audit umbrella)
+
+Cold-start for *what to improve next* (not the day-to-day translate loop): the full-audit
+`/ask` umbrella sequences factory residues → health-gated drain → existing TM/gloss plans.
+
+- **PLAN index:** [`docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.md)
+- Also indexes (do not supersede): [pubgrade TM](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_pubgrade_tm_oral_2026H2.md) · [Sa→Ru gloss](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md)
 
 ## Operating the pipeline (quickstart)
 

--- a/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_full_audit_improvement.md
+++ b/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_full_audit_improvement.md
@@ -1,0 +1,108 @@
+# ARCHITECTURE — RussianTranslation full-audit improvement (wave-1)
+
+_Created: 23-07-2026 · Last updated: 23-07-2026_
+
+Parent: [PLAN_RussianTranslation_full_audit_improvement_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.md).
+
+## Component map (wave-1 touch surface only)
+
+```
+wf_output / execution artifacts
+        │
+        ▼
+audit_window.py  ──► window_reports.py ──► window_ledger.jsonl
+   │ auto wall-clock (A2)                    stage_boundary events (A2)
+   │ performance_metrics fields
+   ▼
+requeue keys / judge_sample / status
+        │
+        ▼
+promote_final_cards.py
+   │ refuse defect keys without --force (A3)
+   │ ready_partial clean-subset helper (A3)
+   │ ── dry-run / fixtures only in wave-1 ──
+   ▼
+[fenced] pwg_ru_translated.jsonl
+
+NEW (Track B, pure + tests):
+  promotion_receipt.py (or under pilot/)
+    · AttemptRunBinding
+    · PromotionReceipt
+    · reconcile_startup(receipts, store_snapshot) → actions
+  fixtures under src/pilot/fixtures/cohort_scaffold/
+```
+
+## Build-vs-reuse (prior-art)
+
+| Piece | Verdict | Evidence |
+|---|---|---|
+| Wall-clock on ledger | **Extend** `audit_window.py` / `window_reports.py` | Flags already exist (`--wall-clock-minutes`); H1403/H390: only 12/458 rows filled — auto-derive missing |
+| stage_boundary | **Extend** `dashboard_events.py` if present; else minimal emit in audit path | H1403 A2; avoid new event bus |
+| Promote defect refuse | **Extend** `promote_final_cards.py` | Footgun H255_NO_PWG_W02 in LAUNCH_FUCKUPS; `--force` already exists for store-shrink |
+| ready_partial promote | **Extend** coordinator / promote path helpers already aware of `ready_partial` | `coordinator.py` states; automate clean-subset path mandated by runbook |
+| Cohort binding/receipt | **New thin module + tests**; do **not** implement H1437 scheduler | H1437 claimed for multi-profile; Track B = P0 data shapes only |
+| Quality apply | **New small CLI** reusing sheet `decisions.json` schema from csl-pyutil / review sheets | No store write |
+| Umbrella docs | **New** under `docs/`; link existing PLANs | R2.5 |
+| TM/gloss | **Reuse** existing PLAN docs only | R3.5 |
+
+## Data contracts
+
+### A2 — performance_metrics (ledger row)
+
+When CLI omits economy flags, derive:
+
+| Field | Derivation (default) |
+|---|---|
+| `wall_clock_minutes` | Prefer explicit flag; else `mtime(wf_output) - parse(meta.generated_at)` if both exist; else `null` + `wall_clock_source: "unavailable"` |
+| `wall_clock_source` | `"cli"` \| `"derived_mtime"` \| `"unavailable"` |
+| `gen_model` | Already from `workflow_meta.gen_model` if stamped |
+
+**Default on ambiguity:** never invent tokens; null + source tag beats a wrong number (H1403 caveat: generated_at→mtime conflates operator idle — document in status note; stage_boundary later separates).
+
+### A3 — promote defect refusal
+
+| Input | Behavior |
+|---|---|
+| Keys present in current `requeue.keys.txt` / `.defect` for the same root/window (or explicit `--defect-keys` file) | **Refuse** promote of those keys unless `--force` |
+| Clean keys only | Promote as today |
+| No defect list available | Proceed (default); log `defect_guard: skipped_no_list` |
+
+**Default:** fail closed only when a defect list is discoverable for the window being promoted.
+
+### B — PromotionReceipt (minimal schema)
+
+```json
+{
+  "schema": "pwg_ru.promotion_receipt.v1",
+  "run_id": "string",
+  "attempt_id": "string",
+  "lease_id": "string",
+  "keys_accepted": ["..."],
+  "keys_rejected": ["..."],
+  "store_path": "relative-or-fixture",
+  "row_count_before": 0,
+  "row_count_after": 0,
+  "tm_rebuild": false,
+  "created_at": "ISO-8601"
+}
+```
+
+`reconcile_startup(receipts, observed_store_keys) → {promote_missing, skip_already_present, error_inconsistent}` pure function; fixture-tested.
+
+## Interfaces with H1437
+
+- Track B **must not** change default live routing or multi-profile admission.
+- If H1437 worktree already added the same module names, **adapt to H1437's names** (default: prefer existing H1437 symbols) rather than dual systems.
+- Track B PR may land before H1437 finishes; H1437 rebases and consumes.
+
+## LANG_PARITY
+
+Any SHARED edit to promote/audit surfaces used by EN: update
+[LANG_PARITY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md)
+entry + `verified_sha256` via the repo's existing check script.
+
+## Out of architecture (wave-1)
+
+Multi-profile barrier scheduler, Message Batches API, COMET-QE, live drain, review-sheet HTML regeneration.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_full_audit_improvement.md
+++ b/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_full_audit_improvement.md
@@ -1,0 +1,155 @@
+# IMPLEMENTATION — RussianTranslation full-audit improvement (wave-1)
+
+_Created: 23-07-2026 · Last updated: 23-07-2026_
+
+Parent: [PLAN_RussianTranslation_full_audit_improvement_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.md).
+
+Execute **one track handoff at a time** (or parallel handoffs in separate worktrees).
+Order for a single agent doing the must set: **C (if docs not already on master) → A → B → D → E**.
+
+Working directory for all steps:
+`C:\Users\user\Documents\GitHub\SanskritLexicography\RussianTranslation`
+(via worktree checkout of the monorepo root).
+
+---
+
+## Track C — umbrella docs (often already landed by the `/ask` authoring session)
+
+1. Confirm these files exist under `RussianTranslation/docs/`:
+   - `PLAN_RussianTranslation_full_audit_improvement_2026H2.md` (+ `.meta.md`)
+   - `ROADMAP_…`, `ARCHITECTURE_…`, `IMPLEMENTATION_…`, `VERIFICATION_…`
+2. Add a row to [Uprava/ROADMAP_INDEX.md](https://github.com/gasyoun/Uprava/blob/main/ROADMAP_INDEX.md) Tier-1 RussianTranslation table pointing at the ROADMAP.
+3. Add a short “Improvement programme” pointer near the top of
+   [RussianTranslation/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/README.md)
+   Operating / Milestones section → full blob URL to the PLAN.
+4. Append `[Unreleased]` CHANGELOG bullet for the plan set.
+5. Point `.ai_state.md` Next Steps at the PLAN + track handoffs.
+
+**Files:** docs/* listed · README.md · CHANGELOG.md · `.ai_state.md` · Uprava ROADMAP_INDEX.md
+
+---
+
+## Track A+F — H1403 A2+A3 (must)
+
+### A2 — instrumentation
+
+1. Read `src/pilot/audit_window.py` CLI block (~429+) and `window_reports.py` ledger writer.
+2. Implement `derive_wall_clock_minutes(wf_path, meta, cli_value) -> (minutes|None, source)` in
+   `window_reports.py` (or a tiny helper in the same module — no new package).
+3. When `args.wall_clock_minutes` is None, call derive; stamp `performance_metrics` /
+   ledger fields with `wall_clock_source`.
+4. Emit one `stage_boundary` dashboard event at audit start and audit end if
+   `dashboard_events.py` already has an emit API; if not, add a minimal
+   `emit_stage_boundary(stage, window_tag, ts)` append-only JSONL under
+   `src/pilot/output/` (gitignored path) — do not invent a server.
+5. Pin tests in `window_selftest.py`:
+   - explicit CLI wins over derive
+   - derive from fixture mtimes
+   - unavailable → null + source tag (no crash)
+
+### A3 — promote defect refusal
+
+1. Read `src/promote_final_cards.py` argparse (`--force` ~970) and merge path.
+2. Add discovery of defect keys: optional `--defect-keys PATH`; else if
+   `src/pilot/output/requeue.keys.defect` or sibling `.defect` exists for the
+   invoked context, load it.
+3. Before merge, intersect incoming keys with defect set; if any overlap and not
+   `--force`, exit non-zero with a clear list (no store write).
+4. Selftest: temp store + temp defect list → refuse; with `--force` → allow
+   (still use temp store only).
+
+### A3 — ready_partial helper
+
+1. Add `promote_ready_partial_clean(lease_or_report, *, dry_run=True)` either as
+   a function in `promote_final_cards.py` or `coordinator.py` **called only from
+   CLI with default dry_run=True**.
+2. Behavior: given an audit report JSON marking clean vs pending keys, promote
+   **only** clean keys into a **fixture store** in tests; production CLI requires
+   explicit `--apply` (still fenced in wave-1 handoff: document but tests use temp).
+3. Default for wave-1 agent: implement + test; do not run `--apply` on live store.
+
+### LANG_PARITY
+
+1. If SHARED with EN (`promote_en` path or shared report fields), update
+   `LANG_PARITY.md` and re-hash via `lang_parity_check.py`.
+
+### Verify A
+
+```powershell
+python -m py_compile src\pilot\audit_window.py src\pilot\window_reports.py src\promote_final_cards.py
+python src\pilot\window_selftest.py
+python src\pilot\lang_parity_check.py
+```
+
+---
+
+## Track B — cohort / promotion ledger scaffold (must)
+
+**Do not implement the multi-profile scheduler.** Align names with H1437 if that
+branch already landed symbols on master.
+
+1. Add `src/pilot/promotion_receipt.py` (or H1437's chosen path if present):
+   - dataclasses / TypedDict for binding + receipt
+   - `write_receipt(path, receipt)`, `load_receipts(dir)`
+   - `reconcile_startup(receipts, store_keys) -> ReconcilePlan`
+2. Fixtures under `src/pilot/fixtures/cohort_scaffold/`:
+   - serial accept
+   - crash after receipt before store (promote_missing)
+   - double receipt same keys (skip_already_present)
+   - inconsistent row counts (error)
+3. `promotion_receipt_selftest.py` or block inside `window_selftest.py`.
+4. Optional: document field list in ARCHITECTURE (already) — no coordinator wiring
+   required for wave-1 complete.
+
+### Verify B
+
+```powershell
+python src\pilot\promotion_receipt_selftest.py
+# or the window_selftest block name documented in the PR
+python src\pilot\window_selftest.py
+```
+
+**If H1437 worktree conflicts:** stop Track B code; leave a Dev Note; do not
+overwrite H1437 in-flight files (autonomy stop condition c).
+
+---
+
+## Track D — quality apply dry-run (best-effort)
+
+1. New `src/pilot/apply_editorial_decisions.py` (name OK to adjust):
+   - `--abbrev-decisions pwg_ru/eval/h1303_abbrev.decisions.json`
+   - `--style-decisions pwg_ru/eval/h1306_style.decisions.json`
+   - `--store` default to canonical store path helper **read-only**
+   - `--dry-run` default True; **refuse** if dry-run false unless env
+     `PWG_RU_ALLOW_EDITORIAL_APPLY=1` (wave-1 never sets this)
+2. Output: JSON + markdown delta counts (tokens that would change, sample keys).
+3. If decisions files missing: exit 0 with `status: pending_votes` (not a failure).
+4. Selftest with synthetic decisions + 2–3 fixture store rows in temp dir.
+
+---
+
+## Track E — thin pointers (best-effort, complete when handoff body is filled)
+
+Handoff body contains only:
+
+```
+Read <PLAN_pubgrade_tm> and execute its wave-1 track A offline scope.
+Read <PLAN_saru_gloss> and execute remaining waves per that plan's autonomy contract.
+```
+
+No new code required for E to be “done”.
+
+---
+
+## PR / git sequence (each track)
+
+1. `git fetch origin`
+2. `git worktree add … -b h<id>-<slug> origin/master`
+3. Implement + tests
+4. Commit (complete sentences)
+5. Push + `gh pr create` + enable auto-merge if green
+6. Remove worktree after merge
+
+Never commit in the shared `SanskritLexicography` main checkout.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.md
+++ b/RussianTranslation/docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.md
@@ -1,0 +1,139 @@
+# PLAN — RussianTranslation full audit → improvement portfolio (2026 H2)
+
+_Created: 23-07-2026 · Last updated: 23-07-2026_
+
+**Index / cover doc.** Entry point for the post-audit improvement programme of
+[`RussianTranslation/`](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation).
+A fresh agent executes a **wave-1 track** by reading this file, then the four
+layer docs, then its handoff's scoped section. Every decision a builder would
+hit is ruled below — a dangling `@DECIDE` on a wave-1 must-complete path is a
+defect.
+
+## Goal (one paragraph)
+
+RussianTranslation is a mature hybrid: a production PWG→RU factory (headless
+CLI, coordinator, ~11.6k promoted rows, heavy hardening through H1339/H1386)
+plus research/TM/gloss tracks and a large human-gated editorial surface. A
+full audit (23-07-2026) found that **the highest leverage is not new
+mechanisms** — the H1403 speed audit already showed 0/8 greenfield speed
+ideas surviving unmodified — but **closing operator/telemetry residues,
+scaffolding the cohort ledger H1437 depends on, and giving operators one
+umbrella sequence** over the two existing `/ask` plans (pubgrade TM, Sa→Ru
+gloss) and the live drain. Wave-1 is an **offline ≥8 h portfolio**: production
+path residues (A+F), cohort/promotion ledger scaffold (B), and this umbrella
+doc set (C), with best-effort quality-apply dry-run machinery (D) and thin
+pointers to existing TM/gloss plans (E). **No paid generation. No live store
+mutation.** Wave-2 starts only after wave-1 + a fresh health GO.
+
+## The four layer docs
+
+| Layer | Doc |
+|---|---|
+| Waves, deliverables, non-goals | [ROADMAP_RussianTranslation_full_audit_improvement_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/ROADMAP_RussianTranslation_full_audit_improvement_2026H2.md) |
+| Component boundaries, data model, build-vs-reuse | [ARCHITECTURE_RussianTranslation_full_audit_improvement.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_full_audit_improvement.md) |
+| File-level, step-ordered build sequence | [IMPLEMENTATION_RussianTranslation_full_audit_improvement.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_full_audit_improvement.md) |
+| Acceptance criteria, proof commands, risk register | [VERIFICATION_RussianTranslation_full_audit_improvement.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/VERIFICATION_RussianTranslation_full_audit_improvement.md) |
+
+## Existing plans this umbrella indexes (authoritative for their scope)
+
+| Programme | PLAN (do not rewrite decisions) |
+|---|---|
+| Publication-grade Sa→Ru TM + oral (finish H215) | [PLAN_RussianTranslation_pubgrade_tm_oral_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_pubgrade_tm_oral_2026H2.md) |
+| Sa→Ru gloss quality uplift | [PLAN_RussianTranslation_saru-gloss-quality_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md) |
+| Bounded multi-profile cohort (claimed, deeper than Track B) | [H1437](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1437-Fable_RussianTranslation_bounded-wave-barrier-promotion-ledger_21.07.26.md) |
+| Live medium50 / serial-c4 drain prep | [H1447 packet](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h1447/H1447_C4_LIVE_GATE_2026-07-22.md) |
+
+## Decisions taken (Phase-2 interview, 23-07-2026)
+
+| # | Fork | Ruling | Rationale |
+|---|---|---|---|
+| R1.1 | Wave-1 “done” | **Balanced portfolio (2–3 must tracks + best-effort)** | Full coverage without a single mega-handoff. |
+| R1.2 | 1–2 month primary objective | **One handoff per programme/track** | Portfolio of scoped executables, not one omnibus task. |
+| R1.3 | Out of wave-1 | **No paid live generation** | Max/API spend reserved for wave-2 after health GO. |
+| R1.4 | Relation to existing `/ask` plans | **Umbrella: index + order only** | H215 and Sa→Ru gloss plans stay authoritative for their scope. |
+| R1.5 | Store safety | **Never risk gitignored store** | Dry-run / fixtures only in wave-1; no real promote merge. |
+| R1.6 | Portfolio size | **8 h wave-1 + clear wave-2/3** | Enough for unattended build; later waves sketched for minting. |
+| R2.1 | Wave-1 tracks | **Must: A+F, B, C · Best-effort: D then E** | A includes instrumentation (F is not a separate code path). |
+| R2.2 | Handoff minting | **One handoff per wave-1 track** | A, B, C, D, E → five handoffs; E is a thin pointer. |
+| R2.3 | Live drain placement | **Wave-2 immediately after wave-1 + fresh health GO** | Production volume is next, not blocked on editorial votes. |
+| R2.4 | Build style | **Surgical only — extend existing modules** | No greenfield frameworks. |
+| R2.5 | Existing PLAN docs | **Keep authoritative; umbrella links** | No mega-rewrite of H215 / gloss plans. |
+| R2.6 | Wave-1 success bar | **Green selftests + PR(s) merged + umbrella docs committed** | Machine-checkable. |
+| R3.1 | Time ranking | **Must A+F/B/C; best-effort D then E** | Core 8 h protected. |
+| R3.2 | Track A scope | **Full H1403 A2+A3 set** | Telemetry auto + promote defect-refusal + ready_partial helper. |
+| R3.3 | Track B depth | **Scaffold + selftests only; no multi-profile live** | Does not replace H1437; feeds its Phase-0 prerequisites. |
+| R3.4 | Track D without votes | **Apply machinery + dry-run; never write store** | Votes remain human `@DO`. |
+| R3.5 | Track E body | **None — handoff points at existing PLANs only** | Avoid re-implementing H215/H1349. |
+| R3.6 | LANG_PARITY | **Update ledger + hashes when SHARED surfaces change** | Standing MG rule: EN stays level with RU. |
+| R4.1 | Track A proof | **Pinned `window_selftest` + module selftests green** | |
+| R4.2 | Track B proof | **Schema + selftests; no live coordinator run** | |
+| R4.3 | Track C proof | **Five-layer docs + metadoc + ROADMAP_INDEX row** | |
+| R5.1 | On ambiguity | **Pick plan default, log in `.ai_state` Dev Notes, continue** | |
+| R5.2 | Commit authority | **Worktree → PR → auto-merge on green CI** | Never commit in shared main checkout. |
+| R5.3 | Explicit fence (R5 multi) | **No paid generation / Max Workflow / headless production translate** | Combined with R1.5 store fence. |
+
+## Autonomy contract (verbatim — unattended execution rules)
+
+**On unplanned ambiguity.** Apply the plan's marked default for that fork, record
+the choice in [`RussianTranslation/.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md)
+Dev Notes (one line: `default-taken: <fork> → <choice>`), and continue. Park-and-skip
+an item ONLY when no default in this plan applies. Never halt the whole portfolio for
+one fork.
+
+**Stop conditions (halt that track + report; other tracks may continue).** Halt a
+track if: (a) CI goes red and the fix is outside the track's file list; (b) a change
+would require writing the live store or running paid generation; (c) H1437's claimed
+worktree already owns a file and a clean merge is impossible without overwriting
+in-flight H1437 work — park Track B with a note, do not force; (d) `window_selftest`
+cannot be made green after one genuine fix attempt on the failing assertion.
+
+**Commit authority.** Full commit → PR → auto-merge on green CI, **one PR per track
+handoff**, in an isolated worktree off `origin/master`
+(`SanskritLexicography-h<id>-<pid>`). Delete branch after merge; remove worktree same
+pass. Prefer rebase onto latest master before open if H1437 or other PRs land mid-run.
+
+**The fence — never do these unattended:**
+
+1. **No paid generation** — no Max Workflow, no headless production translate, no
+   health probes that burn model quota (offline fixtures and pure-Python probes only).
+2. **No live store mutation** — never run `promote_final_cards.py` against
+   `src/pwg_ru_translated.jsonl` without `--dry-run` (and even dry-run must not
+   rewrite the store). Fixtures and temp dirs only.
+3. **No publication** — no Pages, visibility, DOI, Zenodo.
+4. **No direct commits to guarded main-tree checkout** — worktree only.
+5. **No destruction of non-rebuildable assets** — `corpus_lexicon.jsonl`, live TM
+   bulk, NWS dumps: read-only.
+6. **Scope** — RussianTranslation + Uprava handoff registry only (no SamudraManthanam
+   / SanskritRussian data rewrites in wave-1).
+
+## Wave summary
+
+| Wave | Tracks | Paid gen? | Store write? |
+|---|---|---|---|
+| **1 (8 h must)** | A+F production residues · B ledger scaffold · C umbrella docs | No | No |
+| **1 best-effort** | D quality dry-run apply · E thin PLAN pointers | No | No |
+| **2** | Fresh health GO → medium50 / serial-c4 drain (H1447 path) | Yes (gated) | Yes (audited promote only) |
+| **3** | H215 pubgrade TM + Sa→Ru gloss continuation + editorial apply after votes | Mostly offline / rights-gated | Editorial apply only after votes |
+
+## Autonomy-readiness gate verdict
+
+**PASS.** Every must-complete wave-1 deliverable has architecture, ordered
+implementation steps, acceptance criteria, and risks. Zero blocking forks remain
+on the must path. Prior-art: surgical extension of existing pilot modules; H215
+and gloss plans reused not rebuilt; H1437 remains the live multi-profile vehicle
+— Track B only scaffolds binding/receipt/reconcile tests it needs. Defaults cover
+ambiguity (R5.1). Best-effort D/E may finish partial without failing the gate.
+
+## Audit snapshot (inputs to this plan)
+
+| Axis | Finding (23-07-2026) |
+|---|---|
+| Store | ~11,603 rows / ~26 MB; ~8–10% of long-run target |
+| Code | ~298 `src/**/*.py`, ~89 `src/pilot/*.py` |
+| Production route | Headless CLI + coordinator (H1110); Workflow forensics only |
+| Speed (H1403) | Needle = execute queued work + telemetry; not new orchestration |
+| Live head | H1447 medium50 prepared; needs **fresh** health PASS |
+| Human gates | H1303, H1306, h178 residual, Renou v2, H180×3 await votes |
+| Doc surface | Many dated audits; umbrella reduces cold-start thrash |
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.meta.md
+++ b/RussianTranslation/docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.meta.md
@@ -1,0 +1,51 @@
+# PLAN_RussianTranslation_full_audit_improvement_2026H2 — metadoc
+
+_Created: 23-07-2026 · Last updated: 23-07-2026_
+
+Companion record for [PLAN_RussianTranslation_full_audit_improvement_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.md)
+and its four layer docs (ROADMAP / ARCHITECTURE / IMPLEMENTATION / VERIFICATION).
+
+## Purpose
+
+Execution-ready `/ask` umbrella for the RussianTranslation **full audit → improvement
+portfolio**: offline wave-1 (production residues + cohort ledger scaffold + docs), then
+health-gated drain, then existing TM/gloss/editorial programmes. Single cold-start index
+so agents stop re-deriving priority from dozens of dated audits.
+
+## Audience
+
+- Fresh execution agents (Sonnet/Opus) on track handoffs A–E
+- MG for human votes and wave-2 health GO
+
+## Provenance
+
+- Authored 23-07-2026 via `/ask` (interview 4 rounds: goals · architecture · implementation ·
+  verification/autonomy).
+- Model for this authoring session: Grok 4.5 (`grok-4.5` / xAI Grok Build).
+- Audit inputs: live `.ai_state.md`, store ~11,603 rows, H1403 speed audit, H1437 handoff,
+  existing pubgrade-TM and Sa→Ru gloss `/ask` plans, SCALE_READINESS and pipeline history.
+
+## Key decisions
+
+Must tracks A+F/B/C; best-effort D then E; no paid gen; never risk store; surgical edits;
+umbrella indexes (does not supersede) H215 and gloss plans; one handoff per track; drain is
+wave-2 after fresh health GO. Full table in the PLAN.
+
+## Improvement backlog (ranked)
+
+1. After Track A lands, re-measure ledger fill rate (target: wall_clock_source non-null on ≥80% of new rows).
+2. When H1437 merges, mark Track B scaffold as consumed / delete duplicate if any.
+3. After H1303/H1306 votes, promote Track D from dry-run to a gated apply handoff.
+4. Optional wave-2+: Message Batches API probe (H1403 A8) as a separate research handoff.
+
+## Limitations
+
+- Wave-1 does not move store coverage numbers.
+- Track B is intentionally weaker than full H1437 (scaffold only).
+- Stale-audit map is a filter, not an archive migration (files stay in place).
+
+## Revision history
+
+- 23-07-2026 — created (`/ask` full-audit improvement).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/ROADMAP_RussianTranslation_full_audit_improvement_2026H2.md
+++ b/RussianTranslation/docs/ROADMAP_RussianTranslation_full_audit_improvement_2026H2.md
@@ -1,0 +1,78 @@
+# ROADMAP — RussianTranslation full-audit improvement programme (2026 H2)
+
+_Created: 23-07-2026 · Last updated: 23-07-2026_
+
+Parent index: [PLAN_RussianTranslation_full_audit_improvement_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.md).
+
+## Wave 1 — offline factory + umbrella (must, ≥8 h portfolio)
+
+Unblocks safe, measured operation and a single navigation hub. **No paid gen, no store write.**
+
+| Track | Deliverable | Unblocks | Effort |
+|---|---|---|---|
+| **A+F** | H1403 A2+A3 residues: auto wall-clock + stage_boundary; promote refuse defect keys without `--force`; `ready_partial` clean-subset promote helper; LANG_PARITY update if SHARED | Closed-loop economy; removes promote-then-revert footgun | ~3–4 h |
+| **B** | Attempt/result/run binding + promotion receipt + reconcile pure functions + fixture selftests (no multi-profile live) | H1437 Phase-0 prerequisites; crash-safe promote accounting | ~2–3 h |
+| **C** | This five-layer plan + metadoc + ROADMAP_INDEX + README pointer + stale-audit map | Cold-start; one handoff per later programme | ~1–2 h (authoring session) |
+
+**Must-complete success:** each of A, B, C has a merged PR (or C lands with the plan PR) and green tests per [VERIFICATION](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/VERIFICATION_RussianTranslation_full_audit_improvement.md).
+
+### Wave 1 best-effort
+
+| Track | Deliverable | If incomplete |
+|---|---|---|
+| **D** | `apply_style_abbrev_decisions.py` (name flexible) dry-run CLI over H1303/H1306 `decisions.json` → delta report; never writes store | Handoff remains queued; zero partial store risk |
+| **E** | Thin handoff bodies whose starter lines point at pubgrade TM + Sa→Ru gloss PLANs | Pointer-only is complete |
+
+## Wave 2 — live drain (after wave-1 + fresh health GO)
+
+| Step | Deliverable | Gate |
+|---|---|---|
+| 2.0 | Fresh c4 (or chosen profile) health PASS via `/pwg-live-gate` Step 1 | Stale GO (incl. H1447's) never authorizes spend |
+| 2.1 | Resume H1447 medium50 plan (regenerate claims if worktree state gone) | `--stop-before-promote` |
+| 2.2 | `/pwg-window-close` path for clean windows; requeue defect/transient | Track A refuse-defect on any accidental promote |
+| 2.3 | Serial frequency / nominal drain per [RUN_FREQ_MAX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_FREQ_MAX.md) | ≤3-wide global; single promoter |
+
+**Non-goals for wave-2:** multi-profile live (that's H1437 after scaffold); monster kAla-class without explicit human budget.
+
+## Wave 3 — research + editorial (parallel after or alongside late wave-2)
+
+| Programme | Source of truth | Notes |
+|---|---|---|
+| Pubgrade TM + oral | [PLAN_…_pubgrade_tm_oral…](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_pubgrade_tm_oral_2026H2.md) | Tracks A/B/C as already ruled; nothing auto-publishes |
+| Sa→Ru gloss W3–W4 | [PLAN_…_saru-gloss…](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_saru-gloss-quality_2026H2.md) | No published-data rewrite without human GO |
+| Editorial apply | Track D machinery + MG votes on H1303/H1306/h178/Renou/H180 | Apply only after `decisions.json` present |
+| Cohort multi-profile | [H1437](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1437-Fable_RussianTranslation_bounded-wave-barrier-promotion-ledger_21.07.26.md) | Fable + Codex phase gates; offline until P0 proven |
+
+## Stale-audit map (cold-start filter)
+
+Treat as **history / evidence**, not live queue:
+
+| Doc | Role today |
+|---|---|
+| [STRATEGY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/STRATEGY.md) | Historical strategy; concurrency numbers pre-headless |
+| [REVIEW_AND_ROADMAP.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/REVIEW_AND_ROADMAP.md) | Jun 2026 corpus-first narrative; frequency pivot still valid |
+| [ARCHITECTURE_AUDIT_2026-07-02.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ARCHITECTURE_AUDIT_2026-07-02.md) | S10 failure modes — mostly closed |
+| [SCALE_READINESS_CENSUS_2026-07-12.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/SCALE_READINESS_CENSUS_2026-07-12.md) | Point-in-time; API state changes daily |
+| [PWG_RU_SPEED_…_2026-07-20.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_RU_SPEED_ORCHESTRATION_BOTTLENECK_AUDIT_2026-07-20.md) | Action map still load-bearing for Track A |
+| [PIPELINE_CAPABILITY_AUDIT_2026-07-08.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_CAPABILITY_AUDIT_2026-07-08.md) | H335; government etc. largely landed |
+
+**Live truth order:** [`.ai_state.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md) → this PLAN → `src/pilot/RUN_FREQ_MAX.md` → `window_status.json` / coordinator state.
+
+## Explicit non-goals (whole programme unless a later interview re-opens)
+
+- Rebuilding Max-Workflow as the production route
+- Greenfield orchestration daemon
+- Anthropic Message Batches integration in wave-1 (probe is wave-2+ research, optional)
+- mw_ru re-translation
+- EN bulk scale-up (LANG_PARITY mechanical only)
+- Agent-cast votes on review sheets
+- csl-orig corrections
+- Auto-publish of TM / store text
+
+## Human `@DO` (not agent wave-1)
+
+- Vote H1303 abbrev sheet, H1306 style sheet, h178 residual, Renou v2, H180×3
+- Fresh health only when intending wave-2 spend
+- Optional: authenticate c5/c6 (not required for serial-c4)
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/VERIFICATION_RussianTranslation_full_audit_improvement.md
+++ b/RussianTranslation/docs/VERIFICATION_RussianTranslation_full_audit_improvement.md
@@ -1,0 +1,94 @@
+# VERIFICATION — RussianTranslation full-audit improvement
+
+_Created: 23-07-2026 · Last updated: 23-07-2026_
+
+Parent: [PLAN_RussianTranslation_full_audit_improvement_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_full_audit_improvement_2026H2.md).
+
+## Track acceptance criteria
+
+### Track A+F (must)
+
+| # | Criterion | Proof command / artifact |
+|---|---|---|
+| A1 | Wall-clock auto-derive when CLI flag omitted | `window_selftest` case; ledger fixture shows `wall_clock_source` |
+| A2 | Explicit `--wall-clock-minutes` still wins | unit assertion |
+| A3 | stage_boundary or documented emit path exists | test or grep-stable function + one fixture call |
+| A4 | Promote refuses intersection with defect keys without `--force` | promote selftest on temp store |
+| A5 | Promote allows same with `--force` | same selftest |
+| A6 | ready_partial clean-subset helper tested dry | selftest; no live store |
+| A7 | `window_selftest` green; `lang_parity_check` no unexpected drift | full run |
+| A8 | PR merged | GitHub PR URL in handoff close note |
+
+### Track B (must)
+
+| # | Criterion | Proof |
+|---|---|---|
+| B1 | Receipt schema v1 load/save round-trip | selftest |
+| B2 | reconcile: missing / present / inconsistent cases | three fixtures |
+| B3 | No multi-profile live code required | PR diff review — no default route change |
+| B4 | `window_selftest` or dedicated selftest green | CI |
+| B5 | PR merged | URL |
+
+### Track C (must)
+
+| # | Criterion | Proof |
+|---|---|---|
+| C1 | Five layer docs + PLAN.meta.md present | paths under `docs/` |
+| C2 | ROADMAP_INDEX Tier-1 row | Uprava file |
+| C3 | README pointer to PLAN | link resolves |
+| C4 | CHANGELOG `[Unreleased]` bullet | file |
+| C5 | Full blob URLs, dated header, byline | md hygiene |
+
+### Track D (best-effort)
+
+| # | Criterion | Proof |
+|---|---|---|
+| D1 | Dry-run default; missing votes → pending status exit 0 | CLI |
+| D2 | Synthetic decisions → non-empty delta report | selftest |
+| D3 | Cannot write store without explicit env gate | selftest attempting write fails |
+
+### Track E (best-effort)
+
+| # | Criterion | Proof |
+|---|---|---|
+| E1 | Handoff starter lines point at existing PLANs | handoff file |
+
+## Portfolio done (wave-1)
+
+- [ ] A1–A8
+- [ ] B1–B5
+- [ ] C1–C5
+- [ ] D optional
+- [ ] E optional
+- [ ] Live store row count unchanged by agent actions (spot-check mtime/size before/after)
+- [ ] Zero paid generation in session logs
+
+## Risks & spikes
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| H1437 concurrent edit of same files | Track B conflict | Stop condition c; prefer H1437 symbols; park B |
+| derived wall-clock overstates gen time | Bad economy metrics | `wall_clock_source` tag; stage_boundary later |
+| Defect list path wrong → silent skip | Footgun remains | Log `defect_guard: skipped_no_list`; test discoverable paths |
+| ready_partial helper mis-wired to live promote | Store risk | Default dry_run; wave-1 fence; temp-only tests |
+| LANG_PARITY dirty CI | Red PR | Update hashes same PR |
+| Agent treats H1447 resume as wave-1 | Paid spend | Explicit fence; handoff scope = offline only |
+
+## Non-goals verification (must stay false)
+
+- [ ] No new commits that invoke `headless_worker` production translate
+- [ ] No decrease in `pwg_ru_translated.jsonl` size from agent promote
+- [ ] No Pages/DOI actions
+
+## Suggested smoke after all must tracks merge
+
+```powershell
+cd RussianTranslation
+python src\pilot\window_selftest.py
+python src\pilot\lang_parity_check.py
+python -m py_compile src\promote_final_cards.py src\pilot\window_reports.py
+# optional if B landed:
+python src\pilot\promotion_receipt_selftest.py
+```
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
## Summary
- Full /ask audit + layered umbrella plan under RussianTranslation/docs/
- Wave-1 offline tracks H1553-H1556; indexes existing TM/gloss plans
- README + CHANGELOG + .ai_state pointers

## Test plan
- [x] Docs only; links use full blob URLs