### PR TITLE
chore(release): cut v1.75.0

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.75.0] — 2026-07-26
+
 ### Changed — H1633 rulings R1–R5 recorded; G6b gate born; A51 deferred to 2028 (26-07-2026)
 
 - MG ruled the five gold-cut sign-off items in one pass (chat, 26-07-2026):

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.75.0] — 2026-07-26
+
 ### Added
 - **H1657 — ACC×NCC P2 agent adjudication of all 49,019 Tier C/D rows (26-07-2026).**
   Per MG's ruling В2, the adjudicator moves from a human to an agent while the


### PR DESCRIPTION
Promotes the [Unreleased] entries to **v1.75.0**: H1633 rulings R1–R5 + G6b gate + A51 deferral ([PR #780](https://github.com/gasyoun/SanskritLexicography/pull/780)) and H1657 ACC×NCC 49k agent adjudication ([PR #781](https://github.com/gasyoun/SanskritLexicography/pull/781), root changelog). Tag + GitHub release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)