### PR TITLE
feat(pwg_ru): the cache prefix is UNSTABLE, not expiring — cache_prefix_stability_probe.py

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,9 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added
+- **`src/pilot/cache_prefix_stability_probe.py` — settle WHY every call re-creates its cache (02-08-2026, Opus 5 1M `claude-opus-5[1m]`):** [#986](https://github.com/gasyoun/SanskritLexicography/pull/986) left two candidates — an unstable prefix across `claude -p` invocations, or a lapsing TTL. **It is the prefix; the TTL hypothesis is refuted.** Two arms (repo cwd vs bare cwd) × 2 identical `--max-turns 1` calls, **4 paid calls, $1.0469**. Every write went to `ephemeral_1h_input_tokens` and a **1-hour** TTL cannot lapse between calls issued seconds apart; two identical repo-cwd calls re-created **49 153 → 49 165** tokens with cache read pinned at 28 882, i.e. **the second re-wrote exactly what the first had just written and nothing carried over**. The prefix decomposes into a stable **~29 k** core plus a volatile **~49 k** segment; in a bare cwd the volatile part falls to ~32–38 k and is the only place any cross-call reuse appears (read **+5 553** / create **−5 553**, exactly complementary), so **CLAUDE.md + git-state injection is what breaks it**, worth ~11–17 k tokens per call. **Free measured win: running the lane from a bare cwd is −33 % cost and −30 % wall clock**, no code change and no guard weakened. Structural read: with `--max-turns 1` the floor is **~19–29 s of non-API overhead against ~2–3 s of API time** and ~32–49 k tokens re-written per call regardless of payload — a one-shot CLI subprocess **cannot amortise its own system prompt**, which is a property of the route, not a tuning knob. Table: [`RESULTS_LOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md). Port tracked as [H2158](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2158-Opus_RussianTranslation_pwg-messages-api-port_02.08.26.md).
+
 ## [1.126.0] - 2026-08-02
 
 ### Fixed

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -4,6 +4,66 @@ _Created: 09-07-2026 · Last updated: 02-08-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
+## 02-08-2026 (later still) — the cache prefix is UNSTABLE, not expiring: a second identical call re-creates what the first just wrote
+
+Opus 5 1M (`claude-opus-5[1m]`), follow-on to the H2152 audit. **4 paid calls, $1.0469, no
+window, no store write.** Tool: [`src/pilot/cache_prefix_stability_probe.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/cache_prefix_stability_probe.py) (new).
+
+[#986](https://github.com/gasyoun/SanskritLexicography/pull/986) left two candidates for why every
+call re-creates 56–68 k tokens of cache: **(a)** the prefix is not stable across `claude -p`
+invocations, or **(b)** the TTL lapses between 2–3-minute calls. **It is (a). (b) is refuted.**
+
+Identical `claude -p --max-turns 1` calls, ~30 B prompt, output 4 tokens, back-to-back:
+
+| arm | # | wall ms | `duration_api_ms` | cache **create** | cache **read** | USD |
+|---|---|---|---|---|---|---|
+| repo cwd | 1 | 26 262 | 2 995 | **49 153** | 28 882 | $0.3036 |
+| repo cwd | 2 | 29 087 | 2 813 | **49 165** | 28 882 | $0.3037 |
+| bare cwd | 1 | 20 401 | 2 193 | 37 814 | 28 882 | $0.2356 |
+| bare cwd | 2 | 19 057 | 2 624 | **32 261** | **34 435** | **$0.2040** |
+
+**(b) is dead on arithmetic.** Every write went to `ephemeral_1h_input_tokens` (`5m` = 0), and a
+**1-hour** TTL cannot lapse between calls issued seconds apart. Two identical repo-cwd calls
+re-created **49 153 → 49 165** tokens — the second re-wrote what the first had just written, with
+cache read pinned at 28 882 both times. **Nothing carried over at all.**
+
+**The prefix decomposes cleanly:** a stable cached core of **~29 k** that reads every time, plus a
+**volatile ~49 k** segment that is re-written every time. In a bare cwd the volatile segment shrinks
+to ~32–38 k, and bare #2 shows the only cross-call reuse in the whole run — read **+5 553**, create
+**−5 553**, exactly complementary. So **project-context injection (CLAUDE.md + git state) is what
+breaks the prefix**, and it is worth ~11–17 k tokens per call.
+
+### The free win, measured
+
+Running the lane from a **bare cwd** instead of the repo:
+
+| | repo cwd | bare cwd | delta |
+|---|---|---|---|
+| cost/call | $0.3036 | $0.2040 | **−33 %** |
+| wall/call | 26–29 s | 19–20 s | **−30 %** |
+| `duration_api_ms` | 2 813–2 995 | 2 193–2 624 | −13 % |
+
+Zero code change, no guard weakened, no ceiling moved.
+
+### What it means for scaling
+
+With `--max-turns 1` the floor is visible: **~19–29 s of every call is non-API overhead against
+~2–3 s of actual API time**, and **~32–49 k tokens are re-written per call regardless of payload**.
+At $6/M that fixed write **is** the ~$0.30, i.e. it is the entire cost of a call that translates
+nothing. A one-shot CLI subprocess **cannot amortise its own system prompt** — each invocation is a
+cold process paying a fresh cache write, which is structural to the route, not a tuning knob.
+
+The equivalent stable prefix on the Messages API would be a **cache read of ~15 k at $0.30/M ≈
+$0.0045/call** — roughly **65× cheaper** on the fixed component. That is the scaling lever, and it
+also dissolves the 180 s subprocess ceiling, [§270](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)'s
+hang-instead-of-429, and [§273](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)'s destroyed
+rate-limit signal in one move. Ported under
+[H2158](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2158-Opus_RussianTranslation_pwg-messages-api-port_02.08.26.md).
+
+⚠️ These are 4-token-output calls; they isolate the **fixed** overhead and say nothing about
+per-card translation cost. ⚠️ The 65× figure is an estimate from list rates and an assumed ~15 k
+prefix, not a measurement — H2158 must measure it.
+
 ## 02-08-2026 (later) — H2152 call-shape audit: quota is not binding; wall clock is
 
 Opus 5 1M (`claude-opus-5[1m]`), [H2152](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2152-Opus_RussianTranslation_c4-quota-call-shape-audit_02.08.26.md),

--- a/RussianTranslation/src/pilot/cache_prefix_stability_probe.py
+++ b/RussianTranslation/src/pilot/cache_prefix_stability_probe.py
@@ -1,0 +1,97 @@
+"""Decide WHY every headless call re-creates ~50k tokens of cache (PR #986's open hypothesis).
+
+#986 left two candidates: (a) the cache prefix is not stable across `claude -p`
+invocations, or (b) the TTL lapses between 2-3 minute calls. H2152's ping already
+narrows it: the write went to `ephemeral_1h_input_tokens`, and a 1-hour TTL cannot
+expire between calls minutes apart. This probe confirms by firing identical calls
+back-to-back and watching cache_creation vs cache_read.
+
+Two arms, because the fix is in the second one:
+  repo  -- cwd = the SanskritLexicography worktree (CLAUDE.md + git context injected)
+  bare  -- cwd = an empty temp dir (no CLAUDE.md, no git repo, no project context)
+
+If `bare` creates materially less than `repo`, the varying prefix is project context
+injection and the mitigation is to run the paid lane from a fixed minimal cwd.
+
+Read-only apart from the paid calls themselves. Prints a table; writes nothing.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+sys.stdout.reconfigure(encoding='utf-8')
+
+CONFIG_DIR = r'D:\ClaudeTools\profiles\claude4\.claude'
+PROMPT = 'Reply with exactly: ok'
+REPO_CWD = r'C:\Users\user\Documents\GitHub\SanskritLexicography'
+N = 2
+
+# The Windows npm launcher is a .cmd shim that subprocess cannot exec directly (the
+# H818 defect). headless_worker.claude_argv_prefix already resolves it to
+# [node, <cli>.cjs] -- reuse it rather than re-deriving the resolution.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from headless_worker import claude_argv_prefix  # noqa: E402
+
+ARGV = claude_argv_prefix('claude') + [
+    '-p', PROMPT, '--model', 'claude-sonnet-5',
+    '--output-format', 'json', '--max-turns', '1']
+
+
+def one_call(cwd):
+    env = dict(os.environ, CLAUDE_CONFIG_DIR=CONFIG_DIR)
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(ARGV, cwd=cwd, env=env, capture_output=True,
+                              encoding='utf-8', timeout=200)
+    except subprocess.TimeoutExpired:
+        return {'error': 'timeout at 200s', 'wall_ms': 200000}
+    wall = int((time.monotonic() - start) * 1000)
+    try:
+        w = json.loads(proc.stdout)
+    except Exception as exc:
+        return {'error': 'unparseable envelope: %s' % exc, 'wall_ms': wall}
+    u = w.get('usage', {}) or {}
+    cc = u.get('cache_creation', {}) or {}
+    return {
+        'wall_ms': wall,
+        'api_ms': w.get('duration_api_ms'),
+        'create': u.get('cache_creation_input_tokens'),
+        'read': u.get('cache_read_input_tokens'),
+        'out': u.get('output_tokens'),
+        'ttl_1h': cc.get('ephemeral_1h_input_tokens'),
+        'ttl_5m': cc.get('ephemeral_5m_input_tokens'),
+        'usd': w.get('total_cost_usd'),
+    }
+
+
+def main():
+    bare = tempfile.mkdtemp(prefix='c4probe-')
+    rows = []
+    for arm, cwd in (('repo', REPO_CWD), ('bare', bare)):
+        for i in range(1, N + 1):
+            r = one_call(cwd)
+            r['arm'], r['n'] = arm, i
+            rows.append(r)
+            print('%-5s #%d  %s' % (arm, i, json.dumps(r, ensure_ascii=False)))
+
+    print('\n%-5s %-3s %9s %9s %9s %9s %8s' %
+          ('arm', '#', 'wall_ms', 'api_ms', 'create', 'read', 'usd'))
+    for r in rows:
+        if 'error' in r:
+            print('%-5s %-3d %9d  %s' % (r['arm'], r['n'], r['wall_ms'], r['error']))
+            continue
+        print('%-5s %-3d %9d %9s %9s %9s %8.4f' %
+              (r['arm'], r['n'], r['wall_ms'], r['api_ms'], r['create'],
+               r['read'], r['usd'] or 0.0))
+
+    good = [r for r in rows if 'error' not in r and r['create'] is not None]
+    if len(good) >= 2:
+        total = sum(r['usd'] or 0 for r in good)
+        print('\ntotal spend on this probe: $%.4f over %d calls' % (total, len(good)))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Follow-on to the [H2152](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H2152-Opus_RussianTranslation_c4-quota-call-shape-audit_02.08.26.md) audit. **4 paid calls, $1.0469.** No window, no store write, no constant moved.

[#986](https://github.com/gasyoun/SanskritLexicography/pull/986) left two candidates for why every call re-creates 56–68 k tokens of cache: **(a)** an unstable prefix across `claude -p` invocations, or **(b)** a lapsing TTL. **It is (a). (b) is refuted.**

Identical `--max-turns 1` calls, ~30 B prompt, 4 output tokens, back-to-back:

| arm | # | wall ms | `duration_api_ms` | cache **create** | cache **read** | USD |
|---|---|---|---|---|---|---|
| repo cwd | 1 | 26 262 | 2 995 | **49 153** | 28 882 | $0.3036 |
| repo cwd | 2 | 29 087 | 2 813 | **49 165** | 28 882 | $0.3037 |
| bare cwd | 1 | 20 401 | 2 193 | 37 814 | 28 882 | $0.2356 |
| bare cwd | 2 | 19 057 | 2 624 | **32 261** | **34 435** | **$0.2040** |

**(b) dies on arithmetic.** Every write went to `ephemeral_1h_input_tokens` (`5m` = 0), and a **1-hour** TTL cannot lapse between calls issued seconds apart. Two identical repo-cwd calls re-created **49 153 → 49 165** with cache read pinned at 28 882 — the second re-wrote exactly what the first had just written, and **nothing carried over**.

**The prefix decomposes:** a stable **~29 k** core that reads every time, plus a volatile **~49 k** segment re-written every time. In a bare cwd the volatile part falls to ~32–38 k, and bare #2 carries the only cross-call reuse in the run — read **+5 553** / create **−5 553**, exactly complementary. So **CLAUDE.md + git-state injection is what breaks the prefix**, worth ~11–17 k tokens per call.

## The free win, measured

| | repo cwd | bare cwd | delta |
|---|---|---|---|
| cost/call | $0.3036 | $0.2040 | **−33 %** |
| wall/call | 26–29 s | 19–20 s | **−30 %** |

Zero code change, no guard weakened, no ceiling moved.

## Why this is the scaling lever

With `--max-turns 1` the floor is visible: **~19–29 s of non-API overhead against ~2–3 s of API time**, and ~32–49 k tokens re-written per call regardless of payload. At $6/M that fixed write **is** the ~$0.30 — the entire cost of a call that translates nothing. A one-shot CLI subprocess **cannot amortise its own system prompt**; that is a property of the route, not a knob.

The equivalent stable prefix on the Messages API would be a cache **read** of ~15 k at $0.30/M ≈ **$0.0045/call**, and it also dissolves the 180 s subprocess ceiling, [§270](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)'s hang-instead-of-429 and [§273](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)'s destroyed rate-limit signal. Ported under [H2158](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2158-Opus_RussianTranslation_pwg-messages-api-port_02.08.26.md).

## Caveats

- These are **4-token-output** calls. They isolate the **fixed** overhead and say nothing about per-card translation cost.
- The **65×** figure is an estimate from list rates and an assumed ~15 k prefix, **not a measurement** — H2158 must measure it.
- n = 2 per arm.

Reuses `headless_worker.claude_argv_prefix` for the Windows `.cmd` shim ([H818](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/headless_worker.py#L48)) rather than re-deriving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)