### PR TITLE
chore(release): cut v1.73.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.69.0
+version: 1.73.0
 date-released: "2026-07-26"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.73.0] - 2026-07-26
+
 ### Added — H1656 Rāmāyaṇa recension concordances (Gorresio↔Southern + Southern↔Critical) (26-07-2026)
 
 - MG ruled 21-07-2026 (weekly `@DECIDE`): build the Gorresio↔Southern concordance —


### PR DESCRIPTION
Promotes the H1656 [Unreleased] entries to [1.73.0] and syncs CITATION.cff (was lagging at 1.69.0). Tag + GitHub release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)