### PR TITLE
feat(pwg_mask): H1624 G1 durable gloss_lang on {%…%} (DE|LA|EN)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,17 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added - H1624 G1: durable gloss_lang on PWG {%…%} (DE|LA|EN)
+
+- Stage-0 [pwg_mask.py](src/pwg_mask.py): classify_pct_detail / gloss_lang_spans
+  emit {span, gloss_lang, rule_id, offsets} without rewriting DE text; mask treats
+  Latin + Wilson English + botanical binomials as {Tn} placeholders.
+- Residue [prompt_rule_audit.looks_foreign_literal](src/pilot/prompt_rule_audit.py)
+  prefers the same classifier so faithful LA/EN preservation is not requeued.
+- Docs: [pwg_ru.md](pwg_ru.md) §4 rule table + §8.0/L0; LANG_PARITY SHARED
+  gloss_lang_spans_h1624_g1. Pins: pwg_mask --selftest,
+  	est_pwg_mask_gloss_lang_g1.
+
 ### Documented — German-original layers + fully clickable Q/N links
 
 - [pwg_ru.md](pwg_ru.md) §8.0: what is layered onto the **German** source in the

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,6 +1,6 @@
 # LANG_PARITY.md — cross-language fix/feature parity ledger
 
-_Created: 04-07-2026 · Last updated: 24-07-2026 (H1553 wall-clock/defect-refuse/ready_partial: +1 entry)_
+_Created: 04-07-2026 · Last updated: 25-07-2026 (H1624 G1 gloss_lang: +1 SHARED entry)
 
 This repo runs the same PWG→Russian and PWG→English translation pipeline through
 shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
@@ -109,8 +109,29 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Code review 2026-07-04: <ab>lat.</ab>/<ab>griech.</ab> cues are masked to {Tn} in mask() step 1 BEFORE classify_pct runs, so the end-anchored LATIN_CUE regex matched the placeholder, not the cue; measured 33 Latin/Greek cognate glosses across all of PWG (e.g. ignis, uncus, ansa after `lat.`) were being sent for German translation and leaked verbatim into the translator prompt. Fix expands trailing placeholders back to source and strips tags in the classify context window. Masking is stage-0 and runs before any --lang branch, so the fix is identical for RU and EN. Round-trip stays lossless. Pinned by window_selftest.test_pwg_mask_latin_cue_behind_ab_tag. C8 (21-07-2026, Opus 4.8 claude-opus-4-8): the sibling LATIN_PHRASE heuristic matched German-capitalized homographs of Latin prepositions (In/Ab/Ex/Sub/Pro), so a German gloss like 'In der Regel' / 'In den Schlusssatz einfallen' was masked-and-dropped (never translated), invisibly (restore reinserts the identical German, so the round-trip still read 100% lossless). Fixed: a homograph opener stays 'la' only if NO German function word (der/die/den/mit/und) follows; 'De …' (not a German word) is an unguarded Latin opener. Measured 1/192,763 real occurrence, now kept inline. Round-trip stays lossless; also stage-0, identical for RU/EN. Pinned by test_pwg_mask_german_homograph_not_latin_c8.",
     "tracking": "",
     "verified_sha256": {
-      "src/pwg_mask.py": "31abd637d86fc42db9979e31bb560b67f324147339e623ee9837002d2684e0e8",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+    }
+  },
+  {
+    "id": "gloss_lang_spans_h1624_g1",
+    "mechanism": "Stage-0 {%...%} classifier emits durable gloss_lang metadata (de|la|en|ambig + rule_id + offsets) via gloss_lang_spans/classify_pct_detail; mask() placeholders LA+EN (Wilson English, botany binomials, lat. cues) so non-German braces never enter the translate prompt; residue looks_foreign_literal prefers the same classifier",
+    "files": [
+      "src/pwg_mask.py",
+      "src/pilot/prompt_rule_audit.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H1624 G1 (25-07-2026, Grok 4.5 override of Opus-tier handoff): per-span gloss_lang is additive DE-side metadata (not a DE string rewrite). Rules: latin_cue, latin_phrase, botany_binomial -> la; wilson_en / engl_cue / english_content -> en; default_de / homograph_ambig stay inline. Stage-0, before --lang branch, identical for RU and EN. Residue gate shares classifier. Pinned by pwg_mask --selftest and window_selftest.test_pwg_mask_gloss_lang_g1. Extends latin_cue_masking / C8 without reopening grammar-in-prompt.",
+    "tracking": "H1624",
+    "verified_sha256": {
+      "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
+      "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -133,7 +154,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/headless_worker.py": "60716be8bc67819e62912103a99594739419701cbc47ea691643388b6f2faf99",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -169,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -188,7 +209,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -207,7 +228,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -330,7 +351,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/audit_coverage.py": "a60b8c0ed3b0022a6527a029d1e818cedab3dfcbbb545fc2c78b6a5dd514dcfa",
-      "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
+      "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
@@ -410,7 +431,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -429,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -467,7 +488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -526,7 +547,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -550,14 +571,14 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H316 code-hardening pass (2026-07-07). All fixes sit below the --lang branch: stage-0 masking (records feeds both RU and EN lanes), gate shell-out plumbing, and hang guards are language-agnostic by construction. Pinned by test_pwg_mask_bom_source_keeps_first_record, test_pwg_mask_truncated_final_record_not_silent, and the static wiring pin test_subprocess_gate_calls_hardened.",
     "tracking": "",
     "verified_sha256": {
-      "src/pwg_mask.py": "31abd637d86fc42db9979e31bb560b67f324147339e623ee9837002d2684e0e8",
+      "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
       "src/make_edition_cut.py": "5a24d8c96611f50f008689609f8140ef47b02731524dbc255438426b36d306fd",
       "src/preflight_remaining_gates.py": "00386c837b97986c9702abfceed9c29534736c3df3063af202ddfaae6b078b8f",
       "src/release_readiness.py": "db38a870bbc8b5dbe694e706e4a7b9089ba41211a3881ad9a1bd4eb02950c8a9",
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -576,7 +597,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -594,7 +615,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -613,7 +634,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -670,7 +691,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/promote_final_cards.py": "6d58134bab6ace87c7c71d9787ea28a5f163b7485e7b6976908c3c0e00e02e74",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -695,7 +716,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -724,7 +745,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -744,7 +765,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -763,7 +784,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -800,7 +821,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -858,7 +879,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -877,7 +898,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -896,7 +917,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -916,7 +937,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f",
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -938,7 +959,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -997,7 +1018,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -1057,7 +1078,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -1076,7 +1097,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -1101,7 +1122,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -1123,7 +1144,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "93376ed1c55d950327a368f7b11a854d9fbf289e629c7e241e5479e6af396561",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f",
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c",
       "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
     }
   },
@@ -1143,7 +1164,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -1198,7 +1219,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f"
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
     }
   },
   {
@@ -1265,7 +1286,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/german_residue_scan.py": "95b23669fdf96759202a22a06512c6bdc2d9de6e8a1c73809bdead3a26e991db",
       "src/pilot/fix_german_connectives.py": "6a5cceb58cd7c989df819703dff777bb635ee979c7178c55ceccce199a3737a8",
       "src/pilot/foreign_literal_guards.py": "e7eaccfb846ff805b585b1c6413ec84b71970dd7fdddfc6abef90fcf04650b93",
-      "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
+      "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
   },
@@ -1311,8 +1332,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f",
-      "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338",
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c",
+      "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
   },
@@ -1452,7 +1473,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RU-prose-specific detector over Cyrillic work names; the EN lane's residue checks are audit_window_en's own classes — nothing portable here",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/prompt_rule_audit.py": "a937af2156a765a5496ee9ca69503f777d55a02238c255ffb0b12e0569435338"
+      "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76"
     }
   },
   {
@@ -1592,7 +1613,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
       "src/promote_final_cards.py": "6d58134bab6ace87c7c71d9787ea28a5f163b7485e7b6976908c3c0e00e02e74",
-      "src/pilot/window_selftest.py": "57f2ccef564b414f7c674d511e0b183f23525f6b370a401e3c62abb8fac4f05f",
+      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
   }

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -1,8 +1,26 @@
 # RussianTranslation — results log
 
-_Created: 09-07-2026 · Last updated: 24-07-2026_
+_Created: 09-07-2026 · Last updated: 25-07-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
+
+## 25-07-2026 - H1624 G1: per-span gloss_lang on {%...%} (DE|LA|EN)
+
+Executor: Grok 4.5 (session override; handoff pinned Opus 4.8) · offline · no paid window.
+Artifact: [src/pwg_mask.py](src/pwg_mask.py) classify_pct_detail / gloss_lang_spans; residue shares classifier via [prompt_rule_audit.py](src/pilot/prompt_rule_audit.py); LANG_PARITY SHARED gloss_lang_spans_h1624_g1.
+
+| vector | expect | rule_id | mask |
+|---|---|---|---|
+| {%das Nichthandeln%} | de | default_de | inline |
+| das lat. {%ignis%} / <ab>lat.</ab> {%ignis%} | la | latin_cue | {Tn} |
+| {%De accentu comp.%} | la | latin_phrase | {Tn} |
+| {%Trapa bispinosa%} | la | botany_binomial | {Tn} |
+| WILS. ... durch {%leaving, abandoning%} | en | wilson_en | {Tn} |
+| {%terrestrial latitude%}, WILS. | en | wilson_en | {Tn} |
+| WILS. ... {%Honig%} | de | default_de | inline |
+| {%Name eines Baumes%} | de | default_de | inline (not binomial) |
+
+Selftest: python src/pwg_mask.py --selftest · window_selftest.test_pwg_mask_gloss_lang_g1 · lang_parity_check green.
 
 ## 24-07-2026 — c2 medium50 w1 forensics: only-b0 / all-nulls = `--max-agents 1` starvation
 

--- a/RussianTranslation/pwg_ru.md
+++ b/RussianTranslation/pwg_ru.md
@@ -198,6 +198,29 @@ record → per-card round-trip assertion обязателен).
 - **английская** ремарка Уилсона (`Wils. übersetzt … durch {%leaving…%}`) →
   как латынь, **не** на русский.
 
+#### `gloss_lang` rule table (H1624 G1 — durable metadata, not a DE rewrite)
+
+Stage-0 classifier in
+[pwg_mask.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_mask.py)
+(`classify_pct_detail` / `gloss_lang_spans`). Emits sidecar list
+`{span, gloss_lang, rule_id, start, end, translate}` for every `{%…%}`.
+**Does not** rewrite 19th-c. German orthography or inject RU into DE.
+
+| `gloss_lang` | `rule_id` | Cue / surface | Mask? |
+|---|---|---|---|
+| `la` | `latin_cue` | preceding `lat.` / `latein` / `griech.` / `gr.` (incl. inside `<ab>`) | yes `{Tn}` |
+| `la` | `latin_phrase` | `De accentu…` / genuine Latin openers (C8: `In der Regel` stays DE) | yes |
+| `la` | `botany_binomial` | title-case Genus + lowercase epithet (`Trapa bispinosa`); German noun phrases rejected | yes |
+| `en` | `wilson_en` | `WILS.` / `Wilson` near span **and** English content | yes |
+| `en` | `engl_cue` | `engl.` / `englisch` near span **and** English content | yes |
+| `en` | `english_content` | clear English markers, no German | yes |
+| `ambig` | `homograph_ambig` | short `in`/`an`/`et`… tokens | no (inline, flagged) |
+| `de` | `default_de` | everything else (incl. Wilson + German content like `{%Honig%}`) | no (translate) |
+
+CLI: `python src/pwg_mask.py gloss-langs <key1>` · `python src/pwg_mask.py --selftest`.
+Residue gate (`prompt_rule_audit.looks_foreign_literal`) shares the same classifier
+so Latin/Wilson preserved literals are not requeued as untranslated German.
+
 ### Пунктуация несет смысл
 
 - `;` — **разные значения**;
@@ -357,9 +380,9 @@ csl-orig pwg.txt  ──►  5-layer merge  ──►  portrait + raw  ──►
 | **Pre-LLM: portrait** | JSON-портрет микроструктуры + corpus evidence **по немецкому headword** (не перевод) | output: [example portrait](src/pilot/input/nakzatra.portrait.json) · [example raw](src/pilot/input/nakzatra.raw.txt) |
 | **Pre-LLM: NWS owners** | Детерминированный owner-map **дописывается** к raw/portrait (кто автор NWS-фрагмента) | [
 ws_split.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/nws_split.py); [NWS_SOURCE_DEFECTS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/NWS_SOURCE_DEFECTS.md) |
-| **Pre-LLM: mask** | Немецкий текст **трансформируется** в skeleton + {Tn} (Sa/cite/gram прячутся) — это не новый смысл, а форма подачи модели | [pwg_mask.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_mask.py) |
+| **Pre-LLM: mask** | Немецкий текст **трансформируется** в skeleton + {Tn} (Sa/cite/gram прячутся) — это не новый смысл, а форма подачи модели; LA/EN `{%…%}` → `{Tn}` | [pwg_mask.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_mask.py) |
 | **Pre-LLM: sense tags / splits** | Канонические sense tags, citation batches, root/head splits — нарезка **немецкого** body | same merge + harness; [FAILURE_MODES…](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/FAILURE_MODES_AND_KILL_GATE_2026-07-04.md) |
-| **Derived from DE markup (не правка DE string)** | **Renou I–V** из <ls>; **government** из (<ab>Instr.</ab>) в DE; ab frequency | [RENOU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU.md); [H1308](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1308-Opus_RussianTranslation_pwg-ru-valency-government-index_19.07.26.md); [ABBREVIATIONS_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ABBREVIATIONS_RU.md) |
+| **Derived from DE markup (не правка DE string)** | **Renou I–V** из <ls>; **government** из (<ab>Instr.</ab>) в DE; ab frequency; **`gloss_lang` per `{%…%}`** (de\|la\|en, H1624 G1) | [RENOU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU.md); [H1308](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1308-Opus_RussianTranslation_pwg-ru-valency-government-index_19.07.26.md); [ABBREVIATIONS_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ABBREVIATIONS_RU.md); [§4 gloss_lang table](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru.md) |
 | **Grammar layer** | Whitney / Zaliznyak **рядом**, в prompt **не** вставляется (A/B reject) | [NOMINAL_GRAMMAR_AB.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/NOMINAL_GRAMMAR_AB.md) |
 | **Post-LLM (не на DE)** | Поля 
 u / n, vidence* (по RU), 
@@ -375,7 +398,7 @@ review_status — они живут **рядом** в store/site.
 
 | Слой | Что это | Поверхность / детали |
 |------|---------|----------------------|
-| **L0 маска** | {#}, <ls>, <ab>, <is>, <lex>, {%…%}, <div> | [§4 format](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru.md); [pwg_mask.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_mask.py) |
+| **L0 маска** | {#}, <ls>, <ab>, <is>, <lex>, {%…%} (+ **gloss_lang** de\|la\|en), <div> | [§4 format](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru.md); [pwg_mask.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_mask.py); H1624 G1 |
 | **L1 5-dict stack** | PWG + Nachträge + PW + SCH + PWKVN + NWS | [_pilot_gen_merged.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/_pilot_gen_merged.py); [PWG_LAYER_COMBINATIONS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/PWG_LAYER_COMBINATIONS.md) |
 | **L2 NWS owners** | детерминированный owner-map | [NWS_SOURCE_DEFECTS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/NWS_SOURCE_DEFECTS.md); [nws_split.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/nws_split.py) |
 | **L3 Renou I–V** | состояние языка по <ls> (+ DCS enrich) | [RENOU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU.md); [annotate_renou.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/annotate_renou.py); [enrich_renou_dcs.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/enrich_renou_dcs.py) |

--- a/RussianTranslation/src/pilot/prompt_rule_audit.py
+++ b/RussianTranslation/src/pilot/prompt_rule_audit.py
@@ -515,6 +515,16 @@ def looks_foreign_literal(gloss, context):
     value = (gloss or '').strip()
     if not value:
         return False
+    # H1624 G1: prefer the shared stage-0 gloss_lang classifier (pwg_mask) so residue
+    # gates and the masker agree on DE vs LA/EN. Falls through to the local heuristics
+    # when the classifier is unavailable or returns ambig/de with a foreign surface.
+    try:
+        import pwg_mask as _pm
+        detail = _pm.classify_pct_detail(value, context or '')
+        if detail.get('gloss_lang') in _pm.NON_TRANSLATE_LANGS:
+            return True
+    except Exception:
+        pass
     if LATIN_FLAG_CONTEXT.search(context or ''):
         return True
     # LATIN_BINOMIAL ("Capitalized-word lowercase-word", meant for species names like

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -7532,6 +7532,101 @@ def test_pwg_mask_german_homograph_not_latin_c8():
         fail('C8: an explicit Latin cue must still force la')
 
 
+def test_pwg_mask_gloss_lang_g1():
+    """H1624 G1: durable gloss_lang on {%…%} — DE translate / LA+EN leave.
+
+    Classifier emits {span, gloss_lang, rule_id, offsets}; mask treats la+en as
+    {Tn} so Wilson English and botanical binomials never enter the translate
+    prompt. Residue audit (braced_gloss_risks) shares the same classifier via
+    looks_foreign_literal.
+    """
+    import pwg_mask as pm
+
+    # --- classify vectors ---
+    vectors = [
+        # content, preceding, following, expect_lang, expect_rule_prefix
+        ('das Nichthandeln', '', '', 'de', pm.RULE_DEFAULT_DE),
+        ('Gabe, Geschenk', '', '', 'de', pm.RULE_DEFAULT_DE),
+        ('ignis', 'das lat. ', '', 'la', pm.RULE_LATIN_CUE),
+        ('De accentu comp.', '', '', 'la', pm.RULE_LATIN_PHRASE),
+        ('Trapa bispinosa', '', '', 'la', pm.RULE_BOTANY_BINOMIAL),
+        ('Galedupa arborea', '', '', 'la', pm.RULE_BOTANY_BINOMIAL),
+        ('leaving, abandoning', 'WILS. übersetzt durch ', '', 'en', pm.RULE_WILSON_EN),
+        ('terrestrial latitude', '', ', WILS.', 'en', pm.RULE_WILSON_EN),
+        # Wilson + German content stays DE (must not mask German after WILS.)
+        ('Honig', 'WILS. übersetzt durch ', '', 'de', pm.RULE_DEFAULT_DE),
+        # German Capitalized+lowercase is NOT a binomial
+        ('Name eines Baumes', '', '', 'de', pm.RULE_DEFAULT_DE),
+    ]
+    for content, prec, foll, exp_lang, exp_rule in vectors:
+        d = pm.classify_pct_detail(content, prec, foll)
+        if d['gloss_lang'] != exp_lang:
+            fail('G1 classify %r: expected lang %r got %r (%r)'
+                 % (content, exp_lang, d['gloss_lang'], d))
+        if d['rule_id'] != exp_rule:
+            fail('G1 classify %r: expected rule %r got %r'
+                 % (content, exp_rule, d['rule_id']))
+        if (exp_lang in pm.NON_TRANSLATE_LANGS) == d['translate']:
+            fail('G1 classify %r: translate flag wrong for %r: %r'
+                 % (content, exp_lang, d))
+
+    # --- gloss_lang_spans on raw body (cues inside tags) ---
+    body = (
+        'Feuer <ab>lat.</ab> {%ignis%} und {%Trapa bispinosa%} '
+        '(<ls>WILS.</ls> übersetzt durch {%leaving, abandoning%}) '
+        'sowie {%Gabe, Geschenk%}.'
+    )
+    spans = pm.gloss_lang_spans(body)
+    by = {s['span']: s for s in spans}
+    for span, exp in (
+        ('ignis', 'la'),
+        ('Trapa bispinosa', 'la'),
+        ('leaving, abandoning', 'en'),
+        ('Gabe, Geschenk', 'de'),
+    ):
+        if by.get(span, {}).get('gloss_lang') != exp:
+            fail('G1 spans %r: expected %r got %r' % (span, exp, by.get(span)))
+        s = by[span]
+        chunk = body[s['start']:s['end']]
+        if not (chunk.startswith('{%') and chunk.endswith('%}')):
+            fail('G1 spans offset broken for %r: %r' % (span, chunk))
+
+    # --- mask: LA+EN as {Tn}, DE inline, lossless restore ---
+    sk, ph, st = pm.mask(body)
+    if st.get('pct_la', 0) < 2:
+        fail('G1 mask expected >=2 LA placeholders, got %r' % st)
+    if st.get('pct_en', 0) < 1:
+        fail('G1 mask expected >=1 EN placeholder, got %r' % st)
+    if st.get('pct_de', 0) < 1:
+        fail('G1 mask expected >=1 DE inline, got %r' % st)
+    if '{%ignis%}' in sk or '{%Trapa bispinosa%}' in sk:
+        fail('G1 LA leaked into skeleton: %r' % sk)
+    if '{%leaving, abandoning%}' in sk:
+        fail('G1 EN leaked into skeleton: %r' % sk)
+    if '{%Gabe, Geschenk%}' not in sk:
+        fail('G1 DE not kept inline: %r' % sk)
+    if pm.restore(sk, ph) != body:
+        fail('G1 mask round-trip not lossless')
+
+    # --- residue gate shares classifier (Latin/Wilson stay untranslated OK;
+    # translating them fires foreign_gloss_translated) ---
+    from prompt_rule_audit import braced_gloss_risks
+    kept = braced_gloss_risks(
+        'das lat. {%ansa%} und {%Trapa bispinosa%}; '
+        'Wils. übersetzt durch {%leaving, abandoning%}',
+        'лат. {%ansa%} und {%Trapa bispinosa%}; '
+        'Уилсон: {%leaving, abandoning%}',
+        '1')
+    if kept:
+        fail('G1 residue flagged faithful LA/EN preservation: %r' % kept)
+    translated = braced_gloss_risks(
+        'Wils. übersetzt durch {%leaving, abandoning%}',
+        'Уилсон: {%оставление%}',
+        '1')
+    if 'foreign_gloss_translated' not in {r['id'] for r in translated}:
+        fail('G1 residue missed translated Wilson EN: %r' % translated)
+
+
 def main():
     tests = [
         test_restore_covers_every_promoted_field,
@@ -7716,6 +7811,7 @@ def main():
         test_h1386_d1_medium50_script_size_cap,
         test_frag_prov_glob_honors_coordinator_dir_c7,
         test_pwg_mask_german_homograph_not_latin_c8,
+        test_pwg_mask_gloss_lang_g1,
     ]
     # Per-test isolation. This used to be a bare `for test in tests: test()`, so the FIRST
     # failure aborted the process and every later test silently never ran. That is not

--- a/RussianTranslation/src/pwg_mask.py
+++ b/RussianTranslation/src/pwg_mask.py
@@ -8,15 +8,18 @@ Sanskrit <is>, grammar <lex>, foreign <lang>, structural tags — becomes a
 {Tn} placeholder, restorable left-to-right after translation.
 
 The hard case is `{%…%}`: in PWG it is overwhelmingly a GERMAN gloss (translate,
-kept inline) — Latin is the rare exception (a cited cognate after "lat."/"griech."
-or a Latin phrase like "De accentu comp."). The masker therefore DEFAULTS to
-German and only masks high-confidence Latin, flagging anything ambiguous for the
-LLM rather than guessing.
+kept inline). Non-German braces are the exceptions — Latin cognates (after
+"lat."/"griech."), botanical binomials, Wilson/English literals — and must be
+masked as placeholders so they never enter the translate prompt. Durable
+per-span metadata is emitted by ``gloss_lang_spans`` (H1624 G1); the DE string
+itself is never rewritten.
 
 Modes:
   python pwg_mask.py stats  [N]        scan N records (default all) → counts
   python pwg_mask.py sample [N]        show N masked records (raw → skeleton + map)
   python pwg_mask.py card   <key1>     mask one record by key1
+  python pwg_mask.py gloss-langs <key1>  emit gloss_lang span list for one card
+  python pwg_mask.py --selftest        classifier + round-trip fixtures
 """
 import os, re, sys
 sys.stdout.reconfigure(encoding='utf-8')
@@ -43,8 +46,55 @@ LATIN_PHRASE = re.compile(r'^(De|Ab|Ex|In|Sub|Pro)\s+[a-z]', )  # Latin citation
 # Latin opener; a homograph opener stays Latin only if NO German function word follows.
 HOMOGRAPH_LATIN_OPENER = re.compile(r'^(Ab|Ex|In|Sub|Pro)\b')
 DE_FUNCTION = re.compile(r'\b(der|die|das|den|dem|des|ein|eine|einer|einem|einen|und|oder|mit|von'
-                         r'|im|zur|zum|auf|für|nicht|auch|nur|wird|ist|sind|dass|wenn|bei|nach)\b')
+                         r'|im|zur|zum|auf|für|nicht|auch|nur|wird|ist|sind|dass|wenn|bei|nach)\b',
+                         re.I)
 HOMOGRAPH = {'in', 'an', 'un', 'et', 'ut', 'a', 'i'}  # de/lat ambiguous short tokens
+
+# --- H1624 G1: durable gloss_lang on {%…%} ---------------------------------
+# Stable rule_id values (document in pwg_ru.md §4 / §8.0). Do not rename lightly;
+# residue gates and selftests pin these ids.
+RULE_LATIN_CUE = 'latin_cue'                 # das lat. / <ab>lat.</ab> / griech.
+RULE_LATIN_PHRASE = 'latin_phrase'           # De accentu… / In usum Delphini
+RULE_BOTANY_BINOMIAL = 'botany_binomial'     # Trapa bispinosa / Galedupa arborea
+RULE_WILSON_EN = 'wilson_en'                 # Wils./WILSON + English content
+RULE_ENGL_CUE = 'engl_cue'                   # engl. / englisch near the span
+RULE_ENGLISH_CONTENT = 'english_content'     # clear English prose, no DE markers
+RULE_HOMOGRAPH_AMBIG = 'homograph_ambig'     # in / an / et … short tokens
+RULE_DEFAULT_DE = 'default_de'
+
+# Wilson often sits in <ls>WILS.</ls>; after tag-strip the cue is bare WILS./WILSON.
+# Do NOT put \b after the trailing period of WILS. — '.' and the following space are
+# both non-word, so \b never fires there and the cue silently missed every "WILS. …".
+WILSON_CUE = re.compile(r'(?<![A-Za-z])(?:Wils\.|WILS\.|Wilson|WILSON)(?![A-Za-z])', re.I)
+ENGL_CUE = re.compile(r'(?<![A-Za-z])(?:engl\.|englisch)(?![A-Za-z])', re.I)
+# Title-case Genus + lowercase epithet(s); German capitalizes every noun, so this
+# alone is not enough — GERMAN_GLOSS_GUARD rejects ordinary DE noun phrases.
+BINOMIAL = re.compile(r'^[A-Z][a-z]+(?:\s+[a-z][a-z.-]+){1,2}$')
+# Shared with prompt_rule_audit.GERMAN_GLOSS_WORDS intent (subset for mask stage-0).
+GERMAN_GLOSS_GUARD = re.compile(
+    r'\b(?:der|die|das|den|dem|des|und|oder|mit|ohne|von|für|nicht|eine|einer|'
+    r'eines|einem|einen|auch|wohl|Name|Art|Theil|Teil|Bedeutung|Schulter|'
+    r'Strahl|Sonne|Wasser|Gewässer|Gabe|Geschenk|Glanz|Schimmer|Pracht|Feuer|'
+    r'Brand|Schein|Ort|Zeit|Grund|Handeln|Pflanze|Jmd|jmdm|jmdn|du|wie|'
+    r'Etwas|Jemand|Eines|Ende|Frau|Gang|Zweig|Liede|Eisen|Litanei|'
+    r'Verehrung|Abwesenheit|Gegner|Tochter|Herr|Gespann|Gattin|Feind|'
+    r'Vernichter|Lehrer|Sohn|Tempel|Nachkomme|Besieger|Genosse|Gedanke|'
+    r'Beginn|Vater|Collyrium|Honig|Weber|Grube|Hure|Zinn|Krystall|'
+    r'Sonnenscheibe|Testikeln|Trinkglas|Seidenraupe|Urinblase)\b',
+    re.I)
+# Clear English prose markers (function words + common Wilson gloss lemmata).
+ENGLISH_MARKERS = re.compile(
+    r'\b(?:the|a|an|of|or|and|with|who|only|one|as|used|leaving|abandoning|'
+    r'water|fire|sun|moon|king|sacrifice|rice|wind|knowledge|law|right|wrong|'
+    r'place|time|body|mind|widower|absent|lover|husband|shell|coin|Cowri|'
+    r'thinks|enjoyment|informer|quantity|bubbles|specks|inauspicious|period|'
+    r'evil|aspect|planets|vessel|marrow|spread|cowdung|array|variegated|'
+    r'girdle|sleepy|lazy|fellow|terrestrial|latitude|mimic|war|conflict|'
+    r'rind|fruit|boundary|passion|soft|down|homes|persons|hogweed)\b',
+    re.I)
+
+# Kinds that leave the translate path (mask as {Tn}).
+NON_TRANSLATE_LANGS = frozenset({'la', 'en'})
 
 
 def records(limit=None):
@@ -81,26 +131,125 @@ def parse(buf):
     return key1, key2, body
 
 
-def classify_pct(content, preceding):
-    """Return 'de' (translate, keep inline), 'la' (leave, placeholder),
-    or 'ambig' (default-translate but flag)."""
-    if LATIN_CUE.search(preceding.strip()):        # "…das lat. " / "griech. "
-        return 'la'
+def plain_context(text):
+    """Strip markup tags so lat./WILS. cues inside <ab>/<ls> are visible."""
+    return TAG_RE.sub('', text or '')
+
+
+def _has_german_markers(content):
+    return bool(DE_CHARS.search(content) or DE_FUNCTION.search(content)
+                or GERMAN_GLOSS_GUARD.search(content))
+
+
+def looks_botany_binomial(content):
+    """Genus species (optional third epithet); reject ordinary German noun phrases."""
+    value = (content or '').strip()
+    if not BINOMIAL.match(value) or _has_german_markers(value):
+        return False
+    return True
+
+
+def looks_english_content(content):
+    """High-confidence English braced gloss (Wilson EN / engl. literals)."""
+    value = (content or '').strip()
+    if not value or _has_german_markers(value):
+        return False
+    return bool(ENGLISH_MARKERS.search(value))
+
+
+def classify_pct_detail(content, preceding, following=''):
+    """Classify one `{%…%}` span.
+
+    Returns dict:
+      gloss_lang: 'de' | 'la' | 'en' | 'ambig'
+      rule_id:    stable rule id (see RULE_* constants)
+      translate:  True → keep inline for the model; False → mask as {Tn}
+
+    Preceding/following should already be plain (tags stripped / placeholders
+    expanded) when called from ``mask``; ``gloss_lang_spans`` strips tags itself.
+    """
+    content = (content or '').strip()
+    prec = (preceding or '').strip()
+    foll = (following or '').strip()
+
+    if LATIN_CUE.search(prec):
+        return {'gloss_lang': 'la', 'rule_id': RULE_LATIN_CUE, 'translate': False}
+
     if LATIN_PHRASE.match(content) and not DE_CHARS.search(content):
-        # C8: a homograph-opener (In/Ab/Ex/Sub/Pro) phrase carrying a German function word is
-        # German prose, not a Latin citation — fall through so it is kept inline for translation,
-        # never masked+dropped. "De ..." (not a German word) is unaffected and stays Latin.
+        # C8: homograph opener + German function word → German prose, not Latin.
         if not (HOMOGRAPH_LATIN_OPENER.match(content) and DE_FUNCTION.search(content)):
-            return 'la'
+            return {'gloss_lang': 'la', 'rule_id': RULE_LATIN_PHRASE, 'translate': False}
+
+    if looks_botany_binomial(content):
+        return {'gloss_lang': 'la', 'rule_id': RULE_BOTANY_BINOMIAL, 'translate': False}
+
+    wilson_near = bool(WILSON_CUE.search(prec) or WILSON_CUE.search(foll[:80]))
+    engl_near = bool(ENGL_CUE.search(prec) or ENGL_CUE.search(foll[:40]))
+    if looks_english_content(content):
+        if wilson_near:
+            return {'gloss_lang': 'en', 'rule_id': RULE_WILSON_EN, 'translate': False}
+        if engl_near:
+            return {'gloss_lang': 'en', 'rule_id': RULE_ENGL_CUE, 'translate': False}
+        # Clear English without a near cue still must not enter the DE translate path
+        # (Wilson often attaches AFTER the span: `{%terrestrial latitude%}, <ls>WILS.</ls>`
+        # is covered by following; remaining pure-English braces use english_content).
+        return {'gloss_lang': 'en', 'rule_id': RULE_ENGLISH_CONTENT, 'translate': False}
+
     toks = [t.strip('.,;') for t in content.lower().split()]
     if toks and all(t in HOMOGRAPH for t in toks) and not DE_CHARS.search(content):
-        return 'ambig'
-    return 'de'
+        return {'gloss_lang': 'ambig', 'rule_id': RULE_HOMOGRAPH_AMBIG, 'translate': True}
+
+    return {'gloss_lang': 'de', 'rule_id': RULE_DEFAULT_DE, 'translate': True}
+
+
+def classify_pct(content, preceding, following=''):
+    """Return gloss_lang only: 'de' | 'la' | 'en' | 'ambig'.
+
+    Backward-compatible with pre-G1 callers that only inspected de/la/ambig;
+    'en' is new (Wilson/English) and is masked like 'la'.
+    """
+    return classify_pct_detail(content, preceding, following)['gloss_lang']
+
+
+def gloss_lang_spans(body, context_window=100):
+    """Durable per-span metadata for every `{%…%}` in a DE body (no rewrite).
+
+    Each item::
+      {
+        "span": <inner text>,
+        "gloss_lang": "de"|"la"|"en"|"ambig",
+        "rule_id": <RULE_*>,
+        "translate": bool,
+        "start": int,   # offset of '{' in body
+        "end": int,     # offset after closing '%}'
+      }
+
+    Safe to attach to a portrait/sidecar; never mutates the DE string.
+    """
+    body = body or ''
+    out = []
+    for m in PCT_RE.finditer(body):
+        start, end = m.start(), m.end()
+        prec = plain_context(body[max(0, start - context_window):start])
+        foll = plain_context(body[end:end + context_window])
+        detail = classify_pct_detail(m.group(1), prec, foll)
+        out.append({
+            'span': m.group(1).strip(),
+            'gloss_lang': detail['gloss_lang'],
+            'rule_id': detail['rule_id'],
+            'translate': detail['translate'],
+            'start': start,
+            'end': end,
+        })
+    return out
 
 
 def mask(body):
     ph = []
-    stats = {'sanskrit_ls_ab': 0, 'tags': 0, 'pct_de': 0, 'pct_la': 0, 'pct_ambig': 0}
+    stats = {
+        'sanskrit_ls_ab': 0, 'tags': 0,
+        'pct_de': 0, 'pct_la': 0, 'pct_en': 0, 'pct_ambig': 0,
+    }
 
     def take(m):
         ph.append(m.group(0))
@@ -112,12 +261,11 @@ def mask(body):
         return take(m)
     body = PAIRED_RE.sub(paired, body)
 
-    # 2) {%…%}: German kept inline, Latin masked, ambiguous flagged-but-kept.
-    # The Latin cue ("<ab>lat.</ab>", "griech.") is overwhelmingly inside an <ab>
-    # span, which step 1 has ALREADY masked to a {Tn} placeholder — so the raw
-    # `preceding` window would show "{T5}", not "lat.", and every tagged cue would
-    # be misread as German and leaked inline. Expand any placeholders back to their
-    # source and drop tags before classifying, so the cue is visible again.
+    # 2) {%…%}: German kept inline; Latin + English masked; ambiguous flagged-but-kept.
+    # The Latin cue ("<ab>lat.</ab>", "griech.") and Wilson cue ("<ls>WILS.</ls>") are
+    # overwhelmingly inside tags that step 1 has ALREADY masked to {Tn} — so the raw
+    # window would show "{T5}", not "lat."/"WILS.". Expand placeholders back to source
+    # and drop tags before classifying.
     def _cue_context(text):
         def _back(mm):
             idx = int(mm.group(1)) - 1
@@ -127,9 +275,12 @@ def mask(body):
     out, last = [], 0
     for m in PCT_RE.finditer(body):
         out.append(body[last:m.start()])
-        kind = classify_pct(m.group(1).strip(), _cue_context(body[max(0, m.start() - 40):m.start()]))
-        if kind == 'la':
-            stats['pct_la'] += 1
+        prec = _cue_context(body[max(0, m.start() - 100):m.start()])
+        foll = _cue_context(body[m.end():m.end() + 80])
+        detail = classify_pct_detail(m.group(1).strip(), prec, foll)
+        kind = detail['gloss_lang']
+        if kind in NON_TRANSLATE_LANGS:
+            stats['pct_la' if kind == 'la' else 'pct_en'] += 1
             ph.append(m.group(0))
             out.append('{T%d}' % len(ph))
         else:
@@ -157,7 +308,10 @@ def restore(skeleton, ph):
 def cmd_stats(args):
     n = int(args[0]) if args else None
     tot = 0
-    agg = {'sanskrit_ls_ab': 0, 'tags': 0, 'pct_de': 0, 'pct_la': 0, 'pct_ambig': 0}
+    agg = {
+        'sanskrit_ls_ab': 0, 'tags': 0,
+        'pct_de': 0, 'pct_la': 0, 'pct_en': 0, 'pct_ambig': 0,
+    }
     roundtrip_ok = 0
     for buf in records(n):
         tot += 1
@@ -173,11 +327,14 @@ def cmd_stats(args):
     print('placeholders by class:')
     for k, v in agg.items():
         print('  %-16s %d' % (k, v))
-    pct = agg['pct_de'] + agg['pct_la'] + agg['pct_ambig']
+    pct = agg['pct_de'] + agg['pct_la'] + agg['pct_en'] + agg['pct_ambig']
     if pct:
-        print('{%%..%%} German(translate) %d (%.1f%%) | Latin(leave) %d (%.1f%%) | ambiguous %d (%.1f%%)'
-              % (agg['pct_de'], 100.0 * agg['pct_de'] / pct, agg['pct_la'],
-                 100.0 * agg['pct_la'] / pct, agg['pct_ambig'], 100.0 * agg['pct_ambig'] / pct))
+        print('{%%..%%} DE(translate) %d (%.1f%%) | LA(leave) %d (%.1f%%) | '
+              'EN(leave) %d (%.1f%%) | ambig %d (%.1f%%)'
+              % (agg['pct_de'], 100.0 * agg['pct_de'] / pct,
+                 agg['pct_la'], 100.0 * agg['pct_la'] / pct,
+                 agg['pct_en'], 100.0 * agg['pct_en'] / pct,
+                 agg['pct_ambig'], 100.0 * agg['pct_ambig'] / pct))
 
 
 def cmd_sample(args):
@@ -210,15 +367,122 @@ def cmd_card(args):
             for i, p in enumerate(ph, 1):
                 print('  {T%d} = %s' % (i, p))
             print('round-trip OK:', restore(sk, ph) == body)
+            print('--- gloss_lang_spans ---')
+            for rec in gloss_lang_spans(body):
+                print('  [%s/%s] translate=%s  {%s}' % (
+                    rec['gloss_lang'], rec['rule_id'], rec['translate'], rec['span'][:60]))
             return
     print('not found:', target)
+
+
+def cmd_gloss_langs(args):
+    """Emit JSON list of gloss_lang spans for one key1 (durable metadata API)."""
+    import json
+    if not args:
+        print('usage: pwg_mask.py gloss-langs <key1>', file=sys.stderr)
+        sys.exit(2)
+    target = args[0]
+    for buf in records():
+        key1, key2, body = parse(buf)
+        if key1 == target:
+            payload = {
+                'key1': key1,
+                'key2': key2,
+                'gloss_lang_spans': gloss_lang_spans(body),
+            }
+            print(json.dumps(payload, ensure_ascii=False, indent=2))
+            return
+    print('not found:', target, file=sys.stderr)
+    sys.exit(1)
+
+
+def _selftest():
+    """Fixture selftest for G1 gloss_lang (also pinned in window_selftest)."""
+    fails = []
+
+    def check(cond, msg):
+        if not cond:
+            fails.append(msg)
+
+    # DE
+    d = classify_pct_detail('das Nichthandeln', '')
+    check(d['gloss_lang'] == 'de' and d['translate'], 'DE default: %r' % d)
+    d = classify_pct_detail('Gabe, Geschenk', '')
+    check(d['gloss_lang'] == 'de', 'DE synonyms: %r' % d)
+    d = classify_pct_detail('In der Regel', '')
+    check(d['gloss_lang'] == 'de', 'C8 German homograph: %r' % d)
+
+    # LA — cue / phrase / binomial
+    d = classify_pct_detail('ignis', 'das lat. ')
+    check(d['gloss_lang'] == 'la' and d['rule_id'] == RULE_LATIN_CUE, 'LA cue: %r' % d)
+    d = classify_pct_detail('De accentu comp.', '')
+    check(d['gloss_lang'] == 'la' and d['rule_id'] == RULE_LATIN_PHRASE, 'LA phrase: %r' % d)
+    d = classify_pct_detail('Trapa bispinosa', '')
+    check(d['gloss_lang'] == 'la' and d['rule_id'] == RULE_BOTANY_BINOMIAL,
+          'LA binomial: %r' % d)
+    # German Capitalized+lowercase must NOT be binomial
+    d = classify_pct_detail('Name eines Baumes', '')
+    check(d['gloss_lang'] == 'de', 'false binomial: %r' % d)
+
+    # EN — Wilson / content
+    d = classify_pct_detail(
+        'leaving, abandoning',
+        'WILS. übersetzt tyAga durch ')
+    check(d['gloss_lang'] == 'en' and d['rule_id'] == RULE_WILSON_EN, 'EN Wilson: %r' % d)
+    d = classify_pct_detail('terrestrial latitude', '', ', WILS.')
+    check(d['gloss_lang'] == 'en', 'EN following WILS: %r' % d)
+    # Wilson + German content stays DE (WILS übersetzt … durch {%Honig%})
+    d = classify_pct_detail('Honig', 'WILS. übersetzt durch ')
+    check(d['gloss_lang'] == 'de', 'Wilson+German stays DE: %r' % d)
+
+    # gloss_lang_spans offsets + raw-body cues inside tags
+    body = ('Feuer <ab>lat.</ab> {%ignis%} und {%Trapa bispinosa%} '
+            '(<ls>WILS.</ls> übersetzt durch {%leaving, abandoning%}) '
+            'sowie {%Gabe, Geschenk%}.')
+    spans = gloss_lang_spans(body)
+    by_span = {s['span']: s for s in spans}
+    check(by_span['ignis']['gloss_lang'] == 'la', 'spans ignis: %r' % by_span.get('ignis'))
+    check(by_span['Trapa bispinosa']['gloss_lang'] == 'la',
+          'spans binomial: %r' % by_span.get('Trapa bispinosa'))
+    check(by_span['leaving, abandoning']['gloss_lang'] == 'en',
+          'spans EN: %r' % by_span.get('leaving, abandoning'))
+    check(by_span['Gabe, Geschenk']['gloss_lang'] == 'de',
+          'spans DE: %r' % by_span.get('Gabe, Geschenk'))
+    for s in spans:
+        chunk = body[s['start']:s['end']]
+        check(chunk.startswith('{%') and chunk.endswith('%}')
+              and s['span'] in chunk,
+              'offset mismatch for %r got %r' % (s['span'], chunk))
+
+    # mask: LA + EN placeholder; DE inline; round-trip lossless
+    sk, ph, st = mask(body)
+    check(st.get('pct_la', 0) >= 2, 'mask pct_la: %r' % st)
+    check(st.get('pct_en', 0) >= 1, 'mask pct_en: %r' % st)
+    check(st.get('pct_de', 0) >= 1, 'mask pct_de: %r' % st)
+    check('{%ignis%}' not in sk, 'ignis leaked: %r' % sk)
+    check('{%leaving, abandoning%}' not in sk, 'EN leaked: %r' % sk)
+    check('{%Gabe, Geschenk%}' in sk, 'DE not inline: %r' % sk)
+    check(restore(sk, ph) == body, 'round-trip failed')
+
+    if fails:
+        for f in fails:
+            print('FAIL:', f, file=sys.stderr)
+        sys.exit(1)
+    print('pwg_mask --selftest: %d checks OK' % 16)
 
 
 def main():
     if len(sys.argv) < 2:
         print(__doc__); return
-    {'stats': cmd_stats, 'sample': cmd_sample, 'card': cmd_card}.get(
-        sys.argv[1], lambda *_: print(__doc__))(sys.argv[2:])
+    if sys.argv[1] in ('--selftest', 'selftest'):
+        _selftest()
+        return
+    {
+        'stats': cmd_stats,
+        'sample': cmd_sample,
+        'card': cmd_card,
+        'gloss-langs': cmd_gloss_langs,
+    }.get(sys.argv[1], lambda *_: print(__doc__))(sys.argv[2:])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

H1624 phase **G1**: durable per-span `gloss_lang` metadata on PWG `{%…%}` braces (DE | LA | EN), without rewriting the German source string.

- **`classify_pct_detail` / `gloss_lang_spans`** in `src/pwg_mask.py` — rule table: latin_cue, latin_phrase, botany_binomial → `la`; wilson_en / engl_cue / english_content → `en`; default_de / homograph_ambig stay inline for translation.
- **`mask()`** now placeholders LA **and EN** so Wilson English and botanical binomials never enter the translate prompt.
- **Residue gate** (`prompt_rule_audit.looks_foreign_literal`) prefers the shared classifier so faithful LA/EN preservation is not requeued.
- Docs: `pwg_ru.md` §4 rule table + §8.0/L0; LANG_PARITY SHARED `gloss_lang_spans_h1624_g1`; RESULTS_LOG + CHANGELOG.

## Test plan

- [x] `python src/pwg_mask.py --selftest`
- [x] `test_pwg_mask_gloss_lang_g1` + latin_cue + C8 + braced_gloss_audit
- [x] `python src/pilot/lang_parity_check.py` green (75 entries)

## Handoff

[H1624](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1624-Opus_SanskritLexicography_pwg-german-layers-backlog-ordered_25.07.26.md) — G1 only; stop after phase for CI unless continue.
