### PR TITLE
docs(H2174): second c4 health NO-GO — all three candidate gate numbers fail; route is bimodal

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -480,18 +480,36 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   1-week auto-promote trial with spot-check/halt controls, E1–E3 pre-registered experiments
   (DeepSeek draft / Grok judge / routine-vs-CLI). Wave-0 human prereqs (account logins, DeepSeek
   key, Grok route) tracked in Uprava GTD; the build starts on c4 alone without them.
-- **H2174 🟡 QUEUED — prove the medium50 presplit route LIVE on w1, once c4 health passes
-  (02-08-2026, Opus 5 `claude-opus-5[1m]`).** H2160 diagnosed and fixed the zero-card defect but
-  could not demonstrate it: `/pwg-live-gate` Step 1 returned **NO-GO** (measured 75 561 ms ≥ the
-  65 000 ms ceiling; warm-up 236 358 ms), so per policy no canary was built and **no translation
-  call was made** — 2 paid probe calls, $0.9459, no window, no store write. Everything except the
-  live proof is merged. Re-run the health probe FIRST; a second NO-GO means stop and spend nothing.
-  Then build the **c4-bound canary that has never existed** (every canary manifest on disk is bound
-  to c2) and judge it with `canary_gate.py`. ⚠️ Inherited open question, do not silently resolve:
-  the gate's prose says gate on `duration_api_ms` while `probe_log.derive_fails` gates on **wall**,
-  and on this run the two disagree on the verdict (29 069 ms would PASS, 75 586 ms fails) — a human
-  ruling, on the same footing as [#983](https://github.com/gasyoun/SanskritLexicography/issues/983);
-  until then the wall reading governs. Start with:
+- **H2174 🟡 STILL QUEUED — BLOCKED ON A HUMAN RULING after a SECOND health NO-GO
+  (attempted 02-08-2026 11:04Z, Opus 5 `claude-opus-5[1m]`, isolated worktree).** The handoff's
+  own `Fail =` clause ("a second health NO-GO") fired at Step 1: measured **96 520 ms** ≥ the
+  65 000 ms ceiling. Per policy the session stopped there — **no canary, no window, no store
+  write, no re-roll** — 2 paid probe calls, **$1.0929**. The goal is unchanged and the handoff
+  stays open; minting a residual was **correctly refused** by `mint_handoff.py`'s
+  semantic-collision guard as a duplicate of H2174 itself.
+  **Two findings that change the picture — read before the next attempt:**
+  **(1) The inherited wall-vs-`duration_api_ms` question is no longer the unblocker.** This is
+  the first measured c4 row where `duration_api_ms` (**69 137 ms**) *also* breaches the ceiling
+  — as does the CLI's own `duration_ms` (**77 966 ms**), a third number nobody had named. All
+  three fail, so **no ruling would have opened this window**. The ruling is still owed (it
+  governs future runs) but H2160's fix was never blocked by a mis-read gate.
+  **(2) c4 is bimodal on a timescale of hours, not down.** Three measured attempts on 02-08 went
+  **PASS → NO-GO → NO-GO** (43 815 → 75 561 → 96 520 ms wall; same profile, prompt and ceiling,
+  5¼ h apart). `api_gap_ms` is itself unstable (17 429 → 192 682 ms), so wall and api are **not**
+  related by a fixed correction factor and the ruling cannot be settled by arithmetic. 21-row
+  trend table + per-call ledger in
+  [RESULTS_LOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md).
+  Verified offline (no spend): the five prepared `h1447-m50-w{1..5}` artifacts are still
+  **10/48 keys presplit** (pre-fix), so `h2160_regen_medium50.py --in-place` is a genuine
+  prerequisite, not a precaution. The merged fix (v1.134.0, 10/48 → 44/48) remains
+  **undemonstrated for the second session running**.
+  ⚠️ **Two human `@DECIDE` rulings now gate this**, both tabled in
+  [Uprava GTD](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md) and on
+  [#983](https://github.com/gasyoun/SanskritLexicography/issues/983): **(a)** which number gates
+  — wall / CLI `duration_ms` / `duration_api_ms`; **(b)** the retry policy against a bimodal
+  route, since H2174 forbids a re-roll and calls a second NO-GO terminal, yet the data show a
+  later attempt has a real chance of passing. Until (a) is ruled on, **the wall reading
+  governs**. Do not re-attempt on a third NO-GO without (b). Start with:
 
 ```
 Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H2174-Opus_RussianTranslation_medium50-presplit-live-run-after-health-pass_02.08.26.md and execute it.

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -4,6 +4,101 @@ _Created: 09-07-2026 · Last updated: 02-08-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
+## 02-08-2026 (H2174) — second consecutive c4 health NO-GO: the named stop fired, and this time *every* candidate gate number fails
+
+Opus 5 1M (`claude-opus-5[1m]`), [H2174](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2174-Opus_RussianTranslation_medium50-presplit-live-run-after-health-pass_02.08.26.md)
+(residual of [H2160](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2160-Opus_RussianTranslation_whole-card-b0-hang-and-medium50-completion_02.08.26.md)).
+**2 paid calls (the health probe only), $1.0929. No canary, no window, no store write.**
+H2174's own `Fail =` clause names "a second health NO-GO" as a terminal stop; it fired at
+Step 1, so per the handoff nothing downstream was attempted — no re-roll, no re-warm, no
+reaching for the friendlier number.
+
+### The reading (run `…/2026-08-02T11:04:20Z-pid11056`)
+
+| purpose | wall `elapsed_ms` | CLI `duration_ms` | `duration_api_ms` | `api_gap_ms` | class |
+|---|---:|---:|---:|---:|---|
+| warmup | 55 803 | 35 272 | 28 603 | 27 200 | success |
+| **measured** | **96 520** | **77 966** | **69 137** | 27 383 | success |
+
+Ceiling 65 000 ms. **All three candidate measured numbers exceed it** — 96 520 / 77 966 /
+69 137.
+
+### The finding: the open "which number gates?" question would not have unblocked this window
+
+H2174 inherited an unresolved disagreement — [`/pwg-live-gate`](https://github.com/gasyoun/claude-config/blob/main/commands/pwg-live-gate.md)
+prose says gate on `duration_api_ms`, `probe_log.derive_fails` gates on the measured wall
+reading — and on the 02-08 07:49 H2160 run the two **disagreed on the verdict** (wall 75 561
+NO-GO vs api 29 069 comfortable PASS). That made the ruling look like the unblocker.
+
+It is not. On this reading the two **agree**, and so does the third number nobody had named
+(the CLI's own `duration_ms`). This is the first measured c4 row where `duration_api_ms`
+itself breaches the ceiling. Whichever way a human rules, **this** window was NO-GO. The
+ruling is still owed — it governs future runs — but it is no longer load-bearing for the
+question "was H2160's fix blocked by a mis-read gate?" It was not.
+
+### Why that matters: c4 is intermittent, not down
+
+The full per-account series (`h963_c4_gate0_probe_events.jsonl`, both the canonical and this
+run's worktree copy, deduped by `(ts, run_id, purpose)`):
+
+| # | date (UTC) | purpose | wall `elapsed_ms` | wall | `duration_api_ms` | api | `api_gap_ms` | class |
+|---:|---|---|---:|---|---:|---|---:|---|
+| 1 | 2026-07-22 14:57:34 | warmup | 21 280 | PASS | — | n/a | — | content |
+| 2 | 2026-07-22 20:03:04 | warmup | 59 831 | PASS | — | n/a | — | success |
+| 3 | 2026-07-22 20:04:47 | measured | 102 874 | NO-GO | — | n/a | — | auth |
+| 4 | 2026-07-23 06:06:52 | warmup | 40 003 | PASS | — | n/a | — | success |
+| 5 | 2026-07-23 06:09:40 | measured | 168 352 | NO-GO | — | n/a | — | success |
+| 6 | 2026-07-24 04:23:53 | warmup | 10 838 | PASS | — | n/a | — | rate_limit |
+| 7 | 2026-07-24 07:35:29 | warmup | 9 949 | PASS | — | n/a | — | rate_limit |
+| 8 | 2026-07-25 03:16:04 | warmup | 17 587 | PASS | — | n/a | — | auth |
+| 9 | 2026-07-25 03:18:34 | warmup | 10 918 | PASS | — | n/a | — | auth |
+| 10 | 2026-07-25 16:02:31 | warmup | 17 878 | PASS | — | n/a | — | rate_limit |
+| 11 | 2026-07-25 18:18:27 | warmup | 19 903 | PASS | — | n/a | — | rate_limit |
+| 12 | 2026-07-31 18:59:59 | warmup | 94 606 | NO-GO | — | n/a | — | success |
+| 13 | 2026-07-31 19:01:17 | measured | 78 415 | NO-GO | — | n/a | — | success |
+| 14 | 2026-08-01 20:21:03 | warmup | 39 437 | PASS | 21 171 | PASS | 18 266 | success |
+| 15 | 2026-08-01 20:21:53 | measured | 50 336 | PASS | 27 557 | PASS | 22 779 | success |
+| 16 | 2026-08-02 05:47:17 | warmup | 55 390 | PASS | 37 690 | PASS | 17 700 | success |
+| 17 | 2026-08-02 05:48:01 | **measured** | **43 815** | **PASS** | 26 386 | PASS | 17 429 | success |
+| 18 | 2026-08-02 07:48:25 | warmup | 236 328 | NO-GO | 43 646 | PASS | 192 682 | success |
+| 19 | 2026-08-02 07:49:40 | measured | 75 561 | NO-GO | 29 069 | PASS | 46 492 | success |
+| 20 | 2026-08-02 11:05:16 | warmup | 55 803 | PASS | 28 603 | PASS | 27 200 | success |
+| 21 | 2026-08-02 11:06:53 | **measured** | **96 520** | **NO-GO** | **69 137** | **NO-GO** | 27 383 | success |
+
+Measured readings: **7**; wall PASS **2/7**; api PASS **3/4** of those carrying the field.
+
+Three measured attempts today (rows 17, 19, 21) — **PASS, NO-GO, NO-GO**, spanning 43 815 →
+96 520 ms wall on the same profile, same prompt, same ceiling, within 5¼ hours. So the route
+is **not dead and not reliably healthy**: it is bimodal on a timescale of hours. Two further
+consequences fall out of the table:
+
+- **`api_gap_ms` — the in-CLI scaffolding overhead — is itself unstable**, 17 429 → 192 682 ms
+  across the rows that carry it. H2160's "~45 % of a wall reading is scaffolding" is a
+  property of *that* reading, not a constant, so wall and api cannot be related by a fixed
+  correction factor. This is a second, independent reason the wall-vs-api ruling cannot be
+  settled by arithmetic and needs a human.
+- **The `--selftest`-able gate logic behaved exactly as specified.** Both readings were
+  written to the append-only events log *before* the fail-closed exit, so this NO-GO leaves
+  the same immutable trace as a PASS (the #729 discipline). Nothing here is a tooling defect.
+
+### Also verified offline (no spend): the prepared artifacts are still pre-fix
+
+`h2160_regen_medium50.py --dry-run` against the five prepared windows, read from the
+canonical checkout (`src/pilot/output/` is gitignored, so a fresh worktree has none):
+
+| window | `presplit_keys` on disk | n_batches | n_inputs |
+|---|---|---:|---:|
+| h1447-m50-w1 | `[]` | 3 | 3 |
+| h1447-m50-w2 | `Srama, samIpa, vAhana, vfzwi` | 8 | 12 |
+| h1447-m50-w3 | `rAzwra, vicitra, vyavasTA` | 7 | 11 |
+| h1447-m50-w4 | `SoDana, aDastAt` | 8 | 11 |
+| h1447-m50-w5 | `sAhasra` | 10 | 11 |
+
+**10/48 keys presplit** — exactly H2160's "before" figure, confirming the artifacts on disk
+predate the merged fix and that regeneration is a genuine prerequisite, not a precaution. The
+fix (v1.134.0, presplit 10/48 → 44/48) therefore **remains merged and undemonstrated**, for
+the second session running.
+
 ## 02-08-2026 (H2160) — `b0` was never non-terminating: it was killed BY US at exactly the ceiling, because a per-card presplit floor was masked by the batch budget
 
 Opus 5 1M (`claude-opus-5[1m]`), [H2160](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2160-Opus_RussianTranslation_whole-card-b0-hang-and-medium50-completion_02.08.26.md).

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,11 @@ not an error.
 
 ## [Unreleased]
 
+## [1.137.2] - 2026-08-02
+
+### Added
+- **H2174 — second consecutive c4 health NO-GO recorded; the presplit fix stays undemonstrated (Opus 5 `claude-opus-5[1m]`, 02-08-2026):** [H2174](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2174-Opus_RussianTranslation_medium50-presplit-live-run-after-health-pass_02.08.26.md)'s own `Fail =` clause ("a second health NO-GO") fired at Step 1, so no canary, no window and no store write followed — 2 paid probe calls, $1.0929. Measured 96 520 ms against the 65 000 ms ceiling. **New:** this is the first measured c4 row where `duration_api_ms` (69 137 ms) *also* breaches the ceiling — together with the CLI's own `duration_ms` (77 966 ms), **all three** candidate gate numbers fail, so the still-open "which number gates?" ruling would not have unblocked this window. The 21-row per-account series shows three measured attempts on 02-08 going PASS → NO-GO → NO-GO (43 815 → 96 520 ms wall, same profile/prompt/ceiling, 5¼ h apart): c4 is **bimodal on a timescale of hours**, not down. `api_gap_ms` is itself unstable (17 429 → 192 682 ms), so wall and api are not related by a fixed correction factor. Also verified offline: the five prepared `h1447-m50-w{1..5}` artifacts are still **10/48 keys presplit** (pre-fix), confirming regeneration is a genuine prerequisite. Trend + per-call tables in [RESULTS_LOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md). H2174 stays open (its goal is unchanged and a mint of the residual was correctly refused by the semantic-collision guard as a duplicate of itself); what is newly owed is two *human* rulings, tabled in [GTD_NEXT_ACTIONS.md](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md) — which number gates, and what the retry policy is against a demonstrably bimodal route. Status on [SanskritLexicography#983](https://github.com/gasyoun/SanskritLexicography/issues/983).
+
 ## [1.136.1] - 2026-08-02
 
 ### Changed


### PR DESCRIPTION
## What happened

[H2174](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2174-Opus_RussianTranslation_medium50-presplit-live-run-after-health-pass_02.08.26.md)'s own `Fail =` clause — *"a second health NO-GO"* — fired at Mission Step 1. Per the handoff the session stopped there: **no canary, no window, no store write, no re-roll, no re-warm**. 2 paid probe calls, **$1.0929**.

| purpose | wall `elapsed_ms` | CLI `duration_ms` | `duration_api_ms` | `api_gap_ms` |
|---|---:|---:|---:|---:|
| warmup | 55 803 | 35 272 | 28 603 | 27 200 |
| **measured** | **96 520** | **77 966** | **69 137** | 27 383 |

Ceiling 65 000 ms.

## Two findings that change the picture

**1. The inherited wall-vs-`duration_api_ms` question is no longer the unblocker.** H2174 inherited a real disagreement — [/pwg-live-gate](https://github.com/gasyoun/claude-config/blob/main/commands/pwg-live-gate.md) prose gates on `duration_api_ms`, `probe_log.derive_fails` gates on wall — and on H2160's 07:49 run the two *disagreed on the verdict* (wall 75 561 NO-GO vs api 29 069 comfortable PASS). That made the ruling look like the thing standing between us and a window.

It is not. This is the **first measured c4 row where `duration_api_ms` itself breaches the ceiling**, and so does the CLI's own `duration_ms` — a third number nobody had named. **All three fail.** Whichever way a human rules, *this* window was NO-GO. The ruling is still owed because it governs future runs, but H2160's fix was never blocked by a mis-read gate.

**2. c4 is bimodal on a timescale of hours, not down.** Three measured attempts on 02-08:

| time (UTC) | wall | verdict | api | verdict |
|---|---:|---|---:|---|
| 05:48 | 43 815 | **PASS** | 26 386 | PASS |
| 07:49 | 75 561 | NO-GO | 29 069 | PASS |
| 11:06 | 96 520 | NO-GO | 69 137 | **NO-GO** |

Same profile, same prompt, same ceiling, 5¼ hours apart. `api_gap_ms` is itself unstable across the series (17 429 → 192 682 ms), so wall and api are **not** related by a fixed correction factor — a second, independent reason the ruling cannot be settled by arithmetic.

The full 21-row per-account series is in [RESULTS_LOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md).

## Also verified offline (no spend)

The five prepared `h1447-m50-w{1..5}` artifacts are still **10/48 keys presplit** — exactly H2160's "before" figure — confirming they predate the merged fix and that `h2160_regen_medium50.py --in-place` is a genuine prerequisite, not a precaution. The v1.134.0 fix (10/48 → 44/48) therefore stays **merged and undemonstrated for a second session running**.

## Disposition

**H2174 stays OPEN.** Its goal is unchanged, and `mint_handoff.py`'s semantic-collision guard **correctly refused** a residual as a duplicate of H2174 itself — so rather than force it past the guard with `--allow-dup`, what is newly owed is recorded as two **human rulings**:

- **(a)** which number gates — wall / CLI `duration_ms` / `duration_api_ms`;
- **(b)** the retry policy against a demonstrably bimodal route, since H2174 forbids a re-roll and calls a second NO-GO terminal, yet the data show a later attempt has a real chance of passing.

Both tabled in [Uprava GTD](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md) and on [#983](https://github.com/gasyoun/SanskritLexicography/issues/983). Until (a) is ruled on, the wall reading governs.

## Non-goals / caveats

- No code changed — docs and evidence only. Release **1.137.2**.
- Nothing here is a tooling defect: both readings were written to the append-only events log *before* the fail-closed exit, so this NO-GO leaves the same immutable trace as a PASS (the [#729](https://github.com/gasyoun/SanskritLexicography/issues/729) discipline).
- The `literature/md/**` CRLF phantom was left untouched, per the standing guardrail.

Tracking: [#983](https://github.com/gasyoun/SanskritLexicography/issues/983) · Model: **Opus 5** (`claude-opus-5[1m]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
