### PR TITLE
chore(pwg_ru): re-bind h1682_abbrev_rules sheet lock for MG vote

### DIFF
--- a/RussianTranslation/review/locks/h1682_abbrev_rules.lock.json
+++ b/RussianTranslation/review/locks/h1682_abbrev_rules.lock.json
@@ -1,7 +1,7 @@
 {
   "schema": "review-lock/v1",
   "sheet_id": "h1682_abbrev_rules",
-  "content_hash": "sha256:eb1a2a4283038466f56216bc9dc5e57d30fd0a7eefe08fc7ac2af48ab878f862",
+  "content_hash": "sha256:14403a330a1e4f715967309b9d5f2b2b39902d9232b23e8b01c8b8a0f2b7cba6",
   "generated": "2026-07-26",
   "gate": null,
   "n_items": 33,
@@ -42,6 +42,6 @@
   ],
   "source_html": "h1682_abbrev_rules_sheet.html",
   "mode": "stamped",
-  "created": "2026-07-26",
+  "created": "2026-07-31",
   "tool": "review_binding.py (H1404 binding standard)"
 }


### PR DESCRIPTION
Deliberate re-cut of the [h1682 abbreviation-rules vote sheet](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1682_ABBREV_RULE_COLLAPSE_REPORT_2026-07-26.md) lock: the committed 26-07 generation ([#802](https://github.com/gasyoun/SanskritLexicography/pull/802)) could not be reproduced (gitignored HTML absent locally, inputs moved since) and **zero votes were cast** against it (`pwg_ru/eval/h1303_abbrev.decisions.json` absent), so re-binding loses nothing. Sheet re-emitted locally (33 cards: 12 rule + 17 ambiguous + 3 ls-border + 1 meta) so MG can vote now; lock re-bound via `REVIEW_LOCK_FORCE=1` to `sha256:14403a33...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)