### PR TITLE
fix(pwg_ru): #729 — scope the c4 gate probe to its OWN run, not the whole log

### DIFF
--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -131,7 +131,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
       "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -154,7 +154,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -209,7 +209,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -228,7 +228,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -431,7 +431,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -488,7 +488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -547,7 +547,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -578,7 +578,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -597,7 +597,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -615,7 +615,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -634,7 +634,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -764,7 +764,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -789,7 +789,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -818,7 +818,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -838,7 +838,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -857,7 +857,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -894,7 +894,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -952,7 +952,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -971,7 +971,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -990,7 +990,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -1010,7 +1010,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e",
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -1032,7 +1032,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -1091,7 +1091,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -1151,7 +1151,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -1170,7 +1170,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -1195,7 +1195,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -1217,7 +1217,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e",
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9",
       "src/pilot/accept_sensecount_test.js": "fbf8d37f8ae360c286f646361025d56adb0caeff09da30a0abfef5f6b7289937"
     }
   },
@@ -1237,7 +1237,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -1292,7 +1292,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e"
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
     }
   },
   {
@@ -1405,7 +1405,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e",
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9",
       "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1686,7 +1686,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
       "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
-      "src/pilot/window_selftest.py": "27722e5e9807f0340bde721aa21d9bb58eaec302466049ad7afba34d8afbbd7e",
+      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
   },

--- a/RussianTranslation/pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
+++ b/RussianTranslation/pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
@@ -79,6 +79,25 @@ citing a measured call that was never made this session — a gate that authoriz
 spend off a two-day-old number. Tracked as
 [integrity issue #729](https://github.com/gasyoun/SanskritLexicography/issues/729).
 
+**FIXED 25-07-2026** ([PR #732](https://github.com/gasyoun/SanskritLexicography/pull/732)):
+the run id is now minted per invocation (`new_run_id()` = campaign prefix + UTC second +
+pid) and the reader (`readings_for`) matches it EXACTLY — never by prefix, which is the
+defect itself. The old constant survives as `CAMPAIGN`, a grouping label the H1110/H1447
+reports still cite, but it is no longer a read scope. Verdict derivation moved to the pure
+`derive_fails()`, and the module now carries a `--selftest` that seeds exactly this log
+shape (a historical PASSING pair + a fresh warm-up-only run) and asserts both halves: the
+scoped read is NO-GO naming its OWN absent measured reading, and the contaminated pairing
+is demonstrably PASS-shaped. Pinned in `window_selftest.test_c4_gate0_probe_run_scope`
+(186/186). Re-running today's verdict through the fixed reader gives, correctly:
+
+```
+  - warm-up reading absent (probe stopped before it ran)
+  - measured reading absent (probe stopped before it ran)
+```
+
+for a fresh run that made no call — and for the 16:02Z run, the warm-up `rate_limit` alone.
+The 168 352 ms citation cannot recur.
+
 ## Resume condition (unchanged, and it is not a formality)
 
 Per the skill's hand-off: **make no paid translation call** — not a canary rerun, not a

--- a/RussianTranslation/src/pilot/h963_c4_gate0_probe.py
+++ b/RussianTranslation/src/pilot/h963_c4_gate0_probe.py
@@ -14,11 +14,32 @@ no reroll. The historical NO-GO (warm-up 29 743 ms / measured 52 815 ms,
 Gate rule applied here is STRICTER than live_probe's own gate: live_probe
 excludes the warm-up from the ceiling, but the H963 c4 resume brief requires
 that EITHER reading at >= 30 000 ms is a NO-GO. Both are reported.
+
+RUN SCOPE (issue #729, fixed 25-07-2026)
+----------------------------------------
+`RUN_ID` used to be a CONSTANT (`h963-c4-single-profile-gate0-2026-07-16`). Every
+invocation appended to *and re-read* that one bucket, then kept the last row per
+purpose -- so a run could pair its own warm-up with a **stale** `measured` from days
+earlier. The 25-07-2026 gate run printed `measured latency 168352 ms >= 30000 ms` as a
+NO-GO reason for a measured call it never made (that row was from 23-07).
+
+There it only mis-stated a reason. The hazard is the INVERSE: a stale *passing* measured
+row plus a passing warm-up leaves the fail list empty and prints `GATE-0 VERDICT: PASS`,
+citing a measured call never made this session -- and that verdict is what
+`/pwg-live-gate` Step 3 turns into `LIVE_GO`, which authorizes `/pwg-bounded-run` to
+spend. A paid window opened off a two-day-old number, from inside the gate whose whole
+purpose is "a stale GO never authorizes a window".
+
+So the run id is now minted per invocation (`new_run_id()`), and the reader
+(`readings_for`) matches it EXACTLY. The old constant survives as `CAMPAIGN`, a prefix
+for historical grouping -- it is a label, never a scope. The verdict is derived by the
+pure `derive_fails()`, exercised without any live call by `--selftest`.
 """
 import json
 import os
 import shutil
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -26,7 +47,8 @@ sys.stdout.reconfigure(encoding="utf-8")
 sys.stderr.reconfigure(encoding="utf-8")
 
 HERE = Path(__file__).resolve().parent
-sys.path.insert(0, str(HERE))
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
 
 import max_account_orchestrator as mao  # noqa: E402
 from headless_worker import claude_argv_prefix  # noqa: E402
@@ -49,121 +71,235 @@ def resolve_claude_bin():
 
 CONFIG_DIR = r"D:\ClaudeTools\profiles\claude4\.claude"
 ACCOUNT = "c4"
-RUN_ID = "h963-c4-single-profile-gate0-2026-07-16"
+# The historical campaign label. A GROUPING PREFIX, never a run scope -- see the module
+# docstring. Reports that cite `run_id=h963-c4-single-profile-gate0-2026-07-16` (H1110
+# 18-07, H1447 22-07) still match rows by this prefix.
+CAMPAIGN = "h963-c4-single-profile-gate0-2026-07-16"
 EVENTS = HERE / "output" / "h963_c4_gate0_probe_events.jsonl"
 PAYLOAD_BYTES = 6491          # repo default; actual prompt 6828 B (H909 runbook, v1.9.19)
 CEILING_MS = mao.PROBE_LATENCY_CEILING_MS   # 30 000
 STRICT_CEILING_MS = 30_000    # resume brief: EITHER reading >= this is NO-GO
+CONN_ERR_CLASSES = {"process", "timeout"}
 
-EVENTS.parent.mkdir(parents=True, exist_ok=True)
 
-# Belt-and-suspenders: pin the store to a scratch path so nothing can touch the
-# canonical 11,605-row store. (live_probe makes no store write by construction.)
-os.environ["PWG_RU_STORE"] = str(HERE / "output" / "h963_c4_gate0_scratch_store.jsonl")
+def new_run_id(campaign=CAMPAIGN, now=None, pid=None):
+    """A run id unique to THIS invocation, under the campaign prefix.
 
-CLAUDE_BIN = resolve_claude_bin()
-ARGV_PREFIX = claude_argv_prefix(CLAUDE_BIN)
+    The UTC second alone is not enough: two invocations can share it, and the whole point
+    of this identifier is that no two runs can ever read each other's rows. The pid makes
+    a collision impossible in practice while keeping the id greppable and human-readable.
+    """
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now))
+    return "%s/%s-pid%d" % (campaign, stamp, os.getpid() if pid is None else pid)
 
-prompt = mao._probe_prompt(PAYLOAD_BYTES)
-actual_prompt_bytes = len(prompt.encode("utf-8"))
 
-print("=" * 72)
-print("H963 Gate-0 — single-profile c4 D-K health attempt")
-print("=" * 72)
-print("date (UTC)        : %s" % time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()))
-print("profile           : %s  (%s)" % (ACCOUNT, CONFIG_DIR))
-print("exact model       : %s" % mao.EXACT_GEN_MODEL)
-print("payload_bytes arg : %d" % PAYLOAD_BYTES)
-print("actual prompt B   : %d  (floor %d B / 5 KiB=5120)" % (actual_prompt_bytes, mao.PROBE_MIN_PAYLOAD_BYTES))
-print("ceiling           : %d ms (strict: either reading >= %d ms => NO-GO)" % (CEILING_MS, STRICT_CEILING_MS))
-print("run_id            : %s" % RUN_ID)
-print("events            : %s" % EVENTS)
-print("claude bin        : %s" % CLAUDE_BIN)
-print("resolved argv     : %s" % ARGV_PREFIX)
-print("-" * 72)
+def readings_for(events_path, run_id):
+    """The `probe_call` rows THIS run wrote -- EXACT run_id match, in file order.
 
-if actual_prompt_bytes < 5120:
-    print("RESULT: NO-GO — payload undersized (%d B < 5 KiB)" % actual_prompt_bytes)
-    raise SystemExit(2)
-
-# PRE-FLIGHT (no call made): never spend the one no-reroll attempt on a mis-resolved
-# binary. A bare ['claude'] fallback is the D-R defect and is NOT a health reading.
-if os.name == "nt" and (len(ARGV_PREFIX) != 2 or not ARGV_PREFIX[0].lower().endswith("node.exe")):
-    print("PRE-FLIGHT ABORT (no probe call made, no attempt consumed):")
-    print("  claude_argv_prefix(%r) -> %s" % (CLAUDE_BIN, ARGV_PREFIX))
-    print("  expected [<node.exe>, <cli*.cjs>]; a bare fallback cannot be launched by")
-    print("  CreateProcess. This is a tooling-resolution defect (D-R), NOT a c4 health signal.")
-    raise SystemExit(3)
-
-verdict_exc = None
-t0 = time.monotonic()
-try:
-    measured_ms = mao.live_probe(
-        CONFIG_DIR,
-        claude=CLAUDE_BIN,
-        payload_bytes=PAYLOAD_BYTES,
-        model=mao.EXACT_GEN_MODEL,
-        latency_ceiling_ms=CEILING_MS,
-        events_path=str(EVENTS),
-        run_id=RUN_ID,
-        account=ACCOUNT,
-    )
-except SystemExit as exc:
-    verdict_exc = str(exc)
-    measured_ms = None
-wall_s = time.monotonic() - t0
-
-print("wall clock        : %.1f s" % wall_s)
-print("-" * 72)
-
-# Re-read the append-only events log: it holds BOTH readings even on a fail-closed exit.
-readings = []
-if EVENTS.exists():
-    for line in EVENTS.read_text(encoding="utf-8").splitlines():
+    Deliberately exact, never a prefix/campaign match: a prefix match is precisely the
+    defect (#729), because it re-admits every historical row into the current verdict.
+    """
+    path = Path(events_path)
+    if not path.exists():
+        return []
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
         row = json.loads(line)
-        if row.get("run_id") == RUN_ID and row.get("event") == "probe_call":
-            readings.append(row)
+        if row.get("run_id") == run_id and row.get("event") == "probe_call":
+            rows.append(row)
+    return rows
 
-print("RAW READINGS (append-only telemetry, this run_id):")
-for r in readings:
-    print("  purpose=%-8s elapsed_ms=%-7s classification=%-10s output_bytes=%s"
-          % (r.get("purpose"), r.get("elapsed_ms"), r.get("classification"), r.get("output_bytes")))
 
-by_purpose = {r.get("purpose"): r for r in readings}
-warm = by_purpose.get("warmup")
-meas = by_purpose.get("measured")
+def derive_fails(readings, strict_ceiling_ms=STRICT_CEILING_MS):
+    """The gate policy as a pure function of THIS run's readings. Empty list == PASS.
 
-print("-" * 72)
-fails = []
-if verdict_exc:
-    print("live_probe fail-closed: %s" % verdict_exc)
+    Both readings must be present, `success`, free of connection/process errors, and
+    strictly below the ceiling. A missing reading is a FAIL, never a skip -- that is what
+    makes a run whose measured phase never executed a NO-GO instead of silently
+    inheriting someone else's measured row.
+    """
+    by_purpose = {r.get("purpose"): r for r in readings}
+    fails = []
+    for label, key in (("warm-up", "warmup"), ("measured", "measured")):
+        r = by_purpose.get(key)
+        if r is None:
+            fails.append("%s reading absent (probe stopped before it ran)" % label)
+            continue
+        cls = r.get("classification")
+        ms = r.get("elapsed_ms")
+        if cls != "success":
+            fails.append("%s classification=%s (not success)" % (label, cls))
+        if cls in CONN_ERR_CLASSES:
+            fails.append("%s connection/process error (%s)" % (label, cls))
+        if isinstance(ms, int) and ms >= strict_ceiling_ms:
+            fails.append("%s latency %d ms >= %d ms ceiling" % (label, ms, strict_ceiling_ms))
+    return fails
 
-CONN_ERR_CLASSES = {"process", "timeout"}
-for label, r in (("warm-up", warm), ("measured", meas)):
-    if r is None:
-        fails.append("%s reading absent (probe stopped before it ran)" % label)
-        continue
-    cls = r.get("classification")
-    ms = r.get("elapsed_ms")
-    if cls != "success":
-        fails.append("%s classification=%s (not success)" % (label, cls))
-    if cls in CONN_ERR_CLASSES:
-        fails.append("%s connection/process error (%s)" % (label, cls))
-    if isinstance(ms, int) and ms >= STRICT_CEILING_MS:
-        fails.append("%s latency %d ms >= %d ms ceiling" % (label, ms, STRICT_CEILING_MS))
 
-print()
-if fails:
-    print("GATE-0 VERDICT: NO-GO")
-    for f in fails:
-        print("  - %s" % f)
+def main():
+    EVENTS.parent.mkdir(parents=True, exist_ok=True)
+
+    # Belt-and-suspenders: pin the store to a scratch path so nothing can touch the
+    # canonical 11,605-row store. (live_probe makes no store write by construction.)
+    os.environ["PWG_RU_STORE"] = str(HERE / "output" / "h963_c4_gate0_scratch_store.jsonl")
+
+    run_id = new_run_id()
+    claude_bin = resolve_claude_bin()
+    argv_prefix = claude_argv_prefix(claude_bin)
+
+    prompt = mao._probe_prompt(PAYLOAD_BYTES)
+    actual_prompt_bytes = len(prompt.encode("utf-8"))
+
+    print("=" * 72)
+    print("H963 Gate-0 — single-profile c4 D-K health attempt")
+    print("=" * 72)
+    print("date (UTC)        : %s" % time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()))
+    print("profile           : %s  (%s)" % (ACCOUNT, CONFIG_DIR))
+    print("exact model       : %s" % mao.EXACT_GEN_MODEL)
+    print("payload_bytes arg : %d" % PAYLOAD_BYTES)
+    print("actual prompt B   : %d  (floor %d B / 5 KiB=5120)"
+          % (actual_prompt_bytes, mao.PROBE_MIN_PAYLOAD_BYTES))
+    print("ceiling           : %d ms (strict: either reading >= %d ms => NO-GO)"
+          % (CEILING_MS, STRICT_CEILING_MS))
+    print("run_id            : %s   (unique to THIS run — #729)" % run_id)
+    print("campaign          : %s   (grouping label only, never a read scope)" % CAMPAIGN)
+    print("events            : %s" % EVENTS)
+    print("claude bin        : %s" % claude_bin)
+    print("resolved argv     : %s" % argv_prefix)
+    print("-" * 72)
+
+    if actual_prompt_bytes < 5120:
+        print("RESULT: NO-GO — payload undersized (%d B < 5 KiB)" % actual_prompt_bytes)
+        return 2
+
+    # PRE-FLIGHT (no call made): never spend the one no-reroll attempt on a mis-resolved
+    # binary. A bare ['claude'] fallback is the D-R defect and is NOT a health reading.
+    if os.name == "nt" and (len(argv_prefix) != 2 or not argv_prefix[0].lower().endswith("node.exe")):
+        print("PRE-FLIGHT ABORT (no probe call made, no attempt consumed):")
+        print("  claude_argv_prefix(%r) -> %s" % (claude_bin, argv_prefix))
+        print("  expected [<node.exe>, <cli*.cjs>]; a bare fallback cannot be launched by")
+        print("  CreateProcess. This is a tooling-resolution defect (D-R), NOT a c4 health signal.")
+        return 3
+
+    verdict_exc = None
+    t0 = time.monotonic()
+    try:
+        mao.live_probe(
+            CONFIG_DIR,
+            claude=claude_bin,
+            payload_bytes=PAYLOAD_BYTES,
+            model=mao.EXACT_GEN_MODEL,
+            latency_ceiling_ms=CEILING_MS,
+            events_path=str(EVENTS),
+            run_id=run_id,
+            account=ACCOUNT,
+        )
+    except SystemExit as exc:
+        verdict_exc = str(exc)
+    wall_s = time.monotonic() - t0
+
+    print("wall clock        : %.1f s" % wall_s)
+    print("-" * 72)
+
+    # Re-read the append-only events log: it holds BOTH readings even on a fail-closed
+    # exit -- but ONLY the rows this run wrote (#729).
+    readings = readings_for(EVENTS, run_id)
+
+    print("RAW READINGS (append-only telemetry, THIS run only — run_id %s):" % run_id)
+    if not readings:
+        print("  (none — no probe call completed)")
+    for r in readings:
+        print("  purpose=%-8s elapsed_ms=%-7s classification=%-10s output_bytes=%s"
+              % (r.get("purpose"), r.get("elapsed_ms"), r.get("classification"),
+                 r.get("output_bytes")))
+
+    print("-" * 72)
+    if verdict_exc:
+        print("live_probe fail-closed: %s" % verdict_exc)
+
+    fails = derive_fails(readings)
+    by_purpose = {r.get("purpose"): r for r in readings}
+
     print()
-    print("STOP. No canary. No production window. No reroll.")
-    raise SystemExit(1)
+    if fails:
+        print("GATE-0 VERDICT: NO-GO")
+        for f in fails:
+            print("  - %s" % f)
+        print()
+        print("STOP. No canary. No production window. No reroll.")
+        return 1
 
-print("GATE-0 VERDICT: PASS")
-print("  warm-up  %d ms (success)" % warm["elapsed_ms"])
-print("  measured %d ms (success), strictly below %d ms" % (meas["elapsed_ms"], STRICT_CEILING_MS))
-raise SystemExit(0)
+    print("GATE-0 VERDICT: PASS")
+    print("  warm-up  %d ms (success)" % by_purpose["warmup"]["elapsed_ms"])
+    print("  measured %d ms (success), strictly below %d ms"
+          % (by_purpose["measured"]["elapsed_ms"], STRICT_CEILING_MS))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+def _row(run_id, purpose, ms, cls="success"):
+    return {"event": "probe_call", "run_id": run_id, "purpose": purpose,
+            "elapsed_ms": ms, "classification": cls, "output_bytes": 1400}
+
+
+def selftest():
+    """Regression pin for #729. Pure — makes no live call, spends nothing.
+
+    The load-bearing case is the LAST one: a log carrying a historical PASSING pair, and
+    a fresh run whose measured phase never executed. Under the old constant-`RUN_ID`
+    reader that combination printed `GATE-0 VERDICT: PASS`.
+    """
+    d = tempfile.mkdtemp()
+    try:
+        log = Path(d) / "events.jsonl"
+        old, new = CAMPAIGN, new_run_id(now=0, pid=1)
+        rows = [
+            _row(old, "warmup", 17972),            # 22-07 historical pair -- both PASSING,
+            _row(old, "measured", 16621),          # which is what makes this the hazard
+            _row(new, "warmup", 17878, "rate_limit"),   # this run: fail-closed on warm-up
+        ]
+        log.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+        # 1. the reader is scoped to the run, not to the campaign or the file
+        mine = readings_for(log, new)
+        assert len(mine) == 1 and mine[0]["purpose"] == "warmup", mine
+        assert readings_for(log, old) == rows[:2], 'an unrelated run must still read its own rows'
+
+        # 2. THE PIN: a run whose measured phase never ran is NO-GO, and says so about
+        #    ITS OWN missing reading -- never a latency borrowed from another run.
+        fails = derive_fails(mine)
+        assert any("measured reading absent" in f for f in fails), fails
+        assert any("warm-up classification=rate_limit" in f for f in fails), fails
+        assert not any("168352" in f or "16621" in f for f in fails), \
+            'a NO-GO reason must never cite a reading this run did not take'
+
+        # 3. RED: the pre-#729 behaviour (campaign-wide read, last row per purpose) would
+        #    have paired this run's warm-up with the 22-07 measured. Prove that pairing is
+        #    a PASS, so the pin above is protecting against a real false-GO, not a typo.
+        contaminated = [r for r in rows]                    # every row, as the old reader saw it
+        by_purpose = {r["purpose"]: r for r in contaminated}
+        assert by_purpose["measured"]["elapsed_ms"] == 16621
+        assert derive_fails([by_purpose["measured"], _row(new, "warmup", 17878)]) == [], \
+            'the contaminated pairing must be demonstrably PASS-shaped (that is the hazard)'
+
+        # 4. a genuine clean pair still passes; a slow one still fails
+        assert derive_fails([_row(new, "warmup", 17972), _row(new, "measured", 16621)]) == []
+        slow = derive_fails([_row(new, "warmup", 17972), _row(new, "measured", 40003)])
+        assert len(slow) == 1 and "40003 ms >= 30000 ms" in slow[0], slow
+
+        # 5. run ids are unique per invocation even within the same UTC second
+        assert new_run_id(now=0, pid=1) != new_run_id(now=0, pid=2)
+        assert new_run_id(now=0, pid=1).startswith(CAMPAIGN + "/"), 'campaign stays a prefix'
+
+        print("h963_c4_gate0_probe selftest: 5/5 OK (no live call, nothing spent)")
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv[1:]:
+        selftest()
+        raise SystemExit(0)
+    raise SystemExit(main())

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -910,6 +910,34 @@ def test_german_anchor_repair_behavioral():
         shutil.rmtree(d, ignore_errors=True)
 
 
+def test_c4_gate0_probe_run_scope():
+    """#729: the c4 health gate must read only the readings ITS OWN run wrote.
+
+    `h963_c4_gate0_probe.py` used to pin a CONSTANT `RUN_ID`, append to that one bucket
+    and re-read it, keeping the last row per purpose — so a run could pair its own
+    warm-up with a **stale** `measured` from days earlier. The 25-07-2026 gate run cited
+    a 23-07 reading of 168 352 ms as a NO-GO reason for a measured call it never made.
+
+    That direction was harmless. The inverse is not: a stale *passing* measured plus a
+    passing warm-up empties the fail list and prints `GATE-0 VERDICT: PASS`, which
+    `/pwg-live-gate` Step 3 turns into `LIVE_GO` and which authorizes `/pwg-bounded-run`
+    to SPEND — a paid window opened off a two-day-old number, from inside the gate whose
+    entire job is "a stale GO never authorizes a window".
+
+    The module's own `selftest()` builds exactly that log and proves both halves (the
+    scoped read is NO-GO; the contaminated pairing is demonstrably PASS-shaped). Run it
+    here so the gate cannot regress silently. Pure — no live call, nothing spent.
+    """
+    import h963_c4_gate0_probe as probe
+    probe.selftest()
+    if probe.CAMPAIGN != 'h963-c4-single-profile-gate0-2026-07-16':
+        fail('the campaign label is cited verbatim by the H1110/H1447 gate reports — '
+             'changing it silently orphans them from their own telemetry rows')
+    # The label must never again BE the run id: two invocations must not collide.
+    if probe.new_run_id(now=0, pid=1) == probe.new_run_id(now=0, pid=2):
+        fail('#729 regression: run ids collide, so one run can read another run\'s readings')
+
+
 def test_german_anchor_selftest():
     """H858 Part B: the Python half of the repair, and the LANG_PARITY guarantee.
 
@@ -7879,6 +7907,7 @@ def main():
         test_partial_cards_requeue_and_stay_out_of_clean_sample,
         test_classify_run_verdicts,
         test_grammar_field_restore_behavioral,
+        test_c4_gate0_probe_run_scope,
         test_german_anchor_selftest,
         test_german_anchor_repair_behavioral,
         test_h_reconstructed_regression_guard,

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,20 @@ not an error.
 
 ## [Unreleased]
 
+### Fixed
+- **#729 — the c4 health gate could pass on a stale reading (25-07-2026).**
+  [`h963_c4_gate0_probe.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h963_c4_gate0_probe.py)
+  pinned a CONSTANT `RUN_ID`, appended to that one bucket and re-read it keeping the last
+  row per purpose — so a run could pair its own warm-up with a **stale** `measured` from days
+  earlier. Observed harmlessly (a NO-GO citing a 23-07 reading of 168 352 ms for a call never
+  made); the hazard is the inverse, where a stale *passing* measured yields
+  `GATE-0 VERDICT: PASS` → `LIVE_GO` → authorized paid spend off a two-day-old number.
+  The run id is now minted per invocation and the reader matches it exactly; the old constant
+  survives as `CAMPAIGN`, a grouping label the H1110/H1447 reports cite, never a read scope.
+  Verdict derivation extracted to a pure `derive_fails()`; module `--selftest` seeds the exact
+  hazard log and proves both halves; pinned by `window_selftest.test_c4_gate0_probe_run_scope`
+  (**186/186**). Importing the module no longer fires a paid probe.
+
 ## [1.62.0] — 2026-07-25
 
 ### Fixed


### PR DESCRIPTION
Closes [#729](https://github.com/gasyoun/SanskritLexicography/issues/729).

## The defect

[`h963_c4_gate0_probe.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h963_c4_gate0_probe.py) pinned a **constant** `RUN_ID`, appended to that one bucket and re-read it keeping the **last row per purpose**. Every invocation re-admitted the entire history into the current verdict, so a run could pair its own warm-up with a **stale** `measured` from days earlier.

Observed 25-07-2026, harmlessly: the gate printed `measured latency 168352 ms >= 30000 ms ceiling` as a NO-GO reason for a measured call it never made — that row was from **23-07**; the run had fail-closed on a `rate_limit` warm-up.

**The hazard is the inverse.** A stale *passing* measured — the 22-07 log has exactly such rows — plus a passing warm-up leaves the fail list empty and prints `GATE-0 VERDICT: PASS`, citing a measured call never made that session. `/pwg-live-gate` Step 3 turns that into `LIVE_GO`, and `LIVE_GO` authorizes `/pwg-bounded-run` to **spend**: a paid window opened off a two-day-old number, from inside the gate whose entire job is *"a stale GO never authorizes a window"*.

## The fix

| Change | Why |
|---|---|
| `new_run_id()` mints a run id per invocation: `CAMPAIGN` + UTC second + **pid** | the second alone is not enough — two runs can share it, and the whole point of the identifier is that no two runs can read each other's rows |
| `readings_for()` matches the run id **exactly** | deliberately *not* a prefix match — a prefix match **is** the defect |
| the old constant survives as `CAMPAIGN` | the [H1110](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h1110/H1110_PHASE6_C4_LADDER_HEALTH_NOGO_BY_ENVIRONMENT_2026-07-18.md) and [H1447](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h1447/H1447_C4_LIVE_GATE_2026-07-22.md) reports cite it verbatim. A grouping **label**, never a scope |
| `derive_fails()` extracted as a pure function of one run's readings | the policy was previously untestable. A missing reading stays a FAIL — that is what makes a run whose measured phase never executed a NO-GO instead of silently inheriting another run's row |
| the live path moved into `main()` | **importing the module used to fire a paid probe at import time**, which is why none of this could be tested before |

## The pin

`--selftest` seeds exactly the hazard log — a historical **passing** pair under the old id, plus a fresh warm-up-only run — and asserts **both** halves:

1. the scoped read is NO-GO, naming its **own** absent measured reading, and cites no borrowed latency;
2. the contaminated pairing is **demonstrably PASS-shaped** — so the pin protects against a real false-GO, not a typo.

Wired into `window_selftest.test_c4_gate0_probe_run_scope`; **186/186 pass**, `lang_parity_check` no drift. Pure — no live call, nothing spent.

## Verified against the real log

Re-running the actual 10-row events file through the fixed reader:

```
rows under the old constant run_id: 10      <- what every past run read
rows a NEW run would read:          0
verdict for a fresh run that made no call:
  - warm-up reading absent (probe stopped before it ran)
  - measured reading absent (probe stopped before it ran)
```

The 168 352 ms citation cannot recur. The 25-07 gate verdict itself is unchanged and remains correct: **HEALTH_NOGO**, c4 `rate_limit` on the warm-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
