### PR TITLE
chore(release): cut v1.78.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 1.77.0
+cff-version: 1.78.0
 type: software
 title: SanskritLexicography
 message: >

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.78.0] - 2026-07-26
+
 ### Changed — Gorresio map audit round 1: 28/32 approve; 4 half-verse-shift rows switched off (26-07-2026)
 
 - The 32-card audit sheet was voted (agent vote by Fable 5 `claude-fable-5` on MG's


### PR DESCRIPTION
Promotes [Unreleased] (Gorresio audit round 1 apply + H1651 D1/D3 live-gate follow-up) to [1.78.0]; CITATION.cff synced. Tag + release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)