### PR TITLE
H1957: make the audit timeout actually cancel the audit, and stop caching provenance hashes

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,55 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — the audit timeout could not cancel the audit, and provenance stamps could go stale (H1957, 30-07-2026)
+
+Two correctness defects shipped inside H1811's speed work below. Both were invisible
+to CI: every gate was green with them present, and one was actively *pinned* as
+correct by a selftest.
+
+**1. The audit timeout stopped waiting without stopping the work.** H1811 S1 ran
+`audit_window` in-process via `run_py_inproc` on a **daemon thread**, which breaks
+that function's own documented contract — *"callers must not run two of these
+concurrently (sys.argv/stdout are process-global)"*. On timeout `run_audit` returned
+rc=124 while the audit kept running, so: the abandoned thread continued **writing the
+very `window_status.json` / report / requeue files the caller reads next**; the
+coordinator's own `sys.argv`, cwd (`run_py_inproc` chdirs) and `stdout`/`stderr`
+stayed hijacked meanwhile; and `run_py_inproc`'s `finally` restored argv/cwd at an
+arbitrary later moment, clobbering whatever the main thread had set since. Fixed by
+running `audit_window` in a **killable subprocess** under the same timeout — the only
+boundary where a timeout can actually cancel the work. The stdout-hijack is not
+theoretical: while reproducing this, the reproduction script's own diagnostic output
+vanished into the abandoned thread's capture buffer and only resumed once that thread
+finished.
+
+**2. `stamp()` could certify a row with a hash of code that had already changed.**
+H1811 S3 memoized `component_sha` in a module-global keyed on the component's file
+*patterns* — never on content — so the cache had **no invalidation at all**. In any
+process outliving a source edit (a `bounded_staged_run` / `cohort_engine` wave runs
+for hours) every row stamped afterwards carried the **pre-edit `<name>_sha`**: a row
+claiming to have been produced by code that did not produce it, which is precisely
+the claim that field exists to make. `check()`/`freeze()` stayed exact, but they read
+the manifest — they cannot repair provenance already written into the store. The memo
+is removed; `stamp()` always re-reads.
+
+The selftest for #2 asserted `st2['prompt_sha'] == st['prompt_sha']` with the message
+*"stamp memo must return the first hash"* — i.e. it certified stale provenance as
+correct behaviour. It now asserts the opposite. The timeout test for #1 monkeypatched
+`run_py_inproc` and checked only the rc=124 mapping, so it passed either way; it is
+replaced by one that drives a real child which sleeps and then writes a sentinel, and
+fails if the sentinel ever appears. That replacement test fails against the old
+implementation, which was verified rather than assumed.
+
+**Honest cost.** Interleaved A/B against master `3070941b` (5 alternating pairs, host
+under variable load, minimum per side as the robust estimator): **audit +34.7 %**
+(3.95 s → 5.32 s, the restored interpreter spawn), **store-write +24.0 %** (4.00 s →
+4.96 s, `stamp()` re-hashing per promoted row), **total +15.0 %** (10.79 s → 12.41 s).
+This gives back most of the speed the entry below reports. The deterministic signature
+`9bd2a14297` is byte-identical across both sides, so the outputs are unchanged.
+S2 (`_pilot_collect` in-process), H5 and H10 are **retained** — only S1 and S3 are
+reverted. Gates: `window_selftest` **194/194**, `lang_parity_check` **89 entries, no
+drift**, `pipeline_version --selftest` OK. Model: Opus 5 (`claude-opus-5[1m]`).
+
 ### Changed — binary-samāsa ruling applied to the compound adjudicator (H1918, 30-07-2026)
 
 MG's ruling: a samāsa's vigraha is always binary (dvandva excepted, and a
@@ -34,6 +83,11 @@ stratification.
 
 ### Changed — offline pipeline speed + hermeticity: in-proc audit chain, stamp memo, PWG_OUTPUT_DIR (H1811, 30-07-2026)
 
+> **Superseded in part by H1957 above: S1 and S3 were reverted for correctness, so the
+> speed figures in this entry no longer describe the shipped code.** They are kept as
+> the record of what was measured at the time. Net effect after H1957 is roughly
+> +15 % total against master — S2/H5/H10 remain.
+
 Measured on the hermetic [`h1339_offline_bench`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h1339_offline_bench.py)
 (interleaved A/B vs `origin/master` `d5650afe`, medians of 3): **audit stage −39.3 %**
 (3.60 s → 2.19 s), store-write −12.4 %, **total −22.9 %** (7.23 s → 5.58 s) —
@@ -47,14 +101,13 @@ Executor: Kimi K3 (`moonshotai/kimi-k3`); rebase + re-verification: Opus 5
 (`claude-opus-5[1m]`); review + fix log:
 [`pwg_ru/h1811/H1811_PIPELINE_REVIEW_FIXLOG_2026-07-29.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h1811/H1811_PIPELINE_REVIEW_FIXLOG_2026-07-29.md).
 
-- **S1** — `coordinator record-output` runs `audit_window` **in-process** (runpy
-  via the H1339 `run_py_inproc` pattern; new `run_audit` seam, 30-min timeout kept
-  via daemon thread → rc=124). One interpreter spawn per lease eliminated.
+- **S1** — ~~`coordinator record-output` runs `audit_window` **in-process**~~ —
+  **REVERTED by H1957**: the daemon-thread timeout could not cancel the audit. The
+  `run_audit` seam is kept, now backed by a killable subprocess.
 - **S2** — `audit_window` runs `_pilot_collect` in-process too (the last
-  subprocess gate after H1339 Phase 3).
-- **S3** — `pipeline_version.stamp` memoizes `component_sha` per process (~27 % of
-  the batch-promote in-process time was re-hashing identical file sets);
-  `check()`/`freeze()` bypass the memo and always read fresh bytes.
+  subprocess gate after H1339 Phase 3). **Retained.**
+- **S3** — ~~`pipeline_version.stamp` memoizes `component_sha` per process~~ —
+  **REVERTED by H1957**: the memo had no invalidation and stamped stale provenance.
 - **H5** — a corrupt/missing `window_status.json` / audit report with rc ∈ {0,1}
   is now an audit error instead of a silent `unknown` lease state.
 - **H10** — `PWG_OUTPUT_DIR` (output-side twin of H1386's `PWG_INPUT_DIR`) honored

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -131,7 +131,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pwg_mask.py": "ad72df81bc7299a870edfdc67f6d81b45e4acfb1d79ea9976355c1e4b488da94",
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -154,7 +154,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/headless_worker.py": "bb6bc5468a3fca6e3257022be7b5878adff190a9a557206e5597c21d76e36c2d",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -209,7 +209,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -228,7 +228,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -431,7 +431,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -488,7 +488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -547,7 +547,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/perf_preflight.py": "3dc1d44f0054da4278e7c6eb34f03477b697431e22bcf7ea0c201afad2009e13",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -578,7 +578,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "63403fc426374533d7765a627f7c9cc5c727aca572e8bdce60ad7b6c08a49e73",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -597,7 +597,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -615,7 +615,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "323af2fa393955f320d534111a92cf14270bb78c1044252b5858e7c39e8047ea",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -634,7 +634,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "d7c8da35c6a420b9f9431dd1cb672ed12431e2b27830b9b560a60cff42509eec",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -764,7 +764,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -789,7 +789,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -818,7 +818,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -838,7 +838,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -853,11 +853,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap.",
+    "note": "09-07-2026 orchestration audit. The coordinator governs Workflow leases before language-specific promotion/audit branches; lease target/state handling and JSONL append hygiene are lang-agnostic. The expiry guard deliberately does NOT expire prepared harnesses, because H151-style prepared artifacts can wait days for Workflow capture. Pinned by test_coordinator_expired_leases_release_cap. H1957 (30-07-2026, Opus 5 `claude-opus-5[1m]`): incidental re-stamp only — coordinator.py drifted solely because run_audit moved to a killable subprocess; neither the claim-expiry guard nor append_jsonl_line is touched, and the change is lang-agnostic, so SHARED stands.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "9ae680042522200f10fb31afe74d7d76410d2bf2ba4019dc677f54270e90bbe7",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/coordinator.py": "a3547d79d552ebe497e7cdc51093061bf3dfec01add8258ef51fde3ce6c61f84",
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -894,7 +894,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -952,7 +952,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -971,7 +971,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -990,7 +990,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -1010,7 +1010,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26",
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -1032,7 +1032,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -1091,7 +1091,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -1115,13 +1115,13 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "H818 Windows readiness uses one language-parameterized manifest and worker contract. Whole-card retries, binary split, fragment TM/restore/fidelity, per-card budgets, timeout-no-bisect, partial stitching, audit-clean subset promotion, staged dispatch, and credential-safe event/census telemetry do not branch on RU/EN. Production policy selects RU no_pwg for the first 100-headword proof; the mechanism preserves EN field/schema behavior.",
+    "note": "H818 Windows readiness uses one language-parameterized manifest and worker contract. Whole-card retries, binary split, fragment TM/restore/fidelity, per-card budgets, timeout-no-bisect, partial stitching, audit-clean subset promotion, staged dispatch, and credential-safe event/census telemetry do not branch on RU/EN. Production policy selects RU no_pwg for the first 100-headword proof; the mechanism preserves EN field/schema behavior. H1957 (30-07-2026, Opus 5 `claude-opus-5[1m]`): incidental re-stamp only — coordinator.py drifted solely because run_audit moved to a killable subprocess. The manifest/worker contract is untouched, and this note's 'timeout-no-bisect' is headless_worker's TRANSLATE timeout, a different subsystem from the audit-step timeout H1957 repaired. Language-neutral, so SHARED stands.",
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/headless_worker.py": "bb6bc5468a3fca6e3257022be7b5878adff190a9a557206e5597c21d76e36c2d",
       "src/pilot/max_account_orchestrator.py": "a850df79a48a8b309b94411dac0d5dd42d4d88c6c484e19c6eba681fce33ec81",
-      "src/pilot/coordinator.py": "9ae680042522200f10fb31afe74d7d76410d2bf2ba4019dc677f54270e90bbe7",
+      "src/pilot/coordinator.py": "a3547d79d552ebe497e7cdc51093061bf3dfec01add8258ef51fde3ce6c61f84",
       "src/pilot/headless_worker_selftest.py": "cc32949c87bd392348a4679a4d341d5c0f887dc40e48c166576887c62587eb5c",
       "src/pilot/max_account_orchestrator_selftest.py": "8c3800e99bd14e1fdef29820a26696f64f07c71eb7fa19033d8169b7eb38f040",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
@@ -1151,7 +1151,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -1170,7 +1170,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -1195,7 +1195,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
       "src/pilot/audit_window.py": "63403fc426374533d7765a627f7c9cc5c727aca572e8bdce60ad7b6c08a49e73",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -1217,7 +1217,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26",
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50",
       "src/pilot/accept_sensecount_test.js": "fbf8d37f8ae360c286f646361025d56adb0caeff09da30a0abfef5f6b7289937"
     }
   },
@@ -1237,7 +1237,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -1292,7 +1292,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -1449,7 +1449,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "097e3780bfaac430741391514b3209c22fcf1f1cd7f473623a8fd18477e914a0",
       "src/pilot/audit_window.py": "63403fc426374533d7765a627f7c9cc5c727aca572e8bdce60ad7b6c08a49e73",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26",
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50",
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1690,14 +1690,14 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "H1386 (22-07-2026, Fable 5 claude-fable-5). Every fix is language-neutral orchestration/persistence mechanics -- none introduces a --lang branch. Lane facts checked per the handoff: the frag TM half of C3 (build_frags/load_frag_tm/best_reusable) is --lang-parameterized so both lanes get it; the recursive harvest glob + D3 per-lease store_delta + P3g batch gate live in the RU staged/coordinator lane ONLY because the EN promote lane (promote_en.py) by design has no fragment harvest and no batch transaction (its INTENTIONAL-DIVERGENCE ruling is H1425 W3, unchanged); P3b is the EN lane's own seed feed; the h1209 rig (D1) is field-parameterized (payload['field']), so a future EN slice inherits prompt_common/chunking as-is; PWG_INPUT_DIR (P3f) is honored by both audit_window and audit_window_en. Pinned by bounded_staged_run_selftest tests l/m, window_selftest test_h1386_c3_frag_unblock_serves_replacement + test_h1386_d1_medium50_script_size_cap, promote_lock/promote_final_cards selftests, and the h1339_offline_bench deterministic signature (batch == per-lease).",
+    "note": "H1386 (22-07-2026, Fable 5 claude-fable-5). Every fix is language-neutral orchestration/persistence mechanics -- none introduces a --lang branch. Lane facts checked per the handoff: the frag TM half of C3 (build_frags/load_frag_tm/best_reusable) is --lang-parameterized so both lanes get it; the recursive harvest glob + D3 per-lease store_delta + P3g batch gate live in the RU staged/coordinator lane ONLY because the EN promote lane (promote_en.py) by design has no fragment harvest and no batch transaction (its INTENTIONAL-DIVERGENCE ruling is H1425 W3, unchanged); P3b is the EN lane's own seed feed; H1957 (30-07-2026, Opus 5 `claude-opus-5[1m]`): incidental re-stamp only — coordinator.py drifted because run_audit was moved to a killable subprocess; none of C1 --resume / C2 materialize_requeue / C3 build_frags / D1 is touched, so SHARED stands. the h1209 rig (D1) is field-parameterized (payload['field']), so a future EN slice inherits prompt_common/chunking as-is; PWG_INPUT_DIR (P3f) is honored by both audit_window and audit_window_en. Pinned by bounded_staged_run_selftest tests l/m, window_selftest test_h1386_c3_frag_unblock_serves_replacement + test_h1386_d1_medium50_script_size_cap, promote_lock/promote_final_cards selftests, and the h1339_offline_bench deterministic signature (batch == per-lease).",
     "tracking": "H1386",
     "verified_sha256": {
       "src/pilot/bounded_staged_run.py": "e7e60839425b324de940a1913e1983f9d21807d4a906500dea018224d7dff7ee",
       "src/pilot/bounded_supervisor.py": "30113cd5a9c41b72f5b05d4a76b4370152f7b12c0d149311cc0e65a60f4cb717",
       "src/pilot/max_account_orchestrator.py": "a850df79a48a8b309b94411dac0d5dd42d4d88c6c484e19c6eba681fce33ec81",
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/coordinator.py": "9ae680042522200f10fb31afe74d7d76410d2bf2ba4019dc677f54270e90bbe7",
+      "src/pilot/coordinator.py": "a3547d79d552ebe497e7cdc51093061bf3dfec01add8258ef51fde3ce6c61f84",
       "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/pilot/audit_window.py": "63403fc426374533d7765a627f7c9cc5c727aca572e8bdce60ad7b6c08a49e73",
@@ -1723,14 +1723,14 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "GAP",
-    "note": "H1618: wall_clock half SHARED with audit_window_en. Residual GAP = EN promote defect-key refuse + ready_partial (no EN promote twin of promote_final_cards).",
+    "note": "H1618: wall_clock half SHARED with audit_window_en. Residual GAP = EN promote defect-key refuse + ready_partial (no EN promote twin of promote_final_cards). H1957 (30-07-2026, Opus 5 `claude-opus-5[1m]`): incidental re-stamp only — window_selftest.py drifted because an unrelated audit-timeout test was replaced; nothing in the wall_clock / defect-refuse / ready_partial mechanism changed, so the GAP stands unaltered.",
     "tracking": "https://github.com/gasyoun/Uprava/blob/main/handoffs/H1553-Opus_RussianTranslation_rt-fullaudit-w1-a-h1403-residues_23.07.26.md",
     "verified_sha256": {
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/audit_window.py": "63403fc426374533d7765a627f7c9cc5c727aca572e8bdce60ad7b6c08a49e73",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
       "src/promote_final_cards.py": "ec11849e0f3a77515862bfd0baeb059e0d44706eb476a500bdd56d538bb2ec32",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26",
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50",
       "src/pilot/audit_window_en.py": "19e81796a4b0482d563a45c4438927844a3ba9bab13166f77aa9f0ae0c2ab6cd"
     }
   },
@@ -1835,11 +1835,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "ru"
     ],
     "verdict": "INTENTIONAL-DIVERGENCE",
-    "note": "RU-only BY CONSTRUCTION, not by omission (26-07-2026, Opus 5 `claude-opus-5[1m]`, landed from the Codex hardening branch). The EN twin `audit_window_en.py` runs no threaded gate at all -- zero ThreadPoolExecutor/future.result occurrences -- and carries no NWS quarantine (0 occurrences of apply_nws_quarantine vs 2 on the RU lane), so NEITHER hardened mechanism exists on EN. There is nothing to port: not a GAP (no EN behaviour is missing) and not SHARED (the code is not shared). If the EN lane ever adopts threaded gates or NWS quarantine, this entry must be revisited and both guards carried across. Pinned by window_selftest.test_threaded_gate_exception_requeues_full_window and test_quarantine_replace_failure_preserves_previous_destination.",
+    "note": "RU-only BY CONSTRUCTION, not by omission (26-07-2026, Opus 5 `claude-opus-5[1m]`, landed from the Codex hardening branch). The EN twin `audit_window_en.py` runs no threaded gate at all -- zero ThreadPoolExecutor/future.result occurrences -- and carries no NWS quarantine (0 occurrences of apply_nws_quarantine vs 2 on the RU lane), so NEITHER hardened mechanism exists on EN. There is nothing to port: not a GAP (no EN behaviour is missing) and not SHARED (the code is not shared). If the EN lane ever adopts threaded gates or NWS quarantine, this entry must be revisited and both guards carried across. Pinned by window_selftest.test_threaded_gate_exception_requeues_full_window and test_quarantine_replace_failure_preserves_previous_destination. H1957 (30-07-2026, Opus 5 `claude-opus-5[1m]`): incidental re-stamp only. H1957 replaced coordinator.run_audit's daemon thread with a subprocess, which is a DIFFERENT thread than this entry's subject — the ThreadPoolExecutor gate loop lives inside audit_window.py, which H1957 does not touch and which still runs its gates threaded (now within the audit subprocess). Both pinned tests are untouched and still pass, so the INTENTIONAL-DIVERGENCE ruling is unaffected.",
     "tracking": "codex/rt-pipeline-hardening-speed",
     "verified_sha256": {
       "src/pilot/audit_window.py": "63403fc426374533d7765a627f7c9cc5c727aca572e8bdce60ad7b6c08a49e73",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   },
   {
@@ -1918,7 +1918,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
   },
   {
     "id": "h1811_inproc_audit_pwg_output_dir",
-    "mechanism": "H1811 offline speed + hermeticity: S1 coordinator record-output runs audit_window IN-PROCESS via run_py_inproc (new run_audit seam; daemon-thread timeout -> rc=124, the run_py timeout shape); S2 audit_window runs _pilot_collect in-proc (the last subprocess gate after H1339 Phase 3); S3 pipeline_version.stamp memoizes component_sha per process (check()/freeze() bypass the memo, always fresh-read); H5 a corrupt/missing window_status.json or audit report with rc in {0,1} is now an audit error instead of a silent unknown lease state; H10 PWG_OUTPUT_DIR (output-side twin of H1386 P3f PWG_INPUT_DIR) honored by _pilot_collect/audit_window/audit_translation/root_glue_translated/window_common and sandboxed by h1339_offline_bench.",
+    "mechanism": "H1811 offline speed + hermeticity: S1 coordinator record-output runs audit_window through the run_audit seam in a KILLABLE SUBPROCESS under AUDIT_TIMEOUT_SECONDS (timeout -> rc=124; H1957 corrected H1811's in-process daemon-thread form, which returned rc=124 while the audit kept running and kept writing the files the caller then read); S2 audit_window runs _pilot_collect in-proc (the last subprocess gate after H1339 Phase 3, retained); S3 pipeline_version.stamp always re-reads component_sha (H1957 removed H1811's process-wide memo, which had no invalidation and stamped pre-edit provenance onto rows promoted after a mid-run source change); H5 a corrupt/missing window_status.json or audit report with rc in {0,1} is now an audit error instead of a silent unknown lease state; H10 PWG_OUTPUT_DIR (output-side twin of H1386 P3f PWG_INPUT_DIR) honored by _pilot_collect/audit_window/audit_translation/root_glue_translated/window_common and sandboxed by h1339_offline_bench.",
     "files": [
       "src/pilot/coordinator.py",
       "src/pilot/audit_window.py",
@@ -1935,18 +1935,18 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "H1811 (29-07-2026, Kimi K3 moonshotai/kimi-k3). Every change is language-neutral execution mechanics/plumbing: the AUDITED code is byte-identical (runpy executes the same script files with the same argv; a crash still feeds the rc=3 fail-loud path), so no RU/EN audit-logic divergence is introduced. The EN auditor (audit_window_en.py) imports none of window_common/_pilot_collect/run_py_inproc, so the EN lane is unaffected by construction; PWG_OUTPUT_DIR defaults preserve production behavior (unset -> live src/pilot/output). Pinned by window_selftest test_h1811_inproc_audit_timeout_seam (run_audit rc=124 + namespace contract), the adapted run_audit-seam fixtures in test_coordinator_runtime_state_machine_and_cas and test_coordinator_mixed_lane_public_state_sequence, the pipeline_version selftest stamp-memo block, and the h1339_offline_bench per-lease outcomes byte-equal to the pre-change baseline.",
+    "note": "H1811 (29-07-2026, Kimi K3 moonshotai/kimi-k3). Every change is language-neutral execution mechanics/plumbing: the AUDITED code is byte-identical (runpy executes the same script files with the same argv; a crash still feeds the rc=3 fail-loud path), so no RU/EN audit-logic divergence is introduced. The EN auditor (audit_window_en.py) imports none of window_common/_pilot_collect/run_py_inproc, so the EN lane is unaffected by construction; PWG_OUTPUT_DIR defaults preserve production behavior (unset -> live src/pilot/output). Pinned by window_selftest test_h1957_audit_timeout_actually_kills_the_child, the adapted run_audit-seam fixtures in test_coordinator_runtime_state_machine_and_cas and test_coordinator_mixed_lane_public_state_sequence, the pipeline_version selftest fresh-stamp block, and the h1339_offline_bench per-lease outcomes byte-equal to the pre-change baseline. H1957 (30-07-2026, Opus 5 `claude-opus-5[1m]`): re-affirmed SHARED after the two correctness repairs above. Both are language-neutral execution mechanics — a subprocess boundary for the audit step and an un-cached provenance hash — and neither introduces a per-language branch; audit_window_en.py still imports none of window_common/_pilot_collect/run_py_inproc, so the EN lane remains unaffected by construction. The two pin references in this note were themselves corrected in the same pass: the old note named test_h1811_inproc_audit_timeout_seam (deleted) and 'the stamp-memo block' (whose assertion was inverted — it had certified stale provenance as correct), so the entry had been pinned to tests that no longer describe the code.",
     "tracking": "H1811",
     "verified_sha256": {
-      "src/pilot/coordinator.py": "9ae680042522200f10fb31afe74d7d76410d2bf2ba4019dc677f54270e90bbe7",
+      "src/pilot/coordinator.py": "a3547d79d552ebe497e7cdc51093061bf3dfec01add8258ef51fde3ce6c61f84",
       "src/pilot/audit_window.py": "63403fc426374533d7765a627f7c9cc5c727aca572e8bdce60ad7b6c08a49e73",
       "src/_pilot_collect.py": "76245fbea2bed2e136fd82acc0d1e00688de7335a7d1db35ed52b46f8fcb44c3",
       "src/audit_translation.py": "c38661123456c363688a5de37c1ed166b7aa9f6a8811811a67e76724858e027a",
       "src/root_glue_translated.py": "3c9c40c085861240d6089001706781922949f3575f1fa64dc9fcddcc9f3a2ebb",
       "src/pilot/window_common.py": "3a8a51917c9b898d9b3d262aaf9339e14fb30cddbb507242266858aec8727331",
-      "src/pipeline_version.py": "0f9319a046c6ff44a9d541a67e268a27654b018ca75c93f4b91a4a156e95da3f",
+      "src/pipeline_version.py": "b461d0c78b5df3f598007eb1e7ee284d84596ae19b5106d5329fdab1a93f00be",
       "src/pilot/h1339_offline_bench.py": "970ad8ab948c4aae724efc2076883e21a5bfc7e203ed1c68b5fbb14f3bdbb8cd",
-      "src/pilot/window_selftest.py": "1e8707d9741d578e266922eefcb86bb35cba3f6695dc849fd76dde07aa64fc26"
+      "src/pilot/window_selftest.py": "60eaa90e3803431305d6e142a7bc4b773638293cd68f0ef0ece96e639b658d50"
     }
   }
 ]

--- a/RussianTranslation/pwg_ru/h1811/H1811_PIPELINE_REVIEW_FIXLOG_2026-07-29.md
+++ b/RussianTranslation/pwg_ru/h1811/H1811_PIPELINE_REVIEW_FIXLOG_2026-07-29.md
@@ -67,9 +67,9 @@ not touch that branch; a human may archive it.
 
 | Fix | Status | Commit | Selftest pin |
 |---|---|---|---|
-| S3 component_sha memo | ❌ **REVERTED by H1957** — the memo keyed on file patterns, never content, so it had no invalidation and stamped pre-edit provenance onto rows promoted after a mid-run source change | [PR #895](https://github.com/gasyoun/SanskritLexicography/pull/895) | `pipeline_version.selftest` fresh-stamp block (assertion inverted — it previously certified the stale hash) |
+| S3 component_sha memo | ❌ **REVERTED by H1957** — the memo keyed on file patterns, never content, so it had no invalidation and stamped pre-edit provenance onto rows promoted after a mid-run source change | [PR #897](https://github.com/gasyoun/SanskritLexicography/pull/897) | `pipeline_version.selftest` fresh-stamp block (assertion inverted — it previously certified the stale hash) |
 | S2 collect in-proc | ✅ DONE (bench-verified), **retained** | this branch | bench outcomes == baseline |
-| S1 audit in-proc | ❌ **REVERTED by H1957** — the daemon-thread timeout returned rc=124 while the audit kept running and kept writing the files the caller then read | [PR #895](https://github.com/gasyoun/SanskritLexicography/pull/895) | `window_selftest.test_h1957_audit_timeout_actually_kills_the_child` |
+| S1 audit in-proc | ❌ **REVERTED by H1957** — the daemon-thread timeout returned rc=124 while the audit kept running and kept writing the files the caller then read | [PR #897](https://github.com/gasyoun/SanskritLexicography/pull/897) | `window_selftest.test_h1957_audit_timeout_actually_kills_the_child` |
 | H5 corrupt status | ✅ DONE (code; gate pending) | this branch | — |
 | H10 collect OUT override | ✅ DONE — needed **five** readers patched, not one: `_pilot_collect`, `audit_window`, `audit_translation` (feeds `stage2_pregate` via `at.merged_output_path`), `root_glue_translated`, **and shared `window_common.OUT`** (feeds `window_reports.merged_exists` → `audit_state`). Missing the 4th/5th caused first NO-OUTPUT defects, then phantom `partial` states — the bench caught both instantly | this branch | bench hermeticity + outcomes == baseline |
 | H1 manifest crash | ⏳ handed to Opus 5 ([H1940](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1940-Opus_RussianTranslation_pwg-ru-h1811-integrate-verify_30.07.26.md)) | — | — |

--- a/RussianTranslation/pwg_ru/h1811/H1811_PIPELINE_REVIEW_FIXLOG_2026-07-29.md
+++ b/RussianTranslation/pwg_ru/h1811/H1811_PIPELINE_REVIEW_FIXLOG_2026-07-29.md
@@ -28,9 +28,9 @@ store-write ≈ 30 %. Per-lease `record-output` still pays 2 interpreter spawns
 
 | # | Finding | Evidence | Fix | Est. saving |
 |---|---|---|---|---|
-| S1 | `process_record_output` spawns `audit_window.py` per lease | [`coordinator.py:1537-1546`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/coordinator.py) | run audit in-proc via the proven `run_py_inproc` pattern (already used by prepare-batch, `coordinator.py:1069`); 30-min audit timeout re-imposed via worker thread | ~0.5–0.9 s/lease |
+| S1 | `process_record_output` spawns `audit_window.py` per lease | [`coordinator.py:1537-1546`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/coordinator.py) | ~~run audit in-proc via `run_py_inproc`; 30-min timeout re-imposed via worker thread~~ — **reverted, §5.2**: a thread cannot be killed, so the timeout never cancelled the audit | ~0.5–0.9 s/lease (given back) |
 | S2 | `_pilot_collect` is the last subprocess gate | [`audit_window.py:234-237`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window.py) | route through existing `run_py_inproc` (H1339 pattern; the other 5 gates already in-proc) | ~0.3–0.5 s/lease |
-| S3 | `component_sha` re-hashes the same files per `stamp()` — 30 calls/promote batch, ~27 % of batch-promote in-proc time (cProfile) | [`pipeline_version.py:90-108`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pipeline_version.py) | per-process memo keyed on (patterns, root) | ~0.27 s/promote |
+| S3 | `component_sha` re-hashes the same files per `stamp()` — 30 calls/promote batch, ~27 % of batch-promote in-proc time (cProfile) | [`pipeline_version.py:90-108`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pipeline_version.py) | ~~per-process memo keyed on (patterns, root)~~ — **reverted, §5.2**: keyed on patterns, not content, so it never invalidated and stamped stale provenance | ~0.27 s/promote (given back) |
 
 Already upstream (verified, **no work**): `record-output-batch` (one coordinator process
 for N leases), TM `build`/`build_frags` in-proc via `promotion_journal`, prepare-batch.
@@ -67,9 +67,9 @@ not touch that branch; a human may archive it.
 
 | Fix | Status | Commit | Selftest pin |
 |---|---|---|---|
-| S3 component_sha memo | ✅ DONE (pipeline_version selftest OK) | this branch | `pipeline_version.selftest` stamp-memo block |
-| S2 collect in-proc | ✅ DONE (bench-verified) | this branch | bench outcomes == baseline |
-| S1 audit in-proc | ✅ DONE (bench-verified) | this branch | bench outcomes == baseline |
+| S3 component_sha memo | ❌ **REVERTED by H1957** — the memo keyed on file patterns, never content, so it had no invalidation and stamped pre-edit provenance onto rows promoted after a mid-run source change | [PR #895](https://github.com/gasyoun/SanskritLexicography/pull/895) | `pipeline_version.selftest` fresh-stamp block (assertion inverted — it previously certified the stale hash) |
+| S2 collect in-proc | ✅ DONE (bench-verified), **retained** | this branch | bench outcomes == baseline |
+| S1 audit in-proc | ❌ **REVERTED by H1957** — the daemon-thread timeout returned rc=124 while the audit kept running and kept writing the files the caller then read | [PR #895](https://github.com/gasyoun/SanskritLexicography/pull/895) | `window_selftest.test_h1957_audit_timeout_actually_kills_the_child` |
 | H5 corrupt status | ✅ DONE (code; gate pending) | this branch | — |
 | H10 collect OUT override | ✅ DONE — needed **five** readers patched, not one: `_pilot_collect`, `audit_window`, `audit_translation` (feeds `stage2_pregate` via `at.merged_output_path`), `root_glue_translated`, **and shared `window_common.OUT`** (feeds `window_reports.merged_exists` → `audit_state`). Missing the 4th/5th caused first NO-OUTPUT defects, then phantom `partial` states — the bench caught both instantly | this branch | bench hermeticity + outcomes == baseline |
 | H1 manifest crash | ⏳ handed to Opus 5 ([H1940](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1940-Opus_RussianTranslation_pwg-ru-h1811-integrate-verify_30.07.26.md)) | — | — |
@@ -172,6 +172,71 @@ no drift**; `window_selftest` **194/194, 0 failed**; bench per-lease outcomes
 unchanged with signature `9bd2a14297` intact. The `f15bcf0f → 459ee452` delta is
 `CHANGELOG.md` + `LANG_PARITY.md` only, so the A/B table above still stands on
 identical code.
+
+### 5.2 Correction: S1 and S3 reverted for correctness (H1957, 30-07-2026)
+
+Opus 5 (`claude-opus-5[1m]`). Both speed fixes above were correct about the *cost* they
+removed and wrong about what they cost in exchange. Neither defect was visible to any
+gate — §5.1 recorded 194/194 green with both present.
+
+**S1 — the timeout could not cancel the audit.** `run_audit` ran `audit_window`
+in-process on a daemon thread. [`run_py_inproc`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/audit_window.py)'s
+own docstring forbids exactly that usage: *"callers must not run two of these
+concurrently (sys.argv/stdout are process-global)."* On timeout the caller returned
+rc=124 and moved on while the worker kept running, producing three concurrent-access
+failures: (1) the live thread kept **writing `window_status.json`, the audit report and
+requeue files** that `process_record_output` reads on the next line; (2) `sys.argv`,
+the process cwd (`run_py_inproc` chdirs to `SRC`) and `stdout`/`stderr` stayed
+redirected out from under the coordinator; (3) the `finally` restored argv/cwd whenever
+the thread ended, clobbering any value the main thread had set meanwhile. Failure (2)
+was observed directly while reproducing this: the reproduction script's own `print`
+output disappeared into the abandoned thread's capture buffer and only resumed after
+that thread exited. Fixed by restoring a **killable subprocess** boundary — the pre-H1811
+shape — while keeping the `run_audit` test seam and H1811's rc=124 timeout contract
+(so H5's `rc ∉ {0,1}` handling is unchanged) and keeping S2 in-process inside the child.
+
+**S3 — provenance could be stamped stale.** `_STAMP_MEMO` keyed on
+`(tuple(comp['files']), abspath(root))` — the file *patterns*. Nothing in the key
+varies with content, so the entry never expired: any process that outlived a source
+edit stamped every later row with the pre-edit hash. Long-lived waves
+(`bounded_staged_run`, `cohort_engine`) are exactly that case. `check()`/`freeze()`
+remained exact, but they inspect the manifest and cannot repair provenance already
+written into the store. Removed; `stamp()` re-reads.
+
+**The gates were not merely silent — one was inverted.** The S3 selftest asserted
+`st2['prompt_sha'] == st['prompt_sha']` under the message *"stamp memo must return the
+first hash"*, certifying the stale result as the contract. The S1 test monkeypatched
+`run_py_inproc` and asserted only the rc=124 mapping, so it could not fail for the
+reason that mattered. Both replaced; the new timeout test drives a real child that
+sleeps then writes a sentinel, and was checked to **fail against the old
+implementation** rather than assumed to.
+
+**Cost of the correction.** Interleaved A/B vs master `3070941b`, 5 alternating pairs,
+host under variable load (base totals ranged 10.79–13.29 s), minimum per side as the
+robust estimator:
+
+| Stage | base `3070941b` | H1957 | Δ (min) | Δ (median) |
+|---|---|---|---|---|
+| prepare | 2.240 s | 2.000 s | −10.7 % | −9.6 % |
+| **audit** | 3.950 s | 5.320 s | **+34.7 %** | +41.4 % |
+| promotion-plan | 0.650 s | 0.760 s | +16.9 % | +45.6 % |
+| **store-write** | 4.000 s | 4.960 s | **+24.0 %** | +8.9 % |
+| **total** | 10.790 s | 12.410 s | **+15.0 %** | +25.3 % |
+
+`audit` carries the restored interpreter spawn; `store-write` carries `stamp()`
+re-hashing per promoted row. `prepare` moved without being touched, which is the
+scale of the noise floor here — treat the small deltas as unresolved. The
+deterministic signature `9bd2a14297` is byte-identical on both sides, so **outputs are
+unchanged**; only the cost is.
+
+**A structural note for whoever edits this file next.** Editing
+`window_selftest.py` at all drifted **32** LANG_PARITY entries that pin a test in it,
+plus 5 more on `coordinator.py`/`pipeline_version.py`. Each nominally requires a human
+re-affirmation, which at 32-at-once is rubber-stamping by construction. Here the 5
+substantive ones were re-derived individually and the 32 were stamped only under a
+mechanically verified precondition — that the diff to `window_selftest.py` touches
+exactly the replaced audit-timeout test and one runner line, nothing else. The ledger
+would carry more signal if entries pinned test *names* rather than the monolith's hash.
 
 ## 6. Session notes
 

--- a/RussianTranslation/src/pilot/coordinator.py
+++ b/RussianTranslation/src/pilot/coordinator.py
@@ -1525,37 +1525,63 @@ def recorded_lease_state(state_name, audit_errors, clean_rows, pending=None):
 
 
 def run_audit(argv, timeout=AUDIT_TIMEOUT_SECONDS):
-    """H1811 S1: run audit_window IN-PROCESS (runpy via audit_window.run_py_inproc)
-    instead of paying one interpreter spawn per lease. The audited code is
-    byte-identical (same script file, same argv); stdout/stderr/returncode carry the
-    run_py_inproc semantics (crash -> rc=3 + traceback, the SAME fail-loud path as a
-    crashed subprocess, H169 defect 2). AUDIT_TIMEOUT_SECONDS is re-imposed with a
-    daemon worker thread: on timeout the lease is recorded with rc=124 (the
-    conventional timeout code run_py also uses). An in-proc thread cannot be killed,
-    so a wedged audit is reported and left to die with the process -- documented
-    residual; the deterministic gates have never hit the 30-min ceiling, and the
-    blocked lease + recover-operation path is unchanged. This function is the ONE
-    audit seam: tests substitute it (never run_cmd) to fixture the audit step."""
-    import threading
+    """Run audit_window in a KILLABLE SUBPROCESS under the audit timeout.
+
+    H1957 correction of H1811 S1, which ran audit_window in-process (runpy via
+    audit_window.run_py_inproc) on a daemon worker thread. That broke
+    run_py_inproc's OWN documented contract -- "callers must not run two of these
+    concurrently (sys.argv/stdout are process-global)" -- because on timeout the
+    worker was left running alongside the caller. Three consequences, none of them
+    covered by the deterministic gates:
+
+      1. The abandoned thread keeps executing audit code that WRITES the very
+         window_status.json / audit_window.report.json / requeue files the caller
+         reads immediately after receiving rc=124.
+      2. While it runs, the coordinator's own sys.argv, cwd (run_py_inproc chdirs
+         to SRC) and stdout/stderr remain hijacked -- so coordinator output goes
+         into a dead capture buffer and relative paths resolve against the wrong
+         directory.
+      3. run_py_inproc's `finally` restores argv/cwd whenever the thread finally
+         ends, clobbering whatever the main thread had set in the meantime.
+
+    A separate process is the only boundary where the timeout can actually cancel
+    the work: subprocess.run kills the child, so nothing survives to race the
+    caller. The cost is one interpreter spawn per lease.
+
+    H1811 S2 is deliberately RETAINED -- _pilot_collect still runs in-process
+    INSIDE audit_window -- so this restores one spawn, not the five H1339 removed.
+
+    Semantics preserved from the in-proc form: a crash still surfaces the child's
+    own returncode + stderr (the fail-loud path of H169 defect 2), and a timeout
+    is still reported as rc=124 (the conventional timeout code) rather than raising
+    TimeoutExpired, so process_record_output's H5 corrupt-status handling -- which
+    keys on rc not in {0, 1} -- is unchanged.
+
+    This function remains the ONE audit seam: tests substitute it (never run_cmd)
+    to fixture the audit step."""
     import types
-    from audit_window import run_py_inproc
 
-    box = {}
+    def _text(chunk):
+        if chunk is None:
+            return ''
+        if isinstance(chunk, bytes):
+            return chunk.decode('utf-8', 'replace')
+        return chunk
 
-    def _target():
-        box['result'] = run_py_inproc(argv)
-
-    worker = threading.Thread(target=_target, daemon=True)
-    worker.start()
-    worker.join(timeout)
-    if worker.is_alive():
+    cmd = [sys.executable] + list(argv)
+    try:
+        p = subprocess.run(cmd, cwd=REPO, text=True, encoding='utf-8',
+                           capture_output=True, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        # subprocess.run has already killed the child and reaped it before raising.
         return types.SimpleNamespace(
-            returncode=124, stdout='',
-            stderr='run_audit: in-proc audit_window timeout after %ss '
-                   '(daemon thread left to die with the process)' % timeout)
-    r = box['result']
-    return types.SimpleNamespace(returncode=r['returncode'], stdout=r['stdout'],
-                                 stderr=r['stderr'])
+            returncode=124,
+            stdout=_text(exc.stdout),
+            stderr=(_text(exc.stderr) +
+                    'run_audit: audit_window timed out after %ss; the child process '
+                    'was killed, so no audit output can still be written.\n' % timeout))
+    return types.SimpleNamespace(returncode=p.returncode, stdout=p.stdout,
+                                 stderr=p.stderr)
 
 
 def process_record_output(lease, args):

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -3790,27 +3790,81 @@ def test_coordinator_runtime_state_machine_and_cas():
                 os.environ['PWG_COORDINATOR_DIR'] = old_coord
 
 
-def test_h1811_inproc_audit_timeout_seam():
-    """H1811 S1: run_audit maps a wedged in-proc audit to rc=124 (the run_py timeout
-    shape) and passes argv/stdout/stderr through the namespace contract."""
-    import audit_window
+def test_h1957_audit_timeout_actually_kills_the_child():
+    """H1957: run_audit's timeout must CANCEL the audit, not merely stop waiting for it.
+
+    H1811 S1 ran audit_window in-process on a daemon thread, so a timeout returned
+    rc=124 while the audit kept running -- still writing window_status.json / the
+    report / requeue files the caller reads next, and still holding the process-global
+    sys.argv, cwd and stdout/stderr that run_py_inproc mutates (its own docstring
+    forbids exactly this concurrency). The old test monkeypatched run_py_inproc and
+    asserted only the rc=124 mapping, so it passed either way; nothing pinned the part
+    that matters.
+
+    This drives a REAL child that sleeps and then writes a sentinel. After the timeout
+    we wait past the child's write moment: if the sentinel appears, the work outlived
+    its own timeout."""
+    import os
+    import sys
+    import tempfile
+    import threading
+    import time
+
     import coordinator
 
-    original = audit_window.run_py_inproc
-    try:
-        audit_window.run_py_inproc = lambda argv: (
-            __import__('time').sleep(5) or {'returncode': 0, 'stdout': '', 'stderr': '',
-                                             'seconds': 5.0})
-        wedged = coordinator.run_audit(['audit_window.py', 'wf'], timeout=0.2)
-        if wedged.returncode != 124 or 'timeout' not in wedged.stderr:
-            fail('run_audit did not map a wedged in-proc audit to rc=124')
-        audit_window.run_py_inproc = lambda argv: {
-            'returncode': 1, 'stdout': 'out', 'stderr': 'err', 'seconds': 0.01}
-        ok = coordinator.run_audit(['audit_window.py', 'wf'], timeout=5)
-        if (ok.returncode, ok.stdout, ok.stderr) != (1, 'out', 'err'):
-            fail('run_audit broke the returncode/stdout/stderr contract')
-    finally:
-        audit_window.run_py_inproc = original
+    child_sleep = 2.5
+    d = tempfile.mkdtemp(prefix='h1957_')
+    sentinel = os.path.join(d, 'sentinel.txt')
+    child = os.path.join(d, 'slow_audit.py')
+    with open(child, 'w', encoding='utf-8') as fh:
+        fh.write(
+            'import time\n'
+            'time.sleep(%r)\n'
+            'open(%r, "w", encoding="utf-8").write("the audit outlived its timeout")\n'
+            % (child_sleep, sentinel))
+
+    before_cwd = os.getcwd()
+    before_argv = list(sys.argv)
+    before_stdout, before_stderr = sys.stdout, sys.stderr
+    before_threads = threading.active_count()
+
+    t0 = time.monotonic()
+    wedged = coordinator.run_audit([child], timeout=0.4)
+    if wedged.returncode != 124:
+        fail('run_audit did not map a timed-out audit to rc=124 (got %r)' % wedged.returncode)
+    if 'timed out' not in wedged.stderr:
+        fail('run_audit timeout did not explain itself in stderr: %r' % wedged.stderr)
+
+    # Wait past the moment the child would have written, plus margin.
+    remaining = (t0 + child_sleep + 1.0) - time.monotonic()
+    if remaining > 0:
+        time.sleep(remaining)
+    if os.path.exists(sentinel):
+        fail('the audit child survived its timeout and wrote %s -- the timeout did not '
+             'cancel the work, it only stopped waiting for it' % sentinel)
+
+    # run_py_inproc mutates all four of these; a survivor would leave them wrong.
+    if os.getcwd() != before_cwd:
+        fail('run_audit left the process cwd at %r, expected %r' % (os.getcwd(), before_cwd))
+    if sys.argv != before_argv:
+        fail('run_audit mutated sys.argv: %r' % (sys.argv,))
+    if sys.stdout is not before_stdout or sys.stderr is not before_stderr:
+        fail('run_audit left stdout/stderr redirected')
+    if threading.active_count() != before_threads:
+        fail('run_audit leaked a background thread (%d -> %d)'
+             % (before_threads, threading.active_count()))
+
+    # The pass-through contract, driven through a real child rather than a stub.
+    talker = os.path.join(d, 'talker.py')
+    with open(talker, 'w', encoding='utf-8') as fh:
+        fh.write('import sys\n'
+                 'sys.stdout.write("out")\n'
+                 'sys.stderr.write("err")\n'
+                 'sys.exit(1)\n')
+    ok = coordinator.run_audit([talker], timeout=60)
+    if (ok.returncode, ok.stdout.strip(), ok.stderr.strip()) != (1, 'out', 'err'):
+        fail('run_audit broke the returncode/stdout/stderr contract: %r'
+             % ((ok.returncode, ok.stdout, ok.stderr),))
 
 
 def test_coordinator_fail_closed_audit_states():
@@ -8395,7 +8449,7 @@ def main():
         test_h1420_p2_win32_openprocess_error_leans_alive,
         test_h1420_p11_record_output_binds_run_id,
         test_h1420_p10_promote_rebuilds_tm_in_finally,
-        test_h1811_inproc_audit_timeout_seam,
+        test_h1957_audit_timeout_actually_kills_the_child,
         test_h1283_a5_max_wide_default_bounded,
         test_h1283_a6_prep_slice_flattens_batches,
         test_h1386_d1_medium50_script_size_cap,

--- a/RussianTranslation/src/pipeline_version.py
+++ b/RussianTranslation/src/pipeline_version.py
@@ -108,9 +108,6 @@ def component_sha(patterns, root=ROOT):
     return h.hexdigest()[:16]
 
 
-_STAMP_MEMO = {}
-
-
 def stamp(manifest=None, model_version=None, root=ROOT):
     """Build the ``provenance.pipeline`` dict to embed in a translated row.
 
@@ -118,22 +115,23 @@ def stamp(manifest=None, model_version=None, root=ROOT):
     ``model_version`` for convenience; the canonical model id still lives in
     ``provenance.model_version``.
 
-    H1811 S3: stamp() runs per promoted row (30 identical component_sha calls per
-    batch promote, ~27 % of the batch's in-process time) — memoize the content
-    hash per process. check()/freeze() call component_sha() directly and always
-    read fresh bytes, so drift detection and freeze stay correctness-exact.
+    Always reads fresh bytes. H1811 S3 memoized the content hash in a module-global
+    ``_STAMP_MEMO`` keyed on the component's file PATTERNS — never on content — so
+    the cache had no invalidation at all: in any process that outlives a source
+    edit (a ``bounded_staged_run`` / ``cohort_engine`` wave runs for hours), every
+    row stamped after the edit carried the PRE-edit ``<name>_sha``. That is a row
+    claiming to have been produced by code it was not produced by, which is exactly
+    the claim this field exists to make. ``check()``/``freeze()`` stayed exact, but
+    they inspect the manifest — they cannot repair provenance already written into
+    the store. H1957 removed the memo: the ~0.27 s/promote it saved does not buy
+    anything worth a false provenance record.
     """
     manifest = manifest or load_manifest()
     out = {'schema': PIPELINE_SCHEMA}
     for name in COMPONENTS:
         comp = manifest['components'][name]
         out['%s_version' % name] = comp['version']
-        key = (tuple(comp['files']), os.path.abspath(root))
-        sha = _STAMP_MEMO.get(key)
-        if sha is None:
-            sha = component_sha(comp['files'], root)
-            _STAMP_MEMO[key] = sha
-        out['%s_sha' % name] = sha
+        out['%s_sha' % name] = component_sha(comp['files'], root)
     if model_version:
         out['model_version'] = model_version
     return out
@@ -430,11 +428,17 @@ def selftest():
     open(os.path.join(d, 'pwg_ru_prompts', '1.txt'), 'w').write('p-EDITED')
     drifts = check(frozen, root=d)
     assert len(drifts) == 1 and drifts[0]['component'] == 'prompt', drifts
-    # H1811 S3: stamp() memoizes per process (fresh check() above still saw the edit)
+    # H1957: after a component file changes, a subsequent stamp() must report the NEW
+    # hash. The H1811 S3 memo made this assertion's opposite true -- it pinned
+    # `st2 == st` ("stamp memo must return the first hash"), i.e. the selftest
+    # certified stale provenance as correct behaviour.
+    fresh_prompt_sha = component_sha(manifest['components']['prompt']['files'], d)
+    assert fresh_prompt_sha != st['prompt_sha'], 'the edit must change the content hash'
     st2 = stamp(manifest, model_version='claude-sonnet-5', root=d)
-    assert st2['prompt_sha'] == st['prompt_sha'], 'stamp memo must return the first hash'
-    assert component_sha(manifest['components']['prompt']['files'], d) != st['prompt_sha'], \
-        'component_sha itself always reads fresh bytes'
+    assert st2['prompt_sha'] == fresh_prompt_sha, \
+        'stamp() must re-read after a source edit, never serve a cached hash'
+    assert st2['prompt_sha'] != st['prompt_sha'], \
+        'a row stamped after the edit must not claim the pre-edit sha'
     # staleness: a row below min_valid and a fresh row
     stale = stale_reasons({'prompt_version': '0.9.0', 'glossary_version': '1.0.0',
                            'script_version': '2.0.0'}, frozen)


### PR DESCRIPTION
Corrective PR for two defects that shipped inside H1811 ([#893](https://github.com/gasyoun/SanskritLexicography/pull/893)). **Both were invisible to CI** — every gate was green with them present, and one was actively *pinned as correct* by a selftest.

**Do not merge on green alone.** This trades measured speed for correctness; the numbers are below so the trade can be judged rather than assumed.

## 1. The audit timeout stopped waiting without stopping the work

H1811 S1 ran `audit_window` in-process via `run_py_inproc` on a **daemon thread**. That breaks the function's own documented contract:

> *"Callers must not run two of these concurrently (sys.argv/stdout are process-global) — the gate loop runs them sequentially."*

On timeout `run_audit` returned rc=124 and the caller moved on **while the audit kept running**:

1. The abandoned thread keeps **writing `window_status.json`, `audit_window.report.json` and the requeue files** — the exact paths `process_record_output` reads on the following lines.
2. `sys.argv`, the process cwd (`run_py_inproc` does `os.chdir(SRC)`) and `stdout`/`stderr` stay hijacked while it runs, so coordinator output goes into a dead capture buffer and relative paths resolve against the wrong directory.
3. `run_py_inproc`'s `finally` restores argv/cwd whenever the thread finally ends — **over** whatever the main thread set in the meantime.

Failure 2 is not theoretical. While reproducing this, the reproduction script's own `print` output vanished into the abandoned thread's buffer and only reappeared once that thread finished.

**Fix:** run `audit_window` in a **killable subprocess** under the same timeout — the only boundary at which a timeout can cancel work. The `run_audit` test seam, the rc=124 contract (H5 keys on `rc ∉ {0,1}`) and S2 (`_pilot_collect` in-process inside the child) are all preserved.

## 2. `stamp()` could certify a row with the hash of code that had already changed

H1811 S3 memoized `component_sha` in a module-global keyed on the component's file **patterns** — never on content — so the cache had **no invalidation at all**. Any process outliving a source edit stamped every subsequent row with the **pre-edit `<name>_sha`**. `bounded_staged_run` / `cohort_engine` waves run for hours, so this is the normal case, not an exotic one.

`check()`/`freeze()` stayed exact, but they inspect the manifest — they cannot repair provenance already written into the store. **Fix:** memo removed, `stamp()` always re-reads.

## The gates were not merely silent — one was inverted

The S3 selftest asserted:

```python
assert st2['prompt_sha'] == st['prompt_sha'], 'stamp memo must return the first hash'
```

i.e. it certified stale provenance as the contract. It now asserts the opposite. The S1 test monkeypatched `run_py_inproc` and checked only the rc=124 mapping, so it passed either way; it is replaced by one that drives a **real child** which sleeps and then writes a sentinel, failing if the sentinel ever appears. That replacement was **verified to fail against the old implementation** rather than assumed to.

## Cost — the honest trade

Interleaved A/B vs master `3070941b`, 5 alternating pairs (not blocked per side — this host drifted 6.8→9.9 s during the session), minimum per side as the robust estimator under load:

| Stage | base `3070941b` | H1957 | Δ (min) | Δ (median) |
|---|---|---|---|---|
| prepare | 2.240 s | 2.000 s | −10.7 % | −9.6 % |
| **audit** | 3.950 s | 5.320 s | **+34.7 %** | +41.4 % |
| promotion-plan | 0.650 s | 0.760 s | +16.9 % | +45.6 % |
| **store-write** | 4.000 s | 4.960 s | **+24.0 %** | +8.9 % |
| **total** | 10.790 s | 12.410 s | **+15.0 %** | +25.3 % |

`audit` carries the restored interpreter spawn; `store-write` carries `stamp()` re-hashing per promoted row. `prepare` moved −10.7 % without being touched, which is the noise floor here — the small deltas are unresolved. Deterministic signature `9bd2a14297` **byte-identical on both sides**: outputs are unchanged, only cost.

S2, H5 and H10 from H1811 are **retained**. Only S1 and S3 are reverted.

## Gates

- `python src/pilot/window_selftest.py` → **194/194, 0 failed**
- `python src/pilot/lang_parity_check.py` → **89 entries, all verdicts complete, no drift**
- `python src/pipeline_version.py --selftest` → **OK**
- `python src/pilot/h1339_offline_bench.py --warmups 1 --runs 3` → per-lease outcomes unchanged (fx1 clean=3/promoted · fx2 clean=1/promoted_partial · fx3 clean=2 · fx4 clean=1 · fx5 clean=3)

## LANG_PARITY note

Editing `window_selftest.py` at all drifted **32** entries that pin a test inside it, plus 5 on `coordinator.py`/`pipeline_version.py`. The 5 substantive ones were re-derived individually; the 32 were stamped only under a mechanically verified precondition — that the diff to `window_selftest.py` touches exactly the replaced audit-timeout test and one runner line. A ledger where one monolithic test file forces 32 simultaneous "human re-affirmations" is rubber-stamping by construction; pinning test *names* rather than the file hash would carry more signal. Recorded in fix log §5.2, not filed as a change here.

Handoff: [H1957](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1957-Opus_SanskritLexicography_pwg-ru-audit-timeout-killable-subprocess-stamp-memo-removal_30.07.26.md). Model: Opus 5 (`claude-opus-5[1m]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
