### PR TITLE
chore(release): cut v1.76.0 — H1671 NCC match_key repair

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.74.0
+version: 1.76.0
 date-released: "2026-07-26"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported


### PR DESCRIPTION
Promotes the H1671 `[Unreleased]` entries from [PR #785](https://github.com/gasyoun/SanskritLexicography/pull/785) to **v1.76.0**, and syncs `CITATION.cff`, which had lagged at 1.74.0 through the 1.75.0 cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)