### PR TITLE
feat(pwg_ru): H1554 Track B — promotion_receipt schema v1 + reconcile fixtures

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,18 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added — promotion receipt scaffold (H1554 Track B)
+
+- **`src/pilot/promotion_receipt.py`** — pure offline schema v1:
+  `AttemptRunBinding`, `PromotionReceipt` (`pwg_ru.promotion_receipt.v1`),
+  `write_receipt` / `load_receipt` / `load_receipts`, and
+  `reconcile_startup(receipts, observed_store_keys) → ReconcilePlan`
+  with buckets `{promote_missing, skip_already_present, error_inconsistent}`.
+- Fixtures under `src/pilot/fixtures/cohort_scaffold/` (three reconcile cases).
+- Pinned by `python src/pilot/promotion_receipt_selftest.py` (6/6).
+- Scaffold only for H1437 Phase-1 prerequisites — **no** multi-profile live
+  scheduler, no coordinator wiring, no paid gen, no live store write.
+
 ### Added — H1403 A2+A3 production residues (H1553 Track A)
 
 - **Wall-clock auto-derive** in `window_reports.derive_wall_clock_minutes` /

--- a/RussianTranslation/src/pilot/fixtures/cohort_scaffold/error_inconsistent.json
+++ b/RussianTranslation/src/pilot/fixtures/cohort_scaffold/error_inconsistent.json
@@ -1,0 +1,34 @@
+{
+  "fixture_id": "cohort_scaffold.error_inconsistent",
+  "description": "Two inconsistency modes: partial store presence, and receipt row-count invariant break.",
+  "expected_kind": "error_inconsistent",
+  "observed_store_keys": ["preexisting_root_a", "dah.1"],
+  "receipts": [
+    {
+      "schema": "pwg_ru.promotion_receipt.v1",
+      "run_id": "run-wave1-002",
+      "attempt_id": "attempt-partial",
+      "lease_id": "lease-dah-w02",
+      "keys_accepted": ["dah.1", "dah.2"],
+      "keys_rejected": [],
+      "store_path": "fixtures/cohort_scaffold/store_stub.jsonl",
+      "row_count_before": 1,
+      "row_count_after": 3,
+      "tm_rebuild": false,
+      "created_at": "2026-07-23T13:00:00Z"
+    },
+    {
+      "schema": "pwg_ru.promotion_receipt.v1",
+      "run_id": "run-wave1-003",
+      "attempt_id": "attempt-bad-delta",
+      "lease_id": "lease-dah-w03",
+      "keys_accepted": ["foo.1", "foo.2"],
+      "keys_rejected": [],
+      "store_path": "fixtures/cohort_scaffold/store_stub.jsonl",
+      "row_count_before": 10,
+      "row_count_after": 11,
+      "tm_rebuild": false,
+      "created_at": "2026-07-23T13:01:00Z"
+    }
+  ]
+}

--- a/RussianTranslation/src/pilot/fixtures/cohort_scaffold/promote_missing.json
+++ b/RussianTranslation/src/pilot/fixtures/cohort_scaffold/promote_missing.json
@@ -1,0 +1,21 @@
+{
+  "fixture_id": "cohort_scaffold.promote_missing",
+  "description": "Crash after receipt sealed, before store write — all accepted keys missing from store.",
+  "expected_kind": "promote_missing",
+  "observed_store_keys": ["preexisting_root_a"],
+  "receipts": [
+    {
+      "schema": "pwg_ru.promotion_receipt.v1",
+      "run_id": "run-wave1-001",
+      "attempt_id": "attempt-1",
+      "lease_id": "lease-dah-w01",
+      "keys_accepted": ["dah.1", "dah.2"],
+      "keys_rejected": ["dah.3"],
+      "store_path": "fixtures/cohort_scaffold/store_stub.jsonl",
+      "row_count_before": 1,
+      "row_count_after": 3,
+      "tm_rebuild": false,
+      "created_at": "2026-07-23T12:00:00Z"
+    }
+  ]
+}

--- a/RussianTranslation/src/pilot/fixtures/cohort_scaffold/skip_already_present.json
+++ b/RussianTranslation/src/pilot/fixtures/cohort_scaffold/skip_already_present.json
@@ -1,0 +1,34 @@
+{
+  "fixture_id": "cohort_scaffold.skip_already_present",
+  "description": "Double receipt / resume after successful promote — accepted keys already in store.",
+  "expected_kind": "skip_already_present",
+  "observed_store_keys": ["preexisting_root_a", "dah.1", "dah.2"],
+  "receipts": [
+    {
+      "schema": "pwg_ru.promotion_receipt.v1",
+      "run_id": "run-wave1-001",
+      "attempt_id": "attempt-1",
+      "lease_id": "lease-dah-w01",
+      "keys_accepted": ["dah.1", "dah.2"],
+      "keys_rejected": ["dah.3"],
+      "store_path": "fixtures/cohort_scaffold/store_stub.jsonl",
+      "row_count_before": 1,
+      "row_count_after": 3,
+      "tm_rebuild": true,
+      "created_at": "2026-07-23T12:00:00Z"
+    },
+    {
+      "schema": "pwg_ru.promotion_receipt.v1",
+      "run_id": "run-wave1-001",
+      "attempt_id": "attempt-1-replay",
+      "lease_id": "lease-dah-w01",
+      "keys_accepted": ["dah.1", "dah.2"],
+      "keys_rejected": ["dah.3"],
+      "store_path": "fixtures/cohort_scaffold/store_stub.jsonl",
+      "row_count_before": 1,
+      "row_count_after": 3,
+      "tm_rebuild": true,
+      "created_at": "2026-07-23T12:05:00Z"
+    }
+  ]
+}

--- a/RussianTranslation/src/pilot/promotion_receipt.py
+++ b/RussianTranslation/src/pilot/promotion_receipt.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python
+"""Promotion receipt schema v1 + pure startup reconcile (H1554 Track B scaffold).
+
+Offline / pure-function module. No coordinator wiring, no live store mutation, no
+multi-profile scheduler (that is H1437). Wave-1 only lands:
+
+  * ``AttemptRunBinding`` — run/attempt/lease identity for sealed work
+  * ``PromotionReceipt`` — durable receipt after a wave's acceptance barrier
+  * ``write_receipt`` / ``load_receipt`` / ``load_receipts``
+  * ``reconcile_startup(receipts, observed_store_keys) -> ReconcilePlan``
+
+Contract (ARCHITECTURE_RussianTranslation_full_audit_improvement.md §B):
+
+  reconcile_startup → {promote_missing, skip_already_present, error_inconsistent}
+
+H1437 may later rename/extend symbols; prefer their names if they land first.
+This module is deliberately thin so H1437 can consume it without dual systems.
+
+Authored for H1554 by Grok 4.5 (override of Opus 4.8 lock). Offline only.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+SCHEMA_V1 = 'pwg_ru.promotion_receipt.v1'
+RECEIPT_FILENAME_SUFFIX = '.promotion_receipt.json'
+
+# Reconcile action kinds (stable string tags for fixtures + callers).
+PROMOTE_MISSING = 'promote_missing'
+SKIP_ALREADY_PRESENT = 'skip_already_present'
+ERROR_INCONSISTENT = 'error_inconsistent'
+
+
+@dataclass(frozen=True)
+class AttemptRunBinding:
+    """Identity of one sealed attempt under a scheduler run / lease."""
+
+    run_id: str
+    attempt_id: str
+    lease_id: str
+
+    def __post_init__(self) -> None:
+        for name in ('run_id', 'attempt_id', 'lease_id'):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError('AttemptRunBinding.%s must be a non-empty string' % name)
+
+
+@dataclass(frozen=True)
+class PromotionReceipt:
+    """Durable promotion receipt (schema v1).
+
+    Written after a wave's acceptance barrier *claims* which keys should land;
+    reconcile_startup compares this claim to the observed store key set on restart.
+    """
+
+    schema: str
+    run_id: str
+    attempt_id: str
+    lease_id: str
+    keys_accepted: tuple[str, ...]
+    keys_rejected: tuple[str, ...]
+    store_path: str
+    row_count_before: int
+    row_count_after: int
+    tm_rebuild: bool
+    created_at: str
+
+    def binding(self) -> AttemptRunBinding:
+        return AttemptRunBinding(
+            run_id=self.run_id,
+            attempt_id=self.attempt_id,
+            lease_id=self.lease_id,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'schema': self.schema,
+            'run_id': self.run_id,
+            'attempt_id': self.attempt_id,
+            'lease_id': self.lease_id,
+            'keys_accepted': list(self.keys_accepted),
+            'keys_rejected': list(self.keys_rejected),
+            'store_path': self.store_path,
+            'row_count_before': self.row_count_before,
+            'row_count_after': self.row_count_after,
+            'tm_rebuild': self.tm_rebuild,
+            'created_at': self.created_at,
+        }
+
+
+@dataclass(frozen=True)
+class ReconcileAction:
+    """One reconcile decision for a single receipt's accepted-key set."""
+
+    kind: str
+    lease_id: str
+    run_id: str
+    attempt_id: str
+    keys: tuple[str, ...]
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'kind': self.kind,
+            'lease_id': self.lease_id,
+            'run_id': self.run_id,
+            'attempt_id': self.attempt_id,
+            'keys': list(self.keys),
+            'reason': self.reason,
+        }
+
+
+@dataclass
+class ReconcilePlan:
+    """Partition of receipts into the three reconcile buckets."""
+
+    promote_missing: list[ReconcileAction] = field(default_factory=list)
+    skip_already_present: list[ReconcileAction] = field(default_factory=list)
+    error_inconsistent: list[ReconcileAction] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            PROMOTE_MISSING: [a.to_dict() for a in self.promote_missing],
+            SKIP_ALREADY_PRESENT: [a.to_dict() for a in self.skip_already_present],
+            ERROR_INCONSISTENT: [a.to_dict() for a in self.error_inconsistent],
+        }
+
+
+def make_receipt(
+    binding: AttemptRunBinding,
+    *,
+    keys_accepted: Sequence[str],
+    keys_rejected: Sequence[str] | None = None,
+    store_path: str,
+    row_count_before: int,
+    row_count_after: int,
+    tm_rebuild: bool = False,
+    created_at: str,
+    schema: str = SCHEMA_V1,
+) -> PromotionReceipt:
+    """Build a validated PromotionReceipt from an AttemptRunBinding + payload."""
+    return receipt_from_mapping({
+        'schema': schema,
+        'run_id': binding.run_id,
+        'attempt_id': binding.attempt_id,
+        'lease_id': binding.lease_id,
+        'keys_accepted': list(keys_accepted),
+        'keys_rejected': list(keys_rejected or ()),
+        'store_path': store_path,
+        'row_count_before': row_count_before,
+        'row_count_after': row_count_after,
+        'tm_rebuild': tm_rebuild,
+        'created_at': created_at,
+    })
+
+
+def receipt_from_mapping(data: Mapping[str, Any]) -> PromotionReceipt:
+    """Parse and validate a receipt mapping (JSON object)."""
+    if not isinstance(data, Mapping):
+        raise ValueError('receipt must be a mapping')
+    schema = data.get('schema')
+    if schema != SCHEMA_V1:
+        raise ValueError('unsupported receipt schema %r (want %r)' % (schema, SCHEMA_V1))
+
+    def _req_str(name: str) -> str:
+        value = data.get(name)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError('receipt.%s must be a non-empty string' % name)
+        return value
+
+    def _req_keys(name: str) -> tuple[str, ...]:
+        value = data.get(name)
+        if value is None:
+            value = []
+        if not isinstance(value, list) or any(
+                not isinstance(k, str) or not k.strip() for k in value):
+            raise ValueError('receipt.%s must be a list of non-empty strings' % name)
+        # Stable unique order: first occurrence wins; duplicates are a schema error.
+        seen: set[str] = set()
+        out: list[str] = []
+        for key in value:
+            if key in seen:
+                raise ValueError('receipt.%s has duplicate key %r' % (name, key))
+            seen.add(key)
+            out.append(key)
+        return tuple(out)
+
+    def _req_int(name: str) -> int:
+        value = data.get(name)
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError('receipt.%s must be an int' % name)
+        if value < 0:
+            raise ValueError('receipt.%s must be >= 0' % name)
+        return value
+
+    tm = data.get('tm_rebuild')
+    if not isinstance(tm, bool):
+        raise ValueError('receipt.tm_rebuild must be a bool')
+
+    accepted = _req_keys('keys_accepted')
+    rejected = _req_keys('keys_rejected')
+    overlap = sorted(set(accepted) & set(rejected))
+    if overlap:
+        raise ValueError(
+            'receipt keys_accepted and keys_rejected overlap: %s' % ', '.join(overlap[:10]))
+
+    return PromotionReceipt(
+        schema=schema,
+        run_id=_req_str('run_id'),
+        attempt_id=_req_str('attempt_id'),
+        lease_id=_req_str('lease_id'),
+        keys_accepted=accepted,
+        keys_rejected=rejected,
+        store_path=_req_str('store_path'),
+        row_count_before=_req_int('row_count_before'),
+        row_count_after=_req_int('row_count_after'),
+        tm_rebuild=tm,
+        created_at=_req_str('created_at'),
+    )
+
+
+def write_receipt(path: str, receipt: PromotionReceipt) -> str:
+    """Atomically write a receipt JSON file. Returns the path written."""
+    path = os.path.abspath(path)
+    os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
+    payload = json.dumps(receipt.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
+    payload += '\n'
+    tmp = path + '.tmp'
+    with open(tmp, 'w', encoding='utf-8', newline='\n') as fh:
+        fh.write(payload)
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp, path)
+    return path
+
+
+def load_receipt(path: str) -> PromotionReceipt:
+    """Load one receipt file."""
+    with open(path, encoding='utf-8') as fh:
+        data = json.load(fh)
+    return receipt_from_mapping(data)
+
+
+def load_receipts(directory: str) -> list[PromotionReceipt]:
+    """Load every ``*.promotion_receipt.json`` under *directory* (non-recursive).
+
+    Sorted by basename for deterministic reconcile order.
+    """
+    directory = os.path.abspath(directory)
+    if not os.path.isdir(directory):
+        raise FileNotFoundError('receipts directory not found: %s' % directory)
+    names = sorted(
+        n for n in os.listdir(directory)
+        if n.endswith(RECEIPT_FILENAME_SUFFIX) and os.path.isfile(os.path.join(directory, n))
+    )
+    return [load_receipt(os.path.join(directory, name)) for name in names]
+
+
+def _row_count_invariant_reason(receipt: PromotionReceipt) -> str | None:
+    """Return a human reason if the receipt's own row counts are inconsistent."""
+    expected_delta = len(receipt.keys_accepted)
+    actual_delta = receipt.row_count_after - receipt.row_count_before
+    if receipt.row_count_after < receipt.row_count_before:
+        return (
+            'row_count_after (%d) < row_count_before (%d)'
+            % (receipt.row_count_after, receipt.row_count_before)
+        )
+    # Accepted keys are the rows the receipt claims were added; rejected never land.
+    if actual_delta != expected_delta:
+        return (
+            'row_count delta %d != len(keys_accepted) %d '
+            '(before=%d after=%d)'
+            % (actual_delta, expected_delta,
+               receipt.row_count_before, receipt.row_count_after)
+        )
+    return None
+
+
+def reconcile_startup(
+    receipts: Sequence[PromotionReceipt],
+    observed_store_keys: Iterable[str],
+) -> ReconcilePlan:
+    """Pure startup reconcile: compare sealed receipts to observed store keys.
+
+    For each receipt's ``keys_accepted`` set:
+
+    * all present  → ``skip_already_present`` (idempotent re-entry / double receipt)
+    * all missing  → ``promote_missing`` (crash after receipt, before store write)
+    * partial      → ``error_inconsistent`` (store/receipt drift; human/ops)
+
+    Receipt-internal row-count invariants that fail also go to ``error_inconsistent``
+    and suppress the presence-based action for that receipt (fail closed).
+    """
+    store = set(observed_store_keys)
+    plan = ReconcilePlan()
+
+    for receipt in receipts:
+        keys = receipt.keys_accepted
+        invariant = _row_count_invariant_reason(receipt)
+        if invariant is not None:
+            plan.error_inconsistent.append(ReconcileAction(
+                kind=ERROR_INCONSISTENT,
+                lease_id=receipt.lease_id,
+                run_id=receipt.run_id,
+                attempt_id=receipt.attempt_id,
+                keys=keys,
+                reason=invariant,
+            ))
+            continue
+
+        if not keys:
+            # Empty accept set: nothing to promote; treat as already consistent.
+            plan.skip_already_present.append(ReconcileAction(
+                kind=SKIP_ALREADY_PRESENT,
+                lease_id=receipt.lease_id,
+                run_id=receipt.run_id,
+                attempt_id=receipt.attempt_id,
+                keys=keys,
+                reason='empty keys_accepted; nothing to promote',
+            ))
+            continue
+
+        present = tuple(k for k in keys if k in store)
+        missing = tuple(k for k in keys if k not in store)
+
+        if present and missing:
+            plan.error_inconsistent.append(ReconcileAction(
+                kind=ERROR_INCONSISTENT,
+                lease_id=receipt.lease_id,
+                run_id=receipt.run_id,
+                attempt_id=receipt.attempt_id,
+                keys=keys,
+                reason=(
+                    'partial presence: present=%s missing=%s'
+                    % (list(present), list(missing))
+                ),
+            ))
+        elif missing:
+            plan.promote_missing.append(ReconcileAction(
+                kind=PROMOTE_MISSING,
+                lease_id=receipt.lease_id,
+                run_id=receipt.run_id,
+                attempt_id=receipt.attempt_id,
+                keys=keys,
+                reason='accepted keys absent from store (crash after receipt?)',
+            ))
+        else:
+            plan.skip_already_present.append(ReconcileAction(
+                kind=SKIP_ALREADY_PRESENT,
+                lease_id=receipt.lease_id,
+                run_id=receipt.run_id,
+                attempt_id=receipt.attempt_id,
+                keys=keys,
+                reason='all accepted keys already present in store',
+            ))
+
+    return plan
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Tiny CLI: load receipts from a dir and reconcile against a key list file."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__.split('\n\n', 1)[0])
+    parser.add_argument('--receipts-dir', required=True,
+                        help='Directory of *.promotion_receipt.json files')
+    parser.add_argument(
+        '--store-keys',
+        required=True,
+        help='Text file: one store key per line (fixture / offline only)',
+    )
+    parser.add_argument('--json', action='store_true', help='Emit plan as JSON')
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    receipts = load_receipts(args.receipts_dir)
+    with open(args.store_keys, encoding='utf-8') as fh:
+        keys = [line.strip() for line in fh if line.strip() and not line.startswith('#')]
+    plan = reconcile_startup(receipts, keys)
+    if args.json:
+        print(json.dumps(plan.to_dict(), ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        d = plan.to_dict()
+        for kind in (PROMOTE_MISSING, SKIP_ALREADY_PRESENT, ERROR_INCONSISTENT):
+            print('%s: %d' % (kind, len(d[kind])))
+            for action in d[kind]:
+                print('  - lease=%s keys=%s reason=%s'
+                      % (action['lease_id'], action['keys'], action['reason']))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/RussianTranslation/src/pilot/promotion_receipt_selftest.py
+++ b/RussianTranslation/src/pilot/promotion_receipt_selftest.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+"""Selftests for promotion_receipt.py (H1554 Track B — VERIFICATION B1–B4).
+
+Offline only. No live store, no coordinator, no paid generation.
+
+    python src/pilot/promotion_receipt_selftest.py
+
+B1 — schema v1 load/save round-trip
+B2 — reconcile: promote_missing / skip_already_present / error_inconsistent fixtures
+B3 — (review) no multi-profile live route change — this module is pure
+B4 — this selftest green
+
+Authored for H1554 by Grok 4.5 (model-lock override of Opus 4.8).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import promotion_receipt as pr  # noqa: E402
+
+FIXTURES = os.path.join(HERE, 'fixtures', 'cohort_scaffold')
+
+
+def fail(message: str) -> None:
+    raise AssertionError(message)
+
+
+def load_fixture(name: str) -> dict:
+    path = os.path.join(FIXTURES, name)
+    with open(path, encoding='utf-8') as fh:
+        return json.load(fh)
+
+
+# ---------------------------------------------------------------------------
+# B1 — AttemptRunBinding + PromotionReceipt round-trip
+# ---------------------------------------------------------------------------
+def test_b1_schema_round_trip() -> None:
+    binding = pr.AttemptRunBinding(
+        run_id='run-rt-1',
+        attempt_id='attempt-9',
+        lease_id='lease-x',
+    )
+    receipt = pr.make_receipt(
+        binding,
+        keys_accepted=['k.1', 'k.2'],
+        keys_rejected=['k.3'],
+        store_path='tmp/store.jsonl',
+        row_count_before=100,
+        row_count_after=102,
+        tm_rebuild=False,
+        created_at='2026-07-23T10:00:00Z',
+    )
+    if receipt.schema != pr.SCHEMA_V1:
+        fail('schema must be %r, got %r' % (pr.SCHEMA_V1, receipt.schema))
+    if receipt.binding() != binding:
+        fail('binding() must round-trip AttemptRunBinding fields')
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, 'lease-x' + pr.RECEIPT_FILENAME_SUFFIX)
+        written = pr.write_receipt(path, receipt)
+        if not os.path.isfile(written):
+            fail('write_receipt did not create %s' % written)
+        loaded = pr.load_receipt(written)
+        if loaded.to_dict() != receipt.to_dict():
+            fail('load_receipt != written receipt:\n  wrote=%s\n  load=%s'
+                 % (receipt.to_dict(), loaded.to_dict()))
+
+        # Directory loader picks the file by suffix.
+        batch = pr.load_receipts(tmp)
+        if len(batch) != 1 or batch[0].to_dict() != receipt.to_dict():
+            fail('load_receipts must return the single written receipt')
+
+    # Reject bad schema / empty ids / overlap / non-int counts.
+    bad_cases = [
+        ({'schema': 'nope'}, 'schema'),
+        ({
+            'schema': pr.SCHEMA_V1, 'run_id': '', 'attempt_id': 'a',
+            'lease_id': 'l', 'keys_accepted': [], 'keys_rejected': [],
+            'store_path': 's', 'row_count_before': 0, 'row_count_after': 0,
+            'tm_rebuild': False, 'created_at': 't',
+        }, 'run_id'),
+        ({
+            'schema': pr.SCHEMA_V1, 'run_id': 'r', 'attempt_id': 'a',
+            'lease_id': 'l', 'keys_accepted': ['x'], 'keys_rejected': ['x'],
+            'store_path': 's', 'row_count_before': 0, 'row_count_after': 1,
+            'tm_rebuild': False, 'created_at': 't',
+        }, 'overlap'),
+        ({
+            'schema': pr.SCHEMA_V1, 'run_id': 'r', 'attempt_id': 'a',
+            'lease_id': 'l', 'keys_accepted': [], 'keys_rejected': [],
+            'store_path': 's', 'row_count_before': True, 'row_count_after': 0,
+            'tm_rebuild': False, 'created_at': 't',
+        }, 'bool-as-int'),
+    ]
+    for payload, label in bad_cases:
+        try:
+            pr.receipt_from_mapping(payload)
+        except ValueError:
+            pass
+        else:
+            fail('expected ValueError for bad case %s: %r' % (label, payload))
+
+
+# ---------------------------------------------------------------------------
+# B2 — three cohort_scaffold fixtures
+# ---------------------------------------------------------------------------
+def _run_fixture(filename: str, expected_kind: str) -> pr.ReconcilePlan:
+    fix = load_fixture(filename)
+    if fix.get('expected_kind') != expected_kind:
+        fail('%s fixture expected_kind drift: %r' % (filename, fix.get('expected_kind')))
+    receipts = [pr.receipt_from_mapping(r) for r in fix['receipts']]
+    plan = pr.reconcile_startup(receipts, fix['observed_store_keys'])
+    return plan
+
+
+def test_b2_promote_missing_fixture() -> None:
+    plan = _run_fixture('promote_missing.json', pr.PROMOTE_MISSING)
+    if len(plan.promote_missing) != 1:
+        fail('promote_missing fixture: want 1 promote action, got %s'
+             % plan.to_dict())
+    if plan.skip_already_present or plan.error_inconsistent:
+        fail('promote_missing fixture must not emit other buckets: %s'
+             % plan.to_dict())
+    action = plan.promote_missing[0]
+    if list(action.keys) != ['dah.1', 'dah.2']:
+        fail('promote_missing keys wrong: %s' % list(action.keys))
+    if action.lease_id != 'lease-dah-w01':
+        fail('promote_missing lease_id wrong: %s' % action.lease_id)
+
+
+def test_b2_skip_already_present_fixture() -> None:
+    plan = _run_fixture('skip_already_present.json', pr.SKIP_ALREADY_PRESENT)
+    if len(plan.skip_already_present) != 2:
+        fail('skip fixture: want 2 skip actions (double receipt), got %s'
+             % plan.to_dict())
+    if plan.promote_missing or plan.error_inconsistent:
+        fail('skip fixture must not emit other buckets: %s' % plan.to_dict())
+    for action in plan.skip_already_present:
+        if list(action.keys) != ['dah.1', 'dah.2']:
+            fail('skip keys wrong: %s' % list(action.keys))
+
+
+def test_b2_error_inconsistent_fixture() -> None:
+    plan = _run_fixture('error_inconsistent.json', pr.ERROR_INCONSISTENT)
+    if len(plan.error_inconsistent) != 2:
+        fail('error fixture: want 2 error actions, got %s' % plan.to_dict())
+    if plan.promote_missing or plan.skip_already_present:
+        fail('error fixture must not emit other buckets: %s' % plan.to_dict())
+    reasons = ' | '.join(a.reason for a in plan.error_inconsistent)
+    if 'partial presence' not in reasons:
+        fail('error fixture must include partial-presence reason: %s' % reasons)
+    if 'row_count delta' not in reasons:
+        fail('error fixture must include row_count delta reason: %s' % reasons)
+
+
+def test_b2_fixture_files_present() -> None:
+    required = (
+        'promote_missing.json',
+        'skip_already_present.json',
+        'error_inconsistent.json',
+    )
+    missing = [n for n in required if not os.path.isfile(os.path.join(FIXTURES, n))]
+    if missing:
+        fail('missing cohort_scaffold fixtures: %s' % missing)
+
+
+# ---------------------------------------------------------------------------
+# Extra pure pins (still offline)
+# ---------------------------------------------------------------------------
+def test_empty_accept_skips() -> None:
+    receipt = pr.make_receipt(
+        pr.AttemptRunBinding('r', 'a', 'l'),
+        keys_accepted=[],
+        store_path='s',
+        row_count_before=5,
+        row_count_after=5,
+        created_at='t',
+    )
+    plan = pr.reconcile_startup([receipt], ['anything'])
+    if len(plan.skip_already_present) != 1:
+        fail('empty accept should skip, got %s' % plan.to_dict())
+
+
+def main() -> int:
+    tests = [
+        test_b1_schema_round_trip,
+        test_b2_fixture_files_present,
+        test_b2_promote_missing_fixture,
+        test_b2_skip_already_present_fixture,
+        test_b2_error_inconsistent_fixture,
+        test_empty_accept_skips,
+    ]
+    failed = 0
+    for test in tests:
+        name = test.__name__
+        try:
+            test()
+        except Exception as exc:
+            failed += 1
+            print('FAIL %s: %s' % (name, exc))
+        else:
+            print('ok   %s' % name)
+    print()
+    if failed:
+        print('%d/%d failed' % (failed, len(tests)))
+        return 1
+    print('%d/%d passed (H1554 Track B selftest green)' % (len(tests), len(tests)))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Wave-1 **Track B** from the full-audit improvement plan (H1554): offline promotion-receipt scaffold that feeds H1437 Phase-1 prerequisites without implementing the multi-profile scheduler.

- `AttemptRunBinding` / `PromotionReceipt` schema `pwg_ru.promotion_receipt.v1`
- `write_receipt` / `load_receipt` / `load_receipts`
- Pure `reconcile_startup` → `{promote_missing, skip_already_present, error_inconsistent}`
- Three fixtures under `src/pilot/fixtures/cohort_scaffold/`
- `promotion_receipt_selftest.py` (6/6 green)

## Fence

- No multi-profile live scheduler
- No paid generation
- No live store write / coordinator wiring

## Test plan

- [x] `python src/pilot/promotion_receipt_selftest.py` → 6/6 passed
- [x] H1437 worktree has no conflicting `promotion_receipt` symbols (Phase 0 red tests only)

## VERIFICATION

B1 schema round-trip · B2 three fixtures · B3 no live route change · B4 selftest green · B5 this PR

Handoff: https://github.com/gasyoun/Uprava/blob/main/handoffs/H1554-Opus_RussianTranslation_rt-fullaudit-w1-b-promo-receipt_23.07.26.md