### PR TITLE
docs(pwg_ru): c2 is Pro not Max; inventory the unlanded Codex worktree

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -35,6 +35,25 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **⚠️ UNLANDED Codex work in a parallel worktree — `SanskritLexicography-rt-harden-codex`
+  (noted 26-07-2026).** Branch `codex/rt-pipeline-hardening-speed`, based on the SAME
+  `f96361ca` this day's H858/#729 work branched from, so the two ran in parallel all day.
+  State: **2 unmerged `ai-wip:` commits + ~3 935 uncommitted insertions across 25 tracked
+  files + 5 untracked new modules** (`call_reservation.py`, `promotion_journal.py`, and
+  their selftests, `coordinator_hardening_selftest.py`), 17 commits behind master. The
+  worktree is owned by a different Windows user (`CodexSandboxOffline`), so it needs
+  `git config --global --add safe.directory` even to inspect. Its committed audit is
+  `RussianTranslation/PIPELINE_HARDENING_AUDIT_2026-07-25.md` (P0: Windows timeout can leave
+  a paid descendant alive; P0: promotion is not one recoverable store/coordinator/TM
+  transaction; P1s on result-hash binding, malformed-wrapper cost evaluation, readiness
+  probes bypassing the active-call lock, post-hoc `--max-calls`). **Landing it is a real
+  merge, not a fast-forward:** it independently found the #729 fixed-`RUN_ID` defect and
+  fixed it INCOMPATIBLY — it aborts when the constant id is already in the log, where master
+  (v1.63.0) mints a per-invocation id. Its `headless_worker`/`promote_final_cards` hunks do
+  NOT overlap `normalize_batch` or the provenance builder, so the H858 work is not
+  threatened; the probe file is the one genuine conflict. Nothing here is lost — but nothing
+  here is on master either.
+
 - **H858 Part B 🔴 EXECUTED 25-07-2026 (Opus 5 `claude-opus-5`), isolated worktree — code landed,
   LIVE VALIDATION STILL OWED.** Source-anchored repair of a `{Tn}` span dropped from the model's
   `german` echo: new

--- a/RussianTranslation/pwg_ru/h858/H858_C5_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
+++ b/RussianTranslation/pwg_ru/h858/H858_C5_LIVE_GATE_HEALTH_NOGO_2026-07-25.md
@@ -47,6 +47,12 @@ Neither cause is a code or pipeline defect, and they do not share a root: c4 and
 latency headroom but no quota; c5 has quota but no speed. Swapping profiles therefore does
 **not** unblock the window — it trades one NO-GO for a different one.
 
+**c2 is NOT a candidate — it is a Pro account, not Max** (MG, 26-07-2026). Its
+`h963_c2_gate0_probe_events.jsonl` rows from 24-07 look tempting (warm-up 22 306 ms /
+measured 14 850 ms, both `success`, both under the ceiling — a PASS-shaped pair), but the
+production lane requires a Max profile, so that reading must not be read as "c2 is the
+lane". Recorded here so the next session does not spend a gate attempt on it.
+
 **The c1 reading also says the wait is not "until tomorrow".** It was taken at 02:37Z on a
 FRESH UTC day and still returned `rate_limit`, so whatever cap is binding does not reset at
 the UTC date boundary — consistent with the per-account rolling windows / weekly caps the


### PR DESCRIPTION
Two facts a future session would otherwise waste real work rediscovering.

## c2 is a Pro account, not Max

Its 24-07 rows look like a PASS-shaped pair (warm-up 22 306 ms / measured 14 850 ms, both `success`, both under the 30 s ceiling) — which is exactly *why* this needed writing down. The production lane requires a Max profile, so that reading must not be read as "c2 is the lane". The sweep stays **3/3 NO-GO with no fourth candidate**.

## The Codex worktree is NOT landed

`SanskritLexicography-rt-harden-codex`, branch `codex/rt-pipeline-hardening-speed`:

| | |
|---|---|
| base | `f96361ca` — **the same commit today's H858/#729 work branched from**, so the two ran in parallel all day |
| unmerged commits | 2 (`ai-wip:` prefixed) |
| uncommitted | **~3 935 insertions across 25 tracked files** |
| untracked new modules | 5 (`call_reservation.py`, `promotion_journal.py`, + selftests, `coordinator_hardening_selftest.py`) |
| behind master | 17 commits |
| ownership | a different Windows user (`CodexSandboxOffline`) — inspection needs `git config --global --add safe.directory` |

Its committed audit is [`PIPELINE_HARDENING_AUDIT_2026-07-25.md`](https://github.com/gasyoun/SanskritLexicography/blob/codex/rt-pipeline-hardening-speed/RussianTranslation/PIPELINE_HARDENING_AUDIT_2026-07-25.md): P0 Windows timeout can leave a paid descendant alive; P0 promotion is not one recoverable store/coordinator/TM transaction; P1s on result-hash binding, malformed wrappers looking evaluable at zero cost, readiness probes bypassing the per-profile active-call lock, and post-hoc `--max-calls`.

**Landing it is a real merge, not a fast-forward.** It independently found the [#729](https://github.com/gasyoun/SanskritLexicography/issues/729) fixed-`RUN_ID` defect — same diagnosis, verbatim — and fixed it **incompatibly**: it *aborts* when the constant id is already present in the log, where master ([v1.63.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.63.0)) mints a per-invocation id. Its `headless_worker`/`promote_final_cards` hunks do **not** overlap `normalize_batch` or the provenance builder, so the H858 work is not threatened; the probe file is the one genuine conflict.

Nothing there is lost — but nothing there is on master either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)