### PR TITLE
docs(pwg_ru): retire the stale RV multi-translation queue block

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -547,19 +547,32 @@ Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H2138-Opus_RussianTranslatio
   the hang. Every c4 latency reading taken while the account was rate-limited still measures
   retry delay, not route health.
 
-- **RV multi-translation evidence layer — wave 1a DONE 29-07-2026 (Sonnet 5
-  `claude-sonnet-5`), wave 1b next.**
-  [H1843](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1843-Sonnet_RussianTranslation_rv-multitranslation-spine-w1a_29.07.26.md)
-  executed steps 1-6 of
+- **RV multi-translation evidence layer — 🔴 BOTH WAVES EXECUTED 29-07-2026; no follow-on
+  handoff is open.**
+  [H1843](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H1843-Sonnet_RussianTranslation_rv-multitranslation-spine-w1a_29.07.26.md)
+  (wave 1a, Sonnet 5 `claude-sonnet-5`) executed steps 1-6 of
   [IMPLEMENTATION](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/IMPLEMENTATION_RussianTranslation_rv-multitranslation-evidence.md):
   `pwg_ru/griffith_en_1896.json`, `rv_stanza_translations.jsonl`,
   `rv_lemma_occurrences.jsonl`, `rv_translation_spine.tsv` + schema,
-  `rv_renou_citation_index.jsonl`; `tests/test_rv_spine.py` 20/20 green. Full detail
-  in `✅ Completed` below. **Next:**
-  [H1844](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1844-Opus_RussianTranslation_rv-multitranslation-typing-w1b_29.07.26.md)
-  (wave 1b, intended executor Opus 5 `claude-opus-5[1m]`, typing/alignment/pipeline
-  wiring) is now unblocked. ⚠️ Two of the
-  plan's "measured facts" did not reconcile on execution — read
+  `rv_renou_citation_index.jsonl`; `tests/test_rv_spine.py` 20/20 green.
+  [H1844](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H1844-Opus_RussianTranslation_rv-multitranslation-typing-w1b_29.07.26.md)
+  (wave 1b, steps 7-16, Opus 5 `claude-opus-5[1m]`) then landed via
+  [PR #872](https://github.com/gasyoun/SanskritLexicography/pull/872), and
+  **H1910** extended the layer again on 30-07-2026 — Jamison–Brereton 2014 as a fifth
+  translation column plus the Renou EVP witness, taking pairs 6 → **10** and the
+  deterministic arm 3-of-6 → 4-of-10. Both handoff files are archived and both registry
+  rows read ✅ Done. Full detail for all three in `✅ Completed` below.
+  ⚠️ **What is NOT done, and is a measured stop rather than a queued step:** wave 1b's
+  **layer B failed R14 on all three languages** (de 29.2 % / ru 19.2 % / en 10.5 % against
+  an 85 % bar), so stop condition 3 fired — spine A ships alone, layer B is
+  `low_confidence` and excluded from the gate, the 0.20 `ALIGN_GATE` was deliberately NOT
+  re-tuned, and the ~8.8 h full-scale pass was NOT run. The failure is systematic (the
+  aligner returns the stanza's salient proper noun whatever the token) and LaBSE reproduces
+  it, so it is not a checkpoint problem. Separately **W1.13 cannot be met as written**: all
+  four wisdomlib R11 roles are unpopulated because the on-disk feed is a works catalogue
+  plus a 63-word Vajrayāna Buddhist probe set — the join key was verified sound, the zero is
+  a data fact. Reopening either needs a new handoff and a decision, not a resume.
+  ⚠️ Two of the plan's "measured facts" did not reconcile on execution — read
   [`docs/DECISIONS_LOG_rv_multitranslation.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/docs/DECISIONS_LOG_rv_multitranslation.md)
   before trusting VERIFICATION §1.1's per-mandala Renou table or the "368
   quoted_fr" figure — both are superseded there. ⚠️ `renou_*` in this repo means


### PR DESCRIPTION
Third and last known instance of the defect class fixed in [#972](https://github.com/gasyoun/SanskritLexicography/pull/972): a `## ➡️ Next Steps (Queue)` entry in [RussianTranslation/.ai_state.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/.ai_state.md) pointing at work that had already shipped.

## What was stale

The block read **"wave 1a DONE 29-07-2026 … wave 1b next"** and called [H1844](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H1844-Opus_RussianTranslation_rv-multitranslation-typing-w1b_29.07.26.md) "now unblocked".

H1844 executed the same day — [PR #872](https://github.com/gasyoun/SanskritLexicography/pull/872) merged, the handoff file is archived, and its registry row in [Uprava/handoffs/README.md](https://github.com/gasyoun/Uprava/blob/main/handoffs/README.md) reads ✅ Done. H1910 then extended the layer again on 30-07-2026 (Jamison–Brereton 2014 as a fifth translation column plus the Renou EVP witness, pairs 6 → 10, deterministic arm 3-of-6 → 4-of-10). A registry sweep for `rv-multitranslation` returns no open follow-on handoff.

## What changed

- Flipped to `🔴 BOTH WAVES EXECUTED`, with both archived handoffs linked and H1910's extension recorded.
- **Recorded what is genuinely not done, and why it is a measured stop rather than a queued step** — the distinction the old block could not express, and the reason "wave 1b next" was a misleading way to describe the layer's state:
  - **Layer B failed R14 on all three languages** (de 29.2 % / ru 19.2 % / en 10.5 % against an 85 % bar), so stop condition 3 fired: spine A ships alone, layer B is `low_confidence` and excluded from the gate, the 0.20 `ALIGN_GATE` was deliberately **not** re-tuned, and the ~8.8 h full-scale pass was **not** run. The failure is systematic — the aligner returns the stanza's salient proper noun whatever the token — and LaBSE reproduces it, so it is not a checkpoint problem.
  - **W1.13 cannot be met as written**: all four wisdomlib R11 roles are unpopulated, because the on-disk feed is a works catalogue plus a 63-word Vajrayāna Buddhist probe set. The join key was verified sound; the zero is a data fact.

  Reopening either needs a new handoff and a decision, not a resume — which is precisely what a reader of the old block would have attempted.

## Scope

No code, gate or data touched — journal only. No changelog entry: `.ai_state`-only edits are exempt by the standing cadence rule. The `## 🚧 WIP` section is untouched, including the Codex `codex/rt-pipeline-hardening-speed` entry.

Branched off `origin/master` at `47b34f80`, in worktree `SanskritLexicography-rv-666075` — not the shared main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
