### PR TITLE
chore(release): cut v1.80.0 — H1691 PWG-DCS text crosswalk adjudication

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.76.0
+version: 1.80.0
 date-released: "2026-07-26"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported


### PR DESCRIPTION
Promotes the H1691 `[Unreleased]` entries and syncs `CITATION.cff`.

- 52 `<ls>` abbreviations adjudicated against DCS (12 mapped, 38 rejected, 2 unverifiable)
- backlog classifier corrected in both directions ([#798](https://github.com/gasyoun/SanskritLexicography/issues/798)); FINDINGS §471, §472, and a §465 update

Cut as **1.80.0** rather than 1.79.0: a `v1.79.0` tag already exists from the 26-07 double-cut repair while the changelog carries no matching section, so the next version is taken above the highest existing tag rather than reusing it.

Follows [#797](https://github.com/gasyoun/SanskritLexicography/pull/797).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
