### PR TITLE
fix(pwg_ru): missing locked_store_rewrite import in annotate_renou (H2146 residual, F821)

### DIFF
--- a/RussianTranslation/src/annotate_renou.py
+++ b/RussianTranslation/src/annotate_renou.py
@@ -26,6 +26,7 @@ sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
 
 import renou
+from store_write import locked_store_rewrite
 
 STATES = renou.STATES
 


### PR DESCRIPTION
One-line follow-up to [#980](https://github.com/gasyoun/SanskritLexicography/pull/980): the H2146 writer retrofit converted [`annotate_renou.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/annotate_renou.py) `run()` to the locked writer but the import landed only in its twin `annotate_genres.py` — a latent `NameError` on any non-`--report` run, caught as **F821** by the `Python lint` CI job (which has been red on master since #980 without gating the merges). `ruff check --select=E9,F63,F7,F82 .` now passes repo-wide; module imports verified. Changelog: exempt as a same-window trivial correction — the 1.123.0 entry's description of the retrofit is accurate once this lands. Fable 5 (`claude-fable-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)