### PR TITLE
chore(release): cut v1.67.0 — G5 German-residue gate + batch1v2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.65.0
+version: 1.67.0
 date-released: "2026-07-26"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.67.0] — 2026-07-26
+
 ### Added
 - **Reader-visible German-residue gate for review sheets (H1655, 26-07-2026).** MG aborted
   G5 live-queue batch 1 at 5/150 votes: cards reached the human with visible German. New


### PR DESCRIPTION
Promote [Unreleased] to [1.67.0] (2026-07-26) + CITATION.cff version sync. Content: [changelog 1.67.0](https://github.com/gasyoun/SanskritLexicography/blob/rel-1.67.0/changelog.md) — H1655 reader-visible German gate, G5 batch1v2, positional-id drift fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)