### PR TITLE
chore(release): 1.117.0 — probe ceiling provenance (H2118) + H1702/H2103

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.116.0
+version: 1.117.0
 date-released: 2026-08-01
 # The CONCEPT DOI — version-independent, always resolves to the newest release.
 # This is deliberately NOT a per-version DOI: those change every release and would

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.117.0] - 2026-08-01
+
 ### Added
 - **H1702 Grok override dual-run verify (01-08-2026, Grok 4.5 `grok-4.5`):** independent re-measure of the shipped D4 boundary-wrap pipeline against the live store — residual **1,109** with **byte-identical** ineligible breakdown vs the Sonnet report; dry-run eligible **0** (no store rewrite); selftest **198/198**, pytest **96/96**. Net-new probe only: `〉`/fullwidth-paren normalize would unlock **63** residual rows (not applied; needs precision bar). Report: [`pwg_ru/H1702_GROK_OVERRIDE_DUAL_RUN_VERIFY_2026-08-01.md`](pwg_ru/H1702_GROK_OVERRIDE_DUAL_RUN_VERIFY_2026-08-01.md).
 - **Full Zaliznyak a–f mobility on the stress slot (H2103, Grok 4.5 `grok-4.5`, 01-08-2026):** citation-only `a`/`b` replaced by Whitney matrix schemes (`c` fully mobile monosyllables, `d` weakest-mobile -ant/-an/añc, `f` lexical irregulars). Rebuild: `python src/reverse_index.py --build`. Selftest covers c/d/f fixtures.


### PR DESCRIPTION
Promotes `[Unreleased]` → **1.117.0** and syncs [CITATION.cff](https://github.com/gasyoun/SanskritLexicography/blob/master/CITATION.cff) (`version` + `date-released`).

Contents:

- **H2118 / #946** — probe ceiling provenance: three hard-coded ceilings collapsed to one table, `production_v1` frozen at 30 000, `production_v2` = 65 000, one policy name per ceiling value pinned ([PR #970](https://github.com/gasyoun/SanskritLexicography/pull/970)). ⚠️ The ceiling **value** is unchanged and still unverified — residual [H2138](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2138-Opus_RussianTranslation_probe-ceiling-paired-readings-946_01.08.26.md).
- **H1702** — Grok override dual-run verify of D4 boundary wrap.
- **H2103** — full Zaliznyak a–f mobility on the stress slot.

Release commit built with git plumbing: the disk holding the repo was 100% full, so no working-tree checkout was possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)