### PR TITLE
docs: autostart residual + human @DO for logged-off dashboard tasks

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -22,12 +22,13 @@ Two live tracks:
 
 ## ➡️ Next Steps (Queue)
 
-- **PWG→RU dashboards — autostart registered (H2032 follow-up, 31-07-2026).** Prefer
-  Task Scheduler (not manual): tasks **`SL progress dashboard server`** (8765 / 5 s) and
-  **`SL progress live refresh`** (gh-pages kitchen / 60 s, `--idle-stop 0`). Re-register after
-  clone move:
-  `powershell -ExecutionPolicy Bypass -File progress_dashboard\windows\register_tasks.ps1 -StartNow`
-  · [windows/README](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/windows/README.md).
+- **PWG→RU dashboards — autostart registered (H2032 follow-up, 31-07-2026).** Tasks
+  **`SL progress dashboard server`** (8765 / 5 s) and **`SL progress live refresh`** (60 s
+  web kitchen, `--idle-stop 0`) at logon on WIN-NJTORH3267V. **Optional human `@DO`:** stored
+  credentials so tasks run while logged off — commands in
+  [windows/README § Human @DO](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/windows/README.md).
+  Re-register after clone move:
+  `powershell -ExecutionPolicy Bypass -File progress_dashboard\windows\register_tasks.ps1 -StartNow`.
   Public: https://gasyoun.github.io/SanskritLexicography/progress/
 
 - **H1940 Phase 2 — 🟡 OPEN (Opus 5 `claude-opus-5[1m]`, 30/31-07-2026).** The H1811

--- a/RussianTranslation/src/pilot/dashboard/index.html
+++ b/RussianTranslation/src/pilot/dashboard/index.html
@@ -24,14 +24,16 @@
     <b>Local ops (this page) vs public web kitchen.</b>
     This server reads the gitignored store/ledger on <em>this machine</em> and
     refreshes the browser <b>every 5&nbsp;s</b> — it is <b>not</b> published to
-    GitHub Pages. The public campaign kitchen (progress + speed/cost/idle/calendar/changelog)
-    is at
+    GitHub Pages. Prefer Task Scheduler <code>SL progress dashboard server</code>
+    (logon autostart) over a manual shell. The public campaign kitchen is at
     <a href="https://gasyoun.github.io/SanskritLexicography/progress/" target="_blank" rel="noopener">
       gasyoun.github.io/…/progress/</a>
-    (browser poll <b>60&nbsp;s</b>; numbers move when
-    <code>progress_dashboard/live_refresh.py</code> publishes).
+    (browser poll <b>60&nbsp;s</b>; published by task
+    <code>SL progress live refresh</code>).
     Docs:
     <a href="https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/README.md" target="_blank" rel="noopener">progress_dashboard/README</a>
+    ·
+    <a href="https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/windows/README.md" target="_blank" rel="noopener">windows autostart + human @DO</a>
     ·
     <a href="https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md" target="_blank" rel="noopener">RU deep manual §2d</a>.
   </div>

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,12 @@ not an error.
 
 ## [Unreleased]
 
+## [1.114.7] - 2026-07-31
+
+### Changed
+
+- **Dashboard autostart residual documented (human `@DO` for logged-off run)** (31-07-2026, Grok 4.5 `grok-4.5`, H2032 follow-up): [`progress_dashboard/windows/README.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/windows/README.md) now carries the honest residual inventory + the exact `schtasks /Change /RU … /RP *` commands for “run whether logged on or not”; §2d of the [RU deep manual](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md), [progress_dashboard/README](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/README.md), [MAINTAINER_MANUAL](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/MAINTAINER_MANUAL.md), and both HTML dual-surface banners link that residual and name the Task Scheduler task titles.
+
 ## [1.114.6] - 2026-07-31
 
 ### Added

--- a/docs/manuals/MAINTAINER_MANUAL.md
+++ b/docs/manuals/MAINTAINER_MANUAL.md
@@ -2,6 +2,7 @@
 
 _Created: 10-07-2026 · Last updated: 31-07-2026_
 
+
 For the person (or agent) who **operates and extends** this repository. If you
 just want to *use* the data, read the
 [Data-Reuse Manual](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/DATA_REUSE_MANUAL.md)
@@ -51,8 +52,8 @@ live tooling embedded in the active subprojects.
 | [literature/](https://github.com/gasyoun/SanskritLexicography/tree/master/literature) | Reference PDF/EPUB library + Markdown extractions + Lexicography-Manuals | Reference store | researcher |
 | [docs_site/](https://github.com/gasyoun/SanskritLexicography/tree/master/docs_site) | Static site built from research docs (zettelkasten); built and tested, **not deployed** (origin/gh-pages has no `research/` directory) — deploy is human-gated | Active | maintainer |
 | [epistemic_dashboard/](https://github.com/gasyoun/SanskritLexicography/tree/master/epistemic_dashboard) · [findings_dashboard/](https://github.com/gasyoun/SanskritLexicography/tree/master/findings_dashboard) | Generated HTML dashboards over the governance registries below | Active | maintainer |
-| [progress_dashboard/](https://github.com/gasyoun/SanskritLexicography/tree/master/progress_dashboard) | **Public web kitchen** for PWG→RU — progress + speed/cost/idle/calendar/changelog at […/progress/](https://gasyoun.github.io/SanskritLexicography/progress/). Browser poll **60 s**; publish with `live_refresh.py` while translating. **Not** the same as local ops (below). See [README](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/README.md) · [RU deep manual §2d](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md) | Active | maintainer |
-| Local ops dashboard | `python RussianTranslation/src/pilot/dashboard_server.py` → `http://127.0.0.1:8765/` — run/gate/ledger, browser poll **5 s**, **localhost only** (never Pages) | Active | maintainer |
+| [progress_dashboard/](https://github.com/gasyoun/SanskritLexicography/tree/master/progress_dashboard) | **Public web kitchen** for PWG→RU — […/progress/](https://gasyoun.github.io/SanskritLexicography/progress/), browser poll **60 s**. Autostart: Task Scheduler `SL progress live refresh` (logon; `live_refresh.py --idle-stop 0`). **Not** the same as local ops. [README](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/README.md) · [windows/README](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/windows/README.md) · [§2d](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md) | Active | maintainer |
+| Local ops dashboard | Task `SL progress dashboard server` → `http://127.0.0.1:8765/` (5 s), **localhost only**. Manual fallback: `python RussianTranslation/src/pilot/dashboard_server.py`. Logged-off run = optional human `@DO` (stored credentials) — [windows/README](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/windows/README.md) | Active | maintainer |
 
 ## 3. The governance / epistemic layer — the load-bearing part
 

--- a/docs/manuals/MAINTAINER_MANUAL.meta.md
+++ b/docs/manuals/MAINTAINER_MANUAL.meta.md
@@ -49,6 +49,7 @@ Refreshed by [/workspace-manual](https://github.com/gasyoun/claude-config/blob/m
 
 | Date | Change | By |
 |---|---|---|
+| 31-07-2026 | Subproject map: Task Scheduler task names + optional human `@DO` for logged-off; links windows/README | Grok 4.5 (grok-4.5) |
 | 31-07-2026 | Subproject map: progress_dashboard = public web kitchen (60 s); local ops row 5 s localhost; links to §2d + README | Grok 4.5 (grok-4.5) |
 | 25-07-2026 | H1623 freshness re-verify (LAST_VERIFIED bump + spot probes) | Grok 4.5 (grok-4.5) |
 | 10-07-2026 | Subject manual authored (H479/H535); consolidated H604 11-07-2026 | Fable 5 (`claude-fable-5`) / Opus 4.8 (`claude-opus-4-8`) |

--- a/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md
+++ b/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md
@@ -2,6 +2,7 @@
 
 _Created: 11-07-2026 · Last updated: 31-07-2026_
 
+
 The subsystem deep manual for
 [RussianTranslation/](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation)
 — first item of the deep-manual queue in
@@ -122,25 +123,28 @@ on the same clock.
 **Rules of thumb.**
 
 1. During a paid window on the residential box → open **local 5 s** for gates/next action.
-2. To show campaign progress on the public internet → open **web 60 s**; keep
-   `python progress_dashboard/live_refresh.py` running so Pages stays current.
+2. To show campaign progress on the public internet → open **web 60 s**. Prefer
+   the Task Scheduler daemon (`SL progress live refresh`) over a manual
+   `live_refresh.py` shell.
 3. A web page that *loads* is not automatically *current* — the chip on `/progress/`
    reports stale/idle/on from snapshot age.
 4. Localhost is never a substitute for the Pages URL (and vice versa).
 
-**Autostart (preferred — no manual step).** Residential Task Scheduler at logon:
+**Autostart (preferred — no manual step after logon).** Residential Task Scheduler:
 
-| Task | Role |
-|---|---|
-| `SL progress dashboard server` | local ops :8765 |
-| `SL progress live refresh` | web kitchen publish (`--idle-stop 0`) |
+| Task | Role | When it runs (default) |
+|---|---|---|
+| `SL progress dashboard server` | local ops :8765 | user **logged on** |
+| `SL progress live refresh` | web kitchen publish (`--idle-stop 0`) | user **logged on** |
 
 ```powershell
 # once per machine; -StartNow launches without waiting for next logon
 powershell -ExecutionPolicy Bypass -File progress_dashboard\windows\register_tasks.ps1 -StartNow
 ```
 
-Full notes: [progress_dashboard/windows/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/windows/README.md).
+- Full notes + residual inventory: [progress_dashboard/windows/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/windows/README.md).
+- **Human `@DO` (optional):** if the kitchen must publish while Windows is **logged off**, upgrade both tasks to stored credentials (`schtasks /Change /TN "…" /RU WIN-NJTORH3267V\user /RP *`) — same residual as findings monthly. Commands live in that windows README.
+- **Not automatic by default:** logged-off headless mode; other PCs (re-register after clone); GitHub release tags for every changelog section.
 
 **Manual start (fallback if tasks are off):**
 

--- a/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.meta.md
+++ b/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.meta.md
@@ -58,6 +58,7 @@ Re-run `script_census.py` and `harvest_launch_stats.py` when the pipeline tree o
 
 | Date | Change | By |
 |---|---|---|
+| 31-07-2026 | §2d: autostart residual + human `@DO` for logged-off stored credentials; links windows/README inventory | Grok 4.5 (grok-4.5) |
 | 31-07-2026 | §2d dual dashboards (local 5 s · web 60 s) + doc map row; interlinked with progress_dashboard + dashboard_server UIs (H2032 follow-up) | Grok 4.5 (grok-4.5) |
 | 25-07-2026 | H1623 freshness re-verify (LAST_VERIFIED bump + spot probes) | Grok 4.5 (grok-4.5) |
 | 11-07-2026 | Subject manual authored (H606) | Fable 5 (`claude-fable-5`) |

--- a/progress_dashboard/README.md
+++ b/progress_dashboard/README.md
@@ -2,9 +2,9 @@
 
 _Created: 10-07-2026 · Last updated: 31-07-2026_
 
-## Autostart (no manual step)
+## Autostart (no manual step after logon)
 
-On the residential machine, Task Scheduler starts both surfaces at **logon**:
+On the residential machine (WIN-NJTORH3267V), Task Scheduler starts both surfaces at **logon**:
 
 | Task | Surface |
 |---|---|
@@ -16,7 +16,9 @@ On the residential machine, Task Scheduler starts both surfaces at **logon**:
 powershell -ExecutionPolicy Bypass -File progress_dashboard\windows\register_tasks.ps1 -StartNow
 ```
 
-Details: [`windows/README.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/windows/README.md).
+- **Default:** runs when this Windows user is **logged on** (`InteractiveToken`).
+- **Optional human `@DO`:** stored credentials so tasks run while logged off — commands in [`windows/README.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/windows/README.md) § “Human `@DO`”.
+- Full residual list (tags, handoff, multi-PC paths): same [windows/README](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/windows/README.md) § “Residual inventory”.
 
 Public companion to the [article site](https://gasyoun.github.io/SanskritLexicography/).
 Where the article site shows the **finished** PWG→Russian translations, this shows:

--- a/progress_dashboard/index.html
+++ b/progress_dashboard/index.html
@@ -90,12 +90,11 @@
   <b>Web vs local (do not conflate).</b>
   This page is the <b>public web kitchen</b>: the browser re-fetches JSON
   <b>every 60&nbsp;s</b>; numbers only move when residential
-  <code>progress_dashboard/live_refresh.py</code> has published to gh-pages.
-  For <b>5&nbsp;s</b> run/gate telemetry on the machine doing the work, open the
-  local ops dashboard (not on the public internet):
-  <code>python RussianTranslation/src/pilot/dashboard_server.py</code>
-  → <a class="mono" href="http://127.0.0.1:8765/">http://127.0.0.1:8765/</a>
-  (opens on <em>this</em> PC only — only works when <code>dashboard_server.py</code> is running here).
+  <code>live_refresh.py</code> has published to gh-pages (Task Scheduler
+  <code>SL progress live refresh</code> at logon — no manual start while logged on).
+  For <b>5&nbsp;s</b> run/gate telemetry on the machine doing the work:
+  <a class="mono" href="http://127.0.0.1:8765/">http://127.0.0.1:8765/</a>
+  (task <code>SL progress dashboard server</code>; opens on <em>this</em> PC only).
   <table>
     <tr><th>Surface</th><th>Poll</th><th>Where</th></tr>
     <tr><td>Web kitchen (this page)</td><td class="num">60&nbsp;s</td><td><a href="https://gasyoun.github.io/SanskritLexicography/progress/">/progress/</a></td></tr>
@@ -103,6 +102,8 @@
   </table>
   Docs:
   <a href="https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/README.md">progress_dashboard/README</a>
+  ·
+  <a href="https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/windows/README.md">windows autostart + human @DO</a>
   ·
   <a href="https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md">RU deep manual §2d</a>
   ·

--- a/progress_dashboard/windows/README.md
+++ b/progress_dashboard/windows/README.md
@@ -2,12 +2,14 @@
 
 _Created: 31-07-2026 · Last updated: 31-07-2026_
 
-Keeps both dashboard surfaces running **without a manual start** on the residential machine (WIN-NJTORH3267V), matching the "SL findings dashboard refresh" Task Scheduler pattern (H737).
+Keeps both dashboard surfaces running **without a manual start after logon** on the residential machine (WIN-NJTORH3267V / user `WIN-NJTORH3267V\user`), matching the `SL findings dashboard refresh` Task Scheduler pattern (H737).
 
-| Task name | At | What |
+| Task name | Trigger | What |
 |---|---|---|
 | `SL progress dashboard server` | logon | `run_dashboard_server.cmd` → http://127.0.0.1:8765/ (**5 s** local ops) |
-| `SL progress live refresh` | logon | `run_live_refresh.cmd` → `live_refresh.py --idle-stop 0` (**60 s** web kitchen to gh-pages) |
+| `SL progress live refresh` | logon | `run_live_refresh.cmd` → `live_refresh.py --idle-stop 0` (**60 s** web kitchen → `gh-pages/progress/`) |
+
+Contract of the two surfaces (poll rates, public vs local): [progress_dashboard/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/README.md) · [RU deep manual §2d](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md).
 
 ## Register (once per machine / after path change)
 
@@ -16,30 +18,69 @@ cd C:\Users\user\Documents\GitHub\SanskritLexicography
 powershell -ExecutionPolicy Bypass -File progress_dashboard\windows\register_tasks.ps1 -StartNow
 ```
 
-- **`-StartNow`** — also launches both tasks immediately (do not wait for next logon).
-- **`-Unregister`** — remove both tasks.
-- LogonType = `InteractiveToken` (runs when this user is logged on). Stored-credentials "run whether logged on or not" is a human @DO if needed later.
+| Flag | Effect |
+|---|---|
+| `-StartNow` | Launch both tasks immediately (do not wait for next logon) |
+| `-Unregister` | Remove both tasks |
 
-## Logs
+## Logon mode (what is automatic vs what needs a human)
+
+| Mode | Behaviour | Status |
+|---|---|---|
+| **Default (shipped)** | `InteractiveToken` — tasks run when this Windows user is **logged on** (desktop session). RestartOnFailure every 1 min × 999. `StartWhenAvailable` (missed logon fires later). | **Registered on WIN-NJTORH3267V** (31-07-2026) |
+| **Logged-off / locked headless** | “Run whether user is logged on or not” needs **stored credentials** typed once at the keyboard | **Open human `@DO`** — see below |
+
+### Human `@DO` — stored credentials (optional)
+
+Only needed if the kitchen must keep publishing while the session is **logged off** or the machine is locked without an interactive token.
+
+```powershell
+# Type the password when prompted (*). Run as the same user (or admin).
+schtasks /Change /TN "SL progress dashboard server" /RU WIN-NJTORH3267V\user /RP *
+schtasks /Change /TN "SL progress live refresh"     /RU WIN-NJTORH3267V\user /RP *
+```
+
+Same residual as findings monthly (`SL findings dashboard refresh` still InteractiveToken for the same reason). After changing, verify:
+
+```powershell
+schtasks /Query /TN "SL progress dashboard server" /V /FO LIST
+schtasks /Query /TN "SL progress live refresh" /V /FO LIST
+# Logon Mode should show the stored-credentials form, not "Interactive only"
+```
+
+Smoke after next full logoff/logon (or reboot): open http://127.0.0.1:8765/ and https://gasyoun.github.io/SanskritLexicography/progress/ without starting anything by hand.
+
+## Logs (gitignored)
 
 | File | Source |
 |---|---|
-| `progress_dashboard/windows/dashboard_server.log` | local ops server |
-| `progress_dashboard/windows/live_refresh_daemon.log` | wrapper stdout |
+| `progress_dashboard/windows/dashboard_server.log` | local ops server wrapper |
+| `progress_dashboard/windows/live_refresh_daemon.log` | live_refresh wrapper stdout |
 | `progress_dashboard/live_refresh.log` | Python live_refresh logger |
-
-All three are gitignored under `progress_dashboard/windows/*.log` and the existing `live_refresh.log` rule.
 
 ## Behaviour
 
-- **Dashboard server:** if port 8765 is already LISTENING, the wrapper exits 0 (single-instance). Task Scheduler restarts on failure every 1 min (count 999).
-- **Live refresh:** `--idle-stop 0` so the daemon never exits when the campaign is idle — it sleeps 60 s and keeps watching store/ledger mtimes. Only publishes when artifacts are young (or fingerprint changes). Does **not** spam master; only `gh-pages/progress/`.
-- **Paths:** hard-coded to `C:\Users\user\Documents\GitHub\SanskritLexicography` (this residential clone). Edit the `.cmd` files + re-run `register_tasks.ps1` if the clone moves.
+- **Dashboard server:** if port **8765** is already LISTENING, the wrapper exits 0 (single-instance). Task Scheduler restarts on failure.
+- **Live refresh:** `--idle-stop 0` so the daemon **never exits** when the campaign is idle — it sleeps 60 s and keeps watching store / window_status / ledger / events mtimes. Publishes only when artifacts are young (or payload fingerprint changes). Writes **only** `gh-pages/progress/` — never spams `master`.
+- **Paths:** hard-coded to `C:\Users\user\Documents\GitHub\SanskritLexicography` and prefers `C:\Python314\python.exe`. Edit the `.cmd` files + re-run `register_tasks.ps1` if the clone or Python install moves.
+- **Other machines:** not registered by default; run `register_tasks.ps1` after cloning and fixing paths.
+
+## Residual inventory (honest)
+
+| Item | Status |
+|---|---|
+| Autostart while **logged on** | Done (tasks registered) |
+| Autostart while **logged off** | Open `@DO` (stored credentials above) |
+| Public Pages + local ops code | Done (H2032 PRs #927–#935) |
+| Dual-surface docs interlinked | Done |
+| GitHub release tags for every `1.114.x` changelog section | Optional hygiene (`/cut-release`) — not required for autostart |
+| Uprava H2032 handoff on `origin/main` | May still be local-only if mint push failed |
 
 ## Related
 
-- [progress_dashboard/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/README.md) — 5 s vs 60 s contract
+- [progress_dashboard/README.md](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/README.md)
 - [RU deep manual §2d](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md)
 - Findings monthly twin: task `SL findings dashboard refresh`
+- [MAINTAINER_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/MAINTAINER_MANUAL.md) subproject map
 
 _Dr. Mārcis Gasūns_

--- a/progress_dashboard/windows/register_tasks.ps1
+++ b/progress_dashboard/windows/register_tasks.ps1
@@ -7,7 +7,8 @@
 # Pattern matches "SL findings dashboard refresh" (H737): InteractiveToken,
 # StartWhenAvailable, explicit WorkingDirectory, RestartOnFailure, no battery block.
 # LogonType stays InteractiveToken — "run whether user is logged on or not" needs
-# stored credentials typed at the keyboard (GTD @DO if wanted later).
+# stored credentials typed at the keyboard (human @DO). Exact commands:
+#   progress_dashboard/windows/README.md  § "Human @DO — stored credentials"
 #
 # Usage (elevated not required for current-user tasks):
 #   powershell -ExecutionPolicy Bypass -File progress_dashboard\windows\register_tasks.ps1


### PR DESCRIPTION
## Summary
Documents residual inventory after Task Scheduler autostart (#935):

- **Default:** logged-on only (`InteractiveToken`)
- **Optional human `@DO`:** exact `schtasks /Change /RU … /RP *` for logged-off
- Residual list (tags, handoff, multi-PC paths)

Surfaces: `progress_dashboard/windows/README.md`, progress README, RU §2d, MAINTAINER, both dashboard HTML banners, `.ai_state`, changelog 1.114.7.

Grok 4.5 (`grok-4.5`)