### PR TITLE
docs(RussianTranslation): flip H1802 to EXECUTED in .ai_state.md

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -14,9 +14,21 @@ _Created: 09-07-2026 · Last updated: 28-07-2026_
 > comparison particle, Grassmann s.v. `na` 2). Rule of record, MG: «Это все надо давать ДО, а
 > не ПОСЛЕ» → [FINDINGS §499](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md),
 > fixes gated as [H1801](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1801-Opus_SanskritLexicography_g6-gold-card-evidence-panel_28.07.26.md)
-> (evidence panel) + [H1802](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1802-Sonnet_csl-pyutil_review-sheet-reject-label-picker_28.07.26.md)
-> (required label control in the emitter). **H1665 hard gate 1 (R5) is now half-satisfied** —
-> g6 starter applied; `g5-live-queue-batch1v3` still unvoted (H1655).
+> (evidence panel) + H1802 (required label control in the emitter, EXECUTED below).
+> **H1665 hard gate 1 (R5) is now half-satisfied** — g6 starter applied;
+> `g5-live-queue-batch1v3` still unvoted (H1655).
+
+> **H1802 🔴 EXECUTED 28-07-2026 (Sonnet 5 `claude-sonnet-5`), isolated worktree** —
+> `csl-pyutil` [v0.5.0](https://github.com/sanskrit-lexicon/csl-pyutil/releases/tag/v0.5.0)
+> ([PR #10](https://github.com/sanskrit-lexicon/csl-pyutil/pull/10)) adds
+> `config["reject_labels"]`: a required single-select control on reject, replacing the
+> note-prefix convention that made 5/6 G6 rejects unparseable above. Consumer re-pin
+> ([PR #856](https://github.com/gasyoun/SanskritLexicography/pull/856)):
+> `apply_decisions.py` G6 prefers the new `reject_label` export field (falls back to the
+> note-prefix convention for already-exported sheets); `build_g6_mqm_gold_sheet.py` passes
+> the 5 error-type labels and is re-cut under a new sheet_id
+> (`g6-mqm-gold-starter-reject-picker-2026-07-28`) — the 2026-07-25 generation keeps its
+> own id since it already carries applied votes. Next G6 vote uses the new sheet_id.
 
 > **H1705 🔴 EXECUTED 27-07-2026 (Opus 5 1M `claude-opus-5[1m]`), isolated worktree** —
 > R. (Bomb.) book 7: **both exits measured and rejected, no OCR spent.**


### PR DESCRIPTION
Post-close journal update: H1802 (csl-pyutil reject_labels picker + G6 re-pin) shipped in PR #10 (csl-pyutil) and PR #856 (this repo).