### PR TITLE
docs(pwg_ru): .ai_state resume point for the whole-card b0 hang (H2160)

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -472,6 +472,27 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
 > **and** adding texts/locus crosswalks — not a better matcher, and not more compute.
 
 ## ➡️ Next Steps (Queue)
+- **H2160 🟡 QUEUED — the whole-card `b0` hang, and medium50 still unfinished (02-08-2026,
+  Opus 5 `claude-opus-5[1m]`).** The paid lane was restarted after the 25-07 → 02-08 stoppage and
+  **two windows were attempted; neither produced a single card.** What is settled and must not be
+  re-derived: c4 auth restored; route health real (first decomposed probe — measured wall 50 336 ms
+  / API 27 557 ms, ~45 % of wall is in-CLI scaffolding); the ceiling relaxed 180 s → 300 s by human
+  ruling and enforced in **five** places (raising one is inert); all five medium50 artifacts already
+  re-budgeted to 300000; the CLI now spawns from a bare cwd (−33 % cost, −30 % wall).
+  **The open defect:** `translate b0` died at **180 044 ms** and then at **300 073 ms** — it
+  converges on no ceiling, so it is non-terminating, NOT merely slow. The heal lane by contrast
+  works and the relaxation is validated there (`heal:nakzatra#g2` returned at 176 952 ms, i.e.
+  3 048 ms inside the old bound). **The judgment owed:** fix whole-card, or presplit every card and
+  bypass it (`presplit_keys` is `[]` in all five manifests). Tracking
+  [#983](https://github.com/gasyoun/SanskritLexicography/issues/983). ⚠️ Both windows ran on a
+  **half-satisfied gate** — health PASS, `/pwg-live-gate` Step 2 canary never built (the only
+  canary manifest on disk is bound to c2). ⚠️ Measured cost is **~$0.53/call vs the $0.113**
+  `perf_preflight` prices with (4.7×), and cache creation is ~71 % of each call. Start with:
+
+```
+Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H2160-Opus_RussianTranslation_whole-card-b0-hang-and-medium50-completion_02.08.26.md and execute it.
+```
+
 - **H2138 🟡 QUEUED — DOUBLE-GATED (H2118 residual).** Re-derive `PROBE_LATENCY_CEILING_MS` from
   ≥5 paired readings and land it as `probe_log.POLICIES['production_v3']`. Gated on **(a)** a
   harness permission — H2118 was denied the credential read the §270 quota check needs — and


### PR DESCRIPTION
Session-end journal entry. Records what is settled (c4 auth restored, route health decomposed, ceiling relaxed 180s→300s across five enforcement points, artifacts re-budgeted, bare cwd landed) and the one open defect: `translate b0` died at 180 044 ms and then 300 073 ms — non-terminating, not slow — while the heal lane works and the relaxation is validated there (`heal:nakzatra#g2` at 176 952 ms, 3 048 ms inside the old bound).

Resume: [H2160](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2160-Opus_RussianTranslation_whole-card-b0-hang-and-medium50-completion_02.08.26.md). Tracking [#983](https://github.com/gasyoun/SanskritLexicography/issues/983).

🤖 Generated with [Claude Code](https://claude.com/claude-code)