### PR TITLE
docs(H2174): the c4 ceiling is ~12 s BELOW the median measured reading — gate unpassable by scheduling; H2138's dataset now exists

### DIFF
--- a/RussianTranslation/.ai_state.md
+++ b/RussianTranslation/.ai_state.md
@@ -503,13 +503,31 @@ Two live tracks (full cold-start brief: [`H025-Opus_RussianTranslation_pwg_ru_ma
   **10/48 keys presplit** (pre-fix), so `h2160_regen_medium50.py --in-place` is a genuine
   prerequisite, not a precaution. The merged fix (v1.134.0, 10/48 → 44/48) remains
   **undemonstrated for the second session running**.
-  ⚠️ **Two human `@DECIDE` rulings now gate this**, both tabled in
-  [Uprava GTD](https://github.com/gasyoun/Uprava/blob/main/GTD_NEXT_ACTIONS.md) and on
-  [#983](https://github.com/gasyoun/SanskritLexicography/issues/983): **(a)** which number gates
-  — wall / CLI `duration_ms` / `duration_api_ms`; **(b)** the retry policy against a bimodal
-  route, since H2174 forbids a re-roll and calls a second NO-GO terminal, yet the data show a
-  later attempt has a real chance of passing. Until (a) is ruled on, **the wall reading
-  governs**. Do not re-attempt on a third NO-GO without (b). Start with:
+  ⚠️ **CORRECTED LATER THE SAME SESSION — the blocker is the ceiling VALUE, and it is not
+  H2174's to fix.** Two things that earlier read as open questions are not:
+  **(a) which number gates was ALREADY RULED** — wall `elapsed_ms`, MG 02-08-2026 (H2160,
+  option A), already in [`/pwg-live-gate`](https://github.com/gasyoun/claude-config/blob/main/commands/pwg-live-gate.md)
+  line 27 and already what the code does. H2174's handoff text was stale on this point; it is
+  settled and not reopened. **(b) the retry policy is answerable from the data, not by
+  ruling:** a 4th attempt at 12:46Z came in at **66 291 ms — NO-GO by 1 291 ms (2.0 %)**, not
+  overridden. Across all **8** measured c4 readings the median is **76 988 ms** against a
+  **65 000 ms** ceiling — **the ceiling is ~12 s BELOW the median, pass rate 2/8 (25 %)**. So
+  the gate is *expected* to fail ~75 % of the time; retrying is a 25 % lottery at ~$1.09 a
+  pull, and 4 attempts on 02-08 (~$2.2 in probes) produced no window. **More attempts are not
+  the path.**
+  The 12:46 reading is the tell: wall 66 291 but `duration_api_ms` **16 445 ms** — the fastest
+  API reading ever recorded on c4 — with **49 846 ms** of in-CLI scaffolding. A healthy route
+  failed on overhead. Across the 5 paired readings api/wall spans **0.25 → 0.72**, so the
+  standing "~45 % is scaffolding" figure is not a constant and no fixed factor converts one
+  number to the other.
+  ➡️ **The live blocker is the never-fitted ceiling value, owned by
+  [H2138](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2138-Opus_RussianTranslation_probe-ceiling-paired-readings-946_01.08.26.md)**
+  (65 000 came from the 31-07 `production_v2` ruling, taken when **no reading carried
+  `duration_api_ms` at all`**). **H2138's requested 5 paired readings now EXIST** in the
+  series at zero further cost — it can run without new spend. H2174 must NOT "fix" this by
+  raising a guard so its own run passes. Distribution + quantile + paired tables in
+  [RESULTS_LOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md).
+  **Order: run H2138 first, then H2174.** Start with:
 
 ```
 Read C:\Users\user\Documents\GitHub\Uprava\handoffs\H2174-Opus_RussianTranslation_medium50-presplit-live-run-after-health-pass_02.08.26.md and execute it.

--- a/RussianTranslation/RESULTS_LOG.md
+++ b/RussianTranslation/RESULTS_LOG.md
@@ -4,6 +4,102 @@ _Created: 09-07-2026 · Last updated: 02-08-2026_
 
 Append-only, reverse-chronological. Each entry: date, context, model tier, table.
 
+## 02-08-2026 (H2174, second pass) — the ceiling is ~12 s BELOW c4's median: the gate is unpassable by scheduling, and the blocker is the ceiling VALUE, not the clock
+
+Opus 5 1M (`claude-opus-5[1m]`), [H2174](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2174-Opus_RussianTranslation_medium50-presplit-live-run-after-health-pass_02.08.26.md).
+**2 further paid probe calls. Still no canary, no window, no store write.** Session total
+4 probe calls. Run from the **canonical checkout**, not a worktree, so the rows land in the
+real per-account series ([#1034](https://github.com/gasyoun/SanskritLexicography/issues/1034)).
+
+### Gate attempt 4 — NO-GO by 1 291 ms (2.0 %)
+
+| purpose | wall `elapsed_ms` | `duration_api_ms` | `api_gap_ms` |
+|---|---:|---:|---:|
+| warmup | 61 662 | — | — |
+| **measured** | **66 291** | **16 445** | 49 846 |
+
+Not overridden. A 2 % miss is still a miss — "never re-read a NO-GO on the friendlier
+number" is the gate working, not a technicality.
+
+**But the shape of this reading is the finding:** `duration_api_ms` **16 445 ms** is the
+**fastest API reading ever recorded on c4**, with **49 846 ms** of in-CLI scaffolding.
+The route was extremely healthy and the gate still failed — on overhead.
+
+### The distribution, against the ceiling it is gated on
+
+All 8 measured c4 readings in the append-only series:
+
+| date (UTC) | wall `elapsed_ms` | verdict | `duration_api_ms` |
+|---|---:|---|---:|
+| 2026-07-22 20:04 | 102 874 | NO-GO | — |
+| 2026-07-23 06:09 | 168 352 | NO-GO | — |
+| 2026-07-31 19:01 | 78 415 | NO-GO | — |
+| 2026-08-01 20:21 | 50 336 | **PASS** | 27 557 |
+| 2026-08-02 05:48 | 43 815 | **PASS** | 26 386 |
+| 2026-08-02 07:49 | 75 561 | NO-GO | 29 069 |
+| 2026-08-02 11:06 | 96 520 | NO-GO | 69 137 |
+| 2026-08-02 12:46 | 66 291 | NO-GO | 16 445 |
+
+| statistic | value |
+|---|---:|
+| n | 8 |
+| min / **median** / max | 43 815 / **76 988** / 168 352 |
+| mean | 85 270 |
+| current ceiling | 65 000 |
+| **pass rate at 65 000** | **2/8 (25 %)** |
+| **median − ceiling** | **+11 988 ms** |
+
+**The ceiling sits ~12 s below the median measured reading.** So the gate is not
+occasionally unlucky — it is *expected* to fail ~75 % of the time, and 2/8 observed matches
+that. Waiting for a PASS is a ~25 % lottery at ~$1.09 per pull, and a PASS certifies only
+the instant it was taken, not the window that follows (H2011's 05:48 PASS did not yield a
+completed window either).
+
+Ceiling required to admit a given share of measured readings (nearest-rank, n=8):
+
+| quantile | ceiling needed |
+|---|---:|
+| p50 | 75 561 ms |
+| p75 | 96 520 ms |
+| p90 | 102 874 ms |
+
+### What is and is not settled
+
+- **The clock is settled and correct.** Gate on wall `elapsed_ms` — MG's 02-08-2026 ruling
+  (H2160, option A), already in `/pwg-live-gate` and already what the code does.
+  `KILL_CEIL_MS` is a wall timer, and non-API overhead still kills calls and still bills.
+  Nothing here reopens that.
+- **The ceiling VALUE was never fitted to that clock.** 65 000 came from
+  `PROBE_LATENCY_CEILING_MS` via the 31-07 `production_v2` ruling, taken when **no reading
+  carried `duration_api_ms` at all**. Against the measured distribution it is below the
+  median. That is the live blocker, and it belongs to
+  [H2138](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2138-Opus_RussianTranslation_probe-ceiling-paired-readings-946_01.08.26.md)
+  / the [#950](https://github.com/gasyoun/SanskritLexicography/issues/950)-adjacent @DECIDE —
+  **not to H2174, and not to be "fixed" by raising a guard so one's own run passes.**
+
+### The H2138 dataset now exists — 5 paired readings
+
+H2138 asked for **5 paid paired readings** to re-derive the ceiling. The series now carries
+exactly that, no further spend required:
+
+| date (UTC) | wall | api | `api_gap_ms` | api/wall |
+|---|---:|---:|---:|---:|
+| 2026-08-01 20:21 | 50 336 | 27 557 | 22 779 | 0.55 |
+| 2026-08-02 05:48 | 43 815 | 26 386 | 17 429 | 0.60 |
+| 2026-08-02 07:49 | 75 561 | 29 069 | 46 492 | 0.38 |
+| 2026-08-02 11:06 | 96 520 | 69 137 | 27 383 | 0.72 |
+| 2026-08-02 12:46 | 66 291 | 16 445 | 49 846 | 0.25 |
+
+**api/wall ratio 0.25 → 0.72** (median 0.55); `api_gap_ms` **17 429 → 49 846 ms**. So the
+standing "~45 % of a wall reading is in-CLI scaffolding" figure is wrong in *both*
+directions and is not a constant — no fixed correction factor converts one number into the
+other, which is exactly why option C (api as a second, independently-derived fail
+condition) cannot reuse 65 000.
+
+**Consequence for the retry policy:** more gate attempts are not the path. Four attempts on
+02-08 (05:48 PASS, 07:49, 11:06, 12:46) cost ~$2.2 in probes and produced no window. The
+lane resumes when the ceiling is re-derived, not when the dice land.
+
 ## 02-08-2026 (H2190) — the cost table under-reported every 1 h cache write by 1.6×; repriced against the vendor's own figure
 
 Opus 5 (`claude-opus-5`), [H2190](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H2190-Opus_SanskritLexicography_pwg-cache-write-1h-pricing_02.08.26.md)

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,11 @@ not an error.
 
 ## [Unreleased]
 
+## [1.137.4] - 2026-08-02
+
+### Added
+- **H2174 second pass — the c4 health ceiling is ~12 s BELOW the median measured reading (Opus 5 `claude-opus-5[1m]`, 02-08-2026):** gate attempt 4 returned NO-GO by **1 291 ms (2.0 %)** — not overridden. Across all 8 measured c4 readings the ceiling's implied pass rate is **2/8 (25 %)** and **median − ceiling = +11 988 ms**, so the gate is *expected* to fail ~75 % of the time and more attempts cannot fix it. The 12:46 reading is the tell: wall 66 291 ms but `duration_api_ms` **16 445 ms**, the fastest API reading ever recorded on c4, with 49 846 ms of in-CLI scaffolding — a healthy route failed on overhead. **The clock is settled and not reopened** (gate on wall, MG 02-08-2026 / H2160 option A); what was never fitted is the ceiling *value*, which belongs to [H2138](https://github.com/gasyoun/Uprava/blob/main/handoffs/H2138-Opus_RussianTranslation_probe-ceiling-paired-readings-946_01.08.26.md) — not to H2174, and not to be fixed by raising a guard so one's own run passes. **H2138's requested dataset now exists at zero further cost:** 5 paired readings, api/wall **0.25 → 0.72** and `api_gap_ms` **17 429 → 49 846 ms**, disproving the standing "~45 % is scaffolding" constant in both directions. Distribution + quantile tables in [RESULTS_LOG.md](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/RESULTS_LOG.md). Probe run from the canonical checkout so rows land in the real per-account series ([#1034](https://github.com/gasyoun/SanskritLexicography/issues/1034)).
+
 ## [1.137.3] - 2026-08-02
 
 ### Fixed


### PR DESCRIPTION
docs(H2174): the ceiling is ~12s BELOW c4's median — the gate is unpassable by scheduling

Gate attempt 4 (12:46Z, run from the CANONICAL checkout so the rows land in the real
per-account series, per #1034): measured 66 291 ms — NO-GO by 1 291 ms (2.0 %). Not
overridden; a 2 % miss is still a miss.

The distribution is the finding. Across all 8 measured c4 readings:

  min / median / max = 43 815 / 76 988 / 168 352 ms
  ceiling            = 65 000 ms
  pass rate          = 2/8 (25 %)
  median - ceiling   = +11 988 ms

The ceiling sits ~12 s below the median, so the gate is EXPECTED to fail ~75 % of the
time — 2/8 observed matches. Retrying is a 25 % lottery at ~$1.09 a pull; four attempts
on 02-08 cost ~$2.2 in probes and produced no window. More attempts are not the path.

The 12:46 reading is the tell: wall 66 291 ms but duration_api_ms 16 445 ms — the fastest
API reading ever recorded on c4 — with 49 846 ms of in-CLI scaffolding. A healthy route
failed on overhead.

What is settled vs what is not:

- The CLOCK is settled and NOT reopened. Gate on wall elapsed_ms — MG 02-08-2026 (H2160,
  option A), already in /pwg-live-gate and already what the code does. KILL_CEIL_MS is a
  wall timer and non-API overhead still kills calls and still bills. (H2174's handoff text
  was stale in calling this open; so was this session's first pass.)
- The ceiling VALUE was never fitted to that clock. 65 000 came from the 31-07
  production_v2 ruling, taken when no reading carried duration_api_ms at all. Against the
  measured distribution it is below the median. That belongs to H2138 — not to H2174, and
  not to be "fixed" by raising a guard so one's own run passes.

H2138 asked for 5 paid paired readings to re-derive the ceiling. The series now carries
exactly 5, at zero further cost — so H2138 can run with no new spend:

  api/wall ratio 0.25 -> 0.72 (median 0.55)
  api_gap_ms     17 429 -> 49 846 ms

That disproves the standing "~45 % of a wall reading is scaffolding" constant in both
directions: no fixed factor converts one number into the other, which is why option C
(api as a second, independently-derived fail condition) cannot reuse 65 000.

Order for the lane: run H2138 (re-derive the ceiling), then H2174.

Release 1.137.4.

Model: Opus 5 (claude-opus-5[1m])

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
