### PR TITLE
chore(release): cut v1.72.0

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.72.0] — 2026-07-26
+
 ### Added — H1491: Leonchenko Sinonimy digitized to a synonym evidence lane (26-07-2026)
 
 - [`research/sinonimy/sinonimy.jsonl`](research/sinonimy/README.md) (47,273 rows) digitizes

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,17 @@ not an error.
 
 ## [Unreleased]
 
+## [1.72.0] — 2026-07-26
+
+### Added
+- **H1633 human gold-cut design + A51 methods packet (26-07-2026).** First sampling
+  design for a human-measured DE→RU store precision figure
+  ([RussianTranslation/gold/STORE_DE_RU_GOLD_CUT_SAMPLE_FRAME.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/gold/STORE_DE_RU_GOLD_CUT_SAMPLE_FRAME.md),
+  n=400 recommended, 12 strata, tiered κ plan with no invented metrics, parked for
+  sign-off) + the A51 methods-section draft with a 10-row claims register
+  ([RussianTranslation/pwg_ru/A51_METHODS_DRAFT_DE_LAYERS_RU_PIPELINE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/A51_METHODS_DRAFT_DE_LAYERS_RU_PIPELINE.md)).
+- **H1491 Leonchenko Sinonimy evidence lane** (see RussianTranslation/CHANGELOG.md).
+
 ## [1.71.0] — 2026-07-26
 
 ### Added


### PR DESCRIPTION
Promotes the two [Unreleased] entries (H1633 gold-cut frame + A51 methods packet, [PR #772](https://github.com/gasyoun/SanskritLexicography/pull/772); H1491 Sinonimy evidence lane, [PR #773](https://github.com/gasyoun/SanskritLexicography/pull/773)) to **v1.72.0** in [RussianTranslation/CHANGELOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/CHANGELOG.md) + [changelog.md](https://github.com/gasyoun/SanskritLexicography/blob/master/changelog.md), per /cut-release. Tag + GitHub release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)