### PR TITLE
H1909: NWS bare-citation vs. provenance-note fragment discriminator

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -3381,6 +3381,20 @@ batch [_batch_h1624_dh_followups.tsv](https://github.com/gasyoun/Uprava/blob/mai
   `test_q3_execute_requires_canary_go_receipt_h2159`; `window_selftest` **199/199**.
   Memo gaps remaining: G5/G8/G9/G10.
 
+- **H1909 NWS bare-citation vs. provenance-note discriminator (02-08-2026, Sonnet 5
+  `claude-sonnet-5`)** — H1809 follow-on: `classify_general_bare_citation()` in
+  [nws_ls_markup.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/nws_ls_markup.py)
+  tells genuine bare PWG citations apart from author/year provenance-note fragments across
+  the 929-span NWS-layer sample (bracket-position + bare-year-locus signals, plus a single
+  measured-false-positive siglum exclusion `'H'` — a blanket short-siglum rule was tried
+  and rejected, it also dropped 4 genuine Rāmāyaṇa citations whose Roman-vs-Arabic locus
+  form maps to different editions). Every accepted span validated via `pwg_sources` +
+  `ls_resolver` before marking. Measured 0/195 false positives (full inspection, not a
+  sample). Applied to the canonical store: 110/11,603 rows changed, 195 `<ls>` wraps,
+  byte-identical elsewhere, idempotent. 8 new tests (20/21 pass in the file — 1
+  pre-existing, unrelated failure). Report:
+  [pwg_ru/H1909_NWS_BARE_CITATION_DISCRIMINATOR_REPORT_2026-08-02.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1909_NWS_BARE_CITATION_DISCRIMINATOR_REPORT_2026-08-02.md).
+
 - **H2157 mandatory ceilings on --execute (02-08-2026, Fable 5 `claude-fable-5`)** —
   H2025 gap G3 (F-B1): a paid `bounded_staged_run.py --execute` now refuses to start
   without BOTH `--max-calls` and `--cost-ceiling`; `--allow-unbounded` is the explicit

--- a/RussianTranslation/pwg_ru/H1909_NWS_BARE_CITATION_DISCRIMINATOR_REPORT_2026-08-02.md
+++ b/RussianTranslation/pwg_ru/H1909_NWS_BARE_CITATION_DISCRIMINATOR_REPORT_2026-08-02.md
@@ -1,0 +1,113 @@
+# H1909 — NWS bare-citation vs. provenance-note fragment discriminator — report
+
+_Created: 02-08-2026 · Last updated: 02-08-2026_
+
+Handoff: [H1909](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1909-Sonnet_SanskritLexicography_nws-bare-citation-provenance-discriminator_29.07.26.md)
+· Model: Sonnet 5 (`claude-sonnet-5`) · Tooling:
+[nws_ls_markup.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/nws_ls_markup.py) ·
+Tests: [tests/test_nws_ls_markup.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/tests/test_nws_ls_markup.py).
+
+## What this was
+
+[H1809](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H1809-Sonnet_SanskritLexicography_nws-bare-citation-ls-markup_28.07.26.md)
+fixed the specific defect MG reported (`ṚV(Sā) I 165, 11` not clickable). Its own census, run
+over ALL `g5_card_render._BARE_CIT`-shaped spans in NWS rows (not just the Roman-numeral
+convention it fixed), found **929 matches** store-wide — far more than the handful of genuine
+unlinked citations. H1809 deliberately declined to mark any of them, logging the count and
+stopping rather than guessing at scale (see its own
+[report](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru/H1809_NWS_LS_MARKUP_REPORT_2026-07-29.md)
+§"Explicitly out of scope"). This handoff is that follow-on: build the recognizer.
+
+## Discriminator design — three provenance-fragment signals, one validation gate
+
+`classify_general_bare_citation()` in
+[nws_ls_markup.py](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/nws_ls_markup.py)
+excludes a match as a provenance-note fragment (never marked) on any of:
+
+1. **Bracket position** — lives inside a literal `[NWS: ...]` tag. Strongest single signal,
+   as the handoff's own prerequisite guessed: 125 matches, only 1 borderline case (see §3).
+2. **Bare-year-shaped locus** — a single 4-digit number, no internal separator, in the range
+   1400–2029 (`'Lévi 1925'`, `'Dalal 1934'`). Provenance notes are sometimes rendered as
+   parenthetical or bare-comma prose OUTSIDE the literal bracket too, so this signal alone
+   catches 290 more author+year fragments the bracket check misses.
+3. **`_SPURIOUS_SHORT_SIG`** — one measured false-positive siglum, `'H'` (3 matches; see §3).
+
+Everything surviving all three is a **citation candidate**, then validated exactly like
+H1809's own gate: siglum must resolve in `pwg_sources`' PWG bibliography, and the normalised
+locus must produce a real href via `ls_resolver.generate_href`. Only spans passing **both**
+classification and validation are wrapped in `<ls n="...">`; the locus normaliser
+(`_normalize_general_loc`) generalises H1809's Roman-mandala conversion to the comma-attached
+NWS spelling (`'I,85,12'`, not just the space-separated `'I 165, 11'` the Roman-specific pass
+already handled) — this recovered 49 citations that a first draft using only the space-form
+converter left as false residue.
+
+## Measured false-positive rate — 0/195 in the marked set, not estimated
+
+Every one of the 195 spans this pass actually marks was hand-inspected (full listing in the
+census output, not a sample): all 195 are `ṚV`/`AV` (Ṛgveda/Atharvaveda) citations with a
+genuine multi-part locus. **0/195 = 0% measured false-positive rate**, against the handoff's
+<5% stop condition.
+
+### §3 — how two candidate false positives were found and ruled out
+
+The design process itself surfaced two near-misses, both worth recording since they shaped
+the final rules:
+
+- **`'H. 12'`** (siglum `H`) resolves in PWG's own bibliography (Hemacandra's
+  *Abhidhānacintāmaṇi*) and even generates a valid href for a bare 1–2 digit locus. But
+  every one of the 4 store-wide occurrences of this exact span (1 inside a `[NWS: ...]`
+  bracket, 3 outside) is actually `"2. H. 12. Jh."` = German *"2nd half, 12th century"* — a
+  date descriptor, not a citation. A first-draft fix excluded ALL 1-character sigla, which
+  also silently dropped 4 genuine `'R I.44.6'`-shaped citations (see below) — replaced with
+  a `_SPURIOUS_SHORT_SIG = {'H'}` set naming only the one siglum with concrete evidence.
+- **`'R I.44.6'`, `'R VII.21.42'`, `'R II.12.110'`, `'R III.61.3'`** (siglum `R`, Rāmāyaṇa)
+  are genuine citations that the blanket short-siglum rule above wrongly excluded in the
+  first draft. `'R'` legitimately resolves in PWG's bibliography, and `ls_resolver` even
+  generates an href for SOME locus spellings — but Arabic vs. Roman book numbers there route
+  to **different critical editions** (`ramayanaschl`/Schlegel vs. `ramayanagorr`/Gorresio;
+  measured directly against `ls_resolver.generate_href`). Auto-converting the store's
+  period-separated Roman form (`'I.44.6'`) to Arabic to make it resolve would silently pick
+  an edition MG never specified. This module does not guess: these 4 spans fall through to
+  `residue_no_href` (siglum resolves, locus shape doesn't) — visible in the residue list,
+  not silently dropped, and not marked with a possibly-wrong link.
+
+## Store-wide results (NWS-layer rows: 506 of 11,603)
+
+| Category | Count |
+|---|---|
+| Total `_BARE_CIT`-shaped spans in NWS rows | 929 |
+| — already claimed by H1809's Roman-specific pass or a pre-existing `<ls>` span (unchanged by this pass) | 8 |
+| — inside `[NWS: ...]` bracket (provenance fragment) | 125 |
+| — bare-year-shaped locus outside bracket (provenance fragment) | 290 |
+| — `'H.'` century-descriptor collision (provenance fragment) | 3 |
+| — citation-shaped, siglum not in PWG's bibliography (honest residue) | 276 |
+| — citation-shaped, siglum resolves but locus shape has no `ls_resolver` pattern (honest residue, includes the 4 Rāmāyaṇa spans above) | 32 |
+| **Resolved + marked with `<ls n="...">`** | **195** |
+
+## Store mutation
+
+Applied via `python nws_ls_markup.py apply` against the canonical store
+(`RussianTranslation/src/pwg_ru_translated.jsonl`, resolved through `store_path.py`, same
+loss-safety convention as H1809). Backup:
+`pwg_ru_translated.jsonl.h1809nws.<timestamp>.<pid>.<host>.bak` (H2146/H2153 locked writer,
+gitignored). **110 of 11,603 rows changed** (195 `<ls>` wraps landed across 110 rows — several
+rows carry more than one citation). Verified against the pre-apply backup: every row's fields
+other than `ru` are byte-identical; stripping every newly-added `<ls n="...">...</ls>` wrapper
+from each changed row's `ru` reproduces the backup's `ru` exactly (zero drift beyond the
+wrapper itself). Verified idempotent: a second `apply` run reports 0 rows changed, 0 new
+`resolved + marked`.
+
+## Verification
+
+- `python -m pytest tests/` (full RussianTranslation suite): 103/104 pass. The 1 failure
+  (`test_apply_round_trip_on_a_scratch_store::test_apply_round_trip_on_a_scratch_store`
+  backup-filename assertion) reproduces byte-for-byte identically on the unmodified
+  pre-H1909 code — pre-existing, unrelated to this change, not touched.
+- `python -m pytest tests/test_nws_ls_markup.py`: 20/21 pass (same pre-existing failure); 8
+  new tests added, one per discriminator branch plus one end-to-end `apply()` fixture
+  exercising all of them in a single row.
+- `python -m py_compile RussianTranslation/src/nws_ls_markup.py`: clean.
+- Byte-diff verification script (backup vs. post-apply store): 110 rows changed, 195 net
+  `<ls>` tags added, 0 other-field changes, 0 mismatches beyond the `<ls>` wrapper.
+
+_Dr. Mārcis Gasūns_

--- a/RussianTranslation/src/nws_ls_markup.py
+++ b/RussianTranslation/src/nws_ls_markup.py
@@ -52,6 +52,7 @@ Entry points:
     python nws_ls_markup.py apply  [--store PATH] [--no-backup]
 """
 import argparse
+import collections
 import io
 import json
 import os
@@ -121,6 +122,118 @@ _BRACKET_TAG_DOMAIN = re.compile(
     r'(\s*(?:\([^)]*\))?\s*\])'
 )
 
+# --------------------------------------------------------------------- H1909
+# H1809's own census, run over ALL `g5cr._BARE_CIT`-shaped spans in NWS rows
+# (not just the Roman-numeral convention above), found 929 matches store-wide
+# -- far more than the handful of genuine unlinked citations. This is the
+# discriminator that tells them apart, per the module docstring.
+
+#: Full `[NWS: ...]` provenance-note span -- most bracket-interior _BARE_CIT
+#: matches are author-name+year fragments the note cites for ITS OWN
+#: provenance ('Windisch 1883 : 106'), not a citation the headword makes.
+_NWS_BRACKET_SPAN = re.compile(r'\[NWS:[^\]]*\]')
+
+#: A bare 4-digit number with NO internal separator, in a plausible
+#: publication-year range -- the shape of an author-name+year provenance
+#: fragment ('Dalal 1934', 'Lévi 1925') that lives OUTSIDE the literal
+#: `[NWS: ...]` bracket too (the note is sometimes rendered as parenthetical
+#: or bare-comma prose instead). A genuine PWG locus is a multi-part
+#: comma/period-separated coordinate or a short 1-3 digit page number, never
+#: a bare 4-digit run -- measured over the store: 290 of 804 non-bracket
+#: matches are exactly this shape and none of the 185 spans this module
+#: actually marks would have matched it.
+_YEAR_LIKE_LOC = re.compile(r'^(1[4-9]\d\d|20[0-2]\d)$')
+
+#: Leading Roman-numeral mandala in a `_BARE_CIT` `loc` group, either NWS
+#: space-form ('I 165, 11') or comma-attached ('I,85,12') -- generalises
+#: normalize_nws_locus() above to the shape `_BARE_CIT` actually captures
+#: (one string, not a separate roman/loc pair).
+_ROMAN_LOC_PREFIX = re.compile(r'^([IVXLC]{1,6})[\s,]+(\d[\d,\s]*)$')
+
+#: 'H.' resolves in PWG's own bibliography (Hemacandra's Abhidhānacintāmaṇi)
+#: AND `ls_resolver.generate_href` accepts a bare 1-2 digit locus for it --
+#: but EVERY occurrence of this shape in the NWS layer (measured: all 3
+#: outside-bracket + the 1 inside-bracket instance, store-wide) is actually
+#: "2. H. 12. Jh." = "2nd half, 12th century", a German date fragment, not a
+#: citation. A blanket "reject any 1-char siglum" rule was tried and
+#: rejected: it also caught 4 genuine 'R I.44.6'-shaped Rāmāyaṇa citations
+#: (siglum 'R' legitimately resolves too, and some locus spellings even
+#: generate an href -- but Arabic vs. Roman book numbers there route to
+#: DIFFERENT editions, Schlegel vs. Gorresio, so guessing one would risk a
+#: wrong link; this module correctly leaves 'R'-sigla as `residue_no_href`
+#: via the normal gate below instead). Naming just 'H' is the minimal,
+#: evidence-backed fix for the one siglum that is both short AND resolves to
+#: a valid-but-wrong link for this specific locus shape.
+_SPURIOUS_SHORT_SIG = {'H'}
+
+
+def _normalize_general_loc(loc_raw):
+    """`'I,85,12'` / `'I 85, 12'` -> `'1,85,12'`; a plain Arabic locus passes
+    through comma-normalised unchanged. Returns None only if a Roman-looking
+    prefix does not parse as a real numeral (defensive -- unreachable given
+    `_BARE_CIT`'s own shape, kept honest rather than guessed at)."""
+    loc_raw = loc_raw.strip()
+    m = _ROMAN_LOC_PREFIX.match(loc_raw)
+    if m:
+        mandala = ls_resolver.roman_int20(m.group(1))
+        if not mandala:
+            return None
+        return '%d,%s' % (mandala, re.sub(r'\s*,\s*', ',', m.group(2).strip()))
+    return re.sub(r'\s*,\s*', ',', loc_raw)
+
+
+def classify_general_bare_citation(ru, m):
+    """Does one `g5cr._BARE_CIT` match in an NWS row's `ru` look like a
+    genuine bare PWG citation, or a provenance-note author/year fragment?
+
+    Returns `(verdict, payload)`:
+      'provenance_bracket'   None            -- lives inside a [NWS: ...] tag
+      'provenance_year'      None            -- bare 4-digit year-shaped locus
+      'provenance_short_sig' None            -- siglum in `_SPURIOUS_SHORT_SIG`
+                                                 (measured false-positive
+                                                 source, see that set's
+                                                 docstring)
+      'residue_no_bib'       sig             -- citation-shaped, siglum not
+                                                 in PWG's own bibliography
+      'residue_no_href'      n_attr          -- siglum resolves but
+                                                 ls_resolver has no pattern
+                                                 for this locus shape
+      'resolved'             (n_attr, href)  -- genuine citation, validated
+
+    Only 'resolved' is ever marked with `<ls>`; everything else is honest
+    residue, matching H1809's "report, don't guess" convention (Scope §3/§5
+    of the H1909 handoff)."""
+    if any(b.start() <= m.start() and m.end() <= b.end()
+           for b in _NWS_BRACKET_SPAN.finditer(ru)):
+        return 'provenance_bracket', None
+    sig = g5cr._norm(m.group('sig'))
+    if sig.rstrip('.') in _SPURIOUS_SHORT_SIG:
+        return 'provenance_short_sig', None
+    loc_raw = m.group('loc').strip()
+    if _YEAR_LIKE_LOC.match(loc_raw):
+        return 'provenance_year', None
+    loc_norm = _normalize_general_loc(loc_raw)
+    if loc_norm is None:
+        return 'residue_no_bib', sig
+    sig_norm = sig if sig.endswith('.') else sig + '.'
+    if not pwg_sources.resolve(sig_norm):
+        return 'residue_no_bib', sig
+    n_attr = '%s %s' % (sig_norm, loc_norm)
+    href = ls_resolver.generate_href('pwg', n_attr, '')
+    if not href:
+        return 'residue_no_href', n_attr
+    return 'resolved', (n_attr, href)
+
+
+def _general_bare_citation_matches(ru, claimed):
+    """`g5cr._BARE_CIT` matches in `ru` not already claimed by the
+    Roman-numeral-specific pass (`NWS_ROMAN_CIT`) or an existing store `<ls>`
+    span -- both computed by the caller against the SAME `ru` string so
+    offsets always agree, even after the Roman pass has mutated it."""
+    for m in g5cr._BARE_CIT.finditer(ru):
+        if not any(c.start() <= m.start() and m.end() <= c.end() for c in claimed):
+            yield m
+
 
 def _load_rows(path):
     rows = []
@@ -184,12 +297,16 @@ def census(path):
     residue = []       # (key1, sig, span) -- did not resolve
     domain_hits = []   # (key1, value)
     general_bare_note = 0
+    general_resolved = []      # (key1, n_attr, href, original_span)
+    general_residue = []       # (key1, sig_or_n_attr, original_span)
+    general_provenance = collections.Counter()
     for row in rows:
         if not _is_nws_row(row):
             continue
         ru = row.get('ru') or ''
         nws_rows += 1
-        for m in NWS_ROMAN_CIT.finditer(ru):
+        roman_spans = list(NWS_ROMAN_CIT.finditer(ru))
+        for m in roman_spans:
             span = m.group(0)
             r = resolve_nws_citation(m.group('sig'), m.group('roman'), m.group('loc'))
             if r:
@@ -199,6 +316,16 @@ def census(path):
         for m in _BRACKET_TAG_DOMAIN.finditer(ru):
             domain_hits.append((row.get('key1'), m.group(2)))
         general_bare_note += len(g5cr._BARE_CIT.findall(ru))
+        claimed = roman_spans + list(_STORE_LS.finditer(ru))
+        for m in _general_bare_citation_matches(ru, claimed):
+            verdict, payload = classify_general_bare_citation(ru, m)
+            if verdict == 'resolved':
+                n_attr, href = payload
+                general_resolved.append((row.get('key1'), n_attr, href, m.group(0)))
+            elif verdict in ('residue_no_bib', 'residue_no_href'):
+                general_residue.append((row.get('key1'), payload, m.group(0)))
+            else:
+                general_provenance[verdict] += 1
     return {
         'store_rows': len(rows),
         'nws_rows': nws_rows,
@@ -206,6 +333,9 @@ def census(path):
         'residue': residue,
         'domain_migrations': domain_hits,
         'general_bare_citation_note': general_bare_note,
+        'general_resolved': general_resolved,
+        'general_residue': general_residue,
+        'general_provenance': dict(general_provenance),
     }
 
 
@@ -220,6 +350,8 @@ def apply(path, backup=True, dry_run=False):
     `census()` plus `rows_changed`."""
     rows = _load_rows(path)
     resolved, residue, domain_hits = [], [], []
+    general_resolved, general_residue = [], []
+    general_provenance = collections.Counter()
     rows_changed = 0
     for row in rows:
         if not _is_nws_row(row):
@@ -244,6 +376,27 @@ def apply(path, backup=True, dry_run=False):
             else:
                 residue.append((row.get('key1'), g5cr._norm(m.group('sig')), m.group(0)))
 
+        # H1909 -- general bare-citation discriminator, run AFTER the Roman
+        # pass above so `claimed` and the fresh match list share the SAME
+        # (possibly just-mutated) `ru` offsets. `claimed` covers both spans
+        # the Roman pass just wrapped in <ls> AND ones it left as residue
+        # (e.g. 'Harisv XIII 5, 4, 5') so neither is double-reported here.
+        claimed = list(NWS_ROMAN_CIT.finditer(ru)) + list(_STORE_LS.finditer(ru))
+        general_matches = list(g5cr._BARE_CIT.finditer(ru))
+        for m in sorted(general_matches, key=lambda mm: mm.start(), reverse=True):
+            if any(c.start() <= m.start() and m.end() <= c.end() for c in claimed):
+                continue
+            verdict, payload = classify_general_bare_citation(ru, m)
+            if verdict == 'resolved':
+                n_attr, href = payload
+                ru = _wrap_ls(ru, m, n_attr)
+                general_resolved.append((row.get('key1'), n_attr, href, m.group(0)))
+                changed = True
+            elif verdict in ('residue_no_bib', 'residue_no_href'):
+                general_residue.append((row.get('key1'), payload, m.group(0)))
+            else:
+                general_provenance[verdict] += 1
+
         # domain-slot half-translations -> canonical Latin
         def _migrate(dm):
             domain_hits.append((row.get('key1'), dm.group(2)))
@@ -258,9 +411,14 @@ def apply(path, backup=True, dry_run=False):
             row['ru'] = ru
             rows_changed += 1
 
+    general_stats = {'general_resolved': general_resolved,
+                      'general_residue': general_residue,
+                      'general_provenance': dict(general_provenance)}
+
     if dry_run:
         return {'resolved': resolved, 'residue': residue,
-                'domain_migrations': domain_hits, 'rows_changed': rows_changed}
+                'domain_migrations': domain_hits, 'rows_changed': rows_changed,
+                **general_stats}
 
     # H2146/H2153: locked (PromoteClaim) + unique fsynced backup + atomic replace via
     # the shared writer. The old path was unlocked, and its text-mode backup copy
@@ -269,7 +427,8 @@ def apply(path, backup=True, dry_run=False):
                          serialize=_dump_row)
 
     return {'resolved': resolved, 'residue': residue,
-            'domain_migrations': domain_hits, 'rows_changed': rows_changed}
+            'domain_migrations': domain_hits, 'rows_changed': rows_changed,
+            **general_stats}
 
 
 def _print_census(stats):
@@ -284,10 +443,21 @@ def _print_census(stats):
     print('half-translated domain-slot values to migrate: %d' % len(stats['domain_migrations']))
     for key1, val in stats['domain_migrations']:
         print('  --   %-14s %r -> %r' % (key1, val, DOMAIN_SLOT_MIGRATIONS[val]))
-    if 'general_bare_citation_note' in stats:
-        print('note: %d general bare-citation-shaped spans across NWS rows were NOT touched '
-              '(out of scope -- see module docstring); mostly provenance-note author/year '
-              'fragments, not genuine PWG citations.' % stats['general_bare_citation_note'])
+    if 'general_resolved' in stats:
+        note = (' (out of %d total shaped spans across NWS rows, '
+                'Roman-convention matches above excluded)' % stats['general_bare_citation_note']
+                if 'general_bare_citation_note' in stats else '')
+        print('H1909 general bare-citation discriminator%s:' % note)
+        print('  resolved + marked: %d' % len(stats.get('general_resolved', [])))
+        for key1, n_attr, href, span in stats.get('general_resolved', []):
+            print('    ok   %-14s %-22r -> n=%r  %s' % (key1, span, n_attr, href))
+        print('  residue (citation-shaped, does not resolve): %d'
+              % len(stats.get('general_residue', [])))
+        for key1, detail, span in stats.get('general_residue', []):
+            print('    --   %-14s %-30r %r' % (key1, detail, span))
+        prov = stats.get('general_provenance', {})
+        if prov:
+            print('  excluded as provenance-note noise: %s' % dict(prov))
 
 
 def main():

--- a/RussianTranslation/tests/test_nws_ls_markup.py
+++ b/RussianTranslation/tests/test_nws_ls_markup.py
@@ -14,6 +14,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
 
+import g5_card_render as g5cr  # noqa: E402
 import nws_ls_markup as nlm  # noqa: E402
 
 
@@ -141,6 +142,115 @@ def test_apply_round_trip_on_a_scratch_store(tmp_path):
     assert new_rows[2]['ru'] == rows[2]['ru']  # non-NWS row untouched
 
     assert os.path.exists(str(store) + '.h1809.bak')
+
+
+# --- H1909: general bare-citation discriminator ------------------------------
+# MG's H1809 census found 929 g5cr._BARE_CIT-shaped spans across NWS rows --
+# far more than the Roman-numeral convention above catches -- mostly
+# author-name+year provenance-note fragments, not genuine citations. These
+# probes are the "measured, not guessed at" acceptance test for the
+# discriminator that tells them apart (H1909 goal: <5% false-positive rate).
+
+def test_classify_bracket_interior_is_provenance_not_citation():
+    ru = '{#x#} [NWS: Windisch 1883 : 106]'
+    m = list(g5cr._BARE_CIT.finditer(ru))[0]
+    verdict, payload = nlm.classify_general_bare_citation(ru, m)
+    assert verdict == 'provenance_bracket'
+    assert payload is None
+
+
+def test_classify_bare_year_outside_bracket_is_provenance():
+    ru = 'ādi. Lévi 1925 says so.'
+    m = list(g5cr._BARE_CIT.finditer(ru))[0]
+    verdict, payload = nlm.classify_general_bare_citation(ru, m)
+    assert verdict == 'provenance_year'
+
+
+def test_classify_h_dot_century_descriptor_is_provenance_short_sig():
+    """The one measured false-positive source: 'H.' resolves in PWG's own
+    bibliography (Hemacandra) and even generates a valid href for a bare
+    small-number locus -- but every actual occurrence of this shape in the
+    NWS layer is "2. H. 12. Jh." = "2nd half, 12th century", not a
+    citation."""
+    ru = '[Jin, unsp] (2. H. 12. Jh. , Gujarat) говорить.'
+    m = list(g5cr._BARE_CIT.finditer(ru))[0]
+    assert m.group(0) == 'H. 12'
+    verdict, payload = nlm.classify_general_bare_citation(ru, m)
+    assert verdict == 'provenance_short_sig'
+
+
+def test_classify_genuine_arabic_citation_resolves():
+    ru = 'смысл. ṚV 1,116,15 говорит X.'
+    m = list(g5cr._BARE_CIT.finditer(ru))[0]
+    verdict, payload = nlm.classify_general_bare_citation(ru, m)
+    assert verdict == 'resolved'
+    n_attr, href = payload
+    assert n_attr == 'ṚV. 1,116,15'
+    assert href == 'https://sanskrit-lexicon.github.io/rvlinks/rvhymns/rv01.116.html#rv01.116.15'
+
+
+def test_classify_comma_attached_roman_mandala_resolves():
+    """H1909's generalisation of H1809's Roman-mandala normalisation to the
+    comma-attached NWS spelling ('I,85,12'), not just the space-separated one
+    ('I 165, 11') the Roman-specific pass above already handles."""
+    ru = 'смысл. ṚV I,85,12 говорит X.'
+    m = list(g5cr._BARE_CIT.finditer(ru))[0]
+    verdict, payload = nlm.classify_general_bare_citation(ru, m)
+    assert verdict == 'resolved'
+    assert payload[0] == 'ṚV. 1,85,12'
+
+
+def test_classify_ramayana_period_locus_is_honest_residue_not_a_guess():
+    """'R' resolves in PWG's bibliography and even generates an href for SOME
+    locus spellings -- but Arabic vs. Roman book numbers there route to
+    DIFFERENT critical editions (Schlegel vs. Gorresio). This module does not
+    guess which edition a period-separated Roman locus like 'I.44.6' means,
+    so it stays residue rather than risking a wrong link."""
+    ru = 'смысл. R I.44.6 цитата.'
+    m = list(g5cr._BARE_CIT.finditer(ru))[0]
+    verdict, payload = nlm.classify_general_bare_citation(ru, m)
+    assert verdict == 'residue_no_href'
+
+
+def test_classify_unknown_siglum_is_residue_no_bib():
+    ru = 'смысл. ChU VI 4, 1 says X.'
+    m = list(g5cr._BARE_CIT.finditer(ru))[0]
+    verdict, payload = nlm.classify_general_bare_citation(ru, m)
+    assert verdict == 'residue_no_bib'
+    assert payload == 'ChU'
+
+
+def test_apply_h1909_general_pass_end_to_end(tmp_path):
+    """One row exercising every discriminator branch at once: two genuine
+    citations (plain Arabic + comma-attached Roman) get marked; a bare-year
+    fragment, the 'H.' century-descriptor collision, a Rāmāyaṇa citation with
+    an edition-ambiguous locus, and a bracket-interior provenance note all
+    stay untouched."""
+    store = tmp_path / 'scratch3.jsonl'
+    ru = ('смысл. ṚV 1,116,15 говорит X. ṚV I,85,12 тоже. '
+          'Lévi 1925 предполагает Y. R I.44.6 цитата. '
+          '(2. H. 12. Jh. , Gujarat) говорить. [NWS: Windisch 1883 : 106]')
+    row = {'key1': 'test1', 'layer': 'nws', 'sense_tag': 'NWS-1', 'ru': ru}
+    import json
+    with open(store, 'w', encoding='utf-8') as fh:
+        fh.write(json.dumps(row, ensure_ascii=False) + '\n')
+
+    result = nlm.apply(str(store), backup=False)
+    assert result['rows_changed'] == 1
+    assert len(result['general_resolved']) == 2
+    assert len(result['general_residue']) == 1
+    assert result['general_provenance'] == {
+        'provenance_bracket': 1, 'provenance_short_sig': 1, 'provenance_year': 1}
+
+    with open(store, encoding='utf-8') as fh:
+        new_row = json.loads(fh.readline())
+    new_ru = new_row['ru']
+    assert '<ls n="ṚV. 1,116,15">ṚV 1,116,15</ls>' in new_ru
+    assert '<ls n="ṚV. 1,85,12">ṚV I,85,12</ls>' in new_ru
+    assert new_ru.count('<ls') == 2
+    assert 'Lévi 1925' in new_ru
+    assert 'R I.44.6' in new_ru
+    assert 'H. 12' in new_ru
 
 
 def test_apply_never_rewraps_a_span_already_inside_ls(tmp_path):


### PR DESCRIPTION
## Summary
- H1809 follow-on: `classify_general_bare_citation()` in `nws_ls_markup.py` discriminates genuine bare PWG citations from author/year provenance-note fragments across the 929-span `g5_card_render._BARE_CIT` sample in NWS-layer rows (bracket-position + bare-year-locus signals, plus a single measured false-positive siglum exclusion -- see report Section 3 for how a blanket short-siglum rule was tried and rejected).
- Every accepted span still validates against `pwg_sources` + `ls_resolver` before marking. Measured 0/195 false positives (full inspection, not a sample) -- well under the handoff's <5% stop condition.
- Applied to the canonical store: 110/11,603 rows changed, 195 `<ls>` wraps, byte-identical elsewhere, verified idempotent.
- Full writeup: `RussianTranslation/pwg_ru/H1909_NWS_BARE_CITATION_DISCRIMINATOR_REPORT_2026-08-02.md`.

Handoff: https://github.com/gasyoun/Uprava/blob/main/handoffs/H1909-Sonnet_SanskritLexicography_nws-bare-citation-provenance-discriminator_29.07.26.md

## Test plan
- [x] `python -m pytest RussianTranslation/tests/` -- 103/104 pass (1 pre-existing, unrelated failure, reproduces identically on unmodified code)
- [x] `python -m pytest RussianTranslation/tests/test_nws_ls_markup.py` -- 20/21 pass, 8 new discriminator tests added
- [x] `python -m py_compile RussianTranslation/src/nws_ls_markup.py`
- [x] Byte-diff verification: backup vs. post-apply store, 0 unexpected drift beyond the new `<ls>` wrappers
- [x] Idempotency: second `apply` run reports 0 rows changed

Generated with Claude Code