### PR TITLE
chore(release): cut v1.70.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.70.0] — 2026-07-26
+
 ### Added
 
 - **Selftest isolation guard — production data unreachable by construction (26-07-2026).**


### PR DESCRIPTION
Promotes the `[Unreleased]` block landed by [#761](https://github.com/gasyoun/SanskritLexicography/pull/761) to `1.70.0`. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)