### PR TITLE
chore(release): cut v1.71.0

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.71.0] — 2026-07-26
+
 ### Added — H1628: stratified 200-item review sheet for the compound `differs` queue (26-07-2026)
 
 - [`src/pilot/compound_differs_review_sample.py`](src/pilot/compound_differs_review_sample.py)

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.71.0] — 2026-07-26
+
 ### Added
 - **First intrinsic BLI quality gate for RussianTranslation's `corpus_lexicon.jsonl` (H1521, 26-07-2026).**
   [`RussianTranslation/src/eval/bli_eval.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/eval/bli_eval.py)


### PR DESCRIPTION
Promotes [Unreleased] to v1.71.0: H1521 BLI eval quality gate for `corpus_lexicon.jsonl` + H1628 stratified review sheet for the compound `differs` queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)