### PR TITLE
chore(release): 1.74.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.73.0
+version: 1.74.0
 date-released: "2026-07-26"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.74.0] - 2026-07-26
+
 ### Fixed — "a bigger corpus" was the wrong lever for H1632 constriction 1 (26-07-2026)
 
 - The H1632 frame-comparison report and SL FINDINGS §465 said the 60.2% of PWG

--- a/RussianTranslation/CITATION.cff
+++ b/RussianTranslation/CITATION.cff
@@ -16,7 +16,7 @@ authors:
     affiliation: "Институт лингвистических исследований РАН (ИЛИ РАН)"
 repository-code: "https://github.com/gasyoun/SanskritLexicography"
 license: "CC-BY-SA-4.0"
-version: "1.69.0"
+version: "1.74.0"
 date-released: "2026-07-26"
 keywords:
   - sanskrit


### PR DESCRIPTION
Promotes two merged entries to **v1.74.0**.

- **Fixed** — the H1632 `bigger corpus` lever correction: DCS is already the largest *tagged* Sanskrit corpus, so an untagged corpus (wisdomlib) can raise lemma-level attestation but never sense-level grounding. Follow-on minted as [H1670](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1670-Opus_SanskritLexicography_pwg-dcs-sense-grounding-scale-levers_26.07.26.md).
- **Added** — H1666 Wave-2 coverage monitor + monthly cloud routine.

`CITATION.cff` synced at the freeze: repo-level 1.73.0 → 1.74.0, pwg_ru dataset CFF 1.69.0 → 1.74.0.

Tag + release follow this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)