### PR TITLE
docs(pwg_ru): c4 live gate 25-07 = HEALTH_NOGO; probe RUN_ID contamination (#729)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -47,7 +47,12 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   in `LANG_PARITY.md`. Offline green: `window_selftest` **185/185**, `german_anchor_test.js` against
   a real generated harness, `headless_worker_selftest`, `promote_final_cards --selftest`, parity
   no-drift. **Owed:** the handoff's bounded no_pwg window proving the `{#…#}`-drop null class is
-  gone — PAID, so it waits on a fresh live-gate GO; read `german_anchor_repairs` off that window's
+  gone — PAID. **Gate run 25-07-2026 16:02Z → HEALTH_NOGO: c4 `rate_limit` on the warm-up**
+  (17 878 ms — not a latency block; the measured call never ran). No canary, no window,
+  nothing promoted. Packet:
+  [`pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md).
+  c4 has no clean pair since 23-07 (`rate_limit` ×2 on 24-07, `auth` ×2 earlier on 25-07).
+  Retry Step 1 when the account resets; read `german_anchor_repairs` off that window's
   summary. Fixed in passing: `window_selftest`'s coordinator-requeue test was appending a junk row
   to the tracked `no_pwg_residuals.jsonl` on every run (missing `--no-residual`).
 

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -4,6 +4,29 @@ _Created: 09-07-2026 · Last updated: 25-07-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
+## 25-07-2026 - H858 c4 live gate: HEALTH_NOGO (rate_limit), no window opened
+
+Executor: Opus 5 (`claude-opus-5[1m]`). `/pwg-live-gate c4`, one attempt, no reroll.
+Packet: [`pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md).
+
+| Reading | Elapsed | Classification | Verdict input |
+|---|---|---|---|
+| warm-up | 17 878 ms | `rate_limit` | fail-closed -> STOP |
+| measured | - | never ran | - |
+
+`gate_reason = HEALTH_NOGO` -> `verdict = NO-GO`. **Not a latency block** (17.9 s is well
+inside the 30 000 ms ceiling) - c4 is rate-limited. No canary, no bounded window, nothing
+promoted; one paid warm-up call was spent. The H858 Part B validation window stays owed.
+
+c4 has produced no clean pair since 23-07: `rate_limit` x2 on 24-07, `auth` x2 earlier on
+25-07, `rate_limit` today.
+
+### Probe defect found by this run (integrity)
+
+| Defect | Impact | Tracking |
+|---|---|---|
+| `h963_c4_gate0_probe.py` hardcodes `RUN_ID`, then filters the append-only log by it and keeps the last row per purpose - so every run re-reads the whole history and can pair today's warm-up with a **stale** `measured` | today it only mis-stated a NO-GO reason (cited a 23-07 reading of 168 352 ms for a call never made). The inverse is the hazard: a stale passing `measured` + a passing warm-up prints `GATE-0 VERDICT: PASS`, which Step 3 turns into `LIVE_GO` and authorizes paid spend off a two-day-old number | [#729](https://github.com/gasyoun/SanskritLexicography/issues/729) |
+
 ## 25-07-2026 - H858 Part B: german-anchor repair — offline verification (NO paid run)
 
 Executor: Opus 5 (`claude-opus-5`). Isolated worktree off `origin/master` @ `f96361ca`.

--- a/RussianTranslation/pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
+++ b/RussianTranslation/pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
@@ -1,0 +1,93 @@
+# H858 — c4 live gate: HEALTH_NOGO (25-07-2026), rate_limit on the warm-up
+
+_Created: 25-07-2026 · Last updated: 25-07-2026_
+
+Executor: Opus 5 (`claude-opus-5[1m]`). Skill followed:
+[/pwg-live-gate](https://github.com/gasyoun/claude-config/blob/main/commands/pwg-live-gate.md)
+c4, invoked exactly once — no retry, no re-warm, no reroll. Requested to gate the
+paid validation window still owed by
+[H858 Part B](https://github.com/gasyoun/Uprava/blob/main/handoffs/H858-Opus_SanskritLexicography_pwg_ru_sense_fidelity_anchor_repair_13.07.26.md)
+(code landed [PR #725](https://github.com/gasyoun/SanskritLexicography/pull/725),
+[v1.61.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.61.0)).
+
+## Verdict
+
+```
+gate_reason = HEALTH_NOGO
+verdict     = NO-GO
+```
+
+**No canary was run. No production window. Nothing promoted. One paid call was made
+(the warm-up), and it was rate-limited.**
+
+## Step 1 — health: the ONE attempt taken today
+
+| Reading | Elapsed | Classification | Output | UTC |
+|---|---|---|---|---|
+| warm-up | **17 878 ms** | **`rate_limit`** | 831 B | 2026-07-25T16:02:31Z |
+| measured | — | **never ran** | — | — |
+
+`live_probe` fail-closed on the warm-up (`warm-up probe rate_limit -> STOP`), so the
+measured call was never issued. Latency is not the blocker here — 17.9 s is comfortably
+inside the 30 000 ms ceiling. The blocker is **account state**: c4 is rate-limited.
+
+- Profile: `D:\ClaudeTools\profiles\claude4\.claude` · exact model `claude-sonnet-5`
+- Prompt: 6 828 B actual (≥ 5 KiB floor), schema-carrying, load-representative
+- Binary resolution clean (`[node.exe, cli-wrapper.cjs]`) — not the D-R tooling defect
+- Events (append-only): `src/pilot/output/h963_c4_gate0_probe_events.jsonl`
+
+## c4 recent history (same events log, all rows)
+
+The account has not produced a clean pair since 23-07. Two `auth` readings earlier today
+precede today's `rate_limit`:
+
+| UTC | Purpose | Elapsed | Classification |
+|---|---|---|---|
+| 2026-07-22T14:57:34Z | warm-up | 21 280 ms | content |
+| 2026-07-22T20:03:04Z | warm-up | 59 831 ms | success |
+| 2026-07-22T20:04:47Z | measured | 102 874 ms | auth |
+| 2026-07-23T06:06:52Z | warm-up | 40 003 ms | success |
+| 2026-07-23T06:09:40Z | measured | 168 352 ms | success |
+| 2026-07-24T04:23:53Z | warm-up | 10 838 ms | rate_limit |
+| 2026-07-24T07:35:29Z | warm-up | 9 949 ms | rate_limit |
+| 2026-07-25T03:16:04Z | warm-up | 17 587 ms | auth |
+| 2026-07-25T03:18:34Z | warm-up | 10 918 ms | auth |
+| **2026-07-25T16:02:31Z** | **warm-up** | **17 878 ms** | **rate_limit** |
+
+Note the H1447 22-07 LIVE_GO pair (17 972 / 16 621 ms, both success) is **not** in this
+log — that run wrote to `pwg_ru/h1447/h1447_gate0_probe_events.jsonl`.
+
+## Probe reporting defect found by this run — the verdict cited a two-day-old reading
+
+The probe printed, among its NO-GO reasons:
+
+```
+  - measured latency 168352 ms >= 30000 ms ceiling
+```
+
+**No measured call was made today.** 168 352 ms is the row from **2026-07-23T06:09:40Z**.
+Cause: [`h963_c4_gate0_probe.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h963_c4_gate0_probe.py)
+hardcodes `RUN_ID = 'h963-c4-single-profile-gate0-2026-07-16'`, then filters the
+append-only log by that constant and keeps the **last row per purpose**. Every run appends
+to and re-reads the same bucket, so "RAW READINGS (append-only telemetry, this run_id)"
+is the whole history, and `by_purpose` can pair today's warm-up with a stale `measured`.
+
+Today that only made the reason list wrong, not the verdict — the warm-up failed on its
+own. **The dangerous direction is the inverse:** a stale `measured` row that was `success`
+and under the ceiling, paired with a passing warm-up, yields `GATE-0 VERDICT: PASS`
+citing a measured call that was never made this session — a gate that authorizes paid
+spend off a two-day-old number. Tracked as
+[integrity issue #729](https://github.com/gasyoun/SanskritLexicography/issues/729).
+
+## Resume condition (unchanged, and it is not a formality)
+
+Per the skill's hand-off: **make no paid translation call** — not a canary rerun, not a
+bounded window. Resume only after a **NEW** representative ≥ 5 KB c4 health call (Step 1)
+returns PASS. A stale or prior GO — including H1447's 22-07 LIVE_GO — does not authorize
+resumption. The H858 validation window stays owed and unstarted.
+
+```
+Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H858-Opus_SanskritLexicography_pwg_ru_sense_fidelity_anchor_repair_13.07.26.md and execute it.
+```
+
+_Dr. Mārcis Gasūns_

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,18 @@ not an error.
 
 ## [Unreleased]
 
+### Fixed
+- **Gate-probe integrity, reported not yet repaired (25-07-2026).** A `/pwg-live-gate c4` run
+  for the H858 validation window returned **HEALTH_NOGO** (c4 `rate_limit` on the warm-up,
+  17 878 ms — not a latency block) and, in doing so, exposed that
+  [`h963_c4_gate0_probe.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h963_c4_gate0_probe.py)
+  hardcodes `RUN_ID`: it re-reads the whole append-only history and keeps the last row per
+  purpose, so a run can pair its own warm-up with a **stale** `measured` reading. Today that
+  only mis-stated a NO-GO reason; the inverse would print `GATE-0 VERDICT: PASS` off a
+  two-day-old number and authorize paid spend ([#729](https://github.com/gasyoun/SanskritLexicography/issues/729)).
+  Gate packet:
+  [`pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md).
+
 ## [1.61.0] — 2026-07-25
 
 ### Added


### PR DESCRIPTION
Gate packet for the [/pwg-live-gate](https://github.com/gasyoun/claude-config/blob/main/commands/pwg-live-gate.md) c4 run requested for the [H858 Part B](https://github.com/gasyoun/Uprava/blob/main/handoffs/H858-Opus_SanskritLexicography_pwg_ru_sense_fidelity_anchor_repair_13.07.26.md) validation window. One attempt, no reroll.

## Verdict: NO-GO (`HEALTH_NOGO`)

| Reading | Elapsed | Classification | UTC |
|---|---|---|---|
| warm-up | **17 878 ms** | **`rate_limit`** | 2026-07-25T16:02:31Z |
| measured | — | **never ran** | — |

`live_probe` fail-closed on the warm-up, so the measured call was never issued. **Not a latency block** — 17.9 s is comfortably inside the 30 000 ms ceiling. c4 is rate-limited, and has produced no clean pair since 23-07 (`rate_limit` ×2 on 24-07, `auth` ×2 earlier on 25-07).

No canary, no bounded window, nothing promoted. One paid warm-up call was spent. The H858 validation stays owed.

## The run exposed a defect in the gate's own bookkeeping ([#729](https://github.com/gasyoun/SanskritLexicography/issues/729))

The probe printed, among its NO-GO reasons:

```
  - measured latency 168352 ms >= 30000 ms ceiling
```

No measured call was made today — that row is from **2026-07-23**. [`h963_c4_gate0_probe.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h963_c4_gate0_probe.py) hardcodes `RUN_ID`, filters the append-only log by that constant, and keeps the **last row per purpose** — so every run re-reads the whole history and can pair its own warm-up with a **stale** `measured`.

Today that only mis-stated a reason; the warm-up failed on its own. **The hazard is the inverse:** a stale passing `measured` + a passing warm-up prints `GATE-0 VERDICT: PASS`, which Step 3 turns into `LIVE_GO` and authorizes `/pwg-bounded-run` to spend — a paid window opened off a two-day-old number, defeating the "a stale GO never authorizes a window" rule inside the gate meant to enforce it.

**Reported, not repaired here.** The fix (per-invocation run id + a regression pin) is a code change to the gate itself and deserves its own PR rather than riding along in a docs commit that also records a gate result the current probe produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)