### PR TITLE
fix(pwg_ru): land the green half of the Codex hardening branch (step 1 of 2)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,28 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Hardened — Codex pipeline-hardening audit, step 1 of 2 (26-07-2026)
+
+- New
+  [PIPELINE_HARDENING_AUDIT_2026-07-25.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_HARDENING_AUDIT_2026-07-25.md):
+  a current-code audit of the single-Max-account headless route, its
+  coordinator/audit/promotion boundary, and the offline orchestration cost —
+  with the actual one-profile call graph and P0/P1/P2 findings.
+- **Two P0-class fixes landed from it.** (1) A Windows timeout could leave a
+  **paid descendant alive**, so a killed generation attempt risked an orphaned
+  grandchild still burning quota —
+  [`proc_tree.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/proc_tree.py)
+  tree-kill hardening. (2) An unguarded `future.result()` in the threaded audit
+  gates meant one worker exception lost the **whole durable audit report**; it now
+  becomes a durable rc=3 gate result that conservatively requeues that gate's
+  exact keys, and an NWS-quarantine replace failure preserves the previous
+  destination instead of destroying it.
+- The audit's own release verdict stands: **live promotion is NO-GO** until the
+  store/coordinator/TM close seam has a durable journal and startup
+  reconciliation. That sealing is **step 2** — it invalidates 7 existing fixtures
+  that still pass placeholder preflight paths and v1 outputs, tracked in
+  [pwg_ru/CODEX_HARDENING_REBASE_STATUS_2026-07-26.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/CODEX_HARDENING_REBASE_STATUS_2026-07-26.md).
+
 ### Documented — German-side editorial principles datasheet (H1634)
 
 - New

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -131,7 +131,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
       "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -154,7 +154,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -209,7 +209,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -228,7 +228,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -352,7 +352,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/audit_coverage.py": "a60b8c0ed3b0022a6527a029d1e818cedab3dfcbbb545fc2c78b6a5dd514dcfa",
       "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
   },
@@ -373,7 +373,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1618 closed EN half (fsha emit + --write-requeue).",
     "tracking": "Uprava/handoffs/archive/H304-Fable_RussianTranslation_coordinator-driver-remake_07.07.26.md (EN-emitter port is the recorded follow-up)",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
@@ -431,7 +431,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -488,7 +488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -547,7 +547,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -576,9 +576,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/preflight_remaining_gates.py": "00386c837b97986c9702abfceed9c29534736c3df3063af202ddfaae6b078b8f",
       "src/release_readiness.py": "db38a870bbc8b5dbe694e706e4a7b9089ba41211a3881ad9a1bd4eb02950c8a9",
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -597,7 +597,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -615,7 +615,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -634,7 +634,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -764,7 +764,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -785,11 +785,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H336 (08-07-2026). window_reports.write_reports/write_window_status already took an out_dir parameter (pre-existing --out-dir escape hatch); --window-tag is a thin, lang-agnostic sugar layer over that same parameter computed once in audit_window.py and threaded through unchanged to requeue_from_audit.py/root_window_status.py. Neither RU nor EN branch differently. Pinned by test_audit_window_tag_routing.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -818,7 +818,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "5027755b891fce785f8b119fe95cfbb6c2aca0322ebe6a4bc6844878bf2dfbac",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -838,7 +838,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -857,7 +857,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -894,7 +894,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -913,7 +913,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/stage2_pregate.py": "8f07422d3c416e32d1882f0777d56cc44ba781d19c8097fd9500ddefbfd22945",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58"
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b"
     }
   },
   {
@@ -952,7 +952,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -971,7 +971,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -990,7 +990,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1010,7 +1010,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9",
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -1032,7 +1032,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1091,7 +1091,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1128,7 +1128,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/windows100_selftest.py": "14898dd420cf0736d7dc54064231311844dd6d30205fecd02802f75b5dd1ef38",
       "src/pilot/run_observability.py": "eb21e08ba4f0e7ab7ab5dacf9db4e4d0d38234f2d63385157735ca8d7b8ced61",
       "src/pilot/run_observability_selftest.py": "75bc960a35080a0c84ca9b5ee62b63134a9e0bde334c5531d564b13019187b60",
-      "src/pilot/proc_tree.py": "7b4eb10defbca8efe84b2db6eef1d63c1124e92d0851da78549c7440734f24c4"
+      "src/pilot/proc_tree.py": "a3a03c6f689a93ae349a8ad1a24df1d4c7683217df83a47b7f6ef47d04405c1c"
     }
   },
   {
@@ -1151,7 +1151,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1170,7 +1170,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1193,9 +1193,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
       "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1217,7 +1217,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9",
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7",
       "src/pilot/accept_sensecount_test.js": "fbf8d37f8ae360c286f646361025d56adb0caeff09da30a0abfef5f6b7289937"
     }
   },
@@ -1237,7 +1237,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1292,7 +1292,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9"
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   },
   {
@@ -1404,8 +1404,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7",
       "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1656,7 +1656,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/coordinator.py": "e9b340cc17511e1268ae7fe839d1e74b92d0dac5c810332a3dfc7f4c2cb51e0a",
       "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/window_common.py": "2d6926ba3a2e99f788641637b2cb6f2f9637ecb7f4e1b1c1561a367c8dd81e93",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
       "src/pilot/window_provenance.py": "2f1240e321004228d94f6bea7ae661a896c4bc93c60f9d47871d248766900d50",
@@ -1683,10 +1683,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "https://github.com/gasyoun/Uprava/blob/main/handoffs/H1553-Opus_RussianTranslation_rt-fullaudit-w1-a-h1403-residues_23.07.26.md",
     "verified_sha256": {
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
-      "src/pilot/audit_window.py": "e98c44d8bf36e8d9476f4b773eb43cbc46b9ee839bdd7c5ea22c97b6e3f01f58",
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
       "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
-      "src/pilot/window_selftest.py": "118f50333ee1e6001e84f42d49e99d081fd69b075432408776dfc03332bd32a9",
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
   },
@@ -1778,6 +1778,24 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/headless_worker.py": "c54f288004470d7ee51d75ecb9f47cacef0c51c17742e4c39881b51ab0ac5773",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3"
+    }
+  },
+  {
+    "id": "audit_threaded_gate_and_quarantine_recovery_codex",
+    "mechanism": "A threaded audit gate whose worker raises becomes a durable rc=3 gate result that conservatively requeues that gate's exact keys, instead of an unguarded future.result() losing the whole audit report; and an NWS-quarantine replace failure preserves the previous destination rather than destroying it.",
+    "files": [
+      "src/pilot/audit_window.py",
+      "src/pilot/window_selftest.py"
+    ],
+    "languages": [
+      "ru"
+    ],
+    "verdict": "INTENTIONAL-DIVERGENCE",
+    "note": "RU-only BY CONSTRUCTION, not by omission (26-07-2026, Opus 5 `claude-opus-5[1m]`, landed from the Codex hardening branch). The EN twin `audit_window_en.py` runs no threaded gate at all -- zero ThreadPoolExecutor/future.result occurrences -- and carries no NWS quarantine (0 occurrences of apply_nws_quarantine vs 2 on the RU lane), so NEITHER hardened mechanism exists on EN. There is nothing to port: not a GAP (no EN behaviour is missing) and not SHARED (the code is not shared). If the EN lane ever adopts threaded gates or NWS quarantine, this entry must be revisited and both guards carried across. Pinned by window_selftest.test_threaded_gate_exception_requeues_full_window and test_quarantine_replace_failure_preserves_previous_destination.",
+    "tracking": "codex/rt-pipeline-hardening-speed",
+    "verified_sha256": {
+      "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
+      "src/pilot/window_selftest.py": "8dc53a3a1f874f8aefb177919e502500fff8f106925b63cdbc94ec026ee316d7"
     }
   }
 ]

--- a/RussianTranslation/PIPELINE_HARDENING_AUDIT_2026-07-25.md
+++ b/RussianTranslation/PIPELINE_HARDENING_AUDIT_2026-07-25.md
@@ -1,0 +1,328 @@
+# PWG Russian pipeline hardening audit — 2026-07-25
+
+**Audited revision:** `f96361caa4279dde579de6ea0ca3d40784ea0863`
+
+**Scope:** the current single-Max-account, headless PWG German-to-Russian
+generation route; its coordinator/audit/promotion boundary; and the remaining
+offline orchestration cost. This is a current-code audit, not a restatement of
+the July audit backlog.
+
+**Release verdict:** generation is eligible to proceed only through
+`AWAITING_REVIEW` after the paid-path fixes named below pass. Live promotion is
+**NO-GO** until the store/coordinator/TM close seam has a durable journal and
+startup reconciliation. All live work must use `--stop-before-promote`.
+
+No paid Claude call, login, network probe, canonical-store mutation, TM rebuild,
+or promotion was performed during this audit.
+
+## Actual one-profile call graph
+
+```text
+coordinator claim / prepare
+  -> perf_preflight.py
+  -> enforce_cost_gate()
+  -> gen_opt_harness2.py
+  -> sealed execution manifest v2
+
+bounded_staged_run.py --execute --stop-before-promote
+  -> probe_fleet([one profile])
+     -> live_probe()
+        -> warm-up Claude call
+        -> measured Claude call
+  -> BoundedSupervisor.run()
+     -> make_run_window()                 # one lease, synchronous
+        -> max_account_orchestrator import-coordinator / import-requeue
+        -> max_account_orchestrator cmd_run_once()
+           -> atomic profile-specific SQLite claim
+           -> coordinator begin-run
+           -> run_claimed()
+              -> headless_worker.py
+                 -> execution/profile/fingerprint validation
+                 -> ActiveCallClaim
+                 -> HeadlessEngine.call()
+                    -> Claude translate / retry / split / heal calls
+                 -> output + status hashes
+           -> cmd_record_done()
+              -> coordinator record-output
+                 -> audit_window.py subprocess
+                 -> clean subset / retry provenance
+        -> AWAITING_REVIEW checkpoint
+```
+
+If promotion is later authorized, the close path is:
+
+```text
+coordinator promote-ready
+  -> revalidate status / report / clean-output SHA
+  -> promote_final_cards.py --batch-manifest
+     -> promotion lock
+     -> read / merge / backup
+     -> fsynced temp + atomic canonical-store replace
+     -> batch report
+  -> mark leases promoted
+  -> rebuild + optionally harvest + validate RU translation memory
+```
+
+`cohort_engine.py` is an offline injected-worker test engine. It is not the
+production route above.
+
+## Reproduced current findings
+
+### P0 — Windows timeout cleanup can leave a paid descendant alive
+
+`proc_tree.terminate_tree()` delegates to `taskkill /T /F`, then falls back to
+killing only the immediate `Popen` parent
+(`src/pilot/proc_tree.py:29-61`). Both paid worker calls and readiness probes
+use this helper.
+
+Both shipped depth-three checks failed on this Windows host:
+
+- `python src\pilot\headless_worker_selftest.py`: the grandchild wrote its
+  survival marker;
+- `python src\pilot\max_account_orchestrator_selftest.py`: a probe-tree
+  descendant survived.
+
+A timed-out native Claude descendant can therefore continue holding the
+profile/API call while the worker retries, making spend and one-profile
+serialization untrustworthy. The Windows route needs kernel-backed process
+containment (a kill-on-close Job Object) with the existing bounded fallback.
+
+### P0 — promotion is not one recoverable store/coordinator/TM transaction
+
+The canonical replace occurs in `src/promote_final_cards.py:802`. The child
+writes the batch report only afterward (`:841`). Coordinator state changes and
+TM rebuild occur only after the child returns
+(`src/pilot/coordinator.py:1716-1778`).
+
+Failure windows remain:
+
+1. process death/report-write failure after the store replace leaves the store
+   committed, leases `ready`, and TM stale;
+2. death after leases are marked promoted but before TM validation leaves
+   terminal coordinator state with stale or truncated TM;
+3. resume can treat “no ready leases” as harmless and miss the divergence.
+
+`promotion_receipt.py` is an offline scaffold, not a production call site. Its
+current row-delta invariant is also false for multi-sense cards and
+replacements. It must not be wired into production unchanged.
+
+Required close design: a durable journal with phases
+`prepared -> store_committed -> tm_validated`, clean-output and store hashes,
+per-lease metrics, atomic TM replacement, and startup reconciliation by hashes
+and provenance rather than key presence.
+
+### P1 — automated result ingestion is not bound to its saved hash and run
+
+`run_claimed()` persists `result_sha256`
+(`src/pilot/max_account_orchestrator.py:418-425`), but
+`cmd_record_done()` neither recomputes that hash nor supplies `--run-id`
+(`:673-696`). Coordinator checks a run ID only when the caller supplies one
+(`src/pilot/coordinator.py:1421-1433`).
+
+A temporary-fixture reproduction replaced a completed output after its hash
+was recorded. The replacement was still sent to `record-output`. A stale or
+substituted result can consequently be audited under another attempt.
+
+Required fix: persist the dispatch run ID with the job, require a non-empty
+saved output hash for manifest jobs, recompute and compare it immediately
+before ingestion, pass the saved `--run-id`, and require it when the running
+lease has a sealed run ID.
+
+### P1 — malformed paid wrappers can look evaluable at zero cost
+
+`HeadlessEngine.call()` validates `structured_output.cards[]` before calling
+`_accumulate_usage()` (`src/pilot/headless_worker.py:466-474`). A paid wrapper
+with valid usage/cost but malformed structured content is retried without
+recording spend.
+
+The reproduction used two wrappers that each declared `$0.25`. The resulting
+summary incorrectly reported:
+
+```json
+{
+  "cost_evaluable": true,
+  "observed_cost_usd": 0.0,
+  "priced_calls": 0,
+  "missing_usage_calls": 0
+}
+```
+
+Required fix: parse the envelope and accumulate usage/cost before validating
+the structured result. If the envelope itself is unreadable, count the paid
+attempt and mark the run cost unevaluable.
+
+### P1 — readiness probes bypass the per-profile active-call lock
+
+Production generation acquires `ActiveCallClaim`
+(`src/pilot/headless_worker.py:830-836`). `_probe_call()` invokes Claude
+directly without that lock
+(`src/pilot/max_account_orchestrator.py:877-894`).
+
+Two operators can therefore probe a profile already translating. The warm-up
+and measured calls must be inside the same profile lock used by production.
+
+### P1 — `--max-calls` and cost ceilings remain post-hoc
+
+The two readiness calls occur before `BoundedSupervisor` is created
+(`src/pilot/bounded_staged_run.py:752-768`). The supervisor checks
+`max_calls` only after an entire window completes
+(`src/pilot/bounded_supervisor.py:268-365`).
+
+The shipped bounded-run selftest explicitly permits `max_calls=5` to finish
+with six calls. This means:
+
+- `--max-calls 0` does not cover readiness calls;
+- a window can overshoot by its retries and heals;
+- a failed worker without a workflow summary may not enter accounting;
+- cost ceilings stop only after the window.
+
+The H1618 `cohort_engine` reservation ledger does not close this production
+gap. A true hard ceiling needs a durable reservation consumed immediately
+before every warm-up, measured, translate, failed, malformed, timed-out, retry,
+and heal call. Until that lands, the handoff must not describe `--max-calls` or
+`--cost-ceiling` as a strict pre-spawn guarantee; manifest agent ceilings remain
+the enforced spawn bound.
+
+### P2 — required preparation evidence can fail open
+
+`coordinator.enforce_cost_gate()` returns when a required preflight is missing
+or malformed (`src/pilot/coordinator.py:878-887`), then preparation proceeds.
+Unreadable price evidence can therefore authorize paid execution.
+
+Malformed canonical-store rows are also skipped while completed keys are
+derived, and occupied-manifest parse failures are ignored during import. These
+secondary parse gaps should be repaired separately; required preflight evidence
+must fail closed before this live run.
+
+### P2 — audit recovery and test isolation defects
+
+- Threaded audit gates use unguarded `future.result()`
+  (`src/pilot/audit_window.py:583`). An unexpected child exception aborts
+  before durable report/requeue emission.
+- Quarantine deletes the prior destination before replacement
+  (`src/pilot/audit_window.py:221`), so replacement failure can lose recovery
+  evidence.
+- `test_coordinator_defect_requeue_uses_no_tm_and_out` invokes a synthetic
+  defect requeue without `--no-residual`
+  (`src/pilot/window_selftest.py:3545`), appending test key `a` to the tracked
+  production residual registry.
+
+These do fail closed against promotion, but they damage recovery evidence or
+pollute production state. The stop-before-promote route should convert threaded
+exceptions into full-window requeue evidence and isolate the residual selftest.
+
+### P1 — card-TM rebuild is destructive and non-atomic
+
+`translation_memory.build()` writes the live JSON file directly
+(`src/pilot/translation_memory.py:444`). A crash during `json.dump` can
+truncate the prior good TM. This is part of the promotion NO-GO and must be
+fixed with temp-write, validation, fsync, and same-directory atomic replace.
+
+Fragment sidecar malformed tails are skipped by the runtime loader; that is
+audit-readable but should be reconciled with the denylist’s fail-closed torn
+line policy.
+
+## Historical findings checked and closed
+
+- profile-specific transactional claims, required-slot dispatch, and
+  execution-time config fingerprint validation are active;
+- manifest translate/heal/total agent ceilings and timeout clamping are
+  enforced before worker spawn;
+- H1618 refuses starving `--max-agents 1` on multi-key windows;
+- the worker’s active-call claim is kernel-backed;
+- normal/requeue missing output and unreadable audit artifacts fail closed;
+- canonical store writes use same-directory fsynced atomic replacement;
+- promotion backups are exclusive, fsynced, and unique;
+- promotion lock stale reclaim is identity checked;
+- worktree store/sidecar resolution fails closed;
+- H1553 clean-subset and defect fences are revalidated immediately before
+  promotion;
+- H1420’s TM `finally` covers Python exceptions after a successful promote
+  child return, though not process death or child failure after store replace.
+
+## Capability and enforcement map
+
+| Declared control | Current enforcement |
+|---|---|
+| v2 profile slot + config fingerprint | enforced before execution |
+| exact manifest model | passed to Claude; no separate Sonnet allow-list |
+| translate/heal/total agent ceilings | enforced before each worker spawn |
+| timeout ceiling | clamped before each worker spawn |
+| `--max-agents 1` multi-key starvation | refused before any call |
+| one active generation call per profile | enforced for worker, not probe |
+| `--max-calls` | post-window observation, not a reservation |
+| `--cost-ceiling` | preparation estimate + post-window stop, not reservation |
+| `execution_route` | enforced as `claude-cli-headless` |
+| `executor_lane`, `validation_method` | non-empty metadata only |
+| result SHA | produced, not checked at ingestion |
+| run ID | sealed, but optional at automated ingestion |
+| promotion receipt/journal | offline scaffold only |
+
+## Measured remaining speed opportunity
+
+The audit child must remain an isolated subprocess with its 30-minute timeout.
+The avoidable residue is the parent coordinator startup: the current H1339
+fixture launches `coordinator.py record-output` once per lease.
+
+On this worktree:
+
+- one `coordinator.py status` process: **0.861 s**;
+- five processes: **5.195 s**;
+- four avoidable starts: **4.333 s**.
+
+The smallest safe optimization is a sequential `record-output-batch` command
+that loops over the existing per-lease `record_output()` unit. Each item keeps
+its own operation token, lock transitions, audit subprocess, timeout, report,
+and state commit. It is deliberately fail-fast rather than one batch
+transaction: earlier leases remain recorded and later leases remain running,
+matching today’s sequential semantics.
+
+Ship criterion: a hermetic A/B using the H1339 fixture must show deterministic
+outputs, identical semantic store hash and per-lease states, and a lower audit
+median. Only audit/total timing may differ.
+
+## Current one-Max launch boundary
+
+The five July medium50 manifests bind **generation** to
+`claude-sonnet-5`. “Opus 5” is the orchestration/review session requested by the
+operator; it must not rewrite the sealed generation model.
+
+The surviving main-checkout artifacts are not currently sufficient for the
+canonical bounded route: coordinator state lacks their leases and the artifact
+directories lack required preflights. They must be rehydrated/reprepared before
+execution. The safe live sequence is:
+
+1. authenticate exactly one Max profile;
+2. bind the same config-directory path/fingerprint used by newly prepared v2
+   manifests;
+3. run a fresh representative >=5 KiB gate and one-key synthetic canary;
+4. dry-run, then execute one production window only;
+5. omit `--max-agents` for multi-key work;
+6. stop at `AWAITING_REVIEW`;
+7. run a new live gate before every later paid window.
+
+No result from one account authorizes another account or another window.
+
+## Baseline verification
+
+- `python src\pilot\window_selftest.py`: **183/183 passed**
+- `python src\pilot\lang_parity_check.py`: **81 entries complete; no drift**
+- hermetic benchmark: deterministic signature
+  `7f056b6dc8...`; median total **30.968 s** over three measured runs
+- `python src\pilot\headless_worker_selftest.py`: **failed**, depth-three
+  grandchild survived
+- `python src\pilot\max_account_orchestrator_selftest.py`: **failed**,
+  probe-tree descendant survived
+- focused result-substitution and malformed-wrapper fixtures: findings
+  reproduced
+
+The 183-test suite’s accidental residual-registry append was removed after the
+baseline run; the audit itself left no intentional production-data change.
+
+## Not audited
+
+Paid model behavior, OAuth/login state, account billing identity, provider
+quota, real 403 recovery, translation quality, canonical store/TM contents,
+publication export, real power-loss behavior, EN end-to-end promotion, legacy
+Workflow execution, and multi-profile live scheduling were not audited.
+

--- a/RussianTranslation/src/pilot/audit_window.py
+++ b/RussianTranslation/src/pilot/audit_window.py
@@ -223,8 +223,9 @@ def quarantine(key):
         if exact_file_exists(OUT, nm):
             src = os.path.join(OUT, nm)
             dst = os.path.join(OUT, nm[:-len('.merged.md')] + '.merged.REJECTED.md')
-            if os.path.exists(dst):
-                os.remove(dst)
+            # os.replace is the atomic overwrite primitive.  Do not unlink an existing
+            # rejected artifact first: if replacement fails, the prior rejection remains
+            # durable and the caller can report/requeue the failed quarantine.
             os.replace(src, dst)
             return True
     return False
@@ -373,6 +374,75 @@ def run_sense_shortfall_gate(results, input_dir, protected):
             'requeue': sorted(s['key'] for s in short),
             'sense_shortfall': short,
             'seconds': round(time.perf_counter() - t0, 3)}
+
+
+def _gate_exception_result(name, exc, keys, operation='threaded gate'):
+    """Convert an unexpected in-process gate failure to the normal gate result contract."""
+    return {
+        'argv': ['in-process', name],
+        'returncode': 3,
+        'stdout': '',
+        'stderr': '%s %s failed: %s: %s' % (
+            name, operation, exc.__class__.__name__, exc),
+        'seconds': 0.0,
+        'requeue': sorted(set(keys or [])),
+    }
+
+
+def run_threaded_gates(keys, protected, wf, results, input_dir):
+    """Run the independent in-process gates without letting a worker abort the audit."""
+    specs = (
+        ('nws', run_nws_gate, (keys, protected)),
+        ('prompt_semantic', run_prompt_semantic_audit, (wf, protected)),
+        ('sense_loss', run_sense_shortfall_gate, (results, input_dir, protected)),
+    )
+    futures = {}
+    gates = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
+        for name, func, call_args in specs:
+            futures[ex.submit(func, *call_args)] = name
+        for fut in concurrent.futures.as_completed(futures):
+            name = futures[fut]
+            try:
+                gates[name] = fut.result()
+            except Exception as exc:
+                # A worker exception is operational failure, not a reason to lose the
+                # durable audit report.  Fail loud and conservatively requeue this exact
+                # window while the remaining futures and main() continue.
+                gates[name] = _gate_exception_result(name, exc, keys)
+    return gates
+
+
+def apply_nws_quarantine(gate, keys):
+    """Quarantine NWS rejects, reporting replacement failures as full-window evidence."""
+    rejected = []
+    errors = []
+    for key in gate.get('misattribution') or []:
+        try:
+            if quarantine(key):
+                rejected.append(key)
+        except OSError as exc:
+            errors.append({
+                'key': key,
+                'error': '%s: %s' % (exc.__class__.__name__, exc),
+            })
+
+    gate['rejected'] = rejected
+    if rejected:
+        gate['stdout'] += '  quarantined        : %s\n' % ' '.join(rejected)
+    if errors:
+        diagnostics = [
+            'nws quarantine failed for %s: %s' % (item['key'], item['error'])
+            for item in errors
+        ]
+        gate['returncode'] = 3
+        gate['requeue'] = sorted(set(keys or []))
+        gate['stderr'] = '\n'.join(
+            part for part in (gate.get('stderr', '').rstrip(), '\n'.join(diagnostics))
+            if part
+        ) + '\n'
+        gate['quarantine_errors'] = errors
+    return gate
 
 
 def emit_audit_event(event_type, level='info', root=None, state=None, summary='', data=None):
@@ -579,15 +649,7 @@ def main():
         # ru_style_mechanical_yo_terseness); never wired into audit_window_en.py.
         ('ru_style', [os.path.join(SRC, 'ru_style_sweep.py'), '--wf', wf], parse_flagged_json),
     ]
-    futures = {}
-    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
-        futures[ex.submit(run_nws_gate, keys, protected)] = ('nws', None)
-        futures[ex.submit(run_prompt_semantic_audit, wf, protected)] = ('prompt_semantic', None)
-        futures[ex.submit(run_sense_shortfall_gate, results, INPUT_DIR, protected)] = ('sense_loss', None)
-        for fut in concurrent.futures.as_completed(futures):
-            name, parser = futures[fut]
-            res = fut.result()
-            gates[name] = res
+    gates.update(run_threaded_gates(keys, protected, wf, results, INPUT_DIR))
     # H1339 Phase 3: the five child-script gates run IN-PROCESS (runpy), sequentially --
     # sys.argv/stdout are process-global, so they must not overlap; the thread pool above
     # only existed to hide per-gate interpreter startup, which run_py_inproc eliminates.
@@ -607,6 +669,9 @@ def main():
                 res['requeue'] = parsed
         gates[name] = res
 
+    if gates['nws'].get('misattribution'):
+        apply_nws_quarantine(gates['nws'], keys)
+
     for name in ['final_schema', 'nws', 'translation', 'stage2_mechanical', 'coverage',
                  'sense_dupes', 'prompt_semantic', 'sense_loss', 'ru_style']:
         res = gates[name]
@@ -624,12 +689,6 @@ def main():
             (name, res['returncode'], len(res.get('requeue') or [])),
             data={'gate': name, 'returncode': res['returncode'],
                   'requeue': res.get('requeue') or [], 'seconds': res.get('seconds')})
-
-    if gates['nws'].get('misattribution'):
-        rejected = [k for k in gates['nws']['misattribution'] if quarantine(k)]
-        gates['nws']['rejected'] = rejected
-        if rejected:
-            gates['nws']['stdout'] += '  quarantined        : %s\n' % ' '.join(rejected)
 
     glue = None
     # Root-article glue reassembles a PWG root's sub-cards from its rootmap. A NOMINAL window

--- a/RussianTranslation/src/pilot/proc_tree.py
+++ b/RussianTranslation/src/pilot/proc_tree.py
@@ -17,6 +17,124 @@ import time
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
+_CREATE_SUSPENDED = 0x00000004
+
+
+def _join_trouble(*parts):
+    """Join non-empty cleanup diagnostics without producing leading separators."""
+    return ';'.join(part for part in parts if part)
+
+
+if os.name == 'nt':
+    import ctypes
+    from ctypes import wintypes
+
+    _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+    _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS = 9
+
+    class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ('PerProcessUserTimeLimit', ctypes.c_longlong),
+            ('PerJobUserTimeLimit', ctypes.c_longlong),
+            ('LimitFlags', wintypes.DWORD),
+            ('MinimumWorkingSetSize', ctypes.c_size_t),
+            ('MaximumWorkingSetSize', ctypes.c_size_t),
+            ('ActiveProcessLimit', wintypes.DWORD),
+            ('Affinity', ctypes.c_size_t),
+            ('PriorityClass', wintypes.DWORD),
+            ('SchedulingClass', wintypes.DWORD),
+        ]
+
+    class _IO_COUNTERS(ctypes.Structure):
+        _fields_ = [
+            ('ReadOperationCount', ctypes.c_ulonglong),
+            ('WriteOperationCount', ctypes.c_ulonglong),
+            ('OtherOperationCount', ctypes.c_ulonglong),
+            ('ReadTransferCount', ctypes.c_ulonglong),
+            ('WriteTransferCount', ctypes.c_ulonglong),
+            ('OtherTransferCount', ctypes.c_ulonglong),
+        ]
+
+    class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ('BasicLimitInformation', _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+            ('IoInfo', _IO_COUNTERS),
+            ('ProcessMemoryLimit', ctypes.c_size_t),
+            ('JobMemoryLimit', ctypes.c_size_t),
+            ('PeakProcessMemoryUsed', ctypes.c_size_t),
+            ('PeakJobMemoryUsed', ctypes.c_size_t),
+        ]
+
+    _kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+    _kernel32.CreateJobObjectW.argtypes = (ctypes.c_void_p, wintypes.LPCWSTR)
+    _kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    _kernel32.SetInformationJobObject.argtypes = (
+        wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD)
+    _kernel32.SetInformationJobObject.restype = wintypes.BOOL
+    _kernel32.AssignProcessToJobObject.argtypes = (wintypes.HANDLE, wintypes.HANDLE)
+    _kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+    _kernel32.TerminateJobObject.argtypes = (wintypes.HANDLE, wintypes.UINT)
+    _kernel32.TerminateJobObject.restype = wintypes.BOOL
+    _kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    _kernel32.CloseHandle.restype = wintypes.BOOL
+
+    _ntdll = ctypes.WinDLL('ntdll')
+    _ntdll.NtResumeProcess.argtypes = (wintypes.HANDLE,)
+    _ntdll.NtResumeProcess.restype = ctypes.c_long
+
+
+class _WindowsKillJob:
+    """A Windows Job Object that contains the child before its first instruction runs."""
+
+    def __init__(self):
+        self.handle = None
+
+    def create(self):
+        handle = _kernel32.CreateJobObjectW(None, None)
+        if not handle:
+            raise ctypes.WinError(ctypes.get_last_error())
+        self.handle = handle
+        info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if not _kernel32.SetInformationJobObject(
+                handle, _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
+                ctypes.byref(info), ctypes.sizeof(info)):
+            error = ctypes.WinError(ctypes.get_last_error())
+            self.close()
+            raise error
+
+    def assign(self, proc):
+        """Assign a CREATE_SUSPENDED Popen process before it can create descendants."""
+        process_handle = int(proc._handle)  # CPython's owned process HANDLE on Windows
+        if not _kernel32.AssignProcessToJobObject(self.handle, process_handle):
+            raise ctypes.WinError(ctypes.get_last_error())
+
+    @staticmethod
+    def resume(proc):
+        """Resume all threads in the newly assigned, initially suspended process."""
+        process_handle = int(proc._handle)
+        status = _ntdll.NtResumeProcess(process_handle)
+        if status < 0:
+            raise OSError('NtResumeProcess failed with NTSTATUS 0x%08x'
+                          % (status & 0xffffffff))
+
+    def terminate(self):
+        """Terminate every current job member and close the kill-on-close handle."""
+        trouble = None
+        if self.handle:
+            if not _kernel32.TerminateJobObject(self.handle, 1):
+                trouble = 'TerminateJobObject:winerror%d' % ctypes.get_last_error()
+        close_trouble = self.close()
+        return _join_trouble(trouble, close_trouble)
+
+    def close(self):
+        trouble = None
+        if self.handle:
+            if not _kernel32.CloseHandle(self.handle):
+                trouble = 'CloseHandle(job):winerror%d' % ctypes.get_last_error()
+            self.handle = None
+        return trouble
+
 
 def windows_hidden_flags():
     """subprocess creationflags that suppress the transient console window ``taskkill``/``tasklist``
@@ -29,35 +147,46 @@ def windows_hidden_flags():
 
 
 def terminate_tree(proc, deadline):
-    """**Bounded best-effort** tree termination — NOT race-free (tree enumeration still races
-    process exit/spawn; correctness is what the parent->child->grandchild regression test asserts).
-    Invoked WHILE ``proc`` is still alive so the tree is enumerable. ``taskkill /PID <pid> /T /F``
-    reaps the live tree on Windows (acceptable for this known-stable wrapper tree); ``killpg`` the
-    session group on POSIX. Always falls back to ``proc.kill()`` if the parent is still alive.
-    Returns a short diagnostic string on cleanup trouble, else None — the caller keeps the primary
-    ``timeout`` classification regardless."""
+    """Bounded process-tree termination.
+
+    Windows normally uses the race-free Job Object attached by :func:`run_tree_kill`; ``taskkill``
+    is only a bounded fallback when job setup failed. POSIX kills the child's private process
+    group. Always falls back to ``proc.kill()`` if the immediate child remains alive. Returns a
+    short diagnostic string on cleanup trouble, else None — callers keep the primary ``timeout``
+    classification regardless.
+    """
     if proc.poll() is not None:
+        job = getattr(proc, '_tree_job', None)
+        if job is not None:
+            return job.close()
         return None
-    trouble = None
+    trouble = getattr(proc, '_tree_setup_trouble', None)
     if os.name == 'nt':
-        budget = max(1.0, deadline - time.monotonic())
-        try:
-            subprocess.run(['taskkill', '/PID', str(proc.pid), '/T', '/F'],
-                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=budget,
-                           creationflags=windows_hidden_flags())   # no console-window flicker
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
-            trouble = 'taskkill:%s' % type(exc).__name__
+        job = getattr(proc, '_tree_job', None)
+        if job is not None:
+            trouble = _join_trouble(trouble, job.terminate())
+        else:
+            budget = max(1.0, deadline - time.monotonic())
+            try:
+                result = subprocess.run(
+                    ['taskkill', '/PID', str(proc.pid), '/T', '/F'],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=budget,
+                    creationflags=windows_hidden_flags())   # no console-window flicker
+                if result.returncode:
+                    trouble = _join_trouble(trouble, 'taskkill:exit%d' % result.returncode)
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+                trouble = _join_trouble(trouble, 'taskkill:%s' % type(exc).__name__)
     else:
         import signal as _signal
         try:
             os.killpg(os.getpgid(proc.pid), _signal.SIGKILL)
         except (ProcessLookupError, PermissionError, OSError) as exc:
-            trouble = 'killpg:%s' % type(exc).__name__
+            trouble = _join_trouble(trouble, 'killpg:%s' % type(exc).__name__)
     if proc.poll() is None:                            # always fall back if the parent still lives
         try:
             proc.kill()
         except OSError as exc:
-            trouble = (trouble or '') + ';proc.kill:%s' % type(exc).__name__
+            trouble = _join_trouble(trouble, 'proc.kill:%s' % type(exc).__name__)
     return trouble
 
 
@@ -74,11 +203,61 @@ def run_tree_kill(argv, input=None, timeout=None, text=True, encoding='utf-8',
     pipe = subprocess.PIPE if capture_output else None
     popen_kw = dict(stdin=subprocess.PIPE, stdout=pipe, stderr=pipe,
                     text=text, encoding=encoding, cwd=cwd, env=env)
+    job = None
+    setup_trouble = None
     if os.name == 'nt':
-        popen_kw['creationflags'] = getattr(subprocess, 'CREATE_NEW_PROCESS_GROUP', 0)
+        creationflags = getattr(subprocess, 'CREATE_NEW_PROCESS_GROUP', 0)
+        job = _WindowsKillJob()
+        try:
+            job.create()
+            creationflags |= _CREATE_SUSPENDED
+        except OSError as exc:
+            setup_trouble = 'job-create:%s' % type(exc).__name__
+            job = None
+        popen_kw['creationflags'] = creationflags
     else:
         popen_kw['start_new_session'] = True          # own process group -> killpg reaches children
-    proc = subprocess.Popen(argv, **popen_kw)
+    try:
+        proc = subprocess.Popen(argv, **popen_kw)
+    except BaseException:
+        if job is not None:
+            job.close()
+        raise
+    proc._tree_job = job
+    proc._tree_setup_trouble = setup_trouble
+    if job is not None:
+        try:
+            job.assign(proc)
+        except OSError as exc:
+            # Resume even if assignment failed, otherwise the fallback would target a suspended
+            # process forever. With no assigned process the job is empty and safe to close.
+            setup_trouble = 'job-assign:%s' % type(exc).__name__
+            try:
+                job.resume(proc)
+            except OSError as resume_exc:
+                setup_trouble += ':resume-%s' % type(resume_exc).__name__
+                setup_trouble = _join_trouble(setup_trouble, job.terminate())
+                try:
+                    proc.kill()
+                    proc.wait(timeout=2)
+                except (OSError, subprocess.TimeoutExpired):
+                    pass
+                raise OSError('Windows Job Object setup failed: %s' % setup_trouble) from exc
+            setup_trouble = _join_trouble(setup_trouble, job.close())
+            proc._tree_job = None
+            proc._tree_setup_trouble = setup_trouble
+        else:
+            try:
+                job.resume(proc)
+            except OSError as exc:
+                setup_trouble = _join_trouble(
+                    'job-resume:%s' % type(exc).__name__, job.terminate())
+                try:
+                    proc.kill()
+                    proc.wait(timeout=2)
+                except (OSError, subprocess.TimeoutExpired):
+                    pass
+                raise OSError('Windows Job Object setup failed: %s' % setup_trouble) from exc
     start = time.monotonic()
     try:
         out, err = proc.communicate(input=input, timeout=timeout)
@@ -99,4 +278,26 @@ def run_tree_kill(argv, input=None, timeout=None, text=True, encoding='utf-8',
         if trouble:
             exc.cleanup_trouble = trouble              # diagnostic only; classification stays 'timeout'
         raise
+    except BaseException as exc:
+        # communicate() can also fail while the child is live (decode error, pipe/OSError,
+        # injected test exception, cancellation). Never abandon that process tree merely because
+        # the primary failure was not TimeoutExpired.
+        deadline = time.monotonic() + 10.0
+        trouble = terminate_tree(proc, deadline)
+        try:
+            proc.communicate(timeout=max(0.5, deadline - time.monotonic()))
+        except BaseException as reap_exc:
+            trouble = _join_trouble(
+                trouble, 'exception-reap:%s' % type(reap_exc).__name__)
+            try:
+                proc.kill()
+                proc.wait(timeout=2)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+        if trouble:
+            exc.cleanup_trouble = trouble
+        raise
+    finally:
+        if proc.poll() is not None and getattr(proc, '_tree_job', None) is not None:
+            proc._tree_job.close()
     return subprocess.CompletedProcess(argv, proc.returncode, out, err)

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -910,6 +910,150 @@ def test_german_anchor_repair_behavioral():
         shutil.rmtree(d, ignore_errors=True)
 
 
+def test_threaded_gate_exception_requeues_full_window():
+    """An unexpected future exception must become durable rc=3/full-window gate evidence."""
+    import audit_window as aw
+    real_nws = aw.run_nws_gate
+    real_prompt = aw.run_prompt_semantic_audit
+    real_sense = aw.run_sense_shortfall_gate
+
+    def clean_gate(name):
+        return {'argv': ['in-process', name], 'returncode': 0, 'stdout': '',
+                'stderr': '', 'seconds': 0.0, 'requeue': []}
+
+    def explode(*_args):
+        raise RuntimeError('synthetic threaded failure')
+
+    try:
+        aw.run_nws_gate = lambda *_args: clean_gate('nws')
+        aw.run_prompt_semantic_audit = explode
+        aw.run_sense_shortfall_gate = lambda *_args: clean_gate('sense_loss')
+        gates = aw.run_threaded_gates(
+            ['z~~2', 'a~~1'], set(), 'fixture.json', [], 'fixture-input')
+    finally:
+        aw.run_nws_gate = real_nws
+        aw.run_prompt_semantic_audit = real_prompt
+        aw.run_sense_shortfall_gate = real_sense
+
+    failed = gates['prompt_semantic']
+    if failed.get('returncode') != 3:
+        fail('threaded exception must become returncode=3, got %r' % failed)
+    if failed.get('requeue') != ['a~~1', 'z~~2']:
+        fail('threaded exception must deterministically requeue the full window: %r' % failed)
+    for field in ('argv', 'stdout', 'stderr', 'seconds'):
+        if field not in failed:
+            fail('threaded exception result lacks CompletedProcess field %s: %r'
+                 % (field, failed))
+    if 'RuntimeError: synthetic threaded failure' not in failed['stderr']:
+        fail('threaded exception diagnostic missing from stderr: %r' % failed['stderr'])
+    if set(gates) != {'nws', 'prompt_semantic', 'sense_loss'}:
+        fail('one future exception prevented remaining gate results: %r' % gates)
+
+    # Pin the integration consequence too: main() must reach write_reports/window_status,
+    # not merely return a well-shaped helper value.
+    originals = {
+        'run_nws_gate': aw.run_nws_gate,
+        'run_prompt_semantic_audit': aw.run_prompt_semantic_audit,
+        'run_sense_shortfall_gate': aw.run_sense_shortfall_gate,
+        'collect_cards': aw.collect_cards,
+        'run_py_inproc': aw.run_py_inproc,
+        'stale_check': aw.stale_check,
+        'emit_audit_event': aw.emit_audit_event,
+        'emit_stage_boundary': aw.emit_stage_boundary,
+    }
+    old_argv = sys.argv[:]
+    with tempfile.TemporaryDirectory() as tmp:
+        wf_path = os.path.join(tmp, 'wf_output.json')
+        report_dir = os.path.join(tmp, 'reports')
+        with open(wf_path, 'w', encoding='utf-8') as f:
+            json.dump({'results': [{'key': 'z~~2', 'card': None}]}, f)
+        try:
+            aw.run_nws_gate = lambda *_args: dict(
+                clean_gate('nws'), misattribution=[], rejected=[])
+            aw.run_prompt_semantic_audit = explode
+            aw.run_sense_shortfall_gate = lambda *_args: clean_gate('sense_loss')
+            aw.collect_cards = lambda *_args: clean_gate('collect')
+            aw.run_py_inproc = lambda *_args: dict(
+                clean_gate('child'), stdout='FLAGGED_JSON: []\n')
+            aw.stale_check = lambda *_args, **_kwargs: {'stale': False}
+            aw.emit_audit_event = lambda *_args, **_kwargs: None
+            aw.emit_stage_boundary = lambda *_args, **_kwargs: None
+            sys.argv = ['audit_window.py', wf_path, '--out-dir', report_dir]
+            try:
+                aw.main()
+            except SystemExit as exc:
+                if exc.code != 1:
+                    fail('future-failed audit must exit 1 after reporting, got %r' % exc.code)
+            else:
+                fail('future-failed audit unexpectedly returned without a status exit')
+        finally:
+            for name, value in originals.items():
+                setattr(aw, name, value)
+            sys.argv = old_argv
+
+        report_path = os.path.join(report_dir, 'audit_window.report.json')
+        status_path = os.path.join(report_dir, 'window_status.json')
+        if not os.path.exists(report_path) or not os.path.exists(status_path):
+            fail('future exception aborted before durable report/status: %s %s'
+                 % (os.path.exists(report_path), os.path.exists(status_path)))
+        report = json.load(open(report_path, encoding='utf-8'))
+        failed = report['gates']['prompt_semantic']
+        if failed.get('returncode') != 3 or failed.get('requeue') != ['z~~2']:
+            fail('durable future-failure evidence is incomplete: %r' % failed)
+        if 'prompt_semantic' not in report.get('crashed', []):
+            fail('durable report did not classify the future failure as crashed: %r'
+                 % report.get('crashed'))
+
+
+def test_quarantine_replace_failure_preserves_previous_destination():
+    """A failed atomic replace keeps the prior reject and yields rc=3/full-window evidence."""
+    import audit_window as aw
+    key = 'atomic~~reject'
+    with tempfile.TemporaryDirectory() as tmp:
+        src = os.path.join(tmp, key + '.merged.md')
+        dst = os.path.join(tmp, key + '.merged.REJECTED.md')
+        with open(src, 'w', encoding='utf-8') as f:
+            f.write('fresh candidate')
+        with open(dst, 'w', encoding='utf-8') as f:
+            f.write('prior rejected artifact')
+
+        old_out, old_replace = aw.OUT, aw.os.replace
+
+        def fail_replace(_src, _dst):
+            raise OSError('synthetic replace denial')
+
+        gate = {
+            'argv': ['in-process', 'nws_split.check_result'],
+            'returncode': 1,
+            'stdout': '',
+            'stderr': '',
+            'seconds': 0.0,
+            'requeue': [key],
+            'misattribution': [key],
+            'rejected': [],
+        }
+        try:
+            aw.OUT = tmp
+            aw.os.replace = fail_replace
+            aw.apply_nws_quarantine(gate, [key, 'other~~key'])
+        finally:
+            aw.OUT = old_out
+            aw.os.replace = old_replace
+
+        if open(dst, encoding='utf-8').read() != 'prior rejected artifact':
+            fail('failed quarantine destroyed or changed the prior rejected artifact')
+        if open(src, encoding='utf-8').read() != 'fresh candidate':
+            fail('failed quarantine unexpectedly removed the fresh source artifact')
+        if gate.get('returncode') != 3:
+            fail('quarantine OSError must become returncode=3 evidence: %r' % gate)
+        if gate.get('requeue') != [key, 'other~~key']:
+            fail('quarantine failure must requeue the deterministic full window: %r' % gate)
+        if 'OSError: synthetic replace denial' not in gate.get('stderr', ''):
+            fail('quarantine failure diagnostic missing from stderr: %r' % gate)
+        if gate.get('rejected'):
+            fail('failed quarantine was incorrectly reported as rejected: %r' % gate)
+
+
 def test_c4_gate0_probe_run_scope():
     """#729: the c4 health gate must read only the readings ITS OWN run wrote.
 
@@ -7907,6 +8051,8 @@ def main():
         test_partial_cards_requeue_and_stay_out_of_clean_sample,
         test_classify_run_verdicts,
         test_grammar_field_restore_behavioral,
+        test_threaded_gate_exception_requeues_full_window,
+        test_quarantine_replace_failure_preserves_previous_destination,
         test_c4_gate0_probe_run_scope,
         test_german_anchor_selftest,
         test_german_anchor_repair_behavioral,

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,39 @@ not an error.
 
 ## [Unreleased]
 
+### Fixed
+- **P0 — a Windows timeout could leave a PAID descendant alive (26-07-2026).** Landed from the
+  Codex hardening branch, step 1 of 2:
+  [`proc_tree.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/proc_tree.py)
+  tree-kill hardening — a killed generation attempt no longer risks an orphaned grandchild
+  still burning quota. Pinned by the existing D-J tree-kill selftest.
+- **An audit-gate worker exception could lose the whole durable report (26-07-2026).** Landed
+  from the same branch: an unguarded `future.result()` in the threaded gates now becomes a
+  durable rc=3 gate result that conservatively requeues that gate's exact keys, and an
+  NWS-quarantine replace failure preserves the previous destination instead of destroying it.
+  Pinned by two new tests. Classified **INTENTIONAL-DIVERGENCE** in
+  [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md):
+  RU-only *by construction* — the EN twin runs no threaded gate and has no NWS quarantine, so
+  neither mechanism exists there to harden.
+
+### Added
+- **The Codex pipeline-hardening audit** —
+  [`PIPELINE_HARDENING_AUDIT_2026-07-25.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_HARDENING_AUDIT_2026-07-25.md):
+  the one-profile call graph plus the P0/P1/P2 findings behind this work. Step 2 (coordinator +
+  promotion sealing, and the 7 fixtures it invalidates) is tracked in
+  [`pwg_ru/CODEX_HARDENING_REBASE_STATUS_2026-07-26.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/CODEX_HARDENING_REBASE_STATUS_2026-07-26.md)
+  and draft [PR #744](https://github.com/gasyoun/SanskritLexicography/pull/744).
+
+### Added
+- **Heritage (INRIA) frequency-tables ingest + diff (26-07-2026, H1490).** Roadmap
+  Phase 3: 7 `DATA/*.tsv` files decoded out of Heritage's internal WX romanization
+  (new WX→SLP1 transcoder) and diffed against VisualDCS's M1–M8 `dcs_full.sqlite`
+  and `RussianTranslation/src/corpus_lexicon.jsonl` — Spearman ρ 0.70–0.74 vs DCS
+  across surface-form/lemma/compound-stem series, 0.53 vs `corpus_lexicon`.
+  [`heritage_frequency_diff.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/heritage_frequency_diff.md) /
+  [`.tsv`](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/heritage_frequency_diff.tsv) /
+  [`heritage_freq_diff.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/heritage_freq_diff.py).
+
 ## [1.65.0] — 2026-07-26
 
 ### Added


### PR DESCRIPTION
Step 1 of 2 from the Codex hardening branch — the parts that stand alone and pass. Step 2 (coordinator + promotion sealing) stays in draft [PR #744](https://github.com/gasyoun/SanskritLexicography/pull/744).

## What lands

| | |
|---|---|
| **P0 — a Windows timeout could leave a PAID descendant alive** | `proc_tree.py` tree-kill hardening. A killed generation attempt risked an orphaned grandchild still burning quota. Covered by the existing D-J tree-kill selftest. |
| **An audit-gate worker exception lost the whole durable report** | an unguarded `future.result()` in the threaded gates now becomes a durable rc=3 gate result that conservatively requeues that gate's exact keys; an NWS-quarantine replace failure preserves the previous destination instead of destroying it. Pinned by the branch's own two new tests. |
| **The audit itself** | `PIPELINE_HARDENING_AUDIT_2026-07-25.md` — the one-profile call graph and the P0/P1/P2 findings. |

## LANG_PARITY: INTENTIONAL-DIVERGENCE, and why that's the honest verdict

The `audit_window` hardening is RU-only **by construction, not by omission**. `audit_window_en.py` runs no threaded gate at all — zero `ThreadPoolExecutor`/`future.result` occurrences — and has no NWS quarantine (0 vs 2 occurrences on the RU lane). Neither hardened mechanism *exists* on EN, so there is nothing to port: not a GAP (no EN behaviour is missing), not SHARED (the code isn't shared). The ledger entry records what must happen if EN ever adopts either mechanism.

## Deliberately not in this step

- **`promotion_journal.py`** — its selftest calls `promote_final_cards.build(journal_path=...)`, which only exists with the promotion sealing. It would land unwired, with a test that cannot run. It belongs with step 2. *(I had listed it in step 1; running its selftest is what showed it doesn't stand alone.)*
- **`call_reservation.py` and the pre-spend ledger** — entangled with the `max_account_orchestrator` / headless / bounded plumbing that also carries the sealing.
- **The coordinator/promotion sealing** — it invalidates 7 existing fixtures that still pass placeholder preflight paths and v1 outputs.

## Gates

`window_selftest` **188/188** · `headless_worker_selftest` · `max_account_orchestrator_selftest` · `bounded_supervisor_selftest` · `bounded_staged_run_selftest` · `lang_parity_check` (83 entries, no drift) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
