### PR TITLE
docs(pwg_ru): c1 gate = HEALTH_NOGO; profile sweep now 3/3 NO-GO

### DIFF
--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -4,6 +4,29 @@ _Created: 09-07-2026 · Last updated: 25-07-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
+## 26-07-2026 - H858 c1 live gate: HEALTH_NOGO (rate_limit) - profile sweep now 3/3 NO-GO
+
+Executor: Opus 5 (`claude-opus-5[1m]`). Third profile gated for the same owed H858 window.
+
+| Profile | UTC | Calls | Latency | Blocker |
+|---|---|---|---|---|
+| c4 | 25-07 16:02Z, 18:18Z | warm-up `rate_limit`, measured never ran | 17.9 s / 19.9 s - fine | quota |
+| c5 | 25-07 18:56Z | warm-up + measured both `success` | 59.7 s / 53.0 s - ~2x ceiling | route latency |
+| c1 | 26-07 02:37Z | warm-up `rate_limit`, measured never ran | 6.4 s - fine | quota |
+
+c1: warm-up 6 424 ms `rate_limit`, measured never ran, wall clock 6.4 s. Same class as c4,
+fastest rejection of the three.
+
+**Two things this sweep establishes.** (1) The blockers are orthogonal - two profiles have
+latency headroom but no quota, one has quota but no speed - so profile-swapping does not
+unblock the window, it only changes which NO-GO you get. (2) **The wait is not "until
+tomorrow":** c1 was probed at 02:37Z on a FRESH UTC day and still returned `rate_limit`, so
+the binding cap does not reset at the date boundary. A future session must re-probe and read
+the answer rather than assume a date change cleared anything.
+
+No canary, no window, nothing promoted. Per-account evidence:
+`src/pilot/output/h963_<account>_gate0_probe_events.jsonl`.
+
 ## 25-07-2026 - H858 c5 live gate: HEALTH_NOGO (latency ~2x ceiling) - orthogonal to c4
 
 Executor: Opus 5 (`claude-opus-5[1m]`). First gate ever run on c5, after two c4 attempts the

--- a/RussianTranslation/pwg_ru/h858/H858_C5_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
+++ b/RussianTranslation/pwg_ru/h858/H858_C5_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
@@ -33,16 +33,25 @@ Both readings are **~1.8–2.0× the 30 000 ms ceiling**, so both fail the stric
 - Connection errors: **0**. Both calls returned a valid envelope with real output.
 - Events: `src/pilot/output/h963_c5_gate0_probe_events.jsonl` (per-account series)
 
-## c4 and c5 fail for ORTHOGONAL reasons — that is the finding
+## The profiles fail for ORTHOGONAL reasons — that is the finding
 
-| Profile | Calls | Latency | Blocker |
-|---|---|---|---|
-| **c4** (16:02Z, 18:18Z) | warm-up `rate_limit`, measured never ran | 17.9 s / 19.9 s — **fine** | quota / account state |
-| **c5** (18:56Z) | warm-up + measured both `success` | 59.7 s / 53.0 s — **~2× ceiling** | route latency |
+Three profiles gated, 25-07 → 26-07. **All NO-GO, none for the same reason as its neighbour:**
 
-Neither is a code or pipeline defect, and they do not share a cause: c4 has headroom but
-no quota; c5 has quota but no speed. Swapping profiles therefore does **not** unblock the
-window — it trades one NO-GO for a different one.
+| Profile | UTC | Calls | Latency | Blocker |
+|---|---|---|---|---|
+| **c4** | 25-07 16:02Z, 18:18Z | warm-up `rate_limit`, measured never ran | 17.9 s / 19.9 s — **fine** | quota / account state |
+| **c5** | 25-07 18:56Z | warm-up + measured both `success` | 59.7 s / 53.0 s — **~2× ceiling** | route latency |
+| **c1** | 26-07 02:37Z | warm-up `rate_limit`, measured never ran | 6.4 s — **fine** | quota / account state |
+
+Neither cause is a code or pipeline defect, and they do not share a root: c4 and c1 have
+latency headroom but no quota; c5 has quota but no speed. Swapping profiles therefore does
+**not** unblock the window — it trades one NO-GO for a different one.
+
+**The c1 reading also says the wait is not "until tomorrow".** It was taken at 02:37Z on a
+FRESH UTC day and still returned `rate_limit`, so whatever cap is binding does not reset at
+the UTC date boundary — consistent with the per-account rolling windows / weekly caps the
+`.ai_state` journal records elsewhere (the 24-07 c2 session-limit note). A future session
+should not assume a date change has cleared anything; it should re-probe and read the answer.
 
 c5's numbers sit squarely in the degradation band this repo has tracked since mid-July
 (H963 16-07: 104 870 ms; H1110 18-07: 98 625 ms; the c4 rows of 22-07/23-07: 59 831 ms and


### PR DESCRIPTION
Third profile gated for the same owed H858 window. **c1: NO-GO, `rate_limit`.**

| Reading | Elapsed | Classification | UTC |
|---|---|---|---|
| warm-up | **6 424 ms** | **`rate_limit`** | 2026-07-26T02:37:20Z |
| measured | — | **never ran** | — |

## The sweep, 3/3 NO-GO — and no two for the same reason

| Profile | UTC | Calls | Latency | Blocker |
|---|---|---|---|---|
| **c4** | 25-07 16:02Z, 18:18Z | warm-up `rate_limit`, measured never ran | 17.9 s / 19.9 s — fine | quota |
| **c5** | 25-07 18:56Z | warm-up + measured both `success` | 59.7 s / 53.0 s — ~2× ceiling | route latency |
| **c1** | 26-07 02:37Z | warm-up `rate_limit`, measured never ran | 6.4 s — fine | quota |

Two things this establishes, both now written down so no future session spends an attempt rediscovering them:

1. **The blockers are orthogonal.** Two profiles have latency headroom but no quota; one has quota but no speed. Profile-swapping does not unblock the window — it only changes which NO-GO you get.
2. **The wait is not "until tomorrow".** c1 was probed at 02:37Z on a **fresh UTC day** and still returned `rate_limit`, so the binding cap does not reset at the date boundary — consistent with the rolling/weekly caps the `.ai_state` journal records elsewhere (the 24-07 c2 session-limit note). Re-probe and read the answer; don't assume a date change cleared anything.

## No dedicated c1 packet, deliberately

The per-account events series (`h963_c1_gate0_probe_events.jsonl`) is the durable evidence, and the comparison analysis already lives in the c5 packet — which now carries the full sweep table instead. A third near-empty packet would be padding, not provenance.

No canary, no window, nothing promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
