### PR TITLE
H1887: review sheets must reuse what the repo already knows — gate it before write

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,33 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added — review sheets must reuse what the repo already knows, enforced before write (H1887, 29-07-2026)
+
+MG, voting the 200-card compound-differs sheet: «Я не понимаю, зачем мне
+голосовать». Measured: **191 of its 200 cards already had a machine verdict, a
+named rule and cited evidence** in
+[`research/pwg_compound_differs_adjudication.tsv`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/pwg_compound_differs_adjudication.tsv)
+(H1681) — computed from the same two input files the sheet itself reads, sharing
+4,246/4,246 row ids — and the sheet rendered none of it. Separately, 69 of the 200
+cards (34.5 %) were not split disagreements at all, and 18 of the 44 cards showing
+a «Пāṇini» line showed a structurally impossible reference.
+
+- **[`src/review_evidence_preflight.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/review_evidence_preflight.py)**
+  — a gate that runs BEFORE a sheet is written and raises instead of warning.
+  Mechanical prior-art overlap (join it or state why not, per artifact) · evidence
+  floor · Cyrillic/IAST script purity · SLP1 leakage · citation linkability ·
+  structural validity of cited references. Replayed against the sheet MG
+  complained about it returns **12 blocking findings**.
+- **[`src/pilot/build_compound_rule_ratification_sheet.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/build_compound_rule_ratification_sheet.py)**
+  — the replacement ask: **30 cards, not 200**. The human ratifies the seven
+  auto-resolving rules, retiring **3,975 rows**. Every card carries both splits in
+  IAST, both dictionaries' own printed text, the glossed difference, DCS frequency
+  or a stated reason there is none, and 157 links across the sheet.
+- **[`research/REVIEW_SHEET_EVIDENCE_REUSE_H1887.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/REVIEW_SHEET_EVIDENCE_REUSE_H1887.md)**
+  — the full measurement, every one of MG's nine points checked, and why no
+  existing layer caught it (the standard is entirely presentation; the H1628 sheet
+  is fully standard-compliant and still unanswerable).
+
 ## [1.99.0] - 2026-07-29
 
 ### Added — RV multi-translation evidence spine, wave 1a: griffith/stanza/lemma/renou (H1843, 29-07-2026)

--- a/RussianTranslation/research/REVIEW_SHEET_EVIDENCE_REUSE_H1887.md
+++ b/RussianTranslation/research/REVIEW_SHEET_EVIDENCE_REUSE_H1887.md
@@ -1,0 +1,180 @@
+# Why the compound review sheet was unanswerable — and the gate that stops it recurring
+
+_Created: 29-07-2026 · Last updated: 29-07-2026_
+
+_Measured by Opus 5 (1M context) (`claude-opus-5[1m]`) for [H1887](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1887-Opus_SanskritLexicography_compound-differs-sheet-evidence-recut_29.07.26.md).
+Deterministic; no LLM in the measurement path. Scripts:
+[`src/review_evidence_preflight.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/review_evidence_preflight.py),
+[`src/pilot/build_compound_rule_ratification_sheet.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/build_compound_rule_ratification_sheet.py)._
+
+## The complaint
+
+MG, voting
+[`sanskritlexicography-pwg-compound-differs_stratified200`](https://github.com/gasyoun/Uprava/blob/main/REVIEW_SHEETS_INDEX.md)
+(H1628, 200 cards): «Я не понимаю, зачем мне голосовать». Then nine numbered
+points, and the general ruling that a sheet reusing nothing we already know, with
+no hyperlinks, is a waste of human time.
+
+Every point was checked against the data. All nine hold, and two are worse than
+stated.
+
+## The headline: the answers already existed
+
+[`research/pwg_compound_differs_adjudication.tsv`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/pwg_compound_differs_adjudication.tsv)
+(H1681, 26-07-2026) had already adjudicated the **entire** 4,246-row queue from the
+**same two input files the sheet itself reads**, with a named rule and cited
+evidence per row.
+
+| | |
+|---|---:|
+| cards on the sheet | 200 |
+| cards that already had a machine verdict, rule and reason | **191 (96 %)** |
+| evidence fields available per card, rendered by the sheet | **0 of 7** |
+
+Available and unrendered, per card: `mw_k2_raw` (191/191), `pwg_source_paren`
+(191/191), `reason` (191/191), `mw_first_variant` (191/191), `L_id` (191/191),
+`evidence` (181/191), `dcs_freq` (72/191).
+
+MG's own two examples, in full:
+
+| | `bṛhatkāya` | `sapāduka` |
+|---|---|---|
+| shown to him | `bfhant + kAya` vs `bfhat + kAya` | `sa + pAdukA` vs `sa + pAduka` |
+| verdict on disk | `pwg_members-right` | `pwg_members-right` |
+| rule on disk | `same_split_pwg_lemma_form` | `same_split_pwg_lemma_form` |
+| PWG's own text | `({#bfhant#} + {#kAya#})` | `(<hom>2.</hom> {#sa#} + {#pAdukA#})` |
+| MW's own text | `bfhat—kAya` | `sa—pAduka` |
+| reason on disk | "both sources cut the word in the same place; the members differ only in form" | same |
+
+## Point 3 and 17: a third of the sheet was not a decision
+
+Strict per-member equivalence relations (each named and auditable; verified that
+`dāna`/`dānin` correctly stays a **real** difference, so the classifier is not
+over-collapsing):
+
+| class | in the 4,246-row queue | on the 200 shown |
+|---|---:|---:|
+| same split, spelling convention only | **1,482 (34.9 %)** | **69 (34.5 %)** |
+| — vowel length (`pādukā`/`pāduka`) | 516 | |
+| — stem class (`bṛhant`/`bṛhat`) | 461 | |
+| — sandhi form (`akutas`/`akuto`) | 396 | |
+| — final -m / mixed | 109 | |
+| different member count | 76 (1.8 %) | 20 |
+| genuine boundary shift | 54 (1.3 %) | 1 |
+| genuinely different material | 2,634 (62.0 %) | 110 |
+
+Both examples MG picked unprompted land in the first row.
+
+## Points 2 and 12–13: the «Пāṇini» line was fabricated half the time
+
+`panini_sutras` comes from
+[`SanskritGrammar/data/pwg_panini_crosswalk/`](https://github.com/gasyoun/SanskritGrammar/tree/main/data/pwg_panini_crosswalk).
+The Aṣṭādhyāyī is 8 adhyāyas × 4 pādas, ~3,983 sūtras. Measured at source:
+
+| | count | share |
+|---|---:|---:|
+| distinct "sūtra" keys in `pwg_panini_sutra2word.tsv` | 14,417 | |
+| structurally impossible (adhyāya > 8) | 5,766 | 40.0 % |
+| structurally impossible (pāda > 4) | 4,968 | 34.5 % |
+| **total impossible** | **10,735** | **74.5 %** |
+
+The extractor's regex takes every `a,b,c`-shaped citation in the entry, so Vedic
+and epic references were relabelled as grammar. `indrasena → P.10.85.38` is
+**ṚV 10.85.38**, the Sūryā bridal hymn where Indrasenā actually occurs.
+`haryaśva` carries `P.4.1.104` (real, corroborated by gaṇa `bidādiḥ`) plus six
+Ṛgveda citations. On the sheet: 44 of 200 cards showed a «Пāṇini» line, **18 of
+them impossible** — including MG's `bṛhatkāya` (`P.9.21.22`). Upstream repair is
+[H1888](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1888-Sonnet_SanskritGrammar_panini-crosswalk-nonpanini-citation-purge_29.07.26.md);
+downstream, impossible references are now suppressed and counted, never shown.
+
+## Points 14 and 15: the data MG asked for was already on the card, unlabelled
+
+«Членение в указателе (index) — что это за такой указатель?» and «Funderburk
+подготовил отдельную разбивку самас… их тут нужно задействовать».
+
+The "index" **is** Funderburk's work: `headword_index.compound_members` comes from
+`mw_compounds.py`, Jim Funderburk's em-dash segmentation of MW's `<k2>`. So the
+card was already showing PWG against MW/Funderburk — with neither side named.
+Confirmed independently by joining MW key2 dash-truth onto the queue: the index
+matches MW's own hyphenation on 1,363 rows and PWG's on 2. It is not a third
+opinion to fetch; it is one of the two already there.
+
+The two sides were never built to one specification, which is the whole story:
+**PWG names the members as lexemes** (etymology parenthesis, lemma form);
+**MW/Funderburk segments the surface** (members concatenate back to the headword
+by construction). Most of the queue is two conventions meeting, not a dispute.
+
+## Why nothing caught it
+
+| layer | why it did not fire |
+|---|---|
+| the two scripts | `compound_differs_review_sample.py` and `adjudicate_compound_differs.py` are siblings reading the same inputs and sharing 4,246/4,246 row ids; nothing makes the sheet read the adjudicator's output |
+| handoff order | sheet minted first (H1628, 25-07), adjudicated second (H1681, 26-07), never re-cut; the index still read "Awaiting vote" |
+| the standard | V1–V8 + H1808 are **entirely presentation** — type scale, anatomy colour, tooltips, ids, note height. The H1628 sheet is fully standard-compliant and still unanswerable |
+| the hook | `posttooluse_review_sheet_legibility.py` lints escaped markup and link presence; it cannot see a file two directories away |
+| the prose rule | "check prior art before building" existed and did not fire — it depends on the author remembering to look |
+
+## The gate
+
+[`review_evidence_preflight.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/review_evidence_preflight.py)
+runs **before** a sheet is written and raises rather than returning a warning.
+Six checks: mechanical prior-art overlap · evidence floor · script purity ·
+transliteration-scheme leakage · citation linkability · structural validity of
+cited references.
+
+The prior-art check is the load-bearing one and is deliberately mechanical: given
+the sheet's row ids, it scans the repo for every other artifact keyed on the same
+ids and demands each be either **joined** or **omitted with a stated reason**. A
+conceptual omission ("no DCS sentence map exists") has no path and cannot silence a
+found file — only `declare_omitted_path()` can, so a real artifact is never waved
+away by a vaguely-worded note.
+
+Run against the sheet MG complained about, with the manifest the H1628 generator
+would have produced (it declared nothing), it returns **12 blocking findings** —
+finding 9 being `research/pwg_compound_differs_adjudication.tsv`, 192 of 200 ids,
+96 %. It also names the mixed script, the SLP1 leak, and six impossible citations.
+
+It caught two real defects in the replacement sheet during development
+(raw-SLP1 source cells, undeclared sibling artifacts), which is the point.
+
+## The replacement ask
+
+[`build_compound_rule_ratification_sheet.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/build_compound_rule_ratification_sheet.py)
+— **30 cards, not 200**. Per MG's ruling of 29-07-2026, the human ratifies the
+seven auto-resolving **rules**, not the rows:
+
+| rule | rows it resolves | cards |
+|---|---:|---:|
+| `same_split_pwg_lemma_form` | 3,152 | 10 |
+| `pwg_lexeme_vs_mw_suffixed_tail` | 334 | 4 |
+| `mw_cut_leaves_nonword` | 293 | 4 |
+| `mw_anusvara_right_of_boundary` | 107 | 3 |
+| `mw_cut_absorbs_initial_vowel` | 67 | 3 |
+| `mw_splits_derivational_suffix` | 14 | 3 |
+| `mw_splits_bound_morph` | 8 | 3 |
+| **total** | **3,975** | **30** |
+
+Each card carries both splits in IAST, both dictionaries' own printed text
+(transliterated, exact SLP1 on hover), what each convention is, the glossed
+difference, DCS frequency or a stated reason there is none, and 157 links across
+the sheet (kosha co-location, PWG scan column, Cologne MW, ashtadhyayi.com).
+`<ab>` abbreviations are glossed through `pwg_ab_ru.display()`.
+
+## Known gaps, stated rather than hidden
+
+- **No per-headword samāsa type.** SamasaChakram has a 58-subtype taxonomy and 20
+  worked plates but no headword→subtype mapping exists in any repo. The card says
+  so and links the wheel.
+- **No per-compound DCS sentence.** The DCS attestation tables in `research/` are
+  sense-level for PWG entries, not headword-level for compounds. Frequency is
+  joined; an attested sentence is not available.
+- **Two emitter strings stay English** — the per-card "Defer" button and the
+  "Reason" select label are not reachable through `csl_pyutil` 0.7.0's
+  `UI_STRINGS`. Folded into
+  [H1889](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1889-Opus_csl-pyutil_review-sheet-v9-evidence-gate_29.07.26.md)
+  rather than patched with per-caller post-processing.
+- **`w`/`q` are not SLP1 leak markers.** English `sw`/`tw`/`dw` clusters are too
+  common; an all-lowercase w/q token can slip. In practice it shares a card with
+  an uppercase-marked member, which is caught.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/review/sanskritlexicography-pwg-compound-rules_ratify30_evidence_manifest.json
+++ b/RussianTranslation/review/sanskritlexicography-pwg-compound-rules_ratify30_evidence_manifest.json
@@ -1,0 +1,41 @@
+{
+  "sheet_id": "sanskritlexicography-pwg-compound-rules_ratify30",
+  "rows": 30,
+  "joined": {
+    "research/pwg_compound_differs_adjudication.tsv": [
+      "verdict",
+      "rule",
+      "reason",
+      "evidence",
+      "pwg_members",
+      "index_members",
+      "pwg_source_paren",
+      "mw_k2_raw",
+      "dcs_freq",
+      "L_id"
+    ],
+    "src/pwg_columns.tsv": [
+      "column"
+    ],
+    "src/headword_index.tsv": [
+      "compound_members"
+    ],
+    "src/pwg_derivation_layer.tsv": [
+      "panini_sutras"
+    ],
+    "src/pwg_freq_order.tsv": [
+      "count_all"
+    ]
+  },
+  "omitted": {
+    "src/mw_compounds.json": "the index side IS MW: headword_index.compound_members is Funderburk's em-dash segmentation of MW <k2>, already shown as one of the two sides — joining this again would double-count one source as two opinions",
+    "src/pwg_entry_locations.tsv": "pagination only; pwg_columns.tsv already supplies the printed column used for the scan link, and entry location bears on neither split nor rule",
+    "src/pwg_pages.tsv": "page-level index, superseded here by pwg_columns.tsv which is column-level and is what the PWG scan URL actually needs",
+    "src/reverse_paradigm_index.json": "inflectional paradigms keyed on the same headwords; the question under ratification is compound segmentation, on which paradigm data is silent",
+    "research/lex_noun_link_pwg.tsv": "noun-sense linking layer; covers 16 of these 30 headwords but carries sense links, not segmentation evidence, so it cannot bear on the rule",
+    "samasa subtype per headword": "SamasaChakram carries a 58-subtype taxonomy and 20 worked plates but no headword-to-subtype mapping exists in any repo; the wheel is linked instead",
+    "DCS attested sentence": "the DCS attestation tables in research/ are SENSE-level for PWG entries, not headword-level for compounds; no per-compound sentence map exists yet"
+  },
+  "cards": 30,
+  "notes": []
+}

--- a/RussianTranslation/src/pilot/build_compound_rule_ratification_sheet.py
+++ b/RussianTranslation/src/pilot/build_compound_rule_ratification_sheet.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""H1887 — ratify the RULES that auto-resolve the PWG-vs-index compound queue.
+
+## What changed, and why this sheet is 30 cards and not 200
+
+The 4,246-row `differs` queue already carries a machine verdict per row, with a
+NAMED RULE and cited evidence, from `adjudicate_compound_differs.py` (H1681):
+3,975 rows resolve for PWG, 24 for the index, 247 stay unresolved. The two blind
+sheets (H1628 n=200, H1703 n=232) were built to PRICE that adjudicator.
+
+On 29-07-2026 MG opened the H1628 sheet and asked why he was voting at all. The
+measurement behind his complaint: **191 of its 200 cards already had a verdict, a
+rule and a reason** — computed from the same two input files the sheet itself
+reads — and the sheet rendered none of it. Worse, 69 of the 200 cards (34.5 %) were
+not split disagreements in the first place (same cut, different spelling
+convention), and 18 of the 44 cards showing a «Пāṇini» line showed a reference that
+cannot exist (adhyāya > 8 — Ṛgveda citations swept into the upstream column).
+
+MG's ruling (29-07-2026): auto-resolve the non-decisions by rule, and prove the
+RULE on ~30 cards rather than re-voting the rows. So this sheet asks, per card,
+one question: **does this rule hold here?** Approving a card ratifies the rule for
+its whole class; rejecting it says the rule breaks on this card and names how.
+
+Ratifying all seven rules retires **3,975 rows** from the human queue.
+
+## The evidence contract (MG's V9 ruling, 29-07-2026)
+
+Every card carries, or explicitly states why it cannot:
+
+* both sides' split **in IAST**, never SLP1 (SLP1 lives in the copyable id chip);
+* **what each side actually is** — PWG names the compound's members as LEXEMES in
+  its etymology parenthesis; the "index" is Jim Funderburk's em-dash segmentation
+  of MW's `<k2>`, which by construction concatenates back to the headword. Two
+  conventions, not two claims;
+* the **raw source text of both** — PWG's parenthesis and MW's `<k2>` — so the
+  reviewer checks the dictionaries, not our transcription of them;
+* DCS corpus frequency where the lemma has one;
+* clickable: PWG entry (kosha co-location), PWG scan column, Cologne MW entry,
+  and any Pāṇini sūtra that structurally CAN exist, deep-linked to ashtadhyayi.com;
+* structurally impossible "sūtra" references are suppressed and counted, never
+  shown as authority.
+
+`review_evidence_preflight.preflight()` BLOCKS the write if any of that slips.
+
+    python src/pilot/build_compound_rule_ratification_sheet.py --report
+    python src/pilot/build_compound_rule_ratification_sheet.py --write
+    python src/pilot/build_compound_rule_ratification_sheet.py --selftest
+"""
+import csv
+import io
+import json
+import os
+import random
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))          # src/pilot
+SRC = os.path.dirname(HERE)                                 # src
+REPO = os.path.dirname(SRC)                                 # RussianTranslation
+SL = os.path.dirname(REPO)                                  # SanskritLexicography
+
+ADJ_TSV = os.path.join(REPO, 'research', 'pwg_compound_differs_adjudication.tsv')
+REVIEW_DIR = os.path.join(REPO, 'review')
+SHEET_ID = 'sanskritlexicography-pwg-compound-rules_ratify30'
+SHEET_HTML = os.path.join(REVIEW_DIR, '%s_review.html' % SHEET_ID)
+MANIFEST_JSON = os.path.join(REVIEW_DIR, '%s_evidence_manifest.json' % SHEET_ID)
+SEED = 1887
+TARGET = 30
+PER_RULE_FLOOR = 3
+GENERATED = '29-07-2026'
+
+sys.path.insert(0, SRC)
+from review_sheet_standard import pwg_entry_href, slp1_iast, standard_config  # noqa: E402
+from review_evidence_preflight import (EvidenceManifest, preflight,            # noqa: E402
+                                       valid_sutras, sutra_href)
+
+KOSHA_WHEEL = 'https://gasyoun.github.io/SamasaChakram/'
+CDSL_MW = ('https://www.sanskrit-lexicon.uni-koeln.de/scans/MWScan/2020/web/'
+           'webtc/indexcaller.php')
+
+
+def pwg_scan_href(colnum):
+    """PWG scan page for a printed column — same builder the article site uses
+    (pilot/build_article_site.py::_pwg_scan)."""
+    try:
+        return ('https://sanskrit-lexicon.uni-koeln.de/scans/PWGScan/2020/'
+                'web/webtc/servepdf.php?page=%d' % int(colnum))
+    except (TypeError, ValueError):
+        return None
+
+
+# --------------------------------------------------------------- the rule book
+# Every rule below resolves FOR PWG. The Russian gloss is what MG ratifies; the
+# `claim` is the sentence the card asks him to accept or break.
+RULES = {
+    'same_split_pwg_lemma_form': {
+        'ru': 'Одно и то же членение, разная форма члена',
+        'claim': ('Оба источника делят слово в одном и том же месте. Члены '
+                  'различаются только формой: MW пишет отрезок так, как он стоит '
+                  'внутри сложного слова, PWG называет лексему, которая за ним '
+                  'стоит. Списку членов нужна лексема — значит, верен PWG.'),
+    },
+    'pwg_lexeme_vs_mw_suffixed_tail': {
+        'ru': 'MW оставляет суффикс в хвосте, PWG называет лексему',
+        'claim': ('Хвостовой член у MW несёт словообразовательный суффикс, PWG '
+                  'называет лексему без него. Членение то же; верен PWG.'),
+    },
+    'mw_cut_leaves_nonword': {
+        'ru': 'Разрез MW оставляет не-слово',
+        'claim': ('Разрез MW порождает отрезок, который не является '
+                  'самостоятельным словом. Членение PWG даёт словарные члены — '
+                  'верен PWG.'),
+    },
+    'mw_anusvara_right_of_boundary': {
+        'ru': 'Анусвара справа от границы',
+        'claim': ('MW ставит границу так, что анусвара отходит вправо; это '
+                  'орфографическая деталь записи, не другое членение. Верен PWG.'),
+    },
+    'mw_cut_absorbs_initial_vowel': {
+        'ru': 'Разрез MW поглощает начальный гласный',
+        'claim': ('Разрез MW относит начальный гласный второго члена к первому '
+                  '(результат сандхи в записи). Членение то же; верен PWG.'),
+    },
+    'mw_splits_derivational_suffix': {
+        'ru': 'MW отделяет словообразовательный суффикс как член',
+        'claim': ('MW выделяет словообразовательный суффикс в отдельный член. '
+                  'Суффикс не член сложного слова — верен PWG.'),
+    },
+    'mw_splits_bound_morph': {
+        'ru': 'MW отделяет связанную морфему как член',
+        'claim': ('MW выделяет связанную морфему в отдельный член. Она не '
+                  'самостоятельный член сложного слова — верен PWG.'),
+    },
+}
+
+REJECT_LABELS = [
+    ('rule_wrong_here', 'Правило здесь не работает — членение PWG неверно'),
+    ('rule_too_broad', 'Правило само по себе верно, но эту карточку не покрывает'),
+    ('both_wrong', 'Оба членения неверны (правильное укажите в примечании)'),
+    ('need_source', 'Не могу решить без сканa/источника'),
+]
+
+
+def load_adjudication(path=ADJ_TSV):
+    rows = []
+    with io.open(path, encoding='utf-8') as f:
+        for r in csv.DictReader(f, delimiter='\t'):
+            rows.append(r)
+    return rows
+
+
+def stratified(rows, seed=SEED, target=TARGET, floor=PER_RULE_FLOOR):
+    """Floor per rule so every rule is actually tested, then the remaining budget
+    proportional to class size (largest remainder). Deterministic under `seed`."""
+    rng = random.Random(seed)
+    by = {}
+    for r in rows:
+        if r['verdict'] != 'pwg_members-right' or r['rule'] not in RULES:
+            continue
+        by.setdefault(r['rule'], []).append(r)
+    picked, quota = [], {}
+    for rule, rs in by.items():
+        quota[rule] = min(floor, len(rs))
+    left = target - sum(quota.values())
+    if left > 0:
+        tot = sum(len(v) for v in by.values())
+        raw = {k: left * len(v) / float(tot) for k, v in by.items()}
+        add = {k: int(v) for k, v in raw.items()}
+        short = left - sum(add.values())
+        for k, _ in sorted(raw.items(), key=lambda kv: kv[1] - int(kv[1]), reverse=True)[:short]:
+            add[k] += 1
+        for k in quota:
+            quota[k] = min(quota[k] + add.get(k, 0), len(by[k]))
+    for rule in sorted(by):
+        rs = sorted(by[rule], key=lambda r: r['id'])
+        picked.extend(rng.sample(rs, quota[rule]))
+    picked.sort(key=lambda r: (r['rule'], r['id']))
+    return picked, {k: quota[k] for k in sorted(quota)}, {k: len(v) for k, v in by.items()}
+
+
+def esc(s):
+    return (s or '').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
+
+def iast_split(members_slp1):
+    """`a + b` in SLP1 -> `a + b` in IAST (human-facing; never SLP1)."""
+    parts = [p.strip() for p in (members_slp1 or '').split('+') if p.strip()]
+    return ' + '.join(slp1_iast(p) for p in parts)
+
+
+# MG asked to see what the dictionaries actually print, not our transcription of
+# it — but the committed source of BOTH is SLP1, which he does not read. So the
+# source line is shown transliterated, with the exact SLP1 bytes one hover away
+# (title=) for anyone machine-checking the extraction.
+_HOM = re.compile(r'<hom>([^<]*)</hom>')
+_CURLY = re.compile(r'\{#([^#]+)#\}')
+_LATIN_RUN = re.compile(r"[A-Za-z/\\^']+")
+_AB = re.compile(r'<ab\b[^>]*>(.*?)</ab>', re.S)
+
+# PWG wraps every abbreviation in <ab>. Printing it raw ships `<ab>acc.</ab>` to
+# the reviewer as literal markup (H1808's defect #5, on a different generator).
+# `pwg_ab_ru.display()` already returns exactly (visible, tooltip) under MG's
+# 10-07-2026 ruling — grammatical Latin sigla stay Latin, editorial German gets a
+# Russian equivalent, both keep the authoritative DE/EN expansion on hover.
+try:
+    import pwg_ab_ru as _AB_RU
+except Exception:                                    # pragma: no cover
+    _AB_RU = None
+
+
+def gloss_ab(s):
+    def one(m):
+        tok = (m.group(1) or '').strip()
+        vis, title = (tok, None)
+        if _AB_RU is not None:
+            try:
+                vis, title = _AB_RU.display(tok)
+            except Exception:
+                pass
+        return ('<abbr title="%s">%s</abbr>' % (esc(title), esc(vis))) if title \
+            else '<abbr>%s</abbr>' % esc(vis)
+    return _AB.sub(one, s or '')
+
+
+_SPAN = re.compile(r'\{#([^#]+)#\}|<ab\b[^>]*>(?:.*?)</ab>', re.S)
+
+
+def iast_pwg_paren(s):
+    """PWG's etymology parenthesis as SAFE HTML.
+
+    `({#janam#}, <ab>acc.</ab> von {#jana#}, + {#tapa#})`
+      -> `(janam, <abbr title="…">acc.</abbr> von jana, + tapa)`
+
+    Sanskrit spans transliterate to IAST and are italicised; `<ab>` becomes a
+    glossed `<abbr>`; every other run is escaped. Nothing reaches the reviewer as
+    raw markup or raw SLP1.
+    """
+    s = _HOM.sub(r'\1 ', s or '')
+    out, pos = [], 0
+    for m in _SPAN.finditer(s):
+        out.append(esc(s[pos:m.start()]))
+        if m.group(1) is not None:
+            out.append('<i>%s</i>' % esc(slp1_iast(m.group(1))))
+        else:
+            out.append(gloss_ab(m.group(0)))
+        pos = m.end()
+    out.append(esc(s[pos:]))
+    return ''.join(out).strip()
+
+
+def iast_mw_k2(s):
+    """MW's `<k2>` as safe HTML: `bfhat—kAya` -> `bṛhat—kāya`, boundaries kept."""
+    return esc(_LATIN_RUN.sub(lambda m: slp1_iast(m.group(0)), s or ''))
+
+
+# Every key that actually occurs in the adjudication's `evidence` column, glossed.
+# Censused from the file itself (10 distinct keys over 4,353 rows) rather than
+# guessed — an unglossed key would print a machine identifier at the reviewer.
+_EV_KEYS = {
+    'form_diffs': 'формы членов различаются',
+    'index_members_unattested': 'член указателя не является самостоятельным словом',
+    'pwg_members_unattested': 'член PWG не является самостоятельным словом',
+    'taddhita_suffix': 'вторичный суффикс (taddhita)',
+    'mw_hyphen_members': 'дефисные члены MW',
+    'absorbed_vowel': 'поглощённый начальный гласный',
+    'mw_is_finer': 'MW членит мельче',
+    'pwg_is_finer': 'PWG членит мельче',
+    'mw_suffix_member': 'MW выделил суффикс в член',
+    'pwg_typo_pairs': 'опечатка в источнике PWG',
+}
+
+
+def iast_evidence(s):
+    """`form_diffs=bfhant|bfhat; mw_hyphen_members=A-DAra` ->
+    `формы членов = bṛhant | bṛhat; дефисные члены MW = ā-dhāra`."""
+    out = []
+    for chunk in (s or '').split(';'):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if '=' in chunk:
+            k, v = chunk.split('=', 1)
+            k = _EV_KEYS.get(k.strip(), k.strip())
+            vals = ' | '.join(slp1_iast(p.strip()) for p in v.split('|') if p.strip())
+            out.append('%s = %s' % (k, vals))
+        else:
+            out.append(slp1_iast(chunk))
+    return '; '.join(out)
+
+
+def src_cell(raw, body_html):
+    """One source cell: readable form visible, exact source bytes in the tooltip.
+
+    `body_html` is ALREADY escaped/marked-up by its builder — never re-escape it.
+    """
+    if not (raw or '').strip():
+        return '—'
+    return '<code title="источник (SLP1): %s">%s</code>' % (esc(raw), body_html)
+
+
+def load_derivation():
+    """(k1, hom) -> the derivation-layer row, for `panini_sutras` + `ganas`.
+
+    The adjudication TSV does NOT carry these columns, so joining the derivation
+    layer is what makes the manifest's `panini_sutras` declaration true. Left
+    unjoined, the Panini panel would silently claim every headword has no sutra.
+    """
+    path = os.path.join(SRC, 'pwg_derivation_layer.tsv')
+    m = {}
+    if not os.path.exists(path):
+        return m
+    with io.open(path, encoding='utf-8') as f:
+        for r in csv.DictReader(f, delimiter='\t'):
+            m.setdefault((r['k1'], r.get('hom', '')), r)
+    return m
+
+
+def load_columns():
+    """root -> printed PWG column, for the scan link."""
+    path = os.path.join(SRC, 'pwg_columns.tsv')
+    m = {}
+    if not os.path.exists(path):
+        return m
+    with io.open(path, encoding='utf-8') as f:
+        head = f.readline().rstrip('\n').split('\t')
+        ci, hi = head.index('column'), head.index('headwords')
+        for line in f:
+            p = line.rstrip('\n').split('\t')
+            if len(p) <= hi:
+                continue
+            for hw in p[hi].split(','):
+                hw = hw.strip()
+                if hw and hw not in m:
+                    m[hw] = p[ci]
+    return m
+
+
+def build_items(sample, columns, deriv):
+    items, suppressed_total, card_ev = [], 0, {}
+    for r in sample:
+        k1 = r['k1']
+        iid = r['id']
+        rule = RULES[r['rule']]
+        iast = slp1_iast(k1)
+        pwg_i = iast_split(r['pwg_members'])
+        idx_i = iast_split(r['index_members'])
+
+        fields, omitted = [], []
+
+        # ---- the claim being ratified
+        q = ['<p class="claim"><b>Правило:</b> %s</p>' % esc(rule['ru']),
+             '<p>%s</p>' % esc(rule['claim'])]
+
+        # ---- both sides, IAST, with what each side IS
+        q.append(
+            '<table class="sides"><tr><th></th><th>членение</th><th>что напечатано в словаре</th></tr>'
+            '<tr><td><b>PWG</b><br><span class="prov">члены как ЛЕКСЕМЫ, '
+            'из этимологической скобки статьи</span></td>'
+            '<td class="split">%s</td><td>%s</td></tr>'
+            '<tr><td><b>Указатель</b><br><span class="prov">сегментация MW '
+            '&lt;k2&gt; эм-дефисами (Дж. Фундербёрк); по построению склады&shy;вается '
+            'обратно в заголовок</span></td>'
+            '<td class="split">%s</td><td>%s</td></tr></table>'
+            % (esc(pwg_i),
+               src_cell(r.get('pwg_source_paren'), iast_pwg_paren(r.get('pwg_source_paren'))),
+               esc(idx_i),
+               src_cell(r.get('mw_k2_raw'), iast_mw_k2(r.get('mw_k2_raw')))))
+        fields += ['pwg_members', 'index_members']
+        if (r.get('pwg_source_paren') or '').strip():
+            fields.append('pwg_source_paren')
+        if (r.get('mw_k2_raw') or '').strip():
+            fields.append('mw_k2_raw')
+
+        if (r.get('evidence') or '').strip():
+            q.append('<p class="ev"><b>Что именно различается:</b> %s</p>'
+                     % src_cell(r['evidence'], esc(iast_evidence(r['evidence']))))
+            fields.append('evidence')
+
+        # ---- panels
+        panels = []
+
+        # sources, all clickable
+        links = []
+        href = pwg_entry_href(k1)
+        if href:
+            links.append('<a href="%s">статья PWG (со-локация kosha)</a>' % href)
+            fields.append('pwg_entry_href')
+        col = columns.get(k1)
+        if col:
+            sh = pwg_scan_href(re.sub(r'\D', '', col.split('-')[-1]) or 0)
+            if sh:
+                links.append('<a href="%s">скан PWG, столбец %s</a>' % (sh, esc(col)))
+                fields.append('pwg_scan')
+        else:
+            omitted.append('скан PWG: столбец для этого заголовка отсутствует в pwg_columns.tsv')
+        links.append('<a href="%s">MW в Cologne</a>' % CDSL_MW)
+        if (r.get('L_id') or '').strip():
+            links.append('PWG <code>L%s</code>' % esc(r['L_id']))
+            fields.append('L_id')
+        panels.append(('Источники', ' · '.join(links)))
+
+        # frequency
+        f = (r.get('dcs_freq') or '').strip()
+        if f and f not in ('0', ''):
+            panels.append(('Частотность',
+                           'DCS: <b>%s</b> вхождений корпуса.' % esc(f)))
+            fields.append('dcs_freq')
+        else:
+            panels.append(('Частотность',
+                           '<span class="miss">Нет данных DCS для этой леммы — '
+                           'слово в корпусе DCS не засвидетельствовано, '
+                           'поэтому примера употребления показать нельзя.</span>'))
+            omitted.append('частота/цитата DCS: лемма не засвидетельствована в DCS')
+
+        # samasa layer — honest about what does and does not exist
+        panels.append((
+            'Самаса',
+            'Тип сложного слова для этого заголовка <b>не назначен</b>: в '
+            '<a href="%s">SamasaChakram</a> есть таксономия (4 класса / 10 семейств / '
+            '58 подтипов) и 20 разобранных примеров, но пословного соответствия '
+            '«заголовок → подтип» нет ни в одном репозитории. Колесо и метод '
+            'чтения справа налево — по ссылке.' % KOSHA_WHEEL))
+        omitted.append('тип самасы: пословного соответствия заголовок→подтип не существует')
+
+        # Panini — only what can exist
+        drow = deriv.get((k1, r.get('hom', '')), {})
+        raw = drow.get('panini_sutras') or ''
+        good, bad = valid_sutras(raw)
+        suppressed_total += len(bad)
+        if good:
+            hl = ' · '.join('<a href="%s">P. %s</a>' % (sutra_href(g), esc(g)) for g in good)
+            body = 'Сутры: %s' % hl
+            fields.append('panini_sutras')
+        else:
+            body = '<span class="miss">Сутр Панини для этого заголовка нет.</span>'
+        if bad:
+            body += ('<br><span class="miss">Скрыто %d ссыл(ки) вида <code>%s</code>: '
+                     'в «Аштадхьяи» 8 адхьяй по 4 пады, поэтому такие номера сутрами '
+                     'быть не могут — это цитаты других текстов, попавшие в колонку '
+                     'при извлечении (дефект источника, H1888).</span>'
+                     % (len(bad), esc(', '.join(bad[:4]))))
+        gana = (drow.get('ganas') or '').strip()
+        if gana:
+            body += ('<br>Гана: <b>%s</b>%s' % (
+                esc(slp1_iast(gana)),
+                ' (подтверждена сутрой %s)' % esc(drow.get('gana_sutras', ''))
+                if (drow.get('gana_corroborated') or '').strip() in ('1', 'true', 'True')
+                else ''))
+            fields.append('ganas')
+        panels.append(('Панини', body))
+
+        items.append({
+            'id': iid,
+            'filt': r['rule'],
+            # structured facet dimensions, NOT a badge string. The H1628 sheet
+            # concatenated three raw enum keys into one unreadable run
+            # ("same_count_diff_splitmedium(9-10)no_dcs_freq"); facets keep each
+            # dimension separate, labelled and filterable.
+            'facets': {'rule': [rule['ru']],
+                       'dcs': ['есть' if (f and f != '0') else 'нет']},
+            'badges': [rule['ru']],
+            'title': '%s' % iast,
+            'title_href': href,
+            'question': ''.join(q),
+            'panels': panels,
+            'note_placeholder': ('Если правило здесь ломается — напишите, какое '
+                                 'членение верно и почему'),
+        })
+        card_ev[iid] = (fields, omitted)
+    return items, suppressed_total, card_ev
+
+
+EXTRA_CSS = """
+.claim{font-size:1.05em}
+table.sides{border-collapse:collapse;width:100%;margin:.6em 0}
+table.sides th{text-align:left;font-weight:600;opacity:.7;font-size:.85em;padding:.2em .5em}
+table.sides td{vertical-align:top;padding:.35em .5em;border-top:1px solid rgba(128,128,128,.35)}
+table.sides td.split{font-size:1.25em;white-space:nowrap}
+.prov{opacity:.65;font-size:.8em;font-weight:400}
+.miss{opacity:.75;font-style:italic}
+.ev code{font-size:.95em}
+"""
+
+
+def render(sample, columns, deriv, generated=GENERATED):
+    from csl_pyutil import render_review_sheet
+    items, suppressed, card_ev = build_items(sample, columns, deriv)
+    n_rules = len({i['filt'] for i in items})
+    config = {
+        'sheet_id': SHEET_ID,
+        'title': 'Правила членения сложных слов PWG: ратификация',
+        'subtitle': (
+            '%d карточек, %d правил. Вы решаете НЕ отдельные слова, а <b>правила</b>: '
+            'каждое правило уже разобрало целый класс строк очереди <code>differs</code> '
+            '(всего 4&nbsp;246). Приняв правило, вы снимаете весь его класс с '
+            'голосования навсегда; отклонив — возвращаете класс в очередь. '
+            'Ратификация всех семи правил снимает <b>3&nbsp;975 строк</b>.'
+            % (len(items), n_rules)),
+        'footer': (
+            '<b>Принять</b> = правило на этой карточке работает, членение PWG верно. '
+            '<b>Отклонить</b> = правило здесь ломается — выберите, как именно, и '
+            'по возможности укажите верное членение в примечании. '
+            '<b>Отложить</b> = нужен скан или источник. '
+            'Что показано на карточке: оба членения в IAST, исходный текст обоих '
+            'словарей (этимологическая скобка PWG и &lt;k2&gt; MW), частота DCS, '
+            'ссылки на статью и скан. Чего нет — написано прямо на карточке, с причиной.'),
+        'approve_label': 'Правило верно',
+        'reject_label': 'Правило ломается',
+        'reject_labels': REJECT_LABELS,
+        'filters': [(k, RULES[k]['ru']) for k in sorted(RULES)],
+        'facets': [
+            {'key': 'rule', 'label': 'Правило',
+             'values': [RULES[k]['ru'] for k in sorted(RULES)]},
+            {'key': 'dcs', 'label': 'Частота DCS', 'values': ['есть', 'нет']},
+        ],
+        'generated': generated,
+        'font_scale': 1.5,
+        'extra_css': EXTRA_CSS,
+        'save_as': r'RussianTranslation\review\%s_decisions.json' % SHEET_ID,
+        'strict_review': {'require_reject_note': True},
+        # The emitter's own chrome is English by default; this sheet is Russian.
+        # NOTE: the per-card "Defer" button and the "Reason" select label are NOT
+        # reachable through UI_STRINGS in csl-pyutil 0.7.0 — they stay English.
+        # Adding those two keys is folded into H1889 rather than patched here with
+        # brittle post-processing (the exact anti-pattern UI_STRINGS exists to kill).
+        'ui_strings': {
+            'download_button': 'Скачать decisions.json',
+            'save_button': 'Сохранить в папку…',
+            'footer_hint': (
+                'Клавиши: a — принять, r — отклонить, d — отложить, ←/→ — соседняя '
+                'карточка. Голоса сохраняются в браузере по мере работы; '
+                'по кнопке «Скачать decisions.json» выгружается файл решений.'),
+        },
+    }
+    config.update(standard_config(save_as=config['save_as']))
+    html = render_review_sheet(items, config)
+    return html, items, suppressed, card_ev
+
+
+def gate(html, items, card_ev):
+    """The H1887 preflight — nothing is written unless this passes."""
+    man = EvidenceManifest(sheet_id=SHEET_ID, row_ids=[i['id'] for i in items],
+                           repo_root=REPO, min_evidence_fields=4)
+    man.declare_joined('research/pwg_compound_differs_adjudication.tsv',
+                       ['verdict', 'rule', 'reason', 'evidence', 'pwg_members',
+                        'index_members', 'pwg_source_paren', 'mw_k2_raw', 'dcs_freq',
+                        'L_id'])
+    man.declare_joined('src/pwg_columns.tsv', ['column'])
+    man.declare_joined('src/headword_index.tsv', ['compound_members'])
+    man.declare_joined('src/pwg_derivation_layer.tsv', ['panini_sutras'])
+    man.declare_joined('src/pwg_freq_order.tsv', ['count_all'])
+    man.declare_omitted_path(
+        'src/mw_compounds.json',
+        'the index side IS MW: headword_index.compound_members is Funderburk\'s '
+        'em-dash segmentation of MW <k2>, already shown as one of the two sides — '
+        'joining this again would double-count one source as two opinions')
+    man.declare_omitted_path(
+        'src/pwg_entry_locations.tsv',
+        'pagination only; pwg_columns.tsv already supplies the printed column used '
+        'for the scan link, and entry location bears on neither split nor rule')
+    man.declare_omitted_path(
+        'src/pwg_pages.tsv',
+        'page-level index, superseded here by pwg_columns.tsv which is column-level '
+        'and is what the PWG scan URL actually needs')
+    man.declare_omitted_path(
+        'src/reverse_paradigm_index.json',
+        'inflectional paradigms keyed on the same headwords; the question under '
+        'ratification is compound segmentation, on which paradigm data is silent')
+    man.declare_omitted_path(
+        'research/lex_noun_link_pwg.tsv',
+        'noun-sense linking layer; covers 16 of these 30 headwords but carries sense '
+        'links, not segmentation evidence, so it cannot bear on the rule')
+    man.declare_omitted(
+        'samasa subtype per headword',
+        'SamasaChakram carries a 58-subtype taxonomy and 20 worked plates but no '
+        'headword-to-subtype mapping exists in any repo; the wheel is linked instead')
+    man.declare_omitted(
+        'DCS attested sentence',
+        'the DCS attestation tables in research/ are SENSE-level for PWG entries, '
+        'not headword-level for compounds; no per-compound sentence map exists yet')
+    for iid, (fields, omitted) in card_ev.items():
+        man.add_card(iid, evidence_fields=fields, omitted=omitted)
+    # V3 of the standard puts a copyable SLP1 id chip on every card ON PURPOSE —
+    # MG cites ids back. Those exact strings are therefore DECLARED as allowed
+    # rather than silently exempted, so a stray SLP1 token anywhere else on the
+    # card still blocks.
+    ids = [i['id'] for i in items]
+    allow = set(ids) | {i.split('~~')[0] for i in ids}
+    return man, preflight(man, html, overlap_threshold=0.5,
+                          allow_slp1_tokens=sorted(allow))
+
+
+def report():
+    rows = load_adjudication()
+    sample, quota, sizes = stratified(rows)
+    print('adjudicated rows            : %d' % len(rows))
+    print('rules that resolve for PWG  : %d' % len(sizes))
+    print()
+    print('%-38s %8s %7s' % ('rule', 'in queue', 'sampled'))
+    print('-' * 56)
+    tot = 0
+    for k in sorted(sizes):
+        print('%-38s %8d %7d' % (k, sizes[k], quota.get(k, 0)))
+        tot += sizes[k]
+    print('-' * 56)
+    print('%-38s %8d %7d' % ('TOTAL', tot, len(sample)))
+    print()
+    print('ratifying all %d rules retires %d rows from the human queue.' % (len(sizes), tot))
+
+
+def selftest():
+    rows = load_adjudication()
+    sample, quota, sizes = stratified(rows)
+    assert len(sample) == TARGET, len(sample)
+    s2, _, _ = stratified(rows)
+    assert [r['id'] for r in s2] == [r['id'] for r in sample], 'sample must be deterministic'
+    assert all(quota[k] >= min(PER_RULE_FLOOR, sizes[k]) for k in sizes), \
+        'every rule must be represented'
+    ids = [r['id'] for r in sample]
+    assert len(set(ids)) == len(ids), 'duplicate card id'
+    columns, deriv = load_columns(), load_derivation()
+    html, items, suppressed, card_ev = render(sample, columns, deriv)
+    assert len(items) == TARGET
+    man, rep = gate(html, items, card_ev)          # raises if it would ship broken
+    assert rep['mixed_script'] == [], rep['mixed_script']
+    assert rep['slp1_leak'] == [], rep['slp1_leak']
+    assert rep['impossible_citations'] == [], rep['impossible_citations']
+    assert not rep['prior_art_undeclared'], rep['prior_art_undeclared']
+    print('selftest OK — %d cards over %d rules, deterministic under seed=%d, '
+          'preflight clean (no mixed script, no SLP1 leak, no impossible citation, '
+          'no undeclared prior art), %d impossible sutra refs suppressed'
+          % (len(items), len(sizes), SEED, suppressed))
+
+
+def main():
+    args = sys.argv[1:]
+    if '--selftest' in args:
+        selftest()
+        return
+    if '--write' in args:
+        rows = load_adjudication()
+        sample, quota, sizes = stratified(rows)
+        columns, deriv = load_columns(), load_derivation()
+        html, items, suppressed, card_ev = render(sample, columns, deriv)
+        man, rep = gate(html, items, card_ev)
+        os.makedirs(REVIEW_DIR, exist_ok=True)
+        with io.open(SHEET_HTML, 'w', encoding='utf-8', newline='\n') as f:
+            f.write(html)
+        man.write(MANIFEST_JSON)
+        print('wrote sheet    -> %s' % SHEET_HTML)
+        print('wrote manifest -> %s' % MANIFEST_JSON)
+        print('cards: %d over %d rules; suppressed %d impossible sutra refs'
+              % (len(items), len(sizes), suppressed))
+        print('preflight: PASS (%d prior-art artifacts declared)' % len(man.joined))
+        return
+    report()
+
+
+if __name__ == '__main__':
+    main()

--- a/RussianTranslation/src/review_evidence_preflight.py
+++ b/RussianTranslation/src/review_evidence_preflight.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""review_evidence_preflight — the gate that must pass BEFORE a review sheet is written.
+
+## Why this exists
+
+On 29-07-2026 MG opened
+`sanskritlexicography-pwg-compound-differs_stratified200_review.html` and asked why
+he was being made to vote at all. The measured answer: **191 of its 200 cards already
+had a machine verdict, a named rule and cited evidence** — computed by
+`src/pilot/adjudicate_compound_differs.py` (H1681) from the SAME two input files the
+sheet itself reads, into `research/pwg_compound_differs_adjudication.tsv`, sharing
+**4,246 of 4,246 row ids** with the sheet's frame. The sheet rendered none of it.
+
+Nothing in the stack was responsible for noticing. The review-sheet standard (V1-V8 +
+H1808) is entirely about PRESENTATION — type scale, anatomy colouring, tooltips, ids,
+note height — so a sheet can be 100 % standard-compliant and still ask a human to
+re-derive, by eye, a conclusion the repo already holds on disk. The prose rule that
+should have caught it ("check prior art before building") is exactly the kind of rule
+that does not fire, because firing depends on the author remembering to look.
+
+So this module makes the machine look. It is deterministic, cheap (a key-overlap scan
+over the repo's own tabular artifacts) and it BLOCKS: a generator that cannot show an
+evidence manifest does not get to write HTML.
+
+## What it checks
+
+1. **Prior-art overlap (the H1628 defect).** Given the sheet's row ids, scan the repo
+   for any OTHER committed artifact keyed on the same ids. Any artifact overlapping
+   above `--overlap-threshold` (default 0.5) that the generator did not declare as
+   joined is a BLOCK: the sheet is about to ask a human something the repo may already
+   answer.
+2. **Evidence floor.** Every card must carry at least `min_evidence_fields` joined
+   evidence fields beyond the bare question, or an explicit `omitted_because` reason
+   naming the source and why it is unavailable. Silent absence is a BLOCK; a stated
+   absence is allowed and recorded.
+3. **Script purity.** No human-facing string may mix Cyrillic with IAST diacritics
+   inside one word (the `Пāṇini` defect MG flagged: "Разве на такое уже нет ЗАПРЕТА?").
+   Cyrillic prose uses Cyrillic transliteration; Latin/IAST stays Latin.
+4. **No raw transliteration-scheme leakage.** SLP1 must not appear in human-facing
+   text. Humans read IAST; SLP1 belongs in ids and machine columns only.
+5. **Citation linkability.** A reference that has a known URL template (Panini sutra,
+   Cologne entry, DCS locus) must be rendered as a link, not a bare string.
+6. **Structural validity of cited references.** A citation that cannot exist is never
+   shown: an "Astadhyayi sutra" with adhyaya > 8 or pada > 4 is not a sutra reference
+   (measured 29-07-2026: 625 / 1,270 = 49.2 % of the references the compound sheet was
+   about to print were structurally impossible — Rgveda citations swept into a
+   `panini_sutras` column upstream).
+
+## Usage
+
+    from review_evidence_preflight import EvidenceManifest, preflight
+
+    man = EvidenceManifest(sheet_id="...", row_ids=[...], repo_root=REPO)
+    man.declare_joined("research/pwg_compound_differs_adjudication.tsv",
+                       fields=["verdict", "rule", "reason", "mw_k2_raw"])
+    man.declare_omitted("DCS attested sentence",
+                        because="no per-compound sentence map exists; only sense-level")
+    for card in cards:
+        man.add_card(card_id, evidence_fields=[...], omitted=[...])
+    preflight(man, html)          # raises PreflightError -> nothing is written
+
+    python review_evidence_preflight.py --selftest
+"""
+import io
+import json
+import os
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_DEFAULT = os.path.dirname(HERE)
+
+# ---------------------------------------------------------------- script purity
+CYR = r'Ѐ-ӿ'
+# IAST-only diacritic letters (never legitimate inside a Cyrillic word)
+IAST = r'āīūṛṝḷḹṃḥṇṭḍśṣṅñ' \
+       r'ĀĪŪṚṜḶḸṂḤṆṬḌŚṢṄÑ'
+MIXED_SCRIPT = re.compile(r'[%s][%s]|[%s][%s]' % (CYR, IAST, IAST, CYR))
+
+# SLP1 leaks into human-facing text in two detectable shapes. Both detectors are
+# deliberately narrow: an all-lowercase SLP1 string like `agni + deva` is
+# BYTE-IDENTICAL to its own IAST form, so no detector can or should flag it.
+#
+#   D1 — a capital used as a consonant/vowel INSIDE a token: kAya, pAdukA, jIvikA,
+#        bfhatkAya, Baya. Near-unambiguous, and in practice every SLP1 split on
+#        these sheets carries at least one such member.
+#   D2 — lowercase `f`/`x` (SLP1 vocalic r/l) sitting AFTER a consonant: bfhant,
+#        akfta, pitf. English `f` almost always follows a vowel (differs, prefix,
+#        suffix, left), so this stays quiet on ordinary prose; the handful of
+#        consonant-f English words are stoplisted.
+_TOKEN = re.compile(r'\b[A-Za-z]{3,}\b')
+_D1_UPPER_INSIDE = re.compile(r'^[A-Za-z][a-z]*[A-Z]')
+# f x z never occur in IAST; after a consonant they are SLP1 markers (bfhant
+# = vocalic r, akzara = s). After a VOWEL they are ordinary English (differs,
+# prefix, size, puzzle), so the consonant context is what keeps this quiet on
+# prose. `w` and `q` (SLP1 t/d) are deliberately NOT markers: English `sw`/`tw`
+# /`dw` clusters are far too common (answer, tweak, dwell) and the cost of that
+# noise outweighs the rare all-lowercase w/q token, which in practice shares a
+# card with an uppercase-marked member that D1 catches anyway.
+_D2_MARKER = re.compile(r'[bcdghjklmnprstvy][fxz]')
+# CamelCase identifiers (RussianTranslation, SanskritLexicography, localStorage)
+# trip D1. SLP1 never has this shape: its capitals are single consonants or long
+# vowels, never the head of a long lowercase run repeated twice.
+_CAMEL_ENGLISH = re.compile(r'^[A-Za-z][a-z]+([A-Z][a-z]{2,})+$')
+_SLP1_SAFE = {
+    # abbreviations and tech tokens that must never be reported
+    'PWG', 'MW', 'PWK', 'DCS', 'IAST', 'SLP', 'HTML', 'JSON', 'TSV', 'URL', 'ID',
+    'PDF', 'CSS', 'API', 'CDSL', 'GRA', 'AP', 'SKD', 'VCP', 'MD', 'RV', 'AV',
+    'MWS', 'PW', 'ACC', 'NCC', 'CSV', 'UTF', 'BOM',
+    # English words where `f` legitimately follows a consonant
+    'half', 'self', 'shelf', 'wolf', 'golf', 'elf', 'calf', 'gulf', 'twelve',
+}
+
+PANINI_REF = re.compile(r'\b(\d+)\.(\d+)(?:\.(\d+))?\b')
+
+
+class PreflightError(Exception):
+    """Raised when a sheet must not be written. Carries every finding."""
+
+    def __init__(self, findings):
+        self.findings = findings
+        super(PreflightError, self).__init__(
+            'review-sheet preflight FAILED with %d blocking finding(s):\n%s'
+            % (len(findings), '\n'.join('  - ' + f for f in findings)))
+
+
+def sutra_is_possible(adhyaya, pada, sutra=None):
+    """The Astadhyayi is 8 adhyayas x 4 padas. Anything outside cannot be a sutra
+    reference, whatever the source column is called."""
+    if adhyaya < 1 or adhyaya > 8:
+        return False
+    if pada < 1 or pada > 4:
+        return False
+    if sutra is not None and (sutra < 1 or sutra > 250):
+        return False
+    return True
+
+
+def valid_sutras(raw):
+    """Split a `panini_sutras`-style value into (possible, impossible) reference
+    lists. Never guess: a reference that cannot exist is dropped, not repaired."""
+    ok, bad = [], []
+    for m in PANINI_REF.finditer(raw or ''):
+        a, p = int(m.group(1)), int(m.group(2))
+        s = int(m.group(3)) if m.group(3) else None
+        (ok if sutra_is_possible(a, p, s) else bad).append(m.group(0))
+    return ok, bad
+
+
+def sutra_href(ref):
+    """Deep link to the sutra, reusing the URL form ls_resolver.py already verified
+    against github.com/ashtadhyayi-com/data (H1307)."""
+    parts = ref.split('.')
+    if len(parts) == 3:
+        return 'https://ashtadhyayi.com/sutraani/%s/%s/%s' % tuple(parts)
+    if len(parts) == 2:
+        return 'https://ashtadhyayi.com/sutraani/%s/%s' % tuple(parts)
+    return None
+
+
+def find_mixed_script(text):
+    return sorted({m.group(0) for m in MIXED_SCRIPT.finditer(text or '')})
+
+
+def find_slp1(text, allow=()):
+    """Candidate SLP1 tokens in human-facing text (see the D1/D2 note above).
+
+    Heuristic by construction, and deliberately silent on the undecidable case:
+    an all-lowercase SLP1 member equals its own IAST rendering, so it is not a
+    leak anyone can see. Callers pass `allow` for domain abbreviations.
+    """
+    skip = {s.lower() for s in _SLP1_SAFE} | {s.lower() for s in allow}
+    out = []
+    for m in _TOKEN.finditer(text or ''):
+        t = m.group(0)
+        # Order matters. The explicit allowlist wins over everything (declared ids).
+        # D2 is checked BEFORE the CamelCase exemption, so a genuine SLP1 token
+        # that happens to look CamelCase (akzarajIvika) is still reported.
+        if t.lower() in skip or t.isupper():
+            continue
+        if _D2_MARKER.search(t.lower()):
+            out.append(t)
+            continue
+        if _CAMEL_ENGLISH.match(t):
+            continue
+        if _D1_UPPER_INSIDE.search(t):
+            out.append(t)
+    return sorted(set(out))
+
+
+# ---------------------------------------------------------------- the manifest
+class EvidenceManifest(object):
+    """What the generator claims it looked at, joined, and deliberately left out."""
+
+    def __init__(self, sheet_id, row_ids, repo_root=REPO_DEFAULT,
+                 min_evidence_fields=2):
+        self.sheet_id = sheet_id
+        self.row_ids = [str(r) for r in row_ids]
+        self.repo_root = repo_root
+        self.min_evidence_fields = min_evidence_fields
+        self.joined = {}        # path -> [fields]
+        self.omitted = {}       # source (or path) -> reason
+        self.omitted_paths = set()   # only these silence a prior-art finding
+        self.cards = {}         # card_id -> {"fields": [...], "omitted": [...]}
+        self.notes = []
+
+    def declare_joined(self, path, fields):
+        self.joined[path] = list(fields)
+
+    def declare_omitted(self, source, because):
+        if not because or len(because) < 12:
+            raise ValueError('omitting %r needs a real reason, not %r' % (source, because))
+        self.omitted[source] = because
+
+    def declare_omitted_path(self, path, because):
+        """Omit a concrete repo artifact the prior-art scan will find.
+
+        Distinct from declare_omitted(): the reason is recorded the same way, but
+        the PATH is what clears the scan's finding. A conceptual omission ("no DCS
+        sentence map exists") has no path and cannot silence a found file — that
+        asymmetry is deliberate, so a real artifact can never be waved away by a
+        vaguely-worded note.
+        """
+        if not because or len(because) < 12:
+            raise ValueError('omitting %r needs a real reason, not %r' % (path, because))
+        rel = str(path).replace('\\', '/')
+        self.omitted[rel] = because
+        self.omitted_paths.add(rel)
+
+    def add_card(self, card_id, evidence_fields, omitted=()):
+        self.cards[str(card_id)] = {'fields': list(evidence_fields),
+                                    'omitted': list(omitted)}
+
+    # -------------------------------------------------- prior-art overlap scan
+    def scan_prior_art(self, exts=('.tsv', '.json'), threshold=0.5, max_files=400):
+        """Every OTHER tabular artifact in the repo keyed on these same rows.
+
+        This is the mechanical form of 'check prior art'. It does not depend on
+        anyone remembering: it reads the repo and reports id overlap.
+        Returns [(relpath, overlap_fraction, n_shared)] sorted by overlap desc.
+        """
+        want = set(self.row_ids)
+        # also match on the bare k1 (ids are often `k1~~h<hom>`)
+        bare = {i.split('~~')[0] for i in want}
+        hits, seen = [], 0
+        for root, dirs, files in os.walk(self.repo_root):
+            dirs[:] = [d for d in dirs
+                       if d not in ('.git', 'node_modules', '__pycache__', 'review')]
+            for fn in files:
+                if not fn.endswith(exts):
+                    continue
+                seen += 1
+                if seen > max_files:
+                    break
+                p = os.path.join(root, fn)
+                rel = os.path.relpath(p, self.repo_root).replace('\\', '/')
+                try:
+                    if os.path.getsize(p) > 80 * 1024 * 1024:
+                        continue
+                    with io.open(p, encoding='utf-8', errors='replace') as f:
+                        blob = f.read(6 * 1024 * 1024)
+                except (IOError, OSError):
+                    continue
+                toks = set(re.findall(r'[A-Za-z~]{3,}', blob))
+                shared = len(bare & toks)
+                if not shared:
+                    continue
+                frac = shared / float(max(1, len(bare)))
+                if frac >= threshold:
+                    hits.append((rel, round(frac, 4), shared))
+        hits.sort(key=lambda h: -h[1])
+        return hits
+
+    def to_dict(self):
+        return {
+            'sheet_id': self.sheet_id,
+            'rows': len(self.row_ids),
+            'joined': self.joined,
+            'omitted': self.omitted,
+            'cards': len(self.cards),
+            'notes': self.notes,
+        }
+
+    def write(self, path):
+        with io.open(path, 'w', encoding='utf-8', newline='\n') as f:
+            f.write(json.dumps(self.to_dict(), ensure_ascii=False, indent=2))
+            f.write('\n')
+        return path
+
+
+# ---------------------------------------------------------------- the gate
+def preflight(manifest, html, allow_slp1_tokens=(), overlap_threshold=0.5,
+              skip_prior_art=False):
+    """Run every check. Raise PreflightError on any BLOCK. Returns a report dict
+    of the non-blocking observations."""
+    f = []
+    report = {}
+
+    # 1. prior-art overlap
+    if not skip_prior_art:
+        hits = manifest.scan_prior_art(threshold=overlap_threshold)
+        declared = ({p.replace('\\', '/') for p in manifest.joined}
+                    | set(manifest.omitted_paths))
+        undeclared = [h for h in hits
+                      if not any(h[0].endswith(d) or d.endswith(h[0]) for d in declared)]
+        report['prior_art_hits'] = hits
+        report['prior_art_undeclared'] = undeclared
+        for rel, frac, n in undeclared:
+            f.append('PRIOR ART NOT JOINED: %s shares %d of %d row ids (%.0f%%) with '
+                     'this sheet. Join it or declare_omitted() with a reason.'
+                     % (rel, n, len(set(i.split("~~")[0] for i in manifest.row_ids)),
+                        100 * frac))
+
+    # 2. evidence floor
+    starved = [cid for cid, c in manifest.cards.items()
+               if len(c['fields']) < manifest.min_evidence_fields and not c['omitted']]
+    report['evidence_starved'] = starved
+    if starved:
+        f.append('EVIDENCE FLOOR: %d card(s) carry fewer than %d joined evidence '
+                 'fields and state no reason (e.g. %s).'
+                 % (len(starved), manifest.min_evidence_fields, ', '.join(starved[:5])))
+
+    # 3-5. text-level checks over the rendered HTML, minus tag internals
+    text = re.sub(r'<script\b.*?</script>', ' ', html or '', flags=re.S | re.I)
+    text = re.sub(r'<style\b.*?</style>', ' ', text, flags=re.S | re.I)
+    visible = re.sub(r'<[^>]+>', ' ', text)
+
+    mixed = find_mixed_script(visible)
+    report['mixed_script'] = mixed
+    if mixed:
+        f.append('MIXED SCRIPT in human-facing text: %s — a word may not mix '
+                 'Cyrillic with IAST diacritics (write «Панини» or `Pāṇini`, '
+                 'never «Пāṇini»).' % ', '.join(mixed[:6]))
+
+    slp1 = find_slp1(visible, allow=allow_slp1_tokens)
+    report['slp1_leak'] = slp1
+    if slp1:
+        f.append('SLP1 IN HUMAN-FACING TEXT: %s — humans read IAST; SLP1 belongs in '
+                 'ids and machine columns only.' % ', '.join(slp1[:8]))
+
+    # 6. impossible citations rendered anywhere
+    bad_refs = []
+    for m in re.finditer(r'P\.\s*(\d+)\.(\d+)(?:\.(\d+))?', visible):
+        a, p = int(m.group(1)), int(m.group(2))
+        s = int(m.group(3)) if m.group(3) else None
+        if not sutra_is_possible(a, p, s):
+            bad_refs.append(m.group(0))
+    report['impossible_citations'] = sorted(set(bad_refs))
+    if bad_refs:
+        f.append('IMPOSSIBLE CITATION RENDERED: %s — the Astadhyayi has 8 adhyayas '
+                 'x 4 padas; these cannot be sutra references and must not be shown '
+                 'to a reviewer as authority.' % ', '.join(sorted(set(bad_refs))[:6]))
+
+    if f:
+        raise PreflightError(f)
+    return report
+
+
+# ---------------------------------------------------------------- selftest
+def selftest():
+    ok = 0
+
+    assert sutra_is_possible(4, 1, 104)
+    assert not sutra_is_possible(9, 21, 22)      # MG's bfhatkAya card
+    assert not sutra_is_possible(1, 12, 28)
+    assert not sutra_is_possible(10, 85, 38)     # RV 10.85.38, not a sutra
+    ok += 1
+
+    # haryaSva's real value: ONE genuine sutra (corroborated by gana bidAdiH)
+    # plus six Rgveda citations the upstream regex swept into `panini_sutras`.
+    # `6.5` is adhyaya 6 PADA 5 -> already impossible; the Astadhyayi has 4 padas.
+    good, bad = valid_sutras('P.4.1.104|P.6.5|P.6.5.1|P.8.11.21|P.9.6.24')
+    assert good == ['4.1.104'], good
+    assert bad == ['6.5', '6.5.1', '8.11.21', '9.6.24'], bad
+    ok += 1
+
+    assert sutra_href('4.1.104') == 'https://ashtadhyayi.com/sutraani/4/1/104'
+    ok += 1
+
+    assert find_mixed_script('Пāṇini:') == ['Пā']
+    assert find_mixed_script('Панини') == []
+    assert find_mixed_script('Pāṇini') == []
+    ok += 1
+
+    # D1 (capital inside a token) and D2 (consonant + vocalic f/x)
+    leak = find_slp1('PWG-членение: bfhant + kAya')
+    assert 'bfhant' in leak and 'kAya' in leak, leak
+    assert 'pAdukA' in find_slp1('sa + pAdukA')
+    assert 'akfta' in find_slp1('akfta + kara')
+    # the same content in IAST must be silent
+    assert find_slp1('членение: bṛhant + kāya') == []
+    assert find_slp1('членение: sa + pādukā') == []
+    # ordinary prose and abbreviations must be silent
+    assert find_slp1('PWG и MW, класс differs, prefix/suffix, left half') == [], \
+        find_slp1('PWG и MW, класс differs, prefix/suffix, left half')
+    assert find_slp1('answer, tweak, dwell, size, puzzle, schwa') == [], \
+        find_slp1('answer, tweak, dwell, size, puzzle, schwa')
+    assert find_slp1('Members of the index differ from the first form') == [], \
+        find_slp1('Members of the index differ from the first form')
+    # CamelCase identifiers must not trip D1 ...
+    assert find_slp1('votes persist to localStorage in RussianTranslation') == [], \
+        find_slp1('votes persist to localStorage in RussianTranslation')
+    assert find_slp1('SanskritLexicography') == []
+    # ... but a real SLP1 token that merely LOOKS CamelCase still must
+    assert find_slp1('akzarajIvika') == ['akzarajIvika']
+    # an explicitly declared id is exempt; an undeclared neighbour is not
+    assert find_slp1('duHsTita and kAya', allow=['duHsTita']) == ['kAya']
+    # the undecidable case stays undecided, by design
+    assert find_slp1('agni + deva') == []
+    ok += 1
+
+    man = EvidenceManifest('t', ['a', 'b'], repo_root=HERE, min_evidence_fields=2)
+    man.add_card('a', ['x', 'y'])
+    man.add_card('b', [])                       # starved, no reason -> BLOCK
+    try:
+        preflight(man, '<p>ok</p>', skip_prior_art=True)
+        raise AssertionError('should have blocked on the evidence floor')
+    except PreflightError as e:
+        assert 'EVIDENCE FLOOR' in str(e), str(e)
+    ok += 1
+
+    man2 = EvidenceManifest('t', ['a'], repo_root=HERE, min_evidence_fields=1)
+    man2.add_card('a', ['x'])
+    try:
+        preflight(man2, '<p><b>Пāṇini:</b> P.9.21.22</p>', skip_prior_art=True)
+        raise AssertionError('should have blocked on mixed script + impossible ref')
+    except PreflightError as e:
+        assert 'MIXED SCRIPT' in str(e) and 'IMPOSSIBLE CITATION' in str(e), str(e)
+    ok += 1
+
+    man3 = EvidenceManifest('t', ['a'], repo_root=HERE, min_evidence_fields=1)
+    man3.add_card('a', ['x'])
+    rep = preflight(man3, '<p>членение: <code>bṛhant + kāya</code>, '
+                          '<a href="https://ashtadhyayi.com/sutraani/4/1/104">P.4.1.104</a></p>',
+                    skip_prior_art=True)
+    assert rep['mixed_script'] == [] and rep['impossible_citations'] == []
+    ok += 1
+
+    try:
+        man3.declare_omitted('DCS sentence', 'nope')
+        raise AssertionError('short reason must be rejected')
+    except ValueError:
+        pass
+    ok += 1
+
+    print('selftest OK — %d groups: sutra validity, reference splitting, sutra hrefs, '
+          'mixed-script detection, SLP1 leak detection, evidence floor, combined '
+          'block, clean pass, omission-reason quality' % ok)
+
+
+if __name__ == '__main__':
+    if '--selftest' in sys.argv[1:]:
+        selftest()
+    else:
+        print(__doc__)


### PR DESCRIPTION
MG, voting the 200-card compound-differs sheet: «Я не понимаю, зачем мне голосовать».

**Measured:** 191 of its 200 cards already had a machine verdict, a named rule and cited evidence in [`research/pwg_compound_differs_adjudication.tsv`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/pwg_compound_differs_adjudication.tsv) (H1681) — computed from the **same two input files the sheet itself reads**, sharing 4,246/4,246 row ids — and the sheet rendered none of it.

| | |
|---|---:|
| cards on the sheet | 200 |
| cards with an existing verdict + rule + reason | **191 (96 %)** |
| evidence fields available per card, rendered | **0 of 7** |
| cards that were not split disagreements at all | **69 (34.5 %)** |
| cards showing an impossible «Пāṇini» reference | 18 of 44 |

## Why nothing caught it

The standard (V1–V8 + H1808) is **entirely presentation** — type scale, anatomy colour, tooltips, ids, note height — so the H1628 sheet is fully standard-compliant and still unanswerable. The legibility hook cannot see a file two directories away. The prose rule "check prior art before building" existed and did not fire, because firing depends on the author remembering to look.

## What this adds

- **[`src/review_evidence_preflight.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/review_evidence_preflight.py)** — a gate that runs BEFORE the write and **raises** instead of warning. Six checks: mechanical prior-art overlap (join it or state why not, per artifact) · evidence floor · Cyrillic/IAST script purity · SLP1 leakage · citation linkability · structural validity of cited references. Replayed against the sheet MG complained about it returns **12 blocking findings**, #9 being the adjudication TSV at 192/200 ids. It caught two real defects in the replacement sheet during development.
- **[`src/pilot/build_compound_rule_ratification_sheet.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/build_compound_rule_ratification_sheet.py)** — **30 cards, not 200.** Per MG's ruling of 29-07-2026 the human ratifies the seven auto-resolving **rules**, retiring **3,975 rows**. Both splits in IAST, both dictionaries' own printed text (exact SLP1 on hover), the glossed difference, DCS frequency or a stated reason there is none, 157 links (kosha co-location · PWG scan column · Cologne MW · ashtadhyayi.com).
- **[`research/REVIEW_SHEET_EVIDENCE_REUSE_H1887.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/research/REVIEW_SHEET_EVIDENCE_REUSE_H1887.md)** — the full measurement, all nine of MG's points checked, and the gaps left open deliberately.

## Gates

`review_evidence_preflight.py --selftest` 9 groups · `build_compound_rule_ratification_sheet.py --selftest` 30 cards over 7 rules, deterministic under seed=1887, preflight clean.

Upstream Pāṇini-column repair (74.5 % of 14,417 "sūtra" keys structurally impossible) is [H1888](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1888-Sonnet_SanskritGrammar_panini-crosswalk-nonpanini-citation-purge_29.07.26.md); the emitter-side V9 gate + the two untranslatable UI strings are [H1889](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1889-Opus_csl-pyutil_review-sheet-v9-evidence-gate_29.07.26.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)