### PR TITLE
chore(release): cut v1.66.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.66.0] — 2026-07-26
+
 ### Fixed
 - **P0 — a Windows timeout could leave a PAID descendant alive (26-07-2026).** Landed from the
   Codex hardening branch, step 1 of 2:


### PR DESCRIPTION
Promotes the `[Unreleased]` block landed by [#746](https://github.com/gasyoun/SanskritLexicography/pull/746) to `1.66.0`. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)