### PR TITLE
chore(release): 1.121.0 — heal-lane timeout wall diagnosis

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.121.0] - 2026-08-02
+
 ### Added
 - **`src/pilot/reservation_timeline.py` — difference the ledger's `time_ns` stamps (02-08-2026, Opus 5 1M `claude-opus-5[1m]`):** H2056 Q2 noted `call_reservation.py` persists wall stamps that nothing differences. That gap is load-bearing, because an unevaluable call finalizes through `unevaluable_telemetry()` with no `duration_ms` at all — so its duration exists nowhere else, and "hung to the ceiling" cannot be told from "failed fast". Read-only reporter over an existing ledger; zero paid calls.
 


### PR DESCRIPTION
Promotes `[Unreleased]` to **1.121.0** — mandatory same-pass follow-through for the changelog edit in [#982](https://github.com/gasyoun/SanskritLexicography/pull/982).

Ships the heal-lane hard-timeout diagnosis (12/16 paid calls killed at `HARD_TIMEOUT_MS`, zero cards, 75% of spend recorded as $0) and the new `reservation_timeline.py`. Tracking issue: [#983](https://github.com/gasyoun/SanskritLexicography/issues/983).

`v1.121.0` is tagged once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)