### PR TITLE
fix(pwg_ru): Gorresio map audit round 1 — 4 half-verse-shift rows switched off

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,15 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Changed — Gorresio map audit round 1: 28/32 approve; 4 half-verse-shift rows switched off (26-07-2026)
+
+- The 32-card audit sheet was voted (agent vote by Fable 5 `claude-fable-5` on MG's
+  direct delegation) — 28 approve incl. all 5 scan-verified gold anchors; the 4 rejects
+  are a single OCR-segmentation sub-class (merged half-verses pairing with the tail
+  verse) now marked `audit-rejected` in
+  [ramayana_gorresio_southern_verse_map.tsv](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ramayana_gorresio_southern_verse_map.tsv)
+  and inert for reuse (selftest pins the 4 rows). Detection heuristic queued into H1689.
+
 ### Added — H1651 store wrapper-defect sweep D1-D4, live gate follow-up (26-07-2026)
 
 - Main pass ([#789](https://github.com/gasyoun/SanskritLexicography/pull/789)): D1

--- a/RussianTranslation/pwg_ru/COVERED_TEXTS_RU.md
+++ b/RussianTranslation/pwg_ru/COVERED_TEXTS_RU.md
@@ -274,6 +274,16 @@ recension), `gorresio-etext-gap` (sarga awaiting the vols 2/4/uk OCR pass),
 becomes an invented offset — the 166k lesson stands. The `/review-sheet` audit sheet
 remains as a quality surface (votes refine the map), not a blocker.
 
+**Audit round 1 (26-07-2026, voted same day).** 32 sampled pairs (incl. 5 scan-verified
+gold anchors), agent-voted by Fable 5 (`claude-fable-5`) on MG's direct delegation:
+**28 approve / 4 reject (87.5%)**. All 4 rejects are one systematic sub-class —
+OCR lost a ॥N॥ marker, two half-verses merged, and the aligner paired the chunk with
+the verse matching its TAIL (half-verse shift: G 1,12,28 · 1,48,11 · 1,62,8 · 2,4,7).
+Those rows are switched off as `audit-rejected` in the verse map (loader reads only
+matched/fuzzy). Detection heuristic for the residue: over-long G-chunks or chunks with
+an interior ॥N॥ — queued into H1689's refinement pass. Vote record:
+`review/sanskritlexicography-gorresio-southern-map_audit-26-07-26_decisions.json` (local).
+
 ## Retro-application plan
 
 The lookup is wired into the generation path (`corpus_gate.build_card` gains a

--- a/RussianTranslation/src/build_ramayana_concordance.py
+++ b/RussianTranslation/src/build_ramayana_concordance.py
@@ -521,8 +521,15 @@ def cmd_selftest(_args):
 
     gsv = list(csv.DictReader(open(OUT_GSV, encoding='utf-8'), delimiter='\t'))
     check(len(gsv) > 9000, 'gorresio verse map has %d rows (>9000)' % len(gsv))
-    ok_cls = {'matched', 'fuzzy', 'moved', 'gorresio_only', 'no_southern_corpus'}
+    # 'audit-rejected' = row switched off by a voted review sheet (the 26-07-2026
+    # audit killed 4 half-verse-shift pairs); the citation_tm loader only reads
+    # matched/fuzzy, so these are inert by construction — keep them for the trail.
+    ok_cls = {'matched', 'fuzzy', 'moved', 'gorresio_only', 'no_southern_corpus',
+              'audit-rejected'}
     check({r['class'] for r in gsv} <= ok_cls, 'verse-map classes are typed')
+    rej = [r for r in gsv if r['class'] == 'audit-rejected']
+    check(len(rej) == 4 and all(r['g_kanda'] in ('1', '2') for r in rej),
+          '4 audit-rejected rows from the 26-07-2026 sheet stay switched off')
     anchor = [r for r in gsv if (r['g_kanda'], r['g_sarga'], r['g_verse'])
               == ('1', '22', '1')]
     check(anchor and anchor[0]['s_sarga'] == '19' and anchor[0]['class'] == 'matched',

--- a/RussianTranslation/src/ramayana_gorresio_southern_verse_map.tsv
+++ b/RussianTranslation/src/ramayana_gorresio_southern_verse_map.tsv
@@ -561,7 +561,7 @@ g_kanda	g_sarga	g_verse	s_kanda	s_sarga	s_verse	score	class
 1	12	25	1	13	30	0.328	fuzzy
 1	12	26					gorresio_only
 1	12	27					gorresio_only
-1	12	28	1	13	33	0.262	fuzzy
+1	12	28	1	13	33	0.262	audit-rejected
 1	12	30	1	13	34	0.413	fuzzy
 1	12	31	1	13	35	0.714	matched
 1	12	32	1	13	36	0.609	matched
@@ -1421,7 +1421,7 @@ g_kanda	g_sarga	g_verse	s_kanda	s_sarga	s_verse	score	class
 1	48	7					gorresio_only
 1	48	8					gorresio_only
 1	48	10					gorresio_only
-1	48	11	1	47	8	0.277	fuzzy
+1	48	11	1	47	8	0.277	audit-rejected
 1	48	12	1	47	10	1.0	matched
 1	48	13	1	47	11	0.656	matched
 1	48	14	1	47	12	0.327	fuzzy
@@ -1711,7 +1711,7 @@ g_kanda	g_sarga	g_verse	s_kanda	s_sarga	s_verse	score	class
 1	62	5					gorresio_only
 1	62	6					gorresio_only
 1	62	7					gorresio_only
-1	62	8	1	60	7	0.391	fuzzy
+1	62	8	1	60	7	0.391	audit-rejected
 1	62	10					gorresio_only
 1	62	11					gorresio_only
 1	62	12	1	60	12	0.571	matched
@@ -2303,7 +2303,7 @@ g_kanda	g_sarga	g_verse	s_kanda	s_sarga	s_verse	score	class
 2	4	3	2	5	3	0.441	fuzzy
 2	4	4	2	5	4	0.5	matched
 2	4	6					gorresio_only
-2	4	7	2	5	7	0.286	fuzzy
+2	4	7	2	5	7	0.286	audit-rejected
 2	4	10	2	5	10	0.892	matched
 2	4	12	2	5	11	0.367	fuzzy
 2	4	14	2	5	13	0.391	fuzzy


### PR DESCRIPTION
Applies [the voted decisions](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/COVERED_TEXTS_RU.md) of the 32-card audit sheet (agent vote, Fable 5 `claude-fable-5`, on MG's direct delegation — «vote the audit sheet now, apply my decisions after»).

**28 approve / 4 reject (87.5%).** All rejects = one sub-class: OCR lost a ॥N॥ marker → merged half-verses → the aligner paired the chunk with the verse matching its tail. Rows G 1,12,28 · 1,48,11 · 1,62,8 · 2,4,7 → class `audit-rejected` (inert: the citation_tm loader reads only matched/fuzzy; selftest pins the 4 rows). Yuddha pairs verified against the corpus jsonl directly (yuddha not in corpus.db). Detection heuristic for the residual sub-class (over-long chunks / interior ॥N॥) queued into [H1689](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1689-Opus_SanskritLexicography_gorresio-vols-2-4-uk-ocr-etext_26.07.26.md).

Model: Fable 5 (`claude-fable-5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)