### PR TITLE
docs(lang-parity): H1717 — re-affirm citation_tm verdict after H1705

### DIFF
--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -88,7 +88,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "ru"
     ],
     "verdict": "INTENTIONAL-DIVERGENCE",
-    "note": "H1304: the citation translation-memory is RU-only by construction. The reuse assets are Russian translations of record (Elizarenkova RV, Leonov Ramayana, Ocean of Stories, ...); there is NO parallel English citation-TM corpus, so there is nothing to port to the EN path. If an EN citation-TM corpus is ever assembled, this becomes a GAP to port; until then RU-only is intended, not an oversight.",
+    "note": "H1304: the citation translation-memory is RU-only by construction. The reuse assets are Russian translations of record (Elizarenkova RV, Leonov Ramayana, Ocean of Stories, ...); there is NO parallel English citation-TM corpus, so there is nothing to port to the EN path. If an EN citation-TM corpus is ever assembled, this becomes a GAP to port; until then RU-only is intended, not an oversight. H1717 (27-07-2026): re-affirmed after H1705/#823 split a new miss reason, ru-translation-unpublished, out of locus-not-in-corpus. The new reason is about Russian translations of record, RU-only by the same construction as the entry it lives under, and assembles no EN citation-TM corpus, so the verdict still holds; re-pinned (hash already re-verified in #837/b060e35a).",
     "tracking": "",
     "verified_sha256": {
       "src/citation_tm.py": "af4f42298469ccd36e037ef53fdfe818d0fd54a3e6a0618a6cc29f63b3b8baa1"


### PR DESCRIPTION
## Summary
- Closes H1717. The mechanical repair (re-pinning `citation_tm_ru_translation_of_record`'s `verified_sha256` after H1705's `src/citation_tm.py` change) already landed as an attributed side-fix in [#837](https://github.com/gasyoun/SanskritLexicography/pull/837) (`b060e35a`) before this session started.
- This PR closes the remaining gap: the verdict reasoning existed only in that commit's message, not in the ledger entry's own `note` field, which is the audit trail `lang_parity_check.py` actually reads. Folded it in: the `ru-translation-unpublished` reason H1705 introduced is about Russian translations of record, RU-only by the same construction as the entry it lives under, and assembles no EN citation-TM corpus — so `INTENTIONAL-DIVERGENCE` still holds.
- No re-pin needed here; the hash (`af4f4229...`) is already current.

## Verification
- `python RussianTranslation/src/pilot/lang_parity_check.py` — `85 entries, all verdicts complete, no drift`
- `python RussianTranslation/src/pilot/window_selftest.py` — `193/193 passed`
- CI on `master` HEAD (`5bdce09f`) — `RussianTranslation gates` job: success (confirmed via `gh run view`)

## Test plan
- [x] Parity check clean
- [x] Window selftest 193/193
- [x] Master CI green (pre-existing, confirmed not this PR's doing)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>