### PR TITLE
docs(pwg_ru): H1634 editorial principles for German-side layers

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,16 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Documented — German-side editorial principles datasheet (H1634)
+
+- New
+  [pwg_ru/EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md)
+  (+ metadoc): field inventory after H1624 G1–G6 — **derived / voted / undecided**
+  with confidence, design fence, G5 (H1306) and G7 (Palsule) blockers, form_notes
+  and form_labels. Cross-linked from [pwg_ru.md](pwg_ru.md) §8.0 / §8.4 and deep
+  manual §2c.
+- Does **not** invent style or abbrev policy; does not rewrite the store.
+
 ## [1.62.0] - 2026-07-25
 
 ### Added - H1404 Wave 1: review/gold/voting deep manual + sheet↔decisions binding standard

--- a/RussianTranslation/pwg_ru.md
+++ b/RussianTranslation/pwg_ru.md
@@ -471,6 +471,9 @@ eview_status / human gold? | review | mostly i_translated | [HUMAN_GOLD_PROTOCO
 - Human sheets **не** «почти done» без *.decisions.json (см. linked review HTML).
 - Presentation (L10) **не** чинить правкой store «для красоты».
 - §8.0 отвечает: *что именно навешивается на немецкий оригинал* vs *что появляется только после LLM*.
+- **derived vs voted:** see
+  [EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md)
+  — do not invent H1306/H1303 style or abbrev policy before `decisions.json`.
 
 English twin:
 [docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md) §2b–§2c.

--- a/RussianTranslation/pwg_ru/EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md
+++ b/RussianTranslation/pwg_ru/EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md
@@ -1,4 +1,4 @@
-# Editorial principles — German-side layers (H1624 G1–G6)
+# Editorial principles — German-side layers (H1624 G1–G6 + form layer)
 
 _Created: 25-07-2026 · Last updated: 25-07-2026_
 
@@ -19,6 +19,19 @@ the extractor that produces it deterministically.
 
 Cross-referenced from [pwg_ru.md §8.0](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru.md)
 and [RUSSIANTRANSLATION_DEEP_MANUAL.md §2b–§2c](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md).
+
+
+## Design fence (non-negotiable)
+
+| Do | Do not |
+|---|---|
+| Attach structure/indexes derived from DE markup | Rewrite 19th-c. German orthography |
+| Label supplement layers / owners / span types | Inject Russian into `de` / raw DE |
+| Store derived fields on portrait / sense schema | Put `corpus_gate` / `review_status` into DE body |
+| Keep grammar off the translate prompt (A/B already rejected) | Re-open grammar-in-prompt without a new measured A/B |
+| Classify shared schema/path changes in [LANG_PARITY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md) | Fix EN-only or RU-only without a ledger row |
+
+One-line rule: **German layers thicken the edition graph; they do not smuggle RU, review scores, or quality labels into the DE string.**
 
 ## How to read this table
 
@@ -59,6 +72,21 @@ Rule cue reference (do not rename `rule_id` values lightly — they are a stable
 
 Honest floor-vs-ceiling banner stays on [government.html](https://gasyoun.github.io/SanskritLexicography/government.html) per H1624 design fence.
 
+
+## Form layer (H1624 sibling of G2) — `form_labels` + `form_notes`
+
+H1624 also shipped a DE-side morphosyntax layer that is **not** Rektion. Handed
+as PRs [#717](https://github.com/gasyoun/SanskritLexicography/pull/717) /
+[#718](https://github.com/gasyoun/SanskritLexicography/pull/718); inventory required
+by [H1634](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1634-Sonnet_SanskritLexicography_pwg-de-editorial-principles-doc_25.07.26.md).
+
+| Field | Source | Derived / voted | Confidence |
+|---|---|---|---|
+| `form_labels` (number / gender / voice / case_form) | DE `<ab>sg./du./pl.</ab>`, `<lex>m.</lex>` / unambiguous `masc./fem./neutr.`, `act./med./pass.`, `nom./voc.` via [`form_labels.extract_form_labels`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/form_labels.py) | derived | Floor: bare `<ab>n.</ab>` is **not** gender (too often "note"); never invents labels |
+| `form_notes` (dedicated nom./voc.) | Same DE markers; first-class field separate from multi-axis `form_labels` and from `government` | derived | High on narrow axis; shape `{case: nom|voc, kind, span}` via `extract_form_notes` |
+
+Stamped at promote + portrait; backfill via `annotate_form_labels.py`. LANG_PARITY: `form_labels_number_gender_voice_h1624`, `form_notes_nom_voc_dedicated_h1624`.
+
 ## G3 — `citation_edges` (normalized `<ls>` graph)
 
 | Field | Source | Derived / voted | Confidence |
@@ -89,6 +117,13 @@ Honest floor-vs-ceiling banner stays on [government.html](https://gasyoun.github
 | `conflict` (bool), `conflict_kind` | `compound_status == 'differs'` (PWG split ≠ index `compound_members`) | **derived + undecided flag** | Measured: **4,226 / 39,539 rows (10.69%)** flagged `differs` (H1624 G6 conflict-rate report) — never auto-adjudicated |
 | `needs_human` (bool) | `compound_status` in `{differs, index-only}` | **derived + undecided flag** | Same measured rate; this is the field that routes the ~4.2k disagreements to a future `/review-sheet` sample (N11), not a silent resolution |
 
+
+## G7 — DHĀTUP. → Palsule wiring — blocked
+
+| Field | Source | Derived / voted | Confidence |
+|---|---|---|---|
+| DHĀTUP. tooltip / Palsule concordance link | Would wire from Palsule XLS once present | **undecided (data-gated)** | Confidence: **zero today**. XLS absent; delegated to [H1333](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1333-Opus_RussianTranslation_pwg-ru-dhatup-palsule-wire-from-xls_19.07.26.md). Do not invent a machine list. |
+
 ## Field-family summary
 
 | Family | Bucket | Notes |
@@ -98,7 +133,9 @@ Honest floor-vs-ceiling banner stays on [government.html](https://gasyoun.github
 | G3 `citation_edges` | derived | Ceiling bounded by `ls_source_map`; honest coverage % |
 | G4 `edition_rel` | derived (+ voted display names, optional) | Machine class ships without waiting on typology vote |
 | G5 H1306 DE tags | **voted, unratified** | Zero confidence until `h1306_style.decisions.json` |
+| form_labels / form_notes | derived | Not Rektion; nom/voc dedicated field |
 | G6 `derivation`/`conflict`/`needs_human` | derived + undecided flag | 10.69% measured disagreement, routed to human review, not resolved |
+| G7 Palsule | **data-gated** | XLS absent; H1333 |
 
 ## Explicit non-goals of this datasheet
 
@@ -113,5 +150,10 @@ Honest floor-vs-ceiling banner stays on [government.html](https://gasyoun.github
 - [RUSSIANTRANSLATION_DEEP_MANUAL.md §2b–§2c](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md) — operator-facing English twin
 - [H1306](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1306-Fable_RussianTranslation_pwg-ru-style-research-doublets-apresyan_19.07.26.md) — owns the G5 vote
 - [H1282 archive](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H1282-Opus_SanskritLexicography_pwg-ru-derivation-portrait-enrichment_19.07.26.md) — G6 residue origin
+
+## Provenance (dual-run salvage)
+
+- First land: [PR #737](https://github.com/gasyoun/SanskritLexicography/pull/737) (Claude Code session, 25-07-2026) — G1–G6 core tables.
+- Gap fill: [PR #738](https://github.com/gasyoun/SanskritLexicography/pull/738) (Grok 4.5) — design fence, **form_labels/form_notes** (H1634 Do list), G7 blocked table, metadoc, LANG_PARITY pointers.
 
 _Dr. Mārcis Gasūns_

--- a/RussianTranslation/pwg_ru/EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.meta.md
+++ b/RussianTranslation/pwg_ru/EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.meta.md
@@ -1,0 +1,57 @@
+# EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md — metadoc
+
+_Created: 25-07-2026 · Last updated: 25-07-2026_
+
+Companion record for
+[EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md).
+
+## Purpose & audience
+
+Authority-class datasheet for **German-side** pwg_ru fields after H1624:
+derived vs voted vs undecided, with confidence and blockers (G5/G7). Audience:
+editors, agents, and DH reviewers who must not invent style policy or rewrite DE.
+
+## Provenance
+
+| Field | Value |
+|---|---|
+| Handoff | [H1634](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1634-Sonnet_SanskritLexicography_pwg-de-editorial-principles-doc_25.07.26.md) |
+| Parent | [H1624](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1624-Opus_SanskritLexicography_pwg-german-layers-backlog-ordered_25.07.26.md) |
+| Model | Dual-run: Claude Code PR #737 (G1–G6 core) + Grok 4.5 (`grok-4.5`) PR #738 gap-fill |
+| Date | 25-07-2026 |
+
+## Improvement backlog
+
+| # | Item | Status |
+|---|---|---|
+| 1 | Cross-link from pwg_ru.md §8.0 + deep manual §2c | **done** H1634 |
+| 2 | form_labels / form_notes rows (H1634 Do list) | **done** dual-run salvage PR #738 |
+| 3 | Design fence + G7 blocked table | **done** PR #738 |
+| 4 | Fill G5 rows after h1306_style.decisions.json | open (blocked on vote / H1627) |
+| 5 | Fill G7 rows after Palsule XLS + H1333 | open |
+| 6 | Optional: per-field population % from live store (local-only) | open |
+| 7 | Optional: Russian short abstract for editor manual | open |
+
+## Known limitations
+
+- Does not re-measure store population (gitignored store); confidence is
+  extractor-class, not live coverage %.
+- H180 typology *display names* remain optional; machine subtypes are authoritative
+  for `edition_rel` until a vote renames them.
+- Conflict rate for G6 is a snapshot from PR #722 era — re-run
+  `enrich_portrait_derivation --conflict-rate` before citing as current.
+
+## Related documents
+
+- [pwg_ru.md §8](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru.md)
+- [RUSSIANTRANSLATION_DEEP_MANUAL.md §2b–§2c](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md)
+- [LANG_PARITY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md)
+- [DATA_STATEMENT.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/DATA_STATEMENT.md)
+
+## Revision history
+
+| Date | Change |
+|---|---|
+| 25-07-2026 | Initial H1634 inventory of G1–G6 + form_notes + G5/G7 blockers |
+
+_Dr. Mārcis Gasūns_

--- a/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md
+++ b/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md
@@ -101,6 +101,7 @@ in this order on first contact.
 | Judge-model policy (Sonnet bulk, Opus on rejects) | [research/JUDGE_POLICY.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/JUDGE_POLICY.md) |
 | The five harvested Sa→Ru dictionaries (Russian) | [src/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/README.md) |
 | **What markup layers can / cannot answer** (Q/N matrix) | [pwg_ru.md §8](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru.md) (canonical; editor RU) + **§2b below** (EN summary) |
+| **DE editorial principles** (derived vs voted vs undecided) | [EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md) (H1634) |
 
 Trust order when they disagree: **command output** (`root_window_status.py`,
 `window_status.json`) > `.ai_state.md` > the dated docs. Several docs carry
@@ -161,16 +162,18 @@ editor for the sole operator of these drafts.
 
 Full table: [pwg_ru.md §8.0](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru.md).
 
+**Editorial principles (derived / voted / undecided + confidence):**
+[EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md)
+(H1634) — field inventory after H1624 G1–G6; G5 style tags and G7 Palsule remain blocked.
+
 | Phase | Added to / derived from **German** | Not on German |
 |---|---|---|
 | Print/XML already | {#}, <ls>, <ab>, <div>, {%…%}, PWG Nachträge | — |
 | Pre-LLM merge | PW + SCH + PWKVN + NWS German bodies, labeled in raw; portrait; NWS owners | RU/EN text |
-| Pre-LLM transform | mask {Tn} skeleton of DE | — |
-| Derived indexes | Renou from <ls>; government from (Instr.) in DE; ab stats | evidence on RU |
+| Pre-LLM transform | mask {Tn} skeleton of DE; `gloss_lang` on `{%…%}` (G1) | — |
+| Derived indexes | Renou; government; form_labels / form_notes; citation_edges; edition_rel; derivation conflict flags | evidence on RU |
 | Parallel data | grammar/Zaliznyak (not in prompt) | — |
-| Post-LLM | — | 
-u/n, vidence*, 
-eview_status, provenance, site tooltips |
+| Post-LLM | — | ru/en, evidence*, review_status, provenance, site tooltips |
 
 Example pre-LLM inputs (local): [nakzatra.raw.txt](../../RussianTranslation/src/pilot/input/nakzatra.raw.txt) · [nakzatra.portrait.json](../../RussianTranslation/src/pilot/input/nakzatra.portrait.json).
 

--- a/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.meta.md
+++ b/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.meta.md
@@ -1,6 +1,6 @@
 # RUSSIANTRANSLATION_DEEP_MANUAL.md — metadoc
 
-_Created: 18-07-2026 · Last updated: 25-07-2026_
+_Created: 18-07-2026 · Last updated: 25-07-2026 (H1634 link)_
 
 Companion record for [docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md) (subsystem deep manual, H606).
 
@@ -34,6 +34,7 @@ COMMANDS_SPOT_RUN: 4
 | 8 | EN operator checklist subsection | open |
 | 9 | pwg_ru.md sibling metadoc | open |
 | 10 | Capability Q/N matrix (layers → questions) | **done** 25-07 — pwg_ru.md §8 + deep manual §2b |
+| 11 | Link DE editorial principles datasheet (H1634) | **done** 25-07 — §2c + cold-start table → EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md |
 
 ## Known limitations
 


### PR DESCRIPTION
## Summary
- Adds [EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md](https://github.com/gasyoun/SanskritLexicography/blob/docs/h1634-de-editorial-principles/RussianTranslation/pwg_ru/EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md): field inventory after H1624 G1–G6 — **derived / voted / undecided** with confidence, design fence, form_labels/form_notes, G5 (H1306) and G7 (Palsule) blockers.
- Metadoc sibling; cross-links from [pwg_ru.md](https://github.com/gasyoun/SanskritLexicography/blob/docs/h1634-de-editorial-principles/RussianTranslation/pwg_ru.md) §8.0/§8.4 and deep manual §2c + cold-start table; CHANGELOG [Unreleased].

## Handoff
[H1634](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1634-Sonnet_SanskritLexicography_pwg-de-editorial-principles-doc_25.07.26.md) (Grok 4.5 override of Sonnet lock)

## Non-goals (honoured)
- No store rewrite; no invented H1306/H1303 policy; no compound auto-adjudication; no csl-orig commit.

## Test plan
- [x] Doc has dated header + byline; full blob URLs; no HTML scaffold
- [x] Linked from pwg_ru.md §8.0 and deep manual §2c
- [x] Metadoc + CHANGELOG present