### PR TITLE
chore(release): 1.137.8 — OPT-6 citation coverage_key (H2225)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,8 +10,10 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
+## [1.137.8] - 2026-08-03
+
 ### Fixed
-- **OPT-6 citation coverage single source of truth (H2225, 02-08-2026, Grok 4.5 `grok-4.5`):** [`build_citation_index.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_citation_index.py) extracts pure `coverage_key` + `coverage_bucket` and a shared `coverage_rows_from_pairs` kernel used by both the distinct-ref path (`CITATION_SOURCES.md`) and occurrence path (`UNCOVERED_SOURCES.md` / `COVERAGE_COMPARISON.md`), so the two reports cannot disagree on covered vs truly-uncovered vs non-coordinate label by construction (CODE_REVIEW 2026-07-04 debt). **Before/after:** CITATION_SOURCES `unresolved` previously = `total − resolved` (labels counted as unresolved debt); after = explicit `unresolved` bucket only, with labels broken out as their own metric — same classifier as UNCOVERED. Pinned by `python src/build_citation_index.py --selftest`. Inventory OPT-6 flipped done.
+- **OPT-6 citation coverage single source of truth (H2225, 02-08-2026, Grok 4.5 `grok-4.5`):** [`build_citation_index.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_citation_index.py) extracts pure `coverage_key` + `coverage_bucket` and a shared `coverage_rows_from_pairs` kernel used by both the distinct-ref path (`CITATION_SOURCES.md`) and occurrence path (`UNCOVERED_SOURCES.md` / `COVERAGE_COMPARISON.md`), so the two reports cannot disagree on covered vs truly-uncovered vs non-coordinate label by construction (CODE_REVIEW 2026-07-04 debt). **Before/after:** CITATION_SOURCES `unresolved` previously = `total − resolved` (labels counted as unresolved debt); after = explicit `unresolved` bucket only, with labels broken out as their own metric — same classifier as UNCOVERED. Pinned by `python src/build_citation_index.py --selftest`. Inventory OPT-6 flipped done. [PR #1049](https://github.com/gasyoun/SanskritLexicography/pull/1049).
 
 ## [1.137.7] - 2026-08-03
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,10 @@ not an error.
 
 ## [Unreleased]
 
+## [1.137.8] - 2026-08-03
+### Fixed
+- **OPT-6 citation coverage single source of truth (H2225, Grok 4.5 `grok-4.5`, 02-08-2026):** `build_citation_index.py` extracts pure `coverage_key` + `coverage_bucket` + shared kernel so `CITATION_SOURCES` / `UNCOVERED_SOURCES` cannot disagree on covered vs truly-uncovered vs non-coordinate labels. Labels no longer inflate distinct-ref `unresolved`. `python src/build_citation_index.py --selftest` green. [PR #1049](https://github.com/gasyoun/SanskritLexicography/pull/1049).
+
 ## [1.137.7] - 2026-08-03
 ### Fixed
 - **OPT-1 EN promote parity (H2224, Grok 4.5 `grok-4.5`, 02-08-2026):** `promote_en.py` gains B08 better-attempt-wins, B20 model-identity cross-check, and H1553 defect-key refuse (+ optional ready_partial filter); helpers single-sourced from `promote_final_cards` (EN stays attach-overlay). LANG_PARITY `h1339_en_promote_parity_gap` + `h1553_wall_clock_defect_ready_partial` → SHARED. [PR #1047](https://github.com/gasyoun/SanskritLexicography/pull/1047).


### PR DESCRIPTION
Promote H2225 OPT-6 changelog from [Unreleased] to **1.137.8** (root + RussianTranslation). Tag `v1.137.8` already pushed.

Feature: [PR #1049](https://github.com/gasyoun/SanskritLexicography/pull/1049)