### PR TITLE
chore(release): cut v1.64.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.64.0] — 2026-07-25
+
 ### Added
 - **Gate-0 probe is profile-parameterised (25-07-2026).**
   [`h963_c4_gate0_probe.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h963_c4_gate0_probe.py)


### PR DESCRIPTION
Promotes the `[Unreleased]` block landed by [#735](https://github.com/gasyoun/SanskritLexicography/pull/735) to `1.64.0`. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)