### PR TITLE
chore(release): renumber the H1707 probe section to v1.86.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.85.0
+version: 1.86.0
 date-released: "2026-07-26"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,7 @@ not an error.
 
 ## [Unreleased]
 
-## [1.85.0] — 2026-07-26
+## [1.86.0] — 2026-07-26
 
 ### Added
 - **H1707 probe — the Calcutta Mahābhārata is obtainable after all, and PWG's citation


### PR DESCRIPTION
Two `## [1.85.0]` sections landed on master: a concurrent session published v1.85.0 for the H1683 gloss source-check while [#818](https://github.com/gasyoun/SanskritLexicography/pull/818) was in CI. That published tag stands; this moves the H1707 Calcutta-probe section to **v1.86.0** and syncs `CITATION.cff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)