### PR TITLE
docs(pwg_ru): c4 gate attempt 2 = HEALTH_NOGO; #729 fix verified live

### DIFF
--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -21,6 +21,23 @@ promoted; one paid warm-up call was spent. The H858 Part B validation window sta
 c4 has produced no clean pair since 23-07: `rate_limit` x2 on 24-07, `auth` x2 earlier on
 25-07, `rate_limit` today.
 
+### Attempt 2 (18:18Z, through the fixed probe v1.63.0)
+
+| Reading | Elapsed | Classification | Verdict input |
+|---|---|---|---|
+| warm-up | 19 903 ms | `rate_limit` | fail-closed -> STOP |
+| measured | - | never ran | - |
+
+Same `HEALTH_NOGO`. c4's rate-limit window has not reset: three `rate_limit` readings now
+span 24-07 -> 25-07 18:18Z with two `auth` between, and latency is fine in every one
+(9.9-19.9 s, all far inside the 30 000 ms ceiling). Quota/account state, not code or route -
+further probing today is spend without information.
+
+First live proof of the #729 fix: RAW READINGS printed ONE row (this run's, under a
+per-invocation run id) and the NO-GO reasons name this run's own absent measured reading.
+The old constant `RUN_ID` would have re-read all 10 historical rows and cited the 23-07
+168 352 ms again.
+
 ### Probe defect found by this run (integrity)
 
 | Defect | Impact | Tracking |

--- a/RussianTranslation/pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
+++ b/RussianTranslation/pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
@@ -98,6 +98,37 @@ is demonstrably PASS-shaped. Pinned in `window_selftest.test_c4_gate0_probe_run_
 for a fresh run that made no call — and for the 16:02Z run, the warm-up `rate_limit` alone.
 The 168 352 ms citation cannot recur.
 
+## Attempt 2 — 18:18Z, same verdict, and the #729 fix proving itself
+
+Re-run 2 h 16 min after the first, through the **fixed** probe
+([v1.63.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.63.0)):
+
+| Reading | Elapsed | Classification | UTC |
+|---|---|---|---|
+| warm-up | **19 903 ms** | **`rate_limit`** | 2026-07-25T18:18:27Z |
+| measured | — | **never ran** | — |
+
+```
+GATE-0 VERDICT: NO-GO
+  - warm-up classification=rate_limit (not success)
+  - measured reading absent (probe stopped before it ran)
+```
+
+Two things worth reading off this.
+
+**c4's rate-limit window has not reset.** Three `rate_limit` readings now span 24-07 →
+25-07 18:18Z, with two `auth` readings between them; latency is fine in every one of them
+(9.9–19.9 s, all far inside the 30 000 ms ceiling). The blocker is quota/account state and
+nothing else — no code change, no route change, and no amount of re-probing will move it.
+Further attempts today are spend without information.
+
+**The #729 fix works, verified on its first live run.** The RAW READINGS block printed
+**one** row — this run's — under a per-invocation run id
+(`…-2026-07-16/2026-07-25T18:18:08Z-pid20556`), and the NO-GO reasons name this run's own
+absent measured reading. Under the old constant `RUN_ID` this same run would have re-read
+all 10 historical rows and cited the 23-07 `168 352 ms` again. The verdict is now derived
+only from readings the run actually took.
+
 ## Resume condition (unchanged, and it is not a formality)
 
 Per the skill's hand-off: **make no paid translation call** — not a canary rerun, not a


### PR DESCRIPTION
Second c4 gate attempt, 2 h 16 min after the first — and the first live run of the [#729](https://github.com/gasyoun/SanskritLexicography/issues/729) fix ([v1.63.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.63.0)).

## Verdict: NO-GO (`HEALTH_NOGO`), unchanged

| Reading | Elapsed | Classification | UTC |
|---|---|---|---|
| warm-up | **19 903 ms** | **`rate_limit`** | 2026-07-25T18:18:27Z |
| measured | — | **never ran** | — |

```
GATE-0 VERDICT: NO-GO
  - warm-up classification=rate_limit (not success)
  - measured reading absent (probe stopped before it ran)
```

## c4's rate-limit window has not reset

Three `rate_limit` readings now span 24-07 → 25-07 18:18Z, with two `auth` readings between them. **Latency is fine in every one of them** — 9.9–19.9 s, all far inside the 30 000 ms ceiling. The blocker is quota/account state, not code and not the route, so no amount of re-probing moves it. Further attempts today are spend without information; the sensible next probe is after the quota window rolls.

## The #729 fix, proving itself on its first real run

The RAW READINGS block printed **one** row — this run's — under a per-invocation run id:

```
RAW READINGS (append-only telemetry, THIS run only — run_id
  h963-c4-single-profile-gate0-2026-07-16/2026-07-25T18:18:08Z-pid20556):
  purpose=warmup   elapsed_ms=19903   classification=rate_limit output_bytes=831
```

…and the NO-GO reasons name **this run's own** absent measured reading. Under the old constant `RUN_ID` this same run would have re-read all 10 historical rows and cited the 23-07 `168 352 ms` again — exactly the contamination [#729](https://github.com/gasyoun/SanskritLexicography/issues/729) described.

No canary, no bounded window, nothing promoted. The H858 Part B validation window stays owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
