### PR TITLE
docs(pwg_ru): H1610 c2 only-b0 forensics — max-agents starvation

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Prove bounded PWG→Russian CLI correctness on one profile, then scale + the CDSL article-comparison study
 
-_Created: 09-07-2026 · Last updated: 23-07-2026_
+_Created: 09-07-2026 · Last updated: 24-07-2026_
 
 Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/archive/H025-Opus_RussianTranslation_pwg_ru_max_25.06.26.md)):
 
@@ -13,6 +13,15 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 > the root copy. Audited + reconciled 2026-06-26.
 
 ## ➡️ Next Steps (Queue)
+
+- **c2 medium50 w1 after session reset (24-07-2026, Grok 4.5).** Gate-0 + canary PASS on
+  c2 Pro earlier this session. Forensic root of 0/3 “only b0” runs is **`--max-agents 1`**
+  total-spawn starvation (ledger `C2_M50_W1_MAX_AGENTS1_2026-07-24`,
+  [`RESULTS_LOG.md`](RESULTS_LOG.md)). Fix re-run without the flag multi-spawned then hit
+  **c2 session limit** on b1 (`rate_limit`, resets **15:30 Europe/Moscow**). **Next paid
+  action:** after reset, re-run w1 with manifest budgets only (no `--max-agents`), then
+  audit; still stop-before-promote / no live store until clean. Grok-vs-Opus compare arm
+  waits on a clean Grok baseline.
 
 - **H1457 Track A (Sa→Ru pub-grade TM technical hardening) — DONE 22-07-2026, Sonnet 5
   (`claude-sonnet-5`), isolated worktree; rebased + PR this pass.** All of spike S1 + A1-A6

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,17 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Documented — c2 medium50 w1 only-b0/all-nulls forensics (`--max-agents 1` total-spawn starvation)
+
+- [`LAUNCH_FUCKUPS.md`](LAUNCH_FUCKUPS.md) id `C2_M50_W1_MAX_AGENTS1_2026-07-24`: measured
+  0/3 nulls with single `b0` attempt were **operator misuse of `--max-agents`**, not c2 Pro
+  host failure. The flag caps **total** translate+heal spawns; `N=1` starves multi-key
+  windows; `selfheal-nothing-resolved` overwrites `budget_exceeded` notes while
+  `budget_stops` (23–24) is the smoking gun. Fix re-run without the flag multi-spawned then
+  hit a separate c2 Pro **session** limit (`rate_limit`, reset 15:30 Europe/Moscow).
+- Comparison table: [`RESULTS_LOG.md`](RESULTS_LOG.md) (24-07-2026 entry). Guardrail: never
+  copy canary `--max-agents 1` onto multi-key/heal-capable windows.
+
 ### Added — H1458 Track C: publication/release prep for the Sa→Ru TM (D13 terminology + rights-partitioned bundles + datasheet)
 
 - **C1** [`src/terminology_build.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/terminology_build.py)

--- a/RussianTranslation/LAUNCH_FUCKUPS.md
+++ b/RussianTranslation/LAUNCH_FUCKUPS.md
@@ -536,6 +536,30 @@ classes, expected-vs-actual metrics, residual status, and unknown recurrence.
   "guardrail": "v2 gates direction-aligned with canonical accept(): HARD {Tn}-multiset fidelity over record.grammar+sense.german AND over the translation field (mask-level supersets of the two HARD accept() rejects), sense gate shortfall-only vs source_senses (SAN-LOSS direction; over-emission never flagged), retry feedback explicitly forbids notes-parking. canonical_audit.py is the authoritative promote-DRY verdict (independent adversarial review: 7/7 dimensions faithful to accept()). v2 rerun wf_e858f3cf-6af: 3/3 canonical PASS (79/79 34/34, 78/78 34/34, 74/74 32/32), self-report == canonical, 8 agents, 544,056 tokens.",
   "residual_status": "fixed",
   "residual_risk": "Any future side-harness gate authored from scratch can drift from accept() the same way; derive gate constants from card_fields/the manifest's hardened fields and re-run canonical_audit.py after every rig change before trusting a self-reported promote verdict."
+ },
+ {
+  "id": "C2_M50_W1_MAX_AGENTS1_2026-07-24",
+  "handoff": "live-c2-forensics",
+  "date": "2026-07-24",
+  "title": "c2 medium50 w1: only b0 / 0-of-3 nulls under --max-agents 1 (budget starvation misread as host failure)",
+  "lane": "headless CLI, profile c2 Pro, medium50 window1 (nakzatra/sarvatra/sakft)",
+  "model": "claude-sonnet-5",
+  "orchestrator": "Grok 4.5 session + headless_worker.py",
+  "expected": {
+   "agents": "manifest budgets max_translate_agents=19 / max_heal_agents=41; 3 whole-card batches (b0..b2) plus heal if needed",
+   "tokens": "canary-scale: prior c2 canary ~3/3 in ~93s; full w1 expected multi-batch"
+  },
+  "actual": {
+   "agents": "full-config: translate_spent=1 heal_spent=0 budget_stops=24 (~.60); stripped: translate_spent=1 heal_spent=0 budget_stops=23 timeout on b0; fix-run without --max-agents: multi-heal fan-out then HardFailure rate_limit on b1",
+   "tokens": "full-config ~179k subagent tokens / .599; stripped ; fix-run partial spend then session-limit 429"
+  },
+  "passes": 3,
+  "symptoms": "Only attempt label b0 (nakzatra). All three keys null with error selfheal-nothing-resolved. status headless_attempts lists a single batch. Operator hypothesis: Pro cannot translate / host rate-limit / stripped-config needed.",
+  "classification": "operator/process",
+  "root_cause": "--max-agents N is a TOTAL spawn ceiling (translate+heal across the whole run), not concurrency width. With N=1 the first whole-card call consumes the entire budget; remaining translate batches and every self_heal fragment refuse as budget_exceeded without spawning. self_heal then stamps selfheal-nothing-resolved when senses stay empty, OVERWRITING the earlier budget_exceeded notes in failures{}. So the summary looks like content failure (3x selfheal-nothing-resolved) while the smoking gun is budget_stops>=23 + translate_agents_spent=1 + only b0 in headless_attempts. Code: headless_worker._budget_ok / call / self_heal note at selfheal-nothing-resolved. Stripped CLAUDE_CONFIG_DIR (H1517) cannot fix this class.",
+  "guardrail": "Never pass --max-agents 1 on multi-key or heal-capable windows. Use it only for true single-spawn canaries (one key that must finish in one call) or when deliberately starving the run. Production multi-card windows rely on manifest budgets (max_translate_agents / max_heal_agents) with --max-agents omitted or set to their sum. When diagnosing only-b0/all-nulls: check budget_stops and translate_agents_spent BEFORE rate_limit/content theories. Prefer failures that retain budget_exceeded if a code fix later prevents note-overwrite (optional hardening).",
+  "residual_status": "structurally-guarded",
+  "residual_risk": "Bounded-run docs (H1447/H1110 ladder) still recommend --max-agents 1 for tiny canaries; copy-pasting that flag onto medium50/nominal windows re-creates the incident. c2 Pro also hit session limit mid fix-run (resets 15:30 Europe/Moscow) — separate concurrency/api residual; do not conflate with the budget flag."
  }
 ]
 ```

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -1,8 +1,31 @@
 # RussianTranslation — results log
 
-_Created: 09-07-2026 · Last updated: 20-07-2026_
+_Created: 09-07-2026 · Last updated: 24-07-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
+
+## 24-07-2026 — c2 medium50 w1 forensics: only-b0 / all-nulls = `--max-agents 1` starvation
+
+Executor: Grok 4.5 (session) · gen model: Sonnet 5 (`claude-sonnet-5`) · profile: **c2 Pro**
+(not Max) · keys: `nakzatra` / `sarvatra` / `sakft` · artifacts under
+`src/pilot/output/c2_m50_w1*` (gitignored). Ledger:
+[`LAUNCH_FUCKUPS.md`](LAUNCH_FUCKUPS.md) id `C2_M50_W1_MAX_AGENTS1_2026-07-24`.
+
+| run | config | `--max-agents` | ok/null | attempts seen | translate/heal spent | budget_stops | cost USD | terminal |
+|---|---|---:|---|---|---|---:|---:|---|
+| full w1 | c2 full profile | **1** | 0/3 | **b0 only** (success 161.8s) | 1 / 0 | **24** | 0.599 | all errors `selfheal-nothing-resolved` |
+| stripped w1 | c2-stripped (H1517) | **1** | 0/3 | **b0 only** (timeout 180.3s) | 1 / 0 | **23** | 0.000 | same error stamp |
+| fix w1 | c2 full profile | **omit** (manifest 19/41) | aborted | b0 timeout + **many** `heal:nakzatra#g*` + b1 | multi-spawn | n/a (HardFailure) | partial (~0.50+ on last call) | **`rate_limit`** session limit; resets 15:30 Europe/Moscow |
+
+**Root cause (operator/process, not Pro-host):** `--max-agents N` caps **total** model
+spawns (translate+heal) for the whole run. `N=1` spends the budget on the first batch;
+remaining work refuses as `budget_exceeded` without spawning; `self_heal` overwrites notes
+with `selfheal-nothing-resolved`. Smoking gun triad: `budget_stops ≫ 0` +
+`translate_agents_spent=1` + single `b0` in `headless_attempts`.
+
+**Guardrail:** do not copy `--max-agents 1` from single-key canaries onto multi-key windows.
+**Separate residual:** c2 Pro session limit blocked the fix-run before a clean 3/3; re-run
+after reset without the flag.
 
 ## 20-07-2026 — Sa→Ru gloss layer, wave 4: read-only TM lookup wired (H1349 W4 — H1349 COMPLETE)
 


### PR DESCRIPTION
## Summary
- Forensic write-up for c2 medium50 w1 0/3 «only b0» runs: root cause is `--max-agents 1` (total translate+heal spawn ceiling), not c2 Pro host failure.
- Ledger entry `C2_M50_W1_MAX_AGENTS1_2026-07-24`, RESULTS_LOG comparison table, CHANGELOG + `.ai_state` next step after session reset.
- Fix re-run without the flag multi-spawned, then hit a separate c2 Pro **session** limit (resets 15:30 Europe/Moscow).

## Test plan
- [x] `python src/pilot/check_launch_ledger.py` → 19 entries complete
- [ ] CI green (docs-only)

Handoff: H1610