### PR TITLE
chore(release): 1.137.6 — H2222 inventory

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >
   data/FAIR_RELEASE_1.md.
 license: MIT
 repository-code: https://github.com/gasyoun/SanskritLexicography
-version: 1.137.5
+version: 1.137.6
 date-released: 2026-08-02
 # The CONCEPT DOI — version-independent, always resolves to the newest release.
 # This is deliberately NOT a per-version DOI: those change every release and would

--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,8 +10,10 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.137.6] - 2026-08-02
+
 ### Added
-- **PWG translation duplication → optimization inventory (02-08-2026, Grok 4.5 `grok-4.5`, H2222):** durable map of *intentional* vs *unjustified* duplication so the next session hunts **code/logic twins**, not edition restates or style doublets. Taxonomy A–D (lexicographic / target-language product / process / code twin); §2 leave-alone (relationship restates, doublets, SHARED stage-0, resolveGroup/healGroup); ranked **OPT-1–8** (EN promote GAP, audit_window twin extract, selfheal↔autosplit defer, H1209 JS field param, citation coverage single source, TM defect invalidation, ops double-run); content spend C-1–5; drain order P0–P3. Doc: [`PWG_TRANSLATION_DUPLICATION_OPTIMIZATION_INVENTORY_2026-08.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_TRANSLATION_DUPLICATION_OPTIMIZATION_INVENTORY_2026-08.md). Pointers from [`pwg_ru.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru.md). No production code path change.
+- **PWG translation duplication → optimization inventory (02-08-2026, Grok 4.5 `grok-4.5`, H2222):** durable map of *intentional* vs *unjustified* duplication so the next session hunts **code/logic twins**, not edition restates or style doublets. Taxonomy A–D (lexicographic / target-language product / process / code twin); §2 leave-alone (relationship restates, doublets, SHARED stage-0, resolveGroup/healGroup); ranked **OPT-1–8** (EN promote GAP, audit_window twin extract, selfheal↔autosplit defer, H1209 JS field param, citation coverage single source, TM defect invalidation, ops double-run); content spend C-1–5; drain order P0–P3. Doc: [`PWG_TRANSLATION_DUPLICATION_OPTIMIZATION_INVENTORY_2026-08.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_TRANSLATION_DUPLICATION_OPTIMIZATION_INVENTORY_2026-08.md). Pointers from [`pwg_ru.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/pwg_ru.md). No production code path change. [PR #1043](https://github.com/gasyoun/SanskritLexicography/pull/1043).
 
 ## [1.137.3] - 2026-08-02
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,10 @@ not an error.
 
 ## [Unreleased]
 
+## [1.137.6] - 2026-08-02
+### Added
+- **PWG translation duplication → optimization inventory (H2222, Grok 4.5 `grok-4.5`, 02-08-2026):** durable map of intentional vs unjustified duplication so optimization hunts **code/logic twins** (EN promote GAP, audit_window fork, H1209 JS field, citation coverage SoT), not edition restates or style doublets. Doc: [`RussianTranslation/PWG_TRANSLATION_DUPLICATION_OPTIMIZATION_INVENTORY_2026-08.md`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/PWG_TRANSLATION_DUPLICATION_OPTIMIZATION_INVENTORY_2026-08.md). [PR #1043](https://github.com/gasyoun/SanskritLexicography/pull/1043).
+
 ## [1.137.5] - 2026-08-02
 ### Added
 - **Progress kitchen residual B1+B9+B10 + historical metric backfill (H2218, Grok 4.5 `grok-4.5`, 02-08-2026):** optional subscription-window $ card from gitignored `economy_subscription.json` (never invent dollars); idle-gap **reason** classes (`human` · `weekly_cap` · `health_nogo` · `machine_off` · `waiting_requeue` · `unknown`) from operator log + measured auto-rules; store-vs-`article_site` root parity card; [`backfill_ledger_metrics.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/progress_dashboard/backfill_ledger_metrics.py) best-effort wall-clock/gen_model recovery with provenance flags. Additive keys on `pwg.kitchen.v2`. Examples under [`progress_dashboard/examples/`](https://github.com/gasyoun/SanskritLexicography/tree/master/progress_dashboard/examples).


### PR DESCRIPTION
Release cut for H2222 durable inventory doc merged in #1043.