### PR TITLE
fix(progress): clickable localhost link in footer

### DIFF
--- a/progress_dashboard/index.html
+++ b/progress_dashboard/index.html
@@ -183,7 +183,7 @@
   <code>live_refresh.py</code> (every <b>60&nbsp;s</b> while translation is on) or the monthly
   findings-dashboard workflow. Local ops twin (<b>5&nbsp;s</b> poll, not public):
   <code>python RussianTranslation/src/pilot/dashboard_server.py</code>
-  → <span class="mono">http://127.0.0.1:8765/</span>.
+  → <a class="mono" href="http://127.0.0.1:8765/">http://127.0.0.1:8765/</a>.
   Source:
   <a href="https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/">progress_dashboard/</a>.
 </footer>


### PR DESCRIPTION
Follow-up to #930: footer still had a plain span. Same href=http://127.0.0.1:8765/.