### PR TITLE
chore(release): cut v1.77.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 1.2.0
+cff-version: 1.77.0
 type: software
 title: SanskritLexicography
 message: >

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.77.0] - 2026-07-26
+
 ### Added — H1656 follow-on: Gorresio e-text recovered; Rāmāyaṇa citation reuse ON (26-07-2026)
 
 - **MG ruled: reuse always ON by default** — the validation gate is an audit, not a


### PR DESCRIPTION
Promotes the H1656 follow-on [Unreleased] entries (Gorresio e-text + reuse ON + aligner fix) to [1.77.0]; CITATION.cff synced. Tag + release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)