### PR TITLE
docs(pwg_ru): execution-ready plan — RV multi-translation evidence layer (H1843/H1844)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -222,6 +222,25 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 
 ## ➡️ Next Steps (Queue)
 
+- **RV multi-translation evidence layer — PLANNED 29-07-2026 (Opus 5 1M
+  `claude-opus-5[1m]`, `/ask`, 4 rounds, 17 rulings), NOT started.** Five layer docs
+  under [`docs/`](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation/docs);
+  the index is
+  [`PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md).
+  Joins the Ṛgveda to Grassmann 1876–77 / Geldner 1951–57 / Elizarenkova 1989–99 /
+  Griffith 1896 at lemma granularity, types the divergences, and wires the result in
+  three ways (judge witness · contradiction gate · TM tier for **ru AND en**).
+  Extends the H1801 evidence panel, which carries GRA + Russian context but nothing
+  about what the *other* translators did with the same stanza. Execution:
+  [H1843](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1843-Sonnet_RussianTranslation_rv-multitranslation-spine-w1a_29.07.26.md)
+  (wave 1a, Sonnet, deterministic, unblocked) then
+  [H1844](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1844-Opus_RussianTranslation_rv-multitranslation-typing-w1b_29.07.26.md)
+  (wave 1b, Opus, blocked on 1a). **Measured facts the plan rests on:** 10,552 stanzas ·
+  164,758 tokens, each already carrying `id_gra`/`id_pwg`/`id_mw`; Geldner covers 10,548,
+  omitting exactly RV 10.106.5–8; Elizarenkova's commentary holds 2,213 Renou mentions,
+  368 with a French quotation. ⚠️ `renou_*` in this repo means the 1956 language-states
+  axis — everything in this layer uses the `rv_renou_*` prefix.
+
 - **H1801 DONE 29-07-2026 (Opus 5 1M `claude-opus-5[1m]`) — G6 cards now carry
   dictionary + root + contexts BEFORE the vote.** New
   [`src/gold_evidence_panel.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/gold_evidence_panel.py);

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,41 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added — execution-ready plan: the Rig-Veda multi-translation evidence layer (H1843/H1844, 29-07-2026)
+
+Five cross-linked layer docs under [`docs/`](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation/docs),
+authored by Opus 5 (`claude-opus-5[1m]`) via `/ask` after a 4-round interview (17 rulings):
+[PLAN](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md)
+(+ its [metadoc](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.meta.md)) ·
+[ROADMAP](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/ROADMAP_RussianTranslation_rv-multitranslation-evidence_2026H2.md) ·
+[ARCHITECTURE](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_rv-multitranslation-evidence.md) ·
+[IMPLEMENTATION](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_rv-multitranslation-evidence.md) ·
+[VERIFICATION](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/VERIFICATION_RussianTranslation_rv-multitranslation-evidence.md).
+
+The layer joins the Ṛgveda to four translations (Grassmann 1876–77 · Geldner 1951–57 ·
+Elizarenkova 1989–99 · Griffith 1896) at lemma granularity, types where the translators diverge,
+and wires the result into the pipeline three ways — judge witness, contradiction gate, and a new
+TM tier serving **`ru` and `en` alike**. It extends the G6 evidence panel shipped the same day
+([H1801](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1801-Opus_SanskritLexicography_g6-gold-card-evidence-panel_28.07.26.md),
+after the `na` → «словно» reversal at id 122): that panel already routes a Vedic card to GRA's
+sense list plus Russian passage context, but carries nothing about what the *other* translators
+did with the same stanza — Geldner, Griffith, and Grassmann's own **translation** as distinct
+from his dictionary. This layer supplies exactly that, plus the divergence signal.
+
+**Measured during the audit, and load-bearing for the design** (full list in VERIFICATION §2):
+the Ṛgveda has 10,552 stanzas and **164,758 tokens**; `lemmatization.json`'s `transformContext`
+already carries `id_gra`/`id_pwg`/`id_mw` **per token**, so the dictionary anchor need not be
+built; Grassmann and Elizarenkova cover all 10,552 stanzas but **Geldner covers 10,548** —
+the four he does not translate are exactly **RV 10.106.5–8**, which turns the `omitted_by_one`
+class into a regression test with known ground truth; and Elizarenkova's commentary carries
+**2,213** mentions of Renou, **368** with a directly quoted French fragment.
+
+No code and no data shipped in this entry — plan only. Execution is
+[H1843](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1843-Sonnet_RussianTranslation_rv-multitranslation-spine-w1a_29.07.26.md)
+(wave 1a, deterministic) and
+[H1844](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1844-Opus_RussianTranslation_rv-multitranslation-typing-w1b_29.07.26.md)
+(wave 1b, gated).
+
 ### Changed — the G5 card is legible: печатный вид, кликабельные цитаты, подсказки к пометам (H1808, 29-07-2026)
 
 MG filed five defects while voting

--- a/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_rv-multitranslation-evidence.md
+++ b/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_rv-multitranslation-evidence.md
@@ -1,0 +1,243 @@
+# ARCHITECTURE — Rig-Veda multi-translation evidence layer
+
+_Created: 29-07-2026 · Last updated: 29-07-2026_
+
+Component boundaries, data model and contracts for the layer specified in
+[PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md).
+Every field name and count below was verified against the committed feeds on 29-07-2026, not
+assumed.
+
+---
+
+## 1. The measured substrate
+
+These are facts about the existing data, established by direct inspection. They are what makes
+the deterministic spine deterministic.
+
+| Fact | Value | Source |
+|---|---|---|
+| Stanzas in the Ṛgveda per VedaWeb | 10,552 | `contents` length of the accented-text and lemmatization exports |
+| Tokens in the Ṛgveda | **164,758** | sum over `contents[i].transformContext` |
+| Per-token fields already present | `form`, `lemma`, `lemma_ewaia`, `id_gra[]`, `id_mw[]`, `id_pwg[]` | `transformContext` (a JSON **string**, parse it) |
+| Stanza key | `location`, dotted form `1.1.1` | every export |
+| Grassmann 1876–77 coverage | 10,552 / 10,552 | `grassmann_de_1876_1877.json` |
+| Elizarenkova 1989–99 coverage | 10,552 / 10,552 | `elizarenkova_ru_1989_1999.json` |
+| Geldner 1951–57 coverage | **10,548 / 10,552** | `geldner_de_1951_1957.json` |
+| Stanzas Geldner does not translate | **RV 10.106.5, 10.106.6, 10.106.7, 10.106.8** | set difference of the two location sets |
+| Empty-text rows in any translation | 0 | all three files |
+
+**Two consequences the implementation must not miss.**
+
+First: the dictionary anchor is *already given per token*. `id_gra` and `id_pwg` sit on every
+one of the 164,758 tokens. The GRA and PWG crosswalks in VisualDCS remain useful as
+entry-level aggregates, but the layer does not need them to attach a Ṛgvedic token to a
+dictionary entry — that edge already exists. No fuzzy matching is required anywhere in spine A.
+
+Second: **RV 10.106.5–8 is the natural regression anchor for the "omitted by one" class.** It
+is a real, pre-existing gap in Geldner (the notoriously obscure Aśvin hymn), it is exactly four
+stanzas, and any pipeline that reports a different count for Geldner's omissions is broken. It
+also proves the class is worth modelling: MG's question "who translated how, and who did not
+translate at all" has a non-empty answer before any model is run.
+
+## 2. Component boundaries
+
+Five components, each with one job.
+
+```
+  VisualDCS/non-derived/vedaweb/        rvlinks/RV_sa-hn-ru-de-en_1.html
+  (read-only feed, R17)                 (read-only source)
+            |                                     |
+            |                                     v
+            |                          [C1] griffith_extract
+            |                                     |
+            v                                     v
+  [C2] spine_build  <---------------------------- +
+            |
+            +--> rv_stanza_translations.jsonl  (10,552 stanzas x 4, canonical)
+            +--> rv_lemma_occurrences.jsonl    (lemma -> 164,758 tokens, canonical)
+            +--> rv_translation_spine.tsv      (flat mirror, generated)
+            |
+            +------------------> [C3] divergence_type
+            |                              |
+            +------------------> [C4] wordlevel_align
+                                           |
+                       [C5] pipeline_bridge <- both, + wisdomlib
+                                           |
+                       judge witness · contradiction gate · TM tier
+```
+
+**C1 `griffith_extract`** — HTML in, JSON out. Reads the `p.stamp` / `p.en` pairs from the
+committed 5-layer HTML, normalises `rv01.001.01` → `1.1.1`, emits `griffith_en_1896.json` with
+the *same* record shape as the three VedaWeb translation files
+(`{createdAt, archived, text, location}` inside a `contents` list, with a `meta` block naming
+Griffith, 1896, `en`, and the extraction provenance). Deterministic; no model.
+
+**C2 `spine_build`** — the deterministic join. Reads the lemmatization export and the four
+translation files; groups the 164,758 tokens by lemma; for each lemma emits every stanza it
+occurs in together with all four renderings of that stanza. Records absence explicitly rather
+than dropping the row. Deterministic; no model. **This is spine A of ruling R5.**
+
+**C3 `divergence_type`** — the only component that exercises model judgment on a large scale.
+Consumes the spine, emits a typed label per (stanza × translator-pair). Gated: pilot →
+human agreement → full run (R13, R15).
+
+**C4 `wordlevel_align`** — layer B of R5. For a given token and a given translation of its
+stanza, propose the span of the translation that renders it, with a confidence. Re-uses the
+existing calibrated machinery rather than introducing a new aligner; output is **advisory** and
+is never written into reviewed data.
+
+**C5 `pipeline_bridge`** — the three integration points of R7 plus the four wisdomlib roles of
+R11. This is the only component that touches existing pipeline code.
+
+## 3. Data model
+
+**Normalised on purpose — measured, not guessed.** The four translations average 152–171
+characters per stanza. A single denormalised file carrying all four texts inline at every one
+of the 164,758 token occurrences measures **~65 MB**; splitting the stanza texts out and
+referencing them by `location` measures **~18 MB** for the same information. Ruling R12 asks for
+JSONL plus a flat TSV mirror; it does not ask for a 65 MB blob in git. So the canonical form is
+two files that join on `location`.
+
+### 3.1 `pwg_ru/rv_stanza_translations.jsonl` — one record per stanza (10,552)
+
+```
+{
+  "location": "1.1.1",
+  "mandala": 1, "hymn": 1, "stanza": 1,
+  "translations": {
+    "grassmann_de_1876":    {"status": "present", "text": "Den Priester Agni preise ich, …"},
+    "geldner_de_1951":      {"status": "present", "text": "Agni berufe ich als Bevollmächtigten, …"},
+    "elizarenkova_ru_1989": {"status": "present", "text": "Агни призываю я – во главе поставленного…"},
+    "griffith_en_1896":     {"status": "present", "text": "I Laud Agni, the chosen Priest, …"}
+  },
+  "divergence": null
+}
+```
+
+`status` is one of `present` · `absent_from_source` (the translator's edition does not carry
+this stanza at all — the Geldner 10.106.5–8 case) · `empty` (carried but blank). Distinguishing
+`absent_from_source` from `empty` is the whole point of the field; collapsing them to a null
+text destroys the "who did not translate" question this layer exists to answer.
+
+### 3.2 `pwg_ru/rv_lemma_occurrences.jsonl` — one record per lemma
+
+```
+{
+  "lemma": "agní-",
+  "lemma_ewaia": "",
+  "id_gra": ["79"],
+  "id_pwg": ["349"],
+  "id_mw": ["890"],
+  "occurrence_count": 1234,
+  "occurrences": [
+    {"location": "1.1.1", "form": "agním", "token_index": 0, "wordlevel": null}
+  ]
+}
+```
+
+`divergence` (§3.1) and `wordlevel` (here) are `null` after wave 1a and filled by C3 and C4.
+Keeping both keys in the schema from the start makes wave 1b an in-place enrichment rather than
+a reshape.
+
+### 3.3 `pwg_ru/rv_translation_spine.tsv` — flat mirror, generated
+
+One row per `lemma × location × translator`. Columns: `lemma`, `id_gra`, `id_pwg`, `location`,
+`form`, `translator`, `status`, `text`, `divergence_class`, `wordlevel_span`,
+`wordlevel_confidence`. Denormalised on purpose — this is the artifact that gets grepped, read
+into a spreadsheet, and fed to `/review-sheet`. It is generated **from** the two JSONL files,
+never edited by hand and never a second source of truth. Because it is a derived view it may be
+regenerated rather than committed if it proves unwieldy; the two JSONL files are the contract.
+
+### 3.4 `pwg_ru/rv_renou_citation_index.jsonl`
+
+**Naming, deliberately.** This repo already uses the token `renou` for something else entirely:
+Louis Renou's *Histoire de la langue sanskrite* (1956) five language-states axis, indexed as
+`{code}.renou.jsonl` and driven by [`src/renou_pipeline.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/renou_pipeline.py)
+and [`RENOU.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RENOU.md).
+That is a *register* axis and has nothing to do with Renou's French *translation* of the
+Ṛgveda. Everything in this layer therefore carries the `rv_renou_*` prefix, and no file, script
+or field here may be named `renou_*` alone.
+
+```
+{
+  "location": "1.1.1",
+  "mandala": 1, "hymn": 1, "stanza": 1,
+  "mention_kind": "quoted_fr" | "paraphrase_ru",
+  "context_ru": "…Рену: «aux ailes d'oiseau»…",
+  "quote_fr": "aux ailes d'oiseau",
+  "source": "elizarenkova_commentary"
+}
+```
+
+`quote_fr` is populated only for the 368 mentions carrying a Latin-script quotation; the other
+~1,845 are `paraphrase_ru` with `quote_fr: null`. Per PLAN §5, `context_ru` is a bounded
+context window around the mention, not the surrounding commentary paragraph.
+
+### 3.5 Divergence taxonomy — the five classes
+
+Scoped to a **translator pair** at a **stanza**, because "divergence" between four translators
+at once is not a well-formed claim.
+
+| Class | Definition | Deterministic? |
+|---|---|---|
+| `agreement` | Both render the token with semantically equivalent material | no — model |
+| `lexical_variant` | Same referent, different word choice (*Priester* vs *Bevollmächtigter*) | no — model |
+| `semantic_shift` | The two readings are not interchangeable; a real interpretive difference | no — model |
+| `omitted_by_one` | One translator's stanza does not render the token at all | partly — `absent_from_source` is deterministic, in-stanza omission is not |
+| `added_by_one` | One translator supplies material with no counterpart in the other | no — model |
+
+The `absent_from_source` sub-case of `omitted_by_one` is computed by C2 without any model and
+must match the measured baseline (4 stanzas for Geldner, 0 for the other three).
+
+### 3.6 TM tier extension
+
+Not a new subsystem. [`schemas/translation_memory.schema.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/schemas/translation_memory.schema.json)
+already defines `trust_level` (`reviewed_exact` · `machine_exact` · `legacy_promoted` ·
+`suggestion`), `reuse_policy`, and `lang: [ru, en]`; and
+[`src/tm_source_weights.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_source_weights.json)
+already carries `rigveda: 0.72` and `atharvaveda: 0.72` under `by_work_contains`.
+
+The extension is therefore: one new `trust_level` value (`corpus_translation_witness`), a
+`reuse_policy` of `suggest_only` for it, and per-translator weight rows. Because `lang` is
+already an enum over `[ru, en]` and the weights file is keyed by work rather than by language,
+**R7's "not for Russian only" requirement is satisfied by configuration, and a third language
+is a new enum member plus a weights row — not a rewrite.** Any change here must be classified
+in [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md)
+as SHARED / INTENTIONAL-DIVERGENCE / GAP before the work is called done; `lang_parity_check.py`
+enforces it in the test suite.
+
+## 4. Build-vs-reuse verdict per component
+
+| Component | Verdict | Evidence |
+|---|---|---|
+| C1 `griffith_extract` | **Build** — small, ~100 lines | Nothing extracts the `p.en` layer today; it exists only inside the HTML |
+| C2 `spine_build` | **Build on top of existing feeds** | The join keys (`location`, `id_gra`, `id_pwg`) all pre-exist; no matching logic is invented |
+| C3 `divergence_type` | **Build** — genuinely new | No divergence typing exists anywhere in the org; `pwg_vedaweb_gloss_crosswalk.tsv` puts Geldner and Grassmann in one row but never compares them |
+| C4 `wordlevel_align` | **REUSE — do not write a new aligner** | [`src/tm_align.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_align.py) ships a per-pair LaBSE confidence calibrated at `agreement >= 0.20` ([ALIGN_GATE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ALIGN_GATE.md)); [`src/tm_saru_align_labse.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_saru_align_labse.py) ships a Vecalign monotone DP at precision 0.966 ([LABSE_ALIGN.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/LABSE_ALIGN.md)) |
+| C5 `pipeline_bridge` | **Extend, do not fork** | TM schema, source weights and the parity ledger already have the shape; adding a tier is configuration plus a wiring commit |
+| wisdomlib access | **REUSE** | Crawler, index and `word_traditions.jsonl` exist in SamudraManthanam; wave 1 reads them and performs no crawl (R17) |
+
+## 5. Interfaces and contracts
+
+- **Feed access is sibling-path and read-only.** The layer reads
+  [`VisualDCS/non-derived/vedaweb/`](https://github.com/gasyoun/VisualDCS/tree/main/non-derived/vedaweb)
+  through a resolved sibling path with a graceful "feed absent" failure — the same pattern
+  WhitneyRoots uses for `dcs_ppp_verified.tsv`. It never writes there and never calls the
+  VedaWeb API (the bulk export's `pickupKey` is single-use).
+- **The spine is generated, never hand-edited.** Both artifacts are outputs of C2. A human
+  correction goes into the generator or into a committed override file, never into the JSONL.
+- **Layer B is advisory by construction.** `wordlevel.*` fields carry a `confidence` and a
+  `low_confidence` flag; nothing downstream may promote a `low_confidence` span into reviewed
+  data. This is the same posture the Elizarenkova lookup already has in this repo.
+- **The contradiction gate queues, it never rejects.** Its output is a review queue entry, not
+  a verdict on the card.
+
+## 6. Where this sits relative to what exists
+
+The layer is a **sibling of** `pwg_vedaweb_gloss_crosswalk.tsv`, not a replacement. That
+crosswalk answers "which PWG entries are RV-attested, and what did the two Germans say about an
+example locus" at entry granularity. This layer answers "for this lemma, at every one of its
+occurrences, what did all four translators do, and where did they part company" at
+lemma × stanza granularity. The crosswalk stays where it is and keeps its consumers.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_rv-multitranslation-evidence.md
+++ b/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_rv-multitranslation-evidence.md
@@ -1,0 +1,303 @@
+# IMPLEMENTATION — Rig-Veda multi-translation evidence layer, wave 1
+
+_Created: 29-07-2026 · Last updated: 29-07-2026_
+
+File-level, step-ordered build sequence for wave 1 of
+[PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md).
+Data model and contracts: [ARCHITECTURE](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_rv-multitranslation-evidence.md).
+Acceptance: [VERIFICATION](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/VERIFICATION_RussianTranslation_rv-multitranslation-evidence.md).
+
+Every step names the files it touches and what it depends on. **Each step also names its
+marked default** — the choice the agent takes without asking if the step turns out ambiguous
+(ruling R16).
+
+---
+
+## Preconditions — check before step 1, halt if unmet
+
+1. The sibling feed resolves and these five files are readable under
+   `VisualDCS/non-derived/vedaweb/`: `lemmatization.json`,
+   `geldner_de_1951_1957.json`, `grassmann_de_1876_1877.json`,
+   `elizarenkova_ru_1989_1999.json`, `accented_text_scarlata_widmer_lubotsky.json`.
+2. `rvlinks/RV_sa-hn-ru-de-en_1.html` resolves as a sibling repo checkout.
+3. The SamudraManthanam Ṛgveda commentary files resolve
+   (`Index/lib/x86_64-win64/add/To_add/NN_rigveda.no_tags`, 10 files).
+4. `SamudraManthanam/web/corpus_builder/wisdomlib/entries_index.jsonl` and
+   `word_traditions.jsonl` are present **on disk** — no network access is permitted (R17).
+
+A missing input is stop condition 1. Do not synthesise, do not fetch.
+
+## Windows and encoding rules — apply to every script written below
+
+Org-level, mechanically linted: `sys.stdout.reconfigure(encoding='utf-8')` and
+`sys.stderr.reconfigure(encoding='utf-8')` at the top of every printing script; `encoding='utf-8'`
+on every output-capturing `subprocess.run`; never write a UTF-8 BOM. Multi-step work goes in a
+`.py` file, not an inline shell one-liner. Repo CI additionally enforces: no trailing
+whitespace, newline at EOF, Markdown lint and link-check clean.
+
+---
+
+# Wave 1a — deterministic spine (handoff H1843)
+
+## Step 1 — `src/rv_griffith_extract.py`
+
+**Touches:** new `src/rv_griffith_extract.py`; writes `pwg_ru/griffith_en_1896.json`.
+**Depends on:** nothing.
+
+Parse `rvlinks/RV_sa-hn-ru-de-en_1.html`. The file is a flat sequence of blocks; the locus is
+carried by `p.stamp` in the form `rv01.001.01`, and the English text by the following `p.en`.
+Convert `rv01.001.01` → `1.1.1` (strip the `rv` prefix, drop leading zeros in each of the three
+fields). Emit the same envelope the VedaWeb translation files use: a top-level object with
+`meta` (author `Ralph T. H. Griffith`, year `1896`, language `en`, plus a `provenance` string
+naming this extraction and its source commit) and a `contents` list of
+`{createdAt, archived, text, location}`.
+
+- **Marked default — `<BR>` handling:** the English blocks contain literal line breaks. Replace
+  them with `\n`, do not collapse to a space; Elizarenkova's records already use `\n` the same way.
+- **Marked default — locus not in the VedaWeb set:** record it in the run log and skip the
+  record. Do not invent a mapping.
+- **Marked default — duplicate locus:** keep the first, log the collision.
+
+## Step 2 — `src/rv_spine_build.py` (part 1: stanza table)
+
+**Touches:** new `src/rv_spine_build.py`; writes `pwg_ru/rv_stanza_translations.jsonl`.
+**Depends on:** step 1.
+
+Load the four translation files, key each by `location`, and emit one record per stanza in the
+canonical 10,552-stanza set (taken from `lemmatization.json`, which is the authority for what
+stanzas exist). For each translator write `status` + `text` per ARCHITECTURE §3.1:
+`present` when the locus is in that translator's `contents` with non-blank text,
+`absent_from_source` when the locus is missing from that file entirely, `empty` when present
+but blank. Also split `location` into integer `mandala` / `hymn` / `stanza`.
+
+- **Marked default — a translator's file has a locus not in the canonical set:** log and ignore;
+  the lemmatization export defines the stanza universe.
+- **Hard invariant:** exactly four stanzas must come out `absent_from_source` for Geldner
+  (`10.106.5`–`10.106.8`) and zero for Grassmann and Elizarenkova. If the numbers differ, the
+  parse is wrong — that is a bug to fix, not a finding to record.
+
+## Step 3 — `src/rv_spine_build.py` (part 2: lemma occurrences)
+
+**Touches:** same script; writes `pwg_ru/rv_lemma_occurrences.jsonl`.
+**Depends on:** step 2.
+
+For each of the 10,552 records in `lemmatization.json`, parse `transformContext` — it is a
+**JSON string**, not a nested object, so `json.loads` it — yielding a list of tokens each with
+`form`, `lemma`, `lemma_ewaia`, `id_gra`, `id_mw`, `id_pwg`. Group by `lemma`; emit one record
+per lemma with its `occurrence_count` and the full `occurrences` list
+(`location`, `form`, `token_index`, `wordlevel: null`).
+
+This step **is** deliverable W1.5 — the dictionary anchors are already on the tokens, so no
+separate crosswalk join is needed. Carry `id_gra` / `id_pwg` / `id_mw` up to the lemma record as
+the union over its tokens.
+
+- **Marked default — a token's `lemma` is empty:** key it under the `form` and set
+  `lemma_missing: true`. Do not drop the token; the total must reconcile to 164,758.
+- **Marked default — conflicting `id_pwg` across tokens of one lemma:** keep the union, sorted,
+  and do not attempt to pick a winner.
+
+## Step 4 — `src/rv_spine_build.py` (part 3: flat mirror) + schema
+
+**Touches:** same script; writes `pwg_ru/rv_translation_spine.tsv`,
+`schemas/rv_translation_spine.schema.json`.
+**Depends on:** steps 2 and 3.
+
+Emit the denormalised TSV (columns in ARCHITECTURE §3.3) and a JSON Schema covering both JSONL
+files. Follow the existing house style in `schemas/translation_memory.schema.json`:
+`$schema` draft 2020-12, a `$id`, `$defs` for the shared enums (`status`, `translator`,
+`divergence_class`).
+
+- **Marked default — the TSV exceeds 200 MB:** do not commit it; emit it under a gitignored
+  path, commit the generator plus a 500-row sample as
+  `pwg_ru/rv_translation_spine.sample.tsv`, and note it in the run log. The two JSONL files are
+  the contract, the TSV is a convenience view.
+
+## Step 5 — `src/rv_renou_citations.py`
+
+**Touches:** new `src/rv_renou_citations.py`; writes `pwg_ru/rv_renou_citation_index.jsonl`.
+**Depends on:** nothing (can run in parallel with steps 1–4).
+
+Scan the ten `NN_rigveda.no_tags` commentary files for mentions of `Рену`. For each: resolve the
+enclosing stanza locus from the commentary's own numbering, capture a bounded Russian context
+window, and detect whether a Latin-script quotation in guillemets follows within ~25 characters —
+if so, extract it as `quote_fr` and set `mention_kind: "quoted_fr"`, otherwise
+`mention_kind: "paraphrase_ru"` with `quote_fr: null`.
+
+**Do not use the `renou_` prefix for anything here** — that token already means the 1956
+language-states axis in this repo (ARCHITECTURE §3.4). Everything is `rv_renou_*`.
+
+- **Hard invariant:** 2,213 total mentions, 368 with a Latin-script quotation. Per-maṇḍala
+  totals for cross-checking: I 459 · II 117 · III 161 · IV 118 · V 158 · VI 110 · VII 171 ·
+  VIII 123 · IX 226 · X 287.
+- **Marked default — the locus cannot be resolved:** emit the row with `location: null` and a
+  `locus_unresolved: true` flag rather than dropping it, so the count still reconciles.
+- **Marked default — context window length:** 300 characters centred on the mention, clipped to
+  sentence boundaries where they exist. Per PLAN §5 this stays a bounded window; do not widen it
+  to the surrounding paragraph.
+
+## Step 6 — tests and wave-1a close-out
+
+**Touches:** new `tests/test_rv_spine.py`; updates `changelog.md`, `.ai_state.md`.
+**Depends on:** steps 1–5.
+
+Tests asserting every hard invariant above (see VERIFICATION §2). Then the standard close-out:
+an `[Unreleased]` changelog bullet, `.ai_state.md` updated, commit → PR → merge.
+
+---
+
+# Wave 1b — typing, alignment, wiring (handoff H1844)
+
+## Step 7 — `src/rv_divergence_type.py`, pilot
+
+**Touches:** new `src/rv_divergence_type.py`; writes `pwg_ru/rv_divergence_pilot.jsonl`.
+**Depends on:** wave 1a merged.
+
+Type ~2,000 stanzas over the five classes of ARCHITECTURE §3.5, **per translator pair** (six
+pairs over four translators). Compute the `absent_from_source` sub-case deterministically before
+any model call — it is already in the stanza table and must not cost a token.
+
+- **Marked default — sampling frame:** stratified by maṇḍala proportionally to stanza count,
+  seeded deterministically so the pilot is reproducible.
+- **Marked default — a pair where one side is `absent_from_source`:** label
+  `omitted_by_one` deterministically and skip the model call.
+
+## Step 8 — the human gate
+
+**Touches:** writes `review/rv_divergence_gate_<date>.html` and, after voting,
+`review/rv_divergence_gate_<date>.decisions.json`.
+**Depends on:** step 7.
+
+Sample 100 stanzas out of the pilot into a `/review-sheet` HTML voting sheet — **an HTML sheet,
+never a Markdown checkbox list**, which is banned org-wide. Human votes the class per item.
+Agreement ≥ 80 % releases step 9 (R15).
+
+**This is the one step that requires a human and therefore cannot complete inside an unattended
+run.** The agent produces the sheet, records that it is awaiting a vote, mirrors a `@DO` row
+into [`Uprava/GTD_NEXT_ACTIONS.md`](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md),
+and proceeds to step 10 — which does not depend on it. It does **not** stop the run, and it does
+**not** self-approve the gate.
+
+## Step 9 — full typing run
+
+**Touches:** writes `pwg_ru/rv_divergence.jsonl`; enriches `rv_stanza_translations.jsonl`'s
+`divergence` field.
+**Depends on:** step 8 passing.
+
+All 10,552 stanzas, six translator pairs. Runs under the repo's existing cost gate.
+
+- **Marked default — the gate has not been voted when the agent reaches this step:** do not run.
+  Leave it queued, log it, finish everything else. A full run without the gate is exactly the
+  waste ruling R13 exists to prevent.
+
+## Step 10 — `src/rv_wordlevel_align.py`
+
+**Touches:** new `src/rv_wordlevel_align.py`; writes `pwg_ru/rv_wordlevel.jsonl`, enriches
+`rv_lemma_occurrences.jsonl`'s `wordlevel` field.
+**Depends on:** wave 1a merged. Independent of steps 7–9 — run it in parallel.
+
+**Reuse, do not rewrite.** [`src/tm_align.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_align.py)
+already provides per-pair LaBSE confidence through the in-env `nn_api.embed` path, calibrated at
+`agreement >= 0.20` ([ALIGN_GATE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ALIGN_GATE.md));
+[`src/tm_saru_align_labse.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_saru_align_labse.py)
+provides the monotone Vecalign DP ([LABSE_ALIGN.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/LABSE_ALIGN.md)).
+This step parameterises those for the token → span case; it introduces no new aligner.
+
+Every emitted span carries `confidence` and a `low_confidence` boolean. Nothing here is ever
+written into reviewed `pwg_ru` data (R5, R17).
+
+- **Marked default — the 0.20 threshold was calibrated on mined running text, not on Vedic:**
+  keep 0.20 for the first pass and record the observed distribution in the run log; do not
+  silently re-tune. Re-calibration is a separate, evidence-backed step.
+- **Marked default — a stanza where the translation has no plausible span:** emit no row rather
+  than a low-confidence guess. Absence is a cleaner signal than noise.
+
+## Step 11 — the 300-token gold sample
+
+**Touches:** writes `gold/rv_wordlevel_gold.jsonl`, `gold/rv_wordlevel_precision_report.md`.
+**Depends on:** step 10.
+
+Draw 300 tokens stratified by corpus frequency, score precision separately for ru / de / en
+(R14). Follow the existing protocol in [`gold/HUMAN_GOLD_PROTOCOL.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md).
+
+- **Marked default — precision below 85 % on one or two languages:** ship those languages
+  flagged `low_confidence` and exclude them from the contradiction gate; the others proceed.
+- **Below 85 % on all three:** stop condition 3 — ship spine A alone and report.
+
+## Step 12 — pipeline bridge: judge witness
+
+**Touches:** the judge prompt-assembly path; `REUSE_MAP.md`.
+**Depends on:** steps 9 and 10 (uses whatever is available; degrades to spine-only).
+
+For a headword with an `id_pwg` present in the spine, attach a compact witness block: up to N
+example loci with all four renderings. Advisory context, not an instruction to copy.
+
+- **Marked default — N:** 3 loci, chosen by descending corpus frequency of the lemma.
+
+## Step 13 — pipeline bridge: contradiction gate
+
+**Touches:** the audit/gate path alongside the existing gates; `REVIEW_QUEUE_TRIAGE.md`.
+**Depends on:** step 12.
+
+If a produced Russian (or English) gloss contradicts **all four** translators at every attested
+locus, queue the card for human review. Queue — never reject, never rewrite.
+
+- **Marked default — "contradicts" is not mechanically decidable:** require the gate to fire
+  only on the unanimous case, and log near-misses at a lower severity without queueing them.
+  A noisy gate gets switched off; a quiet one gets trusted.
+
+## Step 14 — pipeline bridge: the TM tier
+
+**Touches:** `schemas/translation_memory.schema.json`, `src/tm_source_weights.json`,
+`LANG_PARITY.md`, the TM build path.
+**Depends on:** step 9.
+
+Add `trust_level: "corpus_translation_witness"` with `reuse_policy: "suggest_only"`, and
+per-translator weight rows. `lang` is already an enum over `[ru, en]` and the weights file is
+keyed by work rather than language, so R7's "not for Russian only" is satisfied by
+configuration.
+
+**Mandatory:** classify this change in [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md)
+as SHARED / INTENTIONAL-DIVERGENCE / GAP before calling the step done —
+`lang_parity_check.py` fails the suite otherwise, and an unclassified entry is a process defect.
+
+- **Marked default — classification:** SHARED. The tier is language-parameterised by
+  construction; if the implementation turns out to force a RU-only path, that is
+  INTENTIONAL-DIVERGENCE only with a written why, otherwise it is a GAP with a tracked follow-up.
+
+## Step 15 — wisdomlib, four roles
+
+**Touches:** new `src/rv_wisdomlib_bridge.py`; `REUSE_MAP.md`.
+**Depends on:** nothing beyond the on-disk wisdomlib data.
+
+1. **EN gloss tier for PWG→EN** — English term definitions keyed to SLP1, entering the TM as
+   `suggest_only` at the same tier as step 14.
+2. **Tradition-based sense disambiguation** — `word_traditions.jsonl` narrows which PWG sense is
+   live in a given context.
+3. **Fifth witness in the contradiction gate** — covers the whole lexicon, not just RV-attested
+   headwords, so it is the one witness available outside the Ṛgveda.
+4. **AV citation-locus source** — staged for wave 3 as a committed index; no AV work now (R3).
+
+- **Hard constraint:** read only the already-downloaded files. **No network crawl** (R17).
+- **Marked default — a wisdomlib entry has no resolvable SLP1 key:** skip it and count it; do
+  not transliterate speculatively.
+
+## Step 16 — close-out
+
+**Touches:** `changelog.md`, `.ai_state.md`, `REUSE_MAP.md`, `RESULTS_LOG.md`.
+
+Run the full existing test suite plus the new tests; `lang_parity_check.py` must pass. Persist
+every results table produced (coverage, divergence-class distribution, per-language precision)
+to `RESULTS_LOG.md` with date, context and model tier + exact version — a table that exists only
+in a chat reply is an unfinished step. Then `[Unreleased]` changelog bullet → `/cut-release` →
+commit → PR → merge, and `/artifact-propagate` for the hub sweep.
+
+---
+
+## Parallelism map
+
+Steps 1 and 5 are independent and can run concurrently. Steps 7–9 (typing) and steps 10–11
+(alignment) are independent of one another after wave 1a merges. Step 15 is independent of
+everything. Step 8 is the only human-blocked step and it blocks step 9 alone — nothing else in
+wave 1b waits on it.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md
+++ b/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md
@@ -1,0 +1,170 @@
+# PLAN — Rig-Veda multi-translation evidence layer for PWG→RU/EN
+
+_Created: 29-07-2026 · Last updated: 29-07-2026_
+
+Cover/index document for the **Rig-Veda multi-translation evidence layer**: a lemma-keyed
+join of the Ṛgveda against four translations (Grassmann 1876–77 · Geldner 1951–57 ·
+Elizarenkova 1989–99 · Griffith 1896), a typed divergence taxonomy over them, an advisory
+word-level alignment layer, and the wiring that makes all of it visible to the PWG→Russian
+and PWG→English translation pipeline.
+
+Authored by `/ask` (Opus 5, `claude-opus-5[1m]`) on 29-07-2026 after a 4-round interview.
+Execution handoffs: [H1843](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1843-Sonnet_RussianTranslation_rv-multitranslation-spine-w1a_29.07.26.md)
+(wave 1a) and [H1844](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1844-Opus_RussianTranslation_rv-multitranslation-typing-w1b_29.07.26.md)
+(wave 1b).
+
+**Layer docs:**
+[ROADMAP](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/ROADMAP_RussianTranslation_rv-multitranslation-evidence_2026H2.md) ·
+[ARCHITECTURE](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_rv-multitranslation-evidence.md) ·
+[IMPLEMENTATION](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_rv-multitranslation-evidence.md) ·
+[VERIFICATION](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/VERIFICATION_RussianTranslation_rv-multitranslation-evidence.md)
+
+---
+
+## 1. Goal in one paragraph
+
+The Ṛgveda is the one Sanskrit text where the same 10,552 stanzas exist in four independent,
+century-spanning scholarly translations into three target languages. That makes it the natural
+**calibration and evidence corpus** for a machine translation pipeline whose output is a
+Russian (and later English) rendering of a German dictionary. This plan turns that latent
+resource into a committed, queryable layer: for any Ṛgvedic lemma, what did each translator
+make of it, where did they disagree, and where did one of them decline to translate at all.
+The layer then feeds the pipeline in three places — as evidence shown to the judge, as a
+contradiction gate that queues suspect cards for review, and as a new translation-memory tier
+supplying candidate glosses for **every** target language, not Russian alone.
+
+## 2. What already exists — do NOT rebuild
+
+Recorded from the `/prior-art` audit run on 29-07-2026. Every item below is committed and live.
+
+| Asset | Where | What it already gives us |
+|---|---|---|
+| VedaWeb 2.0 bulk export (H096, CC BY 4.0) | [`VisualDCS/non-derived/vedaweb/`](https://github.com/gasyoun/VisualDCS/tree/main/non-derived/vedaweb) | Casaretto accented word-split + morphology, lemmatization + CDSD cross-refs, Scarlata–Widmer accented text, Lubotsky padapāṭha, metrical data 2024 — all 10,552 stanzas, position-aligned on `location` |
+| GRA ↔ VedaWeb crosswalk (H097) | [`gra_vedaweb_crosswalk.tsv`](https://github.com/gasyoun/VisualDCS/blob/main/non-derived/vedaweb/gra_vedaweb_crosswalk.tsv) | VedaWeb's `id_gra` **equals** the Grassmann `<L>` number — the join is local, no fuzzy matching. 9,945/12,785 GRA entries (77.8 %) RV-attested |
+| PWG ↔ VedaWeb gloss crosswalk (H362) | [`pwg_vedaweb_gloss_crosswalk.tsv`](https://github.com/gasyoun/VisualDCS/blob/main/non-derived/vedaweb/pwg_vedaweb_gloss_crosswalk.tsv) | 10,182 PWG entries RV-attested, each row already carrying `geldner_text` **and** `grassmann_text` side by side. The Grassmann-vs-Geldner comparison MG asked for has its raw material here |
+| Three translation layers | `geldner_de_1951_1957.json`, `grassmann_de_1876_1877.json`, `elizarenkova_ru_1989_1999.json` in the same directory | Stanza-keyed, CC BY 4.0, 10,552 stanzas each |
+| Five-layer aligned Ṛgveda | [`rvlinks/RV_sa-hn-ru-de-en_1.html`](https://github.com/sanskrit-lexicon/rvlinks/blob/main/RV_sa-hn-ru-de-en_1.html) (12.4 MB) = the page published at [gasyoun.github.io](https://gasyoun.github.io) | Devanāgarī + IAST + Elizarenkova + Geldner + **Griffith** — the only place the English layer exists in aligned form. 1,029 per-hymn pages in [`rvhymns/`](https://github.com/sanskrit-lexicon/rvlinks/tree/main/rvhymns) |
+| Calibrated alignment gate | [`src/ALIGN_GATE.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ALIGN_GATE.md) + [`src/tm_align.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_align.py) | Per-pair LaBSE confidence, gate calibrated at `agreement >= 0.20` (H1457 A3) |
+| LaBSE/Vecalign sentence aligner | [`src/LABSE_ALIGN.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/LABSE_ALIGN.md) + [`src/tm_saru_align_labse.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_saru_align_labse.py) | Monotone DP alignment, precision@sample 0.966 (H1457 A5) |
+| TM contract + source priors | [`schemas/translation_memory.schema.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/schemas/translation_memory.schema.json), [`src/tm_source_weights.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/tm_source_weights.json) | `trust_level` / `reuse_policy` enums, `lang: [ru, en]`, and `by_work_contains` **already carrying `rigveda: 0.72` and `atharvaveda: 0.72`** |
+| wisdomlib crawler | [`SamudraManthanam/web/corpus_builder/wisdomlib/`](https://github.com/gasyoun/SamudraManthanam/tree/main/web/corpus_builder/wisdomlib) | `entries_index.jsonl`, `word_traditions.jsonl`, `definitions.py`; bulk-public rights ruling of 28-07-2026 |
+| Renou-footnote carrier | Elizarenkova's commentary inside SamudraManthanam (`Index/.../NN_rigveda.no_tags`) | **2,213** mentions of Renou across the 10 maṇḍalas, **368** of them carrying a directly quoted French fragment |
+| Atharvaveda text base | [`avlinks`](https://github.com/sanskrit-lexicon/avlinks) | 731 hymns / 5,933 verses, published; no translation layer yet |
+
+**Build-vs-reuse verdict:** nothing in wave 1 is a from-scratch build. Layer A is a join over
+existing committed feeds; layer B is a re-parameterization of an aligner that already ships
+with a calibrated gate; the TM tier is two enum values and a weights row, not a new subsystem.
+The only genuinely new extraction is Griffith (out of our own HTML) and the Renou index.
+
+## 3. Decisions taken — the 17 interview rulings
+
+Every row below was ruled by a human on 29-07-2026 and is **binding on the execution agent**.
+No row may be re-litigated mid-run.
+
+| # | Fork | Ruling | Note |
+|---|---|---|---|
+| R1 | Primary deliverable | **Both, strictly sequential** — wave 1 = working evidence layer for the pipeline; wave 2 = the same layer packaged as a citable dataset + paper | Wave 2 does not start until wave 1 is accepted |
+| R2 | Owning repo | **`SanskritLexicography/RussianTranslation`** | Not VisualDCS; the feed stays where it is and is read sibling-path |
+| R3 | Wave-1 scope | **Ṛgveda only, all 10,552 stanzas.** Atharvaveda begins only once RV work is fully complete | Explicit non-goal for wave 1 |
+| R4 | English layer | **Griffith now** (public domain, extracted from our own HTML); **Jamison–Brereton later as the "gold" reference** | J–B is in copyright (OUP) — sample-scale reference use only, never bulk |
+| R5 | Granularity | **Deterministic spine A + word-level layer B on top.** B is advisory and never written into reviewed data | Answers "how is this particular word translated" without letting alignment error into the store |
+| R6 | Divergence model | **Typed taxonomy** — agreement / lexical variant / semantic shift / omitted by one / added by one | Gives the pipeline a signal and the wave-2 paper a statistic |
+| R7 | Pipeline entry point | **All three at once**: witness shown to the judge, contradiction gate, **and** a new TM tier supplying candidate glosses — **and not for Russian only** | Explicitly serves the EN path and any future third language |
+| R8 | Rights posture | **Ignore rights as a blocker.** Internal use unrestricted, including the grey-rights Samudra commentary and the Renou quotations | Human ruling, recorded verbatim; consequence in §5 |
+| R9 | Renou in wave 1 | **Locus index + the 368 extracted French quotations.** Full *Études védiques et pāṇinéennes* not before 2027 | Renou d. 1966 — EVP in copyright in France until 2037 |
+| R10 | Publish boundary | **Everything in the open repo, no split** between rights-clean and grey material | Human ruling; consequence in §5 |
+| R11 | wisdomlib roles | **All four** — EN gloss TM tier for PWG→EN · tradition-based sense disambiguation · contradiction-gate witness · citation-locus source for the AV wave | Uses only already-downloaded data in wave 1 |
+| R12 | Storage format | **JSONL keyed by lemma + flat TSV mirror**, plus a JSON Schema in `schemas/` | Matches the existing crosswalk feeds; no SQLite, no RDF-first |
+| R13 | Typing scale | **Pilot ~2,000 stanzas → gate → full 10,552 run** | Same shape as the existing pwg_ru pilot discipline |
+| R14 | Layer-B acceptance | **300-token gold sample, precision ≥ 85 % per language** (ru/de/en scored separately) | Below the bar, B ships flagged `low_confidence` and is excluded from gates; spine A is unaffected |
+| R15 | Pilot gate | **≥ 80 % agreement with a human on 100 stanzas**, collected through `/review-sheet` HTML voting | Markdown checkbox sheets are banned org-wide |
+| R16 | Ambiguity policy | **Take the marked default, log it, keep going.** Never halt on an unplanned fork | Logged to `DECISIONS_LOG` inside the run |
+| R17 | The fence | Read-only: reviewed `pwg_ru` data · the VisualDCS vedaweb feed · csl-orig and all dictionary sources. **No wisdomlib network crawl during the run** | See §4 |
+
+## 4. The autonomy contract
+
+Recorded verbatim for the execution agent. This is the section that makes a 5–8 hour
+unattended run safe.
+
+**On an unplanned ambiguity (R16).** Every fork this plan anticipates carries a marked
+default in [IMPLEMENTATION](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_rv-multitranslation-evidence.md).
+For a fork this plan did **not** anticipate: choose the more conservative option (the one that
+writes less, asserts less, and leaves the existing pipeline unchanged), append a dated line to
+`docs/DECISIONS_LOG_rv_multitranslation.md` recording the fork, the choice and the reason,
+and continue. Do not stop. Do not ask.
+
+**Stop conditions — the only four.** Halt and report, rather than improvising, when:
+
+1. A required input feed is absent or unreadable (any file listed in §2 that is expected but
+   missing) — the run cannot proceed on invented data.
+2. A write outside the fence is about to happen (see below).
+3. The layer-B gold sample scores below 85 % on **all three** languages — that is not a
+   parameter to tune blind; ship spine A alone, mark B `low_confidence`, and report.
+4. Cumulative token spend crosses the run's cost gate — the repo's existing cost-gate
+   machinery governs, not a new one.
+
+Everything else — a stanza that fails to parse, a lemma with no translation coverage, an
+unexpected divergence class — is logged and skipped, never escalated.
+
+**Commit authority.** Both handoffs are handoff-scoped work under the standing org rule:
+commit → PR → merge in the same pass, no confirmation prompt. Work happens in a
+session-unique worktree off `origin/master`, never in the guarded main checkout.
+
+**The fence (R17) — read-only, no exceptions.**
+
+- Reviewed `pwg_ru` data: `headword_index.tsv`, reviewed cards, the store. The new layer
+  writes only into its own files.
+- [`VisualDCS/non-derived/vedaweb/`](https://github.com/gasyoun/VisualDCS/tree/main/non-derived/vedaweb) —
+  a non-derived bulk export whose re-pull consumes a **single-use** `pickupKey`. Read it; never
+  rewrite it; never hit the VedaWeb API.
+- `csl-orig`, `GRA`, `PWG` and every other dictionary source repo — no commits, ever
+  (standing org rule, restated here so the agent does not have to go looking for it).
+- wisdomlib: use only the already-downloaded `entries_index.jsonl` / `word_traditions.jsonl`.
+  A fresh network crawl is a separate, daytime task.
+
+## 5. Known consequences of R8 + R10 — stated, not re-litigated
+
+The human ruling is that rights do not gate this work and that everything lands in the open
+repo without a rights-based split. Recorded and followed. Three factual consequences the
+execution agent should be aware of, so nobody is surprised later:
+
+1. **Most of the material needs no exemption at all.** Geldner, Grassmann and Elizarenkova as
+   carried by the VedaWeb feed are **CC BY 4.0**; Griffith 1896 is public domain; wisdomlib has
+   a bulk-public ruling of 28-07-2026. The ruling only actually bites on two things: the
+   Samudra copy of Elizarenkova's *commentary* (grey-rights, and the sole carrier of the Renou
+   footnotes) and, later, Jamison–Brereton.
+2. **Keep the Renou artifact quotation-shaped.** The design commits a locus index plus the 368
+   short French fragments Elizarenkova herself quotes — that is quotation with attribution, a
+   materially different act from redistributing the commentary. Copying whole-stanza commentary
+   text into the repo is **not** part of this plan and should not be added on the agent's own
+   initiative; if a step seems to require it, that is an unplanned fork → take the conservative
+   default (index the locus, do not copy the body) and log it.
+3. **Wave 2 will meet a gate.** A citable, DOI-bearing dataset release runs through
+   `/publish-safety-check`, which will flag any grey-rights payload. Because of R10 there is no
+   pre-separated clean subset, so wave 2 must budget a subsetting step. This is a scheduling
+   fact recorded in the roadmap's wave-2 entry, not an objection to R10.
+
+## 6. Wave-1 deliverables at a glance
+
+Full detail in the layer docs; this is the index.
+
+| ID | Deliverable | Handoff | Acceptance |
+|---|---|---|---|
+| W1.1 | `griffith_en_1896.json` — English layer extracted from our own HTML, stanza-keyed like the other three | H1843 | 10,552 stanzas, 0 unmatched loci |
+| W1.2 | `rv_stanza_translations.jsonl` + `rv_lemma_occurrences.jsonl` + schema — lemma → stanzas → 4 translations | H1843 | Every RV lemma present; join is `location`-exact, no fuzzy |
+| W1.3 | `rv_renou_citation_index.jsonl` — 2,213 loci, 368 with quoted French | H1843 | Counts reproduce; every row carries maṇḍala/hymn/stanza |
+| W1.4 | Typed divergence taxonomy, pilot 2,000 → gate → full 10,552 | H1844 | ≥ 80 % human agreement on 100 stanzas (R15) |
+| W1.5 | Word-level layer B with per-pair confidence | H1844 | ≥ 85 % precision per language on 300-token gold (R14) |
+| W1.6 | Pipeline wiring — judge witness, contradiction gate, TM tier (ru **and** en) | H1844 | Existing test suite green; `lang_parity_check.py` passes |
+| W1.7 | wisdomlib in all four roles | H1844 | Each role has a smoke test; no network access during the run |
+
+## 7. Non-goals for wave 1
+
+- Atharvaveda (R3) — begins only after RV is complete.
+- Full Renou EVP (R9) — not before 2027.
+- Jamison–Brereton at bulk scale (R4) — sample-scale reference only.
+- A citable dataset release with a DOI (R1) — that is wave 2.
+- Any change to reviewed `pwg_ru` card data (R17).
+- Re-pulling anything from the VedaWeb API (R17).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.meta.md
+++ b/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.meta.md
@@ -1,0 +1,93 @@
+# PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2 — metadoc
+
+_Created: 29-07-2026 · Last updated: 29-07-2026_
+
+Companion record for [PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md)
+and its four layer docs (ROADMAP / ARCHITECTURE / IMPLEMENTATION / VERIFICATION).
+
+## Purpose
+
+The execution-ready `/ask` plan for the **Rig-Veda multi-translation evidence layer**: a
+lemma-keyed join of the Ṛgveda against Grassmann 1876–77, Geldner 1951–57, Elizarenkova
+1989–99 and Griffith 1896, a typed divergence taxonomy over them, an advisory word-level
+alignment layer, and the wiring that makes all of it visible to the PWG→RU and PWG→EN
+pipeline. It is the doc the wave-1 execution handoffs point at.
+
+## Audience
+
+A fresh execution agent (Sonnet for wave 1a, Opus for wave 1b) running unattended, and a human
+for the single gated fork (the 100-stanza divergence-class vote).
+
+## Provenance
+
+- Authored 29-07-2026 by Opus 5 (`claude-opus-5[1m]`) via the `/ask` skill.
+- Interview: 4 rounds (goal/ownership/scope/EN · architecture forks · rights/wisdomlib/format/scale ·
+  verification + autonomy) — 17 rulings, all in the PLAN decisions table.
+- Audit basis: direct inspection of the committed feeds, not inference. Every count in
+  ARCHITECTURE §1 and VERIFICATION §2 was measured on 29-07-2026 by reading
+  `VisualDCS/non-derived/vedaweb/*.json`, `rvlinks/RV_sa-hn-ru-de-en_1.html`, the
+  SamudraManthanam commentary files and `Uprava/PROJECT_INTERLINKS.md`.
+- Prior art traced to H096 (VedaWeb bulk export), H097 (GRA crosswalk), H362 (PWG gloss
+  crosswalk + the two German translations), H361 (Elizarenkova), H522 (Type-D concordance),
+  H1457 A3/A5 (the alignment gate and the Vecalign pilot).
+
+## Key decisions this plan rests on
+
+Deliverable = both, strictly sequential (working layer first, citable dataset second); owner =
+`RussianTranslation`, not VisualDCS; scope = Ṛgveda only until it is entirely finished, then
+Atharvaveda; EN = Griffith now, Jamison–Brereton later as gold; granularity = deterministic
+spine + advisory word-level layer; divergence = typed taxonomy; pipeline entry = all three
+points at once and not for Russian only; rights = not a blocker, everything in the open repo;
+Renou = locus index + 368 quotations now, full EVP not before 2027; wisdomlib = all four roles;
+storage = normalised JSONL + generated TSV; scale = pilot → human gate → full run. Full table
+in the PLAN.
+
+## What this plan discovered that changed its own design
+
+Three audit findings materially reshaped the plan and are worth keeping visible:
+
+1. **The dictionary anchor already exists per token.** `lemmatization.json`'s
+   `transformContext` carries `id_gra`, `id_pwg` and `id_mw` on each of the 164,758 Ṛgvedic
+   tokens. The planned "attach dictionary IDs" step collapsed into a field read.
+2. **Geldner is missing exactly four stanzas (RV 10.106.5–8).** The `omitted_by_one` class has
+   known ground truth before any model runs, which turned it from a taxonomy label into a
+   regression test.
+3. **The denormalised data model would have been ~65 MB in git.** Measured average stanza
+   lengths (152–171 characters × four translations × 164,758 occurrences) forced the split into
+   a stanza table plus a lemma-occurrence table, ~18 MB.
+
+## Improvement backlog (ranked)
+
+1. After spike S1, replace the "unmatched Griffith loci ≤ 2 %" assumption in VERIFICATION §4
+   with the measured number.
+2. After the 300-token gold, re-examine whether the `agreement >= 0.20` gate from
+   [ALIGN_GATE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ALIGN_GATE.md)
+   transfers to Vedic — it was calibrated on 30 rows of mined running text with one negative.
+3. If the divergence gate fails at 80 %, record the collapsed 3-class taxonomy here as the
+   ruling rather than leaving the 5-class version standing as if it had been validated.
+4. When wave 2 opens, write the rights-subsetting step as its own spec — R10 deferred it, it
+   did not remove it.
+5. When wave 3 (Atharvaveda) opens, check VedaWeb's AV coverage first; this plan asserts only
+   that `avlinks` has the text, not that a translation layer exists to join to.
+
+## Limitations
+
+- The word-level layer's feasibility is genuinely unproven for Vedic. LaBSE's weakness on
+  transliterated Sanskrit is a measured finding in the repo already; the 85 %-per-language bar
+  is a real gate that layer B may not clear, and the plan is built to survive that.
+- The divergence taxonomy's separability (`lexical_variant` vs `semantic_shift`) is assumed, not
+  demonstrated. Spike S2 exists precisely because it might not hold.
+- Renou locus resolution runs against plain-text commentary with no markup; the unresolved
+  share is unknown until the parser runs.
+- The plan follows a human ruling that rights do not gate the work and that everything lands in
+  one open repo. The consequences are recorded in PLAN §5 and risk K6 rather than argued;
+  wave 2's DOI release will meet a `/publish-safety-check` gate that this posture does not
+  pre-clear.
+
+## Revision history
+
+| Date | Change | By |
+|---|---|---|
+| 29-07-2026 | Created — `/ask` interview (4 rounds, 17 rulings) + full audit; five layer docs authored; handoffs H1843/H1844 minted | Opus 5 (`claude-opus-5[1m]`) |
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/ROADMAP_RussianTranslation_rv-multitranslation-evidence_2026H2.md
+++ b/RussianTranslation/docs/ROADMAP_RussianTranslation_rv-multitranslation-evidence_2026H2.md
@@ -1,0 +1,84 @@
+# ROADMAP — Rig-Veda multi-translation evidence layer, 2026 H2 → 2027
+
+_Created: 29-07-2026 · Last updated: 29-07-2026_
+
+Wave plan for the layer specified in
+[PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md).
+Ruling R1 fixes the sequence: the working layer ships first, the citable artifact second, and
+the Atharvaveda only after the Ṛgveda is entirely done (R3).
+
+---
+
+## Wave 1a — the deterministic spine (handoff [H1843](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1843-Sonnet_RussianTranslation_rv-multitranslation-spine-w1a_29.07.26.md), Sonnet tier)
+
+No model judgment anywhere in this wave — every output is a parse or a key-exact join, so it
+is reproducible byte-for-byte and can be re-run at zero risk.
+
+| # | Deliverable | Unblocked by |
+|---|---|---|
+| W1.1 | **Griffith English layer.** Extract the `p.en` blocks from [`rvlinks/RV_sa-hn-ru-de-en_1.html`](https://github.com/sanskrit-lexicon/rvlinks/blob/main/RV_sa-hn-ru-de-en_1.html) keyed by the `p.stamp` locus (`rv01.001.01`), normalise to the VedaWeb `location` form (`1.1.1`), emit `griffith_en_1896.json` with the same shape as the three existing translation JSONs | nothing — the HTML is committed |
+| W1.2 | **The spine.** `rv_stanza_translations.jsonl` (10,552 stanzas x 4 renderings) + `rv_lemma_occurrences.jsonl` (lemma -> its 164,758 token occurrences), joining on `location`. Normalised: the denormalised form measures ~65 MB, this one ~18 MB | W1.1 |
+| W1.3 | **Flat mirror + schema.** `rv_translation_spine.tsv` (one row per lemma × stanza × translator) and `schemas/rv_translation_spine.schema.json` | W1.2 |
+| W1.4 | **Renou locus index.** Parse Elizarenkova's commentary for the 2,213 Renou mentions; emit `rv_renou_citation_index.jsonl` with locus, the Russian context sentence, and — for the 368 that have one — the quoted French fragment | nothing |
+| W1.5 | **Dictionary anchors.** Attach `id_gra` and `id_pwg` to every spine record by re-using the two existing crosswalks; no new matching logic | W1.2 |
+
+**Wave 1a is done when** every one of the 10,552 stanzas resolves in all four translation
+layers or is explicitly recorded as untranslated by that translator, and the Renou counts
+reproduce (2,213 / 368).
+
+## Wave 1b — typing, alignment, wiring (handoff [H1844](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1844-Opus_RussianTranslation_rv-multitranslation-typing-w1b_29.07.26.md), Opus tier)
+
+| # | Deliverable | Unblocked by |
+|---|---|---|
+| W1.6 | **Divergence taxonomy — pilot.** Type ~2,000 stanzas across the five classes (agreement · lexical variant · semantic shift · omitted by one · added by one) | wave 1a complete |
+| W1.7 | **Human gate.** 100 stanzas sampled out of the pilot into a `/review-sheet` HTML voting sheet; ≥ 80 % agreement releases the full run (R15) | W1.6 |
+| W1.8 | **Full typing run.** All 10,552 stanzas, every translator pair | W1.7 passing |
+| W1.9 | **Word-level layer B.** Token → span alignment per language, re-using `tm_align.py`'s calibrated confidence and the Vecalign path; 300-token gold sample scored per language (R14) | wave 1a complete — runs in parallel with W1.6 |
+| W1.10 | **Judge witness.** The spine surfaces to the judge as external evidence for any RV-attested headword | W1.8 |
+| W1.11 | **Contradiction gate.** A card whose Russian (or English) rendering contradicts all four translators is queued for human review rather than promoted | W1.8 |
+| W1.12 | **TM tier.** A new `trust_level` value plus source-weight rows, wired for **`ru` and `en` alike** and structured so a third language is a config row, not a rewrite (R7) | W1.8 |
+| W1.13 | **wisdomlib, four roles.** EN gloss tier for PWG→EN · tradition-based sense disambiguation · fifth witness in the contradiction gate · AV citation-locus source staged for wave 3 (R11) | nothing — data already downloaded |
+
+**Wave 1b is done when** the existing test suite is green, `lang_parity_check.py` passes with
+the new mechanism classified, and both the RU and EN paths see the new tier.
+
+## Wave 2 — the citable artifact (2026 Q4, not before wave 1 is accepted)
+
+- Package the spine + taxonomy as a FAIR dataset via `/data-release`: provenance README, per-source
+  licence table, versioned release, Zenodo concept + version DOI, `CITATION.cff` round-trip.
+- **Budget the subsetting step.** Because R10 put everything in one open repo with no
+  rights-based split, the release must carve out a CC BY/PD-clean subset at this point rather
+  than simply tagging what is there. This is the scheduling consequence recorded in
+  [PLAN §5](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md).
+- Register in [`kosha/data/manifest/datasets.json`](https://github.com/gasyoun/kosha/blob/main/data/manifest/datasets.json),
+  [`Uprava/PROJECT_INTERLINKS.md`](https://github.com/gasyoun/Uprava/blob/main/PROJECT_INTERLINKS.md) and
+  [`FEATURES_INDEX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/FEATURES_INDEX.md) via `/artifact-propagate`.
+- **The paper.** A 150-year diachronic study of Ṛgvedic translation practice: Grassmann 1876
+  → Geldner 1951 → Elizarenkova 1989, measured, not asserted. Gets an `Axx` ID in
+  [`Uprava/ARTICLES.md`](https://github.com/gasyoun/Uprava/blob/main/ARTICLES.md).
+
+## Wave 3 — Atharvaveda (2027, opens only when the Ṛgveda is finished)
+
+R3 is explicit: no AV work while RV work is open. When it opens:
+
+- Text base is [`avlinks`](https://github.com/sanskrit-lexicon/avlinks) — 731 hymns, 5,933 verses, already published.
+- The gap is the translation layer. VedaWeb's AV coverage must be checked before anything is
+  built; Whitney's English translation is public domain and is the obvious first layer;
+  wisdomlib's AV pages are the staged citation-locus source from W1.13.
+- GRA's cross-references into the AV are the natural entry point on the dictionary side.
+
+## Wave 4 — Renou EVP (2027 at the earliest)
+
+R9 defers the full *Études védiques et pāṇinéennes* to 2027. Two prerequisites, both outside
+this plan: a rights track (Renou d. 1966; in copyright in France until 2037) and OCR of 17
+volumes. The wave-1 locus index is what makes this wave cheap when it opens — the loci are
+already known, only the text is missing.
+
+## Explicit non-goals across the whole roadmap
+
+- No commits to `csl-orig`, `GRA`, `PWG` or any dictionary source repo.
+- No re-pull of the VedaWeb bulk export (single-use `pickupKey`).
+- No bulk use of Jamison–Brereton at any wave — sample-scale reference only (R4).
+- No new repository: the layer lives in `RussianTranslation` (R2).
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/docs/VERIFICATION_RussianTranslation_rv-multitranslation-evidence.md
+++ b/RussianTranslation/docs/VERIFICATION_RussianTranslation_rv-multitranslation-evidence.md
@@ -1,0 +1,94 @@
+# VERIFICATION — Rig-Veda multi-translation evidence layer, wave 1
+
+_Created: 29-07-2026 · Last updated: 29-07-2026_
+
+Acceptance criteria, the exact command that proves each one, and the risk register for
+[PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md).
+Build sequence: [IMPLEMENTATION](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_rv-multitranslation-evidence.md).
+
+---
+
+## 1. Acceptance criteria per deliverable
+
+| ID | Deliverable | Criterion | Proven by |
+|---|---|---|---|
+| W1.1 | Griffith English layer | `contents` length equals the number of `p.stamp` blocks in the source HTML; every `location` matches the VedaWeb dotted form; unmatched loci reported, not silently dropped | `pytest tests/test_rv_spine.py -k griffith` |
+| W1.2 | Stanza table | Exactly 10,552 records; `absent_from_source` count is 4 for Geldner and 0 for Grassmann and Elizarenkova; 0 `empty` rows | `pytest tests/test_rv_spine.py -k stanza` |
+| W1.3 | Lemma occurrences | Token count reconciles to **164,758**; every occurrence's `location` exists in the stanza table; `id_gra`/`id_pwg`/`id_mw` present wherever the source token carried them | `pytest tests/test_rv_spine.py -k lemma` |
+| W1.4 | Flat mirror + schema | TSV row count equals total lemma × stanza × translator; both JSONL files validate against `schemas/rv_translation_spine.schema.json` | `python src/rv_spine_build.py --validate` |
+| W1.5 | Renou citation index | **2,213** rows; **368** with `mention_kind == "quoted_fr"`; per-maṇḍala totals match §1.1 below | `pytest tests/test_rv_spine.py -k renou` |
+| W1.6 | Divergence pilot | ~2,000 stanzas typed; every `absent_from_source` pair labelled `omitted_by_one` without a model call | `python src/rv_divergence_type.py --pilot --report` |
+| W1.7 | Human gate | ≥ 80 % agreement between the model's class and the human vote on 100 stanzas | the sheet's own `decisions.json` + the agreement report |
+| W1.8 | Full typing run | All 10,552 stanzas × 6 translator pairs carry a class; distribution table persisted to `RESULTS_LOG.md` | `python src/rv_divergence_type.py --report` |
+| W1.9 | Word-level layer B | Precision ≥ 85 % **per language** on the 300-token gold sample | `gold/rv_wordlevel_precision_report.md` |
+| W1.10 | Judge witness | A headword with an `id_pwg` in the spine receives a witness block; one without receives none | `pytest tests/test_rv_spine.py -k witness` |
+| W1.11 | Contradiction gate | Fires only on unanimous contradiction; a synthetic contradicting card is queued, a synthetic agreeing card is not | `pytest tests/test_rv_spine.py -k gate` |
+| W1.12 | TM tier | New `trust_level` validates against the TM schema; the tier is reachable on **both** `ru` and `en`; the change is classified in `LANG_PARITY.md` | `python src/pilot/window_selftest.py` (includes `test_lang_parity_ledger_complete`) |
+| W1.13 | wisdomlib, four roles | Each role has a smoke test; the run makes **zero** network calls | `pytest tests/test_rv_spine.py -k wisdomlib` |
+
+### 1.1 Renou per-maṇḍala reference counts
+
+Measured 29-07-2026 against the committed commentary files. A parser that does not reproduce
+these is wrong.
+
+| Maṇḍala | I | II | III | IV | V | VI | VII | VIII | IX | X | total |
+|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
+| Renou mentions | 459 | 117 | 161 | 118 | 158 | 110 | 171 | 123 | 226 | 287 | **2,213** |
+
+Of these, **368** carry a Latin-script quotation in guillemets.
+
+## 2. Hard invariants — a failure here is a bug, not a finding
+
+These are measured facts about the committed data as of 29-07-2026. If a run reports something
+different, the code is wrong; do not record the discrepancy as a discovery.
+
+1. Ṛgveda stanzas: **10,552**.
+2. Ṛgveda tokens: **164,758**.
+3. Grassmann coverage **10,552**, Elizarenkova coverage **10,552**, Geldner coverage **10,548**.
+4. The four stanzas Geldner does not translate are exactly **RV 10.106.5, 10.106.6, 10.106.7,
+   10.106.8**.
+5. Zero empty-text rows in any of the three VedaWeb translation files.
+6. `transformContext` is a **JSON string**, not a nested object. A parser that treats it as an
+   object silently yields zero tokens.
+7. Renou mentions **2,213**, of which **368** carry a French quotation.
+
+Invariants 3 and 4 double as the semantic regression test for the whole `omitted_by_one` class:
+they are the one piece of the divergence taxonomy whose ground truth is known before any model
+runs.
+
+## 3. Risks and spikes
+
+| # | Risk | Likelihood | Mitigation |
+|---|---|---|---|
+| K1 | **LaBSE is weak on transliterated Sanskrit.** Already an honest finding in [LABSE_ALIGN.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/LABSE_ALIGN.md) (any-to-any retrieval 0.025 on formulaic epic prose). Vedic is harder than epic prose | high | Layer B is advisory by design (R5). Its failure degrades the layer to spine A, which is unaffected. This is why the 85 % bar exists per language rather than pooled |
+| K2 | **The 0.20 confidence gate was calibrated on a 30-row sample with ONE negative.** [ALIGN_GATE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/ALIGN_GATE.md) says so plainly | high | Do not treat 0.20 as validated for Vedic. Record the observed distribution; re-calibrate only against the new 300-token gold, as a separate evidence-backed step |
+| K3 | **Divergence typing may not be reliably separable.** "Lexical variant" vs "semantic shift" is a judgment call even for humans; the pair may not reach 80 % agreement | medium | That is exactly what the step-8 gate is for. A failed gate means collapsing to a coarser 3-class taxonomy (agreement / divergence / omission), not tuning until it passes |
+| K4 | **Renou locus resolution from prose commentary.** The commentary's stanza numbering must be tracked across a plain-text file with no markup | medium | `locus_unresolved: true` rather than dropping the row, so the 2,213 total always reconciles and the unresolved share is visible |
+| K5 | **Griffith's stanza division may differ from VedaWeb's.** A 19th-century translation need not segment identically | medium | Unmatched loci are logged, not force-fitted. If the unmatched share exceeds 2 %, treat it as a spike: report it and ship the other three layers rather than guessing a mapping |
+| K6 | **Grey-rights material in a public repo** (R8 + R10). The plan commits the Renou index — quotation-shaped — into an open repository | certain, and ruled | The human ruling stands and is followed. The bounded-window design (PLAN §5) keeps the artifact quotation-shaped; whole-stanza commentary text is **not** part of this plan. Wave 2 budgets a subsetting step for the DOI release |
+| K7 | **Concurrent sessions in this repo.** A Codex session is active on `codex/rt-pipeline-hardening-speed` touching the pipeline | medium | Work in a session-unique worktree off `origin/master`; the guarded main tree is never edited. Expect a rebase at PR time on shared files (`LANG_PARITY.md`, `changelog.md`) and resolve by keeping both entries |
+| K8 | **TSV size.** The flat mirror could be large enough to be a poor git citizen | low | Marked default in IMPLEMENTATION step 4: gitignore it above 200 MB, commit a 500-row sample, keep the JSONL pair as the contract |
+
+## 4. Spikes to run before committing to the architecture
+
+Two, both cheap, both before the expensive steps:
+
+**S1 — Griffith locus alignment (before step 2).** Extract the loci only, intersect with the
+VedaWeb set, report the unmatched share. If it exceeds 2 %, K5 has fired and the English layer
+needs a decision before the spine is built on it. Cost: minutes.
+
+**S2 — Divergence separability (before step 7's full pilot).** Type 50 stanzas, eyeball whether
+`lexical_variant` and `semantic_shift` are actually being distinguished or whether the model is
+assigning them arbitrarily. If they are not separable at 50, they will not be at 2,000 — collapse
+to the coarse taxonomy (K3) before spending the pilot. Cost: one small model run.
+
+## 5. What "wave 1 is done" means
+
+All thirteen rows in §1 pass, all seven invariants in §2 hold, the existing test suite and
+`window_selftest.py` are green, every results table is persisted to `RESULTS_LOG.md` with date
+and model tier + exact version, and the changelog entry has been cut into a release. Step 8's
+human vote is the one item that may legitimately remain open at the end of an unattended run —
+it is queued as a `@DO` in [`Uprava/GTD_NEXT_ACTIONS.md`](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md),
+and W1.8 stays blocked behind it rather than being self-approved.
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Five cross-linked layer docs authored via `/ask` after a 4-round interview (17 rulings, all binding on the execution agent). **Plan only — no code, no data.**

- [PLAN](https://github.com/gasyoun/SanskritLexicography/blob/feat/h-rv-multitranslation-evidence/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.md) + [metadoc](https://github.com/gasyoun/SanskritLexicography/blob/feat/h-rv-multitranslation-evidence/RussianTranslation/docs/PLAN_RussianTranslation_rv-multitranslation-evidence_2026H2.meta.md)
- [ROADMAP](https://github.com/gasyoun/SanskritLexicography/blob/feat/h-rv-multitranslation-evidence/RussianTranslation/docs/ROADMAP_RussianTranslation_rv-multitranslation-evidence_2026H2.md) · [ARCHITECTURE](https://github.com/gasyoun/SanskritLexicography/blob/feat/h-rv-multitranslation-evidence/RussianTranslation/docs/ARCHITECTURE_RussianTranslation_rv-multitranslation-evidence.md) · [IMPLEMENTATION](https://github.com/gasyoun/SanskritLexicography/blob/feat/h-rv-multitranslation-evidence/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_rv-multitranslation-evidence.md) · [VERIFICATION](https://github.com/gasyoun/SanskritLexicography/blob/feat/h-rv-multitranslation-evidence/RussianTranslation/docs/VERIFICATION_RussianTranslation_rv-multitranslation-evidence.md)

## What it plans

Joins the Ṛgveda to four translations (Grassmann 1876–77 · Geldner 1951–57 · Elizarenkova 1989–99 · Griffith 1896) at **lemma** granularity, types where they diverge, and wires the result into the pipeline three ways — judge witness, contradiction gate, and a new TM tier serving `ru` **and** `en` alike.

It extends the G6 evidence panel shipped the same day ([H1801](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1801-Opus_SanskritLexicography_g6-gold-card-evidence-panel_28.07.26.md)): that panel routes a Vedic card to GRA's sense list, its Whitney root and Russian passage contexts, but carries nothing about what the *other* translators did with the same stanza — Geldner, Griffith, and Grassmann's own **translation** as distinct from his dictionary.

## Measured during the audit — load-bearing, and each one changed the design

| Fact | Consequence |
|---|---|
| 10,552 stanzas · **164,758 tokens**, each already carrying `id_gra`/`id_pwg`/`id_mw` in `transformContext` | The "attach dictionary IDs" step collapsed into a field read |
| Grassmann 10,552 · Elizarenkova 10,552 · **Geldner 10,548** — the four he omits are exactly **RV 10.106.5–8** | `omitted_by_one` has known ground truth before any model runs; it became a regression test |
| Denormalised data model measures **~65 MB**, normalised **~18 MB** | Forced the split into a stanza table + a lemma-occurrence table |
| Elizarenkova's commentary: **2,213** Renou mentions, **368** with a French quotation | Sized the Renou wave-1 deliverable; the full EVP is deferred to 2027 |

⚠️ `renou_*` already means the 1956 language-states axis in this repo — everything in this layer uses the `rv_renou_*` prefix.

## Execution

[H1843](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1843-Sonnet_RussianTranslation_rv-multitranslation-spine-w1a_29.07.26.md) (wave 1a, Sonnet 5, fully deterministic, unblocked) → [H1844](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1844-Opus_RussianTranslation_rv-multitranslation-typing-w1b_29.07.26.md) (wave 1b, Opus 5, blocked on 1a).

Authored by Opus 5 (`claude-opus-5[1m]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
