### PR TITLE
H1666: Wave-2 coverage monitor for the pwg_ru verb-root drain

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,16 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added — H1666: Wave-2 coverage monitor + monthly cloud routine (26-07-2026)
+
+- [`research/WAVE2_COVERAGE_MONITOR.md`](research/WAVE2_COVERAGE_MONITOR.md) tracks
+  `verb_worklist.py`'s promoted/749-DCS-root % against
+  [ROADMAP_ACL_LESSONS_2026.md](research/ROADMAP_ACL_LESSONS_2026.md)'s Wave-2
+  "~50% coverage" trigger — currently 48/749 ≈ 6.4%, stalled since 04-07-2026. A
+  monthly `claude.ai` cloud routine (RemoteTrigger) recomputes and appends a row,
+  and flags a GTD `@DECIDE` in Uprava once coverage crosses 50%. Registered in
+  `research/README.md`'s Living monitors table.
+
 ## [1.73.0] - 2026-07-26
 
 ### Added — H1656 Rāmāyaṇa recension concordances (Gorresio↔Southern + Southern↔Critical) (26-07-2026)

--- a/RussianTranslation/research/README.md
+++ b/RussianTranslation/research/README.md
@@ -31,6 +31,7 @@ classifications/method-maps so they never get stranded in an ephemeral handoff:
 |---|---|
 | [ACL_ANTHOLOGY_MONITOR.md](ACL_ANTHOLOGY_MONITOR.md) | Monthly ACL-Anthology / NLP-for-DH monitor mapped onto the pwg_ru subsystems (judge · TM · terminology · structured-output · Sanskrit-NLP · data-docs · **word/sentence alignment** · **speech-translation alignment**), each entry with an `Actionable for us?` verdict. Includes the **"three publication-grade TM gaps → NLP directions"** map (verse→word alignment, per-segment QE grading, retrieval-TM). Codex automation `monthly-acl-anthology-sanskrit-nlp-monitor` appends to it. |
 | [INTERVIEWS.md](INTERVIEWS.md) | Recorded conversations with researchers/practitioners relevant to this direction (video + transcript + `Actionable for us?` verdict) — the conversation-shaped twin of the paper-shaped ACL monitor above. |
+| [WAVE2_COVERAGE_MONITOR.md](WAVE2_COVERAGE_MONITOR.md) | H1666 (26-07-2026): tracks the `verb_worklist.py` promoted/749-DCS-root % against Wave 2's "~50% coverage" trigger (currently 6.4%, stalled since 04-07-2026). Monthly `claude.ai` cloud routine appends a row and flags a GTD `@DECIDE` once ≥50%. |
 
 
 ## Data assets

--- a/RussianTranslation/research/WAVE2_COVERAGE_MONITOR.md
+++ b/RussianTranslation/research/WAVE2_COVERAGE_MONITOR.md
@@ -1,0 +1,50 @@
+# Wave-2 coverage monitor — pwg_ru verb-root drain vs the B2/B1/B3 gate
+
+_Created: 26-07-2026 · Last updated: 26-07-2026_
+
+Living monitor (append-only, like [ACL_ANTHOLOGY_MONITOR.md](ACL_ANTHOLOGY_MONITOR.md))
+tracking [ROADMAP_ACL_LESSONS_2026.md](ROADMAP_ACL_LESSONS_2026.md)'s Wave-2 trigger:
+"**Wave 2 (after ~50% coverage):** B1 gold set + scoring, B2 synset crosswalk +
+benchmark packaging (including [sinonimy/](sinonimy/README.md)'s standalone
+PWG-sense crosswalk, scoped out of H1491), B3 milestones 4–5." Minted H1666
+(26-07-2026) after a user question about when Sinonimy gets wired in — the
+roadmap gates that on this number, not a date.
+
+## Metric
+
+`RussianTranslation/src/pilot/verb_worklist.py`'s own defined scope: the
+`verbs01` case-header universe (1,882 PWG roots) ∩ `scale_manifest.freq.json`
+DCS-attestation → **749 DCS-attested roots**, the fixed denominator. Coverage
+= roots promoted into `src/pwg_ru_translated.jsonl` / 749. **50% = 375/749
+promoted.**
+
+Recompute:
+```sh
+cd RussianTranslation && python src/pilot/verb_worklist.py
+```
+Reads the `promoted: N REMAINING: M` line from stdout; `N` is the numerator.
+
+**Not the metric:** the store also holds 11,000+ sense rows across 254
+`key1` cards — most are non-root sub-cards (derived nominals, PW/SCH
+addenda) that don't count toward the 749-root universe. Root-count is the
+only metric the roadmap's "coverage" language maps to (Wave-1's translation
+drain is root-by-root).
+
+## Log
+
+| Date | Promoted | Denominator | % | Δ since last | Source |
+|---|---|---|---|---|---|
+| 04-07-2026 | 48 | 749 | 6.4% | — | `.ai_state.md` line 1123 |
+| 26-07-2026 | 48 | 749 | 6.4% | +0 (3-week stall) | H1666 dig — fresh re-run of `verb_worklist.py` reproduced the identical 04-07-2026 figure |
+
+## Watcher
+
+A monthly `claude.ai` cloud routine (RemoteTrigger, created H1666) re-runs the
+recompute command above on the 1st of each month, appends a row to the Log
+table, and — the first time promoted/749 ≥ 0.50 — opens/updates a GTD
+`@DECIDE` row in
+[Uprava/GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md)
+flagging the Wave-2 gate as reached, then stops flagging (one-time flip, not
+recurring noise). See H1666 for the routine ID and prompt.
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
## Summary
- Adds `research/WAVE2_COVERAGE_MONITOR.md`, a living monitor tracking `verb_worklist.py`'s promoted/749-DCS-root percentage against [ROADMAP_ACL_LESSONS_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/ROADMAP_ACL_LESSONS_2026.md)'s Wave-2 "~50% coverage" trigger (the gate that unblocks B1 gold-set scoring, B2's synset crosswalk + Sinonimy standalone crosswalk, B3 milestones 4-5).
- Current number: **48/749 ≈ 6.4%**, stalled since 04-07-2026 (verified via a fresh re-run today).
- Registered in `research/README.md`'s Living monitors table + a changelog entry.
- A monthly `claude.ai` cloud routine (RemoteTrigger) recomputes this and appends a dated row; once coverage crosses 50% it flags a GTD `@DECIDE` row in Uprava (one-time flip, not recurring noise).

Handoff: [H1666](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1666-Sonnet_SanskritLexicography_wave2-coverage-monitor_26.07.26.md)

## Test plan
- [x] `python src/pilot/verb_worklist.py` reproduces the logged 48/749 figure
- [x] Markdown links resolve, dated header present

🤖 Generated with [Claude Code](https://claude.com/claude-code)