### PR TITLE
chore(release): 1.90.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ not an error.
 
 ## [Unreleased]
 
+## [1.90.1] — 2026-07-27
+
 ### Fixed
 - **Review sheets are now default-denied in `.gitignore`, not enumerated per
   generator.** `RussianTranslation/.gitignore` listed each sheet family by prefix


### PR DESCRIPTION
Promotes the `[Unreleased]` **Fixed** entry from #829 to **v1.90.1** (patch — fix only).

Tag + GitHub release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
