### PR TITLE
H9: a transient probe failure no longer strands cohort leases forever (H1940 Phase 2)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,40 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed — a transient probe failure could strand cohort leases forever, silently (H9 / H1940 Phase 2, 30-07-2026)
+
+`cohort_engine` treated a probe exception as a **durable** verdict about a profile. The
+failed profile was written into the checkpoint twice over: into `failed_profiles`, and
+into `probed` (the in-process marker that stops a wave re-paying the ledger for a probe
+it already attempted). On resume, both came back — so the profile was never re-probed,
+`_is_window_runnable` kept rejecting it, the terminal barrier skipped its leases as
+"no work will ever run here", and the wave still settled `promoted`/`tm_done=True`. Its
+leases were then unreachable forever: a settled wave returns immediately on every later
+resume. A transient network blip during one probe was enough to lose those leases with
+**no error, no warning, and no trace in the summary** — the wave reported plain success.
+
+Two changes, both surgical:
+
+- **A probe failure is now per-life evidence, not a durable verdict.** `failed_profiles`
+  is no longer persisted at all, and only *successfully* probed profiles are written to
+  `probed`. A resumed life re-probes and, when the failure really was transient,
+  dispatches the leases normally. Older checkpoints carrying the key are ignored, not
+  read back.
+- **Settling with undispatched leases is no longer silent.** When a wave settles while
+  admitted, unparked leases were never dispatched, `stop_reason` now names each one with
+  its profile and cause (`probe_failed` / `budget_exhausted`), and that reason is
+  persisted to the checkpoint so an operator sees it without attaching to the process.
+  It is recomputed on each settle, so a life that recovers the leases clears a stale
+  reason from an earlier one.
+
+Settling itself is deliberately unchanged — promoting the clean subset is the same
+partial-wave behaviour the budget path already had. What changed is that it now says so.
+
+Pinned by `cohort_engine_selftest` pins 8 and 9, **each verified to fail against the
+pre-H9 engine** — the H1811 S3 lesson that a gate which passes both ways certifies
+nothing. Gates: `window_selftest` 194/194, `lang_parity_check` 89 entries no drift
+(`h1437_cohort_width_offline` SHARED verdict re-derived, not rubber-stamped).
+
 ### Fixed — the audit timeout could not cancel the audit, and provenance stamps could go stale (H1957, 30-07-2026)
 
 Two correctness defects shipped inside H1811's speed work below. Both were invisible

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1890,11 +1890,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "Language-agnostic single-source control plane (26-07-2026, Fable 5 `claude-fable-5`): the bounded driver drains whichever lane's prepared leases it is pointed at and never reads or writes a target-language field; there is no per-language twin file to port. Pinned by bounded_staged_run_selftest tests (q)/(r) (renamed from (o)/(p) during the H1724 worktree-drain merge — master had since claimed those letters for test_o_preflight_before_probe/test_p_resume_requires_existing_ledger_run).",
+    "note": "Language-agnostic single-source control plane (26-07-2026, Fable 5 `claude-fable-5`): the bounded driver drains whichever lane's prepared leases it is pointed at and never reads or writes a target-language field; there is no per-language twin file to port. Pinned by bounded_staged_run_selftest tests (q)/(r) (renamed from (o)/(p) during the H1724 worktree-drain merge — master had since claimed those letters for test_o_preflight_before_probe/test_p_resume_requires_existing_ledger_run). SHARED re-derived 30-07-2026 (H1940 Phase 2 / H9, Opus 5 `claude-opus-5[1m]`) against this session's own diff, not rubber-stamped: H9 stops persisting the per-life `_failed_profiles` set (so a transient probe exception is re-probed on resume instead of stranding its leases forever) and records a `stop_reason` when a wave settles with runnable-undispatched leases. Both touch only checkpoint bookkeeping and the terminal barrier — no target-language field is read or written, and no per-language branch is introduced — so the language-agnostic control-plane rationale above is unchanged. Pinned by cohort_engine_selftest pins 8 and 9, each verified to FAIL against the pre-H9 engine.",
     "tracking": "H1437",
     "verified_sha256": {
       "src/pilot/bounded_staged_run.py": "e7e60839425b324de940a1913e1983f9d21807d4a906500dea018224d7dff7ee",
-      "src/pilot/cohort_engine.py": "81bd38b495034d3da5b0ebc2afc2de500f38066f626b8e0fc8254d5acd53881a"
+      "src/pilot/cohort_engine.py": "c8c587cf07ad7802a164eb4a9dbb8454eab418cbda37dc1e3933acfa6ff96bb8"
     }
   },
   {

--- a/RussianTranslation/pwg_ru/h1811/H1811_PIPELINE_REVIEW_FIXLOG_2026-07-29.md
+++ b/RussianTranslation/pwg_ru/h1811/H1811_PIPELINE_REVIEW_FIXLOG_2026-07-29.md
@@ -78,7 +78,7 @@ not touch that branch; a human may archive it.
 | H4 dup lease-id | ⏳ handed to Opus 5 (H1940) | — | — |
 | H7 drain spin | ⏳ handed to Opus 5 (H1940) | — | — |
 | H8 preflight timeout | ⏳ handed to Opus 5 (H1940) | — | — |
-| H9 cohort stranding | ⏳ handed to Opus 5 (H1940) | — | — |
+| H9 cohort stranding | ✅ DONE 30-07-2026 (H1940 Phase 2) — `_failed_profiles` is no longer persisted and a failed probe no longer persists into `probed`, so a **transient** probe exception is re-probed on resume instead of becoming a permanent verdict; a wave that settles with runnable-undispatched leases now records a `stop_reason` naming each lease/profile/cause. Settling itself is unchanged (same partial-wave semantics as the budget path) — what changed is that it is no longer silent | [PR #899](https://github.com/gasyoun/SanskritLexicography/pull/899) | `cohort_engine_selftest` pins **8** (transient probe re-probed on resume) and **9** (settle records `stop_reason`), each verified to FAIL against the pre-H9 engine |
 
 **Bench verification (fixture, per-lease outcomes must equal the pre-change baseline):**
 fx1 clean=3/promoted · fx2 clean=1/promoted_partial (transient `_a_g_ata`, defect

--- a/RussianTranslation/src/pilot/cohort_engine.py
+++ b/RussianTranslation/src/pilot/cohort_engine.py
@@ -87,8 +87,15 @@ class CohortEngine:
             'accepted_order': list(self.accepted_order),
             'stop_reason': self.stop_reason,
             'effective_width': self.effective_width,
-            'probed': sorted(self._probed),
-            'failed_profiles': sorted(self._failed_profiles),
+            # H9: persist ONLY profiles whose probe actually succeeded, and do not
+            # persist the failed set at all. `_probed` deliberately absorbs a failed
+            # profile in-process (a failed probe already consumed the ledger, so this
+            # life must not pay for it twice) — but persisting that marker turned a
+            # TRANSIENT probe exception into a permanent one: on resume the profile was
+            # never re-probed, `_is_window_runnable` kept rejecting it, the terminal
+            # barrier skipped its leases, and the wave still settled promoted/tm_done,
+            # stranding those leases forever. A fresh life re-probes and can recover.
+            'probed': sorted(self._probed - self._failed_profiles),
             'coord_dir': self.coord_dir,
         }
 
@@ -122,7 +129,10 @@ class CohortEngine:
         self.stop_reason = data.get('stop_reason')
         self.effective_width = int(data.get('effective_width') or 1)
         self._probed = set(data.get('probed') or [])
-        self._failed_profiles = set(data.get('failed_profiles') or [])
+        # H9: `_failed_profiles` is intentionally NOT restored — it is per-life state.
+        # A probe failure is evidence about one process, not a durable verdict on the
+        # profile. Older checkpoints may still carry a 'failed_profiles' key; it is
+        # ignored on purpose rather than read back.
         # Clear non-terminal running phases so resume re-dispatches them.
         for wid, lease in list(self.leases.items()):
             if lease.get('phase') == PHASE_RUNNING:
@@ -361,6 +371,22 @@ class CohortEngine:
             self.wave['tm_done'] = True
             self._save_checkpoint()
 
+    # ---- stranded-lease reporting ---------------------------------------------
+
+    @staticmethod
+    def _undispatched_stop_reason(undispatched):
+        """H9: one-line reason for a wave that settled with leases that never ran.
+
+        `undispatched` is a list of (lease_id, profile, cause). Returns None when the
+        wave settled cleanly, so this is safe to assign unconditionally at settle time.
+        """
+        if not undispatched:
+            return None
+        detail = '; '.join('%s(profile=%s, %s)' % (wid, profile, cause)
+                           for wid, profile, cause in sorted(undispatched))
+        return ('wave settled with %d runnable lease(s) never dispatched: %s'
+                % (len(undispatched), detail))
+
     # ---- summary --------------------------------------------------------------
 
     def summary(self):
@@ -433,6 +459,7 @@ class CohortEngine:
             # campaign ledger is exhausted (partial wave of what finished), OR the
             # wave was already promoted (TM-only resume).
             terminal_ok = True
+            undispatched = []   # H9: admitted+unparked leases this wave will never run
             for w in self.plan:
                 profile = w.get('profile')
                 if self.admitted and profile not in self.admitted:
@@ -443,12 +470,22 @@ class CohortEngine:
                 if lease.get('phase') != PHASE_DONE:
                     # Budget-exhausted partial wave: allow promote of what finished.
                     if self.max_calls is not None and self.calls_reserved >= self.max_calls:
+                        undispatched.append((w['id'], profile, 'budget_exhausted'))
                         continue
-                    # Profile probe failed: no work will ever run here this life.
+                    # Profile probe failed: no work will run for it in THIS life.
                     if profile in self._failed_profiles:
+                        undispatched.append((w['id'], profile, 'probe_failed'))
                         continue
                     terminal_ok = False
                     break
+
+            if terminal_ok:
+                # H9: settling while runnable leases were never dispatched used to be
+                # entirely silent — the wave reported success, promoted/tm_done went
+                # True, and those leases were stranded with no signal anywhere. Record
+                # WHY. Recomputed (not appended) on every settle, so a life that
+                # recovers the stranded leases clears a stale reason from an earlier one.
+                self.stop_reason = self._undispatched_stop_reason(undispatched)
 
             if terminal_ok or self.wave.get('promoted'):
                 self._promote_and_tm()

--- a/RussianTranslation/src/pilot/cohort_engine_selftest.py
+++ b/RussianTranslation/src/pilot/cohort_engine_selftest.py
@@ -837,6 +837,144 @@ def test_7_coord_dir_and_admitted_parked_filtering(td):
 # Runner — run ALL pins, report each RED with its missing-behavior reason.
 # ---------------------------------------------------------------------------
 
+def test_8_transient_probe_failure_is_reprobed_on_resume(td):
+    """H9: a probe exception is per-life evidence, never a durable verdict.
+
+    The stranding chain this pins: a TRANSIENT probe failure used to be written into the
+    checkpoint twice over — the profile landed in the persisted `probed` set (so resume
+    never re-probed it) and in a persisted `failed_profiles` set (so `_is_window_runnable`
+    kept rejecting it). Its leases were then skipped by the terminal barrier while the wave
+    settled promoted/tm_done=True, i.e. stranded with no signal. A fresh life must re-probe.
+    """
+    td = os.path.join(td, 't8'); os.makedirs(td)
+    windows = [{'id': 'leaseA', 'profile': 'c1'}, {'id': 'leaseB', 'profile': 'c2'}]
+    checkpoint = os.path.join(td, 'cp.json')
+    store = os.path.join(td, 'store.txt')
+    promoter = FakePromoter(store)
+    tm = FakeTM()
+
+    # Life 1: c1's probe fails TRANSIENTLY; leaseB crashes so the wave cannot settle.
+    probe_calls_1 = []
+
+    def transient_probe(profile):
+        probe_calls_1.append(profile)
+        if profile == 'c1':
+            raise SimulatedCrash('transient probe failure on c1')
+        return 1.0
+
+    meter1 = ConcurrencyProbe()
+    engine = build_engine(
+        windows, FakeWorker(td, meter1, crash_ids={'leaseB'}), checkpoint,
+        audit=clean_audit, promote_wave=promoter, rebuild_tm=tm, width=2,
+        admitted={'c1', 'c2'}, probe=transient_probe,
+        contract='a transient probe failure must not be persisted as a permanent verdict; '
+                 'a resumed life must re-probe the profile and dispatch its leases')
+    crashed = False
+    try:
+        engine.run()
+    except SimulatedCrash:
+        crashed = True
+    assert crashed, 'fixture defect: the injected leaseB crash must propagate'
+    assert 'c1' in probe_calls_1, ('fixture defect: c1 must have been probed in life 1: %r'
+                                   % probe_calls_1)
+    assert 'leaseA' not in meter1.launches, (
+        'fixture defect: leaseA must not have launched behind a failed probe: %r'
+        % meter1.launches)
+
+    # THE PIN (durability half): the failure must not survive on disk in EITHER form.
+    with open(checkpoint, encoding='utf-8') as f:
+        cp = json.load(f)
+    assert 'c1' not in (cp.get('probed') or []), (
+        'a FAILED probe was persisted as probed — resume will never re-probe c1 and its '
+        'leases strand forever: probed=%r' % (cp.get('probed'),))
+    assert 'c1' not in (cp.get('failed_profiles') or []), (
+        'the per-life failed-profile set was persisted — resume inherits a permanent '
+        'verdict from one transient exception: failed_profiles=%r'
+        % (cp.get('failed_profiles'),))
+
+    _forget_engine_module()
+
+    # Life 2: resume with a now-healthy probe. c1 MUST be re-probed and leaseA MUST run.
+    probe_calls_2 = []
+
+    def healthy_probe(profile):
+        probe_calls_2.append(profile)
+        return 1.0
+
+    meter2 = ConcurrencyProbe()
+    engine2 = build_engine(
+        windows, FakeWorker(td, meter2), checkpoint, audit=clean_audit,
+        promote_wave=promoter, rebuild_tm=tm, width=2, admitted={'c1', 'c2'},
+        resume=True, probe=healthy_probe,
+        contract='a transient probe failure must not be persisted as a permanent verdict; '
+                 'a resumed life must re-probe the profile and dispatch its leases')
+    summary = engine2.run()
+
+    # THE PIN (recovery half).
+    assert 'c1' in probe_calls_2, (
+        'c1 was never re-probed on resume — the transient failure became permanent: %r'
+        % probe_calls_2)
+    assert 'leaseA' in meter2.launches, (
+        'leaseA never dispatched on resume — it is stranded behind a stale probe verdict: '
+        '%r' % meter2.launches)
+    assert 'c2' not in probe_calls_2, (
+        'c2 probed twice — a SUCCESSFUL probe is durable and must not be repaid: %r'
+        % probe_calls_2)
+    assert summary.get('stop_reason') is None, (
+        'a fully-dispatched wave must settle with no stranding reason: %r'
+        % summary.get('stop_reason'))
+    assert len(promoter.commits) == 1, promoter.commits
+    assert set(promoter.commits[0]) == {'leaseA', 'leaseB'}, promoter.commits
+
+
+def test_9_settling_with_undispatched_leases_reports_stop_reason(td):
+    """H9: a wave that settles while runnable leases were never dispatched must say so.
+
+    Settling is deliberate here (the same partial-wave semantics the budget path uses), so
+    this pins the SIGNAL, not a behaviour change: before H9 the wave reported plain success
+    and the skipped leases were invisible in the summary and on disk.
+    """
+    td = os.path.join(td, 't9'); os.makedirs(td)
+    windows = [{'id': 'leaseA', 'profile': 'c1'}, {'id': 'leaseB', 'profile': 'c2'}]
+    checkpoint = os.path.join(td, 'cp.json')
+    store = os.path.join(td, 'store.txt')
+
+    def hard_down_probe(profile):
+        if profile == 'c1':
+            raise SimulatedCrash('c1 is down for this whole wave')
+        return 1.0
+
+    meter = ConcurrencyProbe()
+    promoter = FakePromoter(store)
+    engine = build_engine(
+        windows, FakeWorker(td, meter), checkpoint, audit=clean_audit,
+        promote_wave=promoter, rebuild_tm=FakeTM(), width=2, admitted={'c1', 'c2'},
+        probe=hard_down_probe,
+        contract='a wave that settles with runnable-but-undispatched leases must record a '
+                 'stop_reason naming them, instead of reporting silent success')
+    summary = engine.run()
+
+    # The wave still settles (partial-wave semantics unchanged) ...
+    assert summary['wave']['promoted'] is True, summary['wave']
+    assert promoter.commits == [('leaseB',)], (
+        'only the dispatched lease may be promoted: %r' % promoter.commits)
+    assert meter.launches == ['leaseB'], meter.launches
+
+    # ... but it must NO LONGER do so silently.
+    reason = summary.get('stop_reason')
+    assert reason, (
+        'the wave settled with leaseA never dispatched and reported NO stop_reason — this '
+        'is the silent stranding H9 exists to end: %r' % summary)
+    assert 'leaseA' in reason, ('the stop_reason must name the stranded lease: %r' % reason)
+    assert 'c1' in reason, ('the stop_reason must name the stranded profile: %r' % reason)
+
+    # Durable: an operator reading the checkpoint (not just this process) must see it.
+    with open(checkpoint, encoding='utf-8') as f:
+        cp = json.load(f)
+    assert cp.get('stop_reason') == reason, (
+        'the stranding reason was not persisted to the checkpoint: %r' % cp.get('stop_reason'))
+
+
 TESTS = [
     ('1 two profile-bound leases: peak_concurrency >= 2', test_1_barrier_concurrency),
     ('2 reverse completion == serial order/store bytes', test_2_reverse_completion_determinism),
@@ -845,6 +983,8 @@ TESTS = [
     ('5 promotion-barrier crash: exactly one promotion+TM', test_5_promotion_barrier_crash_exactly_once),
     ('6 max_calls=0/1/3 reservation never exceeded', test_6_reservation_ledger_max_calls),
     ('7 coord-dir exactness + admitted/parked filtering', test_7_coord_dir_and_admitted_parked_filtering),
+    ('8 H9: transient probe failure re-probed on resume', test_8_transient_probe_failure_is_reprobed_on_resume),
+    ('9 H9: settling with undispatched leases reports stop_reason', test_9_settling_with_undispatched_leases_reports_stop_reason),
 ]
 
 


### PR DESCRIPTION
fix(pwg_ru): H9 — a transient probe failure no longer strands cohort leases forever (H1940 Phase 2)

cohort_engine treated a probe exception as a DURABLE verdict about a profile. The
failed profile was checkpointed twice over — into `failed_profiles`, and into
`probed` (the in-process marker that stops a wave re-paying the ledger for a probe
it already attempted). Resume restored both, so the profile was never re-probed,
`_is_window_runnable` kept rejecting it, the terminal barrier skipped its leases as
"no work will ever run here", and the wave still settled promoted/tm_done=True.
Those leases were then unreachable forever: a settled wave returns immediately on
every later resume. One transient blip during one probe lost them with no error, no
warning and no trace in the summary — the wave reported plain success.

Two surgical changes:

- A probe failure is per-life evidence, not a durable verdict. `failed_profiles` is
  no longer persisted at all, and only SUCCESSFULLY probed profiles are written to
  `probed`, so a resumed life re-probes and can recover. Older checkpoints carrying
  the key are ignored rather than read back.
- Settling with undispatched leases is no longer silent. `stop_reason` now names
  each admitted+unparked lease that never ran, with its profile and cause
  (probe_failed / budget_exhausted), and is persisted to the checkpoint. Recomputed
  per settle, so a life that recovers the leases clears an earlier stale reason.

Settling itself is unchanged — promoting the clean subset is the same partial-wave
behaviour the budget path already had. What changed is that it now says so.

Pins: cohort_engine_selftest 8 (transient probe re-probed on resume) and 9 (settle
records stop_reason), EACH VERIFIED TO FAIL against the pre-H9 engine — the H1811 S3
lesson that a gate passing both ways certifies nothing. Against pre-fix code pin 8
reports `probed=['c1','c2']` and pin 9 reports stop_reason=None with the stranded
lease absent from `leases` entirely.

Gates: cohort_engine_selftest 8 GREEN, window_selftest 194/194, lang_parity_check 89
entries no drift (h1437_cohort_width_offline SHARED re-derived against this diff, not
rubber-stamped: no target-language field is read or written).

Pre-existing and NOT touched: cohort_engine_selftest test 6 is RED on clean
origin/master. Its EVIDENCE block (written 24-07, H1618) asserts the legacy
BoundedSupervisor max_calls overshoot as a contrast baseline; #761 (26-07) made
max_calls=0 launch nothing, so the baseline went stale two days after it was written.
It asserts nothing about cohort_engine and is out of H9's scope — left for a ruling
rather than silently rewritten.

No release cut: H1940 says not to cut unilaterally mid-contention, and [Unreleased]
already carries H1957's uncut block.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
