### PR TITLE
fix(changelog): drop the stray [1.66.0] copy of the H1490 Heritage entry

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -976,14 +976,6 @@ PR: [#769](https://github.com/gasyoun/SanskritLexicography/pull/769) · Handoff:
   and draft [PR #744](https://github.com/gasyoun/SanskritLexicography/pull/744).
 
 ### Added
-- **Heritage (INRIA) frequency-tables ingest + diff (26-07-2026, H1490).** Roadmap
-  Phase 3: 7 `DATA/*.tsv` files decoded out of Heritage's internal WX romanization
-  (new WX→SLP1 transcoder) and diffed against VisualDCS's M1–M8 `dcs_full.sqlite`
-  and `RussianTranslation/src/corpus_lexicon.jsonl` — Spearman ρ 0.70–0.74 vs DCS
-  across surface-form/lemma/compound-stem series, 0.53 vs `corpus_lexicon`.
-  [`heritage_frequency_diff.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/heritage_frequency_diff.md) /
-  [`.tsv`](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/heritage_frequency_diff.tsv) /
-  [`heritage_freq_diff.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/HeadwordLists/heritage_freq_diff.py).
 
 ## [1.65.0] — 2026-07-26
 


### PR DESCRIPTION
The 8-line **Heritage (INRIA) frequency-tables ingest + diff (H1490)** entry sits byte-identically in **both** `[1.66.0]` and `[1.65.0]`. Surfaced by the changelog duplicate-entry guard ([#878](https://github.com/gasyoun/SanskritLexicography/pull/878)), whose CI job failed on arrival — correctly, since the duplicate is real and predates that PR.

## Attribution — and it inverts the naive answer

`git log -S` finds nothing: the duplicate arrived via a **merge**, and the pickaxe skips merges by default ([Uprava FINDINGS §246](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md) item iii). So the owner was derived from the underlying **work**: `d10beb57` ("H1490 Phase 3 — ingest Heritage frequency tables") is first contained by **v1.65.0** of 3 tags.

`[1.65.0]` therefore owns the entry; the `[1.66.0]` copy is the stray. That is the **opposite** of "keep the newest section" — guessing would have deleted the real entry and kept the stray.

## Removed as a WHOLE entry

Bullet line plus all 7 indented continuation lines. Deleting only the bullet line is exactly how [Systema #829](https://github.com/gasyoun/Systema-Sanscriticum/pull/829) orphaned five lines under a `### Added` heading.

| Check | After |
|---|---|
| Duplicated entries | **0** |
| Orphaned continuations | **0** |
| Diff | 8 deletions / 0 insertions |

Unblocks #878. Per H1850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
