### PR TITLE
docs(pwg_ru): layer capability map Q/N questions

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,13 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Documented — markup-layer capability map (what Q/N questions layers answer)
+
+- [`pwg_ru.md`](pwg_ru.md) §8: full RU tables — layers L0–L10, **Q1–Q15** answerable
+  now (with caveats), **N1–N18** not yet (human gates, drain, rights, WSD, 403 host…).
+- Deep manual §2b English summary + document-map pointer
+  ([RUSSIANTRANSLATION_DEEP_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md)).
+
 ### Documented — PWG manuals UX pack (cold start, skills, cookbook, census, H1447 example)
 
 - Deep manual §0 cold start; §5.0 skill-primary path; §11 symptom cookbook;

--- a/RussianTranslation/pwg_ru.md
+++ b/RussianTranslation/pwg_ru.md
@@ -1,6 +1,6 @@
 # Словарь `pwg_ru` — русский перевод Большого Петербургского словаря
 
-_Created: 09-07-2026 · Last updated: 24-07-2026_
+_Created: 09-07-2026 · Last updated: 25-07-2026_
 
 > Документ для **редактора**. Описывает, **как устроен** AI-перевод Большого
 > Петербургского словаря (`pwg_ru`, Бетлингк–Рот): кто переводит и кто судит
@@ -320,7 +320,86 @@ HTML, regenerable ledgers.
 
 ---
 
-## 8. Куда идти дальше
+## 8. Что слои разметки **могут** и **ещё не могут** ответить
+
+Карта возможностей — не runbook. Операторский deep manual описывает *как*
+гнать окно; этот раздел — *какой вопрос* уже опирается на слои, *где* смотреть
+ответ, и *где честная дыра*. Покрытие store (25-07-2026): **11 603** sense-row;
+поля `layer` / `provenance` / `review_status` — на всех; `evidence_summary` —
+~10.8k; полный `evidence[]` — ~2.2k; `differentia` — ~4.7k.
+
+### 8.1. Слои (краткий реестр)
+
+| Слой | Что это | Поверхность |
+|------|---------|-------------|
+| **L0 маска** | `{#}`, `<ls>`, `<ab>`, `<is>`, `<lex>`, `{%…%}`, `<div>` | store `de`/`ru`; mask/restore |
+| **L1 5-dict stack** | PWG + Nachträge + PW + SCH + PWKVN + NWS | `layer`, `subcard` (`_zz_*`), portrait |
+| **L2 NWS owners** | детерминированный owner-map | portrait / NWS gate |
+| **L3 Renou I–V** | состояние языка по `<ls>` (+ DCS enrich) | annotation / badges (не reorder) |
+| **L4 government** | Rektion из `(<ab>Instr.</ab>)` и т.п. | [government.html](https://gasyoun.github.io/SanskritLexicography/government.html) |
+| **L5 abbreviations** | tooltips + частоты `<ab>` | [abbreviations.html](https://gasyoun.github.io/SanskritLexicography/abbreviations.html), [ABBREVIATIONS_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ABBREVIATIONS_RU.md) |
+| **L6 evidence / corpus_gate** | pass/divergence vs Koch…; agreement vs KOW | `evidence`, `evidence_summary` |
+| **L7 grammar / Zaliznyak** | class, reverse paradigm | `nominal_grammar` / `reverse_index` — **не** в translate prompt |
+| **L8 relationships** | тип supplement sense | [relationships_rollup.tsv](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/relationships_rollup.tsv) |
+| **L9 provenance** | model, hashes, pipeline | `provenance` object |
+| **L10 presentation** | tooltips, RU purity, Cyrillic `<is>` | render-time only (`build_article_site`) |
+
+### 8.2. Вопросы, на которые **уже** можно ответить (полностью или с оговоркой)
+
+| # | Вопрос | Слои | Где ответ | Честная оговорка |
+|---|--------|------|-----------|------------------|
+| Q1 | Какой русский / немецкий / (EN) текст **этого** sense? | L0, store | article site; store row | Только для **переведённых** sub-card; вселенная ~106k headwords |
+| Q2 | Это PWG-base, PW, SCH, NWS…? | L1 | `layer`, `subcard` suffix | no-PWG lane = standalone `_zz_*` без фейкового PWG |
+| Q3 | Сохранён ли порядок values PWG? | L0 policy | audit sense coverage | Gate, не «ручная уверенность» |
+| Q4 | Что маскировалось (Sa / cite / gram)? | L0 | mask round-trip / fidelity gates | 1 known-lossy PWG record |
+| Q5 | Кто owner у NWS-фрагмента? | L2 | NWS map / reject quarantine | Misattr → REJECTED, не silent |
+| Q6 | Какие **языковые состояния Renou** у sense/леммы? | L3 | Renou fields + badges | `<ls>`-узко; DCS — lemma-level enrich, не затирает per-sense |
+| Q7 | Какие карточки **управляют Instr./Loc./…**? | L4 | government.html | Floor vs ceiling: extractor vs raw `pwg.txt`; mid-drain partial |
+| Q8 | Что значит `<ab>X</ab>` и как часто? | L5 | abbreviations.html | RU purity partial; H1303 vote ещё не applied |
+| Q9 | Согласуется ли RU-термин с **независимым** S→R? | L6 | `evidence` / summary | Non-blocking; `no-check` часто; KOW ≠ sole arbiter |
+| Q10 | Насколько близок RU к **KOW**? | L6 signal 2 | `reference_agreement` path | Сходство, не «истина» |
+| Q11 | Как склоняется / «как *agni*»? | L7 | `nominal_grammar.py --table`, reverse index | Отдельный FAIR grammar package; не смысл слова |
+| Q12 | Supplement = new sense / restatement / correction? | L8 | relationships_rollup | Над классифицированным rollup, не live ad-hoc |
+| Q13 | Какой model/version/hash породил row? | L9 | `provenance` | Точность зависит от pin H818+ |
+| Q14 | `review_status` / human gold? | review fields | store + sheets | Почти всё ещё `ai_translated` |
+| Q15 | Есть ли немецкий residue / broken markup? | L0 gates | requeue / residue sweeps | Детектор ≠ полный semantic audit |
+
+### 8.3. Вопросы, на которые **ещё нельзя** (или только после human gate / данных)
+
+| # | Вопрос | Почему нельзя *yet* | Что разблокирует |
+|---|--------|---------------------|------------------|
+| N1 | «Канонический» **единый** RU для каждого `ab` (Med. vs med., W. с n=…) | H1303 sheet не voted; contextual `n=` class | `h1303_abbrev.decisions.json` → Session 2 |
+| N2 | Норма doublets / `v. l.` / *im Comp.* в промпте и store | H1306 Phase 2 ждёт vote | `h1306_style.decisions.json` |
+| N3 | Печатная «готовая редакция» (G5–G10) | Human gold / double review / edition cut | G5–G6 packets + votes |
+| N4 | Полный PWG→RU **как словарь целиком** | ~5.5k unique remaining; live host 403/latency | Drain + fresh live-gate |
+| N5 | Частотность **смысла** в корпусе (sense-level WSD) | Нет full-corpus sense inventory + join | Wave-2 `senses_pwg` / sense-corpus work |
+| N6 | «Самое частое значение» = sense #1? | PWG order ≠ Zipf; Renou ≠ frequency | Explicit corpus-frequency layer (not built) |
+| N7 | Полный **DHĀTUP. → Palsule** link | Нет machine Palsule list | H1333 + MG XLS |
+| N8 | mw_ru **термин-seed** на каждое общее headword | mw_ru working repo не найден | Locate seed repo |
+| N9 | Public **TM / bulk RU** download | Rights grey on parallel corpus | Clearance + publish-safety |
+| N10 | EN как first-class full twin of RU | EN secondary; intentional divergences | EN drain + parity close |
+| N11 | 100% compound-split vs derivation graph | ~4.2k human disagreements | Review-sheet sample @DO |
+| N12 | Oral / register A–C для всех glosses | Oral track + H1306 | H290 + style vote |
+| N13 | «Этот AI-перевод **лучше** KOW/человека» | Нет gold adjudicated edition | G6 gold + judge protocol |
+| N14 | Diachronic sense change (PW vs PWG vs SCH as history) | Layers co-present, not timeline UI | Dedicated edition-diff product |
+| N15 | Automatic scan-page for every `<ls>` | Link-target partial / dict-dependent | cologne link-target / resolver coverage |
+| N16 | Learner «только school-core» as filter on full PWG | Learner-core list exists; not full-site filter product | Wire learner scores end-to-end on site |
+| N17 | Live CLI drain right now | Gate NO-GO / **403** on profiles (25-07) | Re-auth + LIVE_GO |
+| N18 | Glyph-quarantine «93% bad RU» as truth | Detector almost certainly inflated | Sample ~200 before mass re-translate |
+
+### 8.4. Как читать статус
+
+- **Q*** = можно спрашивать *сейчас* (иногда только на promoted subset / site).
+- **N*** = не выдавать за готовый ответ; в manual/chat честно «ещё нет».
+- Human sheets **не** «почти done» без `*.decisions.json`.
+- Presentation (L10) **не** чинить правкой store «для красоты».
+
+English twin pointer (operator set):
+[docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md) §2 / capability map.
+
+---
+
+## 9. Куда идти дальше
 
 | Нужно | Документ |
 |-------|----------|
@@ -330,5 +409,6 @@ HTML, regenerable ledgers.
 | 18 intent→command maps | [USE_CASES.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/USE_CASES.md) |
 | Очередь / WIP | [.ai_state.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md) |
 | MW-редакторский twin | [mw_ru.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/mw_ru.md) |
+| Сокращения / Rektion | [ABBREVIATIONS_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ABBREVIATIONS_RU.md) |
 
 _Dr. Mārcis Gasūns_

--- a/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md
+++ b/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md
@@ -1,6 +1,6 @@
 # RussianTranslation deep manual — the mw_ru and pwg_ru pipelines
 
-_Created: 11-07-2026 · Last updated: 24-07-2026_
+_Created: 11-07-2026 · Last updated: 25-07-2026_
 
 The subsystem deep manual for
 [RussianTranslation/](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation)
@@ -100,10 +100,54 @@ in this order on first contact.
 | `<ab>`/`<ls>` tooltip + RU-abbreviation-purity policy | [ABBREVIATIONS_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ABBREVIATIONS_RU.md) |
 | Judge-model policy (Sonnet bulk, Opus on rejects) | [research/JUDGE_POLICY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/JUDGE_POLICY.md) |
 | The five harvested Sa→Ru dictionaries (Russian) | [src/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/README.md) |
+| **What markup layers can / cannot answer** (Q/N matrix) | [pwg_ru.md §8](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru.md) (canonical; editor RU) + **§2b below** (EN summary) |
 
 Trust order when they disagree: **command output** (`root_window_status.py`,
 `window_status.json`) > `.ai_state.md` > the dated docs. Several docs carry
 explicit staleness banners — respect them.
+
+## 2b. Capability map — questions layers answer (and do not)
+
+Canonical full tables (RU): [pwg_ru.md §8](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru.md).
+This section is the English operator summary. Store snapshot 25-07-2026:
+**11,603** sense rows; `layer`/`provenance` on all; `evidence_summary` ~10.8k;
+full `evidence[]` ~2.2k.
+
+### Can answer now (with caveats)
+
+| ID | Question | Layers / surface | Caveat |
+|---|---|---|---|
+| Q1 | RU/DE/(EN) text of this sense | store + article site | promoted subset only |
+| Q2 | Which edition layer (PWG/PW/SCH/NWS…)? | `layer`, `_zz_*` subcard | no-PWG lane is real |
+| Q3–Q4 | Sense order / mask fidelity | audit gates | mechanical, not semantic gold |
+| Q5 | NWS owner | owner map | misattr quarantined |
+| Q6 | Renou stage(s) | Renou + optional DCS | badges; not reorder key |
+| Q7 | Case government (Rektion) | [government.html](https://gasyoun.github.io/SanskritLexicography/government.html) | floor vs `pwg.txt` ceiling |
+| Q8 | Abbreviation meaning / frequency | [abbreviations.html](https://gasyoun.github.io/SanskritLexicography/abbreviations.html) | H1303 not ratified |
+| Q9–Q10 | Independent S→R / KOW agreement | `evidence*` | non-blocking; sparse full `evidence[]` |
+| Q11 | Declension / “like *agni*” | grammar package / reverse index | not in translate prompts |
+| Q12 | Supplement typology | relationships_rollup | classified rollup only |
+| Q13–Q15 | Provenance / review_status / residue | store + requeue tools | mostly `ai_translated` |
+
+### Cannot answer yet (honest no)
+
+| ID | Question | Blocker |
+|---|---|---|
+| N1–N2 | Unified `ab` RU map; style doublets / `v. l.` / *im Comp.* | H1303 / H1306 votes |
+| N3 | Print-ready edition G5–G10 | human gold |
+| N4 | Full PWG→RU dictionary | ~5.5k remaining + live host |
+| N5–N6 | Sense frequency / “sense #1 = most common” | no sense-WSD + Zipf layer |
+| N7 | DHĀTUP.→Palsule links | H1333 XLS |
+| N8 | mw_ru term seed | seed repo missing |
+| N9 | Public bulk TM/RU | rights |
+| N10 | EN full twin | EN secondary |
+| N11 | All compound-split adjudications | ~4.2k @DO sheet |
+| N12–N13 | Full oral register; “better than human” | oral track + gold |
+| N14–N16 | Edition timeline UI; full `<ls>` scan links; learner filter product | product gaps |
+| N17 | Paid drain this host *now* | gate 403 / HEALTH_NOGO (25-07) |
+| N18 | “93% glyph quarantine = bad RU” | sample before mass re-translate |
+
+**Rule:** do not claim N* as product answers. Prefer Q* with the caveat column.
 
 ## 3. mw_ru — the finished pipeline (post-mortem chapter)
 

--- a/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.meta.md
+++ b/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.meta.md
@@ -1,6 +1,6 @@
 # RUSSIANTRANSLATION_DEEP_MANUAL.md — metadoc
 
-_Created: 18-07-2026 · Last updated: 24-07-2026_
+_Created: 18-07-2026 · Last updated: 25-07-2026_
 
 Companion record for [docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md) (subsystem deep manual, H606).
 
@@ -33,6 +33,7 @@ COMMANDS_SPOT_RUN: script_census.py (306 files); harvest_launch_stats.py (473 le
 | 7 | Bare-clone offline vs store-required matrix | open |
 | 8 | EN operator checklist subsection | open |
 | 9 | pwg_ru.md sibling metadoc | open |
+| 10 | Capability Q/N matrix (layers → questions) | **done** 25-07 — pwg_ru.md §8 + deep manual §2b |
 
 ## Known limitations
 


### PR DESCRIPTION
## Summary

Draft capability map for markup layers: what questions they can answer now (Q1-Q15) and cannot yet (N1-N18). Canonical tables in pwg_ru.md section 8; English summary in deep manual section 2b.

## Test plan

- [x] Store field counts checked for evidence coverage caveats
- [ ] CI green
