### PR TITLE
docs(.ai_state): log A04 roadmap-drain completion

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Repository documentation, PWG→Russian bounded CLI restart & housekeeping
 
-_Created: 09-07-2026 · Last updated: 31-07-2026_
+_Created: 09-07-2026 · Last updated: 01-08-2026_
 
 Keep the SanskritLexicography data/research workspace documented and its git
 state tidy.
@@ -1236,6 +1236,17 @@ Two live tracks:
   demote to plain text with "(не входит в этот репозиторий)", do not link.
 
 ## ✅ Completed (Recent only)
+
+- [x] **A04 roadmap-drain — ROADMAP_VEDAWEB_REUSE.md Phase 2 checkbox tick (01-08-2026,
+      Sonnet 5 `claude-sonnet-5`).** Discovered Phase 2 (H063 accent-validation run) was
+      already fully merged weeks ago in WhitneyRoots
+      ([PR #24](https://github.com/gasyoun/WhitneyRoots/pull/24), 18/19 cells GO, +
+      [PR #29](https://github.com/gasyoun/WhitneyRoots/pull/29) exception fix) — the
+      roadmap checkbox here had simply never been flipped. No new implementation; ticked
+      the box with links to the real deliverables. Landed:
+      [PR #951](https://github.com/gasyoun/SanskritLexicography/pull/951), merged.
+      Unrelated: 23 pre-existing CRLF-only `literature/md/**` diffs sat dirty in this
+      worktree from before the session started — left untouched (not this session's work).
 
 - [x] 🔴 **H2032 — PWG→RU public kitchen + 60 s live refresh + dual-surface docs +
       Task Scheduler autostart (31-07-2026, Grok 4.5 `grok-4.5`).** Public

--- a/ROADMAP_VEDAWEB_REUSE.md
+++ b/ROADMAP_VEDAWEB_REUSE.md
@@ -1,6 +1,6 @@
 # ROADMAP — VedaWeb 2.0 data reuse across the Sanskrit Lexicon repos
 
-_Created: 03-07-2026 · Last updated: 11-07-2026_
+_Created: 03-07-2026 · Last updated: 01-08-2026_
 
 Scope ruled by M.G. 03-07-2026 (4 decisions, elicited in-session): **full breadth**
 (validation + persistent feed + GRA crosswalk + meter/translation layers) · feed home =
@@ -54,13 +54,21 @@ Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H096-Sonnet_VisualDCS_vedawe
 
 Sonnet-tier chat in `GitHub\VisualDCS`.
 
-### Phase 2 — WhitneyRoots accent-validation run (already queued as H063)
+### Phase 2 — WhitneyRoots accent-validation run — ✅ DONE (H063, discovered already-merged 01-08-2026)
 
-- [ ] Score the 18 rules / 19 cells against attested RV accents; per-cell GO/NO-GO for
+- [x] Score the 18 rules / 19 cells against attested RV accents; per-cell GO/NO-GO for
   the ZALIZNYAK a–f accent-axis emission
   ([ZALIZNYAK_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ZALIZNYAK_INDEX.md)).
   Independent of Phase 1 (its spec can hit the live API), but if the feed has landed,
-  read from it instead.
+  read from it instead. **Result: 18/19 cells GO** (2 thin-evidence
+  measurement-only cells with 0 attested lemmas; the remaining `T8c·oxytone` exception
+  was resolved to a clean 100% GO by H115). Deliverables:
+  [`crosswalk/accent_validation.json`](https://github.com/gasyoun/WhitneyRoots/blob/main/crosswalk/accent_validation.json) +
+  [`docs/ACCENT_VALIDATION_REPORT.md`](https://github.com/gasyoun/WhitneyRoots/blob/main/docs/ACCENT_VALIDATION_REPORT.md),
+  landed via [WhitneyRoots PR #24](https://github.com/gasyoun/WhitneyRoots/pull/24)
+  (Sonnet 5 `claude-sonnet-5`) + follow-up
+  [WhitneyRoots PR #29](https://github.com/gasyoun/WhitneyRoots/pull/29). This roadmap
+  checkbox was merely stale — the checkbox tick itself is this session's only change.
 
 ```
 Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H063-Sonnet_WhitneyRoots_accent_validation_02.07.26.md and execute it.


### PR DESCRIPTION
Follow-up to merged PR #951 — logs the A04 roadmap-drain completion in .ai_state.md Completed section per session-state protocol.