### PR TITLE
chore(release): cut v1.89.0 — H1705 R. (Bomb.) book-7 verdict + Bombay inventory

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.88.0
+version: 1.89.0
 date-released: "2026-07-27"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.89.0] — 2026-07-27
+
 ### Added
 - **H1705 — R. (Bomb.) book 7: measured verdict, no OCR spent.** The Bombay
   uttarakāṇḍa does **not** map ≈1:1 onto the corpus text (111 sargas + 13


### PR DESCRIPTION
Promotes the H1705 `[Unreleased]` block to **v1.89.0** and syncs `CITATION.cff` (version 1.88.0 → 1.89.0).

Ships: the measured rejection of both H1705 exits (Bombay 111 sargas + 13 interpolated vs the corpus's 100, identical verse count in 11/100; and `07_ramayana-uttarakanda.jsonl` = 2,690 `sa` / **0** `ru`), `src/ramayana_bombay_inventory.tsv` (658 sargas, no OCR) + the `build-bombay` command, the `ru-translation-unpublished` retyping in `citation_tm.py`, FINDINGS §480/§481, and integrity issue [#822](https://github.com/gasyoun/SanskritLexicography/issues/822).

🤖 Generated with [Claude Code](https://claude.com/claude-code)