### PR TITLE
docs(vedaweb): ROADMAP_VEDAWEB_REUSE Phase 2 COMPLETE polish (H2099)

### DIFF
--- a/ROADMAP_VEDAWEB_REUSE.md
+++ b/ROADMAP_VEDAWEB_REUSE.md
@@ -7,29 +7,21 @@ Scope ruled by M.G. 03-07-2026 (4 decisions, elicited in-session): **full breadt
 **VisualDCS** · GRA crosswalk **queued** · roadmap doc lives **here** (the Sanskrit-data
 hub repo). Authored by Fable 5 (`claude-fable-5`).
 
-## Where we stand (prior-art verdict: PARTIAL)
+## Where we stand (prior-art verdict: COMPLETE — all roadmap phases done)
 
-**No VedaWeb data has been integrated anywhere yet.** What exists is the on-ramp:
+Phases 0–4 are closed. Hub surfaces that still consume the results (ZALIZNYAK a–f
+emission, Karaoke meter seeds, Elizarenkova RU witness, PWG gloss witness) live
+**outside** this roadmap and are tracked on their own handoffs.
 
-- **Probe, confirmed turnkey 2026-06-29** —
-  [FINDINGS.md §1](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md):
-  live API at `vedaweb.uni-koeln.de/api` (FastAPI, OpenAPI at `/api/openapi.json`), four
-  core Rig-Veda resources identified with IDs (Casaretto et al. 2025 accented word-split
-  `66695e4a14f6d337f7788740`; lemmatization `679b7da2d5b833a67f64b3f7`; accented
-  Scarlata–Widmer/Lubotsky text `66695c4b14f6d337f778873f`; Lubotsky padapāṭha
-  `668ba4460b5942c9849a8684`), bulk `GET /api/resources/{id}/export`, **CC BY 4.0**,
-  in-ecosystem (C-SALT/CDSL). §41: the platform migrated to Tekst; the old app was
-  archived 16-02-2026 — the 2.0 API is the only live target.
-- **First consumer built (rules side):** WhitneyRoots
+- **Probe + feed + GRA crosswalk + rights + accent validation** — all landed (see
+  phases below). Core VisualDCS feed:
+  [`VisualDCS/non-derived/vedaweb/`](https://github.com/gasyoun/VisualDCS/tree/main/non-derived/vedaweb).
+- **Accent rules + validation:** WhitneyRoots
   [crosswalk/accent_rules.json](https://github.com/gasyoun/WhitneyRoots/blob/main/crosswalk/accent_rules.json)
-  (18 Whitney rules, 19-cell matrix,
-  [v1.1.0](https://github.com/gasyoun/WhitneyRoots/releases/tag/v1.1.0)) + the
-  Sonnet-runnable
-  [docs/ACCENT_VALIDATION_SPEC.md](https://github.com/gasyoun/WhitneyRoots/blob/main/docs/ACCENT_VALIDATION_SPEC.md),
-  merged via [WhitneyRoots PR #23](https://github.com/gasyoun/WhitneyRoots/pull/23).
-- **The gap:** zero exports on disk; no registered feed in
-  [PROJECT_INTERLINKS.md](https://github.com/gasyoun/Uprava/blob/main/PROJECT_INTERLINKS.md)
-  (the spec caches to gitignored `scratch/`); GRA / meter / translation surfaces untouched.
+  + [crosswalk/accent_validation.json](https://github.com/gasyoun/WhitneyRoots/blob/main/crosswalk/accent_validation.json)
+  + [docs/ACCENT_VALIDATION_REPORT.md](https://github.com/gasyoun/WhitneyRoots/blob/main/docs/ACCENT_VALIDATION_REPORT.md)
+  — **17/19 cells GO, 0 NO-GO** ([PR #24](https://github.com/gasyoun/WhitneyRoots/pull/24),
+  T8c resolved [PR #29](https://github.com/gasyoun/WhitneyRoots/pull/29) / H115).
 
 ## Phases
 
@@ -54,27 +46,29 @@ Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H096-Sonnet_VisualDCS_vedawe
 
 Sonnet-tier chat in `GitHub\VisualDCS`.
 
-### Phase 2 — WhitneyRoots accent-validation run — ✅ DONE (H063, discovered already-merged 01-08-2026)
+### Phase 2 — WhitneyRoots accent-validation run — ✅ DONE 03-07-2026 (H115 polish 05-07-2026); hub tick 01-08-2026
 
 - [x] Score the 18 rules / 19 cells against attested RV accents; per-cell GO/NO-GO for
   the ZALIZNYAK a–f accent-axis emission
   ([ZALIZNYAK_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ZALIZNYAK_INDEX.md)).
-  Independent of Phase 1 (its spec can hit the live API), but if the feed has landed,
-  read from it instead. **Result: 18/19 cells GO** (2 thin-evidence
-  measurement-only cells with 0 attested lemmas; the remaining `T8c·oxytone` exception
-  was resolved to a clean 100% GO by H115). Deliverables:
+  **Result: 17/19 cells GO, 2 measurement-only (thin evidence), 0 NO-GO** — ZALIZNYAK a–f
+  emission cleared on the GO cells. `T8c·oxytone` resolved to 100% by H115 (rule gap for
+  pratyáñc-type añc-compounds, not lemma noise). Deliverables:
   [`crosswalk/accent_validation.json`](https://github.com/gasyoun/WhitneyRoots/blob/main/crosswalk/accent_validation.json) +
   [`docs/ACCENT_VALIDATION_REPORT.md`](https://github.com/gasyoun/WhitneyRoots/blob/main/docs/ACCENT_VALIDATION_REPORT.md),
   landed via [WhitneyRoots PR #24](https://github.com/gasyoun/WhitneyRoots/pull/24)
   (Sonnet 5 `claude-sonnet-5`) + follow-up
-  [WhitneyRoots PR #29](https://github.com/gasyoun/WhitneyRoots/pull/29). This roadmap
-  checkbox was merely stale — the checkbox tick itself is this session's only change.
+  [WhitneyRoots PR #29](https://github.com/gasyoun/WhitneyRoots/pull/29) / H115.
+  FINDINGS §1 + §54 via [SanskritLexicography PR #104](https://github.com/gasyoun/SanskritLexicography/pull/104).
+  Handoff:
+  [H063](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H063-Sonnet_WhitneyRoots_accent_validation_02.07.26.md)
+  (archived ✅). Hub checkbox was stale until
+  [PR #951](https://github.com/gasyoun/SanskritLexicography/pull/951); summary polish +
+  COMPLETE verdict under
+  [H2099](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2099-Grok_SanskritLexicography_vedaweb-phase2-tick_01.08.26.md)
+  (`/drain tier 1`, Grok 4.5).
 
-```
-Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H063-Sonnet_WhitneyRoots_accent_validation_02.07.26.md and execute it.
-```
-
-Sonnet-tier chat in `GitHub\WhitneyRoots`.
+🔴 EXECUTED: [H063-Sonnet_WhitneyRoots_accent_validation_02.07.26.md](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H063-Sonnet_WhitneyRoots_accent_validation_02.07.26.md)
 
 ### Phase 3 — GRA (Grassmann) ↔ VedaWeb crosswalk — ✅ DONE 08-07-2026
 

--- a/ROADMAP_VEDAWEB_REUSE.meta.md
+++ b/ROADMAP_VEDAWEB_REUSE.meta.md
@@ -1,6 +1,6 @@
 # ROADMAP_VEDAWEB_REUSE.meta.md — metadoc for `ROADMAP_VEDAWEB_REUSE.md`
 
-_Created: 18-07-2026 · Last updated: 18-07-2026_
+_Created: 18-07-2026 · Last updated: 01-08-2026_
 
 This is a **metadoc** — a document *about* a document. Its subject is
 [ROADMAP_VEDAWEB_REUSE.md](https://github.com/gasyoun/SanskritLexicography/blob/master/ROADMAP_VEDAWEB_REUSE.md).
@@ -15,10 +15,9 @@ standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`)
 - **Audience:** Sessions consuming VedaWeb-derived data (WhitneyRoots accent rules,
   RussianTranslation's Elizarenkova witness, SanskritKaraoke meter seeds, PWG German gloss
   witness) or checking VedaWeb licensing before a new use.
-- **Format / contract:** Phase 0–4 (all done) + a still-queued follow-on ("Phase 2:
-  WhitneyRoots accent-validation run") — each phase carries an executable one-line handoff
-  starter (`Read <path> and execute it.`) per the org's session-starters contract. Any new
-  phase gets the same starter-line treatment.
+- **Format / contract:** Phase 0–4 are all done (Phase 2 hub checkbox ticked 01-08-2026;
+  validation itself shipped 03-07-2026 as H063). Historical phase bodies keep archive links;
+  executed handoffs use `🔴 EXECUTED:` rather than live starters.
 
 ## Provenance
 - **Created:** 18-07-2026 (handoff H968, Sonnet 5 `claude-sonnet-5`).
@@ -29,12 +28,11 @@ standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`)
 
 | # | Improvement | Why | Status |
 |---|---|---|---|
-| 1 | Downstream a–f accent-mobility emission into ZALIZNYAK_INDEX, gated on Phase 2's per-cell GO/NO-GO | Explicitly named in the subject's "Dependency order" section as the one still-open follow-on outside this roadmap's own scope | parked — tracked as its own follow-on, not owned by this doc |
+| 1 | Downstream a–f accent-mobility emission into ZALIZNYAK_INDEX, gated on Phase 2's per-cell GO/NO-GO | Explicitly named in the subject's "Dependency order" section as the one still-open follow-on outside this roadmap's own scope | **unblocked** 01-08-2026 (Phase 2 GO/NO-GO landed) — still parked as its own workstream, not owned by this roadmap |
 
 ## Known limitations / caveats
-- All 5 named phases (0–4) are marked done; the doc is close to fully executed — treat it as
-  near-final reference material, not an active work queue, aside from the one flagged
-  follow-on above.
+- All named phases (0–4) are marked done; treat the subject as **reference material**, not an
+  active checkbox queue. The only residual is the external ZALIZNYAK a–f emission follow-on.
 - Rights note: only 2/36 VedaWeb catalog resources originally carried an explicit `license`
   field; the blanket "CC BY 4.0" framing was an unverified assumption at triage time, later
   confirmed in writing by VedaWeb (Kölligan/Reinöhl) for all 4 candidate meter/translation
@@ -59,7 +57,7 @@ standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`)
   deleting, since it is the authoritative record of the VedaWeb rights-confirmation trail.
 
 ## Deprecation status
-`active` (functionally near-complete — see backlog item 1 for the one open thread).
+`active` (phases complete; residual is external follow-on only — backlog item 1).
 
 ## Related documents
 - [FINDINGS.md](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) — §1 (API probe), §72/§73 (renumbered GRA crosswalk and rights findings) cited throughout the subject.
@@ -72,5 +70,6 @@ standing "one metadoc per important document" convention (`~/.claude/CLAUDE.md`)
 | Date | Event | Who |
 |---|---|---|
 | 18-07-2026 | Metadoc created (backfill sweep) | Sonnet 5 (`claude-sonnet-5`), H968 |
+| 01-08-2026 | Phase 2 hub tick already on master (#951); summary → COMPLETE; Phase 2 numbers corrected to 17/19 GO; H063 starter → EXECUTED; backlog item 1 unblocked | Grok 4.5 (`grok-4-1-thinking-0309-reasoning`), H2099 `/drain tier 1` |
 
 _Dr. Mārcis Gasūns_

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,11 @@ not an error.
 
 ## [Unreleased]
 
+## [1.114.10] - 2026-08-01
+
+### Changed
+- **ROADMAP_VEDAWEB_REUSE Phase 2 closeout polish (H2099, Grok 4.5 `grok-4-1-thinking-0309-reasoning`, `/drain tier 1`):** hub checkbox was already ticked on master via [#951](https://github.com/gasyoun/SanskritLexicography/pull/951) after WhitneyRoots [PR #24](https://github.com/gasyoun/WhitneyRoots/pull/24)/[#29](https://github.com/gasyoun/WhitneyRoots/pull/29) (H063/H115). This pass rewrites the stale "Where we stand: PARTIAL" summary to **COMPLETE**, corrects the Phase 2 score line to **17/19 GO / 0 NO-GO**, marks H063 `🔴 EXECUTED`, and updates the metadoc backlog (ZALIZNYAK a–f emission **unblocked**).
+
 ## [1.114.9] - 2026-08-01
 
 ### Changed


### PR DESCRIPTION
## Summary
- `/drain tier 1` sole Bucket A unit was Phase 2 of `ROADMAP_VEDAWEB_REUSE.md`.
- Validation already shipped (WhitneyRoots #24 / #29, H063/H115); hub checkbox already ticked by #951.
- This PR finishes the closeout: rewrite stale **PARTIAL** summary → **COMPLETE**, correct **17/19 GO / 0 NO-GO**, mark H063 `EXECUTED`, update metadoc (ZALIZNYAK a–f unblocked), changelog 1.114.10.

## Test plan
- [x] Diff only roadmap + metadoc + changelog
- [x] No re-run of VedaWeb scoring
- [ ] Re-census `roadmap_drain_report.py --tier 1` after merge → A=0

Handoff: https://github.com/gasyoun/Uprava/blob/main/handoffs/H2099-Grok_SanskritLexicography_vedaweb-phase2-tick_01.08.26.md