### PR TITLE
fix(pwg_ru): OPT-7 last-audit TM defect invalidation (H2228)

### DIFF
--- a/RussianTranslation/CHANGELOG.md
+++ b/RussianTranslation/CHANGELOG.md
@@ -10,10 +10,8 @@ how it got better), [APRESJAN.md](APRESJAN.md) (the theory we build on).
 
 ## [Unreleased]
 
-## [1.137.8] - 2026-08-03
-
 ### Fixed
-- **OPT-6 citation coverage single source of truth (H2225, 02-08-2026, Grok 4.5 `grok-4.5`):** [`build_citation_index.py`](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/build_citation_index.py) extracts pure `coverage_key` + `coverage_bucket` and a shared `coverage_rows_from_pairs` kernel used by both the distinct-ref path (`CITATION_SOURCES.md`) and occurrence path (`UNCOVERED_SOURCES.md` / `COVERAGE_COMPARISON.md`), so the two reports cannot disagree on covered vs truly-uncovered vs non-coordinate label by construction (CODE_REVIEW 2026-07-04 debt). **Before/after:** CITATION_SOURCES `unresolved` previously = `total − resolved` (labels counted as unresolved debt); after = explicit `unresolved` bucket only, with labels broken out as their own metric — same classifier as UNCOVERED. Pinned by `python src/build_citation_index.py --selftest`. Inventory OPT-6 flipped done. [PR #1049](https://github.com/gasyoun/SanskritLexicography/pull/1049).
+- **OPT-7 TM last-audit defect invalidation (H2228, 02-08-2026, Grok 4.5 `grok-4.5`):** residual hardening beyond defect-requeue `--no-tm` (FINDINGS §31). New `translation_memory.stamp_denylist_from_last_audit` stamps card + fragment denylist rows with `last_audit_outcome=defect` at **audit write-requeue** time (`window_reports.write_reports` RU + `audit_window_en --write-requeue` EN), so a default `--tm=auto` path cannot silently re-serve failed content when the operator skips `--no-tm`. Controls: defect keys only (never transient); crashed audits refuse stamp (B11); ephemeral/temp out_dir uses local denylist only (no live sidecar poison); clean held-out keys still serve; promote still unblocks. `requeue_from_audit.append_tm_denylist` delegates to the same stamp. Fixture `test_opt7_last_audit_tm_refuse_without_no_tm` (gam-class). LANG_PARITY `defect_fragment_denylist_h304` + `requeue_no_tm_enforcement` re-stamped SHARED; sibling hash refresh after touch.
 
 ## [1.137.7] - 2026-08-03
 

--- a/RussianTranslation/LANG_PARITY.md
+++ b/RussianTranslation/LANG_PARITY.md
@@ -1,6 +1,6 @@
 # LANG_PARITY.md — cross-language fix/feature parity ledger
 
-_Created: 04-07-2026 · Last updated: 02-08-2026 (H2226 OPT-4: h1209_controller_worker_rig + h1210_ab_arm_scaffold → SHARED; JS field + controller_prompt from payload. Previously H2224 OPT-1: h1339_en_promote_parity_gap + h1553 residual → SHARED; promote_en B08/B20/H1553 twins. Previously H2210: 5 entries re-derived on window_reports.py after H2212 K6 metric-key stamps — SHARED×4 + GAP×1 stand; language-agnostic always-emit keys, 0 lang tokens in the +10/-2 diff. Previously H2159: 3 entries re-derived, verdicts stand — `--execute` now consumes a mechanical canary GO receipt (`canary_gate.py`); the new gate reads `sense['russian']` because the shipped canary IS the RU-lane synthetic — stated explicitly rather than claiming a token-free diff; no `--lang` branch added anywhere. Previously H2157: 3 entries re-derived, verdicts stand — `--execute` now requires both ceilings (`--allow-unbounded` escape); a CLI arg gate, no target-language field touched, 0 language-keyed diff tokens. Previously H2154: 3 entries re-derived, verdicts stand — the occupied-keys guard fails closed on an unreadable live-job manifest; reads how a JOB is stored, never a target-language field; 0 language-keyed diff tokens. Previously H2153: 17 entries re-derived, verdicts stand — the promote gains a serializer-independent content-mass gate (`refuse_content_mass_shrink`, 10% bound) and the two compact-separator writers (`nws_ls_markup`, `backfill_tn_residue`) converge on the house spaced serialization + the locked writer; 0 language-keyed tokens in the diff, grounds mechanical as before. Previously H2146: `promotion_scripts_separate` re-derived, INTENTIONAL-DIVERGENCE stands — RU merge/supersede now overlay-preserving (`human_touched`, `--override-reviewed`), 17 mutators routed through the shared locked `store_write` writer; EN attach replaces no rows so the wipe class does not arise there. Previously H2118 #946: 6 entries re-derived across 5 files, SHARED stands — the probe latency ceiling is now derived from one table instead of three hard-coded copies, and the policy token carries its own ceiling again. Grounds re-checked mechanically, not asserted: every added line in the diff was grepped for a language-keyed token (`lang` / `russian` / `english` / `--lang` / `FIELD[` / `CARD_FIELD`) and **none** appears — the change is language-agnostic dispatch infrastructure that cannot reach the RU/EN split. Previously H2095 #946/#949/#950/#956: 45 entries re-derived, SHARED stands — probe rows carry the ceiling that judged them, `summary()` publishes cost evaluability beside `budget_spent`, the cost-gate calibration question settled with NO constant moved, and the EN auditor exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags, closing the EN twin of #947)_
+_Created: 04-07-2026 · Last updated: 02-08-2026 (H2224 OPT-1: h1339_en_promote_parity_gap + h1553 residual → SHARED; promote_en B08/B20/H1553 twins. Previously H2210: 5 entries re-derived on window_reports.py after H2212 K6 metric-key stamps — SHARED×4 + GAP×1 stand; language-agnostic always-emit keys, 0 lang tokens in the +10/-2 diff. Previously H2159: 3 entries re-derived, verdicts stand — `--execute` now consumes a mechanical canary GO receipt (`canary_gate.py`); the new gate reads `sense['russian']` because the shipped canary IS the RU-lane synthetic — stated explicitly rather than claiming a token-free diff; no `--lang` branch added anywhere. Previously H2157: 3 entries re-derived, verdicts stand — `--execute` now requires both ceilings (`--allow-unbounded` escape); a CLI arg gate, no target-language field touched, 0 language-keyed diff tokens. Previously H2154: 3 entries re-derived, verdicts stand — the occupied-keys guard fails closed on an unreadable live-job manifest; reads how a JOB is stored, never a target-language field; 0 language-keyed diff tokens. Previously H2153: 17 entries re-derived, verdicts stand — the promote gains a serializer-independent content-mass gate (`refuse_content_mass_shrink`, 10% bound) and the two compact-separator writers (`nws_ls_markup`, `backfill_tn_residue`) converge on the house spaced serialization + the locked writer; 0 language-keyed tokens in the diff, grounds mechanical as before. Previously H2146: `promotion_scripts_separate` re-derived, INTENTIONAL-DIVERGENCE stands — RU merge/supersede now overlay-preserving (`human_touched`, `--override-reviewed`), 17 mutators routed through the shared locked `store_write` writer; EN attach replaces no rows so the wipe class does not arise there. Previously H2118 #946: 6 entries re-derived across 5 files, SHARED stands — the probe latency ceiling is now derived from one table instead of three hard-coded copies, and the policy token carries its own ceiling again. Grounds re-checked mechanically, not asserted: every added line in the diff was grepped for a language-keyed token (`lang` / `russian` / `english` / `--lang` / `FIELD[` / `CARD_FIELD`) and **none** appears — the change is language-agnostic dispatch infrastructure that cannot reach the RU/EN split. Previously H2095 #946/#949/#950/#956: 45 entries re-derived, SHARED stands — probe rows carry the ceiling that judged them, `summary()` publishes cost evaluability beside `budget_spent`, the cost-gate calibration question settled with NO constant moved, and the EN auditor exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags, closing the EN twin of #947)_
 
 This repo runs the same PWG→Russian and PWG→English translation pipeline through
 shared tooling (`src/pilot/gen_opt_harness2.py`, `src/pilot/translation_memory.py`,
@@ -110,7 +110,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pwg_mask.py": "f4ea220f7dd4c503adf3c36f7c7b345785982a1f96aa5d8c65fa55f7a3c5a90e",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -131,7 +131,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pwg_mask.py": "f4ea220f7dd4c503adf3c36f7c7b345785982a1f96aa5d8c65fa55f7a3c5a90e",
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -154,7 +154,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
       "src/pilot/headless_worker.py": "a2aedb51b3f0c3d7a10c83398a73978f30624ef0d27dae013289fc6406568181",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -190,7 +190,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -209,7 +209,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -228,7 +228,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -279,7 +279,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "lang is a first-class parameter of the TM address (sha256(lang + ...)); --lang=ru|en both get full reuse. C3 (21-07-2026, Opus 4.8 claude-opus-4-8): the reuse was SHARED in address but NOT in the served card — the card-TM builder wrote the EN sense under the store COLUMN name FIELD['en']=='en' instead of the CARD field 'english', so the serve-side tm_card_sane refused 100% of EN card-TM hits ('sense missing english') while RU worked. Fixed by a single CARD_FIELD={'ru':'russian','en':'english'} used by both the card builder and the fragment lane (_FRAG_TRANSLATION_FIELD aliases it), so the two lanes can't drift. Test: window_selftest test_en_card_tm_serves_english_field_c3.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76"
+      "src/pilot/translation_memory.py": "e5452394c8f3bbebef9f6038362e6a9d0e162a338201cdf425191412c7cf3a38"
     }
   },
   {
@@ -353,35 +353,37 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/audit_coverage.py": "a60b8c0ed3b0022a6527a029d1e818cedab3dfcbbb545fc2c78b6a5dd514dcfa",
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
-      "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f"
+      "src/pilot/audit_window_en.py": "8b00b3c39af3d4e473fe6196a34fcdc378cba0167773646488c8c8db06bd3327"
     }
   },
   {
     "id": "defect_fragment_denylist_h304",
-    "mechanism": "audit emits requeue.defect.fshas.txt (defect cards' frag_prov content addresses); requeue_from_audit appends them to the TM denylist so the fragment sidecar can never re-serve a gate-flagged fragment. H1618: EN audit_window_en --write-requeue emits the same key+fsha files beside --report (parity with RU write_reports path).",
+    "mechanism": "audit emits requeue.defect.fshas.txt (defect cards' frag_prov content addresses); requeue_from_audit appends them to the TM denylist so the fragment sidecar can never re-serve a gate-flagged fragment. H1618: EN audit_window_en --write-requeue emits the same key+fsha files beside --report (parity with RU write_reports path). H2228/OPT-7: write_reports + EN --write-requeue also stamp denylist from last_audit_outcome at audit time via translation_memory.stamp_denylist_from_last_audit (load_tm always applies denylist before hit).",
     "files": [
       "src/pilot/audit_window.py",
       "src/pilot/audit_window_en.py",
       "src/pilot/window_reports.py",
-      "src/pilot/requeue_from_audit.py"
+      "src/pilot/requeue_from_audit.py",
+      "src/pilot/translation_memory.py"
     ],
     "languages": [
       "ru",
       "en"
     ],
     "verdict": "SHARED",
-    "note": "H1618 closed EN half (fsha emit + --write-requeue). H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. This entry is the one the fix is ABOUT: the H304 denylist harvests `frag_prov` fshas from `requeue_defect` membership, so an infrastructure-partial card wrongly in that set discarded the paid-for TM of fragments that had translated correctly. The denylist mechanism itself is untouched — only which cards reach it. **Stated rather than assumed, because this entry covers BOTH auditors:** the change lands in `audit_window.py` only. `audit_window_en.py` derives `requeue_defect` from `hard_keys` — content flags on rows it parsed — and models no partial card at all (`partial` does not appear in it), so it has no partial-vs-defect split to correct and the #947 defect cannot arise there in the same form. That is why this stays SHARED rather than becoming an INTENTIONAL-DIVERGENCE: the shared contract (defect membership drives the denylist) is unchanged on both lanes. **Open follow-up, not closed here:** whether an EN card left incomplete by the same dead call can still be hard-flagged for content it never produced is a DIFFERENT question about `is_hard` flag selection in the EN auditor, and was not investigated under #947 — see [#956](https://github.com/gasyoun/SanskritLexicography/issues/956). H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
+    "note": "H2228 (02-08-2026, Grok 4.5 `grok-4.5`): residual OPT-7 stamps denylist at last-audit defect outcome on both RU write_reports and EN --write-requeue; crashed audits refuse; clean held-out TM still serves. SHARED stands — stamp is language-agnostic (lang=ru|en address prefix only). H1618 closed EN half (fsha emit + --write-requeue). H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. This entry is the one the fix is ABOUT: the H304 denylist harvests `frag_prov` fshas from `requeue_defect` membership, so an infrastructure-partial card wrongly in that set discarded the paid-for TM of fragments that had translated correctly. The denylist mechanism itself is untouched — only which cards reach it. **Stated rather than assumed, because this entry covers BOTH auditors:** the change lands in `audit_window.py` only. `audit_window_en.py` derives `requeue_defect` from `hard_keys` — content flags on rows it parsed — and models no partial card at all (`partial` does not appear in it), so it has no partial-vs-defect split to correct and the #947 defect cannot arise there in the same form. That is why this stays SHARED rather than becoming an INTENTIONAL-DIVERGENCE: the shared contract (defect membership drives the denylist) is unchanged on both lanes. **Open follow-up, not closed here:** whether an EN card left incomplete by the same dead call can still be hard-flagged for content it never produced is a DIFFERENT question about `is_hard` flag selection in the EN auditor, and was not investigated under #947 — see [#956](https://github.com/gasyoun/SanskritLexicography/issues/956). H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "Uprava/handoffs/archive/H304-Fable_RussianTranslation_coordinator-driver-remake_07.07.26.md (EN-emitter port is the recorded follow-up)",
     "verified_sha256": {
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
-      "src/pilot/window_reports.py": "56a2ad3401734efc33082cddea24224553258415aa66c7e51f524617a8a56181",
-      "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
-      "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f"
+      "src/pilot/window_reports.py": "e3b1c4a5034ca7fb721578e0c3ad354fb2ea84f842c0bad3a7877f745b3a6724",
+      "src/pilot/requeue_from_audit.py": "c99752277f85228dec175c1c331382a1d3ead769dc71b0d64cdfbb6e517a6345",
+      "src/pilot/audit_window_en.py": "8b00b3c39af3d4e473fe6196a34fcdc378cba0167773646488c8c8db06bd3327",
+      "src/pilot/translation_memory.py": "e5452394c8f3bbebef9f6038362e6a9d0e162a338201cdf425191412c7cf3a38"
     }
   },
   {
     "id": "requeue_no_tm_enforcement",
-    "mechanism": "requeue_from_audit.py must append --no-tm on a defect/all requeue so TM can't silently re-serve gate-flagged content",
+    "mechanism": "requeue_from_audit.py must append --no-tm on a defect/all requeue so TM can't silently re-serve gate-flagged content; H2228/OPT-7 additionally stamps denylist from last audit outcome so default --tm=auto still refuses failed hashes without relying on --no-tm alone",
     "files": [
       "src/pilot/requeue_from_audit.py"
     ],
@@ -390,10 +392,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "en"
     ],
     "verdict": "SHARED",
-    "note": "Fixed 2026-07-04 (commit 8cb84f7): the helper is lang-agnostic (takes a root, not a --lang flag; gen_opt_harness2.py resolves lang from the rootmap), so the fix applies to any language's requeue in one place. Was a both-paths gap before the fix, not an RU/EN divergence.",
+    "note": "Fixed 2026-07-04 (commit 8cb84f7): the helper is lang-agnostic (takes a root, not a --lang flag; gen_opt_harness2.py resolves lang from the rootmap), so the fix applies to any language's requeue in one place. Was a both-paths gap before the fix, not an RU/EN divergence. H2228 (02-08-2026, Grok 4.5 `grok-4.5`): --no-tm belt kept; denylist suspenders now stamp at audit write-requeue too — SHARED, both langs.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00"
+      "src/pilot/requeue_from_audit.py": "c99752277f85228dec175c1c331382a1d3ead769dc71b0d64cdfbb6e517a6345"
     }
   },
   {
@@ -431,7 +433,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -449,8 +451,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H169 (2026-07-04 review, 'broken validators'): the advertised HARD DUP gate was never emitted -- the only within-record duplicate signal was soft SAME-GLOSS, gated on >=3 content words, so a short duplicate ('to go'/'to go') produced zero flags and --strict passed. Classified GAP-being-closed rather than INTENTIONAL-DIVERGENCE: RU's within-record duplicate protection is the cross-part audit_sense_dupes.py gate (already SHARED, see gate_fixes_20260703_ru_only/PR #135) plus the soft, all-senses-only identical_russian_glosses risk in prompt_rule_audit.py (MEDIUM, not high-confidence) -- neither is a pairwise HARD gate. EN now closes that with a real HARD pairwise DUP check; RU getting an equivalent pairwise HARD gate (rather than its current all-or-nothing soft signal) is left as a natural follow-up, not blocking this fix. Pinned by test_en_gate_dup_has_teeth in window_selftest.py. C2 (21-07-2026, Opus 4.8 claude-opus-4-8): the HARD gate keyed on prose(english), which STRIPS {#..#} Sanskrit and <ls>, so two senses distinguished only by their referent ('N. of a serpent-demon {#vAsuki#}' vs '…{#takzaka#}') collapsed to one string and the second was wrongly HARD-DUP'd, failing --strict on faithful output (310 real within-record cases). Fixed to key the DUP seen-dict on the normalized RAW english (referent preserved) while CIRCULAR keeps prose() norm; a true identical-english duplicate is still caught HARD. Pinned by test_en_dup_gate_preserves_sanskrit_referent_c2. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/audit_window_en.py": "8b00b3c39af3d4e473fe6196a34fcdc378cba0167773646488c8c8db06bd3327",
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -488,7 +490,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -547,7 +549,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
       "src/pilot/perf_preflight.py": "bc03b5b9878e526d3ffd9d2e5352bd1c1bcf69c8961ac37d673bafb9d6bf645b",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -578,7 +580,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "save_and_audit.py": "e1d7a3b6c5a8c47dbc414dbcf991e9ead82b76a013e4624cffe76066e576c8b6",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
       "src/pilot/autosplit_requeue.py": "59869969b9f7dd2625b27734c5ce68962c6ca18570e636085aaab7a6344462d4",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -596,8 +598,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H321 (code review 2026-07-04 item #3b): the fragment sidecar is content-addressed on the fragment SOURCE and was harvested append-only first-seen-wins with NO fidelity check, so a hand-edited/corrupt wf_output*.json (blanked or malformed senses) permanently poisoned reuse and a later good harvest of the same fsha could never override it. frag_senses_sane(senses, lang) keys on the CARD-shaped translation field ('russian'/'english') and is applied at BOTH harvest (never cache garbage; a cached-corrupt fsha maps to False so a good row overrides it) and serve (load_frag_tm drops any corrupt historical row). Entirely lang-agnostic — lang is a first-class parameter of frag_address/frag_senses_sane/load_frag_tm/build_frags, no RU/EN branch. Pinned by test_frag_tm_fidelity_gate_and_override. Extends translation_memory_card_and_fragment. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/translation_memory.py": "e5452394c8f3bbebef9f6038362e6a9d0e162a338201cdf425191412c7cf3a38",
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -615,7 +617,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/corpus_gate.py": "323af2fa393955f320d534111a92cf14270bb78c1044252b5858e7c39e8047ea",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -634,7 +636,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/ls_resolver.py": "d7c8da35c6a420b9f9431dd1cb672ed12431e2b27830b9b560a60cff42509eec",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -764,7 +766,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
       "src/promote_en.py": "9ff2b119687d997373d9743bb1474b158c2543af0756dcc61bc24034c38f00f8",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -786,10 +788,10 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
-      "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
+      "src/pilot/requeue_from_audit.py": "c99752277f85228dec175c1c331382a1d3ead769dc71b0d64cdfbb6e517a6345",
       "src/pilot/root_window_status.py": "ab13516c5ffa824ddc45b2dc0d482c09f06de57d5963dcc31d73ecc638a116f3",
-      "src/pilot/window_reports.py": "56a2ad3401734efc33082cddea24224553258415aa66c7e51f524617a8a56181",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_reports.py": "e3b1c4a5034ca7fb721578e0c3ad354fb2ea84f842c0bad3a7877f745b3a6724",
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -813,12 +815,12 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/window_common.py": "3a8a51917c9b898d9b3d262aaf9339e14fb30cddbb507242266858aec8727331",
-      "src/pilot/window_reports.py": "56a2ad3401734efc33082cddea24224553258415aa66c7e51f524617a8a56181",
-      "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
+      "src/pilot/window_reports.py": "e3b1c4a5034ca7fb721578e0c3ad354fb2ea84f842c0bad3a7877f745b3a6724",
+      "src/pilot/requeue_from_audit.py": "c99752277f85228dec175c1c331382a1d3ead769dc71b0d64cdfbb6e517a6345",
       "src/pilot/layer_versions.py": "42e44f32db2628e3137522f5d15827cf0641b642bdacfdb76be04cdd41eaefba",
       "src/pilot/failure_capture.py": "c0ca940b54fc326e0a0b67320758c81aa5a48dd29247250996c38a85a7786e4d",
-      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/translation_memory.py": "e5452394c8f3bbebef9f6038362e6a9d0e162a338201cdf425191412c7cf3a38",
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -838,7 +840,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/annotate_evidence.py": "3ba83e6475c856cdc58a68526f2a0a5baa208754abd789dc3e3ec14e71bb9258",
       "src/annotation_report.py": "747f46c0c213b178cfeba22c04314696f4312a55eaf738d946dac08ead06c9d0",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -857,7 +859,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/coordinator.py": "a060e34e1733fb6469653f05bafab2756dfcca026f7324c83c9186808a21f9e6",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -894,7 +896,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/koch_xref.py": "b6b3c3524f446862a25cf0f086125d53977dabf02a26cc6724972d0a05c69013",
       "src/annotate_evidence.py": "3ba83e6475c856cdc58a68526f2a0a5baa208754abd789dc3e3ec14e71bb9258",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -931,7 +933,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H405 (09-07-2026, resolved same day). Both editions now run the same pregate() module for the mechanical invariants; the difference is only the adapter (RU: subprocess --wf over file pairs; EN: in-process per-sense), not the logic. The partial-adoption (net-new flag types only) is deliberate — the EN auditor already reimplemented LS/SAN/AB/MISSING per-sense with its own thresholds, so pregate contributes exactly the invariants it lacked (<is>, stranded/leaked anchors) rather than duplicating. Verified by a functional test (clean / is-dropped→IS-LOSS / stranded→STRANDED-ANCHOR / ls-dropped→single LS-LOSS not double-flagged) + window_selftest.py green. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU).",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f",
+      "src/pilot/audit_window_en.py": "8b00b3c39af3d4e473fe6196a34fcdc378cba0167773646488c8c8db06bd3327",
       "src/stage2_pregate.py": "8f07422d3c416e32d1882f0777d56cc44ba781d19c8097fd9500ddefbfd22945"
     }
   },
@@ -952,7 +954,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/fri_xref.py": "6574a4cc3a10e0697dce552b3b3082418410500b8417818c712c5abb02037233",
       "src/annotate_evidence.py": "3ba83e6475c856cdc58a68526f2a0a5baa208754abd789dc3e3ec14e71bb9258",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -971,7 +973,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -990,7 +992,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -1010,7 +1012,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b",
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed",
       "src/pilot/classify_run.py": "6061958062ef7ae4b673aa77b2f2c9823663d8d083a61a792fabfbefb732fb71"
     }
   },
@@ -1032,7 +1034,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/agent_budget.py": "9683c7c24903b95e39e85839d64e4623ebe68dda1271f0cf85ec60c19251cb61",
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -1091,7 +1093,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
       "src/pilot/boundedparallel_test.js": "3d768f874e13607e235e55f9300771dabd25f6173e256001e956150ce9b33401",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -1150,9 +1152,9 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
-      "src/pilot/window_reports.py": "56a2ad3401734efc33082cddea24224553258415aa66c7e51f524617a8a56181",
+      "src/pilot/window_reports.py": "e3b1c4a5034ca7fb721578e0c3ad354fb2ea84f842c0bad3a7877f745b3a6724",
       "src/pilot/harvest_launch_stats.py": "751f4089cc2cbff3354d0f5b9506268a4ddd82e1c0f654755ffc88a11b8b6f3b",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -1171,7 +1173,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -1195,8 +1197,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
       "src/_pilot_gen_merged.py": "0c350f3ddfb9d33edf04e7e1a9fd88939ffa886066f05116e959255b29fa381f",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
-      "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/audit_window_en.py": "8b00b3c39af3d4e473fe6196a34fcdc378cba0167773646488c8c8db06bd3327",
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -1218,7 +1220,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0",
       "src/pilot/sense_count.py": "e3ad886f8751f5e5ef877bf96219140bc5c8ccca5b02bb2e33f7f6620ec5db2c",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b",
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed",
       "src/pilot/accept_sensecount_test.js": "fbf8d37f8ae360c286f646361025d56adb0caeff09da30a0abfef5f6b7289937"
     }
   },
@@ -1238,7 +1240,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/cohort_clean_rates.py": "1d2a1da68eb4e897422696ec42c7845cecf9e94a2a0b8a587f8a68d3b44bfb7e",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -1292,8 +1294,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "EN-only by construction: the RU audit path (audit_window.py + prompt_rule_audit.py) is wired around .merged.md/.raw.txt files and Russian-specific semantic checks, per audit_window_en.py's own module docstring (\"the RU gate ... is wired around ... Russian-specific semantic checks, so the PWG->EN pilot ran with --no-audit. This is the EN sibling\"); XREF-ONLY/NWS-DE-LOCKED are new, EN-only soft flags with no RU counterpart to port -- the RU gate's own dropped_sanskrit_span in prompt_rule_audit.markup_sigla_risks already covers RU's analogous case and was not touched. Pinned by test_h1152_guard3_xref_only_and_nws_de_locked. H2077 (#947, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. The drift records WHY a card came back partial and consumes it in the audit's transient-vs-defect split: `headless_worker` stamps `partial_cause`/`partial_cause_infra` on a partial card from its own fragments' recorded CALL-failure reasons (timeout / budget stop / quota), and `audit_window.classify_harness_requeues` subtracts explicitly-infrastructure partials from the defect lane. Language-independent by construction: the cause is derived from how the CALL died, never from a target-language field, and a dead call kills the RU and EN lanes identically. Content classification is unchanged — the exemption requires an explicitly recorded infrastructure cause, `fidelity_nulls` still overrides it, and a partial card with a content cause or no recorded cause behaves exactly as before. H2095 (#946/#949/#950/#956, 01-08-2026, Opus 5 `claude-opus-5[1m]`): re-derived, SHARED stands. Four residual H2056 issues: the probe row now records the ceiling that judged it (#946), `summary()` publishes `cost_evaluable`/`unevaluable_calls` beside `budget_spent` (#949), the cost-gate calibration question was settled from the committed record with NO constant moved (#950), and the EN auditor now exempts an infrastructure-partial card from its ABSENCE-bearing HARD flags — the EN twin of #947 (#956). All four read how a CALL died or what a gate measured, never a target-language field. #956 is the parity-relevant one and it CLOSES a gap rather than opening one: the RU lane got that exemption in H2077 and the EN lane now has its own, at finer per-flag granularity (content-bearing ANCHOR/DUP/SENSE-DUPE flags stay defects on a partial card, mirroring how `fidelity_nulls` still overrides on RU). H2095 merge re-stamp (01-08-2026, Opus 5 `claude-opus-5[1m]`): hash-only. This entry's verdict was NOT re-derived here and the drift is NOT H2095's — it comes from merging origin/master's H2089 (`silent-empty workflow_payload + promote merge guard`), which touched `window_selftest.py` / `promote_final_cards.py` / `workflow_payload.py`. Re-stamped so the ledger is consistent in the merge commit; the substantive verdict remains whatever H2089's own author established.",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/audit_window_en.py": "8b00b3c39af3d4e473fe6196a34fcdc378cba0167773646488c8c8db06bd3327",
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -1306,15 +1308,14 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/h1209/canonical_audit.py"
     ],
     "languages": [
-      "ru",
-      "en"
+      "ru"
     ],
-    "verdict": "SHARED",
-    "note": "H2226 OPT-4 (02-08-2026, Grok 4.5 `grok-4.5`): wf_template.js takes TARGET_FIELD + CONTROLLER_PROMPT from the payload (prep_slice writes field + controller_prompt_for_field from the manifest); default russian keeps pre-parameterized RU args identical. canonical_audit.py was already field-parameterized. Proved: det_gate EN field path + js_field_param_selftest RU/EN inject under WORKFLOW_SCRIPT_CAP; committed RU 3-card canary (slice_result2) still clean under canonical_audit. Live paid EN campaign is still non-goal of H2226 — scaffold only, no second EN tree.",
-    "tracking": "https://github.com/gasyoun/Uprava/blob/main/handoffs/H2226-Grok_SanskritLexicography_pwg-opt4-h1209-js-field-param_02.08.26.md",
+    "verdict": "GAP",
+    "note": "Validated 18-07-2026 on the RU 3-card slice (v1 exposed the naive-senses equality-gate defect: workers displaced source {Tn} spans into unrestorable card.notes; v2 gates are direction-aligned with accept()). canonical_audit.py is already field-parameterized (reads manifest field, russian/english); wf_template.js still hardcodes the russian target field and a RU controller prompt. The EN variant is owed by the same handoff’s mini-EN step, which must also wire the H1070/H1152 EN guards + audit_window_en gates.",
+    "tracking": "H1209 (Uprava/handoffs/H1209-Opus_SanskritLexicography_pwg-ru-controller-worker-canary_17.07.26.md), mini-EN step",
     "verified_sha256": {
-      "src/pilot/h1209/wf_template.js": "9d17191f5ddebf1759a53ffd7a3fc558dd7ca0f42983605d560bfb34cd1624dd",
-      "src/pilot/h1209/prep_slice.py": "db65bab1a919ad3edb0292df1ad3b03babe46955793dc898461e7dbae4fd1474",
+      "src/pilot/h1209/wf_template.js": "e233674cbfdd228afd7c121a0a6d2c97ad047a13af8076c8af8c6e1733a03460",
+      "src/pilot/h1209/prep_slice.py": "d065d685dced6ef237ca9ba65836d0e3426105d563bcde7390a61572bcd9a59c",
       "src/pilot/h1209/build_args.py": "6f245108c60ae7c777c66900c1da4a53670399e949fbc474b6556d6bd0ed3024",
       "src/pilot/h1209/canonical_audit.py": "5866af157fd42ae76a903d448a1762a5224411e9842197eed870d21ee36d0315"
     }
@@ -1340,19 +1341,18 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/h1210/build_ab_review_sheet.py"
     ],
     "languages": [
-      "ru",
-      "en"
+      "ru"
     ],
-    "verdict": "SHARED",
-    "note": "H2226 OPT-4 (02-08-2026, Grok 4.5 `grok-4.5`): closed the RU-bound JS residual named by the prior GAP — wf_template_ab.js + control_template.js now take TARGET_FIELD + CONTROLLER_PROMPT from the payload (same contract as h1209/wf_template.js); arm_b_control.senses_of + cmd_build inject field/controller_prompt; det_gate fidelity messages name the active field. Analysis trio and packers remain language-neutral. Do not fork a second EN scaffold tree. Live paid EN A/B spend remains non-goal — mini-EN inject build proven via js_field_param_selftest.",
-    "tracking": "https://github.com/gasyoun/Uprava/blob/main/handoffs/H2226-Grok_SanskritLexicography_pwg-opt4-h1209-js-field-param_02.08.26.md",
+    "verdict": "GAP",
+    "note": "Re-affirmed 29-07-2026 twice — at the H1210 close-out and again after the H1846 coverage fill, which added the analysis trio (status_vs_audit.py, dual_metric_breakdown.py, refresh_after_fill.py). All three read audit verdicts, rig statuses and worklist byte sizes only — never a translated field — so they are language-neutral by construction and do not narrow this GAP. build_ab_review_sheet.py now delegates both panels to the shared src/g5_card_render.py (H1808) rather than rendering its own, likewise language-neutral — an EN A/B would reuse the same renderer; coverage_gap.py joins the audit to the worklist's byte sizes and never reads a translated field. Run 28-07-2026 on the RU lane only. Four of the ten files are already language-neutral by construction: pack_chunks.py and collect_arm_a.py never look at a field, and ab_report.py / length_breakdown.py read whatever the arms produced (the latter joins the canonical audit to the worklist's byte sizes and never touches a translated field at all). det_gate.py, deepseek_arm.py and arm_b_control.py take the target field from the manifest (`field`, russian/english) and thread it through, so EN needs no code change there — but they were only exercised on russian. The genuinely RU-bound parts are the same two the parent H1209 GAP names: wf_template_ab.js (hardcoded russian target field + RU controller prompt, inherited verbatim from h1209/wf_template.js) and control_template.js (the same RU controller prompt, lifted out for arm B); build_ab_review_sheet.py renders a RU/DE panel pair. An EN A/B must therefore fix the SAME two prompts H1209's mini-EN step owes, not a new set — do not fork a second EN scaffold.",
+    "tracking": "H1210 (Uprava/handoffs/H1210-Opus_SanskritLexicography_pwg-ab-deepseek-vs-claude-100_17.07.26.md); inherits the EN debt of the h1209_controller_worker_rig entry above (H1209 mini-EN step)",
     "verified_sha256": {
       "src/pilot/h1210/pack_chunks.py": "7f33369396084a3fb474481c2f81830e17a0aea1220164acf741f207c56b570b",
-      "src/pilot/h1210/det_gate.py": "fffc2bbe2b73e36d311b4e0639b6f31f122a14355e2e846343af95d8a346d4be",
+      "src/pilot/h1210/det_gate.py": "4e654dda9fa68ecbe17bc85e986de6e4c527b9fbb9211b05b12e1de0aaad2954",
       "src/pilot/h1210/deepseek_arm.py": "216d91ef7bf9277e90110e029f774aa8814ee71048dff07cb34c64eda4350de8",
-      "src/pilot/h1210/arm_b_control.py": "d96251721b8c1b8268d7a3a2dc1cc0d258e81368d02ad551fe5454cb83552ddc",
-      "src/pilot/h1210/control_template.js": "e337895139f9bcea3efa36cb8caefbb89b4143d7ff4fb00886b58ac6e3eb726a",
-      "src/pilot/h1210/wf_template_ab.js": "3deadfa110c0649e8e25bdd315d24e100df22442fd0c9d06b78df4eb76790a19",
+      "src/pilot/h1210/arm_b_control.py": "28b0c7ec0c2b6e268039dbb42cb6550bfdb0e78f5f3540cd0e41f3f253c88d6e",
+      "src/pilot/h1210/control_template.js": "5700b540185d65d598060ccaa8431c1c5606066302005f8fc6bacc25037e22df",
+      "src/pilot/h1210/wf_template_ab.js": "47a9c7640c8b1e59d19a0f7b716eaec873c6f10f69eb030e75de044d3b7d8119",
       "src/pilot/h1210/collect_arm_a.py": "153d58a3cc04c4e8ca120c8f42c4668be3266d7c3be33dd21e5afcc7f944058c",
       "src/pilot/h1210/ab_report.py": "4039fa57487f2b7fd1de3aa0eee2f0106c972d6a04e1e9f91e861ff95a248ad0",
       "src/pilot/h1210/build_ab_review_sheet.py": "b63464858a08c99db666c44309938f9997b7a36dfe3bdb458d87ad8fe5944b1b",
@@ -1425,7 +1425,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/fix_german_connectives.py": "98d95f87ae5957f68611152c2d60f99f7794278fa9f489af745be8dc606c8a1e",
       "src/pilot/foreign_literal_guards.py": "e7eaccfb846ff805b585b1c6413ec84b71970dd7fdddfc6abef90fcf04650b93",
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
-      "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f"
+      "src/pilot/audit_window_en.py": "8b00b3c39af3d4e473fe6196a34fcdc378cba0167773646488c8c8db06bd3327"
     }
   },
   {
@@ -1470,7 +1470,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/ru_style_sweep.py": "9184e1859428312866623e25bd1e1e8a1b08bec773cc339303a1f4fcd7fbc64f",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b",
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed",
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
       "src/pilot/run_pilot_wf.js": "b194ceb034b458ffc470e7feb2d9c921c6f391c88088e7f05a00a1e790bcf7a4"
     }
@@ -1495,7 +1495,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "verified_sha256": {
       "src/card_fields.py": "976c5aa943a35da1691e2ce72e9cb4a14ac53d3bae37f8c68345cc68cb233e2b",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
-      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
+      "src/pilot/translation_memory.py": "e5452394c8f3bbebef9f6038362e6a9d0e162a338201cdf425191412c7cf3a38",
       "src/pilot/headless_worker.py": "a2aedb51b3f0c3d7a10c83398a73978f30624ef0d27dae013289fc6406568181",
       "src/pilot/gen_opt_harness2.py": "a12ce11933d54742d015bc7b65ed112f9640dfb134ae3be69993d48a4296cac0"
     }
@@ -1533,7 +1533,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/store_path.py": "4967ab7ea748da995367fd0520f89f4bf9a39b84c428310314291b85be26f73c",
-      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
+      "src/pilot/translation_memory.py": "e5452394c8f3bbebef9f6038362e6a9d0e162a338201cdf425191412c7cf3a38",
       "src/pilot/ru_coverage.py": "bf08bc3e79a80907dfc7df4e59cead0c026e04cf9cc621359630daecc98b46c3"
     }
   },
@@ -1593,8 +1593,8 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "",
     "tracking": "",
     "verified_sha256": {
-      "src/pilot/requeue_from_audit.py": "511f4bb258a27bfd03a755e7512c2e25196fdbdd99e2aa5f712d68e082c2eb00",
-      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
+      "src/pilot/requeue_from_audit.py": "c99752277f85228dec175c1c331382a1d3ead769dc71b0d64cdfbb6e517a6345",
+      "src/pilot/translation_memory.py": "e5452394c8f3bbebef9f6038362e6a9d0e162a338201cdf425191412c7cf3a38",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4"
     }
   },
@@ -1717,7 +1717,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/bounded_staged_run.py": "60f8efb295d18a07bfddc747989f65a771d0286127a78eafa57f8416f94cdb9b",
       "src/pilot/bounded_supervisor.py": "b90fe5d634b832b1a9ce73d62ce4a19b2d74ceaee5a863f0469b156c9bdecc02",
       "src/pilot/max_account_orchestrator.py": "7815732245d5c095d485e3d382a9865ce7e9fc8c2958299099e4ae695ca79ecb",
-      "src/pilot/translation_memory.py": "e5014c7a872ca6c89458a052690de45576fae15e09094be72bfa7aa30b1d0b76",
+      "src/pilot/translation_memory.py": "e5452394c8f3bbebef9f6038362e6a9d0e162a338201cdf425191412c7cf3a38",
       "src/pilot/coordinator.py": "a060e34e1733fb6469653f05bafab2756dfcca026f7324c83c9186808a21f9e6",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
       "src/promote_lock.py": "f8dda14a7423dfecac77893f10f7735361db8bd6c79297172243aafaf1d28ef4",
@@ -1748,13 +1748,13 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "note": "H2224 (02-08-2026, Grok 4.5 `grok-4.5`): residual EN defect refuse + ready_partial filter closed on promote_en (OPT-1). Prior history: wall_clock SHARED via audit_window_en (H1618); H2077/H2095 infra-partial classification; incidental re-stamps H1957/H2095 merge.",
     "tracking": "https://github.com/gasyoun/Uprava/blob/main/handoffs/H2224-Grok_SanskritLexicography_pwg-opt1-en-promote-parity_02.08.26.md",
     "verified_sha256": {
-      "src/pilot/window_reports.py": "56a2ad3401734efc33082cddea24224553258415aa66c7e51f524617a8a56181",
+      "src/pilot/window_reports.py": "e3b1c4a5034ca7fb721578e0c3ad354fb2ea84f842c0bad3a7877f745b3a6724",
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
       "src/pilot/dashboard_events.py": "f28f4a42568479f16d759d5e6aa63f4066c4e54920555102f77c2b0b9311bae6",
       "src/promote_final_cards.py": "085735b03cb6649789264eb309fd0ce6cd58bc0dd10319a7e54382ff4b301ec4",
       "src/promote_en.py": "9ff2b119687d997373d9743bb1474b158c2543af0756dcc61bc24034c38f00f8",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b",
-      "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed",
+      "src/pilot/audit_window_en.py": "8b00b3c39af3d4e473fe6196a34fcdc378cba0167773646488c8c8db06bd3327"
     }
   },
   {
@@ -1862,7 +1862,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "codex/rt-pipeline-hardening-speed",
     "verified_sha256": {
       "src/pilot/audit_window.py": "4687fc9ad0e546519ae95ec54ca5583cf51c57ebaf50fe655e1c288fb0113eec",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   },
   {
@@ -1898,7 +1898,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
     "tracking": "",
     "verified_sha256": {
       "src/pilot/prompt_rule_audit.py": "b235136ea95a7c77eb2cee0a3a6bc393c75df221ba587253a7949d9e3cbe4927",
-      "src/pilot/audit_window_en.py": "a6721309757d5eb6571174c9465bf4aacd2e646f905846973777f7f18b8e283f"
+      "src/pilot/audit_window_en.py": "8b00b3c39af3d4e473fe6196a34fcdc378cba0167773646488c8c8db06bd3327"
     }
   },
   {
@@ -1969,7 +1969,7 @@ verified_sha256   {file: hex} snapshot at last verification; drift trips the gat
       "src/pilot/window_common.py": "3a8a51917c9b898d9b3d262aaf9339e14fb30cddbb507242266858aec8727331",
       "src/pipeline_version.py": "b461d0c78b5df3f598007eb1e7ee284d84596ae19b5106d5329fdab1a93f00be",
       "src/pilot/h1339_offline_bench.py": "970ad8ab948c4aae724efc2076883e21a5bfc7e203ed1c68b5fbb14f3bdbb8cd",
-      "src/pilot/window_selftest.py": "bf3297182536a2c25890211b920fe648648fa981358654dec60f00607e80473b"
+      "src/pilot/window_selftest.py": "74ad62f38ea810387d1df38681c35e6d1e7688329d1a76baa62269174fe5f1ed"
     }
   }
 ]

--- a/RussianTranslation/PWG_TRANSLATION_DUPLICATION_OPTIMIZATION_INVENTORY_2026-08.md
+++ b/RussianTranslation/PWG_TRANSLATION_DUPLICATION_OPTIMIZATION_INVENTORY_2026-08.md
@@ -1,6 +1,6 @@
 # PWG translation — duplication map & unjustified-code optimization inventory
 
-_Created: 02-08-2026 · Last updated: 02-08-2026 (H2229 OPT-8 kitchen banner; H2226 OPT-4 closed)_
+_Created: 02-08-2026 · Last updated: 02-08-2026 (H2228 OPT-7 last-audit denylist; H2229 OPT-8 kitchen banner; H2226 OPT-4 closed)_
 
 **Purpose.** One place to hunt **optimization**: where the PWG→RU/EN pipeline
 _duplicates logic or code without a good reason_. Companion to the product-
@@ -157,9 +157,9 @@ audit-failed card (`agent_expected_after_tm: 0` real work).
 
 | | |
 |--|--|
-| **Optimize** | Already mitigated by `--no-tm` on defect requeue. Residual hardening: TM invalidation keyed on **last audit outcome** (or fragment denylist always applied before TM hit), so a default requeue cannot silently no-op. |
-| **Risk** | Medium (false-invalidates good TM if audit is wrong). |
-| **Prove** | gam-class fixture: requeue without flags still refuses failed hash. |
+| **Optimize** | ~~Already mitigated by `--no-tm` on defect requeue. Residual: last-audit denylist stamp.~~ **Closed H2228** (Grok 4.5 `grok-4.5`, 02-08-2026): `stamp_denylist_from_last_audit` at `write_reports` / EN `--write-requeue`; `load_tm` already applies denylist before hit; defect requeue still forces `--no-tm`. |
+| **Risk** | Medium (false-invalidates good TM if audit is wrong) — controls: defect-only, skip-crashed, clean held-out keys serve, promote unblocks. |
+| **Prove** | `test_opt7_last_audit_tm_refuse_without_no_tm` gam-class fixture: stamp without `--no-tm` refuses failed hash; clean key still hits. |
 
 ### OPT-8 — Multi-execution of the same root (ops)
 

--- a/RussianTranslation/src/pilot/audit_window_en.py
+++ b/RussianTranslation/src/pilot/audit_window_en.py
@@ -576,6 +576,22 @@ def main():
                 f.write('\n'.join(requeue_defect) + ('\n' if requeue_defect else ''))
             with open(defect_fshas, 'w', encoding='utf-8', newline='\n') as f:
                 f.write('\n'.join(requeue_defect_fshas) + ('\n' if requeue_defect_fshas else ''))
+            # H2228 / OPT-7 EN twin: stamp last-audit defect denylist so --tm=auto cannot
+            # re-serve hard-flagged content without --no-tm. Skip on crashed sense-dupe
+            # gates (blast radius). Local denylist under report dir when under tempdir.
+            if requeue_defect or requeue_defect_fshas:
+                if not crashed_files:
+                    import translation_memory as tm
+                    import tempfile as _tf
+                    deny_path = None
+                    abs_out = os.path.abspath(out_dir)
+                    if abs_out.startswith(os.path.abspath(_tf.gettempdir()) + os.sep):
+                        deny_path = os.path.join(out_dir, 'translation_memory.denylist.jsonl')
+                    n_deny, nf_deny = tm.stamp_denylist_from_last_audit(
+                        requeue_defect, lang='en', fshas=requeue_defect_fshas,
+                        root='', reason='last_audit_defect', path=deny_path)
+                    print('tm denylist   : +%d card +%d frag (last_audit_defect)'
+                          % (n_deny, nf_deny))
             print('requeue defect: %s (%d keys, %d fsha)' %
                   (defect_keys, len(requeue_defect), len(requeue_defect_fshas)))
     if production_metrics:

--- a/RussianTranslation/src/pilot/requeue_from_audit.py
+++ b/RussianTranslation/src/pilot/requeue_from_audit.py
@@ -16,7 +16,6 @@ import json
 import os
 import subprocess
 import sys
-import datetime
 import argparse
 
 sys.stdout.reconfigure(encoding='utf-8')
@@ -30,7 +29,6 @@ REQUEUE = os.path.join(OUT, 'requeue.keys.txt')
 
 sys.path.insert(0, SRC)
 from safe_filename import safe_name
-from window_common import sha256_file, append_jsonl_line
 
 sys.path.insert(0, HERE)
 import translation_memory
@@ -89,45 +87,27 @@ def refuse_crashed_audit(requeue_file, tag):
                  'report.' % ', '.join(str(c) for c in crashed[:5]))
 
 
-def append_tm_denylist(root, keys, which, lang='ru', fsha_file=None):
+def append_tm_denylist(root, keys, which, lang='ru', fsha_file=None, path=None):
     """Invalidate exact card-TM addresses for defect/all requeues. Append-only and local-only.
 
     H304: also invalidate the flagged cards' FRAGMENT addresses. build_frags harvests
     frag_prov from raw wf_output before any gate runs, so without this a defect card's
     fragments stay reusable in the sidecar and --tm=auto re-serves the flagged content on
     the next window that shares a fragment. audit_window writes the fshas to
-    requeue.defect.fshas.txt next to the requeue key files."""
+    requeue.defect.fshas.txt next to the requeue key files.
+
+    H2228 / OPT-7: delegates to translation_memory.stamp_denylist_from_last_audit so the
+    same last-audit-outcome stamp is used at requeue time and at audit --write-requeue.
+    """
     if which == 'transient':
         return 0, 0
-    path = translation_memory.denylist_path()
-    now = datetime.datetime.now(datetime.timezone.utc).isoformat(
-        timespec='seconds').replace('+00:00', 'Z')
-    n = 0
-    for k in keys:
-        raw = os.path.join(INP, k + '.raw.txt')
-        if not os.path.exists(raw):
-            continue
-        address = '%s:%s' % (lang, sha256_file(raw))
-        # H336/H-3: one os.write() per row (window_common.append_jsonl_line) — a bare
-        # buffered 'a' handle can split one line across writes, and a concurrent
-        # appender (another account's requeue) can then tear it.
-        append_jsonl_line(path, {'schema': 'pwg.translation_memory.denylist.v1',
-                                 'kind': 'card', 'address': address, 'key': k,
-                                 'root': root, 'lang': lang, 'reason': 'requeue_%s' % which,
-                                 'blocked_at': now})
-        n += 1
-    nf = 0
+    fshas = []
     fp = fsha_file or os.path.join(OUT, 'requeue.defect.fshas.txt')
     if os.path.exists(fp):
         fshas = [ln.strip() for ln in open(fp, encoding='utf-8') if ln.strip()]
-        for fsha in fshas:
-            append_jsonl_line(path, {'schema': 'pwg.translation_memory.denylist.v1',
-                                     'kind': 'frag', 'fsha': fsha,
-                                     'root': root, 'lang': lang,
-                                     'reason': 'requeue_%s_fragment' % which,
-                                     'blocked_at': now})
-            nf += 1
-    return n, nf
+    return translation_memory.stamp_denylist_from_last_audit(
+        keys, lang=lang, fshas=fshas, root=root,
+        reason='requeue_%s' % which, path=path, inp_dir=INP)
 
 
 def main():

--- a/RussianTranslation/src/pilot/translation_memory.py
+++ b/RussianTranslation/src/pilot/translation_memory.py
@@ -332,6 +332,70 @@ def _atomic_extend_plain_jsonl(path, rows, fault_hook=None):
         raise
 
 
+def stamp_denylist_from_last_audit(keys, lang='ru', fshas=(), root='',
+                                   reason='last_audit_defect', path=None,
+                                   inp_dir=None, timestamp=None):
+    """Invalidate TM card/fragment addresses from the last *defect* audit outcome.
+
+    Residual OPT-7 / Uprava FINDINGS §31: content-addressed TM reuses by input hash,
+    not by whether the cached translation passed QA. Defect requeue already forces
+    ``--no-tm``; this stamps the denylist at **audit outcome** time so a default
+    ``--tm=auto`` path (operator forgets ``--no-tm``, or bypasses requeue_from_audit)
+    still refuses the failed hash and forces a real re-translate.
+
+    False-invalidation controls (do NOT weaken these):
+      * only **defect** keys/fshas — never transient nulls
+      * callers MUST skip crashed-auditor blast-radius sets (B11 / refuse_crashed_audit)
+      * clean keys are never listed; held-out clean TM still serves
+      * promote still clears via append_unblock once a gate-passing replacement lands
+
+    Returns (n_card_addresses, n_fragment_fshas) appended.
+    """
+    from window_common import sha256_file  # local import: avoid circular at module load
+    if lang not in ('ru', 'en'):
+        raise ValueError('lang must be ru|en, got %r' % lang)
+    p = denylist_path(path)
+    now = timestamp or datetime.datetime.now(datetime.timezone.utc).isoformat(
+        timespec='seconds').replace('+00:00', 'Z')
+    # H1386 / gen_opt: PWG_INPUT_DIR can redirect raw inputs for hermetic harnesses.
+    base_inp = inp_dir or os.environ.get('PWG_INPUT_DIR') or os.path.join(HERE, 'input')
+    n = 0
+    for k in keys or ():
+        raw = os.path.join(base_inp, k + '.raw.txt')
+        if not os.path.exists(raw):
+            continue
+        address = '%s:%s' % (lang, sha256_file(raw))
+        append_jsonl_line(p, {
+            'schema': 'pwg.translation_memory.denylist.v1',
+            'kind': 'card',
+            'address': address,
+            'key': k,
+            'root': root or '',
+            'lang': lang,
+            'last_audit_outcome': 'defect',
+            'reason': reason,
+            'blocked_at': now,
+        })
+        n += 1
+    nf = 0
+    for fsha in fshas or ():
+        fsha = (fsha or '').strip()
+        if not fsha:
+            continue
+        append_jsonl_line(p, {
+            'schema': 'pwg.translation_memory.denylist.v1',
+            'kind': 'frag',
+            'fsha': fsha,
+            'root': root or '',
+            'lang': lang,
+            'last_audit_outcome': 'defect',
+            'reason': reason + '_fragment' if reason else 'last_audit_defect_fragment',
+            'blocked_at': now,
+        })
+        nf += 1
+    return n, nf
+
+
 def append_unblock(addresses=(), fshas=(), reason='', path=None,
                    timestamp=None, fault_hook=None):
     """B12 (H1339): supersede matching denylist entries with 'unblock' rows.

--- a/RussianTranslation/src/pilot/window_reports.py
+++ b/RussianTranslation/src/pilot/window_reports.py
@@ -428,6 +428,60 @@ def audit_state(report):
     return 'clean'
 
 
+def _is_ephemeral_out_dir(out_dir):
+    """True when out_dir is a fixture/ephemeral scratch — never stamp the live denylist."""
+    if not out_dir:
+        return False
+    abs_out = os.path.abspath(out_dir)
+    if 'pwg_audit_ephemeral_' in abs_out:
+        return True
+    try:
+        import tempfile
+        tmp_root = os.path.abspath(tempfile.gettempdir())
+        if abs_out == tmp_root or abs_out.startswith(tmp_root + os.sep):
+            return True
+    except Exception:  # noqa: BLE001 — tempdir probe is advisory only
+        pass
+    return False
+
+
+def _stamp_last_audit_denylist(report, out_dir):
+    """OPT-7: apply last-audit defect outcome to the TM denylist (or a local fixture path).
+
+    Returns a small status dict for the report; never raises into the audit path for
+    missing raws (stamp skips unknown keys). Crashed audits and empty defect sets no-op.
+    """
+    crashed = report.get('crashed') or []
+    defect_keys = list(report.get('requeue_defect') or [])
+    defect_fshas = list(report.get('requeue_defect_fshas') or [])
+    if crashed:
+        return {'stamped': False, 'reason': 'crashed_audit_refused', 'crashed': list(crashed)}
+    if not defect_keys and not defect_fshas:
+        return {'stamped': False, 'reason': 'no_defect_keys'}
+    import translation_memory as tm  # late: keep window_reports import surface thin
+    lang = report.get('lang') or 'ru'
+    if lang not in ('ru', 'en'):
+        lang = 'ru'
+    # Ephemeral/temp audits: stamp a *local* denylist under out_dir so fixtures can prove
+    # refuse-on-fail without poisoning the shared live sidecar.
+    deny_path = None
+    if _is_ephemeral_out_dir(out_dir):
+        deny_path = os.path.join(out_dir, 'translation_memory.denylist.jsonl')
+    n, nf = tm.stamp_denylist_from_last_audit(
+        defect_keys, lang=lang, fshas=defect_fshas,
+        root=report.get('root') or '',
+        reason='last_audit_defect', path=deny_path)
+    return {
+        'stamped': True,
+        'cards': n,
+        'frags': nf,
+        'lang': lang,
+        'denylist': deny_path or tm.denylist_path(),
+        'false_invalidation_controls': (
+            'defect-only; skip-crashed; clean keys untouched; promote unblocks'),
+    }
+
+
 def write_reports(report, write_requeue, write_requeue_file=True, out_dir=None):
     # out_dir defaults to the live OUT dir. An ephemeral/fixture audit (see audit_window.py
     # --ephemeral) passes a throwaway scratch dir so a self-test or temp-file run can NEVER
@@ -544,6 +598,15 @@ def write_reports(report, write_requeue, write_requeue_file=True, out_dir=None):
             atomic_write_text(
                 os.path.join(out_dir, fname),
                 '\n'.join(keys_) + ('\n' if keys_ else ''))
+        # H2228 / OPT-7: stamp TM denylist from last *defect* audit outcome at write-requeue
+        # time (not only when requeue_from_audit runs). load_tm always applies the denylist
+        # before a hit, so a default --tm=auto requeue cannot silently re-serve failed
+        # content even without operator --no-tm. Controls:
+        #   * defect keys/fshas only (never transient)
+        #   * skip crashed blast-radius sets (B11)
+        #   * never touch the live canonical denylist from ephemeral/temp out_dir
+        #   * clean held-out keys stay serveable
+        report['tm_denylist_stamped'] = _stamp_last_audit_denylist(report, out_dir)
     status_json, status_md = write_window_status(report, out_dir)
     return (json_path, md_path,
             requeue_path if write_requeue and write_requeue_file else None,

--- a/RussianTranslation/src/pilot/window_selftest.py
+++ b/RussianTranslation/src/pilot/window_selftest.py
@@ -6454,7 +6454,7 @@ def test_defect_fragment_denylist_round_trip():
     rfa.INP = inp
     try:
         n, nf = rfa.append_tm_denylist('h304root', [key], 'defect', lang='ru',
-                                       fsha_file=fsha_file)
+                                       fsha_file=fsha_file, path=deny_path)
     finally:
         rfa.translation_memory.denylist_path = old_dp
         rfa.INP = old_inp
@@ -6487,9 +6487,136 @@ def test_defect_fragment_denylist_round_trip():
     if fsha_good not in cache:
         fail('clean fragment wrongly dropped by the denylist')
     # transient requeues must not denylist anything
-    n, nf = rfa.append_tm_denylist('h304root', [], 'transient', lang='ru')
+    n, nf = rfa.append_tm_denylist('h304root', [], 'transient', lang='ru', path=deny_path)
     if (n, nf) != (0, 0):
         fail('transient requeue must never append denylist rows')
+
+
+def test_opt7_last_audit_tm_refuse_without_no_tm():
+    """H2228 / OPT-7 / FINDINGS §31 residual: last-audit defect outcome stamps the denylist
+    so a default --tm=auto path (no operator --no-tm) still refuses the failed hash and
+    forces real re-translate work. gam-class synthetic fixture:
+
+      * defect key has a TM hit that would otherwise make agent_expected_after_tm=0
+      * write_reports(--write-requeue) stamps denylist from requeue_defect
+      * load_tm then refuses the failed address; clean held-out key still serves
+      * crashed audit does NOT stamp (blast-radius control)
+      * false-invalidation: clean key never denylisted
+    """
+    import translation_memory as tm
+    from window_reports import write_reports, _stamp_last_audit_denylist
+    tmp = tempfile.mkdtemp(prefix='pwg_audit_ephemeral_opt7_')
+    inp = os.path.join(tmp, 'input')
+    os.makedirs(inp)
+    # gam-class: one defect key + one clean key (held-out clean TM must survive)
+    defect_key = 'gam~~h0_zz_pw03'
+    clean_key = 'gam~~h0_zz_clean'
+    for key, body in ((defect_key, 'gam flagged defect raw COVERAGE-LOW'),
+                      (clean_key, 'gam clean held-out raw')):
+        with open(os.path.join(inp, key + '.raw.txt'), 'w', encoding='utf-8') as f:
+            f.write(body)
+    defect_addr = 'ru:%s' % sha256(os.path.join(inp, defect_key + '.raw.txt'))
+    clean_addr = 'ru:%s' % sha256(os.path.join(inp, clean_key + '.raw.txt'))
+    fsha_bad = tm.frag_address('ru', 'gam defect fragment body')
+    fsha_good = tm.frag_address('ru', 'gam clean fragment body')
+
+    # Pre-stamp synthetic TM as if a prior run cached both (the §31 trap: defect is cached)
+    card_tm = os.path.join(tmp, 'translation_memory.ru.json')
+    with open(card_tm, 'w', encoding='utf-8') as f:
+        json.dump({'schema': tm.CARD_SCHEMA, 'lang': 'ru', 'entries': {
+            defect_addr: {
+                'id': defect_addr,
+                'card': {'records': [{'senses': [
+                    {'russian': 'cached defect %d' % i} for i in range(47)]}]},
+                'trust_level': tm.TRUST_MACHINE,
+                'gate_status': 'machine_gated',
+                'reuse_policy': 'auto_exact',
+            },
+            clean_addr: {
+                'id': clean_addr,
+                'card': {'records': [{'senses': [{'russian': 'cached clean'}]}]},
+                'trust_level': tm.TRUST_MACHINE,
+                'gate_status': 'machine_gated',
+                'reuse_policy': 'auto_exact',
+            },
+        }}, f, ensure_ascii=False)
+    # Without denylist both serve — proves the trap surface exists for this fixture
+    before = tm.load_tm('ru', card_tm, denylist=os.path.join(tmp, 'empty_deny.jsonl'))
+    if defect_addr not in before or clean_addr not in before:
+        fail('fixture TM must serve both addresses before last-audit stamp')
+
+    old_inp = os.environ.get('PWG_INPUT_DIR')
+    os.environ['PWG_INPUT_DIR'] = inp
+    try:
+        report = {
+            'workflow': 'wf_output_gam_opt7_fixture.json',
+            'root': 'gam',
+            'lang': 'ru',
+            'keys': [defect_key, clean_key],
+            'requeue': [defect_key],
+            'requeue_transient': [],
+            'requeue_defect': [defect_key],
+            'requeue_defect_fshas': [fsha_bad],
+            'crashed': [],
+            'gates': {},
+            'state': 'needs_requeue',
+            'null_cards': [],
+            'partial_cards': {},
+            'failure_reasons': {},
+        }
+        write_reports(report, True, out_dir=tmp)
+        stamp = report.get('tm_denylist_stamped') or {}
+        if not stamp.get('stamped'):
+            fail('write_reports must stamp last-audit denylist for defect keys: %r' % stamp)
+        if stamp.get('cards', 0) < 1:
+            fail('expected ≥1 card denylist row from defect raw: %r' % stamp)
+        deny_path = stamp.get('denylist')
+        if not deny_path or not os.path.exists(deny_path):
+            fail('local last-audit denylist missing under ephemeral out_dir')
+        after = tm.load_tm('ru', card_tm, denylist=deny_path)
+        if defect_addr in after:
+            fail('last-audit defect address still served by load_tm (OPT-7 refuse failed)')
+        if clean_addr not in after:
+            fail('clean held-out TM falsely invalidated by last-audit stamp')
+        # Fragment lane: denylisted fsha refused; clean fsha still live
+        senses = [{'tag': '1', 'german': 'x', 'russian': 'y'}]
+        sidecar = os.path.join(tmp, 'translation_memory.frag.ru.jsonl')
+        with open(sidecar, 'w', encoding='utf-8') as f:
+            for fsha in (fsha_good, fsha_bad):
+                f.write(json.dumps({'schema': tm.FRAG_SCHEMA_V2, 'fsha': fsha,
+                                    'senses': senses, 'owners': [['x', '']]}) + '\n')
+        frag = tm.load_frag_tm('ru', sidecar, denylist=deny_path)
+        if fsha_bad in frag:
+            fail('last-audit defect fsha still served by load_frag_tm')
+        if fsha_good not in frag:
+            fail('clean fragment falsely invalidated')
+        # Default requeue path without operator --no-tm still forces real work for the
+        # defect key: TM miss on the failed hash means agent_expected cannot be 0 solely
+        # from that hit (simulate the gen_opt address lookup).
+        hit_after_stamp = after.get(defect_addr)
+        if hit_after_stamp is not None:
+            fail('default-path TM hit must be None for last-audit-failed hash')
+        # agent work residual: 1 defect key refused → non-zero real translate path
+        agent_expected_after_tm = 0 if hit_after_stamp else 1
+        if agent_expected_after_tm < 1:
+            fail('gam-class fixture must prove non-zero real translate path after stamp')
+        # Crashed audit must not stamp (false-invalidation / blast-radius control)
+        crash_report = {
+            'root': 'gam', 'lang': 'ru', 'keys': [clean_key],
+            'requeue': [clean_key], 'requeue_defect': [clean_key],
+            'requeue_defect_fshas': [], 'crashed': ['coverage'],
+            'gates': {}, 'state': 'blocked',
+        }
+        crash_stamp = _stamp_last_audit_denylist(crash_report, tmp)
+        if crash_stamp.get('stamped'):
+            fail('crashed audit must not stamp denylist: %r' % crash_stamp)
+        if 'false_invalidation_controls' not in (stamp or {}):
+            fail('stamp status must document false-invalidation controls')
+    finally:
+        if old_inp is None:
+            os.environ.pop('PWG_INPUT_DIR', None)
+        else:
+            os.environ['PWG_INPUT_DIR'] = old_inp
 
 
 def test_h1386_p3d_p3e_run_py_inproc_exit_semantics():
@@ -8688,6 +8815,7 @@ def main():
         test_lang_parity_hash_crlf_independent,
         test_frag_groups_presplit_parity,
         test_defect_fragment_denylist_round_trip,
+        test_opt7_last_audit_tm_refuse_without_no_tm,
         test_write_reports_emits_defect_fsha_file,
         test_ledger_stamps_gen_model,
         test_h1553_wall_clock_auto_derive,


### PR DESCRIPTION
## Summary
- **H2228 / OPT-7 residual** beyond defect-requeue `--no-tm` (Uprava FINDINGS §31): stamp TM denylist from **last audit defect outcome** at `write_reports` (RU) and `audit_window_en --write-requeue` (EN).
- New `translation_memory.stamp_denylist_from_last_audit`; `requeue_from_audit.append_tm_denylist` delegates to it.
- `load_tm` / `load_frag_tm` already apply denylist **before** any hit — so default `--tm=auto` cannot re-serve a failed hash even without operator `--no-tm`.

## False-invalidation controls
- defect keys/fshas only (never transient nulls)
- crashed audits refuse stamp (B11 blast radius)
- ephemeral/temp out_dir → local denylist only (no live sidecar poison)
- clean held-out keys still serve
- promote still unblocks

## Prove
- `test_opt7_last_audit_tm_refuse_without_no_tm` (gam-class synthetic)
- `test_defect_fragment_denylist_round_trip` + coordinator `--no-tm` pin still green
- `lang_parity_check` 90 entries no drift; SHARED on denylist / no-tm entries

## Non-goals
- invalidating all TM
- production paid re-run of windows
- weakening store-hit preflight

Handoff: H2228 (Grok 4.5) — OPT-7 TM invalidation keyed on last audit outcome