### PR TITLE
chore(release): cut v1.84.0 — H1652 MBH Calcutta map built, measured, rejected

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.83.0
+version: 1.84.0
 date-released: "2026-07-26"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.84.0] — 2026-07-26
+
 ### Added
 - **H1652 — the MBH Calcutta↔critical map: built, measured, rejected**
   ([H1652](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1652-Opus_SanskritLexicography_citation-tm-ramayana-mbh-concordance-wiring_26.07.26.md),


### PR DESCRIPTION
Promotes the H1652 `[Unreleased]` entries to **v1.84.0** and syncs `CITATION.cff`.

Contents: the Calcutta↔critical Mahābhārata map MG ruled to build — built, measured at 11.2% within ±2 verses against a 2.5% random null (1/43 on unambiguous anchors), and rejected; plus the Rāmāyaṇa kāṇḍa 4/6/7 fabricated-`canonical_id` fix. Shipped in [#812](https://github.com/gasyoun/SanskritLexicography/pull/812).

🤖 Generated with [Claude Code](https://claude.com/claude-code)