### PR TITLE
docs: fix stale roadmap drift in headword-list and PWG-wave2 docs (H1877)

### DIFF
--- a/docs/ROADMAP_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md
+++ b/docs/ROADMAP_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md
@@ -1,4 +1,4 @@
-_Created: 19-07-2026 · Last updated: 19-07-2026_
+_Created: 19-07-2026 · Last updated: 29-07-2026_
 
 # ROADMAP — PWG data layers 2026 H2
 
@@ -27,6 +27,30 @@ Ordered; each step states what unblocks it. Full file-level steps in [IMPLEMENTA
 
 - MG reviews the staged csl-corrections change files, runs [/cologne-batch-pr](https://github.com/gasyoun/claude-config/blob/main/commands/cologne-batch-pr.md) → one consolidated PR to csl-orig at most ~monthly.
 - Sense-segmentation disagreements (an editorial claim about Böhtlingk, higher evidence bar) get a separate review sheet before any are proposed.
+
+**Gate — three open `@DECIDE`s block Wave-2 execution** (filed from the 20-07-2026 Wave-1 pass
+in [Uprava GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md);
+restated here so this roadmap is self-contained and does not require cross-referencing
+`.ai_state.md`/GTD):
+
+1. **RU-store quarantine — re-translate or not.** W1.4 quarantined the `〉`-contaminated RU
+   cards into a side marker (`reports/pwg_ru_glyph_quarantine.jsonl`) without touching the RU
+   store itself. A human must rule whether those quarantined cards get re-translated against
+   the corrected `〉` segmentation (this is also the trigger condition for Wave 3) or left as-is
+   with the contamination flagged in place.
+2. **`senses_pwg.jsonl` full-corpus build scope.** W1.7 extended `senses_pwg.jsonl` only over
+   the data Wave 1 touched; a human must decide whether Wave 2 commits to a full-corpus
+   `senses_pwg.jsonl` build (all 123,366 PWG records) versus staying scoped to the subset
+   already covered.
+3. **The untraceable "12 PWG typos" list.** A previously-cited count of "12 PWG typos" cannot be
+   traced back to a concrete, itemized source list; a human must rule whether to (a) re-derive
+   the list from the current typo-candidate pool, (b) treat the number as stale and drop it, or
+   (c) accept it unverified for Wave-2 planning purposes.
+
+Until all three are ruled, Wave-2 candidates (4)/(5) in
+[PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/PLAN_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md)
+— the `〉` glyph-tier xref/OntoLex follow-ons and the DeepSeek sanity-check fix — can be staged
+but not shipped.
 
 ## Wave 3 — requeue the `〉`-contaminated RU cards (budget-gated)
 

--- a/papers/ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md
+++ b/papers/ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md
@@ -2,7 +2,7 @@
 
 ## Roadmap 2026–2027 · public portrait + book/monograph appendix
 
-_Created: 12-07-2026 · Last updated: 13-07-2026_
+_Created: 12-07-2026 · Last updated: 29-07-2026_
 
 > **What this is.** A plan to build the Sanskrit analog of Duden's *Sprache in Zahlen* — the
 > quantitative "language in numbers" appendix that closes the [Duden Universalwörterbuch](https://www.duden.de/)
@@ -83,7 +83,7 @@ Counts from this repo's [`HeadwordLists/now-2026/`](https://github.com/gasyoun/S
 | PWG | große Petersburger Wörterbuch (Böhtlingk-Roth, 1855–75) | **110,438** | the 7-volume "big" PW — the *Universalwörterbuch*-scale anchor |
 | PWK | Böhtlingk, kürzere Fassung (1879–89) | **155,688** | the abridgement is *larger* by headword count (finer splitting) |
 | SCH | Schmidt, *Nachträge* | **28,519** | addenda layer |
-| PW / PD | kleineres PW | ≈ 104,941 (2014 export) | **prerequisite: needs a now-2026 re-export** — see [§8](#8-open-decisions--prerequisites) |
+| PW / PD | kleineres PW | **104,968** (now-2026 re-export) | prerequisite satisfied — see [§8](#8-open-decisions--prerequisites) |
 
 The de-duplicated union is **not** the sum; it comes from the A40/A55 overlap matrix.
 
@@ -216,8 +216,13 @@ Considered and ruled out — a future session should not re-propose these withou
    учебник that the PDF booklet appends to (D5). **`@DECIDE`:** name its repo/build (is it a
    Systema-Sanscriticum asset, an ORS-FAQ asset, or a separate LaTeX/book project?). Blocks
    wave 2's PDF render only — not wave 0/1.
-2. **PW / PD now-2026 re-export.** The kleineres PW headword list exists only as a 2014 export
-   ([`then-2014/PD-unique-key2-104941.txt`](https://github.com/gasyoun/SanskritLexicography/tree/master/HeadwordLists/then-2014)). Re-run the extractor for a current count before the vocabulary-size table is frozen.
+2. ~~**PW / PD now-2026 re-export.**~~ **DONE (verified 29-07-2026).** The kleineres PW
+   now-2026 re-export already exists —
+   [`now-2026/PD-unique-key1-104959.txt`](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/now-2026/PD-unique-key1-104959.txt) /
+   [`now-2026/PD-unique-key2-104968.txt`](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/now-2026/PD-unique-key2-104968.txt) —
+   superseding the 2014 export
+   ([`then-2014/PD-unique-key2-104941.txt`](https://github.com/gasyoun/SanskritLexicography/tree/master/HeadwordLists/then-2014)).
+   No further extractor run is needed before the vocabulary-size table is frozen.
 3. **samskrte.ru publish surface + rights.** samskrte.ru is Systema/LMS territory; confirm the
    publish surface and run [`/publish-safety-check`](https://github.com/gasyoun/claude-config/blob/main/commands/publish-safety-check.md) before go-live (wave 4).
 4. **Module 9 depth.** Decide whether best-effort samāsa typing (segmentation-based) is enough for


### PR DESCRIPTION
## Summary
- `papers/ROADMAP_SANSKRIT_IN_NUMBERS_2026_2027.md`: the PW/PD now-2026 headword re-export already exists (`HeadwordLists/now-2026/PD-unique-key1-104959.txt`, `PD-unique-key2-104968.txt` — line counts match filenames exactly). Section 8 item 2 marked done instead of an open prerequisite blocker; the §3.1 table count updated from the 2014 export figure to the current now-2026 figure.
- `docs/ROADMAP_SanskritLexicography_PWG_DATA_LAYERS_2026H2.md`: inlined the three MG `@DECIDE` gates blocking Wave 2 (RU-store quarantine re-translate-or-not, `senses_pwg.jsonl` full-corpus build scope, the untraceable "12 PWG typos" list) directly into the Wave 2 section, so the roadmap is self-contained instead of only being documented in `RussianTranslation/.ai_state.md` / Uprava GTD.

Part of the H1877 multi-repo roadmap-drift sweep.

## Test plan
- [x] Verified `HeadwordLists/now-2026/PD-unique-key1-104959.txt` (104959 lines) and `PD-unique-key2-104968.txt` (104968 lines) exist with names/counts matching the catalogued drift item.
- [x] Verified `.ai_state.md` and `RussianTranslation/.ai_state.md` framing of the three @DECIDEs and cross-checked against the roadmap doc's prior Wave 2 section (no @DECIDE detail present there before this change).
- [x] Dated headers bumped to 29-07-2026 on both edited files per the org dated-header convention.