### PR TITLE
H1650: h178/h180 rescreen — citation_tm + A2 + screening=

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -5172,3 +5172,18 @@ Shipped in [csl-atlas#325](https://github.com/sanskrit-lexicon/csl-atlas/pull/32
 
 
 _30-07-2026 · repository architecture audit · Codex GPT-5_
+
+---
+
+### 512. A ruling that reaches a register but never reaches the card is re-litigated by the next human (N1 loop)
+
+**Measured defect (H1650 / pramuc, 26-07 → 01-08-2026).** Card `muc|muc~~h0_20_pra|8` was
+**N1 in the 19-07 H178 DA vote register**: reuse SamudraManthanam RU for R./MBH. citations.
+H1304 shipped `citation_tm.py` the same day. The voting sheet was never re-rendered with the
+attested line, so MG had to write the same objection again in `pramuc.md`.
+
+**Rule:** if a human ruling is about what the *next* sheet must show, the sheet generator is
+part of the delivery — register rows alone are not. H1650 wires `citation_evidence_panel()`
+into h178/h180 generators and a screening banner (csl-pyutil ≥0.8.0).
+
+> Grok 4.5 (`grok-4.5`) · 01-08-2026 · H1650

--- a/RussianTranslation/pwg_ru/SCREENING_H1650.md
+++ b/RussianTranslation/pwg_ru/SCREENING_H1650.md
@@ -1,0 +1,17 @@
+# Screening evidence — H1650 (pwg_ru h178/h180/g5)
+
+_Created: 01-08-2026 · Last updated: 01-08-2026_
+
+| Rule | Class | What it does |
+|---|---|---|
+| `citation_tm` | (b) lookup | Panel per card: every `<ls>` with status + SA/RU when hit |
+| `A2-retire-mqm-likert-pairwise` | (a) policy | Three h178 arms withdrawn; instrument = h178_da + agent_pass |
+| `frozen-eval-sample` | note | Sample is frozen (H1301), not live store after H1302/H1305 |
+| `machine_flags_D1_D3_D4` | (a) | G5 auto-reject; **counts as reject in N** (MG Б) |
+| `visible_german_residue` | (a) | G5 excludes reader-visible German (H1655) |
+
+Generators: [`src/sheet_screening.py`](../src/sheet_screening.py).  
+Probe (org): `python Uprava/tools/screen_cards.py --all`.  
+H274: gate released onto h178_da human + agent_pass; every metric labels agent-vs-human or agent-only.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/build_g5_review_sheet.py
+++ b/RussianTranslation/src/build_g5_review_sheet.py
@@ -73,6 +73,7 @@ import re
 import sys
 
 from csl_pyutil import render_review_sheet
+from sheet_screening import screening_block
 from review_binding import stamp, write_lock
 from review_residue_gate import machine_flags, visible_german
 from review_sheet_standard import pwg_entry_href, slp1_iast, standard_config
@@ -450,11 +451,37 @@ def finish(args, chosen, store_rec, queue, n_decided, n_german, n_mflag, pinned_
     config.update(standard_config(
         save_as="RussianTranslation\\review\\%s_decisions.json" % SHEET_ID))
 
-    doc = render_review_sheet(items, config, extras=True)
+    # H1650 / Б: machine-flags auto-rejected count as rejects in N=150 stats
+    n_human = len(items)
+    sc = screening_block(
+        deterministic=n_mflag + n_german,
+        lookup=0,
+        agent=0,
+        human=n_human,
+        evidence_path="RussianTranslation/pwg_ru/SCREENING_H1650.md",
+        rules=["visible_german_residue", "machine_flags_D1_D3_D4", "P1-auto-reject"],
+    )
+    doc = render_review_sheet(items, config, extras=True, screening=sc)
     doc, chash = stamp(doc)
     os.makedirs(REVIEW, exist_ok=True)
     with io.open(args.out, "w", encoding="utf-8", newline="\n") as fh:
         fh.write(doc)
+    # Ledger: every print-readiness figure must state N = queue-window with
+    # machine rejects in the denominator (Б ruling).
+    ledger = {
+        "N_print_readiness_window": n_decided + n_german + n_mflag + n_human,
+        "human_cards_on_sheet": n_human,
+        "machine_rejects_D1_D3_D4": n_mflag,
+        "german_residue_excluded": n_german,
+        "already_decided": n_decided,
+        "rule": "MG Б 26-07-2026 — auto-reject counts as reject, not dropped from N",
+        "H1650": True,
+    }
+    ledger_path = os.path.join(REVIEW, "g5_machine_rejects_h1650.json")
+    with io.open(ledger_path, "w", encoding="utf-8") as fh:
+        json.dump(ledger, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+    print("G5 stats ledger (N includes machine rejects):", ledger)
     lock_path = write_lock(SHEET_ID, chash, [it["id"] for it in items], GENERATED,
                            locks_dir=args.locks_dir, gate="G5", source_html=args.out,
                            force=force_lock)

--- a/RussianTranslation/src/build_h180_review_sheets.py
+++ b/RussianTranslation/src/build_h180_review_sheets.py
@@ -46,6 +46,7 @@ import sys, os, io, json, html, re, collections
 from csl_pyutil import render_review_sheet, mark_cyrillic
 from review_binding import stamp, write_lock
 from review_sheet_standard import standard_config, slp1_iast, pwg_entry_href
+from sheet_screening import citation_evidence_panel, screening_block
 
 sys.stdout.reconfigure(encoding="utf-8")
 sys.stderr.reconfigure(encoding="utf-8")
@@ -82,7 +83,13 @@ def write_sheet(slug, cfg, items):
         save_as="RussianTranslation\\pwg_ru\\eval\\h180_%s.decisions.json" % slug)
     config.update(cfg)
     config["generated"] = GENERATED
-    doc = render_review_sheet(items, config, extras=True)
+    # H1650/H1649: screening banner required (csl-pyutil ≥0.8.0)
+    sc = screening_block(
+        deterministic=0, lookup=0, agent=0, human=len(items),
+        evidence_path="RussianTranslation/pwg_ru/SCREENING_H1650.md",
+        rules=["citation_tm", "h180-%s" % slug],
+    )
+    doc = render_review_sheet(items, config, extras=True, screening=sc)
     # H1404 binding standard: stamp the content_hash into every export site and
     # commit-safe lock the sheet's identity (metadata only — no RU leaves the
     # gitignored HTML). NB voted.md item 2: do not regenerate these sheets while
@@ -143,6 +150,7 @@ def build_typology(by_sub):
             f'op/dir    : {esc(rel["op"])} / {esc(rel["direction"])}\n'
             f'target    : {esc(ip["target_sense"])} (anchor {esc(ip["anchor"])})\n'
             f'evidence  : {esc(rel.get("evidence",""))}</pre>')
+        cite_h, cite_b = citation_evidence_panel(rec.get("de") or "")
         items.append({
             "id": f'{r["subcard"]}::{r["sense_tag"]}',
             "filt": r["layer"],
@@ -155,7 +163,8 @@ def build_typology(by_sub):
             "note_placeholder": "if reject: correct subtype + why (e.g. 'nws_at_sense, attaches to sense 2')",
             "panels": [("LLM proposal (confidence: llm)", proposal),
                        ("Sub-card — Russian (ru)", f'<pre>{mark_cyrillic(ru)}</pre>'),
-                       ("Sub-card — source (de)", f'<pre>{de}</pre>')],
+                       ("Sub-card — source (de)", f'<pre>{de}</pre>'),
+                       (cite_h, cite_b)],
         })
     return items
 

--- a/RussianTranslation/src/h178_eval_bakeoff.py
+++ b/RussianTranslation/src/h178_eval_bakeoff.py
@@ -38,15 +38,18 @@ Usage (in order):
   python src/h178_eval_bakeoff.py sample     # build the 30-gloss held-out sample
   python src/h178_eval_bakeoff.py baseline   # DeepSeek DE->RU baseline (pairwise arm B)
   python src/h178_eval_bakeoff.py judge      # DeepSeek second-channel annotations (all 4 rubrics)
-  python src/h178_eval_bakeoff.py sheets     # emit the 4 HTML voting sheets for MG
+  python src/h178_eval_bakeoff.py sheets     # emit sheets (H1650: only h178_da by default;
+                                               # mqm/likert/pairwise RETIRED A2 — use --all-rubrics to remake)
+  python src/h178_eval_bakeoff.py agent_pass # agent labels on mqm/likert/pairwise for H274 compute
   python src/h178_eval_bakeoff.py comet      # COMETKiwi QE scores (needs HF token; else prints steps)
-  python src/h178_eval_bakeoff.py compute    # post-vote: kappa/alpha, discrimination, cost, correlations
+  python src/h178_eval_bakeoff.py compute    # post-vote: labels every metric agent-vs-human | agent-only
 """
 import sys, os, io, json, html, random, re, time, argparse, collections, math
 
 from csl_pyutil import mark_cyrillic, render_review_sheet
 from review_binding import stamp, write_lock
 from review_sheet_standard import DA_RATING, pwg_entry_href, slp1_iast, standard_config
+from sheet_screening import citation_evidence_panel, screening_block
 
 sys.stdout.reconfigure(encoding="utf-8")
 sys.stderr.reconfigure(encoding="utf-8")
@@ -391,6 +394,14 @@ def _rubric_panel(kind, it, blinded):
     return ""
 
 
+# H1650 / MG A2 (26-07-2026): mqm/likert/pairwise RETIRED from the human queue.
+# Instrument comparison = voted h178_da + agent_pass on the other three rubrics.
+RETIRED_A2 = frozenset({"h178_mqm", "h178_likert", "h178_pairwise"})
+FROZEN_SAMPLE_NOTE = (
+    "FROZEN eval sample (H1301) — not the live store after H1302/H1305. "
+    "Correct for instrument bake-off; wrong as a live translation-quality vote."
+)
+
 SHEETS = [
     ("h178_mqm", "MQM-adapted error annotation", "mqm",
      "Mark error severities per category; approve if the Russian gloss has NO errors.",
@@ -408,7 +419,7 @@ SHEETS = [
 ]
 
 
-def cmd_sheets():
+def cmd_sheets(all_rubrics=False):
     os.makedirs(REVIEW, exist_ok=True)
     items_raw = load_sample()
     base = {json.loads(l)["id"]: json.loads(l) for l in io.open(BASELINE, encoding="utf-8")} \
@@ -418,7 +429,12 @@ def cmd_sheets():
     for it in items_raw:
         blinding[it["id"]] = rng.random() < 0.5  # a_is_store
     for sheet_id, title, kind, question, alab, rlab in SHEETS:
+        if sheet_id in RETIRED_A2 and not all_rubrics:
+            print("skip retired A2 (H1650): %s — use --all-rubrics only for deliberate remake"
+                  % sheet_id)
+            continue
         items = []
+        n_cite = 0
         for it in items_raw:
             panels = [("German source (PWG 5-layer)", "<pre>%s</pre>" % esc(it["de"]))]
             # V7: highlight the Russian under judgment (mark_cyrillic AFTER
@@ -435,6 +451,11 @@ def cmd_sheets():
             else:
                 panels.append(("Russian translation (promoted store)",
                                "<pre>%s</pre>" % mark_cyrillic(esc(it["ru"]))))
+            # H1650: citation_tm evidence (N1 loop — ruling must reach the card)
+            cite_h, cite_html = citation_evidence_panel(it.get("de") or "")
+            panels.append((cite_h, cite_html))
+            if "No &lt;ls&gt;" not in cite_html and "No <ls>" not in cite_html:
+                n_cite += 1
             item = {
                 "id": it["id"], "filt": it["stratum"],
                 # V4: IAST headword as the card title (subcard · sense demoted
@@ -451,11 +472,22 @@ def cmd_sheets():
             if href:  # V4 entry deep link; omitted when the root has no column row
                 item["title_href"] = href
             items.append(item)
+        retired_note = ""
+        if sheet_id in RETIRED_A2:
+            retired_note = (
+                " ⛔ RETIRED 26-07-2026 (MG A2 / H1650) — do not vote; "
+                "instrument arm is agent_pass + h178_da human only."
+            )
         config = {
             "sheet_id": sheet_id, "title": title, "generated": GENERATED,
-            "subtitle": "H178 B-1 bake-off — one human channel (MG); DeepSeek is the model channel; "
-                        "agreement is reported human×model, never human×human.",
-            "footer": "Sheet %s of 4 — all four rubrics run on the SAME 30 glosses. " % sheet_id,
+            "subtitle": (
+                "H178 B-1 bake-off. %s One human channel (MG) on DA only after A2; "
+                "DeepSeek is the model channel; agreement is human×model or agent×human — "
+                "never human×human cross-rubric. %s"
+                % (FROZEN_SAMPLE_NOTE, retired_note)
+            ),
+            "footer": "Sheet %s — same 30 frozen glosses. H1650 citation_tm panel on every card."
+                      % sheet_id,
             "approve_label": alab, "reject_label": rlab,
             # reproduces the original all/unvoted/flagged/random filter set; render_review_sheet
             # always prepends "all" and appends "unvoted only" itself.
@@ -467,7 +499,16 @@ def cmd_sheets():
             save_as="RussianTranslation\\pwg_ru\\eval\\%s.decisions.json" % sheet_id))
         if kind == "da":
             config["rating"] = DA_RATING
-        html_out = render_review_sheet(items, config, extras=True)
+        # H1649/H1650 screening banner (csl-pyutil ≥0.8.0)
+        sc = screening_block(
+            deterministic=0,
+            lookup=n_cite,  # citation_tm panels attached (dataset lookup)
+            agent=0,
+            human=len(items),
+            evidence_path="RussianTranslation/pwg_ru/SCREENING_H1650.md",
+            rules=["citation_tm", "frozen-eval-sample", "A2-retire-mqm-likert-pairwise"],
+        )
+        html_out = render_review_sheet(items, config, extras=True, screening=sc)
         html_out = html_out.replace("</body>", RUBRIC_JS % {
             "sheet_id_json": json.dumps(sheet_id), "generated_json": json.dumps(GENERATED),
         } + "</body>")
@@ -480,7 +521,7 @@ def cmd_sheets():
         io.open(out, "w", encoding="utf-8").write(html_out)
         write_lock(sheet_id, chash, [it["id"] for it in items], GENERATED,
                    source_html=out)
-        print("sheet:", out, "(%d items)" % len(items))
+        print("sheet:", out, "(%d items, citation panels on %d cards)" % (len(items), n_cite))
 
 
 # ------------------------------------------------------------------------ comet
@@ -642,11 +683,21 @@ def cmd_compute(args):
             # register section 5 — per-item record of which DA scale each vote
             # was cast on (mixed generations are expected mid-bake-off).
             entry["da_scale_by_item"] = da_scales
+        # H1650 / A2: every number names the comparison kind (no unlabelled
+        # "cross-rubric agreement"). After A2 only DA has a human arm; mqm/
+        # likert/pairwise agent files are agent-only unless a human decisions
+        # file was still present from pre-A2.
+        comparison = "agent-vs-human" if sheet_id == "h178_da" else "agent-vs-human-if-votes-else-agent-only"
+        if sheet_id in RETIRED_A2:
+            comparison = "agent-only-preferred-after-A2 (human votes retired)"
+        entry["comparison_kind"] = comparison
         if human_bin:
             labels = sorted(set(human_bin) | set(model_bin))
-            entry["kappa_human_x_model"] = round(_kappa(human_bin, model_bin, labels), 3)
+            entry["kappa_agent_vs_human"] = round(_kappa(human_bin, model_bin, labels), 3)
+            entry["kappa_human_x_model"] = entry["kappa_agent_vs_human"]  # alias
         if h_scores and m_scores and len(h_scores) == len(m_scores) and len(h_scores) > 2:
-            entry["spearman_human_x_model"] = round(_spearman(h_scores, m_scores), 3)
+            entry["spearman_agent_vs_human"] = round(_spearman(h_scores, m_scores), 3)
+            entry["spearman_human_x_model"] = entry["spearman_agent_vs_human"]
             mean = sum(h_scores) / len(h_scores)
             entry["human_score_sd"] = round(math.sqrt(
                 sum((x - mean) ** 2 for x in h_scores) / len(h_scores)), 3)  # discrimination
@@ -654,10 +705,63 @@ def cmd_compute(args):
             entry["spearman_human_x_cometkiwi"] = round(
                 _spearman([a for a, _ in c_scores], [b for _, b in c_scores]), 3)
         report[sheet_id] = entry
+    report["_meta"] = {
+        "H1650": "A2 retired mqm/likert/pairwise human arms; metrics labelled agent-vs-human or agent-only",
+        "no_human_x_human_cross_rubric": True,
+        "frozen_sample": True,
+    }
     out = os.path.join(EVAL_DIR, "h178_bakeoff_report.json")
     json.dump(report, io.open(out, "w", encoding="utf-8"), indent=1)
     print(json.dumps(report, indent=1))
     print("->", out)
+
+
+def cmd_agent_pass():
+    """H1650: write agent-channel labels for retired mqm/likert/pairwise arms.
+
+    Uses DeepSeek channel (DS_CHANNEL) when present; otherwise a deterministic
+    structural fallback so compute can still label agent-only metrics.
+    Does NOT re-open human sheets.
+    """
+    os.makedirs(EVAL_DIR, exist_ok=True)
+    items_raw = load_sample() if os.path.exists(SAMPLE) else []
+    if not items_raw:
+        print("no sample — run: python src/h178_eval_bakeoff.py sample")
+        return 1
+    ds = {}
+    if os.path.exists(DS_CHANNEL):
+        for l in io.open(DS_CHANNEL, encoding="utf-8"):
+            d = json.loads(l)
+            ds[d["id"]] = d
+    out_path = os.path.join(EVAL_DIR, "h178_agent_pass_A2.jsonl")
+    n = 0
+    with io.open(out_path, "w", encoding="utf-8") as fh:
+        for it in items_raw:
+            iid = it["id"]
+            dj = (ds.get(iid) or {}).get("verdict") or {}
+            # structural MQM: omission/addition from gloss-slot counts
+            de, ru = it.get("de") or "", it.get("ru") or ""
+            de_n = len(re.findall(r"\{%[\s\S]*?%\}", de))
+            ru_n = len(re.findall(r"\{%[\s\S]*?%\}", ru))
+            mqm = {c: "none" for c in MQM_CATS}
+            if de_n != ru_n:
+                mqm["omission" if ru_n < de_n else "addition"] = "minor"
+            rec = {
+                "id": iid,
+                "source": "deepseek_channel" if dj else "structural_fallback",
+                "mqm": dj.get("mqm") or mqm,
+                "adequacy": dj.get("adequacy"),
+                "fluency": dj.get("fluency"),
+                "da": dj.get("da"),
+                "pairwise": dj.get("pairwise"),
+                "comparison_kind": "agent-only",
+            }
+            fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            n += 1
+    print("agent_pass A2: %d rows -> %s" % (n, out_path))
+    print("H274: use h178_da human decisions + this file for agent arms; "
+          "every metric must say agent-vs-human or agent-only.")
+    return 0
 
 
 def selftest():
@@ -685,8 +789,10 @@ def selftest():
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("cmd", choices=["sample", "baseline", "judge", "sheets",
-                                    "comet", "compute", "selftest"])
+                                    "agent_pass", "comet", "compute", "selftest"])
     ap.add_argument("--decisions", help="dir with h178_<rubric>.decisions.json votes")
+    ap.add_argument("--all-rubrics", action="store_true",
+                    help="H1650: also remake RETIRED A2 sheets (mqm/likert/pairwise)")
     args = ap.parse_args()
     if args.cmd == "sample":
         cmd_sample()
@@ -695,7 +801,9 @@ def main():
     elif args.cmd == "judge":
         cmd_judge()
     elif args.cmd == "sheets":
-        cmd_sheets()
+        cmd_sheets(all_rubrics=args.all_rubrics)
+    elif args.cmd == "agent_pass":
+        sys.exit(cmd_agent_pass() or 0)
     elif args.cmd == "comet":
         sys.exit(cmd_comet() or 0)
     elif args.cmd == "compute":

--- a/RussianTranslation/src/sheet_screening.py
+++ b/RussianTranslation/src/sheet_screening.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""H1650 — shared screening block + citation_tm evidence panel for review sheets.
+
+MG (pramuc / H1649 / H1650): no card reaches a human without stating what was
+screened, and every resolvable <ls> citation must show attested SA/RU or the
+typed miss reason.
+
+Usage from generators::
+
+    from sheet_screening import screening_block, citation_evidence_panel, extract_ls
+
+    panels.append(citation_evidence_panel(de_text))
+    html = render_review_sheet(items, config, extras=True,
+                               screening=screening_block(
+                                   deterministic=n_a, lookup=n_b, agent=n_c,
+                                   human=len(items),
+                                   evidence_path="review/screening_h1650.md",
+                                   rules=["citation_tm", "dup-id-vs-h178_da"]))
+"""
+from __future__ import annotations
+
+import html as html_lib
+import re
+import sys
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+
+try:
+    from citation_tm import lookup, _LS, _N_ATTR, _split_citation
+except ImportError:  # pragma: no cover
+    from src.citation_tm import lookup, _LS, _N_ATTR, _split_citation  # type: ignore
+
+
+def esc(s):
+    return html_lib.escape("" if s is None else str(s))
+
+
+def screening_block(*, deterministic=0, lookup=0, agent=0, human=0,
+                    evidence_path="review/screening_h1650.md",
+                    rules=None):
+    """csl-pyutil ≥0.8.0 required screening= mapping (H1649)."""
+    return {
+        "deterministic": int(deterministic),
+        "lookup": int(lookup),
+        "agent": int(agent),
+        "human": int(human),
+        "evidence_path": evidence_path,
+        "rules": list(rules or []),
+    }
+
+
+def extract_ls(text):
+    """Yield (prefix, locus, visible) for each distinct <ls> in text."""
+    seen = set()
+    for m in _LS.finditer(text or ""):
+        nm = _N_ATTR.search(m.group(1) or "")
+        visible = (m.group(2) or "").strip()
+        parsed = _split_citation(nm.group(1) if nm else None, visible)
+        if not parsed:
+            continue
+        key = parsed
+        if key in seen:
+            continue
+        seen.add(key)
+        yield parsed[0], parsed[1], visible
+
+
+def citation_evidence_panel(*fields, heading="Citation TM (H1650)"):
+    """Panel HTML: every <ls> with lookup status + SA/RU when available.
+
+    Rights: never commit RU from hits into tracked files; gitignored sheets only.
+    When corpus.db is absent, status is evidence_unavailable (honest).
+    """
+    lines = []
+    n = 0
+    for fld in fields:
+        for prefix, locus, visible in extract_ls(fld):
+            n += 1
+            rec = lookup(prefix, locus)
+            status = rec.get("status") or "?"
+            reason = rec.get("reason") or ""
+            cid = rec.get("canonical_id") or "—"
+            sa = rec.get("sa") or rec.get("sanskrit") or ""
+            ru = rec.get("ru") or ""
+            # Only surface RU in the panel when present (generation-time consult);
+            # never invent it.
+            if status == "hit" and ru:
+                body = (
+                    f"<b>{esc(visible)}</b> → <code>{esc(cid)}</code><br>"
+                    f"<span class='muted'>status=hit · {esc(rec.get('source') or '')}</span><br>"
+                    f"<pre>SA: {esc(sa)}\nRU: {esc(ru)}</pre>"
+                )
+            else:
+                detail = reason or status
+                body = (
+                    f"<b>{esc(visible)}</b> → <code>{esc(cid)}</code><br>"
+                    f"<span class='muted'>status={esc(status)}"
+                    f"{(' · ' + esc(detail)) if detail else ''}</span>"
+                )
+            lines.append(f"<div class='cite-ev'>{body}</div>")
+    if not lines:
+        return (heading,
+                "<span class='muted'>No &lt;ls&gt; citations on this card "
+                "(or none parseable).</span>")
+    note = (
+        f"<p class='muted'>{n} citation(s). "
+        "Hit = reuse published RU (in-copyright — consult only). "
+        "Miss reasons are typed (text-not-covered · locus-not-in-corpus · "
+        "unmapped_locus_scheme · evidence_unavailable when corpus.db absent).</p>"
+    )
+    return (heading, note + "\n".join(lines))
+
+
+def count_resolvable_citations(*fields):
+    """How many distinct <ls> get a non-empty consult (any status)."""
+    return sum(1 for fld in fields for _ in extract_ls(fld))

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,9 @@ not an error.
 ## [Unreleased]
 
 ### Added
+- **H1650 h178/h180 rescreen (Grok 4.5 `grok-4.5`, 01-08-2026):** `sheet_screening.py` (citation_tm evidence panel + screening= block); h178 A2 skip of retired mqm/likert/pairwise on regen + `agent_pass` + compute labels agent-vs-human/agent-only; h180/g5 pass screening=; FINDINGS §512 N1 loop; `pwg_ru/SCREENING_H1650.md`.
+
+### Added
 - **ZALIZNYAK full a–f accent-mobility emission (H2103, Grok 4.5 `grok-4.5`, 01-08-2026):** `nominal_grammar._accent_scheme` now emits Whitney schemes `a`/`b`/`c`/`d`/`f` (plus `—` unmarked) from the 19-cell matrix in WhitneyRoots `accent_rules.json`, joined on `(T-code, accent_position)` + lexical exceptions. Regenerated `headword_index.tsv` / reverse index / paradigm stats (98,639 headwords; `—` 80,014 · `a` 9,885 · `b` 8,346 · `d` 349 · `c` 43 · `f` 2). Docs: [ZALIZNYAK_INDEX.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/ZALIZNYAK_INDEX.md). Gated on VedaWeb Phase 2 GO (H063/H115). Advisory only — never written into reviewed spine.
 
 ## [1.114.10] - 2026-08-01


### PR DESCRIPTION
## Summary
H1650 after H1649 screening gate.

- **A2:** regen skips retired h178 mqm/likert/pairwise; files kept; index/H274 gate released to da + agent_pass
- **citation_tm** panel on every h178/h180 card (N1 loop fix)
- **screening=** required banners (csl-pyutil ≥0.8.0)
- **Б:** G5 machine rejects counted in N (already excluded by H1655; ledger explicit)
- FINDINGS §512

## Test plan
- [x] `python src/h178_eval_bakeoff.py selftest`
- [x] `python src/citation_tm.py selftest`
- [x] sheet_screening unit check