### PR TITLE
H2158: resolve the API credential from .secrets + a key-shape probe (arm still blocked, now knowably)

### DIFF
--- a/RussianTranslation/pwg_ru/h2158/raw_api/api_nakzatra_1.envelope.json
+++ b/RussianTranslation/pwg_ru/h2158/raw_api/api_nakzatra_1.envelope.json
@@ -1,0 +1,16 @@
+{
+  "row": {
+    "arm": "api",
+    "key": "nakzatra",
+    "wall_ms": 4442,
+    "failure_class": "http_401",
+    "error_type": "authentication_error",
+    "retry_after": null,
+    "detail": "Error code: 401 - {'type': 'error', 'error': {'type': 'authentication_error', 'message': 'invalid x-api-key'}, 'request_id': 'req_011CddwedrRzkGDcxofksH9H'}",
+    "usage": {},
+    "n": 1,
+    "cost_usd_1h_write": 0.0,
+    "cost_usd_5m_write": 0.0
+  },
+  "raw": null
+}

--- a/RussianTranslation/pwg_ru/h2158/raw_api/api_nakzatra_2.envelope.json
+++ b/RussianTranslation/pwg_ru/h2158/raw_api/api_nakzatra_2.envelope.json
@@ -1,0 +1,16 @@
+{
+  "row": {
+    "arm": "api",
+    "key": "nakzatra",
+    "wall_ms": 287,
+    "failure_class": "http_401",
+    "error_type": "authentication_error",
+    "retry_after": null,
+    "detail": "Error code: 401 - {'type': 'error', 'error': {'type': 'authentication_error', 'message': 'invalid x-api-key'}, 'request_id': 'req_011CddwefBoPqWPAEfP4rAdQ'}",
+    "usage": {},
+    "n": 2,
+    "cost_usd_1h_write": 0.0,
+    "cost_usd_5m_write": 0.0
+  },
+  "raw": null
+}

--- a/RussianTranslation/pwg_ru/h2158/raw_api/api_sarvatra_1.envelope.json
+++ b/RussianTranslation/pwg_ru/h2158/raw_api/api_sarvatra_1.envelope.json
@@ -1,0 +1,16 @@
+{
+  "row": {
+    "arm": "api",
+    "key": "sarvatra",
+    "wall_ms": 277,
+    "failure_class": "http_401",
+    "error_type": "authentication_error",
+    "retry_after": null,
+    "detail": "Error code: 401 - {'type': 'error', 'error': {'type': 'authentication_error', 'message': 'invalid x-api-key'}, 'request_id': 'req_011CddwegKm1tHgwcJsG8kUi'}",
+    "usage": {},
+    "n": 1,
+    "cost_usd_1h_write": 0.0,
+    "cost_usd_5m_write": 0.0
+  },
+  "raw": null
+}

--- a/RussianTranslation/pwg_ru/h2158/raw_api/api_sarvatra_2.envelope.json
+++ b/RussianTranslation/pwg_ru/h2158/raw_api/api_sarvatra_2.envelope.json
@@ -1,0 +1,16 @@
+{
+  "row": {
+    "arm": "api",
+    "key": "sarvatra",
+    "wall_ms": 261,
+    "failure_class": "http_401",
+    "error_type": "authentication_error",
+    "retry_after": null,
+    "detail": "Error code: 401 - {'type': 'error', 'error': {'type': 'authentication_error', 'message': 'invalid x-api-key'}, 'request_id': 'req_011CddwehWCgpJg4X9Ra9uv5'}",
+    "usage": {},
+    "n": 2,
+    "cost_usd_1h_write": 0.0,
+    "cost_usd_5m_write": 0.0
+  },
+  "raw": null
+}

--- a/RussianTranslation/pwg_ru/h2158/raw_api/rows.json
+++ b/RussianTranslation/pwg_ru/h2158/raw_api/rows.json
@@ -1,0 +1,70 @@
+{
+  "manifest": "h1209_slice3.manifest.json",
+  "model": "claude-sonnet-5",
+  "keys": [
+    "nakzatra",
+    "sarvatra"
+  ],
+  "repeats": 2,
+  "rates": {
+    "input": 3.0,
+    "output": 15.0,
+    "cache_write_1h": 6.0,
+    "cache_write_5m": 3.75,
+    "cache_read": 0.3
+  },
+  "rows": [
+    {
+      "arm": "api",
+      "key": "nakzatra",
+      "wall_ms": 4442,
+      "failure_class": "http_401",
+      "error_type": "authentication_error",
+      "retry_after": null,
+      "detail": "Error code: 401 - {'type': 'error', 'error': {'type': 'authentication_error', 'message': 'invalid x-api-key'}, 'request_id': 'req_011CddwedrRzkGDcxofksH9H'}",
+      "usage": {},
+      "n": 1,
+      "cost_usd_1h_write": 0.0,
+      "cost_usd_5m_write": 0.0
+    },
+    {
+      "arm": "api",
+      "key": "nakzatra",
+      "wall_ms": 287,
+      "failure_class": "http_401",
+      "error_type": "authentication_error",
+      "retry_after": null,
+      "detail": "Error code: 401 - {'type': 'error', 'error': {'type': 'authentication_error', 'message': 'invalid x-api-key'}, 'request_id': 'req_011CddwefBoPqWPAEfP4rAdQ'}",
+      "usage": {},
+      "n": 2,
+      "cost_usd_1h_write": 0.0,
+      "cost_usd_5m_write": 0.0
+    },
+    {
+      "arm": "api",
+      "key": "sarvatra",
+      "wall_ms": 277,
+      "failure_class": "http_401",
+      "error_type": "authentication_error",
+      "retry_after": null,
+      "detail": "Error code: 401 - {'type': 'error', 'error': {'type': 'authentication_error', 'message': 'invalid x-api-key'}, 'request_id': 'req_011CddwegKm1tHgwcJsG8kUi'}",
+      "usage": {},
+      "n": 1,
+      "cost_usd_1h_write": 0.0,
+      "cost_usd_5m_write": 0.0
+    },
+    {
+      "arm": "api",
+      "key": "sarvatra",
+      "wall_ms": 261,
+      "failure_class": "http_401",
+      "error_type": "authentication_error",
+      "retry_after": null,
+      "detail": "Error code: 401 - {'type': 'error', 'error': {'type': 'authentication_error', 'message': 'invalid x-api-key'}, 'request_id': 'req_011CddwehWCgpJg4X9Ra9uv5'}",
+      "usage": {},
+      "n": 2,
+      "cost_usd_1h_write": 0.0,
+      "cost_usd_5m_write": 0.0
+    }
+  ]
+}

--- a/RussianTranslation/src/pilot/h2158_key_shape.py
+++ b/RussianTranslation/src/pilot/h2158_key_shape.py
@@ -1,0 +1,88 @@
+"""H2158 -- report the SHAPE of the configured Anthropic credential, never its value.
+
+The API arm came back 401 with a credential present, which has several distinct causes
+that need different fixes and are indistinguishable without looking at the prefix:
+
+  * `sk-ant-api...`  a real Messages API key -> should work; a 401 means revoked,
+                     wrong org/workspace, or a stray quote/newline in the file.
+  * `sk-ant-oat...`  an OAuth access token -> goes on `Authorization: Bearer` WITH the
+                     `anthropic-beta: oauth-2025-04-20` header, NOT on `x-api-key`.
+                     The SDK's api_key= path sends x-api-key, hence 401.
+  * `sk-ant-sid...`  a session/console cookie value, not an API credential at all.
+  * anything else    not an Anthropic credential.
+
+Prints only length, prefix, and whether stray whitespace/quotes survived parsing. The
+value itself is never printed, so this is safe to run with output captured in a
+transcript.
+
+    python src/pilot/h2158_key_shape.py
+
+Model: authored by Opus 5 (`claude-opus-5`) for handoff H2158.
+"""
+import os
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+
+SECRETS_ENV = r'C:\Users\user\.secrets\anthropic.env'
+NAMES = ('ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN')
+
+KNOWN = {
+    'sk-ant-api': 'Messages API key -- correct type for this arm',
+    'sk-ant-oat': 'OAuth ACCESS TOKEN -- needs Authorization: Bearer + the '
+                  'anthropic-beta: oauth-2025-04-20 header, NOT x-api-key',
+    'sk-ant-ort': 'OAuth REFRESH token -- not directly usable; exchange it first',
+    'sk-ant-sid': 'console session id -- not an API credential',
+}
+
+
+def classify(value):
+    for prefix, meaning in KNOWN.items():
+        if value.startswith(prefix):
+            return prefix, meaning
+    if value.startswith('sk-ant-'):
+        return value[:11], 'unrecognised sk-ant- subtype'
+    return value[:4], 'does not look like an Anthropic credential'
+
+
+def report(source, name, raw):
+    value = raw.strip().strip('"').strip("'")
+    prefix, meaning = classify(value)
+    print('  source      : %s' % source)
+    print('  name        : %s' % name)
+    print('  length      : %d (after stripping quotes/whitespace)' % len(value))
+    print('  raw length  : %d %s' % (len(raw),
+                                     '(!! stray whitespace or quotes in the file)'
+                                     if len(raw) != len(value) else ''))
+    print('  prefix      : %s...' % prefix)
+    print('  verdict     : %s' % meaning)
+    if any(c in value for c in ' \t\r\n'):
+        print('  !! the value contains an INTERNAL space/newline -- likely a wrapped paste')
+    print()
+
+
+def main():
+    found = False
+    for name in NAMES:
+        raw = os.environ.get(name)
+        if raw:
+            found = True
+            report('environment', name, raw)
+    if os.path.exists(SECRETS_ENV):
+        with open(SECRETS_ENV, encoding='utf-8-sig') as fh:
+            for line in fh:
+                if line.strip().startswith('#') or '=' not in line:
+                    continue
+                name, _, raw = line.partition('=')
+                if name.strip() in NAMES:
+                    found = True
+                    report(SECRETS_ENV, name.strip(), raw.rstrip('\n'))
+    else:
+        print('  %s does not exist' % SECRETS_ENV)
+    if not found:
+        print('  no Anthropic credential found in the environment or in %s' % SECRETS_ENV)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/RussianTranslation/src/pilot/h2158_route_ab.py
+++ b/RussianTranslation/src/pilot/h2158_route_ab.py
@@ -203,14 +203,34 @@ def call_api(client, manifest, key, prefix, tail, max_tokens):
     }, msg.model_dump()
 
 
+# The operator's durable credential store, outside every clone so it cannot be staged by
+# accident (siblings: ftp_samskrtam.env, samskrtam-wp.env, x_api.json which post_tweet.py
+# reads). Checked as a FALLBACK because a key set with `setx` is invisible to shells that
+# were already running -- which is exactly how this arm stayed blocked once already.
+SECRETS_ENV = r'C:\Users\user\.secrets\anthropic.env'
+
+
 def api_client():
     """Return (client, note). Presence-only auth report -- never echo the credential."""
     import anthropic
     for var in ('ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'):
         if os.environ.get(var):
             return anthropic.Anthropic(), '%s present in environment' % var
-    return None, ('no ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN in environment and the '
-                  '`ant` CLI is absent, so no OAuth profile can be resolved either')
+    if os.path.exists(SECRETS_ENV):
+        with open(SECRETS_ENV, encoding='utf-8') as fh:
+            for line in fh:
+                line = line.strip()
+                if line.startswith('#') or '=' not in line:
+                    continue
+                name, _, value = line.partition('=')
+                if name.strip() in ('ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'):
+                    value = value.strip().strip('"').strip("'")
+                    if value:
+                        return (anthropic.Anthropic(api_key=value),
+                                '%s read from %s' % (name.strip(), SECRETS_ENV))
+    return None, ('no ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN in environment, none in %s, '
+                  'and the `ant` CLI is absent, so no OAuth profile can be resolved either'
+                  % SECRETS_ENV)
 
 
 def main():


### PR DESCRIPTION
Follow-up to [#1015](https://github.com/gasyoun/SanskritLexicography/pull/1015)/[#1017](https://github.com/gasyoun/SanskritLexicography/pull/1017). A key was supplied, the arm was attempted, and it is **still blocked** — but on a diagnosed cause rather than a mystery.

## What changed

1. `api_client()` falls back to the operator secrets store when `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN` are unset. A key set with `setx` is invisible to already-running shells — which is exactly how the arm stayed blocked minutes after the key was supplied.
2. New `h2158_key_shape.py` reports the **shape** of the configured credential (length, prefix, stray quotes/whitespace) and **never its value**, so it is safe to run with output captured in a transcript.

## Why the probe was needed

A present-but-401 credential has several causes that need different fixes and are indistinguishable without the prefix:

| prefix | meaning |
|---|---|
| `sk-ant-api…` | Messages API key — correct for this arm |
| `sk-ant-oat…` | OAuth access token — needs `Authorization: Bearer` + `anthropic-beta: oauth-2025-04-20`, **not** `x-api-key` |
| `sk-ant-sid…` | console session id — not an API credential |

Measured: the supplied key is **`sk-Z…`, 51 chars** — the OpenAI/DeepSeek shape, not Anthropic's `sk-ant-api…` (~108 chars). Still blocked, now knowably.

## Evidence committed

The four 401 envelopes are kept because they are data for the report's failure-class table: the API route returned a **typed 401 in 287 ms** where the CLI route hangs to the **300 s** ceiling and yields no envelope at all. Verified to contain no key material (`detail` is `invalid x-api-key`). **Nothing billed.**

Unblocking needs an Anthropic key from console.anthropic.com with a little credit; the arm is then one command and no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)