### PR TITLE
feat(pwg_ru): H1651 follow-up -- wire D1/D3 into the live generation-time gate

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -2,6 +2,28 @@
 
 _Created: 09-07-2026 · Last updated: 26-07-2026_
 
+> **H1651 🔴 EXECUTED 26-07-2026 (Sonnet 5 `claude-sonnet-5`), isolated worktree, two
+> concurrent sessions** — pwg_ru store wrapper-defect sweep D1–D4:
+> [H1651_WRAPPER_DEFECT_SWEEP_REPORT_2026-07-26.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1651_WRAPPER_DEFECT_SWEEP_REPORT_2026-07-26.md)
+> (+ Addendum). **Main pass** ([PR #789](https://github.com/gasyoun/SanskritLexicography/pull/789),
+> merged): D1 repaired (34 rows/58 spans, issue [#752](https://github.com/gasyoun/SanskritLexicography/issues/752)
+> closed); D3 ruled ({%..%} is the store convention per `DATA_STATEMENT.md` §D) and
+> bulk-applied under an exact DE-gloss/RU-guillemet count-match rule (343/463 rows fixed,
+> 46 residual left for manual review); D4 triaged (2,860 rows; found a new 2,539-row
+> markup-fidelity-loss class, content intact, not auto-fixed — no safe positional boundary
+> anchoring without more validation, flagged for a follow-up handoff). **Addendum** (this
+> session, a *different* concurrent worktree that discovered the collision after the fact):
+> the main pass's "CI gate" (`test_h1651_wrapper_defect_gate`) only tests the standalone
+> `wrapper_defect_scan.py`/`fix_wrapper_defects.py` tools — neither is wired into the live
+> per-card generation-time audit, so a future generation run could still reintroduce the
+> class undetected by the pipeline itself. Added `cyrillic_in_sanskrit_wrapper`
+> (HIGH_CONFIDENCE) and `gloss_wrapper_became_guillemet` (report-only) to
+> `prompt_rule_audit.markup_sigla_risks`; LANG_PARITY
+> `wrapper_fidelity_cyrillic_and_guillemet_h1651` SHARED. 192/192 selftests + 18/18 pytest
+> green both passes. **Concurrency note:** the original PR #790 from this addendum's first
+> attempt (built on stale pre-#789 store measurements) was closed unmerged in favor of this
+> narrower, rebased follow-up — see the closed-PR comment for the reconciliation.
+
 > **H1629 🔴 EXECUTED 26-07-2026 (Opus 5 `claude-opus-5[1m]`), isolated worktree** — DE
 > edition-graph export profile:
 > [`src/export_de_edition.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/export_de_edition.py)

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,20 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added — H1651 store wrapper-defect sweep D1-D4, live gate follow-up (26-07-2026)
+
+- Main pass ([#789](https://github.com/gasyoun/SanskritLexicography/pull/789)): D1
+  repaired (34 rows/58 spans, closes
+  [#752](https://github.com/gasyoun/SanskritLexicography/issues/752)); D3 ruled and
+  bulk-applied (343/463 rows, 46 residual); D4 triaged (2,860 rows, no auto-fix — see
+  [pwg_ru/H1651_WRAPPER_DEFECT_SWEEP_REPORT_2026-07-26.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1651_WRAPPER_DEFECT_SWEEP_REPORT_2026-07-26.md)).
+- Addendum (this follow-up): the main pass's CI gate only tested the standalone scan/fix
+  tools, not the live per-card generation-time audit. New
+  `cyrillic_in_sanskrit_wrapper` (HIGH_CONFIDENCE) and `gloss_wrapper_became_guillemet`
+  (report-only) risks in
+  [prompt_rule_audit.markup_sigla_risks](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/prompt_rule_audit.py)
+  close that gap.
+
 ## [1.77.0] - 2026-07-26
 
 ### Added — H1656 follow-on: Gorresio e-text recovered; Rāmāyaṇa citation reuse ON (26-07-2026)

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -130,8 +130,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H1624",
     "verified_sha256": {
       "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
-      "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -154,7 +154,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/headless_worker.py": "bb6bc5468a3fca6e3257022be7b5878adff190a9a557206e5597c21d76e36c2d",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -209,7 +209,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -228,7 +228,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -351,7 +351,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/audit_coverage.py": "a60b8c0ed3b0022a6527a029d1e818cedab3dfcbbb545fc2c78b6a5dd514dcfa",
-      "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
+      "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
       "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
@@ -431,7 +431,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -488,7 +488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -547,7 +547,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -578,7 +578,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -597,7 +597,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -615,7 +615,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -634,7 +634,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -764,7 +764,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -789,7 +789,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -818,7 +818,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -838,7 +838,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -857,7 +857,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "016c91c2d3b650a0fb7e33df6a3dd82f5d4ab95d32d8fd293dce76ec8044e091",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -894,7 +894,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -952,7 +952,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -971,7 +971,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -990,7 +990,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -1010,7 +1010,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d",
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -1032,7 +1032,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -1091,7 +1091,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -1151,7 +1151,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -1170,7 +1170,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -1195,7 +1195,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
       "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -1217,7 +1217,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d",
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81",
       "src/pilot/accept_sensecount_test.js": "fbf8d37f8ae360c286f646361025d56adb0caeff09da30a0abfef5f6b7289937"
     }
   },
@@ -1237,7 +1237,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -1292,7 +1292,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -1359,7 +1359,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/german_residue_scan.py": "95b23669fdf96759202a22a06512c6bdc2d9de6e8a1c73809bdead3a26e991db",
       "src/pilot/fix_german_connectives.py": "6a5cceb58cd7c989df819703dff777bb635ee979c7178c55ceccce199a3737a8",
       "src/pilot/foreign_literal_guards.py": "e7eaccfb846ff805b585b1c6413ec84b71970dd7fdddfc6abef90fcf04650b93",
-      "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
+      "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
   },
@@ -1405,8 +1405,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "018aee3c3262405b493a5dac74f937684fcbac6f763923583d83604a4e5dcb93",
       "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d",
-      "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76",
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81",
+      "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
   },
@@ -1546,7 +1546,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RU-prose-specific detector over Cyrillic work names; the EN lane's residue checks are audit_window_en's own classes — nothing portable here",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/prompt_rule_audit.py": "bd9ffe91532741d608bfb318a1e7c15b9bfa22856d9c85e75ad4b4921993ad76"
+      "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927"
     }
   },
   {
@@ -1686,7 +1686,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
       "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d",
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
   },
@@ -1795,7 +1795,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "codex/rt-pipeline-hardening-speed",
     "verified_sha256": {
       "src/pilot/audit_window.py": "979d8f98e889dd3444320dc7f4b9de177610b7e7fb139f836f98be0a7cffc21b",
-      "src/pilot/window_selftest.py": "98dd7f3e660f25afe5d235db839f810594b7ad0e550141c834db026dfad3646d"
+      "src/pilot/window_selftest.py": "f8bef8832046839db55b8fb41e372abd23e0f77267ab22eca54803ff41248c81"
     }
   },
   {
@@ -1813,6 +1813,25 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H1629",
     "verified_sha256": {
       "src/export_de_edition.py": "b0c72b7093ff6a768dcab8c20360de4f86d949f3de787dd994ea489923ac9ac9"
+    }
+  },
+  {
+    "id": "wrapper_fidelity_cyrillic_and_guillemet_h1651",
+    "mechanism": "H1651 follow-up: {#..#} must carry ONLY Sanskrit/IAST -- a foreign-language word leaking inside it is a defect, detected per-language with a language-appropriate signal (mirrors the H1302 shared-invariant/per-language-token-set pattern). RU side (NEW, this entry): prompt_rule_audit.markup_sigla_risks raises cyrillic_in_sanskrit_wrapper (HIGH_CONFIDENCE) when a {#..#} span in the ru field contains a Cyrillic word -- the live generation-time half of the H1651 D1 fix; PR #789 fixed the 34 store rows and added a standalone regression test (wrapper_defect_scan.py/fix_wrapper_defects.py, test_h1651_wrapper_defect_gate) but did not wire the check into this per-card audit. EN side (PRE-EXISTING, unchanged by this pass): audit_window_en.nws_de_locked() flags the same invariant via a German umlaut/eszett/cue signal instead of Cyrillic. Also adds gloss_wrapper_became_guillemet (RU-only, report-only/soft) alongside the pre-existing markup_wrapper_dropped: a {%%..%%} gloss wrapper rendered as Russian <<..>> guillemets instead of vanishing outright (PR #789 D3) -- this sub-case has no EN analog (guillemet-as-gloss-wrapper is a RU rendering-style artifact, not a pattern the EN pipeline produces).",
+    "files": [
+      "src/pilot/prompt_rule_audit.py",
+      "src/pilot/audit_window_en.py"
+    ],
+    "languages": [
+      "ru",
+      "en"
+    ],
+    "verdict": "SHARED",
+    "note": "The {#..#}-must-be-Sanskrit-only invariant is enforced on both sides with a per-language leak signal (Cyrillic for RU, German cue for EN) -- same shape as german_prose_residue_h1302. The RU-only gloss_wrapper_became_guillemet addition is a narrower sub-check with no EN equivalent by design (see mechanism); it does not change the SHARED verdict on the {#..#}-fidelity invariant itself.",
+    "tracking": "",
+    "verified_sha256": {
+      "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
+      "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
   }
 ]

--- a/RussianTranslation/pwg_ru/H1651_WRAPPER_DEFECT_SWEEP_REPORT_2026-07-26.md
+++ b/RussianTranslation/pwg_ru/H1651_WRAPPER_DEFECT_SWEEP_REPORT_2026-07-26.md
@@ -159,4 +159,23 @@ Re-translation beyond what a wrapper repair required: none performed. `g5_batch1
 `h178_*` sheets: not touched. `<ls>` citation wiring (H1652): not touched. D5: not
 implemented.
 
+## Addendum 26-07-2026 (Sonnet 5, `claude-sonnet-5`) — live generation-time gate
+
+A concurrent session worked this same handoff in parallel; this addendum landed as a
+separate, narrower follow-up PR (linked from the [handoffs registry](https://github.com/gasyoun/Uprava/blob/main/handoffs/README.md)
+H1651 row) after discovering the collision, rather than reopening the (already-merged,
+already-correct) work above.
+
+`wrapper_defect_scan.py`/`fix_wrapper_defects.py` detect and repair D1/D3 in a periodic
+store scan, but neither is wired into the live per-card generation-time audit
+(`prompt_rule_audit.markup_sigla_risks`) — so a future generation run could reintroduce
+Cyrillic-in-`{#..#}`, or grow the guillemet-drift residual, undetected by the pipeline
+itself. Added: `cyrillic_in_sanskrit_wrapper` (HIGH_CONFIDENCE, mirrors the pre-existing
+EN-side `audit_window_en.nws_de_locked()`) and `gloss_wrapper_became_guillemet`
+(report-only, alongside the pre-existing `markup_wrapper_dropped`). LANG_PARITY
+`wrapper_fidelity_cyrillic_and_guillemet_h1651` (SHARED). Selftest:
+`test_h1651_live_gate_cyrillic_and_guillemet`, distinct from this PR's own
+`test_h1651_wrapper_defect_gate` (which tests the standalone scan/fix tools, not the live
+gate). No store data touched by this addendum — code-only.
+
 _Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/prompt_rule_audit.py
+++ b/RussianTranslation/src/pilot/prompt_rule_audit.py
@@ -66,6 +66,7 @@ TRANSLATED_SOURCE_SIGLUM = re.compile(
     r'\b(?:ригвед|атхарвавед|махабхарат|рамаян|ману(?!скрип))[а-яё]*\W{0,3}\d',
     re.I)
 BRACED_GLOSS = re.compile(r'\{%(.*?)%\}', re.S)
+GUILLEMET_GLOSS = re.compile(r'«(.*?)»', re.S)
 LATIN_FLAG_CONTEXT = re.compile(
     r'(?:das\s+lat\.|lat\.|latin|latein|griech\.|greek|engl\.|english|Wils\.\s+übersetzt)',
     re.I)
@@ -121,6 +122,7 @@ IAST_DIACRITIC = re.compile(r'[āīūṛṝḷḹṅñṭḍṇśṣ]')
 RETAINED_SPAN = re.compile(r'\{%.*?%\}|\{#.*?#\}|<(?:ab|ls|is)\b[^>]*>.*?</(?:ab|ls|is)>'
                            r'|<(?:ab|ls|is)\b[^>]*>', re.S | re.I)
 SANSKRIT_SPAN = re.compile(r'\{#.*?#\}', re.S)
+SANSKRIT_SPAN_CONTENT = re.compile(r'\{#(.*?)#\}', re.S)
 # A leading structural-head span: a {#..#} that is a sub-entry preverb/root/headword LABEL, not
 # an intra-sense Sanskrit span. A faithful Russian translation may legitimately omit such a head
 # label (it is card-level metadata), so it must NOT count as a dropped translation span. H960
@@ -159,6 +161,7 @@ HIGH_RISKS = {
     'missing_senses',
     'broken_markup_token',
     'unbalanced_sanskrit_delimiters',
+    'cyrillic_in_sanskrit_wrapper',
     'translated_grammar_siglum',
     'translated_source_siglum',
     'untranslated_braced_german_gloss',
@@ -187,6 +190,7 @@ HIGH_CONFIDENCE_RISKS = {
     'empty_russian',
     'broken_markup_token',
     'unbalanced_sanskrit_delimiters',
+    'cyrillic_in_sanskrit_wrapper',
     'translated_grammar_siglum',
     'translated_source_siglum',
     'untranslated_german_residue',
@@ -601,6 +605,19 @@ def markup_sigla_risks(sense, russian, german, grammar, tag):
     if russian.count('{#') != russian.count('#}'):
         add_risk(risks, 'unbalanced_sanskrit_delimiters',
                  'Russian field has unbalanced {#...#} delimiters', tag=tag)
+    # H1651 D1: {#..#} is the Sanskrit/SLP1 citation wrapper -- transliterated Sanskrit is
+    # always Latin+diacritics, never Cyrillic, so any Cyrillic word inside it means the model
+    # wrapped a Russian gloss in the Sanskrit delimiter instead of the {%..%} gloss delimiter.
+    # The 34 live store instances found by the H1651 sweep (26-07-2026) were already repaired
+    # (wrapper_defect_scan.py/fix_wrapper_defects.py, PR #789) -- this is the live generation-
+    # time gate those tools did not add: neither is wired into this per-card audit, so a future
+    # generation run could reintroduce the class undetected by the pipeline itself.
+    cyr_wrapped = [m.group(1) for m in SANSKRIT_SPAN_CONTENT.finditer(russian)
+                   if CYR_WORD.search(m.group(1))]
+    if cyr_wrapped:
+        add_risk(risks, 'cyrillic_in_sanskrit_wrapper',
+                 'Russian gloss wrapped in the Sanskrit {#..#} delimiter instead of {%%..%%} '
+                 '(%d span(s)): %s' % (len(cyr_wrapped), cyr_wrapped[0][:80]), tag=tag)
     if grammar and re.search(r'\b(?:m|f|n|Pl|Du|Sg)\.', grammar) and TRANSLATED_GRAMMAR_SIGLUM.search(russian):
         add_risk(risks, 'translated_grammar_siglum',
                  'grammar abbreviation appears translated rather than kept verbatim', tag=tag)
@@ -620,6 +637,23 @@ def markup_sigla_risks(sense, russian, german, grammar, tag):
         add_risk(risks, 'markup_wrapper_dropped',
                  'braced gloss wrapper {%%..%%} dropped: %d source vs %d target' % (sgloss, dgloss),
                  tag=tag)
+        # H1651 D3: of the rows with a dropped {%..%} wrapper, a subset rendered the gloss
+        # inside Russian guillemets <<..>> instead of losing the wrapper outright. RULED
+        # (PR #789, 26-07-2026): {%..%} is the store's documented gloss convention
+        # (pwg_ru/DATA_STATEMENT.md sec. D); a guillemet rendering is drift, not an accepted
+        # alternative. 343/463 candidate rows were bulk-repaired there under an exact
+        # DE-gloss/RU-guillemet count-match rule; ~46-54 rows remain as residual (count
+        # mismatch, left for manual review rather than guessed at). Soft/report-only here too
+        # -- content is intact either way, only the markup differs -- and this is the live
+        # generation-time half of that fix: neither wrapper_defect_scan.py nor
+        # fix_wrapper_defects.py is wired into this per-card audit, so this stops a future
+        # generation run from growing the residual further.
+        deficit = sgloss - dgloss
+        guillemets = min(deficit, len(GUILLEMET_GLOSS.findall(russian or '')))
+        if guillemets:
+            add_risk(risks, 'gloss_wrapper_became_guillemet',
+                     'braced gloss wrapper {%%..%%} rendered as <<..>> guillemets instead '
+                     '(~%d span(s))' % guillemets, tag=tag)
     # H960 (H911 backlog #3): a {#..#} Sanskrit span present in the German source but dropped from
     # the Russian translation. The harness accept()/tm gates count {#..#} only in the german echo,
     # never the translation field, so an intra-sense span that survives the echo but vanishes from

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -1730,6 +1730,42 @@ def test_h1651_wrapper_defect_gate():
         fail('H1651: fix_d3 must refuse a count-mismatched row rather than guess')
 
 
+def test_h1651_live_gate_cyrillic_and_guillemet():
+    """H1651 follow-up: wrapper_defect_scan.py/fix_wrapper_defects.py (PR #789) detect and
+    repair D1/D3 in a periodic store scan, but neither is wired into the live per-card
+    generation-time audit (prompt_rule_audit.markup_sigla_risks) -- so a future generation run
+    could still reintroduce Cyrillic-in-{#..#} (or grow the guillemet-drift residual)
+    undetected by the pipeline itself. This tests that live gate, distinct from
+    test_h1651_wrapper_defect_gate above (which tests the standalone scan/fix tools)."""
+    import prompt_rule_audit as pr
+
+    def ids(ru, de=''):
+        return [r['id'] for r in pr.markup_sigla_risks({}, ru, de, '', '3')]
+
+    # D1: Cyrillic wrapped in {#..#} fires HIGH_CONFIDENCE.
+    if 'cyrillic_in_sanskrit_wrapper' not in ids('{#полагать, думать#}: {#mfto vetti#}'):
+        fail('cyrillic_in_sanskrit_wrapper must fire on a Cyrillic {#..#} span')
+    if 'cyrillic_in_sanskrit_wrapper' in ids('{#mfto vetti#} значит "знать"'):
+        fail('cyrillic_in_sanskrit_wrapper must NOT fire on a genuine Sanskrit span')
+    if 'cyrillic_in_sanskrit_wrapper' not in pr.HIGH_CONFIDENCE_RISKS:
+        fail('cyrillic_in_sanskrit_wrapper must be HIGH_CONFIDENCE (unambiguous, always wrong)')
+
+    # D3: a {%..%} gloss dropped AND rendered as a guillemet fires the soft companion risk
+    # alongside the pre-existing markup_wrapper_dropped.
+    found = ids('«полагать»', de='{%glauben%}')
+    if 'markup_wrapper_dropped' not in found or 'gloss_wrapper_became_guillemet' not in found:
+        fail('gloss_wrapper_became_guillemet must fire alongside markup_wrapper_dropped')
+    if {'markup_wrapper_dropped', 'gloss_wrapper_became_guillemet'} & set(ids('{%полагать%}', de='{%glauben%}')):
+        fail('neither D3 risk should fire when the {%..%} wrapper survives')
+    plain = ids('полагать', de='{%glauben%}')
+    if 'markup_wrapper_dropped' not in plain:
+        fail('markup_wrapper_dropped must still fire on a bare unwrapped drop')
+    if 'gloss_wrapper_became_guillemet' in plain:
+        fail('gloss_wrapper_became_guillemet must NOT fire without a guillemet span')
+    if 'gloss_wrapper_became_guillemet' in pr.HIGH_CONFIDENCE_RISKS:
+        fail('gloss_wrapper_became_guillemet must stay report-only (never requeue)')
+
+
 def test_semantic_review_prioritizer():
     high = {
         'key': 'high',
@@ -8178,6 +8214,7 @@ def main():
         test_h1302_german_prose_residue_scan,
         test_h1305_ru_style_mechanical,
         test_h1651_wrapper_defect_gate,
+        test_h1651_live_gate_cyrillic_and_guillemet,
         test_semantic_review_prioritizer,
         test_noisy_source_type_not_requeue,
         test_report_only_risks_never_requeue,


### PR DESCRIPTION
## Summary
- [#789](https://github.com/gasyoun/SanskritLexicography/pull/789) (merged) fixed D1 (34/58 spans), bulk-applied D3 (343/463 rows), triaged D4, and closed #752 — the store-level fix is done and correct.
- Its "CI gate" (`test_h1651_wrapper_defect_gate`) only tests the standalone `wrapper_defect_scan.py`/`fix_wrapper_defects.py` tools — neither is wired into `prompt_rule_audit.markup_sigla_risks`, the per-card audit that runs during real generation and drives requeues via `HIGH_CONFIDENCE_RISKS`. A future generation run could still reintroduce Cyrillic-in-`{#..#}` (or grow the guillemet-drift residual) with the pipeline itself never noticing.
- Adds `cyrillic_in_sanskrit_wrapper` (HIGH_CONFIDENCE, mirrors the pre-existing EN-side `audit_window_en.nws_de_locked()`) and `gloss_wrapper_became_guillemet` (report-only, alongside the pre-existing `markup_wrapper_dropped`). New selftest `test_h1651_live_gate_cyrillic_and_guillemet`, distinct from #789's `test_h1651_wrapper_defect_gate`. LANG_PARITY `wrapper_fidelity_cyrillic_and_guillemet_h1651` (SHARED).
- No store data touched — code-only. Addendum appended to `pwg_ru/H1651_WRAPPER_DEFECT_SWEEP_REPORT_2026-07-26.md` (the report #789 already committed); `.ai_state.md`/`CHANGELOG.md` updated with a consolidated H1651 note since #789 didn't touch either.

## Concurrency note
This branch's first attempt ([PR #790](https://github.com/gasyoun/SanskritLexicography/pull/790)) was built in parallel with #789 on the same handoff (H1651), discovered only after #789 merged. #790 was closed unmerged (see its closing comment) rather than reopening already-correct work; this PR is the rebased, narrowed-down version.

Handoff: [H1651](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1651-Sonnet_SanskritLexicography_pwg-ru-wrapper-defect-sweep-d1-d4_26.07.26.md)

## Test plan
- [x] `python src/pilot/window_selftest.py` — 192/192 passed
- [x] `python -m pytest RussianTranslation -q` — 18/18 passed
- [x] `python src/pilot/lang_parity_check.py` — 85 entries, no drift

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>