### PR TITLE
H1630: top-N citation_edges sigla -> Cologne scan link coverage

### DIFF
--- a/RussianTranslation/CITATION_COVERAGE.md
+++ b/RussianTranslation/CITATION_COVERAGE.md
@@ -1,6 +1,6 @@
 # PWG citation coverage — reports live in the PWG repo
 
-_Created: 02-07-2026 · Last updated: 25-07-2026_
+_Created: 02-07-2026 · Last updated: 26-07-2026_
 
 ## Per-sense citation graph (H1624 G3)
 
@@ -11,6 +11,11 @@ Additive DE-side edges (raw `<ls>` **kept** in the german/de string):
 - `resolver_status`: `map` (ls_source_map) · `bib` (pwgbib only) · `orphan` · `empty`
 - stamped on promote + portrait; store retrofit: `python src/annotate_citation_edges.py`
 - coverage CLI: `python src/citation_edges.py report [--store PATH]` (honest map/bib/orphan %)
+- `scan_href` (additive, H1630): each edge also carries the `ls_resolver.generate_href('pwg', …)`
+  result when a Cologne scan/HTML target actually resolves — independent of `resolver_status`
+  (a `map`/`bib` siglum can still lack a target because Cologne hasn't digitized the work).
+- top-N frequency → scan/HTML coverage: `python src/citation_edges.py topn [--n 25] [--store PATH]`
+  — results + residual list logged in [`RESULTS_LOG.md`](RESULTS_LOG.md) (26-07-2026 entry).
 
 Scan-page links remain optional (see aggregate reports below; not a G3 blocker).
 

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1692,7 +1692,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
   },
   {
     "id": "citation_edges_h1624_g3",
-    "mechanism": "DE-side normalized <ls> citation edges via extract_citation_edges: {raw_ls,n_attr,siglum,work_id,renou,page,bib_ok,resolver_status map|bib|orphan|empty}; stamped at promote and microstructure; annotate_citation_edges backfills; raw <ls> never stripped from de.",
+    "mechanism": "DE-side normalized <ls> citation edges via extract_citation_edges: {raw_ls,n_attr,siglum,work_id,renou,page,bib_ok,resolver_status map|bib|orphan|empty,scan_href}; stamped at promote and microstructure; annotate_citation_edges backfills; raw <ls> never stripped from de.",
     "files": [
       "src/citation_edges.py",
       "src/annotate_citation_edges.py",
@@ -1705,10 +1705,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "H1624 G3 (25-07-2026, Grok 4.5). Pure DE citation layer. map=ls_source_map (Renou); bib=pwgbib only; orphan=neither. Scan hosting optional (build_citation_index). Pinned by citation_edges --selftest, promote_final_cards --selftest, annotate_citation_edges --selftest.",
+    "note": "H1624 G3 (25-07-2026, Grok 4.5). Pure DE citation layer. map=ls_source_map (Renou); bib=pwgbib only; orphan=neither. Scan hosting optional (build_citation_index). Pinned by citation_edges --selftest, promote_final_cards --selftest, annotate_citation_edges --selftest. H1630 (26-07-2026, Sonnet 5 `claude-sonnet-5`) added the additive scan_href field (ls_resolver.generate_href result) -- same as ls_resolver itself (see ls_resolver_rv_av_anchor_h321 below), it keys only on the citation abbreviation + numbers, never on RU/EN prose, so SHARED still holds.",
     "tracking": "H1624",
     "verified_sha256": {
-      "src/citation_edges.py": "88e12985ab21c8768a222b93515aff22f986c312d82381e3e34aa98034d20785",
+      "src/citation_edges.py": "e9ebe19853b9541a7e283fd6ff089eea3de81ff00ca640c410cbc51183cb04c0",
       "src/annotate_citation_edges.py": "ec925f73e1af793c22a602be009b412af67e9989c99209ceed14224bc2cf8022",
       "src/promote_final_cards.py": "6b43da8428d8d9c3ec2164510c979ce41bf8a7fb8a897bc4dada81ea9622e8d3",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9",

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -127,6 +127,88 @@ swept the queue; batch1v2 rebuilt gate-clean. Full audit:
 | batch1v2 cards (all verified German-free) | 150 |
 | positional-id drift: votes initially unresolvable against grown store | 2/5 (fixed: suffix fallback + CI pin) |
 
+## 26-07-2026 — H1630 top-N `citation_edges` sigla → Cologne scan/HTML link coverage
+
+Executor: Sonnet 5 (`claude-sonnet-5`), isolated worktree. Script: `src/citation_edges.py`
+(`topn` subcommand, new; `scan_href` field, new — H1624 G3 parent). Store: the live
+11,603-row `pwg_ru_translated.jsonl` (gitignored, main-worktree canonical copy).
+
+**What's new.** `extract_citation_edges()` gained an additive `scan_href` field —
+`ls_resolver.generate_href('pwg', n_attr, raw_ls)` when it actually resolves a Cologne
+scan/HTML target, else `null`. This is a *different* axis from the existing
+`resolver_status` (map/bib/orphan): `resolver_status` only asks "is this siglum a known
+work", not "does a clickable Cologne target exist for this exact locator" — e.g. `AK. 1`
+is `map` (Amarakośa is a known work) but `scan_href` is `null` (the resolver pattern for
+Amarakośa needs 3–4 coordinate parts, not one).
+
+**Top-25 sigla by raw citation frequency → `scan_href` coverage:**
+
+| siglum | citations | `scan_href` resolved | coverage | sample target |
+|---|---:|---:|---:|---|
+| MBH | 5,753 | 5,737 | 99.7% | [mbhcalc?1.1090](https://sanskrit-lexicon-scans.github.io/mbhcalc?1.1090) |
+| ṚV | 3,705 | 3,697 | 99.8% | [rv01.100.html#rv01.100.05](https://sanskrit-lexicon.github.io/rvlinks/rvhymns/rv01.100.html#rv01.100.05) |
+| R | 3,126 | 3,123 | 99.9% | [ramayanaschl/?1,4,18](https://sanskrit-lexicon-scans.github.io/ramayanaschl/?1,4,18) |
+| BHĀG. P | 2,167 | 2,152 | 99.3% | [bhagp_bom/app1/?10,19,13](https://sanskrit-lexicon-scans.github.io/bhagp_bom/app1/?10,19,13) |
+| ŚAT. BR | 1,781 | 1,770 | 99.4% | [shatapathabr/app1?10,1,2,1](https://sanskrit-lexicon-scans.github.io/shatapathabr/app1?10,1,2,1) |
+| M | 1,636 | 1,635 | 99.9% | [manu/index.html?2,109](https://sanskrit-lexicon-scans.github.io/manu/index.html?2,109) |
+| KATHĀS | 1,472 | 1,472 | 100.0% | [kss/index.html?17,32](https://sanskrit-lexicon-scans.github.io/kss/index.html?17,32) |
+| AV | 1,207 | 1,199 | 99.3% | [av09.005.html#av09.005.12](https://sanskrit-lexicon.github.io/avlinks/avhymns/av09.005.html#av09.005.12) |
+| P (Pāṇini) | 1,049 | 1,034 | 98.6% | [sutraani/6/4/57](https://ashtadhyayi.com/sutraani/6/4/57) |
+| Spr | 1,039 | 1,038 | 99.9% | [boesp1/app1/?1402](https://sanskrit-lexicon-scans.github.io/boesp1/app1/?1402) |
+| HARIV | 905 | 902 | 99.7% | [hariv?3964](https://sanskrit-lexicon-scans.github.io/hariv?3964) |
+| R. GORR | 671 | 671 | 100.0% | [ramayanagorr/?2,5,27](https://sanskrit-lexicon-scans.github.io/ramayanagorr/?2,5,27) |
+| RAGH | 668 | 668 | 100.0% | [raghuvamsa/app1?12,52](https://sanskrit-lexicon-scans.github.io/raghuvamsa/app1?12,52) |
+| PAÑCAT | 607 | 606 | 99.8% | [pantankose/app2?71,24](https://sanskrit-lexicon-scans.github.io/pantankose/app2?71,24) |
+| VARĀH. BṚH. S | 576 | 555 | 96.4% | [brihatsam/app1?79,14](https://sanskrit-lexicon-scans.github.io/brihatsam/app1?79,14) |
+| RĀJA-TAR | 575 | 575 | 100.0% | [rajatar/app1?5,424](https://sanskrit-lexicon-scans.github.io/rajatar/app1?5,424) |
+| ŚĀK | 525 | 522 | 99.4% | [shakuntala/app1?62](https://sanskrit-lexicon-scans.github.io/shakuntala/app1?62) |
+| BHAṬṬ | 460 | 431 | 93.7% | [bhattikavya/app1?2,28](https://sanskrit-lexicon-scans.github.io/bhattikavya/app1?2,28) |
+| Spr. (II) | 450 | 450 | 100.0% | [boesp2/web1/boesp.html?7515](https://sanskrit-lexicon-scans.github.io/boesp2/web1/boesp.html?7515) |
+| VOP | 428 | 404 | 94.4% | [mugdhabodha/app1?26,215](https://sanskrit-lexicon-scans.github.io/mugdhabodha/app1?26,215) |
+| AIT. BR | 409 | 407 | 99.5% | [aitbr/app1?2,16](https://sanskrit-lexicon-scans.github.io/aitbr/app1?2,16) |
+| TS | 394 | 390 | 99.0% | [taittiriyas/app1?6,6,11,5](https://sanskrit-lexicon-scans.github.io/taittiriyas/app1?6,6,11,5) |
+| MĀRK. P | 367 | 367 | 100.0% | [markandeyapurana/app1?101,8](https://sanskrit-lexicon-scans.github.io/markandeyapurana/app1?101,8) |
+| KĀTY. ŚR | 328 | 328 | 100.0% | [katyasr/app1?22,6,16](https://sanskrit-lexicon-scans.github.io/katyasr/app1?22,6,16) |
+| HIT | 308 | 307 | 99.7% | [hitopadesha/app2?20,15](https://sanskrit-lexicon-scans.github.io/hitopadesha/app2?20,15) |
+
+**Residual (top-25 sigla with ZERO `scan_href` hits): none.** Every one of the 25
+highest-frequency works (33,251 of 41,115 total citations, 80.9%) already resolves to a
+Cologne scan/HTML target for the overwhelming majority of its individual locators
+(93.7%–100%); the small per-siglum shortfalls (BHAṬṬ 93.7%, VOP 94.4%, VARĀH. BṚH. S 96.4%)
+are individual malformed/unusual coordinates, not missing targets — the pattern-driven
+resolver already covers this frequency band essentially completely.
+
+**Where the real gaps are (beyond top-25): genuinely-uncovered high-frequency works.**
+`resolver_status == "orphan"` (siglum unknown to `ls_source_map`/`pwgbib` at all — a
+different, stricter failure than a `scan_href` miss) ranked by occurrences with a numeric
+locator (excludes non-coordinate labels like "ed. Bomb."/"ed. Calc." — edition/cross-ref
+notes with no locus, never linkable per the existing `build_citation_index.py` convention):
+
+| rank | siglum | citations | work |
+|---:|---|---:|---|
+| 1 | JĀTAKAM / Jātakam | 95 | Jātaka tales |
+| 2 | MAHĀVY / Mahāvy | 32 | Mahāvyutpatti |
+| 3 | VAJRACCH / Vajracch | 24 | Vajracchedikā |
+| 4 | CAMPAKA | 20 | (Buddhist Skt. text) |
+| 5 | Journ. of the Am | 19 | Journal of the American Oriental Society |
+| 6 | S | 18 | (ambiguous single-letter siglum) |
+| 7 | KĀRAṆḌ | 18 | Kāraṇḍavyūha |
+| 8 | Divyāvad | 16 | Divyāvadāna |
+| 9 | HARṢAC / Harṣac | 14 | Harṣacarita |
+| 10 | Kir | 8 | Kirātārjunīya |
+| 11 | Maitr. S | 8 | Maitrāyaṇī Saṃhitā |
+| 12 | Kauṭ | 8 | Kauṭilīya (Arthaśāstra) |
+
+These are almost entirely Buddhist-Sanskrit / less-common works with **no scan repository
+in `sanskrit-lexicon-scans`** — matches the pre-existing note in `build_citation_index.py`
+("coverage is target-limited, not resolver-limited"). Hard gaps (no Cologne target exists
+to link to at all) — route through [`/cologne-link-target`](https://github.com/gasyoun/claude-config/blob/main/commands/cologne-link-target.md)
+if/when digitization work is prioritized; not attempted here (N15 out of scope, per H1630).
+
+Reproduce: `python src/citation_edges.py topn --n 25` (JSON; the store resolves via
+`store_path.canonical_store`, so this also works unmodified from a linked worktree).
+Selftest for `scan_href` + `topn_scan_coverage`: `python src/citation_edges.py --selftest`.
+
 ## 26-07-2026 - H858 c1 live gate: HEALTH_NOGO (rate_limit) - profile sweep now 3/3 NO-GO
 
 Executor: Opus 5 (`claude-opus-5[1m]`). Third profile gated for the same owed H858 window.

--- a/RussianTranslation/src/citation_edges.py
+++ b/RussianTranslation/src/citation_edges.py
@@ -14,6 +14,13 @@ Each edge is a structured record::
     "page":       str|null,      # locator after siglum (digits/punctuation run)
     "bib_ok":     bool,          # pwgbib resolved the siglum
     "resolver_status": "map" | "bib" | "orphan" | "empty"
+    "scan_href":  str|null,      # ls_resolver.generate_href('pwg', ...) when it
+                                 # resolves an actual Cologne scan/HTML target
+                                 # (H1630). Additive only -- raw <ls> is never
+                                 # touched; independent of resolver_status (a
+                                 # "map"/"bib" siglum can still lack a target
+                                 # because no scan exists, and vice versa a
+                                 # pattern can fire without a ls_source_map hit).
   }
 
 Statuses (honest floor):
@@ -26,6 +33,10 @@ Usage:
   python src/citation_edges.py --selftest
   python src/citation_edges.py extract "<ls>ṚV. 1,1,1</ls>"
   python src/citation_edges.py report [--store PATH] [--limit N]
+  python src/citation_edges.py topn [--n 25] [--store PATH] [--limit N]
+      Top-N highest-frequency sigla -> ls_resolver.generate_href scan/HTML
+      coverage (H1630); distinct from resolver_status (map/bib/orphan only
+      asks "is the siglum known", not "does a Cologne target exist for it").
 """
 from __future__ import annotations
 
@@ -43,6 +54,7 @@ if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
 import pwg_sources as ps  # source_key + resolve (pwgbib)
+import ls_resolver as lsr  # generate_href -> scan_href (H1630)
 
 LS_RE = re.compile(r"<ls\b([^>]*)>(.*?)</ls>", re.S)
 N_ATTR_RE = re.compile(r'\bn\s*=\s*"([^"]*)"')
@@ -107,6 +119,17 @@ def _locator(visible: str, siglum: str) -> str | None:
     return m.group(1).strip() if m else None
 
 
+def _scan_href(n_attr: str | None, visible: str) -> str | None:
+    """ls_resolver.generate_href('pwg', ...), swallowed to None on any failure.
+
+    A resolver miss/exception must never break edge extraction (H1630: purely
+    additive enrichment over the existing map/bib/orphan classification)."""
+    try:
+        return lsr.generate_href("pwg", n_attr, visible)
+    except Exception:
+        return None
+
+
 def extract_citation_edges(text: str | None) -> list[dict]:
     """Extract normalized citation edges from one DE (or mixed) sense body.
 
@@ -133,6 +156,7 @@ def extract_citation_edges(text: str | None) -> list[dict]:
                 "page": None,
                 "bib_ok": False,
                 "resolver_status": "empty",
+                "scan_href": None,
             })
             continue
 
@@ -163,6 +187,7 @@ def extract_citation_edges(text: str | None) -> list[dict]:
             "page": page,
             "bib_ok": bool(bib_exp),
             "resolver_status": status,
+            "scan_href": _scan_href(n_attr, visible),
         })
     return edges
 
@@ -208,6 +233,62 @@ def report_store(store_path: str, limit: int | None = None) -> dict:
     return stats
 
 
+def topn_scan_coverage(store_path: str, n: int = 25, limit: int | None = None) -> dict:
+    """Top-N highest-frequency sigla -> ls_resolver.generate_href scan/HTML
+    coverage (H1630). Distinct from ``resolver_status`` (map/bib/orphan), which
+    only asks whether the siglum is *known*, not whether a Cologne target
+    actually exists for it -- ``scan_href`` answers the latter.
+
+    Returns: {n, rows, top: [{siglum, total, scan_href_ok, scan_href_pct,
+    map, bib, orphan, empty, sample_raw_ls, sample_scan_href}], residual:
+    [siglum, ...]} -- ``residual`` is the subset of the top-N with ZERO
+    ``scan_href`` hits (highest-frequency works this pass could not link)."""
+    freq = Counter()
+    per = {}
+    n_rows = 0
+    with open(store_path, encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            r = json.loads(line)
+            n_rows += 1
+            for e in extract_citation_edges(r.get("de")):
+                siglum = e.get("siglum") or ""
+                if not siglum:
+                    continue
+                freq[siglum] += 1
+                g = per.setdefault(siglum, {
+                    "total": 0, "scan_href_ok": 0,
+                    "map": 0, "bib": 0, "orphan": 0, "empty": 0,
+                    "sample_raw_ls": None, "sample_scan_href": None,
+                })
+                g["total"] += 1
+                g[e.get("resolver_status") or "empty"] += 1
+                if e.get("scan_href"):
+                    g["scan_href_ok"] += 1
+                    if g["sample_scan_href"] is None:
+                        g["sample_scan_href"] = e["scan_href"]
+                        g["sample_raw_ls"] = e.get("raw_ls")
+            if limit and n_rows >= limit:
+                break
+
+    top_sigla = [s for s, _ in freq.most_common(n)]
+    top = []
+    residual = []
+    for s in top_sigla:
+        g = per[s]
+        pct = round(100.0 * g["scan_href_ok"] / g["total"], 1) if g["total"] else 0.0
+        row = {"siglum": s, "total": g["total"], "scan_href_ok": g["scan_href_ok"],
+               "scan_href_pct": pct, "map": g["map"], "bib": g["bib"],
+               "orphan": g["orphan"], "empty": g["empty"],
+               "sample_raw_ls": g["sample_raw_ls"],
+               "sample_scan_href": g["sample_scan_href"]}
+        top.append(row)
+        if g["scan_href_ok"] == 0:
+            residual.append(s)
+    return {"n": n, "rows": n_rows, "top": top, "residual": residual}
+
+
 def selftest() -> None:
     fails = []
 
@@ -227,6 +308,9 @@ def selftest() -> None:
     check(e["page"] == "1,1,1", "page: %r" % e)
     check(e["work_id"] is not None, "work_id: %r" % e)
     check(e["bib_ok"] is True, "bib_ok: %r" % e)
+    check(e["scan_href"] == (
+        "https://sanskrit-lexicon.github.io/rvlinks/rvhymns/rv01.001.html#rv01.001.01"
+    ), "ṚV scan_href: %r" % e)
 
     # n= attribute inheritance
     de = '<ls n="MBH.">3,50</ls>'
@@ -235,6 +319,8 @@ def selftest() -> None:
     check(e["siglum"] in ("MBH", "MBH."), "siglum from n: %r" % e)
     check(e["page"] == "3,50", "page from visible: %r" % e)
     check(e["resolver_status"] == "map", "MBH map: %r" % e)
+    check(e["scan_href"] == "https://sanskrit-lexicon-scans.github.io/mbhcalc?3.50",
+          "MBH scan_href: %r" % e)
 
     # raw DE string is NOT rewritten
     raw = "x <ls>ṚV. 1,1</ls> y"
@@ -249,6 +335,44 @@ def selftest() -> None:
     e = extract_citation_edges("<ls>ZZZNOTAWORK. 1</ls>")[0]
     check(e["resolver_status"] == "orphan", "orphan: %r" % e)
     check(e["renou"] is None and e["work_id"] is None, "orphan fields: %r" % e)
+    check(e["scan_href"] is None, "orphan scan_href: %r" % e)
+
+    # empty <ls> stamps scan_href=None too (schema stays uniform)
+    e = extract_citation_edges("<ls></ls>")
+    if e:
+        check(e[0]["scan_href"] is None, "empty ls scan_href: %r" % e[0])
+
+    # scan_href can miss even when resolver_status is "map"/"bib" (siglum known,
+    # no Cologne target pattern for it) -- the two axes are independent.
+    e = extract_citation_edges("<ls>AK. 1</ls>")[0]
+    check(e["resolver_status"] in ("map", "bib"), "AK known siglum: %r" % e)
+    check(e["scan_href"] is None, "AK no scan pattern (1-param): %r" % e)
+
+    # topn_scan_coverage over a tiny fixture store
+    import tempfile
+    fixture_rows = [
+        {"de": "x <ls>ṚV. 1,1,1</ls> y"},
+        {"de": "x <ls>ṚV. 2,2,2</ls> y"},
+        {"de": "x <ls>ZZZNOTAWORK. 1</ls> y"},
+    ]
+    with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False, encoding="utf-8") as f:
+        for r in fixture_rows:
+            f.write(json.dumps(r) + "\n")
+        fixture_path = f.name
+    try:
+        cov = topn_scan_coverage(fixture_path, n=5)
+        check(cov["rows"] == 3, "topn rows: %r" % cov)
+        top_by_siglum = {r["siglum"]: r for r in cov["top"]}
+        check(top_by_siglum["ṚV"]["total"] == 2, "topn ṚV total: %r" % cov)
+        check(top_by_siglum["ṚV"]["scan_href_ok"] == 2, "topn ṚV scan_href_ok: %r" % cov)
+        check(top_by_siglum["ṚV"]["scan_href_pct"] == 100.0, "topn ṚV pct: %r" % cov)
+        check(top_by_siglum["ZZZNOTAWORK"]["scan_href_ok"] == 0,
+              "topn orphan scan_href_ok: %r" % cov)
+        check("ZZZNOTAWORK" in cov["residual"], "topn residual: %r" % cov)
+        check("ṚV" not in cov["residual"], "topn residual excludes resolved: %r" % cov)
+    finally:
+        os.unlink(fixture_path)
 
     # coverage helper
     edges = extract_citation_edges(
@@ -305,6 +429,31 @@ def main() -> None:
             return
         stats = report_store(store, limit=limit)
         print(json.dumps(stats, ensure_ascii=False, indent=2))
+        return
+    if argv[0] == "topn":
+        from store_path import canonical_store
+        store = canonical_store(os.path.join(HERE, "pwg_ru_translated.jsonl"))
+        n = 25
+        limit = None
+        i = 1
+        while i < len(argv):
+            if argv[i] == "--store" and i + 1 < len(argv):
+                store = argv[i + 1]
+                i += 2
+            elif argv[i] == "--n" and i + 1 < len(argv):
+                n = int(argv[i + 1])
+                i += 2
+            elif argv[i] == "--limit" and i + 1 < len(argv):
+                limit = int(argv[i + 1])
+                i += 2
+            else:
+                i += 1
+        if not os.path.exists(store):
+            print("store not found: %s (pass --store or run on a machine with data)"
+                  % store, file=sys.stderr)
+            sys.exit(1)
+        cov = topn_scan_coverage(store, n=n, limit=limit)
+        print(json.dumps(cov, ensure_ascii=False, indent=2))
         return
     print(__doc__)
     sys.exit(2)


### PR DESCRIPTION
## Summary
- Additive `scan_href` field on every `citation_edges.py` edge — `ls_resolver.generate_href('pwg', n_attr, raw_ls)` when it actually resolves a Cologne scan/HTML target; independent axis from the existing `resolver_status` (map/bib/orphan only asks whether the siglum is *known*, not whether a target exists for the specific locator).
- New `python src/citation_edges.py topn [--n 25] [--store PATH]` CLI: ranks sigla by citation frequency, reports `scan_href` coverage per siglum, and returns a `residual` list (top-N sigla with zero `scan_href` hits).
- Result over the live 11,603-row store: top-25 sigla (80.9% of all 41,115 citations) resolve 93.7–100%, residual = empty. Real remaining gaps (genuinely-unknown sigla, ranked) logged separately in `RESULTS_LOG.md` — mostly Buddhist-Sanskrit works with no Cologne scan repo, pointed at `/cologne-link-target` for any future digitization follow-up.
- `CITATION_COVERAGE.md` updated with a pointer to the new field/subcommand.

## Test plan
- [x] `python src/citation_edges.py --selftest` — OK (new `scan_href` + `topn_scan_coverage` fixture assertions included)
- [x] `python src/annotate_citation_edges.py --selftest` — OK (downstream consumer unaffected)
- [x] `python src/promote_final_cards.py --selftest` — OK (downstream consumer unaffected)
- [x] `python src/citation_edges.py topn --n 25` run against the live store, results transcribed into `RESULTS_LOG.md`

Handoff: H1630 (SanskritLexicography, Sonnet 5 `claude-sonnet-5`, isolated worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)