### PR TITLE
docs: record the Zenodo concept DOI; correct the 'not wired' claim

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,12 +8,14 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.111.5
+version: 1.112.0
 date-released: "2026-07-31"
-# DOI: pending — the Zenodo–GitHub integration is not wired for this repository
-# (no .zenodo.json, no concept DOI). Until it is, a release mints no version DOI.
-# Human @DO (needs MG's Zenodo login): enable the integration, then record the
-# CONCEPT doi here and the per-version DOI in each release's notes.
+# The CONCEPT DOI — version-independent, always resolves to the newest release.
+# This is deliberately NOT a per-version DOI: those change every release and would
+# make this file wrong the moment the next one ships. Each release's own version
+# DOI belongs in that release's notes instead. Verified against the Zenodo API
+# 31-07-2026; the Zenodo–GitHub integration is live and mints on release publish.
+doi: 10.5281/zenodo.21306715
 abstract: >
   A data and research workspace for the Sanskrit Lexicon project: exported
   headword lists, AI-produced Russian translations of Monier-Williams and

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # SanskritLexicography
 
-_Created: 14-06-2026 · Last updated: 24-07-2026_
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21306715.svg)](https://doi.org/10.5281/zenodo.21306715)
+
+_Created: 14-06-2026 · Last updated: 31-07-2026_
 
 A **data and research workspace** for Sanskrit digital lexicography — not a
 software project. Its focus is Cologne Digital Sanskrit Lexicon headword lists,
@@ -192,6 +194,25 @@ In short: fork, create a feature branch, submit a pull request referencing any
 related issue. For larger data changes, include the source of the data, the
 transformation method, and enough counts or checksums for another maintainer to
 reproduce the result.
+
+## Citation
+
+Archived on Zenodo; every published GitHub release is deposited automatically and
+gets its own version DOI.
+
+**Cite the concept DOI — [10.5281/zenodo.21306715](https://doi.org/10.5281/zenodo.21306715)** —
+unless you need to pin an exact snapshot. It is version-independent and always
+resolves to the newest release, so a citation written against it does not rot.
+To cite the precise state you used instead, take the **version** DOI from that
+release's own notes.
+
+Full metadata (author, ORCID, licence, version) is in
+[CITATION.cff](https://github.com/gasyoun/SanskritLexicography/blob/master/CITATION.cff),
+which carries the concept DOI for the same reason.
+
+A **derived dataset** released from this repository carries its own DOI, separate
+from the repository's — see
+[data/FAIR_RELEASE_1.md](https://github.com/gasyoun/SanskritLexicography/blob/master/data/FAIR_RELEASE_1.md).
 
 ## License
 


### PR DESCRIPTION
Closes the recording half of #915. The wiring was already done — this is the part that was actually missing.

**The correction.** [#912](https://github.com/gasyoun/SanskritLexicography/pull/912) added a note to `CITATION.cff` claiming the Zenodo–GitHub integration was not wired. That was wrong, and the reasoning was invalid twice over: the absence of `.zenodo.json` and of a README badge proves nothing (both optional), and the DOI was looked for immediately after `gh release create`, before the webhook had fired.

**Verified against the Zenodo API, 31-07-2026:**

| | |
|---|---|
| Concept DOI | `10.5281/zenodo.21306715` |
| Latest version DOI | `10.5281/zenodo.21719961` (v1.112.0) |
| Linkage | `isSupplementTo .../tree/v1.112.0` |
| License / creator on record | `mit-license` / `Gasūns, Mārcis` |

**Changes**

- `CITATION.cff` carries the **concept** DOI, not a version DOI — a version DOI would make the file wrong the moment the next release ships. `version` synced to 1.112.0; it had been left at 1.111.5 when v1.112.0 shipped, and was eight patch releases stale before #912 touched it.
- `README.md` gains the DOI badge and a **Citation** section stating the concept-vs-version distinction where a human will look for it, plus the reminder that derived datasets carry their own DOIs.

Remaining boxes on #915 (release-notes DOI, optional `.zenodo.json`) are left open deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)