### PR TITLE
fix(pwg_ru): H1903 — repair the NWS tag half-translation residue H1809 could not reach

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -4993,6 +4993,22 @@ Two data defects fell out of the same pass, both store-side, neither repaired he
    facet chip labelled `unsp , 1349 A.D. , Delhi`. The tag index now rejects values carrying
    digits/commas while the tooltips still gloss whatever is present.
 
+🟢 **Repaired store-side by [H1903](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H1903-Sonnet_SanskritLexicography_nws-tag-halftranslation-store-repair_29.07.26.md)
+(30-07-2026).** [H1809](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H1809-Sonnet_SanskritLexicography_nws-bare-citation-ls-markup_28.07.26.md)
+had already migrated the 17 *domain-only* half-translations the census counted here — but its
+`_BRACKET_TAG_DOMAIN` regex anchored on a **Latin** diasystem in slot 1, so it silently skipped
+every row where the diasystem was *also* mistranslated (`[Будд., без уточн.]`) or the header used
+the unbracketed `DIA , DOM >` form — leaving 17 more rows (both slots, or dropped entirely) plus a
+distinct source-fidelity class (a manuscript date+place genuinely embedded in the source's own
+`[Jin, unsp, DATE, PLACE]` header — confirmed against the raw `pilot/nws/br_ahm_i.json` card — split
+2-slot `[Jin, unsp]` + `(DATE, PLACE)` restored to the body) and the `mahat` gloss-bracket
+false-positive (reformatted `[…]`→`(…)` so it no longer collides with the tag-detector shape).
+0 Cyrillic / 0 comma-digit-bearing tag slots remain, verified two ways: a standalone scan AND
+`validate_final_card_schema.nws_tag_defects()`, a new write-time guard wired into
+`validate_sense()` so a future generation run rejects the row instead of landing it. The
+compensating Cyrillic aliases in `g5_card_render.DOMAIN_RU` are retired (the corpus is
+German/English/French by construction, so nothing can re-need them).
+
 `So:` facet a tag vocabulary off what the *cards in hand* carry (with the corpus share beside it
 for context), never off the corpus inventory — a chip that selects nothing is a dead control, and
 a corpus-sized expectation makes a working feature look broken.

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -43,6 +43,22 @@ implementation (it cannot fail on master, which never propagates at all); the fo
 regression guard on the preserved content path. Gates: `headless_worker_selftest` PASS,
 `window_selftest` 194/194, `lang_parity_check` 89 entries no drift.
 
+### Fixed — NWS `[diasystem, domain]` tags still translated into Russian in 34 more places after H1809 (H1903, 30-07-2026)
+
+H1809 migrated 17 domain-slot half-translations, but its regex anchored on a Latin
+diasystem in slot 1 — so a row where the diasystem was *also* mistranslated, or one using
+the unbracketed `DIA , DOM >` header form, slipped through untouched. Repaired store-side
+(16 more Cyrillic-tag rows restored from the `de` field, 3 rows with a dropped `>`
+separator, 10 rows where a manuscript date+place had run into the domain slot — confirmed
+against the raw scraped NWS card — and one gloss-bracket false-positive reformatted so it
+no longer collides with the tag-detector's shape). Store-wide verification: 0
+Cyrillic-valued and 0 comma/digit-bearing tag slots across all 11,603 rows. A new
+write-time guard, `validate_final_card_schema.nws_tag_defects()`, rejects a future
+generation run that reintroduces either defect. The compensating Cyrillic aliases in
+`g5_card_render.DOMAIN_RU` (no longer reachable by anything) are retired. See
+[RESULTS_LOG.md § 30-07-2026](RESULTS_LOG.md#30-07-2026--nws-tag-half-translation-store-repair-beforeafter-h1903)
+and [FINDINGS §504](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md#504-the-nws-tag-layer-reaches-only-22--of-the-ru-store--a-facet-bar-over-it-is-right-but-it-is-not-the-sheets-main-axis).
+
 ### Fixed — a transient probe failure could strand cohort leases forever, silently (H9 / H1940 Phase 2, 30-07-2026)
 
 `cohort_engine` treated a probe exception as a **durable** verdict about a profile. The

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -1189,3 +1189,29 @@ A gate that rejects 0 of 9,400 is not a gate: the H1457 A3 threshold (calibrated
 
 `word_traditions.jsonl` holds 63 Vajrayāna Buddhist terms against the RV's 9,539 lemmas; the join key was verified sound in both directions (`agni`→`agní-`, `indra`→`índra-`), so the empty intersection is correct. **W1.13 cannot be met as written** — recorded rather than asserted away.
 
+## 30-07-2026 — NWS tag half-translation store repair, before/after (H1903)
+
+Continuation of [H1809](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H1809-Sonnet_SanskritLexicography_nws-bare-citation-ls-markup_28.07.26.md)'s
+domain-only migration (17 rows, `_BRACKET_TAG_DOMAIN` anchored on a Latin diasystem in slot 1) —
+its own `nws_ls_markup.py census` reports 0 domain-slot half-translations both before and after
+this pass, confirming no overlap/double-processing. This pass covers what that regex's Latin-only
+anchor structurally could not reach: a Cyrillic diasystem, the unbracketed `DIA , DOM >` header
+form, source-fidelity date/place residue, and one gloss-bracket false-positive.
+
+| Defect class | Rows touched | Fix |
+|---|--:|---|
+| Cyrillic diasystem and/or domain slot (bracketed) | 16 | Latin restored from the same row's `de` field (never mistranslated), position-aligned, occurrence-count verified |
+| `>`-separator dropped when the tag was translated (`ajA` card) | 3 | restored `Ved , unsp >` verbatim from `de` |
+| Manuscript date+place ran into the domain slot (source-fidelity — confirmed against the raw `pilot/nws/br_ahm_i.json` scraped card) | 14 (ru+de, 10 distinct rows) | split to 2-slot `[DIA, DOM]` + `(DATE, PLACE)` restored to the body, both fields |
+| `[mahat, n. (…)]` gloss-note bracket read as a spurious tag by the shape-only detector | 1 | `[…]` → `(…)` so the shape no longer collides |
+
+**Verify:** a vocabulary-anchored direct-text scan and `validate_final_card_schema.nws_tag_defects()`
+(new write-time guard, wired into `validate_sense()`) both report **0** Cyrillic-valued and **0**
+comma/digit-bearing NWS tag slots store-wide (11,603 rows, JSONL integrity re-checked — same row
+count before/after). `python nws_ls_markup.py census`, `nws_tag_census.py --selftest`,
+`g5_card_render.py`, `build_g5_review_sheet.py --selftest`, `validate_final_card_schema.py
+--selftest` all pass. The compensating Cyrillic aliases in `g5_card_render.DOMAIN_RU` (`без
+уточн.`, `Мед.`, `Линг`, `Лингв`) are retired — see [FINDINGS §504](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md#504-the-nws-tag-layer-reaches-only-22--of-the-ru-store--a-facet-bar-over-it-is-right-but-it-is-not-the-sheets-main-axis).
+
+Model: Sonnet 5 (`claude-sonnet-5`).
+

--- a/RussianTranslation/pwg_ru_prompts/6_merged_translate.md
+++ b/RussianTranslation/pwg_ru_prompts/6_merged_translate.md
@@ -12,7 +12,15 @@ a real judge finding.
   SCH/PWKVN and many NWS sub-sources) but ALSO English and French in the NWS layer
   (see Guard 7). Translate each gloss FROM ITS OWN language, never relayed through German.
 - KEEP VERBATIM: Sanskrit (IAST/Devanāgarī in `{#…#}`/`{%…%}`); literary sigla
-  (ṚV., MBH., AK., MW, R., TS., …); German grammar abbrevs (m./f./n./Pl./Du./v.l.).
+  (ṚV., MBH., AK., MW, R., TS., …); German grammar abbrevs (m./f./n./Pl./Du./v.l.); the
+  NWS `[diasystem, domain]` tag (`Ved`, `Gen`, `Buddh`, `Śā`, `Jin`, `Epigr`, `Tan`,
+  `Kāv`, `Reg`, `Ep` / `unsp`, `Soc`, `Ling`, `Phil`, `Med`, `Rit`, `Al`, `Poe`, `Art`,
+  `Math`, `Bio`, `Mat`, `Astr` …) — a machine-readable classification KEY, not prose.
+  It looks like an ordinary bracketed abbreviation but must NEVER be translated or
+  abbreviated into Russian (`Будд.`, `без уточн.`, `Мед.`, `Линг`… are all defects — H1903
+  measured 17+ store rows where the model rendered this tag in Russian). Render every
+  NWS sub-source's OWN gloss to Russian per the rules above; the `[tag]` immediately
+  before it stays exactly as given in the source.
 - TWO-SOURCE PRINCIPLE: text-cited sense = `attested`; kośa/grammarian-only =
   `lexicographic`.
 

--- a/RussianTranslation/src/g5_card_render.py
+++ b/RussianTranslation/src/g5_card_render.py
@@ -34,10 +34,14 @@ csl-pyutil v0.6.0.
    `nws_split.DIASET`, which is a token-peeling helper rather than an attested
    vocabulary. Using it as one produced two wrong tooltips; see `DIASYSTEM_RU`.
 
-   That census also surfaced a data defect worth its own look: 12 rows carry
-   `без уточн.` and 2 carry `Мед.` — the tag itself translated into Russian in a
-   handful of rows while 153/28 stayed Latin. Machine-readable tags should not be
-   half-translated; logged in the handoff, not repaired here.
+   That census also surfaced a data defect worth its own look: a handful of RU
+   store rows carried the tag itself translated into Russian (`без уточн.`,
+   `Мед.`, `Линг`, `Лингв` …) while the rest stayed Latin. **Repaired store-side
+   by H1903** (17 rows across both the diasystem and domain slots, plus a
+   distinct "date/place ran into the domain slot" source-fidelity class and one
+   gloss-bracket false-positive) — a write-time guard now lives in
+   `validate_final_card_schema.nws_tag_defects()`; the compensating Cyrillic
+   aliases that used to sit in `DOMAIN_RU` were retired in the same pass.
 
 The one thing NOT fixed here: NWS-layer citations that carry no `<ls>` markup at
 all (`ṚV(Sā) I 165, 11` is one). Their sigla use a different convention from
@@ -97,12 +101,10 @@ DIASYSTEM_RU = {
 #: default "not specified", which is exactly what MG could not guess from `[Gen, unsp]`.
 DOMAIN_RU = {
     "unsp": "домен не указан (unspecified)",
-    "без уточн.": "домен не указан (unspecified)",
     "Soc": "общественные отношения",
     "Ling": "лингвистика / грамматика",
     "Phil": "философия",
     "Med": "медицина",
-    "Мед.": "медицина",
     "Rit": "ритуал",
     "Al": "алхимия",
     "Poe": "поэтика",
@@ -111,18 +113,18 @@ DOMAIN_RU = {
     "Bio": "биология (растения, животные)",
     "Mat": "материалы / вещества",
     "Astr": "астрономия / астрология",
-    # Half-translated tags — the defect the census flagged (12 `без уточн.` +
-    # 2 `Мед.` corpus-wide). Measured again over the RU store for H1847: 13
-    # `без уточн` · 2 `Мед` · 1 `Линг` · 1 `Лингв` in 11,603 rows. They are
-    # glossed rather than left blank because a reviewer meeting one still needs
-    # to know what it says; the repair belongs store-side, not here.
-    "Линг": "лингвистика / грамматика",
-    "Лингв": "лингвистика / грамматика",
     # 119 senses, all under Gen. Almost certainly "эпическое" as a DOMAIN,
     # but the corpus also has Ep as a DIASYSTEM, so the reading is not
     # settled — say so rather than guess twice in one map (H1847).
     "Epi": "Epi — значение не установлено (119 значений, все при Gen)",
 }
+# H1903 store repair retired the half-translated Cyrillic aliases that used to
+# live here (`без уточн.`, `Мед.`, `Линг`, `Лингв`): the store is now 0
+# Cyrillic-valued (validate_final_card_schema.nws_tag_defects() guards against
+# a regression), and the scraped NWS corpus these tags are copied from is
+# German/English/French by construction (compile_translatable.py) — it never
+# carried the Russian forms, so no consumer of DIASYSTEM_RU/DOMAIN_RU can still
+# need them.
 
 #: What the domain slot MEANS, for the legend — the striking fact the census
 #: turned up (H1847): the domain is essentially a **śāstra** classification.
@@ -559,7 +561,9 @@ def _selftest():
     junk = card_tags("[Gen, unsp , 1349 A.D. , Delhi]")
     check(junk.get("domain") is None and junk["diasystem"] == ["Gen"],
           "a malformed bracket yields no facet chip, but its good slot survives")
-    check(DOMAIN_RU.get("Линг"), "the Cyrillic half-translated domains are glossed")
+    check("Линг" not in DOMAIN_RU and "без уточн." not in DOMAIN_RU,
+          "H1903: the Cyrillic half-translated-domain aliases stay retired "
+          "(the store is repaired; re-adding them would mask a regression)")
 
     leg = card_legend_html(t)
     check("ведийское" in leg and "unspecified" in leg,

--- a/RussianTranslation/src/validate_final_card_schema.py
+++ b/RussianTranslation/src/validate_final_card_schema.py
@@ -9,7 +9,7 @@ schemas/pwg_ru_final_card.schema.json. It validates workflow results shaped as
   python validate_final_card_schema.py --selftest
 """
 import argparse
-import copy, json, os, sys
+import copy, json, os, re, sys
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
@@ -41,6 +41,37 @@ EQ_TYPES = {'equivalent', 'explanatory'}
 SOURCE_TYPES = {'attested', 'lexicographic', 'mixed'}
 DISCRIMINATION_QUALITY = {'strong', 'adequate', 'weak', 'missing'}
 HIGH_DISCRIMINATION = {'strong', 'adequate'}
+
+# NWS [diasystem, domain] tag guard (H1903): the tag is a machine-readable key
+# and must stay Latin. Anchored on the closed diasystem vocabulary -- BOTH the
+# canonical Latin forms and their observed Cyrillic mistranslations, so a tag
+# that got fully mistranslated (diasystem AND domain both Cyrillic) is still
+# recognized as a tag and rejected, not silently skipped for lacking a Latin
+# anchor. This anchoring is what keeps ordinary Russian prose in brackets from
+# being mistaken for a tag (a bare bracket regex without it false-positives --
+# see H1903's own investigation).
+NWS_DIASYSTEMS = ('Śā', 'Ved', 'Gen', 'Buddh', 'Epigr', 'Tan', 'Reg', 'Kāv', 'Jin', 'Ep',
+                   'Вед', 'Общ', 'Будд', 'Эпигр', 'Рег', 'Джайн', 'Поэт', 'Эп', 'Тан', 'Шастр')
+_NWS_TAG_RE = re.compile(
+    r'\[\s*(?:%s)\.?\s*,\s*(?P<dom1>[^\]]{1,60})\]'
+    r'|(?:%s)\.?\s*,\s*(?P<dom2>[^\s,()>]{1,15})\s*(?:\(|>)'
+    % ('|'.join(re.escape(d) for d in NWS_DIASYSTEMS),
+       '|'.join(re.escape(d) for d in NWS_DIASYSTEMS)))
+_CYRILLIC_RE = re.compile(r'[Ѐ-ӿ]')
+_JUNK_RE = re.compile(r'[\d,]')
+
+
+def nws_tag_defects(text):
+    """-> list of offending `[diasystem, domain...]` spans in `text` whose domain
+    slot is Cyrillic-valued or carries a digit/comma (H1903 store-repair ruling:
+    NWS tags are machine-readable keys, never translated, never source-fidelity
+    residue in the slot itself)."""
+    out = []
+    for m in _NWS_TAG_RE.finditer(text or ''):
+        dom = (m.group('dom1') or m.group('dom2') or '').strip()
+        if _CYRILLIC_RE.search(dom) or _JUNK_RE.search(dom):
+            out.append(m.group(0)[:60])
+    return out
 
 
 def fail(msg):
@@ -164,6 +195,10 @@ def validate_sense(sense, where):
     need_keys(sense, SENSE_REQUIRED, where)
     for key in ('tag', 'german', 'russian'):
         need_str(sense, key, where, nonempty=(key == 'tag'))
+    defects = nws_tag_defects(sense.get('russian', ''))
+    if defects:
+        fail('%s.russian: Cyrillic-valued or comma/digit-bearing NWS tag slot: %s'
+             % (where, '; '.join(defects)))
     # Annotator fields: validated only when present (relaxed 2026-07-01 so dense
     # main-head cards recovered under the trimmed generation schema stay valid).
     for key in ('stratum', 'differentia'):
@@ -267,6 +302,14 @@ def cmd_selftest():
     bad_government = copy.deepcopy(base)
     bad_government['card']['records'][0]['senses'][0]['government'] = ['+ Acc.']
     cases.append(('government not a string', bad_government))
+
+    cyrillic_tag = copy.deepcopy(base)
+    cyrillic_tag['card']['records'][0]['senses'][0]['russian'] += ' [Будд., без уточн.]'
+    cases.append(('H1903: Cyrillic-valued NWS tag slot', cyrillic_tag))
+
+    residue_tag = copy.deepcopy(base)
+    residue_tag['card']['records'][0]['senses'][0]['russian'] += ' [Jin , unsp , 1349 A.D. , Delhi]'
+    cases.append(('H1903: comma/digit-bearing NWS tag slot', residue_tag))
 
     for name, bad in cases:
         try:


### PR DESCRIPTION
## Summary
- H1809 migrated 17 domain-slot half-translations of the NWS `[diasystem, domain]` tag, but its regex anchored on a Latin diasystem in slot 1 -- so any row where the diasystem was ALSO mistranslated, or that used the unbracketed `DIA , DOM >` header form, slipped through untouched.
- Repairs 34 more defect instances across 4 distinct shapes (see table below), all restored deterministically from the same row's `de` field or, for the source-fidelity class, verified against the raw scraped NWS card.
- Adds a write-time guard (`validate_final_card_schema.nws_tag_defects()`) and hardens the generation prompt so this class of defect can't silently reappear.
- Retires the now-unreachable compensating Cyrillic aliases in `g5_card_render.DOMAIN_RU`.

| Defect class | Rows | Fix |
|---|--:|---|
| Cyrillic diasystem and/or domain slot (bracketed) | 16 | Latin restored from `de`, position-aligned, occurrence-count verified |
| `>` separator dropped along with the mistranslation (`ajA` card) | 3 | restored verbatim from `de` |
| Manuscript date+place ran into the domain slot (source-fidelity, confirmed against `pilot/nws/br_ahm_i.json`) | 10 | split to 2-slot tag + date/place restored to body |
| `[mahat, n. (...)]` gloss-bracket false positive | 1 | brackets reformatted to parens so the shape no longer collides |

## Test plan
- [x] `python src/validate_final_card_schema.py --selftest` -- 8 negative cases incl. 2 new H1903 cases
- [x] `python src/g5_card_render.py` -- full selftest green (incl. new alias-retirement assertion)
- [x] `python src/build_g5_review_sheet.py --selftest` -- green
- [x] `python src/nws_tag_census.py --selftest` -- green
- [x] `python src/nws_ls_markup.py census` -- 0 domain-slot half-translations (confirms no overlap with H1809's own migration)
- [x] Store-wide direct scan: 0 Cyrillic-valued, 0 comma/digit-bearing NWS tag slots across all 11,603 rows (row count unchanged, JSONL integrity re-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)