### PR TITLE
docs(ai_state): H1624 resume pointer + DH batch starters

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Prove bounded PWG→Russian CLI correctness on one profile, then scale + the CDSL article-comparison study
 
-_Created: 09-07-2026 · Last updated: 24-07-2026_
+_Created: 09-07-2026 · Last updated: 25-07-2026_
 
 > **H1618 🔴 EXECUTED** (Grok 4.5) — unpaid four tracks merged
 > [PR #704](https://github.com/gasyoun/SanskritLexicography/pull/704): max-agents
@@ -19,6 +19,81 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 > the root copy. Audited + reconciled 2026-06-26.
 
 ## ➡️ Next Steps (Queue)
+
+### ⭐ RESUME HERE — H1624 German layers closed; DH batch H1626–H1635 (25-07-2026, Grok 4.5)
+
+**Where we stopped:** H1624 G1–G6 shipped (PRs #715–#722); G5/G7 blocked; DH follow-up
+handoffs **H1626–H1635** minted+filled+registered (Uprava main); docs
+[PR #723](https://github.com/gasyoun/SanskritLexicography/pull/723). Paid drain path
+unchanged (c2/c4 health then medium50, no --max-agents).
+
+**H1624 acceptance (closed):**
+
+| Phase | Status | PR |
+|---|---|---|
+| G1 gloss_lang | done | #715 |
+| G2 government | done | #716 |
+| form_labels / form_notes | done | #717–#718 |
+| G3 citation_edges | done | #720 |
+| G4 edition_rel | done | #721 |
+| G5 H1306 DE tags | blocked | need pwg_ru/eval/h1306_style.decisions.json |
+| G6 derivation conflict flags | done | #722 (4226/39539 differs) |
+| G7 Palsule | blocked | XLS via H1333 |
+
+**Programme:** [H1624](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1624-Opus_SanskritLexicography_pwg-german-layers-backlog-ordered_25.07.26.md)
+
+**DH batch (launchable first):**
+
+| ID | Tier | Topic | Gate |
+|---|---|---|---|
+| H1634 | Sonnet | editorial principles doc | ready |
+| H1628 | Sonnet | ~200 compound differs review-sheet | ready |
+| H1630 | Sonnet | citation top-N scan links | ready |
+| H1631 | Sonnet | edition-diff UI | ready |
+| H1629 | Opus | OntoLex/TEI DE graph export | ready |
+| H1632 | Opus | sense–DCS pilot | ready |
+| H1635 | Opus | Zenodo public sidecars | publish-safety first |
+| H1633 | Fable | gold cut + methods packet | draft ok |
+| H1626 | Fable | H1303 abbrev apply | needs vote |
+| H1627 | Fable | H1306 style apply (G5) | needs vote |
+
+**Literal starters (matching-tier chat):**
+
+```
+Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H1634-Sonnet_SanskritLexicography_pwg-de-editorial-principles-doc_25.07.26.md and execute it.
+```
+
+```
+Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H1628-Sonnet_SanskritLexicography_pwg-compound-differs-review-sheet_25.07.26.md and execute it.
+```
+
+```
+Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H1630-Sonnet_SanskritLexicography_pwg-citation-edges-topn-scan-links_25.07.26.md and execute it.
+```
+
+Sonnet 5 (`claude-sonnet-5`); cwd RussianTranslation; isolated worktree.
+
+```
+Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H1629-Opus_SanskritLexicography_pwg-de-graph-ontolex-tei-export_25.07.26.md and execute it.
+```
+
+Opus 4.8 (`claude-opus-4-8`); cwd RussianTranslation; isolated worktree.
+
+**Orientation:** [pwg_ru.md §8–§9](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru.md) ·
+[RESULTS_LOG](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md) ·
+batch [_batch_h1624_dh_followups.tsv](https://github.com/gasyoun/Uprava/blob/main/handoffs/_batch_h1624_dh_followups.tsv)
+
+**Human unlocks (do not invent):**
+1. Vote review/h1303_abbrev_sheet.html → pwg_ru/eval/h1303_abbrev.decisions.json → H1626
+2. Vote review/h1306_style_sheet.html → pwg_ru/eval/h1306_style.decisions.json → H1627
+3. Drop Palsule XLS → H1333 / G7
+
+**Paid production (Track A, orthogonal) still parked on:**
+- fresh c2/c4 live-gate GO, then medium50 **without** --max-agents (H1618)
+- stop-before-promote / no store until clean
+
+---
+
 
 - **H1624 DH batch H1626–H1635** minted 25-07-2026 (Grok 4.5): see pwg_ru.md §9; G5/G7 still ⏸.
 
@@ -2249,6 +2324,10 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## 🚧 Current Work-In-Progress (WIP)
 
+- **None from H1624** — programme closed for agent execution except blocked G5/G7 and
+  queued DH batch H1626–H1635. Do not invent votes or XLS.
+
+
 - **H1110 handoff authored, not yet executed (17-07-2026, Codex/GPT-5).** Atomic handoff ID minted
   and the active resume pointer moved from H963 to H1110. No code change, live probe, generation,
   promotion, store mutation or TM rebuild occurred in the authoring session.
@@ -2536,6 +2615,10 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   ([SamudraManthanam #16](https://github.com/gasyoun/SamudraManthanam/issues/16)).
 
 ## ✅ Completed (Recent only)
+
+- **H1624 code + DH batch mint (25-07-2026, Grok 4.5).** G1–G6 shipped #715–#722;
+  G5/G7 blocked; H1626–H1635 minted+registered. Docs #723. Resume under Next Steps ⭐.
+
 
 - **H1618 🔴 EXECUTED — unpaid four tracks (24-07-2026, Grok 4.5).**
   [PR #704](https://github.com/gasyoun/SanskritLexicography/pull/704): (1) max-agents


### PR DESCRIPTION
## Summary

Updates `RussianTranslation/.ai_state.md` so a future session can resume after H1624:

- **RESUME HERE** block: G1–G6 status, G5/G7 blockers, H1626–H1635 table
- Literal starter lines for Sonnet/Opus launchables
- Human unlocks (votes / Palsule XLS)
- WIP: none from H1624
- Completed: H1624 code + DH mint

## Test plan

- [x] file has RESUME HERE + H1634 starter
- [x] no store changes
