### PR TITLE
feat(pwg_ru): H1628 stratified 200-item review sheet for compound differs

### DIFF
--- a/RussianTranslation/.gitignore
+++ b/RussianTranslation/.gitignore
@@ -207,6 +207,11 @@ review/g6_*_sheet.html
 review/*_decisions.json
 !review/sanskritlexicography-renou-hypotheses_pilot_decisions.json
 
+# H1628 compound-differs review sheet (compound_differs_review_sample.py): personal
+# voting artifact per the /review-sheet contract — local-only. The metadata-only sample
+# frame TSV (no ru/de store text) IS committed as the sample-design audit trail.
+review/sanskritlexicography-pwg-compound-differs_stratified200_review.html
+
 # Generated Workflow harnesses embed source/portrait payloads and are local-only.
 src/pilot/run_pilot_wf.*.js
 !src/pilot/run_pilot_wf.js

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,19 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added — H1628: stratified 200-item review sheet for the compound `differs` queue (26-07-2026)
+
+- [`src/pilot/compound_differs_review_sample.py`](src/pilot/compound_differs_review_sample.py)
+  draws a deterministic (seed=1628), two-stage stratified sample of 200 from the ~4226-row
+  PWG-vs-index compound `differs` queue (H1624 G6 residual): a flat 20-item quota for the
+  rare `member_count_diff` sub-class, the rest proportional across length x DCS-frequency
+  cells. Sample frame committed
+  ([`review/sanskritlexicography-pwg-compound-differs_stratified200_frame.tsv`](review/sanskritlexicography-pwg-compound-differs_stratified200_frame.tsv));
+  the interactive sheet stays gitignored (personal voting artifact). Vote → store contract
+  documented in [RESULTS_LOG.md](RESULTS_LOG.md) so applying the vote can never bulk-overwrite
+  `derivation.human_reviewed` beyond the sampled ids. Does not close the ~4.2k queue —
+  ~4026 rows stay `needs_human` pending a future sampling round.
+
 ## [1.69.0] - 2026-07-26
 
 > Version numbering follows the repository's **git tag** sequence (…v1.67.0,

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -4,6 +4,64 @@ _Created: 09-07-2026 · Last updated: 26-07-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
+## 26-07-2026 - H1628: stratified 200-item review sheet, PWG-vs-index compound `differs` (H1624 G6 residual)
+
+Executor: Sonnet 5 (`claude-sonnet-5`). Sampled from the ~4226-row `differs` queue the
+[H1624 G6](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1624-Opus_SanskritLexicography_pwg-german-layers-backlog-ordered_25.07.26.md)
+`enrich_portrait_derivation.py --conflict-rate` flags (39539 rows scanned, 4226/39539 =
+10.69% conflict, 10577/39539 = 26.75% needs_human — unchanged from G6's freeze). Sampling
+script:
+[`src/pilot/compound_differs_review_sample.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/compound_differs_review_sample.py)
+(`--selftest` wired; `--report` dry-runs the strata; `--write` emits the frame + sheet).
+
+**Sample frame — two-stage stratified, seed=1628 (deterministic, reproducible):**
+
+1. `vs_index_class` (how PWG's split disagrees with the pre-existing
+   `headword_index.tsv` `compound_members`, not itself stratifiable since the whole
+   queue is `compound_status=differs`): `member_count_diff` (76/4226, 1.8%) gets a flat
+   **guaranteed quota of 20** — proportional allocation would round it to ~1-2 items and
+   bury a structurally distinct failure mode; `same_count_diff_split` (4150/4226) fills
+   the remaining 180 proportionally across length x frequency cells (largest-remainder
+   rounding to land exactly on 180).
+2. `length_bucket` (`len(k1)`): short ≤8 / medium 9-10 / long ≥11 (quartile-derived cuts
+   on the full differs frame).
+3. `freq_bucket` (DCS attestation count via
+   [`src/pwg_freq_order.tsv`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_freq_order.tsv)):
+   `no_dcs_freq` (no match, 58.1% of the frame) / low 1-2 / mid 3-9 / high ≥10.
+
+| stratum | full differs frame (n=4226) | sample (n=200) |
+|---|---:|---:|
+| vs_index_class: member_count_diff | 76 (1.8%) | 20 (10.0%, oversampled by design) |
+| vs_index_class: same_count_diff_split | 4150 (98.2%) | 180 (90.0%) |
+| length: short(≤8) | 1904 (45.1%) | 83 (41.5%) |
+| length: medium(9-10) | 1622 (38.4%) | 78 (39.0%) |
+| length: long(≥11) | 700 (16.6%) | 39 (19.5%) |
+| freq: no_dcs_freq | 2456 (58.1%) | 123 (61.5%) |
+| freq: low(1-2) | 660 (15.6%) | 28 (14.0%) |
+| freq: mid(3-9) | 503 (11.9%) | 22 (11.0%) |
+| freq: high(≥10) | 607 (14.4%) | 27 (13.5%) |
+
+Sample frame (metadata only — k1/hom/both splits/strata/panini/gaṇa, no `ru`/`de` store
+text) committed at
+[`review/sanskritlexicography-pwg-compound-differs_stratified200_frame.tsv`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/review/sanskritlexicography-pwg-compound-differs_stratified200_frame.tsv).
+The interactive sheet itself
+(`review/sanskritlexicography-pwg-compound-differs_stratified200_review.html`) stays
+**gitignored**, per the `/review-sheet` contract — personal voting artifact, not a repo
+deliverable.
+
+**Vote → store contract (so `derivation.human_reviewed` never gets a bulk overwrite):**
+`decisions.json` export carries one decision per `(k1, hom)` id — `approve` = PWG's split
+is correct (a future apply step sets that entry's `derivation.compound.human_reviewed =
+true` with `members` taken from `pwg_members`); `reject` = the index's split is correct
+(same overlay, `members` taken from `index_members`, PWG layer flagged
+`needs_correction`); `defer` = no vote, stays `needs_human`. The overlay write touches
+**only the ~200 sampled `(k1, hom)` keys** — `enrich_portrait_derivation.enrich_portrait_obj`
+already refuses to touch any entry whose `derivation.human_reviewed` is truthy, so applying
+this batch cannot silently re-stamp the other ~4026 unsampled `differs` rows.
+
+**Explicit non-goal:** the remaining ~4026 `differs` rows (4226 − 200) stay `needs_human`;
+this sheet closes zero rows on its own until MG votes and `/decisions-apply` runs.
+
 ## 26-07-2026 - P1 ruling applied: machine-flag layer over the live queue, batch1v3 (H1655)
 
 Executor: Fable 5 (`claude-fable-5`). MG ruled the voting-queue triage `@DECIDE` «auto-reject»

--- a/RussianTranslation/pwg_ru.md
+++ b/RussianTranslation/pwg_ru.md
@@ -486,7 +486,7 @@ English twin:
 |---|---|---|---|
 | [H1626](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1626-Fable_SanskritLexicography_pwg-h1303-abbrev-decisions-apply_25.07.26.md) | Apply H1303 abbrev vote | N1 | Fable ⏸ vote |
 | [H1627](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1627-Fable_SanskritLexicography_pwg-h1306-style-decisions-apply_25.07.26.md) | Apply H1306 = G5 | N2 | Fable ⏸ vote |
-| [H1628](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1628-Sonnet_SanskritLexicography_pwg-compound-differs-review-sheet_25.07.26.md) | ~200 compound differs sheet | N11 sample | Sonnet |
+| [H1628](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1628-Sonnet_SanskritLexicography_pwg-compound-differs-review-sheet_25.07.26.md) | ~200 compound differs sheet ✅ sample built, ⏸ vote | N11 sample | Sonnet |
 | [H1629](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1629-Opus_SanskritLexicography_pwg-de-graph-ontolex-tei-export_25.07.26.md) | OntoLex/TEI DE graph | citability | Opus |
 | [H1630](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1630-Sonnet_SanskritLexicography_pwg-citation-edges-topn-scan-links_25.07.26.md) | Top-N scan links | N15 partial | Sonnet |
 | [H1631](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1631-Sonnet_SanskritLexicography_pwg-edition-diff-ui_25.07.26.md) | Edition-diff UI | N14 | Sonnet |

--- a/RussianTranslation/review/sanskritlexicography-pwg-compound-differs_stratified200_frame.tsv
+++ b/RussianTranslation/review/sanskritlexicography-pwg-compound-differs_stratified200_frame.tsv
@@ -1,0 +1,201 @@
+k1	hom	pwg_members	index_members	vs_index_class	length_bucket	freq_bucket	freq_count	panini_sutras	deriv_base	deriv_suffix	ganas
+mfzArTaka		mfzA + arTa	mfzA + rTa + ka	member_count_diff	medium(9-10)	no_dcs_freq					
+prAyaScitta	1	prAyas + citta	prAyaS + citta	same_count_diff_split	long(>=11)	high(>=10)	268	P.6.1.157			
+gaRqUpada		gaRqu + pada	gaRqU + pada	same_count_diff_split	medium(9-10)	high(>=10)	19				
+putraSfNgI		putra + SfNga	putra + SfNgI	same_count_diff_split	medium(9-10)	no_dcs_freq					
+yajYasena		yajYa + senA	yajYa + sena	same_count_diff_split	medium(9-10)	high(>=10)	42				
+SaracCAli		Sarad + SAli	Sarac + CAli	same_count_diff_split	medium(9-10)	no_dcs_freq					
+BadraSreRya		Badra + SreRi	Badra + SreRya	same_count_diff_split	long(>=11)	mid(3-9)	8				
+girizad		giri + sad	giri + zad	same_count_diff_split	short(<=8)	no_dcs_freq					
+bahudantIsuta		bahu + danta	bahu + dantI + suta	member_count_diff	long(>=11)	no_dcs_freq					
+turaRyasad		turaRy + sad	turaRya + sad	same_count_diff_split	medium(9-10)	low(1-2)	1				
+hflleKa		hfd + leKa	hfl + leKa	same_count_diff_split	short(<=8)	mid(3-9)	6	P.6.3.50			
+yaTArTatas		yaTA + arTa	yaTA + rTa + tas	member_count_diff	medium(9-10)	no_dcs_freq					
+nirIti		nis + Iti	nir + Iti	same_count_diff_split	short(<=8)	no_dcs_freq					
+brahmaDara		brahman + Dara	brahma + Dara	same_count_diff_split	medium(9-10)	no_dcs_freq					
+suKaduHKamaya		suKa + duHKa	suKa + duHKa + maya	member_count_diff	long(>=11)	no_dcs_freq					
+brahmaprI		brahman + prI	brahma + prI	same_count_diff_split	medium(9-10)	no_dcs_freq					
+pakzimfgatA		pakzin + mfga	pakzi + mfgatA	same_count_diff_split	long(>=11)	no_dcs_freq					
+nfmeDa	1	nar + meDa	nf + meDa	same_count_diff_split	short(<=8)	low(1-2)	2				
+cetoBava		cetas + Bava	ceto + Bava	same_count_diff_split	short(<=8)	no_dcs_freq					
+nAmaDeya		nAman + Deya	nAma + Deya	same_count_diff_split	short(<=8)	high(>=10)	167	P.4.22.56|P.5.4.36			
+jyotIrasa		jyotis + rasa	jyotI + rasa	same_count_diff_split	medium(9-10)	mid(3-9)	4				
+raktapittahA		raktapitta + hA	rakta + pitta + hA	member_count_diff	long(>=11)	no_dcs_freq					
+suptANgatA		supta + aNga	suptANga + tA	same_count_diff_split	medium(9-10)	no_dcs_freq					
+suprAta		su + prAtar	su + prAta	same_count_diff_split	short(<=8)	low(1-2)	1	P.5.4.120			
+puMsputra		pumaMs + putra	puMs + putra	same_count_diff_split	medium(9-10)	no_dcs_freq		P.8.3.6			
+durjYAna		duz + jYAna	dur + jYAna	same_count_diff_split	short(<=8)	mid(3-9)	5				
+triviDa		tri + viDA	tri + viDa	same_count_diff_split	short(<=8)	high(>=10)	534				
+bahirmuKa		bahis + muKa	bahir + muKa	same_count_diff_split	medium(9-10)	high(>=10)	13				
+viSvArAj		viSva + rAj	viSvA + rAj	same_count_diff_split	short(<=8)	no_dcs_freq		P.6.3.128			
+triRAman		tri + nAman	tri + RAman	same_count_diff_split	short(<=8)	no_dcs_freq					
+BadraparRA		Badra + parRa	Badra + parRA	same_count_diff_split	medium(9-10)	no_dcs_freq					
+bahumAya		bahu + mAyA	bahu + mAya	same_count_diff_split	short(<=8)	no_dcs_freq					
+satfRam		sa + tfRa	sa + tfRam	same_count_diff_split	short(<=8)	no_dcs_freq		P.2.1.6			
+tatpada		tad + pada	tat + pada	same_count_diff_split	short(<=8)	low(1-2)	1				
+mfdAhvayA		mfd + Ahvaya	mfd + AhvayA	same_count_diff_split	medium(9-10)	no_dcs_freq					
+dviguRa		dvi + guRa	dvi + guRadviguRa	same_count_diff_split	short(<=8)	high(>=10)	701				
+nizkiMcana		nis + kiMcana	niz + kiMcana	same_count_diff_split	medium(9-10)	mid(3-9)	5	P.2.9.6			
+nirnara		nis + nara	nir + nara	same_count_diff_split	short(<=8)	no_dcs_freq					
+ekadevata		eka + devatA	eka + devata	same_count_diff_split	medium(9-10)	no_dcs_freq					
+suzama	2	su + sama	su + zama	same_count_diff_split	short(<=8)	mid(3-9)	6	P.2.1.17|P.4.1.41|P.8.3.88			gOrAdiH
+duHsTita		duz + sTita	duH + sTita	same_count_diff_split	short(<=8)	high(>=10)	12	P.1.5.14			
+trayodaSaviDa		trayodaSan + viDA	trayo + daSa + viDa	member_count_diff	long(>=11)	high(>=10)	19				
+mfgarasA		mfga + rasa	mfga + rasA	same_count_diff_split	short(<=8)	no_dcs_freq					
+naBaHsad		naBas + sad	naBaH + sad	same_count_diff_split	short(<=8)	no_dcs_freq					
+niHsneha		nis + sneha	niH + sneha	same_count_diff_split	short(<=8)	high(>=10)	26	P.35.29			
+niryuktika		nis + yukti	nir + yuktika	same_count_diff_split	medium(9-10)	low(1-2)	2				
+navagraha	2	navan + graha	nava + graha	same_count_diff_split	medium(9-10)	no_dcs_freq					
+alaMjuza		alam + juza	alaM + juza	same_count_diff_split	short(<=8)	no_dcs_freq					
+duryoga		duz + yoga	dur + yoga	same_count_diff_split	short(<=8)	low(1-2)	1				
+BAgaMjaya		BAga + jaya	BAga + Mjaya	same_count_diff_split	medium(9-10)	no_dcs_freq					
+tryASir		tri + ASir	try + ASir	same_count_diff_split	short(<=8)	no_dcs_freq					
+nfloka		nar + loka	nf + loka	same_count_diff_split	short(<=8)	low(1-2)	2	P.1.16.9			
+SvAviD		Svan + viD	SvA + viD	same_count_diff_split	short(<=8)	high(>=10)	41	P.3.21.44|P.6.3.116|P.8.146			
+paYcamAsya	2	paYcan + mAsa	paYca + mAsya	same_count_diff_split	medium(9-10)	no_dcs_freq					
+aBimAtizAha		aBimAti + sAha	aBimAti + zAha	same_count_diff_split	long(>=11)	mid(3-9)	4				
+carmasAra		carman + sAra	carma + sAra	same_count_diff_split	medium(9-10)	low(1-2)	1				
+dAtfpura		dAtar + pura	dAtf + pura	same_count_diff_split	short(<=8)	no_dcs_freq					
+nirgarha		nis + garhA	nir + garha	same_count_diff_split	short(<=8)	no_dcs_freq					
+gotrapawa		gotra + pawa	go + tra + pawa	member_count_diff	medium(9-10)	no_dcs_freq					
+samudratIrIya		samudra + tIra	samudra + tIrIya	same_count_diff_split	long(>=11)	no_dcs_freq					
+nfbAhu		nar + bAhu	nf + bAhu	same_count_diff_split	short(<=8)	no_dcs_freq					
+ftIzah		fti + sah	ftI + zah	same_count_diff_split	short(<=8)	mid(3-9)	6	P.6.3.116			
+gozWeSUra		gozWe + SUra	go + zWe + SUra	member_count_diff	medium(9-10)	no_dcs_freq		P.2.1.48			
+droRadugDA		droRa + dugDa	droRa + dugDA	same_count_diff_split	medium(9-10)	no_dcs_freq					
+BagavaddfSa		Bagavant + dfSa	Bagavad + dfSa	same_count_diff_split	long(>=11)	low(1-2)	2				
+vikAkud		vi + kAkuda	vi + kAkud	same_count_diff_split	short(<=8)	no_dcs_freq		P.5.4.148			
+vizvagaSva		vizvaYc + aSva	vizvag + aSva	same_count_diff_split	medium(9-10)	mid(3-9)	5				
+SvayAtu		Svan + yAtu	Sva + yAtu	same_count_diff_split	short(<=8)	low(1-2)	1				
+leKarzaBa		leKa + fzaBa	leKa + rzaBa	same_count_diff_split	medium(9-10)	low(1-2)	2				
+bAhvaNka		bAhu + aNka	bAhv + aNka	same_count_diff_split	short(<=8)	no_dcs_freq					
+devacCanda		deva + Canda	deva + cCanda	same_count_diff_split	medium(9-10)	low(1-2)	1				
+viSAKadatta		viSAKA + datta	vi + SAKa + datta	member_count_diff	long(>=11)	no_dcs_freq		P.6.3.63			
+nirgarva		nis + garva	nir + garva	same_count_diff_split	short(<=8)	no_dcs_freq					
+daSaSata		daSan + Sata	daSa + Sata	same_count_diff_split	short(<=8)	no_dcs_freq					
+BadrarUpA		Badra + rUpa	Badra + rUpA	same_count_diff_split	medium(9-10)	no_dcs_freq					
+ekavarzikA		eka + varza	eka + varzikA	same_count_diff_split	medium(9-10)	no_dcs_freq					
+yajYayaSasa		yajYa + yaSas	yajYa + yaSasa	same_count_diff_split	long(>=11)	no_dcs_freq					
+agnizwoma		agni + stoma	agni + zwoma	same_count_diff_split	medium(9-10)	high(>=10)	167	P.4.3.66|P.8.3.82			
+antaHsuKa		antar + suKa	antaH + suKa	same_count_diff_split	medium(9-10)	no_dcs_freq					
+Danurgraha		Danus + graha	Danur + graha	same_count_diff_split	medium(9-10)	mid(3-9)	5	P.3.2.9			
+gOrIpuzpa		gOrI + puspa	gOrI + puzpa	same_count_diff_split	medium(9-10)	no_dcs_freq					
+yaTADikAram		yaTA + aDikAra	yaTA + DikAram	same_count_diff_split	long(>=11)	no_dcs_freq		P.4.21.32			
+alaMjIvika		alam + jIvikA	alaM + jIvika	same_count_diff_split	medium(9-10)	no_dcs_freq					
+advezarAgin		a + dvezarAga	adveza + rAgin	same_count_diff_split	long(>=11)	no_dcs_freq					
+kiMSIla		kim + SIla	kiM + SIla	same_count_diff_split	short(<=8)	mid(3-9)	7				
+cIrapattrikA		cIra + pattra	cIra + pattrikA	same_count_diff_split	long(>=11)	no_dcs_freq					
+brahmajyezWa	1	brahman + jyezWa	brahma + jyezWa	same_count_diff_split	long(>=11)	no_dcs_freq					
+nirASaNka		nis + ASaNkA	nir + ASaNka	same_count_diff_split	medium(9-10)	mid(3-9)	3				
+mahattattva		mahant + tattva	mahat + tattva	same_count_diff_split	long(>=11)	no_dcs_freq		P.3.5|P.3.5.29			
+tejapattra		tejas + pattra	teja + pattra	same_count_diff_split	medium(9-10)	no_dcs_freq					
+aparadakziRam		apara + dakziRa	apara + dakziRam	same_count_diff_split	long(>=11)	no_dcs_freq					tizWadgupraBftiH
+jaladakzaya		jalada + kzaya	jala + da + kzaya	member_count_diff	long(>=11)	no_dcs_freq					
+citradaRqaka		citra + daRqa	citra + daRqaka	same_count_diff_split	long(>=11)	no_dcs_freq					
+vyASA		vi + ASA	vy + ASA	same_count_diff_split	short(<=8)	no_dcs_freq					
+niramarza		nis + amarza	nir + amarza	same_count_diff_split	medium(9-10)	low(1-2)	2				
+aDyarDapAdya		aDyarDa + pAda	aDyarDa + pAdya	same_count_diff_split	long(>=11)	no_dcs_freq		P.5.1.34			
+sacCAstra		sant + SAstra	sac + CAstra	same_count_diff_split	medium(9-10)	no_dcs_freq		P.4.2.28|P.35.33			
+marmaspfS		marman + spfS	marma + spfS	same_count_diff_split	medium(9-10)	no_dcs_freq					
+tizyaPalA		tizya + Pala	tizya + PalA	same_count_diff_split	medium(9-10)	low(1-2)	2				
+tacCIla		tad + SIla	tac + CIla	same_count_diff_split	short(<=8)	no_dcs_freq		P.3.2.134			
+karmakft		karman + kft	karma + kft	same_count_diff_split	short(<=8)	low(1-2)	2	P.3.2.89			
+paYcavarga	2	paYcan + varga	paYca + varga	same_count_diff_split	medium(9-10)	high(>=10)	10				
+ahaMnAman		aham + nAman	ahaM + nAman	same_count_diff_split	medium(9-10)	low(1-2)	1				
+atikalyam		ati + kalya	ati + kalyam	same_count_diff_split	medium(9-10)	no_dcs_freq					
+sadvfkza		sant + vfkza	sad + vfkza	same_count_diff_split	short(<=8)	no_dcs_freq					
+gaRacakraka		gaRa + cakra	gaRa + cakraka	same_count_diff_split	long(>=11)	no_dcs_freq					
+tamomaRi		tamas + maRi	tamo + maRi	same_count_diff_split	short(<=8)	mid(3-9)	3				
+adyaSva		adya + Svas	adya + Sva	same_count_diff_split	short(<=8)	low(1-2)	1				
+padDati		pad + hati	pad + Dati	same_count_diff_split	short(<=8)	high(>=10)	29	P.4.1.45|P.4.2.38|P.6.3.54			BikzAdiH|bahvAdiH
+marmaga		marman + ga	marma + ga	same_count_diff_split	short(<=8)	no_dcs_freq					
+SuBapattrikA		SuBa + pattra	SuBa + pattrikA	same_count_diff_split	long(>=11)	no_dcs_freq					
+nirmAna		nis + mAna	nir + mAna	same_count_diff_split	short(<=8)	mid(3-9)	5				
+nirajina		nis + ajina	nir + ajina	same_count_diff_split	short(<=8)	no_dcs_freq		P.6.2.184			nirudakAdiH
+kiMvid		kim + vid	kiM + vid	same_count_diff_split	short(<=8)	no_dcs_freq					
+nistandra		nis + tandrA	nis + tandra	same_count_diff_split	medium(9-10)	mid(3-9)	4				
+kzudravaMSA		kzudra + vaMSa	kzudra + vaMSA	same_count_diff_split	long(>=11)	no_dcs_freq					
+pIvoaSva		pIvas + aSva	pIvo + aSva	same_count_diff_split	short(<=8)	no_dcs_freq					
+halipriya		halin + priya	hali + priya	same_count_diff_split	medium(9-10)	no_dcs_freq					
+jIvanASam		jIva + naS	jIva + nASam	same_count_diff_split	medium(9-10)	no_dcs_freq		P.3.4.43			
+nfpasaBa		nfpa + saBA	nfpa + saBa	same_count_diff_split	short(<=8)	no_dcs_freq					
+purUruc		puru + ruc	purU + ruc	same_count_diff_split	short(<=8)	no_dcs_freq					
+gozWAgAra		gozWa + AgAra	go + zWAgAra	same_count_diff_split	medium(9-10)	no_dcs_freq					
+durvftta	1	duz + vftta	dur + vftta	same_count_diff_split	short(<=8)	high(>=10)	63	P.4.14.7|P.10.44.32|P.22.3			
+nfsena		nar + senA	nf + sena	same_count_diff_split	short(<=8)	no_dcs_freq					
+nirjara	2	nis + jarA	nir + jara	same_count_diff_split	short(<=8)	high(>=10)	25	P.8.6.37|P.10.14.40			
+yAvadamatram		yAvant + amatra	yAvad + amatram	same_count_diff_split	long(>=11)	no_dcs_freq		P.2.1.8			
+brahmaganDa		brahman + ganDa	brahma + ganDa	same_count_diff_split	long(>=11)	no_dcs_freq					
+tadarTIya		tad + arTa	tad + arTIya	same_count_diff_split	medium(9-10)	no_dcs_freq					
+bfhatkAya		bfhant + kAya	bfhat + kAya	same_count_diff_split	medium(9-10)	no_dcs_freq		P.9.21.22			
+sadaSva	2	sant + aSva	sad + aSva	same_count_diff_split	short(<=8)	mid(3-9)	4	P.1.9.2			
+SataKaRqamaya		Sata + KaRqa	Sata + KaRqa + maya	member_count_diff	long(>=11)	no_dcs_freq					
+vikala		vi + kalA	vi + kala	same_count_diff_split	short(<=8)	high(>=10)	70	P.2.1.31|P.2.4.2|P.4.1.41|P.6.2.153|P.7.2.24|P.8.4.8|P.12.1.22|P.23.109|P.97.33			gOrAdiH
+tvaktaraMgaka		tvac + taraMga	tvak + taraMgaka	same_count_diff_split	long(>=11)	low(1-2)	1				
+karmajit		karman + jit	karma + jit	same_count_diff_split	short(<=8)	no_dcs_freq		P.9.22.45			
+duHsTita		duz + sTita	duH + sTita	same_count_diff_split	short(<=8)	high(>=10)	12	P.1.5.14			
+satkula	2	sant + kula	sat + kula	same_count_diff_split	short(<=8)	no_dcs_freq		P.16.24			
+BUpaputra		BUpa + putra	BU + pa + putra	member_count_diff	medium(9-10)	no_dcs_freq		P.124.2			
+Darasena		Dara + senA	Dara + sena	same_count_diff_split	short(<=8)	no_dcs_freq					
+SvaHSva		Svas + Svas	SvaH + Sva	same_count_diff_split	short(<=8)	no_dcs_freq					
+sAraPalgutA		sAra + Palgu	sAra + Palgu + tA	member_count_diff	long(>=11)	no_dcs_freq					
+bfhatsPij		bfhant + sPij	bfhat + sPij	same_count_diff_split	medium(9-10)	mid(3-9)	4				
+yatkfte		yad + kfte	yat + kfte	same_count_diff_split	short(<=8)	high(>=10)	16				
+Kagavaktra		Kaga + vaktra	Ka + ga + vaktra	member_count_diff	medium(9-10)	no_dcs_freq					
+nirDarma	2	nis + Darma	nir + Darma	same_count_diff_split	short(<=8)	mid(3-9)	5				
+gatanAsika		gata + nAsikA	gata + nAsika	same_count_diff_split	medium(9-10)	no_dcs_freq					
+nirASin		nis + ASA	nir + ASin	same_count_diff_split	short(<=8)	no_dcs_freq					
+puMgava		pumaMs + gava	puM + gava	same_count_diff_split	short(<=8)	high(>=10)	669	P.1.9.32|P.3.3.71|P.8.3.6|P.9.10.5			
+mfccaya		mfd + caya	mfc + caya	same_count_diff_split	short(<=8)	no_dcs_freq					
+pakzirAja		pakzin + rAja	pakzi + rAja	same_count_diff_split	medium(9-10)	high(>=10)	10				
+gojavAja		go + aja + vAja	go + javAja	member_count_diff	short(<=8)	no_dcs_freq		P.2.2.31			
+triBajIvA		triBa + jIvA	tri + Ba + jIvA	member_count_diff	medium(9-10)	no_dcs_freq					
+hastipa		hastin + pa	hasti + pa	same_count_diff_split	short(<=8)	mid(3-9)	5	P.10.43.3|P.39.18			
+aBimuKIkaraRa		aBimuKa + kar	aBimuKI + karaRa	same_count_diff_split	long(>=11)	no_dcs_freq		P.2.3.47			
+kAmamAlin		kAma + mAlA	kAma + mAlin	same_count_diff_split	medium(9-10)	no_dcs_freq					
+dvimAtra		dvi + mAtrA	dvi + mAtra	same_count_diff_split	short(<=8)	no_dcs_freq					
+bahutvakka		bahu + tvac	bahu + tvakka	same_count_diff_split	medium(9-10)	no_dcs_freq					
+dvijihva		dvi + jihvA	dvi + jihva	same_count_diff_split	short(<=8)	high(>=10)	13				
+dIptaSiKa		dIpta + SiKA	dIpta + SiKa	same_count_diff_split	medium(9-10)	no_dcs_freq					
+DAmakeSin		DAman + keSa	DAma + keSin	same_count_diff_split	medium(9-10)	no_dcs_freq					
+niHkzatra		nis + kzatra	niH + kzatra	same_count_diff_split	medium(9-10)	mid(3-9)	5	P.1.3.20|P.12.12.25			
+paYcapada		paYcan + pada	paYca + pada	same_count_diff_split	medium(9-10)	no_dcs_freq					
+paYcasidDAntikA		paYcan + sidDAnta	paYca + sidDAntikA	same_count_diff_split	long(>=11)	no_dcs_freq					
+nirgranTa		nis + granTa	nir + granTa	same_count_diff_split	medium(9-10)	high(>=10)	23	P.1.7.10			
+parauru		paras + uru	para + uru	same_count_diff_split	short(<=8)	no_dcs_freq					
+BaNgavAsA		BaNga + vAsa	BaNga + vAsA	same_count_diff_split	medium(9-10)	no_dcs_freq					
+karmakzama		karman + kzama	karma + kzama	same_count_diff_split	medium(9-10)	no_dcs_freq					
+paroviMSa		paras + viMSati	paro + viMSa	same_count_diff_split	medium(9-10)	no_dcs_freq					
+tantuBa		tantu + BA	tantu + Ba	same_count_diff_split	short(<=8)	low(1-2)	1				
+triSAlaka		tri + SAlA	tri + SAlaka	same_count_diff_split	medium(9-10)	no_dcs_freq					
+jAlagoRikA		jAla + goRI	jAla + goRikA	same_count_diff_split	medium(9-10)	no_dcs_freq					
+nfzUta		nar + sUta	nf + zUta	same_count_diff_split	short(<=8)	low(1-2)	1				
+pitfpEtAmaha		pitar + pitAmaha	pitf + pEtAmaha	same_count_diff_split	long(>=11)	high(>=10)	66	P.114.14			
+devasena		deva + senA	deva + sena	same_count_diff_split	short(<=8)	mid(3-9)	5				
+sarvadevatAmaya		sarva + devatA	sarva + deva + tAmaya	member_count_diff	long(>=11)	no_dcs_freq		P.5.23.8			
+sImAnta	1	sImA + anQa	sImA + nta	same_count_diff_split	short(<=8)	high(>=10)	11				
+ADArarUpA		ADAra + rUpa	ADAra + rUpA	same_count_diff_split	medium(9-10)	low(1-2)	1				
+antaHkopa		antar + kopa	antaH + kopa	same_count_diff_split	medium(9-10)	low(1-2)	2				
+dvigu		dvi + go	dvi + gu	same_count_diff_split	short(<=8)	high(>=10)	19	P.2.1|P.2.1.52			
+vigrIva		vi + grIvA	vi + grIva	same_count_diff_split	short(<=8)	low(1-2)	2				
+arDanAva		arDa + nO	arDa + nAva	same_count_diff_split	short(<=8)	low(1-2)	1	P.5.4.100			
+gozWAzwamI		gozWa + azwamI	go + zWAzwamI	same_count_diff_split	medium(9-10)	no_dcs_freq					
+bfhaddarBa		bfhant + darBa	bfhad + darBa	same_count_diff_split	medium(9-10)	no_dcs_freq					
+udaksena		udaYc + senA	udak + sena	same_count_diff_split	short(<=8)	low(1-2)	2				
+jIrRapattrikA		jIrRa + pattra	jIrRa + pattrikA	same_count_diff_split	long(>=11)	low(1-2)	1				
+kiMdAsa		kim + dAsa	kiM + dAsa	same_count_diff_split	short(<=8)	no_dcs_freq		P.4.1.104			
+gozAti		go + sAti	go + zAti	same_count_diff_split	short(<=8)	low(1-2)	2				
+carmataraMga		carman + taraMga	carma + taraMga	same_count_diff_split	long(>=11)	low(1-2)	1				
+tatkAlaDI		tatkAla + DI	tat + kAla + DI	member_count_diff	medium(9-10)	no_dcs_freq					
+saroja		saras + ja	saro + ja	same_count_diff_split	short(<=8)	high(>=10)	53	P.1.15.2|P.3.9.11|P.4.2.51|P.5.2.135			puzkarAdiH
+pAYcalohitika		paYcan + lohita	pAYca + lohitika	same_count_diff_split	long(>=11)	no_dcs_freq		P.5.1.28|P.7.3.17			
+KagasTAna		Kaga + sTAna	Ka + ga + sTAna	member_count_diff	medium(9-10)	no_dcs_freq					
+uzmasveda		uzman + sveda	uzma + sveda	same_count_diff_split	medium(9-10)	no_dcs_freq					
+brahmarasa		brahman + rasa	brahma + rasa	same_count_diff_split	medium(9-10)	no_dcs_freq					
+sadvftti		sant + vftti	sad + vftti	same_count_diff_split	short(<=8)	no_dcs_freq					
+SUramUrDamaya		SUra + mUrDan	SUra + mUrDamaya	same_count_diff_split	long(>=11)	no_dcs_freq					
+darakaRwikA		dara + kaRwaka	dara + kaRwikA	same_count_diff_split	long(>=11)	no_dcs_freq					
+daDyanna		daDi + anna	daDy + anna	same_count_diff_split	short(<=8)	mid(3-9)	3				
+triguRAkfta		triguRa + kfta	tri + guRAkfta	same_count_diff_split	long(>=11)	no_dcs_freq					
+maYjukeSin		maYju + keSa	maYju + keSin	same_count_diff_split	medium(9-10)	no_dcs_freq					
+gopAjihva		gopA + jihvA	go + pA + jihva	member_count_diff	medium(9-10)	no_dcs_freq					

--- a/RussianTranslation/src/pilot/compound_differs_review_sample.py
+++ b/RussianTranslation/src/pilot/compound_differs_review_sample.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""H1628 — stratified sample + review sheet for the ~4.2k PWG-vs-index compound
+`differs` queue flagged by enrich_portrait_derivation.py (H1624 G6).
+
+Never auto-adjudicates: this only samples ~200 for a human vote. The
+remaining ~4k stay `needs_human` in the sidecar until a future sampling round.
+
+  python src/pilot/compound_differs_review_sample.py --report   dry-run: strata + counts, no files written
+  python src/pilot/compound_differs_review_sample.py --write    writes the sample frame TSV + the review sheet HTML
+  python src/pilot/compound_differs_review_sample.py --selftest verify classifier + bucketing on synthetic rows
+"""
+import csv
+import io
+import json
+import os
+import random
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))          # src/pilot
+SRC = os.path.dirname(HERE)                                 # src
+REPO = os.path.dirname(SRC)                                  # RussianTranslation
+DERIV_TSV = os.path.join(SRC, 'pwg_derivation_layer.tsv')
+INDEX_TSV = os.path.join(SRC, 'headword_index.tsv')
+FREQ_TSV = os.path.join(SRC, 'pwg_freq_order.tsv')
+REVIEW_DIR = os.path.join(REPO, 'review')
+SAMPLE_FRAME_TSV = os.path.join(REVIEW_DIR, 'sanskritlexicography-pwg-compound-differs_stratified200_frame.tsv')
+SHEET_HTML = os.path.join(REVIEW_DIR, 'sanskritlexicography-pwg-compound-differs_stratified200_review.html')
+SHEET_ID = 'sanskritlexicography-pwg-compound-differs_stratified200'
+SEED = 1628          # H1628 — fixed for reproducibility of the sample frame
+TARGET_TOTAL = 200
+RARE_CLASS_QUOTA = 20   # guaranteed oversample of the rare member_count_diff class
+
+sys.path.insert(0, SRC)
+from review_sheet_standard import pwg_entry_href, slp1_iast, standard_config  # noqa: E402
+
+
+def _members(s):
+    return [m.strip() for m in (s or '').split('+') if m.strip()]
+
+
+def load_index_members(path=INDEX_TSV):
+    m = {}
+    with io.open(path, encoding='utf-8') as f:
+        for r in csv.DictReader(f, delimiter='\t'):
+            m[(r['k1'], r['hom'])] = r.get('compound_members', '')
+    return m
+
+
+def load_freq(path=FREQ_TSV):
+    m = {}
+    with io.open(path, encoding='utf-8') as f:
+        for r in csv.DictReader(f, delimiter='\t'):
+            try:
+                m[r['k1_slp1']] = int(r['count_all'])
+            except (KeyError, ValueError):
+                continue
+    return m
+
+
+def load_differs(path=DERIV_TSV):
+    rows = []
+    with io.open(path, encoding='utf-8') as f:
+        for r in csv.DictReader(f, delimiter='\t'):
+            if (r.get('compound_status') or '').strip() == 'differs':
+                rows.append(r)
+    return rows
+
+
+def vs_index_class(pwg_members, idx_members):
+    """Sub-classify a `differs` row by HOW PWG's split disagrees with the index
+    (compound_status itself is constant 'differs' for this whole queue, so it
+    cannot stratify on its own — this is the finer-grained class H1628 asked for)."""
+    if len(pwg_members) != len(idx_members):
+        return 'member_count_diff'
+    return 'same_count_diff_split'
+
+
+def length_bucket(k1):
+    n = len(k1)
+    if n <= 8:
+        return 'short(<=8)'
+    if n <= 10:
+        return 'medium(9-10)'
+    return 'long(>=11)'
+
+
+def freq_bucket(k1, freq):
+    n = freq.get(k1)
+    if n is None:
+        return 'no_dcs_freq'
+    if n <= 2:
+        return 'low(1-2)'
+    if n <= 9:
+        return 'mid(3-9)'
+    return 'high(>=10)'
+
+
+def build_frame():
+    """Return the full 4226-row frame with strata columns attached (no sampling)."""
+    idx = load_index_members()
+    freq = load_freq()
+    rows = load_differs()
+    frame = []
+    for r in rows:
+        k1, hom = r['k1'], r['hom']
+        pwg_m = _members(r['compound_members_pwg'])
+        idx_m = _members(idx.get((k1, hom), ''))
+        frame.append({
+            'k1': k1, 'hom': hom,
+            'pwg_members': ' + '.join(pwg_m),
+            'index_members': ' + '.join(idx_m),
+            'vs_index_class': vs_index_class(pwg_m, idx_m),
+            'length_bucket': length_bucket(k1),
+            'freq_bucket': freq_bucket(k1, freq),
+            'freq_count': freq.get(k1, ''),
+            'panini_sutras': r.get('panini_sutras') or '',
+            'deriv_base': r.get('deriv_base') or '', 'deriv_suffix': r.get('deriv_suffix') or '',
+            'ganas': r.get('ganas') or '',
+        })
+    return frame
+
+
+def stratified_sample(frame, seed=SEED, total=TARGET_TOTAL, rare_quota=RARE_CLASS_QUOTA):
+    """Two-stage stratified sample, deterministic under `seed`:
+    1. `member_count_diff` (rare, ~76 rows / 1.8%) gets a guaranteed flat quota —
+       proportional allocation would round it to ~1-2 items and bury a distinct
+       failure mode the review sheet exists to surface.
+    2. The remaining budget is allocated proportionally across
+       (length_bucket x freq_bucket) cells within `same_count_diff_split`,
+       largest-remainder rounding so the total lands exactly on target.
+    """
+    rng = random.Random(seed)
+    rare = [r for r in frame if r['vs_index_class'] == 'member_count_diff']
+    common = [r for r in frame if r['vs_index_class'] == 'same_count_diff_split']
+
+    rare_n = min(rare_quota, len(rare))
+    rare_sample = rng.sample(rare, rare_n)
+
+    remaining = total - rare_n
+    cells = {}
+    for r in common:
+        cells.setdefault((r['length_bucket'], r['freq_bucket']), []).append(r)
+
+    raw_quota = {k: remaining * len(v) / len(common) for k, v in cells.items()}
+    quota = {k: int(q) for k, q in raw_quota.items()}
+    shortfall = remaining - sum(quota.values())
+    # largest-remainder method for the rounding shortfall
+    remainders = sorted(raw_quota.items(), key=lambda kv: kv[1] - int(kv[1]), reverse=True)
+    for k, _ in remainders[:shortfall]:
+        quota[k] += 1
+
+    common_sample = []
+    for k, members_ in cells.items():
+        n = min(quota.get(k, 0), len(members_))
+        common_sample.extend(rng.sample(members_, n))
+
+    sample = rare_sample + common_sample
+    rng.shuffle(sample)
+    return sample
+
+
+def write_frame_tsv(sample, path=SAMPLE_FRAME_TSV):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    cols = ['k1', 'hom', 'pwg_members', 'index_members', 'vs_index_class',
+            'length_bucket', 'freq_bucket', 'freq_count', 'panini_sutras',
+            'deriv_base', 'deriv_suffix', 'ganas']
+    with io.open(path, 'w', encoding='utf-8', newline='') as f:
+        w = csv.DictWriter(f, fieldnames=cols, delimiter='\t')
+        w.writeheader()
+        for r in sample:
+            w.writerow({c: r.get(c, '') for c in cols})
+
+
+def _esc(s):
+    return (s or '').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
+
+def build_items(sample):
+    items = []
+    for r in sample:
+        k1, hom = r['k1'], r['hom']
+        iid = '%s~~h%s' % (k1, hom) if hom else k1
+        display = slp1_iast(k1)
+        href = pwg_entry_href(k1)
+        title = display + (' (h%s)' % hom if hom else '')
+        badges = [r['vs_index_class'], r['length_bucket'], r['freq_bucket']]
+        if r.get('freq_count'):
+            badges.append('DCS n=%s' % r['freq_count'])
+        question = (
+            '<p><b>PWG-членение:</b> <code>%s</code></p>'
+            '<p><b>Членение в указателе (index):</b> <code>%s</code></p>'
+            '<p style="opacity:.75">Класс расхождения: <code>%s</code></p>'
+        ) % (_esc(r['pwg_members']) or '&mdash;', _esc(r['index_members']) or '&mdash;',
+             _esc(r['vs_index_class']))
+        panels = []
+        extra = []
+        if r.get('deriv_suffix'):
+            extra.append('<b>Суффикс:</b> %s (%s), база: %s' % (
+                _esc(r['deriv_suffix']), _esc(r.get('deriv_base', '')), _esc(r.get('deriv_base', ''))))
+        if r.get('panini_sutras'):
+            extra.append('<b>Пāṇini:</b> %s' % _esc(r['panini_sutras']))
+        if r.get('ganas'):
+            extra.append('<b>Gaṇa:</b> %s' % _esc(r['ganas']))
+        if extra:
+            panels.append(('Дополнительно (deriv/pāṇini/gaṇa)', '<br>'.join(extra)))
+        item = {
+            'id': iid, 'filt': r['vs_index_class'], 'title': title, 'badges': badges,
+            'question': question, 'panels': panels,
+            'note_placeholder': 'Если верно ни PWG, ни индекс — укажите правильное членение здесь',
+        }
+        if href:
+            item['title_href'] = href
+        items.append(item)
+    return items
+
+
+def render_sheet(sample, generated):
+    from csl_pyutil import render_review_sheet
+    items = build_items(sample)
+    config = {
+        'sheet_id': SHEET_ID,
+        'title': 'PWG vs указатель: расхождения членения сложных слов (стратифицированная выборка)',
+        'subtitle': (
+            '%d карточек из очереди `differs` (~4226 всего, H1624 G6 / H1282). '
+            'Выборка стратифицирована по длине ключа, частоте DCS и классу расхождения — '
+            'см. RESULTS_LOG.md для полной методологии.' % len(sample)),
+        'footer': (
+            'Approve = PWG-членение верно (указатель будет обновлён под PWG). '
+            'Reject = членение указателя верно, PWG-слой ошибается (indeks остаётся, PWG помечается needs_correction). '
+            'Defer = нужен дополнительный контекст — решение откладывается. '
+            'Голоса НЕ закрывают всю очередь ~4.2k — только эти %d карточек; остальные остаются needs_human.'
+            % len(sample)),
+        'approve_label': 'PWG верно',
+        'reject_label': 'Индекс верно',
+        'filters': [('member_count_diff', 'Разное число членов'),
+                    ('same_count_diff_split', 'Одно число, другое членение')],
+        'generated': generated,
+        'save_as': r'RussianTranslation\review\%s_decisions.json' % SHEET_ID,
+    }
+    config.update(standard_config(save_as=config['save_as']))
+    return render_review_sheet(items, config)
+
+
+def report(frame):
+    from collections import Counter
+    print('frame rows (all differs):', len(frame))
+    print('vs_index_class:', dict(Counter(r['vs_index_class'] for r in frame)))
+    print('length_bucket:', dict(Counter(r['length_bucket'] for r in frame)))
+    print('freq_bucket:', dict(Counter(r['freq_bucket'] for r in frame)))
+
+
+def selftest():
+    assert vs_index_class(['a', 'b'], ['a', 'b']) == 'same_count_diff_split'
+    assert vs_index_class(['a', 'b', 'c'], ['a', 'b']) == 'member_count_diff'
+    assert length_bucket('a' * 5) == 'short(<=8)'
+    assert length_bucket('a' * 9) == 'medium(9-10)'
+    assert length_bucket('a' * 12) == 'long(>=11)'
+    assert freq_bucket('x', {}) == 'no_dcs_freq'
+    assert freq_bucket('x', {'x': 1}) == 'low(1-2)'
+    assert freq_bucket('x', {'x': 5}) == 'mid(3-9)'
+    assert freq_bucket('x', {'x': 50}) == 'high(>=10)'
+    fake = []
+    for i in range(500):
+        fake.append({'k1': 'k%d' % i, 'hom': '', 'vs_index_class': 'same_count_diff_split',
+                     'length_bucket': ['short(<=8)', 'medium(9-10)', 'long(>=11)'][i % 3],
+                     'freq_bucket': ['no_dcs_freq', 'low(1-2)', 'mid(3-9)', 'high(>=10)'][i % 4],
+                     'freq_count': '', 'panini_sutras': '', 'deriv_base': '', 'deriv_suffix': '', 'ganas': '',
+                     'pwg_members': 'a + b', 'index_members': 'a + c'})
+    for i in range(20):
+        fake.append({'k1': 'rare%d' % i, 'hom': '', 'vs_index_class': 'member_count_diff',
+                     'length_bucket': 'short(<=8)', 'freq_bucket': 'no_dcs_freq', 'freq_count': '',
+                     'panini_sutras': '', 'deriv_base': '', 'deriv_suffix': '', 'ganas': '',
+                     'pwg_members': 'a + b + c', 'index_members': 'a + b'})
+    s1 = stratified_sample(fake, seed=42, total=60, rare_quota=10)
+    s2 = stratified_sample(fake, seed=42, total=60, rare_quota=10)
+    assert len(s1) == 60, len(s1)
+    assert [r['k1'] for r in s1] == [r['k1'] for r in s2], 'sample must be deterministic under a fixed seed'
+    assert sum(1 for r in s1 if r['vs_index_class'] == 'member_count_diff') == 10
+    print('selftest OK — classifier, buckets, deterministic stratified sampling (n=%d)' % len(s1))
+
+
+def main():
+    args = sys.argv[1:]
+    if '--selftest' in args:
+        selftest()
+        return
+    frame = build_frame()
+    if '--report' in args or not args:
+        report(frame)
+        return
+    if '--write' in args:
+        sample = stratified_sample(frame)
+        write_frame_tsv(sample)
+        html = render_sheet(sample, generated='26-07-2026')
+        os.makedirs(REVIEW_DIR, exist_ok=True)
+        with io.open(SHEET_HTML, 'w', encoding='utf-8') as f:
+            f.write(html)
+        print('wrote %d-row sample frame -> %s' % (len(sample), SAMPLE_FRAME_TSV))
+        print('wrote review sheet -> %s' % SHEET_HTML)
+        return
+    sys.exit('usage: compound_differs_review_sample.py --report | --write | --selftest')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Stratified (seed=1628, deterministic), two-stage sample of 200 items from the ~4226-row PWG-vs-index compound `differs` queue flagged by [H1624 G6](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1624-Opus_SanskritLexicography_pwg-german-layers-backlog-ordered_25.07.26.md) (`enrich_portrait_derivation.py`, H1282 residue).
- New [`src/pilot/compound_differs_review_sample.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/compound_differs_review_sample.py) — `--report`/`--write`/`--selftest`.
- Guaranteed flat quota (20) for the rare `member_count_diff` sub-class (76/4226, 1.8%); remaining 180 proportional across length x DCS-frequency cells (largest-remainder rounding).
- Sample frame (metadata only, no `ru`/`de` store text) committed at `RussianTranslation/review/sanskritlexicography-pwg-compound-differs_stratified200_frame.tsv`. Interactive HTML sheet generated via `csl_pyutil.render_review_sheet` (19-07-2026 V1-V8 standard) and stays **gitignored** per the `/review-sheet` contract — personal voting artifact.
- Sample design + vote->store contract documented in [RESULTS_LOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md) — the future decisions.json apply step can only stamp `derivation.human_reviewed` on the ~200 sampled `(k1,hom)` ids, never bulk-overwrite the rest.
- Non-goal (explicit): the remaining ~4026 `differs` rows stay `needs_human` — this sheet closes zero rows on its own until MG votes.

## Test plan
- [x] `python src/pilot/compound_differs_review_sample.py --selftest` (classifier + deterministic stratified sampling)
- [x] `python src/pilot/enrich_portrait_derivation.py --selftest` (unaffected, still green)
- [x] `python -m py_compile src/pilot/compound_differs_review_sample.py`
- [x] `--write` run produces 200-row frame TSV + sheet HTML, strata verified against target proportions

🤖 Generated with [Claude Code](https://claude.com/claude-code)