### PR TITLE
docs: correct the "bigger corpus" lever for H1632 constriction 1 (DCS is already the largest TAGGED corpus)

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -3559,13 +3559,26 @@ upper bound it is — a grounded link identifies one sense at one locus, not eve
 lemma.
 
 **Scaling settled it (26-07-2026): three independent constrictions multiply, and compute fixes
-none of the first two.** (1) 60.2% of PWG headwords are absent from DCS entirely — only a
-bigger corpus helps. (2) 88.8% of DCS token mass carries no `m_wordsem` tag — upstream
-annotation coverage, 219/270 texts. (3) Only the *residue* after those two is a matcher/locus
-problem, and it needs texts and crosswalks (Pañcatantra, Kathāsaritsāgara, vulgate↔BORI drift),
-not a better algorithm. So the honest ceiling for any sense-level PWG×DCS product is set by
-(1) and (2) long before matcher quality matters — running the pilot over the whole dictionary
-raised confidence in the diagnosis, not the coverage.
+none of the first two.** (1) 60.2% of PWG headwords are absent from DCS entirely. (2) 88.8% of
+DCS token mass carries no `m_wordsem` tag — upstream annotation coverage, 219/270 texts.
+(3) Only the *residue* after those two is a matcher/locus problem, and it needs texts and
+crosswalks (Pañcatantra, Kathāsaritsāgara, vulgate↔BORI drift), not a better algorithm. So the
+honest ceiling for any sense-level PWG×DCS product is set by (1) and (2) long before matcher
+quality matters — running the pilot over the whole dictionary raised confidence in the
+diagnosis, not the coverage.
+
+**"Get a bigger corpus" is NOT an available lever for (1) — MG, 26-07-2026.** DCS already *is*
+the largest **tagged** Sanskrit corpus; the corpora that are bigger carry **no markup**
+(wisdomlib, currently under scrape). An untagged corpus therefore **can** raise *lemma-level*
+attestation — shrinking the 60.2% "absent everywhere" class, which is a real and separate
+result — but **cannot** raise *sense-level* grounding, because there are no sense tags to bind
+to and none to be had without lemmatising and tagging it ourselves. Treating an untagged corpus
+as a fix for the sense-level number is a category error; keep the two rates in separate tables.
+This repo already consumes a `wl` wisdomlib signal for period-state tagging (§14) — extend that
+lane rather than opening a second one, and check the Cloudflare reality
+([Uprava FINDINGS §4](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)) before any
+scrape. Follow-on:
+[H1670](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1670-Opus_SanskritLexicography_pwg-dcs-sense-grounding-scale-levers_26.07.26.md).
 
 > **Source:** H1632 pilot join + 26-07-2026 scale-up (random + full-PWG frames,
 > [PR #763](https://github.com/gasyoun/SanskritLexicography/pull/763)),

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,23 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — "a bigger corpus" was the wrong lever for H1632 constriction 1 (26-07-2026)
+
+- The H1632 frame-comparison report and SL FINDINGS §465 said the 60.2% of PWG
+  headwords absent from DCS needs "a bigger corpus". **Misleading as written**
+  (MG): *DCS already is the largest **tagged** Sanskrit corpus*; the corpora that
+  are bigger carry **no markup** — wisdomlib, currently under scrape.
+- Both now state the split precisely: an untagged corpus **can** raise
+  *lemma-level* attestation (shrinking the "absent everywhere" class) but
+  **cannot** raise *sense-level* grounding, since there are no sense tags to bind
+  to. Conflating the two is a category error; the rates stay in separate tables.
+- Points at the existing `wl` wisdomlib period-state signal (§14) so a second
+  wisdomlib lane is not opened, and at the Cloudflare constraint before any scrape.
+- Follow-on work minted as
+  [H1670](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1670-Opus_SanskritLexicography_pwg-dcs-sense-grounding-scale-levers_26.07.26.md):
+  the only real levers on the sense-level number are running the H1455 aligner
+  past its own 500 headwords, and adding texts / locus crosswalks.
+
 ### Added — H1666: Wave-2 coverage monitor + monthly cloud routine (26-07-2026)
 
 - [`research/WAVE2_COVERAGE_MONITOR.md`](research/WAVE2_COVERAGE_MONITOR.md) tracks

--- a/RussianTranslation/research/PWG_SENSE_DCS_FRAME_COMPARISON.md
+++ b/RussianTranslation/research/PWG_SENSE_DCS_FRAME_COMPARISON.md
@@ -37,11 +37,22 @@ Three independent constrictions multiply, and only the third is a tractable engi
 
 | # | Constriction | Size | Can more compute fix it? |
 |---|---|---:|---|
-| 1 | PWG headwords with no DCS lemma at all | 60.2% of PWG | **No** — the word is not in the corpus. Only a bigger corpus helps. |
+| 1 | PWG headwords with no DCS lemma at all | 60.2% of PWG | **No** — and **not by a bigger tagged corpus either**: DCS already *is* the largest tagged Sanskrit corpus. See the note below. |
 | 2 | DCS tokens with no `m_wordsem` sense tag | 88.8% of token mass | **No** — upstream annotation coverage (219/270 texts). |
 | 3 | Attested + tagged, but no shared locus to bind a PWG sense | the residue | **Partly** — needs texts and locus crosswalks (Pañcatantra, Kathāsaritsāgara; vulgate↔BORI drift), not a better matcher. |
 
 Scaling the pilot to the whole dictionary — done here — therefore did not and could not raise the grounding rate. It raised **confidence in the diagnosis**: the constraint is data availability at three separate layers, and the honest ceiling for a sense-level PWG×DCS product is set by constrictions 1 and 2 long before matcher quality matters.
+
+### Note — "a bigger corpus" is not an available lever (MG, 26-07-2026)
+
+**DCS is already the largest *tagged* Sanskrit corpus.** The corpora that are bigger carry **no markup** — wisdomlib being the live example, currently under scrape. That splits constriction 1 in a way worth stating precisely, because conflating the two is an easy category error:
+
+| An untagged corpus… | effect |
+|---|---|
+| …raises **lemma-level attestation** (is the headword attested anywhere?) | **yes** — it can shrink the 60.2% "absent everywhere" class |
+| …raises **sense-level grounding** | **no** — there are no sense tags to bind to, and none to be had without lemmatising and tagging it ourselves |
+
+So the realistic levers on the sense-level number are constriction 3 only: run the H1455 aligner over a bigger frame (it has never been run past its own 500 headwords), and add texts / locus crosswalks. Follow-on: [H1670](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1670-Opus_SanskritLexicography_pwg-dcs-sense-grounding-scale-levers_26.07.26.md).
 
 ## Per-frame reports
 

--- a/RussianTranslation/research/compare_frames.py
+++ b/RussianTranslation/research/compare_frames.py
@@ -168,8 +168,9 @@ def main():
     L.append('')
     L.append('| # | Constriction | Size | Can more compute fix it? |')
     L.append('|---|---|---:|---|')
-    L.append('| 1 | PWG headwords with no DCS lemma at all | %s of PWG | **No** — the '
-             'word is not in the corpus. Only a bigger corpus helps. |'
+    L.append('| 1 | PWG headwords with no DCS lemma at all | %s of PWG | **No** — and '
+             '**not by a bigger tagged corpus either**: DCS already *is* the largest '
+             'tagged Sanskrit corpus. See the note below. |'
              % pct(1 - p_pop))
     L.append('| 2 | DCS tokens with no `m_wordsem` sense tag | %s of token mass | '
              '**No** — upstream annotation coverage (219/270 texts). |'
@@ -183,6 +184,26 @@ def main():
              'diagnosis**: the constraint is data availability at three separate layers, '
              'and the honest ceiling for a sense-level PWG×DCS product is set by '
              'constrictions 1 and 2 long before matcher quality matters.')
+    L.append('')
+    L.append('### Note — "a bigger corpus" is not an available lever (MG, 26-07-2026)')
+    L.append('')
+    L.append('**DCS is already the largest *tagged* Sanskrit corpus.** The corpora that '
+             'are bigger carry **no markup** — wisdomlib being the live example, '
+             'currently under scrape. That splits constriction 1 in a way worth stating '
+             'precisely, because conflating the two is an easy category error:')
+    L.append('')
+    L.append('| An untagged corpus… | effect |')
+    L.append('|---|---|')
+    L.append('| …raises **lemma-level attestation** (is the headword attested anywhere?) '
+             '| **yes** — it can shrink the %s "absent everywhere" class |'
+             % pct(1 - p_pop))
+    L.append('| …raises **sense-level grounding** | **no** — there are no sense tags to '
+             'bind to, and none to be had without lemmatising and tagging it ourselves |')
+    L.append('')
+    L.append('So the realistic levers on the sense-level number are constriction 3 only: '
+             'run the H1455 aligner over a bigger frame (it has never been run past its '
+             'own 500 headwords), and add texts / locus crosswalks. Follow-on: '
+             '[H1670](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1670-Opus_SanskritLexicography_pwg-dcs-sense-grounding-scale-levers_26.07.26.md).')
     L.append('')
 
     L.append('## Per-frame reports')


### PR DESCRIPTION
## The correction

H1632's frame-comparison report and [SL FINDINGS §465](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) said the **60.2%** of PWG headwords absent from DCS needs `a bigger corpus`. That is misleading as written (MG, 26-07-2026):

> **DCS already *is* the largest tagged Sanskrit corpus.** The corpora that are bigger carry **no markup** — wisdomlib being the live example, currently under scrape.

## What both surfaces now say

| An untagged corpus… | effect |
|---|---|
| …raises **lemma-level attestation** | **yes** — it can shrink the 60.2% `absent everywhere` class |
| …raises **sense-level grounding** | **no** — no sense tags to bind to, and none to be had without lemmatising + tagging it ourselves |

Conflating the two would be a category error, so the rates stay in separate tables. The realistic levers on the sense-level number are constriction 3 only: run the H1455 aligner past its own 500 headwords (it has never been run wider), and add texts / locus crosswalks.

Also wired in: the existing `wl` wisdomlib period-state signal ([FINDINGS §14](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)) so a **second** wisdomlib lane is not opened, and the Cloudflare path-scoped block ([Uprava FINDINGS §4](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)) before any scrape is attempted.

## Follow-on

Minted **[H1670](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1670-Opus_SanskritLexicography_pwg-dcs-sense-grounding-scale-levers_26.07.26.md)** — aligner-at-scale + locus crosswalks, with the untagged-corpus lever scoped to lemma-level only and a non-goal forbidding any claim that it lifts sense grounding.

## Verification

Regenerating all three frames reproduced the reports and TSVs **byte-identically** (line endings aside) — only the comparison doc changed, confirming the generators are deterministic. No measured value moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)