### PR TITLE
docs: .ai_state H2032 kitchen + changelog 1.114.3 localhost links

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -22,6 +22,18 @@ Two live tracks:
 
 ## ➡️ Next Steps (Queue)
 
+- **PWG→RU dashboards — operator habit (H2032, Grok 4.5, 31-07-2026).** When a
+  translation campaign is on, keep both surfaces honest:
+  1. Local ops (5 s): `cd RussianTranslation` →
+     `python src\pilot\dashboard_server.py` → http://127.0.0.1:8765/
+  2. Web kitchen (60 s): from repo root
+     `python progress_dashboard\live_refresh.py` (publishes `gh-pages/progress/` only).
+  Public URL: https://gasyoun.github.io/SanskritLexicography/progress/ · contract in
+  [progress_dashboard/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/README.md)
+  and [RU deep manual §2d](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md).
+  Optional: register a Task Scheduler entry like findings monthly refresh so live ticks
+  survive session close.
+
 - **H1940 Phase 2 — 🟡 OPEN (Opus 5 `claude-opus-5[1m]`, 30/31-07-2026).** The H1811
   pipeline-review backlog is being drained one item per session, each its own PR with
   selftest pins verified RED against pre-fix master. **Merged: H9**
@@ -1227,6 +1239,22 @@ Two live tracks:
   demote to plain text with "(не входит в этот репозиторий)", do not link.
 
 ## ✅ Completed (Recent only)
+
+- [x] 🔴 **H2032 — PWG→RU public kitchen + 60 s live refresh + dual-surface docs
+      (31-07-2026, Grok 4.5 `grok-4.5`).** Public
+      [/progress/](https://gasyoun.github.io/SanskritLexicography/progress/) now shows
+      process (speed, cost, idle, calendar, web changelog) not only lane denominators.
+      `progress_dashboard/build_kitchen_data.py` + `live_refresh.py` rebuild from the
+      gitignored store and push **only** `gh-pages/progress/` every minute while
+      translation artifacts move; the page re-fetches JSON every 60 s. Dual contract
+      documented and interlinked: **local ops 5 s** (`dashboard_server.py` →
+      `127.0.0.1:8765`) vs **web kitchen 60 s** — [progress_dashboard/README](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/README.md),
+      [RU deep manual §2d](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md),
+      MAINTAINER_MANUAL + both HTML banners. Localhost URLs on the web page are real
+      `href`s (#930/#931). PRs: [#927](https://github.com/gasyoun/SanskritLexicography/pull/927)
+      kitchen, [#929](https://github.com/gasyoun/SanskritLexicography/pull/929) docs,
+      [#930](https://github.com/gasyoun/SanskritLexicography/pull/930)/[#931](https://github.com/gasyoun/SanskritLexicography/pull/931)
+      clickable localhost. Changelog `1.114.0` / `1.114.2` / `1.114.3`.
 
 - [x] 🔴 **H1940 Phase 2 CLOSED — H4 + H3 + O(n²) + stale #6 EVIDENCE (31-07-2026, Opus 5 1M
       `claude-opus-5[1m]`).** The last four hardening items: a duplicate-`--lease-id` guard in

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,12 @@ not an error.
 
 ## [Unreleased]
 
+## [1.114.3] - 2026-07-31
+
+### Fixed
+
+- **Local ops URL on the public kitchen is a real link** (31-07-2026, Grok 4.5 `grok-4.5`, H2032 follow-up, [#930](https://github.com/gasyoun/SanskritLexicography/pull/930)/[#931](https://github.com/gasyoun/SanskritLexicography/pull/931)): `/progress/` dual-surface callout had rendered `127.0.0.1:8765` as monospace text (`<span>`), so it looked linked but was not clickable. All three sites (callout, table, footer) now use `href="http://127.0.0.1:8765/"` (opens the *viewer's* localhost when `dashboard_server.py` is running). `.ai_state.md` updated with H2032 Completed + operator Next Step.
+
 ## [1.114.2] - 2026-07-31
 
 ### Changed


### PR DESCRIPTION
## Summary
- `.ai_state.md`: H2032 Completed entry; Next Step for dual dashboards (5 s local / 60 s web).
- `changelog.md` **1.114.3**: clickable localhost links (#930/#931).

Grok 4.5 (`grok-4.5`)