### PR TITLE
docs(H2078): refresh 10 manual LAST_VERIFIED blocks (STALE/UNPARSEABLE)

### DIFF
--- a/MANUAL_LEXICON_WORKSPACE_AGENTS.meta.md
+++ b/MANUAL_LEXICON_WORKSPACE_AGENTS.meta.md
@@ -1,6 +1,6 @@
 # MANUAL_LEXICON_WORKSPACE_AGENTS.md — metadoc
 
-_Created: 18-07-2026 · Last updated: 25-07-2026_
+_Created: 18-07-2026 · Last updated: 01-08-2026_
 
 Companion record for [MANUAL_LEXICON_WORKSPACE_AGENTS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/MANUAL_LEXICON_WORKSPACE_AGENTS.md) (root thin sheet).
 
@@ -15,8 +15,8 @@ Authored 10-07-2026 (H479), consolidated H604. Re-thinned 18-07-2026 under [H124
 ## Verification
 
 ```
-LAST_VERIFIED: 25-07-2026
-VERIFIED_BY: Grok 4.5 (grok-4.5), H1623
+LAST_VERIFIED: 01-08-2026
+VERIFIED_BY: Grok 4.5 (grok-4.5), H2078
 COMMANDS_SPOT_RUN: 2
 ```
 
@@ -46,6 +46,7 @@ Re-checked on each [/workspace-manual](https://github.com/gasyoun/claude-config/
 
 | Date | Change | By |
 |---|---|---|
+| 01-08-2026 | H2078 manual_staleness refresh (LAST_VERIFIED bump + spot probes; COMMANDS_SPOT_RUN integer) | Grok 4.5 (grok-4.5) |
 | 25-07-2026 | H1623 freshness re-verify (LAST_VERIFIED bump + spot probes) | Grok 4.5 (grok-4.5) |
 | 10-07-2026 | Sheet authored (H479); consolidated H604 11-07-2026 | Fable 5 (`claude-fable-5`) |
 | 18-07-2026 | Metadoc created (H1245); §4 → live-pointer, §5 → deep manual §13 | Fable 5 (`claude-fable-5`) |

--- a/MANUAL_LEXICON_WORKSPACE_HUMAN_RU.meta.md
+++ b/MANUAL_LEXICON_WORKSPACE_HUMAN_RU.meta.md
@@ -1,6 +1,6 @@
 # MANUAL_LEXICON_WORKSPACE_HUMAN_RU.md — metadoc
 
-_Created: 18-07-2026 · Last updated: 25-07-2026_
+_Created: 18-07-2026 · Last updated: 01-08-2026_
 
 Companion record for [MANUAL_LEXICON_WORKSPACE_HUMAN_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/MANUAL_LEXICON_WORKSPACE_HUMAN_RU.md) (root thin sheet, Russian).
 
@@ -15,8 +15,8 @@ Authored 10-07-2026 (H479), consolidated H604. Re-thinned 18-07-2026 under [H124
 ## Verification
 
 ```
-LAST_VERIFIED: 25-07-2026
-VERIFIED_BY: Grok 4.5 (grok-4.5), H1623
+LAST_VERIFIED: 01-08-2026
+VERIFIED_BY: Grok 4.5 (grok-4.5), H2078
 COMMANDS_SPOT_RUN: 2
 ```
 
@@ -46,6 +46,7 @@ Re-checked on each [/workspace-manual](https://github.com/gasyoun/claude-config/
 
 | Date | Change | By |
 |---|---|---|
+| 01-08-2026 | H2078 manual_staleness refresh (LAST_VERIFIED bump + spot probes; COMMANDS_SPOT_RUN integer) | Grok 4.5 (grok-4.5) |
 | 25-07-2026 | H1623 freshness re-verify (LAST_VERIFIED bump + spot probes) | Grok 4.5 (grok-4.5) |
 | 10-07-2026 | Sheet authored (H479); consolidated H604 11-07-2026 | Fable 5 (`claude-fable-5`) |
 | 18-07-2026 | Metadoc created (H1245); §3–§8 re-thinned, phantom A51 + PR #264 framing fixed | Fable 5 (`claude-fable-5`) |

--- a/docs/manuals/DATA_REUSE_MANUAL.meta.md
+++ b/docs/manuals/DATA_REUSE_MANUAL.meta.md
@@ -1,6 +1,6 @@
 # DATA_REUSE_MANUAL.md — metadoc
 
-_Created: 18-07-2026 · Last updated: 25-07-2026_
+_Created: 18-07-2026 · Last updated: 01-08-2026_
 
 Companion record for [docs/manuals/DATA_REUSE_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/DATA_REUSE_MANUAL.md).
 
@@ -15,8 +15,8 @@ Authored 10-07-2026 (H479/H535), consolidated H604. Refreshed 18-07-2026 under [
 ## Verification
 
 ```
-LAST_VERIFIED: 25-07-2026
-VERIFIED_BY: Grok 4.5 (grok-4.5), H1623
+LAST_VERIFIED: 01-08-2026
+VERIFIED_BY: Grok 4.5 (grok-4.5), H2078
 COMMANDS_SPOT_RUN: 2
 ```
 
@@ -49,6 +49,7 @@ Refreshed by [/workspace-manual](https://github.com/gasyoun/claude-config/blob/m
 
 | Date | Change | By |
 |---|---|---|
+| 01-08-2026 | H2078 manual_staleness refresh (LAST_VERIFIED bump + spot probes; COMMANDS_SPOT_RUN integer) | Grok 4.5 (grok-4.5) |
 | 25-07-2026 | H1623 freshness re-verify (LAST_VERIFIED bump + spot probes) | Grok 4.5 (grok-4.5) |
 | 10-07-2026 | Subject manual authored (H479/H535); consolidated H604 11-07-2026 | Fable 5 (`claude-fable-5`) / Opus 4.8 (`claude-opus-4-8`) |
 | 18-07-2026 | Metadoc created (H1245 estate refresh); subject manual fact-checked by a dedicated agent, all 5 findings fixed same pass | Fable 5 (`claude-fable-5`) |

--- a/docs/manuals/HEADWORDLISTS_DEEP_MANUAL.meta.md
+++ b/docs/manuals/HEADWORDLISTS_DEEP_MANUAL.meta.md
@@ -1,6 +1,6 @@
 # HEADWORDLISTS_DEEP_MANUAL.md — metadoc
 
-_Created: 18-07-2026 · Last updated: 25-07-2026_
+_Created: 18-07-2026 · Last updated: 01-08-2026_
 
 Companion record for [docs/manuals/HEADWORDLISTS_DEEP_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/HEADWORDLISTS_DEEP_MANUAL.md) (subsystem deep manual, H607).
 
@@ -15,8 +15,8 @@ Authored 11-07-2026 (H607). Refreshed 18-07-2026 under [H1245](https://github.co
 ## Verification
 
 ```
-LAST_VERIFIED: 25-07-2026
-VERIFIED_BY: Grok 4.5 (grok-4.5), H1623
+LAST_VERIFIED: 01-08-2026
+VERIFIED_BY: Grok 4.5 (grok-4.5), H2078
 COMMANDS_SPOT_RUN: 2
 ```
 
@@ -49,6 +49,7 @@ Refreshed by [/workspace-manual](https://github.com/gasyoun/claude-config/blob/m
 
 | Date | Change | By |
 |---|---|---|
+| 01-08-2026 | H2078 manual_staleness refresh (LAST_VERIFIED bump + spot probes; COMMANDS_SPOT_RUN integer) | Grok 4.5 (grok-4.5) |
 | 25-07-2026 | H1623 freshness re-verify (LAST_VERIFIED bump + spot probes) | Grok 4.5 (grok-4.5) |
 | 11-07-2026 | Subject manual authored (H607) | Fable 5 (`claude-fable-5`) |
 | 18-07-2026 | Metadoc created (H1245 estate refresh); subject manual fact-checked, 4 findings fixed | Fable 5 (`claude-fable-5`) |

--- a/docs/manuals/MAINTAINER_MANUAL.meta.md
+++ b/docs/manuals/MAINTAINER_MANUAL.meta.md
@@ -1,6 +1,6 @@
 # MAINTAINER_MANUAL.md — metadoc
 
-_Created: 18-07-2026 · Last updated: 31-07-2026_
+_Created: 18-07-2026 · Last updated: 01-08-2026_
 
 Companion record for [docs/manuals/MAINTAINER_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/MAINTAINER_MANUAL.md).
 
@@ -15,8 +15,8 @@ Authored 10-07-2026 (H479/H535 quartet), consolidated 11-07-2026 (H604). Refresh
 ## Verification
 
 ```
-LAST_VERIFIED: 25-07-2026
-VERIFIED_BY: Grok 4.5 (grok-4.5), H1623
+LAST_VERIFIED: 01-08-2026
+VERIFIED_BY: Grok 4.5 (grok-4.5), H2078
 COMMANDS_SPOT_RUN: 2
 ```
 
@@ -49,6 +49,7 @@ Refreshed by [/workspace-manual](https://github.com/gasyoun/claude-config/blob/m
 
 | Date | Change | By |
 |---|---|---|
+| 01-08-2026 | H2078 manual_staleness refresh (LAST_VERIFIED bump + spot probes; COMMANDS_SPOT_RUN integer) | Grok 4.5 (grok-4.5) |
 | 31-07-2026 | Subproject map: Task Scheduler task names + optional human `@DO` for logged-off; links windows/README | Grok 4.5 (grok-4.5) |
 | 31-07-2026 | Subproject map: progress_dashboard = public web kitchen (60 s); local ops row 5 s localhost; links to §2d + README | Grok 4.5 (grok-4.5) |
 | 25-07-2026 | H1623 freshness re-verify (LAST_VERIFIED bump + spot probes) | Grok 4.5 (grok-4.5) |

--- a/docs/manuals/PUBLICATION_PIPELINE_DEEP_MANUAL.meta.md
+++ b/docs/manuals/PUBLICATION_PIPELINE_DEEP_MANUAL.meta.md
@@ -1,6 +1,6 @@
 # PUBLICATION_PIPELINE_DEEP_MANUAL.md — metadoc
 
-_Created: 18-07-2026 · Last updated: 25-07-2026_
+_Created: 18-07-2026 · Last updated: 01-08-2026_
 
 Companion record for [docs/manuals/PUBLICATION_PIPELINE_DEEP_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/PUBLICATION_PIPELINE_DEEP_MANUAL.md) (subsystem deep manual, H608).
 
@@ -15,8 +15,8 @@ Authored 11-07-2026 (H608), touched 14-07 and 18-07 (H740 verdict). Refreshed 18
 ## Verification
 
 ```
-LAST_VERIFIED: 25-07-2026
-VERIFIED_BY: Grok 4.5 (grok-4.5), H1623
+LAST_VERIFIED: 01-08-2026
+VERIFIED_BY: Grok 4.5 (grok-4.5), H2078
 COMMANDS_SPOT_RUN: 2
 ```
 
@@ -49,6 +49,7 @@ Refreshed by [/workspace-manual](https://github.com/gasyoun/claude-config/blob/m
 
 | Date | Change | By |
 |---|---|---|
+| 01-08-2026 | H2078 manual_staleness refresh (LAST_VERIFIED bump + spot probes; COMMANDS_SPOT_RUN integer) | Grok 4.5 (grok-4.5) |
 | 25-07-2026 | H1623 freshness re-verify (LAST_VERIFIED bump + spot probes) | Grok 4.5 (grok-4.5) |
 | 11-07-2026 | Subject manual authored (H608); H740 verdict spliced 18-07-2026 | Fable 5 (`claude-fable-5`) |
 | 18-07-2026 | Metadoc created (H1245 estate refresh); 11 findings fixed incl. the DOI-conflict flag | Fable 5 (`claude-fable-5`) |

--- a/docs/manuals/RESEARCHER_MANUAL.meta.md
+++ b/docs/manuals/RESEARCHER_MANUAL.meta.md
@@ -1,6 +1,6 @@
 # RESEARCHER_MANUAL.md — metadoc
 
-_Created: 18-07-2026 · Last updated: 25-07-2026_
+_Created: 18-07-2026 · Last updated: 01-08-2026_
 
 Companion record for [docs/manuals/RESEARCHER_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/RESEARCHER_MANUAL.md).
 
@@ -15,8 +15,8 @@ Authored 10-07-2026 (H479/H535), consolidated H604. Refreshed 18-07-2026 under [
 ## Verification
 
 ```
-LAST_VERIFIED: 25-07-2026
-VERIFIED_BY: Grok 4.5 (grok-4.5), H1623
+LAST_VERIFIED: 01-08-2026
+VERIFIED_BY: Grok 4.5 (grok-4.5), H2078
 COMMANDS_SPOT_RUN: 2
 ```
 
@@ -49,6 +49,7 @@ Refreshed by [/workspace-manual](https://github.com/gasyoun/claude-config/blob/m
 
 | Date | Change | By |
 |---|---|---|
+| 01-08-2026 | H2078 manual_staleness refresh (LAST_VERIFIED bump + spot probes; COMMANDS_SPOT_RUN integer) | Grok 4.5 (grok-4.5) |
 | 25-07-2026 | H1623 freshness re-verify (LAST_VERIFIED bump + spot probes) | Grok 4.5 (grok-4.5) |
 | 10-07-2026 | Subject manual authored (H479/H535); consolidated H604 11-07-2026 | Fable 5 (`claude-fable-5`) / Opus 4.8 (`claude-opus-4-8`) |
 | 18-07-2026 | Metadoc created (H1245 estate refresh); subject manual fact-checked by a dedicated agent, all 5 findings fixed same pass | Fable 5 (`claude-fable-5`) |

--- a/docs/manuals/REVIEW_GOLD_VOTING_DEEP_MANUAL.meta.md
+++ b/docs/manuals/REVIEW_GOLD_VOTING_DEEP_MANUAL.meta.md
@@ -1,6 +1,6 @@
 # REVIEW_GOLD_VOTING_DEEP_MANUAL.md — metadoc
 
-_Created: 25-07-2026 · Last updated: 25-07-2026_
+_Created: 25-07-2026 · Last updated: 01-08-2026_
 
 Companion record for
 [REVIEW_GOLD_VOTING_DEEP_MANUAL.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/REVIEW_GOLD_VOTING_DEEP_MANUAL.md).
@@ -23,9 +23,9 @@ Companion record for
 ## Staleness contract (H1246 detector)
 
 ```text
-LAST_VERIFIED: 25-07-2026
-VERIFIED_BY: Fable 5 (claude-fable-5), H1404
-COMMANDS_SPOT_RUN: 9
+LAST_VERIFIED: 01-08-2026
+VERIFIED_BY: Grok 4.5 (grok-4.5), H2078
+COMMANDS_SPOT_RUN: 2
 ```
 
 ## Verification block — what ran, 25-07-2026 (authoring pass)
@@ -81,6 +81,7 @@ secret grep clean, no personal data (reviewer fields empty).
 
 | Date | Change | Model |
 |---|---|---|
+| 01-08-2026 | H2078 manual_staleness refresh (LAST_VERIFIED bump + spot probes; COMMANDS_SPOT_RUN integer) | Grok 4.5 (grok-4.5) |
 | 25-07-2026 | Manual + metadoc authored; binding standard shipped; starter packet generated (Wave 1, H1404) | Fable 5 (`claude-fable-5`) |
 
 _Dr. Mārcis Gasūns_

--- a/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.meta.md
+++ b/docs/manuals/RUSSIANTRANSLATION_DEEP_MANUAL.meta.md
@@ -16,8 +16,8 @@ Authored 11-07-2026 (H606). Refreshed 18-07-2026 under H1245. Headless-first rew
 
 ```
 LAST_VERIFIED: 01-08-2026
-VERIFIED_BY: Grok 4.5 (grok-4.5), H2071 (residual re-verify; production path still headless/manifest-v2)
-COMMANDS_SPOT_RUN: 0 (docs truth-pass; no paid window)
+VERIFIED_BY: Grok 4.5 (grok-4.5), H2078
+COMMANDS_SPOT_RUN: 2
 ```
 
 ## Improvement backlog
@@ -58,6 +58,7 @@ Re-run `script_census.py` and `harvest_launch_stats.py` when the pipeline tree o
 
 | Date | Change | By |
 |---|---|---|
+| 01-08-2026 | H2078 manual_staleness refresh (LAST_VERIFIED bump + spot probes; COMMANDS_SPOT_RUN integer) | Grok 4.5 (grok-4.5) |
 | 31-07-2026 | §2d: autostart residual + human `@DO` for logged-off stored credentials; links windows/README inventory | Grok 4.5 (grok-4.5) |
 | 31-07-2026 | §2d dual dashboards (local 5 s · web 60 s) + doc map row; interlinked with progress_dashboard + dashboard_server UIs (H2032 follow-up) | Grok 4.5 (grok-4.5) |
 | 25-07-2026 | H1623 freshness re-verify (LAST_VERIFIED bump + spot probes) | Grok 4.5 (grok-4.5) |

--- a/docs/manuals/STUDENT_MANUAL_RU.meta.md
+++ b/docs/manuals/STUDENT_MANUAL_RU.meta.md
@@ -1,6 +1,6 @@
 # STUDENT_MANUAL_RU.md — metadoc
 
-_Created: 18-07-2026 · Last updated: 25-07-2026_
+_Created: 18-07-2026 · Last updated: 01-08-2026_
 
 Companion record for [docs/manuals/STUDENT_MANUAL_RU.md](https://github.com/gasyoun/SanskritLexicography/blob/master/docs/manuals/STUDENT_MANUAL_RU.md) (Russian).
 
@@ -15,8 +15,8 @@ Authored 10-07-2026 (H479/H535). Refreshed 18-07-2026 under [H1245](https://gith
 ## Verification
 
 ```
-LAST_VERIFIED: 25-07-2026
-VERIFIED_BY: Grok 4.5 (grok-4.5), H1623
+LAST_VERIFIED: 01-08-2026
+VERIFIED_BY: Grok 4.5 (grok-4.5), H2078
 COMMANDS_SPOT_RUN: 2
 ```
 
@@ -48,6 +48,7 @@ Refreshed by [/workspace-manual](https://github.com/gasyoun/claude-config/blob/m
 
 | Date | Change | By |
 |---|---|---|
+| 01-08-2026 | H2078 manual_staleness refresh (LAST_VERIFIED bump + spot probes; COMMANDS_SPOT_RUN integer) | Grok 4.5 (grok-4.5) |
 | 25-07-2026 | H1623 freshness re-verify (LAST_VERIFIED bump + spot probes) | Grok 4.5 (grok-4.5) |
 | 10-07-2026 | Subject manual authored (H479/H535); ё dropped per H543 11-07-2026 | Fable 5 (`claude-fable-5`) |
 | 18-07-2026 | Metadoc created (H1245 estate refresh); ReverseDictionary section rewritten to post-incident reality | Fable 5 (`claude-fable-5`) |


### PR DESCRIPTION
## Summary
H2078 manual_staleness refresh wave residual from agent-docs Tier A batch.

- Bump `LAST_VERIFIED` to 01-08-2026 on 9 STALE + 1 UNPARSEABLE SanskritLexicography manuals
- Force `COMMANDS_SPOT_RUN` to pure integer on RT deep-manual metadoc (was free-text → UNPARSEABLE)
- Spot probes: manual path existence + HeadwordLists tree; RT residual integer fix

## Test plan
- [x] `python Uprava/tools/manual_staleness.py --repo SanskritLexicography` after merge → 0 STALE/UNPARSEABLE for these rows