### PR TITLE
fix(gitignore): default-deny review sheets instead of per-generator enumeration

### DIFF
--- a/RussianTranslation/.gitignore
+++ b/RussianTranslation/.gitignore
@@ -186,38 +186,26 @@ pwg_ru/reglue/synth_outputs/*
 # (repo is PUBLIC): keep local-only; only the generator + protocol doc are
 # committed. decisions.json votes land here too (personal review artifacts).
 pwg_ru/eval/
-review/h178_*_sheet.html
 
-# H1303 abbreviation-ratification sheet (csl_pyutil emitter) — same class as the
-# h178/h180 sheets above: personal voting artifact, local-only (repo is PUBLIC).
-review/h1303_*_sheet.html
-
-# H1306 style-rulings ratification sheet (csl_pyutil emitter) — same class:
-# personal voting artifact, local-only (repo is PUBLIC).
-review/h1306_*_sheet.html
-
-# H1682 rule-collapse replacement for h1303_abbrev (csl_pyutil emitter) — same
-# class: personal voting artifact, local-only (repo is PUBLIC). Committed
-# counterpart: review/locks/h1682_abbrev_rules.lock.json (H1404 standard).
-review/h1682_*_sheet.html
-
-# H1404 starter packet (build_g5_review_sheet.py / build_g6_mqm_gold_sheet.py):
-# the G5 sheet embeds unpublished `ru`+`de` from the gitignored store; the G6
-# sheet stays local for consistency. COMMITTED counterpart: the metadata-only
+# ---- Review sheets: DEFAULT-DENY (27-07-2026) --------------------------------
+# Every /review-sheet HTML embeds unpublished `ru`/`de` from the gitignored
+# store, and every downloaded decisions.json is a personal voting artifact —
+# and this repo is PUBLIC. These used to be enumerated per generator
+# (h178_/h1303_/h1306_/h1682_/g5_/g6_ prefixes, plus one line per
+# compound-differs sheet), so every NEW generator leaked until someone
+# remembered to add a line: the gorresio southern-map sheet did exactly that.
+# Deny the shapes instead, and make publishing a sheet a deliberate `!` line.
+# COMMITTED counterpart for a gated sheet: the metadata-only
 # review/locks/<sheet_id>.lock.json binding record (H1404 standard) — never
-# gitignore review/locks/.
-review/g5_*_sheet.html
-review/g6_*_sheet.html
-# downloaded/auto-saved votes are personal working artifacts until applied
+# gitignore review/locks/. Sample-design frames (review/*_frame.tsv, no store
+# text) also stay committed as the sample-design audit trail.
+review/*_sheet.html
+review/*_review.html
 review/*_decisions.json
+# Intentionally published sheets (evidence for committed findings):
+!review/sanskritlexicography-renou-hypotheses_pilot_review.html
 !review/sanskritlexicography-renou-hypotheses_pilot_decisions.json
-
-# H1628 compound-differs review sheet (compound_differs_review_sample.py): personal
-# voting artifact per the /review-sheet contract — local-only. The metadata-only sample
-# frame TSV (no ru/de store text) IS committed as the sample-design audit trail.
-review/sanskritlexicography-pwg-compound-differs_stratified200_review.html
-# H1703 arm 2 (compound_differs_arm2_sample.py) — same contract, same reasons.
-review/sanskritlexicography-pwg-compound-differs_rulestrat_arm2_review.html
+!review/sanskritlexicography-kochergina-okas-guda-sphic_4rows_review.html
 
 # Generated Workflow harnesses embed source/portrait payloads and are local-only.
 src/pilot/run_pilot_wf.*.js

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,20 @@ not an error.
 
 ## [Unreleased]
 
+### Fixed
+- **Review sheets are now default-denied in `.gitignore`, not enumerated per
+  generator.** `RussianTranslation/.gitignore` listed each sheet family by prefix
+  (`h178_`/`h1303_`/`h1306_`/`h1682_`/`g5_`/`g6_`) plus one line per
+  compound-differs sheet, so every *new* generator leaked until someone remembered
+  to add a line — the gorresio southern-map audit sheet did exactly that and sat
+  stageable in a public repo. Replaced with three shape rules
+  (`review/*_sheet.html`, `review/*_review.html`, `review/*_decisions.json`) plus
+  an explicit `!` allowlist for the three sheets that are intentionally published
+  (renou pilot ×2, kochergina 4rows). Publishing a sheet is now a deliberate act;
+  the H1404 `review/locks/` and `*_frame.tsv` counterparts stay committed.
+  Verified: all 8 leaking local artifacts are ignored, and every currently-tracked
+  file under `RussianTranslation/review/` is still trackable.
+
 ## [1.90.0] — 2026-07-27
 
 


### PR DESCRIPTION
## Problem

[`RussianTranslation/.gitignore`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.gitignore) enumerated review sheets **per generator** — `review/h178_*_sheet.html`, `review/h1303_*_sheet.html`, `review/h1306_*_sheet.html`, `review/h1682_*_sheet.html`, `review/g5_*_sheet.html`, `review/g6_*_sheet.html`, plus one hardcoded line per compound-differs sheet.

Consequence: **every new sheet generator leaks until a human remembers to add a line.** The gorresio southern-map audit sheet did exactly that — both it and its `decisions.json` of personal votes sat stageable in a **public** repo, one `git add -A` away from publication. The exposure is worse on any branch cut before the rules were added (e.g. `docs/pwg-german-layers-clickable`, 107 commits behind `master`), where even the `g5_`/`g6_` lines are absent.

## Fix

Default-deny the three shapes, then allowlist what is deliberately published:

```gitignore
review/*_sheet.html
review/*_review.html
review/*_decisions.json
!review/sanskritlexicography-renou-hypotheses_pilot_review.html
!review/sanskritlexicography-renou-hypotheses_pilot_decisions.json
!review/sanskritlexicography-kochergina-okas-guda-sphic_4rows_review.html
```

Publishing a sheet is now a deliberate `!` line rather than the default. The H1404 committed counterparts — `review/locks/<sheet_id>.lock.json` binding records and the metadata-only `*_frame.tsv` sample frames — are untouched and stay tracked.

## Verification

`git check-ignore -v --no-index` over all 8 currently-untracked local sheet/decisions artifacts: **all 8 ignored** (previously 1 was not covered by any rule at all).

`git ls-files RussianTranslation/review/ | git check-ignore --no-index --stdin`: **no output** — no currently-tracked file under `review/` becomes unstageable. The three intentionally-committed sheets resolve to their `!` lines.

## Non-goals

- The redundant root-`.gitignore` `g5_`/`g6_` block (lines 110–116) is left as-is — harmless belt-and-braces.
- Nothing is untracked or deleted; `.gitignore` has no effect on already-tracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
