### PR TITLE
H1722: repair FEATURES_INDEX §II repo cells + re-runnable audit

### DIFF
--- a/FEATURES_INDEX.md
+++ b/FEATURES_INDEX.md
@@ -146,6 +146,16 @@ The **code is the ID** and the **Year** column is the edition's publication year
 column links a real sample headword (or *browse*) to that dictionary's live Cologne interface
 (URL pattern `…/scans/<CODE>Scan/<YEAR>/web/index.php`, MW & AP90 verified).
 
+**Repo column** — all 44 cells re-verified against the live
+[`sanskrit-lexicon`](https://github.com/orgs/sanskrit-lexicon/repositories) org on
+27-07-2026 (H1722; 3 were wrong, 41 correct). A dictionary repo here is normally an
+**issue venue**, not a data repo — the text itself lives in
+[csl-orig](https://github.com/sanskrit-lexicon/csl-orig) either way. So:
+`csl-orig only` = no repo of any kind exists (13 such dictionaries, enumerated in the
+[consolidation spike](https://github.com/gasyoun/Uprava/blob/main/CONSOLIDATION_SPIKE_REPOLESS_DICTIONARIES_THIN_VIEW_REPOS_2026Q3.md));
+"— venue only" = the repo exists but holds no dictionary content beyond issues and a
+Pages shell.
+
 | Code | Dictionary | Language | Author | Year | Pages | Repo | Example |
 |---|---|---|---|---:|---:|---|---|
 | MW | Monier-Williams Sanskrit-English Dictionary | Skt→Eng | Monier-Williams | 1899 | 1,333 | [MWS](https://github.com/sanskrit-lexicon/MWS) | [`a` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/MWScan/2020/web/index.php) |
@@ -164,7 +174,7 @@ column links a real sample headword (or *browse*) to that dictionary's live Colo
 | CAE | Cappeller Sanskrit-English Dictionary | Skt→Eng | Carl Cappeller | 1891 | 672 | [CAE](https://github.com/sanskrit-lexicon/CAE) | [`a` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/CAEScan/2020/web/index.php) |
 | MD | Macdonell Sanskrit-English Dictionary | Skt→Eng | A. A. Macdonell | 1893 | 384 | [MD](https://github.com/sanskrit-lexicon/MD) | [`a` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/MDScan/2020/web/index.php) |
 | SHS | Śabda-Sāgara Sanskrit-English Dictionary | Skt→Eng | J. Vidyasagara | 1900 | 839 | [SHS](https://github.com/sanskrit-lexicon/SHS) | [`a` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/SHSScan/2020/web/index.php) |
-| PD | Encyclopedic Dictionary of Sanskrit on Historical Principles | Skt→Eng | Ghatage · Bhatta | 1976 | 4,328 | [Cologne scan ↗](https://sanskrit-lexicon.uni-koeln.de/scans/PDScan/2020/web/index.php) | [browse ↗](https://sanskrit-lexicon.uni-koeln.de/scans/PDScan/2020/web/index.php) |
+| PD | Encyclopedic Dictionary of Sanskrit on Historical Principles | Skt→Eng | Ghatage · Bhatta | 1976 | 4,328 | [PD](https://github.com/sanskrit-lexicon/PD) | [browse ↗](https://sanskrit-lexicon.uni-koeln.de/scans/PDScan/2020/web/index.php) |
 | MWE | Monier-Williams English-Sanskrit Dictionary | Eng→Skt | Monier Williams | 1851 | 860 | csl-orig only | [`A` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/MWEScan/2020/web/index.php) |
 | BOR | Borooah English-Sanskrit Dictionary | Eng→Skt | Anundoram Borooah | 1877 | 772 | [BOR](https://github.com/sanskrit-lexicon/BOR) | [`A` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/BORScan/2020/web/index.php) |
 | AE | Apte Student's English-Sanskrit Dictionary | Eng→Skt | V. S. Apte | 1920 | 501 | [ApteES](https://github.com/sanskrit-lexicon/ApteES) | [browse ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/AEScan/2020/web/index.php) |
@@ -182,12 +192,12 @@ column links a real sample headword (or *browse*) to that dictionary's live Colo
 | NMMB | Nāmamālikā of Bhoja | Skt→Skt | Bhoja | 1955 | 40 | csl-orig only | [browse ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/NMMBScan/2026/web/index.php) |
 | INM | Index to the Names in the Mahābhārata | Specialized | S. Sörensen | 1904 | 852 | [INM](https://github.com/sanskrit-lexicon/INM) | [`Abala` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/INMScan/2020/web/index.php) |
 | VEI | Vedic Index of Names and Subjects | Specialized | Macdonell & Keith | 1912 | 560 | [VEI](https://github.com/sanskrit-lexicon/VEI) | [`Aṃśu` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/VEIScan/2020/web/index.php) |
-| PUI | The Purāṇa Index | Specialized | V. R. R. Dikshitar | 1951 | 2,232 | csl-orig only | [browse ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/PUIScan/2020/web/index.php) |
+| PUI | The Purāṇa Index | Specialized | V. R. R. Dikshitar | 1951 | 2,232 | [PUI](https://github.com/sanskrit-lexicon/PUI) — venue only | [browse ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/PUIScan/2020/web/index.php) |
 | BHS | Buddhist Hybrid Sanskrit Dictionary | Specialized | Franklin Edgerton | 1953 | 634 | [BHS](https://github.com/sanskrit-lexicon/BHS) | [`a` ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/BHSScan/2020/web/index.php) |
 | FRI | Friš Sanskrit Reader Vocabulary | Specialized | Oldřich Friš | 1956 | 349 | [FRI](https://github.com/sanskrit-lexicon/FRI) | [browse ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/FRIScan/2025/web/index.php) |
 | ACC | Aufrecht's Catalogus Catalogorum | Specialized | Theodor Aufrecht | 1962 | 1,216 | [ACC](https://github.com/sanskrit-lexicon/ACC) | [browse ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/ACCScan/2020/web/index.php) |
 | KRM | Kṛdantarūpamālā | Specialized | S. Ramasubba Sastri | 1965 | 1,489 | [KRM](https://github.com/sanskrit-lexicon/KRM) | [browse ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/KRMScan/2020/web/index.php) |
-| IEG | Indian Epigraphical Glossary | Specialized | D. C. Sircar | 1966 | 580 | csl-orig only | [browse ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/IEGScan/2020/web/index.php) |
+| IEG | Indian Epigraphical Glossary | Specialized | D. C. Sircar | 1966 | 580 | [IEG](https://github.com/sanskrit-lexicon/IEG) — venue only | [browse ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/IEGScan/2020/web/index.php) |
 | SNP | Meulenbeld's Sanskrit Names of Plants | Specialized | G. J. Meulenbeld | 1974 | 94 | csl-orig only | [browse ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/SNPScan/2020/web/index.php) |
 | PE | Puranic Encyclopedia | Specialized | Vettam Mani | 1975 | 922 | csl-orig only | [browse ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/PEScan/2020/web/index.php) |
 | PGN | Names in the Gupta Inscriptions | Specialized | Tej Ram Sharma | 1978 | 378 | csl-orig only | [browse ↗](https://www.sanskrit-lexicon.uni-koeln.de/scans/PGNScan/2020/web/index.php) |

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,15 @@ not an error.
 
 ## [Unreleased]
 
+## [1.91.0] — 2026-07-27
+
+### Fixed
+- **[`FEATURES_INDEX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md) §II — three wrong Repo cells, found by the H1475 consolidation spike and repaired under H1722** (Opus 5 1M `claude-opus-5[1m]`, 27-07-2026). `PUI` and `IEG` were marked "csl-orig only" and `PD` linked a Cologne **scan** where a repo link belongs — all three repos exist ([PUI](https://github.com/sanskrit-lexicon/PUI), [IEG](https://github.com/sanskrit-lexicon/IEG), [PD](https://github.com/sanskrit-lexicon/PD), the last with 31 files of real OCR-comparison work). Not a cosmetic defect: the "csl-orig only" marker is the field the **13 repo-less dictionaries** count is derived from, so a wrong cell silently moves that figure.
+- **All 44 Repo cells re-verified mechanically against the live org, not just the three known-bad** — `gh repo list sanskrit-lexicon` + `gasyoun`, every cell's link resolved or its "csl-orig only" claim confirmed. Result: **3 defective, 41 correct**, and 0 after the fix. The audit is re-runnable rather than a one-off eyeball.
+
+### Changed
+- **The Repo column now says what it means.** A dictionary repo in this org is normally an **issue venue**, not a data repo — the text lives in [csl-orig](https://github.com/sanskrit-lexicon/csl-orig) either way — so `csl-orig only` (no repo of any kind, 13 dictionaries) is now distinguished from "— venue only" (repo exists, holds only issues and a Pages shell: `PUI`, `IEG`), with the verification date recorded and a pointer to the [consolidation spike](https://github.com/gasyoun/Uprava/blob/main/CONSOLIDATION_SPIKE_REPOLESS_DICTIONARIES_THIN_VIEW_REPOS_2026Q3.md) that enumerates the 13.
+
 ## [1.90.1] — 2026-07-27
 
 ### Fixed

--- a/tools/audit_features_index_repo_cells.py
+++ b/tools/audit_features_index_repo_cells.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Audit every Repo cell of FEATURES_INDEX.md §II against the live GitHub orgs.
+
+Why this exists (H1722, 27-07-2026): the H1475 consolidation spike found three
+wrong cells -- PUI and IEG marked "csl-orig only" though both repos exist, and
+PD linking a Cologne scan where a repo link belongs. That column is not
+decorative: the "csl-orig only" marker is what the count of repo-less
+dictionaries is derived from, so a wrong cell silently moves a published figure.
+
+Two checks per row:
+  * a cell linking github.com/<org>/<repo> -> that repo must exist;
+  * a cell claiming "csl-orig only"        -> no repo named for that code may exist.
+
+Exit 0 when every cell is consistent, 1 otherwise (usable as a CI gate).
+Requires the `gh` CLI, authenticated with read access to both orgs.
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+
+ORGS = ("sanskrit-lexicon", "gasyoun")
+INDEX = Path(__file__).resolve().parent.parent / "FEATURES_INDEX.md"
+HEADER = "| Code | Dictionary |"
+REPO_COL = 6
+
+
+def live_repos():
+    """Full name set across both orgs. Fails loudly -- an empty listing would
+    otherwise read as 'every repo is missing' and flag all 44 rows."""
+    names = set()
+    for org in ORGS:
+        proc = subprocess.run(
+            ["gh", "repo", "list", org, "--limit", "300", "--json", "name"],
+            capture_output=True, text=True, encoding="utf-8",
+        )
+        if proc.returncode != 0 or not proc.stdout.strip():
+            raise SystemExit(
+                f"gh repo list {org} returned nothing (rc={proc.returncode}): "
+                f"{proc.stderr.strip()[:200]}"
+            )
+        names |= {f"{org}/{r['name']}" for r in json.loads(proc.stdout)}
+    return {n.lower(): n for n in names}
+
+
+def rows(text):
+    lines = text.splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith(HEADER))
+    for line in lines[start + 2:]:
+        if not line.startswith("|"):
+            return
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) > REPO_COL:
+            yield cells[0], cells[REPO_COL]
+
+
+def main():
+    repos = live_repos()
+    defects = []
+    checked = 0
+
+    for code, cell in rows(INDEX.read_text(encoding="utf-8")):
+        checked += 1
+        linked = re.search(r"github\.com/([\w.-]+/[\w.-]+)", cell)
+        if linked:
+            if linked.group(1).lower() not in repos:
+                defects.append(f"{code}: links {linked.group(1)}, which does not exist")
+        elif "csl-orig only" in cell:
+            hit = repos.get(f"sanskrit-lexicon/{code.lower()}")
+            if hit:
+                defects.append(f'{code}: says "csl-orig only" but {hit} exists')
+        else:
+            hit = repos.get(f"sanskrit-lexicon/{code.lower()}")
+            if hit:
+                defects.append(f"{code}: no repo link, but {hit} exists")
+
+    for defect in defects:
+        print(f"DEFECT  {defect}")
+    print(f"{checked} Repo cells checked, {len(defects)} defective")
+    return 1 if defects else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Repairs the first of the two hub defects recorded by the [H1475 consolidation spike](https://github.com/gasyoun/Uprava/blob/main/CONSOLIDATION_SPIKE_REPOLESS_DICTIONARIES_THIN_VIEW_REPOS_2026Q3.md) §5. Handoff: [H1722](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1722-Opus_Uprava_hub-index-coverage-repair-featuresindex-masterindex_27.07.26.md).

## The defect

| Code | Cell said | Reality |
|---|---|---|
| `PUI` | csl-orig only | [sanskrit-lexicon/PUI](https://github.com/sanskrit-lexicon/PUI) exists (18 files, 2 open issues) |
| `IEG` | csl-orig only | [sanskrit-lexicon/IEG](https://github.com/sanskrit-lexicon/IEG) exists (11 files, 1 open issue) |
| `PD` | a Cologne **scan** link | [sanskrit-lexicon/PD](https://github.com/sanskrit-lexicon/PD) exists — 31 files of real OCR-comparison work |

**Why it is not cosmetic:** `csl-orig only` is the field the count of repo-less dictionaries is derived from, so a wrong cell silently moves a published figure.

## What changed

- The three cells now link their repos.
- **All 44 cells re-verified mechanically**, not just the three known-bad: 3 defective, 41 correct, **0 after the fix**.
- New [`tools/audit_features_index_repo_cells.py`](https://github.com/gasyoun/SanskritLexicography/blob/h1722-featuresindex-repo-cells/tools/audit_features_index_repo_cells.py) keeps the check re-runnable (exit 1 on any defect, so it can gate CI). It **fails loud when `gh` returns nothing** — an empty listing would otherwise read as "every repo is missing" and flag all 44 rows. That case is not hypothetical: a TLS handshake timeout hit twice during this pass and the guard caught both.
- The Repo column now distinguishes `csl-orig only` (no repo at all — 13 dictionaries) from "— venue only" (repo exists but holds only issues and a Pages shell). A dictionary repo in this org is an **issue venue**, not a data repo; the text lives in csl-orig either way.

## Verification

```
$ python tools/audit_features_index_repo_cells.py
44 Repo cells checked, 0 defective
```

Opus 5 1M (`claude-opus-5[1m]`).