### PR TITLE
H2144: D4b bracket-normalize unlock for the 63-row PWG fullwidth-paren residual

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -3340,6 +3340,28 @@ batch [_batch_h1624_dh_followups.tsv](https://github.com/gasyoun/Uprava/blob/mai
   parity ledger 17 entries re-derived (0 language-keyed diff tokens). No canonical-store
   write.
 
+- **H2144 D4b bracket-normalize unlock for the 63-row PWG fullwidth-paren residual
+  (02-08-2026, Sonnet 5 `claude-sonnet-5`)** — extends
+  [d4_boundary_wrap.try_boundary_wrap](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/d4_boundary_wrap.py)
+  with an opt-in `normalize_brackets` param (default `False`, zero behavior change) that
+  treats DE's fullwidth/CJK corner-bracket numbering marker as equivalent to RU's ASCII
+  parens before the exact-affix check, per the adjudication in
+  [H1702_SONNET_DUAL_RUN_COMPARE_2026-08-01.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1702_SONNET_DUAL_RUN_COMPARE_2026-08-01.md).
+  Comparison-only normalization always splices from RU's own bytes, so its native bracket
+  form is never rewritten. Hand-checked all 63 newly-eligible rows (full population, not a
+  sample) — 100% clean, no anchor/citation swallowing. Applied to the live store:
+  `ru_n==0` residual 1,109 -> 1,046. New apply script
+  [fix_d4b_bracket_normalize.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/fix_d4b_bracket_normalize.py)
+  (dry-run/`--store`, uses H2146's `locked_store_rewrite`). Report:
+  [H1702_D4B_BRACKET_NORMALIZE_REPORT_2026-08-02.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1702_D4B_BRACKET_NORMALIZE_REPORT_2026-08-02.md).
+  Also fixed a missing `store_write` import in
+  [annotate_renou.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/annotate_renou.py)
+  inherited from H2146 (PR #980) that broke `master`'s own Python-lint CI (ruff F821) —
+  unrelated to H2144's scope, fixed only because it blocked this PR's merge gate. PR
+  [#981](https://github.com/gasyoun/SanskritLexicography/pull/981). `window_selftest`
+  **199/199**, `pytest` **96/96**, `lang_parity_check` clean (0 drift), ruff `E9,F63,F7,F82`
+  clean repo-wide.
+
 - **H2146 overlay-preserving promote + store-writer lock discipline (02-08-2026, Fable 5
   `claude-fable-5`)** — closes the H2025 audit's top gaps G1+G6
   ([#976](https://github.com/gasyoun/SanskritLexicography/issues/976), FINDINGS §513).

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,9 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Fixed
+- **H2144 D4b bracket-normalize unlock for the 63-row PWG fullwidth-paren residual (02-08-2026, Sonnet 5 `claude-sonnet-5`):** extends [`d4_boundary_wrap.try_boundary_wrap`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/d4_boundary_wrap.py) with an opt-in `normalize_brackets` param (default `False`, zero behavior change for existing rows) that treats DE's fullwidth/CJK corner-bracket numbering marker as equivalent to RU's ASCII parens before the exact-affix check, per the adjudication in [H1702_SONNET_DUAL_RUN_COMPARE_2026-08-01.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1702_SONNET_DUAL_RUN_COMPARE_2026-08-01.md). The comparison-only normalization always splices from RU's own bytes, so its native bracket form is never rewritten into DE's. Hand-checked all 63 newly-eligible rows (full population) — 100% clean, no anchor/citation swallowing. Applied to the live store: `ru_n==0` residual 1,109 -> 1,046. New apply script [`fix_d4b_bracket_normalize.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/fix_d4b_bracket_normalize.py) uses H2146's `locked_store_rewrite`. Report: [H1702_D4B_BRACKET_NORMALIZE_REPORT_2026-08-02.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1702_D4B_BRACKET_NORMALIZE_REPORT_2026-08-02.md). Also fixed a missing `store_write` import in `annotate_renou.py` inherited from H2146 that broke `master`'s own Python-lint CI. PR [#981](https://github.com/gasyoun/SanskritLexicography/pull/981).
+
 ## [1.125.0] - 2026-08-02
 
 ### Fixed

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "f4ea220f7dd4c503adf3c36f7c7b345785982a1f96aa5d8c65fa55f7a3c5a90e",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -131,7 +131,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pwg_mask.py": "f4ea220f7dd4c503adf3c36f7c7b345785982a1f96aa5d8c65fa55f7a3c5a90e",
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -154,7 +154,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/headless_worker.py": "a754caf055c0592013311a299ed9d0d8c7c0c278693a7f583684050de0c52588",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -209,7 +209,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -228,7 +228,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -431,7 +431,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -488,7 +488,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -547,7 +547,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/perf_preflight.py": "bc03b5b9878e526d3ffd9d2e5352bd1c1bcf69c8961ac37d673bafb9d6bf645b",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -578,7 +578,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -597,7 +597,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -615,7 +615,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "323af2fa393955f320d534111a92cf14270bb78c1044252b5858e7c39e8047ea",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -634,7 +634,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "d7c8da35c6a420b9f9431dd1cb672ed12431e2b27830b9b560a60cff42509eec",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -764,7 +764,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -789,7 +789,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -818,7 +818,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -838,7 +838,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "3ba83e6475c856cdc58a68526f2a0a5baa208754abd789dc3e3ec14e71bb9258",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -857,7 +857,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "a060e34e1733fb6469653f05bafab2756dfcca026f7324c83c9186808a21f9e6",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -894,7 +894,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "3ba83e6475c856cdc58a68526f2a0a5baa208754abd789dc3e3ec14e71bb9258",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -952,7 +952,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "3ba83e6475c856cdc58a68526f2a0a5baa208754abd789dc3e3ec14e71bb9258",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -971,7 +971,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -990,7 +990,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -1010,7 +1010,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86",
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -1032,7 +1032,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -1091,7 +1091,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -1152,7 +1152,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -1171,7 +1171,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -1196,7 +1196,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
       "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -1218,7 +1218,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86",
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9",
       "src/pilot/accept_sensecount_test.js": "fbf8d37f8ae360c286f646361025d56adb0caeff09da30a0abfef5f6b7289937"
     }
   },
@@ -1238,7 +1238,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -1293,7 +1293,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -1468,7 +1468,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "9184e1859428312866623e25bd1e1e8a1b08bec773cc339303a1f4fcd7fbc64f",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86",
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9",
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1749,7 +1749,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86",
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9",
       "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f"
     }
   },
@@ -1858,7 +1858,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "codex/rt-pipeline-hardening-speed",
     "verified_sha256": {
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   },
   {
@@ -1965,7 +1965,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/window_common.py": "3a8a51917c9b898d9b3d262aaf9339e14fb30cddbb507242266858aec8727331",
       "src/pipeline_version.py": "b461d0c78b5df3f598007eb1e7ee284d84596ae19b5106d5329fdab1a93f00be",
       "src/pilot/h1339_offline_bench.py": "970ad8ab948c4aae724efc2076883e21a5bfc7e203ed1c68b5fbb14f3bdbb8cd",
-      "src/pilot/window_selftest.py": "675d06dbe7d8a40a8da705c45bce747fe276d68e697c9e63146445e29baaeb86"
+      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
     }
   }
 ]

--- a/RussianTranslation/pwg_ru/H1702_D4B_BRACKET_NORMALIZE_REPORT_2026-08-02.md
+++ b/RussianTranslation/pwg_ru/H1702_D4B_BRACKET_NORMALIZE_REPORT_2026-08-02.md
@@ -1,0 +1,89 @@
+# H1702 D4b — bracket-normalize unlock for the 63-row fullwidth-paren residual subclass
+
+_Created: 02-08-2026 · Last updated: 02-08-2026_
+
+**Handoff:** [H2144](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2144-Sonnet_SanskritLexicography_h1702-d4b-bracket-normalize-unlock_01.08.26.md)
+· Model: Sonnet 5 (`claude-sonnet-5`) · Follows the adjudication in
+[H1702_SONNET_DUAL_RUN_COMPARE_2026-08-01.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1702_SONNET_DUAL_RUN_COMPARE_2026-08-01.md)
+§ Adjudication, which parked this exact 63-row unlock as report-only pending its own
+hand-checked precision sample.
+
+## What this does
+
+Extends `d4_boundary_wrap.try_boundary_wrap` with an opt-in `normalize_brackets` parameter
+(default `False`, so the H1702 exact-affix fixer's existing behavior and already-passing
+rows are unchanged). When `True`, the prefix/suffix affix comparison treats DE's
+fullwidth/CJK corner-bracket numbering marker (`〉`/`）`) as equivalent to RU's plain ASCII
+(`)`/`(`) on both sides before the exact-affix check — the same equivalence table
+(`BRACKET_NORMALIZE`) H2136's probe used, now promoted from a read-only probe into the
+production code path with its own guard.
+
+**Comparison-only, never rewrites stored content:** `BRACKET_NORMALIZE` is a strict 1:1,
+length-preserving character map (each bracket char maps to exactly one ASCII char), so it
+is used only to decide whether an affix *matches* — the actual prefix/suffix/candidate text
+spliced into the result is always sliced from RU's own original (non-normalized) string.
+A stronger guarantee than the handoff asked for: the code was additionally changed so the
+splice uses RU's own prefix/suffix bytes (`gap_ru[:len(prefix)]` /
+`gap_ru[len(gap_ru)-len(suffix):]`) rather than DE's, so RU's native bracket character
+survives untouched in every case — confirmed in all 63 hand-checked rows below.
+
+New apply script, modeled on the existing `fix_d4_boundary_wrap.py` --store/--dry-run/
+`.h1702.bak` convention:
+[`fix_d4b_bracket_normalize.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/fix_d4b_bracket_normalize.py).
+It scans only the pool that plain (`normalize_brackets=False`) `try_boundary_wrap` already
+refuses, re-tries each with `normalize_brackets=True`, and reports/applies only the newly
+unlocked subset — it never touches a row the exact-affix fixer already accepts.
+
+## Results
+
+| metric | value |
+|---|---:|
+| store rows | 11,603 |
+| `ru_n==0` residual before this pass | 1,109 |
+| newly unlocked by bracket-normalize | **63** (matches H2136's probe count exactly, no drift) |
+| `ru_n==0` residual after apply | 1,046 |
+| mechanically eligible (default, post-apply) | 0 |
+| `window_selftest.py` | 199/199 (198 pre-existing + 1 new `test_h2144_d4b_bracket_normalize`) |
+| `pytest` | 96/96 |
+
+## Hand-check (63/63 — full population, not a sample)
+
+Population is small enough that "≥50" means "nearly all of it," so every one of the 63
+newly-eligible rows was read DE/RU/output, not just a sample.
+
+- **Boundary correctness (63/63):** every wrap places `{%...%}` exactly at DE's gloss-span
+  position, correctly mirroring numbering markers (`— N)`), dashes, asterisks, and
+  parenthetical grammar tags (`(<ab>Acc.</ab>)`) as prefix/suffix text outside the gloss.
+- **No anchor swallowing (63/63):** citations (`<ls>...`), abbreviations (`<ab>...`),
+  transliterations (`<is>...`), and the non-anchor `<lex>` tag (row `BAzita|...|2)`) all sit
+  outside every wrapped span.
+- **Bracket preservation confirmed (63/63):** in every row DE uses the fullwidth `〉` and RU
+  already used plain ASCII `)`; the applied output always keeps RU's own `)` — DE's `〉` is
+  never written into the stored RU text.
+- **Multi-gloss rows correctly split at each independent boundary** — two rows
+  (`gam|gam~~h0_zz_pw00|5`, `gam|gam~~h0_zz_pw00|X9.1`) have a second gloss slot elsewhere in
+  the row that itself needed no bracket normalization but was blocked at the whole-row level
+  by the *other* slot's bracket mismatch; both slots now wrap correctly without corrupting
+  the already-correct one.
+- **Translations spot-checked as semantically faithful** across the full 63 (German→Russian
+  correspondence).
+
+**Precision: 63/63 clean = 100%**, well above the ≥90% (≥57/63) bar.
+
+## Store write
+
+Applied via `python src/pilot/fix_d4b_bracket_normalize.py --store`. Per the existing
+`.h1702.bak` convention (shared with `fix_d4_boundary_wrap.py`), the backup is only taken if
+absent — `pwg_ru_translated.jsonl.h1702.bak` already existed from the original H1702 apply
+(26-07-2026) and was correctly left as the single anchor point for the whole H1702 fix
+family, not overwritten per-run.
+
+## Non-goals (honored)
+
+- No relaxation beyond the two bracket-equivalence pairs (`〉`/`）`→`)`, `〈`/`（`→`(`).
+- No re-translation, no D3 residual repair.
+- No change to already-passing rows — `normalize_brackets` defaults to `False`; a control
+  test (`test_h2144_d4b_bracket_normalize`) asserts identical output with the flag on vs.
+  off for an already-exact-match row.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/pilot/d4_boundary_wrap.py
+++ b/RussianTranslation/src/pilot/d4_boundary_wrap.py
@@ -81,6 +81,16 @@ ANCHOR_RE = re.compile(
 )
 BAD_CHARS = set('{}<>')
 
+# H2144: fullwidth/CJK corner-bracket numbering markers that PWG's DE column uses where
+# RU carries the plain ASCII equivalent (or vice versa). A one-to-one, length-preserving
+# char map -- used ONLY to decide whether an affix matches; the actual prefix/suffix text
+# written back to `ru` is always sliced from the ORIGINAL (non-normalized) string, so a
+# fullwidth bracket already present in `ru` is never silently rewritten to ASCII.
+BRACKET_NORMALIZE = str.maketrans({
+    '〉': ')', '）': ')',  # 〉 ）
+    '〈': '(', '（': '(',  # 〈 （
+})
+
 
 def split_by_anchors(text):
     """Return (gaps, anchors): len(gaps) == len(anchors) + 1."""
@@ -104,13 +114,22 @@ def is_ru_n0_candidate(de_text, ru_text):
     return de_n > 0 and ru_n == 0
 
 
-def try_boundary_wrap(de_text, ru_text):
+def try_boundary_wrap(de_text, ru_text, normalize_brackets=False):
     """Attempt the boundary-anchored wrap. Returns (ok: bool, result: str).
 
     On success, result is the repaired ru text. On failure, result is a short reason code
     (residual-d3-guillemet-present, gloss-span-crosses-anchor, anchor-mismatch,
     multi-gloss-in-gap, prefix-no-match, suffix-no-match, overlap, empty-candidate,
     bad-chars-in-candidate, no-gloss-found) -- never a guess.
+
+    H2144: when `normalize_brackets` is True, the prefix/suffix affix comparison treats
+    the fullwidth/CJK corner-bracket numbering markers in BRACKET_NORMALIZE as equivalent
+    to their ASCII counterparts on BOTH sides -- e.g. de's `e〉` matches ru's `e)`. This is
+    comparison-only: BRACKET_NORMALIZE is a 1:1, length-preserving char map, so the actual
+    prefix/suffix/candidate text spliced into the result is always sliced from the
+    ORIGINAL (non-normalized) `de_text`/`ru_text` -- a fullwidth bracket already present in
+    the stored gloss is never silently rewritten to ASCII. Default False keeps the H1702
+    fixer's existing exact-affix behavior (and its already-passing rows) unchanged.
     """
     de_text = de_text or ''
     ru_text = ru_text or ''
@@ -148,9 +167,15 @@ def try_boundary_wrap(de_text, ru_text):
             return False, 'multi-gloss-in-gap'
         prefix, _gloss_de, suffix = GLOSS_SPAN.split(gap_de)
         gap_ru = gaps_ru[i]
-        if not gap_ru.startswith(prefix):
+        if normalize_brackets:
+            prefix_cmp = prefix.translate(BRACKET_NORMALIZE)
+            suffix_cmp = suffix.translate(BRACKET_NORMALIZE)
+            gap_ru_cmp = gap_ru.translate(BRACKET_NORMALIZE)
+        else:
+            prefix_cmp, suffix_cmp, gap_ru_cmp = prefix, suffix, gap_ru
+        if not gap_ru_cmp.startswith(prefix_cmp):
             return False, 'prefix-no-match'
-        if not gap_ru.endswith(suffix):
+        if not gap_ru_cmp.endswith(suffix_cmp):
             return False, 'suffix-no-match'
         if len(gap_ru) < len(prefix) + len(suffix):
             return False, 'overlap'
@@ -159,7 +184,14 @@ def try_boundary_wrap(de_text, ru_text):
             return False, 'empty-candidate'
         if BAD_CHARS & set(candidate):
             return False, 'bad-chars-in-candidate'
-        new_gaps_ru[i] = prefix + '{%' + candidate + '%}' + suffix
+        # Splice using RU's OWN prefix/suffix bytes, not DE's. Under exact-affix matching
+        # (normalize_brackets=False) the two are guaranteed byte-identical, so this is a
+        # no-op for existing rows. Under bracket-normalize matching they may differ only in
+        # bracket form (e.g. de `e〉` / ru `e)`) -- using ru's own slice keeps ru's native
+        # bracket character untouched, so only the added {%...%} markers are new content.
+        ru_prefix = gap_ru[:len(prefix)]
+        ru_suffix = gap_ru[len(gap_ru) - len(suffix):] if suffix else ''
+        new_gaps_ru[i] = ru_prefix + '{%' + candidate + '%}' + ru_suffix
 
     if not any_gloss:
         return False, 'no-gloss-found'

--- a/RussianTranslation/src/pilot/fix_d4b_bracket_normalize.py
+++ b/RussianTranslation/src/pilot/fix_d4b_bracket_normalize.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""H2144: D4b bracket-normalize unlock for the D4 `ru_n==0` residual subclass.
+
+H2136's bracket-normalize probe found 63 of the 1,109 residual `ru_n==0` rows refused by
+d4_boundary_wrap.try_boundary_wrap ONLY because DE uses a fullwidth/CJK corner-bracket
+numbering marker (`〉`/`）`) where RU carries the plain ASCII `)` equivalent (or
+the reverse pairing) -- a punctuation-only affix mismatch, not a genuine boundary
+ambiguity. This script scans the SAME ineligible pool that plain (non-normalized)
+try_boundary_wrap refuses, re-tries each with normalize_brackets=True, and reports (or
+applies) only the newly-unlocked subset -- it never touches a row that plain
+try_boundary_wrap already accepts or that bracket-normalize still refuses.
+
+  python src/pilot/fix_d4b_bracket_normalize.py            # dry-run report (default)
+  python src/pilot/fix_d4b_bracket_normalize.py --store    # apply to the live store
+"""
+import argparse
+import json
+import os
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = os.path.dirname(HERE)
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+from d4_boundary_wrap import is_ru_n0_candidate, try_boundary_wrap  # noqa: E402
+
+
+def run_store(dry=True):
+    from store_path import canonical_store
+    default_local = os.path.join(SRC, 'pwg_ru_translated.jsonl')
+    store = canonical_store(default_local)
+    if not os.path.exists(store):
+        sys.exit('STORE ABSENT: %s' % store)
+
+    rows = []
+    with open(store, encoding='utf-8') as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if line:
+                rows.append(json.loads(line))
+
+    newly_unlocked = []
+    still_refused = {}
+    for r in rows:
+        de = r.get('de') or ''
+        ru = r.get('ru') or ''
+        if not is_ru_n0_candidate(de, ru):
+            continue
+        label = '%s|%s|%s' % (r.get('key1'), r.get('subcard'), r.get('sense_tag'))
+        ok_plain, _ = try_boundary_wrap(de, ru)
+        if ok_plain:
+            # Already handled by the H1702 exact-affix fixer -- out of scope here.
+            continue
+        ok_norm, result_norm = try_boundary_wrap(de, ru, normalize_brackets=True)
+        if ok_norm:
+            newly_unlocked.append((r, label, result_norm))
+            if not dry:
+                r['ru'] = result_norm
+        else:
+            still_refused.setdefault(result_norm, []).append(label)
+
+    print('D4B BRACKET NORMALIZE %s' % ('(DRY RUN)' if dry else ''))
+    print('store                          : %s' % store)
+    print('rows                           : %d' % len(rows))
+    print('newly unlocked                 : %d' % len(newly_unlocked))
+    print('still refused                  : %d' % sum(len(v) for v in still_refused.values()))
+    for reason, labels in sorted(still_refused.items(), key=lambda x: -len(x[1])):
+        print('  %-25s %d' % (reason, len(labels)))
+    for _r, label, result in newly_unlocked:
+        print('  UNLOCKED: %s -> %s' % (label, result[:120]))
+
+    if not dry and newly_unlocked:
+        # H2146: locked (PromoteClaim) + unique per-run backup + atomic replace, same
+        # convention as fix_d4_boundary_wrap.py -- an unlocked '.tmp' rewrite here would
+        # be the same last-writer-wins hazard FINDINGS §513 fixed for the sibling fixer.
+        from store_write import locked_store_rewrite
+        locked_store_rewrite(store, rows, tag='h2144fix')
+        print('wrote                          : %s' % store)
+
+    return {
+        'rows_unlocked': len(newly_unlocked),
+        'rows_still_refused': sum(len(v) for v in still_refused.values()),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--store', action='store_true', help='apply to the live store (default: dry-run)')
+    args = parser.parse_args()
+    run_store(dry=not args.store)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -1870,6 +1870,57 @@ def test_h1702_boundary_wrap_gate():
         fail('H1702: expected gloss-span-crosses-anchor, got %r' % (reason6,))
 
 
+def test_h2144_d4b_bracket_normalize():
+    """H2144: D4b bracket-normalize unlock. de's fullwidth/CJK corner-bracket numbering
+    marker (e.g. `〉`) and ru's plain ASCII equivalent (`)`) must be treated as the same
+    affix boundary when normalize_brackets=True, WITHOUT rewriting ru's own bracket
+    character into de's form and WITHOUT changing default (normalize_brackets=False)
+    behavior at all."""
+    from d4_boundary_wrap import try_boundary_wrap
+
+    # POSITIVE: de uses the fullwidth corner bracket, ru already uses plain ASCII ")" --
+    # refused by default (exact-affix), unlocked under normalize_brackets=True, and ru's
+    # own ")" is preserved verbatim in the result (not rewritten to de's "〉").
+    de = '<div n="2">— e〉 {%zum Vorschein gekommen%}.'
+    ru = '<div n="2">— e) появившийся.'
+    ok_default, reason_default = try_boundary_wrap(de, ru)
+    if ok_default:
+        fail('H2144: bracket-mismatched affix must be refused by default (normalize_brackets=False)')
+    if reason_default != 'prefix-no-match':
+        fail('H2144: expected prefix-no-match by default, got %r' % (reason_default,))
+    ok_norm, result_norm = try_boundary_wrap(de, ru, normalize_brackets=True)
+    want = '<div n="2">— e) {%появившийся%}.'
+    if not ok_norm or result_norm != want:
+        fail('H2144: bracket-normalize wrap did not reproduce the expected wrap (ru bracket must survive verbatim): %r' % (result_norm,))
+
+    # POSITIVE (reverse pairing): de uses ASCII, ru uses the fullwidth bracket -- ru's own
+    # fullwidth bracket must survive the wrap untouched.
+    de_rev = '<div n="2">— e) {%zum Vorschein gekommen%}.'
+    ru_rev = '<div n="2">— e〉 появившийся.'
+    ok_rev, result_rev = try_boundary_wrap(de_rev, ru_rev, normalize_brackets=True)
+    want_rev = '<div n="2">— e〉 {%появившийся%}.'
+    if not ok_rev or result_rev != want_rev:
+        fail('H2144: reverse bracket-normalize wrap must preserve ru\'s fullwidth bracket verbatim: %r' % (result_rev,))
+
+    # CONTROL: an already-exact-match row must produce an IDENTICAL result under
+    # normalize_brackets=True as under the default -- the flag must never change behavior
+    # for rows that did not need it.
+    de_exact = '<div n="2">— 2〉 {%an sich nehmen%}.'
+    ru_exact = '<div n="2">— 2〉 принимать на себя.'
+    ok_a, result_a = try_boundary_wrap(de_exact, ru_exact)
+    ok_b, result_b = try_boundary_wrap(de_exact, ru_exact, normalize_brackets=True)
+    if not (ok_a and ok_b and result_a == result_b):
+        fail('H2144: normalize_brackets=True must not change the outcome for an already-exact-match row')
+
+    # NEGATIVE: a genuine (non-bracket) affix mismatch stays refused even with
+    # normalize_brackets=True -- the flag only widens bracket equivalence, nothing else.
+    de_bad = '<div n="1">— 2〉 {%an sich nehmen%}.'
+    ru_bad = 'принимать на себя.'
+    ok_bad, reason_bad = try_boundary_wrap(de_bad, ru_bad, normalize_brackets=True)
+    if ok_bad:
+        fail('H2144: a dropped-<div>-prefix row must still be refused under normalize_brackets=True: %r' % (reason_bad,))
+
+
 def test_semantic_review_prioritizer():
     high = {
         'key': 'high',
@@ -8531,6 +8582,7 @@ def main():
         test_h1651_wrapper_defect_gate,
         test_h1651_live_gate_cyrillic_and_guillemet,
         test_h1702_boundary_wrap_gate,
+        test_h2144_d4b_bracket_normalize,
         test_semantic_review_prioritizer,
         test_noisy_source_type_not_requeue,
         test_report_only_risks_never_requeue,


### PR DESCRIPTION
## Summary
- Handoff: [H2144](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2144-Sonnet_SanskritLexicography_h1702-d4b-bracket-normalize-unlock_01.08.26.md) — extends the H1702 D4 boundary-anchor fixer to treat DE's fullwidth/CJK corner-bracket numbering marker (`〉`/`）`) as equivalent to RU's ASCII `)`/`(` before the exact-affix check, per the adjudication in [H1702_SONNET_DUAL_RUN_COMPARE_2026-08-01.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1702_SONNET_DUAL_RUN_COMPARE_2026-08-01.md).
- `try_boundary_wrap` gains an opt-in `normalize_brackets` param (default `False`, zero behavior change for existing rows); the comparison-only normalization always splices from RU's own bytes so its native bracket form is never rewritten.
- Applied to the live store after a full hand-check (not a sample) of all 63 newly-eligible rows: 100% clean, no anchor/citation swallowing. `ru_n==0` residual: 1,109 -> 1,046.
- Full report: [H1702_D4B_BRACKET_NORMALIZE_REPORT_2026-08-02.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1702_D4B_BRACKET_NORMALIZE_REPORT_2026-08-02.md)

## Test plan
- [x] `python src/pilot/window_selftest.py` — 199/199 (198 pre-existing + 1 new `test_h2144_d4b_bracket_normalize`)
- [x] `python -m pytest` — 96/96
- [x] `python src/pilot/lang_parity_check.py` — clean, no drift
- [x] Dry-run confirmed exactly 63 newly-eligible rows (matches H2136's probe, no drift)
- [x] Hand-checked all 63 rows (full population, not a sample) — 63/63 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
