### PR TITLE
fix(FINDINGS): repair epistemic-integrity gate — §488-498 headings missing §

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.94.0
-date-released: "2026-07-27"
+version: 1.95.0
+date-released: "2026-07-28"
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported
   headword lists, AI-produced Russian translations of Monier-Williams and

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -28,7 +28,7 @@ do), and a blockquoted (`> `) **Source** paragraph linking the exact statement a
 with a `— repo · date` tag — the `>` gives the Source line its left indent and muted rendering
 in plain Markdown; no HTML in this file, ever. Keep findings grounded (a number, a file, a
 probe), never a hunch. **Importance label:** every finding carries a colour dot at the start of its claim line and its index entry — 🔴 3 important · 🟠 2 medium · 🟡 1 not that important — assign one when appending. **Numbers are append-only:** a new finding takes the next free number
-(currently §493) whatever its section, so existing numbers never shift; when a finding is later
+(currently §499) whatever its section, so existing numbers never shift; when a finding is later
 refuted or superseded, strike it and say why — never reuse its number. **Verifiability class (H1362):** every finding has a re-derivability class — **A** auto-reproducible · **B** re-probeable (live host) · **C** historically fixed · **D** not reproducible as stated — ruled in [`epistemic_dashboard/FINDINGS_VERIFIABILITY_RULING_2026.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/epistemic_dashboard/FINDINGS_VERIFIABILITY_RULING_2026.md) and machine-readable in [`epistemic_dashboard/verifiability.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/epistemic_dashboard/verifiability.json). **A class-D finding must be cited with its non-reproducibility named** — never as a bare `§N` carrying the authority of a recomputable row; the D findings are marked `⚠️ class D — not reproducible as stated` in place.
 
 ## Index
@@ -4467,7 +4467,7 @@ Committed as a reproducible probe with the trap in its docstring:
 
 _27-07-2026 · [H1476](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1476-Opus_SanskritGrammar_pedagogy-aspect-measurable-result-metrics_22.07.26.md) · Opus 5 1M (`claude-opus-5[1m]`)_
 
-### 488. DCS stem co-occurrence graph is extreme-sparse with function-word hubs
+### §488. DCS stem co-occurrence graph is extreme-sparse with function-word hubs
 
 🟠 **The full Sanskrit-stem co-occurrence table (dcs-stem-cooccurrence-full) is a directed L/R adjacency list over 176,676 stems (353,352 directed rows): 57.2% of directed rows have degree 0, median degree is 0, mean ~9.2, and the degree tail is dominated by function words (ca, 	ad, va, iti, 	u, pi).** Class A.
 
@@ -4481,7 +4481,7 @@ Implication: any collocation / distributional-semantics claim over this table mu
 
 > **Source:** graduates [GAPS §7](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) · manifest dcs-stem-cooccurrence-full · [VisualDCS](https://github.com/gasyoun/VisualDCS) · H1735 · 27-07-2026 · Grok 4.5 (grok-4.5)
 
-### 489. Sintagmatic appendix-6 is a 6.3k-lemma core nested in the 80k all-corpus table
+### §489. Sintagmatic appendix-6 is a 6.3k-lemma core nested in the 80k all-corpus table
 
 🟡 **DCS syntagmatic appendix 7 (all-corpus) has 79,985 lemmas; the seven period files of appendix 6 cover a 6,338-lemma union that is almost entirely nested in appendix 7 (6,337/6,338), while period-to-period lemma Jaccard is low (1∩3=0.23, 1∩7=0.17, 3∩7=0.30).** Class A.
 
@@ -4491,7 +4491,7 @@ Implication: appendix 6 is a **frequency-core slice by historical period**, not 
 
 > **Source:** graduates [GAPS §8](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) · manifest dcs-sintagmatic-appendix7 / dcs-sintagmatic-appendix6-periods · [VisualDCS](https://github.com/gasyoun/VisualDCS) · H1735 · 27-07-2026 · Grok 4.5 (grok-4.5)
 
-### 490. Heritage×kosha form intersection agrees 78.3%; disagreements are classifiable
+### §490. Heritage×kosha form intersection agrees 78.3%; disagreements are classifiable
 
 🟠 **On the 94,264-form Heritage∩kosha intersection, 78.26% agree on lemma and 21.74% (20,496) disagree; disagreement classes are genuine-or-ambiguous 12,905 (63.0%), stem-granularity 7,132 (34.8%), 
 asal-variant 459 (2.2%), with participles the largest Heritage category among disagreements (8,289).** Class A (re-derive from committed TSV + stats JSON).
@@ -4503,7 +4503,7 @@ asal-variant are mostly mechanical, genuine-or-ambiguous needs human/lexicograph
 
 > **Source:** graduates [GAPS §9](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) · [heritage_forms_oracle_stats.json](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/heritage_forms_oracle_stats.json) · H1735 · 27-07-2026 · Grok 4.5 (grok-4.5)
 
-### 491. Verb-form frequency prelim is an unlabeled 42-row XLS with empty tense names
+### §491. Verb-form frequency prelim is an unlabeled 42-row XLS with empty tense names
 
 🟡 **The file registered as dcs-verb-form-frequency-prelim is OLE2 Excel (magic d0cf11e0), mis-suffixed .csv, with 42 data rows whose Tense/Mood column is entirely empty — only numeric IDs 1–42 and frequencies (sum 781,618; max 233,080 on ID 19; four IDs at frequency 0). It cannot be finalised as a labelled tense/mood frequency table without recovering the ID→label legend from an external source.** Class A.
 
@@ -4513,7 +4513,7 @@ Implication: keep the manifest preliminary marker; do not feed this table into a
 
 > **Source:** graduates [GAPS §11](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) · manifest dcs-verb-form-frequency-prelim · [VisualDCS](https://github.com/gasyoun/VisualDCS) · H1735 · 27-07-2026 · Grok 4.5 (grok-4.5)
 
-### 492. Stopovye is a 102-file subset of Polnorazmernye, not a stopword filter of the full 506k
+### §492. Stopovye is a 102-file subset of Polnorazmernye, not a stopword filter of the full 506k
 
 🟠 **PARA/Stopovye is a proper subset of PARA/Polnorazmernye by filename (102 of 245 CSVs; 0 stop-only names), with 139,817 stop rows vs 506,787 full rows (~27.6%); content is related but not identical (sample first-500 line Jaccard 0.23–0.50; some orthographic ṃ/m drift and extra commentary lines).** Class A.
 
@@ -4529,7 +4529,7 @@ Implication: Stopovye is **not** «the full parallel export with stopwords remov
 
 
 
-### 493. Cross-vendor LLM second pass on routing gold is κ=1.0 — still not human IAA
+### §493. Cross-vendor LLM second pass on routing gold is κ=1.0 — still not human IAA
 
 🟡 **A Grok 4.5 second annotation of the 24-scenario which-dictionary routing benchmark agrees with Fable 5 gold on 24/24 (Cohen's κ = 1.0 strict); this is cross-vendor LLM agreement, not human inter-annotator reliability.** Graduates GAPS §10 only partially.
 
@@ -4539,7 +4539,7 @@ Implication: the scenarios are **highly determinate** for current model families
 
 > **Source:** graduates [GAPS §10](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) (partial — human IAA still open) · [routing-benchmark.json](https://github.com/sanskrit-lexicon/csl-guides/blob/main/src/data/routing-benchmark.json) · H1745 · 27-07-2026 · Grok 4.5 (grok-4.5)
 
-### 494. Homonym token-attribution residual is a 38-group single-lemma_id ceiling
+### §494. Homonym token-attribution residual is a 38-group single-lemma_id ceiling
 
 🟠 **Of 72 homonym groups in WhitneyRoots `token_attribution.json`, 26 are reliable and 46 are not: 38 fail because DCS exposes a single verb lemma_id for the whole lump, and 8 collapse onto one homonym under the current gloss map. Lowering the coverage≥0.55 floor cannot create splits when n_lemma_id=1.**
 
@@ -4549,7 +4549,7 @@ Implication: residual work is **sense/gloss gold or DCS sense-level IDs**, not m
 
 > **Source:** measures [GAPS §4](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) · [token_attribution.json](https://github.com/gasyoun/WhitneyRoots/blob/main/crosswalk/token_attribution.json) · H1747 · 27-07-2026 · Grok 4.5 (grok-4.5)
 
-### 495. Cyrillic name indices: 61 IAST-bearing seed files vs 47 pure-Cyrillic — rules still unsafe
+### §495. Cyrillic name indices: 61 IAST-bearing seed files vs 47 pure-Cyrillic — rules still unsafe
 
 🟡 **A filesystem probe of SamudraManthanam + RussianTranslation name-like files found 61 files with inline IAST parentheses (seedable for a proper-noun lookup table) and 47 Cyrillic-heavy files with zero IAST hits; character-rule reverse transcription remains unsafe (FINDINGS §60 stands).**
 
@@ -4559,7 +4559,7 @@ Implication: GAPS §6 is not closed — the 3 fully-Cyrillic glossaries still ne
 
 > **Source:** measures [GAPS §6](https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md) · [FINDINGS §60](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) · H1746 · 27-07-2026 · Grok 4.5 (grok-4.5)
 
-### 496. Edit-distance record linkage over Sanskrit headwords is 70–98 % false matches — use a length-preserving normalization key and measure the false-match rate against the dictionary's own inventory
+### §496. Edit-distance record linkage over Sanskrit headwords is 70–98 % false matches — use a length-preserving normalization key and measure the false-match rate against the dictionary's own inventory
 
 ⚠️ **Reusable method gotcha, and a load-bearing one:** any join between two spellings of the same
 Sanskrit headword (correction logs, OCR vs. clean text, cross-dictionary crosswalks, spell-check
@@ -4612,7 +4612,7 @@ had been an artefact of the join rather than a fact about the dictionary.
 > [H1477](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1477-Opus_csl-observatory_capture-recapture-fuzzy-linkage-corrector-pair_22.07.26.md)
 > ([PR #120](https://github.com/sanskrit-lexicon/csl-observatory/pull/120)) — csl-observatory · 27-07-2026, Opus 5 1M (`claude-opus-5[1m]`).
 
-### 497. The csl-orig L-number is not a join key — only 35 % of form-era L-codes still point at their own headword
+### §497. The csl-orig L-number is not a join key — only 35 % of form-era L-codes still point at their own headword
 
 ⚠️ **The most tempting key in the corpus, and the worst.** Joining two records of the same
 dictionary by their csl-orig `<L>` number looks strictly better than any string key: every
@@ -4669,7 +4669,7 @@ on validity, i.e. a lower bound on drift.**
 > — salvaged from a duplicate [H1477](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1477-Opus_csl-observatory_capture-recapture-fuzzy-linkage-corrector-pair_22.07.26.md)
 > session whose figures were re-measured, not imported · 27-07-2026, Opus 5 1M (`claude-opus-5[1m]`).
 
-### 498. Word-initial Harvard-Kyoto capitals never decode — 113 correction-event headwords entered the corpus mis-transcoded
+### §498. Word-initial Harvard-Kyoto capitals never decode — 113 correction-event headwords entered the corpus mis-transcoded
 
 🐛 **A live data defect with a one-character cause.** `build_correction_events.looks_hk` decides
 whether a roman cell is Harvard-Kyoto and needs transcoding to IAST:

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,11 @@ not an error.
 
 ## [Unreleased]
 
+## [1.95.0] — 2026-07-28
+
+### Fixed
+- **Epistemic-integrity gate repair — FINDINGS §488–§498 headings were missing their `§` marker** (28-07-2026, Sonnet 5 `claude-sonnet-5`, [H1752](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1752-Sonnet_SanskritLexicography_red-branch-repair-findings-488-492-dangling-index_27.07.26.md)): `master` went red at PR #845/H1735's GAPS→FINDINGS graduation — the checker reported §488–§492 (later §488–§498) as dangling Index rows with no heading. The section bodies were never missing; eleven headings were written as `### 488.` instead of `### §488.` (`§` required by `epistemic_integrity_check.py`'s heading regex), so heading↔Index parity failed. Fixed by adding the missing `§`, bumping the next-free marker to §499, and regenerating both dashboards (156 distinct FINDINGS headings, up from the stale 124). `python tools/epistemic_integrity_check.py --dir .` now reports 0 defects.
+
 ## [1.94.0] — 2026-07-27
 
 ### Added

--- a/epistemic_dashboard/epistemic.json
+++ b/epistemic_dashboard/epistemic.json
@@ -1,20 +1,20 @@
 {
- "generated_at": "2026-07-26T04:41:06Z",
+ "generated_at": "2026-07-28T04:49:15Z",
  "side": "Sanskrit-data",
  "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
  "core": {
   "key": "FINDINGS",
   "act": "measuring — the settled facts the seven siblings graduate into",
   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md",
-  "total": 124,
+  "total": 156,
   "by_importance": {
-   "3": 26,
-   "2": 80,
-   "1": 18
+   "3": 41,
+   "2": 90,
+   "1": 25
   },
   "by_origin": {
    "auto": 0,
-   "human": 124
+   "human": 156
   }
  },
  "layers": [
@@ -22,18 +22,18 @@
    "key": "ASSUMPTIONS",
    "act": "relying on an unproven premise",
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md",
-   "total": 7,
+   "total": 10,
    "by_importance": {
-    "3": 5,
-    "2": 2,
+    "3": 6,
+    "2": 4,
     "1": 0
    },
    "by_origin": {
     "auto": 0,
-    "human": 7
+    "human": 10
    },
-   "categories": 3,
-   "interlinks": 6,
+   "categories": 4,
+   "interlinks": 9,
    "entries": [
     {
      "title": "§1. DCS lemma == CDSL headword",
@@ -46,6 +46,12 @@
      "importance": 3,
      "origin": "human",
      "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#2-one-transliteration-scheme-keys-all-dcs-files"
+    },
+    {
+     "title": "§8. A lemma's declension class can be read off its citation form",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#8-a-lemmas-declension-class-can-be-read-off-its-citation-form"
     },
     {
      "title": "§3. A dict's giant verb root lives at homonym index 0",
@@ -72,6 +78,18 @@
      "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#6-a-verified-correction-queue-stays-valid-until-filed"
     },
     {
+     "title": "§9. A threshold set by argument is a decision rule",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#9-a-threshold-set-by-argument-is-a-decision-rule"
+    },
+    {
+     "title": "§10. A gold-agreement rate transfers between aspects",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/ASSUMPTIONS.md#10-a-gold-agreement-rate-transfers-between-aspects"
+    },
+    {
      "title": "§7. «Рамаяна. Книга 5. Сундараканда 2026.html» — финальная редакция перевода",
      "importance": 3,
      "origin": "human",
@@ -83,15 +101,15 @@
    "key": "CONTRADICTIONS",
    "act": "≥2 sources disagree, no verdict",
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md",
-   "total": 8,
+   "total": 9,
    "by_importance": {
-    "3": 1,
+    "3": 2,
     "2": 6,
     "1": 0
    },
    "by_origin": {
     "auto": 0,
-    "human": 8
+    "human": 9
    },
    "categories": 3,
    "interlinks": 6,
@@ -143,6 +161,12 @@
      "importance": 2,
      "origin": "human",
      "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md#8-the-ch-14-correction-dataset-doi-false-and-unminted-vs-genuinely-minted-bookplan-vs-fairrelease1---ruled"
+    },
+    {
+     "title": "§9. Corpus kāṇḍas 6–7 are labelled \"Southern (Leonov)\" but their text is the Baroda critical edition",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md#9-corpus-kāṇḍas-67-are-labelled-southern-leonov-but-their-text-is-the-baroda-critical-edition"
     }
    ]
   },
@@ -150,15 +174,15 @@
    "key": "GAPS",
    "act": "not-yet-knowing (the frontier)",
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md",
-   "total": 12,
+   "total": 14,
    "by_importance": {
     "3": 1,
-    "2": 4,
+    "2": 6,
     "1": 7
    },
    "by_origin": {
     "auto": 5,
-    "human": 7
+    "human": 9
    },
    "categories": 3,
    "interlinks": 11,
@@ -234,6 +258,18 @@
      "importance": 3,
      "origin": "human",
      "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#12-сундараканда-стихи-песней-2-и-28--пропуск-оцифровки-или-воля-переводчика"
+    },
+    {
+     "title": "§14. Which `-ī` stems are the monosyllabic type, and which `-at` citations are genuine `-ant` stems?",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#14-which--ī-stems-are-the-monosyllabic-type-and-which--at-citations-are-genuine--ant-stems"
+    },
+    {
+     "title": "§13. No Russian Uttarakāṇḍa (or Kiṣkindhā, or Yuddha) exists — 1,765 PWG `R.` book-7 citations wait on a translator",
+     "importance": 2,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/GAPS.md#13-no-russian-uttarakāṇḍa-or-kiṣkindhā-or-yuddha-exists--1765-pwg-r-book-7-citations-wait-on-a-translator"
     }
    ]
   },
@@ -241,18 +277,18 @@
    "key": "DEAD_ENDS",
    "act": "abandoning an approach",
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md",
-   "total": 13,
+   "total": 14,
    "by_importance": {
-    "3": 9,
+    "3": 10,
     "2": 3,
     "1": 0
    },
    "by_origin": {
     "auto": 1,
-    "human": 12
+    "human": 13
    },
    "categories": 4,
-   "interlinks": 12,
+   "interlinks": 13,
    "entries": [
     {
      "title": "§1. Body-text / reverse-dict headword mining — abandoned",
@@ -331,6 +367,12 @@
      "importance": 2,
      "origin": "human",
      "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#10-gemini-ocr-санскритских-комментариев-сундараканды--вытеснен-скрейпом"
+    },
+    {
+     "title": "§13. Building a Bombay↔corpus verse concordance for PWG's `R.` book 7 — abandoned before the OCR was spent",
+     "importance": 3,
+     "origin": "human",
+     "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/DEAD_ENDS.md#13-building-a-bombaycorpus-verse-concordance-for-pwgs-r-book-7--abandoned-before-the-ocr-was-spent"
     }
    ]
   },
@@ -541,19 +583,19 @@
   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/epistemic_dashboard/FINDINGS_VERIFIABILITY_RULING_2026.md"
  },
  "totals": {
-  "rows": 175,
+  "rows": 182,
   "auto": 120,
-  "human": 55,
+  "human": 62,
   "by_importance": {
-   "3": 22,
-   "2": 29,
+   "3": 25,
+   "2": 33,
    "1": 8
   },
   "layers": 7,
-  "entry_rows": 61,
+  "entry_rows": 68,
   "candidates": 6,
-  "categories": 20,
-  "interlinks": 56,
-  "findings": 124
+  "categories": 21,
+  "interlinks": 60,
+  "findings": 156
  }
 }

--- a/findings_dashboard/data.json
+++ b/findings_dashboard/data.json
@@ -1,12 +1,12 @@
 {
- "generated_at": "2026-07-26T04:40:40Z",
+ "generated_at": "2026-07-28T04:49:05Z",
  "stale_days_threshold": 180,
  "counts": {
-  "total": 124,
+  "total": 156,
   "by_importance": {
-   "2": 80,
-   "1": 18,
-   "3": 26
+   "2": 90,
+   "1": 25,
+   "3": 41
   },
   "stale": 0
  },
@@ -17,7 +17,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-29",
-   "age_days": 27,
+   "age_days": 29,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#1-whitney-accent-mobility-rules-are-machine-encodable"
   },
   {
@@ -26,7 +26,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-14",
-   "age_days": 42,
+   "age_days": 44,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#2-homonym-token-splitting-has-a-hard-morphological-ceiling"
   },
   {
@@ -35,7 +35,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-06-13",
-   "age_days": 43,
+   "age_days": 45,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#3-the-warnemyr-scrape-union-smears-homonym-classes"
   },
   {
@@ -44,7 +44,7 @@
    "section": "Grammar & morphology data",
    "importance": 1,
    "evidence_date": "2026-06-29",
-   "age_days": 27,
+   "age_days": 29,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#4-pwg-nominal-grammar-compresses-into-335-paradigm-tokens"
   },
   {
@@ -53,7 +53,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 24,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#42-whitney-self-contradicts-on-derivative-ī-stem-genpl-accent"
   },
   {
@@ -62,7 +62,7 @@
    "section": "Grammar & morphology data",
    "importance": 2,
    "evidence_date": "2026-07-05",
-   "age_days": 21,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#54-whitney-accent-axis-validates-at-1719-matrix-cells-go-against-attested-rv-accents"
   },
   {
@@ -71,7 +71,7 @@
    "section": "Grammar & morphology data",
    "importance": 1,
    "evidence_date": "2026-07-07",
-   "age_days": 19,
+   "age_days": 21,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#63-vidyut-dhātupāṭha-adjudicates-the-2014-palsule-exclusion-dispute-five-añc-dhātus-no-and-but-ast-is-paninian"
   },
   {
@@ -80,7 +80,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 32,
+   "age_days": 34,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#5-the-parallel-corpus-rarely-attests-prefixed-verb-forms"
   },
   {
@@ -89,7 +89,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 32,
+   "age_days": 34,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#6-no-printed-frequency-dictionary-of-sanskrit-exists"
   },
   {
@@ -98,7 +98,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 32,
+   "age_days": 34,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#7-dcs-lemma-data-is-keyed-in-two-transliterations"
   },
   {
@@ -107,7 +107,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 41,
+   "age_days": 43,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#8-unaccented-dcs-cannot-distinguish-present-class-i-from-vi"
   },
   {
@@ -116,7 +116,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 3,
    "evidence_date": "2026-06-06",
-   "age_days": 50,
+   "age_days": 52,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#9-dcs-occid-and-sent_id-are-not-unique-keys"
   },
   {
@@ -125,7 +125,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-06",
-   "age_days": 50,
+   "age_days": 52,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#10-dcs-ud-tense-marking-conflates-aorist-and-perfect"
   },
   {
@@ -134,7 +134,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-06",
-   "age_days": 50,
+   "age_days": 52,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#11-dcs-2021-and-2026-vintages-are-not-directly-comparable"
   },
   {
@@ -143,7 +143,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-06-11",
-   "age_days": 45,
+   "age_days": 47,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#12-a-fifth-of-dcs-lemmas-have-no-cdsl-headword"
   },
   {
@@ -152,7 +152,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 1,
    "evidence_date": "2026-07-01",
-   "age_days": 25,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#13-sa-ru-glossary-token-coverage-plateaus-at-866-percent"
   },
   {
@@ -161,7 +161,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-01",
-   "age_days": 25,
+   "age_days": 27,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#14-renou-period-state-tagging-covers-770k-entries-in-8-dicts"
   },
   {
@@ -170,7 +170,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-07",
-   "age_days": 19,
+   "age_days": 21,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#62-varga-distribution-is-almost-epoch-stable-cramérs-v--0037--and-the-gasūns-2014-dissertation-prose-read-its-own-χ²-table-backwards"
   },
   {
@@ -179,7 +179,7 @@
    "section": "Corpus & parallel-text data",
    "importance": 2,
    "evidence_date": "2026-07-07",
-   "age_days": 19,
+   "age_days": 21,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#65-66--of-the-deepseek-corpus-word-alignments-ground-to-nothing-in-their-verse"
   },
   {
@@ -188,7 +188,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 32,
+   "age_days": 34,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#15-pwg-encodes-secondary-stems-inline-not-in-div-markup"
   },
   {
@@ -197,7 +197,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 32,
+   "age_days": 34,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#16-giant-verb-roots-sit-at-non-zero-homonym-indexes"
   },
   {
@@ -206,7 +206,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-24",
-   "age_days": 32,
+   "age_days": 34,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#17-pwg-orders-senses-genetically-not-historically"
   },
   {
@@ -215,7 +215,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 32,
+   "age_days": 34,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#18-vedic-citation-density-separates-the-dictionary-traditions"
   },
   {
@@ -224,7 +224,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 41,
+   "age_days": 43,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#19-skd-and-vcp-carry-essentially-zero-western-markup"
   },
   {
@@ -233,7 +233,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 32,
+   "age_days": 34,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#20-the-ls-source-map-recognises-724-percent-of-pwg-citations"
   },
   {
@@ -242,7 +242,7 @@
    "section": "Dictionary structure & markup",
    "importance": 1,
    "evidence_date": "2026-07-02",
-   "age_days": 24,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#21-pwg-citation-occurrences-track-distinct-references"
   },
   {
@@ -251,7 +251,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 30,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#22-mw-has-no-sense-level-div-markup"
   },
   {
@@ -260,7 +260,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 41,
+   "age_days": 43,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#23-apte-is-three-dictionaries-keys-differ-stem-vs-nominative"
   },
   {
@@ -269,7 +269,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-07",
-   "age_days": 11,
+   "age_days": 13,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#24-about-9-percent-of-typo-corrections-are-collisions"
   },
   {
@@ -278,7 +278,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07",
-   "age_days": 11,
+   "age_days": 13,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#25-a-verified-correction-queue-decays-against-live-csl-orig"
   },
   {
@@ -287,7 +287,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-13",
-   "age_days": 43,
+   "age_days": 45,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#26-citation-density-is-register-bound-not-comparable-raw"
   },
   {
@@ -296,7 +296,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-15",
-   "age_days": 41,
+   "age_days": 43,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#27-sense-granularity-is-a-family-trait-not-a-diachronic-trend"
   },
   {
@@ -305,7 +305,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-03",
-   "age_days": 53,
+   "age_days": 55,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#28-mw-inherited-the-pwg-apparatus-skeleton-not-its-prose"
   },
   {
@@ -314,7 +314,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 30,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#29-pwg-and-mw-share-94753-headwords-in-the-union-index"
   },
   {
@@ -323,7 +323,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-06-15",
-   "age_days": 41,
+   "age_days": 43,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#30-body-text-headword-mining-is-a-dead-end-386-percent-precision"
   },
   {
@@ -332,7 +332,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-06-24",
-   "age_days": 32,
+   "age_days": 34,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#31-detector-precision-stratifies-by-digitization-quality"
   },
   {
@@ -341,7 +341,7 @@
    "section": "Dictionary structure & markup",
    "importance": 1,
    "evidence_date": "2026-06-17",
-   "age_days": 39,
+   "age_days": 41,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#32-correction-events-concentrate-in-sense-text"
   },
   {
@@ -350,7 +350,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#46-twelve-years-of-corrections-cover-only-1014--of-the-estimated-error-population"
   },
   {
@@ -359,7 +359,7 @@
    "section": "Dictionary structure & markup",
    "importance": 3,
    "evidence_date": "2026-07-05",
-   "age_days": 21,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#64-pw-only-headwords-outnumber-pwg-only-ones-6-to-1--pwg-is-not-the-sole-spine-of-the-local-layer-universe"
   },
   {
@@ -368,7 +368,7 @@
    "section": "Dictionary structure & markup",
    "importance": 2,
    "evidence_date": "2026-07-11",
-   "age_days": 15,
+   "age_days": 17,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#76-the-mwwordnetsemdom-bridge-is-a-candidate-generator-not-a-classifier"
   },
   {
@@ -422,7 +422,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 30,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#33-indigenous-dictionaries-agree-on-derivation-wilson-is-the-outlier"
   },
   {
@@ -431,7 +431,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 30,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#34-the-e-abbreviation-tag-is-polysemous-across-dicts"
   },
   {
@@ -440,7 +440,7 @@
    "section": "Etymology & derivation",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 30,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#35-root-recovery-tiers-err-on-root-form-not-identity"
   },
   {
@@ -449,7 +449,7 @@
    "section": "Encoding & normalization",
    "importance": 3,
    "evidence_date": "2026-06",
-   "age_days": 41,
+   "age_days": 43,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#36-iast-unicode-collides-and-normalises-lossily"
   },
   {
@@ -458,7 +458,7 @@
    "section": "Encoding & normalization",
    "importance": 3,
    "evidence_date": "2026-07",
-   "age_days": 11,
+   "age_days": 13,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#100-nfold-earns-sandhi-tolerant-recall-by-fusing-every-nasal-to-n--which-manufactures-false-quotation-matches-unless-every-hit-is-re-verified-on-norm"
   },
   {
@@ -467,7 +467,7 @@
    "section": "Encoding & normalization",
    "importance": 3,
    "evidence_date": "2026-07",
-   "age_days": 11,
+   "age_days": 13,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#102-dcs-sentencetext_sandhied-is-not-reliably-sandhied--some-rows-store-analyzed-word-forms-which-silently-downgrades-verbatim-quotations-to-partial-matches"
   },
   {
@@ -476,7 +476,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06",
-   "age_days": 41,
+   "age_days": 43,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#37-bom-state-is-inconsistent-across-exports"
   },
   {
@@ -485,7 +485,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06-27",
-   "age_days": 29,
+   "age_days": 31,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#38-injected-boms-crash-the-hw-record-parser"
   },
   {
@@ -494,7 +494,7 @@
    "section": "Encoding & normalization",
    "importance": 1,
    "evidence_date": "2026-06",
-   "age_days": 41,
+   "age_days": 43,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#39-devanagari_to_slp1-mis-routes-retroflex-la"
   },
   {
@@ -503,7 +503,7 @@
    "section": "Encoding & normalization",
    "importance": 2,
    "evidence_date": "2026-06-26",
-   "age_days": 30,
+   "age_days": 32,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#40-gloss-language-spelling-drift-tracks-reform-type-not-age"
   },
   {
@@ -512,7 +512,7 @@
    "section": "Encoding & normalization",
    "importance": 1,
    "evidence_date": "2026-07-05",
-   "age_days": 21,
+   "age_days": 23,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#60-practical-russian-transcription-of-sanskrit-names-has-no-safe-reverse-transliteration"
   },
   {
@@ -521,7 +521,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 24,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#41-the-sanskrit-dictionary-platform-landscape-probed-live"
   },
   {
@@ -530,7 +530,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#47-heritage-data-is-acquirable-despite-the-anubis-wall--via-a-github-mirror-the-morphology-xml-is-not-in-it"
   },
   {
@@ -539,7 +539,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 24,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#43-skdvcp-sensecitation-fusion-is-a-record-type-effect-not-a-dictionary-level-one"
   },
   {
@@ -548,7 +548,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 24,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#44-raw-latin-string-tallies-over-gloss-text-include-etymological-false-positives-bopp-lacks-yabh"
   },
   {
@@ -557,7 +557,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-02",
-   "age_days": 24,
+   "age_days": 26,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#45-siglum-prefix-families-routinely-bundle-several-distinct-works-the-diacritic-stripping-fold-has-poisoned-keys"
   },
   {
@@ -566,7 +566,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#48-vedaweb-20s-resource-export-is-an-async-task-behind-a-pickup-key-not-a-direct-get--and-the-server-went-unresponsive-mid-attempt"
   },
   {
@@ -575,7 +575,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#49-mwheritage-coverage-highlighting-is-a-duplicate-anchor-pattern-not-a-css-class--and-the-mirrors-current-dictionary-is-a-different-scope-asset-than-the-2014-reader-stem-list"
   },
   {
@@ -584,7 +584,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#50-cdsl-display-paths-are-not-uniformly-2020web--and-two-new-digitizations-landed-in-june-2026"
   },
   {
@@ -602,7 +602,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#51-huet-correspondence-predates-this-session-2021--the-morphology-xml-gate-was-already-resolved-in-writing-direct-download-urls-recovered"
   },
   {
@@ -611,7 +611,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#52-heritage-vs-kosha-forms-diff-the-small-raw-overlap-is-mostly-convention--model-difference-and-disagreements-are-two-thirds-lemmatization-policy-not-error"
   },
   {
@@ -620,7 +620,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#53-the-wil-etymology-extractions-affix-field-is-half-noise--wilson-outlier-figures-are-substantially-a-measurement-artifact"
   },
   {
@@ -629,7 +629,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#56-dicos-entry-anchors-nest-three-structural-roles-under-one-html-class--only-one-is-a-true-entry-boundary"
   },
   {
@@ -638,7 +638,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#55-gen_opt_harness2py-output-budget-coarser-wins-on-both-knobs-in-opposite-directions"
   },
   {
@@ -647,7 +647,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#57-samskrtamruz-is-id-addressed-with-no-name-lookup--deep-linking-needs-a-scraped-rootid-table-8-primer-basic-roots-are-absent"
   },
   {
@@ -656,7 +656,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#58-pwg-ru-promoted-store-has-input-level-provenance-but-old-ru-rows-lacked-exact-model-versions"
   },
   {
@@ -674,7 +674,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-03",
-   "age_days": 23,
+   "age_days": 25,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#70-pwg_ru-tm-composite-grade-a-is-consensus-gated-57-and-a-reference-free-surface-qe-cannot-detect-wrong-sense"
   },
   {
@@ -683,7 +683,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-07",
-   "age_days": 19,
+   "age_days": 21,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#61-the-reverse-dictionarys-30-sources-split-18-pd-vs-10-in-copyright--the-merged-headword-list-is-not-automatically-publishable"
   },
   {
@@ -692,7 +692,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-08",
-   "age_days": 18,
+   "age_days": 20,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#71-pwg-marks-case-government-explicitly-3853-times-across-3222-senses--a-deterministic-census-not-an-estimate"
   },
   {
@@ -701,7 +701,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-08",
-   "age_days": 18,
+   "age_days": 20,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#72-vedawebs-id_gra-token-field-is-the-grassmann-l-entry-number--no-fuzzy-text-matching-needed-for-a-gravedaweb-crosswalk"
   },
   {
@@ -710,7 +710,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-08",
-   "age_days": 18,
+   "age_days": 20,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#73-vedaweb-20s-cc-by-40-for-everything-claim-is-not-machine-confirmed--only-236-catalog-resources-carry-an-explicit-license-field"
   },
   {
@@ -719,7 +719,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-08",
-   "age_days": 18,
+   "age_days": 20,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#74-the-ls-graph-citation-matrix-is-degenerate-for-mw--its-top-abbreviations-sit-unresolved-use-the-citation-apparatus-siglum-matrix-for-cross-dict-citation-profiles"
   },
   {
@@ -728,7 +728,7 @@
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": "2026-07-10",
-   "age_days": 16,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#66-the-dcs-ql-frequency-workbooks-slp1-and-length-columns-are-truncated-at-ṣṭhḍh-clusters"
   },
   {
@@ -737,7 +737,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-10",
-   "age_days": 16,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#67-in-pwg-article-size-dwarfs-every-parametric-statistic-you-can-extract-from-the-entry"
   },
   {
@@ -746,7 +746,7 @@
    "section": "External platforms & services",
    "importance": 2,
    "evidence_date": "2026-07-10",
-   "age_days": 16,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#68-the-sanskrit-spellchecker-landscape-one-dormant-demo-one-license-unsettled-543k-wordlist-no-occupant"
   },
   {
@@ -755,7 +755,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-10",
-   "age_days": 16,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#69-hand-transcribed-telemetry-cannot-adjudicate-code-vs-infra--and-a-local-only-ledger-silently-swaps-your-denominator"
   },
   {
@@ -764,7 +764,7 @@
    "section": "External platforms & services",
    "importance": 1,
    "evidence_date": "2026-07-10",
-   "age_days": 16,
+   "age_days": 18,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#75-the-full-devībhāgavata-purāṇa-sanskrit-is-not-on-gretil--only-the-devigita-fragment-the-complete-mūla-lives-on-sanskritdocumentsorg-without-dbhp_-markers"
   },
   {
@@ -1111,12 +1111,12 @@
   },
   {
    "n": 465,
-   "title": "PWG sense × DCS attestation collapses from 100% at lemma level to 0.67% at sense level — and two independent ceilings cause it",
+   "title": "PWG sense × DCS attestation collapses from ~40% at lemma level to 0.67% at sense level — and three independent constrictions cause it",
    "section": "External platforms & services",
    "importance": 3,
    "evidence_date": null,
    "age_days": null,
-   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#465-pwg-sense--dcs-attestation-collapses-from-100-at-lemma-level-to-067-at-sense-level--and-two-independent-ceilings-cause-it"
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#465-pwg-sense--dcs-attestation-collapses-from-40-at-lemma-level-to-067-at-sense-level--and-three-independent-constrictions-cause-it"
   },
   {
    "n": 466,
@@ -1126,6 +1126,294 @@
    "evidence_date": null,
    "age_days": null,
    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#466-mws-cf-and-pwgs-vgl-are-not-independent-witnesses--they-agree-2950-above-chance-so-a-shared-cross-reference-never-counts-as-double-attestation"
+  },
+  {
+   "n": 467,
+   "title": "corpus_lexicon.jsonl gets its first intrinsic BLI quality number — and the obvious gold source (the corpus's own glossary) is circular, so the fix is an independent dictionary ranked by an independent frequency source",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#467-corpus_lexiconjsonl-gets-its-first-intrinsic-bli-quality-number--and-the-obvious-gold-source-the-corpuss-own-glossary-is-circular-so-the-fix-is-an-independent-dictionary-ranked-by-an-independent-frequency-source"
+  },
+  {
+   "n": 468,
+   "title": "PWG's plain `R.` is a THREE-edition composite — books 3–6 carry Gorresio (Bengal-recension) numbering, so keying them into a Southern-recension text silently returns the wrong verse",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#468-pwgs-plain-r-is-a-three-edition-composite--books-36-carry-gorresio-bengal-recension-numbering-so-keying-them-into-a-southern-recension-text-silently-returns-the-wrong-verse"
+  },
+  {
+   "n": 469,
+   "title": "`to_slp1` is case-preserving, so a capitalised IAST headword transliterates into a DIFFERENT SLP1 letter — 60% of NCC match-keys are wrong and 14,379 exact ACC×NCC matches were never proposed",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#469-to_slp1-is-case-preserving-so-a-capitalised-iast-headword-transliterates-into-a-different-slp1-letter--60-of-ncc-match-keys-are-wrong-and-14379-exact-accncc-matches-were-never-proposed"
+  },
+  {
+   "n": 470,
+   "title": "The Cologne scan-viewer page PDFs can carry an embedded digitized text layer — check `get_text()` BEFORE declaring \"no e-text exists\" or commissioning OCR",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#470-the-cologne-scan-viewer-page-pdfs-can-carry-an-embedded-digitized-text-layer--check-get_text-before-declaring-no-e-text-exists-or-commissioning-ocr"
+  },
+  {
+   "n": 471,
+   "title": "A corpus-candidate matcher keyed on a dictionary's OWN bibliographic prose will bury its biggest wins in the \"no corpus side exists\" class — PWG's Pāṇini and Manu, 41,910 citations, sat in `DCS-LACKS`",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#471-a-corpus-candidate-matcher-keyed-on-a-dictionarys-own-bibliographic-prose-will-bury-its-biggest-wins-in-the-no-corpus-side-exists-class--pwgs-pāṇini-and-manu-41910-citations-sat-in-dcs-lacks"
+  },
+  {
+   "n": 472,
+   "title": "Choosing a confidence tier ONCE PER SENSE and then stamping it on many passages inflates the strongest tier — 4.13% of H1670's exact-verse rows were chapter-level",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#472-choosing-a-confidence-tier-once-per-sense-and-then-stamping-it-on-many-passages-inflates-the-strongest-tier--413-of-h1670s-exact-verse-rows-were-chapter-level"
+  },
+  {
+   "n": 473,
+   "title": "OCR the canonical page files themselves — mapping a THIRD-PARTY OCR of \"the same\" scan onto them loses to offset drift, thumbnail decoys, and digit aliasing",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#473-ocr-the-canonical-page-files-themselves--mapping-a-third-party-ocr-of-the-same-scan-onto-them-loses-to-offset-drift-thumbnail-decoys-and-digit-aliasing"
+  },
+  {
+   "n": 474,
+   "title": "PWG's etymology parenthesis is NESTED — a \"first `+`-chain\" regex reads the inner sub-analysis, not the compound's members",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#474-pwgs-etymology-parenthesis-is-nested--a-first--chain-regex-reads-the-inner-sub-analysis-not-the-compounds-members"
+  },
+  {
+   "n": 475,
+   "title": "MW's `<k2>` carries a variant LIST after `;` and two different boundary marks — stripping the punctuation welds variants into a member that is not a word",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#475-mws-k2-carries-a-variant-list-after--and-two-different-boundary-marks--stripping-the-punctuation-welds-variants-into-a-member-that-is-not-a-word"
+  },
+  {
+   "n": 476,
+   "title": "Repairing an extractor GROWS the disagreement queue it feeds — plan for that, not for a shrink",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#476-repairing-an-extractor-grows-the-disagreement-queue-it-feeds--plan-for-that-not-for-a-shrink"
+  },
+  {
+   "n": 477,
+   "title": "35 cards is the floor for a 0.90 Wilson gate — and a censused stratum needs no interval at all",
+   "section": "External platforms & services",
+   "importance": 1,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#477-35-cards-is-the-floor-for-a-090-wilson-gate--and-a-censused-stratum-needs-no-interval-at-all"
+  },
+  {
+   "n": 478,
+   "title": "A blind arm stratified on an agent's own rules must not render the rule — and its card ids must come from the lock, not the frame",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#478-a-blind-arm-stratified-on-an-agents-own-rules-must-not-render-the-rule--and-its-card-ids-must-come-from-the-lock-not-the-frame"
+  },
+  {
+   "n": 479,
+   "title": "PWG's etymology parenthesis: \"first `{#…#}` per `+`-part\" is right until PWG writes a derivation ladder",
+   "section": "External platforms & services",
+   "importance": 1,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#479-pwgs-etymology-parenthesis-first--per--part-is-right-until-pwg-writes-a-derivation-ladder"
+  },
+  {
+   "n": 480,
+   "title": "A non-empty PDF text layer proves nothing — check the SCRIPT; and \"extract the largest embedded image\" breaks when the PDF CROPS a 2-up scan",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#480-a-non-empty-pdf-text-layer-proves-nothing--check-the-script-and-extract-the-largest-embedded-image-breaks-when-the-pdf-crops-a-2-up-scan"
+  },
+  {
+   "n": 481,
+   "title": "A corpus file's PRESENCE is not evidence of its contents — `07_ramayana-uttarakanda.jsonl` is Sanskrit-only CRITICAL-edition text under a \"Southern/Leonov\" label, and a handoff was minted off the filename",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#481-a-corpus-files-presence-is-not-evidence-of-its-contents--07_ramayana-uttarakandajsonl-is-sanskrit-only-critical-edition-text-under-a-southernleonov-label-and-a-handoff-was-minted-off-the-filename"
+  },
+  {
+   "n": 482,
+   "title": "A count column with no stated provenance is not data — it is a ranking, and the difference decides whether you may divide by it",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#482-a-count-column-with-no-stated-provenance-is-not-data--it-is-a-ranking-and-the-difference-decides-whether-you-may-divide-by-it"
+  },
+  {
+   "n": 483,
+   "title": "A resolver that fails closed is a gap; one that fails *open* is a wrong answer — and only the second is an integrity defect",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#483-a-resolver-that-fails-closed-is-a-gap-one-that-fails-open-is-a-wrong-answer--and-only-the-second-is-an-integrity-defect"
+  },
+  {
+   "n": 484,
+   "title": "A quarter of the DCS nominal mass has no case at all — `feat_case='Cpd'` is a compound member, not a ninth case",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#484-a-quarter-of-the-dcs-nominal-mass-has-no-case-at-all--feat_casecpd-is-a-compound-member-not-a-ninth-case"
+  },
+  {
+   "n": 485,
+   "title": "The 2021-sourced \"Nom.Sg = 34.6% of nominal forms, dual < 1% everywhere\" does not reproduce on DCS-2026 — and the second half only survives read per cell",
+   "section": "External platforms & services",
+   "importance": 1,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#485-the-2021-sourced-nomsg--346-of-nominal-forms-dual--1-everywhere-does-not-reproduce-on-dcs-2026--and-the-second-half-only-survives-read-per-cell"
+  },
+  {
+   "n": 486,
+   "title": "Before OCR-ing a library scan, check whether the library already published its OCR — and measure against it rather than guessing",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#486-before-ocr-ing-a-library-scan-check-whether-the-library-already-published-its-ocr--and-measure-against-it-rather-than-guessing"
+  },
+  {
+   "n": 487,
+   "title": "A cross-scheme join is a transliteration step, not a string comparison — a naive IAST-to-SLP1 match selects on diacritics",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#487-a-cross-scheme-join-is-a-transliteration-step-not-a-string-comparison--a-naive-iast-to-slp1-match-selects-on-diacritics"
+  },
+  {
+   "n": 488,
+   "title": "DCS stem co-occurrence graph is extreme-sparse with function-word hubs",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#488-dcs-stem-co-occurrence-graph-is-extreme-sparse-with-function-word-hubs"
+  },
+  {
+   "n": 489,
+   "title": "Sintagmatic appendix-6 is a 6.3k-lemma core nested in the 80k all-corpus table",
+   "section": "External platforms & services",
+   "importance": 1,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#489-sintagmatic-appendix-6-is-a-63k-lemma-core-nested-in-the-80k-all-corpus-table"
+  },
+  {
+   "n": 490,
+   "title": "Heritage×kosha form intersection agrees 78.3%; disagreements are classifiable",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#490-heritagekosha-form-intersection-agrees-783-disagreements-are-classifiable"
+  },
+  {
+   "n": 491,
+   "title": "Verb-form frequency prelim is an unlabeled 42-row XLS with empty tense names",
+   "section": "External platforms & services",
+   "importance": 1,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#491-verb-form-frequency-prelim-is-an-unlabeled-42-row-xls-with-empty-tense-names"
+  },
+  {
+   "n": 492,
+   "title": "Stopovye is a 102-file subset of Polnorazmernye, not a stopword filter of the full 506k",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#492-stopovye-is-a-102-file-subset-of-polnorazmernye-not-a-stopword-filter-of-the-full-506k"
+  },
+  {
+   "n": 493,
+   "title": "Cross-vendor LLM second pass on routing gold is κ=1.0 — still not human IAA",
+   "section": "External platforms & services",
+   "importance": 1,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#493-cross-vendor-llm-second-pass-on-routing-gold-is-κ10--still-not-human-iaa"
+  },
+  {
+   "n": 494,
+   "title": "Homonym token-attribution residual is a 38-group single-lemma_id ceiling",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#494-homonym-token-attribution-residual-is-a-38-group-single-lemma_id-ceiling"
+  },
+  {
+   "n": 495,
+   "title": "Cyrillic name indices: 61 IAST-bearing seed files vs 47 pure-Cyrillic — rules still unsafe",
+   "section": "External platforms & services",
+   "importance": 1,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#495-cyrillic-name-indices-61-iast-bearing-seed-files-vs-47-pure-cyrillic--rules-still-unsafe"
+  },
+  {
+   "n": 496,
+   "title": "Edit-distance record linkage over Sanskrit headwords is 70–98 % false matches — use a length-preserving normalization key and measure the false-match rate against the dictionary's own inventory",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#496-edit-distance-record-linkage-over-sanskrit-headwords-is-7098--false-matches--use-a-length-preserving-normalization-key-and-measure-the-false-match-rate-against-the-dictionarys-own-inventory"
+  },
+  {
+   "n": 497,
+   "title": "The csl-orig L-number is not a join key — only 35 % of form-era L-codes still point at their own headword",
+   "section": "External platforms & services",
+   "importance": 3,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#497-the-csl-orig-l-number-is-not-a-join-key--only-35--of-form-era-l-codes-still-point-at-their-own-headword"
+  },
+  {
+   "n": 498,
+   "title": "Word-initial Harvard-Kyoto capitals never decode — 113 correction-event headwords entered the corpus mis-transcoded",
+   "section": "External platforms & services",
+   "importance": 2,
+   "evidence_date": null,
+   "age_days": null,
+   "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#498-word-initial-harvard-kyoto-capitals-never-decode--113-correction-event-headwords-entered-the-corpus-mis-transcoded"
   }
  ]
 }

--- a/findings_dashboard/timeseries.json
+++ b/findings_dashboard/timeseries.json
@@ -40,7 +40,7 @@
    }
   },
   {
-   "date": "2026-07-26",
+   "date": "2026-07-28",
    "source": "build",
    "metrics": {
     "dcs_cdsl_linkage_pct": 81.4,
@@ -68,11 +68,11 @@
     "queue_decay_pct": 0.82
    },
    "registry": {
-    "total": 124,
+    "total": 156,
     "by_importance": {
-     "2": 80,
-     "1": 18,
-     "3": 26
+     "2": 90,
+     "1": 25,
+     "3": 41
     },
     "stale": 0
    }


### PR DESCRIPTION
## Summary
- `master` went red at PR #845/H1735's GAPS→FINDINGS graduation (`5298f8eb`) — the epistemic-integrity checker reported dangling Index rows (§488–§492, later grown to §488–§498 by subsequent merges).
- Root cause: the section bodies were never missing — eleven headings were written as `### 488.` instead of `### §488.`, so `epistemic_integrity_check.py`'s `### §N.` heading regex never matched them, breaking heading↔Index parity.
- Fix: add the missing `§` to all 11 headings (§488–§498), bump the next-free marker to §499, regenerate `findings_dashboard/data.json` and `epistemic_dashboard/epistemic.json` (156 distinct FINDINGS headings, up from the stale 124), add a changelog entry + version bump to 1.95.0.

Handoff: [H1752](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1752-Sonnet_SanskritLexicography_red-branch-repair-findings-488-492-dangling-index_27.07.26.md)

## Test plan
- [x] `python tools/epistemic_integrity_check.py --dir .` → `EPISTEMIC INTEGRITY: OK — 156 distinct FINDINGS headings, Index parity holds, no duplicate §-numbers, dashboards in sync.`
- [ ] CI green on this PR
- [ ] CI green on `master` after merge (H1723's red-branch check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)