### PR TITLE
docs(pwg_ru): H1624 DH follow-up batch H1626–H1635

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -20,6 +20,8 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **H1624 DH batch H1626–H1635** minted 25-07-2026 (Grok 4.5): see pwg_ru.md §9; G5/G7 still ⏸.
+
 - **c2 medium50 w1 after session reset (24-07-2026, Grok 4.5).** Gate-0 + canary PASS on
   c2 Pro earlier this session. Forensic root of 0/3 “only b0” runs is **`--max-agents 1`**
   total-spawn starvation (ledger `C2_M50_W1_MAX_AGENTS1_2026-07-24`,

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,14 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Documented - H1624 DH follow-up handoff batch H1626–H1635
+
+- Minted+filled 10 handoffs after German-layers G1–G6: post-vote H1303/H1306,
+  compound differs review-sheet, OntoLex/TEI export, citation top-N scans,
+  edition-diff UI, DCS pilot, gold methods, editorial principles, Zenodo sidecars.
+- Registry: [Uprava handoffs README](https://github.com/gasyoun/Uprava/blob/main/handoffs/README.md);
+  programme [H1624](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1624-Opus_SanskritLexicography_pwg-german-layers-backlog-ordered_25.07.26.md).
+
 ### Added - H1624 G6: derivation/compound conflict flags on portraits
 
 - [enrich_portrait_derivation.py](src/pilot/enrich_portrait_derivation.py):

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -4,6 +4,25 @@ _Created: 09-07-2026 · Last updated: 25-07-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
+## 25-07-2026 - H1624 DH follow-up batch minted (H1626–H1635)
+
+Executor: Grok 4.5. Mint-only (no execution). Parent: H1624 German layers closed G1–G6.
+
+| ID | Priority | Topic | Status |
+|---|---|---|---|
+| H1626 | P0 | H1303 abbrev apply | ⏸ vote |
+| H1627 | P0 | H1306 style / G5 | ⏸ vote |
+| H1628 | P1 | compound differs sheet | QUEUED |
+| H1629 | P2 | OntoLex/TEI DE graph | QUEUED |
+| H1630 | P3 | citation top-N scans | QUEUED |
+| H1631 | P4 | edition-diff UI | QUEUED |
+| H1632 | P5 | sense–DCS pilot | QUEUED |
+| H1633 | P7 | gold cut + methods | QUEUED |
+| H1634 | docs | editorial principles | QUEUED |
+| H1635 | FAIR | Zenodo public sidecars | QUEUED (rights) |
+
+G7: existing H1333 (XLS-gated). Spec: Uprava/handoffs/_batch_h1624_dh_followups.tsv.
+
 ## 25-07-2026 - H1624 G6: compound conflict flags + G5/G7 blockers
 
 Executor: Grok 4.5.

--- a/RussianTranslation/pwg_ru.md
+++ b/RussianTranslation/pwg_ru.md
@@ -1,6 +1,6 @@
 # Словарь `pwg_ru` — русский перевод Большого Петербургского словаря
 
-_Created: 09-07-2026 · Last updated: 25-07-2026_
+_Created: 09-07-2026 · Last updated: 25-07-2026
 
 > Документ для **редактора**. Описывает, **как устроен** AI-перевод Большого
 > Петербургского словаря (`pwg_ru`, Бетлингк–Рот): кто переводит и кто судит
@@ -471,7 +471,27 @@ eview_status / human gold? | review | mostly i_translated | [HUMAN_GOLD_PROTOCO
 English twin:
 [docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md) §2b–§2c.
 
-## 9. Куда идти дальше
+## 9. Куда идти дальше (H1624 DH follow-up batch)
+
+После закрытия H1624 (G1–G6 ✅; G5/G7 ⏸) заведена партия handoff-ов DH best practices
+([Uprava H1626–H1635](https://github.com/gasyoun/Uprava/blob/main/handoffs/README.md)):
+
+| ID | Тема | Разблокирует | Tier |
+|---|---|---|---|
+| [H1626](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1626-Fable_SanskritLexicography_pwg-h1303-abbrev-decisions-apply_25.07.26.md) | Apply H1303 abbrev vote | N1 | Fable ⏸ vote |
+| [H1627](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1627-Fable_SanskritLexicography_pwg-h1306-style-decisions-apply_25.07.26.md) | Apply H1306 = G5 | N2 | Fable ⏸ vote |
+| [H1628](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1628-Sonnet_SanskritLexicography_pwg-compound-differs-review-sheet_25.07.26.md) | ~200 compound differs sheet | N11 sample | Sonnet |
+| [H1629](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1629-Opus_SanskritLexicography_pwg-de-graph-ontolex-tei-export_25.07.26.md) | OntoLex/TEI DE graph | citability | Opus |
+| [H1630](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1630-Sonnet_SanskritLexicography_pwg-citation-edges-topn-scan-links_25.07.26.md) | Top-N scan links | N15 partial | Sonnet |
+| [H1631](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1631-Sonnet_SanskritLexicography_pwg-edition-diff-ui_25.07.26.md) | Edition-diff UI | N14 | Sonnet |
+| [H1632](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1632-Opus_SanskritLexicography_pwg-de-sense-dcs-attestation-pilot_25.07.26.md) | Sense–DCS pilot | N5 | Opus |
+| [H1633](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1633-Fable_SanskritLexicography_pwg-human-gold-cut-methods-packet_25.07.26.md) | Gold cut + methods | N3/N13 | Fable |
+| [H1634](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1634-Sonnet_SanskritLexicography_pwg-de-editorial-principles-doc_25.07.26.md) | Editorial principles | DH ethics doc | Sonnet |
+| [H1635](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1635-Opus_SanskritLexicography_pwg-public-sidecar-zenodo-release_25.07.26.md) | Public sidecars Zenodo | FAIR | Opus ⏸ rights |
+
+G7 Palsule остаётся [H1333](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1333-Opus_RussianTranslation_pwg-ru-dhatup-palsule-wire-from-xls_19.07.26.md) (XLS).
+
+## 9b. Прочие указатели
 
 | Нужно | Документ |
 |-------|----------|


### PR DESCRIPTION
## Summary

Indexes the H1624 DH best-practices follow-up handoff batch (H1626–H1635) in:

- `pwg_ru.md` §9 table (N1–N15 mapping)
- CHANGELOG / RESULTS_LOG / `.ai_state.md`

Handoffs live in Uprava (filled + registry). No code changes.

## Test plan

- [x] links resolve to Uprava handoff paths
- [x] no store/payload changes
