### PR TITLE
feat(progress): kitchen dashboard + live refresh every minute (H2032)

### DIFF
--- a/.github/workflows/findings-dashboard.yml
+++ b/.github/workflows/findings-dashboard.yml
@@ -71,6 +71,7 @@ jobs:
           cp progress_dashboard/index.html pages/progress/
           [ -f progress_dashboard/progress_data.json ] && cp progress_dashboard/progress_data.json pages/progress/ || true
           [ -f progress_dashboard/progress_timeseries.json ] && cp progress_dashboard/progress_timeseries.json pages/progress/ || true
+          [ -f progress_dashboard/kitchen_data.json ] && cp progress_dashboard/kitchen_data.json pages/progress/ || true
           cd pages
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ papers/sanskrit_in_numbers/.cache/
 
 # H737: scheduled-task refresh log (written into the main checkout by Task Scheduler)
 findings_dashboard/refresh.log
+progress_dashboard/live_refresh.log
 
 # H1657: regenerable in seconds from p2_agent_verdicts.jsonl.gz, ~5 MB each
 HeadwordLists/works_catalogue/p2_agent_decisions.json

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,12 @@ not an error.
 
 ## [Unreleased]
 
+## [1.114.0] - 2026-07-31
+
+### Added
+
+- **PWG→RU progress kitchen + minute-level live refresh** (31-07-2026, Grok 4.5 `grok-4.5`, [H2032](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2032-Grok_SanskritLexicography_progress-kitchen-live-refresh_31.07.26.md)): public `/progress/` now shows the **kitchen** behind the article site — speed (cards/hour & /24h, mean min/window), cost (tokens/window + economy-ledger agents/$ band per clean card), idle gaps (stage_boundary audit_end→start), campaign calendar heatmap, and a web changelog feed from `RussianTranslation/CHANGELOG.md`. New builders [`build_kitchen_data.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/build_kitchen_data.py) + [`live_refresh.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/live_refresh.py) rebuild from local store/ledger and push **only** `gh-pages/progress/` every 60s while translation artifacts are moving (no master spam). The page re-fetches JSON every minute with `cache: 'no-store'` and surfaces a stale/idle/on chip. Closes the standing caveat that a rendered dashboard is not automatically current.
+
 ## [1.113.1] - 2026-07-31
 
 ### Added
@@ -24,6 +30,7 @@ not an error.
 ### Added
 
 - **Counting-conventions methods report shipped (H1871)** (31-07-2026): [METHODS_HOW_WE_COUNT_A_TRADITION_2026.md](https://github.com/gasyoun/SanskritLexicography/blob/master/METHODS_HOW_WE_COUNT_A_TRADITION_2026.md) — the WS4.1 deliverable of the statistics roadmap. Defines every counting convention in use (dictionaries, headwords key1/key2, union, summed census, entries/records, lemmas, kosha.db rows, senses, `<ls>` citations, DCS denominators, tokens, correction events), each with artifact + exact reproduction query; reconciles 16 groups of divergent published figures; logs the four unreconcilable pairs as [CONTRADICTIONS](https://github.com/gasyoun/SanskritLexicography/blob/master/CONTRADICTIONS.md) §10–§13 instead of picking. New surfaced caveats: the 828,505-citation graph is 64.7 % PWG with MW at 5 placeholder nodes; "210 correctors" is superseded (208); the bare "180,176 DCS lemmas" roadmap figure is unciteable until provenanced. Cites, does not restate, the [C7 drift registry](https://github.com/gasyoun/Uprava/blob/main/CANONICAL_FIGURES_CROSS_PAPER_DRIFT_C7.md). Fable 5 (`claude-fable-5`).
+
 ## [1.112.1] - 2026-07-31
 ### Changed
 

--- a/progress_dashboard/README.md
+++ b/progress_dashboard/README.md
@@ -1,61 +1,113 @@
-# PWG→RU progress dashboard
+# PWG→RU progress & kitchen dashboard
 
-_Created: 10-07-2026 · Last updated: 10-07-2026_
+_Created: 10-07-2026 · Last updated: 31-07-2026_
 
 Public companion to the [article site](https://gasyoun.github.io/SanskritLexicography/).
-Where the article site shows the **finished** PWG→Russian translations, this shows
-**how far along the work is** — the honest denominators for each lane.
+Where the article site shows the **finished** PWG→Russian translations, this shows:
 
-Published at **`/progress/`** on gh-pages once the workflow runs (see below).
+1. **Progress** — honest denominators for each lane (verb funnel, store depth, coverage).
+2. **Kitchen** — the process behind the work: speed, cost, idle gaps, campaign calendar,
+   and the project web changelog.
+
+Published at **`/progress/`** on gh-pages.
+
+> **Caveat (still true):** a dashboard that *renders* is not a dashboard that is *current*.
+> Trust the numbers only when a generator has re-run since the last store change. The fix
+> for live campaigns is [`live_refresh.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/live_refresh.py)
+> (rebuilds + publishes every minute while translation artifacts are moving). The HTML
+> also re-fetches JSON every 60s with `cache: 'no-store'`.
 
 ## What it shows
 
-- **Verb lane funnel** (H151) — vetted PWG verb roots → DCS-attested (in scope) →
-  promoted → runnable / blocked-on-rootmap.
-- **Store depth** — sense-rows translated into the RU spine, split by AI-first-pass
-  vs human-reviewed.
-- **Frequency coverage** — what share of PWG is DCS-attested (the first-pass ceiling).
-- **Nominal lane** + the corpus-lexicon / TM asset.
-- **Trend** — one point per rebuild (append-only timeseries).
+### Progress
+- **Verb lane funnel** (H151) — vetted PWG verb roots → DCS-attested → promoted → runnable / blocked.
+- **Store depth** — sense-rows in the RU spine, AI-first-pass vs human-reviewed.
+- **Frequency coverage** — share of PWG that is DCS-attested (first-pass ceiling).
+- **Nominal lane** + corpus-lexicon / TM asset.
+- **Trend** — one point per rebuild day (append-only timeseries).
+
+### Kitchen
+- **Speed** — cards last hour / 24h, mean wall-clock minutes per window.
+- **Cost** — mean tokens per window; optional economy-ledger agents/$ per clean card.
+- **Idle** — gaps between `stage_boundary` audit_end → next audit_start (ledger fallback).
+- **Calendar** — day heatmap of cards written (store provenance) + window counts.
+- **Web changelog** — recent version bullets from `RussianTranslation/CHANGELOG.md`.
+
+For **sub-second** run/gate telemetry on the residential machine (not published), use the
+local ops server:
+
+```
+python RussianTranslation/src/pilot/dashboard_server.py
+# http://127.0.0.1:8765/  (polls /api/status every 5s)
+```
 
 ## Files
 
 | File | Role |
 |---|---|
-| [`build_progress_data.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/build_progress_data.py) | reads local-only pipeline artifacts, emits the two JSONs below |
-| [`progress_data.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/progress_data.json) | one snapshot of every lane/metric (committed) |
-| [`progress_timeseries.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/progress_timeseries.json) | append-only, one row per build date, for trend lines |
-| [`index.html`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/index.html) | self-contained page; fetches the two JSONs |
+| [`build_progress_data.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/build_progress_data.py) | lane/store/coverage snapshot → `progress_data.json` + timeseries |
+| [`build_kitchen_data.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/build_kitchen_data.py) | speed/cost/idle/calendar/changelog → `kitchen_data.json` |
+| [`live_refresh.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/live_refresh.py) | 60s loop while translation is on → rebuild + push `gh-pages/progress/` |
+| [`progress_data.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/progress_data.json) | progress snapshot (committed occasionally; live ticks go to gh-pages only) |
+| [`progress_timeseries.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/progress_timeseries.json) | append-only daily trend rows |
+| [`kitchen_data.json`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/kitchen_data.json) | kitchen snapshot |
+| [`index.html`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/index.html) | self-contained page; polls JSON every 60s |
 
 ## Refresh
 
-**Runs locally, not in CI.** The numbers come from gitignored / local-only artifacts
-(`RussianTranslation/src/pwg_ru_translated.jsonl`, the `*_batch_worklist.json`
-snapshots, the frequency manifest) that GitHub Actions never checks out — exactly
-like [`build_article_site.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/build_article_site.py).
+**Runs locally, not in CI.** Numbers come from gitignored / local-only artifacts under
+`RussianTranslation/` that Actions never checks out.
+
+### While a translation campaign is on (every minute)
+
+```
+# from the main checkout (or any worktree; data is read via PWG_DATA_ROOT)
+python progress_dashboard/live_refresh.py
+```
+
+Behavior:
+- rebuilds when store / window_status / ledger / events are younger than 15 minutes
+- publishes HTML+JSON to `origin/gh-pages` `progress/` only (does **not** spam master)
+- exits after 5 consecutive idle ticks (configurable `--idle-stop`)
+- logs to `progress_dashboard/live_refresh.log` (gitignored if you add it)
+
+One-shot publish even when idle:
+
+```
+python progress_dashboard/live_refresh.py --once --force
+```
+
+Rebuild without pushing:
+
+```
+python progress_dashboard/live_refresh.py --once --force --no-publish
+```
+
+### Manual builders
 
 ```
 python progress_dashboard/build_progress_data.py
+python progress_dashboard/build_kitchen_data.py
 ```
 
-Then commit the refreshed `progress_data.json` + `progress_timeseries.json`. The
+Building from an isolated worktree that lacks the gitignored data:
+
+```
+PWG_DATA_ROOT=/path/to/main/checkout python progress_dashboard/build_kitchen_data.py
+```
+
+### Monthly CI copy
+
 [`findings-dashboard.yml`](https://github.com/gasyoun/SanskritLexicography/blob/master/.github/workflows/findings-dashboard.yml)
-workflow **copies** the committed HTML+JSON onto gh-pages `/progress/` on its monthly
-run (or `workflow_dispatch`); it does **not** rebuild them.
-
-Building from an isolated worktree that lacks the gitignored data? Point the script
-at the checkout that has it:
-
-```
-PWG_DATA_ROOT=/path/to/main/checkout python progress_dashboard/build_progress_data.py
-```
+copies whatever is committed under `progress_dashboard/` onto gh-pages `/progress/` on its
+monthly run (or `workflow_dispatch`). It does **not** rebuild from the store. Live campaigns
+must use `live_refresh.py`.
 
 ## Provenance
 
-Most numbers are counted live from the pipeline's own files. Two are documented
-constants (marked `*` in the trust block): the frequency **denominator** (106,082
-total PWG headwords, from `RussianTranslation/.ai_state.md`) and the **95.4% corpus
-recall** (measured in H309). "Promoted" means passed the mechanical + review gate and
-written to the shipped store — not merely generated.
+Most numbers are counted live from the pipeline's own files. Two progress denominators are
+documented constants (marked `*` in the trust block): total PWG headwords (106,082) and
+95.4% corpus recall (H309). "Promoted" means passed the mechanical + review gate and written
+to the shipped store — not merely generated.
 
 _Dr. Mārcis Gasūns_

--- a/progress_dashboard/build_kitchen_data.py
+++ b/progress_dashboard/build_kitchen_data.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Build the PWG→RU *kitchen* snapshot (process, not results).
+
+Companion to build_progress_data.py (lane denominators) and the local
+RussianTranslation dashboard_server.py (sub-second ops on localhost:8765).
+
+This emits a small public-safe aggregate for gh-pages /progress/ so the web
+page can show the *process* behind the article site:
+
+  - speed      cards/day, recent wall-clock minutes/window
+  - cost       tokens/window from the window ledger (+ economy band when present)
+  - idle       gaps between stage_boundary audit_end → next audit_start
+  - calendar   day-bucketed card + window activity (heatmap)
+  - changelog  recent version bullets from RussianTranslation/CHANGELOG.md
+
+All inputs are local-only / gitignored pipeline artifacts under
+RussianTranslation/. Missing files degrade that slice; the build never raises.
+
+Run (repo root or via live_refresh.py):
+  python progress_dashboard/build_kitchen_data.py
+  PWG_DATA_ROOT=/path/to/main/checkout python ...  # isolated worktree
+
+Writes: progress_dashboard/kitchen_data.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+
+OUT = Path(__file__).resolve().parent
+REPO = OUT.parent
+DATA_REPO = Path(os.environ.get("PWG_DATA_ROOT", REPO)).resolve()
+RT = DATA_REPO / "RussianTranslation"
+PILOT_OUT = RT / "src" / "pilot" / "output"
+STORE = RT / "src" / "pwg_ru_translated.jsonl"
+LEDGER = PILOT_OUT / "window_ledger.jsonl"
+EVENTS = PILOT_OUT / "dashboard_events.jsonl"
+WINDOW_STATUS = PILOT_OUT / "window_status.json"
+CHANGELOG = RT / "CHANGELOG.md"
+ECONOMY = PILOT_OUT / "economy_ledger.json"
+
+# "Translation is on" if any of these artifacts moved within this window.
+ACTIVE_WITHIN_SECONDS = 15 * 60
+# Gaps shorter than this between audit stages are not counted as idle (pipeline churn).
+MIN_IDLE_SECONDS = 120
+# Calendar depth shown on the public page.
+CALENDAR_DAYS = 120
+# Changelog entries kept for the web feed.
+CHANGELOG_VERSIONS = 12
+CHANGELOG_BULLETS_PER = 4
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def utc_now_iso() -> str:
+    return utc_now().isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _parse_ts(raw):
+    if not raw or not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _day(ts: str | None) -> str | None:
+    if not ts or len(ts) < 10:
+        return None
+    return ts[:10]
+
+
+def _iter_jsonl(path: Path):
+    if not path.exists():
+        return
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def _file_info(path: Path) -> dict:
+    if not path.exists():
+        return {"exists": False, "mtime": None, "age_seconds": None, "size": None}
+    st = path.stat()
+    mtime = datetime.fromtimestamp(st.st_mtime, tz=timezone.utc)
+    return {
+        "exists": True,
+        "mtime": mtime.isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "age_seconds": int((utc_now() - mtime).total_seconds()),
+        "size": st.st_size,
+    }
+
+
+def _mean(vals):
+    nums = [v for v in vals if isinstance(v, (int, float))]
+    if not nums:
+        return None
+    return round(sum(nums) / len(nums), 3)
+
+
+def activity_status() -> dict:
+    """Whether the campaign looks live right now (store / status / ledger mtime)."""
+    infos = {
+        "store": _file_info(STORE),
+        "window_status": _file_info(WINDOW_STATUS),
+        "window_ledger": _file_info(LEDGER),
+        "events": _file_info(EVENTS),
+    }
+    ages = [
+        i["age_seconds"]
+        for i in infos.values()
+        if i.get("exists") and isinstance(i.get("age_seconds"), int)
+    ]
+    youngest = min(ages) if ages else None
+    active = youngest is not None and youngest <= ACTIVE_WITHIN_SECONDS
+    ws = None
+    if WINDOW_STATUS.exists():
+        try:
+            ws = json.loads(WINDOW_STATUS.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            ws = None
+    return {
+        "translation_on": active,
+        "active_within_seconds": ACTIVE_WITHIN_SECONDS,
+        "youngest_artifact_age_seconds": youngest,
+        "window_state": (ws or {}).get("state"),
+        "window_root": (ws or {}).get("root") or ((ws or {}).get("workflow_meta") or {}).get("root"),
+        "next_action": (ws or {}).get("next_action"),
+        "artifacts": infos,
+    }
+
+
+def store_speed() -> dict:
+    """Cards written per recent day / hour from store provenance timestamps."""
+    by_day: dict[str, int] = {}
+    by_hour: dict[str, int] = {}
+    total = 0
+    newest = None
+    if not STORE.exists():
+        return {"measured": False, "total_cards": 0, "cards_by_day": {}, "last_24h": 0, "last_hour": 0}
+    now = utc_now()
+    cutoff_24h = now - timedelta(hours=24)
+    cutoff_1h = now - timedelta(hours=1)
+    last_24h = 0
+    last_hour = 0
+    for row in _iter_jsonl(STORE):
+        prov = row.get("provenance") or {}
+        ts = prov.get("generated_at") or row.get("generated_at")
+        dt = _parse_ts(ts)
+        if not dt:
+            continue
+        total += 1
+        day = dt.date().isoformat()
+        hour = dt.strftime("%Y-%m-%dT%H")
+        by_day[day] = by_day.get(day, 0) + 1
+        by_hour[hour] = by_hour.get(hour, 0) + 1
+        if newest is None or dt > newest:
+            newest = dt
+        if dt >= cutoff_24h:
+            last_24h += 1
+        if dt >= cutoff_1h:
+            last_hour += 1
+    # mean cards/day over the last 14 calendar days that have any activity
+    recent_days = sorted(by_day)[-14:]
+    mean_day = _mean([by_day[d] for d in recent_days]) if recent_days else None
+    return {
+        "measured": total > 0,
+        "total_cards": total,
+        "last_24h": last_24h,
+        "last_hour": last_hour,
+        "mean_cards_per_active_day_14d": mean_day,
+        "newest_card_at": newest.isoformat(timespec="seconds").replace("+00:00", "Z") if newest else None,
+        "cards_by_day": by_day,
+    }
+
+
+def ledger_cost_speed() -> dict:
+    """Recent window wall-clock + token figures from window_ledger.jsonl."""
+    rows = list(_iter_jsonl(LEDGER)) if LEDGER.exists() else []
+    if not rows:
+        return {"measured": False, "windows": 0}
+    minutes = []
+    tokens = []
+    recent = []
+    for r in rows[-80:]:
+        pm = r.get("production_metrics") or {}
+        mins = pm.get("wall_clock_minutes")
+        tok = pm.get("max_output_tokens") or pm.get("output_tokens") or pm.get("total_tokens")
+        if isinstance(mins, (int, float)) and mins > 0:
+            minutes.append(float(mins))
+        if isinstance(tok, (int, float)) and tok > 0:
+            tokens.append(float(tok))
+        recent.append(
+            {
+                "recorded_at": r.get("recorded_at"),
+                "root": r.get("root"),
+                "state": r.get("state"),
+                "workflow_keys": r.get("workflow_keys"),
+                "translated": r.get("translated"),
+                "requeue_count": r.get("requeue_count"),
+                "wall_clock_minutes": mins,
+                "tokens": tok,
+            }
+        )
+    return {
+        "measured": True,
+        "windows": len(rows),
+        "recent_windows_shown": len(recent),
+        "mean_wall_clock_minutes": _mean(minutes),
+        "mean_tokens_per_window": _mean(tokens),
+        "last_window": recent[-1] if recent else None,
+        "recent": recent[-12:],
+    }
+
+
+def economy_band() -> dict:
+    """Optional durable economy ledger (agents/$ per clean card) if present."""
+    if not ECONOMY.exists():
+        # try computing on the fly from the frozen probe log (cheap enough)
+        probe = RT / "src" / "pilot" / "generation_api_probe_log.jsonl"
+        if not probe.exists():
+            return {"measured": False}
+        try:
+            pilot = str(RT / "src" / "pilot")
+            if pilot not in sys.path:
+                sys.path.insert(0, pilot)
+            import economy_ledger as el  # noqa: WPS433
+
+            rows = el.read_rows(str(probe))
+            data = el.build_ledger(rows, source_log=str(probe))
+            # Public kitchen only gets aggregates — never the per-run dump.
+            summary = {}
+            if isinstance(data.get("aggregate"), dict):
+                summary.update(data["aggregate"])
+            if isinstance(data.get("coverage"), dict):
+                summary["coverage"] = data["coverage"]
+            summary["price_basis_usd_per_million"] = data.get("price_basis_usd_per_million")
+            # Convenience aliases for the HTML cards.
+            if "agents_per_clean_incl_requeues" in summary:
+                summary.setdefault(
+                    "agents_per_clean", summary["agents_per_clean_incl_requeues"]
+                )
+            band = {}
+            for key in (
+                "cost_per_clean_floor_usd",
+                "cost_per_clean_ceil_usd",
+                "cost_band_usd_per_clean",
+                "usd_per_clean_floor",
+                "usd_per_clean_ceil",
+            ):
+                if key in summary:
+                    band[key] = summary[key]
+            if band:
+                summary["cost_band_usd_per_clean"] = band
+            return {
+                "measured": True,
+                "source": "generation_api_probe_log.jsonl",
+                "schema": data.get("schema"),
+                "summary": summary,
+            }
+        except Exception as e:  # noqa: BLE001
+            return {"measured": False, "error": str(e)[:200]}
+    try:
+        data = json.loads(ECONOMY.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001
+        return {"measured": False, "error": str(e)[:200]}
+    return {
+        "measured": True,
+        "source": "economy_ledger.json",
+        "schema": data.get("schema"),
+        "summary": data.get("summary") or data.get("aggregate") or data,
+    }
+
+
+def idle_gaps() -> dict:
+    """Operator idle = gap between audit_end and the next audit_start (stage_boundary).
+
+    Falls back to gaps between consecutive window_ledger rows when stage_boundary
+    events are sparse.
+    """
+    boundaries = []
+    for e in _iter_jsonl(EVENTS) if EVENTS.exists() else []:
+        if e.get("type") != "stage_boundary":
+            continue
+        dt = _parse_ts(e.get("ts"))
+        if not dt:
+            continue
+        stage = e.get("state") or (e.get("data") or {}).get("stage")
+        if stage not in ("audit_start", "audit_end"):
+            # accept summary form stage_boundary:audit_end
+            summary = str(e.get("summary") or "")
+            if "audit_start" in summary:
+                stage = "audit_start"
+            elif "audit_end" in summary:
+                stage = "audit_end"
+            else:
+                continue
+        boundaries.append((dt, stage, e.get("root")))
+
+    gaps = []
+    last_end = None
+    for dt, stage, root in sorted(boundaries, key=lambda x: x[0]):
+        if stage == "audit_end":
+            last_end = (dt, root)
+        elif stage == "audit_start" and last_end is not None:
+            secs = (dt - last_end[0]).total_seconds()
+            if secs >= MIN_IDLE_SECONDS:
+                gaps.append(
+                    {
+                        "from": last_end[0].isoformat(timespec="seconds").replace("+00:00", "Z"),
+                        "to": dt.isoformat(timespec="seconds").replace("+00:00", "Z"),
+                        "seconds": int(secs),
+                        "after_root": last_end[1],
+                        "before_root": root,
+                    }
+                )
+            last_end = None
+
+    # ledger fallback if no stage_boundary gaps
+    if not gaps and LEDGER.exists():
+        prev = None
+        for r in _iter_jsonl(LEDGER):
+            dt = _parse_ts(r.get("recorded_at"))
+            if not dt:
+                continue
+            if prev is not None:
+                secs = (dt - prev[0]).total_seconds()
+                if secs >= MIN_IDLE_SECONDS:
+                    gaps.append(
+                        {
+                            "from": prev[0].isoformat(timespec="seconds").replace("+00:00", "Z"),
+                            "to": dt.isoformat(timespec="seconds").replace("+00:00", "Z"),
+                            "seconds": int(secs),
+                            "after_root": prev[1],
+                            "before_root": r.get("root"),
+                            "source": "ledger_gap",
+                        }
+                    )
+            prev = (dt, r.get("root"))
+
+    total_idle = sum(g["seconds"] for g in gaps)
+    # current idle: time since youngest artifact if translation is not on
+    act = activity_status()
+    current_idle = None
+    if not act["translation_on"] and act["youngest_artifact_age_seconds"] is not None:
+        current_idle = act["youngest_artifact_age_seconds"]
+
+    return {
+        "measured": bool(gaps) or current_idle is not None,
+        "min_idle_seconds": MIN_IDLE_SECONDS,
+        "gap_count": len(gaps),
+        "total_idle_seconds": total_idle,
+        "total_idle_hours": round(total_idle / 3600, 2) if gaps else 0,
+        "mean_gap_seconds": _mean([g["seconds"] for g in gaps]),
+        "current_idle_seconds": current_idle,
+        "recent_gaps": gaps[-15:],
+    }
+
+
+def calendar(store_speed_data: dict, ledger_rows_hint: int = 0) -> dict:
+    """Day cells for a contribution-style heatmap (last CALENDAR_DAYS)."""
+    by_day = dict(store_speed_data.get("cards_by_day") or {})
+    # overlay window counts from ledger
+    windows_by_day: dict[str, int] = {}
+    for r in _iter_jsonl(LEDGER) if LEDGER.exists() else []:
+        d = _day(r.get("recorded_at"))
+        if d:
+            windows_by_day[d] = windows_by_day.get(d, 0) + 1
+
+    end = utc_now().date()
+    start = end - timedelta(days=CALENDAR_DAYS - 1)
+    cells = []
+    cur = start
+    while cur <= end:
+        iso = cur.isoformat()
+        cards = by_day.get(iso, 0)
+        wins = windows_by_day.get(iso, 0)
+        cells.append({"date": iso, "cards": cards, "windows": wins, "level": _heat_level(cards)})
+        cur += timedelta(days=1)
+    return {
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "days": CALENDAR_DAYS,
+        "cells": cells,
+        "max_cards": max((c["cards"] for c in cells), default=0),
+        "active_days": sum(1 for c in cells if c["cards"] or c["windows"]),
+    }
+
+
+def _heat_level(n: int) -> int:
+    if n <= 0:
+        return 0
+    if n < 5:
+        return 1
+    if n < 25:
+        return 2
+    if n < 100:
+        return 3
+    return 4
+
+
+def web_changelog() -> dict:
+    """Parse recent version sections from RussianTranslation/CHANGELOG.md."""
+    if not CHANGELOG.exists():
+        return {"measured": False, "entries": []}
+    text = CHANGELOG.read_text(encoding="utf-8", errors="replace")
+    # ## [1.111.5] - 2026-07-31   or ## [Unreleased]
+    ver_re = re.compile(r"^## \[([^\]]+)\](?:\s*-\s*(\d{4}-\d{2}-\d{2}))?\s*$", re.M)
+    bullet_re = re.compile(r"^###\s+(.+)$", re.M)
+    matches = list(ver_re.finditer(text))
+    entries = []
+    for i, m in enumerate(matches[: CHANGELOG_VERSIONS + 2]):  # skip Unreleased if empty
+        ver = m.group(1)
+        date = m.group(2)
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[start:end]
+        bullets = []
+        for bm in bullet_re.finditer(body):
+            title = bm.group(1).strip()
+            # first prose paragraph after the heading (up to blank line)
+            after = body[bm.end() :]
+            para = after.split("\n\n", 1)[0]
+            para = re.sub(r"\s+", " ", para).strip()
+            if len(para) > 280:
+                para = para[:277] + "…"
+            bullets.append({"title": title, "summary": para})
+            if len(bullets) >= CHANGELOG_BULLETS_PER:
+                break
+        if ver.lower() == "unreleased" and not bullets:
+            continue
+        entries.append({"version": ver, "date": date, "bullets": bullets})
+        if len(entries) >= CHANGELOG_VERSIONS:
+            break
+    return {
+        "measured": True,
+        "source": "RussianTranslation/CHANGELOG.md",
+        "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/CHANGELOG.md",
+        "entries": entries,
+    }
+
+
+def main():
+    act = activity_status()
+    speed = store_speed()
+    ledger = ledger_cost_speed()
+    idle = idle_gaps()
+    cal = calendar(speed)
+    clog = web_changelog()
+    econ = economy_band()
+
+    data = {
+        "generated_at": utc_now_iso(),
+        "schema": "pwg.kitchen.v1",
+        "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
+        "site_url": "https://gasyoun.github.io/SanskritLexicography/",
+        "progress_url": "https://gasyoun.github.io/SanskritLexicography/progress/",
+        "local_ops_note": (
+            "For sub-second run/gate telemetry on the residential machine, run "
+            "`python RussianTranslation/src/pilot/dashboard_server.py` (default "
+            "http://127.0.0.1:8765/, polls every 5s)."
+        ),
+        "activity": act,
+        "speed": {
+            "cards_last_hour": speed.get("last_hour"),
+            "cards_last_24h": speed.get("last_24h"),
+            "mean_cards_per_active_day_14d": speed.get("mean_cards_per_active_day_14d"),
+            "mean_wall_clock_minutes": ledger.get("mean_wall_clock_minutes"),
+            "newest_card_at": speed.get("newest_card_at"),
+            "measured": bool(speed.get("measured") or ledger.get("measured")),
+        },
+        "cost": {
+            "mean_tokens_per_window": ledger.get("mean_tokens_per_window"),
+            "windows_in_ledger": ledger.get("windows"),
+            "economy": econ,
+            "measured": bool(ledger.get("measured") or econ.get("measured")),
+        },
+        "idle": idle,
+        "calendar": cal,
+        "changelog": clog,
+        "recent_windows": ledger.get("recent") or [],
+        "last_window": ledger.get("last_window"),
+    }
+
+    out_path = OUT / "kitchen_data.json"
+    out_path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"kitchen_data.json written ({data['generated_at']}).")
+    print(
+        f"  translation_on={act['translation_on']}  "
+        f"cards_24h={speed.get('last_24h')}  "
+        f"mean_min/window={ledger.get('mean_wall_clock_minutes')}  "
+        f"idle_gaps={idle.get('gap_count')}  "
+        f"changelog_entries={len(clog.get('entries') or [])}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/progress_dashboard/build_progress_data.py
+++ b/progress_dashboard/build_progress_data.py
@@ -167,7 +167,9 @@ def corpus():
 
 
 def main():
-    today = datetime.now(timezone.utc).date().isoformat()
+    now = datetime.now(timezone.utc)
+    today = now.date().isoformat()
+    generated_at = now.isoformat(timespec="seconds").replace("+00:00", "Z")
     verb = verb_lane()
     nom = nominal_lane()
     st = store_depth()
@@ -175,9 +177,12 @@ def main():
     cor = corpus()
 
     data = {
-        "generated_at": today,
+        "generated_at": generated_at,
+        "snapshot_date": today,
         "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
         "site_url": "https://gasyoun.github.io/SanskritLexicography/",
+        "kitchen_url": "https://gasyoun.github.io/SanskritLexicography/progress/",
+        "refresh_hint_seconds": 60,
         "lanes": {"verb": verb, "nominal": nom},
         "store": st,
         "coverage": cov,
@@ -187,7 +192,7 @@ def main():
     (OUT / "progress_data.json").write_text(
         json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
     )
-    print(f"progress_data.json written ({today}).")
+    print(f"progress_data.json written ({generated_at}).")
 
     # append-only timeseries: one row per build date (last write per date wins)
     ts_path = OUT / "progress_timeseries.json"
@@ -199,6 +204,7 @@ def main():
             ts = {"snapshots": []}
     row = {
         "date": today,
+        "generated_at": generated_at,
         "verb_promoted": verb.get("promoted"),
         "verb_dcs_attested": verb.get("dcs_attested"),
         "senses": st.get("senses"),

--- a/progress_dashboard/index.html
+++ b/progress_dashboard/index.html
@@ -3,19 +3,30 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>PWG→RU progress — SanskritLexicography</title>
+<title>PWG→RU progress &amp; kitchen — SanskritLexicography</title>
 <style>
   :root { --fg:#1f2328; --mut:#59636e; --bg:#fff; --card:#f6f8fa; --line:#d1d9e0;
-          --accent:#0969da; --done:#1a7f37; --run:#9a6700; --block:#d1242f; }
+          --accent:#0969da; --done:#1a7f37; --run:#9a6700; --block:#d1242f;
+          --heat0:#ebedf0; --heat1:#9be9a8; --heat2:#40c463; --heat3:#30a14e; --heat4:#216e39; }
   @media (prefers-color-scheme: dark) {
     :root { --fg:#e6edf3; --mut:#9198a1; --bg:#0d1117; --card:#161b22; --line:#30363d;
-            --accent:#4493f8; --done:#3fb950; --run:#d29922; --block:#f85149; }
+            --accent:#4493f8; --done:#3fb950; --run:#d29922; --block:#f85149;
+            --heat0:#161b22; --heat1:#0e4429; --heat2:#006d32; --heat3:#26a641; --heat4:#39d353; }
   }
   body { font: 15px/1.5 system-ui, sans-serif; color:var(--fg); background:var(--bg);
-         max-width: 1080px; margin: 0 auto; padding: 1.5rem; }
+         max-width: 1100px; margin: 0 auto; padding: 1.5rem; }
   h1 { font-size: 1.5rem; margin-bottom:.2rem; } h2 { font-size: 1.15rem; margin-top: 2.2rem; }
   .mut { color: var(--mut); font-size: .85rem; }
   a { color: var(--accent); }
+  .top-live { display:flex; flex-wrap:wrap; gap:.8rem 1.2rem; align-items:center;
+              margin: .8rem 0 1.2rem; padding:.7rem 1rem; background:var(--card);
+              border:1px solid var(--line); border-radius:8px; font-size:.9rem; }
+  .chip { display:inline-block; padding:.1rem .55rem; border-radius:999px; font-size:.78rem;
+          font-weight:600; border:1px solid var(--line); background:var(--bg); }
+  .chip.on { color:var(--done); border-color:var(--done); }
+  .chip.off { color:var(--mut); }
+  .chip.stale { color:var(--block); border-color:var(--block); }
+  .chip.warn { color:var(--run); border-color:var(--run); }
   .cards { display: flex; gap: .8rem; flex-wrap: wrap; margin: 1rem 0; }
   .card { background: var(--card); border: 1px solid var(--line); border-radius: 8px;
           padding: .7rem 1.1rem; min-width: 8.5rem; }
@@ -25,7 +36,6 @@
   th, td { text-align: left; padding: .35rem .6rem; border-bottom: 1px solid var(--line); }
   th { color: var(--mut); font-weight: 600; }
   td.num { text-align: right; font-variant-numeric: tabular-nums; }
-  /* funnel + bars */
   .bar-wrap { background: var(--card); border:1px solid var(--line); border-radius:8px;
               padding:.9rem 1.1rem; margin:.6rem 0; }
   .bar-row { display:flex; align-items:center; gap:.7rem; margin:.35rem 0; }
@@ -43,27 +53,74 @@
            border-radius:6px; padding:.7rem 1rem; font-size:.83rem; color:var(--mut); margin:1rem 0; }
   .trust b { color:var(--fg); }
   .chart { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding:.6rem; }
-  .flags { font-size:.8rem; }
   .est { color:var(--run); cursor:help; }
   footer { margin-top:2.5rem; color:var(--mut); font-size:.8rem; }
+  .cal { display:grid; grid-template-columns: repeat(auto-fill, 12px); gap:3px;
+         background:var(--card); border:1px solid var(--line); border-radius:8px; padding:.8rem; }
+  .cal i { width:12px; height:12px; border-radius:2px; display:block; }
+  .cal i.l0{background:var(--heat0);} .cal i.l1{background:var(--heat1);}
+  .cal i.l2{background:var(--heat2);} .cal i.l3{background:var(--heat3);}
+  .cal i.l4{background:var(--heat4);}
+  .clog { border-left:3px solid var(--line); padding-left:1rem; margin:.8rem 0; }
+  .clog h3 { margin:.2rem 0; font-size:1rem; }
+  .clog ul { margin:.3rem 0 .8rem; padding-left:1.1rem; }
+  .clog li { margin:.25rem 0; }
+  .two { display:grid; grid-template-columns:1fr 1fr; gap:1rem; }
+  @media (max-width:720px){ .two { grid-template-columns:1fr; } }
+  .note { color:var(--mut); font-size:.85rem; }
+  .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size:.85rem; }
 </style>
 </head>
 <body>
-<h1>PWG → Russian — translation progress</h1>
+<h1>PWG → Russian — progress &amp; kitchen</h1>
 <p class="mut">How the machine-assisted translation of the <b>Petersburg Dictionary</b>
-  (Böhtlingk–Roth, PWG) into Russian is progressing. The finished articles are browsable at the
-  <a id="sitelink" href="https://gasyoun.github.io/SanskritLexicography/">article site</a>;
-  this page is the <em>backlog-and-coverage</em> companion. <span id="stamp"></span></p>
-<p class="mut">Glossary-layer coverage across dicts (sibling chart):
-  <a href="../data/viz/ru_gloss_gaps.html">RU-gloss gap ranking cards</a>
-  (committed H685 stats — not the full gitignored gap list).</p>
+  (Böhtlingk–Roth, PWG) into Russian is progressing — both the <em>results</em> (lane
+  denominators) and the <em>kitchen</em> (speed, cost, idle time, calendar, changelog).
+  Finished articles:
+  <a id="sitelink" href="https://gasyoun.github.io/SanskritLexicography/">article site</a>.
+  Sibling dashboards:
+  <a href="../findings/">findings</a> ·
+  <a href="../episteme/">epistemic</a>.</p>
+
+<div class="top-live" id="livebar">
+  <span id="liveChip" class="chip off">loading</span>
+  <span class="mut">Snapshot <b id="stamp">—</b></span>
+  <span class="mut">Page poll <b id="pollAge">—</b></span>
+  <span class="mut">Data age <b id="dataAge">—</b></span>
+  <span class="mut" id="nextPoll">auto-refresh every 60s</span>
+</div>
 
 <div class="cards" id="cards"></div>
 
+<h2 id="kitchen">Kitchen — process while translation is on</h2>
+<p class="mut">Speed, cost, time when nothing was going on, campaign calendar, and the project
+  web changelog. Numbers come from local pipeline ledgers; this page re-fetches JSON every
+  minute. A residential <code>live_refresh.py</code> loop rebuilds + publishes to gh-pages while
+  the store is moving.</p>
+<div class="cards" id="kitchenCards"></div>
+<div class="two">
+  <div>
+    <h3>Recent windows</h3>
+    <div id="recentWindows" class="note">—</div>
+  </div>
+  <div>
+    <h3>Idle gaps</h3>
+    <div id="idleGaps" class="note">—</div>
+  </div>
+</div>
+
+<h3>Campaign calendar</h3>
+<p class="mut" id="calLegend">cards written per day (store provenance)</p>
+<div class="cal" id="calendar" aria-label="activity calendar"></div>
+
+<h3>Web changelog</h3>
+<p class="mut">Recent method/pipeline versions from
+  <a id="clogLink" href="https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/CHANGELOG.md">RussianTranslation/CHANGELOG.md</a>.</p>
+<div id="changelog"></div>
+
 <h2>Verb lane — the priority workstream (H151)</h2>
 <p class="mut">The dictionary is topped by verbal roots (<code>sTA</code> 379 senses, <code>i</code> 272,
-  <code>gam</code> 213…). They are translated root-by-root through the Claude Workflow harness. Funnel
-  from every vetted PWG verb root down to what is actually promoted:</p>
+  <code>gam</code> 213…). Funnel from every vetted PWG verb root down to what is actually promoted:</p>
 <div class="bar-wrap" id="verbfunnel"></div>
 <div class="legend">
   <span><i class="sw c-univ"></i>vetted universe</span>
@@ -87,22 +144,39 @@
 <table id="misc"></table>
 
 <h2>Trend</h2>
-<p class="mut">One point per dashboard rebuild. A single point shows the current value; the line
+<p class="mut">One point per dashboard rebuild day. A single point shows the current value; the line
   appears once a second snapshot exists.</p>
 <div class="cards" id="charts"></div>
 
 <div class="trust" id="trust"></div>
 
 <footer>
-  Built by <code>progress_dashboard/build_progress_data.py</code> from local-only pipeline artifacts;
-  published to <code>/progress/</code> on gh-pages. Source:
+  Built by <code>progress_dashboard/build_progress_data.py</code> +
+  <code>build_kitchen_data.py</code>; published to <code>/progress/</code> on gh-pages by
+  <code>live_refresh.py</code> (every minute while translation is on) or the monthly
+  findings-dashboard workflow. Local sub-second ops:
+  <code>python RussianTranslation/src/pilot/dashboard_server.py</code>.
+  Source:
   <a href="https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/">progress_dashboard/</a>.
 </footer>
 
 <script>
 'use strict';
-const esc = s => String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
-const fmt = n => (n == null ? '—' : n.toLocaleString('en-US'));
+const POLL_MS = 60_000;
+const STALE_WARN_S = 10 * 60;   // snapshot older than 10 min → warn
+const STALE_BAD_S  = 60 * 60;   // older than 1 h → stale
+
+const esc = s => String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const fmt = n => (n == null || Number.isNaN(n) ? '—' : Number(n).toLocaleString('en-US'));
+const fmtDur = secs => {
+  if (secs == null || !Number.isFinite(secs)) return '—';
+  secs = Math.max(0, Math.floor(secs));
+  if (secs < 60) return secs + 's';
+  if (secs < 3600) return Math.floor(secs/60) + 'm ' + (secs%60) + 's';
+  const h = Math.floor(secs/3600), m = Math.floor((secs%3600)/60);
+  if (h < 48) return h + 'h ' + m + 'm';
+  return Math.floor(h/24) + 'd ' + (h%24) + 'h';
+};
 
 function barRow(label, sub, value, total, cls, valText) {
   const pct = total ? Math.max(1.5, value / total * 100) : 0;
@@ -142,19 +216,55 @@ function line(el, series, label, suffix) {
      </svg></div>`);
 }
 
-async function j(f) { try { const r = await fetch(f); return r.ok ? r.json() : null; } catch { return null; } }
+async function j(f) {
+  try {
+    const r = await fetch(f + (f.includes('?') ? '&' : '?') + 't=' + Date.now(), { cache: 'no-store' });
+    return r.ok ? r.json() : null;
+  } catch { return null; }
+}
 
-(async () => {
-  const d = await j('progress_data.json');
+function parseIso(s) {
+  if (!s) return null;
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function ageSeconds(iso) {
+  const d = parseIso(iso);
+  if (!d) return null;
+  return Math.floor((Date.now() - d.getTime()) / 1000);
+}
+
+function setLiveBar(d, k) {
+  const gen = (k && k.generated_at) || (d && d.generated_at) || null;
+  document.getElementById('stamp').textContent = gen || '—';
+  const age = ageSeconds(gen);
+  document.getElementById('dataAge').textContent = age == null ? '—' : fmtDur(age);
+  const on = k && k.activity && k.activity.translation_on;
+  const chip = document.getElementById('liveChip');
+  if (age != null && age > STALE_BAD_S) {
+    chip.className = 'chip stale';
+    chip.textContent = 'snapshot stale';
+  } else if (on) {
+    chip.className = 'chip on';
+    chip.textContent = 'translation on';
+  } else if (age != null && age > STALE_WARN_S) {
+    chip.className = 'chip warn';
+    chip.textContent = 'idle / aging';
+  } else {
+    chip.className = 'chip off';
+    chip.textContent = on === false ? 'translation idle' : 'snapshot ok';
+  }
+}
+
+function renderProgress(d) {
   if (!d) {
-    document.getElementById('cards').innerHTML = '<p class="bad">progress_data.json not found.</p>';
+    document.getElementById('cards').innerHTML = '<p class="note">progress_data.json not found.</p>';
     return;
   }
   const v = d.lanes.verb, nm = d.lanes.nominal, st = d.store, cov = d.coverage, cor = d.corpus;
-  document.getElementById('stamp').textContent = 'Snapshot ' + d.generated_at + '.';
   if (d.site_url) document.getElementById('sitelink').href = d.site_url;
 
-  // headline cards
   document.getElementById('cards').innerHTML = [
     `<div class="card"><b>${fmt(st.senses)}</b><span class="sub">sense-rows translated (RU)</span></div>`,
     `<div class="card"><b>${fmt(st.roots)}</b><span class="sub">roots with translations</span></div>`,
@@ -162,35 +272,34 @@ async function j(f) { try { const r = await fetch(f); return r.ok ? r.json() : n
     `<div class="card"><b>${cov.pct}%</b><span class="sub">of PWG is DCS-attested</span></div>`,
   ].join('');
 
-  // verb funnel
   const vf = document.getElementById('verbfunnel');
   const U = v.universe || 0;
+  const scopePct = v.dcs_attested ? (v.promoted / v.dcs_attested * 100).toFixed(1) : '—';
   vf.innerHTML =
     barRow('Vetted PWG verb roots', 'universe_verbs01', v.universe, U, 'c-univ') +
     barRow('DCS-attested (in scope)', 'first-pass target', v.dcs_attested, U, 'c-att') +
     barRow('Promoted', 'shipped to store', v.promoted, U, 'c-done',
-           `${fmt(v.promoted)} <span class="mut">(${(v.promoted / v.dcs_attested * 100).toFixed(1)}% of scope)</span>`) +
+           `${fmt(v.promoted)} <span class="mut">(${scopePct}% of scope)</span>`) +
     barRow('Runnable now', 'has rootmap', v.runnable, U, 'c-run') +
     barRow('Blocked', 'missing rootmap', v.blocked, U, 'c-block');
 
-  // store review split
   const rb = document.getElementById('reviewbar');
   const human = st.human_reviewed || 0;
   const ai = (st.senses || 0) - human;
+  const aiPct = st.senses ? (ai / st.senses * 100).toFixed(1) : '—';
+  const huPct = st.senses ? (human / st.senses * 100).toFixed(1) : '—';
   rb.innerHTML =
     barRow('AI first pass', 'awaiting human QA', ai, st.senses, 'c-run',
-           `${fmt(ai)} <span class="mut">(${(ai / st.senses * 100).toFixed(1)}%)</span>`) +
+           `${fmt(ai)} <span class="mut">(${aiPct}%)</span>`) +
     barRow('Human-reviewed', 'signed off', human, st.senses, 'c-done',
-           `${fmt(human)} <span class="mut">(${(human / st.senses * 100).toFixed(1)}%)</span>`);
+           `${fmt(human)} <span class="mut">(${huPct}%)</span>`);
 
-  // coverage bar
   const cb = document.getElementById('covbar');
   cb.innerHTML =
     barRow('DCS-attested headwords', 'in first-pass scope', cov.dcs_attested_headwords, cov.total_headwords, 'c-att',
            `${fmt(cov.dcs_attested_headwords)} <span class="mut">(${cov.pct}%)</span>`) +
     barRow('Total PWG headwords', 'whole dictionary', cov.total_headwords, cov.total_headwords, 'c-univ');
 
-  // misc table
   const est = t => `<span class="est" title="documented constant, not counted live">${esc(t)} *</span>`;
   document.getElementById('misc').innerHTML =
     '<tr><th>Item</th><th class="num">Value</th><th>Note</th></tr>' +
@@ -199,18 +308,6 @@ async function j(f) { try { const r = await fetch(f); return r.ok ? r.json() : n
     `<tr><td>Corpus lexicon (TM source)</td><td class="num">${cor.pairs_measured ? fmt(cor.pairs) : est(fmt(cor.pairs))}</td><td class="mut">Sa→Ru alignment pairs</td></tr>` +
     `<tr><td>Alignment recall</td><td class="num">${est(cor.recall_pct + '%')}</td><td class="mut">measured H309</td></tr>`;
 
-  // trend charts
-  const ts = await j('progress_timeseries.json');
-  if (ts && ts.snapshots && ts.snapshots.length) {
-    const el = document.getElementById('charts');
-    const pick = key => ts.snapshots.filter(s => s[key] != null).map(s => [s.date, s[key]]);
-    let s;
-    if ((s = pick('senses')).length) line(el, s, 'Sense-rows translated');
-    if ((s = pick('verb_promoted')).length) line(el, s, 'Verb roots promoted');
-    if ((s = pick('coverage_pct')).length) line(el, s, 'DCS coverage', '%');
-  }
-
-  // trust block
   const flag = ok => ok ? '<b style="color:var(--done)">measured live</b>' : '<span class="est">documented constant *</span>';
   document.getElementById('trust').innerHTML =
     `<b>Provenance.</b> Snapshot <b>${esc(d.generated_at)}</b>. ` +
@@ -218,8 +315,125 @@ async function j(f) { try { const r = await fetch(f); return r.ok ? r.json() : n
     `the frequency denominator (${fmt(cov.total_headwords)} headwords) and the ${cor.recall_pct}% recall are ` +
     `documented constants (marked <span class="est">*</span>). ` +
     `Store: ${flag(st.measured)}. Verb lane: ${flag(v.measured)}. Coverage numerator: ${flag(cov.measured)}. ` +
-    `“Promoted” = passed the mechanical + review gate and written to the shipped store, not merely generated.`;
-})();
+    `"Promoted" = passed the mechanical + review gate and written to the shipped store, not merely generated. ` +
+    `A dashboard that renders is not automatically current — trust this page only when ` +
+    `<code>live_refresh.py</code> (or a manual rebuild) has run since the last store change.`;
+}
+
+function renderKitchen(k) {
+  if (!k) {
+    document.getElementById('kitchenCards').innerHTML =
+      '<p class="note">kitchen_data.json not found yet — run <code>build_kitchen_data.py</code> or <code>live_refresh.py --once --force</code>.</p>';
+    return;
+  }
+  const sp = k.speed || {}, co = k.cost || {}, id = k.idle || {};
+  const econ = (co.economy && co.economy.summary) || {};
+  const agents = econ.agents_per_clean ?? econ.agents_per_clean_incl_requeues;
+  const band = econ.cost_per_clean_band || econ.cost_band_usd_per_clean || econ.usd_per_clean;
+  let costLabel = '—';
+  if (co.mean_tokens_per_window != null) costLabel = fmt(Math.round(co.mean_tokens_per_window));
+  let bandLabel = null;
+  if (band && typeof band === 'object' && (band.floor_usd != null || band.ceil_usd != null)) {
+    bandLabel = `$${Number(band.floor_usd).toFixed(2)}–$${Number(band.ceil_usd).toFixed(2)}`;
+  } else if (band != null && typeof band !== 'object') {
+    bandLabel = String(band);
+  }
+  document.getElementById('kitchenCards').innerHTML = [
+    `<div class="card"><b>${fmt(sp.cards_last_hour)}</b><span class="sub">cards last hour</span></div>`,
+    `<div class="card"><b>${fmt(sp.cards_last_24h)}</b><span class="sub">cards last 24h</span></div>`,
+    `<div class="card"><b>${sp.mean_wall_clock_minutes != null ? sp.mean_wall_clock_minutes : '—'}</b><span class="sub">mean min / window</span></div>`,
+    `<div class="card"><b>${costLabel}</b><span class="sub">mean tokens / window</span></div>`,
+    `<div class="card"><b>${fmtDur(id.current_idle_seconds != null ? id.current_idle_seconds : id.mean_gap_seconds)}</b><span class="sub">${id.current_idle_seconds != null ? 'current idle' : 'mean idle gap'}</span></div>`,
+    `<div class="card"><b>${id.total_idle_hours != null ? id.total_idle_hours + 'h' : '—'}</b><span class="sub">recorded idle total</span></div>`,
+    agents != null ? `<div class="card"><b>${esc(typeof agents === 'number' ? agents.toFixed(2) : agents)}</b><span class="sub">agents / clean card</span></div>` : '',
+    bandLabel ? `<div class="card"><b>${esc(bandLabel)}</b><span class="sub">$ band / clean card</span></div>` : '',
+    econ.total_clean != null ? `<div class="card"><b>${fmt(econ.total_clean)}</b><span class="sub">clean cards in economy log</span></div>` : '',
+  ].join('');
+
+  const recent = k.recent_windows || [];
+  if (recent.length) {
+    document.getElementById('recentWindows').innerHTML =
+      '<table><thead><tr><th>When</th><th>Root</th><th>State</th><th class="num">Keys</th><th class="num">Tr</th><th class="num">Rq</th><th class="num">Min</th></tr></thead><tbody>' +
+      recent.slice().reverse().map(r =>
+        `<tr><td class="mono">${esc((r.recorded_at||'').replace('T',' ').replace('Z',''))}</td>` +
+        `<td>${esc(r.root||'—')}</td><td>${esc(r.state||'—')}</td>` +
+        `<td class="num">${fmt(r.workflow_keys)}</td><td class="num">${fmt(r.translated)}</td>` +
+        `<td class="num">${fmt(r.requeue_count)}</td><td class="num">${r.wall_clock_minutes ?? '—'}</td></tr>`
+      ).join('') + '</tbody></table>';
+  } else {
+    document.getElementById('recentWindows').textContent = 'no window ledger rows yet';
+  }
+
+  const gaps = (id.recent_gaps || []).slice().reverse();
+  if (gaps.length) {
+    document.getElementById('idleGaps').innerHTML =
+      '<table><thead><tr><th>From</th><th>To</th><th class="num">Idle</th><th>Roots</th></tr></thead><tbody>' +
+      gaps.map(g =>
+        `<tr><td class="mono">${esc((g.from||'').replace('T',' ').replace('Z',''))}</td>` +
+        `<td class="mono">${esc((g.to||'').replace('T',' ').replace('Z',''))}</td>` +
+        `<td class="num">${fmtDur(g.seconds)}</td>` +
+        `<td class="mut">${esc(g.after_root||'—')} → ${esc(g.before_root||'—')}</td></tr>`
+      ).join('') + '</tbody></table>';
+  } else if (id.current_idle_seconds != null) {
+    document.getElementById('idleGaps').textContent =
+      'Currently idle for ' + fmtDur(id.current_idle_seconds) + ' (no recent stage_boundary pairs).';
+  } else {
+    document.getElementById('idleGaps').textContent = 'no idle gaps measured yet';
+  }
+
+  const cal = k.calendar || {};
+  const cells = cal.cells || [];
+  document.getElementById('calLegend').textContent =
+    `cards/day · ${cal.start || '?'} → ${cal.end || '?'} · ${cal.active_days || 0} active days · max ${cal.max_cards || 0}`;
+  document.getElementById('calendar').innerHTML = cells.map(c =>
+    `<i class="l${c.level||0}" title="${esc(c.date)}: ${c.cards||0} cards, ${c.windows||0} windows"></i>`
+  ).join('');
+
+  if (k.changelog && k.changelog.url) document.getElementById('clogLink').href = k.changelog.url;
+  const entries = (k.changelog && k.changelog.entries) || [];
+  document.getElementById('changelog').innerHTML = entries.length ? entries.map(e =>
+    `<div class="clog"><h3>${esc(e.version)}${e.date ? ' <span class="mut">· ' + esc(e.date) + '</span>' : ''}</h3>` +
+    (e.bullets && e.bullets.length
+      ? `<ul>${e.bullets.map(b => `<li><b>${esc(b.title)}</b> — ${esc(b.summary)}</li>`).join('')}</ul>`
+      : '<p class="note">no bullets parsed</p>') +
+    `</div>`
+  ).join('') : '<p class="note">changelog not available</p>';
+}
+
+async function renderTrends() {
+  const el = document.getElementById('charts');
+  el.innerHTML = '';
+  const ts = await j('progress_timeseries.json');
+  if (ts && ts.snapshots && ts.snapshots.length) {
+    const pick = key => ts.snapshots.filter(s => s[key] != null).map(s => [s.date, s[key]]);
+    let s;
+    if ((s = pick('senses')).length) line(el, s, 'Sense-rows translated');
+    if ((s = pick('verb_promoted')).length) line(el, s, 'Verb roots promoted');
+    if ((s = pick('coverage_pct')).length) line(el, s, 'DCS coverage', '%');
+  }
+}
+
+let lastPoll = null;
+async function refresh() {
+  const [d, k] = await Promise.all([j('progress_data.json'), j('kitchen_data.json')]);
+  lastPoll = new Date();
+  document.getElementById('pollAge').textContent = lastPoll.toLocaleTimeString();
+  setLiveBar(d, k);
+  renderProgress(d);
+  renderKitchen(k);
+  await renderTrends();
+}
+
+refresh();
+setInterval(refresh, POLL_MS);
+// keep the "data age" label honest even between polls
+setInterval(() => {
+  const stamp = document.getElementById('stamp').textContent;
+  if (stamp && stamp !== '—') {
+    const age = ageSeconds(stamp);
+    document.getElementById('dataAge').textContent = age == null ? '—' : fmtDur(age);
+  }
+}, 15_000);
 </script>
 </body>
 </html>

--- a/progress_dashboard/kitchen_data.json
+++ b/progress_dashboard/kitchen_data.json
@@ -1,0 +1,1264 @@
+{
+  "generated_at": "2026-07-31T18:23:31Z",
+  "schema": "pwg.kitchen.v1",
+  "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
+  "site_url": "https://gasyoun.github.io/SanskritLexicography/",
+  "progress_url": "https://gasyoun.github.io/SanskritLexicography/progress/",
+  "local_ops_note": "For sub-second run/gate telemetry on the residential machine, run `python RussianTranslation/src/pilot/dashboard_server.py` (default http://127.0.0.1:8765/, polls every 5s).",
+  "activity": {
+    "translation_on": false,
+    "active_within_seconds": 900,
+    "youngest_artifact_age_seconds": 88006,
+    "window_state": "needs_requeue",
+    "window_root": "no_pwg_w05",
+    "next_action": "Run python src\\pilot\\requeue_from_audit.py <root>, rerun Max Workflow, then rerun audit_window.py.",
+    "artifacts": {
+      "store": {
+        "exists": true,
+        "mtime": "2026-07-30T17:56:39Z",
+        "age_seconds": 88006,
+        "size": 24904391
+      },
+      "window_status": {
+        "exists": true,
+        "mtime": "2026-07-15T20:26:10Z",
+        "age_seconds": 1375035,
+        "size": 53853
+      },
+      "window_ledger": {
+        "exists": true,
+        "mtime": "2026-07-15T20:26:10Z",
+        "age_seconds": 1375035,
+        "size": 314319
+      },
+      "events": {
+        "exists": true,
+        "mtime": "2026-07-24T18:39:44Z",
+        "age_seconds": 603822,
+        "size": 3486985
+      }
+    }
+  },
+  "speed": {
+    "cards_last_hour": 0,
+    "cards_last_24h": 0,
+    "mean_cards_per_active_day_14d": 891.846,
+    "mean_wall_clock_minutes": 3.0,
+    "newest_card_at": "2026-07-14T04:10:54Z",
+    "measured": true
+  },
+  "cost": {
+    "mean_tokens_per_window": null,
+    "windows_in_ledger": 473,
+    "economy": {
+      "measured": true,
+      "source": "generation_api_probe_log.jsonl",
+      "schema": "pwg.economy_ledger.v1",
+      "summary": {
+        "agents_per_clean_incl_requeues": 2.836735,
+        "agents_per_clean_incl_requeues_label": "total agents to fully drain incl. requeues",
+        "agents_per_clean_incl_requeues_basis": "139 agents / 49 clean over 5 rows w/ structured agents_used & clean>0 (fresh windows + their requeues pooled)",
+        "agents_per_clean_first_pass": 3.518519,
+        "agents_per_clean_first_pass_basis": "95 agents / 27 clean over 3 fresh (non-_rq) rows; LEXICAL _rq heuristic — wf_a2b29683-835/no_pwg_w03 is semantically a w02 requeue but carries a fresh-looking label, so first-pass is an approximation",
+        "cost_per_clean_band": {
+          "floor_usd": 0.069861,
+          "ceil_usd": 0.698609,
+          "true_upper_output_rate_usd": 3.493045,
+          "basis": "floor=cache_read rate, ceil=fresh-input rate; EXCLUDES output premium"
+        },
+        "cost_per_clean_band_basis": "pooled 13739312 subagent_tokens over 59 clean cards (blunt total / total clean, all priced outcome rows incl. mixed lanes and the clean=0 wasted run)",
+        "total_tokens": 13739312,
+        "total_clean": 59,
+        "wasted_agents": 58,
+        "wasted_tokens": 1798042,
+        "coverage": {
+          "outcome_rows": 9,
+          "structured_agents_used": 6,
+          "enter_agents_per_clean": 5,
+          "clean0_wasted": 1,
+          "nulled_incomplete": 3,
+          "line": "6/9 outcome rows carry structured agents_used; 5/9 enter agents-per-clean (1 has clean=0 -> wasted_calls; 3 nulled -> incomplete)"
+        },
+        "price_basis_usd_per_million": {
+          "input": 3.0,
+          "output": 15.0,
+          "cache_write": 3.75,
+          "cache_read": 0.3
+        },
+        "agents_per_clean": 2.836735
+      }
+    },
+    "measured": true
+  },
+  "idle": {
+    "measured": true,
+    "min_idle_seconds": 120,
+    "gap_count": 127,
+    "total_idle_seconds": 1549947,
+    "total_idle_hours": 430.54,
+    "mean_gap_seconds": 12204.307,
+    "current_idle_seconds": 88011,
+    "recent_gaps": [
+      {
+        "from": "2026-07-04T20:44:40Z",
+        "to": "2026-07-04T20:52:05Z",
+        "seconds": 445,
+        "after_root": "dah",
+        "before_root": "dah",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-04T20:52:05Z",
+        "to": "2026-07-05T21:37:54Z",
+        "seconds": 89149,
+        "after_root": "dah",
+        "before_root": "nominal_w1_100small",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-05T21:37:54Z",
+        "to": "2026-07-05T21:40:01Z",
+        "seconds": 127,
+        "after_root": "nominal_w1_100small",
+        "before_root": "nominal_w1_100small",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-05T21:40:01Z",
+        "to": "2026-07-05T22:10:50Z",
+        "seconds": 1849,
+        "after_root": "nominal_w1_100small",
+        "before_root": "nominal_w1_100small",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-05T22:10:50Z",
+        "to": "2026-07-06T08:46:37Z",
+        "seconds": 38147,
+        "after_root": "nominal_w1_100small",
+        "before_root": "no_pwg_w1",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-06T08:48:41Z",
+        "to": "2026-07-06T20:55:18Z",
+        "seconds": 43597,
+        "after_root": "no_pwg_w1",
+        "before_root": "dah",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-06T20:55:18Z",
+        "to": "2026-07-10T17:29:32Z",
+        "seconds": 333254,
+        "after_root": "dah",
+        "before_root": "no_pwg_w02",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-10T17:29:32Z",
+        "to": "2026-07-11T12:35:01Z",
+        "seconds": 68729,
+        "after_root": "no_pwg_w02",
+        "before_root": "no_pwg_w03",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-11T12:35:01Z",
+        "to": "2026-07-11T14:07:24Z",
+        "seconds": 5543,
+        "after_root": "no_pwg_w03",
+        "before_root": "no_pwg_w03",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-11T14:07:24Z",
+        "to": "2026-07-11T14:11:53Z",
+        "seconds": 269,
+        "after_root": "no_pwg_w03",
+        "before_root": "no_pwg_w03_rq1",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-11T14:11:53Z",
+        "to": "2026-07-11T17:49:52Z",
+        "seconds": 13079,
+        "after_root": "no_pwg_w03_rq1",
+        "before_root": "no_pwg_w04",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-11T17:49:52Z",
+        "to": "2026-07-11T17:54:25Z",
+        "seconds": 273,
+        "after_root": "no_pwg_w04",
+        "before_root": "no_pwg_w04_rq1",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-11T17:54:25Z",
+        "to": "2026-07-11T18:28:43Z",
+        "seconds": 2058,
+        "after_root": "no_pwg_w04_rq1",
+        "before_root": "no_pwg_w05",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-11T18:28:43Z",
+        "to": "2026-07-11T18:34:18Z",
+        "seconds": 335,
+        "after_root": "no_pwg_w05",
+        "before_root": "no_pwg_w05_rq1",
+        "source": "ledger_gap"
+      },
+      {
+        "from": "2026-07-11T18:34:18Z",
+        "to": "2026-07-15T20:25:23Z",
+        "seconds": 352265,
+        "after_root": "no_pwg_w05_rq1",
+        "before_root": null,
+        "source": "ledger_gap"
+      }
+    ]
+  },
+  "calendar": {
+    "start": "2026-04-03",
+    "end": "2026-07-31",
+    "days": 120,
+    "cells": [
+      {
+        "date": "2026-04-03",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-04",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-05",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-06",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-07",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-08",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-09",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-10",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-11",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-12",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-13",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-14",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-15",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-16",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-17",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-18",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-19",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-20",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-21",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-22",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-23",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-24",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-25",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-26",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-27",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-28",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-29",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-04-30",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-01",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-02",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-03",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-04",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-05",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-06",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-07",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-08",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-09",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-10",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-11",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-12",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-13",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-14",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-15",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-16",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-17",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-18",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-19",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-20",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-21",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-22",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-23",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-24",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-25",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-26",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-27",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-28",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-29",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-30",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-05-31",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-01",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-02",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-03",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-04",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-05",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-06",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-07",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-08",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-09",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-10",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-11",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-12",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-13",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-14",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-15",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-16",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-17",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-18",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-19",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-20",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-21",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-22",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-23",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-24",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-25",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-26",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-06-27",
+        "cards": 0,
+        "windows": 13,
+        "level": 0
+      },
+      {
+        "date": "2026-06-28",
+        "cards": 0,
+        "windows": 40,
+        "level": 0
+      },
+      {
+        "date": "2026-06-29",
+        "cards": 6033,
+        "windows": 174,
+        "level": 4
+      },
+      {
+        "date": "2026-06-30",
+        "cards": 2530,
+        "windows": 52,
+        "level": 4
+      },
+      {
+        "date": "2026-07-01",
+        "cards": 1194,
+        "windows": 119,
+        "level": 4
+      },
+      {
+        "date": "2026-07-02",
+        "cards": 0,
+        "windows": 16,
+        "level": 0
+      },
+      {
+        "date": "2026-07-03",
+        "cards": 673,
+        "windows": 20,
+        "level": 4
+      },
+      {
+        "date": "2026-07-04",
+        "cards": 416,
+        "windows": 9,
+        "level": 4
+      },
+      {
+        "date": "2026-07-05",
+        "cards": 306,
+        "windows": 3,
+        "level": 4
+      },
+      {
+        "date": "2026-07-06",
+        "cards": 79,
+        "windows": 4,
+        "level": 3
+      },
+      {
+        "date": "2026-07-07",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-08",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-09",
+        "cards": 14,
+        "windows": 0,
+        "level": 2
+      },
+      {
+        "date": "2026-07-10",
+        "cards": 61,
+        "windows": 1,
+        "level": 3
+      },
+      {
+        "date": "2026-07-11",
+        "cards": 188,
+        "windows": 7,
+        "level": 4
+      },
+      {
+        "date": "2026-07-12",
+        "cards": 48,
+        "windows": 0,
+        "level": 3
+      },
+      {
+        "date": "2026-07-13",
+        "cards": 37,
+        "windows": 0,
+        "level": 3
+      },
+      {
+        "date": "2026-07-14",
+        "cards": 15,
+        "windows": 0,
+        "level": 2
+      },
+      {
+        "date": "2026-07-15",
+        "cards": 0,
+        "windows": 15,
+        "level": 0
+      },
+      {
+        "date": "2026-07-16",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-17",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-18",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-19",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-20",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-21",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-22",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-23",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-24",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-25",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-26",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-27",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-28",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-29",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-30",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      },
+      {
+        "date": "2026-07-31",
+        "cards": 0,
+        "windows": 0,
+        "level": 0
+      }
+    ],
+    "max_cards": 6033,
+    "active_days": 17
+  },
+  "changelog": {
+    "measured": true,
+    "source": "RussianTranslation/CHANGELOG.md",
+    "url": "https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/CHANGELOG.md",
+    "entries": [
+      {
+        "version": "1.111.5",
+        "date": "2026-07-31",
+        "bullets": [
+          {
+            "title": "Fixed — checkpoints and status files were atomic but never flushed to disk (H3 / H1940 Phase 2, 31-07-2026, Opus 5 `claude-opus-5[1m]`)",
+            "summary": ""
+          },
+          {
+            "title": "Fixed — `claim` accepted a duplicate `--lease-id` and persisted an unreachable second lease (H4 / H1940 Phase 2, 31-07-2026, Opus 5 `claude-opus-5[1m]`)",
+            "summary": ""
+          },
+          {
+            "title": "Changed — the residual ledger re-read itself once per key (O(n²) / H1940 Phase 2, 31-07-2026, Opus 5 `claude-opus-5[1m]`)",
+            "summary": ""
+          },
+          {
+            "title": "Fixed — a stalled window burned its whole iteration ceiling at full speed instead of stopping (H7 / H1940 Phase 2, 31-07-2026, Opus 5 `claude-opus-5[1m]`)",
+            "summary": ""
+          }
+        ]
+      },
+      {
+        "version": "1.111.2",
+        "date": "2026-07-30",
+        "bullets": [
+          {
+            "title": "Fixed — LANG_PARITY re-affirmed for the three files H1902 left drifting; master is green again (H1940, 30-07-2026)",
+            "summary": ""
+          },
+          {
+            "title": "Fixed — FINDINGS citation-number collision from the H1910 propagation pass (30-07-2026)",
+            "summary": ""
+          }
+        ]
+      },
+      {
+        "version": "1.111.1",
+        "date": "2026-07-30",
+        "bullets": [
+          {
+            "title": "Fixed — LANG_PARITY hash re-stamped on human authorisation; the selftest suite is fully green (H1910 follow-up, 30-07-2026)",
+            "summary": ""
+          }
+        ]
+      },
+      {
+        "version": "1.111.0",
+        "date": "2026-07-30",
+        "bullets": [
+          {
+            "title": "Added — Jamison–Brereton 2014 as a fifth translation column, Renou EVP as a locus witness (H1910, 30-07-2026)",
+            "summary": ""
+          },
+          {
+            "title": "Changed — ratification sheet v2: eight corrections from MG's first read (H1907, 30-07-2026)",
+            "summary": ""
+          }
+        ]
+      },
+      {
+        "version": "1.110.0",
+        "date": "2026-07-30",
+        "bullets": [
+          {
+            "title": "Changed — ratification sheet v2: eight corrections from MG's first read ([H1923](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1923-Opus_SanskritLexicography_ratification-sheet-v2-mg-eight-points_30.07.26.md), 30-07-2026)",
+            "summary": ""
+          }
+        ]
+      },
+      {
+        "version": "1.108.0",
+        "date": "2026-07-29",
+        "bullets": [
+          {
+            "title": "Fixed — NWS-layer citations in the Roman-numeral convention now resolve to Cologne links (H1809, 29-07-2026)",
+            "summary": ""
+          }
+        ]
+      },
+      {
+        "version": "1.106.0",
+        "date": "2026-07-29",
+        "bullets": [
+          {
+            "title": "Added — review sheets must reuse what the repo already knows, enforced before write (H1887, 29-07-2026)",
+            "summary": ""
+          }
+        ]
+      },
+      {
+        "version": "1.99.0",
+        "date": "2026-07-29",
+        "bullets": [
+          {
+            "title": "Added — RV multi-translation evidence spine, wave 1a: griffith/stanza/lemma/renou (H1843, 29-07-2026)",
+            "summary": ""
+          },
+          {
+            "title": "Added — audit record for the Gorresio map audit sheet; G2.4.7 flagged for re-vote (29-07-2026)",
+            "summary": ""
+          },
+          {
+            "title": "Added — execution-ready plan: the Rig-Veda multi-translation evidence layer (H1843/H1844, 29-07-2026)",
+            "summary": ""
+          },
+          {
+            "title": "Changed — the G5 card is legible: печатный вид, кликабельные цитаты, подсказки к пометам (H1808, 29-07-2026)",
+            "summary": ""
+          }
+        ]
+      },
+      {
+        "version": "1.82.0",
+        "date": "2026-07-26",
+        "bullets": [
+          {
+            "title": "Added — H1689: Gorresio vols 2/4/uk OCRed, e-text now covers all 7 kāṇḍas — `gorresio-etext-gap` extinct (26-07-2026)",
+            "summary": ""
+          },
+          {
+            "title": "Added — H1682: h1303_abbrev review-sheet rule-collapse (26-07-2026)",
+            "summary": ""
+          }
+        ]
+      },
+      {
+        "version": "1.79.0",
+        "date": "2026-07-26",
+        "bullets": [
+          {
+            "title": "Changed — Gorresio map audit round 1: 28/32 approve; 4 half-verse-shift rows switched off (26-07-2026)",
+            "summary": ""
+          },
+          {
+            "title": "Added — H1651 store wrapper-defect sweep D1-D4, live gate follow-up (26-07-2026)",
+            "summary": ""
+          }
+        ]
+      },
+      {
+        "version": "1.78.0",
+        "date": "2026-07-26",
+        "bullets": [
+          {
+            "title": "Fixed — H1670: PWG-sense × DCS grounding 0.67% → 12.25% (26-07-2026)",
+            "summary": ""
+          }
+        ]
+      },
+      {
+        "version": "1.77.0",
+        "date": "2026-07-26",
+        "bullets": [
+          {
+            "title": "Added — H1656 follow-on: Gorresio e-text recovered; Rāmāyaṇa citation reuse ON (26-07-2026)",
+            "summary": ""
+          },
+          {
+            "title": "Fixed — shingle phase-parity bug in the concordance aligner (26-07-2026)",
+            "summary": ""
+          },
+          {
+            "title": "Changed — H1664 voting-queue triage: every pending sheet ruled A/HYBRID/HUMAN-ONLY (26-07-2026)",
+            "summary": ""
+          },
+          {
+            "title": "Changed — H1633 rulings R1–R5 recorded; G6b gate born; A51 deferred to 2028 (26-07-2026)",
+            "summary": ""
+          }
+        ]
+      }
+    ]
+  },
+  "recent_windows": [
+    {
+      "recorded_at": "2026-07-15T20:25:28Z",
+      "root": null,
+      "state": "needs_requeue",
+      "workflow_keys": 47,
+      "translated": 40,
+      "requeue_count": 29,
+      "wall_clock_minutes": null,
+      "tokens": null
+    },
+    {
+      "recorded_at": "2026-07-15T20:25:30Z",
+      "root": null,
+      "state": "needs_requeue",
+      "workflow_keys": 13,
+      "translated": 11,
+      "requeue_count": 4,
+      "wall_clock_minutes": null,
+      "tokens": null
+    },
+    {
+      "recorded_at": "2026-07-15T20:25:31Z",
+      "root": null,
+      "state": "transient_only",
+      "workflow_keys": 2,
+      "translated": 1,
+      "requeue_count": 1,
+      "wall_clock_minutes": null,
+      "tokens": null
+    },
+    {
+      "recorded_at": "2026-07-15T20:25:33Z",
+      "root": null,
+      "state": "needs_requeue",
+      "workflow_keys": 35,
+      "translated": 31,
+      "requeue_count": 17,
+      "wall_clock_minutes": null,
+      "tokens": null
+    },
+    {
+      "recorded_at": "2026-07-15T20:25:35Z",
+      "root": null,
+      "state": "needs_requeue",
+      "workflow_keys": 13,
+      "translated": 10,
+      "requeue_count": 5,
+      "wall_clock_minutes": null,
+      "tokens": null
+    },
+    {
+      "recorded_at": "2026-07-15T20:25:38Z",
+      "root": null,
+      "state": "needs_requeue",
+      "workflow_keys": 44,
+      "translated": 37,
+      "requeue_count": 25,
+      "wall_clock_minutes": null,
+      "tokens": null
+    },
+    {
+      "recorded_at": "2026-07-15T20:25:40Z",
+      "root": null,
+      "state": "needs_requeue",
+      "workflow_keys": 21,
+      "translated": 17,
+      "requeue_count": 7,
+      "wall_clock_minutes": null,
+      "tokens": null
+    },
+    {
+      "recorded_at": "2026-07-15T20:25:42Z",
+      "root": null,
+      "state": "needs_requeue",
+      "workflow_keys": 5,
+      "translated": 5,
+      "requeue_count": 1,
+      "wall_clock_minutes": null,
+      "tokens": null
+    },
+    {
+      "recorded_at": "2026-07-15T20:25:44Z",
+      "root": null,
+      "state": "needs_requeue",
+      "workflow_keys": 58,
+      "translated": 46,
+      "requeue_count": 55,
+      "wall_clock_minutes": null,
+      "tokens": null
+    },
+    {
+      "recorded_at": "2026-07-15T20:25:46Z",
+      "root": null,
+      "state": "needs_requeue",
+      "workflow_keys": 52,
+      "translated": 45,
+      "requeue_count": 51,
+      "wall_clock_minutes": null,
+      "tokens": null
+    },
+    {
+      "recorded_at": "2026-07-15T20:25:49Z",
+      "root": null,
+      "state": "needs_requeue",
+      "workflow_keys": 46,
+      "translated": 40,
+      "requeue_count": 41,
+      "wall_clock_minutes": null,
+      "tokens": null
+    },
+    {
+      "recorded_at": "2026-07-15T20:26:10Z",
+      "root": null,
+      "state": "needs_requeue",
+      "workflow_keys": 44,
+      "translated": 37,
+      "requeue_count": 25,
+      "wall_clock_minutes": null,
+      "tokens": null
+    }
+  ],
+  "last_window": {
+    "recorded_at": "2026-07-15T20:26:10Z",
+    "root": null,
+    "state": "needs_requeue",
+    "workflow_keys": 44,
+    "translated": 37,
+    "requeue_count": 25,
+    "wall_clock_minutes": null,
+    "tokens": null
+  }
+}

--- a/progress_dashboard/live_refresh.py
+++ b/progress_dashboard/live_refresh.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Live progress/kitchen dashboard refresh — residential machine entrypoint.
+
+WHY LOCAL, NOT CI: progress + kitchen numbers are derived from gitignored
+RussianTranslation artifacts (store, window_ledger, events). GitHub Actions
+never sees them. This script:
+
+  1. Detects whether a translation campaign is *on* (store / window_status /
+     ledger mtime within --active-within seconds, default 15 min).
+  2. While on (or always with --force / --once), rebuilds:
+       progress_dashboard/progress_data.json
+       progress_dashboard/progress_timeseries.json
+       progress_dashboard/kitchen_data.json
+  3. Publishes HTML+JSON to origin/gh-pages under progress/ only — never spams
+     master with minute-level commits.
+  4. Sleeps --interval seconds (default 60) and repeats when in loop mode.
+
+Usage:
+  # one shot (rebuild + publish if active or --force)
+  python progress_dashboard/live_refresh.py --once --force
+
+  # loop while translation is on (stops after --idle-stop consecutive idle ticks)
+  python progress_dashboard/live_refresh.py
+
+  # rebuild only, no git push (local preview)
+  python progress_dashboard/live_refresh.py --once --no-publish --force
+
+Data root: by default the main checkout next to this worktree is used when the
+worktree lacks gitignored artifacts. Override with PWG_DATA_ROOT.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent  # SanskritLexicography checkout (may be a worktree)
+
+PUBLISH = [
+    "index.html",
+    "progress_data.json",
+    "progress_timeseries.json",
+    "kitchen_data.json",
+]
+
+
+def log(msg: str) -> None:
+    stamp = datetime.now().isoformat(timespec="seconds")
+    line = f"[{stamp}] {msg}"
+    print(line, flush=True)
+    try:
+        log_path = HERE / "live_refresh.log"
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except OSError:
+        pass
+
+
+def run(cmd, cwd, check=True):
+    log("$ " + " ".join(str(c) for c in cmd))
+    return subprocess.run(cmd, cwd=cwd, check=check)
+
+
+def resolve_data_root(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit).resolve()
+    env = os.environ.get("PWG_DATA_ROOT")
+    if env:
+        return Path(env).resolve()
+    # Prefer the canonical main checkout when this is a worktree without the store.
+    main = Path(r"C:\Users\user\Documents\GitHub\SanskritLexicography")
+    store_here = REPO / "RussianTranslation" / "src" / "pwg_ru_translated.jsonl"
+    store_main = main / "RussianTranslation" / "src" / "pwg_ru_translated.jsonl"
+    if not store_here.exists() and store_main.exists():
+        return main
+    return REPO
+
+
+def is_translation_on(data_root: Path, active_within: int) -> tuple[bool, int | None]:
+    paths = [
+        data_root / "RussianTranslation" / "src" / "pwg_ru_translated.jsonl",
+        data_root / "RussianTranslation" / "src" / "pilot" / "output" / "window_status.json",
+        data_root / "RussianTranslation" / "src" / "pilot" / "output" / "window_ledger.jsonl",
+        data_root / "RussianTranslation" / "src" / "pilot" / "output" / "dashboard_events.jsonl",
+        data_root / "RussianTranslation" / "src" / "pilot" / "output" / "coordinator" / "dashboard.json",
+    ]
+    now = time.time()
+    ages = []
+    for p in paths:
+        try:
+            ages.append(int(now - p.stat().st_mtime))
+        except OSError:
+            continue
+    if not ages:
+        return False, None
+    youngest = min(ages)
+    return youngest <= active_within, youngest
+
+
+def rebuild(data_root: Path) -> Path:
+    """Run builders into a fresh temp copy of progress_dashboard HTML+scripts."""
+    env = os.environ.copy()
+    env["PWG_DATA_ROOT"] = str(data_root)
+    # Build into THIS checkout's progress_dashboard/ so source HTML stays canonical.
+    for script in ("build_progress_data.py", "build_kitchen_data.py"):
+        cmd = [sys.executable, str(HERE / script)]
+        log(f"build: {' '.join(cmd)}  PWG_DATA_ROOT={data_root}")
+        subprocess.run(cmd, cwd=str(REPO), check=True, env=env)
+    return HERE
+
+
+def payload_fingerprint(dash_dir: Path) -> str:
+    h = hashlib.sha256()
+    for name in PUBLISH:
+        p = dash_dir / name
+        if not p.exists():
+            h.update(f"missing:{name}\n".encode())
+            continue
+        h.update(name.encode())
+        h.update(b"\0")
+        h.update(p.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()[:16]
+
+
+def publish_gh_pages(dash_dir: Path) -> bool:
+    """Copy built files to a throwaway gh-pages worktree and push if changed."""
+    run(["git", "fetch", "origin", "gh-pages"], REPO)
+    tmp = Path(tempfile.mkdtemp(prefix="progress-live-"))
+    wt = tmp / "pages"
+    try:
+        run(
+            ["git", "worktree", "add", "--detach", str(wt), "origin/gh-pages"],
+            REPO,
+        )
+        dest = wt / "progress"
+        dest.mkdir(exist_ok=True)
+        for name in PUBLISH:
+            src = dash_dir / name
+            if src.exists():
+                shutil.copy2(src, dest / name)
+            elif name == "kitchen_data.json":
+                log(f"warn: {name} missing — publish without it")
+        # nojekyll already at root; nothing else
+        run(["git", "add", "progress"], wt)
+        diff = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=wt)
+        if diff.returncode == 0:
+            log("gh-pages: no content change")
+            return False
+        msg = (
+            "chore(progress-dashboard): live kitchen refresh "
+            + datetime.now().strftime("%Y-%m-%d %H:%M")
+        )
+        run(["git", "commit", "-m", msg], wt)
+        run(["git", "push", "origin", "HEAD:gh-pages"], wt)
+        log("gh-pages: published progress/")
+        return True
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(wt)],
+            cwd=REPO,
+            capture_output=True,
+        )
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def tick(args, data_root: Path, last_fp: str | None) -> str | None:
+    on, age = is_translation_on(data_root, args.active_within)
+    log(
+        f"activity: translation_on={on} youngest_age={age}s "
+        f"(threshold={args.active_within}s) force={args.force}"
+    )
+    if not on and not args.force and not args.once_idle_ok:
+        return last_fp
+
+    dash = rebuild(data_root)
+    fp = payload_fingerprint(dash)
+    if fp == last_fp and not args.force_publish:
+        log(f"payload unchanged ({fp}) — skip publish")
+        return fp
+
+    if args.no_publish:
+        log(f"built {fp}; --no-publish set")
+        return fp
+
+    published = publish_gh_pages(dash)
+    if published:
+        log(f"published fingerprint={fp}")
+    return fp
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--once", action="store_true", help="single rebuild cycle then exit")
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="rebuild even if translation looks idle",
+    )
+    ap.add_argument(
+        "--once-idle-ok",
+        action="store_true",
+        help="with --once, rebuild even when idle (alias of --force for one-shot)",
+    )
+    ap.add_argument("--no-publish", action="store_true", help="rebuild only, no gh-pages push")
+    ap.add_argument(
+        "--force-publish",
+        action="store_true",
+        help="push even when payload fingerprint is unchanged",
+    )
+    ap.add_argument("--interval", type=int, default=60, help="seconds between ticks (default 60)")
+    ap.add_argument(
+        "--active-within",
+        type=int,
+        default=15 * 60,
+        help="seconds: artifact younger than this ⇒ translation on (default 900)",
+    )
+    ap.add_argument(
+        "--idle-stop",
+        type=int,
+        default=5,
+        help="in loop mode, exit after N consecutive idle ticks (default 5; 0=never)",
+    )
+    ap.add_argument("--data-root", default=None, help="override PWG_DATA_ROOT")
+    args = ap.parse_args()
+    if args.once_idle_ok:
+        args.force = True
+
+    data_root = resolve_data_root(args.data_root)
+    log(f"=== live_refresh start repo={REPO} data_root={data_root} ===")
+    last_fp = None
+    idle_streak = 0
+
+    while True:
+        on, _age = is_translation_on(data_root, args.active_within)
+        if not on and not args.force:
+            idle_streak += 1
+            log(f"idle streak {idle_streak}/{args.idle_stop or '∞'}")
+            if args.once:
+                log("idle + --once without --force: nothing to do")
+                break
+            if args.idle_stop and idle_streak >= args.idle_stop:
+                log("idle-stop reached — exiting loop")
+                break
+            time.sleep(args.interval)
+            continue
+
+        idle_streak = 0
+        try:
+            last_fp = tick(args, data_root, last_fp)
+        except subprocess.CalledProcessError as e:
+            log(f"ERROR: command failed: {e}")
+            if args.once:
+                raise
+        except Exception as e:  # noqa: BLE001
+            log(f"ERROR: {e}")
+            if args.once:
+                raise
+
+        if args.once:
+            break
+        # After a successful active tick, drop --force so we only continue while live.
+        args.force = False
+        time.sleep(args.interval)
+
+    log("=== live_refresh done ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/progress_dashboard/progress_data.json
+++ b/progress_dashboard/progress_data.json
@@ -1,15 +1,18 @@
 {
-  "generated_at": "2026-07-18",
+  "generated_at": "2026-07-31T17:39:01Z",
+  "snapshot_date": "2026-07-31",
   "repo_url": "https://github.com/gasyoun/SanskritLexicography/blob/master",
   "site_url": "https://gasyoun.github.io/SanskritLexicography/",
+  "kitchen_url": "https://gasyoun.github.io/SanskritLexicography/progress/",
+  "refresh_hint_seconds": 60,
   "lanes": {
     "verb": {
       "measured": true,
       "universe": 1882,
       "dcs_attested": 749,
       "promoted": 48,
-      "runnable": 701,
-      "blocked": 0
+      "runnable": 0,
+      "blocked": 701
     },
     "nominal": {
       "measured": true,
@@ -27,7 +30,9 @@
     "senses": 11603,
     "roots": 254,
     "review": {
-      "ai_translated": 11603
+      "approved": 3,
+      "ai_translated": 11598,
+      "needs_review": 2
     },
     "human_reviewed": 0
   },

--- a/progress_dashboard/progress_timeseries.json
+++ b/progress_dashboard/progress_timeseries.json
@@ -15,6 +15,15 @@
       "senses": 11603,
       "roots": 254,
       "coverage_pct": 41.4
+    },
+    {
+      "date": "2026-07-31",
+      "generated_at": "2026-07-31T17:39:01Z",
+      "verb_promoted": 48,
+      "verb_dcs_attested": 749,
+      "senses": 11603,
+      "roots": 254,
+      "coverage_pct": 41.4
     }
   ]
 }


### PR DESCRIPTION
## Summary
Public `/progress/` now shows the **kitchen** behind PWG→RU (speed, cost, idle, calendar, web changelog) and can stay current while a campaign runs.

- `build_kitchen_data.py` + `live_refresh.py` (60s rebuild → gh-pages only while translation artifacts move)
- `index.html` polls JSON every 60s (`cache: no-store`) with on/idle/stale chip
- Full ISO timestamps on progress snapshots

Handoff: https://github.com/gasyoun/Uprava/blob/main/handoffs/H2032-Grok_SanskritLexicography_progress-kitchen-live-refresh_31.07.26.md

Supersedes closed #926 (rebase conflict on changelog).

Model: Grok 4.5 (`grok-4.5`)