### PR TITLE
H1940: re-affirm the 3 LANG_PARITY verdicts H1902 left drifting — master is green again

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,7 +10,36 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
-## [1.111.2] - 2026-07-30
+### Fixed — LANG_PARITY re-affirmed for the three files H1902 left drifting; master is green again (H1940, 30-07-2026)
+
+H1902 ([#892](https://github.com/gasyoun/SanskritLexicography/pull/892)) unified
+sibling-root resolution across `src/` but did not re-affirm the parity verdicts of
+the three tracked files it touched, so `lang_parity_check` reported **3 violations
+on master itself** and `test_lang_parity_ledger_complete` took the whole
+`window_selftest` suite red. Every PR opened since inherited that failure —
+[#893](https://github.com/gasyoun/SanskritLexicography/pull/893) is where it
+surfaced, though it neither caused nor could fix it (the three files are
+byte-identical between master and that branch).
+
+Each verdict was re-derived rather than rubber-stamped. H1902's edit is the same
+`+2/-1` substitution in all three files — the hard-coded
+`os.path.join(HERE,'..','..','..')` guess replaced by `sibling_root(HERE)` — and
+[`src/sibling_root.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/sibling_root.py)
+contains **no language-conditional logic whatsoever** (0 language tokens in 108
+lines). Since all three verdicts rest on *which language assets exist*, not on how
+paths resolve, none of their grounds moved:
+
+- `citation_tm_ru_translation_of_record` — INTENTIONAL-DIVERGENCE holds; `GITHUB`
+  feeds `CORPUS_DB` only, and no EN citation-TM corpus was assembled.
+- `corpus_gate_evidence_markers_fl7_h321` — INTENTIONAL-DIVERGENCE holds; the
+  marker mechanism and the wired authority set are unchanged, no Sanskrit-English
+  authority was added.
+- `genre_sense_join_h339` — SHARED holds, and is arguably *strengthened*: `GH`
+  feeds the shared German `pwg.txt`, and the removed hard-coded guess was
+  precisely what could resolve differently between checkouts.
+
+The reasoning is recorded in each ledger note, not only here. Gates after:
+`lang_parity_check` **88 entries, no drift**, `window_selftest` **193/193**.
 
 ### Fixed — FINDINGS citation-number collision from the H1910 propagation pass (30-07-2026)
 

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -88,10 +88,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "ru"
     ],
     "verdict": "INTENTIONAL-DIVERGENCE",
-    "note": "H1304: the citation translation-memory is RU-only by construction. The reuse assets are Russian translations of record (Elizarenkova RV, Leonov Ramayana, Ocean of Stories, ...); there is NO parallel English citation-TM corpus, so there is nothing to port to the EN path. If an EN citation-TM corpus is ever assembled, this becomes a GAP to port; until then RU-only is intended, not an oversight. H1717 (27-07-2026): re-affirmed after H1705/#823 split a new miss reason, ru-translation-unpublished, out of locus-not-in-corpus. The new reason is about Russian translations of record, RU-only by the same construction as the entry it lives under, and assembles no EN citation-TM corpus, so the verdict still holds; re-pinned (hash already re-verified in #837/b060e35a).",
+    "note": "H1304: the citation translation-memory is RU-only by construction. The reuse assets are Russian translations of record (Elizarenkova RV, Leonov Ramayana, Ocean of Stories, ...); there is NO parallel English citation-TM corpus, so there is nothing to port to the EN path. If an EN citation-TM corpus is ever assembled, this becomes a GAP to port; until then RU-only is intended, not an oversight. H1717 (27-07-2026): re-affirmed after H1705/#823 split a new miss reason, ru-translation-unpublished, out of locus-not-in-corpus. The new reason is about Russian translations of record, RU-only by the same construction as the entry it lives under, and assembles no EN citation-TM corpus, so the verdict still holds; re-pinned (hash already re-verified in #837/b060e35a). H1940 (30-07-2026): re-affirmed after H1902/#892 replaced the hard-coded os.path.join(HERE,'..','..','..') sibling-root guess with sibling_root(HERE). The edit is filesystem path resolution only (+2/-1 lines); GITHUB feeds CORPUS_DB (SamudraManthanam) and no citation-TM asset is added, removed or language-keyed. sibling_root.py contains no language-conditional logic at all (0 language tokens in 108 lines), so the RU-only-by-construction basis is untouched and the verdict stands.",
     "tracking": "",
     "verified_sha256": {
-      "src/citation_tm.py": "af4f42298469ccd36e037ef53fdfe818d0fd54a3e6a0618a6cc29f63b3b8baa1"
+      "src/citation_tm.py": "c2c81d97a91cbd2d14a49372bc45c6c8312ce1b0a8482273f0263ca1071693fe"
     }
   },
   {
@@ -611,10 +611,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "ru"
     ],
     "verdict": "INTENTIONAL-DIVERGENCE",
-    "note": "H321 (architecture audit FL7 / code review 2026-07-04 item #4). corpus_gate.py is the RU-only stage-4 correctness gate: it joins a PWG headword to the independent Sanskrit->RUSSIAN dictionaries (Кочергина/Кнауэр/Фриш/Смирнов/Коссович) and the SamudraManthanam RU-aligned verse corpus. The EN pilot has no analogous corpus gate (no Sanskrit-English authority set is wired here), so this fix is inherently Russian-only — an INTENTIONAL-DIVERGENCE, not a GAP to port. The marker mechanism (SOURCES_PRESENT / evidence_status() / corpus_examples_with_status) would generalize if an EN correctness gate is ever built; revisit then. Pinned by test_corpus_gate_evidence_and_db_markers.",
+    "note": "H321 (architecture audit FL7 / code review 2026-07-04 item #4). corpus_gate.py is the RU-only stage-4 correctness gate: it joins a PWG headword to the independent Sanskrit->RUSSIAN dictionaries (Кочергина/Кнауэр/Фриш/Смирнов/Коссович) and the SamudraManthanam RU-aligned verse corpus. The EN pilot has no analogous corpus gate (no Sanskrit-English authority set is wired here), so this fix is inherently Russian-only — an INTENTIONAL-DIVERGENCE, not a GAP to port. The marker mechanism (SOURCES_PRESENT / evidence_status() / corpus_examples_with_status) would generalize if an EN correctness gate is ever built; revisit then. Pinned by test_corpus_gate_evidence_and_db_markers. H1940 (30-07-2026): re-affirmed after H1902/#892 swapped the hard-coded sibling-root guess for sibling_root(HERE) (+2/-1 lines, path resolution only). GITHUB feeds CORPUS_DB; the SOURCES_PRESENT / evidence_status() / corpus_examples_with_status marker mechanism and the set of wired authorities are unchanged, and no Sanskrit-English authority set was added, so the INTENTIONAL-DIVERGENCE basis holds. Note this entry also tracks src/pilot/window_selftest.py, whose hash was NOT disturbed here.",
     "tracking": "",
     "verified_sha256": {
-      "src/corpus_gate.py": "65429923536739d8b0410092aa65a679ef7e8c69140ad0a3a95fa41ff0ec7a89",
+      "src/corpus_gate.py": "323af2fa393955f320d534111a92cf14270bb78c1044252b5858e7c39e8047ea",
       "src/pilot/window_selftest.py": "95e847ba8e2a549b3640ca0f94cb56146a42bd1fa06e6fd1e0d80fc3c84c2ac1"
     }
   },
@@ -871,10 +871,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "H339 (08-07-2026). The join reads <ls> citation markup shared verbatim by both RU and EN editions (renou.keys_in_text is the same siglum parser annotate_renou.py already treats as language-independent) and never touches translation text itself. Read-only over the store; selftest-gated.",
+    "note": "H339 (08-07-2026). The join reads <ls> citation markup shared verbatim by both RU and EN editions (renou.keys_in_text is the same siglum parser annotate_renou.py already treats as language-independent) and never touches translation text itself. Read-only over the store; selftest-gated. H1940 (30-07-2026): re-affirmed after H1902/#892 replaced the hard-coded sibling-root guess with sibling_root(HERE) (+2/-1 lines). GH feeds PWG_TXT — the shared German source text, not a per-language asset — and the resolver is language-independent, so both editions resolve the identical path by the identical rule. The SHARED verdict is if anything strengthened: the previous hard-coded guess was the thing that could silently resolve differently between checkouts (the git-worktree case H1902 fixed).",
     "tracking": "",
     "verified_sha256": {
-      "src/annotate_genres.py": "5eea7d5269c716d5c96ceb81be5c22358fe45542b066f66963a8fdd1562d89e3"
+      "src/annotate_genres.py": "75df2211d72b7486a3eff63f0205b05deeb1c726e29d8cafff729be013c994d0"
     }
   },
   {


### PR DESCRIPTION
Master itself has been failing `lang_parity_check` with **3 violations** since H1902 ([#892](https://github.com/gasyoun/SanskritLexicography/pull/892), `af299375`), which unified sibling-root resolution across `src/` without re-affirming the parity verdicts of the three tracked files it touched. That single failure also takes `test_lang_parity_ledger_complete` red, so the whole `window_selftest` suite reports 193/194 — and **every PR opened since inherits it**. It surfaced during H1940 Phase 1 verification of [#893](https://github.com/gasyoun/SanskritLexicography/pull/893), which neither caused it nor could fix it: the three files are byte-identical between `master` and that branch.

## Each verdict re-derived, not rubber-stamped

H1902 made the *same* `+2/-1` substitution in all three files — the hard-coded `os.path.join(HERE,'..','..','..')` guess replaced by `sibling_root(HERE)` — and [`src/sibling_root.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/sibling_root.py) contains **no language-conditional logic whatsoever** (0 language tokens across 108 lines). All three verdicts rest on *which language assets exist*, not on how paths resolve, so none of their grounds moved:

| Entry | Verdict | Why it still holds |
|---|---|---|
| `citation_tm_ru_translation_of_record` | INTENTIONAL-DIVERGENCE | `GITHUB` feeds `CORPUS_DB` only; no EN citation-TM corpus was assembled |
| `corpus_gate_evidence_markers_fl7_h321` | INTENTIONAL-DIVERGENCE | marker mechanism and wired authority set unchanged; no Sanskrit-English authority added |
| `genre_sense_join_h339` | SHARED | `GH` feeds the shared German `pwg.txt`; the removed hard-coded guess was precisely what could resolve differently between checkouts, so the verdict is arguably strengthened |

The reasoning is written into each ledger note in [`LANG_PARITY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/LANG_PARITY.md), not only into the changelog — a bare hash bump is what that ledger exists to prevent.

## Gates

- `python src/pilot/lang_parity_check.py` → **88 entries, all verdicts complete, no drift**; 25 language-aware files tracked or exempt
- `python src/pilot/window_selftest.py` → **193/193, 0 failed**

## Note for #893

`corpus_gate_evidence_markers_fl7_h321` also tracks `src/pilot/window_selftest.py`, whose hash is **not** disturbed here. [#893](https://github.com/gasyoun/SanskritLexicography/pull/893) does modify that file and stamps that entry itself, so once this merges, #893 needs a rebase with a keep-both resolution on `LANG_PARITY.md` (this side's `corpus_gate.py` hash + #893's `window_selftest.py` hash).

Handoff: [H1940](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1940-Opus_RussianTranslation_pwg-ru-h1811-integrate-verify_30.07.26.md) Phase 1. Model: Opus 5 (`claude-opus-5[1m]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)