### PR TITLE
diag(pwg_ru): the heal lane cannot finish inside its own 3-minute ceiling

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,12 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added
+- **`src/pilot/reservation_timeline.py` — difference the ledger's `time_ns` stamps (02-08-2026, Opus 5 1M `claude-opus-5[1m]`):** H2056 Q2 noted `call_reservation.py` persists wall stamps that nothing differences. That gap is load-bearing, because an unevaluable call finalizes through `unevaluable_telemetry()` with no `duration_ms` at all — so its duration exists nowhere else, and "hung to the ceiling" cannot be told from "failed fast". Read-only reporter over an existing ledger; zero paid calls.
+
+### Fixed
+- *(diagnosis, no code change)* **medium50 w1 aborted — the heal lane cannot finish inside its own 3-minute ceiling (02-08-2026, Opus 5 1M `claude-opus-5[1m]`):** first paid run since 25-07 produced **zero cards** in 16 calls. Differencing the stamps put **12 of 16 calls at 180 04x–180 23x ms**, i.e. `HARD_TIMEOUT_MS = 180000` hit to the millisecond — a hard-timeout wall, not the §270 rate-limit hang and not content failure. It cannot be tuned at the group level: heal groups are already at the floor (six of `nakzatra`'s eight hold a **single fragment**) and single-fragment calls still time out, because one fragment's heal call burns **199 370 subagent tokens**. Successful calls ran 120.4→164.3 s, i.e. 67 %→**91 %** of budget, so the margin is gone and shrinking. Recorded `$2.1543` is a **floor** ([#949](https://github.com/gasyoun/SanskritLexicography/issues/949)) — the 12 dead calls burned real compute and contributed 0. Measured **~$0.53/call vs the $0.113** `perf_preflight` prices with (4.7×). Raising the ceiling is a human decision: `HARD_TIMEOUT_MS` carries the standing in-code ruling `"NOTHING runs past 3 min (MG)"` (R4/C-15). Table: [`RESULTS_LOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md).
+
 ## [1.120.0] - 2026-08-02
 
 ### Fixed

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -1,8 +1,69 @@
 # RussianTranslation — results log
 
-_Created: 09-07-2026 · Last updated: 01-08-2026_
+_Created: 09-07-2026 · Last updated: 02-08-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
+
+## 02-08-2026 — medium50 w1 aborted: the heal lane cannot finish inside its own 3-minute ceiling
+
+Opus 5 1M (`claude-opus-5[1m]`), live paid run on c4 (`h1447-m50-2026-08-02`), **16 calls,
+run stopped by the operator after 2 of 3 keys, ZERO cards produced**. The first paid PWG→RU
+attempt since 25-07-2026. Health gate had PASSed the same night (entry below); the Step 2
+canary was **not** run, so this window ran on a half-satisfied gate.
+
+### Per-call timeline (`src/pilot/reservation_timeline.py`, new)
+
+| bucket | n | min | median | max |
+|---|---|---|---|---|
+| evaluable | 4 | 120 375 ms | 134 511 ms | 164 266 ms |
+| **UNEVALUABLE** | **12** | 18 845 ms¹ | **180 128 ms** | **180 231 ms** |
+
+¹ the single sub-ceiling row is the in-flight call killed by the operator stop.
+
+**Every other unevaluable call landed at 180 04x–180 23x ms — `HARD_TIMEOUT_MS = 180000`, hit
+to the millisecond.** This is a hard-timeout wall, not the FINDINGS §270 rate-limit hang (a
+throttled CLI hangs *without* returning; these were killed by our own ceiling) and not content
+failure. Route health was fine, exactly as the gate measured.
+
+### Why it cannot be tuned away at the group level
+
+The heal groups are **already at the floor** — splitting further is arithmetically impossible:
+
+| key | groups | fragment sizes |
+|---|---|---|
+| `nakzatra` | 8 | 1, 1, 1, 1, 1, 1, 2, 2 |
+| `sarvatra` | 7 | 1, 1, 1, 1, 1, 1, 3 |
+| `sakft` | 6 | 1, 1, 1, 1, 1, 7 |
+
+Six of `nakzatra`'s eight groups hold a **single fragment**, and single-fragment heal calls
+still time out. The whole-card batches `b0` and `b1` timed out too, so it is not lane-specific.
+The cost is per-call overhead, not content: one heal call for **one fragment** burned
+**199 370 subagent tokens**. Lowering `SELFHEAL_GROUP_BUDGET` therefore cannot fix this.
+
+### The margin is gone, and shrinking
+
+Successful calls: 120.4 s → 132.0 s → 134.5 s → **164.3 s**, i.e. 67 % → **91 %** of the 180 s
+budget. Any call above the median dies. That is the mechanical answer to H818's owner brief
+("1 month, nothing works, I want to start translating").
+
+### Spend
+
+`observed_cost_usd` = **$2.1543** with `cost_evaluable=false` — a **floor, not the spend**
+([#949](https://github.com/gasyoun/SanskritLexicography/issues/949)). The 12 unevaluable calls
+were real paid spawns that each burned up to a full 180 s of subagent compute and contributed
+**0** to that total. 609 106 subagent tokens are recorded across the 4 evaluable calls alone
+(~152 k each). **75 % of the calls, and the majority of real spend, produced nothing.**
+
+Measured per-call cost on the evaluable calls is **~$0.53**, against the `PER_AGENT_USD_HEALTHY
+= $0.113` that `perf_preflight` prices windows with — 4.7×. The preflight put w1 at $0.46.
+
+⚠️ `HARD_TIMEOUT_MS` carries an explicit standing ruling in code — `"NOTHING runs past 3 min
+(MG)"` (R4/C-15) — so raising the ceiling is a human decision, not a tuning fix. The open
+options are all human: relax that ruling, cut per-call overhead (the ~25–30 k framework prompt
+plus subagent scaffolding), or accept partial cards.
+
+⚠️ Raw ledger is gitignored (`.gitignore:67`); this table and the timeline tool are the only
+committed record.
 
 ## 01-08-2026 (later) — the first decomposed c4 readings; c4 auth restored
 

--- a/RussianTranslation/src/pilot/reservation_timeline.py
+++ b/RussianTranslation/src/pilot/reservation_timeline.py
@@ -1,0 +1,111 @@
+"""Difference the call-reservation ledger's `time_ns` stamps into a per-call timeline.
+
+Why this exists
+---------------
+H2056 Q2 observed that `call_reservation.py` persists wall `time.time_ns()` stamps that
+**nothing differences**. That gap matters precisely for the calls you most need to explain:
+a call with no CLI envelope finalizes through `unevaluable_telemetry()`, which carries no
+`duration_ms` at all, so an unevaluable call has its duration recorded *nowhere else*. Wall
+`reserved_at_ns` -> `finalized_at_ns` is the only surviving signal, and differencing it is
+what separates "hung to the ceiling" from "failed fast" -- two conditions with opposite
+remedies that are otherwise indistinguishable in every artifact the run leaves behind.
+
+It was written after a medium50 window recorded 12 unevaluable calls in 16: differencing the
+stamps put every one of them at 180 04x-180 23x ms against `HARD_TIMEOUT_MS = 180000`, i.e.
+a hard-timeout wall rather than the rate-limit hang of FINDINGS 270 or a content failure.
+Nothing in the wf output, the status file or the usage summary showed that.
+
+Read-only; it opens the ledger and prints. Usage:
+
+    python src/pilot/reservation_timeline.py <ledger.json> [run_id]
+
+`run_id` defaults to the lexically last run in the file.
+"""
+import json
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+
+HEADER = '%-4s %-18s %-26s %-9s %9s %9s %9s %10s'
+EVALUABLE_LABEL = {True: 'yes', False: 'NO', None: 'in-flight'}
+
+
+def load_run(path, run_id=None):
+    with open(path, encoding='utf-8') as handle:
+        data = json.load(handle)
+    runs = data.get('runs') or {}
+    if not runs:
+        raise SystemExit('ledger has no runs: %s' % path)
+    if run_id is None:
+        run_id = sorted(runs)[-1]
+    if run_id not in runs:
+        raise SystemExit('run_id %r not in ledger (have: %s)' % (run_id, ', '.join(sorted(runs))))
+    return run_id, runs[run_id]
+
+
+def wall_ms(row):
+    start, end = row.get('reserved_at_ns'), row.get('finalized_at_ns')
+    if not start or not end:
+        return None
+    return (end - start) // 1_000_000
+
+
+def report(run_id, run):
+    rows = run.get('reservations') or []
+    print('run_id      : %s' % run_id)
+    print('max_calls   : %s' % run.get('max_calls'))
+    print('reservations: %d' % len(rows))
+    print()
+    print(HEADER % ('#', 'purpose', 'detail', 'evaluable', 'wall_ms', 'dur_ms', 'api_ms', 'usd'))
+    print('-' * 104)
+
+    buckets = {True: [], False: []}
+    subagent_total = 0
+    for row in rows:
+        tel = row.get('telemetry') or {}
+        evaluable = tel.get('cost_evaluable')
+        wall = wall_ms(row)
+        if wall is not None and evaluable is not None:
+            buckets[bool(evaluable)].append(wall)
+        subagent_total += tel.get('subagent_tokens') or 0
+        cost = tel.get('observed_cost_usd')
+        print(HEADER % (
+            row.get('ordinal'),
+            (row.get('purpose') or '')[:18],
+            (row.get('detail') or '')[:26],
+            EVALUABLE_LABEL[evaluable],
+            wall if wall is not None else '-',
+            tel.get('duration_ms') or '-',
+            tel.get('duration_api_ms') or '-',
+            ('%.4f' % cost) if cost else '-',
+        ))
+
+    print()
+    for flag, label in ((True, 'evaluable'), (False, 'UNEVALUABLE')):
+        vals = sorted(buckets[flag])
+        if vals:
+            print('%-12s n=%-3d min=%6d  median=%6d  max=%6d ms'
+                  % (label, len(vals), vals[0], vals[len(vals) // 2], vals[-1]))
+
+    finalized = len(buckets[True]) + len(buckets[False])
+    print()
+    print('unevaluable calls : %d of %d finalized' % (len(buckets[False]), finalized))
+    print('subagent tokens   : %d total' % subagent_total)
+    usage = run.get('usage') or {}
+    print('recorded floor    : $%.4f  (cost_evaluable=%s)'
+          % (usage.get('observed_cost_usd') or 0, usage.get('cost_evaluable')))
+    if buckets[False]:
+        print()
+        print('NOTE: the recorded cost is a FLOOR. Each unevaluable call was a real paid spawn')
+        print('      that produced no envelope, so it contributes 0 to the total (issue #949).')
+
+
+def main():
+    if len(sys.argv) < 2:
+        raise SystemExit(__doc__)
+    run_id, run = load_run(sys.argv[1], sys.argv[2] if len(sys.argv) > 2 else None)
+    report(run_id, run)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
First paid PWG→RU run since 25-07-2026. **16 calls, zero cards.** Operator-stopped after 2 of 3 keys. Diagnosis only — no constant moved, no ceiling changed.

## The tool this needed

H2056 Q2 observed that `call_reservation.py` persists wall `time.time_ns()` stamps that **nothing differences**. That gap turns out to be load-bearing: a call with no CLI envelope finalizes through `unevaluable_telemetry()`, which carries **no `duration_ms` at all** — so an unevaluable call's duration exists nowhere else in any artifact, and "hung to the ceiling" is indistinguishable from "failed fast". Two conditions with opposite remedies.

New [`src/pilot/reservation_timeline.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/reservation_timeline.py) differences them. Read-only, zero paid calls. A grep first confirmed nothing else reads `reserved_at_ns`.

## What it found

| bucket | n | min | median | max |
|---|---|---|---|---|
| evaluable | 4 | 120 375 ms | 134 511 ms | 164 266 ms |
| **UNEVALUABLE** | **12** | 18 845 ms¹ | **180 128 ms** | **180 231 ms** |

¹ the one sub-ceiling row is the in-flight call killed by the operator stop.

**Every other unevaluable call landed at 180 04x–180 23x ms — `HARD_TIMEOUT_MS = 180000`, hit to the millisecond.** This is our own ceiling killing the calls. It is *not* the [FINDINGS §270](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md) rate-limit hang — a throttled CLI hangs *without returning*, whereas these were reaped by us — and it is not content failure. Route health was fine, matching the gate reading taken hours earlier.

## Why `SELFHEAL_GROUP_BUDGET` cannot fix it

The heal groups are **already at the arithmetic floor**:

| key | groups | fragment sizes |
|---|---|---|
| `nakzatra` | 8 | 1, 1, 1, 1, 1, 1, 2, 2 |
| `sarvatra` | 7 | 1, 1, 1, 1, 1, 1, 3 |
| `sakft` | 6 | 1, 1, 1, 1, 1, 7 |

Six of `nakzatra`'s eight groups hold a **single fragment**, and single-fragment heal calls still time out. You cannot split below one. The whole-card batches `b0` and `b1` timed out too, so it is not lane-specific.

The cost is **per-call overhead, not content**: one heal call for *one fragment* burned **199 370 subagent tokens**. This is Q5's fixed-per-call-overhead problem surfacing as a wall-clock failure.

## The margin is gone, and shrinking

Successful calls ran **120.4 s → 132.0 s → 134.5 s → 164.3 s** — 67 % → **91 %** of the 180 s budget. Any call above the median dies. That is the mechanical answer to H818's owner brief, *"1 month, nothing works, I want to start translating."*

## Spend

`observed_cost_usd = $2.1543` with `cost_evaluable=false` — a **floor, not the spend** ([#949](https://github.com/gasyoun/SanskritLexicography/issues/949)). The 12 unevaluable calls were real paid spawns, each burning up to a full 180 s of subagent compute, contributing **0**. 609 106 subagent tokens are recorded across the 4 evaluable calls alone. **75 % of calls, and the majority of real spend, produced nothing.**

Measured **~$0.53/call** against the `PER_AGENT_USD_HEALTHY = $0.113` that `perf_preflight` prices windows with — **4.7×**. The preflight put w1 at $0.46.

## Deliberately not done

`HARD_TIMEOUT_MS` carries a standing in-code ruling — `"NOTHING runs past 3 min (MG)"` (R4/C-15) — so **no constant was touched**. The remedies are all human decisions: relax that ruling, cut the per-call overhead (the ~25–30 k framework prompt plus subagent scaffolding), or accept partial cards. This PR records the measurement so the choice is made on data.

Also worth flagging: the window ran on a **half-satisfied gate** — health PASSed, the Step 2 canary was not run.

⚠️ The raw ledger is gitignored (`.gitignore:67`); the committed table and this tool are the only durable record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
