### PR TITLE
fix(hash-determinism): CRLF-vulnerable writers in RussianTranslation pinned into cross-machine hashes (H1769)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,26 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — `make_edition_cut.py`'s `release_manifest.json` sha256 was a property of the build host, not the content (H1769, 28-07-2026)
+
+- `copy_file` was a bare `shutil.copy2` and `copy_tree` a bare `shutil.copytree`
+  over CHANGELOG.md / DOI_PLAN.md / CITATION.cff / `schemas/` / `roadmap/` —
+  none of which carry a `.gitattributes eol=lf` pin. On a Windows checkout with
+  `core.autocrlf=true` those source bytes are already CRLF, so a Windows-cut
+  edition and a Linux-cut edition of the identical commit pinned two different
+  sha256 values for the same logical file in the "immutable" release manifest.
+  `copy_file` now LF-normalises text assets before writing (binary assets pass
+  through verbatim); `copy_tree` routes through the same helper. Regression:
+  [`tests/test_make_edition_cut_lf_determinism.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/tests/test_make_edition_cut_lf_determinism.py).
+- `ru_style_sweep.py`'s `_write_rows_atomic` (the sole writer of the canonical
+  `pwg_ru_translated.jsonl` store on `--apply`/`--repair-from --apply`) opened
+  its temp file in plain text mode with no `newline=` guard, so a Windows run
+  applied universal-newline translation to every row and silently converted
+  the store's line endings to CRLF — and its `before_sha256`/`after_sha256`,
+  recorded into the persisted repair report for audit, inherited the same
+  host-dependence. Now opens with `newline='\n'`. Regression:
+  [`tests/test_ru_style_sweep_lf_determinism.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/tests/test_ru_style_sweep_lf_determinism.py).
+
 ### Changed — LOD namespace ruled: `pwg-ru` → `repwg` ("rePWG"), one namespace for all graphs (27-07-2026)
 
 - Publication-IRI `@DECIDE` **closed** ([#809](https://github.com/gasyoun/SanskritLexicography/issues/809)).

--- a/RussianTranslation/src/make_edition_cut.py
+++ b/RussianTranslation/src/make_edition_cut.py
@@ -47,11 +47,41 @@ def sha256(path):
     return h.hexdigest()
 
 
+def _looks_like_text(data):
+    """Heuristic: no NUL byte and decodes as UTF-8 -> treat as a text asset."""
+    if b'\x00' in data:
+        return False
+    try:
+        data.decode('utf-8')
+        return True
+    except UnicodeDecodeError:
+        return False
+
+
 def copy_file(src, dst):
+    """Copy src -> dst, normalising text assets to LF (H1769).
+
+    release_manifest.json pins a sha256 per file below, and that manifest
+    ships as part of an "immutable" edition -- the hash must be a property
+    of CONTENT, not of the build host's checkout newline translation.
+    `shutil.copy2` is itself a byte-for-byte copy, but its SOURCE (a tracked
+    text file with no `.gitattributes eol=lf` pin) can already be CRLF on a
+    Windows checkout, so a Windows-cut edition and a Linux-cut edition would
+    pin different hashes for identical content. Binary assets are copied
+    verbatim; only files that decode cleanly as UTF-8 text are normalised.
+    """
     if not os.path.exists(src):
         raise FileNotFoundError(src)
     os.makedirs(os.path.dirname(dst), exist_ok=True)
-    shutil.copy2(src, dst)
+    with open(src, 'rb') as f:
+        data = f.read()
+    if _looks_like_text(data):
+        text = data.decode('utf-8').replace('\r\n', '\n').replace('\r', '\n')
+        with open(dst, 'w', encoding='utf-8', newline='\n') as f:
+            f.write(text)
+    else:
+        with open(dst, 'wb') as f:
+            f.write(data)
 
 
 def copy_tree(src, dst):
@@ -59,7 +89,7 @@ def copy_tree(src, dst):
         raise FileNotFoundError(src)
     if os.path.exists(dst):
         shutil.rmtree(dst)
-    shutil.copytree(src, dst)
+    shutil.copytree(src, dst, copy_function=copy_file)
 
 
 def ensure_interop(args):

--- a/RussianTranslation/src/ru_style_sweep.py
+++ b/RussianTranslation/src/ru_style_sweep.py
@@ -348,7 +348,12 @@ def _write_rows_atomic(store, rows, initial_hash, backup_dir=None, stamp=None):
     backup = _create_verified_backup(store, backup_dir=backup_dir, stamp=stamp)
     tmp = '%s.tmp.%d' % (store, os.getpid())
     try:
-        with open(tmp, 'x', encoding='utf-8') as stream:
+        # newline='\n' (H1769): a bare text-mode 'x' open applies universal
+        # newline translation (LF -> CRLF on Windows), which would silently
+        # convert the canonical JSONL store's line endings on every apply and
+        # make its sha256 (recorded in before_sha256/after_sha256 below, and
+        # in the backup's verified hash) a property of the build host.
+        with open(tmp, 'x', encoding='utf-8', newline='\n') as stream:
             for row in rows:
                 stream.write(json.dumps(row, ensure_ascii=False) + '\n')
         if _file_sha256(store) != initial_hash:

--- a/RussianTranslation/tests/test_make_edition_cut_lf_determinism.py
+++ b/RussianTranslation/tests/test_make_edition_cut_lf_determinism.py
@@ -1,0 +1,96 @@
+"""Line-ending determinism gate for `make_edition_cut.py` (H1769).
+
+`release_manifest.json` pins a sha256 per file it copies into an "immutable"
+release edition (assembled_cards.jsonl, the OntoLex/TEI interop exports,
+schemas/, roadmap/, CHANGELOG.md, DOI_PLAN.md, CITATION.cff). None of those
+paths carry a `.gitattributes eol=lf` pin, so on a Windows checkout with
+`core.autocrlf=true` the SOURCE bytes are already CRLF before this script
+ever touches them. `copy_file` used to be a bare `shutil.copy2` -- a
+byte-for-byte copy of whatever CRLF/LF the checkout produced -- so the
+sha256 recorded in the manifest was a property of the build host, not the
+content: a Windows-cut edition and a Linux-cut edition of the identical
+commit would pin two different hashes for the same logical file.
+
+This module proves the fix (`copy_file` now LF-normalises text assets
+before writing, `copy_tree` routes through the same helper) by feeding it
+one CRLF "checkout" and one LF "checkout" of the same content and asserting
+the resulting sha256 is identical either way.
+
+Run: `pytest tests/test_make_edition_cut_lf_determinism.py` (working dir
+RussianTranslation).
+"""
+import hashlib
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
+
+import make_edition_cut as mec  # noqa: E402
+
+
+def _sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def test_copy_file_normalises_crlf(tmp_path):
+    """A CRLF source (e.g. CHANGELOG.md checked out with autocrlf) must land
+    in the edition as LF."""
+    src = tmp_path / 'CHANGELOG.md'
+    src.write_bytes(b'# Changelog\r\n\r\n## [Unreleased]\r\n- fix\r\n')
+    dst = tmp_path / 'out' / 'CHANGELOG.md'
+    mec.copy_file(str(src), str(dst))
+    out = dst.read_bytes()
+    assert b'\r\n' not in out
+    assert out == b'# Changelog\n\n## [Unreleased]\n- fix\n'
+
+
+def test_copy_file_leaves_binary_verbatim(tmp_path):
+    """A genuinely binary asset (contains NUL / non-UTF-8 bytes) must pass
+    through byte-for-byte -- normalisation only applies to text."""
+    src = tmp_path / 'blob.bin'
+    data = bytes([0, 1, 2, 0x0d, 0x0a, 0xff, 0xfe])
+    src.write_bytes(data)
+    dst = tmp_path / 'out' / 'blob.bin'
+    mec.copy_file(str(src), str(dst))
+    assert dst.read_bytes() == data
+
+
+def test_manifest_sha256_is_platform_independent(tmp_path):
+    """The defect, reproduced directly: copy the SAME logical content once
+    as a CRLF 'Windows checkout' and once as an LF 'Linux checkout', and
+    assert manifest_files() pins the identical sha256 either way."""
+    logical_content = 'schema: pwg_ru.final_card.v1\nversion: 3\n'
+
+    win_dir = tmp_path / 'edition_win'
+    lin_dir = tmp_path / 'edition_lin'
+    win_dir.mkdir()
+    lin_dir.mkdir()
+
+    win_src = tmp_path / 'src_win.json'
+    win_src.write_bytes(logical_content.replace('\n', '\r\n').encode('utf-8'))
+    lin_src = tmp_path / 'src_lin.json'
+    lin_src.write_bytes(logical_content.encode('utf-8'))
+
+    mec.copy_file(str(win_src), str(win_dir / 'schema.json'))
+    mec.copy_file(str(lin_src), str(lin_dir / 'schema.json'))
+
+    win_manifest = mec.manifest_files(str(win_dir))
+    lin_manifest = mec.manifest_files(str(lin_dir))
+
+    assert win_manifest['schema.json']['sha256'] == lin_manifest['schema.json']['sha256']
+    assert win_manifest['schema.json']['sha256'] == _sha256_bytes(logical_content.encode('utf-8'))
+
+
+def test_copy_tree_routes_through_the_same_normalisation(tmp_path):
+    """`copy_tree` (used for schemas/ and roadmap/) must not bypass the
+    normalising `copy_file` via a bare shutil.copytree default."""
+    src_dir = tmp_path / 'schemas'
+    src_dir.mkdir()
+    (src_dir / 'a.schema.json').write_bytes(b'{\r\n  "a": 1\r\n}\r\n')
+
+    dst_dir = tmp_path / 'edition' / 'schemas'
+    mec.copy_tree(str(src_dir), str(dst_dir))
+
+    out = (dst_dir / 'a.schema.json').read_bytes()
+    assert b'\r\n' not in out
+    assert out == b'{\n  "a": 1\n}\n'

--- a/RussianTranslation/tests/test_ru_style_sweep_lf_determinism.py
+++ b/RussianTranslation/tests/test_ru_style_sweep_lf_determinism.py
@@ -1,0 +1,69 @@
+"""Line-ending determinism gate for `ru_style_sweep.py`'s store writer (H1769).
+
+`_write_rows_atomic` is the sole writer of the canonical `pwg_ru_translated.jsonl`
+store on `--apply`/`--repair-from --apply`, and its own before/after sha256 is
+recorded into the persisted repair report (`before_sha256`, `after_sha256`,
+the verified backup's `sha256`) for audit/provenance. It used to open the temp
+file in plain text mode (`open(tmp, 'x', encoding='utf-8')`) with no
+`newline=` guard, so a Windows run would apply universal-newline translation
+(LF -> CRLF) to every row it wrote -- silently converting the canonical
+store's line endings, and making every recorded sha256 a property of the
+build host rather than the content.
+
+Run: `pytest tests/test_ru_style_sweep_lf_determinism.py` (working dir
+RussianTranslation).
+"""
+import hashlib
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
+
+import ru_style_sweep as rss  # noqa: E402
+
+
+def _sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def test_write_rows_atomic_emits_lf_only(tmp_path):
+    store = tmp_path / 'pwg_ru_translated.jsonl'
+    row0 = {'key1': 'a', 'subcard': 'a~~1', 'sense_tag': '1', 'ru': 'x'}
+    store.write_bytes((json.dumps(row0, ensure_ascii=False) + '\n').encode('utf-8'))
+    initial_hash = _sha256_bytes(store.read_bytes())
+
+    rows = [
+        {'key1': 'a', 'subcard': 'a~~1', 'sense_tag': '1', 'ru': 'вм.'},
+        {'key1': 'b', 'subcard': 'b~~1', 'sense_tag': '1', 'ru': 'в знач.'},
+    ]
+    rss._write_rows_atomic(str(store), rows, initial_hash, backup_dir=str(tmp_path))
+
+    raw = store.read_bytes()
+    assert b'\r\n' not in raw
+    expected = (
+        (json.dumps(rows[0], ensure_ascii=False) + '\n').encode('utf-8')
+        + (json.dumps(rows[1], ensure_ascii=False) + '\n').encode('utf-8')
+    )
+    assert raw == expected
+
+
+def test_write_rows_atomic_hash_is_platform_independent(tmp_path):
+    """The defect, reproduced directly: writing the SAME rows must yield the
+    SAME sha256 regardless of what newline convention happened to be active."""
+    rows = [{'key1': 'k', 'subcard': 'k~~1', 'sense_tag': '1', 'ru': 'test'}]
+
+    store_a = tmp_path / 'a' / 'store.jsonl'
+    store_a.parent.mkdir()
+    store_a.write_bytes(b'')
+    hash_a = _sha256_bytes(store_a.read_bytes())
+    rss._write_rows_atomic(str(store_a), rows, hash_a, backup_dir=str(store_a.parent))
+
+    store_b = tmp_path / 'b' / 'store.jsonl'
+    store_b.parent.mkdir()
+    store_b.write_bytes(b'')
+    hash_b = _sha256_bytes(store_b.read_bytes())
+    rss._write_rows_atomic(str(store_b), rows, hash_b, backup_dir=str(store_b.parent))
+
+    assert store_a.read_bytes() == store_b.read_bytes()
+    assert rss._file_sha256(str(store_a)) == rss._file_sha256(str(store_b))


### PR DESCRIPTION
Part of org handoff [H1769](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1769-Sonnet_multi_os-dependent-text-output-hash-audit_28.07.26.md) (audit for the H1768 hash/write-determinism defect class).

5 files flagged by the static scanner in `RussianTranslation/`; 2 confirmed defects, 3 already-safe/not-relied-on:

- **`src/make_edition_cut.py` — defect, fixed.** `copy_file()`/`copy_tree()` were bare `shutil.copy2`/`shutil.copytree` over untracked-eol text assets (`CHANGELOG.md`, `DOI_PLAN.md`, `CITATION.cff`, `schemas/`, `roadmap/`) whose sha256 is pinned into the immutable edition's `release_manifest.json`. No `.gitattributes eol=lf` pin existed for those paths, so a Windows-cut vs. Linux-cut edition of the identical commit pinned different hashes for identical content.
- **`src/ru_style_sweep.py` — defect, fixed.** `_write_rows_atomic()` (sole writer of the canonical `pwg_ru_translated.jsonl` store on `--apply`) opened its temp file in text mode with no `newline=` guard — a Windows apply silently converted the store to CRLF, and the `before_sha256`/`after_sha256` recorded into the repair report inherited the host-dependence. Now opens with `newline='\n'`.
- `src/audit_sense_glyph.py`, `src/pilot/h1339_population_rederive.py`, `src/pilot/window_common.py` — not-relied-on / already-safe (read-only hashing or in-memory-string hashing; see PR diff / H1769 FINDINGS.md entry for detail).

Regression tests added, proven to fail pre-fix — `tests/test_make_edition_cut_lf_determinism.py` (3/4 failed pre-fix: `test_copy_file_normalises_crlf`, `test_manifest_sha256_is_platform_independent`, `test_copy_tree_routes_through_the_same_normalisation`) and `tests/test_ru_style_sweep_lf_determinism.py` (1/2 failed pre-fix: `test_write_rows_atomic_emits_lf_only`). Post-fix: all 6 pass; `src/ru_style_sweep.py --selftest` also passes. CHANGELOG `[Unreleased]` bullets added for both fixes.