### PR TITLE
feat(pwg_ru): H858 Part B — source-anchored repair of dropped german spans

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -20,6 +20,22 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **H858 Part B 🔴 EXECUTED 25-07-2026 (Opus 5 `claude-opus-5`), isolated worktree — code landed,
+  LIVE VALIDATION STILL OWED.** Source-anchored repair of a `{Tn}` span dropped from the model's
+  `german` echo: new
+  [`src/german_anchor.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/german_anchor.py),
+  wired into `headless_worker.normalize_batch` (production) and the harness `accept()` from ONE
+  authored source (`js_source()` interpolation, the C-01/C-17 pattern). Repair-then-verify: it runs
+  only on a card that already failed the `<ls>`/`{#` count and the same count re-verifies, so clean
+  cards are byte-untouched; anything that is not a pure drop is refused and rejects as before.
+  Stamped into promoted-row provenance (`german_anchor`) + `summary.german_anchor_repairs`. SHARED
+  in `LANG_PARITY.md`. Offline green: `window_selftest` **185/185**, `german_anchor_test.js` against
+  a real generated harness, `headless_worker_selftest`, `promote_final_cards --selftest`, parity
+  no-drift. **Owed:** the handoff's bounded no_pwg window proving the `{#…#}`-drop null class is
+  gone — PAID, so it waits on a fresh live-gate GO; read `german_anchor_repairs` off that window's
+  summary. Fixed in passing: `window_selftest`'s coordinator-requeue test was appending a junk row
+  to the tracked `no_pwg_residuals.jsonl` on every run (missing `--no-residual`).
+
 ### ⭐ RESUME HERE — H1624 German layers closed; DH batch H1626–H1635 (25-07-2026, Grok 4.5)
 
 **Where we stopped:** H1624 G1–G6 shipped (PRs #715–#722); G5/G7 blocked; DH follow-up

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,6 +1,6 @@
 # LANG_PARITY.md — cross-language fix/feature parity ledger
 
-_Created: 04-07-2026 · Last updated: 25-07-2026 (H1624 G6 derivation conflict flags: +1 SHARED)
+_Created: 04-07-2026 · Last updated: 25-07-2026 (H858 Part B german-anchor repair: +1 SHARED)
 
 This repo runs the same PWG→Russian and PWG→English translation pipeline through
 shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -131,7 +131,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
       "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -151,10 +151,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "C1 (bug-hunt review, Opus 4.8 claude-opus-4-8, 21-07-2026). The check keys off TARGET_FIELD (JS) / manifest['field'] (Python) = the per-language field, so it applies identically to ru and en with no language branching. Ported to every off-batch lane the batch accept() H1152 guard never reached: JS heal (stitched-translation-fidelity-reject), headless normalize_batch + selfheal stitch (translation-fidelity-reject / stitched-translation-fidelity-reject), autosplit cmd_merge + stitch_topup (complete-stitch fidelity drift -> reject). Tests: window_selftest test_heal_lane_target_field_fidelity_wired / test_autosplit_stitch_topup_rejects_target_field_drop / test_autosplit_merge_rejects_target_field_drop; headless_worker_selftest test_normalize_batch_translation_fidelity_reject / test_headless_heal_stitch_translation_fidelity_reject.",
     "tracking": "H1412",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/headless_worker.py": "60716be8bc67819e62912103a99594739419701cbc47ea691643388b6f2faf99",
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -171,7 +171,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
   {
@@ -189,8 +189,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -208,8 +208,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -227,8 +227,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -245,7 +245,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
   {
@@ -262,7 +262,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
   {
@@ -296,7 +296,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
   {
@@ -313,7 +313,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
   {
@@ -330,7 +330,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 closes the former divergence: exact model provenance is required across four accounts, so both RU and EN now request and stamp claude-sonnet-5. This prevents account/profile alias resolution from making cross-window provenance incomparable.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
   {
@@ -411,7 +411,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge. C6 (21-07-2026, Opus 4.8 claude-opus-4-8): the SCRIPTS stay separate, but the {Tn}-residue promotion guard is now SHARED — promote_en.py imports TN_RE + UnrestoredPlaceholder from promote_final_cards.py rather than duplicating them, closing the gap where the RU C-01 path refused a card carrying an unrestored {Tn} while the EN attach() silently wrote it into the store. Pinned by the C6 block in promote_en.selftest(). C9 (21-07-2026, Opus 4.8 claude-opus-4-8): the EN backup used a second-resolution timestamp + a plain open('w'), so two lock-serialized runs in the SAME second overwrote the earlier .preEN recovery copy (defeating the docstring's per-run-backup promise). Fixed to a µs+pid+uuid name (_en_backup_path) + the RU lane's O_EXCL fsynced copier (_fsynced_backup, imported — single source). Pinned by the C9 block in promote_en.selftest(). H1425 W3 audit (21-07-2026, Opus 4.8 claude-opus-4-8): confirmed nothing new to share — the shared primitives (TN_RE / UnrestoredPlaceholder / _fsynced_backup) are already imported (C6/C9); the rest of promote_en (norm_de / en_index / match_en / attach) is EN-ATTACH-specific — it attaches an `en` field onto the existing RU store, a different job from promote_final_cards' RU store WRITER — and _en_backup_path's `.preEN` marker is intentionally per-lane. P9 (21-07-2026, Opus 4.8 claude-opus-4-8, H1421): the last shareable primitive is now SHARED too — promote_en.py imports _atomic_write_rows from promote_final_cards.py and its store write is fsync-before-replace durable. The old EN write was a bare open('w') + os.replace: atomic (the rename is all-or-nothing) but NOT durable — a crash/power-loss between the write and the metadata flush could leave a non-durable/truncated store even after the rename, and under --no-backup that write is the ONLY thing between an interrupted write and total loss. As a bonus both lanes now write the store byte-identically ('\\n' newlines; the old EN write CRLF-translated on Windows). Pinned by the P9 block in promote_en.selftest() (fsync-called + round-trip + single-source identity assertion). Adversarial verification note: bug-hunt P1 (merge_store_rows had no better-attempt-wins guard) was ALSO an H1421 item but was already fixed upstream by B08 (H1339) — merge_store_rows is better-attempt-wins with pinned regression selftests — so P1 needed no code change. INTENTIONAL-DIVERGENCE re-affirmed (the scripts stay separate; every low-level store-safety primitive — {Tn} residue, fsynced backup, durable atomic write — is now single-sourced from the RU lane).",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
@@ -430,8 +430,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -468,7 +468,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED same day (2026-07-04): PR #140 (feat(provenance): pipeline versioning) added pipeline_version stamping only to promote_final_cards.py; found as a GAP while re-affirming H169's parity re-hash, closed immediately. promote_en.py now calls `pipeline_version.stamp(model_version=gen_model_version)` inside `en_index()`'s per-subcard provenance block, stored as `en_provenance.pipeline` (mirrors RU's `provenance.pipeline`; a distinct field since EN attaches onto an existing RU row rather than owning it). Pinned by an added assertion in `promote_en.selftest()`.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
@@ -487,8 +487,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -506,7 +506,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 1.1. The layer is derived purely from the sub-card KEY structure, which is identical for RU and EN. promote_en.py ATTACHES english onto the RU-owned row and leaves it otherwise untouched, so EN inherits `layer` for free — no EN-specific code needed. layer_of() pinned by dict_merge.py selftest + a promote_final_cards.selftest assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/dict_merge.py": "0266e11980e3b8b12d0699665b2051b9f7b8b16ed89d5810adfe5a458e880eea"
     }
   },
@@ -525,8 +525,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3"
     }
   },
   {
@@ -545,9 +545,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -578,7 +578,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -597,7 +597,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -615,7 +615,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -634,7 +634,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -689,7 +689,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1624 G2 (25-07-2026, Grok 4.5): closes the gap where government only appeared after a separate annotate_government backfill. New windows stamp at promote; new portraits stamp at microstructure gen. Schema shape unchanged (array of hit dicts per D4/H338). PW capitalized (Instr.) still caught (H1308). government.html still re-extracts from de_raw (honest floor banner). Pinned by promote_final_cards --selftest, enrich_portrait_government --selftest, government_census selftest, build_article_site --selftest.",
     "tracking": "H1624",
     "verified_sha256": {
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9",
       "src/pilot/enrich_portrait_government.py": "dcbcaaeabd4754436c295ad08eaf18acefab8cf9263fe2262d7f92c6ecf49660",
       "src/annotate_government.py": "b90849653909a551180a776e02ba36b6ce4da4cc4874353b2d1258e37c357848",
@@ -716,9 +716,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/form_labels.py": "ddd51c21bc86e84cf1abbc46ba78fdb477d1906283a3deae4a840b6bbd38311b",
       "src/annotate_form_labels.py": "cc03e4bb9454094996bdab87fa4e226bb6fb1574b42a70e82bd81953317629ce",
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9",
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
   {
@@ -740,7 +740,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/form_labels.py": "ddd51c21bc86e84cf1abbc46ba78fdb477d1906283a3deae4a840b6bbd38311b",
       "src/annotate_form_labels.py": "cc03e4bb9454094996bdab87fa4e226bb6fb1574b42a70e82bd81953317629ce",
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9"
     }
   },
@@ -762,9 +762,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -789,7 +789,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -818,7 +818,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -838,7 +838,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -857,7 +857,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -894,7 +894,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -952,7 +952,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -970,8 +970,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -989,8 +989,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -1009,8 +1009,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c",
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -1031,8 +1031,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -1069,7 +1069,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/store_path.py": "4967ab7ea748da995367fd0520f89f4bf9a39b84c428310314291b85be26f73c",
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
@@ -1089,9 +1089,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -1118,11 +1118,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 Windows readiness uses one language-parameterized manifest and worker contract. Whole-card retries, binary split, fragment TM/restore/fidelity, per-card budgets, timeout-no-bisect, partial stitching, audit-clean subset promotion, staged dispatch, and credential-safe event/census telemetry do not branch on RU/EN. Production policy selects RU no_pwg for the first 100-headword proof; the mechanism preserves EN field/schema behavior.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/headless_worker.py": "60716be8bc67819e62912103a99594739419701cbc47ea691643388b6f2faf99",
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773",
       "src/pilot/max_account_orchestrator.py": "03a59329720faa2cdbb56dd71284128ef3db62e301fb650cf51d4a2d4fec3a68",
       "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
-      "src/pilot/headless_worker_selftest.py": "124e088713e9d01658e67f1d684746a5dbff8a32fe8a8af701d986f3ae3d024d",
+      "src/pilot/headless_worker_selftest.py": "15c48ed0e6b890ff28671ee00159cc9cde4f74426f73a32afa3c1ebfd391126b",
       "src/pilot/max_account_orchestrator_selftest.py": "41d1060b729d2f2507224ee0c072b07437c01f2285405f528c70ab8bf7df40af",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
@@ -1148,10 +1148,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H390 Phase 1 (12-07-2026, Opus 4.8 claude-opus-4-8), extended by H818. gen_model is written into language-agnostic run meta and flows through the shared ledger writer and harvester identically for RU/EN; both paths now stamp exact claude-sonnet-5. Pinned by test_ledger_stamps_gen_model in window_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -1169,8 +1169,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H823, fixes the H255 presplit-cohort loss). Both the citation presplit trigger (_presplit_hit) and the single-card kill budget (killBudgetForCur) are language-independent — they key on <ls>/fragment counts and FRAGS, never on --lang; the same floor + CEIL apply to RU and EN identically. Extends no_fallback_single_kill_budget_and_nominal_key_echo (H220) from no-fallback singles to all singles. Pinned by test_presplit_cite_floor_and_single_ceil.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -1195,7 +1195,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -1215,10 +1215,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H960 (15-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes H920's explicitly-deferred accept()-side sense-count consumption. Language-neutral: accept() counts SENSE OBJECTS (records[].senses[]), never a gloss language, and source_senses is sense_count.count_source_senses over the German source markers (identical for the RU and EN lanes — the source is German for both). SOFT by default (SANLOSS_HARD_REJECT=false): a shortfall is telemetry only (no reject/requeue), so live traffic can measure the true drop-vs-false-flag rate before the reject is armed (owner-gated ladder). The shared counter is hardened against the ~4.78%-of-cards cross-reference over-count the naive count carried (gam~~h2_31_pari 2->1, s_ud~~h0_05_pra 4->2, _a_srayatva 2->0); under-counting is the safe direction, never a false shortfall. Pinned by test_h960_accept_sanloss_soft_gate (builds the real harness, extracts the emitted accept()+countOf, asserts soft-keep / surplus-ok / FP-regression / ls-sk-first / armed-hard-reject via accept_sensecount_test.js) plus the 3 cross-reference fixtures in sense_count._selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c",
-      "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e",
+      "src/pilot/accept_sensecount_test.js": "fbf8d37f8ae360c286f646361025d56adb0caeff09da30a0abfef5f6b7289937"
     }
   },
   {
@@ -1237,7 +1237,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -1255,8 +1255,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1152 guard 2 (17-07-2026, Sonnet 4.6 claude-sonnet-4-6), closing H1070's r102 finding (PWG->EN FU1 pilot, vac~~h0_00_pwg00: a {#uc#} span inside a <F> footnote survived the german echo 33/33 but was dropped from english 32/33 -- invisible to the pre-existing check because it never reads the translation field). accept() is lang-parameterized code shared by both lanes (field = 'russian' or 'english', same code path); the new check is symmetric and applies identically to RU and EN generation. Verified against the live RU regression suite: window_selftest.py full run stays green (137/137 baseline, +2 new content-check tests for guards 1/3), and the new/updated fixtures in accept_sensecount_test.js reproduce the exact r102 shape (RED before this change -- proven via git-stash against the pre-fix accept(), the fixture is silently ACCEPTED -- GREEN after). No RU store data touched; this only changes the generation-time accept-path gate for FUTURE generation, never re-validates the 11,605 already-promoted RU rows.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/accept_sensecount_test.js": "e3ef2b0fb016f6697bcf4c2d087c15b0f76d3422ee70193f064370ab34e3bad1"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/accept_sensecount_test.js": "fbf8d37f8ae360c286f646361025d56adb0caeff09da30a0abfef5f6b7289937"
     }
   },
   {
@@ -1292,7 +1292,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c"
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
     }
   },
   {
@@ -1380,8 +1380,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1226: the {Tn} pairing is stamped in the SHARED accept() (runs for both languages) and BOTH promote lanes (promote_final_cards.py RU, promote_en.py EN) carry it to provenance.tnmask, so neither store silently drops the field accept() stamps. Only accept() stamps it: the heal path's acceptFrag hard-rejects fragment {Tn} mismatches, so no un-rejected expansion reaches a healed card. Makes the TNMASK false-flag rate MEASURABLE (H1150 DO_NOT_ARM, denominator 1); TNMASK_HARD_REJECT stays = false — arming is a human @DECIDE. Pinned by window_selftest.test_tnmask_persist_and_offline_detect + tnmask_offline.selftest.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
       "src/pilot/tnmask_offline.py": "c857fe425fadbe18c1cdf398892f53b590709048ca66faf94fd05e046730ffea"
     }
@@ -1405,7 +1405,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c",
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e",
       "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1429,10 +1429,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/card_fields.py": "976c5aa943a35da1691e2ce72e9cb4a14ac53d3bae37f8c68345cc68cb233e2b",
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/headless_worker.py": "60716be8bc67819e62912103a99594739419701cbc47ea691643388b6f2faf99",
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac"
+      "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773",
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
   {
@@ -1508,8 +1508,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac",
-      "src/pilot/headless_worker.py": "60716be8bc67819e62912103a99594739419701cbc47ea691643388b6f2faf99"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773"
     }
   },
   {
@@ -1530,7 +1530,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77"
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3"
     }
   },
   {
@@ -1654,7 +1654,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/max_account_orchestrator.py": "03a59329720faa2cdbb56dd71284128ef3db62e301fb650cf51d4a2d4fec3a68",
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
       "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
       "src/pilot/window_common.py": "2d6926ba3a2e99f788641637b2cb6f2f9637ecb7f4e1b1c1561a367c8dd81e93",
@@ -1685,8 +1685,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
-      "src/pilot/window_selftest.py": "9fc239b118f42388f432ee2bb7693f8ce46bc16a21b27d451749e20ea7b1841c",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
   },
@@ -1710,9 +1710,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/citation_edges.py": "88e12985ab21c8768a222b93515aff22f986c312d82381e3e34aa98034d20785",
       "src/annotate_citation_edges.py": "ec925f73e1af793c22a602be009b412af67e9989c99209ceed14224bc2cf8022",
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9",
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac"
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
   {
@@ -1736,8 +1736,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/edition_rel.py": "bb4ae2271dad9e9f30ced97d60fa14f5c9dee8d810b9dd43f422c7d2659883a9",
       "src/annotate_edition_rel.py": "928ec162b61dc7ea261b3e3dd5f07fd151103675a1ff34358d7ce4daf1e5c9ba",
       "src/build_relationships.py": "76d03cc81a79f83624065d79bd47845c3a72b8e2f993a01dfc4fbe9931049725",
-      "src/promote_final_cards.py": "9b432c9c21276cc09571ce079b647b5e3dfde0c4dc33f449435f9fdf0ee22c77",
-      "src/pilot/gen_opt_harness2.py": "0fbab719c91e59be6cb105b2aa624f9e79b38d878548902153cb5c99ad3790ac"
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
   {
@@ -1755,6 +1755,29 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H1624",
     "verified_sha256": {
       "src/pilot/enrich_portrait_derivation.py": "c2612664b77b7435e086bba233a66f42eec607d06daf9e7fcead4dca85b8f0de"
+    }
+  },
+  {
+    "id": "german_anchor_repair_h858",
+    "mechanism": "A card whose `german` SOURCE echo dropped a masked {Tn} span is repaired from the source skeleton (each dropped span re-injected next to its nearest surviving neighbour) instead of being nulled by the <ls>/{# fidelity count. Repair-then-verify: it runs ONLY on a card that already failed that count, and the same count is re-run as the verifier, so a passing card is byte-untouched. Refused unless the echo is a strict order-preserving subsequence of the source. Both lanes are driven from one authored source — german_anchor.py, whose js_source() is interpolated into the harness (the C-01/C-17 pattern).",
+    "files": [
+      "src/german_anchor.py",
+      "src/pilot/headless_worker.py",
+      "src/pilot/gen_opt_harness2.py",
+      "src/promote_final_cards.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "H858 Part B (25-07-2026, Opus 5 `claude-opus-5`). Language-agnostic BY CONSTRUCTION: it repairs only the `german` source echo, which is identical on the RU and EN lanes, and never reads or writes the target-language field — `test_german_anchor_selftest` asserts both (identical repair for target='russian' and 'english'; the target field untouched; no language literal in the emitted JS). The H1152 C1 translation-fidelity guard downstream is unchanged and still rejects a target-side drop on a repaired card, pinned on both lanes. Pinned by german_anchor.selftest(), headless_worker_selftest.test_normalize_batch_german_anchor_repair, and german_anchor_test.js against a real generated harness.",
+    "tracking": "H858",
+    "verified_sha256": {
+      "src/german_anchor.py": "751a6bf9c1cf9bc6201397d28f429cd02c680f668c1b2340be8ca55f54e8a276",
+      "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773",
+      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3"
     }
   }
 ]

--- a/RussianTranslation/PIPELINE_HISTORY.md
+++ b/RussianTranslation/PIPELINE_HISTORY.md
@@ -1,6 +1,6 @@
 # PWG→RU/EN pipeline — history: solutions, failures, current state
 
-_Created: 04-07-2026 · Last updated: 24-07-2026_
+_Created: 04-07-2026 · Last updated: 25-07-2026_
 
 This is the orientation document for anyone (human or session) who needs the
 **shape** of how this pipeline got here, without reading the full
@@ -8,6 +8,54 @@ This is the orientation document for anyone (human or session) who needs the
 narrated). Read this first; go to `.ai_state.md` for exact dates/PRs/numbers on
 any specific claim below, and to [`src/pilot/RUN_FREQ_MAX.md`](src/pilot/RUN_FREQ_MAX.md)
 for the current operating procedure.
+
+### H858 Part B — the `{#…#}`-span drop stops nulling cards: source-anchored german repair (25-07-2026)
+
+The clean-rate ceiling on the no_pwg windows was never transport. A card is nulled when its
+restored `<ls>`/`{#` counts differ from the source, and that count reads `sense.german` — the
+model's **echo** of the masked skeleton. When the model drops one `{Tn}` from that echo, the
+whole card dies and **a requeue reproduces it**, because the drop is a property of the echo,
+not of the call: `asaMskfta` `avyāhata` `avyagra` `darvī` `glāna` `hasita` at `{# 0/1`, `1/2`,
+`1/3` (H858, 13-07-2026), and 6 of the 7 residual nulls in `no_pwg_w10` (H1283) — spec'd then,
+unshipped for twelve days.
+
+The dropped span is not lost information: it is in the source skeleton, and the tokens the
+model DID echo say where it belongs. [`src/german_anchor.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/german_anchor.py)
+re-injects each missing `{Tn}` next to its nearest surviving neighbour — after the preceding
+span or before the following one, whichever is closer in the source. Nearest-neighbour rather
+than always-after matters across a sense boundary: a citation dropped from the end of sense 2
+has its predecessor back in sense 1. Everything before the first surviving span goes to the
+head of the first sense — the dropped headword, the largest sub-class.
+
+Two design choices carry the risk. **Repair-then-verify:** the repair runs ONLY on a card that
+already failed the count, and the SAME count is re-run as the verifier — so a card that passes
+today is byte-untouched and the clean yield cannot regress, the only cards it can reach being
+cards that were already being thrown away. **Refuse anything that is not a pure drop:** the
+echo must be a strict order-preserving subsequence of the source (no foreign token, no
+duplicate, no reordering); under that precondition the only possible defect IS a drop, and the
+source fixes it deterministically. Everything else rejects as before, with the refusal reason
+recorded. Every repaired card is stamped (`german_anchor`) into the promoted row's provenance,
+so a machine-re-injected citation is never indistinguishable in the store from one the model
+got right — the H1150/H1226 "denominator 1" trap.
+
+Both lanes run ONE authored implementation: `german_anchor.js_source()` is interpolated into
+the harness exactly as `card_fields` already injects `RESTORE_SPEC` (C-01) and
+`TOKEN_FIDELITY_SPEC` (C-17), the two constants that drifted precisely because each lane kept
+its own hand-written copy. SHARED under [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md)
+by construction — it touches only the `german` source echo, never the target-language field,
+and the H1152 C1 translation-fidelity guard downstream is unchanged: a repaired german still
+does not launder a target-side drop (pinned on both lanes).
+
+**Not measured live.** The offline pins are green on both lanes (`window_selftest` 185/185,
+`german_anchor_test.js` against a real generated harness, `headless_worker_selftest`), but the
+handoff's own validation — a bounded no_pwg window showing the null class gone — is a PAID run
+and stays gated on a fresh live-gate GO. The `summary.german_anchor_repairs` / `_detail`
+counters exist to answer it the moment a window runs.
+
+*Found in passing:* `window_selftest`'s coordinator-requeue test ran a real `--defect` requeue
+without `--no-residual`, so every suite run appended a junk row to the tracked
+`no_pwg_residuals.jsonl` — the registry that decides which keys are BLOCKED from requeue.
+Fixed with the flag; the polluting row was reverted.
 
 ### H1386 — the H1339 review landing set: resume recovery, frag-TM memory, prepare-batch (22-07-2026)
 

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -4,6 +4,42 @@ _Created: 09-07-2026 · Last updated: 25-07-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
+## 25-07-2026 - H858 Part B: german-anchor repair — offline verification (NO paid run)
+
+Executor: Opus 5 (`claude-opus-5`). Isolated worktree off `origin/master` @ `f96361ca`.
+**Scope honesty: these are OFFLINE gates only.** The handoff's own validation — a bounded
+no_pwg window showing the `{#…#}`-drop null class eliminated — is a PAID run and was NOT
+performed: it needs a fresh live-gate GO, and the last c2/c4 readings were NOGO/rate-limited.
+The live answer will come from `summary.german_anchor_repairs` on the first window that runs.
+
+### Gates run
+
+| Gate | Lane | Result |
+|---|---|---|
+| `german_anchor.selftest()` | Python (authored source) | 8/8 OK |
+| `german_anchor_test.js` vs a REAL generated harness | JS (interpolated twin) | 21/21 PASS |
+| `headless_worker_selftest.py` (incl. the new H858 test) | Python production route | PASS |
+| `window_selftest.py` | both | **185/185**, 0 failed |
+| `promote_final_cards.py --selftest` | store provenance | PASS |
+| `lang_parity_check.py` | ledger | 82 entries, no drift, coverage complete |
+
+### Behaviour pinned (both lanes, identical fixtures)
+
+| Case | Before | After |
+|---|---|---|
+| headword `{#…#}` dropped from the echo (`{# 0/1`) | card NULLED, requeue reproduces it | repaired at sense head, stamped, promoted |
+| mid-card span dropped (`1/2`, `1/3`) | card NULLED | re-injected at its nearest surviving neighbour |
+| span dropped in a multi-sense card | card NULLED | lands in the correct sense (nearest-neighbour, not always-after) |
+| echo faithful | accepted | accepted, **byte-identical, unstamped** |
+| echo duplicates / fabricates / reorders a span | rejected | rejected, reason recorded (`german-anchor duplicate-token`, …) |
+| german repaired but TARGET field dropped the span | `translation-fidelity-reject` | `translation-fidelity-reject` (unchanged — no laundering) |
+
+### Integrity defect found in passing (pre-existing, unrelated to H858)
+
+| File | Defect | Fix |
+|---|---|---|
+| `src/pilot/window_selftest.py` (coordinator-requeue test) | ran a real `--defect` requeue without `--no-residual`, appending a junk `{"key": "a"}` row to the tracked `no_pwg_residuals.jsonl` on EVERY suite run — the registry that decides which keys are BLOCKED from requeue | `--no-residual` added; polluting row reverted; the test's own assertions unaffected |
+
 ## 25-07-2026 - H1624 DH follow-up batch minted (H1626–H1635)
 
 Executor: Grok 4.5. Mint-only (no execution). Parent: H1624 German layers closed G1–G6.

--- a/RussianTranslation/src/german_anchor.py
+++ b/RussianTranslation/src/german_anchor.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python
+r"""H858 Part B — source-anchored repair of `{Tn}` spans dropped from a card's `german` echo.
+
+THE DEFECT
+----------
+The model is handed a MASKED German skeleton (`{Tn}` = one untranslatable span: an `<ls>`
+citation, a `{#…#}` Sanskrit span, a stray tag) and must echo it back verbatim in each
+sense's `german` while producing only the translation field. When it drops one `{Tn}` from
+that echo, the restored card carries fewer `<ls>`/`{#` occurrences than the source, and the
+fidelity guard (`headless_worker.count_card` / the JS `countOf`) nulls the WHOLE card —
+every paid call on it is lost and the key is requeued to fail the same way.
+
+Measured on the `no_pwg` windows (H858, 13-07-2026): `asaMskfta` `avyAhata` `avyagra`
+`darvI` `glAna` `hasita` all nulled on `{# 0/1`, `1/2`, `1/3` — six of the seven residual
+nulls in `no_pwg_w10` (H1283), and a `--max-wide` requeue provably cannot fix them: the
+drop is a property of the echo, not of transport.
+
+THE REPAIR
+----------
+The dropped span is not lost information — it is sitting in the source skeleton, and the
+tokens the model DID echo say exactly where it belongs. So, pre-restore:
+
+    want   = the skeleton's `{Tn}` in source order          (unique by construction: `pwg_mask.mask`
+                                                             hands every span its own index)
+    got    = the `{Tn}` in `sense.german`, document order
+    missing= want - got
+
+and every missing token is re-injected next to its NEAREST surviving neighbour — after the
+preceding one or before the following one, whichever sits closer to it in the source
+skeleton — inside that neighbour's own sense. Nearest-neighbour rather than
+always-after-the-predecessor matters across a sense boundary: a citation dropped from the
+end of sense 2 has its predecessor back in sense 1, and anchoring it there would file it
+under the wrong sense. A card that dropped EVERY span has no neighbour to anchor to, so its
+spans go to the head of the first sense (the headword-span case, `{# 0/1` — the single
+largest measured sub-class).
+
+WHY THIS IS NOT "TRUST THE MODEL LESS, GUESS MORE"
+--------------------------------------------------
+The repair refuses unless the card's echo is a strict ORDER-PRESERVING SUBSEQUENCE of the
+source: no foreign token, no duplicate, no reordering. Under that precondition the only
+possible defect IS a drop, and the source fixes it deterministically. Anything else —
+paraphrased german, reordered senses, a fabricated `{Tn}` — is refused, and the caller
+rejects the card exactly as before.
+
+DELIBERATE SCOPE LIMITS
+-----------------------
+* **Repair-then-verify, never repair-by-default.** The caller runs the repair only on a card
+  that ALREADY failed the german-side fidelity count, and re-runs that same count afterwards;
+  a card that passes today is byte-untouched. This is why the change cannot regress the clean
+  yield — the only cards it can reach are cards that were being thrown away.
+* **The `german` field only.** The target-language field (`russian`/`english`) is NOT
+  repaired: a span missing from the translation is a genuine translation loss with no
+  deterministic home (`translation-fidelity-reject`, H1152 C1, still requeues it).
+* **`record.grammar` is neither read nor written.** A token echoed into `grammar` is still
+  MISSING from `german` as far as `count_card` is concerned (that count is german-only on
+  purpose — see its docstring), so grammar plays no part in presence.
+* **Not wired into the fragment lane.** `heal_group`'s guard is a MULTISET equality over
+  `grammar` + `german` (C-17) — a different denominator with its own duplicate-echo
+  semantics. Repairing there needs its own analysis; it is not this correction.
+
+Every repaired card is STAMPED (`card['german_anchor']`) and the stamp is carried into the
+promoted row's provenance, so a machine-patched german is never indistinguishable from one
+the model got right.
+
+The JS twin is emitted from `js_source()` in THIS module and interpolated into the harness —
+authored once, not re-typed per lane (the C-01/C-17 drift lesson).
+"""
+import re
+
+TOKEN_RE = re.compile(r'\{T\d+\}')
+
+# Why a card was refused repair. Reported verbatim in telemetry so a refusal is diagnosable
+# without re-running the window.
+REFUSALS = (
+    'source-token-repeat',   # the skeleton itself repeats a {Tn} -- anchoring is ambiguous
+    'no-senses',             # nothing to anchor into
+    'foreign-token',         # german carries a {Tn} the source never had (fabrication)
+    'duplicate-token',       # german repeats a {Tn} (expansion, not a drop)
+    'reordered-token',       # german's tokens are not in source order (not a pure drop)
+    'nothing-missing',       # every source token is present -- the counts failed for some
+                             # other reason (a literal `<ls`/`{#` typed into the german)
+)
+
+
+def tokens(text):
+    """The `{Tn}` placeholders in `text`, in order of appearance."""
+    return TOKEN_RE.findall(text or '')
+
+
+def card_senses(card):
+    """Every sense of `card` in document order (records, then senses within each record)."""
+    return [sense
+            for record in card.get('records') or []
+            for sense in record.get('senses') or []
+            if isinstance(sense, dict)]
+
+
+def plan(card, skeleton):
+    """Decide whether `card`'s german echo is a repairable drop of `skeleton`'s spans.
+
+    Returns `(ok, info)`. On `ok` the info carries `after` and `before` (surviving token ->
+    the missing tokens to insert after / before it), `head` (used only when the card kept no
+    span at all) and `missing` (all of them, source order). On refusal it carries `reason`
+    (one of `REFUSALS`).
+    """
+    spans = [(m.group(0), m.start(), m.end()) for m in TOKEN_RE.finditer(skeleton or '')]
+    want = [token for token, _s, _e in spans]
+    if len(set(want)) != len(want):
+        return False, {'reason': 'source-token-repeat'}
+    senses = card_senses(card)
+    if not senses:
+        return False, {'reason': 'no-senses'}
+    order = {token: index for index, token in enumerate(want)}
+    seen, last = set(), -1
+    for sense in senses:
+        for token in tokens(sense.get('german')):
+            if token not in order:
+                return False, {'reason': 'foreign-token', 'token': token}
+            if token in seen:
+                return False, {'reason': 'duplicate-token', 'token': token}
+            if order[token] <= last:
+                return False, {'reason': 'reordered-token', 'token': token}
+            seen.add(token)
+            last = order[token]
+    missing = [token for token in want if token not in seen]
+    if not missing:
+        return False, {'reason': 'nothing-missing'}
+    after, before, head = {}, {}, []
+    for index, (token, start, end) in enumerate(spans):
+        if token in seen:
+            continue
+        prev = next((s for s in reversed(spans[:index]) if s[0] in seen), None)
+        nxt = next((s for s in spans[index + 1:] if s[0] in seen), None)
+        if prev is None:
+            # Nothing survives BEFORE it in the source, so it belongs at the very start of
+            # the card -- the dropped headword span (`{# 0/1`), the dominant sub-class. Filing
+            # it just before the next surviving token would push it past that token's own
+            # German prose instead.
+            head.append(token)
+        elif nxt is None:
+            after.setdefault(prev[0], []).append(token)
+        elif (start - prev[2]) <= (nxt[1] - end):
+            after.setdefault(prev[0], []).append(token)
+        else:
+            before.setdefault(nxt[0], []).append(token)
+    return True, {'after': after, 'before': before, 'head': head, 'missing': missing}
+
+
+def reanchor(card, skeleton):
+    """Re-inject every dropped source span into `card`'s `german` fields, in place.
+
+    Returns `(ok, info)` from `plan`; on `ok` the card has been mutated and `info['missing']`
+    lists exactly what was re-injected. The caller MUST re-run its fidelity count afterwards
+    — this function never claims the card is now acceptable, only that it applied the plan.
+    """
+    ok, info = plan(card, skeleton)
+    if not ok:
+        return ok, info
+    after, before, head = info['after'], info['before'], info['head']
+    senses = card_senses(card)
+
+    def expand(match):
+        token = match.group(0)
+        return (''.join(t + ' ' for t in before.get(token, ())) + token
+                + ''.join(' ' + t for t in after.get(token, ())))
+
+    for sense in senses:
+        text = sense.get('german')
+        if not isinstance(text, str) or not TOKEN_RE.search(text):
+            continue
+        sense['german'] = TOKEN_RE.sub(expand, text)
+    if head:
+        first = senses[0]
+        text = first.get('german')
+        first['german'] = ' '.join(head) + (' ' + text if isinstance(text, str) and text else '')
+    return True, info
+
+
+def stamp(info):
+    """The provenance stamp for a repaired card (`card['german_anchor']`).
+
+    Brace-stripped exactly like the H1226 `tnmask` pairing, so the stamp can never be
+    mistaken for a raw `{Tn}` residue by the C-01 placeholder scanners.
+    """
+    return {'reinjected': [t.strip('{}') for t in info['missing']],
+            'head': [t.strip('{}') for t in info['head']]}
+
+
+# ---------------------------------------------------------------------------
+# The JS twin. Authored HERE and interpolated into the generated harness, so the two lanes
+# cannot drift the way `restoreCard`/`restore_card` did (C-01) or `cardTokens` did (C-17).
+_JS = r'''
+// H858 Part B: source-anchored repair of {Tn} spans the model dropped from its `german`
+// echo. Python twin: src/german_anchor.py (authored there and interpolated here — never
+// re-typed per lane). Repair-then-verify: accept() calls this ONLY for a card that already
+// failed the german-side fidelity count, and re-runs that count afterwards, so a card that
+// passes today is byte-untouched. Refuses unless the echo is a strict order-preserving
+// subsequence of the source (no foreign token, no duplicate, no reordering) — under that
+// precondition the only possible defect is a drop, which the source fixes deterministically.
+const GA_TOKEN_RE = /\{T\d+\}/g
+const gaTokens = t => ((t || '').match(GA_TOKEN_RE) || [])
+const gaSenses = card => { const out = []; for (const rec of (card.records || [])) for (const s of (rec.senses || [])) if (s && typeof s === 'object') out.push(s); return out }
+const gaSpans = skeleton => { const out = []; let m; const re = new RegExp(GA_TOKEN_RE.source, 'g'); while ((m = re.exec(skeleton || '')) !== null) out.push([m[0], m.index, m.index + m[0].length]); return out }
+const gaPlan = (card, skeleton) => {
+  const spans = gaSpans(skeleton)
+  const want = spans.map(s => s[0])
+  if (new Set(want).size !== want.length) return { ok: false, reason: 'source-token-repeat' }
+  const senses = gaSenses(card)
+  if (!senses.length) return { ok: false, reason: 'no-senses' }
+  const order = new Map(want.map((t, i) => [t, i]))
+  const seen = new Set()
+  let last = -1
+  for (const s of senses) for (const t of gaTokens(s.german)) {
+    if (!order.has(t)) return { ok: false, reason: 'foreign-token', token: t }
+    if (seen.has(t)) return { ok: false, reason: 'duplicate-token', token: t }
+    if (order.get(t) <= last) return { ok: false, reason: 'reordered-token', token: t }
+    seen.add(t); last = order.get(t)
+  }
+  const missing = want.filter(t => !seen.has(t))
+  if (!missing.length) return { ok: false, reason: 'nothing-missing' }
+  const after = new Map(), before = new Map(), head = []
+  const push = (map, key, t) => { if (!map.has(key)) map.set(key, []); map.get(key).push(t) }
+  for (let i = 0; i < spans.length; i++) {
+    const [token, start, end] = spans[i]
+    if (seen.has(token)) continue
+    let prev = null, nxt = null
+    for (let j = i - 1; j >= 0; j--) if (seen.has(spans[j][0])) { prev = spans[j]; break }
+    for (let j = i + 1; j < spans.length; j++) if (seen.has(spans[j][0])) { nxt = spans[j]; break }
+    if (prev === null) head.push(token)                          // nothing survives before it
+    else if (nxt === null) push(after, prev[0], token)
+    else if ((start - prev[2]) <= (nxt[1] - end)) push(after, prev[0], token)
+    else push(before, nxt[0], token)
+  }
+  return { ok: true, after: after, before: before, head: head, missing: missing }
+}
+const gaReanchor = (card, skeleton) => {
+  const p = gaPlan(card, skeleton)
+  if (!p.ok) return p
+  const senses = gaSenses(card)
+  const expand = m => (p.before.get(m) || []).map(t => t + ' ').join('') + m
+                      + (p.after.get(m) || []).map(t => ' ' + t).join('')
+  for (const s of senses) {
+    if (typeof s.german !== 'string' || !s.german.match(GA_TOKEN_RE)) continue
+    s.german = s.german.replace(GA_TOKEN_RE, expand)
+  }
+  if (p.head.length) {
+    const first = senses[0]
+    const text = typeof first.german === 'string' ? first.german : ''
+    first.german = p.head.join(' ') + (text ? ' ' + text : '')
+  }
+  return p
+}
+const gaStamp = p => ({ reinjected: p.missing.map(t => t.replace(/[{}]/g, '')), head: p.head.map(t => t.replace(/[{}]/g, '')) })
+'''
+
+
+def js_source():
+    """The JS twin of `plan`/`reanchor`/`stamp`, for interpolation into the harness."""
+    return _JS
+
+
+# ---------------------------------------------------------------------------
+def _card(*germans):
+    return {'key1': 'k', 'records': [{'h': 'k', 'grammar': '',
+                                      'senses': [{'tag': str(i + 1), 'german': g, 'russian': 'x'}
+                                                 for i, g in enumerate(germans)]}]}
+
+
+def selftest():
+    """Fail-loud, no I/O. Mirrored by `german_anchor_test.js` on the JS lane."""
+    # 1. head drop -- the headword span, the largest measured sub-class ({# 0/1).
+    card = _card('Feuer {T2}')
+    ok, info = reanchor(card, '{T1} Feuer {T2}')
+    assert ok and info['missing'] == ['{T1}'], info
+    assert card_senses(card)[0]['german'] == '{T1} Feuer {T2}', card
+
+    # 2. mid drop, anchored after its surviving predecessor.
+    card = _card('{T1} Feuer {T3}')
+    ok, info = reanchor(card, '{T1} a {T2} Feuer {T3}')
+    assert ok and info['missing'] == ['{T2}'], info
+    assert card_senses(card)[0]['german'] == '{T1} {T2} Feuer {T3}', card
+
+    # 3. multi-sense: nearest-neighbour keeps each drop in the RIGHT sense. {T2} is adjacent
+    #    to {T1} (sense 1); {T3} is adjacent to {T4} (sense 2). An always-after-the-predecessor
+    #    rule would file {T3} under sense 1, because its predecessor {T2} is itself missing.
+    card = _card('{T1} a', 'b {T4}')
+    ok, info = reanchor(card, '{T1} {T2} a — b {T3} {T4}')
+    assert ok and info['missing'] == ['{T2}', '{T3}'], info
+    germans = [s['german'] for s in card_senses(card)]
+    assert germans == ['{T1} {T2} a', 'b {T3} {T4}'], germans
+
+    # 4. tail drop -- no successor, so it anchors after the last surviving span.
+    card = _card('{T1} Feuer')
+    ok, info = reanchor(card, '{T1} Feuer {T2}')
+    assert ok and info['missing'] == ['{T2}'], info
+    assert card_senses(card)[0]['german'] == '{T1} {T2} Feuer', card
+
+    # 5. refusals -- anything that is not a pure drop is left to the existing reject.
+    for german, skeleton, reason in (
+            ('{T1} {T9}', '{T1} {T2}', 'foreign-token'),
+            ('{T1} {T1}', '{T1} {T2}', 'duplicate-token'),
+            ('{T2} {T1}', '{T1} {T2}', 'reordered-token'),
+            ('{T1} {T2}', '{T1} {T2}', 'nothing-missing'),
+            ('{T1}', '{T1} {T1}', 'source-token-repeat')):
+        ok, info = reanchor(_card(german), skeleton)
+        assert not ok and info['reason'] == reason, (german, skeleton, info)
+    ok, info = reanchor({'key1': 'k', 'records': []}, '{T1}')
+    assert not ok and info['reason'] == 'no-senses', info
+
+    # 6. the repair is exactly a drop-repair: the token multiset now equals the source's.
+    skeleton = '{T1} a {T2} b {T3} c {T4}'
+    card = _card('a {T2} b', 'c')
+    ok, _ = reanchor(card, skeleton)
+    assert ok
+    got = [t for s in card_senses(card) for t in tokens(s['german'])]
+    assert sorted(got) == sorted(tokens(skeleton)), got
+
+    # 7. a card that kept NO span at all: everything goes to the head of the first sense.
+    card = _card('Feuer', 'Glut')
+    ok, info = reanchor(card, '{T1} Feuer {T2} Glut')
+    assert ok and info['head'] == ['{T1}', '{T2}'], info
+    assert [s['german'] for s in card_senses(card)] == ['{T1} {T2} Feuer', 'Glut'], card
+
+    # 8. the stamp never carries braces (it must not read as a {Tn} residue downstream).
+    _ok, info = plan(_card('a'), '{T1} a')
+    assert stamp(info) == {'reinjected': ['T1'], 'head': ['T1']}, stamp(info)
+    print('german_anchor selftest: 8/8 OK')
+
+
+if __name__ == '__main__':
+    import sys
+    sys.stdout.reconfigure(encoding='utf-8')
+    selftest()

--- a/RussianTranslation/src/pilot/accept_sensecount_test.js
+++ b/RussianTranslation/src/pilot/accept_sensecount_test.js
@@ -45,6 +45,13 @@ const SANLOSS_DETAIL = []
 let TNMASK_HARD_REJECT = false
 let TNMASK_MISMATCHES = 0
 const TNMASK_DETAIL = []
+// H858 Part B: accept() now calls the anchored-repair twin on the fidelity-reject path, so its
+// globals must exist here too. The fixtures below carry no `skeleton`, so every repair attempt
+// refuses ('nothing-missing') and the reject behaviour they pin is unchanged -- which is the
+// point: the repair may not alter any pre-existing verdict. Its own behaviour is pinned by
+// german_anchor_test.js.
+let GERMAN_ANCHOR_REPAIRS = 0
+const GERMAN_ANCHOR_DETAIL = []
 // Direct eval so the extracted functions close over the locals above.
 const countOf = eval('(' + one('countOf') + ')')
 const countOfField = eval('(' + one('countOfField') + ')')
@@ -52,6 +59,18 @@ const TARGET_FIELD = eval(one('TARGET_FIELD'))
 const tokensOf = eval('(' + one('tokensOf') + ')')
 const TOKEN_FIDELITY_SPEC = eval('(' + one('TOKEN_FIDELITY_SPEC') + ')')   // R2/C-17: cardTokens is spec-driven now
 const cardTokens = eval('(' + one('cardTokens') + ')')
+const GA_TOKEN_RE = eval(one('GA_TOKEN_RE'))
+const gaTokens = eval('(' + one('gaTokens') + ')')
+const gaSenses = eval('(' + one('gaSenses') + ')')
+const gaSpans = eval('(' + one('gaSpans') + ')')
+const block = name => {
+  const m = src.match(new RegExp('const ' + name + ' = \\([^)]*\\) => \\{[\\s\\S]*?\\n\\}'))
+  if (!m) { console.error('FAIL: ' + name + ' not found in ' + harnessPath); process.exit(1) }
+  return m[0].replace(new RegExp('^const ' + name + ' = '), '')
+}
+const gaPlan = eval('(' + block('gaPlan') + ')')
+const gaReanchor = eval('(' + block('gaReanchor') + ')')
+const gaStamp = eval('(' + one('gaStamp') + ')')
 const accept = eval('(' + am[0].replace(/^const accept = /, '') + ')')
 
 let failed = 0

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -44,6 +44,7 @@ from window_common import INP, REPO, SRC, input_paths, load_json, read_text, roo
 from agent_budget import derive_agent_budget
 import pwg_mask
 import card_fields                                    # C-01: the one restore/promote field set
+import german_anchor                                  # H858 Part B: the anchored-repair twin, authored once
 from autosplit_requeue import plan as split_plan     # deterministic per-card sense/citation split
 from sense_count import count_source_senses           # H920/H960 deterministic top-level source-sense count
 sys.path.insert(0, SRC)
@@ -1647,6 +1648,12 @@ const SANLOSS_DETAIL = []
 const TNMASK_HARD_REJECT = false
 let TNMASK_MISMATCHES = 0
 const TNMASK_DETAIL = []
+// H858 Part B german-anchor telemetry: how many cards were SAVED from an ls/sk fidelity-reject
+// by re-injecting a dropped source span, and which spans. Unlike the two soft gates above this
+// is not a rollout switch — the repair only ever runs on a card that was already being thrown
+// away, and only lands when it verifies exactly source-faithful, so there is nothing to arm.
+let GERMAN_ANCHOR_REPAIRS = 0
+const GERMAN_ANCHOR_DETAIL = []
 const isConn = e => !!(e && !(e instanceof KillTimeout) && /connection closed|connection error|econnreset|econnrefused|socket hang up|fetch failed|network error/i.test(String(e && e.message)))
 async function agentKill(prompt, opts, skelBytes, budgetMsOverride) {
   const healLane = !!(opts && opts.label && /^heal:/.test(String(opts.label)))
@@ -1682,6 +1689,7 @@ const tokensOf = t => ((t || '').match(/\\{T\\d+\\}/g) || []).sort().join(' ')
 // Python `card_token_multiset` collects from, so the two twins cannot drift (the C-17 defect was
 // the Python lane omitting `grammar` while this JS lane hard-coded rec.grammar + s.german).
 const TOKEN_FIDELITY_SPEC = %(token_fidelity_spec)s
+%(german_anchor_js)s
 const cardTokens = card => { let a = []; for (const rec of (card.records || [])) { for (const f of TOKEN_FIDELITY_SPEC.record) a = a.concat((rec[f] || '').match(/\\{T\\d+\\}/g) || []); for (const s of (rec.senses || [])) for (const f of TOKEN_FIDELITY_SPEC.sense) a = a.concat((s[f] || '').match(/\\{T\\d+\\}/g) || []) } return a.sort().join(' ') }
 // Index a returned cards[] by its self-declared key1 (the prompt requires key1 to echo the
 // '=== CARD <key> ===' header). Used to match responses by KEY first, position second —
@@ -1771,13 +1779,40 @@ const accept = (c, k) => {
       log('{Tn} multiset mismatch (soft): ' + k + ' — kept, telemetry only')
     }
   }
+  // H858 Part B: snapshot the PRE-restore card. The anchored repair below works on {Tn}
+  // tokens, which restoreCard consumes — after it a dropped span is indistinguishable from
+  // prose and can no longer be anchored. Python twin: headless_worker.normalize_batch.
+  const masked = JSON.parse(JSON.stringify(c))
   c = restoreCard(c, k)
   // Fidelity guard: restored <ls>/{#..#} counts MUST match the source — a mismatch
   // means misalignment / dropped {Tn}. Reject -> deterministic requeue, never emit garbled.
-  const ls = countOf(c, /<ls\\b/g), sk = countOf(c, /\\{#/g)
+  let ls = countOf(c, /<ls\\b/g), sk = countOf(c, /\\{#/g)
   if (ls !== INPUTS[k].ls || sk !== INPUTS[k].sk) {
-    noteFail(k, 'fidelity-reject: <ls> ' + ls + '/' + INPUTS[k].ls + ', {# ' + sk + '/' + INPUTS[k].sk)
-    return null
+    // H858 Part B: the model dropped a masked span from its `german` echo — the dominant
+    // retry-RESISTANT null class (6 of 7 residual nulls in no_pwg_w10, H1283): a requeue
+    // reproduces it, because the drop is a property of the echo, not of transport. Re-inject
+    // the dropped spans from the source skeleton and re-run THIS SAME count as the verifier.
+    // Accepted only when the repair makes the card exactly source-faithful; anything else
+    // falls through to the identical reject as before. A card that passed the count above
+    // never enters this branch, so clean cards are byte-untouched.
+    const rep = gaReanchor(masked, INPUTS[k].skeleton || '')
+    const cand = rep.ok ? restoreCard(masked, k) : null
+    const cls = cand ? countOf(cand, /<ls\\b/g) : -1, csk = cand ? countOf(cand, /\\{#/g) : -1
+    if (cand && cls === INPUTS[k].ls && csk === INPUTS[k].sk) {
+      // `masked` was snapshotted AFTER the tnmask block above, so the repaired card already
+      // carries the same H1226 pre-restore pairing — the stamp keeps describing what the model
+      // actually emitted, never the repaired text.
+      c = cand
+      c.german_anchor = gaStamp(rep)
+      GERMAN_ANCHOR_REPAIRS++
+      GERMAN_ANCHOR_DETAIL.push({ key: k, reinjected: c.german_anchor.reinjected })
+      log('german-anchor repair: ' + k + ' re-injected ' + c.german_anchor.reinjected.join(',') + ' from source')
+      ls = cls; sk = csk
+    } else {
+      noteFail(k, 'fidelity-reject: <ls> ' + ls + '/' + INPUTS[k].ls + ', {# ' + sk + '/' + INPUTS[k].sk +
+        '; german-anchor ' + (rep.ok ? 'verify-failed' : (rep.reason || 'refused')))
+      return null
+    }
   }
   // H1152 guard 2: the check above counts <ls>/{#..#} ONLY in the `german` source-echo
   // field (countOf's hard-coded `s.german` read) -- it proves the model faithfully copied
@@ -2292,6 +2327,8 @@ const summary = { root: META.root, lang: META.lang, cards: out.length, ok: _ok,
                   // H960 grammar-{Tn} multiset telemetry (SOFT — no reject unless TNMASK_HARD_REJECT).
                   tnmask_mismatches: TNMASK_MISMATCHES, tnmask_hard_reject: TNMASK_HARD_REJECT,
                   tnmask_detail: TNMASK_DETAIL,
+                  german_anchor_repairs: GERMAN_ANCHOR_REPAIRS,
+                  german_anchor_detail: GERMAN_ANCHOR_DETAIL,
                   null_keys: out.filter(r => !r.card).map(r => r.key),
                   partial_keys: out.filter(r => r.card && r.card.partial).map(r => r.key),
                   failures: _failures }
@@ -2304,6 +2341,10 @@ return { meta: META, summary, results: out }
         # with a raw {Tn}. The JS cannot import Python, so the constant is injected instead.
         'restore_spec': card_fields.js_restore_spec(field),
         'token_fidelity_spec': card_fields.js_token_fidelity_spec(),
+        # H858 Part B: the anchored-repair twin is AUTHORED in german_anchor.py and injected
+        # here, for the same reason as the two constants above -- a hand-copied second lane is
+        # exactly how restoreCard (C-01) and cardTokens (C-17) drifted apart.
+        'german_anchor_js': german_anchor.js_source(),
         # Language-aware meta + model pin. EN path pins Sonnet 5 explicitly
         # (the bare 'sonnet' alias resolved to 4.6 on a prior run); RU path
         # keeps the 'sonnet' alias unchanged so the autonomous RU runs are untouched.

--- a/RussianTranslation/src/pilot/german_anchor_test.js
+++ b/RussianTranslation/src/pilot/german_anchor_test.js
@@ -1,0 +1,172 @@
+// H858 Part B behavioral pin: the anchored repair of a masked span the model dropped from its
+// `german` echo — the dominant retry-RESISTANT null class (6 of 7 residual nulls in no_pwg_w10,
+// H1283; `asaMskfta` `avyAhata` `avyagra` `darvI` `glAna` `hasita` at `{# 0/1`, `1/2`, `1/3`).
+//
+// Extracts the REAL gaPlan/gaReanchor/gaStamp AND the REAL accept() emitted by
+// gen_opt_harness2.py (FINDINGS §82: never test a hand-written copy of the thing under test),
+// so this cannot drift from the generator or from the Python twin it is interpolated from.
+// The Python-side twin of these same cases is german_anchor.selftest().
+//
+//   node src/pilot/german_anchor_test.js <path-to-a-generated-harness.js>
+const fs = require('fs')
+
+const harnessPath = process.argv[2]
+if (!harnessPath) { console.error('FAIL: usage: node german_anchor_test.js <harness.js>'); process.exit(1) }
+const src = fs.readFileSync(harnessPath, 'utf8')
+
+const one = name => {
+  const m = src.match(new RegExp('const ' + name + ' = [^\\n]*'))
+  if (!m) { console.error('FAIL: ' + name + ' not found in ' + harnessPath); process.exit(1) }
+  return m[0].replace(new RegExp('^const ' + name + ' = '), '')
+}
+const block = name => {
+  const m = src.match(new RegExp('const ' + name + ' = \\([^)]*\\) => \\{[\\s\\S]*?\\n\\}'))
+  if (!m) { console.error('FAIL: ' + name + ' not found in ' + harnessPath); process.exit(1) }
+  return m[0].replace(new RegExp('^const ' + name + ' = '), '')
+}
+const am = src.match(/const accept = \(c, k\) => \{[\s\S]*?\n\}/)
+if (!am) { console.error('FAIL: accept not found in ' + harnessPath); process.exit(1) }
+
+// Runtime globals the extracted functions close over.
+let INPUTS = {}
+let PH = {}
+const FAIL = {}
+const noteFail = (k, why) => { FAIL[k] = String(why).slice(0, 300) }
+const log = () => {}
+let SANLOSS_HARD_REJECT = false
+let SANLOSS_SHORTFALLS = 0
+const SANLOSS_DETAIL = []
+let TNMASK_HARD_REJECT = false
+let TNMASK_MISMATCHES = 0
+const TNMASK_DETAIL = []
+let GERMAN_ANCHOR_REPAIRS = 0
+const GERMAN_ANCHOR_DETAIL = []
+const GA_TOKEN_RE = eval(one('GA_TOKEN_RE'))
+const gaTokens = eval('(' + one('gaTokens') + ')')
+const gaSenses = eval('(' + one('gaSenses') + ')')
+const gaSpans = eval('(' + one('gaSpans') + ')')
+const gaPlan = eval('(' + block('gaPlan') + ')')
+const gaReanchor = eval('(' + block('gaReanchor') + ')')
+const gaStamp = eval('(' + one('gaStamp') + ')')
+// The REAL restore machinery, so the accept()-level cases below run the true masked -> restored
+// round trip rather than an identity mock (this is what proves the repair lands a real citation).
+const RESTORE_SPEC = eval('(' + one('RESTORE_SPEC') + ')')
+const restore = eval('(' + one('restore') + ')')
+const rcM = src.match(/function restoreCard\([\s\S]*?\n\}/)
+if (!rcM) { console.error('FAIL: restoreCard not found in ' + harnessPath); process.exit(1) }
+const restoreCard = eval('(' + rcM[0].replace(/^function restoreCard/, 'function ') + ')')
+const countOf = eval('(' + one('countOf') + ')')
+const countOfField = eval('(' + one('countOfField') + ')')
+const TARGET_FIELD = eval(one('TARGET_FIELD'))
+const tokensOf = eval('(' + one('tokensOf') + ')')
+const TOKEN_FIDELITY_SPEC = eval('(' + one('TOKEN_FIDELITY_SPEC') + ')')
+const cardTokens = eval('(' + one('cardTokens') + ')')
+const accept = eval('(' + am[0].replace(/^const accept = /, '') + ')')
+
+let failed = 0
+const check = (name, cond, extra) => { if (cond) { console.log('PASS: ' + name) } else { console.error('FAIL: ' + name + (extra ? ' -- ' + extra : '')); failed++ } }
+const one_sense_card = (...germans) => ({
+  key1: 'k', iast: 'k', notes: '',
+  records: [{ h: 'k', grammar: '', senses: germans.map((g, i) => ({ tag: String(i + 1), german: g, [TARGET_FIELD]: 'x' })) }],
+})
+const germansOf = c => gaSenses(c).map(s => s.german)
+
+// ==== unit: the same 8 cases german_anchor.selftest() pins on the Python lane ==============
+let c, p
+
+c = one_sense_card('Feuer {T2}')
+p = gaReanchor(c, '{T1} Feuer {T2}')
+check('head drop: the dropped headword span is re-injected at the card start',
+  p.ok && germansOf(c)[0] === '{T1} Feuer {T2}', JSON.stringify(germansOf(c)))
+
+c = one_sense_card('{T1} Feuer {T3}')
+p = gaReanchor(c, '{T1} a {T2} Feuer {T3}')
+check('mid drop: anchored after its nearest surviving predecessor',
+  p.ok && germansOf(c)[0] === '{T1} {T2} Feuer {T3}', JSON.stringify(germansOf(c)))
+
+c = one_sense_card('{T1} a', 'b {T4}')
+p = gaReanchor(c, '{T1} {T2} a — b {T3} {T4}')
+check('multi-sense: nearest-neighbour keeps each drop in the RIGHT sense',
+  p.ok && JSON.stringify(germansOf(c)) === JSON.stringify(['{T1} {T2} a', 'b {T3} {T4}']),
+  JSON.stringify(germansOf(c)))
+
+c = one_sense_card('{T1} Feuer')
+p = gaReanchor(c, '{T1} Feuer {T2}')
+check('tail drop: anchored after the last surviving span',
+  p.ok && germansOf(c)[0] === '{T1} {T2} Feuer', JSON.stringify(germansOf(c)))
+
+for (const [german, skeleton, reason] of [
+  ['{T1} {T9}', '{T1} {T2}', 'foreign-token'],
+  ['{T1} {T1}', '{T1} {T2}', 'duplicate-token'],
+  ['{T2} {T1}', '{T1} {T2}', 'reordered-token'],
+  ['{T1} {T2}', '{T1} {T2}', 'nothing-missing'],
+  ['{T1}', '{T1} {T1}', 'source-token-repeat'],
+]) {
+  p = gaReanchor(one_sense_card(german), skeleton)
+  check('refused (' + reason + '): anything that is not a pure drop is left to the reject',
+    !p.ok && p.reason === reason, JSON.stringify(p))
+}
+p = gaReanchor({ records: [] }, '{T1}')
+check('refused (no-senses)', !p.ok && p.reason === 'no-senses', JSON.stringify(p))
+
+c = one_sense_card('Feuer', 'Glut')
+p = gaReanchor(c, '{T1} Feuer {T2} Glut')
+check('a card that kept NO span: every span goes to the head of the first sense',
+  p.ok && JSON.stringify(germansOf(c)) === JSON.stringify(['{T1} {T2} Feuer', 'Glut']),
+  JSON.stringify(germansOf(c)))
+
+c = one_sense_card('a {T2} b', 'c')
+p = gaReanchor(c, '{T1} a {T2} b {T3} c {T4}')
+check('after repair the token multiset equals the source exactly',
+  p.ok && gaSenses(c).map(s => gaTokens(s.german)).flat().sort().join(' ') === '{T1} {T2} {T3} {T4}',
+  JSON.stringify(germansOf(c)))
+
+check('the stamp never carries braces (it must not read as a {Tn} residue downstream)',
+  JSON.stringify(gaStamp(gaPlan(one_sense_card('a'), '{T1} a'))) === JSON.stringify({ reinjected: ['T1'], head: ['T1'] }))
+
+// ==== accept()-level: the real null class, end to end through the real restore ============
+// `avyagra` shape: source has one {#..#} span (the headword) and one <ls>; the model's german
+// echo drops the {#..#}. Pre-H858 this nulled the card ({# 0/1) and a requeue reproduced it.
+const reset = () => { GERMAN_ANCHOR_REPAIRS = 0; GERMAN_ANCHOR_DETAIL.length = 0; for (const k in FAIL) delete FAIL[k] }
+const masked = (german, translation) => ({
+  key1: 'av', iast: 'av', notes: '',
+  records: [{ h: 'av', grammar: '', senses: [{ tag: '1', german: german, [TARGET_FIELD]: translation }] }],
+})
+INPUTS = { av: { ls: 1, sk: 1, source_senses: 1, skeleton: '{T1} unverwirrt {T2}' } }
+PH = { av: ['{#avyagra#}', '<ls>ṚV. 1,1</ls>'] }
+
+reset()
+let r = accept(masked('unverwirrt {T2}', '{T1} невозмутимый {T2}'), 'av')
+check('accept(): a {#..#} span dropped from the german echo is REPAIRED, not nulled',
+  r !== null && FAIL.av === undefined, JSON.stringify(FAIL))
+check('accept(): the repaired german carries the real restored span',
+  r && r.records[0].senses[0].german === '{#avyagra#} unverwirrt <ls>ṚV. 1,1</ls>',
+  r && JSON.stringify(r.records[0].senses[0].german))
+check('accept(): the repair is stamped on the card (never silently patched)',
+  r && r.german_anchor && JSON.stringify(r.german_anchor.reinjected) === JSON.stringify(['T1']),
+  r && JSON.stringify(r.german_anchor))
+check('accept(): the repair is counted in the window telemetry',
+  GERMAN_ANCHOR_REPAIRS === 1 && GERMAN_ANCHOR_DETAIL[0] && GERMAN_ANCHOR_DETAIL[0].key === 'av',
+  JSON.stringify(GERMAN_ANCHOR_DETAIL))
+
+// CONTROL 1: a faithful card is byte-untouched and never stamped.
+reset()
+r = accept(masked('{T1} unverwirrt {T2}', '{T1} невозмутимый {T2}'), 'av')
+check('accept(): a faithful card is untouched and carries NO repair stamp',
+  r !== null && r.german_anchor === undefined && GERMAN_ANCHOR_REPAIRS === 0)
+
+// CONTROL 2: the repair must not launder a TRANSLATION-side drop. german is repaired, but the
+// russian/english still lacks the span -> H1152's translation-fidelity-reject must still fire.
+reset()
+r = accept(masked('unverwirrt {T2}', 'невозмутимый {T2}'), 'av')
+check('accept(): a repaired german does NOT launder a translation-side drop',
+  r === null && /translation-fidelity-reject/.test(FAIL.av || ''), JSON.stringify(FAIL))
+
+// CONTROL 3: a card whose german is not a pure drop still rejects, with the reason recorded.
+reset()
+r = accept(masked('{T2} unverwirrt {T2}', '{T1} невозмутимый {T2}'), 'av')
+check('accept(): a duplicated span is refused repair and still rejects, reason recorded',
+  r === null && /german-anchor duplicate-token/.test(FAIL.av || ''), JSON.stringify(FAIL))
+
+if (failed) { console.error(failed + ' check(s) failed'); process.exit(1) }
+console.log('german_anchor_test: PASS')

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -2,6 +2,7 @@
 """Execute one PWG translation manifest through Claude Code headless mode."""
 import argparse
 import collections
+import copy
 import glob
 import hashlib
 import json
@@ -22,6 +23,7 @@ if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 from proc_tree import run_tree_kill, terminate_tree, windows_hidden_flags  # noqa: E402  (shared D-J tree-kill runner)
 import card_fields  # noqa: E402  (C-01: the one restore/promote field set, shared with the JS lane)
+import german_anchor  # noqa: E402  (H858 Part B: source-anchored repair of a dropped `german` span)
 from window_common import portrait_key_iast  # noqa: E402  (B02: one iast derivation for both stitch twins)
 from execution_contract import ActiveCallClaim, SCHEMA_V1, SCHEMA_V2, validate_manifest, validate_profile  # noqa: E402
 
@@ -276,24 +278,48 @@ def normalize_batch(manifest, keys, structured):
         if card is None:
             error = 'missing-or-mismatched-key'
         else:
-            unmapped = []
-            card = restore_card(card, manifest['field'],
-                                manifest['placeholder_maps'].get(key, []), unmapped)
             inp = manifest['inputs'][key]
             field = manifest['field']
+            phs = manifest['placeholder_maps'].get(key, [])
+            # H858 Part B: keep the PRE-restore card. The repair below works on `{Tn}`
+            # tokens, which `restore_card` consumes -- after it the dropped span is
+            # indistinguishable from prose and can no longer be anchored.
+            masked = copy.deepcopy(card)
+            unmapped = []
+            card = restore_card(card, field, phs, unmapped)
             if count_card(card, '<ls') != inp['ls'] or count_card(card, '{#') != inp['sk']:
-                error = 'fidelity-reject'
-                card = None
-            elif (count_card_field(card, field, '<ls') != inp['ls']
-                  or count_card_field(card, field, '{#') != inp['sk']):
-                # H1152 parity (C1): german echo is faithful, but the translation dropped a
-                # span -- requeue instead of promoting a lossy card.
-                error = 'translation-fidelity-reject'
-                card = None
-            elif unmapped:
-                # C-42: an out-of-range {Tn} maps nothing and cannot be recovered downstream.
-                error = 'unmapped-token-reject'
-                card = None
+                # H858 Part B: the model dropped a masked span from its `german` echo. That is
+                # the dominant retry-RESISTANT null class (6 of 7 residual nulls in no_pwg_w10,
+                # H1283) -- a requeue reproduces it, because the drop is a property of the echo,
+                # not of transport. Re-inject the dropped spans from the source skeleton, then
+                # re-run THIS SAME count as the verifier: the repair is accepted only when it
+                # makes the card exactly source-faithful, and refused cards fall through to the
+                # identical reject as before. A card that passed the count above never enters
+                # this branch, so clean cards are byte-untouched.
+                ok, info = german_anchor.reanchor(masked, inp.get('skeleton') or '')
+                candidate, cand_unmapped = None, []
+                if ok:
+                    candidate = restore_card(masked, field, phs, cand_unmapped)
+                if (candidate is not None
+                        and count_card(candidate, '<ls') == inp['ls']
+                        and count_card(candidate, '{#') == inp['sk']):
+                    card, unmapped = candidate, cand_unmapped
+                    card['german_anchor'] = german_anchor.stamp(info)
+                else:
+                    error = 'fidelity-reject: german-anchor %s' % (
+                        'verify-failed' if ok else info.get('reason', 'refused'))
+                    card = None
+            if card is not None:
+                if (count_card_field(card, field, '<ls') != inp['ls']
+                        or count_card_field(card, field, '{#') != inp['sk']):
+                    # H1152 parity (C1): german echo is faithful, but the translation dropped a
+                    # span -- requeue instead of promoting a lossy card.
+                    error = 'translation-fidelity-reject'
+                    card = None
+                elif unmapped:
+                    # C-42: an out-of-range {Tn} maps nothing and cannot be recovered downstream.
+                    error = 'unmapped-token-reject'
+                    card = None
         row = {'key': key, 'card': card, 'judge': None, 'judge_sonnet': None,
                'escalated': False}
         if error:
@@ -786,6 +812,16 @@ def execute(manifest, claude='claude', timeout=7200, runner=None, max_agents_ove
                'tm': sum(bool(row.get('tm')) for row in results),
                'degenerate_passthrough': sum(bool(row.get('degenerate_passthrough')) for row in results),
                'null_keys': list(failures), 'partial_keys': [], 'failures': failures,
+               # H858 Part B: how many cards were SAVED from an ls/sk fidelity-reject by
+               # re-injecting a dropped source span, and which spans -- the measurement the
+               # handoff's "is the {#-drop null class gone?" question is answered from. JS twin:
+               # summary.german_anchor_repairs / german_anchor_detail.
+               'german_anchor_repairs': sum(bool((row.get('card') or {}).get('german_anchor'))
+                                            for row in results),
+               'german_anchor_detail': [{'key': row['key'],
+                                         'reinjected': row['card']['german_anchor']['reinjected']}
+                                        for row in results
+                                        if (row.get('card') or {}).get('german_anchor')],
                'translate_agents_spent': engine.translate_calls,
                'heal_agents_spent': engine.heal_calls,
                'budget_stops': engine.budget_stops,

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -318,6 +318,47 @@ def test_normalize_batch_translation_fidelity_reject():
     print('  C1 normalize_batch: german-faithful but target-dropped card -> translation-fidelity-reject')
 
 
+def test_normalize_batch_german_anchor_repair():
+    """H858 Part B: a card whose `german` echo DROPPED a masked span is repaired from the source
+    skeleton instead of nulled — the dominant retry-RESISTANT null class (6 of 7 residual nulls in
+    no_pwg_w10, H1283: a requeue reproduces the drop, because it is a property of the echo, not of
+    transport). Four properties, all on the REAL production route:
+
+      1. the drop is repaired and the card survives, carrying the genuine restored span;
+      2. the repair is STAMPED (`german_anchor`) — a machine-patched german is never
+         indistinguishable in the store from one the model echoed correctly;
+      3. a faithful card is byte-untouched and unstamped (the repair can only reach cards that
+         were already being thrown away, so the clean yield cannot regress);
+      4. a german that is NOT a pure drop (duplicate/foreign/reordered span) is refused repair
+         and rejects exactly as before, with the refusal reason recorded for diagnosis.
+    """
+    m = manifest()   # inputs.agni skeleton='{T1} Feuer' ls=1 sk=0; PH=['<ls>RV.</ls>']
+    def card(german, russian):
+        return {'key1': 'agni', 'records': [{'grammar': '', 'senses': [
+            {'tag': '1', 'german': german, 'russian': russian}]}]}
+
+    repaired = h.normalize_batch(m, ['agni'], {'cards': [card('Feuer', '{T1} огонь')]})
+    row = repaired[0]
+    assert row.get('error') is None and row['card'], row
+    assert row['card']['records'][0]['senses'][0]['german'] == '<ls>RV.</ls> Feuer', row['card']
+    assert row['card']['german_anchor'] == {'reinjected': ['T1'], 'head': ['T1']}, row['card']
+
+    clean = h.normalize_batch(m, ['agni'], {'cards': [card('{T1} Feuer', '{T1} огонь')]})
+    assert clean[0].get('error') is None and clean[0]['card'], clean
+    assert 'german_anchor' not in clean[0]['card'], clean[0]['card']
+
+    # Not a pure drop -> refused, rejected, reason recorded (and never silently repaired).
+    dup = h.normalize_batch(m, ['agni'], {'cards': [card('{T1} {T1} Feuer', '{T1} огонь')]})
+    assert dup[0]['card'] is None and 'german-anchor duplicate-token' in dup[0].get('error', ''), dup
+
+    # The repair must not launder a TRANSLATION-side drop (H1152 C1 still owns that class).
+    ru_drop = h.normalize_batch(m, ['agni'], {'cards': [card('Feuer', 'огонь')]})
+    assert ru_drop[0]['card'] is None, ru_drop
+    assert ru_drop[0].get('error') == 'translation-fidelity-reject', ru_drop
+    print('  H858 normalize_batch: dropped german span repaired+stamped; clean card untouched; '
+          'non-drop refused; translation-side drop still rejected')
+
+
 def test_headless_heal_stitch_translation_fidelity_reject():
     """H1152 parity (C1): the headless selfheal stitch (twin of the JS selfHeal check) must reject
     a COMPLETE stitched card whose german echo is faithful but whose TARGET field dropped a span.
@@ -573,6 +614,7 @@ console.log(JSON.stringify(restoreCard(card, 'agni')))
     test_frag_tm_stitch_retains_owner()
     test_null_owner_fragment_tm_refused_before_any_call()
     test_normalize_batch_translation_fidelity_reject()
+    test_normalize_batch_german_anchor_repair()
     test_headless_heal_stitch_translation_fidelity_reject()
     print('headless_worker_selftest: PASS')
 

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -861,6 +861,77 @@ def test_grammar_field_restore_behavioral():
         shutil.rmtree(d, ignore_errors=True)
 
 
+def test_german_anchor_repair_behavioral():
+    """H858 Part B: the anchored repair of a masked span dropped from the model's `german` echo.
+
+    The `{#…#}`-span drop was the clean-rate ceiling on the no_pwg windows — 6 of 7 residual
+    nulls in `no_pwg_w10` (H1283), and provably NOT fixable by a `--max-wide` requeue: the drop
+    is a property of the echo, not of transport. `accept()` now re-injects the dropped spans
+    from the source skeleton and re-runs the SAME `<ls>`/`{#` count as the verifier, so a repair
+    lands only when it makes the card exactly source-faithful, and a card that already passed
+    never enters the branch at all.
+
+    Two-part pin, matching the H960/H1226 pattern: (1) the repair twin + its telemetry are
+    emitted into the harness at all; (2) the behavioural half runs the REAL emitted
+    gaPlan/gaReanchor/gaStamp AND the REAL accept() + restoreCard (german_anchor_test.js), so
+    it cannot drift from the generator. The Python twin of the same cases is
+    `german_anchor.selftest()`, run by `test_german_anchor_selftest` below — the two lanes are
+    interpolated from ONE authored source (`german_anchor.js_source()`), the C-01/C-17 lesson.
+    """
+    import gen_opt_harness2 as gh
+    saved_ip, saved_kill = gh.input_paths, gh.KILL
+    d = tempfile.mkdtemp()
+    try:
+        rp = os.path.join(d, 'ga~~h0_zz_pw.raw.txt')
+        pp = os.path.join(d, 'ga~~h0_zz_pw.portrait.json')
+        with open(rp, 'w', encoding='utf-8') as f:
+            f.write('=== LAYER: PW ===\n\n{#ga#}¦ {%m%}\n— 1〉 {%a%}.')
+        with open(pp, 'w', encoding='utf-8') as f:
+            f.write('[]')
+        gh.input_paths = lambda k, input_dir=None: (rp, pp)
+        gh.KILL = False
+        js, _ = gh.build('zz_ganchor', ['ga~~h0_zz_pw'], None, 12000,
+                         nominal=True, grammar_on=False, tm_path=None)
+        for needle in ('const gaPlan = ', 'const gaReanchor = ', 'const gaStamp = ',
+                       'GERMAN_ANCHOR_REPAIRS', 'german_anchor_repairs', 'german-anchor '):
+            if needle not in js:
+                fail('H858 german-anchor repair not emitted into the harness (missing %r)' % needle)
+        harness = os.path.join(d, 'ganchor_harness.js')
+        with open(harness, 'w', encoding='utf-8', newline='\n') as f:
+            f.write(js)
+        test_js = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               'german_anchor_test.js')
+        p = subprocess.run(['node', test_js, harness],
+                           capture_output=True, text=True, encoding='utf-8', timeout=30)
+        if p.returncode:
+            fail('german-anchor repair behavioral test failed:\n%s\n%s' % (p.stdout, p.stderr))
+    finally:
+        gh.input_paths, gh.KILL = saved_ip, saved_kill
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_german_anchor_selftest():
+    """H858 Part B: the Python half of the repair, and the LANG_PARITY guarantee.
+
+    `german_anchor` is SHARED (not language-specific): it repairs the `german` SOURCE echo,
+    which is identical on the RU and EN lanes, and never touches the target-language field. So
+    one selftest covers both languages by construction — the divergence LANG_PARITY.md exists
+    to catch cannot arise here, and this test asserts that the module is genuinely
+    field-agnostic rather than merely believed to be.
+    """
+    import german_anchor
+    german_anchor.selftest()
+    if 'russian' in german_anchor._JS or 'english' in german_anchor._JS:
+        fail('german_anchor must stay language-agnostic (SHARED under LANG_PARITY.md)')
+    for target in ('russian', 'english'):
+        card = {'records': [{'senses': [{'german': 'Feuer', target: 'x'}]}]}
+        ok, info = german_anchor.reanchor(card, '{T1} Feuer')
+        if not ok or card['records'][0]['senses'][0]['german'] != '{T1} Feuer':
+            fail('german_anchor repaired differently for target field %r: %r' % (target, info))
+        if card['records'][0]['senses'][0][target] != 'x':
+            fail('german_anchor must never touch the target field %r' % target)
+
+
 def test_h960_dropped_sanskrit_span():
     """H960 (H911 backlog #3): a {#..#} Sanskrit span present in the German source but dropped from
     the Russian translation is flagged (dropped_sanskrit_span). The harness/tm fidelity gates count
@@ -3573,7 +3644,14 @@ def test_coordinator_defect_requeue_uses_no_tm_and_out():
         rq.INP = inp
         rq.subprocess.run = fake_run
         rq.append_tm_denylist = lambda *_args, **_kwargs: (1, 0)
-        sys.argv = ['requeue_from_audit.py', 'nominal_selftest', '--defect',
+        # `--no-residual` (H1618) is NOT decoration: without it this test's `--defect` run
+        # reaches requeue_from_audit's C-49 residual stamp, which writes to the REAL tracked
+        # `no_pwg_residuals.jsonl` — so every selftest run appended a junk
+        # `{"key": "a", "source_window": "nominal_selftest"}` row to the registry that decides
+        # which keys are BLOCKED from requeue. The test stubs INP / subprocess.run /
+        # append_tm_denylist but never that path. Found 25-07-2026 while running this suite for
+        # H858; the assertions below (coordinator flag pass-through) are unaffected by the flag.
+        sys.argv = ['requeue_from_audit.py', 'nominal_selftest', '--defect', '--no-residual',
                     '--nominal', '--no-grammar', '--requeue-file=%s' % rqfile,
                     '--out=%s' % out, '--manifest-out=%s' % manifest_out]
         try:
@@ -7801,6 +7879,8 @@ def main():
         test_partial_cards_requeue_and_stay_out_of_clean_sample,
         test_classify_run_verdicts,
         test_grammar_field_restore_behavioral,
+        test_german_anchor_selftest,
+        test_german_anchor_repair_behavioral,
         test_h_reconstructed_regression_guard,
         test_h1283_a1_pid_alive_and_dirlock_owner,
         test_h1420_p2_win32_openprocess_error_leans_alive,

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -405,6 +405,16 @@ def provenance(entry, subkey, model_version):
             and isinstance(tnmask.get('got'), str)
             and isinstance(tnmask.get('want'), str)):
         prov['tnmask'] = {'got': tnmask['got'], 'want': tnmask['want']}
+    # H858 Part B: a card whose `german` echo dropped a masked span is REPAIRED from the source
+    # skeleton instead of being nulled -- so the row must say so. Without this stamp a
+    # machine-re-injected citation is indistinguishable in the store from one the model echoed
+    # correctly, and the repair's real-world precision could never be audited after the fact
+    # (the exact H1150/H1226 "denominator 1" trap the tnmask pairing above exists to avoid).
+    # Same discipline: carried only when well-formed, never fabricated, never back-filled.
+    anchor = card.get('german_anchor')
+    if isinstance(anchor, dict) and isinstance(anchor.get('reinjected'), list):
+        prov['german_anchor'] = {'reinjected': [str(t) for t in anchor['reinjected']],
+                                 'head': [str(t) for t in anchor.get('head') or []]}
     return prov
 
 
@@ -1033,6 +1043,21 @@ def selftest():
     bp = list(rows_for('p_a~~h5_00_pwg00', badentry, 'ai_translated',
                        SELFTEST_MODEL_VERSION))[0]['provenance']
     assert 'tnmask' not in bp, 'a malformed tnmask pairing must not be promoted'
+    # H858 Part B: a card repaired by the german-anchor lane must SAY SO on every row it yields --
+    # otherwise a machine-re-injected citation is indistinguishable in the store from one the model
+    # echoed correctly, and the repair's real-world precision is unauditable after the fact. Same
+    # discipline as tnmask above: never fabricated, and a malformed stamp is dropped.
+    assert 'german_anchor' not in p, 'an unrepaired card must not fabricate a german_anchor stamp'
+    garow = list(rows_for('p_a~~h5_00_pwg00',
+                          dict(entry, card=dict(entry['card'],
+                                                german_anchor={'reinjected': ['T4'], 'head': []})),
+                          'ai_translated', SELFTEST_MODEL_VERSION))[0]['provenance']
+    assert garow['german_anchor'] == {'reinjected': ['T4'], 'head': []}, \
+        'a german-anchor repair must ride on the promoted row provenance'
+    gabad = list(rows_for('p_a~~h5_00_pwg00',
+                          dict(entry, card=dict(entry['card'], german_anchor={'head': []})),
+                          'ai_translated', SELFTEST_MODEL_VERSION))[0]['provenance']
+    assert 'german_anchor' not in gabad, 'a malformed german_anchor stamp must not be promoted'
     # collect_cards: a non-null card wins over a null for the same sub-card key.
     d = tempfile.mkdtemp()
     nullf = os.path.join(d, 'wf_output.sc.x.json')

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,30 @@ not an error.
 
 ## [Unreleased]
 
+### Added
+- **H858 Part B — source-anchored repair of a dropped `german` span (Opus 5 `claude-opus-5`, 25-07-2026).**
+  New [`RussianTranslation/src/german_anchor.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/german_anchor.py):
+  a card whose `german` echo dropped a masked `{Tn}` span is repaired from the source skeleton
+  instead of being nulled by the `<ls>`/`{#` fidelity count — the dominant retry-RESISTANT null
+  class (6 of 7 residual nulls in `no_pwg_w10`, H1283; a `--max-wide` requeue provably cannot fix
+  it). Repair-then-verify (runs only on a card that already failed the count, the same count re-run
+  as the verifier, so a passing card is byte-untouched) and refused unless the echo is a strict
+  order-preserving subsequence of the source. Wired into both lanes from ONE authored source —
+  `headless_worker.normalize_batch` (production) and the harness `accept()` via
+  `german_anchor.js_source()`, the C-01/C-17 injection pattern. Every repair is stamped into the
+  promoted row's provenance (`german_anchor`) and counted in `summary.german_anchor_repairs`.
+  SHARED in [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md).
+  Offline-green on both lanes (`window_selftest` 185/185, `german_anchor_test.js`,
+  `headless_worker_selftest`, `promote_final_cards --selftest`); the handoff's live no_pwg
+  validation window is PAID and stays gated on a fresh live-gate GO.
+
+### Fixed
+- **`window_selftest` polluted the tracked residual registry (integrity, 25-07-2026).** The
+  coordinator-requeue test ran a real `--defect` requeue without `--no-residual`, so every suite
+  run appended a junk `{"key": "a", "source_window": "nominal_selftest"}` row to
+  [`no_pwg_residuals.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/no_pwg_residuals.jsonl)
+  — the registry that decides which keys are BLOCKED from requeue. Flag added; the polluting row reverted.
+
 ### Changed
 - **H1623 docs-freshness (Grok 4.5 grok-4.5, 25-07-2026):** re-verify big-manuals estate — LAST_VERIFIED 25-07-2026 on workspace AGENTS/HUMAN_RU + 6 docs/manuals deep manuals; RT deep metadoc COMMANDS_SPOT_RUN forced to integer 4 (was free-text, broke manual_staleness.py); MAINTAINER papers range updated A30-A67.
 


### PR DESCRIPTION
Closes the code half of [H858 Part B](https://github.com/gasyoun/Uprava/blob/main/handoffs/H858-Opus_SanskritLexicography_pwg_ru_sense_fidelity_anchor_repair_13.07.26.md) — spec'd 13-07-2026, unshipped since, and named by [H1283](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H1283-Opus_SanskritLexicography_pwg-ru-pipeline-speed-bug-audit_19.07.26.md) as the clean-rate ceiling.

## The defect

A card is nulled when its restored `<ls>`/`{#` counts differ from the source, and that count reads `sense.german` — the model's **echo** of the masked skeleton, not a deliverable. Drop one `{Tn}` from the echo and the whole card dies, taking every paid call on it. **A requeue reproduces it**: the drop is a property of the echo, not of transport. Measured: `asaMskfta` `avyāhata` `avyagra` `darvī` `glāna` `hasita` at `{# 0/1`, `1/2`, `1/3`, and 6 of the 7 residual nulls in `no_pwg_w10`.

## The repair

The dropped span is not lost information — it is in the source skeleton, and the tokens the model *did* echo say where it belongs. [`src/german_anchor.py`](https://github.com/gasyoun/SanskritLexicography/blob/h858-german-anchor/RussianTranslation/src/german_anchor.py) re-injects each missing `{Tn}` next to its **nearest surviving neighbour** — after the preceding span or before the following one, whichever is closer by source offset. Nearest-neighbour rather than always-after matters across a sense boundary: a citation dropped from the end of sense 2 has its predecessor back in sense 1. Spans with nothing surviving before them go to the head of sense 1 — the dropped headword, the largest sub-class.

Two properties bound the blast radius, both pinned by tests:

- **Repair-then-verify.** It runs ONLY on a card that already failed the count, and the SAME count is re-run as the verifier. A card that passes today never enters the branch — byte-untouched. The clean yield cannot regress, because the only cards the repair can reach are cards that were already being thrown away.
- **Refuse anything that is not a pure drop.** The echo must be a strict order-preserving subsequence of the source (no foreign token, no duplicate, no reordering). Under that precondition the only possible defect *is* a drop, and the source fixes it deterministically. Everything else rejects exactly as before, with the reason recorded (`fidelity-reject: german-anchor duplicate-token`, …).

## Why the handoff's literal spec was not implemented

It asked to "stop accepting the model's `german`; set german = the restored source skeleton". A wholesale re-slice needs a sense segmentation the **model** owns, and the skeleton carries content that legitimately belongs to no sense's german (the `=== LAYER: … ===` headers, the `h`/`grammar` region). Mis-cut german is a *content* regression on a published column — strictly worse than the reject it replaces. Repairing only what was dropped reaches the same stop condition with zero blast radius on clean cards.

## Both lanes, one implementation

`german_anchor.js_source()` is interpolated into the harness exactly as `card_fields` injects `RESTORE_SPEC` (C-01) and `TOKEN_FIDELITY_SPEC` (C-17) — the two constants that drifted *because* each lane kept a hand-written copy. SHARED in [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/h858-german-anchor/RussianTranslation/LANG_PARITY.md) by construction: german-only, target field never read or written.

Every repair is stamped into the promoted row's provenance (`german_anchor`) and counted in `summary.german_anchor_repairs` — a machine-re-injected citation must never be indistinguishable in the store from one the model echoed correctly (the H1150/H1226 "denominator 1" trap).

## Non-goals, stated

| Not done | Why |
|---|---|
| fragment / heal lane | its guard is a MULTISET over `grammar` + `german` (C-17) — different denominator, own duplicate-echo semantics; needs its own analysis |
| target-language field | a span missing from the translation is a genuine loss with no deterministic home. `translation-fidelity-reject` (H1152 C1) still requeues it, and a repaired german provably does **not** launder one — pinned on both lanes |
| **the live validation** | the handoff's own stop condition (a bounded no_pwg window showing the null class gone) is a **PAID** run. Last c2/c4 readings were NOGO/rate-limited; a stale gate never authorizes a window. `summary.german_anchor_repairs` exists to answer it on the first window that runs |

## Gates

| Gate | Result |
|---|---|
| `german_anchor.selftest()` | 8/8 OK |
| `german_anchor_test.js` vs a REAL generated harness | 21/21 PASS |
| `headless_worker_selftest.py` (incl. the new H858 test) | PASS |
| `window_selftest.py` | **185/185**, 0 failed |
| `promote_final_cards.py --selftest` | PASS |
| `lang_parity_check.py` | 82 entries, no drift, coverage complete |

## Also fixed (integrity, pre-existing, unrelated)

`window_selftest`'s coordinator-requeue test ran a real `--defect` requeue without `--no-residual`, so **every suite run** appended a junk `{"key": "a", "source_window": "nominal_selftest"}` row to the tracked `no_pwg_residuals.jsonl` — the registry that decides which keys are BLOCKED from requeue. Flag added; the polluting row reverted; the test's own assertions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
