### PR TITLE
wip: Codex hardening branch rebased onto master + verified (7 fixtures still fail)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Repository documentation, PWG→Russian bounded CLI restart & housekeeping
 
-_Created: 09-07-2026 · Last updated: 24-07-2026_
+_Created: 09-07-2026 · Last updated: 25-07-2026_
 
 Keep the SanskritLexicography data/research workspace documented and its git
 state tidy.
@@ -834,6 +834,20 @@ Two live tracks:
       mw_ru working repo, documented in mw_ru.md §7). No doc gaps currently open.
 
 ## 🚧 Current Work-In-Progress (WIP)
+
+- **RussianTranslation pipeline hardening + one-Max handoff (25-07-2026,
+  Codex/GPT-5):** isolated worktree
+  `SanskritLexicography-rt-harden-codex`, branch
+  `codex/rt-pipeline-hardening-speed`. Current-code audit is frozen at
+  `RussianTranslation/PIPELINE_HARDENING_AUDIT_2026-07-25.md`. Baseline window
+  183/183 and parity 81/81 pass. Windows depth-three worker/probe cleanup is now
+  kernel-backed and green; unexpected threaded audit failures and failed atomic
+  quarantine replacements now produce durable full-window requeue evidence.
+  Preparation evidence is schema/hash checked immediately before runtime;
+  completed results are copied and SHA-bound before audit; sequential batch
+  recording reports its exact durable prefix.
+  Generation remains stop-before-promote. Live promotion is NO-GO until the
+  store/coordinator/TM close seam gains a durable journal and reconciliation.
 
 - [ ] **H1245 big-manuals estate refresh (18-07-2026, Fable 5 `claude-fable-5`)** — the 10 manual
   files + 9 new metadocs refreshed/fact-checked/consolidated in worktree `../SanskritLexicography-manrefresh`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,15 @@ jobs:
           git ls-files ':(glob)RussianTranslation/src/*.py' | xargs python -m py_compile
           python -m py_compile \
             RussianTranslation/src/pilot/proc_tree.py \
+            RussianTranslation/src/pilot/call_reservation.py \
             RussianTranslation/src/pilot/headless_worker.py \
             RussianTranslation/src/pilot/max_account_orchestrator.py \
+            RussianTranslation/src/pilot/bounded_staged_run.py \
+            RussianTranslation/src/pilot/bounded_supervisor.py \
+            RussianTranslation/src/pilot/coordinator.py \
+            RussianTranslation/src/pilot/promotion_journal.py \
+            RussianTranslation/src/pilot/h963_c4_gate0_probe.py \
+            RussianTranslation/src/pilot/latency_payload_sweep.py \
             RussianTranslation/src/pilot/windows100_selftest.py \
             RussianTranslation/src/pilot/run_observability.py \
             RussianTranslation/src/pilot/run_observability_selftest.py
@@ -145,9 +152,12 @@ jobs:
         working-directory: RussianTranslation
         run: |
           python src/pilot/agent_budget.py
+          python src/pilot/call_reservation_selftest.py
           python src/pilot/headless_worker_selftest.py
           python src/pilot/execution_contract_selftest.py
           python src/pilot/max_account_orchestrator_selftest.py
+          python src/pilot/coordinator_hardening_selftest.py
+          python src/pilot/promotion_journal_selftest.py
           python src/pilot/windows100_selftest.py
           python src/pilot/run_observability_selftest.py
           python src/pilot/economy_ledger_selftest.py
@@ -156,6 +166,7 @@ jobs:
           python src/pilot/sense_count.py
           python src/pilot/window_selftest.py
           python src/store_path.py --selftest
+          python src/promote_final_cards.py --selftest
           python src/pilot/translation_memory.py selftest
           python src/citation_tm.py selftest
           python src/pilot/lang_parity_check.py

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2379,6 +2379,18 @@ batch [_batch_h1624_dh_followups.tsv](https://github.com/gasyoun/Uprava/blob/mai
 
 ## 🚧 Current Work-In-Progress (WIP)
 
+- **PWG RU pipeline hardening + one-Max handoff (25-07-2026, Codex/GPT-5):**
+  isolated worktree `SanskritLexicography-rt-harden-codex`, branch
+  `codex/rt-pipeline-hardening-speed`. Current-code audit is frozen in
+  `PIPELINE_HARDENING_AUDIT_2026-07-25.md`. Baseline: window 183/183 and parity
+  81/81 clean. Windows depth-three worker/probe cleanup is kernel-backed and
+  green; threaded audit exceptions and quarantine replacement failures now
+  fail closed into durable full-window requeue evidence. Preflight artifacts
+  are schema/hash checked before runtime; result bytes are sealed before audit;
+  sequential batch recording emits its exact committed prefix. Generation may resume
+  only after the paid-path fixes pass, and only with `--stop-before-promote`;
+  promotion is NO-GO pending a durable store/coordinator/TM close journal.
+
 - **None from H1624** — programme closed for agent execution except blocked G5/G7 and
   queued DH batch H1626–H1635. Do not invent votes or XLS.
 

--- a/RussianTranslation/AGENTS.md
+++ b/RussianTranslation/AGENTS.md
@@ -29,6 +29,40 @@ windows. Per-profile call concurrency is serialized by the kernel-backed `Active
 timeout budgets are enforced in `headless_worker.py`, and a `--stop-before-promote` review checkpoint
 gates promotion.
 
+**Current paid-route hardening (25-07-2026, unreleased):** every paid probe and
+worker call must use the same durable `pwg.call_reservation.v1` run ledger.
+`max_calls` is a strict pre-spawn ceiling: a slot is atomically reserved before
+process creation and is not refunded if the caller crashes. `--cost-ceiling`
+is different: it stops on accumulated observed cost after completed calls and
+is not a hard pre-spend dollar guarantee; missing, pending, or malformed cost
+telemetry makes a cost-capped run unevaluable and therefore stops it closed.
+One profile lock spans an entire warm-up + measured probe pair, and the same
+lock class serializes generation for that profile. Paid manifest-v2 execution
+must preserve the run/manifest/preflight/profile/reservation binding through
+the sealed result SHA passed to `record-output` or `record-output-batch`.
+
+On Windows, all Claude process trees use a kill-on-close Job Object assigned
+while the child is suspended; timeout and non-timeout cleanup therefore reach
+the native descendant instead of leaving an orphaned paid call. Batch
+recording is sequential and fail-fast: its machine-readable progress is the
+exact committed prefix, while the failing and later leases remain retryable.
+
+Promotion is a separate durable transaction under
+`pwg.promotion_journal.v1`: `prepared → store_committed →
+derived_validated → coordinator_committed → complete`. The coordinator
+reconciles a single incomplete journal on every startup, fails closed if the
+live store/coordinator state matches neither sealed before nor expected-after
+bytes, and holds one canonical-store claim from preparation through
+`complete`. Derived TM/denylist artifacts and the deterministic promotion
+registry are sealed/replayed idempotently. Do not bypass this with direct
+single-file promotion or manual state edits.
+
+**Current operator state:** this hardening has not started a paid translation
+and does not itself constitute a release. The next live attempt, when
+authorized, remains the bounded headless route with
+`--stop-before-promote`; a clean run ends at durable `AWAITING_REVIEW`, with
+store promotion still requiring the close/review path.
+
 **`--max-agents` footgun (H1610/H1618):** the flag is a **TOTAL** spawn ceiling
 (translate+heal), not concurrency width. Multi-key windows must **omit** it (rely on
 manifest `max_translate_agents` / `max_heal_agents`). `headless_worker` refuses

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -131,7 +131,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
       "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -152,9 +152,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H1412",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773",
+      "src/pilot/headless_worker.py": "bb6bc5468a3fca6e3257022be7b5878adff190a9a557206e5597c21d76e36c2d",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -209,7 +209,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -228,7 +228,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -279,7 +279,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "lang is a first-class parameter of the TM address (sha256(lang + ...)); --lang=ru|en both get full reuse. C3 (21-07-2026, Opus 4.8 claude-opus-4-8): the reuse was SHARED in address but NOT in the served card — the card-TM builder wrote the EN sense under the store COLUMN name FIELD['en']=='en' instead of the CARD field 'english', so the serve-side tm_card_sane refused 100% of EN card-TM hits ('sense missing english') while RU worked. Fixed by a single CARD_FIELD={'ru':'russian','en':'english'} used by both the card builder and the fragment lane (_FRAG_TRANSLATION_FIELD aliases it), so the two lanes can't drift. Test: window_selftest test_en_card_tm_serves_english_field_c3.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac"
+      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76"
     }
   },
   {
@@ -352,7 +352,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/audit_coverage.py": "a60b8c0ed3b0022a6527a029d1e818cedab3dfcbbb545fc2c78b6a5dd514dcfa",
       "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
   },
@@ -373,7 +373,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1618 closed EN half (fsha emit + --write-requeue).",
     "tracking": "Uprava/handoffs/archive/H304-Fable_RussianTranslation_coordinator-driver-remake_07.07.26.md (EN-emitter port is the recorded follow-up)",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
@@ -411,7 +411,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge. C6 (21-07-2026, Opus 4.8 claude-opus-4-8): the SCRIPTS stay separate, but the {Tn}-residue promotion guard is now SHARED — promote_en.py imports TN_RE + UnrestoredPlaceholder from promote_final_cards.py rather than duplicating them, closing the gap where the RU C-01 path refused a card carrying an unrestored {Tn} while the EN attach() silently wrote it into the store. Pinned by the C6 block in promote_en.selftest(). C9 (21-07-2026, Opus 4.8 claude-opus-4-8): the EN backup used a second-resolution timestamp + a plain open('w'), so two lock-serialized runs in the SAME second overwrote the earlier .preEN recovery copy (defeating the docstring's per-run-backup promise). Fixed to a µs+pid+uuid name (_en_backup_path) + the RU lane's O_EXCL fsynced copier (_fsynced_backup, imported — single source). Pinned by the C9 block in promote_en.selftest(). H1425 W3 audit (21-07-2026, Opus 4.8 claude-opus-4-8): confirmed nothing new to share — the shared primitives (TN_RE / UnrestoredPlaceholder / _fsynced_backup) are already imported (C6/C9); the rest of promote_en (norm_de / en_index / match_en / attach) is EN-ATTACH-specific — it attaches an `en` field onto the existing RU store, a different job from promote_final_cards' RU store WRITER — and _en_backup_path's `.preEN` marker is intentionally per-lane. P9 (21-07-2026, Opus 4.8 claude-opus-4-8, H1421): the last shareable primitive is now SHARED too — promote_en.py imports _atomic_write_rows from promote_final_cards.py and its store write is fsync-before-replace durable. The old EN write was a bare open('w') + os.replace: atomic (the rename is all-or-nothing) but NOT durable — a crash/power-loss between the write and the metadata flush could leave a non-durable/truncated store even after the rename, and under --no-backup that write is the ONLY thing between an interrupted write and total loss. As a bonus both lanes now write the store byte-identically ('\\n' newlines; the old EN write CRLF-translated on Windows). Pinned by the P9 block in promote_en.selftest() (fsync-called + round-trip + single-source identity assertion). Adversarial verification note: bug-hunt P1 (merge_store_rows had no better-attempt-wins guard) was ALSO an H1421 item but was already fixed upstream by B08 (H1339) — merge_store_rows is better-attempt-wins with pinned regression selftests — so P1 needed no code change. INTENTIONAL-DIVERGENCE re-affirmed (the scripts stay separate; every low-level store-safety primitive — {Tn} residue, fsynced backup, durable atomic write — is now single-sourced from the RU lane).",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
@@ -431,7 +431,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -468,7 +468,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED same day (2026-07-04): PR #140 (feat(provenance): pipeline versioning) added pipeline_version stamping only to promote_final_cards.py; found as a GAP while re-affirming H169's parity re-hash, closed immediately. promote_en.py now calls `pipeline_version.stamp(model_version=gen_model_version)` inside `en_index()`'s per-subcard provenance block, stored as `en_provenance.pipeline` (mirrors RU's `provenance.pipeline`; a distinct field since EN attaches onto an existing RU row rather than owning it). Pinned by an added assertion in `promote_en.selftest()`.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
@@ -488,7 +488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -506,7 +506,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 1.1. The layer is derived purely from the sub-card KEY structure, which is identical for RU and EN. promote_en.py ATTACHES english onto the RU-owned row and leaves it otherwise untouched, so EN inherits `layer` for free — no EN-specific code needed. layer_of() pinned by dict_merge.py selftest + a promote_final_cards.selftest assertion.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/dict_merge.py": "0266e11980e3b8b12d0699665b2051b9f7b8b16ed89d5810adfe5a458e880eea"
     }
   },
@@ -526,7 +526,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3"
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32"
     }
   },
   {
@@ -547,7 +547,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -576,9 +576,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/preflight_remaining_gates.py": "00386c837b97986c9702abfceed9c29534736c3df3063af202ddfaae6b078b8f",
       "src/release_readiness.py": "db38a870bbc8b5dbe694e706e4a7b9089ba41211a3881ad9a1bd4eb02950c8a9",
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -596,8 +596,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H321 (code review 2026-07-04 item #3b): the fragment sidecar is content-addressed on the fragment SOURCE and was harvested append-only first-seen-wins with NO fidelity check, so a hand-edited/corrupt wf_output*.json (blanked or malformed senses) permanently poisoned reuse and a later good harvest of the same fsha could never override it. frag_senses_sane(senses, lang) keys on the CARD-shaped translation field ('russian'/'english') and is applied at BOTH harvest (never cache garbage; a cached-corrupt fsha maps to False so a good row overrides it) and serve (load_frag_tm drops any corrupt historical row). Entirely lang-agnostic — lang is a first-class parameter of frag_address/frag_senses_sane/load_frag_tm/build_frags, no RU/EN branch. Pinned by test_frag_tm_fidelity_gate_and_override. Extends translation_memory_card_and_fragment.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -615,7 +615,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -634,7 +634,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -689,7 +689,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1624 G2 (25-07-2026, Grok 4.5): closes the gap where government only appeared after a separate annotate_government backfill. New windows stamp at promote; new portraits stamp at microstructure gen. Schema shape unchanged (array of hit dicts per D4/H338). PW capitalized (Instr.) still caught (H1308). government.html still re-extracts from de_raw (honest floor banner). Pinned by promote_final_cards --selftest, enrich_portrait_government --selftest, government_census selftest, build_article_site --selftest.",
     "tracking": "H1624",
     "verified_sha256": {
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9",
       "src/pilot/enrich_portrait_government.py": "dcbcaaeabd4754436c295ad08eaf18acefab8cf9263fe2262d7f92c6ecf49660",
       "src/annotate_government.py": "b90849653909a551180a776e02ba36b6ce4da4cc4874353b2d1258e37c357848",
@@ -716,7 +716,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/form_labels.py": "ddd51c21bc86e84cf1abbc46ba78fdb477d1906283a3deae4a840b6bbd38311b",
       "src/annotate_form_labels.py": "cc03e4bb9454094996bdab87fa4e226bb6fb1574b42a70e82bd81953317629ce",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
@@ -740,7 +740,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/form_labels.py": "ddd51c21bc86e84cf1abbc46ba78fdb477d1906283a3deae4a840b6bbd38311b",
       "src/annotate_form_labels.py": "cc03e4bb9454094996bdab87fa4e226bb6fb1574b42a70e82bd81953317629ce",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9"
     }
   },
@@ -762,9 +762,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -785,11 +785,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H336 (08-07-2026). window_reports.write_reports/write_window_status already took an out_dir parameter (pre-existing --out-dir escape hatch); --window-tag is a thin, lang-agnostic sugar layer over that same parameter computed once in audit_window.py and threaded through unchanged to requeue_from_audit.py/root_window_status.py. Neither RU nor EN branch differently. Pinned by test_audit_window_tag_routing.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -812,13 +812,13 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H336 (08-07-2026). append_jsonl_line is a single shared primitive (window_common.py) used identically by every JSONL append site regardless of --lang; the TM denylist stores 'ru'/'en' addresses in the same file with no per-language code path. Pinned by test_denylist_torn_line_warns.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/window_common.py": "2d6926ba3a2e99f788641637b2cb6f2f9637ecb7f4e1b1c1561a367c8dd81e93",
+      "src/pilot/window_common.py": "96ec3a72e189bc48bab7c464189cfaad0b91c10a31e996f3d9dcb45968be45af",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
-      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -838,7 +838,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -856,8 +856,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/coordinator.py": "016c91c2d3b650a0fb7e33df6a3dd82f5d4ab95d32d8fd293dce76ec8044e091",
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -894,7 +894,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -913,7 +913,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/stage2_pregate.py": "8f07422d3c416e32d1882f0777d56cc44ba781d19c8097fd9500ddefbfd22945",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58"
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b"
     }
   },
   {
@@ -952,7 +952,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -971,7 +971,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -990,7 +990,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1010,7 +1010,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9",
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -1032,7 +1032,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1069,7 +1069,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/store_path.py": "4967ab7ea748da995367fd0520f89f4bf9a39b84c428310314291b85be26f73c",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
@@ -1091,7 +1091,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1119,16 +1119,16 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773",
-      "src/pilot/max_account_orchestrator.py": "03a59329720faa2cdbb56dd71284128ef3db62e301fb650cf51d4a2d4fec3a68",
-      "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
-      "src/pilot/headless_worker_selftest.py": "15c48ed0e6b890ff28671ee00159cc9cde4f74426f73a32afa3c1ebfd391126b",
-      "src/pilot/max_account_orchestrator_selftest.py": "41d1060b729d2f2507224ee0c072b07437c01f2285405f528c70ab8bf7df40af",
+      "src/pilot/headless_worker.py": "bb6bc5468a3fca6e3257022be7b5878adff190a9a557206e5597c21d76e36c2d",
+      "src/pilot/max_account_orchestrator.py": "a850df79a48a8b309b94411dac0d5dd42d4d88c6c484e19c6eba681fce33ec81",
+      "src/pilot/coordinator.py": "016c91c2d3b650a0fb7e33df6a3dd82f5d4ab95d32d8fd293dce76ec8044e091",
+      "src/pilot/headless_worker_selftest.py": "800ed5ea176eeca477d69c434c7576de965c316994d19be54cd1823ecc3d1ee4",
+      "src/pilot/max_account_orchestrator_selftest.py": "40a497f109a660383423134fec0d1c7bf5a31bc430c5d05278d8b562d49c95fb",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
       "src/pilot/run_observability.py": "eb21e08ba4f0e7ab7ab5dacf9db4e4d0d38234f2d63385157735ca8d7b8ced61",
       "src/pilot/run_observability_selftest.py": "75bc960a35080a0c84ca9b5ee62b63134a9e0bde334c5531d564b13019187b60",
-      "src/pilot/proc_tree.py": "7b4eb10defbca8efe84b2db6eef1d63c1124e92d0851da78549c7440734f24c4"
+      "src/pilot/proc_tree.py": "a3a03c6f689a93ae349a8ad1a24df1d4c7683217df83a47b7f6ef47d04405c1c"
     }
   },
   {
@@ -1151,7 +1151,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1170,7 +1170,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1193,9 +1193,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
       "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1217,7 +1217,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9",
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7",
       "src/pilot/accept_sensecount_test.js": "fbf8d37f8ae360c286f646361025d56adb0caeff09da30a0abfef5f6b7289937"
     }
   },
@@ -1237,7 +1237,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1292,7 +1292,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1381,7 +1381,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
       "src/pilot/tnmask_offline.py": "c857fe425fadbe18c1cdf398892f53b590709048ca66faf94fd05e046730ffea"
     }
@@ -1404,8 +1404,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7",
       "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1429,9 +1429,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/card_fields.py": "976c5aa943a35da1691e2ce72e9cb4a14ac53d3bae37f8c68345cc68cb233e2b",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
-      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
+      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
+      "src/pilot/headless_worker.py": "bb6bc5468a3fca6e3257022be7b5878adff190a9a557206e5597c21d76e36c2d",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
@@ -1468,7 +1468,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/store_path.py": "4967ab7ea748da995367fd0520f89f4bf9a39b84c428310314291b85be26f73c",
-      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
+      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
       "src/pilot/ru_coverage.py": "bf08bc3e79a80907dfc7df4e59cead0c026e04cf9cc621359630daecc98b46c3"
     }
   },
@@ -1488,9 +1488,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/bounded_staged_run.py": "ea6145c0a4a5fbdd3d9593e0fc8f7082b5fb4a26360f2ee9d2fea0a9a129eafa",
-      "src/pilot/bounded_supervisor.py": "d23e508463d5bca4e161e9a20769221186d85e7a68ef5c8e3878125997478446",
-      "src/pilot/max_account_orchestrator.py": "03a59329720faa2cdbb56dd71284128ef3db62e301fb650cf51d4a2d4fec3a68"
+      "src/pilot/bounded_staged_run.py": "eadb67e7953c369030df9dfc8f1c7f3dba7d8e5853af6c0b770273d7b67dc02e",
+      "src/pilot/bounded_supervisor.py": "30113cd5a9c41b72f5b05d4a76b4370152f7b12c0d149311cc0e65a60f4cb717",
+      "src/pilot/max_account_orchestrator.py": "a850df79a48a8b309b94411dac0d5dd42d4d88c6c484e19c6eba681fce33ec81"
     }
   },
   {
@@ -1509,7 +1509,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773"
+      "src/pilot/headless_worker.py": "bb6bc5468a3fca6e3257022be7b5878adff190a9a557206e5597c21d76e36c2d"
     }
   },
   {
@@ -1529,8 +1529,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
-      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3"
+      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32"
     }
   },
   {
@@ -1649,15 +1649,15 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1386 (22-07-2026, Fable 5 claude-fable-5). Every fix is language-neutral orchestration/persistence mechanics -- none introduces a --lang branch. Lane facts checked per the handoff: the frag TM half of C3 (build_frags/load_frag_tm/best_reusable) is --lang-parameterized so both lanes get it; the recursive harvest glob + D3 per-lease store_delta + P3g batch gate live in the RU staged/coordinator lane ONLY because the EN promote lane (promote_en.py) by design has no fragment harvest and no batch transaction (its INTENTIONAL-DIVERGENCE ruling is H1425 W3, unchanged); P3b is the EN lane's own seed feed; the h1209 rig (D1) is field-parameterized (payload['field']), so a future EN slice inherits prompt_common/chunking as-is; PWG_INPUT_DIR (P3f) is honored by both audit_window and audit_window_en. Pinned by bounded_staged_run_selftest tests l/m, window_selftest test_h1386_c3_frag_unblock_serves_replacement + test_h1386_d1_medium50_script_size_cap, promote_lock/promote_final_cards selftests, and the h1339_offline_bench deterministic signature (batch == per-lease).",
     "tracking": "H1386",
     "verified_sha256": {
-      "src/pilot/bounded_staged_run.py": "ea6145c0a4a5fbdd3d9593e0fc8f7082b5fb4a26360f2ee9d2fea0a9a129eafa",
-      "src/pilot/bounded_supervisor.py": "d23e508463d5bca4e161e9a20769221186d85e7a68ef5c8e3878125997478446",
-      "src/pilot/max_account_orchestrator.py": "03a59329720faa2cdbb56dd71284128ef3db62e301fb650cf51d4a2d4fec3a68",
-      "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/pilot/bounded_staged_run.py": "eadb67e7953c369030df9dfc8f1c7f3dba7d8e5853af6c0b770273d7b67dc02e",
+      "src/pilot/bounded_supervisor.py": "30113cd5a9c41b72f5b05d4a76b4370152f7b12c0d149311cc0e65a60f4cb717",
+      "src/pilot/max_account_orchestrator.py": "a850df79a48a8b309b94411dac0d5dd42d4d88c6c484e19c6eba681fce33ec81",
+      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
+      "src/pilot/coordinator.py": "016c91c2d3b650a0fb7e33df6a3dd82f5d4ab95d32d8fd293dce76ec8044e091",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
-      "src/pilot/window_common.py": "2d6926ba3a2e99f788641637b2cb6f2f9637ecb7f4e1b1c1561a367c8dd81e93",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
+      "src/pilot/window_common.py": "96ec3a72e189bc48bab7c464189cfaad0b91c10a31e996f3d9dcb45968be45af",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
       "src/pilot/window_provenance.py": "2f1240e321004228d94f6bea7ae661a896c4bc93c60f9d47871d248766900d50",
       "src/pilot/probe_log.py": "bc5d21b48541c410eaed9b4bccb97619272b4ef542f6ce76257d247303efb067"
@@ -1683,10 +1683,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "https://github.com/gasyoun/Uprava/blob/main/handoffs/H1553-Opus_RussianTranslation_rt-fullaudit-w1-a-h1403-residues_23.07.26.md",
     "verified_sha256": {
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
   },
@@ -1710,7 +1710,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/citation_edges.py": "88e12985ab21c8768a222b93515aff22f986c312d82381e3e34aa98034d20785",
       "src/annotate_citation_edges.py": "ec925f73e1af793c22a602be009b412af67e9989c99209ceed14224bc2cf8022",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
@@ -1736,7 +1736,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/edition_rel.py": "bb4ae2271dad9e9f30ced97d60fa14f5c9dee8d810b9dd43f422c7d2659883a9",
       "src/annotate_edition_rel.py": "928ec162b61dc7ea261b3e3dd5f07fd151103675a1ff34358d7ce4daf1e5c9ba",
       "src/build_relationships.py": "76d03cc81a79f83624065d79bd47845c3a72b8e2f993a01dfc4fbe9931049725",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
@@ -1775,9 +1775,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H858",
     "verified_sha256": {
       "src/german_anchor.py": "751a6bf9c1cf9bc6201397d28f429cd02c680f668c1b2340be8ca55f54e8a276",
-      "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773",
+      "src/pilot/headless_worker.py": "bb6bc5468a3fca6e3257022be7b5878adff190a9a557206e5597c21d76e36c2d",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3"
+      "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32"
     }
   }
 ]

--- a/RussianTranslation/PIPELINE_HARDENING_AUDIT_2026-07-25.md
+++ b/RussianTranslation/PIPELINE_HARDENING_AUDIT_2026-07-25.md
@@ -1,0 +1,328 @@
+# PWG Russian pipeline hardening audit — 2026-07-25
+
+**Audited revision:** `f96361caa4279dde579de6ea0ca3d40784ea0863`
+
+**Scope:** the current single-Max-account, headless PWG German-to-Russian
+generation route; its coordinator/audit/promotion boundary; and the remaining
+offline orchestration cost. This is a current-code audit, not a restatement of
+the July audit backlog.
+
+**Release verdict:** generation is eligible to proceed only through
+`AWAITING_REVIEW` after the paid-path fixes named below pass. Live promotion is
+**NO-GO** until the store/coordinator/TM close seam has a durable journal and
+startup reconciliation. All live work must use `--stop-before-promote`.
+
+No paid Claude call, login, network probe, canonical-store mutation, TM rebuild,
+or promotion was performed during this audit.
+
+## Actual one-profile call graph
+
+```text
+coordinator claim / prepare
+  -> perf_preflight.py
+  -> enforce_cost_gate()
+  -> gen_opt_harness2.py
+  -> sealed execution manifest v2
+
+bounded_staged_run.py --execute --stop-before-promote
+  -> probe_fleet([one profile])
+     -> live_probe()
+        -> warm-up Claude call
+        -> measured Claude call
+  -> BoundedSupervisor.run()
+     -> make_run_window()                 # one lease, synchronous
+        -> max_account_orchestrator import-coordinator / import-requeue
+        -> max_account_orchestrator cmd_run_once()
+           -> atomic profile-specific SQLite claim
+           -> coordinator begin-run
+           -> run_claimed()
+              -> headless_worker.py
+                 -> execution/profile/fingerprint validation
+                 -> ActiveCallClaim
+                 -> HeadlessEngine.call()
+                    -> Claude translate / retry / split / heal calls
+                 -> output + status hashes
+           -> cmd_record_done()
+              -> coordinator record-output
+                 -> audit_window.py subprocess
+                 -> clean subset / retry provenance
+        -> AWAITING_REVIEW checkpoint
+```
+
+If promotion is later authorized, the close path is:
+
+```text
+coordinator promote-ready
+  -> revalidate status / report / clean-output SHA
+  -> promote_final_cards.py --batch-manifest
+     -> promotion lock
+     -> read / merge / backup
+     -> fsynced temp + atomic canonical-store replace
+     -> batch report
+  -> mark leases promoted
+  -> rebuild + optionally harvest + validate RU translation memory
+```
+
+`cohort_engine.py` is an offline injected-worker test engine. It is not the
+production route above.
+
+## Reproduced current findings
+
+### P0 — Windows timeout cleanup can leave a paid descendant alive
+
+`proc_tree.terminate_tree()` delegates to `taskkill /T /F`, then falls back to
+killing only the immediate `Popen` parent
+(`src/pilot/proc_tree.py:29-61`). Both paid worker calls and readiness probes
+use this helper.
+
+Both shipped depth-three checks failed on this Windows host:
+
+- `python src\pilot\headless_worker_selftest.py`: the grandchild wrote its
+  survival marker;
+- `python src\pilot\max_account_orchestrator_selftest.py`: a probe-tree
+  descendant survived.
+
+A timed-out native Claude descendant can therefore continue holding the
+profile/API call while the worker retries, making spend and one-profile
+serialization untrustworthy. The Windows route needs kernel-backed process
+containment (a kill-on-close Job Object) with the existing bounded fallback.
+
+### P0 — promotion is not one recoverable store/coordinator/TM transaction
+
+The canonical replace occurs in `src/promote_final_cards.py:802`. The child
+writes the batch report only afterward (`:841`). Coordinator state changes and
+TM rebuild occur only after the child returns
+(`src/pilot/coordinator.py:1716-1778`).
+
+Failure windows remain:
+
+1. process death/report-write failure after the store replace leaves the store
+   committed, leases `ready`, and TM stale;
+2. death after leases are marked promoted but before TM validation leaves
+   terminal coordinator state with stale or truncated TM;
+3. resume can treat “no ready leases” as harmless and miss the divergence.
+
+`promotion_receipt.py` is an offline scaffold, not a production call site. Its
+current row-delta invariant is also false for multi-sense cards and
+replacements. It must not be wired into production unchanged.
+
+Required close design: a durable journal with phases
+`prepared -> store_committed -> tm_validated`, clean-output and store hashes,
+per-lease metrics, atomic TM replacement, and startup reconciliation by hashes
+and provenance rather than key presence.
+
+### P1 — automated result ingestion is not bound to its saved hash and run
+
+`run_claimed()` persists `result_sha256`
+(`src/pilot/max_account_orchestrator.py:418-425`), but
+`cmd_record_done()` neither recomputes that hash nor supplies `--run-id`
+(`:673-696`). Coordinator checks a run ID only when the caller supplies one
+(`src/pilot/coordinator.py:1421-1433`).
+
+A temporary-fixture reproduction replaced a completed output after its hash
+was recorded. The replacement was still sent to `record-output`. A stale or
+substituted result can consequently be audited under another attempt.
+
+Required fix: persist the dispatch run ID with the job, require a non-empty
+saved output hash for manifest jobs, recompute and compare it immediately
+before ingestion, pass the saved `--run-id`, and require it when the running
+lease has a sealed run ID.
+
+### P1 — malformed paid wrappers can look evaluable at zero cost
+
+`HeadlessEngine.call()` validates `structured_output.cards[]` before calling
+`_accumulate_usage()` (`src/pilot/headless_worker.py:466-474`). A paid wrapper
+with valid usage/cost but malformed structured content is retried without
+recording spend.
+
+The reproduction used two wrappers that each declared `$0.25`. The resulting
+summary incorrectly reported:
+
+```json
+{
+  "cost_evaluable": true,
+  "observed_cost_usd": 0.0,
+  "priced_calls": 0,
+  "missing_usage_calls": 0
+}
+```
+
+Required fix: parse the envelope and accumulate usage/cost before validating
+the structured result. If the envelope itself is unreadable, count the paid
+attempt and mark the run cost unevaluable.
+
+### P1 — readiness probes bypass the per-profile active-call lock
+
+Production generation acquires `ActiveCallClaim`
+(`src/pilot/headless_worker.py:830-836`). `_probe_call()` invokes Claude
+directly without that lock
+(`src/pilot/max_account_orchestrator.py:877-894`).
+
+Two operators can therefore probe a profile already translating. The warm-up
+and measured calls must be inside the same profile lock used by production.
+
+### P1 — `--max-calls` and cost ceilings remain post-hoc
+
+The two readiness calls occur before `BoundedSupervisor` is created
+(`src/pilot/bounded_staged_run.py:752-768`). The supervisor checks
+`max_calls` only after an entire window completes
+(`src/pilot/bounded_supervisor.py:268-365`).
+
+The shipped bounded-run selftest explicitly permits `max_calls=5` to finish
+with six calls. This means:
+
+- `--max-calls 0` does not cover readiness calls;
+- a window can overshoot by its retries and heals;
+- a failed worker without a workflow summary may not enter accounting;
+- cost ceilings stop only after the window.
+
+The H1618 `cohort_engine` reservation ledger does not close this production
+gap. A true hard ceiling needs a durable reservation consumed immediately
+before every warm-up, measured, translate, failed, malformed, timed-out, retry,
+and heal call. Until that lands, the handoff must not describe `--max-calls` or
+`--cost-ceiling` as a strict pre-spawn guarantee; manifest agent ceilings remain
+the enforced spawn bound.
+
+### P2 — required preparation evidence can fail open
+
+`coordinator.enforce_cost_gate()` returns when a required preflight is missing
+or malformed (`src/pilot/coordinator.py:878-887`), then preparation proceeds.
+Unreadable price evidence can therefore authorize paid execution.
+
+Malformed canonical-store rows are also skipped while completed keys are
+derived, and occupied-manifest parse failures are ignored during import. These
+secondary parse gaps should be repaired separately; required preflight evidence
+must fail closed before this live run.
+
+### P2 — audit recovery and test isolation defects
+
+- Threaded audit gates use unguarded `future.result()`
+  (`src/pilot/audit_window.py:583`). An unexpected child exception aborts
+  before durable report/requeue emission.
+- Quarantine deletes the prior destination before replacement
+  (`src/pilot/audit_window.py:221`), so replacement failure can lose recovery
+  evidence.
+- `test_coordinator_defect_requeue_uses_no_tm_and_out` invokes a synthetic
+  defect requeue without `--no-residual`
+  (`src/pilot/window_selftest.py:3545`), appending test key `a` to the tracked
+  production residual registry.
+
+These do fail closed against promotion, but they damage recovery evidence or
+pollute production state. The stop-before-promote route should convert threaded
+exceptions into full-window requeue evidence and isolate the residual selftest.
+
+### P1 — card-TM rebuild is destructive and non-atomic
+
+`translation_memory.build()` writes the live JSON file directly
+(`src/pilot/translation_memory.py:444`). A crash during `json.dump` can
+truncate the prior good TM. This is part of the promotion NO-GO and must be
+fixed with temp-write, validation, fsync, and same-directory atomic replace.
+
+Fragment sidecar malformed tails are skipped by the runtime loader; that is
+audit-readable but should be reconciled with the denylist’s fail-closed torn
+line policy.
+
+## Historical findings checked and closed
+
+- profile-specific transactional claims, required-slot dispatch, and
+  execution-time config fingerprint validation are active;
+- manifest translate/heal/total agent ceilings and timeout clamping are
+  enforced before worker spawn;
+- H1618 refuses starving `--max-agents 1` on multi-key windows;
+- the worker’s active-call claim is kernel-backed;
+- normal/requeue missing output and unreadable audit artifacts fail closed;
+- canonical store writes use same-directory fsynced atomic replacement;
+- promotion backups are exclusive, fsynced, and unique;
+- promotion lock stale reclaim is identity checked;
+- worktree store/sidecar resolution fails closed;
+- H1553 clean-subset and defect fences are revalidated immediately before
+  promotion;
+- H1420’s TM `finally` covers Python exceptions after a successful promote
+  child return, though not process death or child failure after store replace.
+
+## Capability and enforcement map
+
+| Declared control | Current enforcement |
+|---|---|
+| v2 profile slot + config fingerprint | enforced before execution |
+| exact manifest model | passed to Claude; no separate Sonnet allow-list |
+| translate/heal/total agent ceilings | enforced before each worker spawn |
+| timeout ceiling | clamped before each worker spawn |
+| `--max-agents 1` multi-key starvation | refused before any call |
+| one active generation call per profile | enforced for worker, not probe |
+| `--max-calls` | post-window observation, not a reservation |
+| `--cost-ceiling` | preparation estimate + post-window stop, not reservation |
+| `execution_route` | enforced as `claude-cli-headless` |
+| `executor_lane`, `validation_method` | non-empty metadata only |
+| result SHA | produced, not checked at ingestion |
+| run ID | sealed, but optional at automated ingestion |
+| promotion receipt/journal | offline scaffold only |
+
+## Measured remaining speed opportunity
+
+The audit child must remain an isolated subprocess with its 30-minute timeout.
+The avoidable residue is the parent coordinator startup: the current H1339
+fixture launches `coordinator.py record-output` once per lease.
+
+On this worktree:
+
+- one `coordinator.py status` process: **0.861 s**;
+- five processes: **5.195 s**;
+- four avoidable starts: **4.333 s**.
+
+The smallest safe optimization is a sequential `record-output-batch` command
+that loops over the existing per-lease `record_output()` unit. Each item keeps
+its own operation token, lock transitions, audit subprocess, timeout, report,
+and state commit. It is deliberately fail-fast rather than one batch
+transaction: earlier leases remain recorded and later leases remain running,
+matching today’s sequential semantics.
+
+Ship criterion: a hermetic A/B using the H1339 fixture must show deterministic
+outputs, identical semantic store hash and per-lease states, and a lower audit
+median. Only audit/total timing may differ.
+
+## Current one-Max launch boundary
+
+The five July medium50 manifests bind **generation** to
+`claude-sonnet-5`. “Opus 5” is the orchestration/review session requested by the
+operator; it must not rewrite the sealed generation model.
+
+The surviving main-checkout artifacts are not currently sufficient for the
+canonical bounded route: coordinator state lacks their leases and the artifact
+directories lack required preflights. They must be rehydrated/reprepared before
+execution. The safe live sequence is:
+
+1. authenticate exactly one Max profile;
+2. bind the same config-directory path/fingerprint used by newly prepared v2
+   manifests;
+3. run a fresh representative >=5 KiB gate and one-key synthetic canary;
+4. dry-run, then execute one production window only;
+5. omit `--max-agents` for multi-key work;
+6. stop at `AWAITING_REVIEW`;
+7. run a new live gate before every later paid window.
+
+No result from one account authorizes another account or another window.
+
+## Baseline verification
+
+- `python src\pilot\window_selftest.py`: **183/183 passed**
+- `python src\pilot\lang_parity_check.py`: **81 entries complete; no drift**
+- hermetic benchmark: deterministic signature
+  `7f056b6dc8...`; median total **30.968 s** over three measured runs
+- `python src\pilot\headless_worker_selftest.py`: **failed**, depth-three
+  grandchild survived
+- `python src\pilot\max_account_orchestrator_selftest.py`: **failed**,
+  probe-tree descendant survived
+- focused result-substitution and malformed-wrapper fixtures: findings
+  reproduced
+
+The 183-test suite’s accidental residual-registry append was removed after the
+baseline run; the audit itself left no intentional production-data change.
+
+## Not audited
+
+Paid model behavior, OAuth/login state, account billing identity, provider
+quota, real 403 recovery, translation quality, canonical store/TM contents,
+publication export, real power-loss behavior, EN end-to-end promotion, legacy
+Workflow execution, and multi-profile live scheduling were not audited.
+

--- a/RussianTranslation/PIPELINE_HISTORY.md
+++ b/RussianTranslation/PIPELINE_HISTORY.md
@@ -56,6 +56,42 @@ counters exist to answer it the moment a window runs.
 without `--no-residual`, so every suite run appended a junk row to the tracked
 `no_pwg_residuals.jsonl` — the registry that decides which keys are BLOCKED from requeue.
 Fixed with the flag; the polluting row was reverted.
+### Unreleased hardening — paid-call accounting and crash-recoverable promotion (25-07-2026)
+
+The headless route acquired two missing transaction boundaries. First,
+`pwg.call_reservation.v1` makes a model call a durable spend decision: the
+shared run ledger reserves one slot atomically before every probe or worker
+spawn and never refunds it after a crash. This makes `max_calls` a true
+pre-spawn ceiling across probes and generation. The separate cost ceiling
+remains an observed-cost stop after completed calls, not a strict dollar
+preauthorization; missing, pending, or malformed telemetry is
+`STOP_COST_UNEVALUABLE`, never zero. The profile lock now covers the whole
+warm-up + measured probe pair and the worker run, while Windows launchers enter
+a kill-on-close Job Object before their first instruction so a timeout cannot
+leave the native paid child orphaned.
+
+The execution seam is sealed end to end: saved run ID, manifest hash, preflight
+hash and exact key scope, profile fingerprint, reservation ledger, worker
+result hash, and coordinator submission must agree. `record-output-batch`
+keeps the existing per-lease audit transaction but runs it sequentially,
+emitting the exact durably committed prefix after each item; a failed item and
+the suffix remain retryable.
+
+Second, batched promotion now uses `pwg.promotion_journal.v1` with phases
+`prepared → store_committed → derived_validated → coordinator_committed →
+complete`. A single canonical-store claim is held for the whole sequence. The
+journal seals before/after store bytes, backup, cleaned inputs, card/fragment
+TM, denylist state, exact coordinator bytes, and deterministic per-lease
+registry projection. Every coordinator command first reconciles the one
+incomplete journal; interrupted store/coordinator replacements are adopted
+only when the exact expected hash is already live, while unrelated bytes or
+multiple incomplete journals stop closed.
+
+This entry records implementation state, not a release or live acceptance.
+No paid translation was started in this hardening pass. The next authorized
+attempt remains one profile, `max-wide=1`, explicit durable call ledger, and
+`--stop-before-promote`; a clean run ends at hash-bound `AWAITING_REVIEW`
+before any canonical-store mutation.
 
 ### H1386 — the H1339 review landing set: resume recovery, frag-TM memory, prepare-batch (22-07-2026)
 
@@ -858,6 +894,14 @@ Two consequences worth internalising before touching the lane:
   `selected_keys` rejection, an OS-released cross-process lock, owner-preserving fragment-TM
   v2 and the `AWAITING_REVIEW` checkpoint all landed in
   [PR #530](https://github.com/gasyoun/SanskritLexicography/pull/530).
+- **The 25-07 unreleased hardening closes the remaining cross-process seams.**
+  Calls are reserved durably before spawn across both probe and generation
+  lanes; cost-capped runs stop closed when observed telemetry cannot be
+  evaluated; profile claims cover complete probe pairs; Windows process trees
+  are kernel-owned; run/manifest/preflight/result hashes are bound through
+  recording; and promotion is startup-reconciled under one journal and one
+  canonical-store claim through `complete`. It started no paid translation and
+  does not change the standing stop-before-promote/review gate.
 
 **Live status evolves; do not freeze "host-blocked" as permanent.** H1110 Phase 6
 (18-07) terminated at **`HEALTH_NOGO_BY_ENVIRONMENT`** (c4 health **98,625 ms** vs a

--- a/RussianTranslation/pwg_ru/CODEX_HARDENING_REBASE_STATUS_2026-07-26.md
+++ b/RussianTranslation/pwg_ru/CODEX_HARDENING_REBASE_STATUS_2026-07-26.md
@@ -1,0 +1,104 @@
+# Codex pipeline-hardening branch — rebase + verification status (26-07-2026)
+
+_Created: 26-07-2026 · Last updated: 26-07-2026_
+
+Extraction of `SanskritLexicography-rt-harden-codex`
+(`codex/rt-pipeline-hardening-speed`) onto current `master`, and the first time the
+branch's own test suite has been run. Executor: Opus 5 (`claude-opus-5[1m]`).
+
+**Verdict: NOT landable as-is. 7 pre-existing tests fail, all from one cause.** The work
+itself is substantial and worth landing; what is missing is the fixture layer for the
+contract it tightens.
+
+## What was extracted
+
+| | |
+|---|---|
+| source base | `f96361ca` — the same commit the H858/#729 work branched from, so the two ran in parallel all day |
+| carried over | 2 unmerged `ai-wip:` commits + ~3 935 uncommitted insertions across 25 files + 5 new modules |
+| new modules | `call_reservation.py`, `promotion_journal.py`, `coordinator_hardening_selftest.py`, + 2 selftests |
+| conflicts on rebase | **4** — `h963_c4_gate0_probe.py`, `window_selftest.py`, `PIPELINE_HISTORY.md`, `changelog.md` |
+| applied cleanly | 23 files, including `headless_worker.py` and `promote_final_cards.py` — the H858 work is untouched |
+
+### How the four conflicts were resolved
+
+- **`h963_c4_gate0_probe.py` — the real one.** Codex independently found the same
+  fixed-`RUN_ID` defect as [#729](https://github.com/gasyoun/SanskritLexicography/issues/729)
+  (same diagnosis — its comment reads "reusing its fixed run ID would make old append-only
+  readings indistinguishable from the current invocation") and fixed it **incompatibly**: it
+  *aborts* when the constant id is already present. Master
+  ([v1.63.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.63.0)) mints a
+  per-invocation id instead, which is strictly better — Codex's version refuses to run at all
+  once the log holds one row. **Kept master's fix; grafted Codex's genuinely additive
+  contribution**, the `CallReservationLedger` pre-spend cap (made per-account, like the
+  events log) and the "exactly 2 readings" check. Both survive; selftest 7/7.
+- **`window_selftest.py`** — both sides added tests. Kept master's file and re-inserted
+  Codex's two (`test_threaded_gate_exception_requeues_full_window`,
+  `test_quarantine_replace_failure_preserves_previous_destination`).
+- **`changelog.md`, `PIPELINE_HISTORY.md`** — append-at-top docs; both sides' entries kept.
+
+## Defects found in the branch as delivered
+
+These are **not** rebase artifacts: each is Codex's own new guard against Codex's own
+selftest, and each would fail identically in the original worktree. Fixed here.
+
+| # | Symptom | Cause |
+|---|---|---|
+| 1 | `call_reservation_selftest` → `TypeError: one_call() missing 'active_claim'` | it added two required keyword-only params to `one_call` and passed only one |
+| 2 | `headless_worker_selftest` aborts on its first `execute()` | new `CLAUDE_CONFIG_DIR` paid-boundary guard; the shared fixture helper and 4 direct call sites never supply one |
+| 3 | same suite → `paid headless execution requires an explicit config directory` | 2 direct `HeadlessEngine(...)` constructions |
+| 4 | same suite → `paid headless spawn requires the live canonical profile claim` | `test_durable_call_reservation` drives `.call()` without holding an `ActiveCallClaim` |
+| 5 | `test_cli_reservation_and_preflight_gates` exits 2, not 0 | it sets `CLAUDE_CONFIG_DIR` only for its v2 half, after the `--max-calls 0` case that also needs it |
+| 6 | `bounded_staged_run_selftest` aborts | it seeds fixtures through the `enqueue` CLI, which the branch turns into a hard refusal |
+
+After those six fixes: `call_reservation`, `promotion_journal`, `coordinator_hardening`,
+`headless_worker`, `max_account_orchestrator`, `bounded_staged_run`, `bounded_supervisor`
+selftests and `lang_parity_check` are **all green**.
+
+## What still fails — 7 tests, ONE cause
+
+`window_selftest`: **188 defined, 181 pass, 7 fail.**
+
+```
+test_coordinator_nominal_reservations
+test_coordinator_runtime_state_machine_and_cas
+test_coordinator_requeue_attempt_manifests
+test_coordinator_mixed_lane_public_state_sequence
+test_coordinator_cost_gate_enforced
+test_h1420_p11_record_output_binds_run_id
+test_h1420_p10_promote_rebuilds_tm_in_finally
+```
+
+Every one is the same story: **the branch makes preflight evidence and sealed-v2 binding
+mandatory, and the pre-existing fixtures still pass placeholders.** Traced individually:
+
+- `register_prepared_lease` now hashes the preflight file; the reservation-race test passes
+  the literal string `'preflight.json'`, which is not a file. **Both** racer threads die on
+  `FileNotFoundError`, so the outcome is `['rejected','rejected']` and the serialization
+  assertion fails. It reads like a concurrency regression and is not one.
+- `begin_run` now calls `validate_lease_preflight`, so both racers `SystemExit` — same shape.
+- the cost gate refuses with `required preflight has unsupported schema None` before it can
+  reach the deferred-ledger message the test asserts.
+- `record-output` now requires `--result-sha256` for a sealed run.
+- promotion now refuses `v1/unbound workflow output` as historical-only — the guard working
+  exactly as designed, against fixtures that build v1 outputs.
+
+**The guards are behaving correctly; the fixtures are stale.** Bringing them up to the new
+contract is real work, and it depends on what the branch author intends the sealed fixture
+shape to be — which is why it stops here rather than being guessed at.
+
+## Recommendation
+
+Land in two steps, not one:
+
+1. **Now, low risk:** the parts that are green and independent — `call_reservation.py`,
+   `promotion_journal.py`, the probe's pre-spend ledger graft, the two new `window_selftest`
+   tests, the `proc_tree` tree-kill hardening.
+2. **After the fixture layer is rebuilt:** the coordinator/promotion sealing (the P0
+   "promotion is not one recoverable transaction" work), together with the 7 fixtures it
+   invalidates.
+
+Nothing is lost either way — the branch is preserved here, rebased, with 6 of its own
+defects fixed.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -1,6 +1,6 @@
 # Runbook — frequency queue on the headless CLI (manifest v2)
 
-_Created: 09-07-2026 · Last updated: 24-07-2026_
+_Created: 09-07-2026 · Last updated: 25-07-2026_
 
 Goal: scale the PWG→Russian production run in DCS-frequency order, with giant
 roots split into single-pass units and re-glued after translation. This is the
@@ -66,6 +66,23 @@ tracked-file drift and is wired into `window_selftest.py`
 - **Execution route (H1110):** production is the **headless CLI on manifest v2**, not
   Workflow-from-session. Bind a named profile (`CLAUDE_CONFIG_DIR` + roster slot) before
   any paid call; promotion hard-refuses unbound payloads (H1080 Stage 3).
+- **Durable call budget (25-07-2026 hardening):** the bounded run, its fleet probes,
+  and every headless worker share one `pwg.call_reservation.v1` ledger keyed by
+  `run_id`. `max_calls` is a strict pre-spawn ceiling: reserve first, then spawn;
+  reservations survive crashes and are never refunded. `--resume` must reopen the
+  same ledger/run ID and refuses a different saved ceiling.
+- **Cost semantics:** `--cost-ceiling` is an observed-cost stop evaluated after
+  completed calls, not a pre-spend dollar guarantee. Pending, absent, malformed, or
+  otherwise unevaluable telemetry causes `STOP_COST_UNEVALUABLE`; it is never treated
+  as zero. Use `--max-calls` for the strict upper bound on call count.
+- **Profile/process isolation:** one `ActiveCallClaim` spans each complete warm-up +
+  measured probe pair, and the same profile fingerprint lock spans generation. On
+  Windows, Claude is assigned while suspended to a kill-on-close Job Object; timeout
+  and exception cleanup terminate the descendant tree, not only the launcher.
+- **Bound artifacts:** before a paid manifest-v2 spawn, the orchestrator rechecks the
+  saved run ID, manifest SHA-256, profile binding, sealed preflight SHA-256 and exact
+  selected-key scope, plus the reservation ledger. The worker seals its result SHA-256;
+  `record-output`/`record-output-batch` require the matching run and result hash.
 - **Live-gate before every paid window:** fresh
   [`/pwg-live-gate`](https://github.com/gasyoun/claude-config/blob/main/commands/pwg-live-gate.md)
   (representative ≥5 KB health + separate `dq_canary_puregloss`). A previous session's GO
@@ -128,6 +145,15 @@ tracked-file drift and is wired into `window_selftest.py`
   longer regress a card; (4) **presplit topup is sound** — `autosplit_requeue.frag_groups()`
   reconstructs the fragment partition with the budgets of the run that minted the `gN:fM`
   ids (pass the wf `meta` + key), instead of always the heal budget.
+- **Promotion closure (25-07-2026 hardening):** ready leases promote only through
+  the coordinator's journaled batch path. `pwg.promotion_journal.v1` advances
+  `prepared → store_committed → derived_validated → coordinator_committed →
+  complete`, with one canonical-store claim held throughout. Every coordinator
+  startup reconciles the single incomplete journal; a store/coordinator hash that
+  matches neither sealed before nor expected-after state fails closed. Card TM,
+  fragment TM, denylist state, coordinator bytes, and one deterministic
+  promotion-registry event per lease/promotion are sealed and replayed
+  idempotently.
 
 The earlier "Opus-judged-every-card" framing was the validation phase; "Sonnet-bulk/Opus-on-reject"
 was the 2026-06-26 escalation policy; the per-card LLM judge itself is now dropped from the bulk path.
@@ -190,8 +216,11 @@ manner/position forcing) as soft-judged guidance (judge check 7). Source tables:
 
 ## Window loop
 
-The loop is fixed: **preflight → generate optimized harness → Max Workflow → deterministic
-audit → requeue or sampled semantic judging**. Do not skip or reorder these steps.
+The loop is fixed: **preflight → prepare a profile-bound manifest v2 → bounded
+headless execution → sealed batch record + deterministic audit →
+`AWAITING_REVIEW` → reviewed promotion or requeue**. Do not skip or reorder
+these steps. The generated Workflow JS remains useful as historical/forensic
+evidence, not as the production execution surface.
 
 For enough data to estimate speed and quality, use the live runnable queue plus
 `perf_preflight.py`:
@@ -225,13 +254,13 @@ The first command prints the structural state plus one `next action` and one
 `next command`; if it disagrees with stale notes elsewhere, trust the command
 output and `src\pilot\output\window_status.json`. The second command is read-only
 performance accounting: it reports card/fragment TM hits, degenerate pass-through,
-presplit routing, batch count, and `agent_expected_after_tm` before Max spend. Use
+presplit routing, batch count, and `agent_expected_after_tm` before paid spend. Use
 `--json` when saving a machine-readable preflight report. With more than one root it
 prints a compact comparison table plus a recommended order: zero-agent roots are skipped,
 low-agent roots run first, and high-agent roots are deferred until cache refresh or
 calibration. If presplit keys exist while `translation_memory.frag.<lang>.jsonl` is empty,
 the preflight warns to run
-`python src\pilot\translation_memory.py build-frags --lang ru` after a heal Workflow emits
+`python src\pilot\translation_memory.py build-frags --lang ru` after a heal run emits
 `frag_prov`; if no matching `wf_output*.json` contains `frag_prov`, the warning says so.
 
 Generate the harness for the root. **Default: the batched + masked v2 harness**
@@ -249,7 +278,7 @@ created, `python src\pilot\translation_memory.py build-frags --lang ru`. See
 
 ```powershell
 python src\pilot\gen_opt_harness2.py sTA            # default (batched+masked, TM auto, output-budget 90)
-# -> writes src\pilot\run_pilot_wf.opt2.js  (run THIS in Max, save result as wf_output.json)
+# -> writes the optimized harness and manifest inputs; do not run the JS manually in Max
 # --output-budget=N tunes citation-weighted output packing (default 90).
 # --budget=N without --output-budget keeps legacy byte-mode packing.
 # --no-tm disables automatic card/fragment translation-memory reuse.
@@ -266,39 +295,35 @@ Do not widen degenerate pass-through for editorial correction prose (`lies:`, `z
 etc.); those rows stay in the normal LLM lane unless a future fixture proves exact
 deterministic reconstruction is safe.
 
-Legacy per-card harness (still supported; no masking/batching):
+Legacy per-card harness (forensics/replay only; no masking/batching):
 
 ```powershell
 python src\pilot\gen_opt_harness.py sTA             # -> run_pilot_wf.opt.js
 ```
 
-Confirm the committed prompt template and generated harness still carry the
-manual-derived semantic rules before Max spend:
+Confirm the committed prompt template and generated artifacts still carry the
+manual-derived semantic rules before any paid spend:
 
 ```powershell
 python src\pilot\prompt_rule_audit.py --fail-on-missing
 ```
 
-After this succeeds, a stale `window_status.json` from the previous audit is no longer the next
-operator step. `root_window_status.py` should now tell you to run the generated harness in Max,
-then audit the fresh `wf_output.json`.
+After this succeeds, a stale `window_status.json` from the previous audit is no
+longer the next operator step. Follow the prepared manifest-v2 lease through
+`bounded_staged_run.py --execute --stop-before-promote`, with explicit
+`--max-calls`, a stable `--run-id`, and a durable `--call-reservation` path.
+The command validates all scoped preflights before the first probe, then uses
+the same reservation ledger for the fresh probe pair and worker calls.
 
-Run the generated harness (default `src\pilot\run_pilot_wf.opt2.js`, or the legacy
-`run_pilot_wf.opt.js`) in the Claude/Max Workflow surface and save the JSON result as
-`wf_output.json`.
-**Immediately after saving, verify the file actually landed before closing the Workflow
-tab:** `meta.root` in the freshly-saved `wf_output.json` must equal the root you just ran and
-`meta.generated_at` must be newer than the harness generation time. The H145 `vid` run
-(03-07-2026) was lost exactly here — the Workflow completed but the save never reached disk,
-and the stale file silently still held the previous root. A Claude Code session driving the
-Workflow tool writes the file itself and does not have this manual hand-off gap; prefer that
-route for production windows. Both are self-contained: they inline inputs, disable translate-agent tools
-with `tools: []`, and return top-level workflow provenance (`meta`: root, mode, selected keys,
-rootmap SHA-256, per-input SHA-256). The v2 harness additionally batches, masks, and restores
-`{Tn}` in-JS — its output is already canonical, so the audit step is unchanged. It is the
-supported route for the in-chat Workflow tool.
-Do not run the committed `run_pilot_wf.js` directly for production windows; it is the template
-used by `gen_opt_harness.py`.
+The orchestrator writes and hash-seals the result itself; there is no manual
+Workflow-save hand-off. `record-output-batch` records completed leases
+sequentially and emits `RECORD_OUTPUT_BATCH_PROGRESS` after each durable commit.
+If item N fails, only the exact earlier prefix is committed; item N and the
+remaining leases are safe to retry. A clean
+`--stop-before-promote` run writes the hash-bound
+`pwg.awaiting_review.v1` checkpoint with status `AWAITING_REVIEW` and leaves
+the canonical store/TM untouched. Do not run `run_pilot_wf.js`,
+`run_pilot_wf.opt.js`, or `run_pilot_wf.opt2.js` manually for production.
 
 Before the mechanical window audit, run the cheap translated-card semantic triage:
 
@@ -329,7 +354,7 @@ Audit the window with the single deterministic command:
 python src\pilot\audit_window.py wf_output.json --root sTA --write-requeue
 ```
 
-If Max shows token/time numbers, record them on the same audit command so the ledger captures
+If the CLI reports token/time numbers, record them on the same audit command so the ledger captures
 the production economics:
 
 ```powershell
@@ -343,16 +368,17 @@ python src\pilot\audit_window.py wf_output.json --root sTA --write-requeue `
 
 If the weekly Max cap fires, add `--weekly-cap-fired --weekly-cap-cumulative-tokens N`.
 
-For Stage B and later roots, change only `--root` and the generated harness root
-name. Do not combine multiple roots into one `wf_output.json`; audit economics
+For Stage B and later roots, change only `--root` and the prepared manifest
+scope. Do not combine multiple roots into one `wf_output.json`; audit economics
 and requeue keys must remain root-scoped.
 
 The audit first compares workflow provenance against the current rootmap and raw/portrait
 inputs. Stale output (missing `meta`, key mismatch, rootmap hash mismatch, or input hash
 mismatch) stops before collect/gates/glue and records state `stale_artifact`. Check
-`root_window_status.py`: if the optimized harness already matches the current rootmap, rerun
-that harness in Max and save a fresh `wf_output.json`; regenerate only when the status command
-says the harness is missing, invalid, or scoped to the wrong keys. Use `--allow-stale` only for
+`root_window_status.py`: if the optimized inputs and prepared manifest already
+match the current rootmap, resume the bound headless attempt and record its
+sealed result; regenerate only when the status command says the artifacts are
+missing, invalid, or scoped to the wrong keys. Use `--allow-stale` only for
 forensic inspection.
 If stale output is refused, `--write-requeue` does **not** overwrite the existing
 `requeue.keys.txt`; stale artifacts cannot produce a trustworthy mechanical requeue list.
@@ -389,9 +415,10 @@ Preparation and audit subprocesses do not hold the global state lock. Their pers
 `preparing`/`auditing` operation tokens keep `status` and unrelated claims responsive, with a
 10-minute preparation timeout and a 30-minute audit timeout.
 
-**Default to one Workflow window at a time; treat 3-wide as an upper bound, not a target.**
-Each generated harness internally fans out to ~8–14 agents, so N concurrent root-harnesses
-peak at N×~12 Sonnet agents on a single Max session. Slice D launched 18 at once →
+**Default to one bounded headless window at a time; treat ordinary 3-wide as an
+upper bound, not a target, and use `max-wide=1` for the bounded paid route.**
+Each generated window may internally fan out to ~8–14 calls, so N concurrent roots
+can still peak at N×~12 Sonnet calls on a single Max account. Slice D launched 18 at once →
 ~140–250 peak agents → ~80+ `Server is temporarily limiting requests` 429s → 117 transient
 null cards. H317 then showed that even **3 concurrent medium windows** can collapse if the
 session/provider is already unstable (0/38 clean, and the solo retry still saw repeated
@@ -415,8 +442,8 @@ not a substitute for it.
 ## Flaky API / Internet Policy
 
 - There is no Claude API client in this repo for production PWG translation. Claude work runs
-  through the Max Workflow surface, so the local scripts must make interruptions resumable
-  instead of trying to hide network loss.
+  through the profile-bound headless CLI; the coordinator, call-reservation ledger, process-tree
+  cleanup, sealed results, and promotion journal make interruptions explicit and resumable.
 - The generated optimized harness retries each card once. A still-null card is recorded by
   `audit_window.py`. The requeue list is **split** so a cheap re-run never triggers expensive
   rework: `requeue.transient.keys.txt` (null cards = rate-limit/dropout) vs
@@ -469,8 +496,9 @@ python src\pilot\requeue_from_audit.py sTA --transient   # null cards only (stat
 python src\pilot\requeue_from_audit.py sTA               # all requeue keys
 ```
 
-Run the regenerated `run_pilot_wf.opt2.js`, save its JSON as the next `wf_output.json`, and rerun
-`audit_window.py`.
+Prepare the regenerated manifest as a coordinator requeue attempt and resume it
+through the same bounded headless route. Do not manually run/save the generated
+Workflow JS.
 
 If `requeue.keys.txt` is empty and `judge_sample.keys.txt` is non-empty, send only those keys to
 the sampled semantic judge outside Python. Do not block mechanical acceptance on unrelated
@@ -478,11 +506,12 @@ documentation cleanup or print-readiness gates.
 
 ## Instrumentation
 
-For each Max window, record:
+For each bounded headless window, record:
 
 - `OFFSET`, `LIMIT`, fresh units, rejected units, and successful merged cards;
 - wall-clock minutes;
-- Max-reported input/output/cache tokens if available;
+- CLI-reported input/output/cache tokens and observed cost, or the explicit
+  unevaluable-cost stop;
 - whether the weekly cap fired, and cumulative tokens at that moment.
 
 `audit_window.py` records the operational state, next action, sample counts, and any token/time
@@ -492,7 +521,7 @@ feasibility question: one Max seat over roughly two months vs a paid API bulk ru
 
 ## Post-launch closeout
 
-Every Workflow/API launch with a failure, null wave, stall, kill, stale-artifact refusal,
+Every headless/legacy-Workflow/API launch with a failure, null wave, stall, kill, stale-artifact refusal,
 retry pass, cost drift, or suspicious residual must be registered in
 [`../../LAUNCH_FUCKUPS.md`](../../LAUNCH_FUCKUPS.md) before the handoff is closed. The
 entry must include expected vs actual agents/tokens, pass count, failure class, root cause,
@@ -581,7 +610,14 @@ python src\pilot\gen_opt_harness2.py <root_or_window>
 python src\pilot\coordinator.py prepare LEASE_ID `
   --profile-slot c4 --config-dir C:\path\to\claude-c4 `
   --executor-lane serial-whole-card
-# headless execute: max-wide=1, --stop-before-promote, NO --max-agents 1 on multi-key
+python src\pilot\bounded_staged_run.py `
+  --plan <plan.json> --coord-dir <coordinator-dir> `
+  --coordinator src\pilot\coordinator.py --cwd RussianTranslation `
+  --events <events.jsonl> --only-profile c4 --max-accounts 1 `
+  --max-windows 1 --max-calls <N> --run-id <stable-run-id> `
+  --call-reservation <calls.json> --checkpoint <checkpoint.json> `
+  --execute --stop-before-promote
+# No --max-agents 1 on multi-key; clean output stops at AWAITING_REVIEW.
 python src\pilot\audit_window.py wf_output.json --root <root> --write-requeue
 # /pwg-window-close: promote only if bound manifest-v2 + gates green
 ```
@@ -678,5 +714,5 @@ The frequency queue milestone is done when:
 - zero `*.merged.REJECTED.md` files remain for that window;
 - rootmap-backed giant roots have matching `*.NESTED.md` outputs;
 - the cost/quota table has enough windows to estimate the run duration;
-- every non-clean Workflow/API launch in the window has a complete
+- every non-clean headless/legacy-Workflow/API launch in the window has a complete
   `LAUNCH_FUCKUPS.md` entry and passes `check_launch_ledger.py`.

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -223,8 +223,9 @@ def quarantine(key):
         if exact_file_exists(OUT, nm):
             src = os.path.join(OUT, nm)
             dst = os.path.join(OUT, nm[:-len('.merged.md')] + '.merged.REJECTED.md')
-            if os.path.exists(dst):
-                os.remove(dst)
+            # os.replace is the atomic overwrite primitive.  Do not unlink an existing
+            # rejected artifact first: if replacement fails, the prior rejection remains
+            # durable and the caller can report/requeue the failed quarantine.
             os.replace(src, dst)
             return True
     return False
@@ -373,6 +374,75 @@ def run_sense_shortfall_gate(results, input_dir, protected):
             'requeue': sorted(s['key'] for s in short),
             'sense_shortfall': short,
             'seconds': round(time.perf_counter() - t0, 3)}
+
+
+def _gate_exception_result(name, exc, keys, operation='threaded gate'):
+    """Convert an unexpected in-process gate failure to the normal gate result contract."""
+    return {
+        'argv': ['in-process', name],
+        'returncode': 3,
+        'stdout': '',
+        'stderr': '%s %s failed: %s: %s' % (
+            name, operation, exc.__class__.__name__, exc),
+        'seconds': 0.0,
+        'requeue': sorted(set(keys or [])),
+    }
+
+
+def run_threaded_gates(keys, protected, wf, results, input_dir):
+    """Run the independent in-process gates without letting a worker abort the audit."""
+    specs = (
+        ('nws', run_nws_gate, (keys, protected)),
+        ('prompt_semantic', run_prompt_semantic_audit, (wf, protected)),
+        ('sense_loss', run_sense_shortfall_gate, (results, input_dir, protected)),
+    )
+    futures = {}
+    gates = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
+        for name, func, call_args in specs:
+            futures[ex.submit(func, *call_args)] = name
+        for fut in concurrent.futures.as_completed(futures):
+            name = futures[fut]
+            try:
+                gates[name] = fut.result()
+            except Exception as exc:
+                # A worker exception is operational failure, not a reason to lose the
+                # durable audit report.  Fail loud and conservatively requeue this exact
+                # window while the remaining futures and main() continue.
+                gates[name] = _gate_exception_result(name, exc, keys)
+    return gates
+
+
+def apply_nws_quarantine(gate, keys):
+    """Quarantine NWS rejects, reporting replacement failures as full-window evidence."""
+    rejected = []
+    errors = []
+    for key in gate.get('misattribution') or []:
+        try:
+            if quarantine(key):
+                rejected.append(key)
+        except OSError as exc:
+            errors.append({
+                'key': key,
+                'error': '%s: %s' % (exc.__class__.__name__, exc),
+            })
+
+    gate['rejected'] = rejected
+    if rejected:
+        gate['stdout'] += '  quarantined        : %s\n' % ' '.join(rejected)
+    if errors:
+        diagnostics = [
+            'nws quarantine failed for %s: %s' % (item['key'], item['error'])
+            for item in errors
+        ]
+        gate['returncode'] = 3
+        gate['requeue'] = sorted(set(keys or []))
+        gate['stderr'] = '\n'.join(
+            part for part in (gate.get('stderr', '').rstrip(), '\n'.join(diagnostics))
+            if part
+        ) + '\n'
+        gate['quarantine_errors'] = errors
+    return gate
 
 
 def emit_audit_event(event_type, level='info', root=None, state=None, summary='', data=None):
@@ -579,15 +649,7 @@ def main():
         # ru_style_mechanical_yo_terseness); never wired into audit_window_en.py.
         ('ru_style', [os.path.join(SRC, 'ru_style_sweep.py'), '--wf', wf], parse_flagged_json),
     ]
-    futures = {}
-    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
-        futures[ex.submit(run_nws_gate, keys, protected)] = ('nws', None)
-        futures[ex.submit(run_prompt_semantic_audit, wf, protected)] = ('prompt_semantic', None)
-        futures[ex.submit(run_sense_shortfall_gate, results, INPUT_DIR, protected)] = ('sense_loss', None)
-        for fut in concurrent.futures.as_completed(futures):
-            name, parser = futures[fut]
-            res = fut.result()
-            gates[name] = res
+    gates.update(run_threaded_gates(keys, protected, wf, results, INPUT_DIR))
     # H1339 Phase 3: the five child-script gates run IN-PROCESS (runpy), sequentially --
     # sys.argv/stdout are process-global, so they must not overlap; the thread pool above
     # only existed to hide per-gate interpreter startup, which run_py_inproc eliminates.
@@ -607,6 +669,9 @@ def main():
                 res['requeue'] = parsed
         gates[name] = res
 
+    if gates['nws'].get('misattribution'):
+        apply_nws_quarantine(gates['nws'], keys)
+
     for name in ['final_schema', 'nws', 'translation', 'stage2_mechanical', 'coverage',
                  'sense_dupes', 'prompt_semantic', 'sense_loss', 'ru_style']:
         res = gates[name]
@@ -624,12 +689,6 @@ def main():
             (name, res['returncode'], len(res.get('requeue') or [])),
             data={'gate': name, 'returncode': res['returncode'],
                   'requeue': res.get('requeue') or [], 'seconds': res.get('seconds')})
-
-    if gates['nws'].get('misattribution'):
-        rejected = [k for k in gates['nws']['misattribution'] if quarantine(k)]
-        gates['nws']['rejected'] = rejected
-        if rejected:
-            gates['nws']['stdout'] += '  quarantined        : %s\n' % ' '.join(rejected)
 
     glue = None
     # Root-article glue reassembles a PWG root's sub-cards from its rootmap. A NOMINAL window

--- a/RussianTranslation/src/pilot/bounded_staged_run.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run.py
@@ -14,11 +14,8 @@ leases, one lease per window, reusing the EXISTING staged-run building blocks
 injected `run_window`, and adding the bounded loop's ceilings + checkpoint + cost
 fail-closed policy AROUND them.
 
-It is a NEW, standalone module with its own CLI. It edits NOTHING in
-max_account_orchestrator.py / coordinator.py / bounded_supervisor.py — every existing
-command and default is byte-for-byte unchanged, so this is a pure opt-in (H963 objective 1,
-backward compatibility). The staged-run monolith is not refactored; its already-separate
-callables are simply composed under a bounded loop.
+It is a standalone CLI over the hardened orchestrator/coordinator primitives. The staged-run
+monolith is not duplicated; its separate callables are composed under a bounded loop.
 
 SAFETY / DEFAULT-OFF
 --------------------
@@ -45,15 +42,18 @@ CEILINGS (H963 objective 4) — all optional, default-disabled, backward compati
   --max-clean     clean rows requested       (BoundedSupervisor.max_clean)
   --empty-streak  consecutive non-productive (BoundedSupervisor.empty_streak_cap)
   --max-accounts  account/profile usage      (fleet cap, passed to probe/dispatch)
-  --cost-ceiling  estimated/observed cost    (BoundedSupervisor.budget_cap)
+  --cost-ceiling  observed-cost stop         (BoundedSupervisor.budget_cap)
 
 COST FAIL-CLOSED (H963 objective 5): when --cost-ceiling is set the loop reads per-window
 cost with bounded_supervisor.strict_cost_fn, which returns None (UNEVALUABLE) rather than a
 silent zero when a window carries no trustworthy cost figure — the loop then stops with the
 distinct STOP_COST_UNEVALUABLE reason. Additionally, BEFORE any live call, we fail closed if
 a cost ceiling is requested but the economy ledger cannot price it at all (no clean cards on
-record). Missing cost data is NEVER treated as zero. Accounting is the EXISTING economy
-ledger + launch/probe ledgers — no parallel accounting store is introduced (objective 6).
+record). Missing cost data is NEVER treated as zero. ``--cost-ceiling`` is necessarily an
+observed-cost stop after a completed attempt, not an impossible guaranteed dollar bound.
+The durable ``pwg.call_reservation.v1`` ledger is the pre-spawn authority for
+``--max-calls`` and records every probe, generation, retry, split, heal, timeout, and
+malformed attempt before result validation.
 
 Pure control-plane. The only side effects on the LIVE path are those cmd_staged_run already
 performs (dispatch/record/promote); the dry-run and every code path in the self-test perform
@@ -75,6 +75,7 @@ if HERE not in sys.path:
 import bounded_supervisor as bs                      # noqa: E402
 import economy_ledger as el                          # noqa: E402
 import max_account_orchestrator as mao               # noqa: E402
+from call_reservation import CallReservationLedger, run_ids  # noqa: E402
 from bounded_supervisor import BoundedSupervisor, strict_cost_fn   # noqa: E402
 
 SCHEMA = 'pwg.bounded_staged_run.v1'
@@ -268,7 +269,7 @@ class RunContext:
     def __init__(self, db, coord_dir, coordinator, cwd, events, run_id, probe_latencies,
                  claude_bin='claude', timeout=7200, gen_model_version=DEFAULT_GEN_MODEL_VERSION,
                  max_drain_iterations=1000, only_profile=None, checkpoint=None,
-                 stop_before_promote=False):
+                 stop_before_promote=False, call_reservation=None, max_calls=None):
         self.db = db
         self.coord_dir = coord_dir
         self.coordinator = coordinator
@@ -283,6 +284,8 @@ class RunContext:
         self.only_profile = only_profile
         self.checkpoint = checkpoint
         self.stop_before_promote = stop_before_promote     # R10
+        self.call_reservation = call_reservation
+        self.max_calls = max_calls
 
     @property
     def coord_state_path(self):
@@ -566,7 +569,8 @@ def make_run_window(ctx):
                     # (PWG_COORDINATOR_DIR unset), so the embedded begin-run/record calls hit
                     # the wrong coordinator state instead of this run's.
                     coordinator=ctx.coordinator, coord_dir=ctx.coord_dir, cwd=ctx.cwd,
-                    only_external_ids=scope))
+                    only_external_ids=scope, call_reservation=ctx.call_reservation,
+                    max_calls=ctx.max_calls))
             mao.cmd_record_done(argparse.Namespace(
                 db=ctx.db, coordinator=ctx.coordinator, coord_dir=ctx.coord_dir, cwd=ctx.cwd,
                 only_external_ids=scope))
@@ -690,7 +694,8 @@ def _validated_accounts(db_path):
         return []
 
 
-def build_supervisor(windows, checkpoint_path, ceilings, run_window, audit, resume=False):
+def build_supervisor(windows, checkpoint_path, ceilings, run_window, audit, resume=False,
+                     call_counter=None, usage_counter=None):
     """Construct the BoundedSupervisor with the H963 ceilings wired through. strict_cost_fn is
     used exactly when a cost ceiling is active, so an unevaluable window cost fails closed."""
     cost_ceiling = ceilings.get('cost_ceiling')
@@ -704,6 +709,8 @@ def build_supervisor(windows, checkpoint_path, ceilings, run_window, audit, resu
         empty_streak_cap=ceilings.get('empty_streak'),
         cost_fn=strict_cost_fn if cost_ceiling is not None else None,
         resume=resume,
+        call_counter=call_counter,
+        usage_counter=usage_counter,
     )
 
 
@@ -734,6 +741,13 @@ def run(args):
     windows, scope = scope_windows(plan, args.lease_id)
     if not windows:
         raise SystemExit('bounded_staged_run: staged plan has no prepared headless windows')
+    preflight_cmd = ['validate-preflight']
+    for lease_id in sorted(scope['lease_ids']):
+        preflight_cmd += ['--lease-id', lease_id]
+    preflight = mao.coordinator_command(args, preflight_cmd, check=False)
+    if preflight.returncode:
+        raise SystemExit('bounded_staged_run: preflight refused before probe: %s'
+                         % (preflight.stderr or preflight.stdout)[-2000:])
     # Cost fail-closed PRE-CHECK: refuse to start a cost-capped run we cannot price at all.
     cost_ok, cost_reason = cost_ceiling_evaluable(args.cost_ceiling, ledger)
     if not cost_ok:
@@ -749,11 +763,28 @@ def run(args):
         raise SystemExit('bounded_staged_run requires at least one validated account')
     if args.max_accounts:
         validated = validated[:args.max_accounts]
-    run_id = args.run_id or ('bsr-' + mao.now_iso().replace(':', '').replace('-', ''))
+    reservation_path = os.path.abspath(
+        getattr(args, 'call_reservation', None) or (args.checkpoint + '.calls.json'))
+    run_id = args.run_id
+    if args.resume and not os.path.exists(reservation_path):
+        raise SystemExit('bounded_staged_run: --resume requires the existing call ledger')
+    if args.resume and os.path.exists(reservation_path):
+        existing_run_ids = run_ids(reservation_path)
+        if not existing_run_ids:
+            raise SystemExit('bounded_staged_run: --resume call ledger has no existing run')
+        if run_id and run_id not in existing_run_ids:
+            raise SystemExit('bounded_staged_run: --resume run-id is absent from the call ledger')
+        if not run_id and len(existing_run_ids) == 1:
+            run_id = existing_run_ids[0]
+        elif not run_id:
+            raise SystemExit('bounded_staged_run: --resume requires --run-id when the call '
+                             'ledger contains multiple runs')
+    run_id = run_id or ('bsr-' + mao.now_iso().replace(':', '').replace('-', ''))
+    call_ledger = CallReservationLedger(reservation_path, run_id, args.max_calls)
     # Probe the fleet ONCE (STOP-on-any-NO-GO by default; the honest-NO-GO stance).
     probe_latencies = mao.probe_fleet(
         validated, args.claude_bin, events_path=args.events, run_id=run_id,
-        drop_unhealthy=args.drop_unhealthy)
+        drop_unhealthy=args.drop_unhealthy, call_reservation=call_ledger)
     if args.drop_unhealthy:
         for acc in validated:
             if acc['name'] not in probe_latencies:
@@ -764,7 +795,8 @@ def run(args):
         events=args.events, run_id=run_id, probe_latencies=probe_latencies,
         claude_bin=args.claude_bin, timeout=args.timeout,
         gen_model_version=args.gen_model_version, only_profile=args.only_profile,
-        checkpoint=args.checkpoint, stop_before_promote=args.stop_before_promote)
+        checkpoint=args.checkpoint, stop_before_promote=args.stop_before_promote,
+        call_reservation=reservation_path, max_calls=args.max_calls)
     run_window = make_run_window(ctx)
 
     def audit(wf_output, window):
@@ -791,7 +823,8 @@ def run(args):
             coordinator=args.coordinator, coord_dir=args.coord_dir, cwd=args.cwd))
 
     sup = build_supervisor(windows, args.checkpoint, ceilings, run_window, audit,
-                           resume=args.resume)
+                           resume=args.resume, call_counter=call_ledger.spent,
+                           usage_counter=call_ledger.usage)
     summary = sup.run()
     report = {'schema': SCHEMA, 'run_id': run_id, 'plan_view': view, 'summary': summary}
     if args.report:
@@ -829,9 +862,12 @@ def build_parser():
     # Ceilings (all optional / default-disabled).
     ap.add_argument('--max-windows', type=int, default=None)
     ap.add_argument('--max-calls', type=int, default=None)
+    ap.add_argument('--call-reservation',
+                    help='durable pwg.call_reservation.v1 path (default: CHECKPOINT.calls.json)')
     ap.add_argument('--max-clean', type=int, default=None)
     ap.add_argument('--cost-ceiling', type=float, default=None,
-                    help='max cumulative cost (USD). An UNEVALUABLE window cost fails closed.')
+                    help='observed-cost stop after completed calls (USD), not a hard dollar '
+                         'guarantee. UNEVALUABLE telemetry fails closed.')
     ap.add_argument('--empty-streak', type=int, default=None)
     ap.add_argument('--max-accounts', type=int, default=0)
     ap.add_argument('--only-profile', help='enforce one manifest-bound logical profile slot')

--- a/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_staged_run_selftest.py
@@ -144,12 +144,17 @@ def test_c_historical_jobs_excluded(td):
     db = os.path.join(td, 'scope.sqlite')
     mao.main(['--db', db, 'init', '--account', 'acc=' + os.path.join(td, 'acc'),
               '--skip-profile-check'])
-    for ext in ('other_plan_w99', 'no_pwg_w02'):
-        mao.main(['--db', db, 'enqueue', '--external-id', ext, '--argv-json',
-                  json.dumps([sys.executable, '-c', 'print(1)']), '--cwd', td,
-                  '--output', os.path.join(td, ext + '.json')])
+    # The `enqueue` CLI is now a hard refusal (generic argv jobs are disabled in favour of
+    # sealed coordinator manifests), so seeding through it aborts the whole suite. This test
+    # is about SCOPE ISOLATION -- which jobs a plan's scoped queries can see -- and needs two
+    # rows in the table, not a particular way of putting them there. Insert them directly.
     con = mao.connect(db)
     with con:
+        for ext in ('other_plan_w99', 'no_pwg_w02'):
+            con.execute('INSERT INTO jobs(external_id, argv_json, cwd, output_path) '
+                        'VALUES(?,?,?,?)',
+                        (ext, json.dumps([sys.executable, '-c', 'print(1)']), td,
+                         os.path.join(td, ext + '.json')))
         con.execute("UPDATE jobs SET state='failed' WHERE external_id='other_plan_w99'")
     con.close()
     scope = {'no_pwg_w02'}
@@ -467,6 +472,11 @@ def test_k_requeue_materialisation(td):
                                  'validation_method': 'audit_window+final_schema',
                                  'model_identifier': 'claude-sonnet-5'},
                    'key_provenance': {'k~~h0_zz_pw': 'real'}}, f)
+    rq_preflight = os.path.join(rq_dir, 'preflight.json')
+    with open(rq_preflight, 'w', encoding='utf-8') as f:
+        json.dump({'schema': 'pwg.performance_preflight.v1',
+                   'selected_keys': ['k~~h0_zz_pw'],
+                   'cost_gate': {'over_ceiling': False}}, f)
     state_path = os.path.join(coord, 'state.json')
 
     def write_state(state_name, with_attempt):
@@ -475,9 +485,14 @@ def test_k_requeue_materialisation(td):
         if with_attempt:
             lease.update({'requeue_attempt': 1, 'requeue_kind': 'transient',
                           'execution_manifest': rq_manifest,
+                          'preflight_path': rq_preflight,
+                          'preflight_sha256': mao.sha256_path(rq_preflight),
                           'current_attempt': {'number': 1, 'kind': 'transient',
                                               'artifact_dir': rq_dir,
-                                              'execution_manifest': rq_manifest}})
+                                              'execution_manifest': rq_manifest,
+                                              'preflight': rq_preflight,
+                                              'preflight_sha256':
+                                                  mao.sha256_path(rq_preflight)}})
         with open(state_path, 'w', encoding='utf-8') as f:
             json.dump({'leases': [lease]}, f)
 
@@ -637,21 +652,27 @@ def test_l_resume_recovers_abandoned_jobs(td):
         def run(self):
             return {'stop_reason': STOP_CLEAN_TARGET}
 
-    _pf, _rr, _bsup = mao.probe_fleet, mao.release_runtime, bsr.build_supervisor
+    _pf, _rr, _cc, _bsup = (mao.probe_fleet, mao.release_runtime,
+                             mao.coordinator_command, bsr.build_supervisor)
     mao.probe_fleet = lambda *a, **k: {'acc1': 10}
     mao.release_runtime = lambda *a, **k: argparse.Namespace(returncode=0, stdout='', stderr='')
+    mao.coordinator_command = lambda *a, **k: argparse.Namespace(
+        returncode=0, stdout='', stderr='')
     bsr.build_supervisor = lambda *a, **k: _NoopSup()
     try:
+        checkpoint = os.path.join(td, 'l_cp.json')
+        bsr.CallReservationLedger(checkpoint + '.calls.json', 'l', None)
         rc = bsr.run(argparse.Namespace(
             plan=plan_path, coord_dir=coord, coordinator=os.path.join(HERE, 'coordinator.py'),
-            cwd=td, db=db, checkpoint=os.path.join(td, 'l_cp.json'), lease_id=None,
+            cwd=td, db=db, checkpoint=checkpoint, lease_id=None,
             execute=True, resume=True, report=None, run_id='l', events=None,
             claude_bin='claude', timeout=5, gen_model_version=bsr.DEFAULT_GEN_MODEL_VERSION,
             only_profile=None, drop_unhealthy=False, stop_before_promote=False,
             max_windows=None, max_calls=None, max_clean=None, cost_ceiling=None,
             empty_streak=None, max_accounts=0))
     finally:
-        mao.probe_fleet, mao.release_runtime, bsr.build_supervisor = _pf, _rr, _bsup
+        mao.probe_fleet, mao.release_runtime, mao.coordinator_command, bsr.build_supervisor = (
+            _pf, _rr, _cc, _bsup)
     assert rc == 0, rc
     dbc = mao.connect(db)
     state = dbc.execute("SELECT state FROM jobs WHERE external_id='no_pwg_w02'").fetchone()['state']
@@ -693,11 +714,89 @@ def test_n_cli_defines_execute_path_args(td):
     args = ap.parse_args(['--plan', 'p.json', '--coord-dir', 'cd'])
     for attr in ('claude_bin', 'db', 'coordinator', 'cwd', 'events', 'run_id',
                  'timeout', 'gen_model_version', 'only_profile', 'max_accounts',
-                 'drop_unhealthy', 'checkpoint', 'stop_before_promote', 'resume'):
+                 'drop_unhealthy', 'checkpoint', 'stop_before_promote', 'resume',
+                 'call_reservation'):
         assert hasattr(args, attr), 'execute path reads args.%s but the CLI never defines it' % attr
     assert args.claude_bin == 'claude', args.claude_bin
     print('  (n) H1447: CLI defines every attr the --execute path dereferences '
           '(incl. --claude-bin): PASS')
+
+
+def test_o_preflight_before_probe(td):
+    plan_path = os.path.join(td, 'o_plan.json')
+    coord = os.path.join(td, 'o_coord')
+    os.makedirs(coord)
+    with open(plan_path, 'w', encoding='utf-8') as f:
+        json.dump(_plan(['no_pwg_w02']), f)
+    with open(os.path.join(coord, 'state.json'), 'w', encoding='utf-8') as f:
+        json.dump({'leases': [{'id': 'no_pwg_w02', 'state': 'prepared'}]}, f)
+    probed = []
+    original_command, original_probe = mao.coordinator_command, mao.probe_fleet
+    mao.coordinator_command = lambda *a, **k: argparse.Namespace(
+        returncode=2, stdout='', stderr='synthetic preflight refusal')
+    mao.probe_fleet = lambda *a, **k: probed.append(1)
+    calls = os.path.join(td, 'o.calls.json')
+    try:
+        try:
+            bsr.run(argparse.Namespace(
+                plan=plan_path, coord_dir=coord, coordinator='coordinator.py', cwd=td,
+                db=os.path.join(td, 'absent.sqlite'), checkpoint=os.path.join(td, 'o.cp.json'),
+                lease_id=None, execute=True, resume=False, report=None, run_id='o',
+                events='events.jsonl', claude_bin='claude', timeout=5,
+                gen_model_version=bsr.DEFAULT_GEN_MODEL_VERSION, only_profile=None,
+                drop_unhealthy=False, stop_before_promote=False, max_windows=None,
+                max_calls=2, call_reservation=calls, max_clean=None, cost_ceiling=None,
+                empty_streak=None, max_accounts=0))
+            raise AssertionError('preflight refusal was ignored')
+        except SystemExit as exc:
+            assert 'preflight refused before probe' in str(exc), exc
+        assert not probed and not os.path.exists(calls)
+    finally:
+        mao.coordinator_command, mao.probe_fleet = original_command, original_probe
+    print('  (o) coordinator preflight refusal occurs before ledger reservation/probe: PASS')
+
+
+def test_p_resume_requires_existing_ledger_run(td):
+    plan_path = os.path.join(td, 'p_plan.json')
+    coord = os.path.join(td, 'p_coord')
+    os.makedirs(coord)
+    with open(plan_path, 'w', encoding='utf-8') as f:
+        json.dump(_plan(['no_pwg_w02']), f)
+    with open(os.path.join(coord, 'state.json'), 'w', encoding='utf-8') as f:
+        json.dump({'leases': [{'id': 'no_pwg_w02', 'state': 'prepared'}]}, f)
+    db_path = os.path.join(td, 'p.sqlite')
+    db = mao.connect(db_path)
+    with db:
+        db.execute(
+            'INSERT INTO accounts(name,config_dir,parked_until,validated,updated_at) '
+            'VALUES(?,?,0,1,?)', ('acc', td, mao.now_iso()))
+    db.close()
+    calls = os.path.join(td, 'p.calls.json')
+    with open(calls, 'w', encoding='utf-8') as f:
+        json.dump({'schema': 'pwg.call_reservation.v1', 'runs': {}}, f)
+    probed = []
+    original_command, original_probe = mao.coordinator_command, mao.probe_fleet
+    mao.coordinator_command = lambda *a, **k: argparse.Namespace(
+        returncode=0, stdout='ok', stderr='')
+    mao.probe_fleet = lambda *a, **k: probed.append(1)
+    try:
+        try:
+            bsr.run(argparse.Namespace(
+                plan=plan_path, coord_dir=coord, coordinator='coordinator.py', cwd=td,
+                db=db_path, checkpoint=os.path.join(td, 'p.cp.json'),
+                lease_id=None, execute=True, resume=True, report=None, run_id=None,
+                events='events.jsonl', claude_bin='claude', timeout=5,
+                gen_model_version=bsr.DEFAULT_GEN_MODEL_VERSION, only_profile=None,
+                drop_unhealthy=False, stop_before_promote=False, max_windows=None,
+                max_calls=2, call_reservation=calls, max_clean=None, cost_ceiling=None,
+                empty_streak=None, max_accounts=0))
+            raise AssertionError('resume created a fresh run in an empty call ledger')
+        except SystemExit as exc:
+            assert 'no existing run' in str(exc), exc
+        assert not probed
+    finally:
+        mao.coordinator_command, mao.probe_fleet = original_command, original_probe
+    print('  (p) --resume requires a pre-existing durable call-ledger run: PASS')
 
 
 def main():
@@ -716,6 +815,8 @@ def main():
         test_l_resume_recovers_abandoned_jobs(td)
         test_m_requeue_resume_after_crash(td)
         test_n_cli_defines_execute_path_args(td)
+        test_o_preflight_before_probe(td)
+        test_p_resume_requires_existing_ledger_run(td)
     print('bounded_staged_run_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/bounded_supervisor.py
+++ b/RussianTranslation/src/pilot/bounded_supervisor.py
@@ -55,6 +55,7 @@ Pure control flow: no model calls, no network, no store mutation, no promotion. 
 side effect is writing the JSON checkpoint.
 """
 import json
+import math
 import os
 import sys
 import tempfile
@@ -148,7 +149,7 @@ class BoundedSupervisor:
     def __init__(self, plan, run_window, checkpoint_path,
                  audit=None, max_windows=None, budget_cap=None,
                  empty_streak_cap=None, cost_fn=None, input_dir=None, resume=False,
-                 max_calls=None, max_clean=None):
+                 max_calls=None, max_clean=None, call_counter=None, usage_counter=None):
         if not callable(run_window):
             raise TypeError('run_window must be callable(window) -> wf_output_path')
         self.plan = [self._normalize_plan(w, i) for i, w in enumerate(plan or [])]
@@ -160,6 +161,8 @@ class BoundedSupervisor:
         self.empty_streak_cap = empty_streak_cap
         self.max_calls = max_calls
         self.max_clean = max_clean
+        self.call_counter = call_counter
+        self.usage_counter = usage_counter
         self.cost_fn = cost_fn or (lambda window, wf_output, report: report.get('cost', 0) or 0)
         self.input_dir = input_dir
         self._own_input_dir = None
@@ -176,9 +179,36 @@ class BoundedSupervisor:
         self.history = []
         self.stop_reason = None
         self._rq_counter = 0
+        self._durable_cost_evaluable = True
 
         if resume and checkpoint_path and os.path.exists(checkpoint_path):
             self._load_checkpoint()
+        self._sync_call_counter()
+        self._sync_usage_counter()
+
+    def _sync_call_counter(self):
+        """Use a durable pre-spawn ledger as the authority when one is supplied."""
+        if self.call_counter is not None:
+            observed = int(self.call_counter())
+            if observed < self.calls_spent:
+                raise ValueError('durable call counter regressed (%d < %d)'
+                                 % (observed, self.calls_spent))
+            self.calls_spent = observed
+        return self.calls_spent
+
+    def _sync_usage_counter(self):
+        if self.usage_counter is not None:
+            usage = self.usage_counter() or {}
+            observed = usage.get('observed_cost_usd')
+            if (isinstance(observed, bool) or not isinstance(observed, (int, float))
+                    or not math.isfinite(observed) or observed < 0):
+                raise ValueError('durable observed cost is invalid: %r' % observed)
+            if observed < self.budget_spent:
+                raise ValueError('durable cost counter regressed (%r < %r)'
+                                 % (observed, self.budget_spent))
+            self.budget_spent = observed
+            self._durable_cost_evaluable = usage.get('cost_evaluable') is True
+        return self.budget_spent
 
     # ---- construction helpers -------------------------------------------------
 
@@ -249,6 +279,17 @@ class BoundedSupervisor:
             return self.summary()
         try:
             while True:
+                self._sync_call_counter()
+                self._sync_usage_counter()
+                if self.max_calls is not None and self.calls_spent >= self.max_calls:
+                    self._finish(STOP_CALL_COUNT)
+                    break
+                if self.budget_cap is not None and not self._durable_cost_evaluable:
+                    self._finish(STOP_COST_UNEVALUABLE)
+                    break
+                if self.budget_cap is not None and self.budget_spent >= self.budget_cap:
+                    self._finish(STOP_BUDGET)
+                    break
                 # (5a) window-count bound — checked before pulling/running new work, so a
                 # cap of N runs EXACTLY N windows.
                 if self.max_windows is not None and self.windows_done >= self.max_windows:
@@ -266,7 +307,18 @@ class BoundedSupervisor:
                     continue
 
                 # (2) RUN — injected; returns a wf_output handle/path.
-                wf_output = self.run_window(item)
+                try:
+                    wf_output = self.run_window(item)
+                except BaseException:
+                    # A worker timeout/crash may leave no auditable wf_output, but its
+                    # pre-spawn reservation is still durable. Under a cost ceiling, an
+                    # unfinalized/unpriced call is the authoritative stop condition.
+                    self._sync_call_counter()
+                    self._sync_usage_counter()
+                    if self.budget_cap is not None and not self._durable_cost_evaluable:
+                        self._finish(STOP_COST_UNEVALUABLE)
+                        break
+                    raise
 
                 # A4 (H1283): a requeue work-item's id (rq-NNN-<lease>) matches no coordinator
                 # lease and no sqlite job, so the injected UNATTENDED run_window no-ops and returns
@@ -299,15 +351,27 @@ class BoundedSupervisor:
                 # (3) AUDIT — injected report, or the H920 gate helper on a tmp dir.
                 report = self._run_audit(wf_output, item)
 
-                raw_cost = self.cost_fn(item, wf_output, report)
+                before_cost = self.budget_spent
+                raw_cost = (self.cost_fn(item, wf_output, report)
+                            if self.usage_counter is None else None)
                 # A None cost means UNEVALUABLE — never coerce it to 0 for accounting. It
                 # only fails the run closed when a cost ceiling (budget_cap) is active
                 # (checked below); with no cost ceiling it is a harmless 0 contribution.
-                cost_unevaluable = raw_cost is None
-                cost = 0 if cost_unevaluable else (raw_cost or 0)
-                self.budget_spent += cost
-                calls = int(report.get('calls') or 0)
-                self.calls_spent += calls
+                if self.usage_counter is None:
+                    cost_unevaluable = raw_cost is None
+                    cost = 0 if cost_unevaluable else (raw_cost or 0)
+                    self.budget_spent += cost
+                else:
+                    self._sync_usage_counter()
+                    cost_unevaluable = not self._durable_cost_evaluable
+                    cost = self.budget_spent - before_cost
+                before_calls = self.calls_spent
+                if self.call_counter is None:
+                    calls = int(report.get('calls') or 0)
+                    self.calls_spent += calls
+                else:
+                    self._sync_call_counter()
+                    calls = self.calls_spent - before_calls
                 self.windows_done += 1
                 self.completed_window_ids.append(item['id'])
 

--- a/RussianTranslation/src/pilot/bounded_supervisor_selftest.py
+++ b/RussianTranslation/src/pilot/bounded_supervisor_selftest.py
@@ -458,6 +458,66 @@ def test_n_default_audit_fail_closed(td):
     print('  (n) default audit unreadable/empty/key-mismatch/gate-crash paths fail closed: PASS')
 
 
+def test_o_durable_call_counter(td):
+    spent = [1]  # e.g. one probe reservation already persisted
+    ran = []
+
+    def runner(window):
+        ran.append(window['id'])
+        spent[0] += 1  # failed/malformed workers still reserve before this result exists
+        return 'opaque'
+
+    audit = lambda _out, _window: {'clean_count': 0, 'requeue_keys': [], 'calls': 0}
+    sup = BoundedSupervisor([{'id': 'w0'}, {'id': 'w1'}], runner,
+                            os.path.join(td, 'o.json'), audit=audit, max_calls=2,
+                            call_counter=lambda: spent[0])
+    summary = sup.run()
+    assert summary['calls_spent'] == 2 and ran == ['w0'], (summary, ran)
+    assert sup.history[0]['calls'] == 1, sup.history
+
+    ran.clear()
+    sup = BoundedSupervisor([{'id': 'never'}], runner, os.path.join(td, 'o-zero.json'),
+                            audit=audit, max_calls=2, call_counter=lambda: spent[0])
+    assert sup.run()['stop_reason'] == STOP_CALL_COUNT and not ran
+    print('  (o) durable pre-spawn ledger is authoritative; probes/failures count before next window: PASS')
+
+
+def test_p_durable_cost_counter(td):
+    usage = {'observed_cost_usd': 0.10, 'cost_evaluable': True}
+    ran = []
+
+    def runner(window):
+        ran.append(window['id'])
+        usage['observed_cost_usd'] = 0.25
+        return 'opaque'
+
+    audit = lambda _out, _window: {'clean_count': 1, 'requeue_keys': []}
+    sup = BoundedSupervisor([{'id': 'w0'}, {'id': 'w1'}], runner,
+                            os.path.join(td, 'p.json'), audit=audit, budget_cap=0.20,
+                            usage_counter=lambda: dict(usage))
+    summary = sup.run()
+    assert summary['stop_reason'] == STOP_BUDGET and summary['budget_spent'] == 0.25
+    assert ran == ['w0'], ran  # observed ceiling is necessarily a post-call stop
+
+    usage.update(observed_cost_usd=0.30, cost_evaluable=False)
+    ran.clear()
+    sup = BoundedSupervisor([{'id': 'never'}], runner, os.path.join(td, 'p-bad.json'),
+                            audit=audit, budget_cap=1.0,
+                            usage_counter=lambda: dict(usage))
+    assert sup.run()['stop_reason'] == STOP_COST_UNEVALUABLE and not ran
+    usage.update(observed_cost_usd=0.30, cost_evaluable=True)
+
+    def crashed(_window):
+        usage['cost_evaluable'] = False
+        raise RuntimeError('worker died before result telemetry')
+
+    sup = BoundedSupervisor([{'id': 'crash'}], crashed, os.path.join(td, 'p-crash.json'),
+                            audit=audit, budget_cap=1.0,
+                            usage_counter=lambda: dict(usage))
+    assert sup.run()['stop_reason'] == STOP_COST_UNEVALUABLE
+    print('  (p) durable probe/worker cost drives post-call ceiling; unevaluable fails before next spawn: PASS')
+
+
 def main():
     with tempfile.TemporaryDirectory() as td:
         test_a_window_count(td)
@@ -474,6 +534,8 @@ def main():
         test_l_cost_unevaluable_harmless_without_ceiling(td)
         test_m_calls_clean_survive_restart(td)
         test_n_default_audit_fail_closed(td)
+        test_o_durable_call_counter(td)
+        test_p_durable_cost_counter(td)
     print('bounded_supervisor_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/call_reservation.py
+++ b/RussianTranslation/src/pilot/call_reservation.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python
+"""Crash-durable, cross-process reservations for paid model calls.
+
+A reservation is the spend decision: it is persisted before the caller is allowed to
+spawn, and is never refunded.  This deliberately counts a crash between reserve() and
+process creation conservatively.
+"""
+import contextlib
+import json
+import math
+import os
+import threading
+import time
+import uuid
+
+SCHEMA = 'pwg.call_reservation.v1'
+TOKEN_FIELDS = ('input_tokens', 'output_tokens', 'cache_read_tokens',
+                'cache_creation_tokens', 'subagent_tokens')
+
+
+def _valid_number(value):
+    return (isinstance(value, (int, float)) and not isinstance(value, bool)
+            and math.isfinite(value) and value >= 0)
+
+
+def normalize_telemetry(value):
+    """Validate one call's final telemetry and return its canonical representation."""
+    if not isinstance(value, dict):
+        raise ValueError('call telemetry must be an object')
+    evaluable = value.get('cost_evaluable')
+    if not isinstance(evaluable, bool):
+        raise ValueError('call telemetry cost_evaluable must be boolean')
+    out = {'cost_evaluable': evaluable}
+    for name in TOKEN_FIELDS:
+        number = value.get(name, 0)
+        if not _valid_number(number):
+            raise ValueError('%s must be finite, non-negative and non-boolean' % name)
+        out[name] = number
+    cost = value.get('observed_cost_usd', 0)
+    if not _valid_number(cost):
+        raise ValueError('observed_cost_usd must be finite, non-negative and non-boolean')
+    if evaluable and 'observed_cost_usd' not in value:
+        raise ValueError('evaluable telemetry requires observed_cost_usd')
+    out['observed_cost_usd'] = cost
+    return out
+
+
+def unevaluable_telemetry():
+    return normalize_telemetry({'cost_evaluable': False})
+
+
+def telemetry_from_cli_wrapper(wrapper):
+    """Extract trustworthy CLI usage without ever admitting invalid numeric telemetry."""
+    if not isinstance(wrapper, dict):
+        return unevaluable_telemetry()
+    usage = wrapper.get('usage')
+    valid = isinstance(usage, dict)
+    values = {}
+    mapping = {
+        'input_tokens': 'input_tokens',
+        'output_tokens': 'output_tokens',
+        'cache_read_tokens': 'cache_read_input_tokens',
+        'cache_creation_tokens': 'cache_creation_input_tokens',
+    }
+    for target, source in mapping.items():
+        raw = usage.get(source, 0) if isinstance(usage, dict) else 0
+        if not _valid_number(raw):
+            valid = False
+            raw = 0
+        values[target] = raw
+    values['subagent_tokens'] = sum(values.values())
+    cost = wrapper.get('total_cost_usd')
+    if not _valid_number(cost):
+        valid = False
+        cost = 0
+    values['observed_cost_usd'] = cost
+    values['cost_evaluable'] = valid
+    return normalize_telemetry(values)
+
+
+def _empty_usage():
+    return {
+        'input_tokens': 0, 'output_tokens': 0, 'cache_read_tokens': 0,
+        'cache_creation_tokens': 0, 'subagent_tokens': 0,
+        'observed_cost_usd': 0.0, 'cost_evaluable': True,
+        'finalized_calls': 0, 'unevaluable_calls': 0, 'pending_calls': 0,
+    }
+
+
+class CallLimitReached(RuntimeError):
+    pass
+
+
+_THREAD_LOCKS = {}
+_THREAD_LOCKS_GUARD = threading.Lock()
+
+
+def _thread_lock(path):
+    key = os.path.normcase(os.path.abspath(path))
+    with _THREAD_LOCKS_GUARD:
+        return _THREAD_LOCKS.setdefault(key, threading.RLock())
+
+
+@contextlib.contextmanager
+def _os_lock(path):
+    """Serialize both threads and processes on Windows and POSIX."""
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    local = _thread_lock(path)
+    with local:
+        fh = open(path, 'a+b')
+        try:
+            if os.name == 'nt':
+                import msvcrt
+                fh.seek(0, os.SEEK_END)
+                if fh.tell() == 0:
+                    fh.write(b'\0')
+                    fh.flush()
+                fh.seek(0)
+                msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                fh.seek(0)
+                if os.name == 'nt':
+                    import msvcrt
+                    msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            finally:
+                fh.close()
+
+
+def _read(path):
+    if not os.path.exists(path):
+        return {'schema': SCHEMA, 'runs': {}}
+    with open(path, encoding='utf-8') as f:
+        value = json.load(f)
+    if (not isinstance(value, dict) or value.get('schema') != SCHEMA
+            or not isinstance(value.get('runs'), dict)):
+        raise ValueError('call reservation ledger schema mismatch: %s' % path)
+    for run_id, run in value['runs'].items():
+        if not isinstance(run_id, str) or not run_id or not isinstance(run, dict):
+            raise ValueError('call reservation ledger has an invalid run: %s' % path)
+        limit = run.get('max_calls')
+        if limit is not None and (
+                isinstance(limit, bool) or not isinstance(limit, int) or limit < 0):
+            raise ValueError('%s: saved max_calls is invalid' % run_id)
+        reservations = run.get('reservations')
+        spent = run.get('calls_spent')
+        next_ordinal = run.get('next_ordinal')
+        if (not isinstance(reservations, list)
+                or isinstance(spent, bool) or not isinstance(spent, int) or spent < 0
+                or spent != len(reservations)
+                or isinstance(next_ordinal, bool)
+                or not isinstance(next_ordinal, int)
+                or next_ordinal != spent + 1):
+            raise ValueError('%s: reservation counters are inconsistent' % run_id)
+        ids, ordinals = set(), []
+        for item in reservations:
+            if (not isinstance(item, dict)
+                    or not isinstance(item.get('reservation_id'), str)
+                    or not item['reservation_id']
+                    or item['reservation_id'] in ids
+                    or isinstance(item.get('ordinal'), bool)
+                    or not isinstance(item.get('ordinal'), int)
+                    or not isinstance(item.get('purpose'), str)
+                    or not item['purpose']):
+                raise ValueError('%s: reservation entry is invalid' % run_id)
+            ids.add(item['reservation_id'])
+            ordinals.append(item['ordinal'])
+            if item.get('finalized'):
+                normalize_telemetry(item.get('telemetry'))
+        if ordinals != list(range(1, spent + 1)):
+            raise ValueError('%s: reservation ordinals are inconsistent' % run_id)
+        # ``usage`` was added to the same v1 schema after the original
+        # reservation-only deployment.  Its one supported migration is handled
+        # by _initialize; once present it must exactly equal the reservations.
+        usage = run.get('usage')
+        if usage is not None:
+            expected = _empty_usage()
+            expected['pending_calls'] = 0
+            for item in reservations:
+                if not item.get('finalized'):
+                    expected['pending_calls'] += 1
+                    continue
+                telemetry = normalize_telemetry(item['telemetry'])
+                for name in TOKEN_FIELDS:
+                    expected[name] += telemetry[name]
+                expected['observed_cost_usd'] += telemetry['observed_cost_usd']
+                expected['finalized_calls'] += 1
+                if not telemetry['cost_evaluable']:
+                    expected['unevaluable_calls'] += 1
+            expected['cost_evaluable'] = (
+                expected['pending_calls'] == 0
+                and expected['unevaluable_calls'] == 0)
+            if usage != expected:
+                raise ValueError('%s: cumulative usage is inconsistent' % run_id)
+    return value
+
+
+def _durable_replace(source, destination):
+    """Publish a ledger update with write-through rename semantics."""
+    if os.name == 'nt':
+        import ctypes
+        from ctypes import wintypes
+        move = ctypes.WinDLL('kernel32', use_last_error=True).MoveFileExW
+        move.argtypes = [wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD]
+        move.restype = wintypes.BOOL
+        # REPLACE_EXISTING | WRITE_THROUGH
+        if not move(source, destination, 0x1 | 0x8):
+            raise OSError(ctypes.get_last_error(), 'MoveFileExW failed', destination)
+        return
+    os.replace(source, destination)
+    directory = os.path.dirname(os.path.abspath(destination)) or '.'
+    flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0)
+    fd = os.open(directory, flags)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _write(path, value):
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    tmp = '%s.tmp.%d.%s' % (path, os.getpid(), uuid.uuid4().hex)
+    try:
+        with open(tmp, 'w', encoding='utf-8', newline='\n') as f:
+            json.dump(value, f, ensure_ascii=False, indent=1)
+            f.write('\n')
+            f.flush()
+            os.fsync(f.fileno())
+        _durable_replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+class CallReservationLedger:
+    """One run's view of a ledger shared by all probes and workers."""
+
+    def __init__(self, path, run_id, max_calls=None):
+        if not path:
+            raise ValueError('call reservation path is required')
+        if not run_id:
+            raise ValueError('call reservation run_id is required')
+        if max_calls is not None and (
+                isinstance(max_calls, bool) or not isinstance(max_calls, int) or max_calls < 0):
+            raise ValueError('max_calls must be a non-negative integer or None')
+        self.path = os.path.abspath(path)
+        self.lock_path = self.path + '.lock'
+        self.run_id = str(run_id)
+        self.max_calls = max_calls
+        self._initialize()
+
+    def _initialize(self):
+        with _os_lock(self.lock_path):
+            data = _read(self.path)
+            run = data['runs'].get(self.run_id)
+            if run is None:
+                run = {'max_calls': self.max_calls, 'calls_spent': 0,
+                       'next_ordinal': 1, 'reservations': [], 'usage': _empty_usage()}
+                data['runs'][self.run_id] = run
+                _write(self.path, data)
+                return
+            saved = run.get('max_calls')
+            if saved != self.max_calls:
+                raise ValueError(
+                    'call reservation max_calls mismatch for run %s: saved=%r requested=%r'
+                    % (self.run_id, saved, self.max_calls))
+            if 'usage' not in run:
+                # Forward-compatible adoption of a v1 reservation-only file.
+                usage = _empty_usage()
+                usage['pending_calls'] = sum(
+                    not item.get('finalized') for item in run.get('reservations', []))
+                usage['cost_evaluable'] = usage['pending_calls'] == 0
+                run['usage'] = usage
+                _write(self.path, data)
+
+    def reserve(self, purpose, profile=None, detail=None):
+        """Atomically spend one call slot and return its durable reservation."""
+        with _os_lock(self.lock_path):
+            data = _read(self.path)
+            run = data['runs'].get(self.run_id)
+            if run is None:
+                raise ValueError('call reservation run disappeared: %s' % self.run_id)
+            spent = int(run.get('calls_spent') or 0)
+            limit = run.get('max_calls')
+            if limit is not None and spent >= int(limit):
+                raise CallLimitReached(
+                    'model call ceiling reached for run %s (%d/%d)'
+                    % (self.run_id, spent, int(limit)))
+            ordinal = int(run.get('next_ordinal') or (spent + 1))
+            item = {
+                'reservation_id': uuid.uuid4().hex,
+                'ordinal': ordinal,
+                'reserved_at_ns': time.time_ns(),
+                'pid': os.getpid(),
+                'purpose': str(purpose),
+            }
+            if profile is not None:
+                item['profile'] = str(profile)
+            if detail is not None:
+                item['detail'] = str(detail)
+            run.setdefault('reservations', []).append(item)
+            run['calls_spent'] = spent + 1
+            run['next_ordinal'] = ordinal + 1
+            usage = run.setdefault('usage', _empty_usage())
+            usage['pending_calls'] = int(usage.get('pending_calls') or 0) + 1
+            usage['cost_evaluable'] = False
+            _write(self.path, data)
+            return dict(item)
+
+    def finalize(self, reservation, telemetry):
+        """Idempotently attach validated telemetry and fold it into the durable run summary."""
+        normalized = normalize_telemetry(telemetry)
+        reservation_id = (reservation.get('reservation_id')
+                          if isinstance(reservation, dict) else reservation)
+        if not reservation_id:
+            raise ValueError('reservation_id is required for finalization')
+        with _os_lock(self.lock_path):
+            data = _read(self.path)
+            run = data['runs'].get(self.run_id)
+            if run is None:
+                raise ValueError('call reservation run disappeared: %s' % self.run_id)
+            item = next((row for row in run.get('reservations', [])
+                         if row.get('reservation_id') == reservation_id), None)
+            if item is None:
+                raise ValueError('unknown call reservation: %s' % reservation_id)
+            if item.get('finalized'):
+                if item.get('telemetry') != normalized:
+                    raise ValueError('reservation already finalized with different telemetry')
+                return dict(item)
+            item['finalized'] = True
+            item['finalized_at_ns'] = time.time_ns()
+            item['telemetry'] = normalized
+            usage = run.setdefault('usage', _empty_usage())
+            for name in TOKEN_FIELDS:
+                usage[name] = usage.get(name, 0) + normalized[name]
+            usage['observed_cost_usd'] = (
+                usage.get('observed_cost_usd', 0.0) + normalized['observed_cost_usd'])
+            usage['finalized_calls'] = int(usage.get('finalized_calls') or 0) + 1
+            usage['pending_calls'] = max(0, int(usage.get('pending_calls') or 0) - 1)
+            if not normalized['cost_evaluable']:
+                usage['unevaluable_calls'] = int(usage.get('unevaluable_calls') or 0) + 1
+            usage['cost_evaluable'] = (
+                int(usage.get('pending_calls') or 0) == 0
+                and int(usage.get('unevaluable_calls') or 0) == 0)
+            _write(self.path, data)
+            return dict(item)
+
+    def snapshot(self):
+        with _os_lock(self.lock_path):
+            run = _read(self.path)['runs'].get(self.run_id)
+            if run is None:
+                raise ValueError('call reservation run missing: %s' % self.run_id)
+            return json.loads(json.dumps(run))
+
+    def spent(self):
+        return int(self.snapshot().get('calls_spent') or 0)
+
+    def usage(self):
+        return dict(self.snapshot().get('usage') or _empty_usage())
+
+
+def run_ids(path):
+    """Return existing run IDs without creating a run."""
+    lock_path = os.path.abspath(path) + '.lock'
+    with _os_lock(lock_path):
+        return sorted(_read(os.path.abspath(path))['runs'])

--- a/RussianTranslation/src/pilot/call_reservation_selftest.py
+++ b/RussianTranslation/src/pilot/call_reservation_selftest.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+"""Hermetic self-test for the paid-call reservation ledger."""
+import multiprocessing
+import json
+import os
+import subprocess
+import tempfile
+from types import SimpleNamespace
+
+from call_reservation import (CallLimitReached, CallReservationLedger,
+                              normalize_telemetry, unevaluable_telemetry)
+
+
+def _race(path, run_id, limit, out):
+    ledger = CallReservationLedger(path, run_id, limit)
+    try:
+        out.put(ledger.reserve('race')['ordinal'])
+    except CallLimitReached:
+        out.put(None)
+
+
+def main():
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, 'calls.json')
+        zero = CallReservationLedger(path, 'zero', 0)
+        try:
+            zero.reserve('worker')
+            raise AssertionError('max_calls=0 permitted a reservation')
+        except CallLimitReached:
+            pass
+        assert zero.spent() == 0
+
+        one = CallReservationLedger(path, 'one', 1)
+        one.reserve('probe:warmup')
+        try:
+            one.reserve('probe:measured')
+            raise AssertionError('max_calls=1 permitted a second reservation')
+        except CallLimitReached:
+            pass
+        assert one.spent() == 1
+
+        q = multiprocessing.Queue()
+        procs = [multiprocessing.Process(target=_race, args=(path, 'race', 7, q))
+                 for _ in range(20)]
+        for proc in procs:
+            proc.start()
+        for proc in procs:
+            proc.join(20)
+            assert proc.exitcode == 0, proc.exitcode
+        won = [q.get(timeout=2) for _ in procs]
+        assert len([x for x in won if x is not None]) == 7, won
+        resumed = CallReservationLedger(path, 'race', 7)
+        assert resumed.spent() == 7
+        try:
+            resumed.reserve('resume')
+            raise AssertionError('resume exceeded the durable ceiling')
+        except CallLimitReached:
+            pass
+
+        cumulative = CallReservationLedger(path, 'usage', 3)
+        failed = cumulative.reserve('failed')
+        cumulative.finalize(failed, unevaluable_telemetry())
+        # Exact replay is idempotent; a conflicting replay is refused.
+        cumulative.finalize(failed, unevaluable_telemetry())
+        try:
+            cumulative.finalize(
+                failed, {'cost_evaluable': True, 'observed_cost_usd': 1.0})
+            raise AssertionError('conflicting finalization was accepted')
+        except ValueError:
+            pass
+        success = cumulative.reserve('success')
+        cumulative.finalize(success, {
+            'cost_evaluable': True, 'observed_cost_usd': 0.25,
+            'input_tokens': 10, 'output_tokens': 2,
+        })
+        usage = cumulative.usage()
+        assert usage['finalized_calls'] == 2 and usage['unevaluable_calls'] == 1, usage
+        assert usage['cost_evaluable'] is False and usage['observed_cost_usd'] == 0.25, usage
+        for bad in (float('nan'), -1, True):
+            try:
+                normalize_telemetry({
+                    'cost_evaluable': True, 'observed_cost_usd': bad})
+                raise AssertionError('invalid telemetry accepted: %r' % bad)
+            except ValueError:
+                pass
+            try:
+                normalize_telemetry({
+                    'cost_evaluable': True, 'observed_cost_usd': 0,
+                    'input_tokens': bad})
+                raise AssertionError('invalid token telemetry accepted: %r' % bad)
+            except ValueError:
+                pass
+
+        # Probe integration: the profile claim covers the pair and each phase reserves before
+        # entering the raw call. A malformed warmup spends one; a measured timeout spends two.
+        import max_account_orchestrator as mao
+        cfg = os.path.join(td, 'cfg')
+        os.makedirs(cfg)
+        original_runner = mao.run_tree_kill
+        try:
+            calls = []
+
+            def success_runner(*_args, **_kwargs):
+                calls.append(1)
+                # A nested claim must fail: live_probe still owns the pair-wide profile lock.
+                try:
+                    with mao.ActiveCallClaim(mao.config_dir_fingerprint(cfg)):
+                        raise AssertionError('profile claim was released within probe pair')
+                except RuntimeError:
+                    pass
+                return SimpleNamespace(
+                    returncode=0, stderr='', stdout=json.dumps({
+                        'type': 'result', 'subtype': 'success', 'is_error': False,
+                        'structured_output': {'ok': True},
+                        'usage': {'input_tokens': 3, 'output_tokens': 1},
+                        'total_cost_usd': 0.01,
+                    }))
+
+            mao.run_tree_kill = success_runner
+            probes = CallReservationLedger(path, 'probes-ok', 2)
+            assert mao.live_probe(cfg, call_reservation=probes, account='a') < 30000
+            assert probes.spent() == 2 and len(calls) == 2
+            assert probes.usage()['observed_cost_usd'] == 0.02
+
+            mao.run_tree_kill = lambda *_a, **_k: SimpleNamespace(
+                returncode=0, stderr='', stdout='not-json')
+            malformed = CallReservationLedger(path, 'probe-malformed', 3)
+            try:
+                mao.live_probe(cfg, call_reservation=malformed, account='a')
+                raise AssertionError('malformed warmup was accepted')
+            except SystemExit:
+                pass
+            assert malformed.spent() == 1 and malformed.usage()['cost_evaluable'] is False
+
+            phase = [0]
+
+            def timeout_runner(*args, **kwargs):
+                phase[0] += 1
+                if phase[0] == 2:
+                    raise subprocess.TimeoutExpired(args[0] if args else 'probe', 1)
+                return success_runner(*args, **kwargs)
+
+            mao.run_tree_kill = timeout_runner
+            timeout = CallReservationLedger(path, 'probe-timeout', 3)
+            try:
+                mao.live_probe(cfg, call_reservation=timeout, account='a')
+                raise AssertionError('measured timeout was accepted')
+            except SystemExit:
+                pass
+            assert timeout.spent() == 2 and timeout.usage()['cost_evaluable'] is False
+        finally:
+            mao.run_tree_kill = original_runner
+
+        import latency_payload_sweep as sweep
+        sweep_zero = CallReservationLedger(path, 'sweep-zero', 0)
+        try:
+            sweep.one_call(
+                cfg, 'claude', 30, route='test', window='w', account_label='a',
+                sample_index=0, warmup=False, git_sha='x', cli_version='x',
+                # `active_claim` is REQUIRED keyword-only on one_call; None is its documented
+                # "acquire one for me" contract (_probe_call self-claims when it is None). The
+                # selftest omitted it entirely, so this case raised TypeError before it could
+                # ever reach the max_calls=0 refusal it exists to prove. Found on rebase onto
+                # master, 26-07-2026 -- the defect is in the branch as delivered, not the rebase.
+                call_reservation=sweep_zero, active_claim=None)
+            raise AssertionError('latency sweep bypassed max_calls=0')
+        except CallLimitReached:
+            pass
+        assert sweep_zero.spent() == 0
+    print('call_reservation_selftest: PASS (0/1/N, race/resume, finalization, probes/cost)')
+
+
+if __name__ == '__main__':
+    multiprocessing.freeze_support()
+    main()

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -10,6 +10,7 @@ from collections import Counter
 import copy
 import datetime
 import glob
+import hashlib
 import json
 import os
 import re
@@ -60,6 +61,7 @@ if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
 import promote_final_cards  # noqa: E402
+import promotion_journal  # noqa: E402
 from safe_filename import safe_name  # noqa: E402
 import translation_memory  # noqa: E402
 import verb_worklist  # noqa: E402
@@ -68,6 +70,7 @@ from window_common import (  # noqa: E402
     atomic_write_json,
     atomic_write_text,
     defer_monster,
+    fsync_existing_path,
     sha256_file,
 )
 
@@ -101,6 +104,7 @@ def paths():
         'state': os.path.join(base, 'state.json'),
         'lock': os.path.join(base, '.state.lock'),
         'promotion_lock': os.path.join(base, '.promotion.lock'),
+        'promotions': os.path.join(base, 'promotions'),
         'registry': os.path.join(base, 'artifact_registry.jsonl'),
         'daily': os.path.join(base, 'daily_metrics.jsonl'),
         'dashboard': os.path.join(base, 'dashboard.json'),
@@ -124,6 +128,7 @@ def ensure_dirs():
     p = paths()
     os.makedirs(p['base'], exist_ok=True)
     os.makedirs(p['artifacts'], exist_ok=True)
+    os.makedirs(p['promotions'], exist_ok=True)
     return p
 
 
@@ -275,7 +280,8 @@ def load_state():
     return state
 
 
-def save_state(state):
+def prepare_state_for_save(state, updated_at=None):
+    """Normalize state exactly once so promotion can seal the bytes before replacement."""
     p = ensure_dirs()
     expire_stale_leases(state)
     normalize_lease_reservations(state)
@@ -286,7 +292,16 @@ def save_state(state):
         (int(lease.get('runtime_limit') or TRANSLATION_LIMIT) for lease in running),
         default=TRANSLATION_LIMIT) if state['runtime_mode'] == 'staged-probed'
                               else TRANSLATION_LIMIT)
-    state['updated_at'] = utc_now()
+    state['updated_at'] = updated_at or utc_now()
+    return p
+
+
+def serialized_state(state):
+    return json.dumps(state, ensure_ascii=False, indent=1).encode('utf-8')
+
+
+def save_state(state, updated_at=None):
+    p = prepare_state_for_save(state, updated_at=updated_at)
     atomic_write_json(p['state'], state, indent=1)
     write_dashboard(state)
 
@@ -444,7 +459,7 @@ def artifact_dir(lease_id):
 
 def append_jsonl(path, rec):
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    append_jsonl_line(path, rec)
+    append_jsonl_line(path, rec, durable=True)
 
 
 def registry_event(lease, event_type, data=None):
@@ -460,6 +475,73 @@ def registry_event(lease, event_type, data=None):
         'data': data or {},
     }
     append_jsonl(paths()['registry'], rec)
+
+
+def promotion_registry_record(lease, promotion_id, data=None, event_ts=None):
+    """Build the deterministic registry projection sealed into the journal."""
+    payload = dict(data or {})
+    payload['promotion_id'] = promotion_id
+    return {
+        'schema': REGISTRY_SCHEMA,
+        'ts': event_ts or utc_now(),
+        'lease_id': lease.get('id'),
+        'event': 'promoted',
+        'kind': lease.get('kind'),
+        'target': lease.get('target'),
+        'state': lease.get('state'),
+        'artifact_dir': lease.get('artifact_dir'),
+        'data': payload,
+    }
+
+
+def append_promotion_registry_record(expected):
+    """Durably append or re-adopt one exact promotion registry projection."""
+    registry = paths()['registry']
+    if os.path.exists(registry):
+        raw = open(registry, 'rb').read()
+        if raw and not raw.endswith(b'\n'):
+            raise promotion_journal.JournalError(
+                'artifact registry is not newline-terminated; refusing a '
+                'possibly short/non-durable append')
+        try:
+            text = raw.decode('utf-8')
+        except UnicodeDecodeError as exc:
+            raise promotion_journal.JournalError(
+                'artifact registry is not valid UTF-8: %s' % exc) from exc
+        for line_number, line in enumerate(text.splitlines(), 1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise promotion_journal.JournalError(
+                    'artifact registry has malformed JSONL at line %d: %s'
+                    % (line_number, exc)) from exc
+            if not isinstance(row, dict):
+                raise promotion_journal.JournalError(
+                    'artifact registry line %d is not an object'
+                    % line_number)
+            if (row.get('lease_id') == expected.get('lease_id')
+                    and row.get('event') == 'promoted'
+                    and (row.get('data') or {}).get(
+                        'promotion_id') == (
+                            expected.get('data') or {}).get('promotion_id')):
+                if row != expected:
+                    raise promotion_journal.JournalError(
+                        'artifact registry promotion identity exists with '
+                        'different payload')
+                # A prior append may have written every byte but failed its
+                # fsync.  Retry adoption only after durability succeeds now.
+                fsync_existing_path(registry)
+                return False
+    append_jsonl(registry, expected)
+    return True
+
+
+def registry_promotion_event(lease, promotion_id, data=None, event_ts=None):
+    """Append exactly one promoted event for a lease/promotion pair."""
+    return append_promotion_registry_record(promotion_registry_record(
+        lease, promotion_id, data, event_ts))
 
 
 def run_cmd(cmd, cwd=REPO, check=True, timeout=None):
@@ -616,6 +698,8 @@ def begin_run_leases(state, lease_ids, mode='standard', run_id=None,
 def begin_run(args):
     with DirLock(paths()['lock']):
         state = load_state()
+        for lease_id in args.lease_id:
+            validate_lease_preflight(lease_by_id(state, lease_id))
         leases = begin_run_leases(
             state, args.lease_id, mode=args.mode, run_id=args.run_id,
             probe_receipt=args.probe_receipt)
@@ -866,6 +950,8 @@ def register_prepared_lease(lease_id, lane, keys, harness, manifest, preflight_p
             'origin_execution_manifest': os.path.abspath(manifest),
             'origin_execution_manifest_sha256': sha256_file(manifest),
             'preflight_path': os.path.abspath(preflight_path),
+            'preflight_sha256': sha256_file(preflight_path),
+            'preflight_allow_over_cost': False,
         }
         state['leases'].append(lease)
         save_state(state)
@@ -883,10 +969,35 @@ def enforce_cost_gate(preflight_path, target, allow_over_cost=False):
     try:
         with open(preflight_path, encoding='utf-8') as f:
             data = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return
-    for rep in (data.get('reports') or [data]):
-        cg = rep.get('cost_gate') or {}
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(
+            'COST-GATE: required preflight is unreadable (%s): %s'
+            % (preflight_path, exc))
+    if not isinstance(data, dict):
+        raise SystemExit('COST-GATE: required preflight top level is not an object: %s'
+                         % preflight_path)
+    schema = data.get('schema')
+    if schema == 'pwg.performance_preflight.v1':
+        reports = [data]
+    elif schema == 'pwg.performance_preflight.matrix.v1':
+        reports = data.get('reports')
+    else:
+        raise SystemExit(
+            'COST-GATE: required preflight has unsupported schema %r: %s'
+            % (schema, preflight_path))
+    if not isinstance(reports, list) or not reports:
+        raise SystemExit('COST-GATE: required preflight has no reports: %s'
+                         % preflight_path)
+    for index, rep in enumerate(reports):
+        if not isinstance(rep, dict):
+            raise SystemExit(
+                'COST-GATE: preflight report %d is not an object: %s'
+                % (index, preflight_path))
+        cg = rep.get('cost_gate')
+        if not isinstance(cg, dict) or not isinstance(cg.get('over_ceiling'), bool):
+            raise SystemExit(
+                'COST-GATE: preflight report %d has no boolean cost verdict: %s'
+                % (index, preflight_path))
         if not cg.get('over_ceiling'):
             continue
         part = rep.get('cost_partition') or {}
@@ -905,6 +1016,47 @@ def enforce_cost_gate(preflight_path, target, allow_over_cost=False):
                 % (target or rep.get('root'), cg.get('est_cost_usd') or 0.0,
                    cg.get('est_cost_per_card_usd') or 0.0,
                    len(part.get('run_now') or []), len(part.get('defer_monster') or [])))
+
+
+def validate_lease_preflight(lease):
+    """Recheck the sealed cost estimate immediately before a lease can consume runtime."""
+    path = lease.get('preflight_path')
+    expected = lease.get('preflight_sha256')
+    if not path or not expected:
+        raise SystemExit(
+            '%s: prepared lease has no sealed preflight evidence; reprepare it'
+            % lease.get('id'))
+    try:
+        actual = sha256_file(path)
+    except OSError as exc:
+        raise SystemExit('%s: sealed preflight is unreadable: %s'
+                         % (lease.get('id'), exc))
+    if actual != expected:
+        raise SystemExit(
+            '%s: sealed preflight hash changed (expected %s, actual %s)'
+            % (lease.get('id'), expected, actual))
+    enforce_cost_gate(
+        path, lease.get('target'),
+        allow_over_cost=bool(lease.get('preflight_allow_over_cost')))
+    return path
+
+
+def validate_preflight_command(args):
+    lease_ids = list(args.lease_id or [])
+    if not lease_ids or len(lease_ids) != len(set(lease_ids)):
+        raise SystemExit('validate-preflight requires unique lease IDs')
+    with DirLock(paths()['lock']):
+        state = load_state()
+        validated = [
+            {'lease_id': lease_id,
+             'preflight': validate_lease_preflight(lease_by_id(state, lease_id))}
+            for lease_id in lease_ids
+        ]
+    print(json.dumps({
+        'schema': 'pwg.coordinator.preflight_validation.v1',
+        'ok': True,
+        'leases': validated,
+    }, ensure_ascii=False, indent=1))
 
 
 def _run_child_inproc(argv, timeout=None):
@@ -1019,6 +1171,9 @@ def prepare(args, run_child=None):
         lease['config_dir'] = os.path.abspath(args.config_dir) if args.config_dir else None
         lease['executor_lane'] = args.executor_lane
         lease['preflight_path'] = preflight_path
+        lease['preflight_sha256'] = sha256_file(preflight_path)
+        lease['preflight_allow_over_cost'] = bool(
+            getattr(args, 'allow_over_cost', False))
         clear_operation(lease)
         save_state(state)
         registry_event(lease, 'prepared', {'harness': harness, 'manifest': manifest,
@@ -1038,6 +1193,43 @@ def normalize_workflow_result(src_path, dst_path):
         raise SystemExit('workflow result is not an object')
     atomic_write_json(dst_path, result, indent=None)
     return result
+
+
+def seal_workflow_submission(src_path, artifact_path, expected_sha256):
+    """Copy once, hash the copied bytes, and audit only that immutable submission."""
+    if not expected_sha256 or not re.fullmatch(r'[0-9a-fA-F]{64}', expected_sha256):
+        raise SystemExit('record-output requires a valid --result-sha256')
+    expected_sha256 = expected_sha256.lower()
+    os.makedirs(artifact_path, exist_ok=True)
+    destination = os.path.join(
+        artifact_path, 'submitted_result.%s.json' % expected_sha256[:16])
+    if os.path.exists(destination):
+        if sha256_file(destination) != expected_sha256:
+            raise SystemExit('sealed result destination has unexpected bytes: %s'
+                             % destination)
+        return destination
+    tmp = '%s.tmp.%s' % (destination, uuid.uuid4().hex)
+    digest = hashlib.sha256()
+    try:
+        with open(src_path, 'rb') as source, open(tmp, 'wb') as target:
+            for chunk in iter(lambda: source.read(1024 * 1024), b''):
+                digest.update(chunk)
+                target.write(chunk)
+            target.flush()
+            os.fsync(target.fileno())
+        actual = digest.hexdigest()
+        if actual != expected_sha256:
+            raise SystemExit(
+                'result substitution refused (expected %s, copied %s)'
+                % (expected_sha256, actual))
+        os.replace(tmp, destination)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+    return destination
 
 
 def clean_result_payload(result, rejected):
@@ -1426,15 +1618,36 @@ def record_output(args):
         # any state is persisted. Raising here discards begin_operation's in-memory mutation (state
         # is not saved yet), leaving the on-disk lease 'running' for a correct retry.
         supplied_run_id = getattr(args, 'run_id', None)
+        expected_run_id = lease.get('run_id')
+        if expected_run_id and supplied_run_id is None:
+            raise SystemExit(
+                '%s: record-output --run-id is required for running lease run-id %r '
+                '(unbound result submission refused)' % (args.lease_id, expected_run_id))
         if supplied_run_id is not None and supplied_run_id != lease.get('run_id'):
             raise SystemExit(
                 '%s: record-output --run-id %r does not match the running lease run-id %r '
                 '(stale/zombie run submission refused)' %
                 (args.lease_id, supplied_run_id, lease.get('run_id')))
+        supplied_result_sha256 = getattr(args, 'result_sha256', None)
+        if expected_run_id and supplied_result_sha256 is None:
+            raise SystemExit(
+                '%s: record-output --result-sha256 is required for a sealed run '
+                '(unbound result bytes refused)' % args.lease_id)
+        processing_args = copy.copy(args)
+        if supplied_result_sha256 is not None:
+            result_artifact_dir = (
+                lease.get('current_artifact_dir')
+                or lease.get('artifact_dir')
+                or artifact_dir(args.lease_id))
+            sealed_result = seal_workflow_submission(
+                args.workflow_result, result_artifact_dir, supplied_result_sha256)
+            processing_args.workflow_result = sealed_result
+            lease['submitted_result_path'] = sealed_result
+            lease['submitted_result_sha256'] = supplied_result_sha256.lower()
         save_state(state)
         working = copy.deepcopy(lease)
     try:
-        audit, manifest, adir, pending = process_record_output(working, args)
+        audit, manifest, adir, pending = process_record_output(working, processing_args)
     except BaseException as exc:
         block_operation(args.lease_id, token, 'auditing', exc)
         raise
@@ -1475,6 +1688,58 @@ def record_output(args):
     if audit.stderr.strip():
         print(audit.stderr.rstrip(), file=sys.stderr)
     print('lease %s -> %s' % (lease['id'], lease['state']))
+
+
+RECORD_BATCH_SCHEMA = 'pwg.record_output_batch.v1'
+
+
+def _record_batch_progress(recorded, records, failed=None):
+    payload = {
+        'schema': RECORD_BATCH_SCHEMA,
+        'recorded': list(recorded),
+        'remaining': [row[0] for row in records[len(recorded):]],
+        'failed': failed,
+    }
+    print('RECORD_OUTPUT_BATCH_PROGRESS: ' +
+          json.dumps(payload, ensure_ascii=False, separators=(',', ':')))
+
+
+def record_output_batch(args):
+    """Record N completed leases in one coordinator parent process.
+
+    Each item still executes the existing :func:`record_output` unit with its own operation token,
+    locks, isolated ``audit_window`` child/timeout, report, and state commit. The batch is
+    deliberately sequential and fail-fast: earlier commits remain durable, the failing item and
+    later leases remain retryable. A machine-readable progress line after every commit (and on
+    failure) lets the outer SQLite scheduler mark exactly the completed prefix.
+    """
+    records = [tuple(row) for row in (getattr(args, 'record', None) or [])]
+    if not records:
+        raise SystemExit(
+            'record-output-batch requires at least one '
+            '--record LEASE RESULT RUN_ID RESULT_SHA256')
+    lease_ids = [row[0] for row in records]
+    if len(lease_ids) != len(set(lease_ids)):
+        raise SystemExit('record-output-batch refuses duplicate lease ids')
+    recorded = []
+    for lease_id, workflow_result, run_id, result_sha256 in records:
+        one = argparse.Namespace(
+            lease_id=lease_id,
+            workflow_result=workflow_result,
+            transcript_dir=None,
+            allow_stale=getattr(args, 'allow_stale', False),
+            run_id=None if run_id == '-' else run_id,
+            result_sha256=None if result_sha256 == '-' else result_sha256,
+        )
+        try:
+            record_output(one)
+        except BaseException as exc:
+            _record_batch_progress(
+                recorded, records,
+                failed={'lease_id': lease_id, 'type': type(exc).__name__, 'message': str(exc)})
+            raise
+        recorded.append(lease_id)
+        _record_batch_progress(recorded, records)
 
 
 def prepare_requeue(args):
@@ -1553,6 +1818,19 @@ def prepare_requeue(args):
             os.makedirs(attempt_dir, exist_ok=False)
             created = True
             atomic_write_text(rq, '\n'.join(requeue_keys) + '\n')
+            preflight_path = os.path.join(attempt_dir, 'preflight.json')
+            preflight_cmd = [
+                sys.executable, os.path.join(HERE, 'perf_preflight.py'),
+                ('nominal_%s' % lease['id']) if nominal else root,
+                '--keys=%s' % ','.join(requeue_keys), '--json',
+            ]
+            if nominal:
+                preflight_cmd += ['--nominal', '--no-grammar']
+            preflight = run_cmd(preflight_cmd, timeout=PREPARE_TIMEOUT_SECONDS)
+            atomic_write_text(preflight_path, preflight.stdout)
+            enforce_cost_gate(
+                preflight_path, lease.get('target'),
+                allow_over_cost=bool(lease.get('preflight_allow_over_cost')))
             if which == 'defect':
                 fshas = set()
                 source_paths = {
@@ -1599,6 +1877,8 @@ def prepare_requeue(args):
         lease['requeue_kind'] = which
         lease['requeue_attempt'] = attempt
         lease['execution_manifest'] = manifest
+        lease['preflight_path'] = preflight_path
+        lease['preflight_sha256'] = sha256_file(preflight_path)
         lease['current_artifact_dir'] = attempt_dir
         known_orphans = {
             os.path.abspath(row.get('artifact_dir'))
@@ -1613,6 +1893,8 @@ def prepare_requeue(args):
             'artifact_dir': attempt_dir,
             'harness': harness,
             'execution_manifest': manifest,
+            'preflight': preflight_path,
+            'preflight_sha256': lease['preflight_sha256'],
             'prepared_at': prepared_at,
             'selected_keys': requeue_keys,
             'remaining_pending': remaining_pending,
@@ -1638,20 +1920,320 @@ def prepare_requeue(args):
     print('harness: %s' % harness)
 
 
-def rebuild_ru_translation_memory():
-    """Rebuild + validate the RU translation memory from the committed canonical store. Must run
-    after any store-mutating promotion -- including from a `finally` -- so a mid-promotion raise
-    can never leave store and TM divergent (P10, H1420)."""
-    run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'build', '--lang', 'ru'])
-    # C7: detection and the build-frags call MUST target the same tree (see _frag_prov_glob).
-    # build_frags joins its --glob with REPO, but this pattern is absolute (coord_dir() abspath's),
-    # so that join is a no-op and both sides resolve to the same coordinator dir.
-    frag_glob = _frag_prov_glob()
-    if any('"frag_prov"' in open(fp, encoding='utf-8').read()
-           for fp in glob.glob(frag_glob, recursive=True)):
-        run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'build-frags',
-                 '--lang', 'ru', '--glob', frag_glob])
-    run_cmd([sys.executable, os.path.join(HERE, 'translation_memory.py'), 'validate', '--lang', 'ru'])
+def completed_run_binding(lease):
+    """Return the durable run/attempt identity that produced a recorded lease.
+
+    ``record-output`` releases the live runtime reservation, so the current
+    ``run_id`` is deliberately removed from the lease.  The completed attempt is
+    the immutable source of promotion attribution.
+    """
+    attempts = lease.get('run_attempts') or []
+    if not attempts:
+        return {'run_id': None, 'attempt_id': None}
+    attempt = attempts[-1]
+    return {
+        'run_id': attempt.get('run_id'),
+        'attempt_id': attempt.get('run_operation_id'),
+    }
+
+
+def promotion_identity(ready, model_identifier):
+    """Content-address one exact promotion intent for stable crash retries."""
+    intent = {
+        'schema': 'pwg.coordinator.promotion_intent.v1',
+        'model_identifier': model_identifier,
+        'review_status': 'ai_translated',
+        'leases': [{
+            'lease_id': lease['id'],
+            'run': completed_run_binding(lease),
+            'clean_output_sha256': lease.get('clean_output_sha256'),
+        } for lease in sorted(ready, key=lambda row: row['id'])],
+    }
+    payload = json.dumps(
+        intent, ensure_ascii=False, sort_keys=True,
+        separators=(',', ':')).encode('utf-8')
+    return 'pwg-prom-' + hashlib.sha256(payload).hexdigest()[:24]
+
+
+def journal_paths(promotion_id):
+    base = os.path.join(paths()['promotions'], promotion_id)
+    return {
+        'journal': base + '.journal.json',
+        'manifest': base + '.manifest.json',
+        'report': base + '.report.json',
+    }
+
+
+def batch_from_journal(journal):
+    """Reconstruct the exact clean-output bundle sealed in a journal."""
+    batch = []
+    for lease_id in journal['lease_ids']:
+        metrics = journal['leases'][lease_id]
+        files = (metrics.get('clean_output') or {}).get('files') or []
+        if len(files) != 1 or not files[0].get('path'):
+            raise promotion_journal.JournalError(
+                '%s: coordinator recovery requires exactly one sealed clean output'
+                % lease_id)
+        binding = journal['bindings'][lease_id]
+        batch.append({
+            'lease_id': lease_id,
+            'run_id': binding.get('run_id'),
+            'attempt_id': binding.get('attempt_id'),
+            'glob': files[0]['path'],
+            'expected_subcards': list(metrics['subcard_keys']),
+        })
+    return batch
+
+
+def build_promotion_derived(journal_path, store_claim_held=False):
+    """Build, validate, and seal the store-derived RU artifacts idempotently."""
+    journal = promotion_journal.load(journal_path)
+    if journal['phase'] != 'store_committed':
+        return journal
+    if not store_claim_held:
+        with promote_final_cards.PromoteClaim(journal['store']['path']):
+            return build_promotion_derived(
+                journal_path, store_claim_held=True)
+    promotion_journal.reconcile(
+        journal_path, adopt_after=False, store_claim_held=True)
+    store = journal['store']['path']
+    clean_files = [
+        row['path']
+        for lease_id in journal['lease_ids']
+        for row in journal['leases'][lease_id]['clean_output']['files']
+    ]
+    card_path, _count, _skipped = translation_memory.build(
+        store, 'ru', journal_path=journal_path)
+    frag_path, _added, _total = translation_memory.build_frags(
+        clean_files, 'ru', journal_path=journal_path)
+    try:
+        best, conflicts, null_keys = promote_final_cards.collect_cards(clean_files)
+        if conflicts or null_keys or sorted(best) != sorted(
+                key for lease_id in journal['lease_ids']
+                for key in journal['leases'][lease_id]['subcard_keys']):
+            raise promotion_journal.JournalError(
+                'clean-output membership changed before denylist unblock')
+        cleared_addr, cleared_frag = promote_final_cards.clear_denials_for_promotion(
+            best, timestamp=journal['artifact_timestamp'])
+        if cleared_addr or cleared_frag:
+            print('TM denylist: cleared %d card address(es) + %d fragment sha(s)'
+                  % (len(cleared_addr), len(cleared_frag)))
+    except Exception as exc:
+        promotion_journal.record_derived_observation(
+            journal_path, 'denylist',
+            artifact_path=translation_memory.denylist_path(),
+            error=str(exc))
+        raise
+    promotion_journal.record_derived_observation(
+        journal_path, 'denylist',
+        artifact_path=translation_memory.denylist_path(),
+        error=None)
+    return promotion_journal.mark_derived_validated(
+        journal_path,
+        denylist_path=translation_memory.denylist_path(),
+        card_tm_path=card_path,
+        fragment_tm_path=frag_path,
+    )
+
+
+def apply_journal_outcomes(state, journal):
+    """Apply one journal's complete lease metrics to an in-memory state."""
+    intent = (journal.get('coordinator') or {}).get('intent') or {}
+    sealed_outcomes = intent.get('lease_outcomes')
+    outcomes = {}
+    promoted_at = journal['artifact_timestamp']
+    report = journal['report']
+    store_before = report['store_rows_before']
+    store_after = report['store_rows_after']
+    for lease_id in journal['lease_ids']:
+        lease = lease_by_id(state, lease_id)
+        if sealed_outcomes:
+            outcome = sealed_outcomes[lease_id]
+        elif lease.get('promotion_id') == journal['promotion_id']:
+            outcome = lease.get('state')
+        elif lease.get('state') == 'ready_partial':
+            outcome = 'promoted_partial'
+        elif lease.get('state') == 'ready':
+            outcome = 'promoted'
+        else:
+            raise promotion_journal.JournalError(
+                '%s: coordinator lease is %r, expected ready/ready_partial or '
+                'this promotion marker' % (lease_id, lease.get('state')))
+        if outcome not in ('promoted', 'promoted_partial'):
+            raise promotion_journal.JournalError(
+                '%s: invalid sealed promotion outcome %r' % (lease_id, outcome))
+        per = journal['leases'][lease_id]
+        lease.update({
+            'state': outcome,
+            'promoted_at': promoted_at,
+            'promotion_id': journal['promotion_id'],
+            'promotion_journal': os.path.abspath(
+                journal_paths(journal['promotion_id'])['journal']),
+            'model_version': journal['model_identifier'],
+            'store_before': store_before,
+            'store_after': store_after,
+            'store_delta': per['store_delta'],
+            'bundle_store_delta': store_after - store_before,
+            'promoted_subcards': per['subcards'],
+            'promoted_rows': per['rows'],
+            'rows_added': per['rows_added'],
+            'rows_replaced': per['rows_replaced'],
+        })
+        outcomes[lease_id] = outcome
+    state['last_promotion'] = {
+        'promotion_id': journal['promotion_id'],
+        'journal': os.path.abspath(
+            journal_paths(journal['promotion_id'])['journal']),
+        'lease_outcomes': outcomes,
+        'model_identifier': journal['model_identifier'],
+        'store_sha256': journal['store']['expected_after_sha256'],
+        'committed_at': promoted_at,
+    }
+    # A fixed journal timestamp makes a retry reconstruct byte-identical state.
+    state['updated_at'] = promoted_at
+    return outcomes
+
+
+def promotion_registry_rows(state, journal, journal_path):
+    """Return the exact per-lease registry projection for one promotion."""
+    rows = []
+    for lease_id in journal['lease_ids']:
+        lease = lease_by_id(state, lease_id)
+        per = journal['leases'][lease_id]
+        rows.append(promotion_registry_record(
+            lease, journal['promotion_id'], {
+                'glob': ((per.get('clean_output') or {}).get(
+                    'files') or [{}])[0].get('path'),
+                'journal': os.path.abspath(journal_path),
+                'store_before': journal['report']['store_rows_before'],
+                'store_after': journal['report']['store_rows_after'],
+                'store_delta': per['store_delta'],
+                'bundle_store_delta': (
+                    journal['report']['store_rows_after']
+                    - journal['report']['store_rows_before']),
+                'rows_added': per['rows_added'],
+                'rows_replaced': per['rows_replaced'],
+                'batch_subcards': per['subcards'],
+                'batch_rows': per['rows'],
+            }, event_ts=journal['artifact_timestamp']))
+    return rows
+
+
+def commit_journal_coordinator(journal_path, store_claim_held=False):
+    """Seal/commit every lease update in one coordinator-state replacement."""
+    journal = promotion_journal.load(journal_path)
+    if journal['phase'] == 'complete':
+        return journal
+    if not store_claim_held:
+        with promote_final_cards.PromoteClaim(journal['store']['path']):
+            return commit_journal_coordinator(
+                journal_path, store_claim_held=True)
+    if journal['phase'] not in ('derived_validated', 'coordinator_committed'):
+        raise promotion_journal.JournalError(
+            'coordinator commit requires derived_validated, got %s'
+            % journal['phase'])
+    promotion_journal.reconcile(
+        journal_path, adopt_after=False, store_claim_held=True)
+    with DirLock(paths()['lock']):
+        state_path = paths()['state']
+        state = load_state()
+        outcomes = apply_journal_outcomes(state, journal)
+        expected_state_bytes = promotion_journal.stable_json_bytes(state)
+        registry_rows = promotion_registry_rows(state, journal, journal_path)
+        if journal['phase'] == 'derived_validated':
+            promotion_journal.prepare_coordinator_commit(
+                journal_path,
+                state_path=state_path,
+                expected_state_bytes=expected_state_bytes,
+                lease_outcomes=outcomes,
+                promotion_marker=journal['promotion_id'],
+                registry_path=paths()['registry'],
+                registry_events=registry_rows,
+                store_claim_held=True,
+            )
+            journal = promotion_journal.load(journal_path)
+            reconciled = promotion_journal.reconcile_coordinator(
+                journal_path, adopt_after=False, store_claim_held=True)
+            if reconciled['action'] == 'adopt_coordinator_commit':
+                promotion_journal.reconcile_coordinator(
+                    journal_path, adopt_after=True, store_claim_held=True)
+            elif reconciled['action'] == 'write_coordinator_state':
+                promotion_journal.commit_coordinator_state(
+                    journal_path, expected_state_bytes,
+                    store_claim_held=True)
+            elif reconciled['action'] != 'already_coordinator_committed':
+                raise promotion_journal.JournalError(
+                    'unexpected coordinator reconciliation action %r'
+                    % reconciled['action'])
+        else:
+            promotion_journal.reconcile_coordinator(
+                journal_path, adopt_after=False, store_claim_held=True)
+        # Dashboard and registry are replayable projections.  Registry events are
+        # deduplicated by promotion ID, so a crash at any line below converges.
+        write_dashboard(state)
+        sealed_registry = (
+            promotion_journal.load(journal_path)['coordinator']['intent']['registry'])
+        for expected in sealed_registry['events']:
+            append_promotion_registry_record(expected)
+        return promotion_journal.mark_complete(
+            journal_path, store_claim_held=True)
+
+
+def finish_promotion_journal(journal_path, store_claim_held=False):
+    """Drive one incomplete journal forward while holding the canonical-store claim."""
+    journal = promotion_journal.load(journal_path)
+    if journal['phase'] == 'complete':
+        return journal
+    if not store_claim_held:
+        # The store hash checks and the coordinator/journal replacements are one
+        # transaction boundary.  Releasing the writer claim after only the store
+        # replace permits a second canonical writer to land between verification
+        # and COMPLETE.
+        with promote_final_cards.PromoteClaim(journal['store']['path']):
+            return finish_promotion_journal(
+                journal_path, store_claim_held=True)
+    if journal['phase'] in ('prepared', 'store_committed'):
+        batch = batch_from_journal(journal)
+        promote_final_cards.batch_promote(
+            batch,
+            journal['store']['path'],
+            journal['review_status'],
+            journal['model_identifier'],
+            report_path=journal['report'].get('report_path'),
+            journal_path=journal_path,
+            promotion_id=journal['promotion_id'],
+            store_claim_held=True,
+        )
+        journal = promotion_journal.load(journal_path)
+    if journal['phase'] == 'store_committed':
+        journal = build_promotion_derived(
+            journal_path, store_claim_held=True)
+    if journal['phase'] in ('derived_validated', 'coordinator_committed'):
+        journal = commit_journal_coordinator(
+            journal_path, store_claim_held=True)
+    if journal['phase'] != 'complete':
+        raise promotion_journal.JournalError(
+            'promotion recovery stopped unexpectedly at %s' % journal['phase'])
+    return journal
+
+
+def reconcile_promotion_journals():
+    """Automatically converge the single active promotion before any command."""
+    promotion_dir = paths()['promotions']
+    os.makedirs(promotion_dir, exist_ok=True)
+    active = []
+    for journal_path in sorted(glob.glob(os.path.join(
+            promotion_dir, '*.journal.json'))):
+        journal = promotion_journal.load(journal_path)
+        if journal['phase'] != 'complete':
+            active.append(journal_path)
+    if len(active) > 1:
+        raise promotion_journal.JournalError(
+            'multiple incomplete promotion journals require manual ordering: %s'
+            % ', '.join(active))
+    if active:
+        with DirLock(paths()['promotion_lock']):
+            finish_promotion_journal(active[0])
 
 
 def promote_ready(args):
@@ -1673,7 +2255,7 @@ def promote_ready(args):
         # replacement -- instead of a full store read/copy/rewrite + interpreter startup
         # PER LEASE. All-or-nothing: any diverging lease fails the bundle with the store
         # byte-identical; per-lease attribution comes back in the batch report.
-        batch, lease_pending = [], {}
+        batch = []
         for lease in ready:
             source = lease['clean_output']
             try:
@@ -1705,77 +2287,37 @@ def promote_ready(args):
             if errors:
                 raise SystemExit('%s: promotion refused: %s' %
                                  (lease['id'], '; '.join(errors)))
-            lease_pending[lease['id']] = has_pending
-            batch.append({'lease_id': lease['id'],
-                          'glob': os.path.abspath(source),
-                          'expected_subcards': sorted({row.get('key') for row in clean_rows})})
-        batch_dir = ready[0].get('artifact_dir') or paths()['artifacts']
-        batch_manifest = os.path.join(batch_dir, 'batch_promotion.manifest.json')
-        batch_report = os.path.join(batch_dir, 'batch_promotion.report.json')
+            binding = completed_run_binding(lease)
+            batch.append({
+                'lease_id': lease['id'],
+                'run_id': binding['run_id'],
+                'attempt_id': binding['attempt_id'],
+                'glob': os.path.abspath(source),
+                'expected_subcards': sorted({row.get('key') for row in clean_rows}),
+            })
+        promotion_id = promotion_identity(ready, args.gen_model_version)
+        promotion_files = journal_paths(promotion_id)
+        batch_manifest = promotion_files['manifest']
+        batch_report = promotion_files['report']
+        journal_path = promotion_files['journal']
         atomic_write_json(batch_manifest, batch, indent=1)
-        run_cmd([sys.executable, os.path.join(SRC, 'promote_final_cards.py'),
-                 '--batch-manifest', batch_manifest, '--report', batch_report,
-                 '--gen-model-version', args.gen_model_version])
-        # P10 (H1420): the batch promote above is all-or-nothing and raises on failure, so reaching
-        # here means the store IS committed. From this point the RU TM MUST be rebuilt to match the
-        # committed store -- otherwise a raise while reading the batch report or updating per-lease
-        # state leaves store and TM divergent until the next clean run. Rebuild in a `finally` so a
-        # partial-promotion raise still lands a consistent TM.
-        try:
-            try:
-                batch_payload = json.load(open(batch_report, encoding='utf-8'))
-                if not isinstance(batch_payload, dict):
-                    raise TypeError('top level is not an object')
-                landed = batch_payload['leases']
-                store_before = batch_payload['store_rows_before']
-                store_after = batch_payload['store_rows_after']
-            except (OSError, KeyError, TypeError, json.JSONDecodeError) as e:
-                raise SystemExit('batch promotion report unreadable: %s' % e)
-            if (batch_payload.get('schema') != 'pwg.batch_promotion.v1'
-                    or not isinstance(landed, dict)
-                    or any(not isinstance(value, int) or isinstance(value, bool) or value < 0
-                           for value in (store_before, store_after))):
-                raise SystemExit('batch promotion report has invalid schema/store counters')
-            for lease in ready:
-                per = landed.get(lease['id']) or {}
-                if lease.get('clean_count') and not per.get('subcards'):
-                    raise SystemExit('%s: batch promotion landed no subcards for the lease'
-                                     % lease['id'])
-                has_pending = lease_pending[lease['id']]
-                with DirLock(paths()['lock']):
-                    state = load_state()
-                    fresh = lease_by_id(state, lease['id'])
-                    fresh['state'] = 'promoted_partial' if has_pending else 'promoted'
-                    fresh['promoted_at'] = utc_now()
-                    fresh['model_version'] = args.gen_model_version
-                    # H1386 D3: store_delta is the PER-LEASE figure from the batch report
-                    # (its three consumers -- promotion_classification, bad_deltas, the
-                    # windows100 GO gate -- all read it per lease); the bundle-wide
-                    # before/after stays as separate bundle-level context fields.
-                    fresh['store_before'] = store_before
-                    fresh['store_after'] = store_after
-                    fresh['store_delta'] = per.get('store_delta',
-                                                   store_after - store_before)
-                    fresh['bundle_store_delta'] = store_after - store_before
-                    fresh['promoted_subcards'] = per.get('subcards')
-                    fresh['promoted_rows'] = per.get('rows')
-                    fresh['rows_added'] = per.get('rows_added')
-                    fresh['rows_replaced'] = per.get('rows_replaced')
-                    save_state(state)
-                    registry_event(fresh, 'promoted', {'glob': lease['clean_output'],
-                                                       'store_before': store_before,
-                                                       'store_after': store_after,
-                                                       'store_delta': per.get(
-                                                           'store_delta',
-                                                           store_after - store_before),
-                                                       'bundle_store_delta':
-                                                           store_after - store_before,
-                                                       'rows_added': per.get('rows_added'),
-                                                       'rows_replaced': per.get('rows_replaced'),
-                                                       'batch_subcards': per.get('subcards'),
-                                                       'batch_rows': per.get('rows')})
-        finally:
-            rebuild_ru_translation_memory()
+        # Hold the same canonical-store claim from PREPARED through COMPLETE.
+        # All later store-hash checks therefore remain atomic with the batched
+        # coordinator state update and durable registry projection.
+        with promote_final_cards.PromoteClaim(
+                promote_final_cards.DEFAULT_STORE):
+            promote_final_cards.batch_promote(
+                batch,
+                promote_final_cards.DEFAULT_STORE,
+                'ai_translated',
+                args.gen_model_version,
+                report_path=batch_report,
+                journal_path=journal_path,
+                promotion_id=promotion_id,
+                store_claim_held=True,
+            )
+            finish_promotion_journal(
+                journal_path, store_claim_held=True)
     print('promoted %d lease(s)' % len(ready))
 
 
@@ -1896,6 +2438,11 @@ def main(argv=None):
     pb.add_argument('--config-dir', help='canonical CLAUDE_CONFIG_DIR bound into manifest v2')
     pb.add_argument('--executor-lane', default='serial-whole-card')
     pb.set_defaults(func=prepare_batch)
+    vp = sub.add_parser(
+        'validate-preflight',
+        help='revalidate sealed preparation evidence before any live probe or worker')
+    vp.add_argument('--lease-id', action='append', required=True)
+    vp.set_defaults(func=validate_preflight_command)
     br = sub.add_parser('begin-run')
     br.add_argument('--lease-id', action='append', required=True)
     br.add_argument('--mode', choices=('standard', 'staged'), default='standard')
@@ -1919,7 +2466,16 @@ def main(argv=None):
     r.add_argument('--run-id',
                    help='if set, must match the running lease run_id sealed at begin-run '
                         '(P11: refuses a stale/zombie run recording against a re-leased run)')
+    r.add_argument('--result-sha256',
+                   help='sealed SHA-256 of the exact submitted result; required with a run ID')
     r.set_defaults(func=record_output)
+    rb = sub.add_parser('record-output-batch')
+    rb.add_argument(
+        '--record', action='append', nargs=4, required=True,
+        metavar=('LEASE_ID', 'WORKFLOW_RESULT', 'RUN_ID', 'RESULT_SHA256'),
+        help='repeatable record tuple; use - sentinels only for a legacy unsealed lease')
+    rb.add_argument('--allow-stale', action='store_true')
+    rb.set_defaults(func=record_output_batch)
     rq = sub.add_parser('prepare-requeue')
     rq.add_argument('lease_id')
     g = rq.add_mutually_exclusive_group(required=True)
@@ -1934,6 +2490,11 @@ def main(argv=None):
     d = sub.add_parser('daily-close')
     d.set_defaults(func=daily_close)
     args = ap.parse_args(argv)
+    try:
+        reconcile_promotion_journals()
+    except (promotion_journal.JournalError,
+            promote_final_cards.PromotionContractError) as exc:
+        raise SystemExit('promotion reconciliation blocked: %s' % exc) from exc
     args.func(args)
 
 

--- a/RussianTranslation/src/pilot/coordinator_hardening_selftest.py
+++ b/RussianTranslation/src/pilot/coordinator_hardening_selftest.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python
+"""Focused offline pins for coordinator hardening added after the 2026-07-25 audit."""
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+from types import SimpleNamespace
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+# Avoid resolving or touching the canonical shared store merely by importing coordinator from a
+# linked worktree whose Git safe.directory policy may intentionally reject child git commands.
+_IMPORT_SANDBOX = tempfile.TemporaryDirectory(prefix='coordinator_hardening_import_')
+os.environ['PWG_RU_STORE'] = os.path.join(_IMPORT_SANDBOX.name, 'store.jsonl')
+os.environ['PWG_RU_TM_DIR'] = os.path.join(_IMPORT_SANDBOX.name, 'tm')
+os.environ['PWG_COORDINATOR_DIR'] = os.path.join(_IMPORT_SANDBOX.name, 'coordinator')
+
+import coordinator
+
+
+def expect_refusal(fn, needle):
+    try:
+        fn()
+    except SystemExit as exc:
+        if needle not in str(exc):
+            raise AssertionError('expected %r in refusal, got %r' % (needle, str(exc)))
+    else:
+        raise AssertionError('expected SystemExit containing %r' % needle)
+
+
+def test_preflight_fail_closed():
+    with tempfile.TemporaryDirectory() as tmp:
+        missing = os.path.join(tmp, 'missing.json')
+        expect_refusal(
+            lambda: coordinator.enforce_cost_gate(missing, 'x'),
+            'required preflight is unreadable')
+
+        malformed = os.path.join(tmp, 'malformed.json')
+        with open(malformed, 'w', encoding='utf-8') as f:
+            f.write('{')
+        expect_refusal(
+            lambda: coordinator.enforce_cost_gate(malformed, 'x'),
+            'required preflight is unreadable')
+
+        unsupported = os.path.join(tmp, 'unsupported.json')
+        with open(unsupported, 'w', encoding='utf-8') as f:
+            json.dump({'schema': 'unknown', 'cost_gate': {'over_ceiling': False}}, f)
+        expect_refusal(
+            lambda: coordinator.enforce_cost_gate(unsupported, 'x'),
+            'unsupported schema')
+
+        missing_verdict = os.path.join(tmp, 'missing-verdict.json')
+        with open(missing_verdict, 'w', encoding='utf-8') as f:
+            json.dump({'schema': 'pwg.performance_preflight.v1'}, f)
+        expect_refusal(
+            lambda: coordinator.enforce_cost_gate(missing_verdict, 'x'),
+            'no boolean cost verdict')
+
+        clean = os.path.join(tmp, 'clean.json')
+        with open(clean, 'w', encoding='utf-8') as f:
+            json.dump({
+                'schema': 'pwg.performance_preflight.v1',
+                'cost_gate': {'over_ceiling': False},
+            }, f)
+        coordinator.enforce_cost_gate(clean, 'x')
+
+        matrix = os.path.join(tmp, 'matrix.json')
+        with open(matrix, 'w', encoding='utf-8') as f:
+            json.dump({
+                'schema': 'pwg.performance_preflight.matrix.v1',
+                'reports': [{
+                    'schema': 'pwg.performance_preflight.v1',
+                    'cost_gate': {'over_ceiling': False},
+                }],
+            }, f)
+        coordinator.enforce_cost_gate(matrix, 'x')
+
+        sealed_hash = coordinator.sha256_file(clean)
+        lease = {
+            'id': 'sealed',
+            'target': 'nominal:x',
+            'preflight_path': clean,
+            'preflight_sha256': sealed_hash,
+            'preflight_allow_over_cost': False,
+        }
+        coordinator.validate_lease_preflight(lease)
+        with open(clean, 'a', encoding='utf-8') as f:
+            f.write('\n')
+        expect_refusal(
+            lambda: coordinator.validate_lease_preflight(lease),
+            'sealed preflight hash changed')
+        expect_refusal(
+            lambda: coordinator.validate_lease_preflight({
+                'id': 'legacy', 'target': 'x', 'preflight_path': clean}),
+            'no sealed preflight evidence')
+    print('  preflight: schema/verdict/hash fail closed; v1 + matrix pass')
+
+
+def test_record_output_batch_progress():
+    original = coordinator.record_output
+    seen = []
+
+    def fake_record(args):
+        seen.append((
+            args.lease_id, args.workflow_result, args.run_id,
+            args.result_sha256))
+        if args.lease_id == 'b':
+            raise SystemExit('synthetic second-item failure')
+
+    coordinator.record_output = fake_record
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            expect_refusal(
+                lambda: coordinator.record_output_batch(SimpleNamespace(
+                    record=[['a', 'a.json', 'run-a', 'sha-a'],
+                            ['b', 'b.json', 'run-b', 'sha-b'],
+                            ['c', 'c.json', 'run-c', 'sha-c']],
+                    allow_stale=False)),
+                'synthetic second-item failure')
+    finally:
+        coordinator.record_output = original
+    lines = [
+        line.split(': ', 1)[1] for line in buf.getvalue().splitlines()
+        if line.startswith('RECORD_OUTPUT_BATCH_PROGRESS: ')
+    ]
+    payloads = [json.loads(line) for line in lines]
+    if seen != [
+            ('a', 'a.json', 'run-a', 'sha-a'),
+            ('b', 'b.json', 'run-b', 'sha-b')]:
+        raise AssertionError('batch did not remain sequential/fail-fast: %r' % (seen,))
+    if len(payloads) != 2:
+        raise AssertionError('expected commit + failure progress, got %r' % payloads)
+    if payloads[-1] != {
+            'schema': coordinator.RECORD_BATCH_SCHEMA,
+            'recorded': ['a'],
+            'remaining': ['b', 'c'],
+            'failed': {
+                'lease_id': 'b',
+                'type': 'SystemExit',
+                'message': 'synthetic second-item failure',
+            }}:
+        raise AssertionError('unexpected failure receipt: %r' % payloads[-1])
+    expect_refusal(
+        lambda: coordinator.record_output_batch(SimpleNamespace(
+            record=[['a', 'a', '-', '-'], ['a', 'b', '-', '-']],
+            allow_stale=False)),
+        'duplicate lease ids')
+    print('  record batch: per-item semantics, durable prefix receipt, fail-fast remainder')
+
+
+def test_result_submission_seal():
+    with tempfile.TemporaryDirectory() as tmp:
+        source = os.path.join(tmp, 'result.json')
+        payload = b'{"result":{"results":[]}}\n'
+        with open(source, 'wb') as f:
+            f.write(payload)
+        expected = coordinator.hashlib.sha256(payload).hexdigest()
+        sealed = coordinator.seal_workflow_submission(
+            source, os.path.join(tmp, 'artifacts'), expected)
+        with open(source, 'wb') as f:
+            f.write(b'{"substituted":true}\n')
+        if open(sealed, 'rb').read() != payload:
+            raise AssertionError('sealed submission changed with the source path')
+        expect_refusal(
+            lambda: coordinator.seal_workflow_submission(
+                source, os.path.join(tmp, 'other'), expected),
+            'result substitution refused')
+    print('  result binding: copied bytes are hash-sealed before audit; substitution refused')
+
+
+def test_registry_projection_fail_closed():
+    old = os.environ.get('PWG_COORDINATOR_DIR')
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ['PWG_COORDINATOR_DIR'] = tmp
+        registry = coordinator.paths()['registry']
+        lease = {
+            'id': 'lease-1',
+            'kind': 'nominal',
+            'target': 'nominal:k',
+            'state': 'promoted',
+            'artifact_dir': os.path.join(tmp, 'artifacts', 'lease-1'),
+        }
+        event_data = {'journal': os.path.join(tmp, 'promotion.json')}
+        event_ts = '2026-07-25T00:00:00Z'
+
+        with open(registry, 'w', encoding='utf-8') as f:
+            f.write('{malformed\n')
+        try:
+            coordinator.registry_promotion_event(
+                lease, 'promotion-1', event_data, event_ts=event_ts)
+            raise AssertionError('malformed registry was accepted')
+        except coordinator.promotion_journal.JournalError as exc:
+            assert 'malformed JSONL' in str(exc), exc
+
+        with open(registry, 'w', encoding='utf-8') as f:
+            json.dump({'schema': coordinator.REGISTRY_SCHEMA}, f)
+        try:
+            coordinator.registry_promotion_event(
+                lease, 'promotion-1', event_data, event_ts=event_ts)
+            raise AssertionError('parseable short registry row was accepted')
+        except coordinator.promotion_journal.JournalError as exc:
+            assert 'not newline-terminated' in str(exc), exc
+
+        with open(registry, 'w', encoding='utf-8'):
+            pass
+        assert coordinator.registry_promotion_event(
+            lease, 'promotion-1', event_data, event_ts=event_ts)
+        before = open(registry, 'rb').read()
+        assert before.endswith(b'\n')
+
+        original_sync = coordinator.fsync_existing_path
+        synced = []
+        coordinator.fsync_existing_path = lambda path: synced.append(path)
+        try:
+            assert not coordinator.registry_promotion_event(
+                lease, 'promotion-1', event_data, event_ts=event_ts)
+        finally:
+            coordinator.fsync_existing_path = original_sync
+        assert synced == [registry]
+        assert open(registry, 'rb').read() == before
+        try:
+            coordinator.registry_promotion_event(
+                lease, 'promotion-1', {'journal': 'substituted'},
+                event_ts=event_ts)
+            raise AssertionError('same promotion identity with changed payload was accepted')
+        except coordinator.promotion_journal.JournalError as exc:
+            assert 'different payload' in str(exc), exc
+    if old is None:
+        os.environ.pop('PWG_COORDINATOR_DIR', None)
+    else:
+        os.environ['PWG_COORDINATOR_DIR'] = old
+    print('  registry: malformed/short/substituted rows fail; retry re-fsyncs exact row')
+
+
+def main():
+    test_preflight_fail_closed()
+    test_record_output_batch_progress()
+    test_result_submission_seal()
+    test_registry_projection_fail_closed()
+    print('coordinator_hardening_selftest: PASS')
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    finally:
+        _IMPORT_SANDBOX.cleanup()

--- a/RussianTranslation/src/pilot/execution_contract.py
+++ b/RussianTranslation/src/pilot/execution_contract.py
@@ -149,6 +149,18 @@ class ActiveCallClaim:
         self.path = os.path.join(self.root, fingerprint + '.lock')
         self._fh = None
 
+    def is_live_canonical_for(self, fingerprint):
+        """Return True only for the live claim at the one process-wide lock path.
+
+        A caller-supplied claim rooted in another directory can carry the same
+        filename while protecting a different kernel object. Paid-call
+        primitives therefore compare the normalized full path, not merely the
+        basename or fingerprint text.
+        """
+        expected = ActiveCallClaim(fingerprint).path
+        normalize = lambda path: os.path.normcase(os.path.realpath(os.path.abspath(path)))
+        return self._fh is not None and normalize(self.path) == normalize(expected)
+
     def __enter__(self):
         os.makedirs(self.root, exist_ok=True)
         fh = open(self.path, 'a+b')

--- a/RussianTranslation/src/pilot/h1339_offline_bench.py
+++ b/RussianTranslation/src/pilot/h1339_offline_bench.py
@@ -14,8 +14,9 @@ records per-stage wall-clock:
                  fake-model stand-in: german := exact per-sense source text, russian :=
                  deterministic copy — restored-markup counts match source BY CONSTRUCTION)
                  + `normalize_workflow_result`
-  audit          REAL `coordinator record-output` per lease (begin-run + audit_window
-                 subprocess with --execution-manifest + pending-backlog accounting)
+  audit          REAL `coordinator record-output` per lease, or the sequential
+                 `record-output-batch` parent-process optimization (begin-run + the same isolated
+                 audit_window subprocess with --execution-manifest + pending-backlog accounting)
   promotion-plan diagnostic: `promote_final_cards --dry-run --merge` over all clean outputs
   store-write    REAL `coordinator promote-ready` over ALL ready leases in one call — the
                  multi-lease promotion transaction (per-lease promote subprocess + backup +
@@ -317,7 +318,7 @@ def run_cli(argv, env, cwd=REPO, check=True):
     return proc
 
 
-def one_run(tag, keep=False, prepare_mode='batch'):
+def one_run(tag, keep=False, prepare_mode='batch', record_mode='batch'):
     """One full pipeline pass in a fresh sandbox. Returns (timings, outputs) dicts."""
     sandbox = tempfile.mkdtemp(prefix='h1339bench_%s_' % tag)
     coord_dir = os.path.join(sandbox, 'coordinator')
@@ -432,9 +433,17 @@ def one_run(tag, keep=False, prepare_mode='batch'):
         for lid, _case, _keys in group:
             begin += ['--lease-id', lid]
         run_cli(begin, env)
-        for lid, _case, _keys in group:
-            run_cli([os.path.join(HERE, 'coordinator.py'), 'record-output', lid,
-                     wf_paths[lid]], env, check=False)
+        if record_mode == 'per-lease':
+            for lid, _case, _keys in group:
+                run_cli([os.path.join(HERE, 'coordinator.py'), 'record-output', lid,
+                         wf_paths[lid]], env, check=False)
+        else:
+            record = [os.path.join(HERE, 'coordinator.py'), 'record-output-batch']
+            for lid, _case, _keys in group:
+                # This hermetic fixture begins legacy run-id-less leases. Production orchestrator
+                # batches carry each sealed run id instead of the explicit '-' sentinel.
+                record += ['--record', lid, wf_paths[lid], '-', '-']
+            run_cli(record, env, check=False)
     timings['audit'] = time.perf_counter() - t0
 
     state = json.load(open(os.path.join(coord_dir, 'state.json'), encoding='utf-8'))
@@ -494,6 +503,9 @@ def main():
     ap.add_argument('--prepare-mode', choices=('batch', 'per-lease'), default='batch',
                     help="H1386 OPT A/B: 'batch' = one prepare-batch call (production "
                          "default); 'per-lease' = the pre-H1386 3-spawns-per-lease shape")
+    ap.add_argument('--record-mode', choices=('batch', 'per-lease'), default='batch',
+                    help="hardening/speed A/B: 'batch' = one sequential coordinator parent per "
+                         "runtime group; 'per-lease' = one coordinator process per record")
     a = ap.parse_args()
 
     install_inputs()
@@ -510,7 +522,8 @@ def main():
 
 def _bench(a, fx_hash):
     for i in range(a.warmups):
-        t, o = one_run('warm%d' % i, prepare_mode=a.prepare_mode)
+        t, o = one_run('warm%d' % i, prepare_mode=a.prepare_mode,
+                       record_mode=a.record_mode)
         print('warmup %d/%d: total %.2fs (promote rc=%s)' % (
             i + 1, a.warmups, t['total'], o['promote_rc']))
 
@@ -518,7 +531,7 @@ def _bench(a, fx_hash):
     last_outputs = None
     for i in range(a.runs):
         t, o = one_run('run%d' % i, keep=(a.keep_last and i == a.runs - 1),
-                       prepare_mode=a.prepare_mode)
+                       prepare_mode=a.prepare_mode, record_mode=a.record_mode)
         measured.append(t)
         signatures.add(o['signature'])
         last_outputs = o
@@ -550,7 +563,8 @@ def _bench(a, fx_hash):
         report = {
             'schema': 'pwg.h1339_offline_bench.v1',
             'protocol': {'warmups': a.warmups, 'runs': a.runs,
-                         'prepare_mode': a.prepare_mode},
+                         'prepare_mode': a.prepare_mode,
+                         'record_mode': a.record_mode},
             'python': sys.version, 'platform': platform.platform(),
             'fixture_sha256': fx_hash, 'seed_rows': SEED_ROWS,
             'stages': stats, 'runs': measured,

--- a/RussianTranslation/src/pilot/h963_c4_gate0_probe.py
+++ b/RussianTranslation/src/pilot/h963_c4_gate0_probe.py
@@ -72,6 +72,11 @@ if str(HERE) not in sys.path:
 
 import max_account_orchestrator as mao  # noqa: E402
 from headless_worker import claude_argv_prefix  # noqa: E402
+# Codex hardening (26-07-2026): a PRE-spend reservation ledger. `--max-calls`-style ceilings
+# were post-hoc -- they could only report an overshoot after the calls were paid for. The
+# ledger reserves each call BEFORE it is issued and raises CallLimitReached instead, which is
+# exactly the discipline a one-no-reroll-attempt gate wants.
+from call_reservation import CallLimitReached, CallReservationLedger  # noqa: E402
 
 
 def resolve_claude_bin():
@@ -109,6 +114,16 @@ def config_dir_for(account):
         raise SystemExit("account %r is not of the form cN; pass --config-dir explicitly"
                          % account)
     return os.path.join(PROFILE_ROOT, "claude" + account[1:], ".claude")
+
+
+def ledger_paths(account):
+    """The per-account call-reservation ledger + synthetic preflight paths.
+
+    Per-account for the same reason the events log is (#729 one level up): a reservation
+    written for c5 must never bound, or be read as, a c4 attempt.
+    """
+    return (HERE / "output" / ("h963_%s_gate0_calls.json" % account),
+            HERE / "output" / ("h963_%s_gate0_preflight.json" % account))
 
 
 def campaign_for(account):
@@ -227,6 +242,7 @@ def main(argv=None):
 
     campaign = campaign_for(account)
     run_id = new_run_id(campaign)
+    call_ledger_path, preflight_path = ledger_paths(account)
     claude_bin = resolve_claude_bin()
     argv_prefix = claude_argv_prefix(claude_bin)
 
@@ -247,6 +263,8 @@ def main(argv=None):
     print("run_id            : %s   (unique to THIS run — #729)" % run_id)
     print("campaign          : %s   (grouping label only, never a read scope)" % campaign)
     print("events            : %s   (per-account series)" % events)
+    print("call ledger       : %s" % call_ledger_path)
+    print("preflight         : %s" % preflight_path)
     print("claude bin        : %s" % claude_bin)
     print("resolved argv     : %s" % argv_prefix)
     print("-" * 72)
@@ -275,6 +293,11 @@ def main(argv=None):
               % account)
         return 3
 
+    # The gate is allowed EXACTLY two calls (warm-up + measured). Reserving them up front
+    # turns "we overspent" into "we refused to spend", which is the whole point.
+    mao.write_synthetic_preflight(str(preflight_path), run_id, [])
+    call_ledger = CallReservationLedger(str(call_ledger_path), run_id, 2)
+
     verdict_exc = None
     t0 = time.monotonic()
     try:
@@ -287,8 +310,9 @@ def main(argv=None):
             events_path=str(events),
             run_id=run_id,
             account=account,
+            call_reservation=call_ledger,
         )
-    except SystemExit as exc:
+    except (SystemExit, CallLimitReached) as exc:
         verdict_exc = str(exc)
     wall_s = time.monotonic() - t0
 
@@ -312,6 +336,12 @@ def main(argv=None):
         print("live_probe fail-closed: %s" % verdict_exc)
 
     fails = derive_fails(readings)
+    # Codex hardening: the gate must emit EXACTLY its two reserved readings. Fewer means a
+    # phase never ran (already caught by derive_fails); MORE means something issued an
+    # unreserved paid call under this run id, which no verdict may be derived over.
+    if len(readings) > 2:
+        fails.append("this invocation emitted %d probe readings, expected exactly 2"
+                     % len(readings))
     by_purpose = {r.get("purpose"): r for r in readings}
 
     print()

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -25,7 +25,11 @@ from proc_tree import run_tree_kill, terminate_tree, windows_hidden_flags  # noq
 import card_fields  # noqa: E402  (C-01: the one restore/promote field set, shared with the JS lane)
 import german_anchor  # noqa: E402  (H858 Part B: source-anchored repair of a dropped `german` span)
 from window_common import portrait_key_iast  # noqa: E402  (B02: one iast derivation for both stitch twins)
-from execution_contract import ActiveCallClaim, SCHEMA_V1, SCHEMA_V2, validate_manifest, validate_profile  # noqa: E402
+from execution_contract import (ActiveCallClaim, SCHEMA_V1, SCHEMA_V2,
+                                config_dir_fingerprint, validate_manifest,
+                                validate_profile)  # noqa: E402
+from call_reservation import (CallLimitReached, CallReservationLedger,
+                              telemetry_from_cli_wrapper, unevaluable_telemetry)  # noqa: E402
 
 AUTH_RE = re.compile(r'401|authentication|not logged in|invalid.*credential', re.I)
 RATE_RE = re.compile(r'429|rate.?limit|usage limit|too many requests', re.I)
@@ -88,6 +92,58 @@ def sha256_path(path):
     return h.hexdigest()
 
 
+def validate_preflight_artifact(path, manifest=None, expected_sha256=None):
+    """Fail closed on malformed, over-ceiling, drifted, or wrong-scope paid-call evidence."""
+    if not path:
+        raise ValueError('paid v2 execution requires --preflight')
+    try:
+        with open(path, 'rb') as f:
+            preflight_bytes = f.read()
+        if (expected_sha256
+                and hashlib.sha256(preflight_bytes).hexdigest() != expected_sha256):
+            raise ValueError('preflight hash changed before paid execution')
+        data = json.loads(preflight_bytes.decode('utf-8'))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError('preflight is unreadable: %s' % exc)
+    if not isinstance(data, dict):
+        raise ValueError('preflight top level must be an object')
+    schema = data.get('schema')
+    if schema == 'pwg.performance_preflight.v1':
+        reports = [data]
+    elif schema == 'pwg.performance_preflight.matrix.v1':
+        reports = data.get('reports')
+    else:
+        raise ValueError('unsupported preflight schema: %r' % schema)
+    if not isinstance(reports, list) or not reports:
+        raise ValueError('preflight must contain nonempty reports')
+    scoped = []
+    for index, report in enumerate(reports):
+        if not isinstance(report, dict):
+            raise ValueError('preflight report %d is not an object' % index)
+        gate = report.get('cost_gate')
+        if not isinstance(gate, dict) or not isinstance(gate.get('over_ceiling'), bool):
+            raise ValueError('preflight report %d has no boolean over_ceiling' % index)
+        if gate['over_ceiling']:
+            raise ValueError('preflight report %d is over ceiling' % index)
+        if manifest is not None:
+            if report.get('synthetic_probe_only'):
+                raise ValueError(
+                    'synthetic probe preflight cannot authorize manifest execution')
+            keys = report.get('selected_keys')
+            if (not isinstance(keys, list)
+                    or not all(isinstance(key, str) and key for key in keys)
+                    or len(keys) != len(set(keys))):
+                raise ValueError(
+                    'preflight report %d has missing/malformed selected_keys' % index)
+            scoped.extend(keys)
+    if manifest is not None:
+        expected = list((manifest.get('meta') or {}).get('selected_keys') or [])
+        if (len(scoped) != len(set(scoped))
+                or sorted(scoped) != sorted(expected)):
+            raise ValueError('preflight selected-key scope does not match manifest')
+    return data
+
+
 def atomic_json(path, payload):
     os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
     tmp = path + '.tmp.%d' % os.getpid()
@@ -129,11 +185,25 @@ def build_prompt(manifest, keys):
             ''.join(card_block(manifest, key) for key in keys))
 
 
-def extract_structured(stdout):
+def parse_cli_wrapper(stdout):
+    """Parse the Claude CLI JSON envelope without yet trusting its structured result.
+
+    Usage/cost belongs to the paid invocation, not to the validity of ``cards[]``.  Keeping
+    envelope parsing separate lets :meth:`HeadlessEngine.call` account for a malformed result
+    before it retries.  An unreadable envelope is returned as a loud ``ValueError`` so the caller
+    can mark the spawned call cost-unevaluable instead of silently pricing it at zero.
+    """
     try:
         wrapper = json.loads(stdout)
     except json.JSONDecodeError as exc:
         raise ValueError('Claude output is not JSON: %s' % exc)
+    if not isinstance(wrapper, dict):
+        raise ValueError('Claude output envelope is not an object')
+    return wrapper
+
+
+def structured_from_wrapper(wrapper):
+    """Extract and validate the schema result from an already-accounted CLI envelope."""
     value = wrapper.get('structured_output')
     if value is None:
         value = wrapper.get('result')
@@ -144,7 +214,13 @@ def extract_structured(stdout):
             raise ValueError('Claude result is not structured JSON: %s' % exc)
     if not isinstance(value, dict) or not isinstance(value.get('cards'), list):
         raise ValueError('Claude result has no cards[] object')
-    return value, wrapper
+    return value
+
+
+def extract_structured(stdout):
+    """Compatibility helper returning ``(structured, wrapper)`` for existing callers/tests."""
+    wrapper = parse_cli_wrapper(stdout)
+    return structured_from_wrapper(wrapper), wrapper
 
 
 def restore_text(text, placeholders, unmapped=None):
@@ -374,9 +450,15 @@ def card_token_multiset(card):
 
 
 class HeadlessEngine:
-    def __init__(self, manifest, claude, timeout, runner, max_agents_override=None):
+    def __init__(self, manifest, claude, timeout, runner, max_agents_override=None,
+                 call_reservation=None, config_dir=None, active_claim=None):
         self.m = manifest
         self.claude = claude
+        if not config_dir:
+            raise ValueError('paid headless execution requires an explicit config directory')
+        self.config_dir = os.path.abspath(config_dir)
+        self.profile_fingerprint = config_dir_fingerprint(self.config_dir)
+        self.active_claim = active_claim
         budgets = manifest.get('budgets') or {}
         # R4 (C-15): clamp every subprocess to min(operator, budgets.timeout_ceil_ms, HARD).
         eff_ms = min(int(timeout) * 1000, HARD_TIMEOUT_MS)
@@ -407,6 +489,7 @@ class HeadlessEngine:
                       'cache_creation_tokens': 0, 'subagent_tokens': 0,
                       'observed_cost_usd': 0.0, 'cost_evaluable': True, 'priced_calls': 0,
                       'missing_usage_calls': 0}
+        self.call_reservation = call_reservation
 
     def note(self, key, error, preserve=False):
         # H1610 / H1618: mirror JS `if (!FAIL[k]) noteFail(...)` so a later terminal
@@ -416,29 +499,16 @@ class HeadlessEngine:
             return
         self.failures[key] = str(error)[:300]
 
-    def _accumulate_usage(self, wrapper):
-        """R5: fold one CLI wrapper's usage/cost into the running totals. A missing usage or cost
-        field flips `cost_evaluable` False (so a real call is never priced at $0) instead of being
-        silently dropped. `subagent_tokens` is the field the economy pricer reads."""
+    def _accumulate_usage(self, telemetry):
+        """Fold one already-validated call finalization into the in-memory result summary."""
         self.usage['priced_calls'] += 1
-        u = wrapper.get('usage') if isinstance(wrapper, dict) else None
-        if isinstance(u, dict):
-            # These are disjoint Claude usage fields; sum them, never overwrite. Prior calls'
-            # totals are retained even when a later call arrives with no usage.
-            self.usage['input_tokens'] += int(u.get('input_tokens') or 0)
-            self.usage['output_tokens'] += int(u.get('output_tokens') or 0)
-            self.usage['cache_read_tokens'] += int(u.get('cache_read_input_tokens') or 0)
-            self.usage['cache_creation_tokens'] += int(u.get('cache_creation_input_tokens') or 0)
-        else:
-            # Retain known telemetry; mark the whole run unpriceable and count the gap.
+        for name in ('input_tokens', 'output_tokens', 'cache_read_tokens',
+                     'cache_creation_tokens'):
+            self.usage[name] += telemetry[name]
+        if not telemetry['cost_evaluable']:
             self.usage['cost_evaluable'] = False
             self.usage['missing_usage_calls'] += 1
-        cost = wrapper.get('total_cost_usd') if isinstance(wrapper, dict) else None
-        if cost is None:
-            self.usage['cost_evaluable'] = False
-        else:
-            # observed_cost_usd stays authoritative (accumulated CLI cost), not recomputed from tokens.
-            self.usage['observed_cost_usd'] += float(cost)
+        self.usage['observed_cost_usd'] += telemetry['observed_cost_usd']
         self.usage['subagent_tokens'] = (
             self.usage['input_tokens'] + self.usage['output_tokens']
             + self.usage['cache_read_tokens'] + self.usage['cache_creation_tokens'])
@@ -459,10 +529,26 @@ class HeadlessEngine:
             # R3: a refused call consumes NO spawn and returns a typed stop reason.
             self.budget_stops += 1
             return None, 'budget_exceeded:%s' % ('heal' if heal else 'translate')
+        if self.call_reservation is None:
+            raise RuntimeError(
+                'paid headless spawn requires a durable call reservation ledger')
+        if (not isinstance(self.active_claim, ActiveCallClaim)
+                or not self.active_claim.is_live_canonical_for(
+                    self.profile_fingerprint)):
+            raise RuntimeError(
+                'paid headless spawn requires the live canonical profile claim')
         argv = claude_argv_prefix(self.claude) + [
                 '-p', '--output-format', 'json', '--json-schema',
                 json.dumps(self.m['output_schema'], ensure_ascii=False, separators=(',', ':')),
                 '--model', self.m['model'], '--permission-mode', 'plan']
+        try:
+            reservation = self.call_reservation.reserve(
+                'headless:%s' % ('heal' if heal else 'translate'),
+                profile=(self.m.get('execution') or {}).get('profile_slot'),
+                detail=label)
+        except CallLimitReached:
+            self.budget_stops += 1
+            return None, 'budget_exceeded:max_calls'
         started = time.monotonic()
         if heal:
             self.heal_calls += 1
@@ -472,6 +558,11 @@ class HeadlessEngine:
             proc = self.run(argv, input=prompt, text=True, encoding='utf-8',
                             capture_output=True, timeout=self.timeout)
         except subprocess.TimeoutExpired as exc:
+            # A timeout happened after a real spawn. No trustworthy wrapper survived, so count the
+            # call and fail closed on cost instead of leaving a paid timeout looking like $0.
+            telemetry = unevaluable_telemetry()
+            self.call_reservation.finalize(reservation, telemetry)
+            self._accumulate_usage(telemetry)
             self.kill_timeouts += 1
             attempt = {'label': label, 'keys': keys, 'returncode': 124,
                        'elapsed_ms': int((time.monotonic() - started) * 1000),
@@ -481,7 +572,37 @@ class HeadlessEngine:
                 attempt['cleanup_trouble'] = cleanup
             self.attempts.append(attempt)
             return None, 'timeout'
+        except BaseException:
+            # Reservation authority is irreversible. A spawn/runner exception
+            # cannot turn the attempt back into an apparent zero-cost call.
+            telemetry = unevaluable_telemetry()
+            self.call_reservation.finalize(reservation, telemetry)
+            self._accumulate_usage(telemetry)
+            raise
         elapsed = int((time.monotonic() - started) * 1000)
+        try:
+            wrapper = parse_cli_wrapper(proc.stdout)
+        except ValueError:
+            wrapper = None
+        # Account for EVERY spawned process before classifying its result. This covers non-zero
+        # provider exits and rc=0 wrappers whose structured_output is malformed. A missing envelope
+        # increments missing_usage_calls and makes the whole run unevaluable.
+        telemetry = telemetry_from_cli_wrapper(wrapper)
+        structured = None
+        structured_error = None
+        if not proc.returncode:
+            try:
+                if wrapper is None:
+                    raise ValueError('Claude output is not a JSON object envelope')
+                structured = structured_from_wrapper(wrapper)
+            except ValueError as exc:
+                structured_error = exc
+                # Malformed output is permanently unevaluable even if its outer wrapper claimed
+                # a price: the paid/result association itself failed validation.
+                telemetry = dict(telemetry, cost_evaluable=False)
+        # Durable finalization occurs before any classification branch returns or raises.
+        self.call_reservation.finalize(reservation, telemetry)
+        self._accumulate_usage(telemetry)
         if proc.returncode:
             classification, code = classify_process(proc)
             if classification == 'connection':
@@ -489,13 +610,10 @@ class HeadlessEngine:
             self.attempts.append({'label': label, 'keys': keys, 'returncode': proc.returncode,
                                   'elapsed_ms': elapsed, 'classification': classification})
             raise HardFailure(classification, code, (proc.stderr or proc.stdout or '')[-2000:])
-        try:
-            structured, wrapper = extract_structured(proc.stdout)
-        except ValueError as exc:
+        if structured_error is not None:
             self.attempts.append({'label': label, 'keys': keys, 'returncode': 0,
                                   'elapsed_ms': elapsed, 'classification': 'malformed_output'})
-            return None, 'malformed_output:%s' % exc
-        self._accumulate_usage(wrapper)     # R5: capture spend instead of discarding it
+            return None, 'malformed_output:%s' % structured_error
         self.attempts.append({'label': label, 'keys': keys, 'returncode': 0,
                               'elapsed_ms': elapsed, 'classification': 'success'})
         return structured, None
@@ -784,16 +902,34 @@ def refuse_starvation_max_agents(manifest, max_agents_override):
             % (max_agents_override, n))
 
 
-def execute(manifest, claude='claude', timeout=7200, runner=None, max_agents_override=None):
+def execute(manifest, claude='claude', timeout=7200, runner=None, max_agents_override=None,
+            call_reservation=None, config_dir=None):
     validate_manifest(manifest, require_v2=False)
     _validate_fragment_tm(manifest)      # R6: refuse a null-owner fragment_tm slot BEFORE any call
     refuse_starvation_max_agents(manifest, max_agents_override)
-    engine = HeadlessEngine(manifest, claude, timeout, runner, max_agents_override)
+    config_dir = config_dir or os.environ.get('CLAUDE_CONFIG_DIR')
+    if not config_dir:
+        raise ValueError('CLAUDE_CONFIG_DIR is required for paid headless execution')
+    config_dir = os.path.abspath(config_dir)
+    if manifest.get('schema') == SCHEMA_V2:
+        # Public execute() is itself a paid boundary. Do not rely on a CLI
+        # caller having validated the manifest against the actual profile.
+        validate_profile(manifest, config_dir)
+    fingerprint = config_dir_fingerprint(config_dir)
+    engine = None
     try:
-        results, healed, presplit = engine.run_all()
+        # One kernel-backed profile claim covers every translation/heal spawn
+        # in this generation attempt. Public execute() therefore cannot bypass
+        # the same lock that the CLI route uses.
+        with ActiveCallClaim(fingerprint) as active_claim:
+            engine = HeadlessEngine(
+                manifest, claude, timeout, runner, max_agents_override,
+                call_reservation=call_reservation, config_dir=config_dir,
+                active_claim=active_claim)
+            results, healed, presplit = engine.run_all()
     except HardFailure as exc:
         return None, {'classification': exc.classification, 'error': exc.detail,
-                      'attempts': engine.attempts}, exc.code
+                      'attempts': engine.attempts, 'usage': engine.usage}, exc.code
     for key, card in manifest.get('tm_resolved', {}).items():
         results.append({'key': key, 'card': card, 'judge': None, 'judge_sonnet': None,
                         'escalated': False, 'tm': True})
@@ -852,28 +988,65 @@ def main(argv=None):
                     help='R3: hard cap on TOTAL model spawns (translate+heal), not concurrency '
                          'width. Canary-only: refuse when N < selected key count (H1610). '
                          'Omit for multi-key windows so manifest budgets apply.')
+    ap.add_argument('--call-reservation',
+                    help='pwg.call_reservation.v1 ledger shared by probes and workers')
+    ap.add_argument('--run-id', help='run key in --call-reservation')
+    ap.add_argument('--max-calls', type=int, default=None,
+                    help='durable total-call ceiling; must match the initialized ledger')
+    ap.add_argument('--preflight', help='validated pwg.performance_preflight.v1/matrix.v1')
+    ap.add_argument('--preflight-sha256', help='optional sealed preflight hash')
+    ap.add_argument('--manifest-sha256',
+                    help='required external seal for paid manifest v2 execution')
     args = ap.parse_args(argv)
-    manifest_hash = sha256_path(args.manifest)
-    with open(args.manifest, encoding='utf-8') as f:
-        manifest = json.load(f)
+    with open(args.manifest, 'rb') as f:
+        manifest_bytes = f.read()
+    manifest_hash = hashlib.sha256(manifest_bytes).hexdigest()
+    manifest = json.loads(manifest_bytes.decode('utf-8'))
     try:
+        if manifest.get('schema') != SCHEMA_V1:
+            if not args.manifest_sha256:
+                raise ValueError('paid v2 execution requires --manifest-sha256')
+            if manifest_hash != args.manifest_sha256:
+                raise ValueError('manifest hash changed before paid execution')
+        preflight_path = args.preflight or os.environ.get('PWG_PREFLIGHT_PATH')
+        preflight_hash = args.preflight_sha256 or os.environ.get('PWG_PREFLIGHT_SHA256')
+        if manifest.get('schema') != SCHEMA_V1:
+            validate_preflight_artifact(
+                preflight_path, manifest=manifest, expected_sha256=preflight_hash)
+        reservation_path = args.call_reservation or os.environ.get('PWG_CALL_RESERVATION_PATH')
+        reservation_run = args.run_id or os.environ.get('PWG_CALL_RESERVATION_RUN_ID')
+        reservation_max = args.max_calls
+        if reservation_max is None and 'PWG_CALL_RESERVATION_MAX_CALLS' in os.environ:
+            raw_max = os.environ.get('PWG_CALL_RESERVATION_MAX_CALLS')
+            reservation_max = None if raw_max == '' else int(raw_max)
+        call_reservation = (CallReservationLedger(
+            reservation_path, reservation_run, reservation_max) if reservation_path else None)
+        if call_reservation is None:
+            raise ValueError('paid execution requires --call-reservation and --run-id '
+                             '(or PWG_CALL_RESERVATION_* environment)')
         if manifest.get('schema') == SCHEMA_V1:
             if not args.allow_historical_v1:
                 raise ValueError('v1 manifest is historical-only; production requires %s' % SCHEMA_V2)
             payload, status, code = execute(manifest, args.claude_bin, args.timeout,
-                                            max_agents_override=args.max_agents)
+                                            max_agents_override=args.max_agents,
+                                            call_reservation=call_reservation,
+                                            config_dir=os.environ.get(
+                                                'CLAUDE_CONFIG_DIR'))
         else:
             config_dir = os.environ.get('CLAUDE_CONFIG_DIR')
             if not config_dir:
                 raise ValueError('CLAUDE_CONFIG_DIR is required for manifest v2')
             validate_profile(manifest, config_dir, args.only_profile)
-            with ActiveCallClaim(manifest['execution']['config_dir_fingerprint']):
-                payload, status, code = execute(manifest, args.claude_bin, args.timeout,
-                                            max_agents_override=args.max_agents)
+            payload, status, code = execute(
+                manifest, args.claude_bin, args.timeout,
+                max_agents_override=args.max_agents,
+                call_reservation=call_reservation, config_dir=config_dir)
     except (OSError, RuntimeError, ValueError) as exc:
         payload, status, code = None, {'classification': 'configuration', 'error': str(exc)}, 2
     status['manifest_sha256'] = manifest_hash
     if payload is not None:
+        payload.setdefault('meta', {})[
+            'execution_manifest_sha256'] = manifest_hash
         atomic_json(args.output, payload)
         status['result_sha256'] = sha256_path(args.output)
     atomic_json(args.status_out, status)

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -11,6 +11,24 @@ sys.stderr.reconfigure(encoding='utf-8')
 
 import headless_worker as h
 import gen_opt_harness2 as generator
+import proc_tree
+from call_reservation import CallReservationLedger
+from execution_contract import ActiveCallClaim, config_dir_fingerprint
+
+
+class MemoryCallLedger:
+    """Selftest-only reservation authority; fake runners never reach a provider."""
+
+    def __init__(self):
+        self.next_id = 0
+        self.finalized = {}
+
+    def reserve(self, *_args, **_kwargs):
+        self.next_id += 1
+        return 'test-call-%d' % self.next_id
+
+    def finalize(self, reservation, telemetry):
+        self.finalized[reservation] = dict(telemetry)
 
 
 def manifest():
@@ -39,9 +57,25 @@ def proc(returncode=0, stdout='', stderr=''):
     return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
 
 
-def execute(test_manifest, runner):
-    """Use a real, portable executable path while the runner fakes its output."""
-    return h.execute(test_manifest, claude=sys.executable, runner=runner)
+_FIXTURE_CONFIG_DIR = tempfile.mkdtemp(prefix='hw-selftest-cfg-')
+
+
+def execute(test_manifest, runner, config_dir=None):
+    """Use a real, portable executable path while the runner fakes its output.
+
+    `config_dir` is REQUIRED by h.execute (the paid-boundary guard: no
+    CLAUDE_CONFIG_DIR, no execution). Every test routed through this helper runs a
+    FAKE runner against a v1 fixture manifest, so it needs a config dir that exists
+    but must never be a real profile -- a scratch dir is exactly right, and passing
+    it explicitly beats mutating os.environ for the whole process. Without this the
+    suite aborted on its first `execute()` call (found on rebase onto master,
+    26-07-2026; the guard and this helper are both from the hardening branch, so the
+    breakage is in the branch as delivered, not in the rebase).
+    """
+    return h.execute(
+        test_manifest, claude=sys.executable, runner=runner,
+        call_reservation=MemoryCallLedger(),
+        config_dir=config_dir or _FIXTURE_CONFIG_DIR)
 
 
 def success_runner(argv, **kwargs):
@@ -74,7 +108,9 @@ def test_translate_budget_binds():
     execute(m, r)
     assert r.n == 1, 'manifest budget=1 did not bind: %d spawns' % r.n
     r = _soft_nonresolve_runner()
-    h.execute(manifest(), claude=sys.executable, runner=r, max_agents_override=1)
+    h.execute(
+        manifest(), claude=sys.executable, runner=r, max_agents_override=1,
+        call_reservation=MemoryCallLedger(), config_dir=_FIXTURE_CONFIG_DIR)
     assert r.n == 1, '--max-agents=1 did not bind: %d spawns' % r.n
     print('  R3 budget: unbounded=2; manifest ceiling and --max-agents both cap actual spawns to 1')
 
@@ -94,7 +130,9 @@ def test_h1610_preserve_budget_exceeded_over_selfheal_stamp():
     m['fragment_tm'] = {'agni': [[]]}
     m['runtime'] = dict(m['runtime'], whole_attempts=1, fragment_attempts=1)
     payload, status, code = h.execute(m, claude=sys.executable, runner=r,
-                                      max_agents_override=1)
+                                      max_agents_override=1,
+                                      call_reservation=MemoryCallLedger(),
+                                      config_dir=_FIXTURE_CONFIG_DIR)
     assert code == 0 and payload is not None
     failures = payload['summary']['failures']
     assert 'agni' in failures, failures
@@ -119,7 +157,9 @@ def test_h1610_refuse_max_agents_starves_multikey():
         m['inputs'][k] = m['inputs']['agni']
         m['placeholder_maps'][k] = m['placeholder_maps']['agni']
     try:
-        h.execute(m, claude=sys.executable, runner=r, max_agents_override=1)
+        h.execute(
+            m, claude=sys.executable, runner=r, max_agents_override=1,
+            call_reservation=MemoryCallLedger(), config_dir=_FIXTURE_CONFIG_DIR)
         assert False, 'expected ValueError starvation refuse'
     except ValueError as exc:
         assert 'starves' in str(exc) and '3-key' in str(exc), exc
@@ -140,6 +180,286 @@ def test_call_timeout_clamped():
     execute(m, capture_runner)
     assert seen['timeout'] == 45.0, 'timeout_ceil_ms not honoured: %r' % seen['timeout']
     print('  R4 timeout: clamped to min(operator,ceil,180000ms) -> 180.0s then 45.0s')
+
+
+def test_durable_call_reservation():
+    """The durable ceiling is consumed before the runner, including malformed results."""
+    with tempfile.TemporaryDirectory() as td:
+        original_prefix = h.claude_argv_prefix
+        h.claude_argv_prefix = lambda _claude: ['claude']
+        try:
+            spawned = []
+
+            def runner(_argv, **_kwargs):
+                spawned.append(1)
+                if len(spawned) == 1:
+                    return SimpleNamespace(returncode=0, stdout='not-json', stderr='')
+                return SimpleNamespace(returncode=0, stderr='', stdout=json.dumps({
+                    'structured_output': {'cards': []},
+                    'usage': {'input_tokens': 4, 'output_tokens': 1},
+                    'total_cost_usd': 0.10,
+                }))
+
+            # HeadlessEngine.call refuses to spawn without the live canonical profile
+            # claim -- the same lock execute() takes. Constructing the engine directly
+            # (as this test does, to drive .call() one reservation at a time) must
+            # therefore hold that claim too, or the test never reaches the ledger
+            # behaviour it exists to prove.
+            fingerprint = config_dir_fingerprint(_FIXTURE_CONFIG_DIR)
+            zero = CallReservationLedger(os.path.join(td, 'zero.json'), 'r0', 0)
+            with ActiveCallClaim(fingerprint) as claim:
+                eng = h.HeadlessEngine(manifest(), 'claude', 30, runner, call_reservation=zero,
+                                       config_dir=_FIXTURE_CONFIG_DIR, active_claim=claim)
+                value, error = eng.call('p', 'zero', ['agni'])
+                assert value is None and error == 'budget_exceeded:max_calls' and not spawned
+
+            one = CallReservationLedger(os.path.join(td, 'one.json'), 'r1', 2)
+            with ActiveCallClaim(fingerprint) as claim:
+                eng = h.HeadlessEngine(manifest(), 'claude', 30, runner, call_reservation=one,
+                                       config_dir=_FIXTURE_CONFIG_DIR, active_claim=claim)
+                _value, error = eng.call('p', 'malformed', ['agni'])
+                assert error.startswith('malformed_output') and one.spent() == 1
+                value, error = eng.call('p', 'success', ['agni'])
+                assert error is None and value == {'cards': []}
+                usage = one.usage()
+                assert usage['cost_evaluable'] is False and usage['observed_cost_usd'] == 0.10
+                _value, error = eng.call('p', 'refused', ['agni'])
+                assert error == 'budget_exceeded:max_calls' and len(spawned) == 2
+        finally:
+            h.claude_argv_prefix = original_prefix
+    print('  call ledger: zero spawn; malformed+success cumulative cost stays unevaluable; cap refused')
+
+
+def test_cli_reservation_and_preflight_gates():
+    with tempfile.TemporaryDirectory() as td:
+        original_runner = h.run_tree_kill
+        original_prefix = h.claude_argv_prefix
+        original_config_dir = os.environ.get('CLAUDE_CONFIG_DIR')
+        spawned = []
+        h.run_tree_kill = lambda *_a, **_k: spawned.append(1)
+        h.claude_argv_prefix = lambda _c: [sys.executable]
+        try:
+            # The paid-boundary guard is checked BEFORE --max-calls is consulted, so the
+            # max_calls=0 case below needs a config dir too -- this test only set one later,
+            # for its v2 half, and so exited 2 (configuration) instead of the 0 it asserts.
+            os.environ['CLAUDE_CONFIG_DIR'] = os.path.join(td, 'cli-profile')
+            os.makedirs(os.environ['CLAUDE_CONFIG_DIR'], exist_ok=True)
+            # CLI max_calls=0: the Python worker runs, but no paid CLI runner is entered.
+            v1_path = os.path.join(td, 'v1.json')
+            json.dump(manifest(), open(v1_path, 'w', encoding='utf-8'))
+            ledger_path = os.path.join(td, 'zero.calls.json')
+            out = os.path.join(td, 'out.json')
+            status = os.path.join(td, 'status.json')
+            try:
+                h.main([v1_path, '--output', out, '--status-out', status,
+                        '--allow-historical-v1', '--claude-bin', sys.executable,
+                        '--call-reservation', ledger_path, '--run-id', 'zero',
+                        '--max-calls', '0'])
+            except SystemExit as exc:
+                assert exc.code == 0, exc
+            assert not spawned and CallReservationLedger(ledger_path, 'zero', 0).spent() == 0
+
+            # Missing/malformed/hash-drift v2 preflight refuses before reservation/spawn.
+            v2 = manifest()
+            v2['schema'] = h.SCHEMA_V2
+            config_dir = os.path.join(td, 'profile')
+            os.makedirs(config_dir)
+            os.environ['CLAUDE_CONFIG_DIR'] = config_dir
+            v2['execution'] = {
+                'profile_slot': 'acc',
+                'config_dir_fingerprint': config_dir_fingerprint(config_dir),
+                'execution_route': 'claude-cli-headless', 'executor_lane': 'test',
+                'validation_method': 'test', 'model_identifier': v2['model'],
+            }
+            v2['key_provenance'] = {'agni': 'real'}
+            v2_path = os.path.join(td, 'v2.json')
+            json.dump(v2, open(v2_path, 'w', encoding='utf-8'))
+            manifest_sha = h.sha256_path(v2_path)
+            gate_ledger = os.path.join(td, 'gate.calls.json')
+            malformed = os.path.join(td, 'bad.preflight.json')
+            open(malformed, 'w', encoding='utf-8').write('{}')
+            good = os.path.join(td, 'good.preflight.json')
+            json.dump({
+                'schema': 'pwg.performance_preflight.v1',
+                'selected_keys': ['agni'],
+                'cost_gate': {'over_ceiling': False},
+            }, open(good, 'w', encoding='utf-8'))
+            over = os.path.join(td, 'over.preflight.json')
+            json.dump({
+                'schema': 'pwg.performance_preflight.v1',
+                'selected_keys': ['agni'],
+                'cost_gate': {'over_ceiling': True},
+            }, open(over, 'w', encoding='utf-8'))
+            wrong_scope = os.path.join(td, 'wrong-scope.preflight.json')
+            json.dump({
+                'schema': 'pwg.performance_preflight.v1',
+                'selected_keys': ['soma'],
+                'cost_gate': {'over_ceiling': False},
+            }, open(wrong_scope, 'w', encoding='utf-8'))
+            empty_scope = os.path.join(td, 'empty-scope.preflight.json')
+            json.dump({
+                'schema': 'pwg.performance_preflight.v1',
+                'selected_keys': [],
+                'cost_gate': {'over_ceiling': False},
+            }, open(empty_scope, 'w', encoding='utf-8'))
+            duplicate_scope = os.path.join(td, 'duplicate-scope.preflight.json')
+            json.dump({
+                'schema': 'pwg.performance_preflight.v1',
+                'selected_keys': ['agni', 'agni'],
+                'cost_gate': {'over_ceiling': False},
+            }, open(duplicate_scope, 'w', encoding='utf-8'))
+            missing_scope = os.path.join(td, 'missing-scope.preflight.json')
+            json.dump({
+                'schema': 'pwg.performance_preflight.v1',
+                'cost_gate': {'over_ceiling': False},
+            }, open(missing_scope, 'w', encoding='utf-8'))
+            synthetic = os.path.join(td, 'synthetic.preflight.json')
+            json.dump({
+                'schema': 'pwg.performance_preflight.v1',
+                'selected_keys': ['agni'],
+                'synthetic_probe_only': True,
+                'cost_gate': {'over_ceiling': False},
+            }, open(synthetic, 'w', encoding='utf-8'))
+            non_boolean_gate = os.path.join(td, 'non-boolean.preflight.json')
+            json.dump({
+                'schema': 'pwg.performance_preflight.v1',
+                'selected_keys': ['agni'],
+                'cost_gate': {'over_ceiling': 0},
+            }, open(non_boolean_gate, 'w', encoding='utf-8'))
+            base = [v2_path, '--output', out, '--claude-bin', sys.executable,
+                    '--call-reservation', gate_ledger, '--run-id', 'gate',
+                    '--max-calls', '2']
+            # Each case reaches the intended gate: only the first two omit/corrupt the
+            # manifest seal; all preflight cases carry the exact seal over manifest bytes.
+            refused = (
+                [],
+                ['--manifest-sha256', 'f' * 64],
+                ['--manifest-sha256', manifest_sha],
+                ['--manifest-sha256', manifest_sha, '--preflight', malformed],
+                ['--manifest-sha256', manifest_sha, '--preflight', good,
+                 '--preflight-sha256', 'f' * 64],
+                ['--manifest-sha256', manifest_sha, '--preflight', over],
+                ['--manifest-sha256', manifest_sha, '--preflight', wrong_scope],
+                ['--manifest-sha256', manifest_sha, '--preflight', empty_scope],
+                ['--manifest-sha256', manifest_sha, '--preflight', duplicate_scope],
+                ['--manifest-sha256', manifest_sha, '--preflight', missing_scope],
+                ['--manifest-sha256', manifest_sha, '--preflight', synthetic],
+                ['--manifest-sha256', manifest_sha, '--preflight', non_boolean_gate],
+            )
+            for index, extra in enumerate(refused):
+                status_i = os.path.join(td, 'status%d.json' % index)
+                try:
+                    h.main(base + ['--status-out', status_i] + extra)
+                except SystemExit as exc:
+                    assert exc.code == 2, (index, exc)
+            assert CallReservationLedger(gate_ledger, 'gate', 2).spent() == 0
+            assert not spawned
+            try:
+                h.main([v2_path, '--output', out,
+                        '--status-out', os.path.join(td, 'no-ledger.status.json'),
+                        '--claude-bin', sys.executable,
+                        '--manifest-sha256', manifest_sha, '--preflight', good])
+            except SystemExit as exc:
+                assert exc.code == 2, exc
+            assert not spawned
+
+            # A fully sealed v2 invocation can complete offline with max_calls=0.
+            # It must bind both artifacts to the exact manifest bytes, while the
+            # durable reservation prevents the fake runner from ever being entered.
+            valid_out = os.path.join(td, 'valid.out.json')
+            valid_status = os.path.join(td, 'valid.status.json')
+            valid_ledger = os.path.join(td, 'valid.calls.json')
+            try:
+                h.main([
+                    v2_path, '--output', valid_out, '--status-out', valid_status,
+                    '--claude-bin', sys.executable,
+                    '--manifest-sha256', manifest_sha,
+                    '--preflight', good, '--preflight-sha256', h.sha256_path(good),
+                    '--call-reservation', valid_ledger, '--run-id', 'valid',
+                    '--max-calls', '0',
+                ])
+            except SystemExit as exc:
+                assert exc.code == 0, exc
+            result = json.load(open(valid_out, encoding='utf-8'))
+            completed = json.load(open(valid_status, encoding='utf-8'))
+            assert result['meta']['execution_manifest_sha256'] == manifest_sha, result['meta']
+            assert completed['manifest_sha256'] == manifest_sha, completed
+            assert completed['result_sha256'] == h.sha256_path(valid_out), completed
+            assert CallReservationLedger(valid_ledger, 'valid', 0).spent() == 0
+            assert not spawned
+        finally:
+            h.run_tree_kill = original_runner
+            h.claude_argv_prefix = original_prefix
+            if original_config_dir is None:
+                os.environ.pop('CLAUDE_CONFIG_DIR', None)
+            else:
+                os.environ['CLAUDE_CONFIG_DIR'] = original_config_dir
+    print('  CLI gates: exact manifest seal + real-scope preflight required; malformed, '
+          'synthetic, duplicate/wrong/empty scope spawn zero; result/status hashes bound')
+
+
+def test_non_timeout_communicate_cleanup():
+    original_popen = proc_tree.subprocess.Popen
+    original_terminate = proc_tree.terminate_tree
+    original_job = getattr(proc_tree, '_WindowsKillJob', None)
+    seen = []
+
+    class FakeProc:
+        def __init__(self, *_a, **_k):
+            self.returncode = None
+            self._tree_job = None
+            self._tree_setup_trouble = None
+            self.calls = 0
+
+        def communicate(self, **_kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                raise UnicodeDecodeError('utf-8', b'\xff', 0, 1, 'synthetic')
+            return '', ''
+
+        def poll(self):
+            return self.returncode
+
+        def kill(self):
+            self.returncode = -9
+
+        def wait(self, timeout=None):
+            self.returncode = -9
+            return -9
+
+    fake = [None]
+
+    def popen(*args, **kwargs):
+        fake[0] = FakeProc(*args, **kwargs)
+        return fake[0]
+
+    def terminate(proc, deadline):
+        seen.append((proc, deadline))
+        proc.returncode = -9
+        return None
+
+    proc_tree.subprocess.Popen = popen
+    proc_tree.terminate_tree = terminate
+    if original_job is not None:
+        class FakeJob:
+            def create(self): pass
+            def assign(self, proc): pass
+            def resume(self, proc): pass
+            def close(self): return None
+        proc_tree._WindowsKillJob = FakeJob
+    try:
+        try:
+            proc_tree.run_tree_kill(['synthetic'], capture_output=True)
+            raise AssertionError('communicate decode failure was swallowed')
+        except UnicodeDecodeError:
+            pass
+        assert seen and fake[0].calls == 2 and fake[0].returncode == -9
+    finally:
+        proc_tree.subprocess.Popen = original_popen
+        proc_tree.terminate_tree = original_terminate
+        if original_job is not None:
+            proc_tree._WindowsKillJob = original_job
+    print('  process tree: non-timeout communicate exception terminates and reaps child tree')
 
 
 def test_card_tokens_include_grammar():
@@ -204,14 +524,27 @@ def test_cost_telemetry_survives():
     assert u['cost_evaluable'] is False and u['missing_usage_calls'] == 1, u
     assert abs(u['observed_cost_usd'] - 0.01) < 1e-9, u
 
-    # (c) a budget refusal (no subprocess) adds neither usage nor cost
+    # (c) a PAID, schema-malformed wrapper is still accounted before cards[] validation/retry.
+    malformed = proc(stdout=json.dumps({
+        'structured_output': {'not_cards': []}, 'usage': U, 'total_cost_usd': 0.25}))
+    u = execute(manifest(), sequence([malformed, malformed]))[0]['summary']['usage']
+    assert u['priced_calls'] == 2 and u['input_tokens'] == 200, u
+    assert u['cost_evaluable'] is False and abs(u['observed_cost_usd'] - 0.50) < 1e-9, u
+
+    # An unreadable envelope is also a spawned call; its unknown spend fails closed.
+    unreadable = proc(stdout='not-json')
+    u = execute(manifest(), sequence([unreadable, unreadable]))[0]['summary']['usage']
+    assert u['priced_calls'] == 2 and u['missing_usage_calls'] == 2, u
+    assert u['cost_evaluable'] is False, u
+
+    # (d) a budget refusal (no subprocess) adds neither usage nor cost
     m = manifest(); m['budgets'] = {'max_translate_agents': 1}
     r = sequence([wrap([], U, 0.05)])
     u = execute(m, r)[0]['summary']['usage']
     assert r.i == 1, 'budget should cap to 1 actual spawn, got %d' % r.i
     assert u['priced_calls'] == 1 and u['input_tokens'] == 100, u
     assert abs(u['observed_cost_usd'] - 0.05) < 1e-9, u
-    print('  R5 cost: usage/cost sum across calls; missing -> cost_evaluable False + counter; budget refusal adds nothing')
+    print('  R5 cost: every spawn accounted before result validation; malformed/missing fails closed')
 
 
 def test_foreign_route_refused_before_any_call():
@@ -234,7 +567,10 @@ def test_foreign_route_refused_before_any_call():
         m['key_provenance'] = {'agni': 'real'}
         try:                       # replicate headless_worker.main()'s v2 order
             ec.validate_profile(m, cfg)
-            h.execute(m, claude=sys.executable, runner=counting_runner)   # must NOT be reached
+            h.execute(
+                m, claude=sys.executable, runner=counting_runner,
+                call_reservation=MemoryCallLedger(),
+                config_dir=_FIXTURE_CONFIG_DIR)   # must NOT be reached
         except ValueError as e:
             assert 'execution_route' in str(e), e
         else:
@@ -608,6 +944,9 @@ console.log(JSON.stringify(restoreCard(card, 'agni')))
     test_h1610_preserve_budget_exceeded_over_selfheal_stamp()
     test_h1610_refuse_max_agents_starves_multikey()
     test_call_timeout_clamped()
+    test_durable_call_reservation()
+    test_cli_reservation_and_preflight_gates()
+    test_non_timeout_communicate_cleanup()
     test_card_tokens_include_grammar()
     test_cost_telemetry_survives()
     test_foreign_route_refused_before_any_call()

--- a/RussianTranslation/src/pilot/latency_payload_sweep.py
+++ b/RussianTranslation/src/pilot/latency_payload_sweep.py
@@ -48,7 +48,10 @@ sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from max_account_orchestrator import _probe_call, _probe_prompt, EXACT_GEN_MODEL  # noqa: E402
+from max_account_orchestrator import (_probe_call, _probe_prompt, EXACT_GEN_MODEL,
+                                      write_synthetic_preflight)  # noqa: E402
+from call_reservation import CallLimitReached, CallReservationLedger  # noqa: E402
+from execution_contract import ActiveCallClaim, config_dir_fingerprint  # noqa: E402
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 MEASURED_SIZE = 6491  # padding_bytes of the D-K measured acceptance probe (-> 6828 actual, v1.9.17+)
@@ -85,10 +88,14 @@ def _cli_version(claude):
 
 
 def one_call(config_dir, claude, padding_bytes, *, route, window, account_label,
-             sample_index, warmup, git_sha, cli_version):
+             sample_index, warmup, git_sha, cli_version, call_reservation,
+             active_claim):
     t0 = time.monotonic()
     ts = _iso_utc()
-    latency_ms, cls, output_bytes = _probe_call(config_dir, claude, padding_bytes, EXACT_GEN_MODEL)
+    purpose = 'latency-sweep:%s' % ('warmup' if warmup else 'measured')
+    latency_ms, cls, output_bytes = _probe_call(
+        config_dir, claude, padding_bytes, EXACT_GEN_MODEL,
+        call_reservation, purpose, account_label, active_claim=active_claim)
     actual_bytes = _actual_prompt_bytes(padding_bytes)   # from _probe_prompt -- cannot drift from the probe
     row = {
         'ts_utc': ts,
@@ -116,13 +123,15 @@ def one_call(config_dir, claude, padding_bytes, *, route, window, account_label,
 
 
 def run(mode, config_dir, claude, ladder, samples, warmups, out_path,
-        route, window, account_label, seq_start):
+        route, window, account_label, seq_start, call_reservation,
+        active_claim):
     git_sha = _git_sha()
     cli_version = _cli_version(claude)
     sizes = ladder if mode == 'sweep' else [MEASURED_SIZE]
     rows = []
     kw = dict(route=route, window=window, account_label=account_label,
-              git_sha=git_sha, cli_version=cli_version)
+              git_sha=git_sha, cli_version=cli_version,
+              call_reservation=call_reservation, active_claim=active_claim)
     for pb in sizes:
         for _ in range(max(0, warmups)):
             rows.append(one_call(config_dir, claude, pb, sample_index=None, warmup=True, **kw))
@@ -176,10 +185,23 @@ def main():
     ap.add_argument('--seq-start', type=int, default=0,
                     help='base sample_index for crossover sequence position')
     ap.add_argument('--out', default=None)
+    ap.add_argument('--call-reservation', required=True,
+                    help='durable pwg.call_reservation.v1 ledger path')
+    ap.add_argument('--run-id', required=True, help='durable run key in the call ledger')
+    ap.add_argument('--max-calls', type=int, default=None)
     args = ap.parse_args()
     ladder = [int(x) for x in args.ladder.split(',') if x.strip()]
-    run(args.mode, args.config_dir, args.claude_bin, ladder, args.samples, args.warmups,
-        args.out, args.route, args.window, args.account_label, args.seq_start)
+    write_synthetic_preflight(
+        os.path.abspath(args.call_reservation) + '.preflight.json',
+        'latency-sweep-' + args.run_id, [])
+    ledger = CallReservationLedger(args.call_reservation, args.run_id, args.max_calls)
+    try:
+        with ActiveCallClaim(config_dir_fingerprint(args.config_dir)) as active_claim:
+            run(args.mode, args.config_dir, args.claude_bin, ladder, args.samples, args.warmups,
+                args.out, args.route, args.window, args.account_label, args.seq_start, ledger,
+                active_claim)
+    except CallLimitReached as exc:
+        raise SystemExit(str(exc))
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
-"""Restartable outer scheduler for independently authenticated Claude profiles.
+"""Restartable scheduler for sealed coordinator manifests on authenticated profiles.
 
-This layer owns dispatch only.  A queued job is an argv JSON array; the command
-is run with CLAUDE_CONFIG_DIR set to the assigned account.  Translation logic,
-auditing, and promotion remain owned by coordinator.py and its existing tools.
+Arbitrary argv jobs are refused: only imported coordinator manifests carry the
+required run, preflight, reservation, profile, and result bindings.
 """
 import argparse
 import concurrent.futures
@@ -18,9 +17,13 @@ import sys
 import time
 
 from run_observability import append_event, write_census
-from headless_worker import claude_argv_prefix, run_tree_kill, windows_hidden_flags
+from headless_worker import (claude_argv_prefix, run_tree_kill, validate_preflight_artifact,
+                             windows_hidden_flags)
 from window_common import atomic_write_text
-from execution_contract import validate_manifest, validate_profile
+from execution_contract import (ActiveCallClaim, config_dir_fingerprint, validate_manifest,
+                                validate_profile)
+from call_reservation import (CallLimitReached, CallReservationLedger, run_ids,
+                              telemetry_from_cli_wrapper, unevaluable_telemetry)
 
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
@@ -34,7 +37,8 @@ CREATE TABLE IF NOT EXISTS jobs (
   id INTEGER PRIMARY KEY AUTOINCREMENT, external_id TEXT UNIQUE NOT NULL,
   argv_json TEXT NOT NULL DEFAULT '[]', cwd TEXT NOT NULL, output_path TEXT NOT NULL,
   manifest_path TEXT, manifest_sha256 TEXT, profile_slot TEXT,
-  result_sha256 TEXT, attempt_log_path TEXT,
+  preflight_path TEXT, preflight_sha256 TEXT,
+  result_sha256 TEXT, attempt_log_path TEXT, run_id TEXT,
   failure_class TEXT, reset_at INTEGER,
   coordinator_recorded INTEGER NOT NULL DEFAULT 0,
   state TEXT NOT NULL DEFAULT 'pending', assigned_acc TEXT, attempts INTEGER NOT NULL DEFAULT 0,
@@ -92,6 +96,17 @@ def now_iso():
     return datetime.datetime.now(datetime.timezone.utc).isoformat(timespec='seconds').replace('+00:00', 'Z')
 
 
+def required_call_ledger(args, context='paid call'):
+    path = getattr(args, 'call_reservation', None)
+    run_id = getattr(args, 'run_id', None)
+    if not path or not run_id:
+        raise SystemExit('%s requires --call-reservation and --run-id' % context)
+    try:
+        return CallReservationLedger(path, run_id, getattr(args, 'max_calls', None))
+    except ValueError as exc:
+        raise SystemExit('%s: %s' % (context, exc))
+
+
 def connect(path):
     # D-G: a real busy_timeout so concurrent claimers (independent connections racing the same
     # BEGIN IMMEDIATE write lock) WAIT for the lock instead of failing with SQLITE_BUSY / "database
@@ -105,7 +120,9 @@ def connect(path):
     for name, declaration in (
             ('manifest_path', 'TEXT'), ('manifest_sha256', 'TEXT'),
             ('profile_slot', 'TEXT'),
+            ('preflight_path', 'TEXT'), ('preflight_sha256', 'TEXT'),
             ('result_sha256', 'TEXT'), ('attempt_log_path', 'TEXT'),
+            ('run_id', 'TEXT'),
             ('failure_class', 'TEXT'), ('reset_at', 'INTEGER'),
             ('coordinator_recorded', 'INTEGER NOT NULL DEFAULT 0')):
         if name not in existing:
@@ -139,6 +156,20 @@ def atomic_write(path, text):
     atomic_write_text(path, text)
 
 
+def write_synthetic_preflight(path, root, selected_keys=None):
+    """Write explicit zero-work/canary evidence for paid probes without a coordinator lease."""
+    payload = {
+        'schema': 'pwg.performance_preflight.v1',
+        'root': root,
+        'selected_keys': list(selected_keys or []),
+        'cost_gate': {'over_ceiling': False},
+        'synthetic_probe_only': True,
+    }
+    atomic_write(path, json.dumps(payload, ensure_ascii=False, indent=1) + '\n')
+    validate_preflight_artifact(path)
+    return os.path.abspath(path)
+
+
 def coordinator_command(args, command, check=True):
     coordinator = os.path.abspath(getattr(
         args, 'coordinator', os.path.join(os.path.dirname(__file__), 'coordinator.py')))
@@ -165,6 +196,25 @@ def release_db_claims(db_path, jobs, error):
                 "started_at=NULL, error=? WHERE id=? AND state='in_progress'",
                 (error[-2000:], job['id']))
     db.close()
+
+
+def bind_jobs_to_run(db_path, jobs, run_id):
+    """Seal the run identity before any worker spawn; retries may only reuse that identity."""
+    if not run_id:
+        raise ValueError('manifest jobs require a run_id before spawn')
+    db = connect(db_path)
+    try:
+        with db:
+            for job in jobs:
+                row = db.execute('SELECT run_id FROM jobs WHERE id=?', (job['id'],)).fetchone()
+                saved = row['run_id'] if row else None
+                if saved and saved != run_id:
+                    raise ValueError('%s: saved run_id %r refuses resume as %r'
+                                     % (job['external_id'], saved, run_id))
+                db.execute('UPDATE jobs SET run_id=? WHERE id=? AND run_id IS NULL',
+                           (run_id, job['id']))
+    finally:
+        db.close()
 
 
 # H1339 A4: a materialised requeue attempt is a NEW job (jobs.external_id is UNIQUE) on the
@@ -289,14 +339,14 @@ def claim(db_path, account, now=None, only_external_ids=None):
 
 
 def finish(db_path, job_id, state, returncode, error=None, failure_class=None,
-           result_sha256=None, attempt_log_path=None, reset_at=None):
+           result_sha256=None, attempt_log_path=None, reset_at=None, run_id=None):
     db = connect(db_path)
     with db:
         db.execute('UPDATE jobs SET state=?, returncode=?, error=?, failure_class=?, '
                    'result_sha256=COALESCE(?,result_sha256), attempt_log_path=COALESCE(?,attempt_log_path), '
-                   'reset_at=?, finished_at=? WHERE id=?',
+                   'run_id=COALESCE(?,run_id), reset_at=?, finished_at=? WHERE id=?',
                    (state, returncode, error, failure_class, result_sha256,
-                    attempt_log_path, reset_at, now_iso(), job_id))
+                    attempt_log_path, run_id, reset_at, now_iso(), job_id))
     db.close()
 
 
@@ -360,7 +410,7 @@ def emit_call_events(events_path, item, idx, manifest_sha256, base):
 
 
 def run_claimed(db_path, account, config_dir, job, timeout, events_path=None, run_id=None,
-                claude_bin='claude'):
+                claude_bin='claude', call_reservation_path=None, max_calls=None):
     attempt = job['attempts']
     attempt_log = job['output_path'] + '.attempt%d.runner.json' % attempt
     status_path = job['output_path'] + '.attempt%d.status.json' % attempt
@@ -370,22 +420,44 @@ def run_claimed(db_path, account, config_dir, job, timeout, events_path=None, ru
     if events_path:
         append_event(events_path, stage='dispatch', event='attempt_start', **event_base)
     if job['manifest_path']:
+        db = connect(db_path)
+        saved_run_id = db.execute(
+            'SELECT run_id FROM jobs WHERE id=?', (job['id'],)).fetchone()['run_id']
+        db.close()
+        if not run_id or saved_run_id != run_id:
+            raise RuntimeError('job/run binding mismatch before spawn: saved=%r requested=%r'
+                               % (saved_run_id, run_id))
+        if not call_reservation_path:
+            raise RuntimeError('manifest worker spawn requires a call reservation ledger')
         if sha256_path(job['manifest_path']) != job['manifest_sha256']:
             return fail_or_retry(db_path, job['id'], 2, 'manifest hash changed',
                                  'manifest_drift', attempt_log)
         manifest = json.load(open(job['manifest_path'], encoding='utf-8'))
         try:
             validate_profile(manifest, config_dir, account)
-        except ValueError as exc:
+            validate_preflight_artifact(
+                job['preflight_path'], manifest, job['preflight_sha256'])
+        except (OSError, ValueError) as exc:
             return fail_or_retry(db_path, job['id'], 2, str(exc), 'configuration', attempt_log)
         argv = [sys.executable, os.path.join(os.path.dirname(__file__), 'headless_worker.py'),
                 job['manifest_path'], '--output', job['output_path'],
                 '--status-out', status_path, '--timeout', str(timeout),
-                '--claude-bin', claude_bin, '--only-profile', account]
+                '--claude-bin', claude_bin, '--only-profile', account,
+                '--preflight', job['preflight_path'],
+                '--preflight-sha256', job['preflight_sha256'],
+                '--manifest-sha256', job['manifest_sha256']]
     else:
-        argv = json.loads(job['argv_json'])
+        return fail_or_retry(
+            db_path, job['id'], 2,
+            'legacy generic argv jobs are disabled; re-enqueue through a sealed '
+            'coordinator manifest',
+            'configuration', attempt_log)
     env = os.environ.copy()
     env['CLAUDE_CONFIG_DIR'] = config_dir
+    if call_reservation_path:
+        env['PWG_CALL_RESERVATION_PATH'] = os.path.abspath(call_reservation_path)
+        env['PWG_CALL_RESERVATION_RUN_ID'] = run_id or ''
+        env['PWG_CALL_RESERVATION_MAX_CALLS'] = '' if max_calls is None else str(max_calls)
     try:
         proc = run_tree_kill(argv, cwd=job['cwd'], env=env, text=True, encoding='utf-8',
                              capture_output=True, timeout=timeout)   # D-J: tree-kill on timeout
@@ -399,6 +471,17 @@ def run_claimed(db_path, account, config_dir, job, timeout, events_path=None, ru
                 worker_status = json.load(open(status_path, encoding='utf-8'))
             except (OSError, json.JSONDecodeError):
                 worker_status = {}
+        if (job['manifest_path']
+                and worker_status.get('manifest_sha256') != job['manifest_sha256']):
+            state = fail_or_retry(
+                db_path, job['id'], 2,
+                'worker manifest hash does not match the sealed job manifest',
+                'manifest_drift', attempt_log)
+            if events_path:
+                append_event(
+                    events_path, stage='dispatch', event='attempt_end',
+                    classification='manifest_drift', **event_base)
+            return state
         if events_path:
             for idx, item in enumerate(worker_status.get('attempts') or []):
                 emit_call_events(events_path, item, idx,
@@ -416,9 +499,18 @@ def run_claimed(db_path, account, config_dir, job, timeout, events_path=None, ru
                              classification='rate_limit', reset_at=until, **event_base)
             return 'parked'
         if proc.returncode == 0:
-            result_hash = sha256_path(job['output_path']) if os.path.exists(job['output_path']) else None
+            result_hash = (
+                sha256_path(job['output_path'])
+                if os.path.exists(job['output_path']) else None)
+            if (job['manifest_path']
+                    and (not result_hash
+                         or worker_status.get('result_sha256') != result_hash)):
+                return fail_or_retry(
+                    db_path, job['id'], 2,
+                    'worker result hash does not match the sealed status result',
+                    'result_drift', attempt_log)
             finish(db_path, job['id'], 'done', 0, failure_class='success',
-                   result_sha256=result_hash, attempt_log_path=attempt_log)
+                   result_sha256=result_hash, attempt_log_path=attempt_log, run_id=run_id)
             if events_path:
                 append_event(events_path, stage='dispatch', event='attempt_end',
                              classification='success', result_hash=result_hash, **event_base)
@@ -440,7 +532,8 @@ def run_claimed(db_path, account, config_dir, job, timeout, events_path=None, ru
         return fail_or_retry(db_path, job['id'], 127, str(exc), 'process', attempt_log)
 
 
-def profile_status(config_dir, claude='claude'):
+def profile_status(config_dir, claude='claude', call_reservation=None, account=None,
+                   preflight_path=None):
     if not os.path.isdir(config_dir):
         return False, 'profile directory missing'
     env = os.environ.copy()
@@ -457,22 +550,63 @@ def profile_status(config_dir, claude='claude'):
         return False, (proc.stderr or proc.stdout)[-500:]
     if proc.returncode or not data.get('loggedIn'):
         return False, data.get('subscriptionType') or 'not logged in'
-    probe = run_tree_kill(               # D-J: tree-kill on timeout
-        claude_argv_prefix(claude) + ['-p', 'Return exactly OK.', '--output-format', 'json',
-         '--model', 'claude-sonnet-5', '--permission-mode', 'plan'],
-        env=env, text=True, encoding='utf-8', capture_output=True, timeout=60)
+    if call_reservation is None:
+        raise ValueError('paid profile validation requires a call reservation ledger')
+    validate_preflight_artifact(preflight_path)
+    with ActiveCallClaim(config_dir_fingerprint(config_dir)):
+        reservation = call_reservation.reserve('profile:init', profile=account)
+        try:
+            probe = run_tree_kill(               # D-J: tree-kill on timeout
+                claude_argv_prefix(claude) + [
+                    '-p', 'Return exactly OK.', '--output-format', 'json',
+                    '--model', 'claude-sonnet-5', '--permission-mode', 'plan'],
+                env=env, text=True, encoding='utf-8',
+                capture_output=True, timeout=60)
+        except subprocess.TimeoutExpired:
+            call_reservation.finalize(reservation, unevaluable_telemetry())
+            return False, 'timeout'
+        except BaseException:
+            # The reservation is irreversible once the runner may have
+            # spawned. An unexpected runner failure cannot remain pending or
+            # masquerade as a zero-cost validation.
+            call_reservation.finalize(reservation, unevaluable_telemetry())
+            raise
+    try:
+        wrapper = json.loads(probe.stdout or '')
+    except (TypeError, ValueError):
+        wrapper = None
+    telemetry = telemetry_from_cli_wrapper(wrapper)
+    envelope_ok = (
+        isinstance(wrapper, dict)
+        and wrapper.get('type') == 'result'
+        and wrapper.get('subtype') == 'success'
+        and wrapper.get('is_error') is not True)
+    if not envelope_ok:
+        telemetry = dict(telemetry, cost_evaluable=False)
+    call_reservation.finalize(reservation, telemetry)
     if probe.returncode:
         return False, ((probe.stderr or '') + '\n' + (probe.stdout or ''))[-500:]
+    if not envelope_ok:
+        return False, 'paid profile validation probe returned no valid success envelope'
     return True, data.get('subscriptionType') or 'unknown'
 
 
 def cmd_init(args):
+    call_reservation = (None if args.skip_profile_check else
+                        required_call_ledger(args, context='init profile probe'))
+    preflight = None
+    if call_reservation is not None:
+        preflight = write_synthetic_preflight(
+            call_reservation.path + '.profile-preflight.json',
+            'profile-init-' + call_reservation.run_id)
     db = connect(args.db)
     with db:
         for item in args.account:
             name, config_dir = item.split('=', 1)
             config_dir = os.path.abspath(config_dir)
-            ok, detail = (True, 'test override') if args.skip_profile_check else profile_status(config_dir, args.claude_bin)
+            ok, detail = ((True, 'test override') if args.skip_profile_check else
+                          profile_status(
+                              config_dir, args.claude_bin, call_reservation, name, preflight))
             if not ok:
                 raise SystemExit('%s: profile validation failed: %s' % (name, detail))
             db.execute('INSERT OR REPLACE INTO accounts(name,config_dir,parked_until,last_error,validated,updated_at) VALUES(?,?,0,NULL,1,?)',
@@ -481,15 +615,9 @@ def cmd_init(args):
 
 
 def cmd_enqueue(args):
-    argv = json.loads(args.argv_json)
-    if not isinstance(argv, list) or not argv or not all(isinstance(x, str) for x in argv):
-        raise SystemExit('--argv-json must be a non-empty JSON string array')
-    db = connect(args.db)
-    with db:
-        db.execute('INSERT INTO jobs(external_id,argv_json,cwd,output_path,max_attempts) VALUES(?,?,?,?,?)',
-                   (args.external_id, json.dumps(argv), os.path.abspath(args.cwd),
-                    os.path.abspath(args.output), args.max_attempts))
-    db.close()
+    raise SystemExit(
+        'generic argv jobs are disabled; import a sealed coordinator manifest '
+        'so run/preflight/reservation/profile/result binding is mandatory')
 
 
 def cmd_import_coordinator(args):
@@ -522,15 +650,22 @@ def cmd_import_coordinator(args):
             if manifest['meta'].get('lang') != 'ru':
                 raise SystemExit('%s: H818 production default is RU only' % lease['id'])
             profile_slot = manifest['execution']['profile_slot']
+            preflight_path = lease.get('preflight_path')
+            preflight_hash = lease.get('preflight_sha256')
+            if not preflight_path or not preflight_hash or not os.path.exists(preflight_path):
+                raise SystemExit('%s: sealed preflight missing' % lease['id'])
+            if sha256_path(preflight_path) != preflight_hash:
+                raise SystemExit('%s: sealed preflight hash changed' % lease['id'])
             keys = set(manifest['meta']['selected_keys'])
             overlap = keys & occupied
             if overlap:
                 raise SystemExit('%s: key overlap with queued/done job: %s' %
                                  (lease['id'], ','.join(sorted(overlap))))
             output = os.path.join(lease['artifact_dir'], 'workflow_result.headless.%s.json' % lease['id'])
-            db.execute('INSERT INTO jobs(external_id,cwd,output_path,manifest_path,manifest_sha256,profile_slot,max_attempts) VALUES(?,?,?,?,?,?,?)',
+            db.execute('INSERT INTO jobs(external_id,cwd,output_path,manifest_path,manifest_sha256,profile_slot,preflight_path,preflight_sha256,max_attempts) VALUES(?,?,?,?,?,?,?,?,?)',
                        (lease['id'], os.path.abspath(args.cwd), output, manifest_path,
-                        sha256_path(manifest_path), profile_slot, args.max_attempts))
+                        sha256_path(manifest_path), profile_slot, preflight_path,
+                        preflight_hash, args.max_attempts))
             occupied.update(keys)
             added += 1
     db.close()
@@ -572,6 +707,12 @@ def cmd_import_requeue(args):
     if manifest['meta'].get('lang') != 'ru':
         raise SystemExit('%s: H818 production default is RU only' % args.lease_id)
     profile_slot = manifest['execution']['profile_slot']
+    preflight_path = attempt.get('preflight') or lease.get('preflight_path')
+    preflight_hash = attempt.get('preflight_sha256') or lease.get('preflight_sha256')
+    if not preflight_path or not preflight_hash or not os.path.exists(preflight_path):
+        raise SystemExit('%s: requeue sealed preflight missing' % args.lease_id)
+    if sha256_path(preflight_path) != preflight_hash:
+        raise SystemExit('%s: requeue sealed preflight hash changed' % args.lease_id)
     external_id = '%s%s%02d-%s' % (args.lease_id, RQ_ID_SEP, number, kind)
     db = connect(args.db)
     existing = {row['external_id'] for row in db.execute('SELECT external_id FROM jobs')}
@@ -595,9 +736,10 @@ def cmd_import_requeue(args):
     output = os.path.join(adir, 'workflow_result.headless.%s.rq%02d-%s.json'
                           % (args.lease_id, number, kind))
     with db:
-        db.execute('INSERT INTO jobs(external_id,cwd,output_path,manifest_path,manifest_sha256,profile_slot,max_attempts) VALUES(?,?,?,?,?,?,?)',
+        db.execute('INSERT INTO jobs(external_id,cwd,output_path,manifest_path,manifest_sha256,profile_slot,preflight_path,preflight_sha256,max_attempts) VALUES(?,?,?,?,?,?,?,?,?)',
                    (external_id, os.path.abspath(args.cwd), output, manifest_path,
-                    sha256_path(manifest_path), profile_slot, args.max_attempts))
+                    sha256_path(manifest_path), profile_slot, preflight_path,
+                    preflight_hash, args.max_attempts))
     db.close()
     print('imported=1 %s' % external_id)
     return external_id
@@ -680,9 +822,60 @@ def cmd_record_done(args):
     for job in jobs:
         if not job['manifest_path'] or not os.path.exists(job['output_path']):
             raise SystemExit('%s: completed coordinator job has no result' % job['external_id'])
+        if not job['result_sha256']:
+            raise SystemExit('%s: completed coordinator job has no saved result hash'
+                             % job['external_id'])
+        actual_hash = sha256_path(job['output_path'])
+        if actual_hash != job['result_sha256']:
+            raise SystemExit('%s: result substitution refused (saved=%s actual=%s)'
+                             % (job['external_id'], job['result_sha256'], actual_hash))
+        if not job['run_id']:
+            raise SystemExit('%s: completed coordinator job has no saved run_id'
+                             % job['external_id'])
+    if len(jobs) > 1:
+        lease_ids = [coordinator_lease_id(job['external_id']) for job in jobs]
+        if len(lease_ids) != len(set(lease_ids)):
+            raise SystemExit('record-done batch refuses duplicate coordinator lease ids')
+        command = ['record-output-batch']
+        for job, lease_id in zip(jobs, lease_ids):
+            command += ['--record', lease_id, job['output_path'], job['run_id'],
+                        job['result_sha256']]
+        proc = coordinator_command(args, command, check=False)
+        progress = None
+        prefix = 'RECORD_OUTPUT_BATCH_PROGRESS: '
+        for line in ((proc.stdout or '') + '\n' + (proc.stderr or '')).splitlines():
+            if line.startswith(prefix):
+                try:
+                    candidate = json.loads(line[len(prefix):])
+                except json.JSONDecodeError:
+                    continue
+                if candidate.get('schema') == 'pwg.record_output_batch.v1':
+                    progress = candidate
+        committed = list((progress or {}).get('recorded') or [])
+        if committed != lease_ids[:len(committed)]:
+            raise SystemExit('record-done batch returned a non-prefix progress receipt')
+        if committed:
+            committed_set = set(committed)
+            db = connect(args.db)
+            with db:
+                for job, lease_id in zip(jobs, lease_ids):
+                    if lease_id in committed_set:
+                        db.execute('UPDATE jobs SET coordinator_recorded=1 WHERE id=?',
+                                   (job['id'],))
+            db.close()
+            recorded = len(committed)
+        print(proc.stdout, end='')
+        print(proc.stderr, end='', file=sys.stderr)
+        if proc.returncode or committed != lease_ids:
+            raise SystemExit('coordinator record-output-batch committed %d/%d'
+                             % (recorded, len(jobs)))
+        print('recorded=%d' % recorded)
+        return
+    for job in jobs:
         proc = coordinator_command(
             args, ['record-output', coordinator_lease_id(job['external_id']),
-                   job['output_path']], check=False)
+                   job['output_path'], '--run-id', job['run_id'],
+                   '--result-sha256', job['result_sha256']], check=False)
         if proc.returncode:
             print(proc.stdout, end='')
             print(proc.stderr, end='', file=sys.stderr)
@@ -782,6 +975,12 @@ def cmd_run_once(args):
         return
     runtime_jobs = [job for _account, job in work if job['manifest_path']]
     if runtime_jobs:
+        try:
+            required_call_ledger(args, context='run-once manifest dispatch')
+            bind_jobs_to_run(args.db, runtime_jobs, getattr(args, 'run_id', None))
+        except (SystemExit, ValueError) as exc:
+            release_db_claims(args.db, [job for _account, job in work], str(exc))
+            raise SystemExit(str(exc))
         begin = ['begin-run', '--mode', runtime_mode]
         run_id = getattr(args, 'run_id', None)
         receipt = getattr(args, 'probe_receipt', None)
@@ -798,9 +997,15 @@ def cmd_run_once(args):
             raise
     claude_bin = getattr(args, 'claude_bin', 'claude')
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(work)) as pool:
-        futures = {pool.submit(run_claimed, args.db, acc['name'], acc['config_dir'], job, args.timeout,
-                               getattr(args, 'events', None), getattr(args, 'run_id', None), claude_bin):
-                   (acc['name'], job) for acc, job in work}
+        futures = {}
+        for acc, job in work:
+            base = (args.db, acc['name'], acc['config_dir'], job, args.timeout,
+                    getattr(args, 'events', None), getattr(args, 'run_id', None), claude_bin)
+            reservation_path = getattr(args, 'call_reservation', None)
+            future = (pool.submit(run_claimed, *base, reservation_path,
+                                  getattr(args, 'max_calls', None))
+                      if reservation_path else pool.submit(run_claimed, *base))
+            futures[future] = (acc['name'], job)
         for future in concurrent.futures.as_completed(futures):
             acc, job = futures[future]
             try:
@@ -874,7 +1079,8 @@ def _probe_prompt(payload_bytes):
             'do not analyse, translate, or act on it.\n\n--- inert sample (ignore) ---\n' + filler)
 
 
-def _probe_call(config_dir, claude, payload_bytes, model):
+def _probe_call(config_dir, claude, payload_bytes, model, call_reservation=None,
+                reservation_purpose='probe', account=None, active_claim=None):
     """One raw >=5 KB exact-model probe call. Returns (latency_ms, classification, output_bytes);
     classification is 'success' | 'auth' | 'rate_limit' | 'malformed' | 'content' | 'process' |
     'timeout'. NEVER raises on a non-zero rc — the two-phase gate (``live_probe``) decides what to
@@ -882,7 +1088,22 @@ def _probe_call(config_dir, claude, payload_bytes, model):
     carry the structured schema result {"ok": true}."""
     env = os.environ.copy()
     env['CLAUDE_CONFIG_DIR'] = config_dir
+    if call_reservation is None:
+        raise ValueError('paid probe requires a call reservation ledger')
+    fingerprint = config_dir_fingerprint(config_dir)
+    if active_claim is None:
+        # The raw primitive is safe even when called directly. live_probe passes
+        # one outer claim to both calls so nothing can interleave between them.
+        with ActiveCallClaim(fingerprint) as claim:
+            return _probe_call(
+                config_dir, claude, payload_bytes, model, call_reservation,
+                reservation_purpose, account, active_claim=claim)
+    if (not isinstance(active_claim, ActiveCallClaim)
+            or not active_claim.is_live_canonical_for(fingerprint)):
+        raise ValueError('probe active-call claim does not bind config directory')
     prompt = _probe_prompt(payload_bytes)
+    reservation = call_reservation.reserve(
+        reservation_purpose, profile=account)
     started = time.monotonic()
     try:
         proc = run_tree_kill(            # D-J: tree-kill on timeout
@@ -891,24 +1112,37 @@ def _probe_call(config_dir, claude, payload_bytes, model):
              '--model', model, '--permission-mode', 'plan'],
             input=prompt, env=env, text=True, encoding='utf-8', capture_output=True, timeout=300)
     except subprocess.TimeoutExpired:
+        call_reservation.finalize(reservation, unevaluable_telemetry())
         return int((time.monotonic() - started) * 1000), 'timeout', 0
+    except BaseException:
+        call_reservation.finalize(reservation, unevaluable_telemetry())
+        raise
     latency_ms = int((time.monotonic() - started) * 1000)
     out = proc.stdout or ''
     combined = out + '\n' + (proc.stderr or '')
     output_bytes = len(out.encode('utf-8'))
+    try:
+        wrapper = json.loads(out)
+    except (ValueError, TypeError):
+        wrapper = None
+    telemetry = telemetry_from_cli_wrapper(wrapper)
     if proc.returncode:
+        call_reservation.finalize(reservation, telemetry)
         return latency_ms, (_probe_err_class(combined) or 'process'), output_bytes
     # rc 0 is NOT sufficient. `claude -p --output-format json` returns the CLI result *envelope*
     # ({"type":"result","subtype":"success","is_error":false,"result":..., "structured_output":...}).
     # Validate it strictly and require the structured schema result {"ok": true}.
-    try:
-        wrapper = json.loads(out)
-    except (ValueError, TypeError):
+    if wrapper is None:
+        call_reservation.finalize(
+            reservation, dict(telemetry, cost_evaluable=False))
         return latency_ms, 'malformed', output_bytes
     if not isinstance(wrapper, dict) or wrapper.get('type') != 'result':
+        call_reservation.finalize(
+            reservation, dict(telemetry, cost_evaluable=False))
         return latency_ms, 'malformed', output_bytes            # not the CLI result envelope
     if wrapper.get('subtype') != 'success' or wrapper.get('is_error'):
         # a valid envelope reporting an ERROR (with rc 0) — it may still carry auth/rate-limit text
+        call_reservation.finalize(reservation, telemetry)
         return latency_ms, (_probe_err_class(json.dumps(wrapper, ensure_ascii=False)) or 'process'), output_bytes
     # extract the structured schema result: `structured_output`, else `result` when it is a JSON
     # string (or already a dict).
@@ -923,15 +1157,19 @@ def _probe_call(config_dir, claude, payload_bytes, model):
         elif isinstance(res, dict):
             payload = res
     if not isinstance(payload, dict) or 'ok' not in payload:
+        call_reservation.finalize(
+            reservation, dict(telemetry, cost_evaluable=False))
         return latency_ms, 'malformed', output_bytes            # missing / invalid structured result
     if payload.get('ok') is not True:
+        call_reservation.finalize(reservation, telemetry)
         return latency_ms, 'content', output_bytes              # {"ok": false} -> content, never success
+    call_reservation.finalize(reservation, telemetry)
     return latency_ms, 'success', output_bytes
 
 
 def live_probe(config_dir, claude='claude', payload_bytes=6491, model=EXACT_GEN_MODEL,
                latency_ceiling_ms=PROBE_LATENCY_CEILING_MS, events_path=None, run_id=None,
-               account=None):
+               account=None, call_reservation=None):
     """D-K deterministic two-phase probe protocol (ceiling unchanged at 30000 ms). Runs EXACTLY
     one warm-up call (same profile + exact model; its latency is EXCLUDED from the acceptance
     gate — it only stabilizes the cold connection), then IMMEDIATELY EXACTLY one measured >=5 KB
@@ -947,6 +1185,8 @@ def live_probe(config_dir, claude='claude', payload_bytes=6491, model=EXACT_GEN_
                          (payload_bytes, PROBE_MIN_PAYLOAD_BYTES))
     if model != EXACT_GEN_MODEL:
         raise SystemExit('probe model %r is not the exact generation model %r' % (model, EXACT_GEN_MODEL))
+    if call_reservation is None:
+        raise ValueError('paid probe requires a call reservation ledger')
 
     def _emit(purpose, latency, cls, obytes):
         if events_path:
@@ -956,24 +1196,31 @@ def live_probe(config_dir, claude='claude', payload_bytes=6491, model=EXACT_GEN_
                          policy=PROBE_POLICY, executor_lane=PROBE_LANE,
                          schema_valid=(cls == 'success'))
 
-    warm_ms, warm_cls, warm_bytes = _probe_call(config_dir, claude, payload_bytes, model)
-    _emit('warmup', warm_ms, warm_cls, warm_bytes)     # excluded from the acceptance latency census
-    if warm_cls != 'success':
-        raise SystemExit('warm-up probe %s -> STOP (auth/model/output/rate-limit/timeout)' % warm_cls)
+    # One profile claim covers the WHOLE pair. Releasing between warmup and measured allowed
+    # another paid worker to interleave on the same config directory and invalidated the reading.
+    with ActiveCallClaim(config_dir_fingerprint(config_dir)) as active_claim:
+        warm_ms, warm_cls, warm_bytes = _probe_call(
+            config_dir, claude, payload_bytes, model, call_reservation,
+            'probe:warmup', account, active_claim=active_claim)
+        _emit('warmup', warm_ms, warm_cls, warm_bytes)
+        if warm_cls != 'success':
+            raise SystemExit('warm-up probe %s -> STOP (auth/model/output/rate-limit/timeout)' % warm_cls)
 
-    meas_ms, meas_cls, meas_bytes = _probe_call(config_dir, claude, payload_bytes, model)
-    _emit('measured', meas_ms, meas_cls, meas_bytes)   # the one gated acceptance reading
-    if meas_cls != 'success':
-        raise SystemExit('measured probe %s -> honest NO-GO (no retry, no re-warm)' % meas_cls)
-    if meas_ms >= latency_ceiling_ms:
-        raise SystemExit('measured probe latency %d ms is not below %d ms health ceiling — honest NO-GO '
-                         '(warm-up already done; no re-roll)' % (meas_ms, latency_ceiling_ms))
+        meas_ms, meas_cls, meas_bytes = _probe_call(
+            config_dir, claude, payload_bytes, model, call_reservation,
+            'probe:measured', account, active_claim=active_claim)
+        _emit('measured', meas_ms, meas_cls, meas_bytes)
+        if meas_cls != 'success':
+            raise SystemExit('measured probe %s -> honest NO-GO (no retry, no re-warm)' % meas_cls)
+        if meas_ms >= latency_ceiling_ms:
+            raise SystemExit('measured probe latency %d ms is not below %d ms health ceiling — honest NO-GO '
+                             '(warm-up already done; no re-roll)' % (meas_ms, latency_ceiling_ms))
     return meas_ms
 
 
 def probe_fleet(accounts, claude='claude', payload_bytes=6491, model=EXACT_GEN_MODEL,
                 latency_ceiling_ms=PROBE_LATENCY_CEILING_MS, events_path=None, run_id=None,
-                drop_unhealthy=False):
+                drop_unhealthy=False, call_reservation=None):
     """GAP #5 (four-profile): probe EACH validated account through the D-K two-phase ``live_probe``
     (exactly one warm-up + one measured >=5 KB call per account, with each account's warm-up latency
     EXCLUDED from the census — a 4-profile fleet therefore yields exactly 4 measured latency samples,
@@ -997,7 +1244,8 @@ def probe_fleet(accounts, claude='claude', payload_bytes=6491, model=EXACT_GEN_M
         try:
             latencies[name] = live_probe(acc['config_dir'], claude, payload_bytes=payload_bytes,
                                          model=model, latency_ceiling_ms=latency_ceiling_ms,
-                                         events_path=events_path, run_id=run_id, account=name)
+                                         events_path=events_path, run_id=run_id, account=name,
+                                         call_reservation=call_reservation)
         except SystemExit as exc:
             if not drop_unhealthy:
                 # STOP-on-any-NO-GO: one unhealthy profile fails the whole fleet (honest NO-GO).
@@ -1050,7 +1298,30 @@ def cmd_staged_run(args):
         raise SystemExit('Windows staged-run requires at least one validated account')
     if getattr(args, 'max_accounts', 0):
         accounts = accounts[:args.max_accounts]
-    run_id = args.run_id or ('win100-' + now_iso().replace(':', '').replace('-', ''))
+    preflight_cmd = ['validate-preflight']
+    for lease_id in sorted(lease_ids):
+        preflight_cmd += ['--lease-id', lease_id]
+    preflight = coordinator_command(args, preflight_cmd, check=False)
+    if preflight.returncode:
+        raise SystemExit('staged-run preflight refused before probe: %s'
+                         % (preflight.stderr or preflight.stdout)[-2000:])
+    reservation_path = getattr(args, 'call_reservation', None)
+    if not reservation_path:
+        raise SystemExit('staged-run requires --call-reservation')
+    run_id = args.run_id
+    if getattr(args, 'resume', False):
+        if not os.path.exists(reservation_path):
+            raise SystemExit('staged-run --resume requires the existing call ledger')
+        known = run_ids(reservation_path)
+        if run_id and run_id not in known:
+            raise SystemExit('staged-run --resume run-id is absent from the call ledger')
+        if not run_id and len(known) == 1:
+            run_id = known[0]
+        elif not run_id:
+            raise SystemExit('staged-run --resume requires --run-id for a multi-run ledger')
+    run_id = run_id or ('win100-' + now_iso().replace(':', '').replace('-', ''))
+    args.run_id = run_id
+    call_ledger = required_call_ledger(args, context='staged-run')
     if getattr(args, 'resume', False):
         cmd_recover(argparse.Namespace(
             db=args.db, coordinator=args.coordinator, coord_dir=args.coord_dir,
@@ -1059,7 +1330,9 @@ def cmd_staged_run(args):
     # STOP-on-any-NO-GO; --drop-unhealthy opts into proceeding on the healthy subset, parking the
     # dropped accounts so the dispatch loop below claims only survivors.
     probe_latencies = probe_fleet(accounts, args.claude_bin, events_path=args.events,
-                                  run_id=run_id, drop_unhealthy=getattr(args, 'drop_unhealthy', False))
+                                  run_id=run_id,
+                                  drop_unhealthy=getattr(args, 'drop_unhealthy', False),
+                                  call_reservation=call_ledger)
     probe_receipt = write_probe_receipt(
         args.coord_dir, run_id, lease_ids, probe_latencies)
     if getattr(args, 'drop_unhealthy', False):
@@ -1142,7 +1415,9 @@ def cmd_staged_run(args):
                                             # never to a capped-out or dropped (unprobed) account.
                                             only_accounts=set(probe_latencies),
                                             only_profile=getattr(args, 'only_profile', None),
-                                            only_external_ids=lease_scope))
+                                            only_external_ids=lease_scope,
+                                            call_reservation=reservation_path,
+                                            max_calls=getattr(args, 'max_calls', None)))
         cmd_record_done(argparse.Namespace(db=args.db, coordinator=args.coordinator,
                                            coord_dir=args.coord_dir, cwd=args.cwd,
                                            only_external_ids=lease_scope))
@@ -1248,7 +1523,17 @@ def cmd_staged_run(args):
 
 
 def cmd_presplit_canary(args):
-    manifest = json.load(open(args.manifest, encoding='utf-8'))
+    try:
+        with open(args.manifest, 'rb') as fh:
+            manifest_bytes = fh.read()
+        manifest_hash = hashlib.sha256(manifest_bytes).hexdigest()
+        manifest = json.loads(manifest_bytes.decode('utf-8'))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SystemExit('presplit canary manifest is unreadable: %s' % exc)
+    try:
+        validate_manifest(manifest, require_v2=True)
+    except ValueError as exc:
+        raise SystemExit('presplit canary preflight: %s' % exc)
     presplit = manifest.get('presplit_keys') or []
     if not presplit:
         raise SystemExit('presplit canary manifest has no presplit_keys')
@@ -1257,26 +1542,60 @@ def cmd_presplit_canary(args):
     db.close()
     if len(accounts) != 1:
         raise SystemExit('presplit canary requires exactly one validated account')
+    try:
+        validate_profile(manifest, accounts[0]['config_dir'], accounts[0]['name'])
+    except ValueError as exc:
+        raise SystemExit('presplit canary preflight: %s' % exc)
     run_id = args.run_id or ('presplit-' + now_iso().replace(':', '').replace('-', ''))
+    args.run_id = run_id
+    call_ledger = required_call_ledger(args, context='presplit-canary')
+    preflight_path = os.path.abspath(args.preflight)
+    validate_preflight_artifact(
+        preflight_path, manifest, args.preflight_sha256)
     latency = live_probe(accounts[0]['config_dir'], args.claude_bin,   # D-K: warmup+measured
-                         events_path=args.events, run_id=run_id, account=accounts[0]['name'])
+                         events_path=args.events, run_id=run_id, account=accounts[0]['name'],
+                         call_reservation=call_ledger)
     env = os.environ.copy()
     env['CLAUDE_CONFIG_DIR'] = accounts[0]['config_dir']
+    env['PWG_CALL_RESERVATION_PATH'] = os.path.abspath(args.call_reservation)
+    env['PWG_CALL_RESERVATION_RUN_ID'] = run_id
+    env['PWG_CALL_RESERVATION_MAX_CALLS'] = (
+        '' if getattr(args, 'max_calls', None) is None else str(args.max_calls))
+    env['PWG_PREFLIGHT_PATH'] = preflight_path
+    env['PWG_PREFLIGHT_SHA256'] = args.preflight_sha256
+    if sha256_path(args.manifest) != manifest_hash:
+        raise SystemExit('presplit canary manifest changed during the health probe')
     cmd = [sys.executable, os.path.join(os.path.dirname(__file__), 'headless_worker.py'),
            os.path.abspath(args.manifest), '--output', os.path.abspath(args.output),
            '--status-out', os.path.abspath(args.status), '--claude-bin', args.claude_bin,
-           '--timeout', str(args.timeout)]
+           '--only-profile', accounts[0]['name'],
+           '--timeout', str(args.timeout), '--preflight', preflight_path,
+           '--preflight-sha256', args.preflight_sha256,
+           '--manifest-sha256', manifest_hash]
     proc = run_tree_kill(cmd, env=env, text=True, encoding='utf-8', capture_output=True,
                          timeout=args.timeout)   # D-J: tree-kill on timeout (presplit canary worker)
     status = json.load(open(args.status, encoding='utf-8')) if os.path.exists(args.status) else {}
     canary_base = {'run_id': run_id, 'account': accounts[0]['name'],
-                   'manifest_hash': status.get('manifest_sha256')}
+                   'manifest_hash': manifest_hash}
     for idx, item in enumerate(status.get('attempts') or []):
         emit_call_events(args.events, item, idx, status.get('manifest_sha256'), canary_base)
     if proc.returncode or status.get('classification') != 'success':
         raise SystemExit('presplit canary NO-GO: %s' %
                          (status.get('classification') or (proc.stderr or proc.stdout)[-500:]))
-    payload = json.load(open(args.output, encoding='utf-8'))
+    if status.get('manifest_sha256') != manifest_hash:
+        raise SystemExit('presplit canary NO-GO: worker manifest hash drift')
+    try:
+        with open(args.output, 'rb') as fh:
+            result_bytes = fh.read()
+        result_hash = hashlib.sha256(result_bytes).hexdigest()
+        payload = json.loads(result_bytes.decode('utf-8'))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SystemExit('presplit canary NO-GO: result is unreadable: %s' % exc)
+    if status.get('result_sha256') != result_hash:
+        raise SystemExit('presplit canary NO-GO: worker result hash drift')
+    if (payload.get('meta') or {}).get(
+            'execution_manifest_sha256') != manifest_hash:
+        raise SystemExit('presplit canary NO-GO: payload manifest seal is absent/drifted')
     failures = (payload.get('summary') or {}).get('failures') or {}
     if failures or (payload.get('summary') or {}).get('presplit', 0) < 1:
         raise SystemExit('presplit canary NO-GO: residuals or route not exercised')
@@ -1294,14 +1613,14 @@ def main(argv=None):
     default_cwd = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
     ap.add_argument('--db', default='max_orchestrator.sqlite')
     sub = ap.add_subparsers(dest='cmd', required=True)
-    p = sub.add_parser('init'); p.add_argument('--account', action='append', required=True); p.add_argument('--claude-bin', default='claude'); p.add_argument('--skip-profile-check', action='store_true', help=argparse.SUPPRESS); p.set_defaults(func=cmd_init)
+    p = sub.add_parser('init'); p.add_argument('--account', action='append', required=True); p.add_argument('--claude-bin', default='claude'); p.add_argument('--skip-profile-check', action='store_true', help=argparse.SUPPRESS); p.add_argument('--call-reservation'); p.add_argument('--run-id'); p.add_argument('--max-calls', type=int); p.set_defaults(func=cmd_init)
     p = sub.add_parser('enqueue'); p.add_argument('--external-id', required=True); p.add_argument('--argv-json', required=True); p.add_argument('--cwd', required=True); p.add_argument('--output', required=True); p.add_argument('--max-attempts', type=int, default=3); p.set_defaults(func=cmd_enqueue)
     p = sub.add_parser('import-coordinator'); p.add_argument('--coord-dir', required=True); p.add_argument('--cwd', required=True); p.add_argument('--lease-id', action='append'); p.add_argument('--max-attempts', type=int, default=3); p.set_defaults(func=cmd_import_coordinator)
     p = sub.add_parser('import-requeue', help='H1339 A4: import one requeue_prepared lease attempt as a runnable job'); p.add_argument('lease_id'); p.add_argument('--coord-dir', required=True); p.add_argument('--cwd', required=True); p.add_argument('--max-attempts', type=int, default=2); p.set_defaults(func=cmd_import_requeue)
     p = sub.add_parser('reset-failed', help='B18: audited scoped recovery of terminal failed jobs (requires --reason)'); p.add_argument('--lease-id', action='append', required=True); p.add_argument('--reason', required=True); p.add_argument('--events'); p.set_defaults(func=cmd_reset_failed)
     p = sub.add_parser('recover'); p.add_argument('--coordinator', default=default_coordinator); p.add_argument('--coord-dir', default=default_coord_dir); p.add_argument('--cwd', default=default_cwd); p.set_defaults(func=cmd_recover)
     p = sub.add_parser('record-done'); p.add_argument('--coordinator', default=default_coordinator); p.add_argument('--coord-dir', default=default_coord_dir); p.add_argument('--cwd', default=default_cwd); p.set_defaults(func=cmd_record_done)
-    p = sub.add_parser('run-once'); p.add_argument('--timeout', type=int, default=7200); p.add_argument('--claude-bin', default='claude'); p.add_argument('--only-profile'); p.add_argument('--coordinator', default=default_coordinator); p.add_argument('--coord-dir', default=default_coord_dir); p.add_argument('--cwd', default=default_cwd); p.set_defaults(func=cmd_run_once)
+    p = sub.add_parser('run-once'); p.add_argument('--timeout', type=int, default=7200); p.add_argument('--claude-bin', default='claude'); p.add_argument('--only-profile'); p.add_argument('--coordinator', default=default_coordinator); p.add_argument('--coord-dir', default=default_coord_dir); p.add_argument('--cwd', default=default_cwd); p.add_argument('--call-reservation'); p.add_argument('--run-id'); p.add_argument('--max-calls', type=int); p.set_defaults(func=cmd_run_once)
     p = sub.add_parser('status'); p.set_defaults(func=cmd_status)
     p = sub.add_parser('staged-run')
     p.add_argument('--coord-dir', required=True); p.add_argument('--cwd', required=True)
@@ -1314,13 +1633,20 @@ def main(argv=None):
     p.add_argument('--drop-unhealthy', action='store_true')        # GAP #5: proceed on healthy subset
     p.add_argument('--report', required=True)
     p.add_argument('--events', required=True); p.add_argument('--census', required=True)
-    p.add_argument('--run-id'); p.set_defaults(func=cmd_staged_run)
+    p.add_argument('--run-id'); p.add_argument('--call-reservation'); p.add_argument('--max-calls', type=int); p.set_defaults(func=cmd_staged_run)
     p = sub.add_parser('presplit-canary')
     p.add_argument('--manifest', required=True); p.add_argument('--output', required=True)
     p.add_argument('--status', required=True); p.add_argument('--events', required=True)
+    p.add_argument('--preflight', required=True)
+    p.add_argument('--preflight-sha256', required=True)
     p.add_argument('--run-id'); p.add_argument('--claude-bin', default='claude')
+    p.add_argument('--call-reservation'); p.add_argument('--max-calls', type=int)
     p.add_argument('--timeout', type=int, default=7200); p.set_defaults(func=cmd_presplit_canary)
-    args = ap.parse_args(argv); args.func(args)
+    args = ap.parse_args(argv)
+    try:
+        args.func(args)
+    except CallLimitReached as exc:
+        raise SystemExit(str(exc))
 
 
 if __name__ == '__main__':

--- a/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
@@ -18,6 +18,39 @@ import max_account_orchestrator as m
 from execution_contract import config_dir_fingerprint
 
 
+class MemoryCallLedger:
+    """Selftest-only reservation authority for fake probe runners."""
+
+    def __init__(self):
+        self.next_id = 0
+        self.finalized = {}
+
+    def reserve(self, *_args, **_kwargs):
+        self.next_id += 1
+        return 'test-probe-%d' % self.next_id
+
+    def finalize(self, reservation, telemetry):
+        self.finalized[reservation] = dict(telemetry)
+
+
+def enqueue_fixture(db_path, external_id, cwd, output_path, max_attempts=3):
+    """Insert an inert legacy row for scheduler-state tests without a CLI escape."""
+    con = m.connect(db_path)
+    with con:
+        con.execute(
+            'INSERT INTO jobs(external_id,argv_json,cwd,output_path,max_attempts) '
+            'VALUES(?,?,?,?,?)',
+            (external_id, '[]', os.path.abspath(cwd),
+             os.path.abspath(output_path), max_attempts))
+    con.close()
+
+
+def finish_fixture_worker(db_path, account, config_dir, job, timeout, *_args, **_kwargs):
+    """Exercise scheduler fan-out without retaining an arbitrary subprocess path."""
+    m.finish(db_path, job['id'], 'done', 0)
+    return 'done'
+
+
 def main():
     staged_plan = {
         'selected_headwords': 2,
@@ -137,9 +170,9 @@ def main():
         m.main(['--db', scoped_db, 'init', '--account', 'acc=' + os.path.join(td, 'acc'),
                 '--skip-profile-check'])
         for external_id in ('historic-failed', 'current'):
-            m.main(['--db', scoped_db, 'enqueue', '--external-id', external_id,
-                    '--argv-json', json.dumps([sys.executable, '-c', 'print(1)']), '--cwd', td,
-                    '--output', os.path.join(td, external_id + '.json')])
+            enqueue_fixture(
+                scoped_db, external_id, td,
+                os.path.join(td, external_id + '.json'))
         con = m.connect(scoped_db)
         with con:
             con.execute("UPDATE jobs SET state='failed' WHERE external_id='historic-failed'")
@@ -156,7 +189,7 @@ def main():
 
     # A profile-bound v2 manifest is a scheduler constraint, not merely a worker-time check.
     # Register accounts in the opposite order from the manifest owner and ask the wrong account
-    # first: it must not reserve the paid job. Generic argv jobs intentionally remain portable.
+    # first: it must not reserve the paid job.
     with tempfile.TemporaryDirectory() as td:
         bound_db = os.path.join(td, 'profile-bound.sqlite')
         acc1_dir = os.path.join(td, 'acc1')
@@ -179,10 +212,18 @@ def main():
                                      'validation_method': 'audit_window+final_schema',
                                      'model_identifier': 'claude-sonnet-5'},
                        'key_provenance': {'bound-key': 'real'}}, f)
+        bound_preflight = os.path.join(artifacts, 'preflight.json')
+        with open(bound_preflight, 'w', encoding='utf-8') as f:
+            json.dump({'schema': 'pwg.performance_preflight.v1',
+                       'selected_keys': ['bound-key'],
+                       'cost_gate': {'over_ceiling': False}}, f)
         with open(os.path.join(coord, 'state.json'), 'w', encoding='utf-8') as f:
             json.dump({'leases': [{'id': 'bound-acc1', 'state': 'prepared',
                                    'artifact_dir': artifacts,
-                                   'execution_manifest': manifest_path}]}, f)
+                                   'execution_manifest': manifest_path,
+                                   'preflight_path': bound_preflight,
+                                   'preflight_sha256':
+                                       m.sha256_path(bound_preflight)}]}, f)
         m.main(['--db', bound_db, 'import-coordinator', '--coord-dir', coord,
                 '--cwd', td, '--lease-id', 'bound-acc1'])
         con = sqlite3.connect(bound_db)
@@ -198,15 +239,72 @@ def main():
         except SystemExit as exc:
             assert 'no eligible/probed account: acc1' in str(exc), exc
 
-        m.main(['--db', bound_db, 'enqueue', '--external-id', 'generic',
-                '--argv-json', json.dumps(['x']), '--cwd', td,
-                '--output', os.path.join(td, 'generic.json')])
-        generic = m.claim(bound_db, 'acc2')
-        assert generic is not None and generic['external_id'] == 'generic'
-        m.finish(bound_db, generic['id'], 'done', 0)
         bound = m.claim(bound_db, 'acc1')
         assert bound is not None and bound['external_id'] == 'bound-acc1'
-    print('  profile-bound claims: wrong/missing owner refused loudly; generic job remains portable')
+    print('  profile-bound claims: wrong/missing owner refused loudly')
+
+    # Arbitrary argv is not a securable paid-call boundary: a neutral wrapper can invoke
+    # anything. Refuse every generic enqueue and every legacy generic row before spawn.
+    with tempfile.TemporaryDirectory() as td:
+        guard_db = os.path.join(td, 'generic-guard.sqlite')
+        m.main(['--db', guard_db, 'init',
+                '--account', 'acc=' + os.path.join(td, 'acc'), '--skip-profile-check'])
+        generic_argvs = [
+            ['Claude', '-p', 'forbidden'],
+            ['claude-code', '-p', 'forbidden'],
+            [sys.executable, os.path.join(td, 'headless_worker.py')],
+            [sys.executable, os.path.join(td, 'latency_payload_sweep.py')],
+            [sys.executable, os.path.join(td, 'H963_c4_gate0_probe.py')],
+            [sys.executable, os.path.join(td, 'model_wrapper.py')],
+            ['node', os.path.join(td, 'model_wrapper.js')],
+            [os.path.join(td, 'renamed.exe'), '-p', 'request'],
+            [sys.executable, '-c', 'print("harmless")'],
+        ]
+        for index, argv in enumerate(generic_argvs):
+            try:
+                m.main(['--db', guard_db, 'enqueue',
+                        '--external-id', 'enqueue-generic-%d' % index,
+                        '--argv-json', json.dumps(argv), '--cwd', td,
+                        '--output', os.path.join(td, 'enqueue-generic-%d.json' % index)])
+                raise AssertionError('generic argv reached enqueue: %r' % argv)
+            except SystemExit as exc:
+                assert 'generic argv jobs are disabled' in str(exc), (argv, exc)
+        con = m.connect(guard_db)
+        assert con.execute(
+            "SELECT count(*) FROM jobs WHERE external_id LIKE "
+            "'enqueue-generic-%'").fetchone()[0] == 0
+        with con:
+            for index, argv in enumerate(generic_argvs):
+                con.execute(
+                    'INSERT INTO jobs(external_id,argv_json,cwd,output_path,max_attempts) '
+                    'VALUES(?,?,?,?,1)',
+                    ('legacy-generic-%d' % index, json.dumps(argv), td,
+                     os.path.join(td, 'legacy-generic-%d.json' % index)))
+        con.close()
+        original_runner = m.run_tree_kill
+        spawned = []
+
+        def reject_spawn(*args, **kwargs):
+            spawned.append((args, kwargs))
+            raise AssertionError('forbidden generic argv was spawned')
+
+        m.run_tree_kill = reject_spawn
+        try:
+            for index in range(len(generic_argvs)):
+                job = m.claim(guard_db, 'acc')
+                assert job and job['external_id'] == 'legacy-generic-%d' % index, job
+                assert m.run_claimed(
+                    guard_db, 'acc', os.path.join(td, 'acc'), job, 5) == 'failed'
+        finally:
+            m.run_tree_kill = original_runner
+        assert not spawned
+        con = m.connect(guard_db)
+        assert con.execute(
+            "SELECT count(*) FROM jobs WHERE external_id LIKE 'legacy-generic-%' "
+            "AND state='failed' AND failure_class='configuration'").fetchone()[0] == len(
+                generic_argvs)
+        con.close()
+    print('  generic argv guard: all arbitrary enqueues + legacy rows refuse before spawn')
 
     # Required profile selection happens before the standard three-account concurrency slice.
     # Otherwise acc4 is permanently hidden behind three alphabetically earlier idle accounts.
@@ -258,11 +356,12 @@ def main():
         m.main(['--db', db, 'init', '--account', 'acc1=' + os.path.join(td, 'a1'),
                 '--account', 'acc2=' + os.path.join(td, 'a2'), '--skip-profile-check'])
         for n in range(2):
-            out = os.path.join(td, 'out%d.json' % n)
-            argv = [sys.executable, '-c', 'import os; print(os.environ["CLAUDE_CONFIG_DIR"])']
-            m.main(['--db', db, 'enqueue', '--external-id', 'j%d' % n,
-                    '--argv-json', json.dumps(argv), '--cwd', td, '--output', out])
-        m.main(['--db', db, 'run-once', '--timeout', '10'])
+            enqueue_fixture(
+                db, 'j%d' % n, td, os.path.join(td, 'out%d.json' % n))
+        for account in ('acc1', 'acc2'):
+            job = m.claim(db, account)
+            assert job is not None
+            m.finish(db, job['id'], 'done', 0)
         con = sqlite3.connect(db)
         assert con.execute("select count(*) from jobs where state='done'").fetchone()[0] == 2
         con.execute("insert into jobs(external_id,argv_json,cwd,output_path,state) values('stale','[]',?,?,'in_progress')", (td, os.path.join(td, 'x')))
@@ -275,52 +374,6 @@ def main():
         con.close()
         assert m.parse_reset('rate limit reset_at=1999999999', now=1) == 1999999999
         assert m.parse_reset('429 too many requests', now=100) == 18100
-
-        timeout_out = os.path.join(td, 'timeout.json')
-        m.main(['--db', db, 'enqueue', '--external-id', 'timeout', '--argv-json',
-                json.dumps([sys.executable, '-c', 'import time;time.sleep(2)']),
-                '--cwd', td, '--output', timeout_out, '--max-attempts', '1'])
-        m.main(['--db', db, 'run-once', '--timeout', '1'])
-        con = sqlite3.connect(db)
-        assert con.execute("select state,failure_class from jobs where external_id='timeout'").fetchone() == ('failed', 'timeout')
-        con.close()
-
-        fail_out = os.path.join(td, 'fail.json')
-        m.main(['--db', db, 'enqueue', '--external-id', 'retry', '--argv-json',
-                json.dumps([sys.executable, '-c', 'raise SystemExit(7)']),
-                '--cwd', td, '--output', fail_out, '--max-attempts', '2'])
-        m.main(['--db', db, 'run-once', '--timeout', '10'])
-        m.main(['--db', db, 'run-once', '--timeout', '10'])
-        con = sqlite3.connect(db)
-        state, attempts = con.execute("select state,attempts from jobs where external_id='retry'").fetchone()
-        assert (state, attempts) == ('failed', 2)
-        con.close()
-
-        crash_out = os.path.join(td, 'crash-after-output.json')
-        code = ('import pathlib,sys;pathlib.Path(sys.argv[1]).write_text("{}",encoding="utf-8");'
-                'raise SystemExit(7)')
-        m.main(['--db', db, 'enqueue', '--external-id', 'crash-after-output', '--argv-json',
-                json.dumps([sys.executable, '-c', code, crash_out]), '--cwd', td,
-                '--output', crash_out, '--max-attempts', '1'])
-        m.main(['--db', db, 'run-once', '--timeout', '10'])
-        assert os.path.exists(crash_out)
-        con = sqlite3.connect(db)
-        assert con.execute("select state from jobs where external_id='crash-after-output'").fetchone()[0] == 'failed'
-        con.close()
-
-        rate_out = os.path.join(td, 'rate.json')
-        m.main(['--db', db, 'enqueue', '--external-id', 'limited', '--argv-json',
-                json.dumps([sys.executable, '-c',
-                            'import sys;sys.stderr.write("429 rate limit reset_at=1999999999");sys.exit(21)']),
-                '--cwd', td, '--output', rate_out])
-        m.main(['--db', db, 'run-once', '--timeout', '10'])
-        con = sqlite3.connect(db)
-        state, failure = con.execute("select state,failure_class from jobs where external_id='limited'").fetchone()
-        assert (state, failure) == ('pending', 'rate_limit')
-        assert con.execute("select count(*) from accounts where parked_until=1999999999").fetchone()[0] == 1
-        con.execute("delete from jobs where external_id='limited'")
-        con.execute("update accounts set parked_until=0")
-        con.commit(); con.close()
 
         coord = os.path.join(td, 'coord'); artifacts = os.path.join(coord, 'artifacts', 'lease1')
         os.makedirs(artifacts)
@@ -337,10 +390,17 @@ def main():
                                      'validation_method': 'audit_window+final_schema',
                                      'model_identifier': 'claude-sonnet-5'},
                        'key_provenance': {'unique': 'real'}}, f)
+        preflight = os.path.join(artifacts, 'preflight.json')
+        with open(preflight, 'w', encoding='utf-8') as f:
+            json.dump({'schema': 'pwg.performance_preflight.v1',
+                       'selected_keys': ['unique'],
+                       'cost_gate': {'over_ceiling': False}}, f)
         with open(os.path.join(coord, 'state.json'), 'w', encoding='utf-8') as f:
             json.dump({'leases': [{'id': 'lease1', 'state': 'prepared',
                                    'artifact_dir': artifacts,
-                                   'execution_manifest': manifest}]}, f)
+                                   'execution_manifest': manifest,
+                                   'preflight_path': preflight,
+                                   'preflight_sha256': m.sha256_path(preflight)}]}, f)
         m.main(['--db', db, 'import-coordinator', '--coord-dir', coord, '--cwd', td,
                 '--lease-id', 'lease1'])
         con = sqlite3.connect(db)
@@ -365,14 +425,24 @@ def main():
                                      'validation_method': 'audit_window+final_schema',
                                      'model_identifier': 'claude-sonnet-5'},
                        'key_provenance': {'rqkey': 'real'}}, f)
+        rq_preflight = os.path.join(rq_dir, 'preflight.json')
+        with open(rq_preflight, 'w', encoding='utf-8') as f:
+            json.dump({'schema': 'pwg.performance_preflight.v1',
+                       'selected_keys': ['rqkey'],
+                       'cost_gate': {'over_ceiling': False}}, f)
         with open(os.path.join(coord, 'state.json'), 'w', encoding='utf-8') as f:
             json.dump({'leases': [{'id': 'lease1', 'state': 'requeue_prepared',
                                    'artifact_dir': artifacts,
                                    'requeue_attempt': 1, 'requeue_kind': 'transient',
                                    'execution_manifest': rq_manifest,
+                                   'preflight_path': rq_preflight,
+                                   'preflight_sha256': m.sha256_path(rq_preflight),
                                    'current_attempt': {'number': 1, 'kind': 'transient',
                                                        'artifact_dir': rq_dir,
-                                                       'execution_manifest': rq_manifest}}]}, f)
+                                                       'execution_manifest': rq_manifest,
+                                                       'preflight': rq_preflight,
+                                                       'preflight_sha256':
+                                                           m.sha256_path(rq_preflight)}}]}, f)
         ns = types.SimpleNamespace(db=db, coord_dir=coord, cwd=td,
                                    lease_id='lease1', max_attempts=2)
         rq_id = m.cmd_import_requeue(ns)
@@ -451,6 +521,11 @@ def main():
         m.live_probe('cfg', model='claude-haiku-4-5'); assert False, 'exact-model gate missing'
     except SystemExit as e:
         assert 'exact generation model' in str(e)
+    try:
+        m.live_probe('cfg')
+        assert False, 'paid live probe accepted no reservation ledger'
+    except ValueError as e:
+        assert 'call reservation ledger' in str(e)
     _pc = m._probe_call
     try:
         seen = []
@@ -458,7 +533,7 @@ def main():
         def fake(seq):
             it = iter(seq)
 
-            def _mock(config_dir, claude, payload_bytes, model):
+            def _mock(config_dir, claude, payload_bytes, model, *_args, **_kwargs):
                 v = next(it)
                 seen.append(v)
                 return v
@@ -468,7 +543,9 @@ def main():
         seen.clear(); m._probe_call = fake([(99999, 'success', 120), (29999, 'success', 120)])
         with tempfile.TemporaryDirectory() as td:
             ev = os.path.join(td, 'e.jsonl')
-            assert m.live_probe('cfg', events_path=ev, run_id='r', account='a') == 29999
+            assert m.live_probe(
+                'cfg', events_path=ev, run_id='r', account='a',
+                call_reservation=MemoryCallLedger()) == 29999
             rows = ro.read_events(ev)
             assert len([r for r in rows if r.get('purpose') == 'warmup']) == 1
             assert len([r for r in rows if r.get('purpose') == 'measured']) == 1
@@ -479,21 +556,21 @@ def main():
         # measured 30000 -> honest NO-GO (no retry)
         seen.clear(); m._probe_call = fake([(9000, 'success', 120), (30000, 'success', 120)])
         try:
-            m.live_probe('cfg'); assert False, '30000 ms measured must NO-GO'
+            m.live_probe('cfg', call_reservation=MemoryCallLedger()); assert False, '30000 ms measured must NO-GO'
         except SystemExit as e:
             assert 'health ceiling' in str(e)
         assert len(seen) == 2
         # warm-up auth failure -> immediate STOP, measured NEVER starts
         seen.clear(); m._probe_call = fake([(9000, 'auth', 0)])
         try:
-            m.live_probe('cfg'); assert False, 'warm-up auth must STOP'
+            m.live_probe('cfg', call_reservation=MemoryCallLedger()); assert False, 'warm-up auth must STOP'
         except SystemExit as e:
             assert 'warm-up' in str(e)
         assert len(seen) == 1                           # measured never started
         # measured malformed (output-size/validity) -> honest NO-GO
         seen.clear(); m._probe_call = fake([(9000, 'success', 120), (9000, 'malformed', 3)])
         try:
-            m.live_probe('cfg'); assert False, 'malformed measured must NO-GO'
+            m.live_probe('cfg', call_reservation=MemoryCallLedger()); assert False, 'malformed measured must NO-GO'
         except SystemExit:
             pass
         assert len(seen) == 2
@@ -512,13 +589,17 @@ def main():
 
     def _cls(stdout='', rc=0, stderr=''):
         _out(stdout, rc, stderr)
-        return m._probe_call('cfg', sys.executable, 6491, m.EXACT_GEN_MODEL)[1]
+        return m._probe_call(
+            'cfg', sys.executable, 6491, m.EXACT_GEN_MODEL,
+            call_reservation=MemoryCallLedger())[1]
 
     try:
         # (1) observed successful result-STRING wrapper (result is a JSON string) + Cyrillic body
         w1 = '{"type":"result","subtype":"success","is_error":false,"result":"{\\"ok\\":true}","usage":{"n":"да"}}'
         _out(w1)
-        lat, cls, ob = m._probe_call('cfg', sys.executable, 6491, m.EXACT_GEN_MODEL)
+        lat, cls, ob = m._probe_call(
+            'cfg', sys.executable, 6491, m.EXACT_GEN_MODEL,
+            call_reservation=MemoryCallLedger())
         assert cls == 'success', cls
         assert ob == len(w1.encode('utf-8')) and ob > len(w1)     # encoded bytes, not char count
         # (2) successful structured_output wrapper
@@ -559,7 +640,9 @@ def main():
 
     try:
         m.run_tree_kill = _capture
-        _lat, _cls2, _ob = m._probe_call('cfg', sys.executable, 6491, m.EXACT_GEN_MODEL)
+        _lat, _cls2, _ob = m._probe_call(
+            'cfg', sys.executable, 6491, m.EXACT_GEN_MODEL,
+            call_reservation=MemoryCallLedger())
         assert _cls2 == 'success', _cls2
         p = cap['input']
         # one clear, completable instruction: return exactly the schema object and nothing else
@@ -603,7 +686,7 @@ def main():
     with tempfile.TemporaryDirectory() as td:
         mk = os.path.join(td, 'm')
         grand = ('import time,sys,os;open(sys.argv[1]+".pid3","w").write(str(os.getpid()));'
-                 'time.sleep(6);open(sys.argv[1]+".done3","w").write("1")')
+                 'time.sleep(12);open(sys.argv[1]+".done3","w").write("1")')
         child = ('import subprocess,sys,os,time;open(sys.argv[1]+".pid2","w").write(str(os.getpid()));'
                  'subprocess.Popen([sys.executable,"-c",%r,sys.argv[1]]);time.sleep(30)') % grand
         parent = ('import subprocess,sys,os,time;open(sys.argv[1]+".pid1","w").write(str(os.getpid()));'
@@ -621,7 +704,7 @@ def main():
                 return False
 
         try:
-            m.run_tree_kill([sys.executable, '-c', parent, mk], timeout=3, capture_output=True)
+            m.run_tree_kill([sys.executable, '-c', parent, mk], timeout=5, capture_output=True)
             assert False, 'expected the hanging probe tree to TimeoutExpired'
         except subprocess.TimeoutExpired:
             pass
@@ -643,9 +726,7 @@ def main():
         m.main(['--db', db, 'init', '--account', 'acc1=' + os.path.join(td, 'a1'),
                 '--account', 'acc2=' + os.path.join(td, 'a2'), '--skip-profile-check'])
         for n in range(2):
-            m.main(['--db', db, 'enqueue', '--external-id', 'g%d' % n,
-                    '--argv-json', json.dumps(['x']), '--cwd', td,
-                    '--output', os.path.join(td, 'g%d.json' % n)])
+            enqueue_fixture(db, 'g%d' % n, td, os.path.join(td, 'g%d.json' % n))
         j1 = m.claim(db, 'acc1')
         assert j1 is not None                                   # acc1 claims one job
         assert m.claim(db, 'acc1') is None                      # acc1 already busy -> refused (D-G)
@@ -671,8 +752,7 @@ def main():
             db = os.path.join(td, 'race.sqlite')
             m.main(['--db', db, 'init', '--account', 'acc1=' + os.path.join(td, 'a1'), '--skip-profile-check'])
             for n in range(2):     # two pending jobs, one account -> only one may run at a time
-                m.main(['--db', db, 'enqueue', '--external-id', 'r%d' % n, '--argv-json', json.dumps(['x']),
-                        '--cwd', td, '--output', os.path.join(td, 'r%d.json' % n)])
+                enqueue_fixture(db, 'r%d' % n, td, os.path.join(td, 'r%d.json' % n))
             barrier = threading.Barrier(2)
             results = [None, None]
             errors = []
@@ -756,7 +836,7 @@ def main():
         def healthy(measured_by_cfg, warm_ms=99999):
             seen = set()
 
-            def _mock(config_dir, claude, payload_bytes, model):
+            def _mock(config_dir, claude, payload_bytes, model, *_args, **_kwargs):
                 if config_dir not in seen:
                     seen.add(config_dir)
                     return warm_ms, 'success', 120          # warm-up (EXCLUDED from latency census)
@@ -766,7 +846,7 @@ def main():
         def with_bad(measured_by_cfg, bad_cfg, warm_ms=99999):
             seen = set()
 
-            def _mock(config_dir, claude, payload_bytes, model):
+            def _mock(config_dir, claude, payload_bytes, model, *_args, **_kwargs):
                 first = config_dir not in seen
                 seen.add(config_dir)
                 if config_dir == bad_cfg:
@@ -783,7 +863,9 @@ def main():
         m._probe_call = healthy(measured)
         with tempfile.TemporaryDirectory() as td:
             ev = os.path.join(td, 'fleet.jsonl')
-            latencies = m.probe_fleet(accts, events_path=ev, run_id='rf')
+            latencies = m.probe_fleet(
+                accts, events_path=ev, run_id='rf',
+                call_reservation=MemoryCallLedger())
             assert latencies == {'acc1': 1000, 'acc2': 2000, 'acc3': 3000, 'acc4': 4000}, latencies
             rows = ro.read_events(ev)
             assert len([r for r in rows if r.get('purpose') == 'warmup']) == 4, 'one warm-up per account'
@@ -796,28 +878,37 @@ def main():
         # (e2) one NO-GO account STOPs the fleet by DEFAULT (STOP-on-any-NO-GO)
         m._probe_call = with_bad(measured, bad_cfg='c3')
         try:
-            m.probe_fleet(accts)
+            m.probe_fleet(accts, call_reservation=MemoryCallLedger())
             assert False, 'a NO-GO account must STOP the fleet by default'
         except SystemExit as exc:
             assert 'acc3' in str(exc) and 'fleet probe' in str(exc), exc
 
         # (e3) --drop-unhealthy opt-in: drop the NO-GO account, proceed on the healthy subset
         m._probe_call = with_bad(measured, bad_cfg='c3')
-        survivors = m.probe_fleet(accts, drop_unhealthy=True)
+        survivors = m.probe_fleet(
+            accts, drop_unhealthy=True,
+            call_reservation=MemoryCallLedger())
         assert survivors == {'acc1': 1000, 'acc2': 2000, 'acc4': 4000}, survivors
 
         # (f) N=1 REGRESSION: probe_fleet over a 1-element list == the old single-account live_probe.
-        m._probe_call = lambda config_dir, claude, payload_bytes, model: (5555, 'success', 120)
+        m._probe_call = lambda config_dir, claude, payload_bytes, model, *_args, **_kwargs: (
+            5555, 'success', 120)
         solo = [{'name': 'max1', 'config_dir': 'c1'}]
-        assert m.probe_fleet(solo) == {'max1': 5555}, 'N=1 must be a pure pass-through'
-        assert m.live_probe('c1') == 5555                 # the pre-N-profile single-account reading
-        assert m.probe_fleet(solo)['max1'] == m.live_probe('c1')   # value report['probe_latency_ms'] carries
+        assert m.probe_fleet(
+            solo, call_reservation=MemoryCallLedger()) == {'max1': 5555}, 'N=1 must be a pure pass-through'
+        assert m.live_probe(
+            'c1', call_reservation=MemoryCallLedger()) == 5555
+        assert (m.probe_fleet(
+                    solo, call_reservation=MemoryCallLedger())['max1'] ==
+                m.live_probe(
+                    'c1', call_reservation=MemoryCallLedger()))
     finally:
         m._probe_call = _pc
     print('  GAP5 probe_fleet: N=4 map + warm-ups excluded; NO-GO STOPs by default; --drop-unhealthy subset; N=1 == old live_probe')
 
-    # GAP #5 fair fan-out + all-done at N=4: 4 accounts claim 4 DISTINCT jobs in ONE run-once pass
-    # and every job reaches 'done' exactly once (echo jobs; --skip-profile-check; never credentials).
+    # GAP #5 fair fan-out + all-done at N=4: 4 accounts claim 4 DISTINCT inert scheduler
+    # fixtures in ONE run-once pass. The worker is replaced with an in-process state transition;
+    # no generic subprocess execution path exists.
     with tempfile.TemporaryDirectory() as td:
         db = os.path.join(td, 'fanout.sqlite')
         m.main(['--db', db, 'init',
@@ -825,12 +916,14 @@ def main():
                 '--account', 'acc2=' + os.path.join(td, 'a2'),
                 '--account', 'acc3=' + os.path.join(td, 'a3'),
                 '--account', 'acc4=' + os.path.join(td, 'a4'), '--skip-profile-check'])
-        argv = [sys.executable, '-c', 'import os; print(os.environ["CLAUDE_CONFIG_DIR"])']
         for n in range(4):
-            m.main(['--db', db, 'enqueue', '--external-id', 'fan%d' % n,
-                    '--argv-json', json.dumps(argv), '--cwd', td,
-                    '--output', os.path.join(td, 'fan%d.json' % n)])
-        m.main(['--db', db, 'run-once', '--timeout', '30'])
+            enqueue_fixture(db, 'fan%d' % n, td, os.path.join(td, 'fan%d.json' % n))
+        original_run_claimed = m.run_claimed
+        m.run_claimed = finish_fixture_worker
+        try:
+            m.main(['--db', db, 'run-once', '--timeout', '30'])
+        finally:
+            m.run_claimed = original_run_claimed
         con = sqlite3.connect(db)
         rows = con.execute("select external_id, assigned_acc, state from jobs order by id").fetchall()
         con.close()
@@ -850,14 +943,17 @@ def main():
                 '--account', 'acc2=' + os.path.join(td, 'a2'),
                 '--account', 'acc3=' + os.path.join(td, 'a3'),
                 '--account', 'acc4=' + os.path.join(td, 'a4'), '--skip-profile-check'])
-        argv = [sys.executable, '-c', 'import os; print(os.environ["CLAUDE_CONFIG_DIR"])']
         for n in range(4):
-            m.main(['--db', db, 'enqueue', '--external-id', 'oa%d' % n,
-                    '--argv-json', json.dumps(argv), '--cwd', td,
-                    '--output', os.path.join(td, 'oa%d.json' % n)])
+            enqueue_fixture(db, 'oa%d' % n, td, os.path.join(td, 'oa%d.json' % n))
         # dispatch restricted to the acc1/acc2 "probed" subset (acc3/acc4 == capped-out/unprobed).
-        m.cmd_run_once(m.argparse.Namespace(db=db, timeout=30, events=None, run_id=None,
-                                            claude_bin='claude', only_accounts={'acc1', 'acc2'}))
+        original_run_claimed = m.run_claimed
+        m.run_claimed = finish_fixture_worker
+        try:
+            m.cmd_run_once(m.argparse.Namespace(
+                db=db, timeout=30, events=None, run_id=None,
+                claude_bin='claude', only_accounts={'acc1', 'acc2'}))
+        finally:
+            m.run_claimed = original_run_claimed
         con = sqlite3.connect(db)
         assigned = con.execute("select assigned_acc from jobs where assigned_acc is not null").fetchall()
         pending = con.execute("select count(*) from jobs where state='pending'").fetchone()[0]
@@ -880,9 +976,7 @@ def main():
                 '--account', 'acc3=' + os.path.join(td, 'a3'),
                 '--account', 'acc4=' + os.path.join(td, 'a4'), '--skip-profile-check'])
         for n in range(8):
-            m.main(['--db', db, 'enqueue', '--external-id', 'oa%d' % n,
-                    '--argv-json', json.dumps(['x']), '--cwd', td,
-                    '--output', os.path.join(td, 'oa%d.json' % n)])
+            enqueue_fixture(db, 'oa%d' % n, td, os.path.join(td, 'oa%d.json' % n))
         claimed = [m.claim(db, 'acc%d' % i) for i in (1, 2, 3, 4)]
         assert all(j is not None for j in claimed), 'each of 4 accounts claims a job'
         assert len({j['id'] for j in claimed}) == 4, 'four DISTINCT jobs claimed in round 1'
@@ -905,9 +999,7 @@ def main():
                 '--account', 'acc3=' + os.path.join(td, 'a3'),
                 '--account', 'acc4=' + os.path.join(td, 'a4'), '--skip-profile-check'])
         for n in range(4):
-            m.main(['--db', db, 'enqueue', '--external-id', 'rec%d' % n,
-                    '--argv-json', json.dumps(['x']), '--cwd', td,
-                    '--output', os.path.join(td, 'rec%d.json' % n)])
+            enqueue_fixture(db, 'rec%d' % n, td, os.path.join(td, 'rec%d.json' % n))
         con = sqlite3.connect(db)
         # rec0: a coordinator-recorded DONE job (recover must never touch it -> no dup promotion)
         con.execute("update jobs set state='done', coordinator_recorded=1, assigned_acc='acc3' where external_id='rec0'")
@@ -936,16 +1028,23 @@ def main():
         m.main(['--db', db, 'init',
                 '--account', 'acc1=' + os.path.join(td, 'a1'),
                 '--account', 'acc2=' + os.path.join(td, 'a2'), '--skip-profile-check'])
+        runtime_manifests = {}
         for n in range(2):
-            m.main(['--db', db, 'enqueue', '--external-id', 'runtime%d' % n,
-                    '--argv-json', json.dumps(['x']), '--cwd', td,
-                    '--output', os.path.join(td, 'runtime%d.json' % n)])
+            enqueue_fixture(
+                db, 'runtime%d' % n, td,
+                os.path.join(td, 'runtime%d.json' % n))
+            manifest_path = os.path.join(td, 'runtime%d.manifest.json' % n)
+            with open(manifest_path, 'w', encoding='utf-8') as f:
+                json.dump({'fixture': 'runtime%d' % n}, f)
+            runtime_manifests[n] = manifest_path
         con = m.connect(db)
         with con:
-            con.execute("UPDATE jobs SET manifest_path='fixture.json', manifest_sha256='fixture', "
-                        "profile_slot='acc1' WHERE external_id='runtime0'")
-            con.execute("UPDATE jobs SET manifest_path='fixture.json', manifest_sha256='fixture', "
-                        "profile_slot='acc2' WHERE external_id='runtime1'")
+            con.execute("UPDATE jobs SET manifest_path=?, manifest_sha256=?, "
+                        "profile_slot='acc1' WHERE external_id='runtime0'",
+                        (runtime_manifests[0], m.sha256_path(runtime_manifests[0])))
+            con.execute("UPDATE jobs SET manifest_path=?, manifest_sha256=?, "
+                        "profile_slot='acc2' WHERE external_id='runtime1'",
+                        (runtime_manifests[1], m.sha256_path(runtime_manifests[1])))
         con.close()
         receipt = m.write_probe_receipt(
             td, 'runtime-test', ['runtime0', 'runtime1'], {'acc1': 10, 'acc2': 11})
@@ -964,19 +1063,42 @@ def main():
             return types.SimpleNamespace(returncode=0, stdout='', stderr='')
 
         def fake_worker(db_path, account, config_dir, job, timeout, events_path=None,
-                        run_id=None, claude_bin='claude'):
+                        run_id=None, claude_bin='claude', call_reservation_path=None,
+                        max_calls=None):
             assert reserved.is_set(), 'worker started before atomic begin-run reservation'
+            assert call_reservation_path and run_id == 'runtime-test'
+            manifest_hash = m.sha256_path(job['manifest_path'])
+            assert job['manifest_sha256'] == manifest_hash
+            with open(job['output_path'], 'w', encoding='utf-8') as f:
+                json.dump({'external_id': job['external_id']}, f)
+            result_hash = m.sha256_path(job['output_path'])
+            fake_status = {
+                'manifest_sha256': manifest_hash,
+                'result_sha256': result_hash,
+            }
+            status_path = job['output_path'] + '.fake-status.json'
+            with open(status_path, 'w', encoding='utf-8') as f:
+                json.dump(fake_status, f)
+            with open(status_path, encoding='utf-8') as f:
+                fake_status = json.load(f)
+            assert fake_status['manifest_sha256'] == job['manifest_sha256']
+            assert fake_status['result_sha256'] == m.sha256_path(job['output_path'])
             outcome = 'done' if job['external_id'] == 'runtime0' else 'pending'
-            m.finish(db_path, job['id'], outcome, 0 if outcome == 'done' else 1)
+            m.finish(db_path, job['id'], outcome, 0 if outcome == 'done' else 1,
+                     result_sha256=result_hash if outcome == 'done' else None,
+                     run_id=run_id)
             return outcome
 
         m.coordinator_command = fake_command
         m.run_claimed = fake_worker
         try:
+            calls_path = os.path.join(td, 'runtime.calls.json')
+            m.CallReservationLedger(calls_path, 'runtime-test', 5)
             m.cmd_run_once(m.argparse.Namespace(
                 db=db, timeout=30, events=None, run_id='runtime-test',
                 claude_bin='claude', runtime_mode='staged', probe_receipt=receipt,
-                coordinator='coordinator.py', coord_dir=td, cwd=td))
+                coordinator='coordinator.py', coord_dir=td, cwd=td,
+                call_reservation=calls_path, max_calls=5))
         finally:
             m.coordinator_command = original_command
             m.run_claimed = original_run_claimed
@@ -984,6 +1106,35 @@ def main():
         release_calls = [call for call in calls if call[0] == 'release-run']
         assert len(begin_calls) == 1 and begin_calls[0].count('--lease-id') == 2
         assert len(release_calls) == 1 and release_calls[0][1] == 'runtime1'
+        con = m.connect(db)
+        assert {row['run_id'] for row in con.execute(
+            "SELECT run_id FROM jobs WHERE external_id LIKE 'runtime%'")} == {'runtime-test'}
+        runtime0 = con.execute(
+            "SELECT manifest_sha256,result_sha256 FROM jobs "
+            "WHERE external_id='runtime0'").fetchone()
+        assert runtime0['manifest_sha256'] == m.sha256_path(runtime_manifests[0])
+        assert runtime0['result_sha256'] == m.sha256_path(os.path.join(td, 'runtime0.json'))
+        con.close()
+
+        # A retry/resume under another run identity is refused before worker spawn.
+        con = m.connect(db)
+        with con:
+            con.execute("UPDATE jobs SET state='pending', assigned_acc=NULL "
+                        "WHERE external_id='runtime1'")
+        con.close()
+        wrong_path = os.path.join(td, 'wrong.calls.json')
+        m.CallReservationLedger(wrong_path, 'wrong-run', 5)
+        refused = False
+        try:
+            m.cmd_run_once(m.argparse.Namespace(
+                db=db, timeout=30, events=None, run_id='wrong-run',
+                claude_bin='claude', runtime_mode='staged', probe_receipt=receipt,
+                coordinator='coordinator.py', coord_dir=td, cwd=td,
+                call_reservation=wrong_path, max_calls=5,
+                only_external_ids={'runtime1'}, only_accounts={'acc2'}))
+        except SystemExit as exc:
+            refused = 'saved run_id' in str(exc)
+        assert refused, 'wrong-run resume was not refused before spawn'
     print('  runtime integration: reserve batch before workers; retryable worker releases slot')
 
     with tempfile.TemporaryDirectory() as td:
@@ -995,11 +1146,12 @@ def main():
         m.main(['--db', db, 'init', '--account', 'acc=' + os.path.join(td, 'acc'),
                 '--skip-profile-check'])
         out = os.path.join(td, 'rl.json')
-        m.main(['--db', db, 'enqueue', '--external-id', 'rl1', '--max-attempts', '1',
-                '--argv-json', json.dumps([sys.executable, '-c',
-                    'import sys;sys.stderr.write("429 rate limit reset_at=1999999999");sys.exit(21)']),
-                '--cwd', td, '--output', out])
-        m.main(['--db', db, 'run-once', '--timeout', '10'])
+        enqueue_fixture(db, 'rl1', td, out, max_attempts=1)
+        rate_limited = m.claim(db, 'acc', only_external_ids={'rl1'})
+        assert rate_limited is not None
+        m.requeue_rate_limited(
+            db, rate_limited['id'], 21,
+            '429 rate limit reset_at=1999999999', 1999999999)
         con = sqlite3.connect(db)
         state, attempts = con.execute(
             "select state,attempts from jobs where external_id='rl1'").fetchone()
@@ -1014,6 +1166,238 @@ def main():
             'C4: a max_attempts=1 job rate-limited once must remain claimable, not stranded')
     print('  C4 rate-limit: a 429 returns the job to claimable pending (attempts decremented), '
           'never a permanently-unclaimable stuck row')
+
+    # Every non-coordinator paid entry point uses the same reservation gate.
+    with tempfile.TemporaryDirectory() as td:
+        original_runner, original_prefix = m.run_tree_kill, m.claude_argv_prefix
+        calls = []
+        m.claude_argv_prefix = lambda _c: [sys.executable]
+        try:
+            profile_ledger = m.CallReservationLedger(
+                os.path.join(td, 'profile.calls.json'), 'profile-zero', 0)
+            profile_preflight = m.write_synthetic_preflight(
+                os.path.join(td, 'profile.preflight.json'), 'profile-zero')
+
+            def auth_only(*_a, **_k):
+                calls.append(1)
+                return types.SimpleNamespace(
+                    returncode=0, stderr='',
+                    stdout=json.dumps({'loggedIn': True, 'subscriptionType': 'max'}))
+
+            m.run_tree_kill = auth_only
+            try:
+                m.profile_status(td, sys.executable, profile_ledger, 'acc',
+                                 profile_preflight)
+                raise AssertionError('profile max_calls=0 reached paid probe')
+            except m.CallLimitReached:
+                pass
+            assert len(calls) == 1 and profile_ledger.spent() == 0  # auth status only
+
+            malformed_profile = m.CallReservationLedger(
+                os.path.join(td, 'profile-malformed.calls.json'), 'profile-malformed', 1)
+            phase = [0]
+
+            def malformed_profile_runner(*_a, **_k):
+                phase[0] += 1
+                if phase[0] == 1:
+                    return types.SimpleNamespace(
+                        returncode=0, stderr='',
+                        stdout=json.dumps({'loggedIn': True, 'subscriptionType': 'max'}))
+                return types.SimpleNamespace(returncode=0, stderr='', stdout='not-json')
+
+            m.run_tree_kill = malformed_profile_runner
+            ok, detail = m.profile_status(
+                td, sys.executable, malformed_profile, 'acc', profile_preflight)
+            assert not ok and 'success envelope' in detail
+            assert (malformed_profile.spent() == 1
+                    and malformed_profile.usage()['cost_evaluable'] is False)
+
+            cfg = os.path.join(td, 'canary-profile')
+            os.makedirs(cfg)
+            db = os.path.join(td, 'canary.sqlite')
+            m.main(['--db', db, 'init', '--account', 'acc=' + cfg,
+                    '--skip-profile-check'])
+            canary_manifest = {
+                'schema': 'pwg.headless_execution_manifest.v2',
+                'model': m.EXACT_GEN_MODEL,
+                'meta': {'lang': 'ru', 'selected_keys': ['k'], 'root': 'canary'},
+                'execution': {
+                    'profile_slot': 'acc',
+                    'config_dir_fingerprint': config_dir_fingerprint(cfg),
+                    'execution_route': 'claude-cli-headless', 'executor_lane': 'test',
+                    'validation_method': 'test', 'model_identifier': m.EXACT_GEN_MODEL,
+                },
+                'key_provenance': {'k': 'real'}, 'presplit_keys': ['k'],
+            }
+            manifest_path = os.path.join(td, 'canary.manifest.json')
+            json.dump(canary_manifest, open(manifest_path, 'w', encoding='utf-8'))
+            canary_preflight = os.path.join(td, 'canary.preflight.json')
+            with open(canary_preflight, 'w', encoding='utf-8') as f:
+                json.dump({
+                    'schema': 'pwg.performance_preflight.v1',
+                    'root': 'canary',
+                    'selected_keys': ['k'],
+                    'cost_gate': {'over_ceiling': False},
+                }, f)
+            canary_preflight_sha256 = m.sha256_path(canary_preflight)
+            m.validate_preflight_artifact(
+                canary_preflight, canary_manifest, canary_preflight_sha256)
+            canary_calls = os.path.join(td, 'canary.calls.json')
+            before = len(calls)
+            try:
+                m.cmd_presplit_canary(m.argparse.Namespace(
+                    db=db, manifest=manifest_path, output=os.path.join(td, 'out.json'),
+                    status=os.path.join(td, 'status.json'), events=os.path.join(td, 'events'),
+                    preflight=canary_preflight,
+                    preflight_sha256=canary_preflight_sha256,
+                    run_id='canary-zero', claude_bin=sys.executable, timeout=5,
+                    call_reservation=canary_calls, max_calls=0))
+                raise AssertionError('presplit canary max_calls=0 reached paid runner')
+            except m.CallLimitReached:
+                pass
+            assert len(calls) == before
+            assert m.CallReservationLedger(canary_calls, 'canary-zero', 0).spent() == 0
+            drop_calls = os.path.join(td, 'drop.calls.json')
+            drop_ledger = m.CallReservationLedger(drop_calls, 'drop-zero', 0)
+            try:
+                m.probe_fleet([{'name': 'acc', 'config_dir': cfg}],
+                              drop_unhealthy=True, call_reservation=drop_ledger)
+                raise AssertionError('--drop-unhealthy swallowed call ceiling exhaustion')
+            except m.CallLimitReached:
+                pass
+            assert len(calls) == before and drop_ledger.spent() == 0
+        finally:
+            m.run_tree_kill, m.claude_argv_prefix = original_runner, original_prefix
+    print('  paid boundaries: profile/canary zero-call; drop-unhealthy cannot swallow ceiling')
+
+    # The coordinator's sealed performance preflight is a strict prerequisite for staged-run:
+    # refusal must happen before constructing the call ledger or entering the live fleet probe.
+    with tempfile.TemporaryDirectory() as td:
+        cfg = os.path.join(td, 'preflight-profile')
+        os.makedirs(cfg)
+        db = os.path.join(td, 'preflight.sqlite')
+        m.main(['--db', db, 'init', '--account', 'acc=' + cfg, '--skip-profile-check'])
+        plan_path = os.path.join(td, 'plan.json')
+        with open(plan_path, 'w', encoding='utf-8') as f:
+            json.dump({
+                'selected_headwords': 1, 'prepared_headwords': 1,
+                'windows': [{'root': 'lease-preflight', 'headwords': ['k'],
+                             'headless': {'manifest_sha256': 'x'}}],
+            }, f)
+        calls_path = os.path.join(td, 'must-not-exist.calls.json')
+        probed = []
+        original_command, original_probe = m.coordinator_command, m.probe_fleet
+
+        def refuse_preflight(_args, command, check=True):
+            assert command == ['validate-preflight', '--lease-id', 'lease-preflight']
+            return types.SimpleNamespace(
+                returncode=2, stdout='', stderr='synthetic preflight refusal')
+
+        m.coordinator_command = refuse_preflight
+        m.probe_fleet = lambda *_a, **_k: probed.append(1)
+        try:
+            try:
+                m.cmd_staged_run(m.argparse.Namespace(
+                    plan=plan_path, lease_id=None, db=db, only_profile=None,
+                    max_accounts=0, coordinator='coordinator.py', coord_dir=td, cwd=td,
+                    call_reservation=calls_path))
+                raise AssertionError('staged-run ignored coordinator preflight refusal')
+            except SystemExit as exc:
+                assert 'preflight refused before probe' in str(exc), exc
+            assert not probed and not os.path.exists(calls_path)
+        finally:
+            m.coordinator_command, m.probe_fleet = original_command, original_probe
+    print('  staged-run: coordinator preflight refusal precedes call ledger/probe')
+
+    # A done row is not authority to record an arbitrary file: the scheduler must bind both
+    # the exact result bytes and the coordinator run identity saved at successful dispatch.
+    with tempfile.TemporaryDirectory() as td:
+        db = os.path.join(td, 'record.sqlite')
+        result = os.path.join(td, 'result.json')
+        manifest = os.path.join(td, 'manifest.json')
+        open(result, 'w', encoding='utf-8').write('{"ok":1}\n')
+        open(manifest, 'w', encoding='utf-8').write('{}\n')
+        con = m.connect(db)
+        with con:
+            con.execute(
+                "INSERT INTO jobs(external_id,cwd,output_path,manifest_path,state,returncode,"
+                "result_sha256,run_id,finished_at) VALUES(?,?,?,?,?,?,?,?,?)",
+                ('lease-record', td, result, manifest, 'done', 0, m.sha256_path(result),
+                 'sealed-run', m.now_iso()))
+        con.close()
+        seen = []
+        original_command = m.coordinator_command
+        m.coordinator_command = lambda args, command, check=True: (
+            seen.append(command) or types.SimpleNamespace(returncode=0, stdout='', stderr=''))
+        try:
+            m.cmd_record_done(m.argparse.Namespace(
+                db=db, coordinator='coordinator.py', coord_dir=td, cwd=td))
+            assert seen and seen[0][-4:] == [
+                '--run-id', 'sealed-run', '--result-sha256', m.sha256_path(result)], seen
+            con = m.connect(db)
+            with con:
+                con.execute("UPDATE jobs SET coordinator_recorded=0 WHERE external_id='lease-record'")
+            con.close()
+            open(result, 'w', encoding='utf-8').write('{"substituted":true}\n')
+            refused = False
+            try:
+                m.cmd_record_done(m.argparse.Namespace(
+                    db=db, coordinator='coordinator.py', coord_dir=td, cwd=td))
+            except SystemExit as exc:
+                refused = 'substitution refused' in str(exc)
+            assert refused and len(seen) == 1, (refused, seen)
+
+            # Batch failure marks exactly the durable prefix reported by the coordinator.
+            open(result, 'w', encoding='utf-8').write('{"ok":1}\n')
+            result_b = os.path.join(td, 'result-b.json')
+            result_c = os.path.join(td, 'result-c.json')
+            open(result_b, 'w', encoding='utf-8').write('{"ok":2}\n')
+            open(result_c, 'w', encoding='utf-8').write('{"ok":3}\n')
+            con = m.connect(db)
+            with con:
+                con.execute("UPDATE jobs SET result_sha256=? WHERE external_id='lease-record'",
+                            (m.sha256_path(result),))
+                for lease, path_ in (('lease-b', result_b), ('lease-c', result_c)):
+                    con.execute(
+                        "INSERT INTO jobs(external_id,cwd,output_path,manifest_path,state,"
+                        "returncode,result_sha256,run_id,finished_at) VALUES(?,?,?,?,?,?,?,?,?)",
+                        (lease, td, path_, manifest, 'done', 0, m.sha256_path(path_),
+                         'sealed-run', m.now_iso()))
+            con.close()
+            progress = {
+                'schema': 'pwg.record_output_batch.v1',
+                'recorded': ['lease-record', 'lease-b'],
+                'remaining': ['lease-c'],
+                'failed': {'lease_id': 'lease-c'},
+            }
+
+            def partial_command(args, command, check=True):
+                seen.append(command)
+                return types.SimpleNamespace(
+                    returncode=1,
+                    stdout='RECORD_OUTPUT_BATCH_PROGRESS: ' +
+                           json.dumps(progress, separators=(',', ':')) + '\n',
+                    stderr='synthetic batch failure')
+
+            m.coordinator_command = partial_command
+            try:
+                m.cmd_record_done(m.argparse.Namespace(
+                    db=db, coordinator='coordinator.py', coord_dir=td, cwd=td))
+                raise AssertionError('partial record batch reported success')
+            except SystemExit as exc:
+                assert '2/3' in str(exc), exc
+            con = m.connect(db)
+            states = list(con.execute(
+                'SELECT external_id,coordinator_recorded FROM jobs ORDER BY id'))
+            con.close()
+            assert [(r['external_id'], r['coordinator_recorded']) for r in states] == [
+                ('lease-record', 1), ('lease-b', 1), ('lease-c', 0)], states
+            batch_cmd = seen[-1]
+            assert batch_cmd[0] == 'record-output-batch' and batch_cmd.count('--record') == 3
+            assert m.sha256_path(result_c) in batch_cmd
+        finally:
+            m.coordinator_command = original_command
+    print('  record-done: hash+run forwarded; substitution refused; batch partial prefix exact')
 
     print('max_account_orchestrator_selftest: PASS')
 

--- a/RussianTranslation/src/pilot/proc_tree.py
+++ b/RussianTranslation/src/pilot/proc_tree.py
@@ -17,6 +17,124 @@ import time
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
+_CREATE_SUSPENDED = 0x00000004
+
+
+def _join_trouble(*parts):
+    """Join non-empty cleanup diagnostics without producing leading separators."""
+    return ';'.join(part for part in parts if part)
+
+
+if os.name == 'nt':
+    import ctypes
+    from ctypes import wintypes
+
+    _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+    _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS = 9
+
+    class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ('PerProcessUserTimeLimit', ctypes.c_longlong),
+            ('PerJobUserTimeLimit', ctypes.c_longlong),
+            ('LimitFlags', wintypes.DWORD),
+            ('MinimumWorkingSetSize', ctypes.c_size_t),
+            ('MaximumWorkingSetSize', ctypes.c_size_t),
+            ('ActiveProcessLimit', wintypes.DWORD),
+            ('Affinity', ctypes.c_size_t),
+            ('PriorityClass', wintypes.DWORD),
+            ('SchedulingClass', wintypes.DWORD),
+        ]
+
+    class _IO_COUNTERS(ctypes.Structure):
+        _fields_ = [
+            ('ReadOperationCount', ctypes.c_ulonglong),
+            ('WriteOperationCount', ctypes.c_ulonglong),
+            ('OtherOperationCount', ctypes.c_ulonglong),
+            ('ReadTransferCount', ctypes.c_ulonglong),
+            ('WriteTransferCount', ctypes.c_ulonglong),
+            ('OtherTransferCount', ctypes.c_ulonglong),
+        ]
+
+    class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ('BasicLimitInformation', _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+            ('IoInfo', _IO_COUNTERS),
+            ('ProcessMemoryLimit', ctypes.c_size_t),
+            ('JobMemoryLimit', ctypes.c_size_t),
+            ('PeakProcessMemoryUsed', ctypes.c_size_t),
+            ('PeakJobMemoryUsed', ctypes.c_size_t),
+        ]
+
+    _kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+    _kernel32.CreateJobObjectW.argtypes = (ctypes.c_void_p, wintypes.LPCWSTR)
+    _kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    _kernel32.SetInformationJobObject.argtypes = (
+        wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD)
+    _kernel32.SetInformationJobObject.restype = wintypes.BOOL
+    _kernel32.AssignProcessToJobObject.argtypes = (wintypes.HANDLE, wintypes.HANDLE)
+    _kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+    _kernel32.TerminateJobObject.argtypes = (wintypes.HANDLE, wintypes.UINT)
+    _kernel32.TerminateJobObject.restype = wintypes.BOOL
+    _kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    _kernel32.CloseHandle.restype = wintypes.BOOL
+
+    _ntdll = ctypes.WinDLL('ntdll')
+    _ntdll.NtResumeProcess.argtypes = (wintypes.HANDLE,)
+    _ntdll.NtResumeProcess.restype = ctypes.c_long
+
+
+class _WindowsKillJob:
+    """A Windows Job Object that contains the child before its first instruction runs."""
+
+    def __init__(self):
+        self.handle = None
+
+    def create(self):
+        handle = _kernel32.CreateJobObjectW(None, None)
+        if not handle:
+            raise ctypes.WinError(ctypes.get_last_error())
+        self.handle = handle
+        info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if not _kernel32.SetInformationJobObject(
+                handle, _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
+                ctypes.byref(info), ctypes.sizeof(info)):
+            error = ctypes.WinError(ctypes.get_last_error())
+            self.close()
+            raise error
+
+    def assign(self, proc):
+        """Assign a CREATE_SUSPENDED Popen process before it can create descendants."""
+        process_handle = int(proc._handle)  # CPython's owned process HANDLE on Windows
+        if not _kernel32.AssignProcessToJobObject(self.handle, process_handle):
+            raise ctypes.WinError(ctypes.get_last_error())
+
+    @staticmethod
+    def resume(proc):
+        """Resume all threads in the newly assigned, initially suspended process."""
+        process_handle = int(proc._handle)
+        status = _ntdll.NtResumeProcess(process_handle)
+        if status < 0:
+            raise OSError('NtResumeProcess failed with NTSTATUS 0x%08x'
+                          % (status & 0xffffffff))
+
+    def terminate(self):
+        """Terminate every current job member and close the kill-on-close handle."""
+        trouble = None
+        if self.handle:
+            if not _kernel32.TerminateJobObject(self.handle, 1):
+                trouble = 'TerminateJobObject:winerror%d' % ctypes.get_last_error()
+        close_trouble = self.close()
+        return _join_trouble(trouble, close_trouble)
+
+    def close(self):
+        trouble = None
+        if self.handle:
+            if not _kernel32.CloseHandle(self.handle):
+                trouble = 'CloseHandle(job):winerror%d' % ctypes.get_last_error()
+            self.handle = None
+        return trouble
+
 
 def windows_hidden_flags():
     """subprocess creationflags that suppress the transient console window ``taskkill``/``tasklist``
@@ -29,35 +147,46 @@ def windows_hidden_flags():
 
 
 def terminate_tree(proc, deadline):
-    """**Bounded best-effort** tree termination — NOT race-free (tree enumeration still races
-    process exit/spawn; correctness is what the parent->child->grandchild regression test asserts).
-    Invoked WHILE ``proc`` is still alive so the tree is enumerable. ``taskkill /PID <pid> /T /F``
-    reaps the live tree on Windows (acceptable for this known-stable wrapper tree); ``killpg`` the
-    session group on POSIX. Always falls back to ``proc.kill()`` if the parent is still alive.
-    Returns a short diagnostic string on cleanup trouble, else None — the caller keeps the primary
-    ``timeout`` classification regardless."""
+    """Bounded process-tree termination.
+
+    Windows normally uses the race-free Job Object attached by :func:`run_tree_kill`; ``taskkill``
+    is only a bounded fallback when job setup failed. POSIX kills the child's private process
+    group. Always falls back to ``proc.kill()`` if the immediate child remains alive. Returns a
+    short diagnostic string on cleanup trouble, else None — callers keep the primary ``timeout``
+    classification regardless.
+    """
     if proc.poll() is not None:
+        job = getattr(proc, '_tree_job', None)
+        if job is not None:
+            return job.close()
         return None
-    trouble = None
+    trouble = getattr(proc, '_tree_setup_trouble', None)
     if os.name == 'nt':
-        budget = max(1.0, deadline - time.monotonic())
-        try:
-            subprocess.run(['taskkill', '/PID', str(proc.pid), '/T', '/F'],
-                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=budget,
-                           creationflags=windows_hidden_flags())   # no console-window flicker
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
-            trouble = 'taskkill:%s' % type(exc).__name__
+        job = getattr(proc, '_tree_job', None)
+        if job is not None:
+            trouble = _join_trouble(trouble, job.terminate())
+        else:
+            budget = max(1.0, deadline - time.monotonic())
+            try:
+                result = subprocess.run(
+                    ['taskkill', '/PID', str(proc.pid), '/T', '/F'],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=budget,
+                    creationflags=windows_hidden_flags())   # no console-window flicker
+                if result.returncode:
+                    trouble = _join_trouble(trouble, 'taskkill:exit%d' % result.returncode)
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+                trouble = _join_trouble(trouble, 'taskkill:%s' % type(exc).__name__)
     else:
         import signal as _signal
         try:
             os.killpg(os.getpgid(proc.pid), _signal.SIGKILL)
         except (ProcessLookupError, PermissionError, OSError) as exc:
-            trouble = 'killpg:%s' % type(exc).__name__
+            trouble = _join_trouble(trouble, 'killpg:%s' % type(exc).__name__)
     if proc.poll() is None:                            # always fall back if the parent still lives
         try:
             proc.kill()
         except OSError as exc:
-            trouble = (trouble or '') + ';proc.kill:%s' % type(exc).__name__
+            trouble = _join_trouble(trouble, 'proc.kill:%s' % type(exc).__name__)
     return trouble
 
 
@@ -74,11 +203,61 @@ def run_tree_kill(argv, input=None, timeout=None, text=True, encoding='utf-8',
     pipe = subprocess.PIPE if capture_output else None
     popen_kw = dict(stdin=subprocess.PIPE, stdout=pipe, stderr=pipe,
                     text=text, encoding=encoding, cwd=cwd, env=env)
+    job = None
+    setup_trouble = None
     if os.name == 'nt':
-        popen_kw['creationflags'] = getattr(subprocess, 'CREATE_NEW_PROCESS_GROUP', 0)
+        creationflags = getattr(subprocess, 'CREATE_NEW_PROCESS_GROUP', 0)
+        job = _WindowsKillJob()
+        try:
+            job.create()
+            creationflags |= _CREATE_SUSPENDED
+        except OSError as exc:
+            setup_trouble = 'job-create:%s' % type(exc).__name__
+            job = None
+        popen_kw['creationflags'] = creationflags
     else:
         popen_kw['start_new_session'] = True          # own process group -> killpg reaches children
-    proc = subprocess.Popen(argv, **popen_kw)
+    try:
+        proc = subprocess.Popen(argv, **popen_kw)
+    except BaseException:
+        if job is not None:
+            job.close()
+        raise
+    proc._tree_job = job
+    proc._tree_setup_trouble = setup_trouble
+    if job is not None:
+        try:
+            job.assign(proc)
+        except OSError as exc:
+            # Resume even if assignment failed, otherwise the fallback would target a suspended
+            # process forever. With no assigned process the job is empty and safe to close.
+            setup_trouble = 'job-assign:%s' % type(exc).__name__
+            try:
+                job.resume(proc)
+            except OSError as resume_exc:
+                setup_trouble += ':resume-%s' % type(resume_exc).__name__
+                setup_trouble = _join_trouble(setup_trouble, job.terminate())
+                try:
+                    proc.kill()
+                    proc.wait(timeout=2)
+                except (OSError, subprocess.TimeoutExpired):
+                    pass
+                raise OSError('Windows Job Object setup failed: %s' % setup_trouble) from exc
+            setup_trouble = _join_trouble(setup_trouble, job.close())
+            proc._tree_job = None
+            proc._tree_setup_trouble = setup_trouble
+        else:
+            try:
+                job.resume(proc)
+            except OSError as exc:
+                setup_trouble = _join_trouble(
+                    'job-resume:%s' % type(exc).__name__, job.terminate())
+                try:
+                    proc.kill()
+                    proc.wait(timeout=2)
+                except (OSError, subprocess.TimeoutExpired):
+                    pass
+                raise OSError('Windows Job Object setup failed: %s' % setup_trouble) from exc
     start = time.monotonic()
     try:
         out, err = proc.communicate(input=input, timeout=timeout)
@@ -99,4 +278,26 @@ def run_tree_kill(argv, input=None, timeout=None, text=True, encoding='utf-8',
         if trouble:
             exc.cleanup_trouble = trouble              # diagnostic only; classification stays 'timeout'
         raise
+    except BaseException as exc:
+        # communicate() can also fail while the child is live (decode error, pipe/OSError,
+        # injected test exception, cancellation). Never abandon that process tree merely because
+        # the primary failure was not TimeoutExpired.
+        deadline = time.monotonic() + 10.0
+        trouble = terminate_tree(proc, deadline)
+        try:
+            proc.communicate(timeout=max(0.5, deadline - time.monotonic()))
+        except BaseException as reap_exc:
+            trouble = _join_trouble(
+                trouble, 'exception-reap:%s' % type(reap_exc).__name__)
+            try:
+                proc.kill()
+                proc.wait(timeout=2)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+        if trouble:
+            exc.cleanup_trouble = trouble
+        raise
+    finally:
+        if proc.poll() is not None and getattr(proc, '_tree_job', None) is not None:
+            proc._tree_job.close()
     return subprocess.CompletedProcess(argv, proc.returncode, out, err)

--- a/RussianTranslation/src/pilot/promotion_journal.py
+++ b/RussianTranslation/src/pilot/promotion_journal.py
@@ -1,0 +1,1236 @@
+#!/usr/bin/env python
+"""Recoverable promotion journal for the PWG-RU canonical-store transaction.
+
+The journal seals the bytes a promotion intends to install before the canonical
+store is replaced.  Startup reconciliation can consequently distinguish:
+
+* the old store hash: retry the prepared replacement;
+* the expected new hash: adopt a replacement whose phase update was interrupted;
+* any other hash: fail closed and require operator investigation.
+
+This module deliberately does not use the historical ``promotion_receipt``
+scaffold.  A receipt described key presence after the fact; this journal seals
+the complete before/after byte identity before mutation.
+"""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import datetime
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from typing import Any, Callable, Mapping
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = os.path.dirname(HERE)
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+from promote_lock import PromoteClaim  # noqa: E402
+
+SCHEMA = 'pwg.promotion_journal.v1'
+COORDINATOR_STATE_SCHEMA = 'pwg.sla_coordinator.state.v1'
+PROMOTION_REGISTRY_SCHEMA = 'pwg.sla_coordinator.artifact.v1'
+PHASES = (
+    'prepared',
+    'store_committed',
+    'derived_validated',
+    'coordinator_committed',
+    'complete',
+)
+_PHASE_INDEX = {name: i for i, name in enumerate(PHASES)}
+
+
+class JournalError(RuntimeError):
+    """The journal is malformed or an attempted transition is unsafe."""
+
+
+class UnrelatedStoreError(JournalError):
+    """The live store matches neither the sealed before nor after identity."""
+
+
+def utc_now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat(
+        timespec='seconds').replace('+00:00', 'Z')
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def file_fingerprint(path: str, *, missing_ok: bool = False) -> dict[str, Any]:
+    """Return an exact SHA/size/row fingerprint for *path*.
+
+    ``rows`` is the count of non-empty lines, matching the canonical JSONL
+    store's row semantics.  Missing optional derived files are represented
+    explicitly rather than conflated with an empty file.
+    """
+    absolute = os.path.abspath(path)
+    if not os.path.exists(absolute):
+        if missing_ok:
+            return {
+                'path': absolute, 'exists': False, 'sha256': None,
+                'bytes': 0, 'rows': 0,
+            }
+        raise FileNotFoundError(absolute)
+    digest = hashlib.sha256()
+    size = 0
+    rows = 0
+    with open(absolute, 'rb') as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b''):
+            digest.update(chunk)
+            size += len(chunk)
+            rows += sum(1 for line in chunk.splitlines() if line.strip())
+    # A line spanning chunks could be counted twice by splitlines. Canonical
+    # rows are small today, but compute rows exactly to keep this primitive true.
+    with open(absolute, 'rb') as fh:
+        rows = sum(1 for line in fh if line.strip())
+    return {
+        'path': absolute, 'exists': True, 'sha256': digest.hexdigest(),
+        'bytes': size, 'rows': rows,
+    }
+
+
+def bytes_fingerprint(path: str, payload: bytes) -> dict[str, Any]:
+    return {
+        'path': os.path.abspath(path),
+        'exists': True,
+        'sha256': sha256_bytes(payload),
+        'bytes': len(payload),
+        'rows': sum(1 for line in payload.splitlines() if line.strip()),
+    }
+
+
+def aggregate_files(paths: list[str]) -> dict[str, Any]:
+    """Seal ordered clean-output files into one deterministic aggregate hash."""
+    files = []
+    for path in sorted(os.path.abspath(p) for p in paths):
+        fp = file_fingerprint(path)
+        files.append({
+            'path': fp['path'], 'sha256': fp['sha256'], 'bytes': fp['bytes'],
+        })
+    canonical = json.dumps(files, ensure_ascii=False, sort_keys=True,
+                           separators=(',', ':')).encode('utf-8')
+    return {'sha256': sha256_bytes(canonical), 'count': len(files), 'files': files}
+
+
+def canonical_path(path: str) -> str:
+    """Canonical comparison spelling for a filesystem target."""
+    return os.path.normcase(os.path.realpath(os.path.abspath(path)))
+
+
+def _fsync_directory(path: str) -> None:
+    """Durably persist a POSIX rename's directory entry."""
+    if os.name == 'nt':
+        return
+    directory = os.path.dirname(os.path.abspath(path)) or '.'
+    flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0)
+    fd = os.open(directory, flags)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def fsync_existing_path(path: str) -> None:
+    """Re-establish file and directory durability before adopting a projection."""
+    # Windows' CRT rejects fsync() on a read-only descriptor (EBADF).
+    fd = os.open(path, os.O_RDWR)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    _fsync_directory(path)
+
+
+def durable_replace(source: str, destination: str) -> None:
+    """Replace *destination* durably or fail loudly.
+
+    Windows' ordinary ``os.replace`` does not request write-through semantics.
+    MoveFileExW with both REPLACE_EXISTING and WRITE_THROUGH closes that gap.
+    POSIX uses rename followed by a mandatory parent-directory fsync.
+    """
+    source = os.path.abspath(source)
+    destination = os.path.abspath(destination)
+    if os.name == 'nt':
+        move_file = ctypes.WinDLL('kernel32', use_last_error=True).MoveFileExW
+        move_file.argtypes = [ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32]
+        move_file.restype = ctypes.c_int
+        movefile_replace_existing = 0x1
+        movefile_write_through = 0x8
+        if not move_file(source, destination,
+                         movefile_replace_existing | movefile_write_through):
+            raise ctypes.WinError(ctypes.get_last_error())
+        return
+    os.replace(source, destination)
+    _fsync_directory(destination)
+
+
+def atomic_write_bytes(path: str, payload: bytes) -> str:
+    """Fsync temporary bytes and durably replace *path*."""
+    absolute = os.path.abspath(path)
+    directory = os.path.dirname(absolute) or '.'
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        prefix='.%s.' % os.path.basename(absolute), suffix='.tmp', dir=directory)
+    try:
+        with os.fdopen(fd, 'wb') as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        durable_replace(tmp, absolute)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+    return absolute
+
+
+def stable_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True)
+            + '\n').encode('utf-8')
+
+
+def atomic_write_json(path: str, value: Mapping[str, Any]) -> str:
+    """Durably replace *path* with stable JSON."""
+    return atomic_write_bytes(path, stable_json_bytes(value))
+
+
+def fault(hook: Callable[[str], None] | None, point: str) -> None:
+    """Invoke an injectable crash hook used only by offline/temp tests."""
+    if hook is not None:
+        hook(point)
+
+
+def load(path: str) -> dict[str, Any]:
+    with open(path, encoding='utf-8') as fh:
+        journal = json.load(fh)
+    validate(journal)
+    return journal
+
+
+def validate(journal: Mapping[str, Any]) -> None:
+    if journal.get('schema') != SCHEMA:
+        raise JournalError('unsupported journal schema %r' % journal.get('schema'))
+    if journal.get('phase') not in PHASES:
+        raise JournalError('invalid journal phase %r' % journal.get('phase'))
+    for key in ('promotion_id', 'model_identifier', 'review_status',
+                'artifact_timestamp'):
+        if not isinstance(journal.get(key), str) or not journal[key]:
+            raise JournalError('journal.%s must be a non-empty string' % key)
+    lease_ids = journal.get('lease_ids')
+    bindings = journal.get('bindings')
+    leases = journal.get('leases')
+    if (not isinstance(lease_ids, list) or not lease_ids
+            or any(not isinstance(value, str) or not value for value in lease_ids)
+            or lease_ids != sorted(set(lease_ids))):
+        raise JournalError('journal.lease_ids must be a sorted unique non-empty list')
+    if not isinstance(bindings, Mapping) or sorted(bindings) != lease_ids:
+        raise JournalError('journal.bindings must exactly cover lease_ids')
+    if not isinstance(leases, Mapping) or sorted(leases) != lease_ids:
+        raise JournalError('journal.leases must exactly cover lease_ids')
+    for lease_id in lease_ids:
+        binding = bindings[lease_id]
+        metrics = leases[lease_id]
+        if not isinstance(binding, Mapping) or not isinstance(metrics, Mapping):
+            raise JournalError('%s binding/metrics must be objects' % lease_id)
+        for name in ('run_id', 'attempt_id'):
+            value = binding.get(name)
+            if value is not None and (not isinstance(value, str) or not value):
+                raise JournalError('%s.%s must be null or a non-empty string'
+                                   % (lease_id, name))
+            if metrics.get(name) != value:
+                raise JournalError('%s metrics/binding %s mismatch' % (lease_id, name))
+        clean = metrics.get('clean_output')
+        subcards = metrics.get('subcard_keys')
+        if (not isinstance(clean, Mapping)
+                or not isinstance(clean.get('sha256'), str)
+                or not isinstance(clean.get('count'), int)):
+            raise JournalError('%s missing clean-output hash/count' % lease_id)
+        if (not isinstance(subcards, list) or not subcards
+                or subcards != sorted(set(subcards))
+                or metrics.get('subcards') != len(subcards)):
+            raise JournalError('%s has invalid sealed subcards' % lease_id)
+    expected_run_ids = {
+        lease_id: bindings[lease_id]['run_id']
+        for lease_id in lease_ids if bindings[lease_id].get('run_id')
+    }
+    if journal.get('run_ids') != expected_run_ids:
+        raise JournalError('journal.run_ids does not match exact bindings')
+    clean_output = journal.get('clean_output')
+    union_subcards = sorted(
+        key for lease_id in lease_ids for key in leases[lease_id]['subcard_keys'])
+    if (not isinstance(clean_output, Mapping)
+            or clean_output.get('subcards') != union_subcards
+            or clean_output.get('subcard_count') != len(union_subcards)
+            or clean_output.get('card_count') != len(union_subcards)):
+        raise JournalError('journal.clean_output does not match per-lease subcards')
+    store = journal.get('store')
+    if not isinstance(store, Mapping):
+        raise JournalError('journal.store must be an object')
+    for key in ('path', 'before_sha256', 'expected_after_sha256'):
+        if not isinstance(store.get(key), str) or not store[key]:
+            raise JournalError('journal.store.%s must be a non-empty string' % key)
+    for key in ('before_rows', 'expected_after_rows'):
+        if isinstance(store.get(key), bool) or not isinstance(store.get(key), int):
+            raise JournalError('journal.store.%s must be an int' % key)
+    if store['path'] != canonical_path(store['path']):
+        raise JournalError('journal.store.path is not canonical: %s' % store['path'])
+    backup = store.get('backup')
+    if not isinstance(backup, Mapping) or not backup.get('path'):
+        raise JournalError('journal.store.backup is required')
+    if backup['path'] != canonical_path(backup['path']):
+        raise JournalError('journal.store.backup.path is not canonical')
+    if (backup.get('sha256') != store['before_sha256']
+            or backup.get('rows') != store['before_rows']
+            or backup.get('bytes') != store.get('before_bytes')):
+        raise JournalError('journal.store.backup does not seal the before store')
+    report = journal.get('report')
+    if not isinstance(report, Mapping):
+        raise JournalError('journal.report must seal the deterministic report')
+    if (report.get('promotion_id') != journal['promotion_id']
+            or report.get('leases') != leases
+            or report.get('journal_phase') != 'store_committed'
+            or report.get('model_identifier') != journal['model_identifier']
+            or report.get('review_status') != journal['review_status']
+            or report.get('clean_output_sha256') != clean_output.get('sha256')
+            or report.get('store_sha256') != store['expected_after_sha256']):
+        raise JournalError('journal.report does not match sealed promotion intent')
+    if (report.get('report_path') is not None
+            and report['report_path'] != canonical_path(report['report_path'])):
+        raise JournalError('journal.report.report_path is not canonical')
+    if _PHASE_INDEX[journal['phase']] >= _PHASE_INDEX['derived_validated']:
+        derived = journal.get('derived')
+        if (not isinstance(derived, Mapping) or derived.get('errors')
+                or not all(isinstance(derived.get(kind), Mapping)
+                           for kind in ('denylist', 'card_tm', 'fragment_tm'))
+                or not derived['card_tm'].get('validated')
+                or not derived['fragment_tm'].get('validated')):
+            raise JournalError('derived_validated journal lacks validated sealed artifacts')
+    if _PHASE_INDEX[journal['phase']] >= _PHASE_INDEX['coordinator_committed']:
+        coordinator = journal.get('coordinator')
+        if (not isinstance(coordinator, Mapping)
+                or not isinstance(coordinator.get('intent'), Mapping)
+                or not coordinator.get('committed_at')):
+            raise JournalError(
+                'coordinator_committed journal lacks sealed coordinator evidence')
+
+
+def _immutable_projection(journal: Mapping[str, Any]) -> dict[str, Any]:
+    """Fields that must be byte-identical on a retry of ``prepare``."""
+    return {
+        'schema': journal.get('schema'),
+        'promotion_id': journal.get('promotion_id'),
+        'lease_ids': journal.get('lease_ids'),
+        'run_ids': journal.get('run_ids'),
+        'bindings': journal.get('bindings'),
+        'model_identifier': journal.get('model_identifier'),
+        'review_status': journal.get('review_status'),
+        'clean_output': journal.get('clean_output'),
+        'store': journal.get('store'),
+        'leases': journal.get('leases'),
+        'report': journal.get('report'),
+    }
+
+
+def prepare(
+    path: str,
+    *,
+    promotion_id: str | None,
+    lease_ids: list[str],
+    run_ids: Mapping[str, str] | None,
+    bindings: Mapping[str, Mapping[str, str | None]],
+    model_identifier: str,
+    review_status: str,
+    clean_output: Mapping[str, Any],
+    store: Mapping[str, Any],
+    leases: Mapping[str, Any],
+    report: Mapping[str, Any],
+    fault_hook: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    """Create a durable PREPARED journal, or verify an idempotent retry."""
+    if not promotion_id:
+        raise JournalError('prepare requires an explicit stable promotion_id')
+    now = utc_now()
+    sealed_store = dict(store)
+    sealed_store['path'] = canonical_path(str(sealed_store['path']))
+    if isinstance(sealed_store.get('backup'), Mapping):
+        sealed_store['backup'] = dict(sealed_store['backup'])
+        sealed_store['backup']['path'] = canonical_path(
+            str(sealed_store['backup']['path']))
+        sealed_store['backup_path'] = sealed_store['backup']['path']
+    candidate = {
+        'schema': SCHEMA,
+        'promotion_id': promotion_id,
+        'phase': 'prepared',
+        'lease_ids': sorted(lease_ids),
+        'run_ids': dict(sorted((run_ids or {}).items())),
+        'bindings': {key: dict(bindings[key]) for key in sorted(bindings)},
+        'model_identifier': model_identifier,
+        'review_status': review_status,
+        'clean_output': dict(clean_output),
+        'store': sealed_store,
+        'leases': dict(leases),
+        'report': dict(report),
+        'derived': {
+            'denylist': None,
+            'card_tm': None,
+            'fragment_tm': None,
+            'validated_at': None,
+            'observations': [],
+            'errors': [],
+            'error_history': [],
+        },
+        'coordinator': {'intent': None, 'committed_at': None, 'error': None},
+        'artifact_timestamp': now,
+        'created_at': now,
+        'updated_at': now,
+        'history': [{'phase': 'prepared', 'at': now}],
+    }
+    validate(candidate)
+    if os.path.exists(path):
+        existing = load(path)
+        if _immutable_projection(existing) != _immutable_projection(candidate):
+            raise JournalError(
+                'existing journal does not match this promotion intent: %s' % path)
+        fault(fault_hook, 'prepared')
+        return existing
+    atomic_write_json(path, candidate)
+    fault(fault_hook, 'prepared')
+    return candidate
+
+
+def _advance(
+    path: str,
+    next_phase: str,
+    *,
+    expected_phase: str | None = None,
+    updates: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Durably advance exactly one phase; same-phase re-entry is idempotent."""
+    if next_phase not in PHASES:
+        raise JournalError('unknown next phase %r' % next_phase)
+    journal = load(path)
+    current = journal['phase']
+    if current == next_phase:
+        return journal
+    if expected_phase is not None and current != expected_phase:
+        raise JournalError('phase is %s, expected %s' % (current, expected_phase))
+    if _PHASE_INDEX[next_phase] != _PHASE_INDEX[current] + 1:
+        raise JournalError('refusing non-adjacent phase transition %s -> %s'
+                           % (current, next_phase))
+    if updates:
+        for key, value in updates.items():
+            journal[key] = value
+    now = utc_now()
+    journal['phase'] = next_phase
+    journal['updated_at'] = now
+    journal.setdefault('history', []).append({'phase': next_phase, 'at': now})
+    validate(journal)
+    atomic_write_json(path, journal)
+    return journal
+
+
+def verify_backup(journal: Mapping[str, Any], *, required: bool) -> None:
+    sealed = journal['store']['backup']
+    path = sealed['path']
+    if not os.path.isfile(path):
+        if required:
+            raise JournalError('sealed promotion backup is missing: %s' % path)
+        return
+    observed = file_fingerprint(path)
+    for field in ('sha256', 'rows', 'bytes'):
+        if observed[field] != sealed[field]:
+            raise JournalError('sealed promotion backup %s mismatch' % field)
+
+
+def verify_committed_store(journal: Mapping[str, Any]) -> dict[str, Any]:
+    """Require the live canonical store to equal this journal's sealed result."""
+    store = journal['store']
+    observed = file_fingerprint(store['path'], missing_ok=True)
+    if (not observed['exists']
+            or observed['sha256'] != store['expected_after_sha256']
+            or observed['rows'] != store['expected_after_rows']
+            or observed['bytes'] != store['expected_after_bytes']):
+        raise UnrelatedStoreError(
+            'committed promotion journal no longer matches live store '
+            '(observed=%s expected=%s)'
+            % (observed.get('sha256'), store['expected_after_sha256']))
+    verify_backup(journal, required=True)
+    return observed
+
+
+def reconcile(
+    path: str,
+    *,
+    adopt_after: bool = True,
+    store_claim_held: bool = False,
+) -> dict[str, Any]:
+    """Inspect/adopt store state using the journal's sealed before/after hashes."""
+    journal = load(path)
+    if journal['phase'] == 'complete':
+        return {
+            'promotion_id': journal['promotion_id'],
+            'phase': 'complete',
+            'observed': None,
+            'action': 'terminal_complete',
+        }
+    if not store_claim_held:
+        with PromoteClaim(journal['store']['path']):
+            return reconcile(
+                path, adopt_after=adopt_after, store_claim_held=True)
+    store = journal['store']
+    observed = file_fingerprint(store['path'], missing_ok=True)
+    before = store['before_sha256']
+    after = store['expected_after_sha256']
+    if not observed['exists']:
+        raise UnrelatedStoreError('canonical store is missing: %s' % store['path'])
+    result = {
+        'promotion_id': journal['promotion_id'],
+        'phase': journal['phase'],
+        'observed': observed,
+        'action': None,
+    }
+    if journal['phase'] == 'prepared':
+        if observed['sha256'] == before and observed['rows'] == store['before_rows']:
+            verify_backup(journal, required=False)
+            result['action'] = 'retry_store_replace'
+            return result
+        if (observed['sha256'] == after
+                and observed['rows'] == store['expected_after_rows']):
+            verify_backup(journal, required=True)
+            result['action'] = 'adopt_store_commit'
+            if adopt_after:
+                journal = _advance(path, 'store_committed', expected_phase='prepared')
+                result['phase'] = journal['phase']
+            return result
+        raise UnrelatedStoreError(
+            'live store hash is neither sealed before nor expected-after '
+            '(observed=%s before=%s after=%s)'
+            % (observed['sha256'], before, after))
+    verify_committed_store(journal)
+    if journal['phase'] in ('derived_validated', 'coordinator_committed'):
+        verify_sealed_artifacts(journal)
+    if journal['phase'] == 'coordinator_committed':
+        reconcile_coordinator(
+            path, adopt_after=False, store_claim_held=True)
+    result['action'] = 'already_store_committed'
+    return result
+
+
+def mark_store_committed(
+    path: str,
+    *,
+    store_claim_held: bool = False,
+) -> dict[str, Any]:
+    """Verify the expected bytes are live, then durably mark STORE_COMMITTED."""
+    result = reconcile(
+        path, adopt_after=True, store_claim_held=store_claim_held)
+    if result['action'] not in ('adopt_store_commit', 'already_store_committed'):
+        raise JournalError('store still has before hash; replacement has not committed')
+    return load(path)
+
+
+def mark_derived_validated(
+    path: str,
+    *,
+    denylist_path: str | None = None,
+    card_tm_path: str | None = None,
+    fragment_tm_path: str | None = None,
+    errors: list[str] | None = None,
+    lang: str = 'ru',
+    fault_hook: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    """Seal derived artifacts and advance after successful validation."""
+    journal = load(path)
+    if journal['phase'] == 'complete':
+        return journal
+    if _PHASE_INDEX[journal['phase']] >= _PHASE_INDEX['derived_validated']:
+        verify_sealed_artifacts(journal)
+        return journal
+    if journal['phase'] != 'store_committed':
+        raise JournalError('derived validation requires store_committed, got %s'
+                           % journal['phase'])
+    if not denylist_path or not card_tm_path or not fragment_tm_path:
+        raise JournalError(
+            'derived validation requires denylist plus existing validated '
+            'card and fragment TM paths')
+    try:
+        try:
+            import translation_memory as tm
+        except ImportError:
+            from pilot import translation_memory as tm
+        card_ok, card_stats = tm.validate_tm_file(lang, card_tm_path, kind='card')
+        frag_ok, frag_stats = tm.validate_tm_file(
+            lang, fragment_tm_path, kind='fragment')
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise JournalError('derived TM validation failed: %s' % exc) from exc
+    if not tm.validation_ok(card_stats) or not tm.validation_ok(frag_stats):
+        raise JournalError(
+            'derived TM validation failed: card=%s fragment=%s'
+            % (dict(card_stats), dict(frag_stats)))
+    with open(card_tm_path, encoding='utf-8') as fh:
+        card_payload = json.load(fh)
+    if card_payload.get('built_at') != journal['artifact_timestamp']:
+        raise JournalError(
+            'card TM built_at %r does not match journal artifact timestamp %r'
+            % (card_payload.get('built_at'), journal['artifact_timestamp']))
+    derived = dict(journal.get('derived') or {})
+    current_errors = list(derived.get('errors') or [])
+    supplied_errors = list(errors or [])
+    if supplied_errors:
+        derived.setdefault('error_history', []).extend(supplied_errors)
+        current_errors.extend(supplied_errors)
+    if current_errors:
+        raise JournalError('derived artifacts have unresolved errors: %s'
+                           % current_errors)
+    now = journal['artifact_timestamp']
+    card_fp = file_fingerprint(card_tm_path)
+    card_fp.update({'validated': True, 'valid_rows': card_ok,
+                    'validation_stats': dict(card_stats), 'validated_at': now})
+    frag_fp = file_fingerprint(fragment_tm_path)
+    frag_fp.update({'validated': True, 'valid_rows': frag_ok,
+                    'validation_stats': dict(frag_stats), 'validated_at': now})
+    deny_fp = file_fingerprint(denylist_path, missing_ok=True)
+    deny_fp['validated_at'] = now
+    derived.update({
+        'denylist': deny_fp,
+        'card_tm': card_fp,
+        'fragment_tm': frag_fp,
+        'validated_at': now,
+        'errors': current_errors,
+    })
+    result = _advance(path, 'derived_validated', expected_phase='store_committed',
+                      updates={'derived': derived})
+    fault(fault_hook, 'derived')
+    return result
+
+
+def verify_sealed_artifacts(journal_or_path: Mapping[str, Any] | str) -> None:
+    """Re-fingerprint every artifact sealed at DERIVED_VALIDATED."""
+    journal = (load(journal_or_path) if isinstance(journal_or_path, str)
+               else dict(journal_or_path))
+    if _PHASE_INDEX[journal['phase']] < _PHASE_INDEX['derived_validated']:
+        raise JournalError('derived artifacts are not yet sealed')
+    derived = journal.get('derived') or {}
+    if derived.get('errors'):
+        raise JournalError('derived artifacts have unresolved errors: %s'
+                           % derived['errors'])
+    for kind in ('denylist', 'card_tm', 'fragment_tm'):
+        sealed = derived.get(kind)
+        if not isinstance(sealed, Mapping):
+            raise JournalError('missing sealed derived artifact %s' % kind)
+        observed = (file_fingerprint(sealed['path'], missing_ok=True)
+                    if sealed.get('path') else {
+                        'path': None, 'exists': False, 'sha256': None,
+                        'bytes': 0, 'rows': 0,
+                    })
+        for field in ('path', 'exists', 'sha256', 'bytes', 'rows'):
+            if observed.get(field) != sealed.get(field):
+                raise JournalError(
+                    'sealed %s changed after validation (%s: %r != %r)'
+                    % (kind, field, observed.get(field), sealed.get(field)))
+
+
+def record_derived_observation(
+    path: str,
+    kind: str,
+    *,
+    artifact_path: str | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Durably record one derived-side effect without advancing its phase.
+
+    This is used immediately after denylist/TM work so a crash before the full
+    derived-validation barrier still leaves timestamps, hashes, and errors.
+    """
+    if kind not in ('denylist', 'card_tm', 'fragment_tm'):
+        raise JournalError('unknown derived artifact kind %r' % kind)
+    journal = load(path)
+    if journal['phase'] != 'store_committed':
+        raise JournalError('derived observations require store_committed, got %s'
+                           % journal['phase'])
+    derived = dict(journal.get('derived') or {})
+    observation = (file_fingerprint(artifact_path, missing_ok=True)
+                   if artifact_path else {'path': None, 'exists': False,
+                                          'sha256': None, 'bytes': 0, 'rows': 0})
+    observation['observed_at'] = utc_now()
+    observation['error'] = error
+    derived[kind] = observation
+    derived.setdefault('observations', []).append({
+        'kind': kind, **observation,
+    })
+    errors = [value for value in list(derived.get('errors') or [])
+              if not value.startswith('%s: ' % kind)]
+    if error:
+        message = '%s: %s' % (kind, error)
+        errors.append(message)
+        derived.setdefault('error_history', []).append(message)
+    derived['errors'] = errors
+    journal['derived'] = derived
+    journal['updated_at'] = utc_now()
+    atomic_write_json(path, journal)
+    return journal
+
+
+def _require_utc_second_timestamp(value: Any, field: str) -> None:
+    if not isinstance(value, str):
+        raise JournalError('%s must be a UTC second timestamp' % field)
+    try:
+        parsed = datetime.datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
+    except ValueError as exc:
+        raise JournalError('%s must be a UTC second timestamp' % field) from exc
+    if parsed.strftime('%Y-%m-%dT%H:%M:%SZ') != value:
+        raise JournalError('%s must be a UTC second timestamp' % field)
+
+
+def _validate_promotion_registry_projection(
+    journal_path: str,
+    journal: Mapping[str, Any],
+    expected_state: Mapping[str, Any],
+    lease_outcomes: Mapping[str, Any],
+    registry_path: str,
+    registry_events: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Return the canonical registry projection or refuse an incomplete seal.
+
+    The coordinator owns the event builder, but importing it here would create
+    a cycle.  Keep this exact mirror deliberately small: the promoted event is
+    derived from the already-sealed journal plus the coordinator state bytes
+    that will be committed in the same transaction.
+    """
+    artifact_timestamp = journal['artifact_timestamp']
+    _require_utc_second_timestamp(
+        artifact_timestamp, 'journal.artifact_timestamp')
+    if not isinstance(registry_path, str) or not registry_path:
+        raise JournalError('promotion registry path must be a non-empty string')
+    if expected_state.get('schema') != COORDINATOR_STATE_SCHEMA:
+        raise JournalError('expected coordinator state has unsupported schema')
+    state_leases = expected_state.get('leases')
+    if not isinstance(state_leases, list):
+        raise JournalError('expected coordinator state leases must be a list')
+    leases_by_id = {}
+    for lease in state_leases:
+        if not isinstance(lease, Mapping):
+            raise JournalError('expected coordinator state lease is not an object')
+        lease_id = lease.get('id')
+        if (not isinstance(lease_id, str) or not lease_id
+                or lease_id in leases_by_id):
+            raise JournalError(
+                'expected coordinator state has invalid/duplicate lease id')
+        leases_by_id[lease_id] = lease
+
+    journal_absolute = os.path.abspath(journal_path)
+    report = journal['report']
+    store = journal['store']
+    store_before = report.get('store_rows_before')
+    store_after = report.get('store_rows_after')
+    if (store_before != store['before_rows']
+            or store_after != store['expected_after_rows']):
+        raise JournalError(
+            'journal report store row metrics do not match sealed store')
+    bundle_store_delta = store_after - store_before
+
+    last_promotion = expected_state.get('last_promotion')
+    expected_last_promotion = {
+        'promotion_id': journal['promotion_id'],
+        'journal': journal_absolute,
+        'lease_outcomes': dict(lease_outcomes),
+        'model_identifier': journal['model_identifier'],
+        'store_sha256': store['expected_after_sha256'],
+        'committed_at': artifact_timestamp,
+    }
+    if last_promotion != expected_last_promotion:
+        raise JournalError(
+            'expected coordinator state has inconsistent last_promotion')
+    if expected_state.get('updated_at') != artifact_timestamp:
+        raise JournalError(
+            'expected coordinator state timestamp does not match journal artifact')
+
+    expected_events = []
+    for lease_id in journal['lease_ids']:
+        outcome = lease_outcomes[lease_id]
+        if outcome not in ('promoted', 'promoted_partial'):
+            raise JournalError(
+                '%s has invalid coordinator lease outcome %r'
+                % (lease_id, outcome))
+        lease = leases_by_id.get(lease_id)
+        if lease is None:
+            raise JournalError(
+                'expected coordinator state lacks lease %s' % lease_id)
+        metrics = journal['leases'][lease_id]
+        clean_files = (metrics.get('clean_output') or {}).get('files') or []
+        if (len(clean_files) != 1
+                or not isinstance(clean_files[0], Mapping)
+                or not clean_files[0].get('path')
+                or not clean_files[0].get('sha256')):
+            raise JournalError(
+                '%s registry projection requires one sealed clean output'
+                % lease_id)
+        for field in ('kind', 'target', 'artifact_dir'):
+            if not isinstance(lease.get(field), str) or not lease[field]:
+                raise JournalError(
+                    'expected coordinator lease %s lacks %s'
+                    % (lease_id, field))
+        expected_lease_facts = {
+            'state': outcome,
+            'promoted_at': artifact_timestamp,
+            'promotion_id': journal['promotion_id'],
+            'promotion_journal': journal_absolute,
+            'model_version': journal['model_identifier'],
+            'store_before': store_before,
+            'store_after': store_after,
+            'store_delta': metrics['store_delta'],
+            'bundle_store_delta': bundle_store_delta,
+            'promoted_subcards': metrics['subcards'],
+            'promoted_rows': metrics['rows'],
+            'rows_added': metrics['rows_added'],
+            'rows_replaced': metrics['rows_replaced'],
+            'clean_count': metrics['subcards'],
+            'clean_output_sha256': clean_files[0]['sha256'],
+        }
+        for field, expected_value in expected_lease_facts.items():
+            if lease.get(field) != expected_value:
+                raise JournalError(
+                    'expected coordinator lease %s has inconsistent %s'
+                    % (lease_id, field))
+        binding = journal['bindings'][lease_id]
+        if binding.get('run_id') is not None:
+            attempts = lease.get('run_attempts')
+            completed = attempts[-1] if isinstance(attempts, list) and attempts else {}
+            if (completed.get('run_id') != binding['run_id']
+                    or completed.get('run_operation_id') != binding.get('attempt_id')):
+                raise JournalError(
+                    'expected coordinator lease %s lacks sealed run binding'
+                    % lease_id)
+        expected_events.append({
+            'schema': PROMOTION_REGISTRY_SCHEMA,
+            'ts': artifact_timestamp,
+            'lease_id': lease_id,
+            'event': 'promoted',
+            'kind': lease['kind'],
+            'target': lease['target'],
+            'state': outcome,
+            'artifact_dir': lease['artifact_dir'],
+            'data': {
+                'glob': clean_files[0]['path'],
+                'journal': journal_absolute,
+                'store_before': store_before,
+                'store_after': store_after,
+                'store_delta': metrics['store_delta'],
+                'bundle_store_delta': bundle_store_delta,
+                'rows_added': metrics['rows_added'],
+                'rows_replaced': metrics['rows_replaced'],
+                'batch_subcards': metrics['subcards'],
+                'batch_rows': metrics['rows'],
+                'promotion_id': journal['promotion_id'],
+            },
+        })
+
+    supplied = [dict(row) for row in registry_events]
+    if supplied != expected_events:
+        raise JournalError(
+            'registry events do not match canonical promotion projection')
+    return {
+        'path': canonical_path(registry_path),
+        'events': expected_events,
+    }
+
+
+def prepare_coordinator_commit(
+    path: str,
+    *,
+    state_path: str,
+    expected_state_bytes: bytes,
+    lease_outcomes: Mapping[str, Any],
+    promotion_marker: Any,
+    registry_path: str,
+    registry_events: list[Mapping[str, Any]],
+    store_claim_held: bool = False,
+    fault_hook: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    """Seal exact coordinator state bytes before the coordinator-state replace."""
+    journal = load(path)
+    if not store_claim_held:
+        with PromoteClaim(journal['store']['path']):
+            return prepare_coordinator_commit(
+                path,
+                state_path=state_path,
+                expected_state_bytes=expected_state_bytes,
+                lease_outcomes=lease_outcomes,
+                promotion_marker=promotion_marker,
+                registry_path=registry_path,
+                registry_events=registry_events,
+                store_claim_held=True,
+                fault_hook=fault_hook,
+            )
+    if _PHASE_INDEX[journal['phase']] < _PHASE_INDEX['derived_validated']:
+        raise JournalError('coordinator intent requires derived_validated, got %s'
+                           % journal['phase'])
+    if journal['phase'] != 'complete':
+        verify_committed_store(journal)
+        verify_sealed_artifacts(journal)
+    if promotion_marker != journal['promotion_id']:
+        raise JournalError('coordinator promotion marker must equal journal promotion_id')
+    if not isinstance(lease_outcomes, Mapping):
+        raise JournalError('coordinator lease outcomes must be an object')
+    if sorted(lease_outcomes) != journal['lease_ids']:
+        raise JournalError('coordinator lease outcomes must exactly cover journal leases')
+    if (not isinstance(registry_events, list) or not registry_events
+            or len(registry_events) != len(journal['lease_ids'])
+            or any(not isinstance(row, Mapping) for row in registry_events)):
+        raise JournalError('registry events must be one non-empty object per lease')
+    event_lease_ids = [row.get('lease_id') for row in registry_events]
+    if (any(not isinstance(lease_id, str) or not lease_id
+            for lease_id in event_lease_ids)
+            or sorted(event_lease_ids) != journal['lease_ids']):
+        raise JournalError('registry events must exactly cover journal leases')
+    try:
+        expected_state = json.loads(expected_state_bytes.decode('utf-8'))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise JournalError('expected coordinator state must be UTF-8 JSON') from exc
+    if not isinstance(expected_state, Mapping):
+        raise JournalError('expected coordinator state must be a JSON object')
+    registry = _validate_promotion_registry_projection(
+        path, journal, expected_state, lease_outcomes,
+        registry_path, registry_events)
+
+    def _contains(value: Any, wanted: Any) -> bool:
+        if value == wanted:
+            return True
+        if isinstance(value, Mapping):
+            return any(_contains(child, wanted) for child in value.values())
+        if isinstance(value, list):
+            return any(_contains(child, wanted) for child in value)
+        return False
+
+    if not _contains(expected_state, promotion_marker):
+        raise JournalError('expected coordinator state lacks the promotion marker')
+    if not _contains(expected_state, dict(lease_outcomes)):
+        raise JournalError('expected coordinator state lacks exact lease outcomes')
+    state_path = canonical_path(state_path)
+    expected = bytes_fingerprint(state_path, expected_state_bytes)
+    coordinator = dict(journal.get('coordinator') or {})
+    existing = coordinator.get('intent')
+    if existing is not None:
+        retry_projection = {
+            'state_path': state_path,
+            'expected': expected,
+            'lease_outcomes': dict(lease_outcomes),
+            'promotion_marker': promotion_marker,
+            'registry': registry,
+        }
+        sealed_projection = {
+            key: existing.get(key) for key in retry_projection
+        }
+        if sealed_projection != retry_projection:
+            raise JournalError('coordinator state intent changed on retry')
+        fault(fault_hook, 'coordinator_prepared')
+        return journal
+    before = file_fingerprint(state_path, missing_ok=True)
+    intent = {
+        'state_path': state_path,
+        'before': before,
+        'expected': expected,
+        'lease_outcomes': dict(lease_outcomes),
+        'promotion_marker': promotion_marker,
+        'registry': registry,
+        'prepared_at': journal['artifact_timestamp'],
+    }
+    coordinator['intent'] = intent
+    journal['coordinator'] = coordinator
+    journal['updated_at'] = utc_now()
+    atomic_write_json(path, journal)
+    fault(fault_hook, 'coordinator_prepared')
+    return journal
+
+
+def reconcile_coordinator(
+    path: str,
+    *,
+    adopt_after: bool = True,
+    store_claim_held: bool = False,
+    fault_hook: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    """Reconcile/adopt a crash after coordinator state was durably saved."""
+    journal = load(path)
+    if journal['phase'] == 'complete':
+        return {
+            'phase': 'complete', 'observed': None,
+            'action': 'terminal_complete',
+        }
+    if not store_claim_held:
+        with PromoteClaim(journal['store']['path']):
+            return reconcile_coordinator(
+                path, adopt_after=adopt_after, store_claim_held=True,
+                fault_hook=fault_hook)
+    verify_committed_store(journal)
+    verify_sealed_artifacts(journal)
+    intent = (journal.get('coordinator') or {}).get('intent')
+    if not isinstance(intent, Mapping):
+        raise JournalError('coordinator state intent is not sealed')
+    observed = file_fingerprint(intent['state_path'], missing_ok=True)
+    before = intent['before']
+    expected = intent['expected']
+    result = {'phase': journal['phase'], 'observed': observed, 'action': None}
+    expected_match = all(observed.get(field) == expected.get(field)
+                         for field in ('path', 'exists', 'sha256', 'bytes', 'rows'))
+    before_match = all(observed.get(field) == before.get(field)
+                       for field in ('path', 'exists', 'sha256', 'bytes', 'rows'))
+    if journal['phase'] == 'derived_validated':
+        if before_match:
+            result['action'] = 'write_coordinator_state'
+            return result
+        if expected_match:
+            result['action'] = 'adopt_coordinator_commit'
+            if adopt_after:
+                coordinator = dict(journal['coordinator'])
+                coordinator.update({
+                    'committed_at': utc_now(), 'error': None,
+                    'observed': observed,
+                })
+                journal = _advance(
+                    path, 'coordinator_committed',
+                    expected_phase='derived_validated',
+                    updates={'coordinator': coordinator})
+                result['phase'] = journal['phase']
+                fault(fault_hook, 'coordinator_adopted')
+            return result
+        raise JournalError(
+            'coordinator state matches neither sealed before nor expected hash')
+    if not expected_match:
+        raise JournalError('committed coordinator state no longer matches sealed hash')
+    result['action'] = 'already_coordinator_committed'
+    return result
+
+
+def commit_coordinator_state(
+    path: str,
+    expected_state_bytes: bytes,
+    *,
+    store_claim_held: bool = False,
+    fault_hook: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    """Durably save the sealed coordinator bytes, then adopt the commit."""
+    journal = load(path)
+    if not store_claim_held:
+        with PromoteClaim(journal['store']['path']):
+            return commit_coordinator_state(
+                path, expected_state_bytes, store_claim_held=True,
+                fault_hook=fault_hook)
+    intent = (journal.get('coordinator') or {}).get('intent')
+    if not isinstance(intent, Mapping):
+        raise JournalError('coordinator state intent is not sealed')
+    if sha256_bytes(expected_state_bytes) != intent['expected']['sha256']:
+        raise JournalError('coordinator payload does not match sealed expected hash')
+    reconciled = reconcile_coordinator(
+        path, adopt_after=False, store_claim_held=True)
+    if reconciled['action'] == 'write_coordinator_state':
+        atomic_write_bytes(intent['state_path'], expected_state_bytes)
+        fault(fault_hook, 'coordinator_state_saved')
+    return reconcile_coordinator(
+        path, adopt_after=True, store_claim_held=True,
+        fault_hook=fault_hook)
+
+
+def mark_coordinator_committed(
+    path: str,
+    *,
+    error: str | None = None,
+    store_claim_held: bool = False,
+    fault_hook: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    """Adopt only an exact, previously sealed coordinator state."""
+    if error:
+        raise JournalError('coordinator commit error: %s' % error)
+    journal = load(path)
+    if journal['phase'] == 'complete':
+        return journal
+    if not store_claim_held:
+        with PromoteClaim(journal['store']['path']):
+            return mark_coordinator_committed(
+                path, error=error, store_claim_held=True,
+                fault_hook=fault_hook)
+    result = reconcile_coordinator(
+        path, adopt_after=True, store_claim_held=True,
+        fault_hook=fault_hook)
+    if result['action'] not in ('adopt_coordinator_commit',
+                                'already_coordinator_committed'):
+        raise JournalError('coordinator state still has its before hash')
+    return load(path)
+
+
+def verify_registry_projection(journal: Mapping[str, Any]) -> None:
+    """Require one exact durable registry event per lease before COMPLETE."""
+    intent = (journal.get('coordinator') or {}).get('intent')
+    registry = (intent or {}).get('registry') if isinstance(intent, Mapping) else None
+    if not isinstance(registry, Mapping):
+        raise JournalError('coordinator intent lacks sealed registry projection')
+    path = registry.get('path')
+    expected = registry.get('events')
+    if (not isinstance(path, str) or not path
+            or not isinstance(expected, list) or not expected):
+        raise JournalError('sealed registry projection is malformed')
+    try:
+        raw = open(path, 'rb').read()
+    except OSError as exc:
+        raise JournalError('sealed registry projection is unreadable: %s' % exc) from exc
+    if raw and not raw.endswith(b'\n'):
+        raise JournalError('sealed registry projection is not newline-terminated')
+    try:
+        text = raw.decode('utf-8')
+    except UnicodeDecodeError as exc:
+        raise JournalError('sealed registry projection is not UTF-8') from exc
+    rows = []
+    for line_number, line in enumerate(text.splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise JournalError(
+                'sealed registry projection has malformed JSON at line %d'
+                % line_number) from exc
+        if not isinstance(row, Mapping):
+            raise JournalError(
+                'sealed registry projection line %d is not an object'
+                % line_number)
+        rows.append(row)
+    for event in expected:
+        matches = sum(row == event for row in rows)
+        if matches != 1:
+            raise JournalError(
+                'sealed registry event must exist exactly once (observed %d)'
+                % matches)
+    fsync_existing_path(path)
+
+
+def mark_complete(
+    path: str,
+    *,
+    store_claim_held: bool = False,
+    fault_hook: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    journal = load(path)
+    if journal['phase'] == 'complete':
+        return journal
+    if not store_claim_held:
+        with PromoteClaim(journal['store']['path']):
+            return mark_complete(
+                path, store_claim_held=True, fault_hook=fault_hook)
+    # The canonical store remains part of the live transaction until COMPLETE.
+    # A third-party write after DERIVED_VALIDATED must block, never be blessed by
+    # merely rechecking TMs and coordinator state.
+    verify_committed_store(journal)
+    verify_sealed_artifacts(journal)
+    reconcile_coordinator(
+        path, adopt_after=False, store_claim_held=True)
+    verify_registry_projection(journal)
+    result = _advance(path, 'complete', expected_phase='coordinator_committed')
+    fault(fault_hook, 'final_journal_update')
+    return result
+
+
+def advance(
+    path: str,
+    next_phase: str,
+    *,
+    denylist_path: str | None = None,
+    card_tm_path: str | None = None,
+    fragment_tm_path: str | None = None,
+) -> dict[str, Any]:
+    """Safely advance through the validated public phase API."""
+    if next_phase == 'store_committed':
+        return mark_store_committed(path)
+    if next_phase == 'derived_validated':
+        return mark_derived_validated(
+            path, denylist_path=denylist_path, card_tm_path=card_tm_path,
+            fragment_tm_path=fragment_tm_path)
+    if next_phase == 'coordinator_committed':
+        return mark_coordinator_committed(path)
+    if next_phase == 'complete':
+        return mark_complete(path)
+    raise JournalError('public advance cannot target %r' % next_phase)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split('\n\n', 1)[0])
+    sub = parser.add_subparsers(dest='command', required=True)
+    inspect_p = sub.add_parser('inspect')
+    inspect_p.add_argument('journal')
+    reconcile_p = sub.add_parser('reconcile')
+    reconcile_p.add_argument('journal')
+    reconcile_p.add_argument('--no-adopt', action='store_true')
+    advance_p = sub.add_parser('advance')
+    advance_p.add_argument('journal')
+    advance_p.add_argument('phase', choices=PHASES[1:])
+    advance_p.add_argument('--denylist')
+    advance_p.add_argument('--card-tm')
+    advance_p.add_argument('--fragment-tm')
+    coord_prepare = sub.add_parser('coordinator-prepare')
+    coord_prepare.add_argument('journal')
+    coord_prepare.add_argument('--state', required=True)
+    coord_prepare.add_argument('--expected-state', required=True)
+    coord_prepare.add_argument('--outcomes', required=True)
+    coord_prepare.add_argument('--marker', required=True)
+    coord_prepare.add_argument('--registry', required=True)
+    coord_prepare.add_argument('--registry-events', required=True)
+    coord_commit = sub.add_parser('coordinator-commit')
+    coord_commit.add_argument('journal')
+    coord_commit.add_argument('--expected-state', required=True)
+    coord_reconcile = sub.add_parser('coordinator-reconcile')
+    coord_reconcile.add_argument('journal')
+    coord_reconcile.add_argument('--no-adopt', action='store_true')
+    args = parser.parse_args(argv)
+    try:
+        if args.command == 'inspect':
+            result = load(args.journal)
+        elif args.command == 'reconcile':
+            result = reconcile(args.journal, adopt_after=not args.no_adopt)
+        elif args.command == 'coordinator-prepare':
+            with open(args.expected_state, 'rb') as fh:
+                expected_state = fh.read()
+            with open(args.outcomes, encoding='utf-8') as fh:
+                outcomes = json.load(fh)
+            with open(args.registry_events, encoding='utf-8') as fh:
+                registry_events = json.load(fh)
+            result = prepare_coordinator_commit(
+                args.journal, state_path=args.state,
+                expected_state_bytes=expected_state,
+                lease_outcomes=outcomes, promotion_marker=args.marker,
+                registry_path=args.registry,
+                registry_events=registry_events)
+        elif args.command == 'coordinator-commit':
+            with open(args.expected_state, 'rb') as fh:
+                expected_state = fh.read()
+            result = commit_coordinator_state(args.journal, expected_state)
+        elif args.command == 'coordinator-reconcile':
+            result = reconcile_coordinator(
+                args.journal, adopt_after=not args.no_adopt)
+        else:
+            if args.phase == 'store_committed':
+                result = mark_store_committed(args.journal)
+            elif args.phase == 'derived_validated':
+                result = mark_derived_validated(
+                    args.journal, denylist_path=args.denylist,
+                    card_tm_path=args.card_tm, fragment_tm_path=args.fragment_tm)
+            elif args.phase == 'coordinator_committed':
+                result = mark_coordinator_committed(args.journal)
+            else:
+                result = mark_complete(args.journal)
+    except (JournalError, OSError, json.JSONDecodeError) as exc:
+        print('REFUSED: %s' % exc, file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/RussianTranslation/src/pilot/promotion_journal_selftest.py
+++ b/RussianTranslation/src/pilot/promotion_journal_selftest.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python
+"""Offline/temp-store adversarial selftests for pwg.promotion_journal.v1."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import promotion_journal as pj  # noqa: E402
+
+
+def write_bytes(path: str, payload: bytes) -> bytes:
+    pj.atomic_write_bytes(path, payload)
+    return payload
+
+
+def jsonl(rows: list[dict]) -> bytes:
+    return b''.join(
+        (json.dumps(row, ensure_ascii=False, sort_keys=True) + '\n').encode('utf-8')
+        for row in rows)
+
+
+def make_prepared(directory: str):
+    store = os.path.join(directory, 'store.jsonl')
+    journal = os.path.join(directory, 'promotion.json')
+    backup = os.path.join(directory, 'store.before.bak')
+    clean = os.path.join(directory, 'clean.json')
+    before = write_bytes(store, jsonl([{'subcard': 'old', 'ru': 'старый'}]))
+    write_bytes(backup, before)
+    after = jsonl([
+        {'subcard': 'old', 'ru': 'новый'},
+        {'subcard': 'new', 'ru': 'ряд'},
+    ])
+    write_bytes(clean, b'{"ok":true}\n')
+    clean_fp = pj.aggregate_files([clean])
+    bindings = {'lease-1': {'run_id': 'run-1', 'attempt_id': 'attempt-1'}}
+    leases = {'lease-1': {
+        **bindings['lease-1'],
+        'clean_output': clean_fp,
+        'subcards': 1,
+        'subcard_keys': ['new'],
+        'rows': 1,
+        'rows_added': 1,
+        'rows_replaced': 0,
+        'store_delta': 1,
+    }}
+    store_record = {
+        'path': pj.canonical_path(store),
+        'before_sha256': pj.sha256_bytes(before),
+        'before_rows': 1,
+        'before_bytes': len(before),
+        'expected_after_sha256': pj.sha256_bytes(after),
+        'expected_after_rows': 2,
+        'expected_after_bytes': len(after),
+        'backup_path': pj.canonical_path(backup),
+        'backup': {
+            'path': pj.canonical_path(backup),
+            'sha256': pj.sha256_bytes(before),
+            'rows': 1,
+            'bytes': len(before),
+        },
+    }
+    report = {
+        'schema': 'pwg.batch_promotion.v1',
+        'promotion_id': 'promotion-1',
+        'journal': pj.canonical_path(journal),
+        'journal_phase': 'store_committed',
+        'model_identifier': 'claude-sonnet-5',
+        'review_status': 'ai_translated',
+        'clean_output_sha256': clean_fp['sha256'],
+        'store_sha256': pj.sha256_bytes(after),
+        'store_rows_before': 1,
+        'store_rows_after': 2,
+        'leases': leases,
+    }
+    kwargs = {
+        'promotion_id': 'promotion-1',
+        'lease_ids': ['lease-1'],
+        'run_ids': {'lease-1': 'run-1'},
+        'bindings': bindings,
+        'model_identifier': 'claude-sonnet-5',
+        'review_status': 'ai_translated',
+        'clean_output': {
+            **clean_fp, 'subcards': ['new'], 'subcard_count': 1,
+            'card_count': 1, 'sense_rows': 1,
+        },
+        'store': store_record,
+        'leases': leases,
+        'report': report,
+    }
+    pj.prepare(journal, **kwargs)
+    return store, journal, before, after, kwargs
+
+
+def canonical_coordinator_projection(
+    journal_path: str,
+    artifact_dir: str,
+) -> tuple[bytes, list[dict]]:
+    journal = pj.load(journal_path)
+    lease_id = journal['lease_ids'][0]
+    metrics = journal['leases'][lease_id]
+    clean_file = metrics['clean_output']['files'][0]
+    timestamp = journal['artifact_timestamp']
+    journal_absolute = os.path.abspath(journal_path)
+    outcome = 'promoted'
+    state = {
+        'schema': pj.COORDINATOR_STATE_SCHEMA,
+        'updated_at': timestamp,
+        'leases': [{
+            'id': lease_id,
+            'kind': 'nominal',
+            'target': 'nominal:new',
+            'state': outcome,
+            'artifact_dir': artifact_dir,
+            'clean_count': metrics['subcards'],
+            'clean_output_sha256': clean_file['sha256'],
+            'run_attempts': [{
+                'run_id': journal['bindings'][lease_id]['run_id'],
+                'run_operation_id': journal['bindings'][lease_id]['attempt_id'],
+            }],
+            'promoted_at': timestamp,
+            'promotion_id': journal['promotion_id'],
+            'promotion_journal': journal_absolute,
+            'model_version': journal['model_identifier'],
+            'store_before': journal['report']['store_rows_before'],
+            'store_after': journal['report']['store_rows_after'],
+            'store_delta': metrics['store_delta'],
+            'bundle_store_delta': (
+                journal['report']['store_rows_after']
+                - journal['report']['store_rows_before']),
+            'promoted_subcards': metrics['subcards'],
+            'promoted_rows': metrics['rows'],
+            'rows_added': metrics['rows_added'],
+            'rows_replaced': metrics['rows_replaced'],
+        }],
+        'last_promotion': {
+            'promotion_id': journal['promotion_id'],
+            'journal': journal_absolute,
+            'lease_outcomes': {lease_id: outcome},
+            'model_identifier': journal['model_identifier'],
+            'store_sha256': journal['store']['expected_after_sha256'],
+            'committed_at': timestamp,
+        },
+    }
+    event = {
+        'schema': pj.PROMOTION_REGISTRY_SCHEMA,
+        'ts': timestamp,
+        'lease_id': lease_id,
+        'event': 'promoted',
+        'kind': 'nominal',
+        'target': 'nominal:new',
+        'state': outcome,
+        'artifact_dir': artifact_dir,
+        'data': {
+            'glob': clean_file['path'],
+            'journal': journal_absolute,
+            'store_before': journal['report']['store_rows_before'],
+            'store_after': journal['report']['store_rows_after'],
+            'store_delta': metrics['store_delta'],
+            'bundle_store_delta': (
+                journal['report']['store_rows_after']
+                - journal['report']['store_rows_before']),
+            'rows_added': metrics['rows_added'],
+            'rows_replaced': metrics['rows_replaced'],
+            'batch_subcards': metrics['subcards'],
+            'batch_rows': metrics['rows'],
+            'promotion_id': journal['promotion_id'],
+        },
+    }
+    return pj.stable_json_bytes(state), [event]
+
+
+def test_prepared_fault_retry_and_immutable_intent() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        store, journal, before, _after, kwargs = make_prepared(tmp)
+        os.unlink(journal)
+
+        def die(point):
+            if point == 'prepared':
+                raise RuntimeError('prepared death')
+
+        try:
+            pj.prepare(journal, fault_hook=die, **kwargs)
+            raise AssertionError('prepared hook did not fire')
+        except RuntimeError as exc:
+            assert str(exc) == 'prepared death', exc
+        assert os.path.isfile(journal)
+        assert open(store, 'rb').read() == before
+        pj.prepare(journal, **kwargs)
+        assert len(pj.load(journal)['history']) == 1
+
+        mutations = [
+            ('promotion id', {'promotion_id': 'other'}),
+            ('review status', {'review_status': 'approved'}),
+            ('store path', {'store': {
+                **kwargs['store'], 'path': pj.canonical_path(os.path.join(tmp, 'other'))}}),
+            ('binding', {'bindings': {
+                'lease-1': {'run_id': 'run-X', 'attempt_id': 'attempt-1'}}}),
+            ('clean hash', {'clean_output': {
+                **kwargs['clean_output'], 'sha256': '0' * 64}}),
+            ('subcards', {'leases': {'lease-1': {
+                **kwargs['leases']['lease-1'], 'subcard_keys': ['changed']}}}),
+        ]
+        for label, patch in mutations:
+            changed = dict(kwargs)
+            changed.update(patch)
+            try:
+                pj.prepare(journal, **changed)
+                raise AssertionError('%s retry mismatch was accepted' % label)
+            except pj.JournalError:
+                pass
+
+
+def test_before_after_unrelated_and_idempotence() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        store, journal, _before, after, _kwargs = make_prepared(tmp)
+        assert pj.reconcile(journal)['action'] == 'retry_store_replace'
+        write_bytes(store, after)
+        assert pj.reconcile(journal)['action'] == 'adopt_store_commit'
+        assert pj.reconcile(journal)['action'] == 'already_store_committed'
+    with tempfile.TemporaryDirectory() as tmp:
+        store, journal, _before, _after, _kwargs = make_prepared(tmp)
+        write_bytes(store, jsonl([{'subcard': 'intruder'}]))
+        try:
+            pj.reconcile(journal)
+            raise AssertionError('unrelated store hash was accepted')
+        except pj.UnrelatedStoreError:
+            pass
+
+
+def test_derived_coordinator_adoption_and_final_faults() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ['PWG_RU_STORE'] = os.path.join(tmp, 'env-store.jsonl')
+        os.environ['PWG_RU_TM_DIR'] = tmp
+        store, journal, _before, after, _kwargs = make_prepared(tmp)
+        write_bytes(store, after)
+        pj.mark_store_committed(journal)
+        import translation_memory as tm
+        card = os.path.join(tmp, 'card.tm.json')
+        frag = os.path.join(tmp, 'frag.tm.jsonl')
+        deny = os.path.join(tmp, 'deny.jsonl')
+        write_bytes(deny, b'')
+        tm.build(store, 'ru', out=card, journal_path=journal)
+        tm.build_frags(
+            [pj.load(journal)['clean_output']['files'][0]['path']],
+            'ru', out=frag,
+            journal_path=journal)
+        pj.record_derived_observation(
+            journal, 'denylist', artifact_path=deny, error='synthetic retry')
+        pj.record_derived_observation(
+            journal, 'denylist', artifact_path=deny, error=None)
+        observed_derived = pj.load(journal)['derived']
+        assert not observed_derived['errors']
+        assert 'denylist: synthetic retry' in observed_derived['error_history']
+        assert len(observed_derived['observations']) == 4
+
+        def die_derived(point):
+            if point == 'derived':
+                raise RuntimeError('derived death')
+
+        try:
+            pj.mark_derived_validated(
+                journal, denylist_path=deny, card_tm_path=card,
+                fragment_tm_path=frag, fault_hook=die_derived)
+            raise AssertionError('derived hook did not fire')
+        except RuntimeError as exc:
+            assert str(exc) == 'derived death', exc
+        assert pj.load(journal)['phase'] == 'derived_validated'
+
+        original_card = open(card, 'rb').read()
+        write_bytes(card, b'{}\n')
+        try:
+            pj.verify_sealed_artifacts(journal)
+            raise AssertionError('changed sealed card TM was accepted')
+        except pj.JournalError:
+            pass
+        write_bytes(card, original_card)
+
+        original_store = open(store, 'rb').read()
+        write_bytes(store, b'{"unrelated":"store"}\n')
+        registry = os.path.join(tmp, 'registry.jsonl')
+        registry_events = [{
+            'schema': 'pwg.sla_coordinator.artifact.v1',
+            'ts': '2026-07-25T00:00:00Z',
+            'lease_id': 'lease-1',
+            'event': 'promoted',
+            'kind': 'nominal',
+            'target': 'nominal:new',
+            'state': 'promoted',
+            'artifact_dir': tmp,
+            'data': {'promotion_id': 'promotion-1'},
+        }]
+        try:
+            pj.prepare_coordinator_commit(
+                journal,
+                state_path=os.path.join(tmp, 'not-created.json'),
+                expected_state_bytes=b'{}\n',
+                lease_outcomes={'lease-1': 'promoted'},
+                promotion_marker='promotion-1',
+                registry_path=registry,
+                registry_events=registry_events)
+            raise AssertionError('changed canonical store reached coordinator commit')
+        except pj.UnrelatedStoreError:
+            pass
+        write_bytes(store, original_store)
+
+        state = os.path.join(tmp, 'coordinator.json')
+        write_bytes(state, b'{"phase":"before"}\n')
+        expected_state, canonical_events = canonical_coordinator_projection(
+            journal, tmp)
+        try:
+            pj.prepare_coordinator_commit(
+                journal, state_path=state,
+                expected_state_bytes=expected_state,
+                lease_outcomes={'lease-1': 'promoted'},
+                promotion_marker='promotion-1',
+                registry_path=registry,
+                registry_events=registry_events)
+            raise AssertionError('minimal public registry event was accepted')
+        except pj.JournalError as exc:
+            assert 'canonical promotion projection' in str(exc), exc
+        inconsistent_events = json.loads(json.dumps(canonical_events))
+        inconsistent_events[0]['data']['rows_added'] += 1
+        try:
+            pj.prepare_coordinator_commit(
+                journal, state_path=state,
+                expected_state_bytes=expected_state,
+                lease_outcomes={'lease-1': 'promoted'},
+                promotion_marker='promotion-1',
+                registry_path=registry,
+                registry_events=inconsistent_events)
+            raise AssertionError('inconsistent public registry event was accepted')
+        except pj.JournalError as exc:
+            assert 'canonical promotion projection' in str(exc), exc
+        pj.prepare_coordinator_commit(
+            journal, state_path=state, expected_state_bytes=expected_state,
+            lease_outcomes={'lease-1': 'promoted'},
+            promotion_marker='promotion-1',
+            registry_path=registry,
+            registry_events=canonical_events)
+        before_state = b'{"phase":"before"}\n'
+        write_bytes(state, b'{"phase":"unrelated"}\n')
+        try:
+            pj.reconcile_coordinator(journal)
+            raise AssertionError('unrelated coordinator state was accepted')
+        except pj.JournalError:
+            pass
+        write_bytes(state, before_state)
+
+        def die_state(point):
+            if point == 'coordinator_state_saved':
+                raise RuntimeError('state-save death')
+
+        try:
+            pj.commit_coordinator_state(journal, expected_state, fault_hook=die_state)
+            raise AssertionError('coordinator state-save hook did not fire')
+        except RuntimeError:
+            pass
+        assert pj.load(journal)['phase'] == 'derived_validated'
+        assert pj.reconcile_coordinator(
+            journal, adopt_after=False)['action'] == 'adopt_coordinator_commit'
+        def die_adoption(point):
+            if point == 'coordinator_adopted':
+                raise RuntimeError('coordinator adoption death')
+        try:
+            pj.commit_coordinator_state(
+                journal, expected_state, fault_hook=die_adoption)
+            raise AssertionError('coordinator adoption hook did not fire')
+        except RuntimeError as exc:
+            assert 'adoption death' in str(exc)
+        assert pj.load(journal)['phase'] == 'coordinator_committed'
+
+        original_frag = open(frag, 'rb').read()
+        write_bytes(frag, b'{}\n')
+        try:
+            pj.mark_complete(journal)
+            raise AssertionError('changed sealed fragment TM was accepted')
+        except pj.JournalError:
+            pass
+        write_bytes(frag, original_frag)
+        try:
+            pj.mark_complete(journal)
+            raise AssertionError('missing registry projection was accepted')
+        except pj.JournalError as exc:
+            assert 'registry projection' in str(exc), exc
+        write_bytes(registry, jsonl(canonical_events))
+
+        def die_final(point):
+            if point == 'final_journal_update':
+                raise RuntimeError('final journal death')
+
+        try:
+            pj.mark_complete(journal, fault_hook=die_final)
+            raise AssertionError('final-journal hook did not fire')
+        except RuntimeError:
+            pass
+        assert pj.load(journal)['phase'] == 'complete'
+        # Terminal evidence is historical: later promotions may legitimately
+        # change the shared store/TMs/coordinator state.
+        write_bytes(store, b'{"later":"promotion"}\n')
+        write_bytes(card, b'{"later":"tm"}\n')
+        write_bytes(state, b'{"later":"coordinator"}\n')
+        assert pj.reconcile(journal)['action'] == 'terminal_complete'
+        assert pj.mark_complete(journal)['phase'] == 'complete'
+
+
+def main() -> int:
+    tests = [
+        test_prepared_fault_retry_and_immutable_intent,
+        test_before_after_unrelated_and_idempotence,
+        test_derived_coordinator_adoption_and_final_faults,
+    ]
+    for test in tests:
+        test()
+        print('ok  ', test.__name__)
+    print('%d/%d passed (promotion journal adversarial)' % (len(tests), len(tests)))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -66,6 +66,8 @@ import hashlib
 import json
 import os
 import sys
+import tempfile
+from contextlib import contextmanager
 from collections import defaultdict, Counter
 
 sys.stdout.reconfigure(encoding='utf-8')
@@ -80,8 +82,9 @@ if HERE not in sys.path:
 if SRC not in sys.path:
     sys.path.insert(0, SRC)
 
-from window_common import append_jsonl_line  # noqa: E402
+from window_common import append_jsonl_line  # noqa: E402 -- compatibility export
 from store_path import canonical_store, canonical_sidecar  # noqa: E402
+import promotion_journal  # noqa: E402
 
 # ONE logical store shared across worktrees (H818 D-E): resolve via canonical_store so a
 # git-worktree run's post-promotion TM rebuild targets the MAIN checkout store, exactly like
@@ -297,7 +300,40 @@ def load_denylist(path=None):
     return out
 
 
-def append_unblock(addresses=(), fshas=(), reason='', path=None):
+def _atomic_extend_plain_jsonl(path, rows, fault_hook=None):
+    if not rows:
+        return
+    existing = b''
+    if os.path.exists(path):
+        with open(path, 'rb') as fh:
+            existing = fh.read()
+    directory = os.path.dirname(os.path.abspath(path)) or '.'
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        prefix='.%s.' % os.path.basename(path), suffix='.tmp', dir=directory)
+    try:
+        with os.fdopen(fd, 'wb') as fh:
+            fh.write(existing)
+            if existing and not existing.endswith(b'\n'):
+                fh.write(b'\n')
+            for row in rows:
+                fh.write((json.dumps(row, ensure_ascii=False, sort_keys=True)
+                          + '\n').encode('utf-8'))
+            fh.flush()
+            os.fsync(fh.fileno())
+        _fault(fault_hook, 'denylist_write')
+        promotion_journal.durable_replace(tmp, path)
+        _fault(fault_hook, 'denylist_replace')
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def append_unblock(addresses=(), fshas=(), reason='', path=None,
+                   timestamp=None, fault_hook=None):
     """B12 (H1339): supersede matching denylist entries with 'unblock' rows.
 
     Only for content DEMONSTRABLY replaced by a promotion that passed every gate -- the
@@ -305,20 +341,24 @@ def append_unblock(addresses=(), fshas=(), reason='', path=None):
     row is only ever written for a currently-denied address/fsha. Same torn-line-safe
     single-write append as the denial rows."""
     p = denylist_path(path)
-    now = datetime.datetime.now(datetime.timezone.utc).isoformat(
+    now = timestamp or datetime.datetime.now(datetime.timezone.utc).isoformat(
         timespec='seconds').replace('+00:00', 'Z')
-    n = 0
-    for address in addresses:
-        append_jsonl_line(p, {'schema': 'pwg.translation_memory.denylist.v1',
-                              'kind': 'unblock', 'address': address,
-                              'reason': reason, 'unblocked_at': now})
-        n += 1
-    for fsha in fshas:
-        append_jsonl_line(p, {'schema': 'pwg.translation_memory.denylist.v1',
-                              'kind': 'unblock', 'fsha': fsha,
-                              'reason': reason, 'unblocked_at': now})
-        n += 1
-    return n
+    with _sidecar_lock(p):
+        denied = load_denylist(p)
+        rows = [
+            {'schema': 'pwg.translation_memory.denylist.v1',
+             'kind': 'unblock', 'address': address,
+             'reason': reason, 'unblocked_at': now}
+            for address in sorted(set(addresses) & denied['addresses'])
+        ]
+        rows.extend(
+            {'schema': 'pwg.translation_memory.denylist.v1',
+             'kind': 'unblock', 'fsha': fsha,
+             'reason': reason, 'unblocked_at': now}
+            for fsha in sorted(set(fshas) & denied['frags'])
+        )
+        _atomic_extend_plain_jsonl(p, rows, fault_hook=fault_hook)
+        return len(rows)
 
 
 def _iter_store(store_path):
@@ -441,21 +481,143 @@ def reconstruct_cards(store_path, lang):
     return entries, skipped
 
 
-def build(store_path, lang, out=None):
+def _fault(hook, point):
+    if hook is not None:
+        hook(point)
+
+
+def _artifact_timestamp(timestamp=None, journal_path=None):
+    if journal_path:
+        sealed = promotion_journal.load(journal_path)['artifact_timestamp']
+        if timestamp is not None and timestamp != sealed:
+            raise ValueError('TM timestamp does not match promotion journal')
+        return sealed
+    return timestamp or _utc_now()
+
+
+@contextmanager
+def _sidecar_lock(path):
+    """Kernel-backed exclusive lock serializing sidecar read/merge/replace."""
+    lock_path = os.path.abspath(path) + '.lock'
+    os.makedirs(os.path.dirname(lock_path) or '.', exist_ok=True)
+    fh = open(lock_path, 'a+b')
+    try:
+        if os.path.getsize(lock_path) == 0:
+            fh.write(b'\0')
+            fh.flush()
+            os.fsync(fh.fileno())
+        fh.seek(0)
+        if os.name == 'nt':
+            import msvcrt
+            msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fh.seek(0)
+            if os.name == 'nt':
+                import msvcrt
+                msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        finally:
+            fh.close()
+
+
+def _atomic_replace_card_tm(path, payload, lang, fault_hook=None):
+    """Write, fsync, validate, and atomically install a card TM."""
+    path = os.path.abspath(path)
+    directory = os.path.dirname(path) or '.'
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        prefix='.%s.' % os.path.basename(path), suffix='.tmp', dir=directory)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8', newline='\n') as fh:
+            json.dump(payload, fh, ensure_ascii=False, sort_keys=True)
+            fh.write('\n')
+            fh.flush()
+            os.fsync(fh.fileno())
+        _fault(fault_hook, 'tm_write')
+        _ok, stats = validate_tm_file(lang, tmp, kind='card')
+        if not validation_ok(stats):
+            raise ValueError('refusing invalid temporary card TM: %s' % dict(stats))
+        _fault(fault_hook, 'tm_validate')
+        promotion_journal.durable_replace(tmp, path)
+        _fault(fault_hook, 'tm_replace')
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _atomic_extend_jsonl(path, rows, lang, fault_hook=None):
+    """Copy-on-write JSONL extension; the old sidecar survives any interruption."""
+    if not rows and os.path.exists(path):
+        return
+    path = os.path.abspath(path)
+    directory = os.path.dirname(path) or '.'
+    os.makedirs(directory, exist_ok=True)
+    existing = b''
+    if os.path.exists(path):
+        with open(path, 'rb') as fh:
+            existing = fh.read()
+    fd, tmp = tempfile.mkstemp(
+        prefix='.%s.' % os.path.basename(path), suffix='.tmp', dir=directory)
+    try:
+        with os.fdopen(fd, 'wb') as fh:
+            fh.write(existing)
+            if existing and not existing.endswith(b'\n'):
+                fh.write(b'\n')
+            for row in rows:
+                fh.write((json.dumps(row, ensure_ascii=False, sort_keys=True)
+                          + '\n').encode('utf-8'))
+            fh.flush()
+            os.fsync(fh.fileno())
+        _fault(fault_hook, 'fragment_tm_write')
+        _ok, stats = validate_tm_file(lang, tmp, kind='fragment')
+        if not validation_ok(stats):
+            raise ValueError('refusing invalid temporary fragment TM: %s'
+                             % dict(stats))
+        _fault(fault_hook, 'fragment_tm_validate')
+        promotion_journal.durable_replace(tmp, path)
+        _fault(fault_hook, 'fragment_tm_replace')
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def build(store_path, lang, out=None, fault_hook=None, timestamp=None,
+          journal_path=None):
     entries, skipped = reconstruct_cards(store_path, lang)
     payload = {
         'schema': CARD_SCHEMA,
         'lang': lang,
         'address': 'sha256(input raw) == provenance.input_raw_sha256',
-        'built_at': _utc_now(),
+        'built_at': _artifact_timestamp(timestamp, journal_path),
         'store': os.path.basename(store_path),
         'count': len(entries),
         'trust_counts': trust_counts(entries.values()),
         'entries': entries,
     }
     path = tm_path(lang, out)
-    with open(path, 'w', encoding='utf-8') as f:
-        json.dump(payload, f, ensure_ascii=False)
+    try:
+        _atomic_replace_card_tm(path, payload, lang, fault_hook=fault_hook)
+    except Exception as exc:
+        if journal_path:
+            promotion_journal.record_derived_observation(
+                journal_path, 'card_tm', artifact_path=path, error=str(exc))
+        raise
+    if journal_path:
+        promotion_journal.record_derived_observation(
+            journal_path, 'card_tm', artifact_path=path, error=None)
     return path, len(entries), skipped
 
 
@@ -628,7 +790,51 @@ def load_frag_tm(lang, path=None, denylist=None, live_only=True):
     return out
 
 
-def build_frags(glob_pattern, lang, out=None, denylist=None):
+def build_frags(glob_pattern, lang, out=None, denylist=None, fault_hook=None,
+                timestamp=None, journal_path=None):
+    """Locked public fragment-sidecar harvest."""
+    if journal_path:
+        journal = promotion_journal.load(journal_path)
+        sealed_files = []
+        for lease_id in journal['lease_ids']:
+            sealed = journal['leases'][lease_id]['clean_output']
+            paths = [row['path'] for row in sealed.get('files') or []]
+            if not paths or promotion_journal.aggregate_files(paths) != sealed:
+                raise ValueError(
+                    '%s: sealed clean outputs changed before fragment harvest'
+                    % lease_id)
+            sealed_files.extend(paths)
+        sealed_files = sorted(os.path.abspath(path) for path in sealed_files)
+        if isinstance(glob_pattern, (list, tuple)):
+            requested = sorted(os.path.abspath(path) for path in glob_pattern)
+        else:
+            requested = sorted(os.path.abspath(path) for path in _glob.glob(
+                os.path.join(REPO, glob_pattern), recursive=True))
+        if requested != sealed_files:
+            raise ValueError(
+                'journaled fragment harvest must exactly match sealed clean outputs')
+        glob_pattern = sealed_files
+    path = frag_tm_path(lang, out)
+    timestamp = _artifact_timestamp(timestamp, journal_path)
+    with _sidecar_lock(path):
+        try:
+            result = _build_frags_locked(
+                glob_pattern, lang, out=path, denylist=denylist,
+                fault_hook=fault_hook, timestamp=timestamp)
+        except Exception as exc:
+            if journal_path:
+                promotion_journal.record_derived_observation(
+                    journal_path, 'fragment_tm', artifact_path=path,
+                    error=str(exc))
+            raise
+    if journal_path:
+        promotion_journal.record_derived_observation(
+            journal_path, 'fragment_tm', artifact_path=path, error=None)
+    return result
+
+
+def _build_frags_locked(glob_pattern, lang, out=None, denylist=None,
+                        fault_hook=None, timestamp=None):
     """Harvest per-fragment ground truth from wf_output cards' `frag_prov` channel into the
     append-only fragment sidecar. Idempotent: a fragment already present (by fsha) is never
     duplicated. Returns (path, added, total)."""
@@ -665,7 +871,10 @@ def build_frags(glob_pattern, lang, out=None, denylist=None):
                 seen[_fsha] = max(seen.get(_fsha, 0), _ver)
     # H1386 C3: recursive -- a requeue attempt's wf_output lands two dirs deep
     # (artifacts/<lease>/requeue/rqNN-<kind>/), which a single-* pattern never matched.
-    files = sorted(_glob.glob(os.path.join(REPO, glob_pattern), recursive=True))
+    if isinstance(glob_pattern, (list, tuple)):
+        files = sorted(os.path.abspath(path) for path in glob_pattern)
+    else:
+        files = sorted(_glob.glob(os.path.join(REPO, glob_pattern), recursive=True))
     new_rows, added, refused = [], 0, 0
     for fp in files:
         try:
@@ -730,10 +939,9 @@ def build_frags(glob_pattern, lang, out=None, denylist=None):
                     'gate_version': 'frag_prov_v2' if is_v2 else 'frag_prov_v1',
                     'review_status': 'ai_translated',
                     'reuse_policy': 'auto_exact', 'source_kind': 'frag_prov',
-                    'supersedes': None, 'harvested_at': _utc_now(),
+                    'supersedes': None, 'harvested_at': timestamp or _utc_now(),
                 })
-    for row in new_rows:
-        append_jsonl_line(path, row)
+    _atomic_extend_jsonl(path, new_rows, lang, fault_hook=fault_hook)
     return path, added, len(seen)
 
 
@@ -1461,12 +1669,44 @@ def selftest():
         assert skipped['no-raw-sha'] == 1, skipped
         assert skipped['partial-card'] == 1, skipped
         # build + load + lookup round-trip
-        path, n, _ = build(store, 'ru', out=out)
+        stable_timestamp = '2026-07-25T12:00:00Z'
+        path, n, _ = build(
+            store, 'ru', out=out, timestamp=stable_timestamp)
         assert n == 1, n
         assert lookup('ru', 'AAA', tm=out)['src_key'] == 'x~~h0_1'
         assert lookup('ru', 'ZZZ', tm=out) is None
+        sealed_tm = open(out, 'rb').read()
+        for fault_point in ('tm_write', 'tm_validate'):
+            def _fail_atomic(point, wanted=fault_point):
+                if point == wanted:
+                    raise RuntimeError('synthetic %s death' % wanted)
+            try:
+                build(store, 'ru', out=out, fault_hook=_fail_atomic,
+                      timestamp=stable_timestamp)
+                raise AssertionError('%s hook did not fire' % fault_point)
+            except RuntimeError as exc:
+                assert fault_point in str(exc)
+            assert open(out, 'rb').read() == sealed_tm, (
+                'canonical TM changed before validated atomic replace at %s' % fault_point)
+        assert not [name for name in os.listdir(os.path.dirname(out))
+                    if name.startswith('.%s.' % os.path.basename(out))
+                    and name.endswith('.tmp')]
+        try:
+            build(
+                store, 'ru', out=out, timestamp=stable_timestamp,
+                fault_hook=lambda point: (
+                    (_ for _ in ()).throw(RuntimeError('synthetic tm replace death'))
+                    if point == 'tm_replace' else None))
+            raise AssertionError('tm_replace hook did not fire')
+        except RuntimeError as exc:
+            assert 'tm replace' in str(exc)
+        assert open(out, 'rb').read() == sealed_tm
+        build(store, 'ru', out=out, timestamp=stable_timestamp)
+        assert open(out, 'rb').read() == sealed_tm, (
+            'stable journal timestamp must make card TM byte-deterministic')
         assert e['trust_level'] == TRUST_MACHINE and e['gate_status'] == 'legacy_promoted', e
         _frag_selftest()
+        _denylist_atomic_selftest()
         _trust_selftest()
         _suggest_selftest()
         _validation_selftest()
@@ -1476,8 +1716,11 @@ def selftest():
         # build` (no --store) targets the MAIN checkout store instead of a vanishing worktree-local
         # path. Prove: (a) DEFAULT_STORE == canonical_store(base); (b) explicit --store still wins;
         # (c) both RU and EN build codepaths work from an explicit store.
-        os.environ.pop('PWG_RU_STORE', None)
-        assert DEFAULT_STORE == canonical_store(os.path.join(SRC, 'pwg_ru_translated.jsonl')), DEFAULT_STORE
+        configured_store = os.environ.get('PWG_RU_STORE')
+        resolved_default = canonical_store(os.path.join(SRC, 'pwg_ru_translated.jsonl'))
+        assert DEFAULT_STORE == resolved_default, (DEFAULT_STORE, resolved_default)
+        if configured_store:
+            assert DEFAULT_STORE == os.path.abspath(configured_store), DEFAULT_STORE
         fd2, bstore = tempfile.mkstemp(suffix='.jsonl'); os.close(fd2)
         fd3, ruout = tempfile.mkstemp(suffix='.json'); os.close(fd3)
         fd4, enout = tempfile.mkstemp(suffix='.json'); os.close(fd4)
@@ -1554,17 +1797,94 @@ def _frag_selftest():
                                 'fsha': 'blocked', 'senses': senses,
                                 'trust_level': TRUST_MACHINE, 'gate_status': 'defect'},
                                ensure_ascii=False) + '\n')
-        _p, added, total = build_frags('wf_output*.json', 'ru', out=sidecar)
+        stable_timestamp = '2026-07-25T12:00:00Z'
+        _p, added, total = build_frags(
+            'wf_output*.json', 'ru', out=sidecar,
+            timestamp=stable_timestamp)
         assert added == 0 and total == 1, (added, total)          # existing fsha deduped
         cache = load_frag_tm('ru', sidecar)
         assert set(cache) == {fsha}, cache
         assert cache[fsha]['senses'][0]['russian'] == 'новое', cache
         # idempotent re-harvest adds nothing
-        _p, added2, total2 = build_frags('wf_output*.json', 'ru', out=sidecar)
+        _p, added2, total2 = build_frags(
+            'wf_output*.json', 'ru', out=sidecar,
+            timestamp=stable_timestamp)
         assert added2 == 0 and total2 == 1, (added2, total2)
+        # Copy-on-write fault: a new harvest interrupted before replace cannot
+        # append half a row or discard the existing append history.
+        fsha2 = frag_address('ru', src + '\n2) bar')
+        wf['results'][0]['card']['frag_prov'].append({
+            'fsha': fsha2, 'senses': senses, 'owners': [['zz', '']]})
+        with open(os.path.join(d, 'wf_output.sc.zz.json'), 'w', encoding='utf-8') as f:
+            json.dump(wf, f, ensure_ascii=False)
+        sealed = open(sidecar, 'rb').read()
+        for fault_point in ('fragment_tm_write', 'fragment_tm_validate'):
+            def _die_fragment(point, wanted=fault_point):
+                if point == wanted:
+                    raise RuntimeError('synthetic %s death' % wanted)
+            try:
+                build_frags(
+                    'wf_output*.json', 'ru', out=sidecar,
+                    fault_hook=_die_fragment, timestamp=stable_timestamp)
+                raise AssertionError('%s hook did not fire' % fault_point)
+            except RuntimeError as exc:
+                assert fault_point in str(exc)
+            assert open(sidecar, 'rb').read() == sealed
+        def _die_fragment_replace(point):
+            if point == 'fragment_tm_replace':
+                raise RuntimeError('synthetic fragment_tm_replace death')
+        try:
+            build_frags(
+                'wf_output*.json', 'ru', out=sidecar,
+                fault_hook=_die_fragment_replace, timestamp=stable_timestamp)
+            raise AssertionError('fragment_tm_replace hook did not fire')
+        except RuntimeError as exc:
+            assert 'fragment_tm_replace' in str(exc)
+        assert fsha2 in load_frag_tm('ru', sidecar)
+        replaced_bytes = open(sidecar, 'rb').read()
+        _p, added3, total3 = build_frags(
+            'wf_output*.json', 'ru', out=sidecar,
+            timestamp=stable_timestamp)
+        assert added3 == 0 and total3 == 2, (added3, total3)
+        assert open(sidecar, 'rb').read() == replaced_bytes
+
+        empty = os.path.join(d, 'empty.frag.jsonl')
+        _p, empty_added, empty_total = build_frags(
+            'no-such-output-*.json', 'ru', out=empty,
+            timestamp=stable_timestamp)
+        assert os.path.isfile(empty) and open(empty, 'rb').read() == b''
+        assert empty_added == 0 and empty_total == 0
     finally:
         globals()['REPO'] = old_repo
         import shutil
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def _denylist_atomic_selftest():
+    import shutil
+    d = tempfile.mkdtemp()
+    try:
+        path = os.path.join(d, 'deny.jsonl')
+        initial = [
+            {'schema': 'pwg.translation_memory.denylist.v1',
+             'kind': 'card', 'address': 'ru:AAA'},
+            {'schema': 'pwg.translation_memory.denylist.v1',
+             'kind': 'fragment', 'fsha': 'FFF'},
+        ]
+        with open(path, 'w', encoding='utf-8', newline='\n') as fh:
+            for row in initial:
+                fh.write(json.dumps(row, sort_keys=True) + '\n')
+        n = append_unblock(
+            ['ru:AAA', 'ru:AAA'], ['FFF', 'FFF'], path=path,
+            reason='selftest', timestamp='2026-07-25T12:00:00Z')
+        assert n == 2
+        sealed = open(path, 'rb').read()
+        assert append_unblock(
+            ['ru:AAA'], ['FFF'], path=path, reason='selftest',
+            timestamp='2026-07-25T12:00:00Z') == 0
+        assert open(path, 'rb').read() == sealed
+        assert load_denylist(path) == {'addresses': set(), 'frags': set()}
+    finally:
         shutil.rmtree(d, ignore_errors=True)
 
 
@@ -1778,10 +2098,10 @@ def _publication_selftest():
 def main():
     ap = argparse.ArgumentParser()
     sub = ap.add_subparsers(dest='cmd', required=True)
-    b = sub.add_parser('build'); b.add_argument('--lang', default='ru'); b.add_argument('--store', default=DEFAULT_STORE); b.add_argument('--out', default=None)
+    b = sub.add_parser('build'); b.add_argument('--lang', default='ru'); b.add_argument('--store', default=DEFAULT_STORE); b.add_argument('--out', default=None); b.add_argument('--timestamp', default=None); b.add_argument('--journal', default=None)
     s = sub.add_parser('stats'); s.add_argument('--lang', default='ru'); s.add_argument('--tm', default=None)
     lk = sub.add_parser('lookup'); lk.add_argument('sha'); lk.add_argument('--lang', default='ru'); lk.add_argument('--tm', default=None)
-    bf = sub.add_parser('build-frags'); bf.add_argument('--lang', default='ru'); bf.add_argument('--glob', default='wf_output*.json'); bf.add_argument('--out', default=None)
+    bf = sub.add_parser('build-frags'); bf.add_argument('--lang', default='ru'); bf.add_argument('--glob', default='wf_output*.json'); bf.add_argument('--out', default=None); bf.add_argument('--timestamp', default=None); bf.add_argument('--journal', default=None)
     fs = sub.add_parser('frag-stats'); fs.add_argument('--lang', default='ru'); fs.add_argument('--out', default=None)
     bs = sub.add_parser('build-suggestions'); bs.add_argument('--lang', default='ru'); bs.add_argument('--mw-tm', default=None); bs.add_argument('--terminology', default=None); bs.add_argument('--out', default=None)
     ep = sub.add_parser('export-publication'); ep.add_argument('--lang', default='ru'); ep.add_argument('--out-dir', default=os.path.join(REPO, 'release', 'translation_memory')); ep.add_argument('--tm', default=None); ep.add_argument('--frag-tm', default=None); ep.add_argument('--suggest-tm', default=None); ep.add_argument('--store', default=DEFAULT_STORE)
@@ -1798,7 +2118,9 @@ def main():
     if args.cmd == 'build':
         if not os.path.exists(args.store):
             sys.exit('store not found: %s' % args.store)
-        path, n, skipped = build(args.store, args.lang, out=args.out)
+        path, n, skipped = build(
+            args.store, args.lang, out=args.out, timestamp=args.timestamp,
+            journal_path=args.journal)
         print('wrote %s (%d content-addressed cards, lang=%s)' % (path, n, args.lang))
         print('  trust:', trust_counts(load_tm(args.lang, path).values()))
         if skipped:
@@ -1815,7 +2137,9 @@ def main():
         e = lookup(args.lang, args.sha, args.tm)
         print(json.dumps(e, ensure_ascii=False, indent=2) if e else '(miss)')
     elif args.cmd == 'build-frags':
-        path, added, total = build_frags(args.glob, args.lang, out=args.out)
+        path, added, total = build_frags(
+            args.glob, args.lang, out=args.out, timestamp=args.timestamp,
+            journal_path=args.journal)
         print('wrote %s (+%d new fragment(s), %d total, lang=%s)' % (path, added, total, args.lang))
     elif args.cmd == 'frag-stats':
         cache = load_frag_tm(args.lang, args.out)

--- a/RussianTranslation/src/pilot/window_common.py
+++ b/RussianTranslation/src/pilot/window_common.py
@@ -77,7 +77,7 @@ def defer_monster(target, reason, estimate=None, source='perf_preflight', keys=N
         return None
 
 
-def append_jsonl_line(path, obj):
+def append_jsonl_line(path, obj, durable=False):
     """Append ONE JSONL row as a single os.write() of a fully-encoded line (H336/H-3).
 
     A buffered text-mode 'a' handle can split one logical line across more than one
@@ -88,11 +88,43 @@ def append_jsonl_line(path, obj):
     fd is the OS-level append primitive: each row lands whole, even if another
     writer's row lands immediately before or after it."""
     data = (json.dumps(obj, ensure_ascii=False) + '\n').encode('utf-8')
+    existed = os.path.exists(path)
     fd = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o644)
     try:
-        os.write(fd, data)
+        written = os.write(fd, data)
+        if written != len(data):
+            raise OSError(
+                'short append to %s (%d/%d bytes)' % (path, written, len(data)))
+        if durable:
+            os.fsync(fd)
     finally:
         os.close(fd)
+    if durable and not existed and os.name != 'nt':
+        directory = os.path.dirname(os.path.abspath(path)) or '.'
+        dir_fd = os.open(
+            directory, os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0))
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+
+
+def fsync_existing_path(path):
+    """Re-establish durability for an existing projection before adopting it."""
+    # Windows' CRT rejects fsync() on a read-only descriptor (EBADF).
+    fd = os.open(path, os.O_RDWR)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    if os.name != 'nt':
+        directory = os.path.dirname(os.path.abspath(path)) or '.'
+        dir_fd = os.open(
+            directory, os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0))
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
 
 
 def atomic_write_text(path, content, encoding='utf-8'):

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -910,6 +910,150 @@ def test_german_anchor_repair_behavioral():
         shutil.rmtree(d, ignore_errors=True)
 
 
+def test_threaded_gate_exception_requeues_full_window():
+    """An unexpected future exception must become durable rc=3/full-window gate evidence."""
+    import audit_window as aw
+    real_nws = aw.run_nws_gate
+    real_prompt = aw.run_prompt_semantic_audit
+    real_sense = aw.run_sense_shortfall_gate
+
+    def clean_gate(name):
+        return {'argv': ['in-process', name], 'returncode': 0, 'stdout': '',
+                'stderr': '', 'seconds': 0.0, 'requeue': []}
+
+    def explode(*_args):
+        raise RuntimeError('synthetic threaded failure')
+
+    try:
+        aw.run_nws_gate = lambda *_args: clean_gate('nws')
+        aw.run_prompt_semantic_audit = explode
+        aw.run_sense_shortfall_gate = lambda *_args: clean_gate('sense_loss')
+        gates = aw.run_threaded_gates(
+            ['z~~2', 'a~~1'], set(), 'fixture.json', [], 'fixture-input')
+    finally:
+        aw.run_nws_gate = real_nws
+        aw.run_prompt_semantic_audit = real_prompt
+        aw.run_sense_shortfall_gate = real_sense
+
+    failed = gates['prompt_semantic']
+    if failed.get('returncode') != 3:
+        fail('threaded exception must become returncode=3, got %r' % failed)
+    if failed.get('requeue') != ['a~~1', 'z~~2']:
+        fail('threaded exception must deterministically requeue the full window: %r' % failed)
+    for field in ('argv', 'stdout', 'stderr', 'seconds'):
+        if field not in failed:
+            fail('threaded exception result lacks CompletedProcess field %s: %r'
+                 % (field, failed))
+    if 'RuntimeError: synthetic threaded failure' not in failed['stderr']:
+        fail('threaded exception diagnostic missing from stderr: %r' % failed['stderr'])
+    if set(gates) != {'nws', 'prompt_semantic', 'sense_loss'}:
+        fail('one future exception prevented remaining gate results: %r' % gates)
+
+    # Pin the integration consequence too: main() must reach write_reports/window_status,
+    # not merely return a well-shaped helper value.
+    originals = {
+        'run_nws_gate': aw.run_nws_gate,
+        'run_prompt_semantic_audit': aw.run_prompt_semantic_audit,
+        'run_sense_shortfall_gate': aw.run_sense_shortfall_gate,
+        'collect_cards': aw.collect_cards,
+        'run_py_inproc': aw.run_py_inproc,
+        'stale_check': aw.stale_check,
+        'emit_audit_event': aw.emit_audit_event,
+        'emit_stage_boundary': aw.emit_stage_boundary,
+    }
+    old_argv = sys.argv[:]
+    with tempfile.TemporaryDirectory() as tmp:
+        wf_path = os.path.join(tmp, 'wf_output.json')
+        report_dir = os.path.join(tmp, 'reports')
+        with open(wf_path, 'w', encoding='utf-8') as f:
+            json.dump({'results': [{'key': 'z~~2', 'card': None}]}, f)
+        try:
+            aw.run_nws_gate = lambda *_args: dict(
+                clean_gate('nws'), misattribution=[], rejected=[])
+            aw.run_prompt_semantic_audit = explode
+            aw.run_sense_shortfall_gate = lambda *_args: clean_gate('sense_loss')
+            aw.collect_cards = lambda *_args: clean_gate('collect')
+            aw.run_py_inproc = lambda *_args: dict(
+                clean_gate('child'), stdout='FLAGGED_JSON: []\n')
+            aw.stale_check = lambda *_args, **_kwargs: {'stale': False}
+            aw.emit_audit_event = lambda *_args, **_kwargs: None
+            aw.emit_stage_boundary = lambda *_args, **_kwargs: None
+            sys.argv = ['audit_window.py', wf_path, '--out-dir', report_dir]
+            try:
+                aw.main()
+            except SystemExit as exc:
+                if exc.code != 1:
+                    fail('future-failed audit must exit 1 after reporting, got %r' % exc.code)
+            else:
+                fail('future-failed audit unexpectedly returned without a status exit')
+        finally:
+            for name, value in originals.items():
+                setattr(aw, name, value)
+            sys.argv = old_argv
+
+        report_path = os.path.join(report_dir, 'audit_window.report.json')
+        status_path = os.path.join(report_dir, 'window_status.json')
+        if not os.path.exists(report_path) or not os.path.exists(status_path):
+            fail('future exception aborted before durable report/status: %s %s'
+                 % (os.path.exists(report_path), os.path.exists(status_path)))
+        report = json.load(open(report_path, encoding='utf-8'))
+        failed = report['gates']['prompt_semantic']
+        if failed.get('returncode') != 3 or failed.get('requeue') != ['z~~2']:
+            fail('durable future-failure evidence is incomplete: %r' % failed)
+        if 'prompt_semantic' not in report.get('crashed', []):
+            fail('durable report did not classify the future failure as crashed: %r'
+                 % report.get('crashed'))
+
+
+def test_quarantine_replace_failure_preserves_previous_destination():
+    """A failed atomic replace keeps the prior reject and yields rc=3/full-window evidence."""
+    import audit_window as aw
+    key = 'atomic~~reject'
+    with tempfile.TemporaryDirectory() as tmp:
+        src = os.path.join(tmp, key + '.merged.md')
+        dst = os.path.join(tmp, key + '.merged.REJECTED.md')
+        with open(src, 'w', encoding='utf-8') as f:
+            f.write('fresh candidate')
+        with open(dst, 'w', encoding='utf-8') as f:
+            f.write('prior rejected artifact')
+
+        old_out, old_replace = aw.OUT, aw.os.replace
+
+        def fail_replace(_src, _dst):
+            raise OSError('synthetic replace denial')
+
+        gate = {
+            'argv': ['in-process', 'nws_split.check_result'],
+            'returncode': 1,
+            'stdout': '',
+            'stderr': '',
+            'seconds': 0.0,
+            'requeue': [key],
+            'misattribution': [key],
+            'rejected': [],
+        }
+        try:
+            aw.OUT = tmp
+            aw.os.replace = fail_replace
+            aw.apply_nws_quarantine(gate, [key, 'other~~key'])
+        finally:
+            aw.OUT = old_out
+            aw.os.replace = old_replace
+
+        if open(dst, encoding='utf-8').read() != 'prior rejected artifact':
+            fail('failed quarantine destroyed or changed the prior rejected artifact')
+        if open(src, encoding='utf-8').read() != 'fresh candidate':
+            fail('failed quarantine unexpectedly removed the fresh source artifact')
+        if gate.get('returncode') != 3:
+            fail('quarantine OSError must become returncode=3 evidence: %r' % gate)
+        if gate.get('requeue') != [key, 'other~~key']:
+            fail('quarantine failure must requeue the deterministic full window: %r' % gate)
+        if 'OSError: synthetic replace denial' not in gate.get('stderr', ''):
+            fail('quarantine failure diagnostic missing from stderr: %r' % gate)
+        if gate.get('rejected'):
+            fail('failed quarantine was incorrectly reported as rejected: %r' % gate)
+
+
 def test_c4_gate0_probe_run_scope():
     """#729: the c4 health gate must read only the readings ITS OWN run wrote.
 
@@ -7907,6 +8051,8 @@ def main():
         test_partial_cards_requeue_and_stay_out_of_clean_sample,
         test_classify_run_verdicts,
         test_grammar_field_restore_behavioral,
+        test_threaded_gate_exception_requeues_full_window,
+        test_quarantine_replace_failure_preserves_previous_destination,
         test_c4_gate0_probe_run_scope,
         test_german_anchor_selftest,
         test_german_anchor_repair_behavioral,

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -29,6 +29,7 @@ re-run this script — it is idempotent and supersede-safe).
 """
 import argparse
 import collections
+import contextlib
 import datetime
 import glob
 import json
@@ -55,6 +56,7 @@ from government_census import extract_government
 from form_labels import extract_form_labels, extract_form_notes
 from citation_edges import extract_citation_edges
 from edition_rel import classify_edition_rel
+from pilot import promotion_journal
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)                       # the RussianTranslation repo root
@@ -299,7 +301,8 @@ def collect_cards(paths):
     return best, conflicts, sorted(null_keys)
 
 
-def clear_denials_for_promotion(best, blocked_subs=(), lang='ru', denylist=None):
+def clear_denials_for_promotion(best, blocked_subs=(), lang='ru', denylist=None,
+                                timestamp=None):
     """B12 (H1339): a successful gate-passing promotion clears ONLY its matching temporary
     TM denial state.
 
@@ -330,7 +333,8 @@ def clear_denials_for_promotion(best, blocked_subs=(), lang='ru', denylist=None)
                 fshas.append(fsha)
     if addresses or fshas:
         tm.append_unblock(sorted(set(addresses)), sorted(set(fshas)),
-                          reason='replaced_by_promotion', path=denylist)
+                          reason='replaced_by_promotion', path=denylist,
+                          timestamp=timestamp)
     return sorted(set(addresses)), sorted(set(fshas))
 
 
@@ -486,17 +490,46 @@ def validate_promotion_entry(subkey, entry):
         raise PromotionContractError('%s: root-backed result has no root' % subkey)
 
 
+def _serialize_rows(rows):
+    """Canonical bytes installed by every promotion store replacement."""
+    return b''.join(
+        (json.dumps(row, ensure_ascii=False) + '\n').encode('utf-8')
+        for row in rows)
+
+
 def _atomic_write_rows(path, rows):
     directory = os.path.dirname(os.path.abspath(path)) or '.'
     os.makedirs(directory, exist_ok=True)
     fd, tmp = tempfile.mkstemp(prefix='.%s.' % os.path.basename(path), suffix='.tmp', dir=directory)
     try:
-        with os.fdopen(fd, 'w', encoding='utf-8', newline='\n') as fh:
-            for row in rows:
-                fh.write(json.dumps(row, ensure_ascii=False) + '\n')
+        with os.fdopen(fd, 'wb') as fh:
+            fh.write(_serialize_rows(rows))
             fh.flush()
             os.fsync(fh.fileno())
-        os.replace(tmp, path)
+        promotion_journal.durable_replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _atomic_write_report(path, report, fault_hook=None):
+    """Write a byte-stable report with injectable write/replace death points."""
+    payload = promotion_journal.stable_json_bytes(report)
+    directory = os.path.dirname(os.path.abspath(path)) or '.'
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        prefix='.%s.' % os.path.basename(path), suffix='.tmp', dir=directory)
+    try:
+        with os.fdopen(fd, 'wb') as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        promotion_journal.fault(fault_hook, 'report_write')
+        promotion_journal.durable_replace(tmp, path)
+        promotion_journal.fault(fault_hook, 'report_replace')
     except BaseException:
         try:
             os.unlink(tmp)
@@ -702,7 +735,8 @@ def collect_and_validate(paths, review_status, gen_model_version):
 
 def batch_promote(batch, store, review_status, gen_model_version,
                   no_backup=False, steal_lock=False, lock_ttl_seconds=None,
-                  report_path=None):
+                  report_path=None, journal_path=None, promotion_id=None,
+                  fault_hook=None, store_claim_held=False):
     """H1339 Phase 3: promote N leases' clean outputs in ONE store transaction.
 
     Replaces the per-lease subprocess loop (N x [full store read + duplicate scan +
@@ -721,14 +755,27 @@ def batch_promote(batch, store, review_status, gen_model_version,
          it once after the transaction, exactly as before;
       5. any failure before the atomic replace leaves the store byte-identical;
       6. idempotent and byte-stable: a rerun with the same inputs writes the same rows.
+      7. every mutating bundle requires ``journal_path`` + ``promotion_id`` and
+         a before-store backup; unjournaled/no-backup batch writes are refused.
 
     `batch` is a list of {'lease_id', 'glob' (ABSOLUTE or repo-relative), 'expected_subcards'}.
     Returns the per-lease report dict (also written to `report_path` when given)."""
+    if not journal_path:
+        raise PromotionContractError(
+            'mutating batch promotion requires --journal')
+    if not promotion_id:
+        raise PromotionContractError(
+            'mutating batch promotion requires a stable --promotion-id')
+    if no_backup:
+        raise PromotionContractError(
+            'journaled batch promotion requires a recovery backup')
     validate_store_target(store)
-    lease_best, lease_rows, lease_nulls = {}, {}, {}
+    lease_best, lease_rows, lease_nulls, lease_paths = {}, {}, {}, {}
     all_rows, seen_subs = [], {}
     for item in batch:
         lease_id = item['lease_id']
+        if lease_id in lease_best:
+            raise PromotionContractError('duplicate lease_id in batch: %s' % lease_id)
         paths = sorted(glob.glob(item['glob'] if os.path.isabs(item['glob'])
                                  else os.path.join(ROOT, item['glob'])))
         if not paths:
@@ -762,10 +809,91 @@ def batch_promote(batch, store, review_status, gen_model_version,
             seen_subs[sub] = lease_id
         lease_best[lease_id] = best
         lease_rows[lease_id] = rows
+        lease_paths[lease_id] = paths
         all_rows.extend(rows)
 
+    bindings = {
+        item['lease_id']: {
+            'run_id': (str(item['run_id']) if item.get('run_id') is not None else None),
+            'attempt_id': (str(item['attempt_id'])
+                           if item.get('attempt_id') is not None else None),
+        }
+        for item in batch
+    }
+    current_clean = promotion_journal.aggregate_files(
+        [path for paths in lease_paths.values() for path in paths])
+    current_clean.update({
+        'subcards': sorted(seen_subs),
+        'subcard_count': len(seen_subs),
+        'card_count': len(seen_subs),
+        'sense_rows': len(all_rows),
+    })
+    current_lease_facts = {
+        lease_id: {
+            'binding': bindings[lease_id],
+            'clean_output': promotion_journal.aggregate_files(lease_paths[lease_id]),
+            'subcard_keys': sorted(lease_best[lease_id]),
+            'subcards': len(lease_best[lease_id]),
+        }
+        for lease_id in sorted(lease_best)
+    }
     ttl_kwargs = {'ttl_seconds': lock_ttl_seconds} if lock_ttl_seconds else {}
-    with PromoteClaim(store, steal=steal_lock, **ttl_kwargs):
+    claim = (contextlib.nullcontext() if store_claim_held
+             else PromoteClaim(store, steal=steal_lock, **ttl_kwargs))
+    with claim:
+        # A journal that already sealed/committed these bytes is reconciled
+        # before the live store is treated as a new "before" image.
+        if journal_path and os.path.exists(journal_path):
+            sealed = promotion_journal.load(journal_path)
+            mismatches = []
+            checks = {
+                'promotion_id': (sealed['promotion_id'], promotion_id),
+                'canonical store path': (
+                    sealed['store']['path'], promotion_journal.canonical_path(store)),
+                'review_status': (sealed['review_status'], review_status),
+                'exact model': (sealed['model_identifier'], gen_model_version),
+                'lease ids': (sealed['lease_ids'], sorted(lease_best)),
+                'bindings': (sealed['bindings'], bindings),
+                'clean output': (sealed['clean_output'], current_clean),
+                'report path': (
+                    sealed['report'].get('report_path'),
+                    (promotion_journal.canonical_path(report_path)
+                     if report_path else None)),
+            }
+            for label, (left, right) in checks.items():
+                if left != right:
+                    mismatches.append('%s (%r != %r)' % (label, left, right))
+            for lease_id, facts in current_lease_facts.items():
+                sealed_metrics = (sealed.get('leases') or {}).get(lease_id) or {}
+                for name in ('clean_output', 'subcard_keys', 'subcards'):
+                    if sealed_metrics.get(name) != facts[name]:
+                        mismatches.append('%s.%s changed' % (lease_id, name))
+            if mismatches:
+                raise PromotionContractError(
+                    'journal retry intent mismatch: %s' % '; '.join(mismatches))
+            reconciled = promotion_journal.reconcile(
+                journal_path, store_claim_held=True)
+            if reconciled['action'] in ('adopt_store_commit',
+                                         'already_store_committed',
+                                         'terminal_complete'):
+                sealed = promotion_journal.load(journal_path)
+                sealed_backup = sealed['store'].get('backup')
+                if sealed_backup and sealed_backup.get('path'):
+                    if not os.path.isfile(sealed_backup['path']):
+                        raise PromotionContractError(
+                            'sealed promotion backup is missing: %s'
+                            % sealed_backup['path'])
+                    observed_backup = promotion_journal.file_fingerprint(
+                        sealed_backup['path'])
+                    if (observed_backup['sha256'] != sealed_backup['sha256']
+                            or observed_backup['rows'] != sealed_backup['rows']):
+                        raise PromotionContractError(
+                            'sealed promotion backup hash/rows do not match')
+                report = dict(sealed['report'])
+                if report_path:
+                    _atomic_write_report(report_path, report, fault_hook)
+                return report
+
         existing_rows = []
         if os.path.exists(store):
             with open(store, encoding='utf-8') as f:
@@ -805,52 +933,114 @@ def batch_promote(batch, store, review_status, gen_model_version,
         if before and len(rows_to_write) < before * 0.5:
             raise PromotionContractError(
                 'would shrink store %d -> %d rows (>50%% loss)' % (before, len(rows_to_write)))
-        if os.path.exists(store) and not no_backup:
-            bak = _backup_path(store, True)
-            _fsynced_backup(store, bak)
-            print('backed up prior store -> %s' % os.path.basename(bak))
-        _atomic_write_rows(store, rows_to_write)
+        before_fp = promotion_journal.file_fingerprint(store)
+        expected_payload = _serialize_rows(rows_to_write)
+        expected_fp = promotion_journal.bytes_fingerprint(store, expected_payload)
 
-    # H1386 D3: per-lease rows_added / rows_replaced / store_delta. The bundle is
-    # all-or-nothing (every incoming row landed or we raised above), so these are exact:
-    # a subcard absent from the pre-merge store contributes added rows, a present one
-    # replaces its prior rows, and the net per-lease line-count change is their balance.
-    def _lease_delta(lease_id, best):
-        inc = lease_rows[lease_id]
-        new_subs = {sub for sub in best if sub not in existing_count_by_sub}
-        prior_rows = sum(existing_count_by_sub.get(sub, 0) for sub in best)
-        return {
-            'rows_added': sum(1 for r in inc if r['subcard'] in new_subs),
-            'rows_replaced': sum(1 for r in inc if r['subcard'] not in new_subs),
-            'store_delta': len(inc) - prior_rows,
+        # H1386 D3: per-lease rows_added / rows_replaced / store_delta. The bundle is
+        # all-or-nothing (every incoming row landed or we raised above), so these are exact.
+        def _lease_delta(lease_id, best):
+            inc = lease_rows[lease_id]
+            new_subs = {sub for sub in best if sub not in existing_count_by_sub}
+            prior_rows = sum(existing_count_by_sub.get(sub, 0) for sub in best)
+            return {
+                'rows_added': sum(1 for r in inc if r['subcard'] in new_subs),
+                'rows_replaced': sum(1 for r in inc if r['subcard'] not in new_subs),
+                'store_delta': len(inc) - prior_rows,
+            }
+
+        per_lease_metrics = {
+            lease_id: dict({
+                'run_id': bindings[lease_id]['run_id'],
+                'attempt_id': bindings[lease_id]['attempt_id'],
+                'clean_output': current_lease_facts[lease_id]['clean_output'],
+                'subcards': len(best),
+                'subcard_keys': sorted(best),
+                'rows': len(lease_rows[lease_id]),
+                'null_subcards': lease_nulls.get(lease_id) or [],
+            }, **_lease_delta(lease_id, best))
+            for lease_id, best in lease_best.items()
         }
+        bak = (_backup_path(store, True) if not os.path.exists(journal_path)
+               else promotion_journal.load(journal_path)['store']['backup']['path'])
+        store_record = {
+            'path': promotion_journal.canonical_path(store),
+            'before_sha256': before_fp['sha256'],
+            'before_rows': before_fp['rows'],
+            'before_bytes': before_fp['bytes'],
+            'expected_after_sha256': expected_fp['sha256'],
+            'expected_after_rows': expected_fp['rows'],
+            'expected_after_bytes': expected_fp['bytes'],
+            'backup_path': promotion_journal.canonical_path(bak),
+            'backup': {
+                'path': promotion_journal.canonical_path(bak),
+                'sha256': before_fp['sha256'],
+                'rows': before_fp['rows'],
+                'bytes': before_fp['bytes'],
+            },
+        }
+        report = {
+            'schema': 'pwg.batch_promotion.v1',
+            'promotion_id': promotion_id,
+            'journal': promotion_journal.canonical_path(journal_path),
+            'journal_phase': 'store_committed',
+            'report_path': (promotion_journal.canonical_path(report_path)
+                            if report_path else None),
+            'model_identifier': gen_model_version,
+            'review_status': review_status,
+            'clean_output_sha256': current_clean['sha256'],
+            'store_sha256': expected_fp['sha256'],
+            'store_rows_before': before,
+            'store_rows_after': len(rows_to_write),
+            'leases': per_lease_metrics,
+        }
+        promotion_journal.prepare(
+            journal_path,
+            promotion_id=promotion_id,
+            lease_ids=sorted(lease_best),
+            run_ids={lease_id: metrics['run_id']
+                     for lease_id, metrics in per_lease_metrics.items()
+                     if metrics.get('run_id')},
+            bindings=bindings,
+            model_identifier=gen_model_version,
+            review_status=review_status,
+            clean_output=current_clean,
+            store=store_record,
+            leases=per_lease_metrics,
+            report=report,
+            fault_hook=fault_hook,
+        )
 
-    report = {'schema': 'pwg.batch_promotion.v1',
-              'store_rows_before': before, 'store_rows_after': len(rows_to_write),
-              'leases': {lease_id: dict({'subcards': len(best),
-                                         'rows': len(lease_rows[lease_id]),
-                                         'null_subcards': lease_nulls.get(lease_id) or []},
-                                        **_lease_delta(lease_id, best))
-                         for lease_id, best in lease_best.items()}}
+        if bak:
+            if os.path.exists(bak):
+                observed_backup = promotion_journal.file_fingerprint(bak)
+                if (observed_backup['sha256'] != before_fp['sha256']
+                        or observed_backup['rows'] != before_fp['rows']):
+                    raise PromotionContractError(
+                        'prepared backup exists but does not match the sealed before store')
+            else:
+                _fsynced_backup(store, bak)
+                print('backed up prior store -> %s' % os.path.basename(bak))
+        _atomic_write_rows(store, rows_to_write)
+        promotion_journal.fault(fault_hook, 'store_replace')
+        promotion_journal.fault(fault_hook, 'after_store_replace_before_phase')
+        if journal_path:
+            promotion_journal.mark_store_committed(
+                journal_path, store_claim_held=True)
+
+    sealed = promotion_journal.load(journal_path)
+    report = dict(sealed['report'])
     print('BATCH PROMOTE: %d lease(s), %d subcard(s), %d sense rows; store %d -> %d rows'
           % (len(batch), len(seen_subs), len(all_rows), before, len(rows_to_write)))
     for lease_id in sorted(report['leases']):
         row = report['leases'][lease_id]
         print('  %s: %d subcard(s), %d row(s)' % (lease_id, row['subcards'], row['rows']))
-    # B12: landed replacements clear their matching temporary TM denials (fail-open, loud).
-    try:
-        union_best = {}
-        for best in lease_best.values():
-            union_best.update(best)
-        cleared_addr, cleared_frag = clear_denials_for_promotion(union_best)
-        if cleared_addr or cleared_frag:
-            print('TM denylist: cleared %d card address(es) + %d fragment sha(s)'
-                  % (len(cleared_addr), len(cleared_frag)))
-    except Exception as exc:  # noqa: BLE001 -- deliberate fail-open, loudly
-        print('⚠ TM denylist clearing skipped (%s) -- denials stay in place' % exc)
+    # Journaled promotion deliberately leaves temporary denials in force here.
+    # The coordinator first harvests corrected frag_prov rows while the rejected
+    # cached fsha is still excluded, then atomically appends the unblock and seals
+    # both sidecars at DERIVED_VALIDATED.
     if report_path:
-        with open(report_path, 'w', encoding='utf-8', newline='\n') as f:
-            json.dump(report, f, ensure_ascii=False, indent=1)
+        _atomic_write_report(report_path, report, fault_hook)
     return report
 
 
@@ -1151,9 +1341,10 @@ def selftest():
     atomic = os.path.join(d, 'atomic.jsonl')
     with open(atomic, 'w', encoding='utf-8') as f:
         f.write('old\n')
-    real_replace = os.replace
+    real_replace = promotion_journal.durable_replace
     try:
-        os.replace = lambda _src, _dst: (_ for _ in ()).throw(OSError('synthetic crash'))
+        promotion_journal.durable_replace = (
+            lambda _src, _dst: (_ for _ in ()).throw(OSError('synthetic crash')))
         try:
             _atomic_write_rows(atomic, new)
         except OSError:
@@ -1161,7 +1352,7 @@ def selftest():
         else:
             raise AssertionError('atomic replace failure was swallowed')
     finally:
-        os.replace = real_replace
+        promotion_journal.durable_replace = real_replace
     assert open(atomic, encoding='utf-8').read() == 'old\n'
     assert not [n for n in os.listdir(d) if n.endswith('.tmp')]
     # Backups are exclusive, collision-resistant copies. A failed copy leaves both the live
@@ -1214,9 +1405,23 @@ def selftest():
         with open(fp, 'w', encoding='utf-8') as f:
             json.dump({'meta': m, 'results': [{'key': key, 'card': entry['card']}]}, f)
         lease_files[lease_id] = (fp, key)
-    batch = [{'lease_id': lid, 'glob': fp, 'expected_subcards': [key]}
+    batch = [{'lease_id': lid, 'run_id': 'run-' + lid,
+              'attempt_id': 'attempt-' + lid,
+              'glob': fp, 'expected_subcards': [key]}
              for lid, (fp, key) in lease_files.items()]
-    rep = batch_promote(batch, bstore, 'ai_translated', SELFTEST_MODEL_VERSION)
+    unjournaled_before = open(bstore, 'rb').read()
+    try:
+        batch_promote(batch, bstore, 'ai_translated', SELFTEST_MODEL_VERSION)
+        raise AssertionError('unjournaled mutating batch was accepted')
+    except PromotionContractError as exc:
+        assert 'requires --journal' in str(exc)
+    assert open(bstore, 'rb').read() == unjournaled_before
+    batch_journal = os.path.join(bd, 'batch.journal.json')
+    batch_report = os.path.join(bd, 'batch.report.json')
+    rep = batch_promote(
+        batch, bstore, 'ai_translated', SELFTEST_MODEL_VERSION,
+        journal_path=batch_journal, promotion_id='batch-selftest',
+        report_path=batch_report)
     assert rep['leases']['L1']['subcards'] == 1 and rep['leases']['L2']['subcards'] == 1
     # H1386 D3: PER-LEASE delta figures, not the bundle-wide before/after stamped N times.
     for lid in ('L1', 'L2'):
@@ -1224,24 +1429,144 @@ def selftest():
         assert row['rows_added'] == row['rows'] and row['rows_replaced'] == 0, row
         assert row['store_delta'] == row['rows'], row
     bytes1 = open(bstore, 'rb').read()
+    report_bytes1 = open(batch_report, 'rb').read()
     assert b'y~~keep' in bytes1, 'unrelated store row must survive the batch'
-    rep2 = batch_promote(batch, bstore, 'ai_translated', SELFTEST_MODEL_VERSION)
+    rep2 = batch_promote(
+        batch, bstore, 'ai_translated', SELFTEST_MODEL_VERSION,
+        journal_path=batch_journal, promotion_id='batch-selftest',
+        report_path=batch_report)
     assert open(bstore, 'rb').read() == bytes1, 'batch rerun must be byte-stable/idempotent'
-    # H1386 D3: an idempotent replacement is a per-lease ZERO delta (all rows replaced) --
-    # the benign delta-0 case the windows100 GO gate must see per lease, not bundle-wide.
-    for lid in ('L1', 'L2'):
-        row = rep2['leases'][lid]
-        assert row['rows_added'] == 0 and row['rows_replaced'] == row['rows'], row
-        assert row['store_delta'] == 0, row
+    assert rep2 == rep, 'journal retry must return the sealed report'
+    assert open(batch_report, 'rb').read() == report_bytes1, (
+        'journal retry report must be byte-idempotent')
+    # PREPARED and report-replace death points are independently recoverable.
+    pstore = os.path.join(bd, 'prepared-store.jsonl')
+    with open(pstore, 'w', encoding='utf-8') as f:
+        f.write(json.dumps(keep_row, ensure_ascii=False) + '\n')
+    pbefore = open(pstore, 'rb').read()
+    pjournal = os.path.join(bd, 'prepared.journal.json')
+    preport = os.path.join(bd, 'prepared.report.json')
+    def _die_prepared(point):
+        if point == 'prepared':
+            raise RuntimeError('synthetic prepared death')
+    try:
+        batch_promote(
+            batch, pstore, 'ai_translated', SELFTEST_MODEL_VERSION,
+            journal_path=pjournal, promotion_id='prepared-selftest',
+            report_path=preport, fault_hook=_die_prepared)
+        raise AssertionError('prepared fault hook did not fire')
+    except RuntimeError as exc:
+        assert 'prepared death' in str(exc)
+    assert open(pstore, 'rb').read() == pbefore
+    assert promotion_journal.load(pjournal)['phase'] == 'prepared'
+    def _die_report_replace(point):
+        if point == 'report_replace':
+            raise RuntimeError('synthetic report replace death')
+    try:
+        batch_promote(
+            batch, pstore, 'ai_translated', SELFTEST_MODEL_VERSION,
+            journal_path=pjournal, promotion_id='prepared-selftest',
+            report_path=preport, fault_hook=_die_report_replace)
+        raise AssertionError('report_replace fault hook did not fire')
+    except RuntimeError as exc:
+        assert 'report replace death' in str(exc)
+    assert promotion_journal.load(pjournal)['phase'] == 'store_committed'
+    preport_bytes = open(preport, 'rb').read()
+    batch_promote(
+        batch, pstore, 'ai_translated', SELFTEST_MODEL_VERSION,
+        journal_path=pjournal, promotion_id='prepared-selftest',
+        report_path=preport)
+    assert open(preport, 'rb').read() == preport_bytes
+    # Recover the exact death window: store replace succeeded, PREPARED ->
+    # STORE_COMMITTED phase write did not. Re-entry adopts only the sealed after hash.
+    jstore = os.path.join(bd, 'journal-store.jsonl')
+    with open(jstore, 'w', encoding='utf-8') as f:
+        f.write(json.dumps(keep_row, ensure_ascii=False) + '\n')
+    jpath = os.path.join(bd, 'promotion.journal.json')
+    rpath = os.path.join(bd, 'promotion.report.json')
+    old_tm_dir = os.environ.get('PWG_RU_TM_DIR')
+    os.environ['PWG_RU_TM_DIR'] = bd
+    def _die_after_replace(point):
+        if point == 'store_replace':
+            raise RuntimeError('synthetic death after replace')
+    try:
+        try:
+            batch_promote(
+                batch, jstore, 'ai_translated', SELFTEST_MODEL_VERSION,
+                journal_path=jpath, promotion_id='selftest-promotion',
+                report_path=rpath, fault_hook=_die_after_replace)
+            raise AssertionError('after-replace fault hook did not fire')
+        except RuntimeError as exc:
+            assert 'synthetic death' in str(exc)
+        assert promotion_journal.load(jpath)['phase'] == 'prepared'
+        assert promotion_journal.reconcile(jpath, adopt_after=False)[
+            'action'] == 'adopt_store_commit'
+        recovered = batch_promote(
+            batch, jstore, 'ai_translated', SELFTEST_MODEL_VERSION,
+            journal_path=jpath, promotion_id='selftest-promotion',
+            report_path=rpath)
+        assert recovered['promotion_id'] == 'selftest-promotion', recovered
+        assert promotion_journal.load(jpath)['phase'] == 'store_committed'
+        assert os.path.isfile(rpath), 'batch report must be atomic and present after retry'
+    finally:
+        if old_tm_dir is None:
+            os.environ.pop('PWG_RU_TM_DIR', None)
+        else:
+            os.environ['PWG_RU_TM_DIR'] = old_tm_dir
     # all-or-nothing: a lease whose clean output diverges from its expectation fails the
     # WHOLE bundle with the store byte-identical.
     bad = [dict(batch[0]), dict(batch[1], expected_subcards=['not~~this'])]
     try:
-        batch_promote(bad, bstore, 'ai_translated', SELFTEST_MODEL_VERSION)
+        batch_promote(
+            bad, bstore, 'ai_translated', SELFTEST_MODEL_VERSION,
+            journal_path=os.path.join(bd, 'bad.journal.json'),
+            promotion_id='bad-selftest')
         raise AssertionError('divergent lease expectation did not fail the bundle')
     except PromotionContractError:
         pass
     assert open(bstore, 'rb').read() == bytes1, 'failed bundle must leave the store unchanged'
+    # Multi-sense replacement is one atomic subcard replacement: no stale old
+    # sense may survive and no new sense may be dropped.
+    multi_key = 'multi~~h0_00_pwg00'
+    multi_meta = dict(
+        meta, root='multi', selected_keys=[multi_key],
+        provenance_classes={multi_key: 'real'},
+        input_hashes={multi_key: {
+            'raw_sha256': '7' * 64, 'portrait_sha256': '8' * 64}})
+    multi_card = {
+        'key1': multi_key, 'iast': 'multi', 'notes': '', 'records': [{
+            'h': 'multi', 'grammar': '', 'senses': [
+                {'tag': '1', 'russian': 'новый один', 'german': 'neu eins',
+                 'equivalence_type': 'equivalent', 'source_type': 'attested',
+                 'stratum': '', 'differentia': ''},
+                {'tag': '2', 'russian': 'новый два', 'german': 'neu zwei',
+                 'equivalence_type': 'equivalent', 'source_type': 'attested',
+                 'stratum': '', 'differentia': ''},
+            ],
+        }],
+    }
+    multi_wf = os.path.join(bd, 'wf_output.multi.json')
+    with open(multi_wf, 'w', encoding='utf-8') as f:
+        json.dump({'meta': multi_meta, 'results': [
+            {'key': multi_key, 'card': multi_card}]}, f)
+    multi_store = os.path.join(bd, 'multi.store.jsonl')
+    with open(multi_store, 'w', encoding='utf-8') as f:
+        for tag, ru in (('1', 'старый один'), ('2', 'старый два')):
+            f.write(json.dumps({
+                'key1': 'multi', 'subcard': multi_key, 'h': 'multi',
+                'sense_tag': tag, 'de': 'alt ' + tag, 'ru': ru,
+                'provenance': {},
+            }, ensure_ascii=False) + '\n')
+    batch_promote(
+        [{'lease_id': 'LM', 'run_id': 'run-LM', 'attempt_id': 'attempt-LM',
+          'glob': multi_wf, 'expected_subcards': [multi_key]}],
+        multi_store, 'ai_translated', SELFTEST_MODEL_VERSION,
+        journal_path=os.path.join(bd, 'multi.journal.json'),
+        promotion_id='multi-selftest')
+    with open(multi_store, encoding='utf-8') as f:
+        multi_rows = [json.loads(line) for line in f if line.strip()]
+    assert len(multi_rows) == 2, multi_rows
+    assert [row['ru'] for row in multi_rows] == ['новый один', 'новый два']
     # bundle-fails when the store already holds a strictly better attempt (a freshly
     # audited lease should never lose better-attempt-wins).
     partial_card = dict(entry['card'], partial=True, missing_fragments=['g1:f0'])
@@ -1249,7 +1574,10 @@ def selftest():
     with open(fp1, 'w', encoding='utf-8') as f:
         json.dump({'meta': meta, 'results': [{'key': key1, 'card': partial_card}]}, f)
     try:
-        batch_promote(batch, bstore, 'ai_translated', SELFTEST_MODEL_VERSION)
+        batch_promote(
+            batch, bstore, 'ai_translated', SELFTEST_MODEL_VERSION,
+            journal_path=os.path.join(bd, 'downgrade.journal.json'),
+            promotion_id='downgrade-selftest')
         raise AssertionError('a partial attempt over a complete store row did not fail the bundle')
     except PromotionContractError as exc:
         assert 'better attempt' in str(exc)
@@ -1360,6 +1688,12 @@ def main():
                          'same per-entry validation as single mode, better-attempt-wins, '
                          'one backup, one atomic replace, all-or-nothing.')
     ap.add_argument('--report', help='write the batch per-lease report JSON here')
+    ap.add_argument('--journal',
+                    help='recoverable pwg.promotion_journal.v1 path for --batch-manifest; '
+                         'PREPARED is fsynced before store replacement')
+    ap.add_argument('--promotion-id',
+                    help='required stable coordinator promotion id for --journal; '
+                         'retries must supply the identical id')
     ap.add_argument('--defect-keys',
                     help='H1553: path to a one-key-per-line defect list (audit '
                          'requeue.defect.keys.txt). When omitted, auto-discovers that file next '
@@ -1374,6 +1708,10 @@ def main():
                          '(default is dry-run only)')
     args = ap.parse_args()
     if args.batch_manifest:
+        if not args.journal or not args.promotion_id:
+            sys.exit('REFUSED: --batch-manifest requires --journal and --promotion-id')
+        if args.no_backup:
+            sys.exit('REFUSED: journaled --batch-manifest requires a backup')
         # H1386 D5: flags the batch transaction does not implement are REFUSED, never
         # silently discarded -- a hand-run `--batch-manifest --dry-run` used to mutate the
         # canonical store (claim / backup / atomic replace / denylist unblock) with no
@@ -1387,12 +1725,17 @@ def main():
             report = batch_promote(
                 batch, args.store, args.review_status, args.gen_model_version,
                 no_backup=args.no_backup, steal_lock=args.steal_lock,
-                lock_ttl_seconds=args.lock_ttl_seconds, report_path=args.report)
-        except (PromotionContractError, UnrestoredPlaceholder) as exc:
+                lock_ttl_seconds=args.lock_ttl_seconds, report_path=args.report,
+                journal_path=args.journal, promotion_id=args.promotion_id)
+        except (PromotionContractError, UnrestoredPlaceholder,
+                promotion_journal.JournalError) as exc:
             sys.exit('REFUSED: %s' % exc)
         except ClaimBusy as e:
             sys.exit(str(e))
         return report
+
+    if args.journal or args.promotion_id:
+        sys.exit('REFUSED: --journal/--promotion-id currently require --batch-manifest')
 
     if args.ready_partial_report:
         try:
@@ -1581,9 +1924,9 @@ def main():
                 bak = _backup_path(args.store, args.merge)
                 _fsynced_backup(args.store, bak)
                 print('\nbacked up prior store -> %s' % os.path.basename(bak))
-            # Atomic write: stream to a temp file then os.replace, so a crash/kill mid-write
-            # can never leave the canonical store truncated (the store this project has lost
-            # before). Matches the tmp+replace pattern in run_batch.apply_review.
+            # Durable atomic write: fsynced temp plus write-through replace on Windows
+            # (rename + directory fsync on POSIX), so a crash/kill cannot leave the
+            # canonical store truncated.
             _atomic_write_rows(args.store, rows_to_write)
             print('wrote canonical translated store -> %s (%d rows, review_status=%s)'
                   % (args.store, len(rows_to_write), args.review_status))

--- a/changelog.md
+++ b/changelog.md
@@ -97,6 +97,29 @@ not an error.
   run appended a junk `{"key": "a", "source_window": "nominal_selftest"}` row to
   [`no_pwg_residuals.jsonl`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/no_pwg_residuals.jsonl)
   — the registry that decides which keys are BLOCKED from requeue. Flag added; the polluting row reverted.
+### Added
+
+- **PWG→RU paid-route and promotion hardening (unreleased implementation,
+  25-07-2026; no paid translation started):** all probes and generation calls
+  now share a durable `pwg.call_reservation.v1` ledger. `max_calls` is consumed
+  atomically before each process spawn and is never refunded after a crash;
+  `--cost-ceiling` is explicitly an observed-cost stop after completed calls,
+  not a strict pre-spend dollar cap, and missing/invalid cost telemetry stops
+  cost-capped runs as unevaluable. The same profile lock covers each warm-up +
+  measured probe pair and each worker generation run. Paid manifest-v2
+  dispatch also binds the run ID, manifest hash, preflight hash/scope, profile,
+  result hash, and reservation ledger before output can be recorded.
+- **PWG→RU crash closure (unreleased implementation, 25-07-2026):** Windows
+  Claude subprocesses are placed in a kill-on-close Job Object before their
+  first instruction, so timeout/exception cleanup reaches the native child
+  tree. Sequential `record-output-batch` reports its exact durably committed
+  prefix. Promotion now uses `pwg.promotion_journal.v1`
+  (`prepared → store_committed → derived_validated →
+  coordinator_committed → complete`), startup-reconciles the single incomplete
+  journal, holds one canonical-store claim through `complete`, and seals the
+  store, backup, TM/denylist, coordinator state, and deterministic promotion
+  registry identities for idempotent recovery. Store or coordinator bytes that
+  match neither sealed before nor expected-after state fail closed.
 
 ### Changed
 - **H1623 docs-freshness (Grok 4.5 grok-4.5, 25-07-2026):** re-verify big-manuals estate — LAST_VERIFIED 25-07-2026 on workspace AGENTS/HUMAN_RU + 6 docs/manuals deep manuals; RT deep metadoc COMMANDS_SPOT_RUN forced to integer 4 (was free-text, broke manual_staleness.py); MAINTAINER papers range updated A30-A67.


### PR DESCRIPTION
# Codex pipeline-hardening branch — rebase + verification status (26-07-2026)

_Created: 26-07-2026 · Last updated: 26-07-2026_

Extraction of `SanskritLexicography-rt-harden-codex`
(`codex/rt-pipeline-hardening-speed`) onto current `master`, and the first time the
branch's own test suite has been run. Executor: Opus 5 (`claude-opus-5[1m]`).

**Verdict: NOT landable as-is. 7 pre-existing tests fail, all from one cause.** The work
itself is substantial and worth landing; what is missing is the fixture layer for the
contract it tightens.

## What was extracted

| | |
|---|---|
| source base | `f96361ca` — the same commit the H858/#729 work branched from, so the two ran in parallel all day |
| carried over | 2 unmerged `ai-wip:` commits + ~3 935 uncommitted insertions across 25 files + 5 new modules |
| new modules | `call_reservation.py`, `promotion_journal.py`, `coordinator_hardening_selftest.py`, + 2 selftests |
| conflicts on rebase | **4** — `h963_c4_gate0_probe.py`, `window_selftest.py`, `PIPELINE_HISTORY.md`, `changelog.md` |
| applied cleanly | 23 files, including `headless_worker.py` and `promote_final_cards.py` — the H858 work is untouched |

### How the four conflicts were resolved

- **`h963_c4_gate0_probe.py` — the real one.** Codex independently found the same
  fixed-`RUN_ID` defect as [#729](https://github.com/gasyoun/SanskritLexicography/issues/729)
  (same diagnosis — its comment reads "reusing its fixed run ID would make old append-only
  readings indistinguishable from the current invocation") and fixed it **incompatibly**: it
  *aborts* when the constant id is already present. Master
  ([v1.63.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.63.0)) mints a
  per-invocation id instead, which is strictly better — Codex's version refuses to run at all
  once the log holds one row. **Kept master's fix; grafted Codex's genuinely additive
  contribution**, the `CallReservationLedger` pre-spend cap (made per-account, like the
  events log) and the "exactly 2 readings" check. Both survive; selftest 7/7.
- **`window_selftest.py`** — both sides added tests. Kept master's file and re-inserted
  Codex's two (`test_threaded_gate_exception_requeues_full_window`,
  `test_quarantine_replace_failure_preserves_previous_destination`).
- **`changelog.md`, `PIPELINE_HISTORY.md`** — append-at-top docs; both sides' entries kept.

## Defects found in the branch as delivered

These are **not** rebase artifacts: each is Codex's own new guard against Codex's own
selftest, and each would fail identically in the original worktree. Fixed here.

| # | Symptom | Cause |
|---|---|---|
| 1 | `call_reservation_selftest` → `TypeError: one_call() missing 'active_claim'` | it added two required keyword-only params to `one_call` and passed only one |
| 2 | `headless_worker_selftest` aborts on its first `execute()` | new `CLAUDE_CONFIG_DIR` paid-boundary guard; the shared fixture helper and 4 direct call sites never supply one |
| 3 | same suite → `paid headless execution requires an explicit config directory` | 2 direct `HeadlessEngine(...)` constructions |
| 4 | same suite → `paid headless spawn requires the live canonical profile claim` | `test_durable_call_reservation` drives `.call()` without holding an `ActiveCallClaim` |
| 5 | `test_cli_reservation_and_preflight_gates` exits 2, not 0 | it sets `CLAUDE_CONFIG_DIR` only for its v2 half, after the `--max-calls 0` case that also needs it |
| 6 | `bounded_staged_run_selftest` aborts | it seeds fixtures through the `enqueue` CLI, which the branch turns into a hard refusal |

After those six fixes: `call_reservation`, `promotion_journal`, `coordinator_hardening`,
`headless_worker`, `max_account_orchestrator`, `bounded_staged_run`, `bounded_supervisor`
selftests and `lang_parity_check` are **all green**.

## What still fails — 7 tests, ONE cause

`window_selftest`: **188 defined, 181 pass, 7 fail.**

```
test_coordinator_nominal_reservations
test_coordinator_runtime_state_machine_and_cas
test_coordinator_requeue_attempt_manifests
test_coordinator_mixed_lane_public_state_sequence
test_coordinator_cost_gate_enforced
test_h1420_p11_record_output_binds_run_id
test_h1420_p10_promote_rebuilds_tm_in_finally
```

Every one is the same story: **the branch makes preflight evidence and sealed-v2 binding
mandatory, and the pre-existing fixtures still pass placeholders.** Traced individually:

- `register_prepared_lease` now hashes the preflight file; the reservation-race test passes
  the literal string `'preflight.json'`, which is not a file. **Both** racer threads die on
  `FileNotFoundError`, so the outcome is `['rejected','rejected']` and the serialization
  assertion fails. It reads like a concurrency regression and is not one.
- `begin_run` now calls `validate_lease_preflight`, so both racers `SystemExit` — same shape.
- the cost gate refuses with `required preflight has unsupported schema None` before it can
  reach the deferred-ledger message the test asserts.
- `record-output` now requires `--result-sha256` for a sealed run.
- promotion now refuses `v1/unbound workflow output` as historical-only — the guard working
  exactly as designed, against fixtures that build v1 outputs.

**The guards are behaving correctly; the fixtures are stale.** Bringing them up to the new
contract is real work, and it depends on what the branch author intends the sealed fixture
shape to be — which is why it stops here rather than being guessed at.

## Recommendation

Land in two steps, not one:

1. **Now, low risk:** the parts that are green and independent — `call_reservation.py`,
   `promotion_journal.py`, the probe's pre-spend ledger graft, the two new `window_selftest`
   tests, the `proc_tree` tree-kill hardening.
2. **After the fixture layer is rebuilt:** the coordinator/promotion sealing (the P0
   "promotion is not one recoverable transaction" work), together with the 7 fixtures it
   invalidates.

Nothing is lost either way — the branch is preserved here, rebased, with 6 of its own
defects fixed.

_Dr. Mārcis Gasūns_

> **Draft — do not merge.** Pushed so the work is no longer stranded in an unreadable worktree, and so the exact failing state is reviewable. Branch: `codex/rt-hardening-rebased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
