### PR TITLE
docs(FINDINGS): §493–§495 GAPS residual (H1745–H1747)

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -41,6 +41,10 @@ refuted or superseded, strike it and say why — never reuse its number. **Verif
 - 🟡 [§491. Verb-form frequency prelim is an unlabeled 42-row XLS with empty tense names](#491-verb-form-frequency-prelim-is-an-unlabeled-42-row-xls-with-empty-tense-names)
 - 🟠 [§492. Stopovye is a 102-file subset of Polnorazmernye, not a stopword filter of the full 506k](#492-stopovye-is-a-102-file-subset-of-polnorazmernye-not-a-stopword-filter-of-the-full-506k)
 
+- 🟡 [§493. Cross-vendor LLM second pass on routing gold is κ=1.0 — still not human IAA](#493-cross-vendor-llm-second-pass-on-routing-gold-is-κ10--still-not-human-iaa)
+- 🟠 [§494. Homonym token-attribution residual is a 38-group single-lemma_id ceiling](#494-homonym-token-attribution-residual-is-a-38-group-single-lemma_id-ceiling)
+- 🟡 [§495. Cyrillic name indices: 61 IAST-bearing seed files vs 47 pure-Cyrillic — rules still unsafe](#495-cyrillic-name-indices-61-iast-bearing-seed-files-vs-47-pure-cyrillic--rules-still-unsafe)
+
 
 **Grammar & morphology data**
 
@@ -4521,3 +4525,33 @@ Implication: Stopovye is **not** «the full parallel export with stopwords remov
 > **Source:** graduates [GAPS §5](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) · manifest stopovye-parallel-passages / dcs-parallel-passages-full · [VisualDCS](https://github.com/gasyoun/VisualDCS) · H1735 · 27-07-2026 · Grok 4.5 (grok-4.5)
 
 
+
+### 493. Cross-vendor LLM second pass on routing gold is κ=1.0 — still not human IAA
+
+🟡 **A Grok 4.5 second annotation of the 24-scenario which-dictionary routing benchmark agrees with Fable 5 gold on 24/24 (Cohen's κ = 1.0 strict); this is cross-vendor LLM agreement, not human inter-annotator reliability.** Graduates GAPS §10 only partially.
+
+Evidence: independent second-pass labels committed before scoring (`tools/gaps_measure_out/h1745_routing_kappa.json` in Uprava H1745 pack; mirror in csl-guides). Answer space 44 codes; splits 18 dev + 6 test. Strict agree 24/24; lenient agree 24/24.
+
+Implication: the scenarios are **highly determinate** for current model families — κ=1 does not prove gold is human-reliable. A human second pass remains required before treating the benchmark as IAA-grounded. Kin: FINDINGS contamination note on same-family κ as reliability statistic.
+
+> **Source:** graduates [GAPS §10](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (partial — human IAA still open) · [routing-benchmark.json](https://github.com/sanskrit-lexicon/csl-guides/blob/main/src/data/routing-benchmark.json) · H1745 · 27-07-2026 · Grok 4.5 (grok-4.5)
+
+### 494. Homonym token-attribution residual is a 38-group single-lemma_id ceiling
+
+🟠 **Of 72 homonym groups in WhitneyRoots `token_attribution.json`, 26 are reliable and 46 are not: 38 fail because DCS exposes a single verb lemma_id for the whole lump, and 8 collapse onto one homonym under the current gloss map. Lowering the coverage≥0.55 floor cannot create splits when n_lemma_id=1.**
+
+Evidence: re-count H1747 (`crosswalk/gaps_s4_homonym_ceiling_report.json`): reliable=26, unreliable=46, reasons={'DCS lumps (1 verb lemma_id)': 38, 'collapses onto one homonym': 8}. Sample lumps: gam, paś, ji, i, pat, stu (DCS single lemma_id). Extends FINDINGS §2 morphological ceiling into the post-gloss-mapping residual.
+
+Implication: residual work is **sense/gloss gold or DCS sense-level IDs**, not more morphology or coverage-threshold tuning. GAPS §4 stays open for the adjudication work itself; the ceiling is now measured.
+
+> **Source:** measures [GAPS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) · [token_attribution.json](https://github.com/gasyoun/WhitneyRoots/blob/main/crosswalk/token_attribution.json) · H1747 · 27-07-2026 · Grok 4.5 (grok-4.5)
+
+### 495. Cyrillic name indices: 61 IAST-bearing seed files vs 47 pure-Cyrillic — rules still unsafe
+
+🟡 **A filesystem probe of SamudraManthanam + RussianTranslation name-like files found 61 files with inline IAST parentheses (seedable for a proper-noun lookup table) and 47 Cyrillic-heavy files with zero IAST hits; character-rule reverse transcription remains unsafe (FINDINGS §60 stands).**
+
+Evidence: H1746 probe scanned 152 candidate files (`RussianTranslation/tools/gaps_s6_cyrillic_name_probe.json`). Recoverable path = validated lookup seeded from IAST-bearing indices, not dental/retroflex-collapsing transcription.
+
+Implication: GAPS §6 is not closed — the 3 fully-Cyrillic glossaries still need human-validated onomasticon rows — but the seed inventory exists and rules-based conversion is reconfirmed as a dead end.
+
+> **Source:** measures [GAPS §6](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) · [FINDINGS §60](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) · H1746 · 27-07-2026 · Grok 4.5 (grok-4.5)

--- a/GAPS.md
+++ b/GAPS.md
@@ -47,6 +47,7 @@ How to close: a human browser download of the two `.xml.gz` URLs (bookmarked in 
 
 ### §4. Homonym token frequency beyond the 26+5 splittable groups
 🟡 ✍️ **We have NOT attributed token frequency for the 33 of 38 DCS-lumped homonym groups that share a present class.**
+> **CEILING MEASURED 27-07-2026 → [FINDINGS §494](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) (38 single-lemma_id lumps; adjudication still open). H1747.**
 Why it matters: token-level "N in this sense · M for the lemma" displays are impossible for these without sense/gloss adjudication; it is the ceiling on per-sense frequency accuracy.
 Blocker: no tool — gaṇa is undistinguishing (unaccented corpus, §8); needs manual gloss adjudication (DCS `meanings` ↔ Warnemyr gloss).
 How to close: extend the coverage≥0.55 gloss-mapping approach in `crosswalk/token_attribution.json`; owner WhitneyRoots.
@@ -65,6 +66,7 @@ How to close: parse the per-passage CSV records, diff against the full-export sa
 
 ### §6. Cyrillic-only Sanskrit name glossaries — no join key exists
 🟠 ✍️ **We have NOT (and cannot safely) build a Cyrillic→SLP1 key for the 3 fully-Cyrillic name glossaries.**
+> **SEED INVENTORY 27-07-2026 → [FINDINGS §495](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) (61 IAST-bearing seeds / 47 pure-Cyrillic; rules still unsafe). H1746.**
 Why it matters: 3 of 6 SamudraManthanam name indices (Потапова, Эрман-Темкин, Бадь Kadambari) are 100% Cyrillic — blocked from any pwg_ru corpus_gate reuse.
 Blocker: no tool that is safe — practical Russian transcription collapses dental/retroflex (т = त and ट); a rule-based converter manufactures wrong keys for exactly the retroflex-bearing epic names.
 How to close: a proper-noun lookup table validated against a Sanskrit onomasticon (not character rules), checked as its own artifact first.
@@ -109,6 +111,7 @@ How to close: tally the disagreement-class distribution, append a FINDINGS row (
 
 ### §10. Which-dictionary routing benchmark has single-annotator gold, no κ
 🟠 ⚙️ **The 24-scenario routing shared-task benchmark (`which-dictionary-routing-benchmark`) has single-annotator gold (Fable 5, one pass) — NO inter-annotator agreement measured over its 44-code answer space.**
+> **PARTIAL 27-07-2026 → [FINDINGS §493](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) (Grok second pass κ=1.0; human IAA still open). H1745.**
 Why it matters: a shared-task benchmark with no κ can't quantify its own gold reliability, which caps the credibility of any leaderboard result built on it (csl-guides `/about/shared-tasks`).
 Blocker: needs a second independent annotation pass (see `/gold-adjudicate`), not just a rerun.
 How to close: second-annotate the 24 scenarios, compute κ + a confusion table, append a FINDINGS row.

--- a/RESULTS_LOG.md
+++ b/RESULTS_LOG.md
@@ -15,3 +15,13 @@ _Created: 27-07-2026 · Last updated: 27-07-2026_
 Systema deploy: root SSH → `deploy.sh` → `5049b4c` + migration; external smoke hairpin fail only.
 
 _Dr. Mārcis Gasūns_
+
+## 27-07-2026 — GAPS residual measure batch H1745–H1747 / H1746 (Grok 4.5)
+
+| Gap | Finding | Headline |
+|---|---|---|
+| SL §10 routing κ | §493 | Grok second pass 24/24, κ=1.0 (not human IAA) |
+| SL §4 homonym residual | §494 | 26 reliable / 46 unreliable (38 single-lemma_id) |
+| SL §6 Cyrillic names | §495 | 61 IAST seeds / 47 pure-Cyrillic; rules unsafe |
+
+Handoffs: H1745, H1746, H1747. Model: Grok 4.5 (`grok-4.5`).

--- a/RussianTranslation/tools/gaps_s6_cyrillic_name_probe.json
+++ b/RussianTranslation/tools/gaps_s6_cyrillic_name_probe.json
@@ -1,0 +1,1142 @@
+{
+  "handoff": "H1746",
+  "gap": "SanskritLexicography/GAPS.md §6",
+  "measured_at": "2026-07-27T11:33:29.133459+00:00",
+  "model": "Grok 4.5 (grok-4.5)",
+  "files_scanned": 152,
+  "files_with_inline_iast": 61,
+  "files_cyrillic_heavy_no_iast": 47,
+  "verdict": "FINDINGS §60 stands: reverse-transcription rules remain unsafe. Recoverable path is a validated proper-noun LOOKUP table seeded from IAST-bearing indices (Гринцер / Rāmāyaṇa), not character rules. This probe inventories seed candidates; full table build needs human spot-check against an onomasticon for the 3 fully-Cyrillic glossaries.",
+  "with_iast_top": [
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\add\\To_add\\dsg_index.html",
+      "bytes": 4902257,
+      "lines_scanned": 4668,
+      "cyrillic_lines": 4378,
+      "iast_paren_hits": 977,
+      "samples": [
+        "<tr><td><a id=\"1\">1</a>/<span class=\"page-link\"data-text=\"1\">1</span></td><td><a class=\"sa\">अ</a><br> <a class=\"iast\">/a/</a><br> <a class=\"HK\"> </a></td><td><p",
+        "<tr><td><a id=\"2\">2</a>/<span class=\"page-link\"data-text=\"1\">1</span></td><td><a class=\"sa\">अं</a><br> <a class=\"iast\">/aṃ/</a><br> <a class=\"HK\">/aM/ </a></td>",
+        "<tr><td><a id=\"6\">6</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अ ೱ क्, जिह्वामूलीय</a><br> <a class=\"iast\">/a ೱ k/, /jihvāmūlīya/</",
+        "<tr><td><a id=\"7\">7</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अ ೱ प्, उपध्मानीय</a><br> <a class=\"iast\">/a ೱ p/, /upadhmānīya/</a>",
+        "<tr><td><a id=\"9\">9</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अक्</a><br> <a class=\"iast\">/ak/</a><br> <a class=\"HK\"> </a></td><td",
+        "<tr><td><a id=\"11\">11</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अकङ्</a><br> <a class=\"iast\">/akaṅ/</a><br> <a class=\"HK\">/akaG/ <",
+        "<tr><td><a id=\"13\">13</a>/<span class=\"page-link\"data-text=\"2-3\">2-3</span></td><td><a class=\"sa\">अकथित</a><br> <a class=\"iast\">/akathita/</a><br> <a class=\"HK\"",
+        "<tr><td><a id=\"16\">16</a>/<span class=\"page-link\"data-text=\"3\">3</span></td><td><a class=\"sa\">अकर्मक</a><br> <a class=\"iast\">/akarmaka/</a><br> <a class=\"HK\"> <"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\Index\\lib\\x86_64-win64\\add\\To_add\\dsg_index.html",
+      "bytes": 4906924,
+      "lines_scanned": 4668,
+      "cyrillic_lines": 4378,
+      "iast_paren_hits": 977,
+      "samples": [
+        "<tr><td><a id=\"1\">1</a>/<span class=\"page-link\"data-text=\"1\">1</span></td><td><a class=\"sa\">अ</a><br> <a class=\"iast\">/a/</a><br> <a class=\"HK\"> </a></td><td><p",
+        "<tr><td><a id=\"2\">2</a>/<span class=\"page-link\"data-text=\"1\">1</span></td><td><a class=\"sa\">अं</a><br> <a class=\"iast\">/aṃ/</a><br> <a class=\"HK\">/aM/ </a></td>",
+        "<tr><td><a id=\"6\">6</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अ ೱ क्, जिह्वामूलीय</a><br> <a class=\"iast\">/a ೱ k/, /jihvāmūlīya/</",
+        "<tr><td><a id=\"7\">7</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अ ೱ प्, उपध्मानीय</a><br> <a class=\"iast\">/a ೱ p/, /upadhmānīya/</a>",
+        "<tr><td><a id=\"9\">9</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अक्</a><br> <a class=\"iast\">/ak/</a><br> <a class=\"HK\"> </a></td><td",
+        "<tr><td><a id=\"11\">11</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अकङ्</a><br> <a class=\"iast\">/akaṅ/</a><br> <a class=\"HK\">/akaG/ <",
+        "<tr><td><a id=\"13\">13</a>/<span class=\"page-link\"data-text=\"2-3\">2-3</span></td><td><a class=\"sa\">अकथित</a><br> <a class=\"iast\">/akathita/</a><br> <a class=\"HK\"",
+        "<tr><td><a id=\"16\">16</a>/<span class=\"page-link\"data-text=\"3\">3</span></td><td><a class=\"sa\">अकर्मक</a><br> <a class=\"iast\">/akarmaka/</a><br> <a class=\"HK\"> <"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\intelligent-nightingale-117af2\\Index\\lib\\x86_64-win64\\add\\To_add\\dsg_index.html",
+      "bytes": 4906924,
+      "lines_scanned": 4668,
+      "cyrillic_lines": 4378,
+      "iast_paren_hits": 977,
+      "samples": [
+        "<tr><td><a id=\"1\">1</a>/<span class=\"page-link\"data-text=\"1\">1</span></td><td><a class=\"sa\">अ</a><br> <a class=\"iast\">/a/</a><br> <a class=\"HK\"> </a></td><td><p",
+        "<tr><td><a id=\"2\">2</a>/<span class=\"page-link\"data-text=\"1\">1</span></td><td><a class=\"sa\">अं</a><br> <a class=\"iast\">/aṃ/</a><br> <a class=\"HK\">/aM/ </a></td>",
+        "<tr><td><a id=\"6\">6</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अ ೱ क्, जिह्वामूलीय</a><br> <a class=\"iast\">/a ೱ k/, /jihvāmūlīya/</",
+        "<tr><td><a id=\"7\">7</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अ ೱ प्, उपध्मानीय</a><br> <a class=\"iast\">/a ೱ p/, /upadhmānīya/</a>",
+        "<tr><td><a id=\"9\">9</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अक्</a><br> <a class=\"iast\">/ak/</a><br> <a class=\"HK\"> </a></td><td",
+        "<tr><td><a id=\"11\">11</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अकङ्</a><br> <a class=\"iast\">/akaṅ/</a><br> <a class=\"HK\">/akaG/ <",
+        "<tr><td><a id=\"13\">13</a>/<span class=\"page-link\"data-text=\"2-3\">2-3</span></td><td><a class=\"sa\">अकथित</a><br> <a class=\"iast\">/akathita/</a><br> <a class=\"HK\"",
+        "<tr><td><a id=\"16\">16</a>/<span class=\"page-link\"data-text=\"3\">3</span></td><td><a class=\"sa\">अकर्मक</a><br> <a class=\"iast\">/akarmaka/</a><br> <a class=\"HK\"> <"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\Data\\Словарь Гринцера из Рамаяны 1-2.txt",
+      "bytes": 88939,
+      "lines_scanned": 463,
+      "cyrillic_lines": 463,
+      "iast_paren_hits": 186,
+      "samples": [
+        "Агастья\t(Agastya) — божественный мудрец, сын Митры и Варуны, герой многих индийских мифов, покровитель юга Индии; ему приписываются более двадцати гимнов «Ригве",
+        "Агни\t(Agni) — бог огня во всех его проявлениях (космический огонь, небесный огонь, жертвенный огонь, домашний огонь и т. д.). Один из древнейших ведийских богов",
+        "Адити\t(Aditi) — одна из дочерей мудреца Дакши, жена Кашьяпы, мать двенадцати богов-адитьев, в том числе Индры.",
+        "Акша\t(Akṣa) — старший сын Раваны, убитый Хануманом.",
+        "Аламбуша\t(Alambuṣā) — жена царя Икшваку.",
+        "Аламбуша\t(Alambuṣā) — одна из апсар.",
+        "Аларка\t(Alarka) — благочестивый царь Каши (Варанаси) и Каруши.",
+        "Амбариша\t(Ambarīṣa) — царь Солнечной династии, потомок Икшваку."
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\Index\\lib\\x86_64-win64\\Data\\Словарь Гринцера из Рамаяны 1-2.txt",
+      "bytes": 88939,
+      "lines_scanned": 463,
+      "cyrillic_lines": 463,
+      "iast_paren_hits": 186,
+      "samples": [
+        "Агастья\t(Agastya) — божественный мудрец, сын Митры и Варуны, герой многих индийских мифов, покровитель юга Индии; ему приписываются более двадцати гимнов «Ригве",
+        "Агни\t(Agni) — бог огня во всех его проявлениях (космический огонь, небесный огонь, жертвенный огонь, домашний огонь и т. д.). Один из древнейших ведийских богов",
+        "Адити\t(Aditi) — одна из дочерей мудреца Дакши, жена Кашьяпы, мать двенадцати богов-адитьев, в том числе Индры.",
+        "Акша\t(Akṣa) — старший сын Раваны, убитый Хануманом.",
+        "Аламбуша\t(Alambuṣā) — жена царя Икшваку.",
+        "Аламбуша\t(Alambuṣā) — одна из апсар.",
+        "Аларка\t(Alarka) — благочестивый царь Каши (Варанаси) и Каруши.",
+        "Амбариша\t(Ambarīṣa) — царь Солнечной династии, потомок Икшваку."
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\intelligent-nightingale-117af2\\Index\\lib\\x86_64-win64\\Data\\Словарь Гринцера из Рамаяны 1-2.txt",
+      "bytes": 88939,
+      "lines_scanned": 463,
+      "cyrillic_lines": 463,
+      "iast_paren_hits": 186,
+      "samples": [
+        "Агастья\t(Agastya) — божественный мудрец, сын Митры и Варуны, герой многих индийских мифов, покровитель юга Индии; ему приписываются более двадцати гимнов «Ригве",
+        "Агни\t(Agni) — бог огня во всех его проявлениях (космический огонь, небесный огонь, жертвенный огонь, домашний огонь и т. д.). Один из древнейших ведийских богов",
+        "Адити\t(Aditi) — одна из дочерей мудреца Дакши, жена Кашьяпы, мать двенадцати богов-адитьев, в том числе Индры.",
+        "Акша\t(Akṣa) — старший сын Раваны, убитый Хануманом.",
+        "Аламбуша\t(Alambuṣā) — жена царя Икшваку.",
+        "Аламбуша\t(Alambuṣā) — одна из апсар.",
+        "Аларка\t(Alarka) — благочестивый царь Каши (Варанаси) и Каруши.",
+        "Амбариша\t(Ambarīṣa) — царь Солнечной династии, потомок Икшваку."
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\Data\\bhagavadgita-erman.html",
+      "bytes": 830765,
+      "lines_scanned": 720,
+      "cyrillic_lines": 720,
+      "iast_paren_hits": 100,
+      "samples": [
+        "<div class=\"citation_block\" id=\"1.35\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 1. 35\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 50\">35</div><di",
+        "<div class=\"chapter_title\" id=\"2\">Глава 2 [24]<a href='#comment_2_69' class='comment_sub'><sup><small>69</small></sup></a></div><div class=\"comments\"><div class",
+        "<div class=\"citation_block\" id=\"2.7\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 7\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 51\">7</div><div c",
+        "<div class=\"citation_block\" id=\"2.11\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 11\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 51\">11</div><di",
+        "<div class=\"citation_block\" id=\"2.13\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 13\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 51\">13</div><di",
+        "<div class=\"citation_block\" id=\"2.15\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 15\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 52\">15</div><di",
+        "<div class=\"citation_block\" id=\"2.16\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 16\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 52\">16</div><di",
+        "<div class=\"citation_block\" id=\"2.17\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 17\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 52\">17</div><di"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\Index\\lib\\x86_64-win64\\Data\\bhagavadgita-erman.html",
+      "bytes": 830765,
+      "lines_scanned": 720,
+      "cyrillic_lines": 720,
+      "iast_paren_hits": 100,
+      "samples": [
+        "<div class=\"citation_block\" id=\"1.35\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 1. 35\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 50\">35</div><di",
+        "<div class=\"chapter_title\" id=\"2\">Глава 2 [24]<a href='#comment_2_69' class='comment_sub'><sup><small>69</small></sup></a></div><div class=\"comments\"><div class",
+        "<div class=\"citation_block\" id=\"2.7\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 7\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 51\">7</div><div c",
+        "<div class=\"citation_block\" id=\"2.11\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 11\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 51\">11</div><di",
+        "<div class=\"citation_block\" id=\"2.13\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 13\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 51\">13</div><di",
+        "<div class=\"citation_block\" id=\"2.15\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 15\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 52\">15</div><di",
+        "<div class=\"citation_block\" id=\"2.16\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 16\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 52\">16</div><di",
+        "<div class=\"citation_block\" id=\"2.17\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 17\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 52\">17</div><di"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\intelligent-nightingale-117af2\\Index\\lib\\x86_64-win64\\Data\\bhagavadgita-erman.html",
+      "bytes": 830765,
+      "lines_scanned": 720,
+      "cyrillic_lines": 720,
+      "iast_paren_hits": 100,
+      "samples": [
+        "<div class=\"citation_block\" id=\"1.35\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 1. 35\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 50\">35</div><di",
+        "<div class=\"chapter_title\" id=\"2\">Глава 2 [24]<a href='#comment_2_69' class='comment_sub'><sup><small>69</small></sup></a></div><div class=\"comments\"><div class",
+        "<div class=\"citation_block\" id=\"2.7\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 7\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 51\">7</div><div c",
+        "<div class=\"citation_block\" id=\"2.11\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 11\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 51\">11</div><di",
+        "<div class=\"citation_block\" id=\"2.13\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 13\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 51\">13</div><di",
+        "<div class=\"citation_block\" id=\"2.15\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 15\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 52\">15</div><di",
+        "<div class=\"citation_block\" id=\"2.16\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 16\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 52\">16</div><di",
+        "<div class=\"citation_block\" id=\"2.17\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 17\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 52\">17</div><di"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\web\\corpus_builder\\jsonl\\bhagavadgita-erman.jsonl",
+      "bytes": 1567318,
+      "lines_scanned": 1701,
+      "cyrillic_lines": 1701,
+      "iast_paren_hits": 99,
+      "samples": [
+        "{\"id\": \"bhagavadgita-erman:1.35.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"1.35.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:1.35\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.70.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.70.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.70\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.11.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.11.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.11\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.13.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.13.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.13\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.15.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.15.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.15\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.16.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.16.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.16\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.16.comm2\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.16.comm2\", \"seg\": \"comm2\", \"group\": \"bhagavadgita-erman:2.16\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.17.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.17.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.17\", \"lang\": \"ru\","
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\web\\corpus_builder\\jsonl\\bhagavadgita-erman.jsonl",
+      "bytes": 1567318,
+      "lines_scanned": 1701,
+      "cyrillic_lines": 1701,
+      "iast_paren_hits": 99,
+      "samples": [
+        "{\"id\": \"bhagavadgita-erman:1.35.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"1.35.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:1.35\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.70.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.70.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.70\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.11.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.11.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.11\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.13.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.13.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.13\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.15.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.15.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.15\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.16.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.16.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.16\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.16.comm2\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.16.comm2\", \"seg\": \"comm2\", \"group\": \"bhagavadgita-erman:2.16\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.17.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.17.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.17\", \"lang\": \"ru\","
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\intelligent-nightingale-117af2\\web\\corpus_builder\\jsonl\\bhagavadgita-erman.jsonl",
+      "bytes": 1567318,
+      "lines_scanned": 1701,
+      "cyrillic_lines": 1701,
+      "iast_paren_hits": 99,
+      "samples": [
+        "{\"id\": \"bhagavadgita-erman:1.35.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"1.35.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:1.35\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.70.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.70.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.70\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.11.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.11.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.11\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.13.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.13.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.13\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.15.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.15.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.15\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.16.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.16.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.16\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.16.comm2\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.16.comm2\", \"seg\": \"comm2\", \"group\": \"bhagavadgita-erman:2.16\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.17.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.17.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.17\", \"lang\": \"ru\","
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\Data\\Рамаяна 3. Словарь.txt",
+      "bytes": 43195,
+      "lines_scanned": 209,
+      "cyrillic_lines": 209,
+      "iast_paren_hits": 81,
+      "samples": [
+        "Агастья (Agastya) — божественный мудрец, сын Митры и Варуны, покровитель юга Индии, герой многих индийских легенд и мифов. Агастье приписываются более двадцати ",
+        "Агни (Agni) — бог огня во всех его проявлениях (космический огонь, небесный огонь, жертвенный огонь, домашний огонь и т. д.). Один из древнейших ведийских богов",
+        "Адити (Aditi) — одна из дочерей мудреца Дакши, жена Кашьяпы, мать двенадцати богов адитьев, в том числе Индры и Варуны.",
+        "Айомукхи (Ayomukhī) — «[имеющая] железное лицо», «железноликая») — ракшаси, обезображенная Лакшманой за нападение на него.",
+        "Ангирас (Aṅgiras) — один из великих риши и праотцов всех живых существ, которому приписываются многие гимны «Ригведы»; родоначальник класса полубогов — небесных",
+        "Ариштанеми (Ariṣṭanemi) — согласно «Рамаяне», один их семнадцати прародителей живых существ (праджапати).",
+        "Атри (Atri) — один из прародителей живых существ (праджапати), великий риши, обитель которого посетил Рама во второй книге «Рамаяны».",
+        "Бала (Bala), или Вала (Vala), — асура, брат Вритры. По ведийскому мифу, спрятал в одноименной пещере (vala) принадлежащих небесным певцам ангирасам коров. Ангир"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\Index\\lib\\x86_64-win64\\Data\\Рамаяна 3. Словарь.txt",
+      "bytes": 43195,
+      "lines_scanned": 209,
+      "cyrillic_lines": 209,
+      "iast_paren_hits": 81,
+      "samples": [
+        "Агастья (Agastya) — божественный мудрец, сын Митры и Варуны, покровитель юга Индии, герой многих индийских легенд и мифов. Агастье приписываются более двадцати ",
+        "Агни (Agni) — бог огня во всех его проявлениях (космический огонь, небесный огонь, жертвенный огонь, домашний огонь и т. д.). Один из древнейших ведийских богов",
+        "Адити (Aditi) — одна из дочерей мудреца Дакши, жена Кашьяпы, мать двенадцати богов адитьев, в том числе Индры и Варуны.",
+        "Айомукхи (Ayomukhī) — «[имеющая] железное лицо», «железноликая») — ракшаси, обезображенная Лакшманой за нападение на него.",
+        "Ангирас (Aṅgiras) — один из великих риши и праотцов всех живых существ, которому приписываются многие гимны «Ригведы»; родоначальник класса полубогов — небесных",
+        "Ариштанеми (Ariṣṭanemi) — согласно «Рамаяне», один их семнадцати прародителей живых существ (праджапати).",
+        "Атри (Atri) — один из прародителей живых существ (праджапати), великий риши, обитель которого посетил Рама во второй книге «Рамаяны».",
+        "Бала (Bala), или Вала (Vala), — асура, брат Вритры. По ведийскому мифу, спрятал в одноименной пещере (vala) принадлежащих небесным певцам ангирасам коров. Ангир"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\intelligent-nightingale-117af2\\Index\\lib\\x86_64-win64\\Data\\Рамаяна 3. Словарь.txt",
+      "bytes": 43195,
+      "lines_scanned": 209,
+      "cyrillic_lines": 209,
+      "iast_paren_hits": 81,
+      "samples": [
+        "Агастья (Agastya) — божественный мудрец, сын Митры и Варуны, покровитель юга Индии, герой многих индийских легенд и мифов. Агастье приписываются более двадцати ",
+        "Агни (Agni) — бог огня во всех его проявлениях (космический огонь, небесный огонь, жертвенный огонь, домашний огонь и т. д.). Один из древнейших ведийских богов",
+        "Адити (Aditi) — одна из дочерей мудреца Дакши, жена Кашьяпы, мать двенадцати богов адитьев, в том числе Индры и Варуны.",
+        "Айомукхи (Ayomukhī) — «[имеющая] железное лицо», «железноликая») — ракшаси, обезображенная Лакшманой за нападение на него.",
+        "Ангирас (Aṅgiras) — один из великих риши и праотцов всех живых существ, которому приписываются многие гимны «Ригведы»; родоначальник класса полубогов — небесных",
+        "Ариштанеми (Ariṣṭanemi) — согласно «Рамаяне», один их семнадцати прародителей живых существ (праджапати).",
+        "Атри (Atri) — один из прародителей живых существ (праджапати), великий риши, обитель которого посетил Рама во второй книге «Рамаяны».",
+        "Бала (Bala), или Вала (Vala), — асура, брат Вритры. По ведийскому мифу, спрятал в одноименной пещере (vala) принадлежащих небесным певцам ангирасам коров. Ангир"
+      ]
+    }
+  ],
+  "pure_cyr_top": [
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\archive\\sanskrit_names.txt",
+      "bytes": 399952,
+      "lines_scanned": 5000,
+      "cyrillic_lines": 5000,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SanskritLexicography-h1746-22440\\RussianTranslation\\release\\reverse_index.jsonl",
+      "bytes": 20024555,
+      "lines_scanned": 5000,
+      "cyrillic_lines": 5000,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\Рамаяна_3.txt",
+      "bytes": 524667,
+      "lines_scanned": 5000,
+      "cyrillic_lines": 4955,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\add\\To_add2\\ramayana-potapovoy.html",
+      "bytes": 2027841,
+      "lines_scanned": 5000,
+      "cyrillic_lines": 2467,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\Index\\lib\\x86_64-win64\\add\\To_add2\\ramayana-potapovoy.html",
+      "bytes": 2027841,
+      "lines_scanned": 5000,
+      "cyrillic_lines": 2467,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\intelligent-nightingale-117af2\\Index\\lib\\x86_64-win64\\add\\To_add2\\ramayana-potapovoy.html",
+      "bytes": 2027841,
+      "lines_scanned": 5000,
+      "cyrillic_lines": 2467,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\deeppavlov_Рамаяна_3.txt",
+      "bytes": 4276769,
+      "lines_scanned": 2466,
+      "cyrillic_lines": 2466,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\archive\\03_all_index.txt",
+      "bytes": 32127,
+      "lines_scanned": 1876,
+      "cyrillic_lines": 1876,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\archive\\index_3.txt",
+      "bytes": 46924,
+      "lines_scanned": 1786,
+      "cyrillic_lines": 1786,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\3_INDEX_oneword.txt",
+      "bytes": 21030,
+      "lines_scanned": 1206,
+      "cyrillic_lines": 1206,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\intelligent-nightingale-117af2\\nkrya-parallel\\diplom-rubanova\\3_INDEX_oneword.txt",
+      "bytes": 21030,
+      "lines_scanned": 1206,
+      "cyrillic_lines": 1206,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\INDEX3_extra.txt",
+      "bytes": 11603,
+      "lines_scanned": 785,
+      "cyrillic_lines": 785,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\intelligent-nightingale-117af2\\nkrya-parallel\\diplom-rubanova\\INDEX3_extra.txt",
+      "bytes": 11603,
+      "lines_scanned": 785,
+      "cyrillic_lines": 785,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\web\\corpus_builder\\jsonl\\erman-temkin.jsonl",
+      "bytes": 235090,
+      "lines_scanned": 597,
+      "cyrillic_lines": 597,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\web\\corpus_builder\\jsonl\\erman-temkin.jsonl",
+      "bytes": 235090,
+      "lines_scanned": 597,
+      "cyrillic_lines": 597,
+      "iast_paren_hits": 0,
+      "samples": []
+    }
+  ],
+  "all_hits": [
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\DOCUMENTATION_INDEX.md",
+      "bytes": 4089,
+      "lines_scanned": 77,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\web\\templates\\compare_index.html",
+      "bytes": 3885,
+      "lines_scanned": 129,
+      "cyrillic_lines": 8,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\web\\templates\\index.html",
+      "bytes": 13262,
+      "lines_scanned": 304,
+      "cyrillic_lines": 28,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\web\\corpus_builder\\chronology\\index.html",
+      "bytes": 288144,
+      "lines_scanned": 166,
+      "cyrillic_lines": 2,
+      "iast_paren_hits": 1,
+      "samples": [
+        "<script id=\"data\" type=\"application/json\">{\"periods\": [{\"period\": \"Vedic Saṃhitā\", \"bucket_date\": -1030}, {\"period\": \"Brāhmaṇa\", \"bucket_date\": -792}, {\"period\""
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\web\\corpus_builder\\jsonl\\bhagavadgita-erman.jsonl",
+      "bytes": 1567318,
+      "lines_scanned": 1701,
+      "cyrillic_lines": 1701,
+      "iast_paren_hits": 99,
+      "samples": [
+        "{\"id\": \"bhagavadgita-erman:1.35.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"1.35.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:1.35\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.70.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.70.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.70\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.11.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.11.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.11\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.13.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.13.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.13\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.15.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.15.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.15\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.16.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.16.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.16\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.16.comm2\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.16.comm2\", \"seg\": \"comm2\", \"group\": \"bhagavadgita-erman:2.16\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.17.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.17.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.17\", \"lang\": \"ru\","
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\web\\corpus_builder\\jsonl\\erman-temkin.jsonl",
+      "bytes": 235090,
+      "lines_scanned": 597,
+      "cyrillic_lines": 597,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\web\\corpus_builder\\jsonl\\slovar-grintsera-iz-bada-kadambari.jsonl",
+      "bytes": 282894,
+      "lines_scanned": 464,
+      "cyrillic_lines": 464,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\web\\corpus_builder\\jsonl\\slovar-potapovoy.jsonl",
+      "bytes": 236160,
+      "lines_scanned": 339,
+      "cyrillic_lines": 339,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\web\\corpus_builder\\wisdomlib\\books_index.jsonl",
+      "bytes": 272543,
+      "lines_scanned": 848,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\web\\corpus_builder\\wisdomlib\\entries_index.jsonl",
+      "bytes": 272535,
+      "lines_scanned": 848,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\.docusaurus\\routesChunkNames.json",
+      "bytes": 742,
+      "lines_scanned": 27,
+      "cyrillic_lines": 1,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\3_INDEX.txt",
+      "bytes": 57097,
+      "lines_scanned": 1831,
+      "cyrillic_lines": 1831,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\3_INDEX_oneword.txt",
+      "bytes": 21030,
+      "lines_scanned": 1206,
+      "cyrillic_lines": 1206,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\3_INDEX_options.txt",
+      "bytes": 4930,
+      "lines_scanned": 38,
+      "cyrillic_lines": 38,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\3_INDEX_phrases.txt",
+      "bytes": 58448,
+      "lines_scanned": 721,
+      "cyrillic_lines": 721,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва: билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\automated_index_01.txt",
+      "bytes": 20515,
+      "lines_scanned": 779,
+      "cyrillic_lines": 779,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\automated_index_01_part.txt",
+      "bytes": 781,
+      "lines_scanned": 32,
+      "cyrillic_lines": 32,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\automated_index_02.txt",
+      "bytes": 16987,
+      "lines_scanned": 591,
+      "cyrillic_lines": 591,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\automated_index_forms_01.txt",
+      "bytes": 59702,
+      "lines_scanned": 779,
+      "cyrillic_lines": 779,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине : ['билвы', '"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\automated_index_forms_01_part.txt",
+      "bytes": 1983,
+      "lines_scanned": 32,
+      "cyrillic_lines": 32,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\automated_index_forms_02.txt",
+      "bytes": 44304,
+      "lines_scanned": 591,
+      "cyrillic_lines": 591,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине : ['билва', '"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\automated_index_forms_Рам_01_02.txt",
+      "bytes": 83561,
+      "lines_scanned": 1103,
+      "cyrillic_lines": 1103,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине : ['билва', '"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\automated_index_forms_Рам_03.txt",
+      "bytes": 44279,
+      "lines_scanned": 578,
+      "cyrillic_lines": 578,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине : ['билву', '"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\automated_index_forms_Рамаяна_3.txt",
+      "bytes": 28828,
+      "lines_scanned": 376,
+      "cyrillic_lines": 376,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине : ['билва', '"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\automated_index_Рам_01_02.txt",
+      "bytes": 28276,
+      "lines_scanned": 1103,
+      "cyrillic_lines": 1103,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\automated_index_Рам_03.txt",
+      "bytes": 16193,
+      "lines_scanned": 578,
+      "cyrillic_lines": 578,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\automated_index_Рамаяна_3.txt",
+      "bytes": 11493,
+      "lines_scanned": 376,
+      "cyrillic_lines": 376,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\deeppavlov_Рамаяна_3.txt",
+      "bytes": 4276769,
+      "lines_scanned": 2466,
+      "cyrillic_lines": 2466,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\INDEX3_extra.txt",
+      "bytes": 11603,
+      "lines_scanned": 785,
+      "cyrillic_lines": 785,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\INDEX3_intersection.txt",
+      "bytes": 55923,
+      "lines_scanned": 1794,
+      "cyrillic_lines": 1794,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – aegle marmelos (correa), вид дикой яблони, листья которой используются в церемониях почитания шивы, недозрелые плоды – в народной медицине"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\INDEX3_lack.txt",
+      "bytes": 1061,
+      "lines_scanned": 33,
+      "cyrillic_lines": 33,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\Ram3_automated_index_forms.txt",
+      "bytes": 28828,
+      "lines_scanned": 376,
+      "cyrillic_lines": 376,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине : ['билва', '"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\Ramayana_names.txt",
+      "bytes": 13836,
+      "lines_scanned": 525,
+      "cyrillic_lines": 525,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – aegle marmelos (correa), вид дикой яблони, листья которой используются в церемониях почитания шивы, недозрелые плоды – в народной медицине"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\Ramayana_names_clean.txt",
+      "bytes": 12236,
+      "lines_scanned": 414,
+      "cyrillic_lines": 414,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\Ramayana_names_clean_united.txt",
+      "bytes": 11501,
+      "lines_scanned": 380,
+      "cyrillic_lines": 380,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\rus_index.txt",
+      "bytes": 8962,
+      "lines_scanned": 293,
+      "cyrillic_lines": 293,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\rus_index_declined.txt",
+      "bytes": 69041,
+      "lines_scanned": 293,
+      "cyrillic_lines": 293,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\rus_index_declined_manual_gold.json",
+      "bytes": 25776,
+      "lines_scanned": 109,
+      "cyrillic_lines": 107,
+      "iast_paren_hits": 1,
+      "samples": [
+        "  \"_comment\": \"Manual gold for ru_rubric_decline.py's accuracy gate (H1207). The 2024-11 note's own gold (index_lone_declined_manual.json) is not in this repo n"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\Рамаяна_3.txt",
+      "bytes": 524667,
+      "lines_scanned": 5000,
+      "cyrillic_lines": 4955,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\node_modules\\unicode-canonical-property-names-ecmascript\\LICENSE-MIT.txt",
+      "bytes": 1077,
+      "lines_scanned": 20,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\node_modules\\unicode-canonical-property-names-ecmascript\\package.json",
+      "bytes": 903,
+      "lines_scanned": 34,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\node_modules\\unicode-canonical-property-names-ecmascript\\README.md",
+      "bytes": 1686,
+      "lines_scanned": 58,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\node_modules\\web-namespaces\\package.json",
+      "bytes": 2097,
+      "lines_scanned": 81,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\node_modules\\web-namespaces\\readme.md",
+      "bytes": 3767,
+      "lines_scanned": 156,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\node_modules\\@babel\\plugin-transform-export-namespace-from\\package.json",
+      "bytes": 888,
+      "lines_scanned": 34,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\node_modules\\@babel\\plugin-transform-export-namespace-from\\README.md",
+      "bytes": 435,
+      "lines_scanned": 19,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\marsel\\test_2\\automated_index_forms_volume_3.txt",
+      "bytes": 164091,
+      "lines_scanned": 1872,
+      "cyrillic_lines": 1872,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине : ['билва']"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\marsel\\test_2\\automated_index_volume_3.txt",
+      "bytes": 53348,
+      "lines_scanned": 1872,
+      "cyrillic_lines": 1872,
+      "iast_paren_hits": 1,
+      "samples": [
+        "билва – Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды – в народной медицине"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\archive\\03_all_index.txt",
+      "bytes": 32127,
+      "lines_scanned": 1876,
+      "cyrillic_lines": 1876,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\archive\\index_3.txt",
+      "bytes": 46924,
+      "lines_scanned": 1786,
+      "cyrillic_lines": 1786,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\diplom-rubanova\\archive\\sanskrit_names.txt",
+      "bytes": 399952,
+      "lines_scanned": 5000,
+      "cyrillic_lines": 5000,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\build\\docs\\Arkhangelskiy_otzyv_na_VKR_Rubanovoy\\index.html",
+      "bytes": 19897,
+      "lines_scanned": 40,
+      "cyrillic_lines": 25,
+      "iast_paren_hits": 1,
+      "samples": [
+        "<script>!function(){function t(t){document.documentElement.setAttribute(\"data-theme\",t)}var e=function(){try{return new URLSearchParams(window.location.search)."
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\build\\docs\\Prilozhenie_VKR_otzyv_ruk_retsenzenta_Gasuns\\index.html",
+      "bytes": 17960,
+      "lines_scanned": 37,
+      "cyrillic_lines": 23,
+      "iast_paren_hits": 1,
+      "samples": [
+        "<script>!function(){function t(t){document.documentElement.setAttribute(\"data-theme\",t)}var e=function(){try{return new URLSearchParams(window.location.search)."
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\nkrya-parallel\\build\\docs\\diplom-rubanova\\ВКР\\index.html",
+      "bytes": 209493,
+      "lines_scanned": 487,
+      "cyrillic_lines": 313,
+      "iast_paren_hits": 5,
+      "samples": [
+        "<script>!function(){function t(t){document.documentElement.setAttribute(\"data-theme\",t)}var e=function(){try{return new URLSearchParams(window.location.search).",
+        "<p>Для обработки текста используются готовые технологии и хорошо известные <strong>методы</strong> NLP: <em>russian stemmer snowball, pymorphy2, mystem, deeppav",
+        "<p>Первая задача, стоящая перед нами в этом исследовании, состоит в извлечении санскритских имен из русского текста. Сегодня существует большое количество работ",
+        "<p>Способы извлечения именованных сущностей в русском языке предложены в следующих статьях: [Подобряев 2013], [Антонова, Соловьев 2013] и [Трофимов 2014]. В раб",
+        "<mark>билва -- Aegle marmelos (Correa), вид дикой яблони, листья которой используются в церемониях почитания Шивы, недозрелые плоды -- в народной медицине</mark"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\Index_pr_stat.txt",
+      "bytes": 0,
+      "lines_scanned": 0,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\Data\\bhagavadgita-erman.html",
+      "bytes": 830765,
+      "lines_scanned": 720,
+      "cyrillic_lines": 720,
+      "iast_paren_hits": 100,
+      "samples": [
+        "<div class=\"citation_block\" id=\"1.35\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 1. 35\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 50\">35</div><di",
+        "<div class=\"chapter_title\" id=\"2\">Глава 2 [24]<a href='#comment_2_69' class='comment_sub'><sup><small>69</small></sup></a></div><div class=\"comments\"><div class",
+        "<div class=\"citation_block\" id=\"2.7\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 7\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 51\">7</div><div c",
+        "<div class=\"citation_block\" id=\"2.11\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 11\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 51\">11</div><di",
+        "<div class=\"citation_block\" id=\"2.13\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 13\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 51\">13</div><di",
+        "<div class=\"citation_block\" id=\"2.15\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 15\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 52\">15</div><di",
+        "<div class=\"citation_block\" id=\"2.16\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 16\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 52\">16</div><di",
+        "<div class=\"citation_block\" id=\"2.17\"><div class=\"range\" title=\"Бхагавадгита в переводе В.Г.Эрмана VI. 2. 17\" id=\"Бхагавадгита, В.Г.Эрман, 2009: 52\">17</div><di"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\Data\\bhagavadgita-erman.html.meta.json",
+      "bytes": 785,
+      "lines_scanned": 22,
+      "cyrillic_lines": 6,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\Data\\Рамаяна 3. Словарь.txt",
+      "bytes": 43195,
+      "lines_scanned": 209,
+      "cyrillic_lines": 209,
+      "iast_paren_hits": 81,
+      "samples": [
+        "Агастья (Agastya) — божественный мудрец, сын Митры и Варуны, покровитель юга Индии, герой многих индийских легенд и мифов. Агастье приписываются более двадцати ",
+        "Агни (Agni) — бог огня во всех его проявлениях (космический огонь, небесный огонь, жертвенный огонь, домашний огонь и т. д.). Один из древнейших ведийских богов",
+        "Адити (Aditi) — одна из дочерей мудреца Дакши, жена Кашьяпы, мать двенадцати богов адитьев, в том числе Индры и Варуны.",
+        "Айомукхи (Ayomukhī) — «[имеющая] железное лицо», «железноликая») — ракшаси, обезображенная Лакшманой за нападение на него.",
+        "Ангирас (Aṅgiras) — один из великих риши и праотцов всех живых существ, которому приписываются многие гимны «Ригведы»; родоначальник класса полубогов — небесных",
+        "Ариштанеми (Ariṣṭanemi) — согласно «Рамаяне», один их семнадцати прародителей живых существ (праджапати).",
+        "Атри (Atri) — один из прародителей живых существ (праджапати), великий риши, обитель которого посетил Рама во второй книге «Рамаяны».",
+        "Бала (Bala), или Вала (Vala), — асура, брат Вритры. По ведийскому мифу, спрятал в одноименной пещере (vala) принадлежащих небесным певцам ангирасам коров. Ангир"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\Data\\Рамаяна 3. Словарь.txt.meta.json",
+      "bytes": 791,
+      "lines_scanned": 21,
+      "cyrillic_lines": 2,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\Data\\Словарь Гринцера из Бада Кадамбари.txt",
+      "bytes": 63958,
+      "lines_scanned": 465,
+      "cyrillic_lines": 465,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\Data\\Словарь Гринцера из Бада Кадамбари.txt.meta.json",
+      "bytes": 830,
+      "lines_scanned": 20,
+      "cyrillic_lines": 2,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\Data\\Словарь Гринцера из Рамаяны 1-2.txt",
+      "bytes": 88939,
+      "lines_scanned": 463,
+      "cyrillic_lines": 463,
+      "iast_paren_hits": 186,
+      "samples": [
+        "Агастья\t(Agastya) — божественный мудрец, сын Митры и Варуны, герой многих индийских мифов, покровитель юга Индии; ему приписываются более двадцати гимнов «Ригве",
+        "Агни\t(Agni) — бог огня во всех его проявлениях (космический огонь, небесный огонь, жертвенный огонь, домашний огонь и т. д.). Один из древнейших ведийских богов",
+        "Адити\t(Aditi) — одна из дочерей мудреца Дакши, жена Кашьяпы, мать двенадцати богов-адитьев, в том числе Индры.",
+        "Акша\t(Akṣa) — старший сын Раваны, убитый Хануманом.",
+        "Аламбуша\t(Alambuṣā) — жена царя Икшваку.",
+        "Аламбуша\t(Alambuṣā) — одна из апсар.",
+        "Аларка\t(Alarka) — благочестивый царь Каши (Варанаси) и Каруши.",
+        "Амбариша\t(Ambarīṣa) — царь Солнечной династии, потомок Икшваку."
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\Data\\Словарь Гринцера из Рамаяны 1-2.txt.meta.json",
+      "bytes": 750,
+      "lines_scanned": 21,
+      "cyrillic_lines": 2,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\add\\To_add\\dsg_index.html",
+      "bytes": 4902257,
+      "lines_scanned": 4668,
+      "cyrillic_lines": 4378,
+      "iast_paren_hits": 977,
+      "samples": [
+        "<tr><td><a id=\"1\">1</a>/<span class=\"page-link\"data-text=\"1\">1</span></td><td><a class=\"sa\">अ</a><br> <a class=\"iast\">/a/</a><br> <a class=\"HK\"> </a></td><td><p",
+        "<tr><td><a id=\"2\">2</a>/<span class=\"page-link\"data-text=\"1\">1</span></td><td><a class=\"sa\">अं</a><br> <a class=\"iast\">/aṃ/</a><br> <a class=\"HK\">/aM/ </a></td>",
+        "<tr><td><a id=\"6\">6</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अ ೱ क्, जिह्वामूलीय</a><br> <a class=\"iast\">/a ೱ k/, /jihvāmūlīya/</",
+        "<tr><td><a id=\"7\">7</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अ ೱ प्, उपध्मानीय</a><br> <a class=\"iast\">/a ೱ p/, /upadhmānīya/</a>",
+        "<tr><td><a id=\"9\">9</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अक्</a><br> <a class=\"iast\">/ak/</a><br> <a class=\"HK\"> </a></td><td",
+        "<tr><td><a id=\"11\">11</a>/<span class=\"page-link\"data-text=\"2\">2</span></td><td><a class=\"sa\">अकङ्</a><br> <a class=\"iast\">/akaṅ/</a><br> <a class=\"HK\">/akaG/ <",
+        "<tr><td><a id=\"13\">13</a>/<span class=\"page-link\"data-text=\"2-3\">2-3</span></td><td><a class=\"sa\">अकथित</a><br> <a class=\"iast\">/akathita/</a><br> <a class=\"HK\"",
+        "<tr><td><a id=\"16\">16</a>/<span class=\"page-link\"data-text=\"3\">3</span></td><td><a class=\"sa\">अकर्मक</a><br> <a class=\"iast\">/akarmaka/</a><br> <a class=\"HK\"> <"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\Index\\lib\\x86_64-win64\\add\\To_add2\\ramayana-potapovoy.html",
+      "bytes": 2027841,
+      "lines_scanned": 5000,
+      "cyrillic_lines": 2467,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\docs_site\\_site\\index.html",
+      "bytes": 21868,
+      "lines_scanned": 476,
+      "cyrillic_lines": 24,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\docs_site\\_site\\guide\\how-to-cite\\index.html",
+      "bytes": 21064,
+      "lines_scanned": 486,
+      "cyrillic_lines": 33,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\docs_site\\_site\\guide\\how-to-search\\index.html",
+      "bytes": 21146,
+      "lines_scanned": 486,
+      "cyrillic_lines": 33,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\docs_site\\_site\\guide\\what-is-the-corpus\\index.html",
+      "bytes": 21981,
+      "lines_scanned": 487,
+      "cyrillic_lines": 34,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\docs_site\\_site\\faq\\mobile-access\\index.html",
+      "bytes": 21125,
+      "lines_scanned": 484,
+      "cyrillic_lines": 31,
+      "iast_paren_hits": 2,
+      "samples": [
+        "  <script type=\"application/ld+json\">{\"@context\": \"https://schema.org\", \"@type\": \"FAQPage\", \"mainEntity\": [{\"@type\": \"Question\", \"name\": \"Работает ли корпус на ",
+        "<ul><li>мобильная оптимизация интерфейса и более лёгкие шрифты;</li><li>установка как веб-приложения (PWA) и офлайн-чтение;</li><li>в перспективе — офлайн-поиск"
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\docs_site\\_site\\faq\\rights-and-access\\index.html",
+      "bytes": 21351,
+      "lines_scanned": 486,
+      "cyrillic_lines": 33,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\docs_site\\_site\\faq\\what-is-inside\\index.html",
+      "bytes": 20666,
+      "lines_scanned": 484,
+      "cyrillic_lines": 31,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\intelligent-nightingale-117af2\\DOCUMENTATION_INDEX.md",
+      "bytes": 4089,
+      "lines_scanned": 77,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\DOCUMENTATION_INDEX.md",
+      "bytes": 4089,
+      "lines_scanned": 77,
+      "cyrillic_lines": 0,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\web\\templates\\compare_index.html",
+      "bytes": 4014,
+      "lines_scanned": 129,
+      "cyrillic_lines": 8,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\web\\templates\\index.html",
+      "bytes": 13566,
+      "lines_scanned": 304,
+      "cyrillic_lines": 28,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\web\\corpus_builder\\chronology\\index.html",
+      "bytes": 288144,
+      "lines_scanned": 166,
+      "cyrillic_lines": 2,
+      "iast_paren_hits": 1,
+      "samples": [
+        "<script id=\"data\" type=\"application/json\">{\"periods\": [{\"period\": \"Vedic Saṃhitā\", \"bucket_date\": -1030}, {\"period\": \"Brāhmaṇa\", \"bucket_date\": -792}, {\"period\""
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\web\\corpus_builder\\jsonl\\bhagavadgita-erman.jsonl",
+      "bytes": 1567318,
+      "lines_scanned": 1701,
+      "cyrillic_lines": 1701,
+      "iast_paren_hits": 99,
+      "samples": [
+        "{\"id\": \"bhagavadgita-erman:1.35.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"1.35.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:1.35\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.70.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.70.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.70\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.11.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.11.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.11\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.13.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.13.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.13\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.15.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.15.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.15\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.16.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.16.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.16\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.16.comm2\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.16.comm2\", \"seg\": \"comm2\", \"group\": \"bhagavadgita-erman:2.16\", \"lang\": \"ru\",",
+        "{\"id\": \"bhagavadgita-erman:2.17.comm1\", \"work\": \"bhagavadgita-erman\", \"passage\": \"2.17.comm1\", \"seg\": \"comm1\", \"group\": \"bhagavadgita-erman:2.17\", \"lang\": \"ru\","
+      ]
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\web\\corpus_builder\\jsonl\\erman-temkin.jsonl",
+      "bytes": 235090,
+      "lines_scanned": 597,
+      "cyrillic_lines": 597,
+      "iast_paren_hits": 0,
+      "samples": []
+    },
+    {
+      "path": "C:\\Users\\user\\Documents\\GitHub\\SamudraManthanam\\.claude\\worktrees\\vigilant-swirles-07eb86\\web\\corpus_builder\\jsonl\\slovar-grintsera-iz-bada-kadambari.jsonl",
+      "bytes": 282894,
+      "lines_scanned": 464,
+      "cyrillic_lines": 464,
+      "iast_paren_hits": 0,
+      "samples": []
+    }
+  ]
+}

--- a/RussianTranslation/tools/gaps_s6_cyrillic_name_probe.py
+++ b/RussianTranslation/tools/gaps_s6_cyrillic_name_probe.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""H1746 / SL GAPS §6 — probe Cyrillic name glossaries for recoverable keys.
+
+Does NOT invent reverse-transliteration rules. Surveys available name-index
+artifacts for: (a) inline IAST already present, (b) fully-Cyrillic-only,
+(c) whether a small validated lookup seed can be built from (a) as onomasticon.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+
+SL = Path(__file__).resolve().parents[2]
+OUT = Path(__file__).resolve().parent / "gaps_s6_cyrillic_name_probe.json"
+
+# Candidate roots from FINDINGS §60 / H184 survey
+SEARCH_ROOTS = [
+    Path(r"C:\Users\user\Documents\GitHub\SamudraManthanam"),
+    SL / "RussianTranslation",
+]
+
+IAST_INLINE = re.compile(
+    r"\(([A-Za-zĀāĪīŪūṚṛṜḹḶḷṂṃḤḥÑñṄṅṬṭḌḍṆṇŚśṢṣ\-\s]+)\)"
+)
+
+
+def scan_file(path: Path, max_lines: int = 5000) -> dict:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except Exception as e:
+        return {"path": str(path), "error": str(e)}
+    lines = text.splitlines()[:max_lines]
+    cyr = 0
+    iast_paren = 0
+    samples = []
+    for ln in lines:
+        if re.search(r"[А-Яа-яЁё]", ln):
+            cyr += 1
+            m = IAST_INLINE.search(ln)
+            if m:
+                iast_paren += 1
+                if len(samples) < 8:
+                    samples.append(ln[:160])
+    return {
+        "path": str(path),
+        "bytes": path.stat().st_size,
+        "lines_scanned": len(lines),
+        "cyrillic_lines": cyr,
+        "iast_paren_hits": iast_paren,
+        "samples": samples,
+    }
+
+
+def main() -> None:
+    hits = []
+    name_tokens = (
+        "potap",
+        "erman",
+        "temkin",
+        "bady",
+        "kadambar",
+        "grincer",
+        "grinzer",
+        "рамаян",
+        "имя",
+        "imena",
+        "names",
+        "onomast",
+        "glossary",
+        "index",
+    )
+    for root in SEARCH_ROOTS:
+        if not root.exists():
+            continue
+        for p in root.rglob("*"):
+            if not p.is_file():
+                continue
+            if p.suffix.lower() not in {".md", ".txt", ".tsv", ".csv", ".json", ".jsonl", ".html"}:
+                continue
+            low = p.name.lower()
+            if not any(t in low for t in name_tokens):
+                # also check path parts for Russian names
+                pl = str(p).lower()
+                if not any(t in pl for t in ("имя", "imena", "names", "onomast", "potap", "erman", "grincer", "кадамб")):
+                    continue
+            if p.stat().st_size > 50_000_000:
+                continue
+            hits.append(scan_file(p))
+
+    with_iast = [h for h in hits if h.get("iast_paren_hits", 0) > 0]
+    pure_cyr = [
+        h
+        for h in hits
+        if h.get("cyrillic_lines", 0) > 20 and h.get("iast_paren_hits", 0) == 0
+    ]
+    report = {
+        "handoff": "H1746",
+        "gap": "SanskritLexicography/GAPS.md §6",
+        "measured_at": datetime.now(timezone.utc).isoformat(),
+        "model": "Grok 4.5 (grok-4.5)",
+        "files_scanned": len(hits),
+        "files_with_inline_iast": len(with_iast),
+        "files_cyrillic_heavy_no_iast": len(pure_cyr),
+        "verdict": (
+            "FINDINGS §60 stands: reverse-transcription rules remain unsafe. "
+            "Recoverable path is a validated proper-noun LOOKUP table seeded from "
+            "IAST-bearing indices (Гринцер / Rāmāyaṇa), not character rules. "
+            "This probe inventories seed candidates; full table build needs human "
+            "spot-check against an onomasticon for the 3 fully-Cyrillic glossaries."
+        ),
+        "with_iast_top": sorted(with_iast, key=lambda h: -h.get("iast_paren_hits", 0))[:15],
+        "pure_cyr_top": sorted(pure_cyr, key=lambda h: -h.get("cyrillic_lines", 0))[:15],
+        "all_hits": hits[:80],
+    }
+    OUT.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "files_scanned": report["files_scanned"],
+                "with_iast": report["files_with_inline_iast"],
+                "pure_cyr": report["files_cyrillic_heavy_no_iast"],
+                "out": str(OUT),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,10 @@ not an error.
 
 ## [Unreleased]
 
+### Added
+- **GAPS residual H1745–H1747** (27-07-2026, Grok 4.5): FINDINGS §493–§495 (routing κ=1.0 LLM second pass; homonym 38 single-lemma_id ceiling; Cyrillic name seed inventory 61/47).
+
+
 ## [1.93.0] — 2026-07-27
 
 ### Added


### PR DESCRIPTION
## Summary
- §493 routing second-pass κ=1.0 (LLM caveat)
- §494 homonym single-lemma_id ceiling
- §495 Cyrillic name seed inventory
- GAPS markers + RESULTS_LOG

## Test plan
- [x] Probe scripts committed under RussianTranslation/tools/

Handoffs H1745–H1747. Grok 4.5 (grok-4.5).