### PR TITLE
feat(pwg_ru): relax the per-call ceiling 180s → 300s (#983, human ruling)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,9 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Changed
+- **The per-call ceiling relaxed 180 s → 300 s, by explicit human ruling (02-08-2026, Opus 5 1M `claude-opus-5[1m]`, [#983](https://github.com/gasyoun/SanskritLexicography/issues/983)):** the standing `"NOTHING runs past 3 min (MG)"` rule (R4/C-15, H189) was the direct cause of a paid window returning **zero cards** — 12 of 16 calls died at exactly 180 04x–180 23x ms, and it was not tunable from below because heal groups were already at a **single fragment** while the kill gate `clamp(BASE + 45×bytes, FLOOR, CEIL)` saturates at CEIL for any fragment >~3.5 KB. Successful calls had crept to 67–**91 %** of the old budget. **The ceiling is enforced in five independent places and raising one is inert** — `headless_worker.HARD_TIMEOUT_MS`, `gen_opt_harness2.KILL_CEIL_MS`, each sealed manifest's `budgets.timeout_ceil_ms`, the `KILL_CEIL_MS` baked into every generated `run_pilot_wf.*.js`, and the operator's own `--timeout`, since the effective bound is their `min()`. The two source constants are now **pinned equal** by a new `headless_worker_selftest.test_kill_ceiling_in_step_with_harness` (verified RED against the drift it guards). 300 s keeps ~1.8× headroom over the worst observed success (164.3 s) and stays below the 390 s agent that prompted H189, so the anti-regression guard against the old 480 000 (8 min) is unchanged and still enforced. Gates: `window_selftest` **199/199**, `lang_parity_check` **90 entries no drift** (52 entries re-stamped; `wall_clock_kill_gate` re-derived in writing — the diff is three integer constants plus comments and greps ZERO hits for any language-keyed token).
+
 ## [1.127.0] - 2026-08-02
 
 ### Added

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "f4ea220f7dd4c503adf3c36f7c7b345785982a1f96aa5d8c65fa55f7a3c5a90e",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -131,7 +131,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pwg_mask.py": "f4ea220f7dd4c503adf3c36f7c7b345785982a1f96aa5d8c65fa55f7a3c5a90e",
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -151,10 +151,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "C1 (bug-hunt review, Opus 4.8 claude-opus-4-8, 21-07-2026). The check keys off TARGET_FIELD (JS) / manifest['field'] (Python) = the per-language field, so it applies identically to ru and en with no language branching. Ported to every off-batch lane the batch accept() H1152 guard never reached: JS heal (stitched-translation-fidelity-reject), headless normalize_batch + selfheal stitch (translation-fidelity-reject / stitched-translation-fidelity-reject), autosplit cmd_merge + stitch_topup (complete-stitch fidelity drift -> reject). Tests: window_selftest test_heal_lane_target_field_fidelity_wired / test_autosplit_stitch_topup_rejects_target_field_drop / test_autosplit_merge_rejects_target_field_drop; headless_worker_selftest test_normalize_batch_translation_fidelity_reject / test_headless_heal_stitch_translation_fidelity_reject. H1940 H1 (30-07-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. headless_worker.py drifted only in main()'s manifest-read boundary -- the open/read/sha256/json.loads moved inside the pre-existing configuration try, and KeyError/TypeError joined its except tuple. The TARGET_FIELD / manifest['field'] fidelity count itself, normalize_batch, the selfheal stitch and both autosplit stitch writers are byte-unchanged. The only interaction is upstream and strictly narrowing: a malformed manifest is now refused as `configuration` before any lane runs, so the guard is never handed one -- it cannot change a verdict it no longer reaches. No language branch is added; the field stays data, not a condition. H1940 H2b (31-07-2026, OpenAI GPT-5.6 Sol `openrouter/openai/gpt-5.6-sol`): re-derived, SHARED stands. The fidelity check is byte-unchanged; only a later typed translate-budget note now preserves its per-key rejection instead of erasing it. The same manifest field still selects RU or EN data without a language branch, and the new pin drives `translation-fidelity-reject` through the real shared path. H1940 H4/H3 (31-07-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. headless_worker.py drifted only by the H3 durability call in atomic_json. This is the most language-sensitive entry in the drifted set, so it is re-derived explicitly rather than by the blanket argument: a flush()+fsync before an already-existing os.replace cannot alter target-field selection, markup fidelity comparison, or the per-field verdict -- it only guarantees the already-decided bytes survive a power loss. The written bytes are unchanged (measured), so even a byte-level fidelity check is unaffected. H2063 (#943/#944, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift is the rate-limit-through-timeout classification: proc_tree now attaches a tree-killed child's drained stdout/stderr to its TimeoutExpired, headless_worker classifies that text and promotes an ACCOUNT-level cause (429/401) to HardFailure exit 21 instead of a bare 'timeout', and the orchestrator probe does the same. It fires only when a call was KILLED and therefore produced no card at all, and it branches on the PROVIDER's message, never on a target-language field — a locked account refuses RU and EN identically. The <ls>/{#..#} target-field guard is untouched and still runs on every promotable lane; a killed call yields no target column to count. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2091 (#948, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift makes `_selfheal_stop_reason` RANKED — a budget stop still wins first (H2a, unchanged), then any other typed INFRASTRUCTURE reason, then the historical `selfheal-nothing-resolved`. A `timeout` previously fell through to that last branch, reporting a dead CALL as a CONTENT verdict on the only per-key cause an operator ever sees. Language-independent by construction: the reason is read from how the call died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Genuine content failures (fidelity reject, missing/mismatched key) keep `selfheal-nothing-resolved` exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "H1412",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/headless_worker.py": "a754caf055c0592013311a299ed9d0d8c7c0c278693a7f583684050de0c52588",
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/headless_worker.py": "237fec8907194adfbfb6d1485efdd6a0ad391966f72c849a057fce0e8ec63f6a",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -171,7 +171,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf"
     }
   },
   {
@@ -189,8 +189,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H155 (2026-07-04): tyaj~~h0_zz_pw (a PW addenda card compressing a whole root article — base verb + Caus/Desid + every prefix combo) packs 35 senses into 11 <ls>, so 1+<ls>=12 ranked it as trivial while its real output surface was the heaviest of the root; it deterministically blew the whole-card StructuredOutput retry cap and stalled ~7 min retrying the identical call. The frag-count trigger is computed from split_plan() length (lang-agnostic; no RU/EN branching) and applies whenever SELFHEAL is on, independent of the citation trigger and of byte/citation batching mode — so it protects both language paths identically. Validated live: the [sam, zz_pw] pair that stalled now returns ok:2/null:0 with zz_pw healed complete via 4 fragment groups. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -205,11 +205,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
+    "note": "H155 follow-up (2026-07-04): the runtime BACKSTOP for whole-card StructuredOutput stalls whose driver isn't yet a structural presplit trigger (gloss volume, masked-token count, multi-layer nesting, novel shapes). Entirely lang-agnostic — the budget keys on masked-skeleton bytes (INPUTS[k].skeleton.length) and setTimeout, no RU/EN branching; both paths get the same gate. Budget calibrated from a tyaj --no-tm timing benchmark (skeleton bytes are the best single time predictor since output ~= 2x skeleton). setTimeout is a relative timer (Date.now() is banned); AbortController is unavailable so a killed call keeps running in the background until its own cap, but the harness stops blocking. Default ON; --no-kill / --kill-factor=N tune it. See FAILURE_MODES_AND_KILL_GATE_2026-07-04.md. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established. #983 ceiling relaxation (02-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. `KILL_CEIL_MS` and `headless_worker.HARD_TIMEOUT_MS` both moved 180000 -> 300000 after an explicit human ruling relaxed 'NOTHING runs past 3 min (MG)'; the ceiling was itself why a paid window returned zero cards (12 of 16 calls died at exactly 180 04x-180 23x ms). The re-derivation is mechanical, not asserted: the whole diff is three integer constants plus comments, and grepping it for lang/ru/en/de/field returns ZERO hits, so nothing language-keyed was touched. The gate still keys on masked-skeleton bytes and a relative timer with no RU/EN branch, and a raised ceiling raises it identically for both lanes. The two constants are now pinned EQUAL by headless_worker_selftest.test_kill_ceiling_in_step_with_harness, because the ceiling is enforced in two places and raising one alone is inert.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -227,8 +227,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H220 (2026-07-06, Opus 4.8 claude-opus-4-8): root-caused the no-PWG lane's ~36% single-card yield to the wall-clock kill gate abandoning valid-but-slow single supplement cards. All three parts are entirely lang-agnostic — (A) keys on FRAGS emptiness + skeleton bytes + KILL_CEIL_MS (no RU/EN branch), (B) keys on META.nominal + nominal_keymap which both RU and EN builds emit identically, (C) is a FAIL[k] message-precedence guard. PWG root windows (nominal=False) keep strict key matching: the tolerance is gated on META.nominal so it is inert there (test_generated_harness_strict_key_matching still green). Pinned by test_no_fallback_single_gets_ceil_kill_budget, test_nominal_key_echo_tolerance_scoped, test_selfheal_no_fallback_preserves_upstream_reason. Extends wall_clock_kill_gate (the kill gate stays for multi-card/splittable batches). H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -245,7 +245,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf"
     }
   },
   {
@@ -262,7 +262,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf"
     }
   },
   {
@@ -296,7 +296,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "_reachable_defs() walks $ref pointers regardless of lang; _strip_post_generation_fields() runs before it and is called unconditionally in build() for both lang paths (no lang-specific field list).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf"
     }
   },
   {
@@ -313,7 +313,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Applies identically on both paths per the 2026-07-01 EN-schema-relaxation commit; RU keeps the same optionality, not a stricter EN-only rule.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf"
     }
   },
   {
@@ -330,7 +330,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H818 closes the former divergence: exact model provenance is required across four accounts, so both RU and EN now request and stamp claude-sonnet-5. This prevents account/profile alias resolution from making cross-window provenance incomparable.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf"
     }
   },
   {
@@ -430,8 +430,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04: the estimator undercounted a 150+-<ls> presplit giant as 1 agent instead of its true ~10-20 fragment calls, making the vid preflight read 13 when the real run spent 102. Computed identically for both langs (frags/presplit/batches are lang-agnostic); fix + pinning test apply to both. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -450,7 +450,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -487,8 +487,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "Fixed 2026-07-04 after the vid run showed 10/10 null cards traced to 2 batches that hard-failed the StructuredOutput retry cap outright, with every null a no-fallback card riding along with a fallback-having card in the same batch. batch_keys is split into fallback/no-fallback lists BEFORE _group_by_budget grouping (both grouped independently, same sizer/budget), which is lang-agnostic (frags/batch_keys carry no lang branching). H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -525,7 +525,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H179 Step 3 pre-run fix. Before this, the nominal promote path (meta.get('nominal') + nominal_keymap) existed in promote_final_cards but the harness never emitted those fields, so a --nominal run's cards would all key to the label (e.g. pril10_w1) instead of kAla/rasa/rUpa. The keymap is built from each card's portrait key1 (_slp1_lex_for_key), which is lang-independent — the identical meta is emitted for RU and EN nominal runs. Pinned by a promote_final_cards.selftest nominal-keying assertion. H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4"
     }
   },
@@ -545,9 +545,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H189 (2026-07-05): fixes the pril10_w1 nominal-window cost blow-up (230 agents / 42.3M tokens / ~$80 / ~3 of 8 cards). Every mechanism keys on lang-agnostic signals — citation/sense counts, masked-skeleton bytes, agent-call count, harness bytes, token/$ estimates — with NO RU/EN branching, so RU and EN get identical behaviour; the presplit lane already ran both languages through the same grouping. Also guards _slp1_lex_for_key against an empty-list portrait ([]) crashing the nominal_keymap emission (the real tyaj~~h0_zz_pw / addenda shape). See POSTMORTEM_pril10_w1.md + H189. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "H189",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
       "src/pilot/perf_preflight.py": "bc03b5b9878e526d3ffd9d2e5352bd1c1bcf69c8961ac37d673bafb9d6bf645b",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -578,7 +578,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -597,7 +597,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -615,7 +615,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "323af2fa393955f320d534111a92cf14270bb78c1044252b5858e7c39e8047ea",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -634,7 +634,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "d7c8da35c6a420b9f9431dd1cb672ed12431e2b27830b9b560a60cff42509eec",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -718,7 +718,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/annotate_form_labels.py": "267cecdef3be3b8ca3cece9c33422016b323ec653d3ac4b9c600a6771ba4493a",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9",
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf"
     }
   },
   {
@@ -764,7 +764,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -789,7 +789,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -818,7 +818,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -838,7 +838,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "3ba83e6475c856cdc58a68526f2a0a5baa208754abd789dc3e3ec14e71bb9258",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -857,7 +857,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "a060e34e1733fb6469653f05bafab2756dfcca026f7324c83c9186808a21f9e6",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -894,7 +894,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "3ba83e6475c856cdc58a68526f2a0a5baa208754abd789dc3e3ec14e71bb9258",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -952,7 +952,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "3ba83e6475c856cdc58a68526f2a0a5baa208754abd789dc3e3ec14e71bb9258",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -970,8 +970,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 (10-07-2026, Opus 4.8 claude-opus-4-8). The heal/kill budget is language-agnostic: healGroup/selfHeal run identically for the RU and EN lanes (the only per-language pin is the model alias, already tracked in sonnet5_explicit_model_pin_en), so a per-card ceiling that bounds the RU-observed medium50 cascade applies verbatim to EN. Sibling of the SHARED wall_clock_kill_gate and selfheal_binary_split entries. Pinned by test_per_card_heal_budget_wired in window_selftest.py. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -989,8 +989,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H442 P0 (10-07-2026). healGroup/selfHeal are language-agnostic generated harness logic shared by RU and EN; the guard keys on wall-clock kill-timeout behavior, not translation language. Pinned by test_heal_group_kill_timeout_does_not_bisect in window_selftest.py. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. The kill-timeout/no-bisect behaviour is unchanged; the timeout reason it already records on fragment keys is now also propagated to the card as `partial_cause`, which is a read of existing state, not a new policy. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -1009,8 +1009,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H462 (10-07-2026, Fable 5 claude-fable-5). The counters live in the language-agnostic generated harness JS (agentKill/healGroup are shared by --lang ru/en; the only per-language pin is the model alias, tracked in sonnet5_explicit_model_pin_en), and classify_run.py reads summary fields that exist identically for both lanes. Pinned by test_run_telemetry_counters_returned and test_classify_run_verdicts in window_selftest.py. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9",
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -1031,8 +1031,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -1089,9 +1089,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H811, from the H255 w07 concurrency finding). The dispatch width control is language-INDEPENDENT: the same MAX_WIDE/STAGGER_MS constants + boundedParallel helper are emitted for every --lang (the harness is lang-parameterized; nothing here branches on language), so a RU or EN requeue uses --max-wide=3 identically. Behavioral test: node src/pilot/boundedparallel_test.js against the REAL emitted fn (caps concurrency, staggers, order-preserving, null-on-throw), wired into window_selftest.test_lowwide_staggered_dispatch. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -1119,11 +1119,11 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "note_h1940_h2b": "31-07-2026, OpenAI GPT-5.6 Sol (`openrouter/openai/gpt-5.6-sol`): SHARED re-derived against the H2b diff. resolve_group changes only failure-note precedence when a retry is refused by a typed translate budget; manifest schema, field selection, split/heal/stitch, scheduler dispatch and all paid boundaries are untouched. The same HeadlessEngine path serves RU and EN with no language branch. The added two-attempt selftest drives the shared manifest fixture and proves the previous clobber.",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/headless_worker.py": "a754caf055c0592013311a299ed9d0d8c7c0c278693a7f583684050de0c52588",
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/headless_worker.py": "237fec8907194adfbfb6d1485efdd6a0ad391966f72c849a057fce0e8ec63f6a",
       "src/pilot/max_account_orchestrator.py": "7815732245d5c095d485e3d382a9865ce7e9fc8c2958299099e4ae695ca79ecb",
       "src/pilot/coordinator.py": "a060e34e1733fb6469653f05bafab2756dfcca026f7324c83c9186808a21f9e6",
-      "src/pilot/headless_worker_selftest.py": "d1021cbe0e8263a1246824514b987b5301055259021d81c79ccaaebfce0897c3",
+      "src/pilot/headless_worker_selftest.py": "874fa17fdb72e3bd5d0125ed61f959653c73ca381db54f880c13f3fced71d2fd",
       "src/pilot/max_account_orchestrator_selftest.py": "543d8d2a2eb6e770a324b3e5b7cf6f8d61e12aa66225acdffcee6c124008be23",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "cb010a7452d1a68fb3a793c3d0ea77d1784eb158d985488cfd09177a1215515d",
@@ -1149,10 +1149,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H390 Phase 1 (12-07-2026, Opus 4.8 claude-opus-4-8), extended by H818. gen_model is written into language-agnostic run meta and flows through the shared ledger writer and harvester identically for RU/EN; both paths now stamp exact claude-sonnet-5. Pinned by test_ledger_stamps_gen_model in window_selftest.py. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
       "src/pilot/window_reports.py": "a20e2b64361f62b1a2b8dfaf10953663a159acd44ba326e868bb31dcc642e2f3",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -1170,8 +1170,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "New mechanism 12-07-2026 (H823, fixes the H255 presplit-cohort loss). Both the citation presplit trigger (_presplit_hit) and the single-card kill budget (killBudgetForCur) are language-independent — they key on <ls>/fragment counts and FRAGS, never on --lang; the same floor + CEIL apply to RU and EN identically. Extends no_fallback_single_kill_budget_and_nominal_key_echo (H220) from no-fallback singles to all singles. Pinned by test_presplit_cite_floor_and_single_ceil. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -1196,7 +1196,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
       "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -1216,9 +1216,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H960 (15-07-2026, Opus 4.8 claude-opus-4-8[1m]): closes H920's explicitly-deferred accept()-side sense-count consumption. Language-neutral: accept() counts SENSE OBJECTS (records[].senses[]), never a gloss language, and source_senses is sense_count.count_source_senses over the German source markers (identical for the RU and EN lanes — the source is German for both). SOFT by default (SANLOSS_HARD_REJECT=false): a shortfall is telemetry only (no reject/requeue), so live traffic can measure the true drop-vs-false-flag rate before the reject is armed (owner-gated ladder). The shared counter is hardened against the ~4.78%-of-cards cross-reference over-count the naive count carried (gam~~h2_31_pari 2->1, s_ud~~h0_05_pra 4->2, _a_srayatva 2->0); under-counting is the safe direction, never a false shortfall. Pinned by test_h960_accept_sanloss_soft_gate (builds the real harness, extracts the emitted accept()+countOf, asserts soft-keep / surplus-ok / FP-regression / ls-sk-first / armed-hard-reject via accept_sensecount_test.js) plus the 3 cross-reference fixtures in sense_count._selftest. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. The SAN-LOSS soft gate still FLAGS an infrastructure-partial card exactly as before; what changes is only that the flag no longer routes that card into the permanent defect lane. Gate thresholds and their RU/EN symmetry are untouched. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f",
       "src/pilot/accept_sensecount_test.js": "fbf8d37f8ae360c286f646361025d56adb0caeff09da30a0abfef5f6b7289937"
     }
   },
@@ -1238,7 +1238,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -1256,7 +1256,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1152 guard 2 (17-07-2026, Sonnet 4.6 claude-sonnet-4-6), closing H1070's r102 finding (PWG->EN FU1 pilot, vac~~h0_00_pwg00: a {#uc#} span inside a <F> footnote survived the german echo 33/33 but was dropped from english 32/33 -- invisible to the pre-existing check because it never reads the translation field). accept() is lang-parameterized code shared by both lanes (field = 'russian' or 'english', same code path); the new check is symmetric and applies identically to RU and EN generation. Verified against the live RU regression suite: window_selftest.py full run stays green (137/137 baseline, +2 new content-check tests for guards 1/3), and the new/updated fixtures in accept_sensecount_test.js reproduce the exact r102 shape (RED before this change -- proven via git-stash against the pre-fix accept(), the fixture is silently ACCEPTED -- GREEN after). No RU store data touched; this only changes the generation-time accept-path gate for FUTURE generation, never re-validates the 11,605 already-promoted RU rows.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
       "src/pilot/accept_sensecount_test.js": "fbf8d37f8ae360c286f646361025d56adb0caeff09da30a0abfef5f6b7289937"
     }
   },
@@ -1293,7 +1293,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -1443,7 +1443,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1226: the {Tn} pairing is stamped in the SHARED accept() (runs for both languages) and BOTH promote lanes (promote_final_cards.py RU, promote_en.py EN) carry it to provenance.tnmask, so neither store silently drops the field accept() stamps. Only accept() stamps it: the heal path's acceptFrag hard-rejects fragment {Tn} mismatches, so no un-rejected expansion reaches a healed card. Makes the TNMASK false-flag rate MEASURABLE (H1150 DO_NOT_ARM, denominator 1); TNMASK_HARD_REJECT stays = false — arming is a human @DECIDE. Pinned by window_selftest.test_tnmask_persist_and_offline_detect + tnmask_offline.selftest. H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
       "src/promote_en.py": "f801b86d267f346e2a11ebbee681103e68e01f6520da0e70e4a20b460ee27d9d",
       "src/pilot/tnmask_offline.py": "c857fe425fadbe18c1cdf398892f53b590709048ca66faf94fd05e046730ffea"
@@ -1468,7 +1468,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "9184e1859428312866623e25bd1e1e8a1b08bec773cc339303a1f4fcd7fbc64f",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f",
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1494,8 +1494,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/card_fields.py": "976c5aa943a35da1691e2ce72e9cb4a14ac53d3bae37f8c68345cc68cb233e2b",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/headless_worker.py": "a754caf055c0592013311a299ed9d0d8c7c0c278693a7f583684050de0c52588",
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
+      "src/pilot/headless_worker.py": "237fec8907194adfbfb6d1485efdd6a0ad391966f72c849a057fce0e8ec63f6a",
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf"
     }
   },
   {
@@ -1571,8 +1571,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H1940 H1 (30-07-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Neither fragment_prompt nor build_prompt is modified; both twins still carry the per-card grammar and portrait. The H1 KeyError pin merely OBSERVES that build_prompt subscripts manifest['inputs'] directly (which is what made a missing section escape as KeyError) -- it does not change that access, and the JS twin in gen_opt_harness2.py is untouched, so the two lanes have not diverged. Language-neutral. H1940 H2b (31-07-2026, OpenAI GPT-5.6 Sol `openrouter/openai/gpt-5.6-sol`): re-derived, SHARED stands. `whole_prompt`, `fragment_prompt`, per-card grammar and portrait injection are untouched; only whole-card failure-note precedence changes after a typed translate-budget refusal. Both language lanes still use the same prompts and engine. H1940 H4/H3 (31-07-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. headless_worker.py drifted only by the H3 durability call in atomic_json. Fragment prompt construction and the per-card evidence it carries are untouched -- H3 sits in the status/output writer, downstream of every prompt decision. The mechanism stays --lang-parameterized exactly as recorded. H2063 (#943/#944, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift is the rate-limit-through-timeout classification: proc_tree now attaches a tree-killed child's drained stdout/stderr to its TimeoutExpired, headless_worker classifies that text and promotes an ACCOUNT-level cause (429/401) to HardFailure exit 21 instead of a bare 'timeout', and the orchestrator probe does the same. It fires only when a call was KILLED and therefore produced no card at all, and it branches on the PROVIDER's message, never on a target-language field — a locked account refuses RU and EN identically. Fragment prompt construction is byte-unchanged; the classification happens after the call is already dead, so no prompt on either twin is affected. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2091 (#948, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift makes `_selfheal_stop_reason` RANKED — a budget stop still wins first (H2a, unchanged), then any other typed INFRASTRUCTURE reason, then the historical `selfheal-nothing-resolved`. A `timeout` previously fell through to that last branch, reporting a dead CALL as a CONTENT verdict on the only per-key cause an operator ever sees. Language-independent by construction: the reason is read from how the call died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Genuine content failures (fidelity reject, missing/mismatched key) keep `selfheal-nothing-resolved` exactly as before.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
-      "src/pilot/headless_worker.py": "a754caf055c0592013311a299ed9d0d8c7c0c278693a7f583684050de0c52588"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
+      "src/pilot/headless_worker.py": "237fec8907194adfbfb6d1485efdd6a0ad391966f72c849a057fce0e8ec63f6a"
     }
   },
   {
@@ -1749,7 +1749,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9",
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f",
       "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f"
     }
   },
@@ -1775,7 +1775,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/annotate_citation_edges.py": "b5462244bcaa5c5712b73bd1c67ae5414549f2fd55760d6704dc5559218a701c",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
       "src/microstructure.py": "3da158ac30613de5f226f749eb41cd5852d8e6d8a3e521a2472054aac3fe6cd9",
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf"
     }
   },
   {
@@ -1800,7 +1800,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/annotate_edition_rel.py": "54141c6723ca144eead648e4cf70ade4de667d1df2be94f9554a1c10f23f5ed6",
       "src/build_relationships.py": "76d03cc81a79f83624065d79bd47845c3a72b8e2f993a01dfc4fbe9931049725",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2"
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf"
     }
   },
   {
@@ -1838,8 +1838,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H858",
     "verified_sha256": {
       "src/german_anchor.py": "751a6bf9c1cf9bc6201397d28f429cd02c680f668c1b2340be8ca55f54e8a276",
-      "src/pilot/headless_worker.py": "a754caf055c0592013311a299ed9d0d8c7c0c278693a7f583684050de0c52588",
-      "src/pilot/gen_opt_harness2.py": "3789b480c7a72cde0b568a2d431d8718746256fc9c7626f3997c753b0dab2cd2",
+      "src/pilot/headless_worker.py": "237fec8907194adfbfb6d1485efdd6a0ad391966f72c849a057fce0e8ec63f6a",
+      "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4"
     }
   },
@@ -1858,7 +1858,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "codex/rt-pipeline-hardening-speed",
     "verified_sha256": {
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   },
   {
@@ -1965,7 +1965,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/window_common.py": "3a8a51917c9b898d9b3d262aaf9339e14fb30cddbb507242266858aec8727331",
       "src/pipeline_version.py": "b461d0c78b5df3f598007eb1e7ee284d84596ae19b5106d5329fdab1a93f00be",
       "src/pilot/h1339_offline_bench.py": "970ad8ab948c4aae724efc2076883e21a5bfc7e203ed1c68b5fbb14f3bdbb8cd",
-      "src/pilot/window_selftest.py": "1deef79bf3f961239301dcfb5105fcc45578ffa6e307d9122850e74b14a070b9"
+      "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
   }
 ]

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -1,6 +1,6 @@
 # Runbook — frequency queue on the headless CLI (manifest v2)
 
-_Created: 09-07-2026 · Last updated: 25-07-2026_
+_Created: 09-07-2026 · Last updated: 02-08-2026_
 
 Goal: scale the PWG→Russian production run in DCS-frequency order, with giant
 roots split into single-pass units and re-glued after translation. This is the
@@ -589,9 +589,17 @@ matters; never reuse H1447's GO a day later.
 | `--max-agents` | **1** is correct **only** for this single-key canary |
 
 Command shape (illustrative): `headless_worker.py <manifest> --output … --status-out …
---only-profile c4 --max-agents 1 --timeout 180` with `CLAUDE_CONFIG_DIR` bound to
+--only-profile c4 --max-agents 1 --timeout 300` with `CLAUDE_CONFIG_DIR` bound to
 the c4 profile. Synthetic output is **never** promoted
 (`provenance_class = synthetic_control`).
+
+> **`--timeout` is part of the ceiling, not just a safety net (#983, 02-08-2026).** The
+> effective per-call bound is `min(--timeout × 1000, budgets.timeout_ceil_ms,
+> HARD_TIMEOUT_MS)`, so passing `--timeout 180` pins the old 3-minute ceiling **even after
+> the constants were raised to 300000** — which is how a paid window returned zero cards
+> with 12 of 16 calls killed at exactly 180 s. A sealed manifest's own
+> `budgets.timeout_ceil_ms` clamps it too and only ever *lowers*, so an artifact prepared
+> before this change must be re-budgeted, not merely re-run.
 
 ### A3 — mechanical LIVE_GO → then stop or spend
 

--- a/RussianTranslation/src/pilot/gen_opt_harness2.py
+++ b/RussianTranslation/src/pilot/gen_opt_harness2.py
@@ -183,11 +183,22 @@ KILL_FLOOR_MS = 45000       # H189 recalibration (MG: ">~60 s per subcard is sus
                             #  fragment: it guaranteed nothing was killed before 2 min even for a
                             #  tiny call, so the pril10_w1 fragments ran 3-6.5 min each. 45 s floor
                             #  + BASE/SLOPE puts a tiny fragment's hard-kill at ~60-70 s.
-KILL_CEIL_MS = 180000       # hard ceiling — NOTHING runs past 3 min (MG). Was 480000 (8 min); the
-                            #  worst pril10_w1 agent ran 390 s (6.5 min) inside the old ceiling. On
-                            #  kill the call is abandoned and its cards fall to the bounded fragment
-                            #  lane / binary-split, so a killed unit is REQUEUED, never silently
-                            #  lost (see resolveGroup/healGroup below).
+KILL_CEIL_MS = 300000       # hard ceiling. On kill the call is abandoned and its cards fall to the
+                            #  bounded fragment lane / binary-split, so a killed unit is REQUEUED,
+                            #  never silently lost (see resolveGroup/healGroup below).
+                            #  History: 480000 (8 min) -> 180000 ("NOTHING runs past 3 min", MG,
+                            #  after the worst pril10_w1 agent ran 390 s) -> 300000 on 02-08-2026,
+                            #  when that rule was RELAXED by explicit human ruling (issue #983).
+                            #  Evidence: the first paid run since 25-07 returned ZERO cards because
+                            #  12 of 16 calls died at exactly the 180 s ceiling; it was not tunable
+                            #  from below, since this gate saturates at CEIL for any fragment
+                            #  >~3.5 KB and heal groups were already down to ONE fragment.
+                            #  Successful calls ran 120.4-164.3 s (67-91% of the old budget).
+                            #  300 s keeps ~1.8x headroom over the worst success and stays below
+                            #  the 390 s that prompted the original ruling. MUST stay in step with
+                            #  `headless_worker.HARD_TIMEOUT_MS` — the Python subprocess ceiling
+                            #  clamps from the outside, this one kills from the inside, and the
+                            #  effective bound is min(operator, budgets.timeout_ceil_ms, HARD).
 # --- live budget kill-switch (H189, 2026-07-05) -----------------------------------
 # The per-call kill gate above bounds ANY SINGLE agent() call, but nothing bounded the
 # WHOLE WINDOW: pril10_w1 spawned 230 agents (est. 174) and burned 42 M tokens before MG

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -40,9 +40,23 @@ EXIT_TIMEOUT = 22
 EXIT_MALFORMED = 23
 EXIT_CONTENT = 24
 
-# R4 (C-15): the hard per-call subprocess ceiling. "NOTHING runs past 3 min (MG)". The bare
-# operator default was 7200 s -- 40x this -- because `budgets.timeout_ceil_ms` was never read.
-HARD_TIMEOUT_MS = 180000
+# R4 (C-15): the hard per-call subprocess ceiling. The bare operator default was 7200 s -- 40x
+# this -- because `budgets.timeout_ceil_ms` was never read.
+#
+# 180000 -> 300000, 02-08-2026 (issue #983). The "NOTHING runs past 3 min (MG)" rule was
+# RELAXED by an explicit human ruling, on measurement rather than preference: the first paid
+# run since 25-07 produced ZERO cards because 12 of 16 calls were killed at exactly this
+# ceiling (180 04x-180 23x ms, `reservation_timeline.py`). It is not tunable from below --
+# heal groups were already at the arithmetic floor (six of nakzatra's eight held a SINGLE
+# fragment) and single-fragment calls still hit it, because the kill gate
+# clamp(KILL_BASE + 45*bytes, FLOOR, CEIL) saturates at CEIL for any fragment >~3.5 KB.
+# Successful calls measured 120.4 / 132.0 / 134.5 / 164.3 s, i.e. 67% -> 91% of the old
+# budget, so the margin was already gone and shrinking. 300 s gives ~1.8x headroom over the
+# worst observed success while staying BELOW the 390 s (6.5 min) pril10_w1 agent that
+# prompted the original ruling -- a middle path, deliberately not a revert to the 480000
+# (8 min) this replaced. Must stay in step with `gen_opt_harness2.KILL_CEIL_MS`: the JS
+# harness kills from the inside, so raising only this constant is inert.
+HARD_TIMEOUT_MS = 300000
 
 
 def claude_argv_prefix(claude_bin):

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -203,13 +203,30 @@ def test_call_timeout_clamped():
     def capture_runner(argv, **kwargs):
         seen['timeout'] = kwargs.get('timeout')
         return success_runner(argv, **kwargs)
-    execute(manifest(), capture_runner)   # operator default 7200 s -> clamp to HARD (180 s)
+    execute(manifest(), capture_runner)   # operator default 7200 s -> clamp to HARD
     assert seen['timeout'] == h.HARD_TIMEOUT_MS / 1000.0, 'not clamped to HARD: %r' % seen['timeout']
     seen.clear()
     m = manifest(); m['budgets'] = {'timeout_ceil_ms': 45000}
     execute(m, capture_runner)
     assert seen['timeout'] == 45.0, 'timeout_ceil_ms not honoured: %r' % seen['timeout']
-    print('  R4 timeout: clamped to min(operator,ceil,180000ms) -> 180.0s then 45.0s')
+    print('  R4 timeout: clamped to min(operator,ceil,%dms) -> %.1fs then 45.0s'
+          % (h.HARD_TIMEOUT_MS, h.HARD_TIMEOUT_MS / 1000.0))
+
+
+def test_kill_ceiling_in_step_with_harness():
+    """#983: the per-call ceiling lives in TWO places and raising only one is inert.
+
+    `HARD_TIMEOUT_MS` clamps the subprocess from the outside; `gen_opt_harness2.KILL_CEIL_MS`
+    kills the agent from the inside. When the 180 s ceiling was relaxed to 300 s (02-08-2026),
+    a change to either constant alone would have left the other still killing at the old bound
+    -- the run would have looked "fixed" and still returned zero cards. Pin them equal.
+    """
+    import gen_opt_harness2 as g
+    assert h.HARD_TIMEOUT_MS == g.KILL_CEIL_MS, (
+        'ceiling drift: HARD_TIMEOUT_MS=%d but KILL_CEIL_MS=%d -- raising one without the '
+        'other is inert (#983)' % (h.HARD_TIMEOUT_MS, g.KILL_CEIL_MS))
+    assert g.KILL_FLOOR_MS < g.KILL_CEIL_MS, 'kill floor must stay below the ceiling'
+    print('  #983 ceiling parity: HARD_TIMEOUT_MS == KILL_CEIL_MS == %d ms' % h.HARD_TIMEOUT_MS)
 
 
 def test_durable_call_reservation():
@@ -1575,6 +1592,7 @@ console.log(JSON.stringify(restoreCard(card, 'agni')))
     test_h2056_944_plain_hang_still_classifies_as_timeout()
     test_h2091_948_infra_stop_is_not_a_content_verdict()
     test_h2091_948_account_refusal_aborts_before_any_bisect()
+    test_kill_ceiling_in_step_with_harness()
     print('headless_worker_selftest: PASS')
 
 

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -5628,16 +5628,22 @@ def test_presplit_card_uses_amortized_grouping():
 
 
 def test_kill_gate_recalibrated_envelope():
-    """H189 (MG: '>~60s per subcard suspicious; >3 min unacceptable'): the kill envelope
-    must be the tightened one — floor <= 45s, ceil <= 180s (3 min) — never a regression
-    back to the 2 min floor / 8 min ceiling that let pril10_w1 fragments run 6.5 min."""
+    """H189: the kill envelope must stay tightened — floor <= 45s — and must never regress
+    to the 2 min floor / 8 min (480000) ceiling that let pril10_w1 fragments run 6.5 min.
+
+    The ceiling bound was 180000 ('>3 min unacceptable', MG). Relaxed to 300000 on
+    02-08-2026 by explicit human ruling (issue #983) after measurement showed the 3 min
+    ceiling was itself the reason a paid window returned zero cards: 12 of 16 calls died at
+    exactly 180 04x-180 23x ms, and it was not tunable from below because heal groups were
+    already at ONE fragment. The anti-regression intent is unchanged and still enforced --
+    480000 remains refused, and 300000 stays below the 390 s agent that prompted H189."""
     import gen_opt_harness2 as gh
     if gh.KILL_FLOOR_MS > 45000:
         fail('KILL_FLOOR_MS must be <= 45000 (was 120000) so a tiny subcard is killed '
              'near MG\'s ~60s suspicion line; got %d' % gh.KILL_FLOOR_MS)
-    if gh.KILL_CEIL_MS > 180000:
-        fail('KILL_CEIL_MS must be <= 180000 (3 min hard ceiling, was 480000); got %d'
-             % gh.KILL_CEIL_MS)
+    if gh.KILL_CEIL_MS > 300000:
+        fail('KILL_CEIL_MS must be <= 300000 (5 min, #983; was 180000, before that 480000); '
+             'got %d' % gh.KILL_CEIL_MS)
 
 
 def test_agent_budget_plan_separates_translate_and_heal_pools():


### PR DESCRIPTION
Reissue of #997 from fresh `origin/master` (that branch went CONFLICTING as master moved). Relaxes the standing `"NOTHING runs past 3 min (MG)"` rule (R4/C-15, H189) **by explicit human ruling**, on measurement rather than preference. Tracking: [#983](https://github.com/gasyoun/SanskritLexicography/issues/983).

## Why

The 3-minute ceiling was itself why the first paid window since 25-07 returned **zero cards**: 12 of 16 calls died at exactly 180 04x–180 23x ms. It was **not tunable from below** — heal groups were already at a **single fragment**, and the kill gate `clamp(BASE + 45×bytes, FLOOR, CEIL)` saturates at CEIL for any fragment >~3.5 KB. Successful calls had crept 120.4 s → 164.3 s, i.e. 67 % → **91 %** of budget.

## The ceiling lives in FIVE places, and raising one is inert

| # | location | kind |
|---|---|---|
| 1 | `headless_worker.HARD_TIMEOUT_MS` | python subprocess clamp |
| 2 | `gen_opt_harness2.KILL_CEIL_MS` | JS kills from the **inside** |
| 3 | `budgets.timeout_ceil_ms` per sealed manifest | artifact; only ever **lowers** |
| 4 | `KILL_CEIL_MS` baked into each `run_pilot_wf.*.js` | generated artifact |
| 5 | the operator's `--timeout` | the documented recipe said `180` |

The effective bound is their `min()`. This moves **1, 2 and 5**, and documents 3/4 in [`RUN_FREQ_MAX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_FREQ_MAX.md) as artifacts that must be **re-budgeted, not merely re-run**.

New pin `headless_worker_selftest.test_kill_ceiling_in_step_with_harness` holds 1 and 2 equal — **verified RED** against the exact drift it guards, because that drift yields a run that looks "fixed" and still returns nothing.

## Why 300000 and not more

~1.8× headroom over the worst observed success (164.3 s), still **below the 390 s** agent that prompted H189. The anti-regression guard against the old 480000 (8 min) is unchanged and still enforced — the envelope test's threshold moved, **its intent did not**.

## Relation to #995

Complementary, not overlapping. [#995](https://github.com/gasyoun/SanskritLexicography/pull/995) settled *why* each call re-creates its cache (unstable prefix, not TTL) and found a free −33 % cost / −30 % wall-clock win by running from a bare cwd. That reduces per-call duration; this raises the bound those durations are measured against. Both are needed before a window completes.

## Gates (re-run on fresh master after the reissue)

- `window_selftest` **199/199**
- `headless_worker_selftest` **PASS**
- `lang_parity_check` **90 entries, no drift** — 52 re-stamped, `wall_clock_kill_gate` **re-derived in writing**: the whole diff is three integer constants plus comments and greps **zero** hits for `lang`/`ru`/`en`/`de`/`field`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)