### PR TITLE
fix(progress): make local ops URL a clickable localhost link

### DIFF
--- a/progress_dashboard/index.html
+++ b/progress_dashboard/index.html
@@ -94,11 +94,12 @@
   For <b>5&nbsp;s</b> run/gate telemetry on the machine doing the work, open the
   local ops dashboard (not on the public internet):
   <code>python RussianTranslation/src/pilot/dashboard_server.py</code>
-  → <span class="mono">http://127.0.0.1:8765/</span>.
+  → <a class="mono" href="http://127.0.0.1:8765/">http://127.0.0.1:8765/</a>
+  (opens on <em>this</em> PC only — only works when <code>dashboard_server.py</code> is running here).
   <table>
     <tr><th>Surface</th><th>Poll</th><th>Where</th></tr>
     <tr><td>Web kitchen (this page)</td><td class="num">60&nbsp;s</td><td><a href="https://gasyoun.github.io/SanskritLexicography/progress/">/progress/</a></td></tr>
-    <tr><td>Local ops</td><td class="num">5&nbsp;s</td><td><span class="mono">127.0.0.1:8765</span> (this PC only)</td></tr>
+    <tr><td>Local ops</td><td class="num">5&nbsp;s</td><td><a class="mono" href="http://127.0.0.1:8765/">http://127.0.0.1:8765/</a> (this PC only)</td></tr>
   </table>
   Docs:
   <a href="https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/README.md">progress_dashboard/README</a>


### PR DESCRIPTION
## Summary
On `/progress/` the dual-surface box showed `127.0.0.1:8765` as monospace **text**, not an `<a href>`. Browsers only make it clickable if it is a real link.

Now: `href="http://127.0.0.1:8765/"` in the callout, table, and footer. Clicking opens the **viewer's** localhost (only useful when `dashboard_server.py` is running on that PC).

## Test plan
- [ ] Open https://gasyoun.github.io/SanskritLexicography/progress/ after publish
- [ ] Link is underlined/clickable
- [ ] With server up on this machine, click reaches local dashboard

Grok 4.5 (`grok-4.5`)