### PR TITLE
docs(findings): §463 — MW cf. and PWG Vgl. are not independent witnesses (H1648)

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -28,7 +28,7 @@ do), and a blockquoted (`> `) **Source** paragraph linking the exact statement a
 with a `— repo · date` tag — the `>` gives the Source line its left indent and muted rendering
 in plain Markdown; no HTML in this file, ever. Keep findings grounded (a number, a file, a
 probe), never a hunch. **Importance label:** every finding carries a colour dot at the start of its claim line and its index entry — 🔴 3 important · 🟠 2 medium · 🟡 1 not that important — assign one when appending. **Numbers are append-only:** a new finding takes the next free number
-(currently §466) whatever its section, so existing numbers never shift; when a finding is later
+(currently §467) whatever its section, so existing numbers never shift; when a finding is later
 refuted or superseded, strike it and say why — never reuse its number. **Verifiability class (H1362):** every finding has a re-derivability class — **A** auto-reproducible · **B** re-probeable (live host) · **C** historically fixed · **D** not reproducible as stated — ruled in [`epistemic_dashboard/FINDINGS_VERIFIABILITY_RULING_2026.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/epistemic_dashboard/FINDINGS_VERIFIABILITY_RULING_2026.md) and machine-readable in [`epistemic_dashboard/verifiability.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/epistemic_dashboard/verifiability.json). **A class-D finding must be cited with its non-reproducibility named** — never as a bare `§N` carrying the authority of a recomputable row; the D findings are marked `⚠️ class D — not reproducible as stated` in place.
 
 ## Index
@@ -108,6 +108,7 @@ refuted or superseded, strike it and say why — never reuse its number. **Verif
 - 🟠 [§34. The E abbreviation tag is polysemous across dicts](#34-the-e-abbreviation-tag-is-polysemous-across-dicts) — Etymology / Epithet / Epic; count the meaning, not the marker.
 - 🟠 [§35. Root-recovery tiers err on root form, not identity](#35-root-recovery-tiers-err-on-root-form-not-identity) — normalize to dhātupāṭha citation form; gate LLM roots through a known-dhātu set.
 - 🟠 [§103. The §83/§97 witness-collapse deflates the union's published "corroboration" 55.9% → 34.7%](#103-quantified-the-8397-witness-collapse-deflates-the-published-15-dict-union-corroboration-from-559-to-347--and-the-unions-own-table-is-pre-fold) — 68,651 "corroborated" headwords rest on one European lineage; Apte kept independent per §83; UNION.md table is pre-fold.
+- 🔴 [§466. MW's `cf.` and PWG's `Vgl.` are NOT independent witnesses](#466-mws-cf-and-pwgs-vgl-are-not-independent-witnesses--they-agree-2950-above-chance-so-a-shared-cross-reference-never-counts-as-double-attestation) — they agree on the target 21.8% of the time vs 0.007% expected (≈2,953×, p < 0.005) on the 2,750 headwords both cross-reference. MW 1899 rests on Böhtlingk–Roth, so "N dictionaries agree" is not N witnesses; the containment asymmetry (~3.2×) is a set-size artifact, not direction.
 
 **Encoding & normalization**
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -3552,3 +3552,47 @@ link identifies one sense at one locus, not every token of the lemma.
 > `m_wordsem` decode inventory recovered in H1453 — and the DCS master
 > `VisualDCS/src/DCS-data-2026/dcs_full.sqlite` (the `src/` and repo-root copies are 0-byte
 > decoys and were not read).
+### §466. MW's `cf.` and PWG's `Vgl.` are NOT independent witnesses — they agree ~2,950× above chance, so a shared cross-reference never counts as double attestation
+
+⚠️ **Kills a whole class of "two dictionaries agree, therefore it's real" argument.** A csl-atlas
+review sheet asked a human to confirm an MW↔PWG cross-reference edge on the grounds that "both
+dictionaries, **independently**, print a cross-reference … two editorial traditions made the same
+link". MG rejected that outright (26-07-2026): **MW depends on PWG and PW** — Monier-Williams 1899
+was built on Böhtlingk–Roth, so a shared reference can be one tradition copied, not two agreeing.
+
+Measured rather than argued
+([`m9_xref_marker_agreement.py`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/scripts/lexico/m9_xref_marker_agreement.py)
+→ [`xref_marker_agreement.json`](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/data/lexico/xref_marker_agreement.json),
+full `xref_edges.csv`, normalisation shared with `m6_xref_lineage.py`, seed 20260726):
+
+| Measure | Value |
+|---|---|
+| MW `cf.` edges (normalized, deduped) | 7,637 |
+| PWG `Vgl.` + `s.` edges | 25,766 |
+| Headwords cross-referenced in **both** | 2,750 |
+| MW edges on those headwords | 3,184 |
+| …whose target PWG also points to | **694 (21.8%)** |
+| Expected under a degree-preserving null (200 draws) | 0.235 (**0.007%**) |
+| Enrichment | **≈2,953×** |
+| Null draws ≥ observed | 0/200 (p < 0.005) |
+
+**Two traps this finding also closes.** (1) The raw containment asymmetry — 11.2% of MW's edges
+appear somewhere in PWG vs 3.5% the other way, ≈3.2× — looks like directional evidence but is
+almost exactly the 3.4× edge-count ratio, i.e. a **set-size artifact**. Do not cite it as showing
+who copied whom; direction comes from the bibliographic record, not this statistic. (2) Enrichment
+proves non-independence, **not** copying specifically: both dictionaries recording the same
+language facts would also produce it. What it does establish is that the *count* of agreeing
+dictionaries is not evidence you may add up.
+
+**Reusable rule.** For any MW/PW/PWG-family corroboration claim, "N dictionaries agree" is not N
+witnesses. State what a shared record actually asserts (here: the edge is *real and lexical*) and
+drop the independence premise. The same caution applies to any derived dataset that scores
+confidence by counting dictionaries in the Petersburg lineage.
+
+Companion trap on the same pipeline: MW and PWG follow **opposite** headword conventions in four
+cases documented by Patel 2016 (śatṛ `-at`/`-a`, vatup/matup `-vat`/`-v`, ṛ-stems `-ṛ`/`-ar`,
+vas/yas `-vas`/`-vaṃs`) which the normaliser does not reconcile — so the 642-edge MW∩PWG
+intersection is an **undercount**, and a ṛ-stem edge cannot intersect at all. See
+[XREF_SHARED_CORE_LABEL_TAXONOMY.md](https://github.com/sanskrit-lexicon/csl-atlas/blob/main/docs/XREF_SHARED_CORE_LABEL_TAXONOMY.md).
+
+_26-07-2026 · [H1648](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1648-Opus_csl-atlas_xref-sheet-ru-and-mw-pwg-dependence_26.07.26.md) · csl-atlas [PR #310](https://github.com/sanskrit-lexicon/csl-atlas/pull/310), [v0.11.0](https://github.com/sanskrit-lexicon/csl-atlas/releases/tag/v0.11.0) · Opus 5 (1M context) `claude-opus-5[1m]`_

--- a/epistemic_dashboard/epistemic.json
+++ b/epistemic_dashboard/epistemic.json
@@ -1,20 +1,20 @@
 {
- "generated_at": "2026-07-21T10:31:16Z",
+ "generated_at": "2026-07-26T04:41:06Z",
  "side": "Sanskrit-data",
  "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
  "core": {
   "key": "FINDINGS",
   "act": "measuring — the settled facts the seven siblings graduate into",
   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md",
-  "total": 116,
+  "total": 124,
   "by_importance": {
-   "3": 20,
-   "2": 78,
+   "3": 26,
+   "2": 80,
    "1": 18
   },
   "by_origin": {
    "auto": 0,
-   "human": 116
+   "human": 124
   }
  },
  "layers": [
@@ -554,6 +554,6 @@
   "candidates": 6,
   "categories": 20,
   "interlinks": 56,
-  "findings": 116
+  "findings": 124
  }
 }

--- a/findings_dashboard/data.json
+++ b/findings_dashboard/data.json
@@ -1,12 +1,12 @@
 {
- "generated_at": "2026-07-21T10:30:50Z",
+ "generated_at": "2026-07-26T04:40:40Z",
  "stale_days_threshold": 180,
  "counts": {
-  "total": 116,
+  "total": 124,
   "by_importance": {
-   "2": 78,
+   "2": 80,
    "1": 18,
-   "3": 20
+   "3": 26
   },
   "stale": 0
  },
@@ -17,7 +17,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-29",
-   "age_days": 22,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#1-whitney-accent-mobility-rules-are-machine-encodable"
   },
   {
@@ -26,7 +26,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-14",
-   "age_days": 37,
+   "age_days": 42,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling"
   },
   {
@@ -35,7 +35,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-13",
-   "age_days": 38,
+   "age_days": 43,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#3-the-warnemyr-scrape-union-smears-homonym-classes"
   },
   {
@@ -44,7 +44,7 @@
    "section": "Grammar & morphology data",
    "importance": 1,
    "evidence_date": "2026-06-29",
-   "age_days": 22,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#4-pwg-nominal-grammar-compresses-into-335-paradigm-tokens"
   },
   {
@@ -53,7 +53,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 19,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#42-whitney-self-contradicts-on-derivative-ī-stem-genpl-accent"
   },
   {
@@ -62,7 +62,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-07-05",
-   "age_days": 16,
+   "age_days": 21,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents"
   },
   {
@@ -71,7 +71,7 @@
    "section": "Grammar & morphology data",
    "importance": 1,
    "evidence_date": "2026-07-07",
-   "age_days": 14,
+   "age_days": 19,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian"
   },
   {
@@ -80,7 +80,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 27,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#5-the-parallel-corpus-rarely-attests-prefixed-verb-forms"
   },
   {
@@ -89,7 +89,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 27,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#6-no-printed-frequency-dictionary-of-sanskrit-exists"
   },
   {
@@ -98,7 +98,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 27,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations"
   },
   {
@@ -107,7 +107,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 36,
+   "age_days": 41,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#8-unaccented-dcs-cannot-distinguish-present-class-i-from-vi"
   },
   {
@@ -116,7 +116,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06-06",
-   "age_days": 45,
+   "age_days": 50,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#9-dcs-occid-and-sent_id-are-not-unique-keys"
   },
   {
@@ -125,7 +125,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-06",
-   "age_days": 45,
+   "age_days": 50,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#10-dcs-ud-tense-marking-conflates-aorist-and-perfect"
   },
   {
@@ -134,7 +134,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-06",
-   "age_days": 45,
+   "age_days": 50,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#11-dcs-2021-and-2026-vintages-are-not-directly-comparable"
   },
   {
@@ -143,7 +143,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-11",
-   "age_days": 40,
+   "age_days": 45,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword"
   },
   {
@@ -152,7 +152,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 1,
    "evidence_date": "2026-07-01",
-   "age_days": 20,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#13-sa-ru-glossary-token-coverage-plateaus-at-866-percent"
   },
   {
@@ -161,7 +161,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-01",
-   "age_days": 20,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#14-renou-period-state-tagging-covers-770k-entries-in-8-dicts"
   },
   {
@@ -170,7 +170,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-07",
-   "age_days": 14,
+   "age_days": 19,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards"
   },
   {
@@ -179,7 +179,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-07",
-   "age_days": 14,
+   "age_days": 19,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse"
   },
   {
@@ -188,7 +188,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 27,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#15-pwg-encodes-secondary-stems-inline-not-in-div-markup"
   },
   {
@@ -197,7 +197,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 27,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes"
   },
   {
@@ -206,7 +206,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 27,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#17-pwg-orders-senses-genetically-not-historically"
   },
   {
@@ -215,7 +215,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 27,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#18-vedic-citation-density-separates-the-dictionary-traditions"
   },
   {
@@ -224,7 +224,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 36,
+   "age_days": 41,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#19-skd-and-vcp-carry-essentially-zero-western-markup"
   },
   {
@@ -233,7 +233,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 27,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#20-the-ls-source-map-recognises-724-percent-of-pwg-citations"
   },
   {
@@ -242,7 +242,7 @@
    "section": "Dictionary structure & markup",
    "importance": 1,
    "evidence_date": "2026-07-02",
-   "age_days": 19,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#21-pwg-citation-occurrences-track-distinct-references"
   },
   {
@@ -251,7 +251,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 25,
+   "age_days": 30,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#22-mw-has-no-sense-level-div-markup"
   },
   {
@@ -260,7 +260,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 36,
+   "age_days": 41,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#23-apte-is-three-dictionaries-keys-differ-stem-vs-nominative"
   },
   {
@@ -269,7 +269,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-07",
-   "age_days": 6,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#24-about-9-percent-of-typo-corrections-are-collisions"
   },
   {
@@ -278,7 +278,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07",
-   "age_days": 6,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#25-a-verified-correction-queue-decays-against-live-csl-orig"
   },
   {
@@ -287,7 +287,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-13",
-   "age_days": 38,
+   "age_days": 43,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#26-citation-density-is-register-bound-not-comparable-raw"
   },
   {
@@ -296,7 +296,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-15",
-   "age_days": 36,
+   "age_days": 41,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#27-sense-granularity-is-a-family-trait-not-a-diachronic-trend"
   },
   {
@@ -305,7 +305,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-03",
-   "age_days": 48,
+   "age_days": 53,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#28-mw-inherited-the-pwg-apparatus-skeleton-not-its-prose"
   },
   {
@@ -314,7 +314,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 25,
+   "age_days": 30,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index"
   },
   {
@@ -323,7 +323,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-15",
-   "age_days": 36,
+   "age_days": 41,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#30-body-text-headword-mining-is-a-dead-end-386-percent-precision"
   },
   {
@@ -332,7 +332,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 27,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#31-detector-precision-stratifies-by-digitization-quality"
   },
   {
@@ -341,7 +341,7 @@
    "section": "Dictionary structure & markup",
    "importance": 1,
    "evidence_date": "2026-06-17",
-   "age_days": 34,
+   "age_days": 39,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#32-correction-events-concentrate-in-sense-text"
   },
   {
@@ -350,7 +350,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#46-twelve-years-of-corrections-cover-only-1014--of-the-estimated-error-population"
   },
   {
@@ -359,7 +359,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-07-05",
-   "age_days": 16,
+   "age_days": 21,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1--pwg-is-not-the-sole-spine-of-the-local-layer-universe"
   },
   {
@@ -368,7 +368,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07-11",
-   "age_days": 10,
+   "age_days": 15,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#76-the-mwwordnetsemdom-bridge-is-a-candidate-generator-not-a-classifier"
   },
   {
@@ -422,7 +422,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 25,
+   "age_days": 30,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#33-indigenous-dictionaries-agree-on-derivation-wilson-is-the-outlier"
   },
   {
@@ -431,7 +431,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 25,
+   "age_days": 30,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#34-the-e-abbreviation-tag-is-polysemous-across-dicts"
   },
   {
@@ -440,7 +440,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 25,
+   "age_days": 30,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#35-root-recovery-tiers-err-on-root-form-not-identity"
   },
   {
@@ -449,7 +449,7 @@
    "section": "Encoding & normalization",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 36,
+   "age_days": 41,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily"
   },
   {
@@ -458,7 +458,7 @@
    "section": "Encoding & normalization",
    "importance": 3,
    "evidence_date": "2026-07",
-   "age_days": 6,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#100-nfold-earns-sandhi-tolerant-recall-by-fusing-every-nasal-to-n--which-manufactures-false-quotation-matches-unless-every-hit-is-re-verified-on-norm"
   },
   {
@@ -467,7 +467,7 @@
    "section": "Encoding & normalization",
    "importance": 3,
    "evidence_date": "2026-07",
-   "age_days": 6,
+   "age_days": 11,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#102-dcs-sentencetext_sandhied-is-not-reliably-sandhied--some-rows-store-analyzed-word-forms-which-silently-downgrades-verbatim-quotations-to-partial-matches"
   },
   {
@@ -476,7 +476,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06",
-   "age_days": 36,
+   "age_days": 41,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#37-bom-state-is-inconsistent-across-exports"
   },
   {
@@ -485,7 +485,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06-27",
-   "age_days": 24,
+   "age_days": 29,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#38-injected-boms-crash-the-hw-record-parser"
   },
   {
@@ -494,7 +494,7 @@
    "section": "Encoding & normalization",
    "importance": 1,
    "evidence_date": "2026-06",
-   "age_days": 36,
+   "age_days": 41,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#39-devanagari_to_slp1-mis-routes-retroflex-la"
   },
   {
@@ -503,7 +503,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 25,
+   "age_days": 30,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#40-gloss-language-spelling-drift-tracks-reform-type-not-age"
   },
   {
@@ -512,7 +512,7 @@
    "section": "Encoding & normalization",
    "importance": 1,
    "evidence_date": "2026-07-05",
-   "age_days": 16,
+   "age_days": 21,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-practical-russian-transcription-of-sanskrit-names-has-no-safe-reverse-transliteration"
   },
   {
@@ -521,7 +521,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 19,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#41-the-sanskrit-dictionary-platform-landscape-probed-live"
   },
   {
@@ -530,7 +530,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#47-heritage-data-is-acquirable-despite-the-anubis-wall--via-a-github-mirror-the-morphology-xml-is-not-in-it"
   },
   {
@@ -539,7 +539,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 19,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#43-skdvcp-sensecitation-fusion-is-a-record-type-effect-not-a-dictionary-level-one"
   },
   {
@@ -548,7 +548,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 19,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#44-raw-latin-string-tallies-over-gloss-text-include-etymological-false-positives-bopp-lacks-yabh"
   },
   {
@@ -557,7 +557,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 19,
+   "age_days": 24,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#45-siglum-prefix-families-routinely-bundle-several-distinct-works-the-diacritic-stripping-fold-has-poisoned-keys"
   },
   {
@@ -566,7 +566,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#48-vedaweb-20s-resource-export-is-an-async-task-behind-a-pickup-key-not-a-direct-get--and-the-server-went-unresponsive-mid-attempt"
   },
   {
@@ -575,7 +575,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#49-mwheritage-coverage-highlighting-is-a-duplicate-anchor-pattern-not-a-css-class--and-the-mirrors-current-dictionary-is-a-different-scope-asset-than-the-2014-reader-stem-list"
   },
   {
@@ -584,7 +584,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#50-cdsl-display-paths-are-not-uniformly-2020web--and-two-new-digitizations-landed-in-june-2026"
   },
   {
@@ -602,7 +602,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#51-huet-correspondence-predates-this-session-2021--the-morphology-xml-gate-was-already-resolved-in-writing-direct-download-urls-recovered"
   },
   {
@@ -611,7 +611,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#52-heritage-vs-kosha-forms-diff-the-small-raw-overlap-is-mostly-convention--model-difference-and-disagreements-are-two-thirds-lemmatization-policy-not-error"
   },
   {
@@ -620,7 +620,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#53-the-wil-etymology-extractions-affix-field-is-half-noise--wilson-outlier-figures-are-substantially-a-measurement-artifact"
   },
   {
@@ -629,7 +629,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#56-dicos-entry-anchors-nest-three-structural-roles-under-one-html-class--only-one-is-a-true-entry-boundary"
   },
   {
@@ -638,7 +638,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#55-gen_opt_harness2py-output-budget-coarser-wins-on-both-knobs-in-opposite-directions"
   },
   {
@@ -647,7 +647,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#57-samskrtamruz-is-id-addressed-with-no-name-lookup--deep-linking-needs-a-scraped-rootid-table-8-primer-basic-roots-are-absent"
   },
   {
@@ -656,7 +656,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#58-pwg-ru-promoted-store-has-input-level-provenance-but-old-ru-rows-lacked-exact-model-versions"
   },
   {
@@ -674,7 +674,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 18,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#70-pwg_ru-tm-composite-grade-a-is-consensus-gated-57-and-a-reference-free-surface-qe-cannot-detect-wrong-sense"
   },
   {
@@ -683,7 +683,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-07",
-   "age_days": 14,
+   "age_days": 19,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#61-the-reverse-dictionarys-30-sources-split-18-pd-vs-10-in-copyright--the-merged-headword-list-is-not-automatically-publishable"
   },
   {
@@ -692,7 +692,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-08",
-   "age_days": 13,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#71-pwg-marks-case-government-explicitly-3853-times-across-3222-senses--a-deterministic-census-not-an-estimate"
   },
   {
@@ -701,7 +701,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-08",
-   "age_days": 13,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#72-vedawebs-id_gra-token-field-is-the-grassmann-l-entry-number--no-fuzzy-text-matching-needed-for-a-gravedaweb-crosswalk"
   },
   {
@@ -710,7 +710,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-08",
-   "age_days": 13,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#73-vedaweb-20s-cc-by-40-for-everything-claim-is-not-machine-confirmed--only-236-catalog-resources-carry-an-explicit-license-field"
   },
   {
@@ -719,7 +719,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-08",
-   "age_days": 13,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#74-the-ls-graph-citation-matrix-is-degenerate-for-mw--its-top-abbreviations-sit-unresolved-use-the-citation-apparatus-siglum-matrix-for-cross-dict-citation-profiles"
   },
   {
@@ -728,7 +728,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-10",
-   "age_days": 11,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#66-the-dcs-ql-frequency-workbooks-slp1-and-length-columns-are-truncated-at-ṣṭhḍh-clusters"
   },
   {
@@ -737,7 +737,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-10",
-   "age_days": 11,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#67-in-pwg-article-size-dwarfs-every-parametric-statistic-you-can-extract-from-the-entry"
   },
   {
@@ -746,7 +746,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-10",
-   "age_days": 11,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#68-the-sanskrit-spellchecker-landscape-one-dormant-demo-one-license-unsettled-543k-wordlist-no-occupant"
   },
   {
@@ -755,7 +755,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-10",
-   "age_days": 11,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#69-hand-transcribed-telemetry-cannot-adjudicate-code-vs-infra--and-a-local-only-ledger-silently-swaps-your-denominator"
   },
   {
@@ -764,7 +764,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-10",
-   "age_days": 11,
+   "age_days": 16,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#75-the-full-devībhāgavata-purāṇa-sanskrit-is-not-on-gretil--only-the-devigita-fragment-the-complete-mūla-lives-on-sanskritdocumentsorg-without-dbhp_-markers"
   },
   {
@@ -1054,6 +1054,78 @@
    "evidence_date": null,
    "age_days": null,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#458-a-sanskrit-dictionarys-big-letters-are-big-because-they-head-preverb-families--and-testing-entries-shrink-over-publication-needs-an-outlier-robust-estimator-not-a-parametric-regression-encyclopedic-dicts-have-single-300k-char-articles"
+  },
+  {
+   "n": 459,
+   "title": "PWG's entry-size decay is a *smooth* funding/energy fade across its whole 20-year run (−14 %/decade), not a one-time correction after the over-detailed first volume — and SKD/VCP carry ~0 digitisation markup",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#459-pwgs-entry-size-decay-is-a-smooth-fundingenergy-fade-across-its-whole-20-year-run-14-decade-not-a-one-time-correction-after-the-over-detailed-first-volume--and-skdvcp-carry-0-digitisation-markup"
+  },
+  {
+   "n": 460,
+   "title": "\"Gold\" in this org means *frozen*, not *human-adjudicated* — 0 of 15 gold datasets have independent human annotation, and every travelling κ is model-vs-model (four contamination mechanisms)",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#460-gold-in-this-org-means-frozen-not-human-adjudicated--0-of-15-gold-datasets-have-independent-human-annotation-and-every-travelling-κ-is-model-vs-model-four-contamination-mechanisms"
+  },
+  {
+   "n": 461,
+   "title": "The r2 kośa-fusion \"separable\" class is substantially an orthographic sandhi artifact — whether an SKD citation counts \"fused\" depends on whether the authority's name begins with a vowel",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#461-the-r2-kośa-fusion-separable-class-is-substantially-an-orthographic-sandhi-artifact--whether-an-skd-citation-counts-fused-depends-on-whether-the-authoritys-name-begins-with-a-vowel"
+  },
+  {
+   "n": 462,
+   "title": "On Windows, repeated repository discovery can dominate a Python pipeline: cache checkout identity, not mutable path overrides",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#462-on-windows-repeated-repository-discovery-can-dominate-a-python-pipeline-cache-checkout-identity-not-mutable-path-overrides"
+  },
+  {
+   "n": 463,
+   "title": "The pwg_ru store's `de` field is NOT a faithful copy of the csl-orig German — Russian connectives have been substituted into the source-of-truth string",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#463-the-pwg_ru-stores-de-field-is-not-a-faithful-copy-of-the-csl-orig-german--russian-connectives-have-been-substituted-into-the-source-of-truth-string"
+  },
+  {
+   "n": 464,
+   "title": "The H1624 G1 `gloss_lang` classifier mislabels German as Latin/English about half the time it fires — and those spans are then withheld from translation",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#464-the-h1624-g1-gloss_lang-classifier-mislabels-german-as-latinenglish-about-half-the-time-it-fires--and-those-spans-are-then-withheld-from-translation"
+  },
+  {
+   "n": 465,
+   "title": "PWG sense × DCS attestation collapses from 100% at lemma level to 0.67% at sense level — and two independent ceilings cause it",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#465-pwg-sense--dcs-attestation-collapses-from-100-at-lemma-level-to-067-at-sense-level--and-two-independent-ceilings-cause-it"
+  },
+  {
+   "n": 466,
+   "title": "MW's `cf.` and PWG's `Vgl.` are NOT independent witnesses — they agree ~2,950× above chance, so a shared cross-reference never counts as double attestation",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#466-mws-cf-and-pwgs-vgl-are-not-independent-witnesses--they-agree-2950-above-chance-so-a-shared-cross-reference-never-counts-as-double-attestation"
   }
  ]
 }

--- a/findings_dashboard/timeseries.json
+++ b/findings_dashboard/timeseries.json
@@ -40,11 +40,11 @@
    }
   },
   {
-   "date": "2026-07-21",
+   "date": "2026-07-26",
    "source": "build",
    "metrics": {
     "dcs_cdsl_linkage_pct": 81.4,
-    "glossary_vidyut_coverage_pct": 86.6,
+    "glossary_vidyut_coverage_pct": null,
     "pwg_citation_coverage_pct": 83.6,
     "queue_verdicts": {
      "PASS": 92,
@@ -68,11 +68,11 @@
     "queue_decay_pct": 0.82
    },
    "registry": {
-    "total": 116,
+    "total": 124,
     "by_importance": {
-     "2": 78,
+     "2": 80,
      "1": 18,
-     "3": 20
+     "3": 26
     },
     "stale": 0
    }


### PR DESCRIPTION
Kills a class of "two dictionaries agree, therefore it's real" argument across the Petersburg lineage.

A csl-atlas review sheet asked a human to confirm an MW↔PWG cross-reference edge because "both dictionaries, **independently**, print a cross-reference". MG rejected that: **MW depends on PWG and PW** (MW 1899 was built on Böhtlingk–Roth).

Measured rather than argued — on the 2,750 headwords cross-referenced in both dictionaries, MW's `cf.` target is also a PWG `Vgl.`/`s.` target **21.8%** of the time vs **0.007%** under a degree-preserving null: **≈2,953× enrichment**, 0/200 null draws at or above observed (p < 0.005).

Two traps the entry also closes:
- The raw containment asymmetry (11.2% vs 3.5%, ≈3.2×) looks directional but is almost exactly the 3.4× edge-count ratio — a **set-size artifact**, not evidence of who copied whom.
- Enrichment establishes **non-independence**, not copying specifically; both dictionaries recording the same language facts would also produce it. What it does kill is treating the *count* of agreeing dictionaries as additive evidence.

Companion trap recorded: four Patel 2016 headword conventions put MW and PWG on opposite sides and are unreconciled by the pipeline, so the 642-edge MW∩PWG intersection is an **undercount**.

Source: csl-atlas [PR #310](https://github.com/sanskrit-lexicon/csl-atlas/pull/310) / [v0.11.0](https://github.com/sanskrit-lexicon/csl-atlas/releases/tag/v0.11.0). Handoff [H1648](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1648-Opus_csl-atlas_xref-sheet-ru-and-mw-pwg-dependence_26.07.26.md). Model: Opus 5 (1M context) (`claude-opus-5[1m]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)