### PR TITLE
docs(pwg_ru): propagate the H2152/H2158 findings into the operator playbook

### DIFF
--- a/RussianTranslation/AGENTS.md
+++ b/RussianTranslation/AGENTS.md
@@ -17,6 +17,14 @@ pipeline, with article-comparison Russian review work as the secondary track.
   if the parent state is relevant.
 - Trust current command output and `src/pilot/output/window_status.json` over
   stale prose in older handoff files.
+- **Paid headless calls run from a BARE cwd, one card per call** (02-08-2026,
+  measured). The CLI injects `CLAUDE.md` + git state into its cache prefix, so a
+  repo cwd costs **+33 % money and +30 % wall clock** per call for nothing. The
+  per-call cache is re-created every time and never reused — that is the route's
+  floor, not a tuning target, and **batching does not fix it** (it also destroys
+  per-card cost attribution for the whole batch). Full rules:
+  [`src/pilot/RUN_FREQ_MAX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_FREQ_MAX.md)
+  § Current operating truth.
 
 ## PWG → Russian Production Loop
 

--- a/RussianTranslation/PIPELINE_HISTORY.md
+++ b/RussianTranslation/PIPELINE_HISTORY.md
@@ -1,6 +1,6 @@
 # PWG→RU/EN pipeline — history: solutions, failures, current state
 
-_Created: 04-07-2026 · Last updated: 26-07-2026_
+_Created: 04-07-2026 · Last updated: 02-08-2026_
 
 This is the orientation document for anyone (human or session) who needs the
 **shape** of how this pipeline got here, without reading the full
@@ -8,6 +8,42 @@ This is the orientation document for anyone (human or session) who needs the
 narrated). Read this first; go to `.ai_state.md` for exact dates/PRs/numbers on
 any specific claim below, and to [`src/pilot/RUN_FREQ_MAX.md`](src/pilot/RUN_FREQ_MAX.md)
 for the current operating procedure.
+
+### H2152/H2158 — the ceiling was never the problem: every call re-writes its own cache (02-08-2026)
+
+The 25-07 → 02-08 arc looks from the outside like five separate failures, and it was one.
+A paid run on 02-08 produced **zero cards in 16 calls**; 12 died at exactly
+`HARD_TIMEOUT_MS = 180000`. The obvious readings were all wrong, and each had already cost a
+session:
+
+| Reading | Verdict |
+|---|---|
+| "the route is down" | wrong — network was healthy throughout ([§268](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md), 9 hypotheses excluded) |
+| "~65 s is CLI startup" | **withdrawn** ([§267](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)) |
+| "it's a rate limit hanging silently" | correct **for 31-07** ([§270](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)), not for 02-08 |
+| "one card per call is the wrong shape under quota" | conditional — quota was not binding ([H2152](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H2152-Opus_RussianTranslation_c4-quota-call-shape-audit_02.08.26.md)) |
+| "199 370 subagent tokens" | a **misnomer** — `subagent_tokens` is the sum of the four token fields; no subagents exist |
+
+**The actual cause:** every `claude -p` invocation re-creates ~32–49 k tokens of cache at the
+premium write rate. Two *identical* back-to-back calls re-created 49 153 → 49 165 with cache read
+pinned at 28 882 — **the second re-wrote exactly what the first had just written.** Not TTL
+expiry: the write lands in `ephemeral_1h_input_tokens`, and a 1-hour TTL cannot lapse between
+calls seconds apart. A one-shot subprocess cannot amortise its own system prompt.
+
+**Two things follow, and they are why this entry exists.** (1) **Call shape is not the lever** —
+heal groups were already at one fragment and still timed out, so there is nothing left to shrink;
+don't spend a session tuning batch sizes. (2) **cwd is a free lever** — `CLAUDE.md` + git-state
+injection is worth ~11–17 k tokens/call, and running from a bare cwd measured **−33 % cost,
+−30 % wall clock** with no code change.
+
+The standing ruling `"NOTHING runs past 3 min (MG)"` was **not** relaxed: raising a ceiling to fit
+an overhead it was never meant to measure is the weaken-a-guard-to-pass-a-gate move this whole arc
+exists to refuse. Route change (Messages API with a prefix we control) is
+[H2158](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2158-Opus_RussianTranslation_pwg-messages-api-port_02.08.26.md),
+blocked on one human trade: the CLI bills against the Max subscription, the API is metered.
+Evidence: [v1.124.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.124.0) ·
+[v1.127.0](https://github.com/gasyoun/SanskritLexicography/releases/tag/v1.127.0) ·
+[FINDINGS §283](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)–[§284](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md).
 
 ### H1655 — the reviewer abort that made "no German before a human" a hard gate (26-07-2026)
 

--- a/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
+++ b/RussianTranslation/src/pilot/RUN_FREQ_MAX.md
@@ -83,6 +83,32 @@ tracked-file drift and is wired into `window_selftest.py`
   saved run ID, manifest SHA-256, profile binding, sealed preflight SHA-256 and exact
   selected-key scope, plus the reservation ledger. The worker seals its result SHA-256;
   `record-output`/`record-output-batch` require the matching run and result hash.
+- **Run every headless call from a BARE cwd — not from the repo (02-08-2026, measured).**
+  The CLI injects `CLAUDE.md` + git state into its prompt prefix, and that injection is worth
+  **~11–17 k re-created cache tokens per call**. Measured on identical `--max-turns 1` calls:
+  repo cwd **$0.3036 / 26–29 s**, bare cwd **$0.2040 / 19–20 s** — **−33 % cost, −30 % wall
+  clock for changing one directory**, no code change and no guard weakened. Pass an empty
+  scratch dir as the subprocess `cwd`; the manifest carries every input the worker needs, so
+  nothing depends on being inside the repo.
+- **The per-call cache is NEVER reused — budget for it, do not try to tune it away.** Two
+  *identical* back-to-back calls each re-created ~49 k tokens (49 153 → 49 165, cache read
+  pinned at 28 882): the second re-wrote exactly what the first had just written. The write is
+  a premium **cache create** (~$6/M), not a **read** (~$0.30/M), and at ~$0.30 it *is* the cost
+  of a call that translates nothing. **This is not TTL expiry** — the write lands in
+  `ephemeral_1h_input_tokens` and a 1-hour TTL cannot lapse between calls issued seconds apart.
+  A one-shot subprocess cannot amortise its own system prompt; that is a property of the route.
+  Do not "fix" it by batching (see the shape ruling below). Route change tracked in
+  [H2158](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2158-Opus_RussianTranslation_pwg-messages-api-port_02.08.26.md);
+  measurement in [`RESULTS_LOG.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md)
+  + [Uprava FINDINGS §284](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md).
+- **Call shape: ONE card per call — and shape is not the lever (H2152, 02-08-2026).** Quota and
+  the 180 s per-call wall bind in **opposite** directions: a quota ceiling penalises *many*
+  calls, a wall-clock ceiling penalises *large* ones. Whichever binds decides the shape, and as
+  of 02-08 it is wall clock, so the small shape wins — which is also what MG's
+  instrument-everything mandate asks for, so the two are not in conflict. `--output-budget=1`
+  is the existing one-card lane; nothing needs building. **Do not flip to batching to save
+  cost:** batching also makes one unevaluable call destroy per-card attribution for *all* N
+  cards in it. Full reasoning: [`pwg_ru/h2152/AUDIT_C4_CALL_SHAPE_QUOTA_VS_WALLCLOCK_02.08.2026.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/h2152/AUDIT_C4_CALL_SHAPE_QUOTA_VS_WALLCLOCK_02.08.2026.md).
 - **Live-gate before every paid window:** fresh
   [`/pwg-live-gate`](https://github.com/gasyoun/claude-config/blob/main/commands/pwg-live-gate.md)
   (representative ≥5 KB health + separate `dq_canary_puregloss`). A previous session's GO
@@ -512,6 +538,15 @@ For each bounded headless window, record:
 - wall-clock minutes;
 - CLI-reported input/output/cache tokens and observed cost, or the explicit
   unevaluable-cost stop;
+- **`cache_creation_input_tokens` vs `cache_read_input_tokens` SEPARATELY, per call** — not a
+  combined total. Creation is billed ~20× read, so the split is the whole cost story, and a
+  combined figure hides it. Record the TTL bucket too (`cache_creation.ephemeral_1h…` vs
+  `…_5m…`): that single field is what refuted the "cache expired" explanation without needing
+  an experiment (FINDINGS §284). Note that `subagent_tokens` is a **legacy misnomer** for the
+  sum of the four token fields — no subagents are involved; never read it as scaffolding cost;
+- **`duration_api_ms` alongside wall clock**, and the derived `api_gap_ms` between them. Gating
+  on wall clock alone silently encodes machine load and CLI startup into what is supposed to be
+  a route measurement (§267/§270 both mis-attributed the same gap);
 - whether the weekly cap fired, and cumulative tokens at that moment.
 
 `audit_window.py` records the operational state, next action, sample counts, and any token/time


### PR DESCRIPTION
The measurements landed in RESULTS_LOG / CHANGELOG / FINDINGS but **not** into the docs an operator or a fresh session actually reads before spending money. This closes that gap — the `/artifact-propagate` half of [#994](https://github.com/gasyoun/SanskritLexicography/pull/994).

## [`RUN_FREQ_MAX.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pilot/RUN_FREQ_MAX.md) § Current operating truth

- **Run every headless call from a BARE cwd, not the repo.** `CLAUDE.md` + git-state injection is ~11–17 k re-created cache tokens per call: repo cwd **$0.3036 / 26–29 s** vs bare **$0.2040 / 19–20 s** — **−33 % cost, −30 % wall clock** for changing one directory.
- **The per-call cache is NEVER reused — budget for it, don't tune it.** Two identical calls re-created **49 153 → 49 165** with read pinned at 28 882. Not TTL: the write lands in `ephemeral_1h_input_tokens`. A one-shot subprocess cannot amortise its own system prompt.
- **Call shape stays ONE card per call, and shape is not the lever.** Quota and the 180 s wall bind in **opposite** directions, so whichever binds decides the shape; batching also destroys per-card attribution for the whole batch.

## `RUN_FREQ_MAX.md` § Instrumentation

Record cache **creation vs read separately** plus the TTL bucket — creation bills ~20× read, and that bucket is what refutes a "cache expired" story *without* an experiment. Record `duration_api_ms` and the derived `api_gap_ms` alongside wall clock. `subagent_tokens` is a **legacy misnomer** for the sum of the four token fields.

## [`AGENTS.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/AGENTS.md)

Short form of the same two rules, pointing at RUN_FREQ_MAX.

## [`PIPELINE_HISTORY.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PIPELINE_HISTORY.md)

A dated entry for the 25-07 → 02-08 arc. From outside it looks like five separate failures and it was one — the entry tabulates each wrong reading against its verdict (route down / 65 s startup / silent rate limit / wrong call shape / "subagent tokens") so the next session doesn't re-derive them, and records that the 3-minute ruling was deliberately **not** relaxed.

## Also landed outside this PR (config repos, not this repo)

- [`/pwg-bounded-run`](https://github.com/gasyoun/claude-config/blob/main/commands/pwg-bounded-run.md): the command block literally said `--cwd .`. Now a bare scratch dir, with the measurement inline.
- [`/pwg-live-gate`](https://github.com/gasyoun/claude-config/blob/main/commands/pwg-live-gate.md): gate on `duration_api_ms`; hang = quota candidate first but distinguish our own 180 s kill; `auth status` proves credentials, not quota.
- **Codex twins** got the same rules — and the `pwg-live-gate` twin was found carrying the **superseded** health policy (`both readings < 30000 ms`), which would have NO-GO'd a route MG unblocked on 31-07-2026. Corrected.

Docs only. No paid call, no constant moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)