### PR TITLE
feat(pwg_ru): spawn the CLI from a bare cwd (H2158) + the 300s ceiling verdict

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,6 +10,12 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+### Added
+- **The CLI child now spawns from a bare cwd, not the repo (02-08-2026, Opus 5 1M `claude-opus-5[1m]`, H2158/[#983](https://github.com/gasyoun/SanskritLexicography/issues/983)):** v1.127.0 measured the win (**−33 % cost, −30 % wall clock**) but made no code change. `proc_tree.run_tree_kill` had always accepted `cwd` and passed it to `Popen` — nothing ever supplied one, so the child silently inherited the repo and paid CLAUDE.md + git-state injection (~11–17 k volatile prefix tokens) on **every** call. New `bare_cli_cwd()` returns a **stable** directory (a fresh one per call would re-break the very prefix this stabilises) and **fails safe**: if the candidate still sits inside a git repo or under a `CLAUDE.md` it returns `None` and the historical inherited-cwd behaviour is kept, rather than silently spawning from a directory that still injects context. Pinned by `headless_worker_selftest.test_cli_spawns_from_a_bare_cwd`, which asserts both halves — that a cwd is passed at all, and that what it points at carries no `CLAUDE.md` and no `.git`. The wall-clock half matters beyond cost: a 30 % shorter call is 30 % more headroom against the ceiling.
+
+### Fixed
+- **The 300 s ceiling is validated for the heal lane and refuted for the whole-card lane (02-08-2026, Opus 5 1M `claude-opus-5[1m]`):** re-run `h1447-m50-2026-08-02b` after [v1.128.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.128.0), stopped externally after 4 calls but decisive. `heal:nakzatra#g2` returned at **176 952 ms** — **3 048 ms inside the old 180 000 ms bound** — and the same heal groups ranged 82–120 s and 134–177 s across the two runs, so the lane's upper tail was genuinely being killed by an outgrown ceiling. **But `translate b0` died at 180 044 ms and then at 300 073 ms**, converging on neither: it is a **non-terminating call**, not a marginally slow one, so for the whole-card lane a higher ceiling strictly *increases* waste (300 s burned per dead attempt instead of 180 s). This corrects the previous entry's framing, which read all 12 timeouts as one phenomenon. The whole-card hang is a separate, still-unfixed defect. Table: [`RESULTS_LOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md).
+
 ## [1.129.0] - 2026-08-02
 
 ### Fixed

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -152,7 +152,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H1412",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
-      "src/pilot/headless_worker.py": "237fec8907194adfbfb6d1485efdd6a0ad391966f72c849a057fce0e8ec63f6a",
+      "src/pilot/headless_worker.py": "a2aedb51b3f0c3d7a10c83398a73978f30624ef0d27dae013289fc6406568181",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
       "src/pilot/window_selftest.py": "237d93d23384e569713ffce1a9f814718b7347cd7b454a0a90e78d6bb84b911f"
     }
@@ -1120,10 +1120,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note_h1940_h2b": "31-07-2026, OpenAI GPT-5.6 Sol (`openrouter/openai/gpt-5.6-sol`): SHARED re-derived against the H2b diff. resolve_group changes only failure-note precedence when a retry is refused by a typed translate budget; manifest schema, field selection, split/heal/stitch, scheduler dispatch and all paid boundaries are untouched. The same HeadlessEngine path serves RU and EN with no language branch. The added two-attempt selftest drives the shared manifest fixture and proves the previous clobber.",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
-      "src/pilot/headless_worker.py": "237fec8907194adfbfb6d1485efdd6a0ad391966f72c849a057fce0e8ec63f6a",
+      "src/pilot/headless_worker.py": "a2aedb51b3f0c3d7a10c83398a73978f30624ef0d27dae013289fc6406568181",
       "src/pilot/max_account_orchestrator.py": "7815732245d5c095d485e3d382a9865ce7e9fc8c2958299099e4ae695ca79ecb",
       "src/pilot/coordinator.py": "a060e34e1733fb6469653f05bafab2756dfcca026f7324c83c9186808a21f9e6",
-      "src/pilot/headless_worker_selftest.py": "874fa17fdb72e3bd5d0125ed61f959653c73ca381db54f880c13f3fced71d2fd",
+      "src/pilot/headless_worker_selftest.py": "00ca8f39d8ec66707a30888c533fb212d3ea153bcdcf87bc3ae9a03e746df9e1",
       "src/pilot/max_account_orchestrator_selftest.py": "543d8d2a2eb6e770a324b3e5b7cf6f8d61e12aa66225acdffcee6c124008be23",
       "src/pilot/no_pwg_scale_plan.py": "7e4bb02a2f2865a3447afe47cf1f4106209bdc24f403cb6dd2b8c524b6928d63",
       "src/pilot/windows100_selftest.py": "cb010a7452d1a68fb3a793c3d0ea77d1784eb158d985488cfd09177a1215515d",
@@ -1494,7 +1494,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/card_fields.py": "976c5aa943a35da1691e2ce72e9cb4a14ac53d3bae37f8c68345cc68cb233e2b",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
       "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/headless_worker.py": "237fec8907194adfbfb6d1485efdd6a0ad391966f72c849a057fce0e8ec63f6a",
+      "src/pilot/headless_worker.py": "a2aedb51b3f0c3d7a10c83398a73978f30624ef0d27dae013289fc6406568181",
       "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf"
     }
   },
@@ -1572,7 +1572,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
-      "src/pilot/headless_worker.py": "237fec8907194adfbfb6d1485efdd6a0ad391966f72c849a057fce0e8ec63f6a"
+      "src/pilot/headless_worker.py": "a2aedb51b3f0c3d7a10c83398a73978f30624ef0d27dae013289fc6406568181"
     }
   },
   {
@@ -1838,7 +1838,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "H858",
     "verified_sha256": {
       "src/german_anchor.py": "751a6bf9c1cf9bc6201397d28f429cd02c680f668c1b2340be8ca55f54e8a276",
-      "src/pilot/headless_worker.py": "237fec8907194adfbfb6d1485efdd6a0ad391966f72c849a057fce0e8ec63f6a",
+      "src/pilot/headless_worker.py": "a2aedb51b3f0c3d7a10c83398a73978f30624ef0d27dae013289fc6406568181",
       "src/pilot/gen_opt_harness2.py": "574012eb389908ddfc10f2ac9d295143f7086132e77e44b6bd40e053e2755fdf",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4"
     }

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -4,6 +4,38 @@ _Created: 09-07-2026 · Last updated: 02-08-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
+## 02-08-2026 (300 s re-run) — the ceiling relaxation is VALIDATED for the heal lane and REFUTED for the whole-card lane
+
+Opus 5 1M (`claude-opus-5[1m]`), run `h1447-m50-2026-08-02b` on c4 after
+[v1.128.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.128.0) raised the
+per-call ceiling 180 s → 300 s and the five prepared artifacts were re-budgeted. **Run stopped
+externally after 4 calls**, so w1 is incomplete — but the calls it did make settle the question.
+
+### Same two calls, both ceilings
+
+| call | 180 s run | 300 s run | verdict |
+|---|---|---|---|
+| `translate b0` | killed at **180 044 ms** | killed at **300 073 ms** | **hangs at ANY ceiling** |
+| `heal:nakzatra#g1` | 120 375 ms ✓ | 82 459 ms ✓ | completes; huge variance |
+| `heal:nakzatra#g2` | 134 511 ms ✓ | **176 952 ms ✓** | **3 048 ms of margin under the old ceiling** |
+
+**Validated for the heal lane.** `g2` returning at 176 952 ms is the proof: under the old
+180 000 ms bound that call had **three seconds** to spare. Across the two runs the same heal
+groups ranged 82–120 s and 134–177 s, so the lane's upper tail was being systematically killed
+by a ceiling it had outgrown — exactly the failure the relaxation targeted.
+
+**Refuted for the whole-card lane, and this corrects the earlier entry's framing.** The
+180 s-run diagnosis read "12 of 16 calls die at the ceiling" as "the ceiling is slightly too
+tight". For `b0` that is false: it died at 180 044 ms and then at 300 073 ms, converging on
+neither. It is a **non-terminating call**, and for that lane a higher ceiling strictly
+*increases* waste — 300 s burned per dead attempt instead of 180 s. The whole-card hang is a
+separate, still-unfixed defect and should not be filed under the ceiling fix.
+
+Cost: `g2` alone billed **$0.8850**; 646 904 tokens across the 2 evaluable calls; recorded floor
+$1.3182 with `cost_evaluable=false` (one 300 s dead call contributes 0).
+
+⚠️ Raw ledger is gitignored (`.gitignore:67`) — this table is the only committed copy.
+
 ## 02-08-2026 (later still) — the cache prefix is UNSTABLE, not expiring: a second identical call re-creates what the first just wrote
 
 Opus 5 1M (`claude-opus-5[1m]`), follow-on to the H2152 audit. **4 paid calls, $1.0469, no

--- a/RussianTranslation/src/pilot/headless_worker.py
+++ b/RussianTranslation/src/pilot/headless_worker.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 
 sys.stdout.reconfigure(encoding='utf-8')
@@ -57,6 +58,49 @@ EXIT_CONTENT = 24
 # (8 min) this replaced. Must stay in step with `gen_opt_harness2.KILL_CEIL_MS`: the JS
 # harness kills from the inside, so raising only this constant is inert.
 HARD_TIMEOUT_MS = 300000
+
+# H2158 (#983, 02-08-2026): spawn the CLI from a BARE directory, not the repo.
+#
+# v1.127.0 measured why every call re-creates its cache: the prompt prefix is a stable ~29 k
+# core plus a VOLATILE ~49 k segment that is re-written every call, and project-context
+# injection (CLAUDE.md + git state) is what makes it volatile -- worth ~11-17 k tokens per
+# call. Measured back-to-back on identical `--max-turns 1` calls: repo cwd $0.3036 / 26-29 s
+# vs bare cwd $0.2040 / 19-20 s, i.e. **-33 % cost and -30 % wall clock**, and the only
+# cross-call cache reuse in the whole experiment appeared in the bare arm (read +5 553 /
+# create -5 553, exactly complementary).
+#
+# The wall-clock half is why this sits next to HARD_TIMEOUT_MS rather than in a cost note: a
+# 30 % shorter call is 30 % more headroom against the ceiling that killed 12 of 16 calls.
+# `proc_tree.run_tree_kill` already accepted `cwd` and passed it to Popen -- nothing ever
+# supplied one, so the child silently inherited the repo.
+#
+# The directory is STABLE (not per-call): a fresh temp dir per call would give the model a
+# different cwd string each time and re-break the very prefix this is stabilising.
+BARE_CLI_CWD_NAME = 'pwg_ru_cli_cwd'
+
+
+def bare_cli_cwd():
+    """A stable, empty, project-context-free directory to spawn the CLI from.
+
+    Fails SAFE: if the candidate would still sit inside a git repo or under a CLAUDE.md, this
+    returns None and the caller keeps the historical inherited-cwd behaviour. Silently
+    spawning from a directory that still injects project context would reintroduce the cost
+    without any signal that it had.
+    """
+    path = os.path.join(tempfile.gettempdir(), BARE_CLI_CWD_NAME)
+    try:
+        os.makedirs(path, exist_ok=True)
+    except OSError:
+        return None
+    probe = os.path.abspath(path)
+    while True:
+        if (os.path.exists(os.path.join(probe, 'CLAUDE.md'))
+                or os.path.exists(os.path.join(probe, '.git'))):
+            return None
+        parent = os.path.dirname(probe)
+        if parent == probe:
+            return path
+        probe = parent
 
 
 def claude_argv_prefix(claude_bin):
@@ -557,6 +601,7 @@ class HeadlessEngine:
         if ceil_ms:
             eff_ms = min(eff_ms, int(ceil_ms))
         self.timeout = eff_ms / 1000.0
+        self.cli_cwd = bare_cli_cwd()   # H2158: None => inherit, the historical behaviour
         self.run = runner or run_tree_kill
         self.attempts = []
         self.failures = {}
@@ -647,7 +692,7 @@ class HeadlessEngine:
             self.translate_calls += 1
         try:
             proc = self.run(argv, input=prompt, text=True, encoding='utf-8',
-                            capture_output=True, timeout=self.timeout)
+                            capture_output=True, timeout=self.timeout, cwd=self.cli_cwd)
         except subprocess.TimeoutExpired as exc:
             # A timeout happened after a real spawn. No trustworthy wrapper survived, so count the
             # call and fail closed on cost instead of leaving a paid timeout looking like $0.

--- a/RussianTranslation/src/pilot/headless_worker_selftest.py
+++ b/RussianTranslation/src/pilot/headless_worker_selftest.py
@@ -213,6 +213,30 @@ def test_call_timeout_clamped():
           % (h.HARD_TIMEOUT_MS, h.HARD_TIMEOUT_MS / 1000.0))
 
 
+def test_cli_spawns_from_a_bare_cwd():
+    """H2158 (#983): the CLI child must not inherit the repo cwd.
+
+    v1.127.0 measured that CLAUDE.md + git-state injection is what makes ~49 k of the prompt
+    prefix volatile and re-written every call (-33 % cost / -30 % wall clock when removed).
+    `proc_tree.run_tree_kill` always accepted `cwd`; nothing supplied one, so the child
+    inherited the repo and paid that every call. Pin BOTH halves: a cwd is passed at all, and
+    what it points at carries no project context.
+    """
+    seen = {}
+    def capture_runner(argv, **kwargs):
+        seen['cwd'] = kwargs.get('cwd')
+        return success_runner(argv, **kwargs)
+    execute(manifest(), capture_runner)
+    cwd = seen.get('cwd')
+    assert cwd is not None, 'no cwd passed -- the child inherits the repo (#983/H2158)'
+    assert os.path.isdir(cwd), 'cwd must exist before the spawn: %r' % cwd
+    assert not os.path.exists(os.path.join(cwd, 'CLAUDE.md')), 'cwd injects CLAUDE.md: %r' % cwd
+    assert not os.path.exists(os.path.join(cwd, '.git')), 'cwd injects git state: %r' % cwd
+    repo = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+    assert os.path.abspath(cwd) != repo, 'cwd is the repo itself: %r' % cwd
+    print('  H2158 bare cwd: CLI spawned from %s (no CLAUDE.md, no .git)' % cwd)
+
+
 def test_kill_ceiling_in_step_with_harness():
     """#983: the per-call ceiling lives in TWO places and raising only one is inert.
 
@@ -1593,6 +1617,7 @@ console.log(JSON.stringify(restoreCard(card, 'agni')))
     test_h2091_948_infra_stop_is_not_a_content_verdict()
     test_h2091_948_account_refusal_aborts_before_any_bisect()
     test_kill_ceiling_in_step_with_harness()
+    test_cli_spawns_from_a_bare_cwd()
     print('headless_worker_selftest: PASS')
 
 


### PR DESCRIPTION
Lands the win [v1.127.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.127.0) measured but explicitly did not implement, and records the verdict on [v1.128.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.128.0)'s ceiling relaxation. Tracking: [#983](https://github.com/gasyoun/SanskritLexicography/issues/983).

## Bare cwd (H2158)

`proc_tree.run_tree_kill` **always** accepted `cwd` and passed it to `Popen` — nothing ever supplied one, so the CLI child silently inherited the repo and paid CLAUDE.md + git-state injection (~11–17 k volatile prefix tokens) on **every call**. v1.127.0 measured the cost of that at **−33 % cost / −30 % wall clock**.

Two deliberate design points:

- **Stable, not per-call.** A fresh temp dir each call would hand the model a different cwd string every time and re-break the very prefix this stabilises.
- **Fails safe.** If the candidate still sits inside a git repo or under a `CLAUDE.md`, `bare_cli_cwd()` returns `None` and the historical inherited-cwd behaviour is kept — silently spawning from a still-polluted directory would reintroduce the cost with no signal.

Pinned by `test_cli_spawns_from_a_bare_cwd`, asserting **both** halves: that a cwd is passed at all, and that what it points at has no `CLAUDE.md` and no `.git`.

The wall-clock half matters beyond cost — a 30 % shorter call is 30 % more headroom against the ceiling below.

## The 300 s ceiling verdict — it splits

Re-run `h1447-m50-2026-08-02b`, stopped externally after 4 calls but decisive:

| call | 180 s run | 300 s run | verdict |
|---|---|---|---|
| `translate b0` | killed at **180 044 ms** | killed at **300 073 ms** | **hangs at ANY ceiling** |
| `heal:nakzatra#g1` | 120 375 ms ✓ | 82 459 ms ✓ | completes; huge variance |
| `heal:nakzatra#g2` | 134 511 ms ✓ | **176 952 ms ✓** | **3 048 ms of margin under the old bound** |

**Validated for the heal lane** — `g2` at 176 952 ms had three seconds to spare under 180 000 ms, and the same groups ranged 82–120 s / 134–177 s across runs, so the upper tail was genuinely being killed.

**Refuted for the whole-card lane, and this corrects my earlier framing.** I read all 12 timeouts as one phenomenon. `b0` died at 180 044 ms and then 300 073 ms, converging on neither — a **non-terminating** call. For that lane a higher ceiling strictly *increases* waste. The whole-card hang is a separate, still-unfixed defect and should not be filed under the ceiling fix.

## Gates

`window_selftest` **199/199** · `headless_worker_selftest` **PASS** · `lang_parity_check` **90 entries, no drift** (5 re-stamped; the diff greps **zero** hits for `lang`/`ru`/`en`/`de`/`field` — a subprocess cwd is language-agnostic by construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)