### PR TITLE
docs(.ai_state): record the H1906/H1908/v4 gate rounds and the queued H1910

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -116,6 +116,58 @@ _Created: 09-07-2026 · Last updated: 30-07-2026_
 > session, so inter-model kappa is still unmeasured. **← resolved same day by H1901
 > below, which REVERSES this handoff's taxonomy ruling.**
 
+> **H1906 · H1908 · v4 🔴 EXECUTED 29/30-07-2026 (Opus 5 `claude-opus-5[1m]`)** — three
+> rounds of MG review on the step-8 gate sheet, each one a real defect:
+>
+> 1. **H1906 ([PR #879](https://github.com/gasyoun/SanskritLexicography/pull/879),
+>    [v1.105.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.105.0))** —
+>    v1 made a human re-derive by eye what the model had already computed. Worse: the typer
+>    **already stored a `why` on all 12,000 pairs** and the sheet discarded every one. New
+>    [`src/rv_divergence_explain.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/rv_divergence_explain.py)
+>    re-queries the 100 sheet items for a **verbatim** span per rendering + a Russian
+>    `why_ru` + an `asymmetry_note`. Spans are verified as exact substrings, never trusted:
+>    20 of 100 came back non-verbatim and are quoted rather than force-highlighted, with the
+>    count printed in the sheet itself.
+> 2. **H1908 ([PR #881](https://github.com/gasyoun/SanskritLexicography/pull/881),
+>    [v1.107.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.107.0))** —
+>    chronology is now first-class. Grassmann 1876–77 → Griffith 1896 → Geldner 1951–57 →
+>    Elizarenkova 1989–99, and each later translator could read the earlier, so a divergence
+>    between later and earlier is **not symmetric** — the later one often departs
+>    *knowingly*. ARCHITECTURE §3.5 defines the classes purely pairwise with no notion of
+>    precedence, so the taxonomy could not express this. Cards carry a deterministic
+>    chronology band and order the renderings earliest-first. Also states what R4's rights
+>    decision left implicit: Griffith 1896 is the layer's **only** English witness while the
+>    standard is Jamison–Brereton 2014, so every English-side finding rests on a translation
+>    **118 years** older than the standard (66 of 100 cards say so).
+> 3. **v4 ([PR #884](https://github.com/gasyoun/SanskritLexicography/pull/884),
+>    [v1.109.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.109.0))** —
+>    two contrast bugs, both mine and both the same mistake: v2/v3 set a `background` on
+>    `mark.rv-hit` / `.rv-why` / `.rv-asym` / `.rv-chrono` and left the foreground to
+>    `inherit`, giving white-on-yellow and pale-on-pale. Every coloured block now sets
+>    **both**. The 10-line subtitle is one line; methodology moved to the page end.
+>
+> **The live sheet is `review/rv_divergence_gate_2026-07-29-v4.html`** (v1–v3 superseded;
+> same 100 item ids throughout, so no vote is lost). Mirrored as a `@DO` in
+> [GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md) and
+> registered in [REVIEW_SHEETS_INDEX.md](https://github.com/gasyoun/Uprava/blob/main/REVIEW_SHEETS_INDEX.md).
+> **Step 9 (full 10,552-stanza run) stays queued behind the vote (R13) — never self-approved.**
+>
+> **Queued next: [H1910](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1910-Opus_RussianTranslation_rv-jamison-brereton-renou-fifth-witness_29.07.26.md)**
+> — MG lifted R4's copyright exclusion on Jamison–Brereton and asked for Renou in the
+> chronology. Both sources are now reachable, so the data blocker is gone and only parsing
+> remains: (a) archive.org OCR of all three J–B volumes — use the **`/download/`** path, not
+> `/stream/` (that returns the viewer page with HTML appended); 4.2 MB, and **10,590
+> stanza-like lines against 10,552 canonical** is the feasibility signal; (b) hymn headings
+> **cannot** be found by roman-numeral patterns — 2,303 matches are overwhelmingly
+> cross-references inside prose, and a parser built on them yields 767 hymns / 6,986 loci of
+> garbage (I built it before checking; do not rebuild it); (c) `rigvedacommentary.alc.ucla.edu`
+> (http only, HTTPS cert mismatch) is J&B's own **commentary**, not the translation — ~20
+> range-downloads across Book 1–10 plus an authoritative **Translation Corrections** page;
+> better for errata + a locus-keyed witness layer, not a replacement column. Renou's EVP is
+> likewise a **selective commentary** and must stay a witness: forcing it into a column would
+> fill it with `absent_from_source` and corrupt `omitted_by_one`, whose meaning depends on
+> absence being real. Renou half-built already — 2,213 mentions, 459 with quoted French.
+
 > **H1901 🔴 EXECUTED 29-07-2026 (Opus 5 `claude-opus-5[1m]`), isolated worktree** —
 > spike S2 closed on three model arms after the operator supplied an
 > `OPENROUTER_API_KEY`. Same seeded 50-stanza sample, 300 (stanza × pair) labels


### PR DESCRIPTION
Session-state catch-up for the three gate-sheet review rounds and the queued J–B/Renou work.

- **H1906** — v1 discarded the `why` the typer already stored on all 12,000 pairs; v2 adds verbatim spans + Russian explanations, with 20/100 non-verbatim quoted rather than force-highlighted.
- **H1908** — chronology made first-class (Grassmann 1876–77 → Griffith 1896 → Geldner 1951–57 → Elizarenkova 1989–99; later translators read the earlier, so divergence is not symmetric), plus the Jamison–Brereton gap stated: Griffith 1896 is the only English witness, 118 years behind the standard.
- **v4** — two contrast bugs, both mine and both the same mistake: backgrounds set without foregrounds, giving white-on-yellow and pale-on-pale. Header cut to one line.

Live sheet is `rv_divergence_gate_2026-07-29-v4.html`; step 9 stays queued behind the human vote (R13).

**H1910** queued with both sources reachable. Records the two probe traps so they are not re-walked: archive.org `/stream/` returns the viewer page (use `/download/`), and roman-numeral heading matching yields 767 hymns / 6,986 loci of garbage from prose cross-references. Also that `rigvedacommentary.alc.ucla.edu` is J&B's **commentary**, not the translation — valuable for errata and as a witness layer, not as a column.