### PR TITLE
chore(release): 1.99.0

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.99.0] - 2026-07-29
+
 ### Added — RV multi-translation evidence spine, wave 1a: griffith/stanza/lemma/renou (H1843, 29-07-2026)
 
 Executes wave 1a (steps 1-6) of


### PR DESCRIPTION
Promotes RussianTranslation/CHANGELOG.md's accumulated [Unreleased] section
(pending since v1.82.0, 26-07-2026) to 1.99.0, including this session's H1843
wave 1a entry. Mechanical, lossless promotion (2 lines inserted, no bullets
touched/reordered) -- diff verified.

Generated with Claude Code
