### PR TITLE
fix(pwg_ru): H2154 fail-closed occupied-keys guard vs duplicate paid window (H2025 G2)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.123.0
+version: 1.125.0
 date-released: 2026-08-02
 # The CONCEPT DOI — version-independent, always resolves to the newest release.
 # This is deliberately NOT a per-version DOI: those change every release and would

--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -3317,6 +3317,16 @@ batch [_batch_h1624_dh_followups.tsv](https://github.com/gasyoun/Uprava/blob/mai
 
 ## ✅ Completed (Recent only)
 
+- **H2154 fail-closed occupied-keys guard (02-08-2026, Fable 5 `claude-fable-5`)** —
+  H2025 gap G2 (census S1-1/S1-2): both orchestrator import paths now share
+  `occupied_keys(db)`, which ABORTS the import when a live job's manifest is
+  unreadable (was: silent zero-key contribution → duplicate paid window). Pinned by
+  `test_occupied_keys_guard_fails_closed_h2154`; orchestrator selftest green,
+  `window_selftest` **198/198**, parity 3 entries re-derived. No paid call, no store
+  write. With this, H2025's S1-class money gaps (G1/G2/G7) are all closed; remaining
+  memo gaps are G3–G5, G8–G10 (ceilings-mandatory, gate consumption, payload rows,
+  route check, doc truth pass, budget hygiene).
+
 - **H2153 content-mass promote gate + serializer unification (02-08-2026, Fable 5
   `claude-fable-5`)** — closes [#977](https://github.com/gasyoun/SanskritLexicography/issues/977)
   (H2025 gap G7). Forensics: the 1.29 MB shrink was serializer formatting only —

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,11 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.125.0] - 2026-08-02
+
+### Fixed
+- **Fail-closed occupied-keys guard (H2154, 02-08-2026, Fable 5 `claude-fable-5`):** H2025 audit gap G2 (census S1-1/S1-2, the lane's only remaining duplicate-paid-spend path). The scheduler's `occupied` set — keys owned by queued/running jobs — was built under a per-manifest `except: pass`, so an unreadable/renamed/mid-write manifest contributed **zero** keys, the overlap check passed, and the same headwords could dispatch into a **second paid window**. Both import paths (`cmd_import_coordinator`, `cmd_import_requeue`) now share one `occupied_keys(db)` helper that **aborts the import** naming the job + manifest when a live job's manifest cannot be read; terminal jobs with lost manifests stay ignorable, and the manifest read no longer leaks a file handle (the Windows sharing-violation class). Pinned by `test_occupied_keys_guard_fails_closed_h2154` (`max_account_orchestrator_selftest` green; `window_selftest` 198/198; parity 3 entries re-derived, 0 language-keyed diff tokens).
+
 ## [1.124.0] - 2026-08-02
 
 ### Added

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,6 +1,6 @@
 # LANG_PARITY.md — cross-language fix/feature parity ledger
 
-_Created: 04-07-2026 · Last updated: 02-08-2026 (H2153: 17 entries re-derived, verdicts stand — the promote gains a serializer-independent content-mass gate (`refuse_content_mass_shrink`, 10% bound) and the two compact-separator writers (`nws_ls_markup`, `backfill_tn_residue`) converge on the house spaced serialization + the locked writer; 0 language-keyed tokens in the diff, grounds mechanical as before. Previously H2146: `promotion_scripts_separate` re-derived, INTENTIONAL-DIVERGENCE stands — RU merge/supersede now overlay-preserving (`human_touched`, `--override-reviewed`), 17 mutators routed through the shared locked `store_write` writer; EN attach replaces no rows so the wipe class does not arise there. Previously H2118 #946: 6 entries re-derived across 5 files, SHARED stands — the probe latency ceiling is now derived from one table instead of three hard-coded copies, and the policy token carries its own ceiling again. Grounds re-checked mechanically, not asserted: every added line in the diff was grepped for a language-keyed token (`lang` / `russian` / `english` / `--lang` / `FIELD[` / `CARD_FIELD`) and **none** appears — the change is language-agnostic dispatch infrastructure that cannot reach the RU/EN split. Previously H2095 #946/#949/#950/#956: 45 entries re-derived, SHARED stands — probe rows carry the ceiling that judged them, `summary()` publishes cost evaluability beside `budget_spent`, the cost-gate calibration question settled with NO constant moved, and the EN auditor exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags, closing the EN twin of #947)_
+_Created: 04-07-2026 · Last updated: 02-08-2026 (H2154: 3 entries re-derived, verdicts stand — the occupied-keys guard fails closed on an unreadable live-job manifest; reads how a JOB is stored, never a target-language field; 0 language-keyed diff tokens. Previously H2153: 17 entries re-derived, verdicts stand — the promote gains a serializer-independent content-mass gate (`refuse_content_mass_shrink`, 10% bound) and the two compact-separator writers (`nws_ls_markup`, `backfill_tn_residue`) converge on the house spaced serialization + the locked writer; 0 language-keyed tokens in the diff, grounds mechanical as before. Previously H2146: `promotion_scripts_separate` re-derived, INTENTIONAL-DIVERGENCE stands — RU merge/supersede now overlay-preserving (`human_touched`, `--override-reviewed`), 17 mutators routed through the shared locked `store_write` writer; EN attach replaces no rows so the wipe class does not arise there. Previously H2118 #946: 6 entries re-derived across 5 files, SHARED stands — the probe latency ceiling is now derived from one table instead of three hard-coded copies, and the policy token carries its own ceiling again. Grounds re-checked mechanically, not asserted: every added line in the diff was grepped for a language-keyed token (`lang` / `russian` / `english` / `--lang` / `FIELD[` / `CARD_FIELD`) and **none** appears — the change is language-agnostic dispatch infrastructure that cannot reach the RU/EN split. Previously H2095 #946/#949/#950/#956: 45 entries re-derived, SHARED stands — probe rows carry the ceiling that judged them, `summary()` publishes cost evaluability beside `budget_spent`, the cost-gate calibration question settled with NO constant moved, and the EN auditor exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags, closing the EN twin of #947)_
 
 This repo runs the same PWG→Russian and PWG→English translation pipeline through
 shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
@@ -1121,10 +1121,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
       "src/pilot/headless_worker.py": "a754caf055c0592013311a299ed9d0d8c7c0c278693a7f583684050de0c52588",
-      "src/pilot/max_account_orchestrator.py": "733902a7410a4a8fce704252386106a2be21c7ffd5f6ab29c3372ffa80fb85ab",
+      "src/pilot/max_account_orchestrator.py": "7815732245d5c095d485e3d382a9865ce7e9fc8c2958299099e4ae695ca79ecb",
       "src/pilot/coordinator.py": "a060e34e1733fb6469653f05bafab2756dfcca026f7324c83c9186808a21f9e6",
       "src/pilot/headless_worker_selftest.py": "d1021cbe0e8263a1246824514b987b5301055259021d81c79ccaaebfce0897c3",
-      "src/pilot/max_account_orchestrator_selftest.py": "13cf76461cca502271eca951354c9bda7da3743d88526d273fb38e8f97c560b8",
+      "src/pilot/max_account_orchestrator_selftest.py": "543d8d2a2eb6e770a324b3e5b7cf6f8d61e12aa66225acdffcee6c124008be23",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "cb010a7452d1a68fb3a793c3d0ea77d1784eb158d985488cfd09177a1215515d",
       "src/pilot/run_observability.py": "ec64afa551a718aa33894a30b4ce738be1306792465953f60fd485b5b01d9c81",
@@ -1553,7 +1553,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/bounded_staged_run.py": "043a6ec7a29cd36181bf021aafdbe3f2f34e2ca2eddc71c0d4505d13dd45c29a",
       "src/pilot/bounded_supervisor.py": "b90fe5d634b832b1a9ce73d62ce4a19b2d74ceaee5a863f0469b156c9bdecc02",
-      "src/pilot/max_account_orchestrator.py": "733902a7410a4a8fce704252386106a2be21c7ffd5f6ab29c3372ffa80fb85ab"
+      "src/pilot/max_account_orchestrator.py": "7815732245d5c095d485e3d382a9865ce7e9fc8c2958299099e4ae695ca79ecb"
     }
   },
   {
@@ -1714,7 +1714,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/bounded_staged_run.py": "043a6ec7a29cd36181bf021aafdbe3f2f34e2ca2eddc71c0d4505d13dd45c29a",
       "src/pilot/bounded_supervisor.py": "b90fe5d634b832b1a9ce73d62ce4a19b2d74ceaee5a863f0469b156c9bdecc02",
-      "src/pilot/max_account_orchestrator.py": "733902a7410a4a8fce704252386106a2be21c7ffd5f6ab29c3372ffa80fb85ab",
+      "src/pilot/max_account_orchestrator.py": "7815732245d5c095d485e3d382a9865ce7e9fc8c2958299099e4ae695ca79ecb",
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
       "src/pilot/coordinator.py": "a060e34e1733fb6469653f05bafab2756dfcca026f7324c83c9186808a21f9e6",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",

--- a/RussianTranslation/src/pilot/max_account_orchestrator.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator.py
@@ -671,6 +671,32 @@ def cmd_enqueue(args):
         'so run/preflight/reservation/profile/result binding is mandatory')
 
 
+def occupied_keys(db):
+    """H2154 (H2025 census S1-1/S1-2): keys owned by queued/running jobs — FAIL-CLOSED.
+
+    The old inline loops swallowed ``(OSError, KeyError, JSONDecodeError)`` per
+    manifest, so an unreadable/renamed/mid-write manifest contributed ZERO keys,
+    the downstream overlap check passed, and the same headwords could be
+    dispatched into a SECOND paid window (duplicate spend + a store
+    double-promote race). A live job whose manifest cannot be read now ABORTS
+    the import — duplicate paid spend is never the silent branch. Terminal
+    (done/failed) jobs are not consulted, exactly as before."""
+    occupied = set()
+    for row in db.execute("SELECT external_id, manifest_path FROM jobs "
+                          "WHERE state IN ('pending','in_progress') "
+                          "AND manifest_path IS NOT NULL"):
+        try:
+            with open(row['manifest_path'], encoding='utf-8') as fh:
+                occupied.update(json.load(fh)['meta']['selected_keys'])
+        except (OSError, KeyError, TypeError, json.JSONDecodeError) as exc:
+            raise SystemExit(
+                'occupied-keys guard: cannot read the manifest of queued/running job '
+                '%s (%s): %s -- refusing to import; an unreadable live manifest would '
+                'let its keys dispatch into a SECOND paid window (H2154)'
+                % (row['external_id'], row['manifest_path'], exc))
+    return occupied
+
+
 def cmd_import_coordinator(args):
     state_path = os.path.join(os.path.abspath(args.coord_dir), 'state.json')
     with open(state_path, encoding='utf-8') as f:
@@ -681,12 +707,7 @@ def cmd_import_coordinator(args):
     if wanted - {lease.get('id') for lease in leases}:
         raise SystemExit('requested lease is not prepared')
     db = connect(args.db)
-    occupied = set()
-    for row in db.execute("SELECT manifest_path FROM jobs WHERE state IN ('pending','in_progress') AND manifest_path IS NOT NULL"):
-        try:
-            occupied.update(json.load(open(row['manifest_path'], encoding='utf-8'))['meta']['selected_keys'])
-        except (OSError, KeyError, json.JSONDecodeError):
-            pass
+    occupied = occupied_keys(db)
     added = 0
     with db:
         for lease in leases:
@@ -771,12 +792,7 @@ def cmd_import_requeue(args):
         db.close()
         print('imported=0 (attempt job exists: %s)' % external_id)
         return external_id
-    occupied = set()
-    for row in db.execute("SELECT manifest_path FROM jobs WHERE state IN ('pending','in_progress') AND manifest_path IS NOT NULL"):
-        try:
-            occupied.update(json.load(open(row['manifest_path'], encoding='utf-8'))['meta']['selected_keys'])
-        except (OSError, KeyError, json.JSONDecodeError):
-            pass
+    occupied = occupied_keys(db)
     keys = set(manifest['meta']['selected_keys'])
     overlap = keys & occupied
     if overlap:

--- a/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
+++ b/RussianTranslation/src/pilot/max_account_orchestrator_selftest.py
@@ -59,6 +59,48 @@ def finish_fixture_worker(db_path, account, config_dir, job, timeout, *_args, **
 
 
 def main():
+    # H2154 (H2025 census S1-1/S1-2): the occupied-keys guard FAILS CLOSED — an
+    # unreadable manifest on a queued/running job aborts the import instead of
+    # contributing zero keys (which let the same headwords dispatch into a second
+    # paid window). Terminal jobs with lost manifests stay ignorable.
+    with tempfile.TemporaryDirectory() as okd:
+        okdb = os.path.join(okd, 'jobs.sqlite')
+        good = os.path.join(okd, 'good.json')
+        with open(good, 'w', encoding='utf-8') as fh:
+            json.dump({'meta': {'selected_keys': ['agni~~h0']}}, fh)
+        torn = os.path.join(okd, 'torn.json')
+        with open(torn, 'w', encoding='utf-8') as fh:
+            fh.write('{"meta": {"selected_keys": ["bhU~~')
+        con = m.connect(okdb)
+        with con:
+            con.execute("INSERT INTO jobs(external_id,cwd,output_path,manifest_path,state) "
+                        "VALUES('j-good','.','o1',?, 'pending')", (good,))
+            con.execute("INSERT INTO jobs(external_id,cwd,output_path,manifest_path,state) "
+                        "VALUES('j-done-lost','.','o2',?, 'done')",
+                        (os.path.join(okd, 'gone.json'),))
+        assert m.occupied_keys(con) == {'agni~~h0'}, \
+            'a terminal job with a lost manifest must stay ignorable'
+        with con:
+            con.execute("INSERT INTO jobs(external_id,cwd,output_path,manifest_path,state) "
+                        "VALUES('j-live-lost','.','o3',?, 'pending')",
+                        (os.path.join(okd, 'gone.json'),))
+        try:
+            m.occupied_keys(con)
+            raise AssertionError('a LIVE job with an unreadable manifest must abort, '
+                                 'not contribute zero keys (duplicate paid window)')
+        except SystemExit as exc:
+            assert 'j-live-lost' in str(exc) and 'H2154' in str(exc)
+        with con:
+            con.execute("UPDATE jobs SET manifest_path=? WHERE external_id='j-live-lost'",
+                        (torn,))
+        try:
+            m.occupied_keys(con)
+            raise AssertionError('a torn live manifest must abort the import')
+        except SystemExit as exc:
+            assert 'j-live-lost' in str(exc)
+        con.close()
+    print('PASS: test_occupied_keys_guard_fails_closed_h2154')
+
     staged_plan = {
         'selected_headwords': 2,
         'prepared_headwords': 1,


### PR DESCRIPTION
Executes [H2154](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2154-Fable_SanskritLexicography_pwg-occupied-guard-fail-closed_02.08.26.md) — H2025 audit gap G2, census S1-1/S1-2 (the lane's top remaining duplicate-paid-spend path). Fable 5 (`claude-fable-5`).

**Defect:** in [`max_account_orchestrator.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/max_account_orchestrator.py) the `occupied` set (keys owned by pending/in-progress jobs) was built under a per-manifest `except (OSError, KeyError, JSONDecodeError): pass` on **both** import paths — an unreadable/renamed/mid-write manifest silently contributed zero keys, the overlap check passed, and the same headwords could dispatch into a **second paid window** (duplicate spend + store double-promote race). Requeues are exactly where manifests are most likely mid-write.

**Fix:** one shared `occupied_keys(db)` helper used by `cmd_import_coordinator` and `cmd_import_requeue`: a LIVE job whose manifest cannot be read **aborts the import**, naming the job id + manifest path; terminal (done/failed) jobs with lost manifests stay ignorable exactly as before; the manifest read uses a context manager (no leaked handle — the Windows `ERROR_SHARING_VIOLATION` class from the census). Residual `except (OSError…)` sites in the file re-checked against the census: probe/result-read classes, not this guard.

**Validation:** new pin `test_occupied_keys_guard_fails_closed_h2154` (valid manifest reads; terminal+lost ignorable; live+lost aborts naming the job; live+torn aborts) — `max_account_orchestrator_selftest` green, `window_selftest` **198/198**, LANG_PARITY 3 entries re-derived (0 language-keyed diff tokens), `ruff --select=E9,F63,F7,F82` clean. No paid call, fixtures only.

Also: CHANGELOG 1.125.0 + CITATION.cff (tag after merge), `.ai_state.md` journal entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)