### PR TITLE
docs: tidy .ai_state after the H2056 arc (H2118 queued)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -462,125 +462,18 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 > **and** adding texts/locus crosswalks — not a better matcher, and not more compute.
 
 ## ➡️ Next Steps (Queue)
+- **H2118 🟡 QUEUED — GATED on the c4 rate limit clearing.** Re-derive
+  `PROBE_LATENCY_CEILING_MS` from >=5 paired readings (wall + `duration_api_ms` + a same-moment
+  quota check) and rule on the two mechanical gates that share the policy name `production_v1`
+  while disagreeing 2.2x ([`probe_log.POLICIES`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/probe_log.py)
+  30 000 ms vs [`max_account_orchestrator`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/max_account_orchestrator.py)
+  65 000 ms). H2095 already shipped the instrumentation this consumes. Issue
+  [#946](https://github.com/gasyoun/SanskritLexicography/issues/946). Start with:
 
-- **H2095 🔴 EXECUTED 01-08-2026 (Opus 5 `claude-opus-5[1m]`) — the LAST four H2056 integrity
-  issues closed ([#946](https://github.com/gasyoun/SanskritLexicography/issues/946),
-  [#949](https://github.com/gasyoun/SanskritLexicography/issues/949),
-  [#950](https://github.com/gasyoun/SanskritLexicography/issues/950),
-  [#956](https://github.com/gasyoun/SanskritLexicography/issues/956)). H2056 is fully drained.**
-  #949: `summary()` now publishes `cost_evaluable`/`unevaluable_calls`/`pending_calls` beside
-  `budget_spent` — a hung call books as $0, so the bare total read as "this run was free".
-  #946: probe rows carry `latency_ceiling_ms`.
-  #950: settled from the committed H963 record, **no constant moved**.
-  #956: EN auditor exempts infra-partial cards from ABSENCE-bearing HARD flags.
-  ⚠️ **NEW DANGER FACT — two mechanical gates, one policy name, 2.2× apart.**
-  `probe_log.POLICIES['production_v1']['latency_ceil_ms']` = **30 000** while
-  `max_account_orchestrator.PROBE_LATENCY_CEILING_MS` = **65 000**. A 50 000 ms reading PASSES
-  `live_probe` and FAILS `probe_log.verdict_for()`, and both stamp rows `production_v1`. Trust a
-  row's own `latency_ceiling_ms` (emitted since H2095) over the POLICIES table. Deliberately NOT
-  reconciled — choosing a ceiling is a human call and 65 000 is itself suspect (calibrated partly
-  against rate-limit backoff, FINDINGS §270). A selftest pin FAILS the moment someone unifies
-  them, so it cannot be closed silently.
-  ⚠️ **#950 arithmetic — do not re-derive.** The "~90 485 tokens per call" premise is WRONG: the
-  H963 table says `calls | 2`, so it is a two-call aggregate (~45 243/call). `$0.29/call` IS
-  right ($0.5848 ÷ 2). And the comparison is category-confused anyway — those constants price a
-  TRANSLATION agent, the figures come from a READINESS PROBE dominated by cache-creation
-  scaffolding.
-  #956 answered #947's open question by enumeration: 6 of 11 EN HARD flags are absence-bearing, so
-  the hazard was real on that lane too.
-  Gates: `window_selftest` 196/196, pilot suite green, LANG_PARITY 89 entries (45 re-derived,
-  including a first-ever note on `h1339_measurement_integrity`).
+```
+Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H2118-Opus_RussianTranslation_rederive-probe-latency-ceiling-946_01.08.26.md and execute it.
+```
 
-- **H2091 🔴 EXECUTED 01-08-2026 (Opus 5 `claude-opus-5[1m]`) — [#948](https://github.com/gasyoun/SanskritLexicography/issues/948)
-  fixed: a dead heal call no longer reports itself as a content verdict.**
-  `_selfheal_stop_reason` tested only for `budget_exceeded:*`, so a `timeout` fell through to
-  `selfheal-nothing-resolved` — a CONTENT verdict, and the only per-key cause an operator or any
-  tool ever sees. Now **RANKED**: budget stop (H2a, unchanged) → any other typed infra reason
-  (`is_infra_failure`) → the historical content verdict.
-  ⚠️ **The ranking is load-bearing — do NOT flatten it.** A flat "first infra wins" lets a
-  low-index `timeout` mask a budget stop and silently repeals H2a. That regression was caught
-  mid-work by `test_h2a_precedence_is_deterministic_and_budget_stays_observable` and is now pinned
-  from both directions.
-  **Q3-F3 needed no change — verified, not assumed.** The whole-card lane bisects a failed batch
-  ON PURPOSE ("isolate the slow one"; the JS twin does the same deliberately), so bisect-after-
-  timeout is correct and must be left alone. It was only wrong for an ACCOUNT refusal, which H2063
-  already closed via `HardFailure` (uncaught by `resolve_group`). Pinned on a multi-key batch:
-  account refusal stops at 1 call, plain timeout still bisects.
-  Gates: LANG_PARITY 89 entries (5 re-derived); new pins green.
-  ⚠️ **Local suite was NOT fully green — machine, not code.** `headless_worker`,
-  `max_account_orchestrator` and `coordinator_hardening` selftests failed on spawn/timing
-  ("level 1 never started", "probe tree never reached depth 3", "hanging preflight never
-  started"). Same-moment A/B: **identical failures on pristine master**, and `bounded_staged_run`
-  failed on master while PASSING patched. Process spawning on this box had degraded (27 stray
-  python processes, mostly leaked `fable_advisor_mcp.py` from prior days — left untouched, not
-  this session's). CI on a clean runner is the authoritative check and was green.
-
-- **H2079 🔴 EXECUTED 01-08-2026 (Opus 5 `claude-opus-5[1m]`) — [#945](https://github.com/gasyoun/SanskritLexicography/issues/945)
-  fixed: `duration_api_ms` is captured, so a latency reading is decomposable.**
-  Every latency gate measured WALL CLOCK, which cannot separate a slow route from a CLI retrying
-  internally against a rate limit. The discriminator was already in the envelope, already parsed,
-  and discarded one line away. `telemetry_from_cli_wrapper` now carries `duration_ms` /
-  `duration_api_ms` into the durable reservation ledger; `live_probe` emits `duration_api_ms` +
-  `api_gap_ms` beside `elapsed_ms`; `_probe_call` gained an optional `timing_out` dict (no
-  return-arity change, so no stub churn).
-  ⚠️ **Recording ONLY — nothing is gated on it.** `elapsed_ms` is still the number the ceiling
-  tests and no threshold moved. Re-deriving the suspect `PROBE_LATENCY_CEILING_MS` needs readings
-  paired with a same-moment quota check — separate work, [#946](https://github.com/gasyoun/SanskritLexicography/issues/946).
-  ⚠️ **Do not "tidy" the fields into always-present.** They are OMITTED when absent, never an
-  explicit `None`: `_read()` re-validates every stored item and `finalize()` compares an
-  already-finalized item against a freshly normalized one, so a pre-H2079 ledger must normalize to
-  exactly the bytes it already holds. A malformed duration must also never demote `cost_evaluable`
-  (evaluability is about COST). Both are pinned in `call_reservation_selftest`.
-  **Past readings stay contaminated** — this fixes capture going forward; the 15-07/16-07/31-07 c4
-  numbers still cannot be decomposed retroactively.
-  Gates: `window_selftest` 195/195, pilot suite green, LANG_PARITY 89 entries (3 re-derived).
-
-- **H2077 🔴 EXECUTED 01-08-2026 (Opus 5 `claude-opus-5[1m]`) — [#947](https://github.com/gasyoun/SanskritLexicography/issues/947)
-  fixed: a quota hang no longer denylists a healthy card or discards its fragments' TM.**
-  The worst harm from H2056, and the only one with permanent consequences.
-  `classify_harness_requeues` split transient-vs-defect on **shape** alone, exempting null keys but
-  not partial ones — so a card left incomplete by a dead heal call was filed as a content defect,
-  which denylisted a healthy card, discarded the `frag_prov` fshas of fragments that DID translate,
-  and wrote the key to `no_pwg_residuals.jsonl` as `blocked`. All three consume the one
-  `requeue_defect` set, so all three are fixed at one point.
-  **The split is now evidence-based:** a partial card records WHY it is partial
-  (`_partial_cause()` → `partial_cause` / `partial_cause_infra`, derived from that card's own
-  fragments' recorded call failures) and the audit subtracts explicitly-infrastructure partials.
-  ⚠️ **Deliberately narrow — do not widen casually.** `INFRA_FAILURE_REASONS` is a CLOSED list
-  (timeout · budget_exceeded · rate_limit · authentication · connection). A content cause, or NO
-  recorded cause (older wf files), behaves exactly as before, and `fidelity_nulls` still overrides.
-  Over-exempting re-opens the 'stubborn null' cheap-re-run loop the fidelity rule exists to stop —
-  the 4-quadrant pin `test_h2077_947_infra_partial_is_not_a_content_defect` exists to catch that.
-  Gates: `window_selftest` 195/195, pilot suite green, LANG_PARITY 89 entries (44 re-derived).
-  **New open question surfaced, not assumed away:** `audit_window_en.py` is a separate auditor with
-  no partial-card model, so this defect cannot arise there in the same form — but whether an EN card
-  can be hard-flagged for content a dead call never produced is unexamined:
-  [#956](https://github.com/gasyoun/SanskritLexicography/issues/956).
-
-- **H2063 🔴 EXECUTED 01-08-2026 (Opus 5 `claude-opus-5[1m]`) — first two H2056 fixes landed:
-  a rate-limited account no longer looks like a local timeout.**
-  [#943](https://github.com/gasyoun/SanskritLexicography/issues/943): `run_tree_kill` now ATTACHES
-  the tree-killed child's drained stdout/stderr to its `TimeoutExpired` (it was dropped on the
-  floor — the root blocker).
-  [#944](https://github.com/gasyoun/SanskritLexicography/issues/944): new `classify_timeout()`
-  promotes an account-level cause (429/401) into the **existing** `HardFailure` path, so the worker
-  exits 21, stops instead of spending into a locked account, and the orchestrator's long-standing
-  `is_rate_limited` → `park` + `requeue_rate_limited` finally fires; the probe gets the same.
-  Deliberately narrower than `classify_process` — a `connection`-ish string in a killed call stays
-  `'timeout'`, so a merely slow window is never falsely parked.
-  Gates: full pilot suite green, `window_selftest` 194/194, LANG_PARITY 89 entries re-derived
-  (6 needed it) with no drift, 3 new selftest pins.
-  ⚠️ **Known load-sensitive test, NOT a regression:** `headless_worker_selftest`'s D-J depth-three
-  tree-kill case can fail `level 3 never started` under heavy machine load — the 3-level spawn
-  chain must write `.pid3` inside the 3 s pre-kill window. Interleaved A/B (5 rounds) showed
-  patched 5/5 = master 5/5; every line H2063 touched runs *after* the timeout fires. Re-run before
-  believing a failure.
-  **Still open from H2056:** 11 findings / 6 issues ([#945](https://github.com/gasyoun/SanskritLexicography/issues/945)–[#950](https://github.com/gasyoun/SanskritLexicography/issues/950)),
-  including the worst one — a quota hang can still denylist a healthy card and discard its TM
-  ([#947](https://github.com/gasyoun/SanskritLexicography/issues/947), `audit_window.py:484`) —
-  plus `duration_api_ms` still parsed nowhere ([#945](https://github.com/gasyoun/SanskritLexicography/issues/945)).
-  No ceiling was changed; whether 180 s is right, and whether repeated `kill_timeouts` should park,
-  remain open for a human.
 
 - **H2056 call-path review 🔴 EXECUTED 01-08-2026 (Opus 5 `claude-opus-5[1m]`, 22-agent Workflow)
   — 13 confirmed defects now awaiting a human ranking; NO fixes applied.**
@@ -3208,6 +3101,28 @@ batch [_batch_h1624_dh_followups.tsv](https://github.com/gasyoun/Uprava/blob/mai
 
 ## 🧠 Dev Notes & Hypotheses
 
+> **BLOCKER (01-08-2026) — the live gate cannot be re-calibrated until the c4 quota clears.**
+> H2118 is written and queued but must not start while c4 is rate-limited: its whole method is
+> ≥5 readings each paired with a same-moment quota check, and a rate-limited profile *hangs*
+> rather than erroring, so a reading taken now measures backoff. Check cheaply first with an
+> authenticated **non-CLI** request (FINDINGS §270 method) before spending anything.
+>
+> **Hypothesis to test when it clears:** the route is healthy in the low tens of seconds and the
+> 65 000 ms ceiling is measuring machine + quota, not c4. Evidence for: `duration_api_ms` was
+> ~12 987 ms against a 78 415 ms wall reading in the H2011 envelope — a ~65 s gap. If that
+> replicates across 5 clean readings, the honest ceiling is far below 65 000 and the raise was
+> calibrated against backoff. Evidence against: none measured yet — this is untested.
+>
+> **Local-environment caveat (01-08-2026):** this box's process spawning degraded badly during a
+> long session — `headless_worker` / `max_account_orchestrator` / `coordinator_hardening`
+> selftests failed on spawn timing (`level 1 never started`, `probe tree never reached depth 3`).
+> Same-moment A/B showed **identical failures on pristine master**, and `bounded_staged_run`
+> failed on master while passing patched. 27 stray python processes were present, mostly leaked
+> `fable_advisor_mcp.py` from prior days (left untouched — not this session's to kill). **Always
+> A/B against pristine master before blaming your own diff**, and treat CI on a clean runner as
+> authoritative.
+
+
 - **Cost model is fragment-count-driven, not card-count-driven — the `pril10_w1` lesson (2026-07-05).**
   The opt2 harness amortizes the ~30 K fixed framework by packing many cards per `agent()` call.
   That amortization **only holds when cards are batched**. In nominal+presplit mode each fragment is
@@ -3336,6 +3251,137 @@ batch [_batch_h1624_dh_followups.tsv](https://github.com/gasyoun/Uprava/blob/mai
   ([SamudraManthanam #16](https://github.com/gasyoun/SamudraManthanam/issues/16)).
 
 ## ✅ Completed (Recent only)
+
+- **v1.115.0 released 01-08-2026 (Opus 5 `claude-opus-5[1m]`)** —
+  [release](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.115.0), tag on
+  `d759c0b8`. Promotes the whole accumulated `[Unreleased]` (7 entries: the H2056 review + all
+  eight integrity fixes + H2047), ending the deliberate accumulation recorded here for the
+  H1811/H1940 series. Version continues the REAL tag sequence (v1.114.5 -> v1.115.0), not either
+  changelog's own line — the two changelogs share one tag sequence but alternate which file gets
+  the section, and this tag also absorbs root sections 1.114.6-1.114.10 that earlier sessions
+  promoted without tagging. `CITATION.cff` synced 1.113.0 -> 1.115.0 (it was lagging the tag).
+  Zenodo version DOI still to be confirmed and pasted into the notes (GTD `@DO`).
+
+
+- **H2095 🔴 EXECUTED 01-08-2026 (Opus 5 `claude-opus-5[1m]`) — the LAST four H2056 integrity
+  issues closed ([#946](https://github.com/gasyoun/SanskritLexicography/issues/946),
+  [#949](https://github.com/gasyoun/SanskritLexicography/issues/949),
+  [#950](https://github.com/gasyoun/SanskritLexicography/issues/950),
+  [#956](https://github.com/gasyoun/SanskritLexicography/issues/956)). H2056 is fully drained.**
+  #949: `summary()` now publishes `cost_evaluable`/`unevaluable_calls`/`pending_calls` beside
+  `budget_spent` — a hung call books as $0, so the bare total read as "this run was free".
+  #946: probe rows carry `latency_ceiling_ms`.
+  #950: settled from the committed H963 record, **no constant moved**.
+  #956: EN auditor exempts infra-partial cards from ABSENCE-bearing HARD flags.
+  ⚠️ **NEW DANGER FACT — two mechanical gates, one policy name, 2.2× apart.**
+  `probe_log.POLICIES['production_v1']['latency_ceil_ms']` = **30 000** while
+  `max_account_orchestrator.PROBE_LATENCY_CEILING_MS` = **65 000**. A 50 000 ms reading PASSES
+  `live_probe` and FAILS `probe_log.verdict_for()`, and both stamp rows `production_v1`. Trust a
+  row's own `latency_ceiling_ms` (emitted since H2095) over the POLICIES table. Deliberately NOT
+  reconciled — choosing a ceiling is a human call and 65 000 is itself suspect (calibrated partly
+  against rate-limit backoff, FINDINGS §270). A selftest pin FAILS the moment someone unifies
+  them, so it cannot be closed silently.
+  ⚠️ **#950 arithmetic — do not re-derive.** The "~90 485 tokens per call" premise is WRONG: the
+  H963 table says `calls | 2`, so it is a two-call aggregate (~45 243/call). `$0.29/call` IS
+  right ($0.5848 ÷ 2). And the comparison is category-confused anyway — those constants price a
+  TRANSLATION agent, the figures come from a READINESS PROBE dominated by cache-creation
+  scaffolding.
+  #956 answered #947's open question by enumeration: 6 of 11 EN HARD flags are absence-bearing, so
+  the hazard was real on that lane too.
+  Gates: `window_selftest` 196/196, pilot suite green, LANG_PARITY 89 entries (45 re-derived,
+  including a first-ever note on `h1339_measurement_integrity`).
+
+- **H2091 🔴 EXECUTED 01-08-2026 (Opus 5 `claude-opus-5[1m]`) — [#948](https://github.com/gasyoun/SanskritLexicography/issues/948)
+  fixed: a dead heal call no longer reports itself as a content verdict.**
+  `_selfheal_stop_reason` tested only for `budget_exceeded:*`, so a `timeout` fell through to
+  `selfheal-nothing-resolved` — a CONTENT verdict, and the only per-key cause an operator or any
+  tool ever sees. Now **RANKED**: budget stop (H2a, unchanged) → any other typed infra reason
+  (`is_infra_failure`) → the historical content verdict.
+  ⚠️ **The ranking is load-bearing — do NOT flatten it.** A flat "first infra wins" lets a
+  low-index `timeout` mask a budget stop and silently repeals H2a. That regression was caught
+  mid-work by `test_h2a_precedence_is_deterministic_and_budget_stays_observable` and is now pinned
+  from both directions.
+  **Q3-F3 needed no change — verified, not assumed.** The whole-card lane bisects a failed batch
+  ON PURPOSE ("isolate the slow one"; the JS twin does the same deliberately), so bisect-after-
+  timeout is correct and must be left alone. It was only wrong for an ACCOUNT refusal, which H2063
+  already closed via `HardFailure` (uncaught by `resolve_group`). Pinned on a multi-key batch:
+  account refusal stops at 1 call, plain timeout still bisects.
+  Gates: LANG_PARITY 89 entries (5 re-derived); new pins green.
+  ⚠️ **Local suite was NOT fully green — machine, not code.** `headless_worker`,
+  `max_account_orchestrator` and `coordinator_hardening` selftests failed on spawn/timing
+  ("level 1 never started", "probe tree never reached depth 3", "hanging preflight never
+  started"). Same-moment A/B: **identical failures on pristine master**, and `bounded_staged_run`
+  failed on master while PASSING patched. Process spawning on this box had degraded (27 stray
+  python processes, mostly leaked `fable_advisor_mcp.py` from prior days — left untouched, not
+  this session's). CI on a clean runner is the authoritative check and was green.
+
+- **H2079 🔴 EXECUTED 01-08-2026 (Opus 5 `claude-opus-5[1m]`) — [#945](https://github.com/gasyoun/SanskritLexicography/issues/945)
+  fixed: `duration_api_ms` is captured, so a latency reading is decomposable.**
+  Every latency gate measured WALL CLOCK, which cannot separate a slow route from a CLI retrying
+  internally against a rate limit. The discriminator was already in the envelope, already parsed,
+  and discarded one line away. `telemetry_from_cli_wrapper` now carries `duration_ms` /
+  `duration_api_ms` into the durable reservation ledger; `live_probe` emits `duration_api_ms` +
+  `api_gap_ms` beside `elapsed_ms`; `_probe_call` gained an optional `timing_out` dict (no
+  return-arity change, so no stub churn).
+  ⚠️ **Recording ONLY — nothing is gated on it.** `elapsed_ms` is still the number the ceiling
+  tests and no threshold moved. Re-deriving the suspect `PROBE_LATENCY_CEILING_MS` needs readings
+  paired with a same-moment quota check — separate work, [#946](https://github.com/gasyoun/SanskritLexicography/issues/946).
+  ⚠️ **Do not "tidy" the fields into always-present.** They are OMITTED when absent, never an
+  explicit `None`: `_read()` re-validates every stored item and `finalize()` compares an
+  already-finalized item against a freshly normalized one, so a pre-H2079 ledger must normalize to
+  exactly the bytes it already holds. A malformed duration must also never demote `cost_evaluable`
+  (evaluability is about COST). Both are pinned in `call_reservation_selftest`.
+  **Past readings stay contaminated** — this fixes capture going forward; the 15-07/16-07/31-07 c4
+  numbers still cannot be decomposed retroactively.
+  Gates: `window_selftest` 195/195, pilot suite green, LANG_PARITY 89 entries (3 re-derived).
+
+- **H2077 🔴 EXECUTED 01-08-2026 (Opus 5 `claude-opus-5[1m]`) — [#947](https://github.com/gasyoun/SanskritLexicography/issues/947)
+  fixed: a quota hang no longer denylists a healthy card or discards its fragments' TM.**
+  The worst harm from H2056, and the only one with permanent consequences.
+  `classify_harness_requeues` split transient-vs-defect on **shape** alone, exempting null keys but
+  not partial ones — so a card left incomplete by a dead heal call was filed as a content defect,
+  which denylisted a healthy card, discarded the `frag_prov` fshas of fragments that DID translate,
+  and wrote the key to `no_pwg_residuals.jsonl` as `blocked`. All three consume the one
+  `requeue_defect` set, so all three are fixed at one point.
+  **The split is now evidence-based:** a partial card records WHY it is partial
+  (`_partial_cause()` → `partial_cause` / `partial_cause_infra`, derived from that card's own
+  fragments' recorded call failures) and the audit subtracts explicitly-infrastructure partials.
+  ⚠️ **Deliberately narrow — do not widen casually.** `INFRA_FAILURE_REASONS` is a CLOSED list
+  (timeout · budget_exceeded · rate_limit · authentication · connection). A content cause, or NO
+  recorded cause (older wf files), behaves exactly as before, and `fidelity_nulls` still overrides.
+  Over-exempting re-opens the 'stubborn null' cheap-re-run loop the fidelity rule exists to stop —
+  the 4-quadrant pin `test_h2077_947_infra_partial_is_not_a_content_defect` exists to catch that.
+  Gates: `window_selftest` 195/195, pilot suite green, LANG_PARITY 89 entries (44 re-derived).
+  **New open question surfaced, not assumed away:** `audit_window_en.py` is a separate auditor with
+  no partial-card model, so this defect cannot arise there in the same form — but whether an EN card
+  can be hard-flagged for content a dead call never produced is unexamined:
+  [#956](https://github.com/gasyoun/SanskritLexicography/issues/956).
+
+- **H2063 🔴 EXECUTED 01-08-2026 (Opus 5 `claude-opus-5[1m]`) — first two H2056 fixes landed:
+  a rate-limited account no longer looks like a local timeout.**
+  [#943](https://github.com/gasyoun/SanskritLexicography/issues/943): `run_tree_kill` now ATTACHES
+  the tree-killed child's drained stdout/stderr to its `TimeoutExpired` (it was dropped on the
+  floor — the root blocker).
+  [#944](https://github.com/gasyoun/SanskritLexicography/issues/944): new `classify_timeout()`
+  promotes an account-level cause (429/401) into the **existing** `HardFailure` path, so the worker
+  exits 21, stops instead of spending into a locked account, and the orchestrator's long-standing
+  `is_rate_limited` → `park` + `requeue_rate_limited` finally fires; the probe gets the same.
+  Deliberately narrower than `classify_process` — a `connection`-ish string in a killed call stays
+  `'timeout'`, so a merely slow window is never falsely parked.
+  Gates: full pilot suite green, `window_selftest` 194/194, LANG_PARITY 89 entries re-derived
+  (6 needed it) with no drift, 3 new selftest pins.
+  ⚠️ **Known load-sensitive test, NOT a regression:** `headless_worker_selftest`'s D-J depth-three
+  tree-kill case can fail `level 3 never started` under heavy machine load — the 3-level spawn
+  chain must write `.pid3` inside the 3 s pre-kill window. Interleaved A/B (5 rounds) showed
+  patched 5/5 = master 5/5; every line H2063 touched runs *after* the timeout fires. Re-run before
+  believing a failure.
+  **Still open from H2056:** 11 findings / 6 issues ([#945](https://github.com/gasyoun/SanskritLexicography/issues/945)–[#950](https://github.com/gasyoun/SanskritLexicography/issues/950)),
+  including the worst one — a quota hang can still denylist a healthy card and discard its TM
+  ([#947](https://github.com/gasyoun/SanskritLexicography/issues/947), `audit_window.py:484`) —
+  plus `duration_api_ms` still parsed nowhere ([#945](https://github.com/gasyoun/SanskritLexicography/issues/945)).
+  No ceiling was changed; whether 180 s is right, and whether repeated `kill_timeouts` should park,
+  remain open for a human.
+
 
 - **H2045 DONE — h1306_style (+ h1682) vote sheets remade for MG vote (31-07-2026,
   Grok 4.5 `grok-4.5`).** Voting was blocked: the 21-07 `h1306_style` sheet was


### PR DESCRIPTION
Session close-out for the H2056 arc.

- Moves the five EXECUTED entries (H2063 / H2077 / H2079 / H2091 / H2095) from `Next Steps` to `Completed` — they were written there while in flight, and all are merged with their handoffs archived, so leaving them misreported finished work as pending.
- `Next Steps` now carries the one real continuation: **H2118** (re-derive `PROBE_LATENCY_CEILING_MS`, reconcile the two `production_v1` gates), gated on the c4 quota, with its literal starter line.
- `Dev Notes` gains the blocker + the **hypothesis to test**: the route is likely healthy in the low tens of seconds and the 65 000 ms ceiling is measuring machine + quota — evidence for is the ~65 s wall-vs-API gap in the H2011 envelope; nothing measured against it yet.
- Also records the local-environment caveat: selftests on this box fail on spawn timing **identically on pristine master**, so A/B before blaming a diff, and treat CI as authoritative.
- Records v1.115.0, which ended the deliberate `[Unreleased]` accumulation.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
