### PR TITLE
docs(pwg_ru): H1664 voting-queue triage results + v1.76.0 changelog

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,19 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.76.0] — 2026-07-26
+
+### Changed — H1664 voting-queue triage: every pending sheet ruled A/HYBRID/HUMAN-ONLY (26-07-2026)
+
+Fable 5 (`claude-fable-5`). The 2,962-judgment pending queue (42 sheets org-wide) now
+carries a verdict per sheet with the enabling dataset named —
+[audit §11](https://github.com/gasyoun/Uprava/blob/main/docs/VOTING_SHEET_SCREENING_AUDIT_26-07-2026.md);
+after the routed adjudications run, the human owes ~1,329 (−55 %). pwg_ru lanes: compound
+`differs` → В2 full-queue adjudication (H1681, the 200-sheet becomes the blind verification
+arm), h1303_abbrev → rule-collapse (H1682, 273 → ~30), article-comparison → pre-vote
+source-check (H1683); G6/G5v3/h1306/Renou-pilot stay HUMAN-ONLY with the reason recorded.
+Results table: [RESULTS_LOG.md 26-07-2026](RESULTS_LOG.md).
+
 ## [1.75.0] — 2026-07-26
 
 ### Changed — H1633 rulings R1–R5 recorded; G6b gate born; A51 deferred to 2028 (26-07-2026)

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -4,6 +4,36 @@ _Created: 09-07-2026 · Last updated: 26-07-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
+## 26-07-2026 - H1664: voting-queue triage — a verdict for every pending sheet, human bill recounted
+
+Executor: Fable 5 (`claude-fable-5`),
+[H1664](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1664-Fable_SanskritLexicography_voting-queue-agent-adjudication-triage_26.07.26.md).
+Full verdict table (all 42 pending sheets org-wide, each with its enabling dataset):
+[VOTING_SHEET_SCREENING_AUDIT_26-07-2026.md §11](https://github.com/gasyoun/Uprava/blob/main/docs/VOTING_SHEET_SCREENING_AUDIT_26-07-2026.md).
+
+| Bucket | Sheets | Judgments now | Owed after routing |
+|---|---|---|---|
+| AGENT-RULEABLE | 1 (+2 zombie rows) | 17 | 0 |
+| HYBRID (В2: agent adjudicates, human votes a blind stratified arm) | 20 | 2,282 | ~666 |
+| HUMAN-ONLY | 21 | 663 | 663 |
+| **Pending queue total** | **42** | **2,962** | **~1,329 (−55 %)** |
+| acc_ncc lane (rerouted 26-07, executed; post-H1671 key repair the C/D set is 10,614) | 1 | 49,019 | 698 |
+
+SL-specific outcomes: compound-`differs` goes В2 —
+[H1681](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1681-Opus_SanskritLexicography_pwg-compound-differs-b2-full-queue-adjudication_26.07.26.md)
+adjudicates all ~4,226 and the H1628 200-card sheet becomes the blind verification arm (same
+200 votes then close the whole queue); h1303_abbrev collapses to rule-level cards
+([H1682](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1682-Sonnet_SanskritLexicography_h1303-abbrev-rule-collapse_26.07.26.md),
+273 → ~30); the 32 article-comparison edits get source-checked pre-vote
+([H1683](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1683-Sonnet_SanskritLexicography_article-comparison-source-check_26.07.26.md));
+h180 stays routed via H1650. HUMAN-ONLY (kept, with the why): G6 gold starter (the label is
+the instrument), G5 batch1v3 (already the В2 human arm), h1306 style, Renou pilot 70,
+Kochergina 4. The acc_ncc blind spot-check (698 rows post-H1671 re-draw; the pre-repair 686 sample was voided unvoted) is now registered in
+[REVIEW_SHEETS_INDEX.md](https://github.com/gasyoun/Uprava/blob/main/REVIEW_SHEETS_INDEX.md)
+the H1671 sequencing gate resolved itself the same day — the key repair merged ([PR #785](https://github.com/gasyoun/SanskritLexicography/pull/785)) and the fresh sample is safe to vote. HY "after" numbers
+are planning estimates — exact arm sizes derive per stratum at execution
+([PR #783](https://github.com/gasyoun/SanskritLexicography/pull/783) pattern).
+
 ## 26-07-2026 - H1628: stratified 200-item review sheet, PWG-vs-index compound `differs` (H1624 G6 residual)
 
 Executor: Sonnet 5 (`claude-sonnet-5`). Sampled from the ~4226-row `differs` queue the

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,19 @@ not an error.
 
 ## [Unreleased]
 
+## [1.76.0] — 2026-07-26
+
+### Added
+- **H1664 — voting-queue triage: a verdict for every pending review sheet (26-07-2026).**
+  Fable 5 (`claude-fable-5`). All 42 pending sheets (2,962 queued human judgments) ruled
+  AGENT-RULEABLE (1) / HYBRID-В2 (20) / HUMAN-ONLY (21), each with its enabling dataset,
+  in [VOTING_SHEET_SCREENING_AUDIT_26-07-2026.md §11](https://github.com/gasyoun/Uprava/blob/main/docs/VOTING_SHEET_SCREENING_AUDIT_26-07-2026.md);
+  human bill drops to ~1,329 (−55 %) once the routed adjudications (H1681–H1688) execute,
+  on top of the acc_ncc lane already banked by H1657 — post-H1671 key repair: 10,614 Tier C/D rows agent-adjudicated, human owes the fresh blind 698-card sample. SL lanes routed:
+  compound-`differs` В2 (H1681), h1303 abbrev rule-collapse (H1682), article-comparison
+  source-check (H1683). Detail table:
+  [RussianTranslation/RESULTS_LOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md).
+
 ### Fixed
 - **H1671 — the NCC `match_key` case bug is repaired and the whole ACC×NCC pipeline
   re-ran on corrected keys (26-07-2026, closes [integrity issue #779](https://github.com/gasyoun/SanskritLexicography/issues/779)).**


### PR DESCRIPTION
**Handoff:** [H1664](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1664-Fable_SanskritLexicography_voting-queue-agent-adjudication-triage_26.07.26.md) — executed by Fable 5 (`claude-fable-5`).

Records the full voting-queue triage in this repo's surfaces:

- [RussianTranslation/RESULTS_LOG.md](https://github.com/gasyoun/SanskritLexicography/blob/docs/h1664-triage-results/RussianTranslation/RESULTS_LOG.md) — before/after table: **42 pending sheets / 2,962 judgments → ~1,329 (−55 %)** after the routed adjudications; acc_ncc lane already 49,019 → 686 (H1657).
- [RussianTranslation/CHANGELOG.md](https://github.com/gasyoun/SanskritLexicography/blob/docs/h1664-triage-results/RussianTranslation/CHANGELOG.md) + root [changelog.md](https://github.com/gasyoun/SanskritLexicography/blob/docs/h1664-triage-results/changelog.md) — v1.76.0 entries.

Verdict table (all 42 sheets, enabling dataset per sheet): [VOTING_SHEET_SCREENING_AUDIT_26-07-2026.md §11](https://github.com/gasyoun/Uprava/blob/main/docs/VOTING_SHEET_SCREENING_AUDIT_26-07-2026.md). SL execution lanes minted: [H1681](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1681-Opus_SanskritLexicography_pwg-compound-differs-b2-full-queue-adjudication_26.07.26.md) (compound differs В2) · [H1682](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1682-Sonnet_SanskritLexicography_h1303-abbrev-rule-collapse_26.07.26.md) (abbrev rule-collapse) · [H1683](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1683-Sonnet_SanskritLexicography_article-comparison-source-check_26.07.26.md) (article-comparison source-check).

Docs-only; no store, sheet, or fenced file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)