### PR TITLE
fix(pwg_ru): H2146 overlay-preserving promote + locked store writers (FINDINGS §513)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.118.0
-date-released: 2026-08-01
+version: 1.120.0
+date-released: 2026-08-02
 # The CONCEPT DOI — version-independent, always resolves to the newest release.
 # This is deliberately NOT a per-version DOI: those change every release and would
 # make this file wrong the moment the next one ships. Each release's own version

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Prove bounded PWG→Russian CLI correctness on one profile, then scale + the CDSL article-comparison study
 
-_Created: 09-07-2026 · Last updated: 01-08-2026_
+_Created: 09-07-2026 · Last updated: 02-08-2026_
 
 > **H1940 Phase 2 — 🔴 EXECUTED 31-07-2026 (Opus 5 `claude-opus-5[1m]`); backlog CLOSED.**
 > The H1811 hardening backlog was drained one item per session, each with its own PR,
@@ -3316,6 +3316,19 @@ batch [_batch_h1624_dh_followups.tsv](https://github.com/gasyoun/Uprava/blob/mai
   ([SamudraManthanam #16](https://github.com/gasyoun/SamudraManthanam/issues/16)).
 
 ## ✅ Completed (Recent only)
+
+- **H2146 overlay-preserving promote + store-writer lock discipline (02-08-2026, Fable 5
+  `claude-fable-5`)** — closes the H2025 audit's top gaps G1+G6
+  ([#976](https://github.com/gasyoun/SanskritLexicography/issues/976), FINDINGS §513).
+  `merge_store_rows` + supersede now preserve human-touched rows (`human_touched()`:
+  reviewer / non-`ai_*` `review_status` / `editorial_decision*`) unless
+  `--override-reviewed`; coordinator batch fails the bundle loudly on a protected
+  subcard; all 17 non-promote store writers route through the new shared
+  [src/store_write.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/store_write.py)
+  `locked_store_rewrite` (PromoteClaim + unique fsynced backup + atomic replace).
+  Validation: `window_selftest` **198/198** (parity ledger re-derived, 0 language-keyed
+  diff tokens), `promote_final_cards --selftest` (new overlay fixtures),
+  `store_write --selftest`, `promote_en --selftest` all green. No canonical-store write.
 
 - **H2025 Fable dual-run pipeline audit of the PWG→RU money lane (01-08-2026, Fable 5
   `claude-fable-5`)** — full `/pipeline-audit` + Phase 2b at rev `b4db4259`, dual-compared

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,11 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.120.0] - 2026-08-02
+
+### Fixed
+- **Overlay-preserving promote + store-writer lock discipline (H2146, 02-08-2026, Fable 5 `claude-fable-5`):** closes the two [integrity] exposures from the H2025 audit ([#976](https://github.com/gasyoun/SanskritLexicography/issues/976), FINDINGS §513). (1) `merge_store_rows` and the full-rebuild (supersede) path now PRESERVE human-touched store rows — named `reviewer`, non-`ai_*` `review_status`, or an `editorial_decision*` stamp — refusing machine replacement unless the new explicit `--override-reviewed` is passed; the coordinator batch lane fails the bundle loudly on a protected subcard; the clean-subset (`ready_partial`) lane preserves unconditionally. (2) All 17 non-promote store writers (9 `annotate_*`, `backfill_tn_residue`, `mark_reconstructed_headwords`, `ru_style_sweep`, `apply_editorial_decisions`, `repair_h178_da_cards`, 3 pilot `fix_*`) now write through the new shared [`src/store_write.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/store_write.py) `locked_store_rewrite` — `PromoteClaim` held across the read-guard-write window + unique fsynced backup + atomic LF-only replace — ending the last-writer-wins seam against a concurrent promote (7 of them previously rewrote the store IN PLACE with a fixed backup name). Selftests: `window_selftest` 198/198 (incl. parity ledger re-derived, INTENTIONAL-DIVERGENCE stands, 0 language-keyed tokens in the diff), `promote_final_cards --selftest` with new overlay fixtures (approved/needs_review/editorial each protect; override lands; siblings still merge; `ClaimBusy` under a held claim), `store_write --selftest`, `promote_en --selftest`.
+
 ## [1.119.0] - 2026-08-01
 
 ### Added

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,6 +1,6 @@
 # LANG_PARITY.md — cross-language fix/feature parity ledger
 
-_Created: 04-07-2026 · Last updated: 01-08-2026 (H2118 #946: 6 entries re-derived across 5 files, SHARED stands — the probe latency ceiling is now derived from one table instead of three hard-coded copies, and the policy token carries its own ceiling again. Grounds re-checked mechanically, not asserted: every added line in the diff was grepped for a language-keyed token (`lang` / `russian` / `english` / `--lang` / `FIELD[` / `CARD_FIELD`) and **none** appears — the change is language-agnostic dispatch infrastructure that cannot reach the RU/EN split. Previously H2095 #946/#949/#950/#956: 45 entries re-derived, SHARED stands — probe rows carry the ceiling that judged them, `summary()` publishes cost evaluability beside `budget_spent`, the cost-gate calibration question settled with NO constant moved, and the EN auditor exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags, closing the EN twin of #947)_
+_Created: 04-07-2026 · Last updated: 02-08-2026 (H2146: `promotion_scripts_separate` re-derived, INTENTIONAL-DIVERGENCE stands — RU merge/supersede now overlay-preserving (`human_touched`, `--override-reviewed`), 17 mutators routed through the shared locked `store_write` writer; EN attach replaces no rows so the wipe class does not arise there. Previously H2118 #946: 6 entries re-derived across 5 files, SHARED stands — the probe latency ceiling is now derived from one table instead of three hard-coded copies, and the policy token carries its own ceiling again. Grounds re-checked mechanically, not asserted: every added line in the diff was grepped for a language-keyed token (`lang` / `russian` / `english` / `--lang` / `FIELD[` / `CARD_FIELD`) and **none** appears — the change is language-agnostic dispatch infrastructure that cannot reach the RU/EN split. Previously H2095 #946/#949/#950/#956: 45 entries re-derived, SHARED stands — probe rows carry the ceiling that judged them, `summary()` publishes cost evaluability beside `budget_spent`, the cost-gate calibration question settled with NO constant moved, and the EN auditor exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags, closing the EN twin of #947)_
 
 This repo runs the same PWG→Russian and PWG→English translation pipeline through
 shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
@@ -408,10 +408,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "INTENTIONAL-DIVERGENCE",
-    "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge. C6 (21-07-2026, Opus 4.8 claude-opus-4-8): the SCRIPTS stay separate, but the {Tn}-residue promotion guard is now SHARED — promote_en.py imports TN_RE + UnrestoredPlaceholder from promote_final_cards.py rather than duplicating them, closing the gap where the RU C-01 path refused a card carrying an unrestored {Tn} while the EN attach() silently wrote it into the store. Pinned by the C6 block in promote_en.selftest(). C9 (21-07-2026, Opus 4.8 claude-opus-4-8): the EN backup used a second-resolution timestamp + a plain open('w'), so two lock-serialized runs in the SAME second overwrote the earlier .preEN recovery copy (defeating the docstring's per-run-backup promise). Fixed to a µs+pid+uuid name (_en_backup_path) + the RU lane's O_EXCL fsynced copier (_fsynced_backup, imported — single source). Pinned by the C9 block in promote_en.selftest(). H1425 W3 audit (21-07-2026, Opus 4.8 claude-opus-4-8): confirmed nothing new to share — the shared primitives (TN_RE / UnrestoredPlaceholder / _fsynced_backup) are already imported (C6/C9); the rest of promote_en (norm_de / en_index / match_en / attach) is EN-ATTACH-specific — it attaches an `en` field onto the existing RU store, a different job from promote_final_cards' RU store WRITER — and _en_backup_path's `.preEN` marker is intentionally per-lane. P9 (21-07-2026, Opus 4.8 claude-opus-4-8, H1421): the last shareable primitive is now SHARED too — promote_en.py imports _atomic_write_rows from promote_final_cards.py and its store write is fsync-before-replace durable. The old EN write was a bare open('w') + os.replace: atomic (the rename is all-or-nothing) but NOT durable — a crash/power-loss between the write and the metadata flush could leave a non-durable/truncated store even after the rename, and under --no-backup that write is the ONLY thing between an interrupted write and total loss. As a bonus both lanes now write the store byte-identically ('\\n' newlines; the old EN write CRLF-translated on Windows). Pinned by the P9 block in promote_en.selftest() (fsync-called + round-trip + single-source identity assertion). Adversarial verification note: bug-hunt P1 (merge_store_rows had no better-attempt-wins guard) was ALSO an H1421 item but was already fixed upstream by B08 (H1339) — merge_store_rows is better-attempt-wins with pinned regression selftests — so P1 needed no code change. INTENTIONAL-DIVERGENCE re-affirmed (the scripts stay separate; every low-level store-safety primitive — {Tn} residue, fsynced backup, durable atomic write — is now single-sourced from the RU lane). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
+    "note": "The two stores (pwg_ru_translated.jsonl vs the EN store) have different schemas and provenance history (RU predates the EN pilot by months); a merged script was never worth the risk of cross-contaminating the two promotion paths for a mechanical CLI split. Revisit only if the two stores' schemas converge. C6 (21-07-2026, Opus 4.8 claude-opus-4-8): the SCRIPTS stay separate, but the {Tn}-residue promotion guard is now SHARED — promote_en.py imports TN_RE + UnrestoredPlaceholder from promote_final_cards.py rather than duplicating them, closing the gap where the RU C-01 path refused a card carrying an unrestored {Tn} while the EN attach() silently wrote it into the store. Pinned by the C6 block in promote_en.selftest(). C9 (21-07-2026, Opus 4.8 claude-opus-4-8): the EN backup used a second-resolution timestamp + a plain open('w'), so two lock-serialized runs in the SAME second overwrote the earlier .preEN recovery copy (defeating the docstring's per-run-backup promise). Fixed to a µs+pid+uuid name (_en_backup_path) + the RU lane's O_EXCL fsynced copier (_fsynced_backup, imported — single source). Pinned by the C9 block in promote_en.selftest(). H1425 W3 audit (21-07-2026, Opus 4.8 claude-opus-4-8): confirmed nothing new to share — the shared primitives (TN_RE / UnrestoredPlaceholder / _fsynced_backup) are already imported (C6/C9); the rest of promote_en (norm_de / en_index / match_en / attach) is EN-ATTACH-specific — it attaches an `en` field onto the existing RU store, a different job from promote_final_cards' RU store WRITER — and _en_backup_path's `.preEN` marker is intentionally per-lane. P9 (21-07-2026, Opus 4.8 claude-opus-4-8, H1421): the last shareable primitive is now SHARED too — promote_en.py imports _atomic_write_rows from promote_final_cards.py and its store write is fsync-before-replace durable. The old EN write was a bare open('w') + os.replace: atomic (the rename is all-or-nothing) but NOT durable — a crash/power-loss between the write and the metadata flush could leave a non-durable/truncated store even after the rename, and under --no-backup that write is the ONLY thing between an interrupted write and total loss. As a bonus both lanes now write the store byte-identically ('\\n' newlines; the old EN write CRLF-translated on Windows). Pinned by the P9 block in promote_en.selftest() (fsync-called + round-trip + single-source identity assertion). Adversarial verification note: bug-hunt P1 (merge_store_rows had no better-attempt-wins guard) was ALSO an H1421 item but was already fixed upstream by B08 (H1339) — merge_store_rows is better-attempt-wins with pinned regression selftests — so P1 needed no code change. INTENTIONAL-DIVERGENCE re-affirmed (the scripts stay separate; every low-level store-safety primitive — {Tn} residue, fsynced backup, durable atomic write — is now single-sourced from the RU lane). H2146 (02-08-2026, Fable 5 `claude-fable-5`): re-derived, INTENTIONAL-DIVERGENCE stands — the scripts stay separate. RU-lane change: merge_store_rows/supersede now PRESERVE human-touched rows (human_touched(): named reviewer, non-ai_* review_status, or an editorial_decision* stamp) unless --override-reviewed, and the 17 non-promote store mutators write through the new shared store_write.locked_store_rewrite (PromoteClaim + unique fsynced backup + atomic replace) — FINDINGS §513. EN classification: promote_en ATTACHES an `en` field onto existing RU store rows in place — it replaces no rows, so the overlay-wipe class cannot arise there in the same form, and it already holds PromoteClaim + the single-sourced backup/atomic primitives (C9/P9). The narrower residual question — whether en-attach onto an `approved` row should require review re-affirmation — is recorded on SanskritLexicography#976 rather than opened as a GAP: no EN attach touches the 5 human rows today. H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
@@ -468,7 +468,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "RESOLVED same day (2026-07-04): PR #140 (feat(provenance): pipeline versioning) added pipeline_version stamping only to promote_final_cards.py; found as a GAP while re-affirming H169's parity re-hash, closed immediately. promote_en.py now calls `pipeline_version.stamp(model_version=gen_model_version)` inside `en_index()`'s per-subcard provenance block, stored as `en_provenance.pipeline` (mirrors RU's `provenance.pipeline`; a distinct field since EN attaches onto an existing RU row rather than owning it). Pinned by an added assertion in `promote_en.selftest()`. H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
@@ -506,7 +506,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 1.1. The layer is derived purely from the sub-card KEY structure, which is identical for RU and EN. promote_en.py ATTACHES english onto the RU-owned row and leaves it otherwise untouched, so EN inherits `layer` for free — no EN-specific code needed. layer_of() pinned by dict_merge.py selftest + a promote_final_cards.selftest assertion. H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/dict_merge.py": "0266e11980e3b8b12d0699665b2051b9f7b8b16ed89d5810adfe5a458e880eea"
     }
   },
@@ -526,7 +526,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa"
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768"
     }
   },
   {
@@ -689,10 +689,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1624 G2 (25-07-2026, Grok 4.5): closes the gap where government only appeared after a separate annotate_government backfill. New windows stamp at promote; new portraits stamp at microstructure gen. Schema shape unchanged (array of hit dicts per D4/H338). PW capitalized (Instr.) still caught (H1308). government.html still re-extracts from de_raw (honest floor banner). Pinned by promote_final_cards --selftest, enrich_portrait_government --selftest, government_census selftest, build_article_site --selftest. H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "H1624",
     "verified_sha256": {
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9",
       "src/pilot/enrich_portrait_government.py": "dcbcaaeabd4754436c295ad08eaf18acefab8cf9263fe2262d7f92c6ecf49660",
-      "src/annotate_government.py": "b90849653909a551180a776e02ba36b6ce4da4cc4874353b2d1258e37c357848",
+      "src/annotate_government.py": "ff00bdce1aa9174d726edfbb516ed938125d2e0aa003ca8e5f86ca81ffafc153",
       "src/government_census.py": "0a004740cc6ba9407c292fef015b07b60fcd62cd82b6252f08fc49a00de6d6d8"
     }
   },
@@ -715,8 +715,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H1624",
     "verified_sha256": {
       "src/form_labels.py": "ddd51c21bc86e84cf1abbc46ba78fdb477d1906283a3deae4a840b6bbd38311b",
-      "src/annotate_form_labels.py": "cc03e4bb9454094996bdab87fa4e226bb6fb1574b42a70e82bd81953317629ce",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/annotate_form_labels.py": "267cecdef3be3b8ca3cece9c33422016b323ec653d3ac4b9c600a6771ba4493a",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
@@ -739,8 +739,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H1624",
     "verified_sha256": {
       "src/form_labels.py": "ddd51c21bc86e84cf1abbc46ba78fdb477d1906283a3deae4a840b6bbd38311b",
-      "src/annotate_form_labels.py": "cc03e4bb9454094996bdab87fa4e226bb6fb1574b42a70e82bd81953317629ce",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/annotate_form_labels.py": "267cecdef3be3b8ca3cece9c33422016b323ec653d3ac4b9c600a6771ba4493a",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9"
     }
   },
@@ -762,7 +762,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
       "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
     }
@@ -836,7 +836,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H337 (08-07-2026). The evidence lanes are inherently Russian: corpus_gate joins a PWG headword to the independent Sanskrit->RUSSIAN dictionaries (Кочергина/Кнауэр/Фриш/Смирнов/Коссович), the Гринцер specialist glossaries, and the SamudraManthanam RU-aligned corpus; the relation classifier tokenises Russian glosses. The EN pilot has no Sanskrit-English authority set wired here, so evidence retrofit is inherently RU-only — the same divergence already recorded for corpus_gate_evidence_markers_fl7_h321. annotation_report.py is a lang-neutral query CLI but reads the RU store; it would generalise if an EN correctness gate is ever built. Pinned by test_annotate_evidence_relation_semantics (annotate_evidence.py's own pure-function --selftest, no gate-source file IO so it runs in CI). H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
+      "src/annotate_evidence.py": "3ba83e6475c856cdc58a68526f2a0a5baa208754abd789dc3e3ec14e71bb9258",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
       "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
     }
@@ -874,7 +874,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H339 (08-07-2026). The join reads <ls> citation markup shared verbatim by both RU and EN editions (renou.keys_in_text is the same siglum parser annotate_renou.py already treats as language-independent) and never touches translation text itself. Read-only over the store; selftest-gated. H1940 (30-07-2026): re-affirmed after H1902/#892 replaced the hard-coded sibling-root guess with sibling_root(HERE) (+2/-1 lines). GH feeds PWG_TXT — the shared German source text, not a per-language asset — and the resolver is language-independent, so both editions resolve the identical path by the identical rule. The SHARED verdict is if anything strengthened: the previous hard-coded guess was the thing that could silently resolve differently between checkouts (the git-worktree case H1902 fixed).",
     "tracking": "",
     "verified_sha256": {
-      "src/annotate_genres.py": "75df2211d72b7486a3eff63f0205b05deeb1c726e29d8cafff729be013c994d0"
+      "src/annotate_genres.py": "d7ca27d03a84f6ea0589138cdbbc84ba08cf5bc6b3f0bfcec81b334bb34a5702"
     }
   },
   {
@@ -893,7 +893,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
-      "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
+      "src/annotate_evidence.py": "3ba83e6475c856cdc58a68526f2a0a5baa208754abd789dc3e3ec14e71bb9258",
       "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
     }
   },
@@ -951,7 +951,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
-      "src/annotate_evidence.py": "641a96e9b111737d8e93eb88a508480a2360acc12aeff59d05db0b4399a084ef",
+      "src/annotate_evidence.py": "3ba83e6475c856cdc58a68526f2a0a5baa208754abd789dc3e3ec14e71bb9258",
       "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
     }
   },
@@ -1069,7 +1069,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/store_path.py": "4967ab7ea748da995367fd0520f89f4bf9a39b84c428310314291b85be26f73c",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d"
     }
   },
@@ -1420,7 +1420,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/german_residue_scan.py": "95b23669fdf96759202a22a06512c6bdc2d9de6e8a1c73809bdead3a26e991db",
-      "src/pilot/fix_german_connectives.py": "6a5cceb58cd7c989df819703dff777bb635ee979c7178c55ceccce199a3737a8",
+      "src/pilot/fix_german_connectives.py": "98d95f87ae5957f68611152c2d60f99f7794278fa9f489af745be8dc606c8a1e",
       "src/pilot/foreign_literal_guards.py": "e7eaccfb846ff805b585b1c6413ec84b71970dd7fdddfc6abef90fcf04650b93",
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
       "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f"
@@ -1444,7 +1444,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
       "src/pilot/tnmask_offline.py": "c857fe425fadbe18c1cdf398892f53b590709048ca66faf94fd05e046730ffea"
     }
@@ -1466,7 +1466,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Russian ё-orthography policy and Russian terse editorial metalanguage («вм.», «в знач.», «Бомбейская ред.») have no EN counterpart by construction -- EN output contains no Cyrillic and uses its own English editorial conventions (no ё letter, no «вместо»/«в значении» abbreviation question). Register §4's h178-vote row \"(SHARED)\" annotation is refined here: the GATE WIRING MECHANISM (an RU-only-detector slot added to audit_window.py's existing commands list, alongside translation/stage2_mechanical/coverage/sense_dupes) is SHARED-capable machinery -- a hypothetical 3rd Cyrillic-scripted language could reuse the same gate-list slot -- but the RULES THEMSELVES (R1-R4, the ё-whitelist, the вм./в знач. terse forms) are RU-only INTENTIONAL-DIVERGENCE, not something to port to audit_window_en.py, which this handoff deliberately does not touch. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/ru_style_sweep.py": "097e3780bfaac430741391514b3209c22fcf1f1cd7f473623a8fd18477e914a0",
+      "src/ru_style_sweep.py": "9184e1859428312866623e25bd1e1e8a1b08bec773cc339303a1f4fcd7fbc64f",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
       "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86",
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
@@ -1492,7 +1492,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/card_fields.py": "976c5aa943a35da1691e2ce72e9cb4a14ac53d3bae37f8c68345cc68cb233e2b",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
       "src/pilot/headless_worker.py": "a754caf055c0592013311a299ed9d0d8c7c0c278693a7f583684050de0c52588",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
@@ -1593,7 +1593,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa"
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768"
     }
   },
   {
@@ -1717,7 +1717,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/max_account_orchestrator.py": "733902a7410a4a8fce704252386106a2be21c7ffd5f6ab29c3372ffa80fb85ab",
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
       "src/pilot/coordinator.py": "a060e34e1733fb6469653f05bafab2756dfcca026f7324c83c9186808a21f9e6",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
       "src/pilot/window_common.py": "3a8a51917c9b898d9b3d262aaf9339e14fb30cddbb507242266858aec8727331",
@@ -1748,7 +1748,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86",
       "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f"
     }
@@ -1772,8 +1772,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H1624",
     "verified_sha256": {
       "src/citation_edges.py": "e9ebe19853b9541a7e283fd6ff089eea3de81ff00ca640c410cbc51183cb04c0",
-      "src/annotate_citation_edges.py": "ec925f73e1af793c22a602be009b412af67e9989c99209ceed14224bc2cf8022",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/annotate_citation_edges.py": "b5462244bcaa5c5712b73bd1c67ae5414549f2fd55760d6704dc5559218a701c",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
@@ -1797,9 +1797,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H1624",
     "verified_sha256": {
       "src/edition_rel.py": "bb4ae2271dad9e9f30ced97d60fa14f5c9dee8d810b9dd43f422c7d2659883a9",
-      "src/annotate_edition_rel.py": "928ec162b61dc7ea261b3e3dd5f07fd151103675a1ff34358d7ce4daf1e5c9ba",
+      "src/annotate_edition_rel.py": "54141c6723ca144eead648e4cf70ade4de667d1df2be94f9554a1c10f23f5ed6",
       "src/build_relationships.py": "76d03cc81a79f83624065d79bd47845c3a72b8e2f993a01dfc4fbe9931049725",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa",
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
     }
   },
@@ -1840,7 +1840,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/german_anchor.py": "751a6bf9c1cf9bc6201397d28f429cd02c680f668c1b2340be8ca55f54e8a276",
       "src/pilot/headless_worker.py": "a754caf055c0592013311a299ed9d0d8c7c0c278693a7f583684050de0c52588",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/promote_final_cards.py": "b270f276578444cd5a23c26743d62b79225b31c3783500ef2ddd31572718eefa"
+      "src/promote_final_cards.py": "e2b3e9343c35c1a90b04774ce0d102472d995c967d76d73508a0f4501ba8c768"
     }
   },
   {

--- a/RussianTranslation/src/annotate_citation_edges.py
+++ b/RussianTranslation/src/annotate_citation_edges.py
@@ -26,6 +26,7 @@ if HERE not in sys.path:
 
 from citation_edges import extract_citation_edges, coverage_stats, report_store
 from store_path import canonical_store
+from store_write import locked_store_rewrite
 
 STORE = canonical_store(os.path.join(HERE, 'pwg_ru_translated.jsonl'))
 
@@ -35,11 +36,9 @@ def load_rows(store):
 
 
 def write_rows(store, rows, no_backup):
-    if not no_backup:
-        os.replace(store, store + '.precite.bak')
-    with open(store, 'w', encoding='utf-8') as f:
-        for r in rows:
-            f.write(json.dumps(r, ensure_ascii=False) + '\n')
+    # H2146: locked (PromoteClaim) + unique fsynced backup + atomic replace — the old
+    # in-place rewrite was unlocked and left a truncated store on crash (FINDINGS §513).
+    locked_store_rewrite(store, rows, tag='precite', no_backup=no_backup)
 
 
 def selftest():

--- a/RussianTranslation/src/annotate_dcs_freq.py
+++ b/RussianTranslation/src/annotate_dcs_freq.py
@@ -36,6 +36,7 @@ sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
 from build_dcs_freq import norm_lemma, sandhi_key   # canonical normalizer + sandhi joiner
+from store_write import locked_store_rewrite
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 FREQ = os.path.join(HERE, 'dcs_freq.json')
@@ -187,11 +188,9 @@ def main():
     if args.dry_run:
         print('\n(dry run — store not written)')
         return
-    if not args.no_backup:
-        os.replace(args.store, args.store + '.prefreq.bak')
-    with open(args.store, 'w', encoding='utf-8') as f:
-        for r in rows:
-            f.write(json.dumps(r, ensure_ascii=False) + '\n')
+    # H2146: locked (PromoteClaim) + unique fsynced backup + atomic replace — the old
+    # in-place rewrite was unlocked and left a truncated store on crash (FINDINGS §513).
+    locked_store_rewrite(args.store, rows, tag='prefreq', no_backup=args.no_backup)
     print('\nwrote annotated store -> %s' % args.store)
 
 

--- a/RussianTranslation/src/annotate_edition_rel.py
+++ b/RussianTranslation/src/annotate_edition_rel.py
@@ -28,6 +28,7 @@ from edition_rel import (
     edition_rel_for_row, build_pwg_gender_index, classify_edition_rel,
 )
 from store_path import canonical_store
+from store_write import locked_store_rewrite
 
 STORE = canonical_store(os.path.join(HERE, 'pwg_ru_translated.jsonl'))
 
@@ -37,11 +38,9 @@ def load_rows(store):
 
 
 def write_rows(store, rows, no_backup):
-    if not no_backup:
-        os.replace(store, store + '.preedition.bak')
-    with open(store, 'w', encoding='utf-8') as f:
-        for r in rows:
-            f.write(json.dumps(r, ensure_ascii=False) + '\n')
+    # H2146: locked (PromoteClaim) + unique fsynced backup + atomic replace — the old
+    # in-place rewrite was unlocked and left a truncated store on crash (FINDINGS §513).
+    locked_store_rewrite(store, rows, tag='preedition', no_backup=no_backup)
 
 
 def selftest():

--- a/RussianTranslation/src/annotate_evidence.py
+++ b/RussianTranslation/src/annotate_evidence.py
@@ -61,6 +61,7 @@ if HERE not in sys.path:
 import corpus_gate as cg
 import koch_xref
 import fri_xref
+from store_write import locked_store_rewrite
 
 STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
 
@@ -379,11 +380,10 @@ def main():
     if args.dry_run:
         print('\n(dry run — store not written)')
         return
-    if not args.no_backup and args.limit is None:
-        os.replace(args.store, args.store + '.pre_evidence.bak')
-    with open(args.store, 'w', encoding='utf-8') as f:
-        for r in rows:
-            f.write(json.dumps(r, ensure_ascii=False) + '\n')
+    # H2146: locked (PromoteClaim) + unique fsynced backup + atomic replace — the old
+    # in-place rewrite was unlocked and left a truncated store on crash (FINDINGS §513).
+    locked_store_rewrite(args.store, rows, tag='pre_evidence',
+                         no_backup=(args.no_backup or args.limit is not None))
     print('\nwrote annotated store -> %s' % args.store)
 
 

--- a/RussianTranslation/src/annotate_form_labels.py
+++ b/RussianTranslation/src/annotate_form_labels.py
@@ -27,6 +27,7 @@ if HERE not in sys.path:
 
 from form_labels import extract_form_labels, extract_form_notes
 from store_path import canonical_store
+from store_write import locked_store_rewrite
 
 STORE = canonical_store(os.path.join(HERE, 'pwg_ru_translated.jsonl'))
 
@@ -36,11 +37,9 @@ def load_rows(store):
 
 
 def write_rows(store, rows, no_backup):
-    if not no_backup:
-        os.replace(store, store + '.preform.bak')
-    with open(store, 'w', encoding='utf-8') as f:
-        for r in rows:
-            f.write(json.dumps(r, ensure_ascii=False) + '\n')
+    # H2146: locked (PromoteClaim) + unique fsynced backup + atomic replace — the old
+    # in-place rewrite was unlocked and left a truncated store on crash (FINDINGS §513).
+    locked_store_rewrite(store, rows, tag='preform', no_backup=no_backup)
 
 
 def selftest():

--- a/RussianTranslation/src/annotate_genres.py
+++ b/RussianTranslation/src/annotate_genres.py
@@ -36,6 +36,8 @@ import json
 import os
 import sys
 
+from store_write import locked_store_rewrite
+
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
@@ -135,29 +137,27 @@ def is_structured(obj):
 def run(path, out, dict_name, report_only):
     stats = {'cards': 0, 'units': 0, 'tagged': 0, 'multi': 0, 'structured': 0,
               'by_coarse': collections.Counter()}
-    tmp = (out + '.tmp') if not report_only else None
-    sink = open(tmp, 'w', encoding='utf-8', newline='') if tmp else None
-    try:
-        with open(path, encoding='utf-8') as fin:
-            for line in fin:
-                line = line.strip()
-                if not line:
-                    continue
-                obj = json.loads(line)
-                if is_structured(obj):
-                    annotate_card(card_of(obj), dict_name, stats)
-                    stats['structured'] += 1
-                else:
-                    annotate_flat(obj, dict_name, stats)
-                stats['cards'] += 1
-                if sink:
-                    sink.write(json.dumps(obj, ensure_ascii=False) + '\n')
-    finally:
-        if sink:
-            sink.close()
-    if tmp:
-        os.replace(tmp, out)
-    report(stats, dict_name, out if tmp else None)
+    annotated = [] if not report_only else None
+    with open(path, encoding='utf-8') as fin:
+        for line in fin:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            if is_structured(obj):
+                annotate_card(card_of(obj), dict_name, stats)
+                stats['structured'] += 1
+            else:
+                annotate_flat(obj, dict_name, stats)
+            stats['cards'] += 1
+            if annotated is not None:
+                annotated.append(obj)
+    if annotated is not None:
+        # H2146: locked (PromoteClaim) + unique fsynced backup + atomic replace — the
+        # old tmp+replace was atomic but unlocked and kept no backup (FINDINGS §513).
+        locked_store_rewrite(out, annotated, tag='pregenre',
+                             no_backup=(os.path.abspath(out) != os.path.abspath(path)))
+    report(stats, dict_name, out if annotated is not None else None)
 
 
 def report(s, dict_name, out):

--- a/RussianTranslation/src/annotate_government.py
+++ b/RussianTranslation/src/annotate_government.py
@@ -34,8 +34,12 @@ if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
 from government_census import extract_government
+from store_path import canonical_store
+from store_write import locked_store_rewrite
 
-STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
+# H2146: resolve the CANONICAL store (main-checkout) like every other mutator — a local
+# worktree path here would also make the PromoteClaim lock guard the wrong file.
+STORE = canonical_store(os.path.join(HERE, 'pwg_ru_translated.jsonl'))
 
 
 def load_rows(store):
@@ -43,11 +47,9 @@ def load_rows(store):
 
 
 def write_rows(store, rows, no_backup):
-    if not no_backup:
-        os.replace(store, store + '.pregov.bak')
-    with open(store, 'w', encoding='utf-8') as f:
-        for r in rows:
-            f.write(json.dumps(r, ensure_ascii=False) + '\n')
+    # H2146: locked (PromoteClaim) + unique fsynced backup + atomic replace — the old
+    # in-place rewrite was unlocked and left a truncated store on crash (FINDINGS §513).
+    locked_store_rewrite(store, rows, tag='pregov', no_backup=no_backup)
 
 
 def selftest():

--- a/RussianTranslation/src/annotate_renou.py
+++ b/RussianTranslation/src/annotate_renou.py
@@ -101,29 +101,27 @@ def is_structured(obj):
 def run(path, out, dict_name, report_only):
     stats = {'cards': 0, 'units': 0, 'cited': 0, 'multi': 0, 'structured': 0,
              'by_state': collections.Counter(), 'oldest_state': collections.Counter()}
-    tmp = (out + '.tmp') if not report_only else None
-    sink = open(tmp, 'w', encoding='utf-8', newline='') if tmp else None
-    try:
-        with open(path, encoding='utf-8') as fin:
-            for line in fin:
-                line = line.strip()
-                if not line:
-                    continue
-                obj = json.loads(line)
-                if is_structured(obj):
-                    annotate_card(card_of(obj), dict_name, stats)
-                    stats['structured'] += 1
-                else:
-                    annotate_flat(obj, dict_name, stats)
-                stats['cards'] += 1
-                if sink:
-                    sink.write(json.dumps(obj, ensure_ascii=False) + '\n')
-    finally:
-        if sink:
-            sink.close()
-    if tmp:
-        os.replace(tmp, out)
-    report(stats, dict_name, out if tmp else None)
+    annotated = [] if not report_only else None
+    with open(path, encoding='utf-8') as fin:
+        for line in fin:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            if is_structured(obj):
+                annotate_card(card_of(obj), dict_name, stats)
+                stats['structured'] += 1
+            else:
+                annotate_flat(obj, dict_name, stats)
+            stats['cards'] += 1
+            if annotated is not None:
+                annotated.append(obj)
+    if annotated is not None:
+        # H2146: locked (PromoteClaim) + unique fsynced backup + atomic replace — the
+        # old tmp+replace was atomic but unlocked and kept no backup (FINDINGS §513).
+        locked_store_rewrite(out, annotated, tag='prerenou',
+                             no_backup=(os.path.abspath(out) != os.path.abspath(path)))
+    report(stats, dict_name, out if annotated is not None else None)
 
 
 def report(s, dict_name, out):

--- a/RussianTranslation/src/annotate_stats.py
+++ b/RussianTranslation/src/annotate_stats.py
@@ -63,6 +63,7 @@ if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
 import pipeline_version as pv
+from store_write import locked_store_rewrite
 
 STORE = os.path.join(HERE, 'pwg_ru_translated.jsonl')
 DCS_FREQ = os.path.join(HERE, 'dcs_freq.json')
@@ -578,11 +579,10 @@ def main():
     if args.dry_run:
         print('\n(dry run — store not written)')
         return
-    if not args.no_backup and args.limit is None:
-        os.replace(args.store, args.store + '.pre_stats.bak')
-    with open(args.store, 'w', encoding='utf-8') as f:
-        for r in rows:
-            f.write(json.dumps(r, ensure_ascii=False) + '\n')
+    # H2146: locked (PromoteClaim) + unique fsynced backup + atomic replace — the old
+    # in-place rewrite was unlocked and left a truncated store on crash (FINDINGS §513).
+    locked_store_rewrite(args.store, rows, tag='pre_stats',
+                         no_backup=(args.no_backup or args.limit is not None))
     print('\nwrote annotated store -> %s' % args.store)
 
 

--- a/RussianTranslation/src/backfill_tn_residue.py
+++ b/RussianTranslation/src/backfill_tn_residue.py
@@ -370,16 +370,21 @@ def atomic_write_bytes(path, data):
 
 
 def apply_repair(store_path, repaired, quarantine, expected_sha, quarantine_path):
-    actual = sha256_file(store_path)
-    if actual.lower() != expected_sha.lower():
-        raise RepairRefusal('source-hash drift: expected %s, got %s' % (expected_sha, actual))
-    stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
-    backup = '%s.pre-h1080.%s.%s.bak' % (store_path, actual[:16], stamp)
-    with open(store_path, 'rb') as fh:
-        original = fh.read()
-    atomic_write_bytes(backup, original)
-    atomic_write_bytes(quarantine_path, jsonl_bytes(quarantine))
-    atomic_write_bytes(store_path, jsonl_bytes(repaired))
+    # H2146: hold PromoteClaim across the hash-check/backup/replace window — the repair
+    # was atomic but unlocked, so a concurrent promote/mutator was last-writer-wins
+    # (FINDINGS §513). The hash gate + unique backup + atomic writes stay as they were.
+    from promote_lock import PromoteClaim
+    with PromoteClaim(store_path):
+        actual = sha256_file(store_path)
+        if actual.lower() != expected_sha.lower():
+            raise RepairRefusal('source-hash drift: expected %s, got %s' % (expected_sha, actual))
+        stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+        backup = '%s.pre-h1080.%s.%s.bak' % (store_path, actual[:16], stamp)
+        with open(store_path, 'rb') as fh:
+            original = fh.read()
+        atomic_write_bytes(backup, original)
+        atomic_write_bytes(quarantine_path, jsonl_bytes(quarantine))
+        atomic_write_bytes(store_path, jsonl_bytes(repaired))
     return backup, sha256_file(store_path), sha256_file(quarantine_path)
 
 

--- a/RussianTranslation/src/mark_reconstructed_headwords.py
+++ b/RussianTranslation/src/mark_reconstructed_headwords.py
@@ -170,15 +170,19 @@ def main():
     for r in gram_syn:
         r['provenance']['grammar_defaulted_empty'] = True
 
-    stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
-    backup = '%s.pre-hstamp.%s.bak' % (STORE, stamp)
-    with open(STORE, 'rb') as s, open(backup, 'wb') as d:
-        d.write(s.read())
-    tmp = STORE + '.tmp'
-    with open(tmp, 'w', encoding='utf-8', newline='\n') as fh:
-        for r in cur:
-            fh.write(json.dumps(r, ensure_ascii=False) + '\n')
-    os.replace(tmp, STORE)
+    # H2146: hold PromoteClaim across the backup/replace window — the stamp pass was
+    # atomic but unlocked (last-writer-wins against a concurrent promote, FINDINGS §513).
+    from promote_lock import PromoteClaim
+    with PromoteClaim(STORE):
+        stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+        backup = '%s.pre-hstamp.%s.bak' % (STORE, stamp)
+        with open(STORE, 'rb') as s, open(backup, 'wb') as d:
+            d.write(s.read())
+        tmp = STORE + '.tmp'
+        with open(tmp, 'w', encoding='utf-8', newline='\n') as fh:
+            for r in cur:
+                fh.write(json.dumps(r, ensure_ascii=False) + '\n')
+        os.replace(tmp, STORE)
 
     print()
     print('APPLIED: %d row(s) stamped h_reconstructed=true' % len(targets))

--- a/RussianTranslation/src/pilot/apply_editorial_decisions.py
+++ b/RussianTranslation/src/pilot/apply_editorial_decisions.py
@@ -36,6 +36,7 @@ if SRC not in sys.path:
     sys.path.insert(0, SRC)
 
 from store_path import canonical_store  # noqa: E402
+from store_write import locked_store_rewrite  # noqa: E402
 
 SCHEMA = 'pwg_ru.editorial_apply.v1'
 ENV_ALLOW_APPLY = 'PWG_RU_ALLOW_EDITORIAL_APPLY'
@@ -237,16 +238,15 @@ def apply_stamps(
             written += 1
         out_lines.append(json.dumps(row, ensure_ascii=False))
 
-    tmp = store_path + '.editorial.tmp'
-    with open(tmp, 'w', encoding='utf-8', newline='\n') as f:
-        f.write('\n'.join(out_lines))
-        if out_lines:
-            f.write('\n')
-    os.replace(tmp, store_path)
+    # H2146: THE overlay writer gets the full discipline — PromoteClaim + unique fsynced
+    # backup + atomic replace. The old fixed '.editorial.tmp' was unlocked, unbacked-up
+    # and shared between concurrent runs (FINDINGS §513).
+    backup = locked_store_rewrite(store_path, out_lines, tag='editorial')
     return {
         'status': 'applied',
         'written': written,
         'store_path': store_path,
+        'backup': backup,
     }
 
 

--- a/RussianTranslation/src/pilot/fix_d4_boundary_wrap.py
+++ b/RussianTranslation/src/pilot/fix_d4_boundary_wrap.py
@@ -67,11 +67,11 @@ def run_store(dry=False):
         if not os.path.exists(bak):
             shutil.copyfile(store, bak)
             print('backup                         : %s' % bak)
-        tmp = store + '.tmp'
-        with open(tmp, 'w', encoding='utf-8') as f:
-            for r in rows:
-                f.write(json.dumps(r, ensure_ascii=False) + '\n')
-        os.replace(tmp, store)
+        # H2146: locked (PromoteClaim) + unique per-run backup + atomic replace — the
+        # fixed '.tmp' rewrite was unlocked (last-writer-wins, FINDINGS §513); the
+        # one-time .h1702.bak above stays as the pre-campaign forensic copy.
+        from store_write import locked_store_rewrite
+        locked_store_rewrite(store, rows, tag='h1702fix')
         print('wrote                          : %s' % store)
 
     return {

--- a/RussianTranslation/src/pilot/fix_german_connectives.py
+++ b/RussianTranslation/src/pilot/fix_german_connectives.py
@@ -164,11 +164,11 @@ def run_store(dry=False):
             import shutil
             shutil.copyfile(store, bak)
             print('backup          : %s' % bak)
-        tmp = store + '.tmp'
-        with open(tmp, 'w', encoding='utf-8') as f:
-            for r in rows:
-                f.write(json.dumps(r, ensure_ascii=False) + '\n')
-        os.replace(tmp, store)
+        # H2146: locked (PromoteClaim) + unique per-run backup + atomic replace — the
+        # fixed '.tmp' rewrite was unlocked (last-writer-wins, FINDINGS §513); the
+        # one-time .h1302.bak above stays as the pre-campaign forensic copy.
+        from store_write import locked_store_rewrite
+        locked_store_rewrite(store, rows, tag='h1302conn')
         print('wrote           : %s' % store)
 
 

--- a/RussianTranslation/src/pilot/fix_wrapper_defects.py
+++ b/RussianTranslation/src/pilot/fix_wrapper_defects.py
@@ -124,11 +124,11 @@ def run_store(dry=False):
         if not os.path.exists(bak):
             shutil.copyfile(store, bak)
             print('backup             : %s' % bak)
-        tmp = store + '.tmp'
-        with open(tmp, 'w', encoding='utf-8') as f:
-            for r in rows:
-                f.write(json.dumps(r, ensure_ascii=False) + '\n')
-        os.replace(tmp, store)
+        # H2146: locked (PromoteClaim) + unique per-run backup + atomic replace — the
+        # fixed '.tmp' rewrite was unlocked (last-writer-wins, FINDINGS §513); the
+        # one-time .h1651.bak above stays as the pre-campaign forensic copy.
+        from store_write import locked_store_rewrite
+        locked_store_rewrite(store, rows, tag='h1651fix')
         print('wrote              : %s' % store)
 
     return {

--- a/RussianTranslation/src/pilot/repair_h178_da_cards.py
+++ b/RussianTranslation/src/pilot/repair_h178_da_cards.py
@@ -118,11 +118,11 @@ def main():
             import shutil
             shutil.copyfile(store, bak)
             print('backup : %s' % bak)
-        tmp = store + '.tmp'
-        with open(tmp, 'w', encoding='utf-8') as f:
-            for r in rows:
-                f.write(json.dumps(r, ensure_ascii=False) + '\n')
-        os.replace(tmp, store)
+        # H2146: locked (PromoteClaim) + unique per-run backup + atomic replace — the
+        # fixed '.tmp' rewrite was unlocked (last-writer-wins, FINDINGS §513); the
+        # one-time .h1302.bak above stays as the pre-campaign forensic copy.
+        from store_write import locked_store_rewrite
+        locked_store_rewrite(store, rows, tag='h1302repair')
         print('wrote  : %s' % store)
 
 

--- a/RussianTranslation/src/promote_final_cards.py
+++ b/RussianTranslation/src/promote_final_cards.py
@@ -223,7 +223,13 @@ def promote_ready_partial_clean(lease_or_report, *, dry_run=True, store=None,
                 line = line.strip()
                 if line:
                     existing_rows.append(json.loads(line))
-    rows_to_write, downgraded = merge_store_rows(existing_rows, rows)
+    # H2146: the clean-subset path never overrides human-reviewed rows — wave-1 agents
+    # must not be able to strip a reviewer stamp; protected subcards keep their store rows.
+    rows_to_write, downgraded, protected = merge_store_rows(existing_rows, rows)
+    if protected:
+        print('⚠ overlay-preserve: store keeps its HUMAN-REVIEWED rows for %d subcard(s); '
+              'incoming machine attempt dropped: %s'
+              % (len(protected), ', '.join(protected[:10])))
     claim_cm = PromoteClaim(store)
     with claim_cm:
         if os.path.exists(store):
@@ -232,6 +238,7 @@ def promote_ready_partial_clean(lease_or_report, *, dry_run=True, store=None,
         _atomic_write_rows(store, rows_to_write)
     result['promoted_keys'] = sorted(selected)
     result['downgraded'] = downgraded
+    result['protected'] = protected
     result['rows_written'] = len(rows_to_write)
     result['status'] = 'applied'
     return result
@@ -592,16 +599,43 @@ def _attempt_quality(rows):
     return (0 if partial else 1, -missing)
 
 
-def merge_store_rows(existing_rows, promoted_rows):
+def human_touched(row):
+    """True when a HUMAN has ruled on this store row (H2146 / FINDINGS §513).
+
+    Three independent signals, any one protects the row from silent machine
+    replacement: a named ``reviewer``; a ``review_status`` outside the machine
+    vocabulary (machine statuses are ``ai_*`` — ``approved``/``needs_review``/
+    any future human status protects); or a non-empty ``editorial_decision*``
+    field. rows_for() stamps machine rows ``reviewer: None`` +
+    ``review_status='ai_translated'``, so machine output never self-protects."""
+    if row.get('reviewer'):
+        return True
+    status = row.get('review_status')
+    if isinstance(status, str) and status and not status.startswith('ai_'):
+        return True
+    return any(k.startswith('editorial_decision') and row[k] for k in row)
+
+
+def merge_store_rows(existing_rows, promoted_rows, override_reviewed=False):
     """Replace the promoted subcards BETTER-ATTEMPT-WINS; retain every unrelated row.
 
     B08 (H1339): the merge used to be an unconditional replace-by-subcard, so promoting an
     older/regressed artifact (a partial heal over a complete card) silently downgraded
     complete store rows. This is the store-level port of H304 rule 3 (save_and_audit
     --merge): complete beats partial, fewer missing fragments beat more, and only a tie or
-    an improvement lets the incoming rows land. Returns (merged_rows, downgraded_subcards)
-    where downgraded_subcards lists incoming subcards REFUSED because the store already
-    holds a strictly better attempt (their existing rows are kept untouched)."""
+    an improvement lets the incoming rows land.
+
+    H2146 (FINDINGS §513): the merge additionally REFUSES to replace a subcard any of
+    whose existing rows a human has touched (``human_touched``) — attempt quality alone
+    used to return an ``approved`` row to ``ai_translated``/``reviewer: None`` with the
+    human stamp gone. ``override_reviewed=True`` (the operator's explicit
+    ``--override-reviewed``) restores the pre-H2146 behaviour for a deliberate
+    re-translation of reviewed content.
+
+    Returns (merged_rows, downgraded_subcards, protected_subcards): ``downgraded`` lists
+    incoming subcards refused because the store holds a strictly better attempt;
+    ``protected`` lists incoming subcards refused because a human touched the existing
+    rows. Both keep their existing rows untouched."""
     incoming = {}
     for row in promoted_rows:
         incoming.setdefault(row['subcard'], []).append(row)
@@ -612,11 +646,15 @@ def merge_store_rows(existing_rows, promoted_rows):
         sub for sub, rows in incoming.items()
         if sub in existing_by_sub
         and _attempt_quality(rows) < _attempt_quality(existing_by_sub[sub]))
-    blocked = set(downgraded)
+    protected = [] if override_reviewed else sorted(
+        sub for sub in incoming
+        if sub in existing_by_sub and sub not in set(downgraded)
+        and any(human_touched(r) for r in existing_by_sub[sub]))
+    blocked = set(downgraded) | set(protected)
     replaced_subs = set(incoming) - blocked
     kept = [row for row in existing_rows if row.get('subcard') not in replaced_subs]
     landed = [row for row in promoted_rows if row['subcard'] not in blocked]
-    return kept + landed, downgraded
+    return kept + landed, downgraded, protected
 
 
 def tn_residue(card, rec, sense):
@@ -736,7 +774,7 @@ def collect_and_validate(paths, review_status, gen_model_version):
 def batch_promote(batch, store, review_status, gen_model_version,
                   no_backup=False, steal_lock=False, lock_ttl_seconds=None,
                   report_path=None, journal_path=None, promotion_id=None,
-                  fault_hook=None, store_claim_held=False):
+                  fault_hook=None, store_claim_held=False, override_reviewed=False):
     """H1339 Phase 3: promote N leases' clean outputs in ONE store transaction.
 
     Replaces the per-lease subprocess loop (N x [full store read + duplicate scan +
@@ -909,13 +947,23 @@ def batch_promote(batch, store, review_status, gen_model_version,
         for row in existing_rows:
             sub = row.get('subcard')
             existing_count_by_sub[sub] = existing_count_by_sub.get(sub, 0) + 1
-        rows_to_write, downgraded = merge_store_rows(existing_rows, all_rows)
+        rows_to_write, downgraded, protected = merge_store_rows(
+            existing_rows, all_rows, override_reviewed=override_reviewed)
         if downgraded:
             raise PromotionContractError(
                 'bundle failed, store unchanged: the store already holds a strictly '
                 'better attempt for %d subcard(s) (%s) -- a freshly audited lease should '
                 'never lose better-attempt-wins; inspect before promoting'
                 % (len(downgraded), ', '.join(downgraded[:10])))
+        if protected:
+            # H2146: a coordinator window should never silently re-land a subcard a human
+            # has ruled on -- that returns approved rows to ai_translated/reviewer: None.
+            raise PromotionContractError(
+                'bundle failed, store unchanged: %d subcard(s) carry HUMAN-REVIEWED store '
+                'rows (%s) -- machine replacement would wipe the review overlay (FINDINGS '
+                '§513). Re-run with override_reviewed/--override-reviewed only for a '
+                'deliberate re-translation of reviewed content'
+                % (len(protected), ', '.join(protected[:10])))
         landed_subs = {r['subcard'] for r in rows_to_write}
         for lease_id, best in lease_best.items():
             missing = sorted(set(best) - landed_subs)
@@ -1312,9 +1360,10 @@ def selftest():
     # Exact-subcard merge is idempotent; a second promotion replaces rather than duplicates.
     old = [{'key1': 'x', 'subcard': 'x~~a'}, {'key1': 'y', 'subcard': 'y~~a'}]
     new = [{'key1': 'x', 'subcard': 'x~~a', 'ru': 'new'}]
-    once, dg1 = merge_store_rows(old, new)
-    twice, dg2 = merge_store_rows(once, new)
+    once, dg1, pr1 = merge_store_rows(old, new)
+    twice, dg2, pr2 = merge_store_rows(once, new)
     assert once == twice and len(once) == 2 and dg1 == [] and dg2 == []
+    assert pr1 == [] and pr2 == [], 'unreviewed rows must not be protected'
     # B08 (H1339): the store merge is better-attempt-wins, the H304 rule ported to the
     # store level. A partial incoming attempt must NOT downgrade complete existing rows;
     # a complete incoming attempt replaces a partial; fewer missing fragments win among
@@ -1322,10 +1371,10 @@ def selftest():
     complete_old = [{'key1': 'x', 'subcard': 'x~~a', 'ru': 'old-good', 'provenance': {}}]
     partial_new = [{'key1': 'x', 'subcard': 'x~~a', 'ru': 'new-partial',
                     'provenance': {'partial_card': True, 'missing_fragments': ['g1:f0']}}]
-    merged, downgraded = merge_store_rows(complete_old, partial_new)
+    merged, downgraded, _pr = merge_store_rows(complete_old, partial_new)
     assert merged == complete_old and downgraded == ['x~~a'], \
         'a partial attempt silently downgraded a complete store row'
-    merged, downgraded = merge_store_rows(partial_new, complete_old)
+    merged, downgraded, _pr = merge_store_rows(partial_new, complete_old)
     assert merged == complete_old and downgraded == [], \
         'a complete attempt must replace a partial store row'
     worse = [{'key1': 'x', 'subcard': 'x~~a', 'ru': 'p3',
@@ -1333,10 +1382,67 @@ def selftest():
                              'missing_fragments': ['g1:f0', 'g1:f1', 'g2:f0']}}]
     better = [{'key1': 'x', 'subcard': 'x~~a', 'ru': 'p1',
                'provenance': {'partial_card': True, 'missing_fragments': ['g1:f0']}}]
-    merged, downgraded = merge_store_rows(worse, better)
+    merged, downgraded, _pr = merge_store_rows(worse, better)
     assert merged == better and downgraded == [], 'fewer missing fragments must win'
-    merged, downgraded = merge_store_rows(better, worse)
+    merged, downgraded, _pr = merge_store_rows(better, worse)
     assert merged == better and downgraded == ['x~~a'], 'more missing fragments must lose'
+
+    # H2146 (FINDINGS §513): human-touched store rows are PROTECTED from machine
+    # replacement -- reviewer stamp, non-ai_* review_status, or editorial_decision*
+    # each protect independently; --override-reviewed restores the old behaviour.
+    machine_new = [{'key1': 'x', 'subcard': 'x~~a', 'ru': 'machine-redo',
+                    'review_status': 'ai_translated', 'reviewer': None,
+                    'provenance': {}}]
+    for label, human_row in (
+            ('approved+reviewer', {'key1': 'x', 'subcard': 'x~~a', 'ru': 'human-kept',
+                                   'review_status': 'approved', 'reviewer': 'MG',
+                                   'provenance': {}}),
+            ('needs_review', {'key1': 'x', 'subcard': 'x~~a', 'ru': 'human-kept',
+                              'review_status': 'needs_review', 'reviewer': None,
+                              'provenance': {}}),
+            ('editorial stamp', {'key1': 'x', 'subcard': 'x~~a', 'ru': 'human-kept',
+                                 'review_status': 'ai_translated', 'reviewer': None,
+                                 'editorial_decision_id': 'D42', 'provenance': {}})):
+        merged, downgraded, protected = merge_store_rows([human_row], machine_new)
+        assert merged == [human_row] and protected == ['x~~a'] and downgraded == [], \
+            'human overlay (%s) must survive a machine re-promote' % label
+        assert merged[0]['review_status'] == human_row['review_status'] \
+            and merged[0].get('reviewer') == human_row.get('reviewer'), \
+            'overlay fields must come back intact (%s)' % label
+    # Explicit override lands the machine attempt (deliberate re-translation).
+    approved = [{'key1': 'x', 'subcard': 'x~~a', 'ru': 'human-kept',
+                 'review_status': 'approved', 'reviewer': 'MG', 'provenance': {}}]
+    merged, downgraded, protected = merge_store_rows(
+        approved, machine_new, override_reviewed=True)
+    assert merged == machine_new and protected == [] and downgraded == [], \
+        '--override-reviewed must land the machine attempt'
+    # Unrelated subcards still merge normally next to a protected one.
+    mixed_store = approved + [{'key1': 'y', 'subcard': 'y~~a', 'ru': 'old',
+                               'review_status': 'ai_translated', 'provenance': {}}]
+    incoming2 = machine_new + [{'key1': 'y', 'subcard': 'y~~a', 'ru': 'new',
+                                'review_status': 'ai_translated', 'reviewer': None,
+                                'provenance': {}}]
+    merged, downgraded, protected = merge_store_rows(mixed_store, incoming2)
+    assert protected == ['x~~a'] and downgraded == []
+    assert any(r['subcard'] == 'y~~a' and r['ru'] == 'new' for r in merged), \
+        'unprotected sibling subcards must still land'
+    assert any(r['subcard'] == 'x~~a' and r['ru'] == 'human-kept' for r in merged)
+    assert not human_touched({'review_status': 'ai_translated', 'reviewer': None}), \
+        'machine rows must never self-protect'
+
+    # H2146: store_write.locked_store_rewrite -- the shared mutator writer -- refuses
+    # to write under a live PromoteClaim (lock serializes mutators against promotes).
+    import store_write
+    sw_store = os.path.join(d, 'sw-store.jsonl')
+    store_write.locked_store_rewrite(sw_store, [{'subcard': 's1'}], tag='selftest')
+    with PromoteClaim(sw_store):
+        try:
+            store_write.locked_store_rewrite(sw_store, [{'subcard': 's2'}], tag='selftest')
+            raise AssertionError('locked_store_rewrite must raise ClaimBusy under a claim')
+        except ClaimBusy:
+            pass
+    swb = store_write.locked_store_rewrite(sw_store, [{'subcard': 's3'}], tag='selftest')
+    assert swb and os.path.isfile(swb), 'mutator rewrite must leave a unique backup'
     # Atomic failure leaves the old store intact and removes the temporary file.
     atomic = os.path.join(d, 'atomic.jsonl')
     with open(atomic, 'w', encoding='utf-8') as f:
@@ -1675,6 +1781,12 @@ def main():
                          'translated sub-cards not in this run). Use for a per-root catch-up — the '
                          'default full overwrite WIPES any root whose wf_output file is no longer '
                          'on disk (the gam-RU loss mode).')
+    ap.add_argument('--override-reviewed', action='store_true',
+                    help='H2146: allow machine replacement of subcards whose store rows a '
+                         'human has touched (reviewer set, non-ai_* review_status, or an '
+                         'editorial_decision* stamp). Default preserves/refuses them '
+                         '(FINDINGS §513); pass this only for a deliberate re-translation '
+                         'of reviewed content.')
     ap.add_argument('--allow-raw-default-merge', action='store_true',
                     help='H2089: override the refuse of --merge into the default pwg_ru store '
                          'without --promotion-id. Prefer coordinator journaled --batch-manifest. '
@@ -1730,7 +1842,8 @@ def main():
                 batch, args.store, args.review_status, args.gen_model_version,
                 no_backup=args.no_backup, steal_lock=args.steal_lock,
                 lock_ttl_seconds=args.lock_ttl_seconds, report_path=args.report,
-                journal_path=args.journal, promotion_id=args.promotion_id)
+                journal_path=args.journal, promotion_id=args.promotion_id,
+                override_reviewed=args.override_reviewed)
         except (PromotionContractError, UnrestoredPlaceholder,
                 promotion_journal.JournalError) as exc:
             sys.exit('REFUSED: %s' % exc)
@@ -1890,6 +2003,7 @@ def main():
             # Guards against the full-overwrite wipe when only a subset of wf_output is on disk.
             kept = 0
             downgraded = []
+            protected = []
             if args.merge and os.path.exists(args.store):
                 promoted_subs = {r['subcard'] for r in rows}
                 touched_roots = {r['key1'] for r in rows}
@@ -1900,7 +2014,8 @@ def main():
                         if not line:
                             continue
                         existing_rows.append(json.loads(line))
-                rows_to_write, downgraded = merge_store_rows(existing_rows, rows)
+                rows_to_write, downgraded, protected = merge_store_rows(
+                    existing_rows, rows, override_reviewed=args.override_reviewed)
                 if downgraded:
                     # B08: better-attempt-wins refused these incoming subcards -- the store
                     # already holds a strictly better attempt (complete vs partial, or
@@ -1909,11 +2024,48 @@ def main():
                           '%d subcard(s); incoming (worse) attempt dropped: %s'
                           % (len(downgraded), ', '.join(downgraded[:10])
                              + (' …' if len(downgraded) > 10 else '')))
-                landed = len(rows) - sum(1 for r in rows if r['subcard'] in set(downgraded))
+                if protected:
+                    # H2146: human-reviewed subcards are preserved, never silently
+                    # machine-replaced (FINDINGS §513). --override-reviewed lands them.
+                    print('\n⚠ overlay-preserve: store keeps its HUMAN-REVIEWED rows for '
+                          '%d subcard(s); incoming machine attempt dropped (pass '
+                          '--override-reviewed for a deliberate re-translation): %s'
+                          % (len(protected), ', '.join(protected[:10])
+                             + (' …' if len(protected) > 10 else '')))
+                blocked_subs_ = set(downgraded) | set(protected)
+                landed = len(rows) - sum(1 for r in rows if r['subcard'] in blocked_subs_)
                 kept = len(rows_to_write) - landed
                 print('\nMERGE: replacing %d sub-card(s) across root(s) %s; keeping %d existing row(s)'
-                      % (len(promoted_subs - set(downgraded)), sorted(touched_roots), kept))
+                      % (len(promoted_subs - blocked_subs_), sorted(touched_roots), kept))
             else:
+                # H2146 (FINDINGS §513): a full rebuild replaces the store with whatever
+                # wf_output is on disk -- if the store holds HUMAN-REVIEWED rows, that
+                # wipes the review overlay wholesale. Refuse; --force does NOT cover this
+                # (it bypasses the shrink guard, a different hazard) -- only the explicit
+                # --override-reviewed does.
+                if os.path.exists(args.store) and not args.override_reviewed:
+                    overlay_subs = set()
+                    try:
+                        with open(args.store, encoding='utf-8') as f:
+                            for line in f:
+                                line = line.strip()
+                                if not line:
+                                    continue
+                                row = json.loads(line)
+                                if human_touched(row):
+                                    overlay_subs.add(row.get('subcard'))
+                    except (OSError, json.JSONDecodeError) as exc:
+                        sys.exit('REFUSED: cannot verify the store overlay state before a '
+                                 'full rebuild (%s) -- fix the store or use --merge' % exc)
+                    if overlay_subs:
+                        sys.exit(
+                            'REFUSED: full (non---merge) rebuild would wipe HUMAN-REVIEWED '
+                            'rows for %d subcard(s): %s (FINDINGS §513). Use --merge (which '
+                            'preserves them), or --override-reviewed for a deliberate '
+                            'rebuild over reviewed content.'
+                            % (len(overlay_subs),
+                               ', '.join(sorted(overlay_subs)[:10])
+                               + (' …' if len(overlay_subs) > 10 else '')))
                 rows_to_write = rows
 
             identities = [(r.get('key1'), r.get('subcard'), r.get('h'),
@@ -1961,7 +2113,7 @@ def main():
             # fail a promotion that already committed.
             try:
                 cleared_addr, cleared_frag = clear_denials_for_promotion(
-                    best, blocked_subs=downgraded)
+                    best, blocked_subs=sorted(set(downgraded) | set(protected)))
                 if cleared_addr or cleared_frag:
                     print('TM denylist: cleared %d card address(es) + %d fragment sha(s) '
                           'superseded by this promotion' % (len(cleared_addr), len(cleared_frag)))

--- a/RussianTranslation/src/ru_style_sweep.py
+++ b/RussianTranslation/src/ru_style_sweep.py
@@ -343,6 +343,16 @@ def _create_verified_backup(store, backup_dir=None, stamp=None):
 
 
 def _write_rows_atomic(store, rows, initial_hash, backup_dir=None, stamp=None):
+    # H2146: hold PromoteClaim across the check/backup/replace window — the sweep's
+    # hash-race checks detect a concurrent writer, but only the lock PREVENTS one
+    # (last-writer-wins against a promote, FINDINGS §513).
+    from promote_lock import PromoteClaim
+    with PromoteClaim(store):
+        return _write_rows_atomic_locked(store, rows, initial_hash,
+                                         backup_dir=backup_dir, stamp=stamp)
+
+
+def _write_rows_atomic_locked(store, rows, initial_hash, backup_dir=None, stamp=None):
     if _file_sha256(store) != initial_hash:
         raise RuntimeError('store changed after read; refusing apply')
     backup = _create_verified_backup(store, backup_dir=backup_dir, stamp=stamp)

--- a/RussianTranslation/src/store_write.py
+++ b/RussianTranslation/src/store_write.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+"""H2146 — the ONE sanctioned rewrite path for canonical sense stores.
+
+Before this module, only the promote entry points held ``PromoteClaim`` while
+rewriting ``pwg_ru_translated.jsonl``; 17 non-promote mutators (the annotate_*
+family, the pilot fix_*/repair_* scripts, ru_style_sweep, backfill_tn_residue,
+mark_reconstructed_headwords, apply_editorial_decisions) wrote the same file
+with no lock — a mutator run concurrent with a promote was last-writer-wins
+(FINDINGS §513). Seven of them also rewrote the store IN PLACE (truncate-then-
+write, a crash leaves the live file half-written), and several kept a FIXED
+backup name each run overwrote.
+
+``locked_store_rewrite`` gives every mutator the same guarantees the promote
+path already has:
+
+  1. ``PromoteClaim`` held across the whole read-guard-write window (TTL lock,
+     ``ClaimBusy`` raised loudly when a promote/mutator is already in flight);
+  2. a UNIQUE fsynced backup copy per run (O_EXCL — never overwrites a prior
+     recovery artifact);
+  3. an atomic replace: fsynced temp file in the store's own directory, then
+     ``os.replace`` (the store is never observable half-written);
+  4. LF-only bytes (``newline='\\n'`` semantics via binary write) — the
+     in-place writers opened text-mode without ``newline=`` and so emitted
+     CRLF on Windows (the §262 class).
+
+Serialization defaults to each mutator's existing form —
+``json.dumps(row, ensure_ascii=False)`` — so a retrofit changes no payload
+bytes, only locking, backup and atomicity.
+"""
+import json
+import os
+import sys
+import tempfile
+import uuid
+
+from promote_lock import PromoteClaim, ClaimBusy, DEFAULT_TTL_SECONDS  # noqa: F401
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+
+def unique_backup_path(store, tag):
+    """Collision-resistant per-run backup name (never a fixed suffix)."""
+    import datetime
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%S.%fZ')
+    return '%s.%s.%s.p%d.%s.bak' % (store, tag, stamp, os.getpid(), uuid.uuid4().hex[:12])
+
+
+def _fsynced_backup(source, destination):
+    """Exclusive fsynced copy; refuses to overwrite a prior recovery artifact."""
+    import shutil
+    fd = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with open(source, 'rb') as src, os.fdopen(fd, 'wb') as dst:
+            fd = None
+            shutil.copyfileobj(src, dst, length=1024 * 1024)
+            dst.flush()
+            os.fsync(dst.fileno())
+    except BaseException:
+        if fd is not None:
+            os.close(fd)
+        try:
+            os.unlink(destination)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def locked_store_rewrite(store, rows, tag, no_backup=False, steal_lock=False,
+                         ttl_seconds=None, serialize=None):
+    """Locked + backed-up + atomic full rewrite of ``store`` with ``rows``.
+
+    ``rows`` is an iterable of dicts (or pre-serialized strings when
+    ``serialize`` is ``str``); ``tag`` names the mutator in the backup filename
+    (e.g. ``'precite'``). Returns the backup path, or ``None`` when no backup
+    was taken (fresh store or ``no_backup``). Raises ``ClaimBusy`` when a
+    promote or another mutator holds the store claim — callers must NOT catch
+    it silently.
+    """
+    serialize = serialize or (lambda row: json.dumps(row, ensure_ascii=False))
+    ttl_kwargs = {'ttl_seconds': ttl_seconds} if ttl_seconds else {}
+    bak = None
+    with PromoteClaim(store, steal=steal_lock, **ttl_kwargs):
+        if not no_backup and os.path.exists(store):
+            bak = unique_backup_path(store, tag)
+            _fsynced_backup(store, bak)
+        directory = os.path.dirname(os.path.abspath(store)) or '.'
+        os.makedirs(directory, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix='.%s.' % os.path.basename(store),
+                                   suffix='.tmp', dir=directory)
+        try:
+            with os.fdopen(fd, 'wb') as fh:
+                for row in rows:
+                    line = row if isinstance(row, str) else serialize(row)
+                    fh.write(line.encode('utf-8') + b'\n')
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, store)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass
+            raise
+    return bak
+
+
+def selftest():
+    import tempfile as _tf
+    d = _tf.mkdtemp()
+    store = os.path.join(d, 'store.jsonl')
+    rows = [{'subcard': 'x~~a', 'ru': 'старый'}, {'subcard': 'y~~a', 'ru': 'row2'}]
+
+    # Fresh store: no backup, exact LF payload bytes.
+    bak = locked_store_rewrite(store, rows, tag='t1')
+    assert bak is None, 'fresh store must not fabricate a backup'
+    payload = open(store, 'rb').read()
+    assert payload == b''.join(
+        (json.dumps(r, ensure_ascii=False) + '\n').encode('utf-8') for r in rows), \
+        'payload bytes must match the historical mutator serialization, LF-only'
+
+    # Rewrite: unique backup holds the prior bytes; two runs -> two backups.
+    bak1 = locked_store_rewrite(store, rows[:1], tag='t1')
+    bak2 = locked_store_rewrite(store, rows, tag='t1')
+    assert bak1 and bak2 and bak1 != bak2, 'backup names must be unique per run'
+    assert open(bak1, 'rb').read() == payload, 'backup must hold the pre-rewrite bytes'
+
+    # A held PromoteClaim blocks the rewrite loudly (never last-writer-wins).
+    with PromoteClaim(store):
+        try:
+            locked_store_rewrite(store, rows, tag='t1')
+            raise AssertionError('rewrite under a live claim must raise ClaimBusy')
+        except ClaimBusy:
+            pass
+
+    # Pre-serialized string rows pass through byte-identically.
+    locked_store_rewrite(store, ['{"raw": 1}'], tag='t2', no_backup=True)
+    assert open(store, 'rb').read() == b'{"raw": 1}\n'
+    print('store_write selftest OK')
+
+
+if __name__ == '__main__':
+    if '--selftest' in sys.argv[1:]:
+        selftest()
+    else:
+        sys.exit('usage: python store_write.py --selftest')


### PR DESCRIPTION
Executes [H2146](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2146-Fable_SanskritLexicography_pwg-overlay-preserving-promote_01.08.26.md) — the top-severity gap (G1+G6) from the H2025 audit ([memo](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_AUDIT_PWG_RU_H2025_01-08-2026.md), [FINDINGS §513](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md)). Fable 5 (`claude-fable-5`).

Closes #976

## 1. Overlay-preserving promote
- `human_touched(row)`: named `reviewer` · non-`ai_*` `review_status` · non-empty `editorial_decision*` — any one protects.
- `merge_store_rows` returns `(merged, downgraded, protected)`; protected subcards keep their existing rows.
- Coordinator batch lane: a protected subcard **fails the bundle loudly** (store unchanged).
- Single `--merge`: preserved + loud ⚠ line; new explicit `--override-reviewed` lands them (`--force` does NOT).
- Full-rebuild (supersede) lane: **refuses** when the store holds human-touched rows, pointing at `--merge`/`--override-reviewed`.
- `ready_partial` clean-subset lane: preserves unconditionally (wave-1 agents cannot strip a reviewer stamp).
- TM denylist clearing now also skips protected subcards.

## 2. Writer census — all 17 non-promote store writers now locked
New shared [`src/store_write.py`](https://github.com/gasyoun/SanskritLexicography/blob/h2146-overlay-preserving-promote/RussianTranslation/src/store_write.py): `locked_store_rewrite` = `PromoteClaim` across the read-guard-write window + unique fsynced O_EXCL backup + atomic LF-only replace; payload serialization unchanged per caller.

| Writer | Before | After |
|---|---|---|
| annotate_citation_edges / edition_rel / form_labels / government / dcs_freq / evidence / stats (7) | in-place rewrite, fixed `.bak` `os.replace`d away, **no lock, non-atomic** | `locked_store_rewrite` |
| annotate_genres / annotate_renou (2) | tmp+replace, **no lock, no backup** | `locked_store_rewrite` |
| backfill_tn_residue | hash-gate + unique backup + atomic, **no lock** | + `PromoteClaim` around the window |
| mark_reconstructed_headwords | backup + fixed `.tmp` + replace, **no lock** | + `PromoteClaim` around the window |
| ru_style_sweep | verified backup + hash-race checks, **no lock** | + `PromoteClaim` (checks detect; lock prevents) |
| apply_editorial_decisions (the human-overlay writer) | fixed shared `.tmp`, **no lock, no backup, no fsync** | `locked_store_rewrite` |
| repair_h178_da_cards / fix_d4_boundary_wrap / fix_german_connectives / fix_wrapper_defects (4) | one-time fixed `.bak` + fixed `.tmp`, **no lock** | `locked_store_rewrite` (forensic first-state `.bak` kept) |

Grep census: zero remaining unlocked `'w'` writers of the canonical store (residual `'w'` hits are derivative-output builders). `annotate_government` also gains `canonical_store()` resolution (its lock would otherwise guard a worktree-local path).

## 3. Validation
- `python src/pilot/window_selftest.py` — **198/198** (incl. `test_lang_parity_ledger_complete` after re-derivation)
- `python src/promote_final_cards.py --selftest` — green incl. new overlay fixtures: approved/needs_review/editorial each protect; `--override-reviewed` lands; sibling subcards still merge; machine rows never self-protect; `ClaimBusy` raised under a held claim
- `python src/store_write.py --selftest` · `python src/promote_lock.py --selftest` · `python src/promote_en.py --selftest` — green
- LANG_PARITY: `promotion_scripts_separate` re-derived, **INTENTIONAL-DIVERGENCE stands** (EN attach replaces no rows; residual en-attach-onto-approved question noted on #976); 0 language-keyed tokens in the src/ diff; 23 drifted entries re-stamped; ledger check: 90 entries clean.
- Fixture stores only — **no canonical-store write, no paid call**.

Also: CHANGELOG 1.120.0 + CITATION.cff bump (tag after merge), `.ai_state.md` journal entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)