### PR TITLE
docs(pwg_ru): dedupe redundant EDITORIAL_PRINCIPLES cross-link

### DIFF
--- a/RussianTranslation/pwg_ru.md
+++ b/RussianTranslation/pwg_ru.md
@@ -394,9 +394,7 @@ mask-форма для модели, (4) производные индексы �
 **Не** добавляются в сам немецкий gloss: русский перевод, corpus_gate verdicts,
 review_status — они живут **рядом** в store/site.
 
-Per-field derived/voted/confidence breakdown for G1–G6 (which fields are
-deterministic extraction vs waiting on a human vote vs derived-with-an-
-undecided-flag): [EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md).
+Per-field derived/voted/confidence breakdown for G1–G6: see §8.4 below.
 
 ### 8.1. Слои (краткий реестр)
 


### PR DESCRIPTION
## Summary
- H1634's two independently-merged PRs (#737, #738) each added a cross-link to `EDITORIAL_PRINCIPLES_DE_LAYERS_2026-07.md` in `pwg_ru.md` -- one at the end of §8.0, one in §8.4.
- Keeps the §8.4 link (fuller context: "how to read status" + the do-not-invent-policy caution) and points §8.0 at it instead of repeating the link.

## Test plan
- [x] Doc-only change; single remaining link still resolves to the same committed file.