### PR TITLE
H2136: Sonnet independent dual-run compare of H1702 Grok override

### DIFF
--- a/RussianTranslation/pwg_ru/H1702_SONNET_DUAL_RUN_COMPARE_2026-08-01.md
+++ b/RussianTranslation/pwg_ru/H1702_SONNET_DUAL_RUN_COMPARE_2026-08-01.md
@@ -1,0 +1,154 @@
+# H1702 Sonnet dual-run compare — independent re-verification vs the Grok override
+
+_Created: 01-08-2026 · Last updated: 01-08-2026_
+
+**Handoff:** [H2136](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2136-Sonnet_SanskritLexicography_h1702-grok-dual-run-compare_01.08.26.md)
+· Model: Sonnet 5 (`claude-sonnet-5`) · Compares
+[H1702_D4_BOUNDARY_ANCHORED_WRAP_REPORT_2026-07-26.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1702_D4_BOUNDARY_ANCHORED_WRAP_REPORT_2026-07-26.md)
+(Sonnet, PR [#810](https://github.com/gasyoun/SanskritLexicography/pull/810), 26-07-2026)
+against
+[H1702_GROK_OVERRIDE_DUAL_RUN_VERIFY_2026-08-01.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1702_GROK_OVERRIDE_DUAL_RUN_VERIFY_2026-08-01.md)
+(Grok 4.5 `grok-4.5`, PR [#969](https://github.com/gasyoun/SanskritLexicography/pull/969), 01-08-2026).
+
+## Why this exists
+
+H1702 is Sonnet-filename-locked. A human overrode that lock so Grok could re-measure the
+already-shipped Sonnet deliverable. Per the dual-run override protocol (H2048 class), the
+override lane cannot be the only close — this residual (H2136) is Sonnet's own independent
+re-run, so the compare is not a rubber-stamp of Grok's numbers.
+
+## Method — independent, not a replay
+
+Ran in a fresh worktree
+([`SanskritLexicography-h2136-658811`](https://github.com/gasyoun/SanskritLexicography),
+branch `h2136-sonnet-dual-run-compare`) off `origin/master`, against the live canonical
+store (`RussianTranslation/src/pwg_ru_translated.jsonl`, resolved via
+[`store_path.canonical_store`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/store_path.py)
+to the shared main-checkout copy, per the H255 worktree-store-loss guard — never a
+worktree-local copy). Code under test unchanged this pass:
+[`d4_boundary_wrap.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/d4_boundary_wrap.py),
+[`fix_d4_boundary_wrap.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/fix_d4_boundary_wrap.py).
+
+Deliberately used **different seeds from Grok's** (7 / 91, not 42 / 11) so the hand-checked
+samples are a genuinely independent draw, not a re-read of the same rows:
+
+1. `python src/pilot/fix_d4_boundary_wrap.py --store --dry-run`
+2. Residual sample: n=30, seed 7, from the current `ru_n==0` ineligible pool — hand-read
+   DE/RU + refuse reason for each.
+3. Fixed-row integrity sample: n=25, seed 91, from rows with `de_n == ru_n >= 1` — checked
+   for citation/abbreviation markup (`{#…#}`, `<ls>`, `<ab>`, `<is>`) swallowed inside an RU
+   `{%…%}` gloss span.
+4. Bracket-normalize probe (own implementation, not copied from Grok's): normalize
+   `〉`/`）`→`)` and `〈`/`（`→`(` on both `de`/`ru`, re-run `try_boundary_wrap` over the full
+   ineligible pool.
+5. `python src/pilot/window_selftest.py`; `python -m pytest`.
+
+Script written for this pass:
+[`h2136_sonnet_independent_check.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/h2136_sonnet_independent_check.py)
+(kept in-tree as the reusable independent-verification harness for this handoff family).
+
+## Results vs both prior reports
+
+| metric | Sonnet 26-07-2026 | Grok 01-08-2026 | Sonnet 01-08-2026 (this pass) | class |
+|---|---:|---:|---:|---|
+| store rows | 11,603 | 11,603 | **11,603** | identical |
+| `ru_n==0` residual (post-fix) | 1,109 | 1,109 | **1,109** | identical |
+| newly eligible for auto-wrap now | 0 (after apply) | 0 dry-run | **0** dry-run | identical |
+| `prefix-no-match` | 576 | 576 | **576** | identical |
+| `suffix-no-match` | 344 | 344 | **344** | identical |
+| `multi-gloss-in-gap` | 83 | 83 | **83** | identical |
+| `residual-d3-guillemet-present` | 46 | 46 | **46** | identical |
+| `anchor-mismatch` | 31 | 31 | **31** | identical |
+| `gloss-span-crosses-anchor` | 15 | 15 | **15** | identical |
+| `overlap` | 7 | 7 | **7** | identical |
+| `bad-chars-in-candidate` | 7 | 7 | **7** | identical |
+| residual sample refuse-precision | (spot-check) | 30/30 (seed 42) | **30/30** (seed 7) | equivalent |
+| fixed-row sample: anchor swallowed into gloss | 0/65 hand-reviewed | 0/25 (seed 11) | **0/25** (seed 91, 1 initial flag hand-cleared — see below) | equivalent |
+| bracket-normalize probe (unlock count) | — | 63 | **63** | identical |
+| `window_selftest` | 193/193 | 198/198 | **198/198** | equivalent (suite unchanged since Grok) |
+| `pytest` | 18/18 | 96/96 | **96/96** | equivalent (suite unchanged since Grok) |
+
+**Store write this pass:** none (dry-run only; zero rows clear the mechanical eligibility
+gate, matching both prior reports).
+
+### Residual sample (n=30, seed 7) — refuse reasons independently confirmed correct
+
+Hand-read all 30 rows (mix of `prefix-no-match`, `suffix-no-match`, `multi-gloss-in-gap`,
+`overlap`) against their `de`/`ru` text. Every refusal is justified under the exact-affix
+rule: DE-side numbering/punctuation (`3〉`, `— 2)`, guillemets) not reproduced byte-for-byte
+on the RU side, RU dropping a leading `<div>`/marker, or a genuine multi-gloss gap. No row
+should have been auto-wrapped by the shipped method. 30/30 justified — same conclusion as
+Grok's independent 30/30 on a disjoint seed.
+
+### Fixed-row integrity sample (n=25, seed 91) — one false-positive flag, hand-cleared
+
+The mechanical "anchor characters inside the RU gloss span" check flagged 1/25:
+`han|han~~h1_00_pwg00|han 2`. Hand inspection: the flagged `<ab>u. s. w.</ab>` sits inside
+the DE gloss span itself —
+`{%schlagend, tödtend, Mörder, zu Grunde richtend, vernichtend, verscheuchend <ab>u. s. w.</ab>%}`
+— and RU mirrors it identically. This is a pre-existing PWG markup pattern (an anchor
+nested inside a gloss span in the *source*, the exact case `d4_boundary_wrap.py`'s
+`gloss-span-crosses-anchor` guard exists to refuse when the fixer would need to touch such
+a row — see module docstring point 6), not a corruption introduced by the D4 wrap. **0/25
+genuine defects**, matching Grok's 0/25.
+
+### Bracket-normalize probe — independently reproduced at 63/1,109
+
+Ran a from-scratch reimplementation of the probe (not Grok's code, same idea): normalizing
+`〉`/`）`→`)` and `〈`/`（`→`(` on both sides before re-running `try_boundary_wrap` over the
+full 1,109-row ineligible pool unlocks **63** rows, all currently refused on
+`prefix-no-match`/`suffix-no-match` purely from that punctuation mismatch (DE uses a
+fullwidth/CJK corner bracket for numbering, RU an ASCII `)`); 1,046 remain refused for
+other reasons. Exact match to Grok's number — **identical**, upgraded from Grok's
+single-report "net-new" to a cross-model-confirmed count.
+
+### Conflicting
+
+**None.** No count, breakdown, sample verdict, or test result diverges between the Sonnet
+original, the Grok override, and this independent Sonnet re-run.
+
+## Acceptance re-check (original H1702 stop condition)
+
+| criterion | verdict |
+|---|---|
+| Boundary-anchor detector still identifies safe RU gloss spans | **YES** — 0 eligible on live residual, 30/30 independent refuse-sample justified |
+| Apply only rows clearing the bar | **N/A apply** — 0 eligible; the 1,430 already-fixed rows remain correctly in store |
+| No corruption of `{#…#}` / `<ab>` / `<ls>` | **YES** — 0/25 genuine defects on independent fixed-row sample |
+| Tests green | **YES** — 198/198 selftest, 96/96 pytest |
+| Never relax bar to hit a count | **honored** — 63-row bracket unlock left unapplied |
+
+## Dual-run salvage classes (Sonnet independent vs Grok vs Sonnet original)
+
+| topic | class | keep |
+|---|---|---|
+| 1,430 fixed / 1,109 residual / ineligible breakdown | identical (3-way) | Sonnet store state + all three reports |
+| Method + guards (D3 mask, gloss-crosses-anchor) | identical (3-way) | shipped code, unchanged |
+| Residual refuse-precision sample | equivalent — disjoint seeds (Grok 42, Sonnet 7), same conclusion | both samples as independent evidence |
+| Fixed-row integrity sample | equivalent — disjoint seeds (Grok 11, Sonnet 91), same 0-defect conclusion (Sonnet's one flag was a detector false positive, hand-cleared) | both samples |
+| `〉`/fullwidth-paren residual subclass (n=63) | identical — cross-model-confirmed count | **adjudicated below** |
+| Test suite counts | equivalent — suite grew once (Sonnet 26-07 → Grok/Sonnet 01-08), stable since | current suite (198/96) |
+
+## Adjudication: the 63-row bracket-normalize unlock
+
+**Decision: keep report-only in this residual — do not apply here, do not skip promoting
+it either.** The unlock is real and now confirmed by two independent implementations
+across two models, so it is not noise. But applying it would relax the exact-affix
+matching to a **new** affix class (fullwidth/CJK bracket ≡ ASCII paren), which per this
+residual's own acceptance bar ("never relax the bar to hit a count") requires its own
+≥50-row / ≥90% hand-checked sample and dedicated guards — that is new production work, not
+compare-and-adjudicate work, and out of scope for a dual-run residual. **Mint a follow-up
+D4b handoff** (`h1702-d4b-bracket-normalize-unlock`) scoped narrowly to: extend the anchor/
+affix normalization to treat `〉`/`）`/`〈`/`（` as equivalent to `)`/`(`, hand-check a
+≥50-row sample of the 63 (population is small enough that 50 is most of it), and apply only
+if the precision bar holds. Until that handoff runs, the 63 rows stay in the `ru_n==0`
+residual, correctly reported as ineligible.
+
+## Non-goals (honored, this pass)
+
+- No re-translation.
+- No D3 residual repair.
+- No store rewrite (dry-run only; 0 eligible).
+- No relaxation of exact-affix matching in this pass — the bracket-normalize unlock is
+  parked for D4b, not applied here.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/h2136_sonnet_independent_check.py
+++ b/RussianTranslation/src/pilot/h2136_sonnet_independent_check.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""H2136: Sonnet independent re-verification of H1702 (D4 boundary wrap), run against
+the Grok 4.5 override re-measure (PR #969). Deliberately uses its own seeds (not Grok's
+42/11) so the residual and fixed-row samples are a genuinely independent draw, not a
+replay of the same rows Grok already read.
+
+  python src/pilot/h2136_sonnet_independent_check.py
+"""
+import json
+import os
+import random
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = os.path.dirname(HERE)
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+from d4_boundary_wrap import (  # noqa: E402
+    GLOSS_SPAN, is_ru_n0_candidate, scan_store, split_by_anchors, try_boundary_wrap,
+)
+from store_path import canonical_store  # noqa: E402
+
+BRACKET_NORMALIZE = str.maketrans({
+    '〉': ')', '）': ')',
+    '〈': '(', '（': '(',
+})
+
+
+def load_rows(store):
+    rows = []
+    with open(store, encoding='utf-8') as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def main():
+    default_local = os.path.join(SRC, 'pwg_ru_translated.jsonl')
+    store = canonical_store(default_local)
+    rows = load_rows(store)
+    print('store: %s' % store)
+    print('rows : %d' % len(rows))
+
+    eligible, ineligible = scan_store(store)
+    total_ineligible = sum(len(v) for v in ineligible.values())
+    print('eligible (mechanical fix): %d' % len(eligible))
+    print('ineligible total          : %d' % total_ineligible)
+    for reason, items in sorted(ineligible.items(), key=lambda x: -len(x[1])):
+        print('  %-28s %d' % (reason, len(items)))
+
+    # residual sample, independent seed (not Grok's 42)
+    flat = [(reason, ln, label) for reason, items in ineligible.items() for ln, label in items]
+    rng = random.Random(7)
+    sample = rng.sample(flat, min(30, len(flat)))
+    print('\n=== residual sample n=%d seed=7 ===' % len(sample))
+    row_by_line = {}
+    with open(store, encoding='utf-8') as f:
+        for ln, line in enumerate(f):
+            row_by_line[ln] = line
+    for reason, ln, label in sample:
+        row = json.loads(row_by_line[ln])
+        de = (row.get('de') or '')[:160]
+        ru = (row.get('ru') or '')[:160]
+        print('- [%s] %s' % (reason, label))
+        print('    DE: %s' % de)
+        print('    RU: %s' % ru)
+
+    # fixed-row sample: rows with de_n == ru_n >= 1 (already wrapped, from prior H1702 apply)
+    fixed_candidates = []
+    for ln, r in enumerate(rows):
+        de = r.get('de') or ''
+        ru = r.get('ru') or ''
+        de_n = len(GLOSS_SPAN.findall(de))
+        ru_n = len(GLOSS_SPAN.findall(ru))
+        if de_n == ru_n >= 1:
+            fixed_candidates.append((ln, r))
+    rng2 = random.Random(91)
+    fixed_sample = rng2.sample(fixed_candidates, min(25, len(fixed_candidates)))
+    print('\n=== fixed-row integrity sample n=%d seed=91 (of %d de_n==ru_n>=1 rows) ===' %
+          (len(fixed_sample), len(fixed_candidates)))
+    bad = 0
+    for ln, r in fixed_sample:
+        ru = r.get('ru') or ''
+        label = '%s|%s|%s' % (r.get('key1'), r.get('subcard'), r.get('sense_tag'))
+        swallowed = False
+        for m in GLOSS_SPAN.finditer(ru):
+            span = m.group(0)
+            if any(tok in span for tok in ('{#', '<ls', '<ab', '<is')):
+                swallowed = True
+        if swallowed:
+            bad += 1
+            print('  ANCHOR-SWALLOWED: %s' % label)
+    print('  anchor-swallowed-into-gloss: %d / %d' % (bad, len(fixed_sample)))
+
+    # bracket-normalize probe on the ineligible pool
+    unlocked = 0
+    still_refused = 0
+    for reason, items in ineligible.items():
+        for ln, label in items:
+            row = json.loads(row_by_line[ln])
+            de = row.get('de') or ''
+            ru = row.get('ru') or ''
+            ru_norm = ru.translate(BRACKET_NORMALIZE)
+            de_norm = de.translate(BRACKET_NORMALIZE)
+            ok, _ = try_boundary_wrap(de_norm, ru_norm)
+            if ok:
+                unlocked += 1
+            else:
+                still_refused += 1
+    print('\n=== bracket-normalize probe (\\u3009/\\uff09 -> ")" etc.) ===')
+    print('  would unlock: %d' % unlocked)
+    print('  still refused: %d' % still_refused)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Independent Sonnet re-run of the H1702 D4 boundary-wrap stop condition (fresh worktree, fresh seeds, own probe reimplementation) against the live canonical store, per the dual-run override protocol (H2048 class) that H2136 exists to satisfy.
- Every number reproduces byte-for-byte against both the Sonnet original (PR #810) and the Grok override (PR #969): 11,603 rows, 1,109 residual, identical 8-way ineligible breakdown, 0 eligible, 30/30 justified refuses on an independent sample, 0/25 genuine defects on an independent fixed-row sample, 63-row bracket-normalize unlock independently reproduced, 198/198 selftest, 96/96 pytest.
- No conflicts found across all three reports. Adjudicates the 63-row `〉`/fullwidth-paren unlock as **report-only** pending a dedicated D4b handoff — applying it would relax the exact-affix bar and needs its own ≥50-row hand-checked sample, out of scope for this compare-and-adjudicate residual.

## Test plan
- [x] `python src/pilot/fix_d4_boundary_wrap.py --store --dry-run` — 0 eligible, 1,109 residual, breakdown matches
- [x] Independent residual sample (n=30, seed 7) hand-read — 30/30 justified refuses
- [x] Independent fixed-row sample (n=25, seed 91) — 0/25 genuine defects (1 flag hand-cleared as pre-existing DE markup)
- [x] Bracket-normalize probe reimplementation — 63 rows, matches Grok
- [x] `python src/pilot/window_selftest.py` — 198/198
- [x] `python -m pytest` — 96/96

Handoff: https://github.com/gasyoun/Uprava/blob/main/handoffs/H2136-Sonnet_SanskritLexicography_h1702-grok-dual-run-compare_01.08.26.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)