### PR TITLE
chore(release): cut v1.85.0 — H1707 probe: Calcutta MBh scan + CE e-text found

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.85.0] — 2026-07-26
+
 ### Added
 - **H1707 probe — the Calcutta Mahābhārata is obtainable after all, and PWG's citation
   scheme is already indexed** (Opus 5 1M `claude-opus-5[1m]`). Same-day successor to the


### PR DESCRIPTION
Promotes the H1707 probe entry to **v1.85.0** and syncs `CITATION.cff`. Shipped in [#816](https://github.com/gasyoun/SanskritLexicography/pull/816).

🤖 Generated with [Claude Code](https://claude.com/claude-code)