### PR TITLE
chore(release): cut v1.83.0 - compound-differs blind arm re-cut and bound

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.81.0
+version: 1.83.0
 date-released: "2026-07-26"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.83.0] — 2026-07-26
+
 ### Fixed
 - **The compound-`differs` blind arm is re-cut, deduped and BOUND (H1681 follow-up,
   MG ruling `re-cut`, 26-07-2026, Opus 5 1M `claude-opus-5[1m]`).**


### PR DESCRIPTION
Promotes `[Unreleased]` (the H1681 follow-up: blind-arm re-cut, dedupe, stamp + lock) to 1.83.0, [PR #811](https://github.com/gasyoun/SanskritLexicography/pull/811). `CITATION.cff` `version:` follows.

Numbering note: tag `v1.82.0` exists with no matching changelog section — the same drift `v1.77.0` and `v1.79.0` already show. Left alone rather than renumbering another session's tag; 1.83.0 is the next free number above the highest tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)