### PR TITLE
fix(ls_resolver): rvps mislink + TS./TBR. arity-gap wiring (H1714)

### DIFF
--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -633,7 +633,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H321 (code review 2026-07-04 item #5). ls_resolver resolves an <ls> citation to a scan/hymns URL independent of the translation language (it keys on the citation abbreviation + numbers, never on RU/EN prose), so both language editions' link-targets share it. The anchored _is_rv_prefix and the _warn_swallowed exception surfacing are pure link-resolution correctness, no lang branch. Pinned by test_ls_resolver_rv_av_anchored.",
     "tracking": "",
     "verified_sha256": {
-      "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
+      "src/ls_resolver.py": "d7c8da35c6a420b9f9431dd1cb672ed12431e2b27830b9b560a60cff42509eec",
       "src/pilot/window_selftest.py": "95e847ba8e2a549b3640ca0f94cb56146a42bd1fa06e6fd1e0d80fc3c84c2ac1"
     }
   },
@@ -1333,7 +1333,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1307 (19-07-2026). The enrichment is render-time and keys only on the citation abbreviation + numbers (P. adhyaya/pada/sutra, Spr. (II) saying number) — never on RU/EN translation prose — so both language editions' <ls> link-targets and tooltips share it with no --lang branch. The Spr. (II) saying text is identical across editions. Pinned by src/pilot/ls_enrichment_selftest.py.",
     "tracking": "",
     "verified_sha256": {
-      "src/ls_resolver.py": "78f1a17e80d7b0ed9fb4dd79fdd5c076f8ef2f1fee245ab0cda9f5e4da8fcfec",
+      "src/ls_resolver.py": "d7c8da35c6a420b9f9431dd1cb672ed12431e2b27830b9b560a60cff42509eec",
       "src/spr_fulltext.py": "446fe8ce8146cfdda3a0cd0b2e6f62c3b76e08cfb872823116549ed3992fe0d5",
       "src/pilot/build_article_site.py": "09ce9d51e88bcfdebfb86ac74b86d57317faa6f182922041a212b96871b24987"
     }

--- a/RussianTranslation/src/ls_resolver.py
+++ b/RussianTranslation/src/ls_resolver.py
@@ -125,6 +125,7 @@ _CODE_TO_PFX = {
     'Pañcat.': 'pantankose',
     'VS.': 'vajasasa',
     'TS.': 'taittiriyas',
+    'TBR.': 'taittiriyabr',
     'Ragh. ed. Calc.': 'raghuvamsacalc',
     'Raghuv.': 'raghuvamsacalc',
     'Ragh. (C)': 'raghuvamsacalc',
@@ -533,9 +534,16 @@ PWG_PATTERNS = [
               'https://ashtadhyayi.com/sutraani/$2/$3'),
     LsPattern(r'^(P[.]) *([1-8])(?![0-9,])',
               'https://ashtadhyayi.com/sutraani/$2'),
-    # Rig Veda Pratisthana
-    LsPattern(r'^(ṚV[.] PRĀTIŚ[.]) *([0-9]+), *([0-9]+)',
-              'rvAvHymnUrl2'),
+    # Rgveda-Pratisakhya (rvps scan) -- NOT the Rgveda hymn pages. This used
+    # to route through 'rvAvHymnUrl2' (the RV hymn-anchor generator), which
+    # silently produced a plausible-looking URL for a different text (and,
+    # for the undotted 'RV. PRAT.' spelling, fell through to a nonexistent
+    # rv00.* mandala-00 URL since no pattern matched it at all). Accepts both
+    # the diacritic 'RV. PRATIS.' and undotted 'RV. PRAT.' spellings. Must
+    # stay above the RV. 2-/3-param patterns below so it wins the
+    # first-match scan. See gasyoun/SanskritLexicography#826.
+    LsPattern(r'^(ṚV[.] PRĀTIŚ[.]|RV[.] PRAT[.]) *([0-9]+), *([0-9]+)',
+              'https://sanskrit-lexicon-scans.github.io/rvps/app1/?$2,$3'),
     # Rig Veda - 3 params
     LsPattern(r'^(ṚV[.]) *([0-9]+), *([0-9]+), *([0-9]+)',
               'rvAvHymnUrl'),
@@ -754,6 +762,13 @@ def href_taittiriya_samhita(data1: str):
     if m is None:
         return None
     return 'https://sanskrit-lexicon-scans.github.io/taittiriyas/app1?%s,%s,%s' % (m.group(1), m.group(2), m.group(3))
+
+
+def href_taittiriya_brahmana(data1: str):
+    m = re.search(r'([0-9]+)[ ,]+([0-9]+)[ ,]+([0-9]+)', data1)
+    if m is None:
+        return None
+    return 'https://sanskrit-lexicon-scans.github.io/taittiriyabr/app1?%s,%s,%s' % (m.group(1), m.group(2), m.group(3))
 
 
 def href_satapatha_brahmana(data1: str):
@@ -1160,33 +1175,35 @@ def generate_href(dict_code: str, n_attribute, visible: str):
         return href_ramayana_gorresio(data1)
     elif pfx in ('MBH.', 'MBHC', 'MBHB', 'MBH'):
         return href_mahabharata(data1, pfx)
-    elif pfx == 'Pañcat.':
+    elif pfx == 'pantankose':
         return href_pancatantra(data1)
-    elif pfx == 'Hariv.':
+    elif pfx == 'hariv':
         return href_harivamsa(data1)
-    elif pfx in ('BhP.', 'bhagp'):
+    elif pfx in ('BhP.', 'bhagp', 'bhp'):
         return href_bhagavata_purana(data1)
     elif pfx in ('Ragh.', 'raghuvamsacalc'):
         return href_raghuvamsa(data1, pfx)
-    elif pfx == 'VS.':
+    elif pfx == 'vajasasa':
         return href_vajasansamhita(data1)
-    elif pfx == 'TS.':
+    elif pfx == 'taittiriyas':
         return href_taittiriya_samhita(data1)
+    elif pfx == 'taittiriyabr':
+        return href_taittiriya_brahmana(data1)
     elif pfx in ('ŚBr.', 'Śat. Br.', 'shatapathabr'):
         return href_satapatha_brahmana(data1)
-    elif pfx == 'Megh.':
+    elif pfx == 'meghaduta':
         return href_meghaduta(data1)
     elif pfx in ('Kum.', 'Kumāras.', 'kumaras'):
         return href_kumarasambhava(data1)
-    elif pfx == 'Mālav.':
+    elif pfx == 'malavikagni':
         return href_malavikagnimitra(data1)
     elif pfx in ('Vikr.', 'vikramor'):
         return href_vikramorvashiya(data1)
-    elif pfx == 'Bhag.':
+    elif pfx == 'bhagavadgita':
         return href_bhagavadgita(data1)
     elif pfx in ('Mn.', 'M.'):
         return href_manu(data1)
-    elif pfx == 'Nir.':
+    elif pfx == 'nir':
         return href_nirukta(data1)
     elif pfx == 'kathas':
         return href_kathasaritsagara(data1)

--- a/RussianTranslation/tests/test_ls_resolver_rvps_arity.py
+++ b/RussianTranslation/tests/test_ls_resolver_rvps_arity.py
@@ -1,0 +1,85 @@
+"""Regression probe for H1714 / gasyoun/SanskritLexicography#826.
+
+Two defect classes fixed:
+
+  1. Mislink -- 'RV. PRAT.' / 'RV. PRATIS.' (Rgveda-Pratisakhya) used to
+     resolve through the Rgveda-hymn generator ('rvAvHymnUrl2'), silently
+     returning a plausible-looking wrong URL (a different text) instead of
+     the rvps scan. The undotted 'RV. PRAT.' spelling matched no pattern at
+     all and fell through to the fallback RV/AV helper, producing a
+     nonexistent rv00.* mandala-00 URL.
+  2. Arity gaps -- TS. and TBR. resolved only at 4-parameter arity because
+     their fallback dispatch branches tested the citation-code literal
+     ('TS.') instead of the prefix-map value the dispatch actually receives
+     ('taittiriyas'); TBR. additionally had no fallback wired at all
+     (uppercase 'TBR.' was absent from the prefix map).
+
+Run: `pytest tests/test_ls_resolver_rvps_arity.py` (working dir RussianTranslation).
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
+
+import ls_resolver as lsr  # noqa: E402
+
+
+# --- Rgveda-Pratisakhya (rvps) mislink --------------------------------------
+
+def test_rvps_undotted_spelling_resolves_to_rvps_scan():
+    url = lsr.generate_href('pwg', 'RV. PRAT. ', '4,12')
+    assert url == 'https://sanskrit-lexicon-scans.github.io/rvps/app1/?4,12'
+
+
+def test_rvps_diacritic_spelling_resolves_to_rvps_scan():
+    url = lsr.generate_href('pwg', 'ṚV. PRĀTIŚ. ', '4,12')
+    assert url == 'https://sanskrit-lexicon-scans.github.io/rvps/app1/?4,12'
+
+
+def test_rvps_undotted_spelling_does_not_fall_through_to_rv_hymn_pages():
+    url = lsr.generate_href('pwg', 'RV. PRAT. ', '4,12')
+    assert url is not None
+    assert 'rv00' not in url
+    assert 'rvlinks' not in url
+
+
+def test_bare_rv_citation_still_resolves_to_the_hymn_pages():
+    """Regression guard: the rvps pattern must not shadow ordinary RV citations."""
+    url = lsr.generate_href('pwg', 'ṚV. ', '10,85,24')
+    assert url == 'https://sanskrit-lexicon.github.io/rvlinks/rvhymns/rv10.085.html#rv10.085.24'
+
+
+# --- Taittiriya Samhita (TS.) arity gap -------------------------------------
+
+def test_ts_resolves_at_4_param_arity():
+    url = lsr.generate_href('pwg', 'TS. ', '1,2,3,4')
+    assert url == 'https://sanskrit-lexicon-scans.github.io/taittiriyas/app1?1,2,3,4'
+
+
+def test_ts_resolves_at_3_param_arity():
+    url = lsr.generate_href('pwg', 'TS. ', '1,2,3')
+    assert url == 'https://sanskrit-lexicon-scans.github.io/taittiriyas/app1?1,2,3'
+
+
+# --- Taittiriya Brahmana (TBR.) arity gap -----------------------------------
+
+def test_tbr_resolves_at_4_param_arity():
+    url = lsr.generate_href('pwg', 'TBR. ', '1,2,3,4')
+    assert url == 'https://sanskrit-lexicon-scans.github.io/taittiriyabr/app1?1,2,3,4'
+
+
+def test_tbr_resolves_at_3_param_arity():
+    url = lsr.generate_href('pwg', 'TBR. ', '1,2,3')
+    assert url == 'https://sanskrit-lexicon-scans.github.io/taittiriyabr/app1?1,2,3'
+
+
+# --- Pancaratra (PANCAR.) -- confirm existing arities still resolve --------
+
+def test_pancar_resolves_at_3_param_arity():
+    url = lsr.generate_href('pwg', 'PAÑCAR. ', '1,2,3')
+    assert url == 'https://sanskrit-lexicon-scans.github.io/pancar/app1?1,2,3'
+
+
+def test_pancar_resolves_at_page_form():
+    url = lsr.generate_href('pwg', 'PAÑCAR. ', 'S. 100')
+    assert url == 'https://sanskrit-lexicon-scans.github.io/pancar/app0?100'


### PR DESCRIPTION
## Summary
- Rgveda-Pratisakhya citations (`RV. PRAT.` / `RV. PRATIS.` diacritic form) now resolve to the `rvps` scan (`https://sanskrit-lexicon-scans.github.io/rvps/app1/?patala,sutra`), not the Rgveda hymn-anchor pages -- the mislink was a silent wrong answer to a different text; the undotted spelling previously fell through to a nonexistent `rv00.*` mandala-00 URL.
- `TS.` 3-param citations now resolve: the `href_taittiriya_samhita` fallback already existed but its dispatch branch tested the citation-code literal `'TS.'` instead of the prefix-map value `'taittiriyas'` it actually receives -- unreachable, one-line fix.
- `TBR.` now has a 3-param fallback wired end-to-end (prefix-map entry + `href_taittiriya_brahmana` helper + dispatch branch); previously uppercase `TBR.` was entirely absent from the prefix map, so any arity below 4 returned `None`.
- Same-class dispatch-literal-vs-value mismatches fixed for `Pañcat.`/`Hariv.`/`BhP.`/`VS.`/`Megh.`/`Mālav.`/`Bhag.`/`Nir.` -- identical bug pattern to the `TS.` one, zero regression risk (they only add reachability to previously-dead branches, never change existing behavior).

## Decisions recorded (no code change)
- **`amara_col` re-keying**: left as-is. `AK.` bare form is cited 16,151 times per the pwg_scan_index tracker (Deslongchamps edition, `amara_dlc`) with the Colebrooke edition (`amara_col`) showing zero measured citation count under that same key -- the routing is correct by design: `COL.`/`COLEBR.`/`AK. ed. COLEBR.` already resolve to `amara_col` correctly, and there's no evidence PWG ever emits a bare `AK.` intending Colebrooke.
- **`PANCAR.` 2-param arity**: confirmed not a wiring gap. The `pancar` scan viewer's only apps are `app1` (3 params: ratra, adhyaya, sloka) and `app0` (page number) -- there's no natural 2-param target, and the canonical `csl-app` Dart source has the same limitation. Left unresolved (fails closed), matching upstream.
- **38 dead prefix-map branches**: the issue's own audit already classified these as "harmless for PWG (which cites in uppercase, covered by PWG_PATTERNS)". 8 of the safely-fixable ones (matching the TS. bug pattern exactly, with a working helper already present) are fixed in this PR. The rest are mixed-case general-dict entries copied wholesale from the Dart port's `_codeToPfx` map; every call site in this repo invokes `generate_href` with `dict_code='pwg'` only, and PWG's own citations use the uppercase forms (already correctly wired via `PWG_PATTERNS` / the `_pwg`-suffixed prefix entries), so these remaining mixed-case keys are inert for real data, not a live safety-net gap. Left as-is rather than risk a wide, hard-to-verify deletion pass.

## Cross-repo finding (not fixed here, flagged for a human decision)
The canonical `csl-app/lib/core/ls_patterns.dart` + `ls_service.dart` **share the same two live bugs**:
- `ls_patterns.dart` line 726-730: the `ṚV. PRĀTIŚ.` pattern also routes through `rvAvHymnUrl2` -- same mislink.
- `ls_service.dart` line 343-344: `else if (pfx == 'TS.')` has the identical dispatch-literal-vs-prefix-value bug (`_codeToPfx['TS.'] == 'taittiriyas'`), so `hrefTaittiriyaSamhita` is dead code there too.

Fixing only this Python port leaves the live Flutter app mislinking Rgveda-Pratisakhya citations. Whether to open a matching PR against `csl-app` is a call a human should make -- filing it here rather than silently fixing app code out of scope.

## Test plan
- [x] New probe test `RussianTranslation/tests/test_ls_resolver_rvps_arity.py` (10 cases): rvps undotted + diacritic spellings assert the exact scan URL (not just "not None"), a regression guard that bare `RV.` citations still resolve to the hymn pages, TS./TBR. at 3- and 4-param arity, PANCAR. at 3-param and page-number form.
- [x] `pytest tests/` (28 tests, full RussianTranslation suite) -- all pass, no regressions.
- [x] Manual run of `ls_resolver.py`'s own `__main__` self-test block -- unchanged output for all pre-existing cases.

Fixes gasyoun/SanskritLexicography#826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)