### PR TITLE
chore(release): cut v1.80.0 + repair invalid cff-version

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 1.79.0
+cff-version: 1.2.0
 type: software
 title: SanskritLexicography
 message: >

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.80.0] — 2026-07-26
+
 ### Added
 - **H1691 — PWG's remaining DCS-carried cited texts adjudicated; 52 abbreviations, 12 mapped
   (26-07-2026, Opus 5 `claude-opus-5[1m]`).** Report


### PR DESCRIPTION
Promotes [Unreleased] to 1.80.0 (H1691 + H1681). `CITATION.cff` already carried `version: 1.80.0`.

Side repair in the same file: `cff-version: 1.79.0` -> `1.2.0`. `cff-version` names the Citation File Format **schema** version, not the repo version, so the file was invalid CFF and GitHub's *Cite this repository* widget could not parse it. The repo version lives in `version:`, which was already right.

Note for whoever next audits the tag/changelog bookkeeping: tags `v1.77.0` and `v1.79.0` exist with no matching changelog section — pre-existing drift from the 26-07 double-cut repair ([#796](https://github.com/gasyoun/SanskritLexicography/pull/796)), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)