### PR TITLE
chore(release): cut v1.89.1 — H1705 R. book-7 count correction (1,781 → 1,765)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.89.0
+version: 1.89.1
 date-released: "2026-07-27"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported

--- a/RussianTranslation/pwg_ru/COVERED_TEXTS_RU.md
+++ b/RussianTranslation/pwg_ru/COVERED_TEXTS_RU.md
@@ -172,7 +172,7 @@ encodes the clean ones and reports a typed non-hit for the rest.
 | KATHĀS. | `taranga,verse` (2-number) | `lambaka.taranga.verse` (3-number) | best-effort |
 | **MBH.** | **continuous Calcutta śloka** (5,7331) | `parvan.adhyaya.verse` (critical) | **UNMAPPED** — the cumulative-adhyāya candidate was built and measured 26-07-2026 (H1652) at 11–16% verse accuracy and REJECTED; needs the Calcutta text itself |
 | **R. GORR.** (+ plain R. books 3–6) | Gorresio Bengal recension | Southern recension (Leonov) | **CONTENT-BASED verse concordance (H1656 + H1689)** — matched/fuzzy → hit; Bengal-only → `no-southern-counterpart`; kāṇḍas 4/6/7 → `ru-translation-unpublished` (`gorresio-etext-gap` extinct since the H1689 OCR pass) |
-| **R. book 7** | Bombay ed. 1859 — 111 sargas + 13 interpolated (`23.1–23.5`, `37.1–37.5`, `59.1–59.3`) | corpus `07_ramayana-uttarakanda`, 100 sargas, **Sanskrit-only, critical text** | **NO MAP, and none is owed** — measured NOT ≈1:1 under H1705 (11/100 sargas share a verse count); 127 of 1,781 citations name a sarga the corpus cannot carry. Returns `ru-translation-unpublished`: no Russian uttarakāṇḍa exists |
+| **R. book 7** | Bombay ed. 1859 — 111 sargas + 13 interpolated (`23.1–23.5`, `37.1–37.5`, `59.1–59.3`) | corpus `07_ramayana-uttarakanda`, 100 sargas, **Sanskrit-only, critical text** | **NO MAP, and none is owed** — measured NOT ≈1:1 under H1705 (11/100 sargas share a verse count); 127 of 1,765 citations name a sarga the corpus cannot carry. Returns `ru-translation-unpublished`: no Russian uttarakāṇḍa exists |
 
 The remaining UNMAPPED case returns `unmapped_locus_scheme` (a documented GAP, **not** a miss):
 
@@ -365,7 +365,7 @@ measurements say so without ambiguity:
 | does the corpus file carry Russian? | **no — 2,690 `sa` segments, 0 `ru`** (kāṇḍa 6 likewise; kāṇḍas 1/2/3/5 are fully paired) | there is nothing to reuse even from a perfect map |
 | is it the Southern text of record? | **no** — 2,688/2,690 rows of `ramayana_southern_critical_concordance.tsv` align to the DCS **critical** edition at the identical `sarga.verse`, 95.5% at score 1.0; kāṇḍas 1/2/3/5 sit at 1–3% identity | the "Southern" column is a mislabel for kāṇḍas 6–7 |
 | is Bombay ≈1:1 with it? | **no** — Bombay 111 sargas + 13 interpolated vs 100; identical verse count in **11/100** sargas; delta −14…+18, mean +4.7 | a direct-with-offset scheme would be dishonest |
-| how much PWG mass is at stake? | **1,781** plain `R.` book-7 citations in the full digitisation (4.5% of 39,845), sargas 1–111; **127** cite a sarga >100 | those 127 cannot resolve against a 100-sarga text at all |
+| how much PWG mass is at stake? | **1,765** plain `R.` book-7 citations in the full digitisation (4.5% of 39,222), sargas 1–111, + 16 edition-qualified (`R. ed. Bomb.` 14, `R. SCHL.` 2); **127** cite a sarga >100 | those 127 cannot resolve against a 100-sarga text at all |
 
 So the blocker order for book 7 is **the Russian first**, and it is not near: the
 [RussianRamayana](https://github.com/gasyoun/RussianRamayana) pipeline lists book IV
@@ -378,7 +378,8 @@ as [`src/ramayana_bombay_inventory.tsv`](https://github.com/gasyoun/SanskritLexi
 [FINDINGS §480](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md).
 
 > Counting scope: the 232/288/376 figures in the table above are **store** counts
-> (the pwg_ru working set); the 1,781 is every `<ls>` in the full csl-orig `pwg.txt`.
+> (the pwg_ru working set); the 1,765 is every plain-`R.` `<ls>` in the full csl-orig
+> `pwg.txt`, edition-qualified forms counted separately.
 > Different denominators, both correct — do not compare them directly.
 
 **Resolver consequence, applied 26-07-2026.** `_RAMA_GORR_WORK` in

--- a/RussianTranslation/pwg_ru/H1705_RAMAYANA_BOMBAY_BOOK7_VERDICT_2026-07-27.md
+++ b/RussianTranslation/pwg_ru/H1705_RAMAYANA_BOMBAY_BOOK7_VERDICT_2026-07-27.md
@@ -24,7 +24,7 @@ missing piece is the Bombay-numbering bridge, not the RU side."* Both clauses fa
 | 1 | the corpus file backs a Russian translation | `07_…jsonl` holds **2,690 `sa` segments and 0 `ru`**; `06_…jsonl` likewise (4,436 `sa`, 0 `ru`). Kāṇḍas 1/2/3/5 are fully paired (2,268 / 4,307 / 2,447 / 2,859 of each) | ❌ the RU side **is** the missing piece |
 | 2 | that Sanskrit is the Southern text of record | **2,688 of 2,690** rows in [`ramayana_southern_critical_concordance.tsv`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ramayana_southern_critical_concordance.tsv) pair kāṇḍa-7 verses with the DCS **critical** edition at the *identical* `sarga.verse`, 95.5% at score 1.0. Kāṇḍa 6: 99.8% identity. Kāṇḍas 1/2/3/5: **1.2–3.0%** | ❌ kāṇḍas 6–7 are critical-edition text wearing a "Southern" label ([SL#822](https://github.com/gasyoun/SanskritLexicography/issues/822)) |
 | 3 | Bombay ≈1:1 with the corpus numbering | Bombay **111** sargas + **13** interpolated vs the corpus's **100**; identical max-verse in **11 of 100** shared sargas; delta −14…+18, mean **+4.7** | ❌ no offset scheme is honest |
-| 4 | the prize justifies an OCR pass | **1,781** plain `R.` book-7 citations in the full csl-orig digitisation (4.5% of 39,845 located `R.` refs), sargas 1–111 — of which **127 cite a sarga > 100**, structurally unresolvable against a 100-sarga text | ⚠️ real mass, zero reachable payoff |
+| 4 | the prize justifies an OCR pass | **1,765** plain `R.` book-7 citations in the full csl-orig digitisation (4.5% of 39,222 located plain-`R.` refs), sargas 1–111, plus 16 edition-qualified ones (`R. ed. Bomb.` 14, `R. SCHL.` 2) — of which **127 cite a sarga > 100**, structurally unresolvable against a 100-sarga text | ⚠️ real mass, zero reachable payoff |
 
 ### Why the corpus file exists but cannot help
 
@@ -123,6 +123,15 @@ in short, the Gorresio recipe (§470/§473) does **not** transfer unmodified:
 - **Kāṇḍa 6 in `indexv3.txt` reaches sarga 130 with 70, 122 and 123 absent** (127 present
   against the vulgate's 128). Out of scope for book 7 — **observed, not repaired**; anyone
   keying book-6 work off this inventory must resolve it first.
+
+> **Counting correction, 27-07-2026 (same day).** The first pass reported 1,781 plain
+> `R.` book-7 citations out of 39,845. Its abbreviation regex ended in a bare `R\.`
+> alternative, so `R. ed. Bomb.` and `R. SCHL.` fell into the plain-`R.` bucket — 16
+> book-7 refs, 623 across all books. Re-counted with every edition qualifier split out:
+> **1,765 plain of 39,222**. The 127 out-of-range figure and every conclusion are
+> unchanged. Worth keeping in view separately: PWG carries **319** explicit
+> `R. ed. Bomb.` citations across all books (only 14 of them in book 7), so Böhtlingk
+> names the Bombay edition well outside the book-7 default.
 
 ## Reproduce
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,22 @@ not an error.
 
 ## [Unreleased]
 
+## [1.89.1] — 2026-07-27
+
+### Fixed
+- **H1705 counting correction (same day).** v1.89.0 reported **1,781** plain `R.`
+  book-7 citations out of 39,845. The abbreviation regex ended in a bare `R\.`
+  alternative, so `R. ed. Bomb.` and `R. SCHL.` were folded into the plain-`R.`
+  bucket — 16 book-7 refs, 623 across all books. Re-counted with every edition
+  qualifier split out: **1,765 plain of 39,222**, plus 16 edition-qualified book-7
+  refs. The 127 out-of-range (sarga >100) figure and every conclusion in the
+  verdict are unchanged. Recorded separately because it is independently useful:
+  PWG carries **319** explicit `R. ed. Bomb.` citations across all books, only 14
+  of them in book 7 — Böhtlingk names the Bombay edition well outside the book-7
+  default. Corrected in
+  [`pwg_ru/H1705_RAMAYANA_BOMBAY_BOOK7_VERDICT_2026-07-27.md`](RussianTranslation/pwg_ru/H1705_RAMAYANA_BOMBAY_BOOK7_VERDICT_2026-07-27.md)
+  and `pwg_ru/COVERED_TEXTS_RU.md`.
+
 ## [1.89.0] — 2026-07-27
 
 ### Added


### PR DESCRIPTION
Same-day correction to the H1705 numbers shipped in [v1.89.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.89.0).

The counting script's abbreviation alternation ended in a bare `R\.`, so `R. ed. Bomb.` and `R. SCHL.` matched it and were counted as plain `R.` — 16 book-7 refs, 623 across all books.

| | v1.89.0 | corrected |
|---|---:|---:|
| plain `R.` book-7 citations | 1,781 | **1,765** |
| plain `R.` citations with a locus | 39,845 | **39,222** |
| book-7 refs citing a sarga >100 | 127 | **127** (unchanged) |
| edition-qualified book-7 refs | folded in | 16 (`R. ed. Bomb.` 14, `R. SCHL.` 2) |

**No conclusion changes.** Also worth its own line: PWG carries **319** explicit `R. ed. Bomb.` citations across all books, only 14 of them in book 7 — Böhtlingk names the Bombay edition well outside the book-7 default, which the H1705 framing did not consider.

Touches docs + `CITATION.cff` only; no code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)