### PR TITLE
chore(release): cut v1.65.0 — H1490 Heritage frequency-tables diff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.62.0
-date-released: "2026-07-25"
+version: 1.65.0
+date-released: "2026-07-26"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported
   headword lists, AI-produced Russian translations of Monier-Williams and

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.65.0] — 2026-07-26
+
 ### Added
 - **Heritage (INRIA) frequency-tables ingest + diff (26-07-2026, H1490).** Roadmap
   Phase 3: 7 `DATA/*.tsv` files decoded out of Heritage's internal WX romanization


### PR DESCRIPTION
## Summary
- Promote [Unreleased] to 1.65.0: Heritage (INRIA) frequency-tables ingest + diff (H1490, PR #743).
- Sync CITATION.cff version/date-released to 1.65.0 / 2026-07-26 (was lagging at 1.62.0/2026-07-25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)