### PR TITLE
chore(release): cut v1.61.0 — H858 Part B german-anchor repair

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.61.0] — 2026-07-25
+
 ### Added
 - **H858 Part B — source-anchored repair of a dropped `german` span (Opus 5 `claude-opus-5`, 25-07-2026).**
   New [`RussianTranslation/src/german_anchor.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/german_anchor.py):


### PR DESCRIPTION
Promotes the `[Unreleased]` block landed by [#725](https://github.com/gasyoun/SanskritLexicography/pull/725) to `1.61.0`, per the standing changelog→release coupling. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)