### PR TITLE
feat(pwg_ru): gate-0 probe takes --account; first c5 reading = HEALTH_NOGO

### DIFF
--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -4,6 +4,36 @@ _Created: 09-07-2026 · Last updated: 25-07-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
+## 25-07-2026 - H858 c5 live gate: HEALTH_NOGO (latency ~2x ceiling) - orthogonal to c4
+
+Executor: Opus 5 (`claude-opus-5[1m]`). First gate ever run on c5, after two c4 attempts the
+same day returned HEALTH_NOGO on `rate_limit`. Packet:
+[`pwg_ru/h858/H858_C5_LIVE_GATE_HEALTH_NOGO_2026-07-25.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h858/H858_C5_LIVE_GATE_HEALTH_NOGO_2026-07-25.md).
+
+| Reading | Elapsed | Classification | Verdict input |
+|---|---|---|---|
+| warm-up | 59 651 ms | `success` | >= 30 000 ms ceiling -> FAIL |
+| measured | 52 960 ms | `success` | >= 30 000 ms ceiling -> FAIL |
+
+Both calls SUCCEEDED with real output and zero connection errors - this is not quota, not
+auth. Wall clock 112.6 s for the pair.
+
+### The finding: c4 and c5 fail for ORTHOGONAL reasons
+
+| Profile | Calls | Latency | Blocker |
+|---|---|---|---|
+| c4 (16:02Z, 18:18Z) | warm-up `rate_limit`, measured never ran | 17.9 s / 19.9 s - fine | quota / account state |
+| c5 (18:56Z) | warm-up + measured both `success` | 59.7 s / 53.0 s - ~2x ceiling | route latency |
+
+Neither is a code defect and they share no cause: c4 has headroom but no quota, c5 has
+quota but no speed. **Swapping profiles does not unblock the window** - it trades one
+NO-GO for a different one. c5's numbers sit in the degradation band tracked since mid-July
+(H963 104 870 ms; H1110 98 625 ms) and match H898's size-independent route-jitter finding:
+the identical 6 828 B prompt read 16 621 ms on c4 at the 22-07 LIVE_GO.
+
+Operational note: c5 is the profile this session runs on - a paid window there competes
+with interactive sessions for the same quota, independent of today's latency verdict.
+
 ## 25-07-2026 - H858 c4 live gate: HEALTH_NOGO (rate_limit), no window opened
 
 Executor: Opus 5 (`claude-opus-5[1m]`). `/pwg-live-gate c4`, one attempt, no reroll.

--- a/RussianTranslation/pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
+++ b/RussianTranslation/pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
@@ -129,6 +129,14 @@ absent measured reading. Under the old constant `RUN_ID` this same run would hav
 all 10 historical rows and cited the 23-07 `168 352 ms` again. The verdict is now derived
 only from readings the run actually took.
 
+## c5 was gated next — and fails for an ORTHOGONAL reason
+
+[H858_C5_LIVE_GATE_HEALTH_NOGO_2026-07-25.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h858/H858_C5_LIVE_GATE_HEALTH_NOGO_2026-07-25.md)
+(18:56Z): both c5 calls **succeeded** with real output and zero connection errors, but read
+59 651 ms / 52 960 ms — roughly 2× the ceiling. So c4 has latency headroom but no quota, and
+c5 has quota but no speed. **Swapping profiles does not unblock the window**; it trades one
+NO-GO for a different one.
+
 ## Resume condition (unchanged, and it is not a formality)
 
 Per the skill's hand-off: **make no paid translation call** — not a canary rerun, not a

--- a/RussianTranslation/pwg_ru/h858/H858_C5_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
+++ b/RussianTranslation/pwg_ru/h858/H858_C5_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
@@ -1,0 +1,78 @@
+# H858 — c5 live gate: HEALTH_NOGO (25-07-2026), latency ~2× the ceiling
+
+_Created: 25-07-2026 · Last updated: 25-07-2026_
+
+Executor: Opus 5 (`claude-opus-5[1m]`). First gate ever run on **c5**, after two c4
+attempts the same day returned `HEALTH_NOGO` on `rate_limit`
+([c4 packet](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h858/H858_C4_LIVE_GATE_HEALTH_NOGO_2026-07-25.md)).
+Gating the paid validation window still owed by
+[H858 Part B](https://github.com/gasyoun/Uprava/blob/main/handoffs/H858-Opus_SanskritLexicography_pwg_ru_sense_fidelity_anchor_repair_13.07.26.md).
+
+## Verdict
+
+```
+gate_reason = HEALTH_NOGO
+verdict     = NO-GO
+```
+
+No canary. No production window. Nothing promoted. Two paid calls were made and both
+**succeeded** — this is not a quota or auth failure.
+
+## Step 1 — health: the ONE attempt taken
+
+| Reading | Elapsed | Classification | Output | UTC |
+|---|---|---|---|---|
+| warm-up | **59 651 ms** | `success` | 1 651 B | 2026-07-25T18:57:56Z |
+| measured | **52 960 ms** | `success` | 1 654 B | 2026-07-25T18:58:49Z |
+
+Both readings are **~1.8–2.0× the 30 000 ms ceiling**, so both fail the strict rule
+(EITHER reading ≥ 30 000 ms ⇒ NO-GO). Wall clock 112.6 s for the pair.
+
+- Profile: `D:\ClaudeTools\profiles\claude5\.claude` · exact model `claude-sonnet-5`
+- Prompt: 6 828 B actual (≥ 5 KiB floor), schema-carrying, load-representative
+- Connection errors: **0**. Both calls returned a valid envelope with real output.
+- Events: `src/pilot/output/h963_c5_gate0_probe_events.jsonl` (per-account series)
+
+## c4 and c5 fail for ORTHOGONAL reasons — that is the finding
+
+| Profile | Calls | Latency | Blocker |
+|---|---|---|---|
+| **c4** (16:02Z, 18:18Z) | warm-up `rate_limit`, measured never ran | 17.9 s / 19.9 s — **fine** | quota / account state |
+| **c5** (18:56Z) | warm-up + measured both `success` | 59.7 s / 53.0 s — **~2× ceiling** | route latency |
+
+Neither is a code or pipeline defect, and they do not share a cause: c4 has headroom but
+no quota; c5 has quota but no speed. Swapping profiles therefore does **not** unblock the
+window — it trades one NO-GO for a different one.
+
+c5's numbers sit squarely in the degradation band this repo has tracked since mid-July
+(H963 16-07: 104 870 ms; H1110 18-07: 98 625 ms; the c4 rows of 22-07/23-07: 59 831 ms and
+168 352 ms), and match [H898](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H898-Opus_SanskritLexicography_pwg-ru-latency-characterization-payload-route-sweep_14.07.26.md)'s
+finding that the breach is **size-independent route jitter**, not payload size — an
+identical 6 828 B prompt read 16 621 ms on c4 at the 22-07 LIVE_GO and 53–60 s here.
+
+**Operational note:** c5 is the profile this session itself runs on. A paid window on c5
+would compete with interactive sessions for the same quota — worth weighing before
+choosing it as the production lane, independently of today's latency verdict.
+
+## Provenance caveat, stated rather than quietly fixed
+
+The two c5 rows above carry `h963-c4-single-profile-gate0-2026-07-16/…` as their run-id
+prefix: the campaign label was still c4-only when this reading was taken, and was made
+account-aware (`campaign_for()`) in the same pass. The rows' own `account: c5` field is
+authoritative, and they live in the c5-only events file. Rows written from now on read
+`h963-c5-single-profile-gate0/…`. The reading itself is untouched — a label is not
+re-derivable evidence, so it is documented, not rewritten.
+
+## Resume condition
+
+Unchanged and profile-independent: **make no paid translation call** until a **NEW**
+representative ≥ 5 KB health call returns PASS on the profile that will run the window. A
+prior GO — including H1447's 22-07 c4 LIVE_GO — authorizes nothing. Both profiles are
+currently NO-GO for different reasons; c4 needs its quota window to roll, c5 needs the
+route to recover.
+
+```
+Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H858-Opus_SanskritLexicography_pwg_ru_sense_fidelity_anchor_repair_13.07.26.md and execute it.
+```
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/h963_c4_gate0_probe.py
+++ b/RussianTranslation/src/pilot/h963_c4_gate0_probe.py
@@ -1,9 +1,27 @@
 #!/usr/bin/env python3
-"""H963 Gate-0: ONE fresh dated D-K health attempt for the c4 profile.
+"""H963 Gate-0: ONE fresh dated D-K health attempt for a Max profile (default c4).
 
-Single-profile c4 only. Runs the repository's own D-K two-phase protocol
-(`max_account_orchestrator.live_probe`) at >= v1.9.17 (natural, schema-carrying,
-load-representative prompt) against the exact generation model.
+Runs the repository's own D-K two-phase protocol (`max_account_orchestrator.live_probe`)
+at >= v1.9.17 (natural, schema-carrying, load-representative prompt) against the exact
+generation model.
+
+    python src/pilot/h963_c4_gate0_probe.py                 # c4 (unchanged default)
+    python src/pilot/h963_c4_gate0_probe.py --account c5
+    python src/pilot/h963_c4_gate0_probe.py --account c5 --config-dir <path>
+
+PROFILE SCOPE (25-07-2026)
+--------------------------
+The account was hardcoded to c4 because H1110 gates c4 only. /pwg-live-gate's own
+"serial multi-profile assessment" section already specifies the shape for other
+profiles -- one health+canary pair per profile, run SERIALLY, each with its own
+distinct `config_dir_fingerprint`, never interleaved and never sharing a fingerprint --
+so the account is now a parameter rather than a copy of this file per profile.
+
+Each account keeps its OWN events log: a profile's health history is its own series,
+and reading two profiles out of one file re-creates the #729 contamination class one
+level up. c4 keeps the original filename (11 rows of history, cited by path in the
+H1110/H1447/H858 gate reports); any other account gets
+`h963_<account>_gate0_probe_events.jsonl`.
 
 Evidence discipline: exactly ONE attempt. Both the warm-up and the measured
 reading are emitted to the append-only events log BEFORE any fail-closed exit,
@@ -35,8 +53,10 @@ So the run id is now minted per invocation (`new_run_id()`), and the reader
 for historical grouping -- it is a label, never a scope. The verdict is derived by the
 pure `derive_fails()`, exercised without any live call by `--selftest`.
 """
+import argparse
 import json
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -71,6 +91,7 @@ def resolve_claude_bin():
 
 CONFIG_DIR = r"D:\ClaudeTools\profiles\claude4\.claude"
 ACCOUNT = "c4"
+PROFILE_ROOT = r"D:\ClaudeTools\profiles"
 # The historical campaign label. A GROUPING PREFIX, never a run scope -- see the module
 # docstring. Reports that cite `run_id=h963-c4-single-profile-gate0-2026-07-16` (H1110
 # 18-07, H1447 22-07) still match rows by this prefix.
@@ -80,6 +101,55 @@ PAYLOAD_BYTES = 6491          # repo default; actual prompt 6828 B (H909 runbook
 CEILING_MS = mao.PROBE_LATENCY_CEILING_MS   # 30 000
 STRICT_CEILING_MS = 30_000    # resume brief: EITHER reading >= this is NO-GO
 CONN_ERR_CLASSES = {"process", "timeout"}
+
+
+def config_dir_for(account):
+    """`cN` -> that profile's config dir, by the repo's own `claudeN` layout."""
+    if not re.fullmatch(r"c\d+", account or ""):
+        raise SystemExit("account %r is not of the form cN; pass --config-dir explicitly"
+                         % account)
+    return os.path.join(PROFILE_ROOT, "claude" + account[1:], ".claude")
+
+
+def campaign_for(account):
+    """The grouping label for `account`.
+
+    c4 keeps the historical string verbatim -- the H1110/H1447/H858 gate reports cite it,
+    and 11 rows carry it. Any other profile gets its own, because a c5 row whose run id
+    reads `h963-c4-...` misleads exactly the reader this label exists to orient.
+    """
+    if account == ACCOUNT:
+        return CAMPAIGN
+    return "h963-%s-single-profile-gate0" % account
+
+
+def events_for(account):
+    """One events log PER ACCOUNT.
+
+    Sharing one file across profiles would re-create the #729 contamination one level up:
+    a c5 row answering for a c4 verdict. c4 keeps the original filename because 11 rows of
+    history live there and the H1110/H1447/H858 gate reports cite it by path.
+    """
+    if account == ACCOUNT:
+        return EVENTS
+    return HERE / "output" / ("h963_%s_gate0_probe_events.jsonl" % account)
+
+
+def preflight_profile(config_dir):
+    """Cheap, FREE provisioning checks. Returns a reason string, or None when usable.
+
+    Deliberately NOT `max_account_orchestrator.profile_status`: that helper fires its own
+    paid `-p` call, and this gate exists to spend exactly one no-reroll attempt. A missing
+    directory or absent credentials is a provisioning fact, readable off the disk — the same
+    discipline as the D-R argv pre-flight below (never burn the attempt on a mis-provisioned
+    profile, and never report a provisioning defect as a health signal).
+    """
+    if not os.path.isdir(config_dir):
+        return "profile directory does not exist: %s" % config_dir
+    if not os.path.isfile(os.path.join(config_dir, ".credentials.json")):
+        return ("no .credentials.json in %s — the profile is not logged in "
+                "(a login is a human action; this gate never performs one)" % config_dir)
+    return None
 
 
 def new_run_id(campaign=CAMPAIGN, now=None, pid=None):
@@ -138,14 +208,25 @@ def derive_fails(readings, strict_ceiling_ms=STRICT_CEILING_MS):
     return fails
 
 
-def main():
-    EVENTS.parent.mkdir(parents=True, exist_ok=True)
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="H963 Gate-0 single-profile D-K health attempt")
+    ap.add_argument("--account", default=ACCOUNT,
+                    help="profile slot to gate (default %s)" % ACCOUNT)
+    ap.add_argument("--config-dir", default=None,
+                    help="that profile's CLAUDE_CONFIG_DIR (default: derived from --account)")
+    args = ap.parse_args(argv)
+    account = args.account
+    config_dir = args.config_dir or (CONFIG_DIR if account == ACCOUNT
+                                     else config_dir_for(account))
+    events = events_for(account)
+    events.parent.mkdir(parents=True, exist_ok=True)
 
     # Belt-and-suspenders: pin the store to a scratch path so nothing can touch the
     # canonical 11,605-row store. (live_probe makes no store write by construction.)
     os.environ["PWG_RU_STORE"] = str(HERE / "output" / "h963_c4_gate0_scratch_store.jsonl")
 
-    run_id = new_run_id()
+    campaign = campaign_for(account)
+    run_id = new_run_id(campaign)
     claude_bin = resolve_claude_bin()
     argv_prefix = claude_argv_prefix(claude_bin)
 
@@ -153,10 +234,10 @@ def main():
     actual_prompt_bytes = len(prompt.encode("utf-8"))
 
     print("=" * 72)
-    print("H963 Gate-0 — single-profile c4 D-K health attempt")
+    print("H963 Gate-0 — single-profile %s D-K health attempt" % account)
     print("=" * 72)
     print("date (UTC)        : %s" % time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()))
-    print("profile           : %s  (%s)" % (ACCOUNT, CONFIG_DIR))
+    print("profile           : %s  (%s)" % (account, config_dir))
     print("exact model       : %s" % mao.EXACT_GEN_MODEL)
     print("payload_bytes arg : %d" % PAYLOAD_BYTES)
     print("actual prompt B   : %d  (floor %d B / 5 KiB=5120)"
@@ -164,8 +245,8 @@ def main():
     print("ceiling           : %d ms (strict: either reading >= %d ms => NO-GO)"
           % (CEILING_MS, STRICT_CEILING_MS))
     print("run_id            : %s   (unique to THIS run — #729)" % run_id)
-    print("campaign          : %s   (grouping label only, never a read scope)" % CAMPAIGN)
-    print("events            : %s" % EVENTS)
+    print("campaign          : %s   (grouping label only, never a read scope)" % campaign)
+    print("events            : %s   (per-account series)" % events)
     print("claude bin        : %s" % claude_bin)
     print("resolved argv     : %s" % argv_prefix)
     print("-" * 72)
@@ -174,27 +255,38 @@ def main():
         print("RESULT: NO-GO — payload undersized (%d B < 5 KiB)" % actual_prompt_bytes)
         return 2
 
+    # PRE-FLIGHT (no call made): a mis-provisioned profile is a PROVISIONING fact, not a
+    # health reading, and must never consume the one no-reroll attempt or be logged as
+    # latency. Free — reads the disk, spends nothing.
+    reason = preflight_profile(config_dir)
+    if reason:
+        print("PRE-FLIGHT ABORT (no probe call made, no attempt consumed):")
+        print("  %s" % reason)
+        print("  This is a provisioning state, NOT a %s health signal." % account)
+        return 4
+
     # PRE-FLIGHT (no call made): never spend the one no-reroll attempt on a mis-resolved
     # binary. A bare ['claude'] fallback is the D-R defect and is NOT a health reading.
     if os.name == "nt" and (len(argv_prefix) != 2 or not argv_prefix[0].lower().endswith("node.exe")):
         print("PRE-FLIGHT ABORT (no probe call made, no attempt consumed):")
         print("  claude_argv_prefix(%r) -> %s" % (claude_bin, argv_prefix))
         print("  expected [<node.exe>, <cli*.cjs>]; a bare fallback cannot be launched by")
-        print("  CreateProcess. This is a tooling-resolution defect (D-R), NOT a c4 health signal.")
+        print("  CreateProcess. This is a tooling-resolution defect (D-R), NOT a %s health signal."
+              % account)
         return 3
 
     verdict_exc = None
     t0 = time.monotonic()
     try:
         mao.live_probe(
-            CONFIG_DIR,
+            config_dir,
             claude=claude_bin,
             payload_bytes=PAYLOAD_BYTES,
             model=mao.EXACT_GEN_MODEL,
             latency_ceiling_ms=CEILING_MS,
-            events_path=str(EVENTS),
+            events_path=str(events),
             run_id=run_id,
-            account=ACCOUNT,
+            account=account,
         )
     except SystemExit as exc:
         verdict_exc = str(exc)
@@ -205,7 +297,7 @@ def main():
 
     # Re-read the append-only events log: it holds BOTH readings even on a fail-closed
     # exit -- but ONLY the rows this run wrote (#729).
-    readings = readings_for(EVENTS, run_id)
+    readings = readings_for(events, run_id)
 
     print("RAW READINGS (append-only telemetry, THIS run only — run_id %s):" % run_id)
     if not readings:
@@ -292,8 +384,38 @@ def selftest():
         # 5. run ids are unique per invocation even within the same UTC second
         assert new_run_id(now=0, pid=1) != new_run_id(now=0, pid=2)
         assert new_run_id(now=0, pid=1).startswith(CAMPAIGN + "/"), 'campaign stays a prefix'
+        # the label is account-aware: a c5 row whose run id reads `h963-c4-...` misleads
+        # exactly the reader the label exists to orient.
+        assert campaign_for("c4") == CAMPAIGN, 'c4 keeps the string the gate reports cite'
+        assert campaign_for("c5") == "h963-c5-single-profile-gate0", campaign_for("c5")
+        assert campaign_for("c5") != campaign_for("c6")
 
-        print("h963_c4_gate0_probe selftest: 5/5 OK (no live call, nothing spent)")
+        # 6. profile scope: c4's log keeps its historical path (reports cite it by name),
+        #    and no two accounts share a file -- sharing one would re-create the #729
+        #    contamination one level up, a c5 row answering for a c4 verdict.
+        assert events_for("c4") == EVENTS, 'c4 must keep its historical events path'
+        seen = {str(events_for(a)) for a in ("c4", "c5", "c6")}
+        assert len(seen) == 3, seen
+        assert config_dir_for("c5").endswith(os.path.join("claude5", ".claude")), config_dir_for("c5")
+        for bad in ("", "cee", "claude5", "c5x"):
+            try:
+                config_dir_for(bad)
+            except SystemExit:
+                pass
+            else:
+                raise AssertionError('config_dir_for(%r) must refuse, not guess a path' % bad)
+
+        # 7. a mis-provisioned profile is refused BEFORE any call, and is reported as a
+        #    provisioning state -- never logged as a health reading.
+        missing = Path(d) / "no-such-profile"
+        assert "does not exist" in (preflight_profile(str(missing)) or ''), 'missing dir must refuse'
+        logged_out = Path(d) / "logged-out" / ".claude"
+        logged_out.mkdir(parents=True)
+        assert "not logged in" in (preflight_profile(str(logged_out)) or ''), 'no creds must refuse'
+        (logged_out / ".credentials.json").write_text("{}", encoding="utf-8")
+        assert preflight_profile(str(logged_out)) is None, 'a provisioned profile must pass pre-flight'
+
+        print("h963_c4_gate0_probe selftest: 7/7 OK (no live call, nothing spent)")
     finally:
         shutil.rmtree(d, ignore_errors=True)
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,23 @@ not an error.
 
 ## [Unreleased]
 
+### Added
+- **Gate-0 probe is profile-parameterised (25-07-2026).**
+  [`h963_c4_gate0_probe.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h963_c4_gate0_probe.py)
+  takes `--account` / `--config-dir` (c4 remains the default and is byte-unchanged in behaviour),
+  so the serial multi-profile assessment `/pwg-live-gate` already specifies no longer needs a copy
+  of the script per profile. Each account keeps its OWN events log and campaign label — sharing
+  one across profiles would re-create the #729 contamination a level up, a c5 row answering for a
+  c4 verdict. A missing profile dir or absent credentials is refused BEFORE any call, as a
+  provisioning state rather than a health reading (free — no paid `profile_status` call).
+  Selftest 7/7.
+- **First c5 gate reading — `HEALTH_NOGO`, and it is orthogonal to c4's.** c5 warm-up 59 651 ms /
+  measured 52 960 ms, both `success` with real output and zero connection errors, both ~2× the
+  30 000 ms ceiling; c4 the same day was `rate_limit` with healthy 17.9–19.9 s latency. c4 has
+  headroom but no quota, c5 has quota but no speed — **swapping profiles does not unblock the
+  window**. Packet:
+  [`pwg_ru/h858/H858_C5_LIVE_GATE_HEALTH_NOGO_2026-07-25.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h858/H858_C5_LIVE_GATE_HEALTH_NOGO_2026-07-25.md).
+
 ## [1.63.0] — 2026-07-25
 
 ### Fixed


### PR DESCRIPTION
Gates **c5** as asked, after two c4 attempts today returned `HEALTH_NOGO` on `rate_limit`. To do it, the probe's hardcoded account became a parameter.

## c5: NO-GO — and it fails for an *orthogonal* reason to c4

| Reading | Elapsed | Classification | UTC |
|---|---|---|---|
| warm-up | **59 651 ms** | `success` | 2026-07-25T18:57:56Z |
| measured | **52 960 ms** | `success` | 2026-07-25T18:58:49Z |

Both calls **succeeded** with real output and zero connection errors — this is not quota and not auth. Both are ~2× the 30 000 ms ceiling, so both fail the strict rule.

| Profile | Calls | Latency | Blocker |
|---|---|---|---|
| **c4** (16:02Z, 18:18Z) | warm-up `rate_limit`, measured never ran | 17.9 s / 19.9 s — **fine** | quota / account state |
| **c5** (18:56Z) | warm-up + measured both `success` | 59.7 s / 53.0 s — **~2× ceiling** | route latency |

**c4 has headroom but no quota; c5 has quota but no speed.** Swapping profiles does not unblock the H858 validation window — it trades one NO-GO for a different one. c5's numbers sit in the degradation band tracked since mid-July (H963 104 870 ms; H1110 98 625 ms) and match [H898](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H898-Opus_SanskritLexicography_pwg-ru-latency-characterization-payload-route-sweep_14.07.26.md)'s size-independent route-jitter finding: the identical 6 828 B prompt read 16 621 ms on c4 at the 22-07 LIVE_GO.

*Operational note:* c5 is the profile this session itself runs on, so a paid window there competes with interactive sessions for the same quota — worth weighing before choosing it as the production lane, independent of today's latency verdict.

## The code change

The account was hardcoded to c4 because H1110 gates c4 only. [`/pwg-live-gate`](https://github.com/gasyoun/claude-config/blob/main/commands/pwg-live-gate.md) already specifies the serial multi-profile shape — one health+canary pair per profile, each with its own `config_dir_fingerprint`, never interleaved — so the account is now `--account` / `--config-dir` rather than a copy of the script per profile. **c4 remains the default and its behaviour is unchanged.**

| Decision | Why |
|---|---|
| each account gets its **own events log** | sharing one file re-creates the [#729](https://github.com/gasyoun/SanskritLexicography/issues/729) contamination a level up — a c5 row answering for a c4 verdict. c4 keeps the historical filename (11 rows; cited by path in the H1110/H1447/H858 reports) |
| each account gets its **own campaign label** | a c5 row whose run id reads `h963-c4-…` misleads exactly the reader the label exists to orient. c4 keeps its string verbatim |
| missing dir / absent credentials refused **before any call** | a provisioning state is not a health reading, and must not consume the one no-reroll attempt. Deliberately **not** `max_account_orchestrator.profile_status` — that helper fires its own paid `-p` call |

## Honest provenance caveat

The two c5 rows were written *before* the campaign label was made account-aware, so they carry the `h963-c4-…` prefix. Their own `account: c5` field is authoritative and they live in the c5-only file; rows from now on read `h963-c5-…`. Documented in the packet rather than rewritten — a label is not re-derivable evidence.

## Gates

`--selftest` **7/7** (now covers per-account log/label separation, `cN` parsing refusals, and the provisioning pre-flight) · `window_selftest` **186/186** · `lang_parity_check` no drift. No canary, no window, nothing promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
