### PR TITLE
chore(release): 1.115.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.113.0
-date-released: 2026-07-31
+version: 1.115.0
+date-released: 2026-08-01
 # The CONCEPT DOI — version-independent, always resolves to the newest release.
 # This is deliberately NOT a per-version DOI: those change every release and would
 # make this file wrong the moment the next one ships. Each release's own version

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.115.0] - 2026-08-01
+
 ### Fixed — the last four H2056 integrity issues (H2095, issues #946 · #949 · #950 · #956, 01-08-2026, Opus 5 `claude-opus-5[1m]`)
 
 **[#949](https://github.com/gasyoun/SanskritLexicography/issues/949) — `budget_spent` was published without the qualifier that makes it readable.**


### PR DESCRIPTION
Cuts `v1.115.0`: promotes `RussianTranslation/CHANGELOG.md` `[Unreleased]` (7 entries) to `[1.115.0] - 2026-08-01`, and syncs `CITATION.cff` (was 1.113.0, lagging the v1.114.5 tag).

**Version choice.** Continues the REAL tag sequence from `v1.114.5`, not either changelog's own line — the two changelogs share one tag sequence (`v1.111.5` matches RT's `[1.111.5]`) but alternate which file gets the section. Minor bump: the release adds capability (`duration_api_ms` capture, cost-evaluability markers) alongside fixes. It also absorbs root `changelog.md` sections 1.114.6–1.114.10, promoted by earlier sessions without tags.

**What ships:** the whole H2056 arc — the 22-agent adversarial review plus all eight integrity fixes derived from it (#943–#950, #956), and the H2089 master repair.

Concept DOI unchanged by design; the version DOI is minted by the Zenodo webhook on publish and belongs in the release notes.

Tag + GitHub release follow the merge (master is protected — no tagging a commit off the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
