### PR TITLE
docs(H2071): RT deep manual live-lane residual re-verify

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,11 @@ not an error.
 
 ## [Unreleased]
 
+## [1.114.9] - 2026-08-01
+
+### Changed
+- **RUSSIANTRANSLATION_DEEP_MANUAL residual re-verify (H2071, Grok 4.5 `grok-4.5`, 01-08-2026):** LAST_VERIFIED stamp + metadoc backlog row 1 closed — production steps remain headless/manifest-v2 only (Workflow forensics); no production-path rewrite required.
+
 ## [1.114.8] - 2026-07-31
 
 ### Changed

--- a/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md
+++ b/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md
@@ -1,7 +1,8 @@
 # RussianTranslation deep manual — the mw_ru and pwg_ru pipelines
 
-_Created: 11-07-2026 · Last updated: 31-07-2026_
+_Created: 11-07-2026 · Last updated: 01-08-2026_
 
+**LAST_VERIFIED:** 01-08-2026 · Grok 4.5 (`grok-4.5`) · [H2071](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2071-Grok_SanskritLexicography_rt-deep-manual-manifest-v2-steps-rewrite_01.08.26.md) — census residual “steps 4–7 still narrate historical Workflow” **closed**: §5 steps 4–9 document headless CLI + manifest v2 only; Workflow is forensics / historical note only (see §0 line 1 and step 4 historical note).
 
 The subsystem deep manual for
 [RussianTranslation/](https://github.com/gasyoun/SanskritLexicography/tree/master/RussianTranslation)

--- a/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.meta.md
+++ b/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.meta.md
@@ -1,6 +1,6 @@
 # RUSSIANTRANSLATION_DEEP_MANUAL.md — metadoc
 
-_Created: 18-07-2026 · Last updated: 31-07-2026_
+_Created: 18-07-2026 · Last updated: 01-08-2026_
 
 Companion record for [docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.md) (subsystem deep manual, H606).
 
@@ -15,16 +15,16 @@ Authored 11-07-2026 (H606). Refreshed 18-07-2026 under H1245. Headless-first rew
 ## Verification
 
 ```
-LAST_VERIFIED: 25-07-2026
-VERIFIED_BY: Grok 4.5 (grok-4.5), H1623
-COMMANDS_SPOT_RUN: 4
+LAST_VERIFIED: 01-08-2026
+VERIFIED_BY: Grok 4.5 (grok-4.5), H2071 (residual re-verify; production path still headless/manifest-v2)
+COMMANDS_SPOT_RUN: 0 (docs truth-pass; no paid window)
 ```
 
 ## Improvement backlog
 
 | # | Item | Status |
 |---|---|---|
-| 1 | Steps 4–7 still narrate Workflow as primary | **done** H1622 |
+| 1 | Steps 4–7 still narrate Workflow as primary | **done** H1622; **re-verified closed** H2071 (01-08-2026) |
 | 2 | §10 script census generated | **done** 24-07 (script_census.py + SCRIPT_CENSUS.md) |
 | 3 | Re-harvest LAUNCH_STATS | **done** 24-07 (473 rows; still mostly Workflow-era date span — re-harvest after headless windows fill ledger) |
 | 4 | Cold start + skill-primary + symptom cookbook | **done** 24-07 |


### PR DESCRIPTION
## Summary
Re-verifies that RUSSIANTRANSLATION_DEEP_MANUAL production path is headless/manifest-v2 only. LAST_VERIFIED 01-08-2026; metadoc backlog row 1 closed. CHANGELOG 1.114.9.

## Test plan
- [x] Docs stamp only; no pipeline changes