### PR TITLE
chore(release): 1.69.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.68.0
+version: 1.69.0
 date-released: "2026-07-26"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,12 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.69.0] - 2026-07-26
+
+> Version numbering follows the repository's **git tag** sequence (…v1.67.0,
+> v1.68.0), which had drifted ahead of the version headings in this file (last
+> heading was `[1.62.0]`). Continuing the tag sequence, per `/cut-release`.
+
 ### Added — H1632 scale-up: unbiased random frame + full-PWG run (26-07-2026)
 
 - The original H1632 pilot ran on a frame **selected DCS-attested**, so its "100%

--- a/RussianTranslation/CITATION.cff
+++ b/RussianTranslation/CITATION.cff
@@ -16,8 +16,8 @@ authors:
     affiliation: "Институт лингвистических исследований РАН (ИЛИ РАН)"
 repository-code: "https://github.com/gasyoun/SanskritLexicography"
 license: "CC-BY-SA-4.0"
-version: "1.49.0"
-date-released: "2026-07-21"
+version: "1.69.0"
+date-released: "2026-07-26"
 keywords:
   - sanskrit
   - russian


### PR DESCRIPTION
Promotes seven merged-but-unreleased changelog entries to **v1.69.0**.

- H1632 PWG-sense x DCS attestation pilot join + the scale-up (unbiased random frame and full-PWG run)
- H1631 edition-diff reading surface over `edition_rel`
- H1629 OntoLex-Lemon + TEI Lex-0 DE export profile, and the data-integrity findings it surfaced
- H1634 German-side editorial-principles datasheet
- Codex pipeline-hardening audit, step 1 of 2

**Version numbering.** Continues the repository's real git tag sequence (v1.68.0 -> 1.69.0). The version headings in `RussianTranslation/CHANGELOG.md` had drifted behind the tags (last heading was `[1.62.0]`); noted inline in the promoted section rather than silently renumbered.

**CITATION.cff synced at the freeze** (both files): repo-level 1.68.0 -> 1.69.0, and the pwg_ru dataset CFF 1.49.0 -> 1.69.0, which had lagged five releases.

Tag + GitHub release follow this merge, per `/cut-release` (never tag a commit that is not on the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)